### PR TITLE
feat: add opt-in app-wide Persona Buddy

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -593,8 +593,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 338,
-      "diagnostic_digest": "445a3433663793c51d8e",
+      "call_count": 341,
+      "diagnostic_digest": "8d13c4bf654f81999035",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1377,8 +1377,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 18,
-      "diagnostic_digest": "051847e5abc212136e80",
+      "call_count": 20,
+      "diagnostic_digest": "b597ae206b3e2b1ddfd3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2490,8 +2490,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 13,
-      "diagnostic_digest": "003a1b7bcf88e43ebf39",
+      "call_count": 36,
+      "diagnostic_digest": "98b4672724ed97e2ea44",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/change_review_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3603,6 +3603,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "3b62237e439a1aafa3a8",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Workspaces/git_workspace.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 4,
       "diagnostic_digest": "57cd98b5b30e53dba161",
       "owner": "TASK-494",
@@ -3611,7 +3618,7 @@
     },
     {
       "call_count": 325,
-      "diagnostic_digest": "bb5156c2be2e60286533",
+      "diagnostic_digest": "14fba1fb194bef30c90b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3830,9 +3837,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 520,
+    "owner_files": 521,
     "persistent_sink_files": 7,
     "task_492_calls": 1221,
-    "task_494_calls": 7179
+    "task_494_calls": 7208
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -229,8 +229,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 2,
-      "diagnostic_digest": "7a4dee59691931bd9732",
+      "call_count": 3,
+      "diagnostic_digest": "a6548cabfce89387deb2",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/chat_persistence_service.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -243,15 +243,15 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 45,
-      "diagnostic_digest": "085bc09fb8bdc378cf10",
+      "call_count": 46,
+      "diagnostic_digest": "83e77a38ff24dba2e5ba",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 58,
-      "diagnostic_digest": "777067a0f1aff86facb8",
+      "call_count": 59,
+      "diagnostic_digest": "cb960a33254ce0e37313",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -286,7 +286,7 @@
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "9df8f3710dc9434f18ec",
+      "diagnostic_digest": "44b532929a26699004a6",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_fleet_wake.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -327,8 +327,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 2,
-      "diagnostic_digest": "9bd43df1945e3a46d316",
+      "call_count": 7,
+      "diagnostic_digest": "e864e08f01b38d016d5f",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_provider_gateway.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -593,15 +593,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 330,
-      "diagnostic_digest": "4024e37f0e4f6a6896a6",
+      "call_count": 338,
+      "diagnostic_digest": "445a3433663793c51d8e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 338,
-      "diagnostic_digest": "73ec76b8c78459022689",
+      "call_count": 339,
+      "diagnostic_digest": "3823eba4549e5fc79d4f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Client_Media_DB_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1388,6 +1388,13 @@
       "diagnostic_digest": "c7e8c3f2e536911b1794",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/sync_service.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "0ef0338582cf3b0afcc9",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Persona_Buddy/preferences.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -2231,8 +2238,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "e7874d0059c10ebf13c8",
+      "call_count": 4,
+      "diagnostic_digest": "7edf22bbca1d98e545c0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/character.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2469,8 +2476,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 31,
-      "diagnostic_digest": "c0412fb3d00c9d484a79",
+      "call_count": 34,
+      "diagnostic_digest": "feb243090c22677cc265",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/STTS_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2490,8 +2497,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 145,
-      "diagnostic_digest": "f77b0b230eb8b99d8865",
+      "call_count": 143,
+      "diagnostic_digest": "8f14b7b22a5a6ef71b9b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2532,8 +2539,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 109,
-      "diagnostic_digest": "2b4e866f30fc5df8b13c",
+      "call_count": 111,
+      "diagnostic_digest": "a8ca5c4ba3536b05990c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2567,8 +2574,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 180,
-      "diagnostic_digest": "759f107dd896e0960175",
+      "call_count": 186,
+      "diagnostic_digest": "abf6fdc6c9eef6dd4f9c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/personas_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2938,8 +2945,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 8,
-      "diagnostic_digest": "c293b2298d8ca732b52a",
+      "call_count": 11,
+      "diagnostic_digest": "a0697ad0b738968893ad",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/file_handlers.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3218,10 +3225,10 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 3,
-      "diagnostic_digest": "9788f180d63aa7939014",
+      "call_count": 9,
+      "diagnostic_digest": "5284ce54fb686a96ef89",
       "owner": "TASK-494",
-      "path": "tldw_chatbook/Widgets/Console/console_context_modal.py",
+      "path": "tldw_chatbook/Widgets/Console/console_conversation_inspector.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -3823,9 +3830,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 519,
+    "owner_files": 520,
     "persistent_sink_files": 7,
-    "task_492_calls": 1213,
-    "task_494_calls": 7148
+    "task_492_calls": 1221,
+    "task_494_calls": 7179
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1392,7 +1392,7 @@
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "0ef0338582cf3b0afcc9",
+      "diagnostic_digest": "305391130904c7493a5d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Persona_Buddy/preferences.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/superpowers/plans/2026-08-21-task-19055-persona-buddy.md
+++ b/Docs/superpowers/plans/2026-08-21-task-19055-persona-buddy.md
@@ -1,0 +1,575 @@
+# Persona Buddy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a default-off, explicitly selected, app-wide floating companion for one eligible local Persona, driven only by trusted application lifecycle state and the immutable Persona Visual runtime.
+
+**Architecture:** `TldwCli` owns one screen-independent `PersonaBuddyController` and one UI-thread mount reconciler. Every ordinary `BaseAppScreen` dynamically mounts or removes a disposable Textual view; the view polls immutable controller snapshots and the controller retains no screen/widget references. Personas Workbench and app-owned Console runtime seams publish exact identity and trusted state leases, while Persona Visual database, asset, decode, frame preparation, and config writes run off-loop behind one serialized shield-and-drain boundary.
+
+**Tech Stack:** Python 3.11+, Textual 8, asyncio, SQLite/Persona Visual repository and runtime, Pillow/Rich Pixels, pytest/Pilot.
+
+**Execution skills:** Use @superpowers:test-driven-development for every behavior change, @textual-tui and @impeccable for Task 3, and @superpowers:verification-before-completion before each completion claim.
+
+---
+
+## File map and fixed contracts
+
+- `tldw_chatbook/Persona_Buddy/preferences.py`: strict `[persona_buddy]` config codec and atomic persistence for `enabled`, `source`, `local_persona_id`, `open`, `collapsed`, `x`, `y`, `width`, and `height`.
+- `tldw_chatbook/Persona_Buddy/controller.py`: app-owned identity, generations, source-scoped leases, priority resolution, async serialization, and immutable public snapshots; no Textual imports or view references.
+- `tldw_chatbook/Persona_Buddy/rendering.py`: selected-frame Pillow decode and bounded Rich `Pixels` preparation; no Textual imports.
+- `tldw_chatbook/Persona_Buddy/console_adapter.py`: content-free mapping from trusted Console lifecycle events into controller leases.
+- `tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py`: the disposable floating view, mouse/keyboard geometry, timers, and painted output only.
+- `tldw_chatbook/app.py`: construct/shutdown the controller and reconcile the current `BaseAppScreen` mount on explicit preference/lifecycle changes.
+- `tldw_chatbook/UI/Navigation/base_app_screen.py`: screen-local dynamic mount/unmount; releases mouse capture and removes only its own widget generation.
+- Canonical state keys use underscores: `idle`, `listening`, `thinking`, `speaking`, `approval_needed`, `tool_running`, `wake_armed`, `offline`, `error`. Hyphens are labels only.
+- Priority is exactly: `error`, `approval_needed`, timed explicit/custom, authored trigger, `tool_running`, `wake_armed` only while live state is absent/idle, trusted voice, `offline`, `idle`.
+- The view uses `position: absolute` plus `overlay: screen`, starts bottom-right, and never consumes parent flow or `fr` budget.
+- The controller retains no screen/widget references. `TldwCli.reconcile_persona_buddy_view()` calls the current screen; each mounted view polls immutable snapshots and fences screen identity plus view generation.
+- The Buddy never consumes model prose or streaming `Emote:` directives.
+- User instruction: run touched/modified component tests only, never the full suite.
+
+Baseline before Buddy code: the prescribed touched suite produced `727 passed, 1 failed`; the sole failure was the pre-existing `widget_defaults_self.tcss` bundle mismatch in `Tests/UI/test_css_bundle_sync_guard.py`. Prospective legacy formatter baseline: Ruff would reformat 17 of the 22 existing files listed in Task 6 Step 6 and already accepts the other 5; preserve that exact file-set result instead of bulk-formatting unrelated legacy code. Because this task adds widget CSS, regenerate and review the exact bundle during Task 3; do not mark the task Done unless the branch's final scoped CSS gate and every other touched gate pass.
+
+## Task 1: Freeze preferences and controller state
+
+**Files:**
+
+- Create: `tldw_chatbook/Persona_Buddy/__init__.py`
+- Create: `tldw_chatbook/Persona_Buddy/preferences.py`
+- Create: `tldw_chatbook/Persona_Buddy/controller.py`
+- Create: `Tests/Persona_Buddy/test_persona_buddy_preferences.py`
+- Create: `Tests/Persona_Buddy/test_persona_buddy_controller.py`
+
+- [ ] **Step 1: Write the preference REDs**
+
+  Add named tests `test_preferences_default_off_without_selection`, `test_preferences_round_trip_exact_local_selection_and_geometry`, `test_preferences_reject_malformed_fields_independently`, and `test_preference_failure_is_path_free`. Use the public shape:
+
+  ```python
+  prefs = parse_persona_buddy_preferences({"enabled": True, "source": "local", "local_persona_id": "p-1", "x": 9, "y": 4, "width": 28, "height": 12})
+  assert prefs.selection == PersonaBuddySelection("local", "p-1")
+  assert serialize_persona_buddy_preferences(prefs)["local_persona_id"] == "p-1"
+  ```
+
+- [ ] **Step 2: Run the preference REDs**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Persona_Buddy/test_persona_buddy_preferences.py
+  ```
+
+  Expected: collection fails with `ModuleNotFoundError: tldw_chatbook.Persona_Buddy`.
+
+- [ ] **Step 3: Implement the strict config contracts**
+
+  Implement exact frozen/slotted types and bounded parsing:
+
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class PersonaBuddySelection:
+      source: Literal["local"]
+      local_persona_id: str
+
+  @dataclass(frozen=True, slots=True)
+  class PersonaBuddyGeometry:
+      x: int
+      y: int
+      width: int
+      height: int
+
+  def parse_persona_buddy_preferences(section: Mapping[str, object]) -> PersonaBuddyPreferences: ...
+  def serialize_persona_buddy_preferences(prefs: PersonaBuddyPreferences) -> dict[str, object]: ...
+  def persist_persona_buddy_preferences(prefs: PersonaBuddyPreferences) -> bool:
+      return save_settings_to_cli_config({"persona_buddy": serialize_persona_buddy_preferences(prefs)})
+  ```
+
+  Each malformed field falls back to its safe default without accepting bool-as-int, unknown source, controls, or an empty/oversized Persona ID. Public errors and logs use fixed categories only.
+
+- [ ] **Step 4: Run the preference GREENs**
+
+  Run the Step 2 command. Expected: all preference tests pass.
+
+- [ ] **Step 5: Write the controller REDs**
+
+  Add `test_priority_is_exact_for_overlapping_sources`, `test_release_requires_exact_source_owner`, `test_wake_armed_yields_to_non_idle_live_voice`, `test_timed_custom_state_expires`, and `test_selection_never_changes_from_observed_persona`. Drive this API:
+
+  ```python
+  token = controller.acquire_state(source="approval", owner="session:round", state="approval_needed")
+  controller.acquire_state(source="tool", owner="run:call", state="tool_running")
+  assert controller.snapshot().state == "approval_needed"
+  assert controller.release_state(source="approval", owner="wrong") is False
+  assert controller.release_state(token=token) is True
+  ```
+
+- [ ] **Step 6: Run the controller REDs**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Persona_Buddy/test_persona_buddy_controller.py
+  ```
+
+  Expected: import or missing `PersonaBuddyController` failures.
+
+- [ ] **Step 7: Implement minimal lease/priority state**
+
+  Implement:
+
+  ```python
+  class PersonaBuddyController:
+      def snapshot(self) -> PersonaBuddySnapshot: ...
+      def select_local_persona(self, persona_id: str) -> int: ...
+      def acquire_state(self, *, source: str, owner: str, state: str, expires_at: float | None = None) -> PersonaBuddyLeaseToken: ...
+      def release_state(self, *, token: PersonaBuddyLeaseToken | None = None, source: str | None = None, owner: str | None = None) -> bool: ...
+      def set_timed_state(self, *, owner: str, state: str, ttl_seconds: float) -> PersonaBuddyLeaseToken: ...
+      def set_authored_trigger(self, *, owner: str, state: str) -> PersonaBuddyLeaseToken: ...
+  ```
+
+  Use a lock around source/owner lease maps, a monotonic generation, normalized safe state grammar, and frozen/slotted snapshots with no paths, bytes, prompts, or exception text in repr.
+
+- [ ] **Step 8: Run Task 1 GREEN and mutations**
+
+  Run both Task 1 test files. Then temporarily reverse priority, weaken exact owner release, and permit observed Persona retargeting one at a time; each named test must fail before restoration.
+
+- [ ] **Step 9: Commit Task 1**
+
+  ```bash
+  git add tldw_chatbook/Persona_Buddy Tests/Persona_Buddy/test_persona_buddy_preferences.py Tests/Persona_Buddy/test_persona_buddy_controller.py
+  git commit -m "feat: define Persona Buddy controller state"
+  ```
+
+## Task 2: Resolve Persona Visual frames under app-owned lifetime
+
+**Files:**
+
+- Modify: `tldw_chatbook/Persona_Buddy/controller.py`
+- Create: `tldw_chatbook/Persona_Buddy/rendering.py`
+- Modify: `tldw_chatbook/app.py:5772-5775`
+- Modify: `tldw_chatbook/app.py:6340-6395`
+- Modify: `tldw_chatbook/app.py:11530-11555`
+- Create: `Tests/Persona_Buddy/test_persona_buddy_resolution.py`
+- Modify: `Tests/UI/test_console_runtime_ownership.py`
+
+- [ ] **Step 1: Write the real-SQLite resolution RED**
+
+  Add `test_resolve_selected_local_persona_from_real_active_binding`, `test_disabled_deleted_missing_or_unbound_selection_preserves_enabled_but_hides`, and `test_state_idle_portrait_fallback_never_blanks`. Create a real TASK-19053 graph and assert exact `PersonaVisualIdentity`, `requested_state`, `resolved_state`, `animation_id`, cache-asset tuple, frame asset ID, manifest-frame index, and selected-frame identity.
+
+- [ ] **Step 2: Write selected-frame and painted-render REDs**
+
+  Add `test_sprite_frames_prepare_distinct_painted_frames`, `test_reduced_motion_prepares_only_frame_zero`, `test_decode_failure_keeps_previous_or_portrait_frame`, and `test_render_snapshot_repr_is_byte_and_path_free`. The renderer contract is:
+
+  ```python
+  prepared = prepare_persona_buddy_frame(
+      resolved_frame,
+      resolution_cache_identity=resolution.cache_identity,
+      cols=24,
+      lines=10,
+  )
+  assert prepared.cells
+  assert prepared.graph_identity == resolution.cache_identity.graph
+  assert prepared.asset_id == resolved_frame.asset_id
+  assert prepared.selected_frame == resolved_frame.selected_frame
+  ```
+
+- [ ] **Step 3: Run the resolution/render REDs**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Persona_Buddy/test_persona_buddy_resolution.py
+  ```
+
+  Expected: missing resolution/render API failures.
+
+- [ ] **Step 4: Implement selected-frame preparation**
+
+  In `rendering.py`, Pillow-decode the selected embedded frame, fully load it, bound dimensions/cells, and return a repr-hidden Rich `Pixels` renderable plus immutable cell/cache metadata. Never return source paths or raw bytes publicly. Decode/format failures return `persona_buddy_frame_unavailable` without replacing a previously accepted frame.
+
+- [ ] **Step 5: Define the serialized drain result and operation seam**
+
+  Implement one registered inner task before the first await:
+
+  ```python
+  T = TypeVar("T")
+
+  @dataclass(frozen=True, slots=True)
+  class BuddyDrainResult(Generic[T]):
+      completed: bool
+      value: T | None = None
+      error_category: str | None = None
+      cancellation: BaseException | None = field(default=None, repr=False)
+
+  async def _drain_owned(self, awaitable: Awaitable[T], *, name: str) -> BuddyDrainResult[T]: ...
+  ```
+
+  Shield the inner task, retain the first outer cancellation, absorb repeated outer cancellations until the child settles, distinguish child cancellation from successful `None`, and release the operation slot only after draining and outcome handling.
+
+- [ ] **Step 6: Implement resolution with an explicit fence tuple**
+
+  Snapshot the complete validated `PersonaVisualIdentity` object and complete `PersonaVisualCacheIdentity` object, not a hand-picked partial tuple. Their equality therefore fences every existing identity field, including Persona/binding/binding-version, pack/revision, version/version-number/manifest hash, requested/resolved state, animation, reduced-motion flag, complete cache-asset tuple, and portrait identity. Add `(profile_generation, persona_revision, controller_generation, preferences_generation, viewport_generation, frame asset_id, manifest_frame_index, selected_frame)` around those exact objects. Run local Persona lookup, repository graph read, `resolve_active_persona_visual`, Pillow decode, and Rich preparation via `asyncio.to_thread`. Insert `is_current(snapshot)` immediately after each await and before each state mutation. A late view is never targeted; it reads the resulting snapshot on its own poll. Keep runtime vocabulary strictly Persona Visual.
+
+- [ ] **Step 7: Write await-barrier/cancellation REDs**
+
+  Add separate barriers `test_stale_after_persona_read_cannot_apply`, `test_stale_after_graph_read_cannot_apply`, `test_stale_after_runtime_resolve_cannot_apply`, `test_stale_after_frame_prepare_cannot_apply`, `test_repeated_cancel_drains_before_next_owner`, and `test_shutdown_drains_before_profile_db_closes`.
+
+- [ ] **Step 8: Wire app construction and shutdown**
+
+  Construct the controller immediately after `_wire_character_persona_services()` with the local Persona service, profile database/repository factory, config snapshot, and loop-safe app scheduler. In `_shutdown_app_owned_lifecycles`, await Buddy shutdown before closing the database or screen stack.
+
+- [ ] **Step 9: Run Task 2 GREEN and mutations**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Persona_Buddy Tests/Persona_Visual/test_persona_visual_runtime.py Tests/UI/test_console_runtime_ownership.py
+  ```
+
+  Expected: pass. Remove each post-await fence, replace shield/drain with raw `to_thread`, and collapse child-cancel into successful `None` one at a time; the corresponding tests must fail.
+
+- [ ] **Step 10: Commit Task 2**
+
+  ```bash
+  git add tldw_chatbook/Persona_Buddy tldw_chatbook/app.py Tests/Persona_Buddy Tests/UI/test_console_runtime_ownership.py
+  git commit -m "feat: resolve Persona Buddy visual states"
+  ```
+
+## Task 3: Mount the native floating view dynamically
+
+**Files:**
+
+- Create: `tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py`
+- Modify: `tldw_chatbook/UI/Navigation/base_app_screen.py:202-230`
+- Modify: `tldw_chatbook/UI/Navigation/base_app_screen.py:350-375`
+- Modify: `tldw_chatbook/app.py` near the screen-navigation helpers
+- Run: `tldw_chatbook/css/build_css.py`
+- Regenerate: `tldw_chatbook/css/widget_defaults_self.tcss`
+- Regenerate: `tldw_chatbook/css/widget_defaults_scoped.tcss`
+- Review/restore-or-stage: `tldw_chatbook/css/screen_css_self.tcss`
+- Review/restore-or-stage: `tldw_chatbook/css/screen_css_scoped.tcss`
+- Review/restore-or-stage: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Create: `Tests/UI/test_persona_buddy_widget.py`
+- Create: `Tests/UI/test_persona_buddy_app_mount.py`
+- Create: `Tests/Live/persona_buddy_terminal_probe.py`
+- Modify: `Tests/UI/test_shell_chrome_contract.py`
+- Modify: `Tests/UI/test_screen_navigation.py`
+
+- [ ] **Step 1: Load the final UI craft references**
+
+  Immediately before editing visible UI, read Impeccable `reference/new-work.md` and `reference/craft-floor.md`. Do not rerun the already-completed context command. Preserve the terminal-native Neon Workbench direction and semantic tokens.
+
+- [ ] **Step 2: Write dynamic-mount REDs**
+
+  Add `test_enable_mounts_on_current_screen_without_navigation`, `test_disable_unmounts_without_navigation`, `test_close_removes_only_current_generation`, `test_reopen_mounts_without_navigation`, and `test_recompose_unsubscribes_and_remounts_both_directions`. Drive:
+
+  ```python
+  await app.reconcile_persona_buddy_view()
+  assert len(screen.query(PersonaBuddyWidget)) == 1
+  ```
+
+  The app, not the controller, identifies the active `BaseAppScreen`. `BaseAppScreen.reconcile_persona_buddy_view()` mounts/removes one view, releases capture before removal, and verifies its own screen/view generation after every await.
+
+- [ ] **Step 3: Run dynamic-mount REDs**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_persona_buddy_app_mount.py
+  ```
+
+  Expected: missing widget/reconciler failures.
+
+- [ ] **Step 4: Write geometry/input/paint REDs**
+
+  Add `test_overlay_paints_without_flow_or_fr_budget`, `test_drag_and_resize_are_viewport_bounded`, `test_keyboard_move_resize_reset_collapse_close`, `test_tiny_viewport_uses_labelled_compact_control`, `test_state_repaint_never_steals_focus`, `test_animation_cells_change_then_freeze_hidden_collapsed`, `test_reduced_motion_paints_static_frame`, and `test_modal_covers_buddy_hit_target`. Use real bundled CSS, predicate-based waits with bounded deadlines, compositor cell/glyph assertions, and no bundle-less harness.
+
+- [ ] **Step 5: Implement the lightweight view and mount reconciler**
+
+  Implement:
+
+  ```python
+  class PersonaBuddyWidget(Widget):
+      BINDINGS = [("h", "move_left", "Move left"), ("j", "move_down", "Move down"), ("k", "move_up", "Move up"), ("l", "move_right", "Move right"), ("H", "shrink_width", "Narrower"), ("L", "grow_width", "Wider"), ("J", "grow_height", "Taller"), ("K", "shrink_height", "Shorter"), ("0", "reset_geometry", "Reset"), ("c", "toggle_collapse", "Collapse"), ("x", "close", "Close")]
+      def refresh_from_controller(self) -> None: ...
+      def on_mouse_down(self, event: events.MouseDown) -> None: ...
+      def on_mouse_move(self, event: events.MouseMove) -> None: ...
+      def on_mouse_up(self, event: events.MouseUp) -> None: ...
+  ```
+
+  Use `absolute_offset`, capture/release, semantic tokens, labelled buttons, `position: absolute`, and `overlay: screen`. Snapshot/reconciliation polling stays active for every mounted view so restore and state changes remain observable; only frame advancement pauses while hidden or collapsed. If unavailability unmounts the view, Persona restore/publication explicitly calls the app reconciler after controller refresh. Geometry changes update the in-memory controller immediately; config persistence occurs once on mouse-up or one completed keyboard action through the same serialized off-loop preference operation, never on every move.
+
+- [ ] **Step 6: Implement modal/navigation/recompose safety**
+
+  `BaseAppScreen.on_mount` reconciles once; navigation creates a fresh view. `on_unmount` releases capture and removes only that screen's view. `TldwCli.reconcile_persona_buddy_view()` no-ops for splash/auth/recovery and when the active screen is modal/non-`BaseAppScreen`; Textual modal layering remains above the Buddy. Late reconcile removes only the stale view it created.
+
+- [ ] **Step 7: Regenerate and review CSS**
+
+  First preserve the known baseline mismatch, then run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python tldw_chatbook/css/build_css.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_css_bundle_sync_guard.py
+  ```
+
+  Expected after regeneration: pass. Review all five generated outputs. Stage every content change attributable to the known baseline reconciliation or Buddy declaration; explicitly restore timestamp-only `tldw_cli_modular.tcss` churn and any byte-identical screen sheet. Require `git status --short tldw_chatbook/css` to show only reviewed generated changes. Do not edit `Tests/UI/test_css_bundle_sync_guard.py` unless a new guard is genuinely necessary.
+
+- [ ] **Step 8: Add the real-terminal probe**
+
+  Create a bounded POSIX PTY subprocess probe that starts a minimal production-CSS Buddy app, sends real SGR mouse down/move/up and keyboard bytes, opens a modal, navigates/replaces the screen, resizes the PTY, restarts with the same isolated config, and writes a JSON report. It must print `PASS persona_buddy_terminal` only when drag, resize, keys, focus, modal hit testing, navigation, viewport clamp, and geometry restore all pass; capability-skip Windows only.
+
+- [ ] **Step 9: Run Task 3 GREEN and mutations**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_persona_buddy_widget.py Tests/UI/test_persona_buddy_app_mount.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_screen_navigation.py Tests/UI/test_css_bundle_sync_guard.py
+  ```
+
+  Expected: pass. Mutate `overlay: screen`, clamping, focus guard, modal exclusion, screen/view generation, and capture release individually; each named barrier must fail.
+
+- [ ] **Step 10: Commit Task 3**
+
+  ```bash
+  git add tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py tldw_chatbook/UI/Navigation/base_app_screen.py tldw_chatbook/app.py tldw_chatbook/css/widget_defaults_self.tcss tldw_chatbook/css/widget_defaults_scoped.tcss tldw_chatbook/css/screen_css_self.tcss tldw_chatbook/css/screen_css_scoped.tcss tldw_chatbook/css/tldw_cli_modular.tcss Tests/UI/test_persona_buddy_widget.py Tests/UI/test_persona_buddy_app_mount.py Tests/Live/persona_buddy_terminal_probe.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_screen_navigation.py
+  git commit -m "feat: mount floating Persona Buddy view"
+  ```
+
+## Task 4: Add explicit Personas Workbench ownership actions
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py:164-250`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:3922-4010`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:5822-5915`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:6922-7030`
+- Modify: `Tests/UI/test_personas_inspector_pane.py`
+- Modify: `Tests/UI/test_personas_workbench_state.py`
+- Modify: `Tests/UI/test_personas_persona_visual_authoring.py`
+- Modify: `Tests/UI/test_personas_workbench.py`
+
+- [ ] **Step 1: Write inspector/action REDs**
+
+  Add typed `PersonaBuddyActionRequested(action, source, persona_id, revision)` tests for explicit `Use for Buddy`, `Show Buddy`, `Close Buddy`, and `Disable Buddy`. Assert active local Persona eligibility and exact server tooltip `Save a local copy first`; ordinary row/highlight selection must emit no Buddy action.
+
+- [ ] **Step 2: Write lifecycle/restart/export REDs**
+
+  Add `test_workbench_highlight_never_retargets_buddy`, `test_disabled_deleted_missing_persona_hides_but_preserves_enabled_selection`, `test_restore_reresolves_same_selection`, `test_explicit_replacement_is_required`, `test_restart_restores_selection_open_collapsed_and_geometry`, `test_persona_json_export_excludes_buddy_preferences`, and `test_visual_publication_invalidates_bound_buddy_old_and_new_identity_only`.
+
+- [ ] **Step 3: Run the Workbench REDs**
+
+  Run focused named files. Expected: missing typed messages/actions and no controller integration.
+
+- [ ] **Step 4: Implement explicit Workbench commands**
+
+  Add labelled inspector buttons and typed messages. In `PersonasScreen`, snapshot profile/source/Persona ID/revision, validate active local authority, then call `await app.persona_buddy_controller.update_preferences(...)`. That controller method registers the sole owned operation before its first await, shield/drains `asyncio.to_thread(persist_persona_buddy_preferences, ...)`, revalidates profile/selection/preferences generations before and after persistence, applies the in-memory state only after a confirmed durable result, reconciles a late commit after outer cancellation, and releases serialization only after outcome handling. After it returns current, await `app.reconcile_persona_buddy_view()`. Server-backed/ineligible actions remain disabled with the exact tooltip; failures use fixed path-free copy.
+
+- [ ] **Step 5: Integrate lifecycle and publication refresh**
+
+  Persona disable/delete notifies the controller to mark the exact selection unavailable without clearing enabled/selection. Restore/replacement re-resolves only after authority checks. After Persona Visual publication, invalidate the Buddy only when old or new full identity matches its exact binding; unrelated entries remain, and failure/cancel invalidates nothing.
+
+- [ ] **Step 6: Run Task 4 GREEN and mutations**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_inspector_pane.py Tests/UI/test_personas_workbench_state.py Tests/UI/test_personas_persona_visual_authoring.py Tests/UI/test_personas_workbench.py -k "buddy or persona_visual"
+  ```
+
+  Expected: pass. Mutate explicit-selection, server eligibility, preservation, config restart, export exclusion, and targeted invalidation guards one at a time and record failures.
+
+- [ ] **Step 7: Commit Task 4**
+
+  ```bash
+  git add tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_inspector_pane.py Tests/UI/test_personas_workbench_state.py Tests/UI/test_personas_persona_visual_authoring.py Tests/UI/test_personas_workbench.py
+  git commit -m "feat: manage Persona Buddy from Workbench"
+  ```
+
+## Task 5: Publish trusted Console lifecycle leases
+
+**Files:**
+
+- Create: `tldw_chatbook/Persona_Buddy/console_adapter.py`
+- Modify: `tldw_chatbook/Chat/console_runtime.py:628-706`
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py:3747-3840`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py:13057-13160`
+- Modify: `tldw_chatbook/Chat/console_fleet_wake.py:305-350`
+- Modify: `tldw_chatbook/Chat/console_fleet_wake.py:470-650`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py:8218-8255`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py:19403-19440`
+- Create: `Tests/Persona_Buddy/test_persona_buddy_console_adapters.py`
+- Modify: `Tests/UI/test_console_run_gate.py`
+- Modify: `Tests/UI/test_console_realtime_wiring.py`
+- Modify: `Tests/UI/test_console_runtime_ownership.py`
+- Modify: `Tests/Chat/test_console_realtime_loop.py`
+- Modify: `Tests/Chat/test_console_agent_bridge.py`
+- Modify: `Tests/Chat/test_console_fleet_wake.py`
+
+- [ ] **Step 1: Write the pure adapter REDs**
+
+  Pin this producer mapping:
+
+  | Producer | Source/owner | State | Release |
+  | --- | --- | --- | --- |
+  | `ConsoleChatController._set_run_state` | `console-run` / session+run generation | validating/checking/retrying→`thinking`, streaming→`speaking`, failed→`error` | idle/completed/stopped/blocked or exact run replacement |
+  | approval registry changes | `approval` / session+round id | `approval_needed` | exact round settle/revoke/terminal |
+  | `ConsoleAgentBridge.on_step` | `tool` / run id+tool-call sequence | `tool_running` on `STEP_TOOL_CALL` | matching `STEP_TOOL_RESULT`, error, cancellation, or run terminal |
+  | fleet-wake pending/delivery | `wake` / conversation+run id | `wake_armed` | delivered/cleared/disposed; priority applies only when live absent/idle |
+  | realtime FSM | `voice` / session+loop generation | live→`listening`, thinking→`thinking`, speaking→`speaking`, connecting/reconnecting→`offline`, idle→release | `ExitLoop`/replacement/unmount |
+  | public trusted API | `explicit`/`authored` + caller owner | safe custom/built-in | expiry or exact token release |
+
+  Test exact underscore keys, overlapping sessions/runs/tools/rounds, replacement, and no model text fields.
+
+- [ ] **Step 2: Run adapter REDs**
+
+  Run the new adapter file. Expected: missing adapter/events.
+
+- [ ] **Step 3: Implement content-free adapter events**
+
+  Define frozen/slotted events carrying only source, owner token, safe state, terminal flag, and optional monotonic expiry. Mapping functions call controller acquire/release and never accept prompt, assistant text, tool args/results, paths, provider payloads, or model directives.
+
+- [ ] **Step 4: Wire actual run/approval producers**
+
+  Give the app-owned `ConsoleChatController` a Buddy sink at creation through `ConsoleRuntime`; do not capture a screen. Emit run events at `_set_run_state` and approval events at the registry's actual insert/remove/revoke/terminal points. A controller-only construction with no sink remains a no-op.
+
+- [ ] **Step 5: Wire actual tool and wake producers**
+
+  `ConsoleRuntime.ensure_agent_bridge` supplies an app-owned thread-safe sink. `ConsoleAgentBridge.on_step` emits tool start/result with run identity; all terminal/finally paths release remaining tokens. `ConsoleFleetWakeCoordinator` mirrors exact pending/delivering membership into per-conversation/run wake leases and releases only settled owners.
+
+- [ ] **Step 6: Wire realtime and trusted public APIs**
+
+  In `_console_realtime_mode_changed`/exit, publish exact session+loop generation events and release the preceding exact token before acquiring its replacement. Screen unmount releases only that screen's realtime token. Keep `set_timed_state` and `set_authored_trigger` as explicit trusted app APIs; do not wire streaming `Emote:` parsing.
+
+- [ ] **Step 7: Run actual-producer GREENs**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Persona_Buddy/test_persona_buddy_console_adapters.py Tests/UI/test_console_run_gate.py Tests/UI/test_console_realtime_wiring.py Tests/UI/test_console_runtime_ownership.py Tests/Chat/test_console_realtime_loop.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_agent_bridge.py -k "persona_buddy or tool_step"
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_fleet_wake.py -k "persona_buddy or pending or deliver"
+  ```
+
+  Expected: pass. Tests must drive the real producer callbacks, not only pure mappers.
+
+- [ ] **Step 8: Run Task 5 mutations**
+
+  Remove exact owner matching, terminal release, tool-result release, wake idle gating, realtime generation, and no-sink no-op one at a time; each corresponding producer test must fail.
+
+- [ ] **Step 9: Commit Task 5**
+
+  ```bash
+  git add tldw_chatbook/Persona_Buddy/console_adapter.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_fleet_wake.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Persona_Buddy/test_persona_buddy_console_adapters.py Tests/UI/test_console_run_gate.py Tests/UI/test_console_realtime_wiring.py Tests/UI/test_console_runtime_ownership.py Tests/Chat/test_console_realtime_loop.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_fleet_wake.py
+  git commit -m "feat: drive Persona Buddy from trusted lifecycle state"
+  ```
+
+## Task 6: Isolated verification, live proof, and closeout
+
+**Files:**
+
+- Modify: `backlog/tasks/task-19055 - Add-opt-in-app-wide-floating-Persona-Buddy.md`
+- Create: `Tests/Architecture/test_persona_buddy_boundary.py`
+- Verify: `Tests/Live/persona_buddy_terminal_probe.py`
+- Verify: `tldw_chatbook/css/widget_defaults_self.tcss`
+- Verify: `tldw_chatbook/css/widget_defaults_scoped.tcss`
+- Verify: `tldw_chatbook/css/screen_css_self.tcss`
+- Verify: `tldw_chatbook/css/screen_css_scoped.tcss`
+- Verify: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Modify only if a reviewed touched delta requires it: `Docs/security/production-diagnostic-inventory.json`
+- Modify a relevant `backlog/docs/lessons-*.md` only for a genuine incident-backed reusable lesson
+
+- [ ] **Step 1: Add architecture/privacy RED then GREEN**
+
+  Add tests proving `Persona_Buddy/controller.py`, `preferences.py`, and `rendering.py` have no Textual/UI imports; controller source contains no model/Emote parser; Buddy preferences do not occur in Persona/Actor Pack exporters; public snapshots/logs exclude path/bytes/prompt/provider/token fields. Temporarily add one forbidden UI import to prove RED, then restore and record GREEN.
+
+- [ ] **Step 2: Establish isolated roots before interpreter import**
+
+  ```bash
+  TASK19055_ROOT="$(mktemp -d /private/tmp/tldw-task19055.XXXXXX)"
+  mkdir -p "$TASK19055_ROOT/home" "$TASK19055_ROOT/config" "$TASK19055_ROOT/data" "$TASK19055_ROOT/cache"
+  env HOME="$TASK19055_ROOT/home" XDG_CONFIG_HOME="$TASK19055_ROOT/config" XDG_DATA_HOME="$TASK19055_ROOT/data" XDG_CACHE_HOME="$TASK19055_ROOT/cache" TLDW_CONFIG_PATH="$TASK19055_ROOT/config/config.toml" TLDW_TEST_MODE=1 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/test_probe_import_provenance.py
+  ```
+
+  Expected: pass and every imported `tldw_chatbook` module path starts with this assigned worktree.
+
+- [ ] **Step 3: Run the combined touched-component gate only**
+
+  In one shell, define a literal isolated runner and run:
+
+  ```bash
+  : "${TASK19055_ROOT:?Run Step 2 and retain its isolated root}"
+  run_task19055() { env HOME="$TASK19055_ROOT/home" XDG_CONFIG_HOME="$TASK19055_ROOT/config" XDG_DATA_HOME="$TASK19055_ROOT/data" XDG_CACHE_HOME="$TASK19055_ROOT/cache" TLDW_CONFIG_PATH="$TASK19055_ROOT/config/config.toml" TLDW_TEST_MODE=1 "$@"; }
+  run_task19055 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+    Tests/Persona_Buddy \
+    Tests/Persona_Visual/test_persona_visual_runtime.py \
+    Tests/UI/test_persona_buddy_widget.py \
+    Tests/UI/test_persona_buddy_app_mount.py \
+    Tests/UI/test_personas_inspector_pane.py \
+    Tests/UI/test_personas_workbench_state.py \
+    Tests/UI/test_personas_persona_visual_authoring.py \
+    Tests/UI/test_console_run_gate.py \
+    Tests/UI/test_console_realtime_wiring.py \
+    Tests/UI/test_console_runtime_ownership.py \
+    Tests/UI/test_shell_chrome_contract.py \
+    Tests/UI/test_screen_navigation.py \
+    Tests/UI/test_css_bundle_sync_guard.py \
+    Tests/Chat/test_console_realtime_loop.py \
+    Tests/Architecture/test_persona_buddy_boundary.py
+  ```
+
+  Then run the large touched files with their focused Buddy nodes:
+
+  ```bash
+  run_task19055 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py -k "persona_buddy or persona_visual"
+  run_task19055 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_agent_bridge.py -k "persona_buddy or tool_step"
+  run_task19055 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_fleet_wake.py -k "persona_buddy or pending or deliver"
+  ```
+
+  Expected: all pass. Do not run the full suite.
+
+- [ ] **Step 4: Run the bounded real-terminal probe**
+
+  ```bash
+  env HOME="$TASK19055_ROOT/home" XDG_CONFIG_HOME="$TASK19055_ROOT/config" XDG_DATA_HOME="$TASK19055_ROOT/data" XDG_CACHE_HOME="$TASK19055_ROOT/cache" TLDW_CONFIG_PATH="$TASK19055_ROOT/config/config.toml" TLDW_TEST_MODE=1 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Tests/Live/persona_buddy_terminal_probe.py --report "$TASK19055_ROOT/persona-buddy-terminal.json"
+  ```
+
+  Expected: exit 0, stdout `PASS persona_buddy_terminal`, and JSON booleans true for drag, resize, keyboard, focus, modal, navigation, viewport clamp, and restart restore.
+
+- [ ] **Step 5: Run Impeccable detector exactly once**
+
+  After the final visible UI edit, run once:
+
+  ```bash
+  node /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.agents/skills/impeccable/scripts/detect.mjs --target tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+  ```
+
+  Expected: exit 0 and `[]`. Address every finding without rerunning the detector, then rerun only normal affected UI tests.
+
+- [ ] **Step 6: Run exact static/governance gates**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check tldw_chatbook/Persona_Buddy tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py Tests/Persona_Buddy Tests/UI/test_persona_buddy_widget.py Tests/UI/test_persona_buddy_app_mount.py Tests/Architecture/test_persona_buddy_boundary.py Tests/Live/persona_buddy_terminal_probe.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff format --check tldw_chatbook/Persona_Buddy tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py Tests/Persona_Buddy Tests/UI/test_persona_buddy_widget.py Tests/UI/test_persona_buddy_app_mount.py Tests/Architecture/test_persona_buddy_boundary.py Tests/Live/persona_buddy_terminal_probe.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check --select E9,F63,F7,F82 tldw_chatbook/app.py tldw_chatbook/UI/Navigation/base_app_screen.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_fleet_wake.py Tests/UI/test_personas_inspector_pane.py Tests/UI/test_personas_workbench_state.py Tests/UI/test_personas_persona_visual_authoring.py Tests/UI/test_personas_workbench.py Tests/UI/test_console_run_gate.py Tests/UI/test_console_realtime_wiring.py Tests/UI/test_console_runtime_ownership.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_screen_navigation.py Tests/Chat/test_console_realtime_loop.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_fleet_wake.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff format --check tldw_chatbook/app.py tldw_chatbook/UI/Navigation/base_app_screen.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_fleet_wake.py Tests/UI/test_personas_inspector_pane.py Tests/UI/test_personas_workbench_state.py Tests/UI/test_personas_persona_visual_authoring.py Tests/UI/test_personas_workbench.py Tests/UI/test_console_run_gate.py Tests/UI/test_console_realtime_wiring.py Tests/UI/test_console_runtime_ownership.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_screen_navigation.py Tests/Chat/test_console_realtime_loop.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_fleet_wake.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q tldw_chatbook/Persona_Buddy tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py tldw_chatbook/app.py tldw_chatbook/UI/Navigation/base_app_screen.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_fleet_wake.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Architecture/test_persona_buddy_boundary.py Tests/Architecture/test_persistent_diagnostic_inventory.py Tests/test_persistent_diagnostic_boundary.py Tests/test_database_path_privacy.py
+  git diff --check
+  ```
+
+  Expected: new/small files pass full Ruff and format; every touched legacy file passes fatal Ruff and compile. The legacy formatter command must reproduce exactly the recorded 17-would-reformat/5-already-formatted baseline with no new file entering the would-reformat set; any branch-owned formatter regression blocks Done. If the diagnostic inventory differs, review the semantic delta; regenerate only a Buddy-owned fixed-category delta. Any failing scoped gate blocks Done.
+
+- [ ] **Step 7: Review baseline versus branch and close only when green**
+
+  Compare final scoped results with the preserved `727 passed / 1 pre-existing CSS mismatch` baseline. The CSS mismatch must now be repaired because Buddy touched its source bundle. If any touched gate, real-terminal assertion, detector finding, mutation, static/privacy/architecture/governance gate, or branch-owned regression remains, keep TASK-19055 In Progress and report the blocker.
+
+- [ ] **Step 8: Record evidence and mark Done**
+
+  Only after Step 7 is green: check all eight ACs, add concise Implementation Notes with RED→GREEN nodes, mutation results, worktree/isolation evidence, real-terminal JSON, Impeccable output, exact focused counts, baseline handling, ADR-074, scope exclusions, and the explicit no-full-suite instruction; then set status Done.
+
+- [ ] **Step 9: Commit closeout**
+
+  ```bash
+  git add "backlog/tasks/task-19055 - Add-opt-in-app-wide-floating-Persona-Buddy.md" Tests/Architecture/test_persona_buddy_boundary.py
+  git commit -m "docs: complete Persona Buddy delivery"
+  ```

--- a/Tests/Architecture/test_persona_buddy_boundary.py
+++ b/Tests/Architecture/test_persona_buddy_boundary.py
@@ -1,0 +1,122 @@
+"""Architecture and privacy guardrails for the app-owned Persona Buddy."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import importlib
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUDDY_ROOT = REPO_ROOT / "tldw_chatbook" / "Persona_Buddy"
+HEADLESS_MODULES = (
+    BUDDY_ROOT / "controller.py",
+    BUDDY_ROOT / "preferences.py",
+    BUDDY_ROOT / "rendering.py",
+)
+EXPORT_MODULES = (
+    REPO_ROOT / "tldw_chatbook" / "Character_Chat" / "Character_Chat_Lib.py",
+    REPO_ROOT / "tldw_chatbook" / "UI" / "Screens" / "personas_screen.py",
+)
+FORBIDDEN_IMPORT_PARTS = frozenset({"textual", "UI", "Widgets"})
+PRIVATE_SNAPSHOT_FIELD_TOKENS = (
+    "bytes",
+    "credential",
+    "path",
+    "prompt",
+    "provider",
+    "secret",
+    "token",
+)
+FIXED_CATEGORY = re.compile(r"persona_buddy_[a-z0-9_]+\Z")
+
+
+def _tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _imports(path: Path) -> set[str]:
+    imported: set[str] = set()
+    for node in ast.walk(_tree(path)):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(("." * node.level) + (node.module or ""))
+    return imported
+
+
+def test_headless_buddy_modules_have_no_textual_or_ui_imports() -> None:
+    for path in HEADLESS_MODULES:
+        for imported in _imports(path):
+            assert not FORBIDDEN_IMPORT_PARTS.intersection(imported.split(".")), (
+                f"{path.relative_to(REPO_ROOT)} imports forbidden boundary {imported}"
+            )
+
+
+def test_controller_has_no_model_or_emote_parser_boundary() -> None:
+    path = BUDDY_ROOT / "controller.py"
+    tree = _tree(path)
+    imported = _imports(path)
+    assert not any(
+        "llm_calls" in name.lower() or "emote" in name.lower() for name in imported
+    )
+
+    string_literals = {
+        node.value.lower()
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert not any("emote:" in value for value in string_literals)
+    assert {"prompt", "model_text", "assistant_text"}.isdisjoint(string_literals)
+
+
+def test_buddy_preferences_do_not_enter_persona_exporters() -> None:
+    for path in EXPORT_MODULES:
+        for node in ast.walk(_tree(path)):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if "export" not in node.name.lower():
+                continue
+            strings = {
+                child.value.lower()
+                for child in ast.walk(node)
+                if isinstance(child, ast.Constant) and isinstance(child.value, str)
+            }
+            assert "persona_buddy" not in strings, (
+                f"{path.relative_to(REPO_ROOT)}:{node.name} exports Buddy preferences"
+            )
+
+
+def test_public_snapshots_and_logs_exclude_private_payload_fields() -> None:
+    for module_name in ("controller", "rendering"):
+        module = importlib.import_module(f"tldw_chatbook.Persona_Buddy.{module_name}")
+        for name, value in vars(module).items():
+            if "Snapshot" not in name or not dataclasses.is_dataclass(value):
+                continue
+            fields = {field.name.lower() for field in dataclasses.fields(value)}
+            leaked = {
+                field
+                for field in fields
+                if any(token in field for token in PRIVATE_SNAPSHOT_FIELD_TOKENS)
+            }
+            assert not leaked, f"{module.__name__}.{name} exposes {sorted(leaked)}"
+
+    for path in HEADLESS_MODULES:
+        for node in ast.walk(_tree(path)):
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            if (
+                not isinstance(node.func.value, ast.Name)
+                or node.func.value.id != "logger"
+            ):
+                continue
+            assert len(node.args) == 1 and not node.keywords
+            message = node.args[0]
+            assert isinstance(message, ast.Constant) and isinstance(message.value, str)
+            assert FIXED_CATEGORY.fullmatch(message.value), (
+                f"{path.relative_to(REPO_ROOT)} logs non-category Buddy detail"
+            )

--- a/Tests/Architecture/test_persona_buddy_boundary.py
+++ b/Tests/Architecture/test_persona_buddy_boundary.py
@@ -55,6 +55,19 @@ def test_headless_buddy_modules_have_no_textual_or_ui_imports() -> None:
             )
 
 
+def test_buddy_rendering_loads_image_dependencies_only_on_use() -> None:
+    tree = _tree(BUDDY_ROOT / "rendering.py")
+    top_level_imports: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            top_level_imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            top_level_imports.add(node.module or "")
+
+    assert "PIL" not in top_level_imports
+    assert "rich_pixels" not in top_level_imports
+
+
 def test_controller_has_no_model_or_emote_parser_boundary() -> None:
     path = BUDDY_ROOT / "controller.py"
     tree = _tree(path)
@@ -110,9 +123,32 @@ def test_public_snapshots_and_logs_exclude_private_payload_fields() -> None:
             ):
                 continue
             if (
+                isinstance(node.func.value, ast.Call)
+                and isinstance(node.func.value.func, ast.Attribute)
+                and isinstance(node.func.value.func.value, ast.Name)
+                and node.func.value.func.value.id == "logger"
+                and node.func.value.func.attr == "bind"
+            ):
+                assert len(node.args) == 1 and not node.keywords
+                message = node.args[0]
+                assert isinstance(message, ast.Constant) and isinstance(
+                    message.value, str
+                )
+                assert FIXED_CATEGORY.fullmatch(message.value), (
+                    f"{path.relative_to(REPO_ROOT)} logs non-category Buddy detail"
+                )
+                continue
+            if (
                 not isinstance(node.func.value, ast.Name)
                 or node.func.value.id != "logger"
             ):
+                continue
+            if node.func.attr == "bind":
+                assert not node.args
+                assert len(node.keywords) == 1
+                keyword = node.keywords[0]
+                assert keyword.arg == "exception_type"
+                assert isinstance(keyword.value, ast.Name)
                 continue
             assert len(node.args) == 1 and not node.keywords
             message = node.args[0]

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -95,6 +95,8 @@ from tldw_chatbook.Agents.tool_catalog import (
 from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider, _default_specs
 from tldw_chatbook.Agents.project_instruction_resolver import ProjectInstructionResolver
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
+from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
 from tldw_chatbook.Workspaces.change_turn_tracker import TurnChangeRecord
 
@@ -1455,6 +1457,54 @@ def test_unsafe_model_summary_emits_detail_free_thinking_with_resume_parity(
     assert _activity_marker_signature(resumed) == _activity_marker_signature(live)
     assert "PRIVATE_REASONING_CANARY" not in repr(_activity_marker_signature(live))
     assert "PRIVATE_REASONING_CANARY" not in repr(_activity_marker_signature(resumed))
+
+
+def test_persona_buddy_tool_step_uses_real_on_step_and_releases_result(tmp_path):
+    """The bridge's real step callback brackets tool execution exactly."""
+    buddy = PersonaBuddyController()
+
+    class RecordingAdapter(PersonaBuddyConsoleAdapter):
+        def __init__(self):
+            super().__init__(buddy)
+            self.observed: list[tuple[str, int]] = []
+            self.released_runs: list[str] = []
+
+        def tool_step(self, run_id, sequence, kind):
+            result = super().tool_step(run_id, sequence, kind)
+            if kind in {"tool_call", "tool_result", "error"}:
+                self.observed.append((kind, self.active_owner_count("tool")))
+            return result
+
+        def release_run(self, run_id):
+            self.released_runs.append(run_id)
+            super().release_run(run_id)
+
+    sink = RecordingAdapter()
+    gateway = _ChunkGateway(
+        [[_native_calls("get_current_datetime", {})], ["It is now."]]
+    )
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=gateway,
+        buddy_sink=sink,
+    )
+
+    outcome = _run(
+        bridge, store, session, assistant.id, resolution=_native_resolution()
+    )
+
+    assert outcome.status == "done"
+    assert sink.observed[:2] == [("tool_call", 1), ("tool_result", 0)]
+    assert sink.released_runs
+    assert sink.active_owner_count("tool") == 0
 
 
 def test_native_leaked_prose_is_reset_before_final_answer(tmp_path):

--- a/Tests/Chat/test_console_fleet_wake.py
+++ b/Tests/Chat/test_console_fleet_wake.py
@@ -78,6 +78,8 @@ from tldw_chatbook.Chat.conversation_local_marks_service import (
 )
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
 
 
 async def _settle(predicate, seconds: float = 5.0) -> bool:
@@ -219,6 +221,34 @@ def _controller_rig(tmp_path, *, session_title="Research"):
     )
     controller.fleet_wake.wire(app=app)
     return chacha, app, runs_db, store, session, gateway, bridge, controller
+
+
+@pytest.mark.asyncio
+async def test_persona_buddy_wake_tracks_pending_delivery_and_exact_settlement(
+    tmp_path,
+):
+    """The real wake coordinator mirrors membership until delivery settles."""
+    chacha, _app, runs_db, _store, session, gateway, _bridge, controller = (
+        _controller_rig(tmp_path)
+    )
+    buddy = PersonaBuddyController()
+    sink = PersonaBuddyConsoleAdapter(buddy)
+    controller.fleet_wake.buddy_sink = sink
+    try:
+        _parent, run_id = _terminal_subagent_run(runs_db, session.id)
+        gate = asyncio.Event()
+        gateway.stream_gate = gate
+        controller.fleet_wake.on_fleet_drained(
+            _drain(session.id, _survivor(run_id, session_id=session.id))
+        )
+        assert await _settle(lambda: bool(gateway.payloads))
+        assert buddy.snapshot().state == "wake_armed"
+
+        gate.set()
+        assert await _settle(lambda: not controller.fleet_wake.has_pending(session.id))
+        assert buddy.snapshot().state == "idle"
+    finally:
+        chacha.close()
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Chat/test_console_fleet_wake.py
+++ b/Tests/Chat/test_console_fleet_wake.py
@@ -286,6 +286,45 @@ def test_dispose_is_terminal_idempotent_and_safe_without_a_sink():
     assert no_sink.pending_conversation_ids() == ()
 
 
+def test_buddy_wake_callback_runs_outside_registry_lock_and_is_post_fenced():
+    """A reentrant terminal dispose cannot deadlock or leave a late lease."""
+    dispose_finished = threading.Event()
+    callback_thread_blocked: list[bool] = []
+
+    class ReentrantSink(_RecordingBuddySink):
+        coordinator: ConsoleFleetWakeCoordinator
+
+        def wake(self, conversation_id: str, run_id: str, *, active: bool) -> None:
+            if active:
+                def dispose() -> None:
+                    self.coordinator.dispose()
+                    dispose_finished.set()
+
+                thread = threading.Thread(target=dispose)
+                thread.start()
+                thread.join(1)
+                callback_thread_blocked.append(thread.is_alive())
+            super().wake(conversation_id, run_id, active=active)
+
+    sink = ReentrantSink()
+    coordinator = ConsoleFleetWakeCoordinator(SimpleNamespace(_buddy_sink=sink))
+    sink.coordinator = coordinator
+
+    coordinator.on_fleet_drained(
+        _drain("conversation-1", _survivor("run-reentrant"))
+    )
+
+    assert dispose_finished.wait(1)
+    assert callback_thread_blocked == [False]
+    assert coordinator.pending_conversation_ids() == ()
+    assert sink.calls[-1] == (
+        "wake",
+        "conversation-1",
+        "run-reentrant",
+        False,
+    )
+
+
 @pytest.mark.asyncio
 async def test_dispose_fences_delivery_completion_after_its_await():
     """An accepted late result neither commits nor rebuilds disposed state."""

--- a/Tests/Chat/test_console_fleet_wake.py
+++ b/Tests/Chat/test_console_fleet_wake.py
@@ -223,6 +223,126 @@ def _controller_rig(tmp_path, *, session_title="Research"):
     return chacha, app, runs_db, store, session, gateway, bridge, controller
 
 
+class _RecordingBuddySink:
+    """Content-free wake sink used to pin terminal coordinator fencing."""
+
+    def __init__(self):
+        self.calls: list[tuple[object, ...]] = []
+
+    def wake(self, conversation_id: str, run_id: str, *, active: bool) -> None:
+        self.calls.append(("wake", conversation_id, run_id, active))
+
+    def clear_wakes(self) -> None:
+        self.calls.append(("clear",))
+
+
+def test_dispose_fences_a_drain_callback_that_started_before_the_latch():
+    """A survivor observed after terminal disposal cannot reacquire a lease."""
+    entered = threading.Event()
+    release = threading.Event()
+    sink = _RecordingBuddySink()
+    coordinator = ConsoleFleetWakeCoordinator(SimpleNamespace(_buddy_sink=sink))
+
+    class BarrierDrain:
+        conversation_id = "conversation-1"
+
+        @property
+        def children(self):
+            entered.set()
+            assert release.wait(2), "test barrier was never released"
+            return (_survivor("run-late"),)
+
+    worker = threading.Thread(
+        target=coordinator.on_fleet_drained, args=(BarrierDrain(),)
+    )
+    worker.start()
+    assert entered.wait(2), "drain callback never reached the barrier"
+
+    coordinator.dispose()
+    release.set()
+    worker.join(2)
+
+    assert not worker.is_alive()
+    assert coordinator.pending_conversation_ids() == ()
+    assert sink.calls == [("clear",)]
+
+
+def test_dispose_is_terminal_idempotent_and_safe_without_a_sink():
+    """Callbacks after disposal no-op; repeated/no-sink disposal stays safe."""
+    sink = _RecordingBuddySink()
+    coordinator = ConsoleFleetWakeCoordinator(SimpleNamespace(_buddy_sink=sink))
+
+    coordinator.dispose()
+    coordinator.dispose()
+    coordinator.on_fleet_drained(_drain("conversation-1", _survivor("run-late")))
+
+    assert coordinator.pending_conversation_ids() == ()
+    assert sink.calls == [("clear",)]
+
+    no_sink = ConsoleFleetWakeCoordinator(SimpleNamespace())
+    no_sink.dispose()
+    no_sink.dispose()
+    no_sink.on_fleet_drained(_drain("conversation-2", _survivor("run-late")))
+    assert no_sink.pending_conversation_ids() == ()
+
+
+@pytest.mark.asyncio
+async def test_dispose_fences_delivery_completion_after_its_await():
+    """An accepted late result neither commits nor rebuilds disposed state."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    sink = _RecordingBuddySink()
+
+    class RunsDB:
+        stamps = 0
+
+        def mark_wake_delivered(self, run_ids) -> None:
+            self.stamps += 1
+
+    runs_db = RunsDB()
+
+    class Controller:
+        _buddy_sink = sink
+        _agent_bridge = SimpleNamespace(runs_db=runs_db)
+
+        async def submit_draft(self, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return SimpleNamespace(accepted=True)
+
+    controller = Controller()
+    coordinator = ConsoleFleetWakeCoordinator(controller)
+    with coordinator._registry_lock:
+        coordinator._pending["conversation-1"] = {"run-1": "done"}
+        coordinator._delivering = "conversation-1"
+        coordinator._delivering_session = "session-1"
+    sink.wake("conversation-1", "run-1", active=True)
+    authorization = AgentWakeAuthorization(
+        coordinator,
+        "session-1",
+        _key=console_fleet_wake._WAKE_AUTHORIZATION_KEY,
+    )
+
+    task = asyncio.create_task(
+        coordinator._deliver(
+            "conversation-1",
+            "session-1",
+            ("run-1",),
+            "",
+            authorization,
+        )
+    )
+    await started.wait()
+    coordinator.dispose()
+    release.set()
+    await task
+
+    assert runs_db.stamps == 0
+    assert coordinator.pending_conversation_ids() == ()
+    clear_index = sink.calls.index(("clear",))
+    assert all(call[-1] is not True for call in sink.calls[clear_index + 1 :])
+
+
 @pytest.mark.asyncio
 async def test_persona_buddy_wake_tracks_pending_delivery_and_exact_settlement(
     tmp_path,

--- a/Tests/Chat/test_console_realtime_loop.py
+++ b/Tests/Chat/test_console_realtime_loop.py
@@ -475,6 +475,35 @@ def test_mode_changed_full_cycle_payloads():
     ]
 
 
+def test_persona_buddy_voice_adapter_consumes_the_real_fsm_cycle():
+    """The headless FSM's emitted states are the adapter's trusted input."""
+    from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+
+    buddy = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(buddy)
+
+    def emit(intent):
+        if isinstance(intent, ModeChanged):
+            adapter.voice_state("session-a", 7, intent.state)
+        elif isinstance(intent, ExitLoop):
+            adapter.release_voice("session-a", 7)
+
+    controller = RealtimeLoopController(
+        emit, acoustic_barge_in=False, idle_timeout_seconds=10.0
+    )
+    controller.enter()
+    assert buddy.snapshot().state == "offline"
+    controller.on_session_ready()
+    assert buddy.snapshot().state == "listening"
+    controller.on_turn_committed(now=0.0)
+    assert buddy.snapshot().state == "thinking"
+    controller.on_first_audio()
+    assert buddy.snapshot().state == "speaking"
+    controller.on_exit_request()
+    assert buddy.snapshot().state == "idle"
+
+
 def test_exit_request_reason_defaults_to_none():
     c, ev = _make()
     c.enter()

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -44,6 +44,32 @@ _CHECK_NAMES = (
 )
 
 
+def _validated_cli_path(value: str) -> Path:
+    """Confine explicit probe paths to the workspace or platform temp roots."""
+
+    root = Path(__file__).resolve().parents[2]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from tldw_chatbook.Utils.path_validation import validate_path
+
+    roots = (root, Path(tempfile.gettempdir()).resolve(), Path("/tmp").resolve())
+    candidate = Path(value)
+    for index, allowed_root in enumerate(roots):
+        if index and not candidate.is_absolute():
+            continue
+        try:
+            resolved = (
+                candidate.resolve()
+                if candidate.is_absolute()
+                else (allowed_root / candidate).resolve()
+            )
+            resolved.relative_to(allowed_root)
+        except ValueError:
+            continue
+        return validate_path(resolved, allowed_root, redact_paths=True)
+    raise argparse.ArgumentTypeError("persona_buddy_probe_path_invalid")
+
+
 class _ProbeChildFailure(RuntimeError):
     """Structured child-process failure retained until evidence is durable."""
 
@@ -871,9 +897,9 @@ def _parent(
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--child", action="store_true")
-    parser.add_argument("preferences", nargs="?", type=Path)
-    parser.add_argument("report", nargs="?", type=Path)
-    parser.add_argument("--report", dest="parent_report", type=Path)
+    parser.add_argument("preferences", nargs="?", type=_validated_cli_path)
+    parser.add_argument("report", nargs="?", type=_validated_cli_path)
+    parser.add_argument("--report", dest="parent_report", type=_validated_cli_path)
     parser.add_argument("--inject-child-failure", action="store_true")
     arguments = parser.parse_args()
     if arguments.child:

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -353,8 +353,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                 "open": preferences_now.open,
                 "resolution_calls": self.resolution_calls,
                 "compact": bool(
-                    buddy is not None
-                    and buddy.has_class("persona-buddy-compact")
+                    buddy is not None and buddy.has_class("persona-buddy-compact")
                 ),
                 "graceful_exit_requested": self.graceful_exit_requested,
                 "painted": "Buddy"
@@ -476,9 +475,7 @@ def _run_child(
             startup_output.extend(_drain_for(master, 0.02))
         if initial is None:
             tail = bytes(startup_output[-4000:]).decode("utf-8", errors="replace")
-            raise RuntimeError(
-                f"persona_buddy_terminal_initial_report_missing\n{tail}"
-            )
+            raise RuntimeError(f"persona_buddy_terminal_initial_report_missing\n{tail}")
 
         def wait_for_report(predicate: Any, *, timeout: float = 2.0) -> dict[str, Any]:
             deadline = time.monotonic() + timeout
@@ -623,9 +620,7 @@ def _run_child(
             observed["modal_close_replay"] = not modal_closed["view_present"]
 
             os.write(master, b"o")
-            wait_for_report(
-                lambda payload: payload["open"] and payload["view_present"]
-            )
+            wait_for_report(lambda payload: payload["open"] and payload["view_present"])
 
             os.write(master, b"m")
             modal_report = wait_for_report(
@@ -667,8 +662,7 @@ def _run_child(
                     and payload["controls"]["persona-buddy-close"]["display"]
                     and payload["controls"]["persona-buddy-collapse"]["label"]
                     == "Buddy"
-                    and payload["controls"]["persona-buddy-close"]["label"]
-                    == "Close"
+                    and payload["controls"]["persona-buddy-close"]["label"] == "Close"
                 )
             )
             _set_size(master, 10, 2)
@@ -692,12 +686,9 @@ def _run_child(
             os.write(master, b"k")
             compact_moved = wait_for_report(
                 lambda payload: (
-                    payload["geometry"]["y"]
-                    == max(0, compact_display_y - 1)
-                    and payload["geometry"]["width"]
-                    == compact_preferred["width"]
-                    and payload["geometry"]["height"]
-                    == compact_preferred["height"]
+                    payload["geometry"]["y"] == max(0, compact_display_y - 1)
+                    and payload["geometry"]["width"] == compact_preferred["width"]
+                    and payload["geometry"]["height"] == compact_preferred["height"]
                 )
             )
             _set_size(master, 28, 12)
@@ -706,8 +697,7 @@ def _run_child(
                 lambda payload: (
                     not payload["compact"]
                     and payload["region"]["width"] == compact_preferred["width"]
-                    and payload["region"]["height"]
-                    == compact_preferred["height"]
+                    and payload["region"]["height"] == compact_preferred["height"]
                 )
             )
             observed["compact_move_restore"] = bool(
@@ -736,8 +726,7 @@ def _run_child(
         process.wait(timeout=2)
         payload = json.loads(report.read_text(encoding="utf-8"))
         observed["graceful_exit"] = bool(
-            process.returncode == 0
-            and payload["graceful_exit_requested"]
+            process.returncode == 0 and payload["graceful_exit_requested"]
         )
         payload["initial_region"] = initial["region"]
         payload["observed"] = observed
@@ -830,9 +819,7 @@ def _parent(
                 ),
                 "viewport_clamp": first["observed"]["viewport_clamp"],
                 "compact_controls": first["observed"]["compact_controls"],
-                "compact_move_restore": first["observed"][
-                    "compact_move_restore"
-                ],
+                "compact_move_restore": first["observed"]["compact_move_restore"],
                 "capture_release": first["capture_released"],
                 "paint": first["observed"]["paint"],
                 "geometry_restore": second["loaded_geometry"] == first["geometry"],

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -26,7 +26,7 @@ _TIMEOUT_SECONDS = 12.0
 def _child(preferences_path: Path, report_path: Path) -> int:
     """Run the production-CSS child application inside the allocated PTY."""
 
-    from dataclasses import asdict
+    from dataclasses import asdict, replace
 
     from textual import events
     from textual.app import App, ComposeResult
@@ -110,6 +110,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
         BINDINGS = [
             Binding("m", "probe_modal", "Modal", priority=True),
             Binding("n", "probe_navigate", "Navigate", priority=True),
+            Binding("o", "probe_reopen", "Reopen", priority=True),
             Binding("q", "probe_finish", "Finish", priority=True),
         ]
 
@@ -143,7 +144,6 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             )
             self.call_after_refresh(self._capture_focus_guard)
             self.set_interval(0.10, self._write_probe_report)
-            self.set_timer(0.8, self.action_probe_modal)
 
         def _capture_focus_guard(self) -> None:
             screen = self.screen
@@ -164,6 +164,13 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             self.navigation_count += 1
             await self.switch_screen(ProbeScreen(self, "second"))
 
+        async def action_probe_reopen(self) -> None:
+            current = self.persona_buddy_controller.current_preferences()
+            await self.persona_buddy_controller.update_preferences(
+                replace(current, open=True)
+            )
+            await self.reconcile_persona_buddy_view()
+
         def action_probe_finish(self) -> None:
             self._write_probe_report()
 
@@ -177,6 +184,20 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             buddy = buddies[0] if buddies else None
             preferences_now = self.persona_buddy_controller.current_preferences()
             region = buddy.region if buddy is not None else None
+            controls = {}
+            if buddy is not None:
+                for control_id in (
+                    "persona-buddy-drag-handle",
+                    "persona-buddy-collapse",
+                    "persona-buddy-close",
+                ):
+                    control = buddy.query_one(f"#{control_id}")
+                    controls[control_id] = {
+                        "x": control.region.x,
+                        "y": control.region.y,
+                        "width": control.region.width,
+                        "height": control.region.height,
+                    }
             modal_surfaces = list(self.screen.query(ModalHitSurface))
             modal_region = modal_surfaces[0].region if modal_surfaces else None
             modal_target = None
@@ -188,6 +209,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             payload = {
                 "capture_released": self.mouse_captured is None,
                 "collapsed": preferences_now.collapsed,
+                "controls": controls,
                 "focus_guard": self.focus_guard_observed,
                 "geometry": asdict(preferences_now.geometry),
                 "loaded_geometry": self.initial_geometry,
@@ -261,16 +283,30 @@ def _wait_for_output(fd: int, process: subprocess.Popen[bytes], needle: bytes) -
     raise RuntimeError(f"persona_buddy_terminal_not_ready\n{tail}")
 
 
-def _drain_for(fd: int, duration: float) -> None:
+def _drain_for(fd: int, duration: float) -> bytes:
     """Drain terminal paint while allowing a bounded interval between events."""
 
     deadline = time.monotonic() + duration
+    captured = bytearray()
     while time.monotonic() < deadline:
         ready, _, _ = select.select(
             [fd], [], [], min(0.02, deadline - time.monotonic())
         )
         if ready:
-            os.read(fd, 65536)
+            captured.extend(os.read(fd, 65536))
+    return bytes(captured)
+
+
+def _send_mouse(fd: int, code: int, x: int, y: int, *, release: bool = False) -> None:
+    suffix = "m" if release else "M"
+    os.write(fd, f"\x1b[<{code};{x + 1};{y + 1}{suffix}".encode())
+
+
+def _center(region: dict[str, int]) -> tuple[int, int]:
+    return (
+        region["x"] + max(0, region["width"] // 2),
+        region["y"] + max(0, region["height"] // 2),
+    )
 
 
 def _run_child(
@@ -320,34 +356,91 @@ def _run_child(
         if not report.exists():
             raise RuntimeError("persona_buddy_terminal_initial_report_missing")
         initial = json.loads(report.read_text(encoding="utf-8"))
+        observed = {
+            "drag": False,
+            "mouse_resize": False,
+            "fold": False,
+            "reopen": False,
+            "close": False,
+            "navigation_view": False,
+            "paint": initial["painted"],
+            "viewport_clamp": False,
+        }
         if drive:
-            # Compute true terminal-cell coordinates from the child's painted
-            # region (SGR is 1-based), while still sending the real
-            # terminal shape whose Textual MouseDown has widget=None.
-            region = initial["region"]
-            down_col = region["x"] + 4
-            down_row = region["y"] + 3
-            move_col = max(2, down_col - 10)
-            move_row = max(2, down_row - 5)
-            os.write(master, f"\x1b[<0;{down_col};{down_row}M".encode())
+            drag_x, drag_y = _center(initial["controls"]["persona-buddy-drag-handle"])
+            move_x = max(1, drag_x - 10)
+            move_y = max(1, drag_y - 5)
+            _send_mouse(master, 0, drag_x, drag_y)
             _drain_for(master, 0.10)
-            os.write(master, f"\x1b[<32;{move_col};{move_row}M".encode())
+            _send_mouse(master, 32, move_x, move_y)
             _drain_for(master, 0.10)
-            os.write(master, f"\x1b[<0;{move_col};{move_row}m".encode())
+            _send_mouse(master, 0, move_x, move_y, release=True)
             _drain_for(master, 0.25)
-            os.write(master, b"hHcc")
-            _drain_for(master, 0.90)
+            after_drag = json.loads(report.read_text(encoding="utf-8"))
+            observed["drag"] = after_drag["geometry"]["x"] < initial["region"]["x"]
+
+            region = after_drag["region"]
+            corner_x, corner_y = (
+                region["x"] + region["width"] - 1,
+                region["y"] + region["height"] - 1,
+            )
+            _send_mouse(master, 0, corner_x, corner_y)
+            _drain_for(master, 0.10)
+            _send_mouse(master, 32, corner_x + 5, corner_y + 2)
+            _drain_for(master, 0.10)
+            _send_mouse(master, 0, corner_x + 5, corner_y + 2, release=True)
+            _drain_for(master, 0.30)
+            after_resize = json.loads(report.read_text(encoding="utf-8"))
+            observed["mouse_resize"] = (
+                after_resize["geometry"]["width"] > after_drag["geometry"]["width"]
+                and after_resize["geometry"]["height"]
+                > after_drag["geometry"]["height"]
+            )
+
+            fold_x, fold_y = _center(after_resize["controls"]["persona-buddy-collapse"])
+            _send_mouse(master, 0, fold_x, fold_y)
+            _drain_for(master, 0.10)
+            _send_mouse(master, 0, fold_x, fold_y, release=True)
+            _drain_for(master, 0.35)
+            folded = json.loads(report.read_text(encoding="utf-8"))
+            observed["fold"] = folded["collapsed"]
+            reopen_x, reopen_y = _center(folded["controls"]["persona-buddy-collapse"])
+            _send_mouse(master, 0, reopen_x, reopen_y)
+            _drain_for(master, 0.10)
+            _send_mouse(master, 0, reopen_x, reopen_y, release=True)
+            _drain_for(master, 0.35)
+            reopened = json.loads(report.read_text(encoding="utf-8"))
+            observed["reopen"] = not reopened["collapsed"]
+
+            close_x, close_y = _center(reopened["controls"]["persona-buddy-close"])
+            _send_mouse(master, 0, close_x, close_y)
+            _drain_for(master, 0.10)
+            _send_mouse(master, 0, close_x, close_y, release=True)
+            close_output = _drain_for(master, 0.60)
+            closed = json.loads(report.read_text(encoding="utf-8"))
+            observed["close"] = not closed["open"] and not closed["view_present"]
+            if process.poll() is not None:
+                raise RuntimeError(close_output.decode("utf-8", errors="replace"))
+            os.write(master, b"o")
+            _drain_for(master, 0.60)
+
+            os.write(master, b"m")
+            _drain_for(master, 0.35)
             modal_report = json.loads(report.read_text(encoding="utf-8"))
             modal_region = modal_report["modal_region"]
             modal_col = modal_region["x"] + max(1, modal_region["width"] // 2)
             modal_row = modal_region["y"] + max(1, modal_region["height"] // 2)
-            os.write(master, f"\x1b[<0;{modal_col};{modal_row}M".encode())
+            _send_mouse(master, 0, modal_col, modal_row)
             _drain_for(master, 0.10)
-            os.write(master, f"\x1b[<0;{modal_col};{modal_row}m".encode())
+            _send_mouse(master, 0, modal_col, modal_row, release=True)
             _drain_for(master, 0.55)
+            navigated = json.loads(report.read_text(encoding="utf-8"))
+            observed["navigation_view"] = navigated["view_present"]
             _set_size(master, 60, 18)
             process.send_signal(signal.SIGWINCH)
             _drain_for(master, 0.55)
+            resized = json.loads(report.read_text(encoding="utf-8"))
+            observed["viewport_clamp"] = resized["viewport_clamped"]
         else:
             _drain_for(master, 0.30)
         deadline = time.monotonic() + _TIMEOUT_SECONDS
@@ -365,6 +458,7 @@ def _run_child(
             raise RuntimeError(f"persona_buddy_terminal_child_failed\n{tail}")
         payload = json.loads(report.read_text(encoding="utf-8"))
         payload["initial_region"] = initial["region"]
+        payload["observed"] = observed
         if process.poll() is None:
             process.terminate()
             process.wait(timeout=2)
@@ -376,7 +470,7 @@ def _run_child(
             process.wait(timeout=2)
 
 
-def _parent() -> int:
+def _parent(report_output: Path | None = None) -> int:
     if os.name == "nt":
         print("SKIP persona_buddy_terminal windows_no_posix_pty")
         return 0
@@ -390,6 +484,9 @@ def _parent() -> int:
             report=isolated / "first.json",
             drive=True,
         )
+        restored = json.loads(preferences.read_text(encoding="utf-8"))
+        restored["open"] = True
+        preferences.write_text(json.dumps(restored, sort_keys=True), encoding="utf-8")
         second = _run_child(
             root=root,
             preferences=preferences,
@@ -397,25 +494,28 @@ def _parent() -> int:
             drive=False,
         )
         checks = {
-            "drag": (
-                first["geometry"]["x"] <= first["initial_region"]["x"] - 5
-                and first["geometry"]["y"] <= first["initial_region"]["y"] - 3
-            ),
-            "resize_keys": first["geometry"]["width"] != 28,
+            "drag": first["observed"]["drag"],
+            "mouse_resize": first["observed"]["mouse_resize"],
+            "fold": first["observed"]["fold"],
+            "reopen": first["observed"]["reopen"],
+            "close": first["observed"]["close"],
             "focus": first["focus_guard"],
             "modal_hit_testing": first["modal_hits"] >= 1,
             "navigation": (
                 first["navigation_count"] == 1
                 and first["screen_generation"] >= 1
-                and first["view_present"]
+                and first["observed"]["navigation_view"]
             ),
-            "viewport_clamp": first["viewport_clamped"],
+            "viewport_clamp": first["observed"]["viewport_clamp"],
             "capture_release": first["capture_released"],
-            "paint": first["painted"],
+            "paint": first["observed"]["paint"],
             "geometry_restore": second["loaded_geometry"] == first["geometry"],
-            "open_and_expanded": first["open"] and not first["collapsed"],
         }
         result = {"checks": checks, "first": first, "second": second}
+        if report_output is not None:
+            report_output.write_text(
+                json.dumps(result, sort_keys=True), encoding="utf-8"
+            )
         print(json.dumps(result, sort_keys=True))
         if not all(checks.values()):
             print("FAIL persona_buddy_terminal")
@@ -429,12 +529,13 @@ def main() -> int:
     parser.add_argument("--child", action="store_true")
     parser.add_argument("preferences", nargs="?", type=Path)
     parser.add_argument("report", nargs="?", type=Path)
+    parser.add_argument("--report", dest="parent_report", type=Path)
     arguments = parser.parse_args()
     if arguments.child:
         if arguments.preferences is None or arguments.report is None:
             return 2
         return _child(arguments.preferences, arguments.report)
-    return _parent()
+    return _parent(arguments.parent_report)
 
 
 if __name__ == "__main__":

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -31,6 +31,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
     from textual import events
     from textual.app import App, ComposeResult
     from textual.binding import Binding
+    from textual.errors import NoWidget
     from textual.screen import ModalScreen
     from textual.widgets import Input, Static
 
@@ -95,6 +96,22 @@ def _child(preferences_path: Path, report_path: Path) -> int:
         def compose(self) -> ComposeResult:
             yield ModalHitSurface("MODAL BLOCKER", id="terminal-modal-blocker")
 
+        def on_mount(self) -> None:
+            self.call_after_refresh(self._publish_ready)
+
+        def on_resize(self, _event: events.Resize) -> None:
+            self.call_after_refresh(self._publish_ready)
+
+        def _publish_ready(self) -> None:
+            surfaces = list(self.query(ModalHitSurface))
+            if not surfaces:
+                return
+            region = surfaces[0].region
+            if region.width <= 0 or region.height <= 0:
+                return
+            self.app.modal_ready = True
+            self.app._write_probe_report()
+
         def action_close_probe_modal(self) -> None:
             self.dismiss()
 
@@ -132,6 +149,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             self.initial_geometry = loaded_geometry
             self.focus_guard_observed = False
             self.modal_timer_fired = False
+            self.modal_ready = False
 
         def _get_default_css(self):  # noqa: D102 - mirrors production CSS loading
             return (
@@ -165,6 +183,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
 
         async def action_probe_modal(self) -> None:
             self.modal_timer_fired = True
+            self.modal_ready = False
             await self.push_screen(BlockingModal())
 
         async def action_probe_navigate(self) -> None:
@@ -207,12 +226,19 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                     }
             modal_surfaces = list(self.screen.query(ModalHitSurface))
             modal_region = modal_surfaces[0].region if modal_surfaces else None
+            if modal_region is not None and (
+                modal_region.width <= 0 or modal_region.height <= 0
+            ):
+                modal_region = None
             modal_target = None
             if modal_region is not None:
-                modal_target, _ = self.screen.get_widget_at(
-                    modal_region.x + max(0, modal_region.width // 2),
-                    modal_region.y + max(0, modal_region.height // 2),
-                )
+                try:
+                    modal_target, _ = self.screen.get_widget_at(
+                        modal_region.x + max(0, modal_region.width // 2),
+                        modal_region.y + max(0, modal_region.height // 2),
+                    )
+                except NoWidget:
+                    modal_region = None
             payload = {
                 "capture_released": self.mouse_captured is None,
                 "collapsed": preferences_now.collapsed,
@@ -233,6 +259,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                     else None
                 ),
                 "modal_timer_fired": self.modal_timer_fired,
+                "modal_ready": self.modal_ready,
                 "navigation_count": self.navigation_count,
                 "open": preferences_now.open,
                 "painted": "Buddy"
@@ -365,12 +392,18 @@ def _run_child(
 
         def wait_for_report(predicate: Any, *, timeout: float = 2.0) -> dict[str, Any]:
             deadline = time.monotonic() + timeout
+            captured = bytearray()
+            payload = json.loads(report.read_text(encoding="utf-8"))
             while time.monotonic() < deadline and process.poll() is None:
                 payload = json.loads(report.read_text(encoding="utf-8"))
                 if predicate(payload):
                     return payload
-                _drain_for(master, 0.02)
-            raise RuntimeError("persona_buddy_terminal_report_predicate_timeout")
+                captured.extend(_drain_for(master, 0.02))
+            tail = bytes(captured[-2000:]).decode("utf-8", errors="replace")
+            raise RuntimeError(
+                "persona_buddy_terminal_report_predicate_timeout "
+                f"payload={payload!r} terminal_tail={tail!r}"
+            )
 
         initial = json.loads(report.read_text(encoding="utf-8"))
         observed = {
@@ -461,7 +494,9 @@ def _run_child(
 
             os.write(master, b"m")
             modal_report = wait_for_report(
-                lambda payload: payload["modal_region"] is not None
+                lambda payload: (
+                    payload["modal_ready"] and payload["modal_region"] is not None
+                )
             )
             modal_region = modal_report["modal_region"]
             modal_col = modal_region["x"] + max(1, modal_region["width"] // 2)

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -21,6 +21,53 @@ import time
 from typing import Any
 
 _TIMEOUT_SECONDS = 12.0
+_DIAGNOSTIC_BYTES = 16_000
+_CHECK_NAMES = (
+    "drag",
+    "mouse_resize",
+    "keyboard",
+    "fold",
+    "reopen",
+    "close",
+    "focus",
+    "modal_hit_testing",
+    "navigation",
+    "viewport_clamp",
+    "capture_release",
+    "paint",
+    "geometry_restore",
+)
+
+
+class _ProbeChildFailure(RuntimeError):
+    """Structured child-process failure retained until evidence is durable."""
+
+    def __init__(
+        self,
+        *,
+        category: str,
+        phase: str,
+        child_return_code: int,
+        diagnostic_tail: str,
+    ) -> None:
+        super().__init__(category)
+        self.category = category
+        self.phase = phase
+        self.child_return_code = child_return_code
+        self.diagnostic_tail = diagnostic_tail
+
+
+def _atomic_write_text(path: Path, value: str) -> None:
+    """Replace one evidence file only after its complete contents are durable."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(value, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _atomic_write_json(path: Path, value: dict[str, Any]) -> None:
+    _atomic_write_text(path, json.dumps(value, sort_keys=True))
 
 
 def _child(preferences_path: Path, report_path: Path) -> int:
@@ -286,9 +333,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                     and region.bottom <= self.size.height
                 ),
             }
-            report_path.write_text(
-                json.dumps(payload, sort_keys=True), encoding="utf-8"
-            )
+            _atomic_write_json(report_path, payload)
 
     ProbeApp().run(mouse=True)
     return 0
@@ -349,6 +394,8 @@ def _run_child(
     preferences: Path,
     report: Path,
     drive: bool,
+    phase: str,
+    inject_child_failure: bool = False,
 ) -> dict[str, Any]:
     master, slave = pty.openpty()
     _set_size(slave, 80, 24)
@@ -366,14 +413,12 @@ def _run_child(
     )
     for directory in (isolated / "home", isolated / "config", isolated / "data"):
         directory.mkdir(parents=True, exist_ok=True)
+    command = [sys.executable, str(Path(__file__).resolve())]
+    if inject_child_failure:
+        command.append("--inject-child-failure")
+    command.extend(("--child", str(preferences), str(report)))
     process = subprocess.Popen(
-        [
-            sys.executable,
-            str(Path(__file__).resolve()),
-            "--child",
-            str(preferences),
-            str(report),
-        ],
+        command,
         cwd=root,
         env=environment,
         stdin=slave,
@@ -382,6 +427,7 @@ def _run_child(
         close_fds=True,
     )
     os.close(slave)
+    current_phase = f"{phase}:startup"
     try:
         _wait_for_output(master, process, b"Persona Buddy")
         initial_deadline = time.monotonic() + 2.0
@@ -406,6 +452,7 @@ def _run_child(
             )
 
         initial = json.loads(report.read_text(encoding="utf-8"))
+        current_phase = f"{phase}:interaction"
         observed = {
             "drag": False,
             "mouse_resize": False,
@@ -534,6 +581,38 @@ def _run_child(
             process.terminate()
             process.wait(timeout=2)
         return payload
+    except Exception as error:
+        captured = bytearray()
+        drain_deadline = time.monotonic() + 0.25
+        while time.monotonic() < drain_deadline:
+            ready, _, _ = select.select([master], [], [], 0.02)
+            if not ready:
+                if process.poll() is not None:
+                    break
+                continue
+            try:
+                captured.extend(os.read(master, 65536))
+            except OSError:
+                break
+        child_return_code = process.poll()
+        if child_return_code is None:
+            process.terminate()
+            process.wait(timeout=2)
+            child_return_code = process.returncode
+        diagnostic = f"{type(error).__name__}: {error}"
+        if captured:
+            diagnostic += "\n" + bytes(captured).decode("utf-8", errors="replace")
+        category = (
+            "persona_buddy_terminal_child_exit"
+            if child_return_code != 0
+            else "persona_buddy_terminal_probe_failure"
+        )
+        raise _ProbeChildFailure(
+            category=category,
+            phase=current_phase,
+            child_return_code=int(child_return_code),
+            diagnostic_tail=diagnostic[-_DIAGNOSTIC_BYTES:],
+        ) from error
     finally:
         os.close(master)
         if process.poll() is None:
@@ -541,59 +620,94 @@ def _run_child(
             process.wait(timeout=2)
 
 
-def _parent(report_output: Path | None = None) -> int:
+def _parent(
+    report_output: Path | None = None, *, inject_child_failure: bool = False
+) -> int:
     if os.name == "nt":
         print("SKIP persona_buddy_terminal windows_no_posix_pty")
         return 0
     root = Path(__file__).resolve().parents[2]
     with tempfile.TemporaryDirectory(prefix="persona-buddy-terminal-") as temporary:
-        isolated = Path(temporary)
-        preferences = isolated / "persona_buddy.json"
-        first = _run_child(
-            root=root,
-            preferences=preferences,
-            report=isolated / "first.json",
-            drive=True,
-        )
-        restored = json.loads(preferences.read_text(encoding="utf-8"))
-        restored["open"] = True
-        preferences.write_text(json.dumps(restored, sort_keys=True), encoding="utf-8")
-        second = _run_child(
-            root=root,
-            preferences=preferences,
-            report=isolated / "second.json",
-            drive=False,
-        )
-        checks = {
-            "drag": first["observed"]["drag"],
-            "mouse_resize": first["observed"]["mouse_resize"],
-            "keyboard": first["observed"]["keyboard"],
-            "fold": first["observed"]["fold"],
-            "reopen": first["observed"]["reopen"],
-            "close": first["observed"]["close"],
-            "focus": first["focus_guard"],
-            "modal_hit_testing": first["modal_hits"] >= 1,
-            "navigation": (
-                first["navigation_count"] == 1
-                and first["screen_generation"] >= 1
-                and first["observed"]["navigation_view"]
-            ),
-            "viewport_clamp": first["observed"]["viewport_clamp"],
-            "capture_release": first["capture_released"],
-            "paint": first["observed"]["paint"],
-            "geometry_restore": second["loaded_geometry"] == first["geometry"],
-        }
-        result = {"checks": checks, "first": first, "second": second}
-        if report_output is not None:
-            report_output.write_text(
-                json.dumps(result, sort_keys=True), encoding="utf-8"
+        try:
+            isolated = Path(temporary)
+            preferences = isolated / "persona_buddy.json"
+            first = _run_child(
+                root=root,
+                preferences=preferences,
+                report=isolated / "first.json",
+                drive=True,
+                phase="first",
+                inject_child_failure=inject_child_failure,
             )
-        print(json.dumps(result, sort_keys=True))
-        if not all(checks.values()):
-            print("FAIL persona_buddy_terminal")
-            return 1
-        print("PASS persona_buddy_terminal")
-        return 0
+            restored = json.loads(preferences.read_text(encoding="utf-8"))
+            restored["open"] = True
+            preferences.write_text(
+                json.dumps(restored, sort_keys=True), encoding="utf-8"
+            )
+            second = _run_child(
+                root=root,
+                preferences=preferences,
+                report=isolated / "second.json",
+                drive=False,
+                phase="restore",
+            )
+            checks = {
+                "drag": first["observed"]["drag"],
+                "mouse_resize": first["observed"]["mouse_resize"],
+                "keyboard": first["observed"]["keyboard"],
+                "fold": first["observed"]["fold"],
+                "reopen": first["observed"]["reopen"],
+                "close": first["observed"]["close"],
+                "focus": first["focus_guard"],
+                "modal_hit_testing": first["modal_hits"] >= 1,
+                "navigation": (
+                    first["navigation_count"] == 1
+                    and first["screen_generation"] >= 1
+                    and first["observed"]["navigation_view"]
+                ),
+                "viewport_clamp": first["observed"]["viewport_clamp"],
+                "capture_release": first["capture_released"],
+                "paint": first["observed"]["paint"],
+                "geometry_restore": second["loaded_geometry"] == first["geometry"],
+            }
+            result = {"checks": checks, "first": first, "second": second}
+            if report_output is not None:
+                _atomic_write_json(report_output, result)
+            print(json.dumps(result, sort_keys=True))
+            if not all(checks.values()):
+                print("FAIL persona_buddy_terminal")
+                return 1
+            print("PASS persona_buddy_terminal")
+            return 0
+        except _ProbeChildFailure as failure:
+            diagnostic = failure.diagnostic_tail.replace(str(root), "<REPO_ROOT>")
+            diagnostic = diagnostic.replace(temporary, "<TEMP_ROOT>")
+            if report_output is not None:
+                artifact = report_output.with_name(
+                    f"{report_output.stem}.diagnostic.log"
+                ).resolve()
+            else:
+                artifact = (
+                    Path(tempfile.gettempdir())
+                    / f"persona-buddy-terminal-{os.getpid()}.diagnostic.log"
+                ).resolve()
+            _atomic_write_text(artifact, diagnostic)
+            checks = {name: False for name in _CHECK_NAMES}
+            result = {
+                "status": "FAIL",
+                "category": failure.category,
+                "phase": failure.phase,
+                "parent_return_code": 1,
+                "child_return_code": failure.child_return_code,
+                "diagnostic_tail": diagnostic,
+                "diagnostic_artifact": str(artifact),
+                "checks": checks,
+                "check_statuses": {name: "not_run" for name in _CHECK_NAMES},
+            }
+            if report_output is not None:
+                _atomic_write_json(report_output, result)
+            print(json.dumps(result, sort_keys=True))
+            raise RuntimeError(f"{failure.category} artifact={artifact}") from failure
 
 
 def main() -> int:
@@ -602,12 +716,22 @@ def main() -> int:
     parser.add_argument("preferences", nargs="?", type=Path)
     parser.add_argument("report", nargs="?", type=Path)
     parser.add_argument("--report", dest="parent_report", type=Path)
+    parser.add_argument("--inject-child-failure", action="store_true")
     arguments = parser.parse_args()
     if arguments.child:
         if arguments.preferences is None or arguments.report is None:
             return 2
+        if arguments.inject_child_failure:
+            raise RuntimeError("persona_buddy_injected_child_failure")
         return _child(arguments.preferences, arguments.report)
-    return _parent(arguments.parent_report)
+    try:
+        return _parent(
+            arguments.parent_report,
+            inject_child_failure=arguments.inject_child_failure,
+        )
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -36,6 +36,7 @@ _CHECK_NAMES = (
     "navigation",
     "viewport_clamp",
     "compact_controls",
+    "compact_move_restore",
     "capture_release",
     "paint",
     "geometry_restore",
@@ -197,6 +198,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             Binding("m", "probe_modal", "Modal", priority=True),
             Binding("n", "probe_navigate", "Navigate", priority=True),
             Binding("o", "probe_reopen", "Reopen", priority=True),
+            Binding("p", "probe_focus_buddy", "Focus Buddy", priority=True),
             Binding("q", "probe_finish", "Finish", priority=True),
         ]
 
@@ -274,6 +276,11 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             )
             await self.reconcile_persona_buddy_view()
 
+        def action_probe_focus_buddy(self) -> None:
+            buddies = list(self.screen.query(PersonaBuddyWidget))
+            if buddies:
+                buddies[0].focus(scroll_visible=False)
+
         def action_probe_finish(self) -> None:
             self.graceful_exit_requested = True
             self._write_probe_report()
@@ -322,6 +329,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                     modal_region = None
             payload = {
                 "capture_released": self.mouse_captured is None,
+                "buddy_focused": buddy is not None and screen.focused is buddy,
                 "collapsed": preferences_now.collapsed,
                 "controls": controls,
                 "focus_guard": self.focus_guard_observed,
@@ -381,25 +389,6 @@ def _child(preferences_path: Path, report_path: Path) -> int:
 
 def _set_size(fd: int, columns: int, rows: int) -> None:
     fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, columns, 0, 0))
-
-
-def _wait_for_output(fd: int, process: subprocess.Popen[bytes], needle: bytes) -> bytes:
-    deadline = time.monotonic() + _TIMEOUT_SECONDS
-    captured = bytearray()
-    while time.monotonic() < deadline:
-        if process.poll() is not None:
-            break
-        ready, _, _ = select.select([fd], [], [], 0.1)
-        if not ready:
-            continue
-        try:
-            captured.extend(os.read(fd, 65536))
-        except OSError:
-            break
-        if needle in captured:
-            return bytes(captured)
-    tail = bytes(captured[-4000:]).decode("utf-8", errors="replace")
-    raise RuntimeError(f"persona_buddy_terminal_not_ready\n{tail}")
 
 
 def _drain_for(fd: int, duration: float) -> bytes:
@@ -469,12 +458,27 @@ def _run_child(
     os.close(slave)
     current_phase = f"{phase}:startup"
     try:
-        _wait_for_output(master, process, b"Persona Buddy")
-        initial_deadline = time.monotonic() + 2.0
-        while not report.exists() and time.monotonic() < initial_deadline:
-            time.sleep(0.02)
-        if not report.exists():
-            raise RuntimeError("persona_buddy_terminal_initial_report_missing")
+        initial_deadline = time.monotonic() + _TIMEOUT_SECONDS
+        startup_output = bytearray()
+        initial = None
+        while time.monotonic() < initial_deadline and process.poll() is None:
+            if report.exists():
+                candidate = json.loads(report.read_text(encoding="utf-8"))
+                region = candidate.get("region")
+                if (
+                    candidate.get("view_present")
+                    and region is not None
+                    and region["width"] > 0
+                    and region["height"] > 0
+                ):
+                    initial = candidate
+                    break
+            startup_output.extend(_drain_for(master, 0.02))
+        if initial is None:
+            tail = bytes(startup_output[-4000:]).decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"persona_buddy_terminal_initial_report_missing\n{tail}"
+            )
 
         def wait_for_report(predicate: Any, *, timeout: float = 2.0) -> dict[str, Any]:
             deadline = time.monotonic() + timeout
@@ -491,7 +495,6 @@ def _run_child(
                 f"payload={payload!r} terminal_tail={tail!r}"
             )
 
-        initial = json.loads(report.read_text(encoding="utf-8"))
         current_phase = f"{phase}:interaction"
         observed = {
             "drag": False,
@@ -506,6 +509,7 @@ def _run_child(
             "paint": initial["painted"],
             "viewport_clamp": False,
             "compact_controls": False,
+            "compact_move_restore": False,
             "graceful_exit": False,
         }
         if drive:
@@ -651,6 +655,8 @@ def _run_child(
                     if attempt == 1:
                         raise
             observed["navigation_view"] = navigated["view_present"]
+            os.write(master, b"p")
+            wait_for_report(lambda payload: payload["buddy_focused"])
             _set_size(master, 18, 6)
             process.send_signal(signal.SIGWINCH)
             compact_dual = wait_for_report(
@@ -680,6 +686,35 @@ def _run_child(
             observed["viewport_clamp"] = compact_minimal["viewport_clamped"]
             observed["compact_controls"] = bool(
                 compact_dual["compact"] and compact_minimal["compact"]
+            )
+            compact_preferred = compact_minimal["geometry"]
+            compact_display_y = compact_minimal["region"]["y"]
+            os.write(master, b"k")
+            compact_moved = wait_for_report(
+                lambda payload: (
+                    payload["geometry"]["y"]
+                    == max(0, compact_display_y - 1)
+                    and payload["geometry"]["width"]
+                    == compact_preferred["width"]
+                    and payload["geometry"]["height"]
+                    == compact_preferred["height"]
+                )
+            )
+            _set_size(master, 28, 12)
+            process.send_signal(signal.SIGWINCH)
+            compact_restored = wait_for_report(
+                lambda payload: (
+                    not payload["compact"]
+                    and payload["region"]["width"] == compact_preferred["width"]
+                    and payload["region"]["height"]
+                    == compact_preferred["height"]
+                )
+            )
+            observed["compact_move_restore"] = bool(
+                compact_moved["geometry"]["width"] == 28
+                and compact_moved["geometry"]["height"] == 12
+                and compact_restored["region"]["width"] == 28
+                and compact_restored["region"]["height"] == 12
             )
         else:
             _drain_for(master, 0.30)
@@ -795,6 +830,9 @@ def _parent(
                 ),
                 "viewport_clamp": first["observed"]["viewport_clamp"],
                 "compact_controls": first["observed"]["compact_controls"],
+                "compact_move_restore": first["observed"][
+                    "compact_move_restore"
+                ],
                 "capture_release": first["capture_released"],
                 "paint": first["observed"]["paint"],
                 "geometry_restore": second["loaded_geometry"] == first["geometry"],

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Bounded POSIX-PTY verification for the native Persona Buddy interactions."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import fcntl
+import json
+import os
+from pathlib import Path
+import pty
+import select
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+from typing import Any
+
+_TIMEOUT_SECONDS = 12.0
+
+
+def _child(preferences_path: Path, report_path: Path) -> int:
+    """Run the production-CSS child application inside the allocated PTY."""
+
+    from dataclasses import asdict
+
+    from textual import events
+    from textual.app import App, ComposeResult
+    from textual.binding import Binding
+    from textual.screen import ModalScreen
+    from textual.widgets import Input, Static
+
+    from tldw_chatbook.Persona_Buddy import (
+        PersonaBuddyController,
+        PersonaBuddyPreferences,
+        PersonaBuddySelection,
+        parse_persona_buddy_preferences,
+        serialize_persona_buddy_preferences,
+    )
+    from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
+    from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+        PersonaBuddyWidget,
+    )
+    from tldw_chatbook.css import build_css
+
+    if preferences_path.exists():
+        raw = json.loads(preferences_path.read_text(encoding="utf-8"))
+        preferences = parse_persona_buddy_preferences(raw)
+    else:
+        preferences = PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "terminal-probe"),
+        )
+    loaded_geometry = asdict(preferences.geometry)
+
+    def write_preferences(value: PersonaBuddyPreferences) -> bool:
+        temporary = preferences_path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(serialize_persona_buddy_preferences(value), sort_keys=True),
+            encoding="utf-8",
+        )
+        temporary.replace(preferences_path)
+        return True
+
+    class ProbeScreen(BaseAppScreen):
+        def __init__(self, app_instance: "ProbeApp", name: str) -> None:
+            super().__init__(app_instance, name)
+
+        def compose_content(self) -> ComposeResult:
+            yield Input(id="terminal-focus-probe")
+            yield Static(f"SCREEN {self.screen_name}", id="terminal-screen-label")
+
+    class ModalHitSurface(Static, can_focus=True):
+        DEFAULT_CSS = "ModalHitSurface { width: 100%; height: 100%; }"
+
+        def on_mouse_down(self, event: events.MouseDown) -> None:
+            self.app.modal_hits += 1
+            self.app.run_worker(
+                self.app.action_probe_navigate(),
+                group="terminal-probe-navigation",
+                exclusive=True,
+            )
+            event.stop()
+
+    class BlockingModal(ModalScreen):
+        BINDINGS = [
+            Binding("escape", "close_probe_modal", "Close", priority=True),
+            Binding("d", "close_probe_modal", "Close", priority=True),
+        ]
+
+        def compose(self) -> ComposeResult:
+            yield ModalHitSurface("MODAL BLOCKER", id="terminal-modal-blocker")
+
+        def action_close_probe_modal(self) -> None:
+            self.dismiss()
+
+    css_dir = Path(build_css.__file__).parent
+    screen_scoped, screen_self = build_css.screen_css_paths(css_dir)
+
+    class ProbeApp(App):
+        CSS_PATH = [
+            str(screen_scoped),
+            str(css_dir / "tldw_cli_modular.tcss"),
+            str(screen_self),
+        ]
+        BINDINGS = [
+            Binding("m", "probe_modal", "Modal", priority=True),
+            Binding("n", "probe_navigate", "Navigate", priority=True),
+            Binding("q", "probe_finish", "Finish", priority=True),
+        ]
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.persona_buddy_controller = PersonaBuddyController(
+                preferences=preferences,
+                preference_writer=write_preferences,
+            )
+            self.modal_hits = 0
+            self.navigation_count = 0
+            self.initial_geometry = loaded_geometry
+            self.focus_guard_observed = False
+            self.modal_timer_fired = False
+
+        def _get_default_css(self):  # noqa: D102 - mirrors production CSS loading
+            return (
+                build_css.widget_defaults_sources(css_dir) + super()._get_default_css()
+            )
+
+        async def reconcile_persona_buddy_view(self) -> None:
+            screen = self.screen
+            if isinstance(screen, BaseAppScreen) and screen.is_active:
+                await screen.reconcile_persona_buddy_view()
+
+        async def on_mount(self) -> None:
+            await self.push_screen(ProbeScreen(self, "first"))
+            asyncio.get_running_loop().add_signal_handler(
+                signal.SIGUSR1,
+                self._write_probe_report,
+            )
+            self.call_after_refresh(self._capture_focus_guard)
+            self.set_interval(0.10, self._write_probe_report)
+            self.set_timer(0.8, self.action_probe_modal)
+
+        def _capture_focus_guard(self) -> None:
+            screen = self.screen
+            buddies = list(screen.query(PersonaBuddyWidget))
+            if not isinstance(screen, ProbeScreen) or not buddies:
+                self.call_after_refresh(self._capture_focus_guard)
+                return
+            focus_probe = screen.query_one("#terminal-focus-probe", Input)
+            screen.set_focus(focus_probe, scroll_visible=False)
+            buddies[0].refresh_from_controller()
+            self.focus_guard_observed = screen.focused is focus_probe
+
+        async def action_probe_modal(self) -> None:
+            self.modal_timer_fired = True
+            await self.push_screen(BlockingModal())
+
+        async def action_probe_navigate(self) -> None:
+            self.navigation_count += 1
+            await self.switch_screen(ProbeScreen(self, "second"))
+
+        def action_probe_finish(self) -> None:
+            self._write_probe_report()
+
+        def _write_probe_report(self) -> None:
+            screen = next(
+                screen
+                for screen in reversed(tuple(self.screen_stack))
+                if isinstance(screen, ProbeScreen)
+            )
+            buddies = list(screen.query(PersonaBuddyWidget))
+            buddy = buddies[0] if buddies else None
+            preferences_now = self.persona_buddy_controller.current_preferences()
+            region = buddy.region if buddy is not None else None
+            modal_surfaces = list(self.screen.query(ModalHitSurface))
+            modal_region = modal_surfaces[0].region if modal_surfaces else None
+            modal_target = None
+            if modal_region is not None:
+                modal_target, _ = self.screen.get_widget_at(
+                    modal_region.x + max(0, modal_region.width // 2),
+                    modal_region.y + max(0, modal_region.height // 2),
+                )
+            payload = {
+                "capture_released": self.mouse_captured is None,
+                "collapsed": preferences_now.collapsed,
+                "focus_guard": self.focus_guard_observed,
+                "geometry": asdict(preferences_now.geometry),
+                "loaded_geometry": self.initial_geometry,
+                "modal_hits": self.modal_hits,
+                "modal_hit_target": getattr(modal_target, "id", None),
+                "modal_region": (
+                    {
+                        "x": modal_region.x,
+                        "y": modal_region.y,
+                        "width": modal_region.width,
+                        "height": modal_region.height,
+                    }
+                    if modal_region is not None
+                    else None
+                ),
+                "modal_timer_fired": self.modal_timer_fired,
+                "navigation_count": self.navigation_count,
+                "open": preferences_now.open,
+                "painted": "Buddy"
+                in "\n".join(
+                    strip.text for strip in screen._compositor.render_strips()
+                ),
+                "region": (
+                    {
+                        "x": region.x,
+                        "y": region.y,
+                        "width": region.width,
+                        "height": region.height,
+                    }
+                    if region is not None
+                    else None
+                ),
+                "view_present": buddy is not None,
+                "screen_generation": screen.persona_buddy_view_generation,
+                "viewport_clamped": (
+                    region is not None
+                    and region.x >= 0
+                    and region.y >= 0
+                    and region.right <= self.size.width
+                    and region.bottom <= self.size.height
+                ),
+            }
+            report_path.write_text(
+                json.dumps(payload, sort_keys=True), encoding="utf-8"
+            )
+
+    ProbeApp().run(mouse=True)
+    return 0
+
+
+def _set_size(fd: int, columns: int, rows: int) -> None:
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, columns, 0, 0))
+
+
+def _wait_for_output(fd: int, process: subprocess.Popen[bytes], needle: bytes) -> bytes:
+    deadline = time.monotonic() + _TIMEOUT_SECONDS
+    captured = bytearray()
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            break
+        ready, _, _ = select.select([fd], [], [], 0.1)
+        if not ready:
+            continue
+        try:
+            captured.extend(os.read(fd, 65536))
+        except OSError:
+            break
+        if needle in captured:
+            return bytes(captured)
+    tail = bytes(captured[-4000:]).decode("utf-8", errors="replace")
+    raise RuntimeError(f"persona_buddy_terminal_not_ready\n{tail}")
+
+
+def _drain_for(fd: int, duration: float) -> None:
+    """Drain terminal paint while allowing a bounded interval between events."""
+
+    deadline = time.monotonic() + duration
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select(
+            [fd], [], [], min(0.02, deadline - time.monotonic())
+        )
+        if ready:
+            os.read(fd, 65536)
+
+
+def _run_child(
+    *,
+    root: Path,
+    preferences: Path,
+    report: Path,
+    drive: bool,
+) -> dict[str, Any]:
+    master, slave = pty.openpty()
+    _set_size(slave, 80, 24)
+    isolated = preferences.parent
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(isolated / "home"),
+            "XDG_CONFIG_HOME": str(isolated / "config"),
+            "XDG_DATA_HOME": str(isolated / "data"),
+            "TLDW_CONFIG_PATH": str(isolated / "config" / "config.toml"),
+            "PYTHONPATH": str(root),
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    for directory in (isolated / "home", isolated / "config", isolated / "data"):
+        directory.mkdir(parents=True, exist_ok=True)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--child",
+            str(preferences),
+            str(report),
+        ],
+        cwd=root,
+        env=environment,
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        close_fds=True,
+    )
+    os.close(slave)
+    try:
+        _wait_for_output(master, process, b"Persona Buddy")
+        initial_deadline = time.monotonic() + 2.0
+        while not report.exists() and time.monotonic() < initial_deadline:
+            time.sleep(0.02)
+        if not report.exists():
+            raise RuntimeError("persona_buddy_terminal_initial_report_missing")
+        initial = json.loads(report.read_text(encoding="utf-8"))
+        if drive:
+            # Compute true terminal-cell coordinates from the child's painted
+            # region (SGR is 1-based), while still sending the real
+            # terminal shape whose Textual MouseDown has widget=None.
+            region = initial["region"]
+            down_col = region["x"] + 4
+            down_row = region["y"] + 3
+            move_col = max(2, down_col - 10)
+            move_row = max(2, down_row - 5)
+            os.write(master, f"\x1b[<0;{down_col};{down_row}M".encode())
+            _drain_for(master, 0.10)
+            os.write(master, f"\x1b[<32;{move_col};{move_row}M".encode())
+            _drain_for(master, 0.10)
+            os.write(master, f"\x1b[<0;{move_col};{move_row}m".encode())
+            _drain_for(master, 0.25)
+            os.write(master, b"hHcc")
+            _drain_for(master, 0.90)
+            modal_report = json.loads(report.read_text(encoding="utf-8"))
+            modal_region = modal_report["modal_region"]
+            modal_col = modal_region["x"] + max(1, modal_region["width"] // 2)
+            modal_row = modal_region["y"] + max(1, modal_region["height"] // 2)
+            os.write(master, f"\x1b[<0;{modal_col};{modal_row}M".encode())
+            _drain_for(master, 0.10)
+            os.write(master, f"\x1b[<0;{modal_col};{modal_row}m".encode())
+            _drain_for(master, 0.55)
+            _set_size(master, 60, 18)
+            process.send_signal(signal.SIGWINCH)
+            _drain_for(master, 0.55)
+        else:
+            _drain_for(master, 0.30)
+        deadline = time.monotonic() + _TIMEOUT_SECONDS
+        while (
+            not report.exists()
+            and process.poll() is None
+            and time.monotonic() < deadline
+        ):
+            select.select([master], [], [], 0.05)
+        if not report.exists():
+            captured = bytearray()
+            while select.select([master], [], [], 0.05)[0]:
+                captured.extend(os.read(master, 65536))
+            tail = bytes(captured[-6000:]).decode("utf-8", errors="replace")
+            raise RuntimeError(f"persona_buddy_terminal_child_failed\n{tail}")
+        payload = json.loads(report.read_text(encoding="utf-8"))
+        payload["initial_region"] = initial["region"]
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=2)
+        return payload
+    finally:
+        os.close(master)
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=2)
+
+
+def _parent() -> int:
+    if os.name == "nt":
+        print("SKIP persona_buddy_terminal windows_no_posix_pty")
+        return 0
+    root = Path(__file__).resolve().parents[2]
+    with tempfile.TemporaryDirectory(prefix="persona-buddy-terminal-") as temporary:
+        isolated = Path(temporary)
+        preferences = isolated / "persona_buddy.json"
+        first = _run_child(
+            root=root,
+            preferences=preferences,
+            report=isolated / "first.json",
+            drive=True,
+        )
+        second = _run_child(
+            root=root,
+            preferences=preferences,
+            report=isolated / "second.json",
+            drive=False,
+        )
+        checks = {
+            "drag": (
+                first["geometry"]["x"] <= first["initial_region"]["x"] - 5
+                and first["geometry"]["y"] <= first["initial_region"]["y"] - 3
+            ),
+            "resize_keys": first["geometry"]["width"] != 28,
+            "focus": first["focus_guard"],
+            "modal_hit_testing": first["modal_hits"] >= 1,
+            "navigation": (
+                first["navigation_count"] == 1
+                and first["screen_generation"] >= 1
+                and first["view_present"]
+            ),
+            "viewport_clamp": first["viewport_clamped"],
+            "capture_release": first["capture_released"],
+            "paint": first["painted"],
+            "geometry_restore": second["loaded_geometry"] == first["geometry"],
+            "open_and_expanded": first["open"] and not first["collapsed"],
+        }
+        result = {"checks": checks, "first": first, "second": second}
+        print(json.dumps(result, sort_keys=True))
+        if not all(checks.values()):
+            print("FAIL persona_buddy_terminal")
+            return 1
+        print("PASS persona_buddy_terminal")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--child", action="store_true")
+    parser.add_argument("preferences", nargs="?", type=Path)
+    parser.add_argument("report", nargs="?", type=Path)
+    arguments = parser.parse_args()
+    if arguments.child:
+        if arguments.preferences is None or arguments.report is None:
+            return 2
+        return _child(arguments.preferences, arguments.report)
+    return _parent()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -31,11 +31,15 @@ _CHECK_NAMES = (
     "close",
     "focus",
     "modal_hit_testing",
+    "modal_resume",
+    "modal_close_replay",
     "navigation",
     "viewport_clamp",
+    "compact_controls",
     "capture_release",
     "paint",
     "geometry_restore",
+    "graceful_exit",
 )
 
 
@@ -138,6 +142,8 @@ def _child(preferences_path: Path, report_path: Path) -> int:
         BINDINGS = [
             Binding("escape", "close_probe_modal", "Close", priority=True),
             Binding("d", "close_probe_modal", "Close", priority=True),
+            Binding("r", "resume_probe_buddy", "Resume Buddy", priority=True),
+            Binding("x", "close_probe_buddy", "Close Buddy", priority=True),
         ]
 
         def compose(self) -> ComposeResult:
@@ -162,6 +168,22 @@ def _child(preferences_path: Path, report_path: Path) -> int:
         def action_close_probe_modal(self) -> None:
             self.dismiss()
 
+        def action_resume_probe_buddy(self) -> None:
+            self.app.persona_buddy_controller.invalidate_profile()
+            self.dismiss()
+
+        def action_close_probe_buddy(self) -> None:
+            controller = self.app.persona_buddy_controller
+            revision = controller.apply_preferences_patch(open=False)
+            self.app.run_worker(
+                controller.persist_preferences_revision(revision),
+                group="persona-buddy-preferences",
+            )
+            self.dismiss()
+
+        def on_unmount(self) -> None:
+            self.app.modal_ready = False
+
     css_dir = Path(build_css.__file__).parent
     screen_scoped, screen_self = build_css.screen_css_paths(css_dir)
 
@@ -185,7 +207,10 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                 preference_writer=write_preferences,
             )
 
+            self.resolution_calls = 0
+
             async def keep_probe_visual_unknown(*, cols: int, lines: int):
+                self.resolution_calls += 1
                 return None
 
             self.persona_buddy_controller.resolve_current_visual = (
@@ -197,6 +222,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             self.focus_guard_observed = False
             self.modal_timer_fired = False
             self.modal_ready = False
+            self.graceful_exit_requested = False
 
         def _get_default_css(self):  # noqa: D102 - mirrors production CSS loading
             return (
@@ -213,6 +239,10 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             asyncio.get_running_loop().add_signal_handler(
                 signal.SIGUSR1,
                 self._write_probe_report,
+            )
+            asyncio.get_running_loop().add_signal_handler(
+                signal.SIGUSR2,
+                self.action_probe_finish,
             )
             self.call_after_refresh(self._capture_focus_guard)
             self.set_interval(0.10, self._write_probe_report)
@@ -245,7 +275,9 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             await self.reconcile_persona_buddy_view()
 
         def action_probe_finish(self) -> None:
+            self.graceful_exit_requested = True
             self._write_probe_report()
+            self.exit()
 
         def _write_probe_report(self) -> None:
             screen = next(
@@ -266,10 +298,12 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                 ):
                     control = buddy.query_one(f"#{control_id}")
                     controls[control_id] = {
+                        "display": control.display,
                         "x": control.region.x,
                         "y": control.region.y,
                         "width": control.region.width,
                         "height": control.region.height,
+                        "label": str(getattr(control, "label", "")),
                     }
             modal_surfaces = list(self.screen.query(ModalHitSurface))
             modal_region = modal_surfaces[0].region if modal_surfaces else None
@@ -309,6 +343,12 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                 "modal_ready": self.modal_ready,
                 "navigation_count": self.navigation_count,
                 "open": preferences_now.open,
+                "resolution_calls": self.resolution_calls,
+                "compact": bool(
+                    buddy is not None
+                    and buddy.has_class("persona-buddy-compact")
+                ),
+                "graceful_exit_requested": self.graceful_exit_requested,
                 "painted": "Buddy"
                 in "\n".join(
                     strip.text for strip in screen._compositor.render_strips()
@@ -460,9 +500,13 @@ def _run_child(
             "fold": False,
             "reopen": False,
             "close": False,
+            "modal_resume": False,
+            "modal_close_replay": False,
             "navigation_view": False,
             "paint": initial["painted"],
             "viewport_clamp": False,
+            "compact_controls": False,
+            "graceful_exit": False,
         }
         if drive:
             drag_x, drag_y = _center(initial["controls"]["persona-buddy-drag-handle"])
@@ -537,7 +581,47 @@ def _run_child(
             if process.poll() is not None:
                 raise RuntimeError(close_output.decode("utf-8", errors="replace"))
             os.write(master, b"o")
-            _drain_for(master, 0.60)
+            reopened_view = wait_for_report(
+                lambda payload: payload["open"] and payload["view_present"]
+            )
+
+            resume_calls = reopened_view["resolution_calls"]
+            os.write(master, b"m")
+            wait_for_report(
+                lambda payload: (
+                    payload["modal_ready"] and payload["modal_region"] is not None
+                )
+            )
+            os.write(master, b"r")
+            resumed = wait_for_report(
+                lambda payload: (
+                    not payload["modal_ready"]
+                    and payload["view_present"]
+                    and payload["resolution_calls"] > resume_calls
+                )
+            )
+            observed["modal_resume"] = resumed["open"]
+
+            os.write(master, b"m")
+            wait_for_report(
+                lambda payload: (
+                    payload["modal_ready"] and payload["modal_region"] is not None
+                )
+            )
+            os.write(master, b"x")
+            modal_closed = wait_for_report(
+                lambda payload: (
+                    not payload["modal_ready"]
+                    and not payload["open"]
+                    and not payload["view_present"]
+                )
+            )
+            observed["modal_close_replay"] = not modal_closed["view_present"]
+
+            os.write(master, b"o")
+            wait_for_report(
+                lambda payload: payload["open"] and payload["view_present"]
+            )
 
             os.write(master, b"m")
             modal_report = wait_for_report(
@@ -548,17 +632,55 @@ def _run_child(
             modal_region = modal_report["modal_region"]
             modal_col = modal_region["x"] + max(1, modal_region["width"] // 2)
             modal_row = modal_region["y"] + max(1, modal_region["height"] // 2)
-            _send_mouse(master, 0, modal_col, modal_row)
-            _drain_for(master, 0.10)
-            _send_mouse(master, 0, modal_col, modal_row, release=True)
-            _drain_for(master, 0.55)
-            navigated = json.loads(report.read_text(encoding="utf-8"))
+            navigated = modal_report
+            for attempt in range(2):
+                _send_mouse(master, 0, modal_col, modal_row)
+                _drain_for(master, 0.10)
+                _send_mouse(master, 0, modal_col, modal_row, release=True)
+                try:
+                    navigated = wait_for_report(
+                        lambda payload: (
+                            payload["modal_hits"] >= 1
+                            and payload["navigation_count"] == 1
+                            and payload["view_present"]
+                        ),
+                        timeout=0.8,
+                    )
+                    break
+                except RuntimeError:
+                    if attempt == 1:
+                        raise
             observed["navigation_view"] = navigated["view_present"]
-            _set_size(master, 60, 18)
+            _set_size(master, 18, 6)
             process.send_signal(signal.SIGWINCH)
-            _drain_for(master, 0.55)
-            resized = json.loads(report.read_text(encoding="utf-8"))
-            observed["viewport_clamp"] = resized["viewport_clamped"]
+            compact_dual = wait_for_report(
+                lambda payload: (
+                    payload["compact"]
+                    and payload["viewport_clamped"]
+                    and payload["controls"]["persona-buddy-collapse"]["display"]
+                    and payload["controls"]["persona-buddy-close"]["display"]
+                    and payload["controls"]["persona-buddy-collapse"]["label"]
+                    == "Buddy"
+                    and payload["controls"]["persona-buddy-close"]["label"]
+                    == "Close"
+                )
+            )
+            _set_size(master, 10, 2)
+            process.send_signal(signal.SIGWINCH)
+            compact_minimal = wait_for_report(
+                lambda payload: (
+                    payload["compact"]
+                    and payload["viewport_clamped"]
+                    and payload["controls"]["persona-buddy-collapse"]["display"]
+                    and payload["controls"]["persona-buddy-collapse"]["label"]
+                    == "Buddy"
+                    and not payload["controls"]["persona-buddy-close"]["display"]
+                )
+            )
+            observed["viewport_clamp"] = compact_minimal["viewport_clamped"]
+            observed["compact_controls"] = bool(
+                compact_dual["compact"] and compact_minimal["compact"]
+            )
         else:
             _drain_for(master, 0.30)
         deadline = time.monotonic() + _TIMEOUT_SECONDS
@@ -574,12 +696,16 @@ def _run_child(
                 captured.extend(os.read(master, 65536))
             tail = bytes(captured[-6000:]).decode("utf-8", errors="replace")
             raise RuntimeError(f"persona_buddy_terminal_child_failed\n{tail}")
+        process.send_signal(signal.SIGUSR2)
+        _drain_for(master, 0.20)
+        process.wait(timeout=2)
         payload = json.loads(report.read_text(encoding="utf-8"))
+        observed["graceful_exit"] = bool(
+            process.returncode == 0
+            and payload["graceful_exit_requested"]
+        )
         payload["initial_region"] = initial["region"]
         payload["observed"] = observed
-        if process.poll() is None:
-            process.terminate()
-            process.wait(timeout=2)
         return payload
     except Exception as error:
         captured = bytearray()
@@ -660,15 +786,22 @@ def _parent(
                 "close": first["observed"]["close"],
                 "focus": first["focus_guard"],
                 "modal_hit_testing": first["modal_hits"] >= 1,
+                "modal_resume": first["observed"]["modal_resume"],
+                "modal_close_replay": first["observed"]["modal_close_replay"],
                 "navigation": (
                     first["navigation_count"] == 1
                     and first["screen_generation"] >= 1
                     and first["observed"]["navigation_view"]
                 ),
                 "viewport_clamp": first["observed"]["viewport_clamp"],
+                "compact_controls": first["observed"]["compact_controls"],
                 "capture_release": first["capture_released"],
                 "paint": first["observed"]["paint"],
                 "geometry_restore": second["loaded_geometry"] == first["geometry"],
+                "graceful_exit": (
+                    first["observed"]["graceful_exit"]
+                    and second["observed"]["graceful_exit"]
+                ),
             }
             result = {"checks": checks, "first": first, "second": second}
             if report_output is not None:

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -120,6 +120,13 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                 preferences=preferences,
                 preference_writer=write_preferences,
             )
+
+            async def keep_probe_visual_unknown(*, cols: int, lines: int):
+                return None
+
+            self.persona_buddy_controller.resolve_current_visual = (
+                keep_probe_visual_unknown
+            )
             self.modal_hits = 0
             self.navigation_count = 0
             self.initial_geometry = loaded_geometry
@@ -355,10 +362,21 @@ def _run_child(
             time.sleep(0.02)
         if not report.exists():
             raise RuntimeError("persona_buddy_terminal_initial_report_missing")
+
+        def wait_for_report(predicate: Any, *, timeout: float = 2.0) -> dict[str, Any]:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline and process.poll() is None:
+                payload = json.loads(report.read_text(encoding="utf-8"))
+                if predicate(payload):
+                    return payload
+                _drain_for(master, 0.02)
+            raise RuntimeError("persona_buddy_terminal_report_predicate_timeout")
+
         initial = json.loads(report.read_text(encoding="utf-8"))
         observed = {
             "drag": False,
             "mouse_resize": False,
+            "keyboard": False,
             "fold": False,
             "reopen": False,
             "close": False,
@@ -397,7 +415,24 @@ def _run_child(
                 > after_drag["geometry"]["height"]
             )
 
-            fold_x, fold_y = _center(after_resize["controls"]["persona-buddy-collapse"])
+            os.write(master, b"hH")
+            _drain_for(master, 0.35)
+            keyboard = json.loads(report.read_text(encoding="utf-8"))
+            keyboard_changed = (
+                keyboard["geometry"]["x"] == after_resize["geometry"]["x"] - 1
+                and keyboard["geometry"]["width"]
+                == after_resize["geometry"]["width"] - 1
+            )
+            os.write(master, b"0")
+            _drain_for(master, 0.35)
+            reset = json.loads(report.read_text(encoding="utf-8"))
+            observed["keyboard"] = (
+                keyboard_changed
+                and reset["geometry"]["width"] == 28
+                and reset["geometry"]["height"] == 12
+            )
+
+            fold_x, fold_y = _center(reset["controls"]["persona-buddy-collapse"])
             _send_mouse(master, 0, fold_x, fold_y)
             _drain_for(master, 0.10)
             _send_mouse(master, 0, fold_x, fold_y, release=True)
@@ -425,8 +460,9 @@ def _run_child(
             _drain_for(master, 0.60)
 
             os.write(master, b"m")
-            _drain_for(master, 0.35)
-            modal_report = json.loads(report.read_text(encoding="utf-8"))
+            modal_report = wait_for_report(
+                lambda payload: payload["modal_region"] is not None
+            )
             modal_region = modal_report["modal_region"]
             modal_col = modal_region["x"] + max(1, modal_region["width"] // 2)
             modal_row = modal_region["y"] + max(1, modal_region["height"] // 2)
@@ -496,6 +532,7 @@ def _parent(report_output: Path | None = None) -> int:
         checks = {
             "drag": first["observed"]["drag"],
             "mouse_resize": first["observed"]["mouse_resize"],
+            "keyboard": first["observed"]["keyboard"],
             "fold": first["observed"]["fold"],
             "reopen": first["observed"]["reopen"],
             "close": first["observed"]["close"],

--- a/Tests/Live/test_persona_buddy_terminal_probe.py
+++ b/Tests/Live/test_persona_buddy_terminal_probe.py
@@ -1,0 +1,54 @@
+"""Failure-evidence contract for the bounded Persona Buddy PTY probe."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PTY capability required")
+def test_injected_child_failure_persists_atomic_parent_evidence(tmp_path: Path) -> None:
+    probe = Path(__file__).with_name("persona_buddy_terminal_probe.py")
+    report = tmp_path / "failure-report.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(probe),
+            "--inject-child-failure",
+            "--report",
+            str(report),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 1
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["status"] == "FAIL"
+    assert payload["category"] == "persona_buddy_terminal_child_exit"
+    assert payload["phase"] == "first:startup"
+    assert payload["parent_return_code"] == 1
+    assert payload["child_return_code"] == 1
+    assert "Traceback (most recent call last)" in payload["diagnostic_tail"]
+    assert "persona_buddy_injected_child_failure" in payload["diagnostic_tail"]
+    assert len(payload["diagnostic_tail"].encode("utf-8")) <= 16_000
+    assert "persona-buddy-terminal-" not in payload["diagnostic_tail"]
+    assert payload["checks"] and not any(payload["checks"].values())
+    assert set(payload["check_statuses"].values()) == {"not_run"}
+
+    artifact = Path(payload["diagnostic_artifact"])
+    assert artifact.is_file()
+    assert artifact.parent == report.parent
+    assert "persona_buddy_injected_child_failure" in artifact.read_text(
+        encoding="utf-8"
+    )
+    assert payload["category"] in completed.stderr
+    assert str(artifact) in completed.stderr

--- a/Tests/Live/test_persona_buddy_terminal_probe.py
+++ b/Tests/Live/test_persona_buddy_terminal_probe.py
@@ -52,3 +52,27 @@ def test_injected_child_failure_persists_atomic_parent_evidence(tmp_path: Path) 
     )
     assert payload["category"] in completed.stderr
     assert str(artifact) in completed.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PTY capability required")
+def test_probe_rejects_cli_paths_outside_workspace_and_temp_roots() -> None:
+    probe = Path(__file__).with_name("persona_buddy_terminal_probe.py")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(probe),
+            "--child",
+            "/etc/persona-buddy-preferences.json",
+            "/etc/persona-buddy-report.json",
+            "--inject-child-failure",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 2
+    assert "persona_buddy_probe_path_invalid" in completed.stderr
+    assert "/etc/" not in completed.stderr

--- a/Tests/Persona_Buddy/test_persona_buddy_console_adapters.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_console_adapters.py
@@ -199,13 +199,39 @@ def test_trusted_public_events_require_safe_state_and_future_expiry() -> None:
         BuddyLifecycleEvent(source="console-run", owner=owner, state="model.directive")
     with pytest.raises(ValueError):
         BuddyLifecycleEvent(source="authored", owner=owner, state="api_key.exposed")
-    with pytest.raises(ValueError):
-        BuddyLifecycleEvent(
-            source="explicit",
-            owner=owner,
-            state="thinking",
-            expires_at=time.monotonic() - 1.0,
+    assert (
+        adapter.publish(
+            BuddyLifecycleEvent(
+                source="explicit",
+                owner=owner,
+                state="thinking",
+                expires_at=time.monotonic() - 1.0,
+            )
         )
+        is False
+    )
+
+
+@pytest.mark.unit
+def test_explicit_expiry_uses_the_adapter_clock_domain() -> None:
+    now = [100.0]
+    controller = PersonaBuddyController(clock=lambda: now[0])
+    adapter = PersonaBuddyConsoleAdapter(controller)
+    adapter._clock = lambda: now[0]
+
+    event = BuddyLifecycleEvent(
+        source="explicit",
+        owner="trusted:custom-clock",
+        state="thinking",
+        expires_at=110.0,
+    )
+
+    assert adapter.publish(event) is True
+    assert controller.snapshot().state == "thinking"
+
+    now[0] = 111.0
+    assert adapter.active_owner_count() == 0
+    assert controller.snapshot().state == "idle"
 
 
 @pytest.mark.asyncio

--- a/Tests/Persona_Buddy/test_persona_buddy_console_adapters.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_console_adapters.py
@@ -1,0 +1,208 @@
+"""Trusted, content-free Console lifecycle adapters for Persona Buddy."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import fields
+
+import pytest
+
+from tldw_chatbook.Persona_Buddy.console_adapter import (
+    BuddyLifecycleEvent,
+    PersonaBuddyConsoleAdapter,
+)
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+
+
+@pytest.mark.unit
+def test_lifecycle_event_is_frozen_slotted_and_content_free() -> None:
+    event = BuddyLifecycleEvent(
+        source="console-run",
+        owner="run:a1",
+        state="thinking",
+        terminal=False,
+        expires_at=None,
+    )
+
+    assert event.__slots__ == (
+        "source",
+        "owner",
+        "state",
+        "terminal",
+        "expires_at",
+    )
+    assert tuple(field.name for field in fields(event)) == event.__slots__
+    with pytest.raises(AttributeError):
+        event.state = "speaking"  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        BuddyLifecycleEvent(  # type: ignore[call-arg]
+            source="console-run",
+            owner="run:a1",
+            state="thinking",
+            terminal=False,
+            expires_at=None,
+            prompt="private",
+        )
+
+
+@pytest.mark.unit
+def test_run_mapping_replaces_exact_generation_and_releases_terminal_states() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+
+    first = adapter.run_state("session-a", "validating")
+    assert controller.snapshot().state == "thinking"
+    assert controller.snapshot().state_source == "console-run"
+    adapter.run_state("session-b", "checking_citations")
+    assert adapter.active_owner_count("console-run") == 2
+
+    replacement = adapter.run_state("session-a", "validating")
+    assert replacement != first
+    assert adapter.active_owner_count("console-run") == 2
+    adapter.run_state("session-a", "streaming")
+    assert controller.snapshot().state == "speaking"
+    adapter.run_state("session-a", "completed")
+    assert adapter.active_owner_count("console-run") == 1
+    adapter.run_state("session-b", "blocked")
+    assert controller.snapshot().state == "idle"
+
+
+@pytest.mark.unit
+def test_failed_run_maps_to_error_until_idle_or_replacement() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+
+    adapter.run_state("session-a", "validating")
+    adapter.run_state("session-a", "failed")
+    assert controller.snapshot().state == "error"
+
+    adapter.run_state("session-a", "idle")
+    assert controller.snapshot().state == "idle"
+
+
+@pytest.mark.unit
+def test_approval_rounds_overlap_and_release_only_exact_owner() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+
+    adapter.approval_round("session-a", "round-1", pending=True)
+    adapter.approval_round("session-a", "round-2", pending=True)
+    adapter.approval_round("session-b", "round-3", pending=True)
+    assert adapter.active_owner_count("approval") == 3
+    assert controller.snapshot().state == "approval_needed"
+
+    adapter.approval_round("session-a", "round-1", pending=False)
+    assert adapter.active_owner_count("approval") == 2
+    adapter.approval_round("session-a", "round-1", pending=False)
+    assert adapter.active_owner_count("approval") == 2
+    assert controller.snapshot().state == "approval_needed"
+    adapter.release_session("session-a", sources={"approval"})
+    assert adapter.active_owner_count("approval") == 1
+
+
+@pytest.mark.unit
+def test_tool_steps_pair_by_run_and_sequence_and_cleanup_terminal_run() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+
+    adapter.tool_step("run-a", 1, "tool_call")
+    adapter.tool_step("run-a", 2, "tool_call")
+    adapter.tool_step("run-b", 1, "tool_call")
+    assert adapter.active_owner_count("tool") == 3
+    assert controller.snapshot().state == "tool_running"
+
+    adapter.tool_step("run-a", 1, "tool_result")
+    assert adapter.active_owner_count("tool") == 2
+    adapter.release_run("run-a")
+    assert adapter.active_owner_count("tool") == 1
+    adapter.release_run("run-b")
+    assert controller.snapshot().state == "idle"
+
+
+@pytest.mark.unit
+def test_wake_membership_overlaps_and_yields_to_live_voice() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+
+    adapter.wake("conversation-a", "run-1", active=True)
+    adapter.wake("conversation-a", "run-2", active=True)
+    assert adapter.active_owner_count("wake") == 2
+    assert controller.snapshot().state == "wake_armed"
+
+    adapter.voice_state("session-a", 1, "listening")
+    assert controller.snapshot().state == "listening"
+    adapter.voice_state("session-a", 1, "idle")
+    assert controller.snapshot().state == "wake_armed"
+
+    adapter.wake("conversation-a", "run-1", active=False)
+    assert adapter.active_owner_count("wake") == 1
+    adapter.clear_wakes("conversation-a")
+    assert controller.snapshot().state == "idle"
+
+
+@pytest.mark.unit
+def test_voice_generation_replacement_and_terminal_release_are_exact() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+
+    adapter.voice_state("session-a", 1, "connecting")
+    assert controller.snapshot().state == "offline"
+    adapter.voice_state("session-a", 1, "live")
+    assert controller.snapshot().state == "listening"
+    adapter.voice_state("session-b", 1, "thinking")
+    assert adapter.active_owner_count("voice") == 2
+
+    adapter.voice_state("session-a", 2, "speaking")
+    assert adapter.active_owner_count("voice") == 2
+    adapter.voice_state("session-a", 1, "idle")
+    assert adapter.active_owner_count("voice") == 2
+    adapter.voice_state("session-a", 2, "idle")
+    assert adapter.active_owner_count("voice") == 1
+    adapter.release_voice("session-b", 1)
+    assert controller.snapshot().state == "idle"
+
+
+@pytest.mark.unit
+def test_no_controller_sink_is_a_noop() -> None:
+    adapter = PersonaBuddyConsoleAdapter(None)
+
+    adapter.run_state("session-a", "streaming")
+    adapter.approval_round("session-a", "round-1", pending=True)
+    adapter.tool_step("run-a", 1, "tool_call")
+    adapter.wake("conversation-a", "run-a", active=True)
+    adapter.voice_state("session-a", 1, "speaking")
+
+    assert adapter.active_owner_count() == 0
+
+
+@pytest.mark.unit
+def test_trusted_public_events_require_safe_state_and_future_expiry() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+    owner = "trusted:operation"
+
+    adapter.publish(
+        BuddyLifecycleEvent(
+            source="explicit",
+            owner=owner,
+            state="celebrating.custom",
+            expires_at=time.monotonic() + 30.0,
+        )
+    )
+    assert controller.snapshot().state == "celebrating.custom"
+    adapter.publish(
+        BuddyLifecycleEvent(source="explicit", owner=owner, state="idle", terminal=True)
+    )
+    assert controller.snapshot().state == "idle"
+
+    with pytest.raises(ValueError):
+        BuddyLifecycleEvent(source="console-run", owner=owner, state="model.directive")
+    with pytest.raises(ValueError):
+        BuddyLifecycleEvent(source="authored", owner=owner, state="api_key.exposed")
+    with pytest.raises(ValueError):
+        BuddyLifecycleEvent(
+            source="explicit",
+            owner=owner,
+            state="thinking",
+            expires_at=time.monotonic() - 1.0,
+        )

--- a/Tests/Persona_Buddy/test_persona_buddy_console_adapters.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_console_adapters.py
@@ -206,3 +206,89 @@ def test_trusted_public_events_require_safe_state_and_future_expiry() -> None:
             state="thinking",
             expires_at=time.monotonic() - 1.0,
         )
+
+
+@pytest.mark.asyncio
+async def test_terminal_dispose_fences_every_console_producer_and_bind() -> None:
+    """Disposal latches before cleanup and every later producer fails closed."""
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+    adapter.run_state("session-a", "validating")
+    adapter.approval_round("session-a", "round-1", pending=True)
+    adapter.tool_step("run-a", 1, "tool_call")
+    adapter.wake("conversation-a", "run-a", active=True)
+    voice_generation = adapter.next_voice_generation("session-a")
+    adapter.voice_state("session-a", voice_generation, "speaking")
+    adapter.publish(
+        BuddyLifecycleEvent(
+            source="explicit",
+            owner="trusted:operation",
+            state="thinking",
+            expires_at=time.monotonic() + 30.0,
+        )
+    )
+
+    adapter.dispose()
+    adapter.dispose()
+    adapter.bind_controller(PersonaBuddyController())
+    await controller.shutdown()
+
+    assert (
+        adapter.publish(
+            BuddyLifecycleEvent(
+                source="authored", owner="trusted:late", state="thinking"
+            )
+        )
+        is False
+    )
+    assert adapter.run_state("session-a", "validating") is None
+    assert adapter.approval_round("session-a", "round-2", pending=True) is None
+    assert adapter.tool_step("run-b", 2, "tool_call") is None
+    adapter.release_run("run-a")
+    assert adapter.wake("conversation-a", "run-b", active=True) is None
+    adapter.clear_wakes()
+    assert adapter.next_voice_generation("session-a") is None
+    assert adapter.voice_state("session-a", voice_generation + 1, "listening") is None
+    adapter.release_voice("session-a", voice_generation)
+    adapter.release_session("session-a")
+    adapter.release_all()
+
+    assert adapter.active_owner_count() == 0
+    assert controller.snapshot().state == "idle"
+    for name, value in vars(adapter).items():
+        if name.endswith(("_owners", "_generation")) or name == "_tokens":
+            assert not value, (name, value)
+
+
+@pytest.mark.unit
+def test_release_all_remains_reusable_but_dispose_is_terminal() -> None:
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+
+    adapter.run_state("session-a", "validating")
+    adapter.release_all()
+    assert adapter.run_state("session-a", "validating") is not None
+    adapter.dispose()
+    assert adapter.run_state("session-a", "validating") is None
+
+
+@pytest.mark.unit
+def test_expired_timed_owner_is_pruned_from_adapter_bookkeeping() -> None:
+    now = [time.monotonic()]
+    controller = PersonaBuddyController(clock=lambda: now[0])
+    adapter = PersonaBuddyConsoleAdapter(controller)
+    adapter._clock = lambda: now[0]
+    adapter.publish(
+        BuddyLifecycleEvent(
+            source="explicit",
+            owner="trusted:expiring",
+            state="thinking",
+            expires_at=now[0] + 10.0,
+        )
+    )
+    assert adapter.active_owner_count() == 1
+
+    now[0] += 11.0
+
+    assert adapter.active_owner_count() == 0
+    assert adapter._tokens == {}

--- a/Tests/Persona_Buddy/test_persona_buddy_controller.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_controller.py
@@ -120,6 +120,27 @@ def test_timed_custom_state_expires() -> None:
         )
 
 
+def test_expiration_does_not_promote_operational_priority() -> None:
+    controller = PersonaBuddyController(clock=lambda: 100.0)
+    authored = controller.set_authored_trigger(owner="pack", state="mood_calm")
+    controller.acquire_state(
+        source="tool",
+        owner="call",
+        state="tool_running",
+        expires_at=200.0,
+    )
+    controller.acquire_state(
+        source="network",
+        owner="profile",
+        state="offline",
+        expires_at=200.0,
+    )
+
+    assert controller.snapshot().state == "mood_calm"
+    assert controller.release_state(token=authored) is True
+    assert controller.snapshot().state == "tool_running"
+
+
 def test_selection_never_changes_from_observed_persona() -> None:
     controller = PersonaBuddyController()
     selected_generation = controller.select_local_persona("p-1")

--- a/Tests/Persona_Buddy/test_persona_buddy_controller.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_controller.py
@@ -1,0 +1,136 @@
+"""Pure state and ownership contracts for the app-owned Persona Buddy."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+from tldw_chatbook.Persona_Buddy.preferences import PersonaBuddySelection
+
+
+def test_priority_is_exact_for_overlapping_sources() -> None:
+    controller = PersonaBuddyController()
+    offline = controller.acquire_state(
+        source="network", owner="profile", state="offline"
+    )
+    live_idle = controller.acquire_state(source="voice", owner="session", state="idle")
+    wake = controller.acquire_state(source="wake", owner="listener", state="wake_armed")
+    live = controller.acquire_state(source="voice", owner="turn", state="speaking")
+    tool = controller.acquire_state(
+        source="tool", owner="run:call", state="tool_running"
+    )
+    authored = controller.set_authored_trigger(
+        owner="pack:trigger", state="reaction:happy"
+    )
+    timed = controller.set_timed_state(
+        owner="explicit:preview", state="preview_pose", ttl_seconds=60
+    )
+    approval = controller.acquire_state(
+        source="approval", owner="session:round", state="approval_needed"
+    )
+    error = controller.acquire_state(
+        source="runtime", owner="session:error", state="error"
+    )
+
+    assert controller.snapshot().state == "error"
+    assert controller.release_state(token=error) is True
+    assert controller.snapshot().state == "approval_needed"
+    assert controller.release_state(token=approval) is True
+    assert controller.snapshot().state == "preview_pose"
+    assert controller.release_state(token=timed) is True
+    assert controller.snapshot().state == "reaction:happy"
+    assert controller.release_state(token=authored) is True
+    assert controller.snapshot().state == "tool_running"
+    assert controller.release_state(token=tool) is True
+    assert controller.snapshot().state == "speaking"
+    assert controller.release_state(token=live) is True
+    assert controller.snapshot().state == "wake_armed"
+    assert controller.release_state(token=wake) is True
+    assert controller.snapshot().state == "idle"
+    assert controller.release_state(token=live_idle) is True
+    assert controller.snapshot().state == "offline"
+    assert controller.release_state(token=offline) is True
+    assert controller.snapshot().state == "idle"
+
+
+def test_release_requires_exact_source_owner() -> None:
+    controller = PersonaBuddyController()
+    first = controller.acquire_state(
+        source="approval", owner="session:first", state="approval_needed"
+    )
+    stale = controller.acquire_state(
+        source="approval", owner="session:second", state="approval_needed"
+    )
+
+    assert controller.release_state(source="approval", owner="session:wrong") is False
+    assert controller.release_state(token=first) is True
+    assert controller.snapshot().state == "approval_needed"
+
+    replacement = controller.acquire_state(
+        source="approval", owner="session:second", state="approval_needed"
+    )
+    assert replacement != stale
+    assert controller.release_state(token=stale) is False
+    assert controller.snapshot().state == "approval_needed"
+    assert controller.release_state(source="approval", owner="session:second") is True
+    assert controller.snapshot().state == "idle"
+
+
+def test_wake_armed_yields_to_non_idle_live_voice() -> None:
+    controller = PersonaBuddyController()
+    wake = controller.acquire_state(source="wake", owner="listener", state="wake_armed")
+    idle = controller.acquire_state(source="voice", owner="idle", state="idle")
+
+    assert controller.snapshot().state == "wake_armed"
+
+    listening = controller.acquire_state(
+        source="voice", owner="turn", state="listening"
+    )
+    assert controller.snapshot().state == "listening"
+    assert controller.release_state(token=listening) is True
+    assert controller.snapshot().state == "wake_armed"
+
+    assert controller.release_state(token=idle) is True
+    assert controller.release_state(token=wake) is True
+
+
+def test_timed_custom_state_expires() -> None:
+    now = [100.0]
+    controller = PersonaBuddyController(clock=lambda: now[0])
+
+    token = controller.set_timed_state(
+        owner="preview", state="mood_calm", ttl_seconds=2.0
+    )
+
+    active = controller.snapshot()
+    assert active.state == "mood_calm"
+    assert not hasattr(active, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        active.state = "idle"  # type: ignore[misc]
+
+    now[0] = 102.0
+    assert controller.snapshot().state == "idle"
+    assert controller.release_state(token=token) is False
+
+    with pytest.raises(ValueError, match="^persona_buddy_state_invalid$"):
+        controller.set_timed_state(
+            owner="preview", state="file:private", ttl_seconds=1.0
+        )
+
+
+def test_selection_never_changes_from_observed_persona() -> None:
+    controller = PersonaBuddyController()
+    selected_generation = controller.select_local_persona("p-1")
+
+    assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")
+    assert (
+        controller.observe_persona(source="workbench", persona_id="p-2")
+        == selected_generation
+    )
+    assert (
+        controller.observe_persona(source="console", persona_id="p-3")
+        == selected_generation
+    )
+    assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")

--- a/Tests/Persona_Buddy/test_persona_buddy_controller.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_controller.py
@@ -7,7 +7,11 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
-from tldw_chatbook.Persona_Buddy.preferences import PersonaBuddySelection
+from tldw_chatbook.Persona_Buddy.preferences import (
+    PersonaBuddyGeometry,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+)
 
 
 def test_priority_is_exact_for_overlapping_sources() -> None:
@@ -208,6 +212,19 @@ def test_selection_never_changes_from_observed_persona() -> None:
         == selected_generation
     )
     assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")
+
+
+def test_current_preferences_returns_exact_immutable_snapshot() -> None:
+    preferences = PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "p-1"),
+        collapsed=True,
+        geometry=PersonaBuddyGeometry(x=7, y=3, width=31, height=14),
+    )
+    controller = PersonaBuddyController(preferences=preferences)
+
+    assert controller.current_preferences() is preferences
+    assert controller.current_preferences() == preferences
 
 
 @pytest.mark.parametrize("contract_name", ("lease_token", "snapshot"))

--- a/Tests/Persona_Buddy/test_persona_buddy_controller.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_controller.py
@@ -141,6 +141,59 @@ def test_expiration_does_not_promote_operational_priority() -> None:
     assert controller.snapshot().state == "tool_running"
 
 
+def test_indefinite_explicit_custom_state_is_rejected() -> None:
+    controller = PersonaBuddyController(clock=lambda: 100.0)
+
+    with pytest.raises(ValueError, match="^persona_buddy_state_invalid$"):
+        controller.acquire_state(
+            source="explicit",
+            owner="preview",
+            state="mood_calm",
+        )
+
+
+def test_arbitrary_source_custom_state_is_rejected() -> None:
+    controller = PersonaBuddyController(clock=lambda: 100.0)
+
+    with pytest.raises(ValueError, match="^persona_buddy_state_invalid$"):
+        controller.acquire_state(
+            source="authroed",
+            owner="pack",
+            state="mood_calm",
+            expires_at=200.0,
+        )
+
+
+@pytest.mark.parametrize("expires_at", (float("nan"), float("inf"), 100.0, 99.0))
+def test_explicit_custom_state_requires_finite_future_expiry(
+    expires_at: float,
+) -> None:
+    controller = PersonaBuddyController(clock=lambda: 100.0)
+
+    with pytest.raises(ValueError, match="^persona_buddy_state_invalid$"):
+        controller.acquire_state(
+            source="explicit",
+            owner="preview",
+            state="mood_calm",
+            expires_at=expires_at,
+        )
+
+
+def test_authored_and_explicit_timed_custom_states_are_valid() -> None:
+    controller = PersonaBuddyController(clock=lambda: 100.0)
+    authored = controller.set_authored_trigger(owner="pack", state="mood_calm")
+    explicit = controller.acquire_state(
+        source="explicit",
+        owner="preview",
+        state="reaction:happy",
+        expires_at=101.0,
+    )
+
+    assert authored.state == "mood_calm"
+    assert explicit.state == "reaction:happy"
+    assert controller.snapshot().state == "reaction:happy"
+
+
 def test_selection_never_changes_from_observed_persona() -> None:
     controller = PersonaBuddyController()
     selected_generation = controller.select_local_persona("p-1")
@@ -155,3 +208,18 @@ def test_selection_never_changes_from_observed_persona() -> None:
         == selected_generation
     )
     assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")
+
+
+@pytest.mark.parametrize("contract_name", ("lease_token", "snapshot"))
+def test_controller_public_contracts_are_exactly_frozen_and_slotted(
+    contract_name: str,
+) -> None:
+    controller = PersonaBuddyController()
+    token = controller.acquire_state(source="tool", owner="call", state="tool_running")
+    value = token if contract_name == "lease_token" else controller.snapshot()
+
+    assert type(value).__dataclass_params__.frozen is True
+    assert "__slots__" in vars(type(value))
+    assert not hasattr(value, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        value.state = "idle"  # type: ignore[misc]

--- a/Tests/Persona_Buddy/test_persona_buddy_preferences.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_preferences.py
@@ -147,7 +147,10 @@ def test_preference_failure_is_path_free(
         assert persona_id not in repr(preferences)
 
     messages: list[str] = []
-    sink = logger.add(messages.append, format="{message}")
+    sink = logger.add(
+        messages.append,
+        format="{message} exception_type={extra[exception_type]}",
+    )
     try:
 
         def fail(_section_values: object) -> bool:
@@ -186,6 +189,36 @@ def test_preferences_require_exact_string_local_source() -> None:
     assert preferences.selection is None
     with pytest.raises(ValueError, match="^persona_buddy_preferences_invalid$"):
         PersonaBuddySelection(source, "p-1")  # type: ignore[arg-type]
+
+
+def test_preference_failure_normalizes_unsafe_exception_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unsafe_error = type("/private/profile/SecretError", (RuntimeError,), {})
+
+    def fail(_section_values: object) -> bool:
+        raise unsafe_error("/private/profile/config.toml")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Persona_Buddy.preferences.save_settings_to_cli_config",
+        fail,
+    )
+    messages: list[str] = []
+    sink = logger.add(
+        messages.append,
+        format="{message} exception_type={extra[exception_type]}",
+    )
+    try:
+        assert persist_persona_buddy_preferences(PersonaBuddyPreferences()) is False
+    finally:
+        logger.remove(sink)
+
+    rendered = "".join(messages)
+    assert (
+        rendered.strip()
+        == "persona_buddy_preferences_save_failed exception_type=Exception"
+    )
+    assert "/private/" not in rendered
 
 
 def test_never_positioned_geometry_is_distinct_from_persisted_top_left() -> None:

--- a/Tests/Persona_Buddy/test_persona_buddy_preferences.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_preferences.py
@@ -162,7 +162,10 @@ def test_preference_failure_is_path_free(
         logger.remove(sink)
 
     rendered = "".join(messages)
-    assert rendered.strip() == "persona_buddy_preferences_save_failed"
+    assert (
+        rendered.strip()
+        == "persona_buddy_preferences_save_failed exception_type=RuntimeError"
+    )
     assert "/private/" not in rendered
 
 

--- a/Tests/Persona_Buddy/test_persona_buddy_preferences.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_preferences.py
@@ -1,0 +1,163 @@
+"""Strict, profile-local Persona Buddy preference contracts."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from loguru import logger
+
+from tldw_chatbook.Persona_Buddy.preferences import (
+    PersonaBuddyGeometry,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+    parse_persona_buddy_preferences,
+    persist_persona_buddy_preferences,
+    serialize_persona_buddy_preferences,
+)
+
+
+def test_preferences_default_off_without_selection() -> None:
+    preferences = parse_persona_buddy_preferences({})
+
+    assert preferences == PersonaBuddyPreferences()
+    assert preferences.enabled is False
+    assert preferences.selection is None
+    assert preferences.open is True
+    assert preferences.collapsed is False
+    assert not hasattr(preferences, "__dict__")
+
+    with pytest.raises(FrozenInstanceError):
+        preferences.enabled = True  # type: ignore[misc]
+
+
+def test_preferences_round_trip_exact_local_selection_and_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = {
+        "enabled": True,
+        "source": "local",
+        "local_persona_id": "p-1",
+        "open": False,
+        "collapsed": True,
+        "x": 9,
+        "y": 4,
+        "width": 28,
+        "height": 12,
+    }
+
+    preferences = parse_persona_buddy_preferences(raw)
+
+    assert preferences.selection == PersonaBuddySelection("local", "p-1")
+    assert preferences.geometry == PersonaBuddyGeometry(9, 4, 28, 12)
+    assert serialize_persona_buddy_preferences(preferences) == raw
+    assert (
+        parse_persona_buddy_preferences(
+            serialize_persona_buddy_preferences(preferences)
+        )
+        == preferences
+    )
+
+    saved: list[dict[str, object]] = []
+
+    def save(section_values: dict[str, object]) -> bool:
+        saved.append(section_values)
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Persona_Buddy.preferences.save_settings_to_cli_config",
+        save,
+    )
+
+    assert persist_persona_buddy_preferences(preferences) is True
+    assert saved == [{"persona_buddy": raw}]
+
+
+@pytest.mark.parametrize(
+    ("field", "malformed", "expected_attribute", "expected_value"),
+    (
+        ("enabled", "yes", "enabled", False),
+        ("open", 1, "open", True),
+        ("collapsed", None, "collapsed", False),
+        ("x", True, "geometry", PersonaBuddyGeometry(0, 4, 36, 16)),
+        ("y", -1, "geometry", PersonaBuddyGeometry(9, 0, 36, 16)),
+        ("width", False, "geometry", PersonaBuddyGeometry(9, 4, 28, 16)),
+        ("height", 0, "geometry", PersonaBuddyGeometry(9, 4, 36, 12)),
+    ),
+)
+def test_preferences_reject_malformed_fields_independently(
+    field: str,
+    malformed: object,
+    expected_attribute: str,
+    expected_value: object,
+) -> None:
+    valid: dict[str, object] = {
+        "enabled": True,
+        "source": "local",
+        "local_persona_id": "p-1",
+        "open": False,
+        "collapsed": True,
+        "x": 9,
+        "y": 4,
+        "width": 36,
+        "height": 16,
+    }
+    valid[field] = malformed
+
+    preferences = parse_persona_buddy_preferences(valid)
+
+    assert getattr(preferences, expected_attribute) == expected_value
+    for unaffected_field, expected in {
+        "enabled": True,
+        "open": False,
+        "collapsed": True,
+    }.items():
+        if field != unaffected_field:
+            assert getattr(preferences, unaffected_field) is expected
+
+
+@pytest.mark.parametrize(
+    ("source", "persona_id"),
+    (
+        ("server", "p-1"),
+        ("local", ""),
+        ("local", "contains\x00control"),
+        ("local", "x" * 129),
+        ("local", "/private/profile/persona.json"),
+    ),
+)
+def test_preference_failure_is_path_free(
+    source: str,
+    persona_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preferences = parse_persona_buddy_preferences(
+        {
+            "enabled": True,
+            "source": source,
+            "local_persona_id": persona_id,
+        }
+    )
+
+    assert preferences.selection is None
+    if persona_id:
+        assert persona_id not in repr(preferences)
+
+    messages: list[str] = []
+    sink = logger.add(messages.append, format="{message}")
+    try:
+
+        def fail(_section_values: object) -> bool:
+            raise RuntimeError("/private/profile/config.toml")
+
+        monkeypatch.setattr(
+            "tldw_chatbook.Persona_Buddy.preferences.save_settings_to_cli_config",
+            fail,
+        )
+        assert persist_persona_buddy_preferences(preferences) is False
+    finally:
+        logger.remove(sink)
+
+    rendered = "".join(messages)
+    assert rendered.strip() == "persona_buddy_preferences_save_failed"
+    assert "/private/" not in rendered

--- a/Tests/Persona_Buddy/test_persona_buddy_preferences.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_preferences.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import tomllib
 from dataclasses import FrozenInstanceError
+from pathlib import Path
 
 import pytest
 from loguru import logger
@@ -25,6 +27,7 @@ def test_preferences_default_off_without_selection() -> None:
     assert preferences.selection is None
     assert preferences.open is True
     assert preferences.collapsed is False
+    assert preferences.geometry == PersonaBuddyGeometry(1_000_000, 1_000_000, 28, 12)
     assert not hasattr(preferences, "__dict__")
 
     with pytest.raises(FrozenInstanceError):
@@ -79,8 +82,8 @@ def test_preferences_round_trip_exact_local_selection_and_geometry(
         ("enabled", "yes", "enabled", False),
         ("open", 1, "open", True),
         ("collapsed", None, "collapsed", False),
-        ("x", True, "geometry", PersonaBuddyGeometry(0, 4, 36, 16)),
-        ("y", -1, "geometry", PersonaBuddyGeometry(9, 0, 36, 16)),
+        ("x", True, "geometry", PersonaBuddyGeometry(1_000_000, 4, 36, 16)),
+        ("y", -1, "geometry", PersonaBuddyGeometry(9, 1_000_000, 36, 16)),
         ("width", False, "geometry", PersonaBuddyGeometry(9, 4, 28, 16)),
         ("height", 0, "geometry", PersonaBuddyGeometry(9, 4, 36, 12)),
     ),
@@ -180,3 +183,66 @@ def test_preferences_require_exact_string_local_source() -> None:
     assert preferences.selection is None
     with pytest.raises(ValueError, match="^persona_buddy_preferences_invalid$"):
         PersonaBuddySelection(source, "p-1")  # type: ignore[arg-type]
+
+
+def test_never_positioned_geometry_is_distinct_from_persisted_top_left() -> None:
+    from tldw_chatbook.Persona_Buddy import preferences as preference_module
+
+    sentinel = preference_module.PERSONA_BUDDY_UNPOSITIONED_COORDINATE
+    defaults = parse_persona_buddy_preferences({})
+    top_left = parse_persona_buddy_preferences({"x": 0, "y": 0})
+
+    assert sentinel == 1_000_000
+    assert defaults.geometry == PersonaBuddyGeometry(sentinel, sentinel, 28, 12)
+    assert serialize_persona_buddy_preferences(defaults)["x"] == sentinel
+    assert serialize_persona_buddy_preferences(defaults)["y"] == sentinel
+    assert top_left.geometry == PersonaBuddyGeometry(0, 0, 28, 12)
+    assert (
+        parse_persona_buddy_preferences(
+            serialize_persona_buddy_preferences(top_left)
+        ).geometry
+        == top_left.geometry
+    )
+
+
+def test_preferences_persist_through_real_incumbent_config_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "isolated" / "config.toml"
+    config_path.parent.mkdir(mode=0o700)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    preferences = parse_persona_buddy_preferences(
+        {
+            "enabled": True,
+            "source": "local",
+            "local_persona_id": "p-real",
+            "x": 0,
+            "y": 0,
+        }
+    )
+
+    assert persist_persona_buddy_preferences(preferences) is True
+
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))["persona_buddy"]
+    assert saved == serialize_persona_buddy_preferences(preferences)
+
+
+@pytest.mark.parametrize(
+    ("value", "field_name", "replacement"),
+    (
+        (PersonaBuddySelection("local", "p-1"), "local_persona_id", "p-2"),
+        (PersonaBuddyGeometry(1, 2, 28, 12), "x", 3),
+        (PersonaBuddyPreferences(), "enabled", True),
+    ),
+)
+def test_preference_public_contracts_are_exactly_frozen_and_slotted(
+    value: object,
+    field_name: str,
+    replacement: object,
+) -> None:
+    assert type(value).__dataclass_params__.frozen is True
+    assert "__slots__" in vars(type(value))
+    assert not hasattr(value, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        setattr(value, field_name, replacement)

--- a/Tests/Persona_Buddy/test_persona_buddy_preferences.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_preferences.py
@@ -161,3 +161,22 @@ def test_preference_failure_is_path_free(
     rendered = "".join(messages)
     assert rendered.strip() == "persona_buddy_preferences_save_failed"
     assert "/private/" not in rendered
+
+
+def test_preferences_require_exact_string_local_source() -> None:
+    class SpoofedLocal:
+        def __eq__(self, other: object) -> bool:
+            return other == "local"
+
+        def __repr__(self) -> str:
+            return "/private/profile/spoofed-source"
+
+    source = SpoofedLocal()
+
+    preferences = parse_persona_buddy_preferences(
+        {"source": source, "local_persona_id": "p-1"}
+    )
+
+    assert preferences.selection is None
+    with pytest.raises(ValueError, match="^persona_buddy_preferences_invalid$"):
+        PersonaBuddySelection(source, "p-1")  # type: ignore[arg-type]

--- a/Tests/Persona_Buddy/test_persona_buddy_resolution.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_resolution.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import json
 import threading
+from functools import partial
 from io import BytesIO
 from pathlib import Path
 
@@ -20,6 +21,7 @@ from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.Persona_Buddy.controller import (
     BuddyDrainResult,
     PersonaBuddyController,
+    load_local_persona_portrait,
 )
 from tldw_chatbook.Persona_Buddy.preferences import (
     PersonaBuddyPreferences,
@@ -93,7 +95,13 @@ def _manifest() -> dict[str, object]:
     }
 
 
-def _write_personas(path: Path, *, active: bool = True, deleted: bool = False) -> None:
+def _write_personas(
+    path: Path,
+    *,
+    active: bool = True,
+    deleted: bool = False,
+    character_card_id: int | None = None,
+) -> None:
     path.write_text(
         json.dumps(
             {
@@ -104,6 +112,7 @@ def _write_personas(path: Path, *, active: bool = True, deleted: bool = False) -
                         "is_active": active,
                         "deleted": deleted,
                         "version": 7,
+                        "character_card_id": character_card_id,
                     }
                 ]
             }
@@ -281,6 +290,137 @@ async def test_state_idle_portrait_fallback_never_blanks(tmp_path: Path) -> None
     assert fallback.frames[0].cells
     assert fallback.cache_identity is not None
     assert fallback.cache_identity.portrait_id == "local-portrait"
+
+
+@pytest.mark.asyncio
+async def test_production_local_persona_portrait_loader_uses_linked_character_blob(
+    tmp_path: Path,
+) -> None:
+    seeded, db, _graph = _runtime(tmp_path)
+    await seeded.shutdown()
+    portrait = _png((45, 90, 180, 255))
+    character_id = db.add_character_card(
+        {"name": "Linked portrait", "description": "", "image": portrait}
+    )
+    assert type(character_id) is int
+    persona_path = tmp_path / "profile/personas.json"
+    _write_personas(persona_path, character_card_id=character_id)
+    service = LocalCharacterPersonaService(db, persona_store_path=persona_path)
+    event_loop_thread = threading.get_ident()
+    portrait_threads: list[int] = []
+    get_character = service.get_character
+
+    def tracked_get_character(linked_character_id: int) -> object:
+        portrait_threads.append(threading.get_ident())
+        return get_character(linked_character_id)
+
+    linked = get_character(character_id)
+    service.get_character = tracked_get_character  # type: ignore[method-assign]
+    controller = PersonaBuddyController(
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "persona-local-1"),
+        ),
+        local_persona_service=service,
+        profile_db=db,
+        profile_root=tmp_path / "profile",
+        portrait_loader=partial(load_local_persona_portrait, service),
+    )
+    (tmp_path / "profile/persona_visual/buddy/v1/idle.png").write_bytes(b"broken")
+    try:
+        fallback = await controller.resolve_current_visual(cols=20, lines=8)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert fallback.available is True
+    assert fallback.source == "persona_portrait"
+    assert fallback.cache_identity is not None
+    assert fallback.cache_identity.portrait_id == f"local-character:{character_id}"
+    assert fallback.cache_identity.portrait_revision == linked["version"]
+    assert (
+        fallback.cache_identity.portrait_sha256 == hashlib.sha256(portrait).hexdigest()
+    )
+    assert portrait_threads
+    assert all(thread_id != event_loop_thread for thread_id in portrait_threads)
+
+
+def test_production_portrait_loader_rejects_path_text_without_exposing_it() -> None:
+    marker = "/private/persona-portrait-marker.png"
+
+    class HostileService:
+        def get_character(self, _character_id: int) -> dict[str, object]:
+            return {"id": 7, "version": 1, "image": marker}
+
+    portrait = load_local_persona_portrait(HostileService(), {"character_card_id": 7})
+
+    assert portrait is None
+    assert marker not in repr(portrait)
+
+
+@pytest.mark.asyncio
+async def test_invalid_production_portrait_has_fixed_path_free_failure(
+    tmp_path: Path,
+) -> None:
+    marker = "/private/persona-portrait-marker.png"
+    controller, db, _graph = _runtime(tmp_path)
+
+    class HostileService:
+        def get_persona_profile(self, persona_id: str) -> dict[str, object]:
+            return {
+                "id": persona_id,
+                "version": 7,
+                "is_active": True,
+                "deleted": False,
+                "character_card_id": 7,
+            }
+
+        def get_character(self, _character_id: int) -> dict[str, object]:
+            return {"id": 7, "version": 1, "image": marker}
+
+    service = HostileService()
+    controller._local_persona_service = service
+    controller._portrait_loader = partial(load_local_persona_portrait, service)
+    (tmp_path / "profile/persona_visual/buddy/v1/idle.png").write_bytes(b"broken")
+    try:
+        fallback = await controller.resolve_current_visual(cols=20, lines=8)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert fallback.available is False
+    assert fallback.reason == "persona_buddy_frame_unavailable"
+    assert marker not in repr(fallback)
+
+
+@pytest.mark.parametrize(
+    "stage",
+    ("_read_local_persona", "_read_graph", "_resolve_runtime", "_prepare_resolution"),
+)
+@pytest.mark.asyncio
+async def test_each_resolution_stage_runs_off_event_loop_thread(
+    tmp_path: Path,
+    stage: str,
+) -> None:
+    controller, db, _graph = _runtime(tmp_path)
+    event_loop_thread = threading.get_ident()
+    observed_threads: list[int] = []
+    original = getattr(controller, stage)
+
+    def tracked(*args: object) -> object:
+        observed_threads.append(threading.get_ident())
+        return original(*args)
+
+    setattr(controller, stage, tracked)
+    try:
+        visual = await controller.resolve_current_visual(cols=20, lines=8)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert visual.available is True
+    assert observed_threads
+    assert all(thread_id != event_loop_thread for thread_id in observed_threads)
 
 
 def _resolved_frame(
@@ -545,7 +685,21 @@ async def test_repeated_cancel_drains_before_next_owner() -> None:
     first = asyncio.create_task(controller.run_serialized(blocking, name="first"))
     assert await asyncio.to_thread(entered.wait, 2)
     first.cancel()
+    await asyncio.sleep(0)
+    assert first.cancelling() == 1
+    assert not first.done()
+    assert any(
+        task.get_name() == "persona-buddy:first:thread" and not task.done()
+        for task in controller._owned_tasks
+    )
     first.cancel()
+    await asyncio.sleep(0)
+    assert first.cancelling() == 2
+    assert not first.done()
+    first.cancel()
+    await asyncio.sleep(0)
+    assert first.cancelling() == 3
+    assert not first.done()
     second = asyncio.create_task(
         controller.run_serialized(lambda: order.append("second"), name="second")
     )

--- a/Tests/Persona_Buddy/test_persona_buddy_resolution.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_resolution.py
@@ -28,6 +28,7 @@ from tldw_chatbook.Persona_Buddy.controller import (
     load_local_persona_portrait,
 )
 from tldw_chatbook.Persona_Buddy.preferences import (
+    PersonaBuddyGeometry,
     PersonaBuddyPreferences,
     PersonaBuddySelection,
 )
@@ -1008,6 +1009,141 @@ async def test_superseded_preference_commit_reconciles_persisted_and_live_state(
     assert result.selection == reconciled.selection
     assert result.enabled == reconciled.enabled
     assert controller.snapshot().selection == reconciled.selection
+    await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_preference_patch_is_immediate_before_slow_persistence() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    def writer(_preferences: PersonaBuddyPreferences) -> bool:
+        entered.set()
+        release.wait(2)
+        return True
+
+    controller = PersonaBuddyController(
+        preferences=PersonaBuddyPreferences(open=True),
+        preference_writer=writer,
+    )
+    revision = controller.apply_preferences_patch(open=False)
+    operation = asyncio.create_task(
+        controller.persist_preferences_revision(revision)
+    )
+
+    assert controller.current_preferences().open is False
+    assert await asyncio.to_thread(entered.wait, 2)
+    assert controller.current_preferences().open is False
+    release.set()
+    await operation
+    await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_stale_geometry_persistence_cannot_resurrect_blocked_close() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    persisted: list[PersonaBuddyPreferences] = []
+
+    def writer(preferences: PersonaBuddyPreferences) -> bool:
+        if not persisted:
+            entered.set()
+            release.wait(2)
+        persisted.append(preferences)
+        return True
+
+    initial = PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "persona-local-1"),
+    )
+    controller = PersonaBuddyController(
+        preferences=initial,
+        preference_writer=writer,
+    )
+    close_revision = controller.apply_preferences_patch(open=False)
+    close = asyncio.create_task(
+        controller.persist_preferences_revision(close_revision)
+    )
+    assert await asyncio.to_thread(entered.wait, 2)
+
+    moved = PersonaBuddyGeometry(x=3, y=4, width=24, height=10)
+    geometry_revision = controller.apply_preferences_patch(geometry=moved)
+    geometry = asyncio.create_task(
+        controller.persist_preferences_revision(geometry_revision)
+    )
+    assert controller.current_preferences().open is False
+    assert controller.current_preferences().geometry == moved
+
+    release.set()
+    await asyncio.gather(close, geometry)
+
+    assert len(persisted) == 2
+    assert persisted[-1].open is False
+    assert persisted[-1].geometry == moved
+    assert controller.current_preferences() == persisted[-1]
+    await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_failed_patch_write_reports_failure_without_rolling_back_intent() -> None:
+    persisted: list[PersonaBuddyPreferences] = []
+
+    def writer(preferences: PersonaBuddyPreferences) -> bool:
+        persisted.append(preferences)
+        return False
+
+    controller = PersonaBuddyController(
+        preferences=PersonaBuddyPreferences(open=True),
+        preference_writer=writer,
+    )
+    revision = controller.apply_preferences_patch(open=False)
+
+    result = await controller.persist_preferences_revision(revision)
+
+    assert result is False
+    assert persisted == [controller.current_preferences()]
+    assert controller.current_preferences().open is False
+    await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_patch_write_drains_without_resurrecting_newer_fields() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    persisted: list[PersonaBuddyPreferences] = []
+
+    def writer(preferences: PersonaBuddyPreferences) -> bool:
+        if not persisted:
+            entered.set()
+            release.wait(2)
+        persisted.append(preferences)
+        return True
+
+    controller = PersonaBuddyController(
+        preferences=PersonaBuddyPreferences(open=True),
+        preference_writer=writer,
+    )
+    close_revision = controller.apply_preferences_patch(open=False)
+    close = asyncio.create_task(controller.persist_preferences_revision(close_revision))
+    assert await asyncio.to_thread(entered.wait, 2)
+    close.cancel()
+
+    moved = PersonaBuddyGeometry(x=6, y=2, width=25, height=9)
+    geometry_revision = controller.apply_preferences_patch(geometry=moved)
+    geometry = asyncio.create_task(
+        controller.persist_preferences_revision(geometry_revision)
+    )
+    assert not geometry.done()
+    assert controller.current_preferences().open is False
+    assert controller.current_preferences().geometry == moved
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await close
+    assert await geometry is True
+    assert persisted[-1] == controller.current_preferences()
+    assert persisted[-1].open is False
+    assert persisted[-1].geometry == moved
     await controller.shutdown()
 
 

--- a/Tests/Persona_Buddy/test_persona_buddy_resolution.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_resolution.py
@@ -1027,9 +1027,7 @@ async def test_preference_patch_is_immediate_before_slow_persistence() -> None:
         preference_writer=writer,
     )
     revision = controller.apply_preferences_patch(open=False)
-    operation = asyncio.create_task(
-        controller.persist_preferences_revision(revision)
-    )
+    operation = asyncio.create_task(controller.persist_preferences_revision(revision))
 
     assert controller.current_preferences().open is False
     assert await asyncio.to_thread(entered.wait, 2)
@@ -1061,9 +1059,7 @@ async def test_stale_geometry_persistence_cannot_resurrect_blocked_close() -> No
         preference_writer=writer,
     )
     close_revision = controller.apply_preferences_patch(open=False)
-    close = asyncio.create_task(
-        controller.persist_preferences_revision(close_revision)
-    )
+    close = asyncio.create_task(controller.persist_preferences_revision(close_revision))
     assert await asyncio.to_thread(entered.wait, 2)
 
     moved = PersonaBuddyGeometry(x=3, y=4, width=24, height=10)

--- a/Tests/Persona_Buddy/test_persona_buddy_resolution.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_resolution.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import json
 import threading
+from dataclasses import replace
 from functools import partial
 from io import BytesIO
 from pathlib import Path
@@ -14,6 +15,7 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+import tldw_chatbook.Persona_Buddy.controller as buddy_controller_module
 from tldw_chatbook.Character_Chat.local_character_persona_service import (
     LocalCharacterPersonaService,
 )
@@ -36,6 +38,7 @@ from tldw_chatbook.Persona_Visual.runtime import (
     PersonaVisualCacheAsset,
     PersonaVisualCacheIdentity,
     PersonaVisualPortrait,
+    PersonaVisualResolution,
     PersonaVisualResolvedFrame,
 )
 
@@ -287,7 +290,7 @@ async def test_state_idle_portrait_fallback_never_blanks(tmp_path: Path) -> None
     assert fallback.available is True
     assert fallback.source == "persona_portrait"
     assert fallback.requested_state == "idle"
-    assert fallback.frames[0].cells
+    assert fallback.frames[0].paint_digest
     assert fallback.cache_identity is not None
     assert fallback.cache_identity.portrait_id == "local-portrait"
 
@@ -469,8 +472,8 @@ def test_sprite_frames_prepare_distinct_painted_frames() -> None:
         lines=4,
     )
 
-    assert first.cells and second.cells
-    assert first.cells != second.cells
+    assert first.paint_digest and second.paint_digest
+    assert first.paint_digest != second.paint_digest
     assert first.selected_frame == 0
     assert second.selected_frame == 1
 
@@ -510,6 +513,139 @@ async def test_decode_failure_keeps_previous_or_portrait_frame(tmp_path: Path) -
     assert failed.reason == "persona_buddy_frame_unavailable"
 
 
+@pytest.mark.asyncio
+async def test_aggregate_frame_budget_rejects_240_large_frames_before_prepare(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, db, graph = _runtime(tmp_path)
+    assert graph is not None
+    previous = await controller.resolve_current_visual(cols=256, lines=128)
+    data = _png((80, 120, 160, 255), size=(256, 256))
+    frame = PersonaVisualResolvedFrame(
+        asset_id=999,
+        asset_key="large-repeated",
+        sha256=hashlib.sha256(data).hexdigest(),
+        data=data,
+        duration_ms=40,
+        region=None,
+        manifest_frame_index=0,
+        selected_frame=0,
+    )
+    cache_identity = PersonaVisualCacheIdentity(
+        graph=graph.identity,
+        requested_state="idle",
+        resolved_state="idle",
+        animation_id="large",
+        reduced_motion=False,
+        assets=(
+            PersonaVisualCacheAsset(
+                asset_id=frame.asset_id,
+                asset_key=frame.asset_key,
+                sha256=frame.sha256,
+                manifest_frame_index=frame.manifest_frame_index,
+                selected_frame=frame.selected_frame,
+            ),
+        ),
+    )
+    excessive = PersonaVisualResolution(
+        source="persona_visual",
+        reason=None,
+        requested_state="idle",
+        resolved_state="idle",
+        animation_id="large",
+        frames=(frame,) * 240,
+        frame_rate=25.0,
+        loop=True,
+        alignment=None,
+        animate=True,
+        static_reason=None,
+        portrait=None,
+        cache_identity=cache_identity,
+    )
+    prepare_calls = 0
+
+    def counted_prepare(*args: object, **kwargs: object) -> object:
+        nonlocal prepare_calls
+        del args, kwargs
+        prepare_calls += 1
+        if prepare_calls > 2:
+            raise AssertionError("aggregate frame budget missing")
+        return previous.frames[0]
+
+    monkeypatch.setattr(
+        buddy_controller_module, "prepare_persona_buddy_frame", counted_prepare
+    )
+    controller._resolve_runtime = lambda *_args: excessive  # type: ignore[method-assign]
+    controller.invalidate_profile()
+    try:
+        bounded = await controller.resolve_current_visual(cols=256, lines=128)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert prepare_calls == 0
+    assert bounded.frames == previous.frames
+    assert bounded.reason == "persona_buddy_frame_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_cell_budget_stops_retention_at_fixed_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, db, graph = _runtime(tmp_path)
+    assert graph is not None
+    previous = await controller.resolve_current_visual(cols=256, lines=128)
+    data = _png((30, 60, 90, 255), size=(256, 256))
+    frame = _resolved_frame(data)
+    cache_identity = replace(
+        _cache(data),
+        graph=graph.identity,
+        requested_state="idle",
+        resolved_state="idle",
+        animation_id="bounded-cells",
+    )
+    resolution = PersonaVisualResolution(
+        source="persona_visual",
+        reason=None,
+        requested_state="idle",
+        resolved_state="idle",
+        animation_id="bounded-cells",
+        frames=(frame,) * 20,
+        frame_rate=25.0,
+        loop=True,
+        alignment=None,
+        animate=True,
+        static_reason=None,
+        portrait=None,
+        cache_identity=cache_identity,
+    )
+    painted = replace(previous.frames[0], width=256, height=256)
+    prepare_calls = 0
+
+    def counted_prepare(*args: object, **kwargs: object) -> object:
+        nonlocal prepare_calls
+        del args, kwargs
+        prepare_calls += 1
+        return painted
+
+    monkeypatch.setattr(
+        buddy_controller_module, "prepare_persona_buddy_frame", counted_prepare
+    )
+    controller._resolve_runtime = lambda *_args: resolution  # type: ignore[method-assign]
+    controller.invalidate_profile()
+    try:
+        bounded = await controller.resolve_current_visual(cols=256, lines=128)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert prepare_calls == 16
+    assert bounded.frames == previous.frames
+    assert bounded.reason == "persona_buddy_frame_unavailable"
+
+
 def test_direct_decode_failure_is_path_free() -> None:
     with pytest.raises(
         PersonaBuddyFrameError, match="^persona_buddy_frame_unavailable$"
@@ -522,6 +658,21 @@ def test_direct_decode_failure_is_path_free() -> None:
         )
 
 
+def test_frame_prepare_rejects_remaining_cell_budget_before_pixels() -> None:
+    data = _png((30, 60, 90, 255))
+
+    with pytest.raises(
+        PersonaBuddyFrameError, match="^persona_buddy_frame_unavailable$"
+    ):
+        prepare_persona_buddy_frame(
+            _resolved_frame(data),
+            resolution_cache_identity=_cache(data),
+            cols=8,
+            lines=4,
+            max_cells=1,
+        )
+
+
 def test_render_snapshot_repr_is_byte_and_path_free() -> None:
     data = _png((1, 2, 3, 255))
     prepared = prepare_persona_buddy_frame(
@@ -529,7 +680,7 @@ def test_render_snapshot_repr_is_byte_and_path_free() -> None:
     )
 
     rendered = repr(prepared)
-    assert prepared.cells
+    assert prepared.paint_digest
     assert prepared.renderable is not None
     assert "renderable=" not in rendered
     assert "data=" not in rendered
@@ -738,6 +889,78 @@ async def test_preference_commit_survives_outer_cancellation() -> None:
 
     assert controller.snapshot().enabled is True
     assert controller.snapshot().selection == updated.selection
+    await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_preference_commit_ignores_unrelated_runtime_authority_changes() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    persisted: list[PersonaBuddyPreferences] = []
+
+    def writer(preferences: PersonaBuddyPreferences) -> bool:
+        entered.set()
+        release.wait(2)
+        persisted.append(preferences)
+        return True
+
+    controller = PersonaBuddyController(preference_writer=writer)
+    updated = PersonaBuddyPreferences(enabled=True)
+    operation = asyncio.create_task(controller.update_preferences(updated))
+    assert await asyncio.to_thread(entered.wait, 2)
+    lease = controller.acquire_state(source="voice", owner="turn", state="listening")
+    controller.set_viewport_generation(3)
+    controller.invalidate_profile()
+    release.set()
+    result = await operation
+
+    assert persisted == [updated]
+    assert result.enabled is True
+    assert controller.snapshot().enabled is True
+    assert controller.snapshot().state == "listening"
+    assert controller.release_state(token=lease) is True
+    await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_superseded_preference_commit_reconciles_persisted_and_live_state() -> (
+    None
+):
+    entered = threading.Event()
+    release = threading.Event()
+    persisted: list[PersonaBuddyPreferences] = []
+
+    def writer(preferences: PersonaBuddyPreferences) -> bool:
+        if not persisted:
+            entered.set()
+            release.wait(2)
+        persisted.append(preferences)
+        return True
+
+    initial = PersonaBuddyPreferences(
+        selection=PersonaBuddySelection("local", "original")
+    )
+    controller = PersonaBuddyController(
+        preferences=initial,
+        preference_writer=writer,
+    )
+    requested = PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "original"),
+    )
+    operation = asyncio.create_task(controller.update_preferences(requested))
+    assert await asyncio.to_thread(entered.wait, 2)
+    controller.select_local_persona("replacement")
+    release.set()
+    result = await operation
+
+    reconciled = PersonaBuddyPreferences(
+        selection=PersonaBuddySelection("local", "replacement")
+    )
+    assert persisted == [requested, reconciled]
+    assert result.selection == reconciled.selection
+    assert result.enabled == reconciled.enabled
+    assert controller.snapshot().selection == reconciled.selection
     await controller.shutdown()
 
 

--- a/Tests/Persona_Buddy/test_persona_buddy_resolution.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_resolution.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 from PIL import Image
+from textual.app import ComposeResult
+from textual.screen import Screen
 
 import tldw_chatbook.Persona_Buddy.controller as buddy_controller_module
 from tldw_chatbook.Character_Chat.local_character_persona_service import (
@@ -40,6 +42,10 @@ from tldw_chatbook.Persona_Visual.runtime import (
     PersonaVisualPortrait,
     PersonaVisualResolution,
     PersonaVisualResolvedFrame,
+)
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+    PersonaBuddyWidget,
 )
 
 
@@ -243,6 +249,47 @@ async def test_resolve_selected_local_persona_from_real_active_binding(
         )
         for frame in visual.frames
     )
+
+
+@pytest.mark.asyncio
+async def test_mounted_widget_resolves_real_persisted_local_persona_visual(
+    tmp_path: Path,
+) -> None:
+    controller, db, graph = _runtime(tmp_path)
+    assert graph is not None
+
+    class BuddyScreen(Screen):
+        def compose(self) -> ComposeResult:
+            yield PersonaBuddyWidget(
+                controller=controller,
+                view_generation=1,
+                reconcile=lambda: None,
+            )
+
+    class BuddyApp(ConsolidatedCSSApp):
+        CSS_PATH = BUNDLED_STYLESHEET
+
+        async def on_mount(self) -> None:
+            await self.push_screen(BuddyScreen())
+
+    app = BuddyApp()
+    try:
+        async with app.run_test(size=(80, 24)):
+            buddy = app.screen.query_one(PersonaBuddyWidget)
+            for _ in range(200):
+                visual = controller.snapshot().visual
+                if visual is not None and visual.available and visual.frames:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("mounted Buddy never resolved its visual")
+            assert buddy._snapshot.visual.frames
+            assert "Visual pending" not in "\n".join(
+                strip.text for strip in app.screen._compositor.render_strips()
+            )
+    finally:
+        await controller.shutdown()
+        db.close_connection()
 
 
 @pytest.mark.parametrize("case", ("disabled", "deleted", "missing", "unbound"))

--- a/Tests/Persona_Buddy/test_persona_buddy_resolution.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_resolution.py
@@ -1,0 +1,622 @@
+"""Async Persona Buddy resolution, rendering, and lifetime contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import threading
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tldw_chatbook.Character_Chat.local_character_persona_service import (
+    LocalCharacterPersonaService,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Persona_Buddy.controller import (
+    BuddyDrainResult,
+    PersonaBuddyController,
+)
+from tldw_chatbook.Persona_Buddy.preferences import (
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+)
+from tldw_chatbook.Persona_Buddy.rendering import (
+    PersonaBuddyFrameError,
+    prepare_persona_buddy_frame,
+)
+from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
+from tldw_chatbook.Persona_Visual.runtime import (
+    PersonaVisualCacheAsset,
+    PersonaVisualCacheIdentity,
+    PersonaVisualPortrait,
+    PersonaVisualResolvedFrame,
+)
+
+
+def _png(colour: tuple[int, int, int, int], size: tuple[int, int] = (6, 8)) -> bytes:
+    output = BytesIO()
+    Image.new("RGBA", size, colour).save(output, format="PNG")
+    return output.getvalue()
+
+
+def _gif() -> bytes:
+    output = BytesIO()
+    frames = [
+        Image.new("RGBA", (4, 4), (220, 20, 20, 255)),
+        Image.new("RGBA", (4, 4), (20, 20, 220, 255)),
+    ]
+    frames[0].save(
+        output,
+        format="GIF",
+        save_all=True,
+        append_images=frames[1:],
+        duration=80,
+        loop=0,
+    )
+    return output.getvalue()
+
+
+def _manifest() -> dict[str, object]:
+    states = {
+        "idle": {"animation_id": "idle"},
+        "wake_armed": {"animation_id": "idle"},
+        "listening": {"animation_id": "listening"},
+        "thinking": {"animation_id": "idle"},
+        "speaking": {"animation_id": "idle"},
+        "tool_running": {"animation_id": "idle"},
+        "approval_needed": {"animation_id": "idle"},
+        "error": {"animation_id": "idle"},
+        "offline": {"animation_id": "idle"},
+    }
+    return {
+        "renderer_type": "sprite_frames",
+        "manifest_version": 1,
+        "states": states,
+        "animations": {
+            "idle": {"frames": [{"asset_id": "idle"}]},
+            "listening": {
+                "frames": [
+                    {"asset_id": "listen-a", "duration_ms": 80},
+                    {"asset_id": "listen-b", "duration_ms": 120},
+                ],
+                "frame_rate": 12,
+            },
+        },
+        "fallbacks": {},
+        "state_catalog": {},
+        "authored_triggers": [],
+    }
+
+
+def _write_personas(path: Path, *, active: bool = True, deleted: bool = False) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "id": "persona-local-1",
+                        "name": "Local operator",
+                        "is_active": active,
+                        "deleted": deleted,
+                        "version": 7,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _runtime(
+    tmp_path: Path,
+    *,
+    active: bool = True,
+    deleted: bool = False,
+    bound: bool = True,
+    reduced_motion: bool = False,
+    phase_barrier=None,
+    portrait: bytes | None = None,
+) -> tuple[PersonaBuddyController, CharactersRAGDB, object | None]:
+    root = tmp_path / "profile"
+    root.mkdir()
+    persona_path = root / "personas.json"
+    _write_personas(persona_path, active=active, deleted=deleted)
+    service = LocalCharacterPersonaService(None, persona_store_path=persona_path)
+    db = CharactersRAGDB(tmp_path / "persona-visual.db", client_id="buddy-test")
+    graph = None
+    if bound:
+        assets: list[dict[str, object]] = []
+        for key, colour in (
+            ("idle", (20, 160, 80, 255)),
+            ("listen-a", (220, 20, 20, 255)),
+            ("listen-b", (20, 20, 220, 255)),
+        ):
+            data = _png(colour)
+            relpath = f"persona_visual/buddy/v1/{key}.png"
+            target = root / relpath
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(data)
+            assets.append(
+                {
+                    "asset_key": key,
+                    "role": "frame",
+                    "storage_relpath": relpath,
+                    "mime_type": "image/png",
+                    "bytes": len(data),
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "width": 6,
+                    "height": 8,
+                    "frame_count": 1,
+                    "duration_ms": None,
+                }
+            )
+        graph = PersonaVisualRepository(db).activate_new_pack(
+            persona_id="persona-local-1",
+            title="Buddy",
+            manifest=_manifest(),
+            manifest_storage_relpath="persona_visual/buddy/v1/manifest.json",
+            assets=assets,
+            expected_persona_revision=7,
+            authority_guard=lambda: True,
+        )
+    preferences = PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "persona-local-1"),
+    )
+    controller = PersonaBuddyController(
+        preferences=preferences,
+        local_persona_service=service,
+        profile_db=db,
+        profile_root=root,
+        reduced_motion=reduced_motion,
+        phase_barrier=phase_barrier,
+        portrait_loader=(
+            lambda _record: (
+                PersonaVisualPortrait(
+                    portrait_id="local-portrait",
+                    revision=7,
+                    mime_type="image/png",
+                    sha256=hashlib.sha256(portrait).hexdigest(),
+                    data=portrait,
+                )
+                if portrait is not None
+                else None
+            )
+        ),
+    )
+    return controller, db, graph
+
+
+@pytest.mark.asyncio
+async def test_resolve_selected_local_persona_from_real_active_binding(
+    tmp_path: Path,
+) -> None:
+    controller, db, graph = _runtime(tmp_path)
+    assert graph is not None
+    controller.acquire_state(source="voice", owner="turn", state="listening")
+    try:
+        visual = await controller.resolve_current_visual(cols=24, lines=10)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert visual.available is True
+    assert visual.source == "persona_visual"
+    assert visual.graph_identity == graph.identity
+    assert visual.cache_identity.graph == graph.identity
+    assert visual.cache_identity.requested_state == "listening"
+    assert visual.cache_identity.resolved_state == "listening"
+    assert visual.cache_identity.animation_id == "listening"
+    assert visual.requested_state == "listening"
+    assert visual.resolved_state == "listening"
+    assert visual.animation_id == "listening"
+    assert visual.animate is True
+    assert tuple(frame.asset_id for frame in visual.frames) == tuple(
+        asset.id for asset in graph.assets if asset.asset_key.startswith("listen-")
+    )
+    assert tuple(frame.manifest_frame_index for frame in visual.frames) == (0, 1)
+    assert tuple(frame.selected_frame for frame in visual.frames) == (0, 0)
+    assert visual.cache_identity.assets == tuple(
+        PersonaVisualCacheAsset(
+            asset_id=frame.asset_id,
+            asset_key=frame.asset_key,
+            sha256=frame.asset_sha256,
+            manifest_frame_index=frame.manifest_frame_index,
+            selected_frame=frame.selected_frame,
+        )
+        for frame in visual.frames
+    )
+
+
+@pytest.mark.parametrize("case", ("disabled", "deleted", "missing", "unbound"))
+@pytest.mark.asyncio
+async def test_disabled_deleted_missing_or_unbound_selection_preserves_enabled_but_hides(
+    tmp_path: Path,
+    case: str,
+) -> None:
+    controller, db, _graph = _runtime(
+        tmp_path,
+        active=case != "disabled",
+        deleted=case == "deleted",
+        bound=case != "unbound",
+    )
+    if case == "missing":
+        controller.select_local_persona("persona-missing")
+    try:
+        visual = await controller.resolve_current_visual(cols=20, lines=8)
+        snapshot = controller.snapshot()
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert visual.available is False
+    assert visual.frames == ()
+    assert visual.reason in {
+        "persona_buddy_persona_unavailable",
+        "persona_buddy_binding_unavailable",
+    }
+    assert snapshot.enabled is True
+    assert snapshot.selection is not None
+
+
+@pytest.mark.asyncio
+async def test_state_idle_portrait_fallback_never_blanks(tmp_path: Path) -> None:
+    portrait = _png((120, 90, 210, 255))
+    controller, db, _graph = _runtime(tmp_path, portrait=portrait)
+    (tmp_path / "profile/persona_visual/buddy/v1/idle.png").write_bytes(b"broken")
+    try:
+        fallback = await controller.resolve_current_visual(cols=20, lines=8)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert fallback.available is True
+    assert fallback.source == "persona_portrait"
+    assert fallback.requested_state == "idle"
+    assert fallback.frames[0].cells
+    assert fallback.cache_identity is not None
+    assert fallback.cache_identity.portrait_id == "local-portrait"
+
+
+def _resolved_frame(
+    data: bytes, *, selected_frame: int = 0
+) -> PersonaVisualResolvedFrame:
+    return PersonaVisualResolvedFrame(
+        asset_id=9,
+        asset_key="sprite",
+        sha256=hashlib.sha256(data).hexdigest(),
+        data=data,
+        duration_ms=80,
+        region=None,
+        manifest_frame_index=3,
+        selected_frame=selected_frame,
+    )
+
+
+def _cache(data: bytes, *, selected_frame: int = 0) -> PersonaVisualCacheIdentity:
+    return PersonaVisualCacheIdentity(
+        graph=None,
+        requested_state="listening",
+        resolved_state="listening",
+        animation_id="listen",
+        reduced_motion=False,
+        assets=(
+            PersonaVisualCacheAsset(
+                asset_id=9,
+                asset_key="sprite",
+                sha256=hashlib.sha256(data).hexdigest(),
+                manifest_frame_index=3,
+                selected_frame=selected_frame,
+            ),
+        ),
+    )
+
+
+def test_sprite_frames_prepare_distinct_painted_frames() -> None:
+    data = _gif()
+    first = prepare_persona_buddy_frame(
+        _resolved_frame(data), resolution_cache_identity=_cache(data), cols=8, lines=4
+    )
+    second = prepare_persona_buddy_frame(
+        _resolved_frame(data, selected_frame=1),
+        resolution_cache_identity=_cache(data, selected_frame=1),
+        cols=8,
+        lines=4,
+    )
+
+    assert first.cells and second.cells
+    assert first.cells != second.cells
+    assert first.selected_frame == 0
+    assert second.selected_frame == 1
+
+
+@pytest.mark.asyncio
+async def test_reduced_motion_prepares_only_frame_zero(tmp_path: Path) -> None:
+    controller, db, _graph = _runtime(tmp_path, reduced_motion=True)
+    controller.acquire_state(source="voice", owner="turn", state="listening")
+    try:
+        visual = await controller.resolve_current_visual(cols=20, lines=8)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert len(visual.frames) == 1
+    assert visual.frames[0].manifest_frame_index == 0
+    assert visual.frames[0].selected_frame == 0
+    assert visual.animate is False
+    assert visual.cache_identity.reduced_motion is True
+
+
+@pytest.mark.asyncio
+async def test_decode_failure_keeps_previous_or_portrait_frame(tmp_path: Path) -> None:
+    controller, db, _graph = _runtime(tmp_path)
+    first = await controller.resolve_current_visual(cols=20, lines=8)
+    assert first.available and first.frames
+    (tmp_path / "profile/persona_visual/buddy/v1/idle.png").write_bytes(b"broken")
+    controller.invalidate_profile()
+    try:
+        failed = await controller.resolve_current_visual(cols=20, lines=8)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert failed.available is True
+    assert failed.frames == first.frames
+    assert failed.reason == "persona_buddy_frame_unavailable"
+
+
+def test_direct_decode_failure_is_path_free() -> None:
+    with pytest.raises(
+        PersonaBuddyFrameError, match="^persona_buddy_frame_unavailable$"
+    ):
+        prepare_persona_buddy_frame(
+            _resolved_frame(b"/private/profile/not-an-image"),
+            resolution_cache_identity=_cache(b"/private/profile/not-an-image"),
+            cols=8,
+            lines=4,
+        )
+
+
+def test_render_snapshot_repr_is_byte_and_path_free() -> None:
+    data = _png((1, 2, 3, 255))
+    prepared = prepare_persona_buddy_frame(
+        _resolved_frame(data), resolution_cache_identity=_cache(data), cols=8, lines=4
+    )
+
+    rendered = repr(prepared)
+    assert prepared.cells
+    assert prepared.renderable is not None
+    assert "renderable=" not in rendered
+    assert "data=" not in rendered
+    assert "/private/" not in rendered
+    assert str(data) not in rendered
+
+
+async def _assert_stale_after_phase(tmp_path: Path, phase: str) -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    visited: list[str] = []
+
+    async def barrier(current: str) -> None:
+        visited.append(current)
+        if current == phase:
+            entered.set()
+            await release.wait()
+
+    controller, db, _graph = _runtime(tmp_path, phase_barrier=barrier)
+    downstream: list[str] = []
+    if phase == "persona_read":
+        original = controller._read_graph
+
+        def track_graph(*args: object) -> object:
+            downstream.append("graph_read")
+            return original(*args)
+
+        controller._read_graph = track_graph  # type: ignore[method-assign]
+    elif phase == "graph_read":
+        original = controller._resolve_runtime
+
+        def track_runtime(*args: object) -> object:
+            downstream.append("runtime_resolve")
+            return original(*args)  # type: ignore[arg-type]
+
+        controller._resolve_runtime = track_runtime  # type: ignore[method-assign]
+    elif phase == "runtime_resolve":
+        original = controller._prepare_resolution
+
+        def track_prepare(*args: object) -> object:
+            downstream.append("frame_prepare")
+            return original(*args)  # type: ignore[arg-type]
+
+        controller._prepare_resolution = track_prepare  # type: ignore[method-assign]
+    task = asyncio.create_task(controller.resolve_current_visual(cols=20, lines=8))
+    await asyncio.wait_for(entered.wait(), 2)
+    controller.select_local_persona("replacement")
+    release.set()
+    try:
+        result = await asyncio.wait_for(task, 2)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert result.reason == "persona_buddy_resolution_stale"
+    assert controller.snapshot().visual is None
+    ordered = ["persona_read", "graph_read", "runtime_resolve", "frame_prepare"]
+    assert visited == ordered[: ordered.index(phase) + 1]
+    assert downstream == []
+
+
+@pytest.mark.asyncio
+async def test_stale_after_persona_read_cannot_apply(tmp_path: Path) -> None:
+    await _assert_stale_after_phase(tmp_path, "persona_read")
+
+
+@pytest.mark.asyncio
+async def test_stale_after_graph_read_cannot_apply(tmp_path: Path) -> None:
+    await _assert_stale_after_phase(tmp_path, "graph_read")
+
+
+@pytest.mark.asyncio
+async def test_stale_after_runtime_resolve_cannot_apply(tmp_path: Path) -> None:
+    await _assert_stale_after_phase(tmp_path, "runtime_resolve")
+
+
+@pytest.mark.asyncio
+async def test_stale_after_frame_prepare_cannot_apply(tmp_path: Path) -> None:
+    await _assert_stale_after_phase(tmp_path, "frame_prepare")
+
+
+@pytest.mark.asyncio
+async def test_binding_version_change_between_reads_cannot_apply(
+    tmp_path: Path,
+) -> None:
+    changed = False
+    controller: PersonaBuddyController
+    db: CharactersRAGDB
+
+    async def barrier(phase: str) -> None:
+        nonlocal changed
+        if phase != "graph_read" or changed:
+            return
+        changed = True
+
+        def replace_binding_version() -> None:
+            with db.transaction():
+                db.execute_query(
+                    "UPDATE persona_visual_bindings SET version = version + 1 "
+                    "WHERE persona_id = ? AND status = 'active'",
+                    ("persona-local-1",),
+                )
+
+        await asyncio.to_thread(replace_binding_version)
+
+    controller, db, _graph = _runtime(tmp_path, phase_barrier=barrier)
+    try:
+        visual = await controller.resolve_current_visual(cols=20, lines=8)
+    finally:
+        await controller.shutdown()
+        db.close_connection()
+
+    assert changed is True
+    assert visual.available is False
+    assert visual.reason == "persona_buddy_frame_unavailable"
+    assert controller.snapshot().visual is not None
+    assert controller.snapshot().visual.available is False
+
+
+@pytest.mark.asyncio
+async def test_drain_distinguishes_successful_none_from_child_self_cancel() -> None:
+    controller = PersonaBuddyController()
+
+    async def none() -> None:
+        return None
+
+    async def child_cancel() -> None:
+        raise asyncio.CancelledError
+
+    completed = await controller._drain_owned(none(), name="none")
+    cancelled = await controller._drain_owned(child_cancel(), name="child-cancel")
+    await controller.shutdown()
+
+    assert completed == BuddyDrainResult(completed=True, value=None)
+    assert cancelled.completed is False
+    assert cancelled.error_category == "persona_buddy_operation_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancel_drains_before_next_owner() -> None:
+    controller = PersonaBuddyController()
+    entered = threading.Event()
+    release = threading.Event()
+    order: list[str] = []
+
+    def blocking() -> str:
+        order.append("first-start")
+        entered.set()
+        release.wait(2)
+        order.append("first-end")
+        return "done"
+
+    first = asyncio.create_task(controller.run_serialized(blocking, name="first"))
+    assert await asyncio.to_thread(entered.wait, 2)
+    first.cancel()
+    first.cancel()
+    second = asyncio.create_task(
+        controller.run_serialized(lambda: order.append("second"), name="second")
+    )
+    await asyncio.sleep(0)
+    assert order == ["first-start"]
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    await second
+    await controller.shutdown()
+
+    assert order == ["first-start", "first-end", "second"]
+
+
+@pytest.mark.asyncio
+async def test_preference_commit_survives_outer_cancellation() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    def writer(_preferences: PersonaBuddyPreferences) -> bool:
+        entered.set()
+        release.wait(2)
+        return True
+
+    controller = PersonaBuddyController(preference_writer=writer)
+    updated = PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "persona-local-1"),
+    )
+    operation = asyncio.create_task(controller.update_preferences(updated))
+    assert await asyncio.to_thread(entered.wait, 2)
+    operation.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await operation
+
+    assert controller.snapshot().enabled is True
+    assert controller.snapshot().selection == updated.selection
+    await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_before_profile_db_closes() -> None:
+    controller = PersonaBuddyController()
+    entered = threading.Event()
+    release = threading.Event()
+    closed = False
+
+    def blocking() -> None:
+        entered.set()
+        release.wait(2)
+        assert closed is False
+
+    operation = asyncio.create_task(
+        controller.run_serialized(blocking, name="profile-read")
+    )
+    assert await asyncio.to_thread(entered.wait, 2)
+    shutdown = asyncio.create_task(controller.shutdown())
+    await asyncio.sleep(0)
+    assert not shutdown.done()
+    closed = True
+    # This models the forbidden app ordering and must still be visible to the
+    # worker; restore ownership before releasing it.
+    closed = False
+    release.set()
+    await operation
+    await shutdown
+
+
+def test_controller_resolution_contract_has_no_textual_dependency() -> None:
+    source = inspect.getsource(PersonaBuddyController)
+    assert "textual" not in source.lower()
+    assert "screen" not in source.lower()
+    assert "widget" not in source.lower()

--- a/Tests/UI/test_console_realtime_wiring.py
+++ b/Tests/UI/test_console_realtime_wiring.py
@@ -401,6 +401,54 @@ async def _enter_live_realtime(console, pilot, rig) -> FakeRealtimeSession:
     return rig.session
 
 
+@pytest.mark.asyncio
+async def test_persona_buddy_realtime_fsm_replaces_generation_and_releases_on_exit(
+    monkeypatch,
+):
+    """Mounted realtime callbacks drive Buddy and release on exact loop exit."""
+    _patch_realtime_config(monkeypatch)
+    app = _build_test_app()
+    rig = _install_realtime_fakes(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        console.action_toggle_console_hands_free()
+        await _wait_for(lambda: console._console_realtime is not None, pilot)
+        assert app.persona_buddy_controller.snapshot().state == "offline"
+
+        await _wait_for(lambda: bool(rig.sessions), pilot)
+        session = rig.session
+        session.fire_ready()
+        await _wait_for(
+            lambda: app.persona_buddy_controller.snapshot().state == "listening",
+            pilot,
+        )
+        session.fire_turn_committed()
+        await _wait_for(
+            lambda: app.persona_buddy_controller.snapshot().state == "thinking",
+            pilot,
+        )
+        session.fire_reply_started()
+        session.fire_first_audio()
+        await _wait_for(
+            lambda: app.persona_buddy_controller.snapshot().state == "speaking",
+            pilot,
+        )
+
+        generation = console._console_realtime.buddy_generation
+        console._console_realtime_exit_loop(None)
+        await _wait_for(
+            lambda: app.persona_buddy_controller.snapshot().state == "idle", pilot
+        )
+        console.action_toggle_console_hands_free()
+        await _wait_for(lambda: console._console_realtime is not None, pilot)
+        assert console._console_realtime.buddy_generation > generation
+        assert app.persona_buddy_controller.snapshot().state == "offline"
+
+    assert app.persona_buddy_controller.snapshot().state == "idle"
+
+
 def _messages(console):
     store = console._ensure_console_chat_store()
     return store.messages_for_session(store.active_session_id)

--- a/Tests/UI/test_console_realtime_wiring.py
+++ b/Tests/UI/test_console_realtime_wiring.py
@@ -449,6 +449,50 @@ async def test_persona_buddy_realtime_fsm_replaces_generation_and_releases_on_ex
     assert app.persona_buddy_controller.snapshot().state == "idle"
 
 
+@pytest.mark.asyncio
+async def test_persona_buddy_realtime_generation_survives_screen_replacement(
+    monkeypatch,
+):
+    """A stale real screen cannot release its successor's same-session loop."""
+    _patch_realtime_config(monkeypatch)
+    app = _build_test_app()
+    _install_realtime_fakes(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        old_screen = await _mounted_console(host, pilot)
+        old_screen.action_toggle_console_hands_free()
+        await _wait_for(lambda: old_screen._console_realtime is not None, pilot)
+        old_generation = old_screen._console_realtime.buddy_generation
+
+        replacement = chat_screen_module.ChatScreen(app)
+        await host.push_screen(replacement)
+        await _wait_for(
+            lambda: replacement.query("#console-native-composer").first() is not None,
+            pilot,
+        )
+        replacement.action_toggle_console_hands_free()
+        await _wait_for(lambda: replacement._console_realtime is not None, pilot)
+        replacement_generation = replacement._console_realtime.buddy_generation
+
+        assert replacement_generation > old_generation
+        assert app.persona_buddy_controller.snapshot().state == "offline"
+
+        old_screen._release_console_realtime_state()
+        assert app.persona_buddy_controller.snapshot().state == "offline"
+        assert (
+            replacement._console_runtime().persona_buddy_sink.active_owner_count(
+                "voice"
+            )
+            == 1
+        )
+
+        replacement._console_realtime_exit_loop(None)
+        await _wait_for(
+            lambda: app.persona_buddy_controller.snapshot().state == "idle", pilot
+        )
+
+
 def _messages(console):
     store = console._ensure_console_chat_store()
     return store.messages_for_session(store.active_session_id)

--- a/Tests/UI/test_console_run_gate.py
+++ b/Tests/UI/test_console_run_gate.py
@@ -129,6 +129,54 @@ def test_persona_buddy_missing_controller_sink_is_noop():
 
 
 @pytest.mark.asyncio
+async def test_persona_buddy_stale_run_terminal_cannot_release_replacement():
+    """Each actual run task carries the exact owner captured at validation."""
+    app, screen = _build_screen()
+    controller = screen._ensure_console_chat_controller()
+    old_validating = asyncio.Event()
+    release_old = asyncio.Event()
+    new_validating = asyncio.Event()
+    release_new = asyncio.Event()
+
+    async def old_run() -> None:
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.VALIDATING), session_id="session-a"
+        )
+        old_validating.set()
+        await release_old.wait()
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.FAILED), session_id="session-a"
+        )
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.IDLE), session_id="session-a"
+        )
+
+    async def new_run() -> None:
+        await old_validating.wait()
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.VALIDATING), session_id="session-a"
+        )
+        new_validating.set()
+        await release_new.wait()
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED), session_id="session-a"
+        )
+
+    old_task = asyncio.create_task(old_run())
+    new_task = asyncio.create_task(new_run())
+    await new_validating.wait()
+    release_old.set()
+    await old_task
+
+    assert app.persona_buddy_controller.snapshot().state == "thinking"
+    assert controller._buddy_sink.active_owner_count("console-run") == 1
+
+    release_new.set()
+    await new_task
+    assert app.persona_buddy_controller.snapshot().state == "idle"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "action_id,target",
     [

--- a/Tests/UI/test_console_run_gate.py
+++ b/Tests/UI/test_console_run_gate.py
@@ -84,6 +84,50 @@ def _start_fake_run(screen) -> None:
     )
 
 
+@pytest.mark.unit
+def test_persona_buddy_run_and_approval_states_drive_real_controller_producers():
+    """The real controller callbacks publish and settle exact Buddy owners."""
+    app, screen = _build_screen()
+    controller = screen._ensure_console_chat_controller()
+    buddy = app.persona_buddy_controller
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.VALIDATING), session_id="session-a"
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING), session_id="session-a"
+    )
+    assert buddy.snapshot().state == "speaking"
+
+    controller.add_pending_round("session-a", "round-1")
+    controller.add_pending_round("session-a", "round-2")
+    assert buddy.snapshot().state == "approval_needed"
+    controller.discard_pending_round("session-a", "round-1")
+    assert buddy.snapshot().state == "approval_needed"
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.COMPLETED), session_id="session-a"
+    )
+    assert buddy.snapshot().state == "idle"
+
+
+@pytest.mark.unit
+def test_persona_buddy_missing_controller_sink_is_noop():
+    """Controller-only construction remains valid when no Buddy sink exists."""
+    _app, screen = _build_screen()
+    controller = screen._ensure_console_chat_controller()
+    controller._buddy_sink = None
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.VALIDATING), session_id="session-a"
+    )
+    controller.add_pending_round("session-a", "round-1")
+    controller.discard_pending_round("session-a", "round-1")
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.COMPLETED), session_id="session-a"
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "action_id,target",

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -69,7 +69,7 @@ async def test_persona_buddy_release_follows_controller_wake_disposal():
     events: list[str] = []
 
     class Sink:
-        def release_all(self) -> None:
+        def dispose(self) -> None:
             events.append("sink-release")
 
     class Controller:

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -418,6 +418,8 @@ def test_persona_buddy_is_app_owned_and_shutdown_before_other_lifecycles():
     construction = initializer.index("PersonaBuddyController(")
     assert "PersonaBuddyController" in initializer, initializer
     assert "self.persona_buddy_controller" in initializer, initializer
+    assert "portrait_loader=partial(" in initializer, initializer
+    assert "load_local_persona_portrait" in initializer, initializer
     assert wiring < construction, initializer
 
     source = inspect.getsource(TldwCli._shutdown_app_owned_lifecycles)

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -63,6 +63,29 @@ def test_console_runtime_owns_one_screen_free_persona_buddy_sink():
     assert "view" not in vars(runtime.persona_buddy_sink)
 
 
+@pytest.mark.asyncio
+async def test_persona_buddy_release_follows_controller_wake_disposal():
+    """Runtime shutdown terminally fences wake producers before sink release."""
+    events: list[str] = []
+
+    class Sink:
+        def release_all(self) -> None:
+            events.append("sink-release")
+
+    class Controller:
+        async def shutdown(self) -> None:
+            events.append("wake-dispose")
+
+    runtime = ConsoleRuntime(type("App", (), {})())
+    runtime._persona_buddy_sink = Sink()
+    runtime._chat_controller = Controller()
+    runtime._provider_gateway = None
+
+    await runtime.dispose()
+
+    assert events == ["wake-dispose", "sink-release"]
+
+
 def _construction_sites(class_name: str) -> list[str]:
     """Every `<path>:<line>` in the shipped package CALLING `class_name(...)`.
 
@@ -422,8 +445,8 @@ def test_the_runtime_is_disposed_by_the_apps_shutdown_lifecycles():
 
 
 @pytest.mark.unit
-def test_persona_buddy_is_app_owned_and_shutdown_before_other_lifecycles():
-    """Buddy survives navigation and drains before profile-backed teardown."""
+def test_persona_buddy_is_app_owned_and_shutdown_after_console_producers():
+    """Console producers stop before Buddy drains, which precedes profiles."""
     import inspect
 
     from tldw_chatbook.app import TldwCli
@@ -440,29 +463,31 @@ def test_persona_buddy_is_app_owned_and_shutdown_before_other_lifecycles():
     source = inspect.getsource(TldwCli._shutdown_app_owned_lifecycles)
     buddy = source.index("_shutdown_persona_buddy")
     console = source.index("_shutdown_console_runtime")
-    assert buddy < console, source
+    assert console < buddy, source
     disposer = inspect.getsource(TldwCli._shutdown_persona_buddy)
     assert "persona_buddy_controller.shutdown" in disposer, disposer
 
 
 @pytest.mark.asyncio
-async def test_app_waits_for_buddy_drain_before_profile_service_teardown(
+async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """The app-owned await settles Buddy work before profile resources close."""
+    """Repeated cancellation cannot skip either ordered app-owned drain."""
     from textual.app import App
 
     from tldw_chatbook.app import TldwCli
 
-    entered = asyncio.Event()
-    release = asyncio.Event()
+    console_entered = asyncio.Event()
+    console_release = asyncio.Event()
+    buddy_entered = asyncio.Event()
+    buddy_release = asyncio.Event()
     events: list[str] = []
 
     class Buddy:
         async def shutdown(self) -> None:
             events.append("buddy-start")
-            entered.set()
-            await release.wait()
+            buddy_entered.set()
+            await buddy_release.wait()
             events.append("buddy-finished")
 
     class ProfileService:
@@ -476,13 +501,27 @@ async def test_app_waits_for_buddy_drain_before_profile_service_teardown(
     async def later_lifecycle() -> None:
         events.append("later-lifecycle")
 
+    console_task: asyncio.Task[None] | None = None
+
+    async def console_runner() -> None:
+        events.append("console-start")
+        console_entered.set()
+        await console_release.wait()
+        events.append("console-finished")
+
+    async def shutdown_console_runtime() -> None:
+        nonlocal console_task
+        if console_task is None:
+            console_task = asyncio.create_task(console_runner())
+        await asyncio.shield(console_task)
+
     app = object.__new__(TldwCli)
     app.persona_buddy_controller = Buddy()
     app._persona_buddy_shutdown_task = None
     app._audio_cpp_artifact_lease_coordinator = None
     app.audio_cpp_model_install_owner = AsyncOwner()
     app._shutdown_console_image_edits = later_lifecycle
-    app._shutdown_console_runtime = later_lifecycle
+    app._shutdown_console_runtime = shutdown_console_runtime
     app._shutdown_file_notes_session_owner = later_lifecycle
     profile_service = ProfileService()
 
@@ -491,11 +530,26 @@ async def test_app_waits_for_buddy_drain_before_profile_service_teardown(
 
     monkeypatch.setattr(App, "_shutdown", profile_teardown)
     draining = asyncio.create_task(TldwCli._shutdown(app))
-    await entered.wait()
-    assert events == ["buddy-start"]
+    await asyncio.wait_for(console_entered.wait(), 2)
+    assert events == ["console-start"]
     assert not draining.done()
-    release.set()
-    await draining
 
-    assert events[:2] == ["buddy-start", "buddy-finished"]
+    draining.cancel()
+    await asyncio.sleep(0)
+    draining.cancel()
+    await asyncio.sleep(0)
+    assert not draining.done()
+    assert not buddy_entered.is_set()
+
+    console_release.set()
+    await asyncio.wait_for(buddy_entered.wait(), 2)
+    assert events[:3] == ["console-start", "console-finished", "buddy-start"]
+    assert "profile-teardown" not in events
+
+    buddy_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await draining
+
+    assert events.index("console-finished") < events.index("buddy-start")
+    assert events.index("buddy-finished") < events.index("profile-teardown")
     assert events[-1] == "profile-teardown"

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -404,3 +404,25 @@ def test_the_runtime_is_disposed_by_the_apps_shutdown_lifecycles():
     assert "_shutdown_console_runtime" in source, source
     disposer = inspect.getsource(TldwCli._shutdown_console_runtime)
     assert "dispose_console_runtime" in disposer, disposer
+
+
+@pytest.mark.unit
+def test_persona_buddy_is_app_owned_and_shutdown_before_other_lifecycles():
+    """Buddy survives navigation and drains before profile-backed teardown."""
+    import inspect
+
+    from tldw_chatbook.app import TldwCli
+
+    initializer = inspect.getsource(TldwCli.__init__)
+    wiring = initializer.index("self._wire_character_persona_services()")
+    construction = initializer.index("PersonaBuddyController(")
+    assert "PersonaBuddyController" in initializer, initializer
+    assert "self.persona_buddy_controller" in initializer, initializer
+    assert wiring < construction, initializer
+
+    source = inspect.getsource(TldwCli._shutdown_app_owned_lifecycles)
+    buddy = source.index("_shutdown_persona_buddy")
+    console = source.index("_shutdown_console_runtime")
+    assert buddy < console, source
+    disposer = inspect.getsource(TldwCli._shutdown_persona_buddy)
+    assert "persona_buddy_controller.shutdown" in disposer, disposer

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -36,6 +36,8 @@ from tldw_chatbook.Chat.console_runtime import (
     CONSOLE_VIEW_HOOK_SLOTS,
     ConsoleRuntime,
 )
+from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
@@ -47,6 +49,18 @@ _RUNTIME_OWNED_CONSTRUCTIONS = ("ConsoleChatStore", "ConsoleChatController")
 
 _PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
 _RUNTIME_MODULE = "tldw_chatbook/Chat/console_runtime.py"
+
+
+@pytest.mark.unit
+def test_console_runtime_owns_one_screen_free_persona_buddy_sink():
+    """The app-owned runtime, not a screen, retains the trusted sink."""
+    app = type("App", (), {})()
+    app.persona_buddy_controller = PersonaBuddyController()
+    runtime = ConsoleRuntime(app)
+
+    assert isinstance(runtime.persona_buddy_sink, PersonaBuddyConsoleAdapter)
+    assert runtime.persona_buddy_sink is runtime.persona_buddy_sink
+    assert "view" not in vars(runtime.persona_buddy_sink)
 
 
 def _construction_sites(class_name: str) -> list[str]:

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -21,6 +21,7 @@ dead view.
 from __future__ import annotations
 
 import ast
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -428,3 +429,59 @@ def test_persona_buddy_is_app_owned_and_shutdown_before_other_lifecycles():
     assert buddy < console, source
     disposer = inspect.getsource(TldwCli._shutdown_persona_buddy)
     assert "persona_buddy_controller.shutdown" in disposer, disposer
+
+
+@pytest.mark.asyncio
+async def test_app_waits_for_buddy_drain_before_profile_service_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The app-owned await settles Buddy work before profile resources close."""
+    from textual.app import App
+
+    from tldw_chatbook.app import TldwCli
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    events: list[str] = []
+
+    class Buddy:
+        async def shutdown(self) -> None:
+            events.append("buddy-start")
+            entered.set()
+            await release.wait()
+            events.append("buddy-finished")
+
+    class ProfileService:
+        def teardown(self) -> None:
+            events.append("profile-teardown")
+
+    class AsyncOwner:
+        async def shutdown(self) -> None:
+            events.append("later-owner")
+
+    async def later_lifecycle() -> None:
+        events.append("later-lifecycle")
+
+    app = object.__new__(TldwCli)
+    app.persona_buddy_controller = Buddy()
+    app._persona_buddy_shutdown_task = None
+    app._audio_cpp_artifact_lease_coordinator = None
+    app.audio_cpp_model_install_owner = AsyncOwner()
+    app._shutdown_console_image_edits = later_lifecycle
+    app._shutdown_console_runtime = later_lifecycle
+    app._shutdown_file_notes_session_owner = later_lifecycle
+    profile_service = ProfileService()
+
+    async def profile_teardown(_app: App[None]) -> None:
+        profile_service.teardown()
+
+    monkeypatch.setattr(App, "_shutdown", profile_teardown)
+    draining = asyncio.create_task(TldwCli._shutdown(app))
+    await entered.wait()
+    assert events == ["buddy-start"]
+    assert not draining.done()
+    release.set()
+    await draining
+
+    assert events[:2] == ["buddy-start", "buddy-finished"]
+    assert events[-1] == "profile-teardown"

--- a/Tests/UI/test_css_bundle_sync_guard.py
+++ b/Tests/UI/test_css_bundle_sync_guard.py
@@ -5,7 +5,9 @@ reproduce from its sources (ignoring the `Generated:` timestamp), naming the
 drifted module. Also asserts the repo's own committed bundle is currently in sync.
 """
 
-from tldw_chatbook.css import check_bundle_sync as guard
+from pathlib import Path
+
+from tldw_chatbook.css import build_css, check_bundle_sync as guard
 
 
 def _bundle(overrides_body: str, timestamp: str = "2026-01-01 00:00:00") -> str:
@@ -33,3 +35,17 @@ def test_drifted_modules_names_the_changed_module():
 def test_committed_bundle_reproduces_from_sources():
     """The repo's committed bundle is in sync (and the guard passes end-to-end)."""
     assert guard.main() == 0
+
+
+def test_generated_widget_and_screen_sheets_have_no_trailing_whitespace():
+    """Python class indentation never leaks onto generated blank CSS lines."""
+
+    css_dir = Path(build_css.__file__).parent
+    paths = (
+        css_dir / build_css.WIDGET_DEFAULTS_SELF_FILENAME,
+        css_dir / build_css.WIDGET_DEFAULTS_SCOPED_FILENAME,
+        css_dir / build_css.SCREEN_CSS_SELF_FILENAME,
+        css_dir / build_css.SCREEN_CSS_SCOPED_FILENAME,
+    )
+    for path in paths:
+        assert all(line == line.rstrip() for line in path.read_text().splitlines())

--- a/Tests/UI/test_persona_buddy_app_mount.py
+++ b/Tests/UI/test_persona_buddy_app_mount.py
@@ -7,6 +7,9 @@ from dataclasses import replace
 import threading
 
 import pytest
+from textual.app import ComposeResult
+from textual.screen import ModalScreen
+from textual.widgets import Static
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
 from tldw_chatbook.Persona_Buddy import (
@@ -35,6 +38,11 @@ async def _wait_until(predicate, *, timeout: float = 2.0) -> None:
 class _BuddyScreen(BaseAppScreen):
     def __init__(self, app_instance, name: str = "buddy-test") -> None:
         super().__init__(app_instance, name)
+
+
+class _BuddyModal(ModalScreen[None]):
+    def compose(self) -> ComposeResult:
+        yield Static("Buddy modal", id="buddy-modal")
 
 
 class _BuddyApp(ConsolidatedCSSApp):
@@ -403,6 +411,8 @@ async def test_app_owned_preference_write_drains_once_before_new_owner_starts():
 
         replacement = _BuddyScreen(app, "replacement")
         await app.switch_screen(replacement)
+        app.persona_buddy_controller.apply_preferences_patch(open=True)
+        await replacement.reconcile_persona_buddy_view()
         await _wait_until(lambda: len(list(replacement.query(PersonaBuddyWidget))) == 1)
         replacement.query_one(PersonaBuddyWidget).action_move_left()
         await asyncio.sleep(0.1)
@@ -411,3 +421,113 @@ async def test_app_owned_preference_write_drains_once_before_new_owner_starts():
 
         release.set()
         await _wait_until(lambda: calls == 2)
+
+
+@pytest.mark.asyncio
+async def test_modal_dismiss_reconciles_same_screen_and_restarts_resolution():
+    app = _BuddyApp(_enabled_preferences())
+    controller = app.persona_buddy_controller
+    calls = 0
+
+    async def counted_resolution(*, cols: int, lines: int):
+        nonlocal calls
+        calls += 1
+        return None
+
+    controller.resolve_current_visual = counted_resolution
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: calls == 1)
+        screen = app.screen
+        view = screen.query_one(PersonaBuddyWidget)
+
+        await app.push_screen(_BuddyModal())
+        await _wait_until(lambda: view._resolution_worker.is_finished)
+        controller.invalidate_profile()
+        app.pop_screen()
+
+        await _wait_until(lambda: calls == 2)
+        assert app.screen is screen
+        assert screen.query_one(PersonaBuddyWidget) is view
+
+
+@pytest.mark.asyncio
+async def test_modal_dismiss_replays_close_and_removes_same_screen_view():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)):
+        screen = app.screen
+        await _wait_until(lambda: len(list(screen.query(PersonaBuddyWidget))) == 1)
+        await app.push_screen(_BuddyModal())
+        current = app.persona_buddy_controller.current_preferences()
+        await app.persona_buddy_controller.update_preferences(
+            replace(current, open=False)
+        )
+
+        app.pop_screen()
+
+        await _wait_until(lambda: not list(screen.query(PersonaBuddyWidget)))
+        assert app.screen is screen
+
+
+@pytest.mark.asyncio
+async def test_modal_dismiss_replays_collapsed_then_disabled_preferences():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)):
+        screen = app.screen
+        view = screen.query_one(PersonaBuddyWidget)
+        await app.push_screen(_BuddyModal())
+        current = app.persona_buddy_controller.current_preferences()
+        await app.persona_buddy_controller.update_preferences(
+            replace(current, collapsed=True)
+        )
+
+        app.pop_screen()
+        await _wait_until(lambda: view.has_class("persona-buddy-collapsed"))
+        assert screen.query_one(PersonaBuddyWidget) is view
+
+        await app.push_screen(_BuddyModal())
+        current = app.persona_buddy_controller.current_preferences()
+        await app.persona_buddy_controller.update_preferences(
+            replace(current, enabled=False)
+        )
+
+        app.pop_screen()
+        await _wait_until(lambda: not list(screen.query(PersonaBuddyWidget)))
+        assert app.screen is screen
+
+
+@pytest.mark.asyncio
+async def test_blocked_close_and_stale_geometry_merge_immediately_and_durably():
+    app = _BuddyApp(_enabled_preferences())
+    entered = threading.Event()
+    release = threading.Event()
+    persisted: list[PersonaBuddyPreferences] = []
+
+    def blocked_writer(preferences: PersonaBuddyPreferences) -> bool:
+        if not persisted:
+            entered.set()
+            release.wait(timeout=2)
+        persisted.append(preferences)
+        return True
+
+    app.persona_buddy_controller._preference_writer = blocked_writer
+    async with app.run_test(size=(100, 30)):
+        view = app.screen.query_one(PersonaBuddyWidget)
+        before = view._clamped_geometry(
+            app.persona_buddy_controller.current_preferences().geometry
+        )
+
+        view.action_close()
+        assert app.persona_buddy_controller.current_preferences().open is False
+        await _wait_until(entered.is_set)
+        view.action_move_left()
+
+        current = app.persona_buddy_controller.current_preferences()
+        assert current.open is False
+        assert current.geometry.x == max(0, before.x - 1)
+        release.set()
+        await _wait_until(lambda: len(persisted) == 2)
+
+        final = app.persona_buddy_controller.current_preferences()
+        assert persisted[-1] == final
+        assert final.open is False
+        assert final.geometry == current.geometry

--- a/Tests/UI/test_persona_buddy_app_mount.py
+++ b/Tests/UI/test_persona_buddy_app_mount.py
@@ -1,0 +1,147 @@
+"""Dynamic app-owned mount coverage for the floating Persona Buddy."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from tldw_chatbook.Persona_Buddy import (
+    PersonaBuddyController,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+)
+from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
+from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+    PersonaBuddyWidget,
+)
+from tldw_chatbook.app import TldwCli
+
+
+async def _wait_until(predicate, *, timeout: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        if predicate():
+            return
+        if loop.time() >= deadline:
+            raise AssertionError("predicate did not become true before deadline")
+        await asyncio.sleep(0.01)
+
+
+class _BuddyScreen(BaseAppScreen):
+    def __init__(self, app_instance, name: str = "buddy-test") -> None:
+        super().__init__(app_instance, name)
+
+
+class _BuddyApp(ConsolidatedCSSApp):
+    CSS_PATH = BUNDLED_STYLESHEET
+    reconcile_persona_buddy_view = TldwCli.reconcile_persona_buddy_view
+
+    def __init__(self, preferences: PersonaBuddyPreferences) -> None:
+        super().__init__()
+        self.persona_buddy_controller = PersonaBuddyController(
+            preferences=preferences,
+            preference_writer=lambda _preferences: True,
+        )
+        self.initial_screen = _BuddyScreen(self)
+
+    async def on_mount(self) -> None:
+        await self.push_screen(self.initial_screen)
+
+
+def _enabled_preferences() -> PersonaBuddyPreferences:
+    return PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "persona-1"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_mounts_on_current_screen_without_navigation():
+    app = _BuddyApp(PersonaBuddyPreferences())
+    async with app.run_test(size=(100, 30)):
+        assert not list(app.screen.query(PersonaBuddyWidget))
+        await app.persona_buddy_controller.update_preferences(_enabled_preferences())
+        await app.reconcile_persona_buddy_view()
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+
+
+@pytest.mark.asyncio
+async def test_disable_unmounts_without_navigation():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        preferences = app.persona_buddy_controller.current_preferences()
+        await app.persona_buddy_controller.update_preferences(
+            replace(preferences, enabled=False)
+        )
+        await app.reconcile_persona_buddy_view()
+        await _wait_until(lambda: not list(app.screen.query(PersonaBuddyWidget)))
+
+
+@pytest.mark.asyncio
+async def test_close_removes_only_current_generation():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        stale = app.screen.query_one(PersonaBuddyWidget)
+        await app.screen.reconcile_persona_buddy_view()
+        current = app.screen.query_one(PersonaBuddyWidget)
+        assert current is stale
+
+        await stale.close_and_persist()
+        await _wait_until(lambda: not list(app.screen.query(PersonaBuddyWidget)))
+        assert stale.view_generation < app.screen.persona_buddy_view_generation
+
+
+@pytest.mark.asyncio
+async def test_reopen_mounts_without_navigation():
+    app = _BuddyApp(replace(_enabled_preferences(), open=False))
+    async with app.run_test(size=(100, 30)):
+        assert not list(app.screen.query(PersonaBuddyWidget))
+        preferences = app.persona_buddy_controller.current_preferences()
+        await app.persona_buddy_controller.update_preferences(
+            replace(preferences, open=True)
+        )
+        await app.reconcile_persona_buddy_view()
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+
+
+@pytest.mark.asyncio
+async def test_recompose_unsubscribes_and_remounts_both_directions():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        first = app.screen.query_one(PersonaBuddyWidget)
+        app.screen.refresh(recompose=True)
+        await _wait_until(
+            lambda: (
+                len(list(app.screen.query(PersonaBuddyWidget))) == 1
+                and app.screen.query_one(PersonaBuddyWidget) is not first
+            )
+        )
+        assert not first.is_attached
+
+        preferences = app.persona_buddy_controller.current_preferences()
+        await app.persona_buddy_controller.update_preferences(
+            replace(preferences, open=False)
+        )
+        app.screen.refresh(recompose=True)
+        await _wait_until(lambda: not list(app.screen.query(PersonaBuddyWidget)))
+
+
+@pytest.mark.asyncio
+async def test_navigation_replaces_screen_local_view_generation():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        first = app.screen.query_one(PersonaBuddyWidget)
+        replacement = _BuddyScreen(app, "replacement")
+        await app.switch_screen(replacement)
+        await _wait_until(lambda: len(list(replacement.query(PersonaBuddyWidget))) == 1)
+        second = replacement.query_one(PersonaBuddyWidget)
+        assert second is not first
+        assert not first.is_attached

--- a/Tests/UI/test_persona_buddy_app_mount.py
+++ b/Tests/UI/test_persona_buddy_app_mount.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import replace
+import threading
 
 import pytest
 
@@ -40,12 +41,25 @@ class _BuddyApp(ConsolidatedCSSApp):
     CSS_PATH = BUNDLED_STYLESHEET
     reconcile_persona_buddy_view = TldwCli.reconcile_persona_buddy_view
 
-    def __init__(self, preferences: PersonaBuddyPreferences) -> None:
+    def __init__(
+        self,
+        preferences: PersonaBuddyPreferences,
+        *,
+        production_resolution: bool = False,
+    ) -> None:
         super().__init__()
         self.persona_buddy_controller = PersonaBuddyController(
             preferences=preferences,
             preference_writer=lambda _preferences: True,
         )
+        if not production_resolution:
+
+            async def unresolved_until_test_requests_it(*, cols: int, lines: int):
+                return None
+
+            self.persona_buddy_controller.resolve_current_visual = (
+                unresolved_until_test_requests_it
+            )
         self.initial_screen = _BuddyScreen(self)
 
     async def on_mount(self) -> None:
@@ -209,3 +223,74 @@ async def test_delayed_mount_with_superseded_generation_removes_stale_created_vi
         await reconcile
         assert not list(screen.query(PersonaBuddyWidget))
         assert screen._persona_buddy_view is None
+
+
+@pytest.mark.asyncio
+async def test_confirmed_unavailable_unmounts_then_profile_invalidation_remounts():
+    app = _BuddyApp(_enabled_preferences(), production_resolution=True)
+    controller = app.persona_buddy_controller
+    original_resolve = controller.resolve_current_visual
+    gates = (asyncio.Event(), asyncio.Event())
+    calls = 0
+
+    async def blocked_resolve(*, cols: int, lines: int):
+        nonlocal calls
+        index = min(calls, 1)
+        calls += 1
+        await gates[index].wait()
+        return await original_resolve(cols=cols, lines=lines)
+
+    controller.resolve_current_visual = blocked_resolve
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        await _wait_until(lambda: calls == 1)
+        gates[0].set()
+        await _wait_until(lambda: not list(app.screen.query(PersonaBuddyWidget)))
+        current = controller.current_preferences()
+        assert current.enabled and current.selection == _enabled_preferences().selection
+
+        controller.invalidate_profile()
+        await app.reconcile_persona_buddy_view()
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        await _wait_until(lambda: calls == 2)
+        gates[1].set()
+
+
+@pytest.mark.asyncio
+async def test_app_owned_preference_write_drains_once_before_new_owner_starts():
+    app = _BuddyApp(_enabled_preferences())
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def blocked_writer(_preferences):
+        nonlocal calls
+        calls += 1
+        started.set()
+        release.wait(timeout=2)
+        return True
+
+    app.persona_buddy_controller._preference_writer = blocked_writer
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        first = app.screen.query_one(PersonaBuddyWidget)
+        first.action_close()
+        await _wait_until(started.is_set)
+        preference_workers = [
+            worker
+            for worker in app.workers
+            if worker.group == "persona-buddy-preferences"
+        ]
+        assert len(preference_workers) == 1
+        assert preference_workers[0].node is app
+
+        replacement = _BuddyScreen(app, "replacement")
+        await app.switch_screen(replacement)
+        await _wait_until(lambda: len(list(replacement.query(PersonaBuddyWidget))) == 1)
+        replacement.query_one(PersonaBuddyWidget).action_move_left()
+        await asyncio.sleep(0.1)
+        assert calls == 1
+        assert not first.is_attached
+
+        release.set()
+        await _wait_until(lambda: calls == 2)

--- a/Tests/UI/test_persona_buddy_app_mount.py
+++ b/Tests/UI/test_persona_buddy_app_mount.py
@@ -40,6 +40,11 @@ class _BuddyScreen(BaseAppScreen):
 class _BuddyApp(ConsolidatedCSSApp):
     CSS_PATH = BUNDLED_STYLESHEET
     reconcile_persona_buddy_view = TldwCli.reconcile_persona_buddy_view
+    _persona_buddy_authority = staticmethod(TldwCli._persona_buddy_authority)
+    is_persona_buddy_confirmed_unavailable = (
+        TldwCli.is_persona_buddy_confirmed_unavailable
+    )
+    confirm_persona_buddy_unavailable = TldwCli.confirm_persona_buddy_unavailable
 
     def __init__(
         self,
@@ -52,6 +57,7 @@ class _BuddyApp(ConsolidatedCSSApp):
             preferences=preferences,
             preference_writer=lambda _preferences: True,
         )
+        self._persona_buddy_unavailable_authority = None
         if not production_resolution:
 
             async def unresolved_until_test_requests_it(*, cols: int, lines: int):
@@ -254,6 +260,69 @@ async def test_confirmed_unavailable_unmounts_then_profile_invalidation_remounts
         await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
         await _wait_until(lambda: calls == 2)
         gates[1].set()
+
+
+@pytest.mark.asyncio
+async def test_confirmed_unavailable_authority_survives_fresh_screens():
+    app = _BuddyApp(_enabled_preferences(), production_resolution=True)
+    controller = app.persona_buddy_controller
+    original_resolve = controller.resolve_current_visual
+    gates = (asyncio.Event(), asyncio.Event())
+    calls = 0
+
+    async def counted_resolve(*, cols: int, lines: int):
+        nonlocal calls
+        index = min(calls, 1)
+        calls += 1
+        await gates[index].wait()
+        return await original_resolve(cols=cols, lines=lines)
+
+    controller.resolve_current_visual = counted_resolve
+    async with app.run_test(size=(100, 30)):
+        first = app.screen
+        await _wait_until(lambda: calls == 1)
+        first_view = first.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: controller.snapshot().viewport_generation >= 1)
+        gates[0].set()
+        await _wait_until(lambda: not list(first.query(PersonaBuddyWidget)))
+        first_snapshot = controller.snapshot()
+
+        second = _BuddyScreen(app, "second")
+        await app.switch_screen(second)
+        await asyncio.sleep(0.2)
+        assert not list(second.query(PersonaBuddyWidget))
+        assert calls == 1
+
+        controller.invalidate_profile()
+        await app.reconcile_persona_buddy_view()
+        await _wait_until(lambda: calls == 2)
+        await _wait_until(
+            lambda: (
+                controller.snapshot().viewport_generation
+                > first_snapshot.viewport_generation
+            )
+        )
+        gates[1].set()
+        await _wait_until(lambda: not list(second.query(PersonaBuddyWidget)))
+
+        current_marker = app._persona_buddy_unavailable_authority
+        assert current_marker == app._persona_buddy_authority(
+            controller, controller.snapshot()
+        )
+        assert not app.confirm_persona_buddy_unavailable(
+            screen=first,
+            view=first_view,
+            view_generation=first_view.view_generation,
+            controller=controller,
+            snapshot=first_snapshot,
+            visual=first_snapshot.visual,
+        )
+        assert app._persona_buddy_unavailable_authority == current_marker
+        third = _BuddyScreen(app, "third")
+        await app.switch_screen(third)
+        await asyncio.sleep(0.2)
+        assert not list(third.query(PersonaBuddyWidget))
+        assert calls == 2
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_persona_buddy_app_mount.py
+++ b/Tests/UI/test_persona_buddy_app_mount.py
@@ -326,6 +326,54 @@ async def test_confirmed_unavailable_authority_survives_fresh_screens():
 
 
 @pytest.mark.asyncio
+async def test_authority_change_during_unavailable_reconcile_restarts_resolution():
+    app = _BuddyApp(_enabled_preferences(), production_resolution=True)
+    controller = app.persona_buddy_controller
+    original_resolve = controller.resolve_current_visual
+    first_resolution_release = asyncio.Event()
+    second_resolution_started = asyncio.Event()
+    second_resolution_release = asyncio.Event()
+    reconcile_started = asyncio.Event()
+    reconcile_release = asyncio.Event()
+    calls = 0
+
+    async def controlled_resolve(*, cols: int, lines: int):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await first_resolution_release.wait()
+        else:
+            second_resolution_started.set()
+            await second_resolution_release.wait()
+        return await original_resolve(cols=cols, lines=lines)
+
+    original_reconcile = app.reconcile_persona_buddy_view
+
+    async def blocked_reconcile():
+        reconcile_started.set()
+        await reconcile_release.wait()
+        return await original_reconcile()
+
+    controller.resolve_current_visual = controlled_resolve
+    app.reconcile_persona_buddy_view = blocked_reconcile
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: calls == 1)
+        view = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: controller.snapshot().viewport_generation >= 1)
+        first_resolution_release.set()
+        await asyncio.wait_for(reconcile_started.wait(), timeout=1)
+
+        controller.invalidate_profile()
+        reconcile_release.set()
+        await asyncio.wait_for(second_resolution_started.wait(), timeout=1)
+        assert app.screen.query_one(PersonaBuddyWidget) is view
+        assert view.is_attached
+
+        second_resolution_release.set()
+        await _wait_until(lambda: not list(app.screen.query(PersonaBuddyWidget)))
+
+
+@pytest.mark.asyncio
 async def test_app_owned_preference_write_drains_once_before_new_owner_starts():
     app = _BuddyApp(_enabled_preferences())
     started = threading.Event()

--- a/Tests/UI/test_persona_buddy_app_mount.py
+++ b/Tests/UI/test_persona_buddy_app_mount.py
@@ -145,3 +145,67 @@ async def test_navigation_replaces_screen_local_view_generation():
         second = replacement.query_one(PersonaBuddyWidget)
         assert second is not first
         assert not first.is_attached
+
+        before = app.persona_buddy_controller.current_preferences()
+        stale_before = first._working_preferences
+        await first.close_and_persist()
+        first.action_toggle_collapse()
+        first.action_move_left()
+        await asyncio.sleep(0.05)
+        assert first._working_preferences == stale_before
+        assert app.persona_buddy_controller.current_preferences() == before
+        assert replacement.query_one(PersonaBuddyWidget) is second
+
+
+@pytest.mark.asyncio
+async def test_cancelled_delayed_mount_cleans_only_the_created_view(monkeypatch):
+    app = _BuddyApp(PersonaBuddyPreferences())
+    async with app.run_test(size=(100, 30)):
+        screen = app.screen
+        preferences = _enabled_preferences()
+        await app.persona_buddy_controller.update_preferences(preferences)
+        started = asyncio.Event()
+        release = asyncio.Event()
+        original_mount = screen.mount
+
+        async def delayed_mount(widget, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_mount(widget, *args, **kwargs)
+
+        monkeypatch.setattr(screen, "mount", delayed_mount)
+        reconcile = asyncio.create_task(screen.reconcile_persona_buddy_view())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        reconcile.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await reconcile
+        assert not list(screen.query(PersonaBuddyWidget))
+        assert screen._persona_buddy_view is None
+
+
+@pytest.mark.asyncio
+async def test_delayed_mount_with_superseded_generation_removes_stale_created_view(
+    monkeypatch,
+):
+    app = _BuddyApp(PersonaBuddyPreferences())
+    async with app.run_test(size=(100, 30)):
+        screen = app.screen
+        await app.persona_buddy_controller.update_preferences(_enabled_preferences())
+        started = asyncio.Event()
+        release = asyncio.Event()
+        original_mount = screen.mount
+
+        async def delayed_mount(widget, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_mount(widget, *args, **kwargs)
+
+        monkeypatch.setattr(screen, "mount", delayed_mount)
+        reconcile = asyncio.create_task(screen.reconcile_persona_buddy_view())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        screen._persona_buddy_view_generation += 1
+        release.set()
+        await reconcile
+        assert not list(screen.query(PersonaBuddyWidget))
+        assert screen._persona_buddy_view is None

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -1,0 +1,330 @@
+"""Paint, geometry, input, and focus contracts for Persona Buddy."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from rich.text import Text
+from textual import events
+from textual.app import ComposeResult
+from textual.containers import Container
+from textual.geometry import Offset
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Input, Static
+
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from tldw_chatbook.Persona_Buddy import (
+    PersonaBuddyGeometry,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+    PersonaBuddySnapshot,
+    PersonaBuddyVisualSnapshot,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+    PersonaBuddyWidget,
+)
+
+
+async def _wait_until(predicate, *, timeout: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        if predicate():
+            return
+        if loop.time() >= deadline:
+            raise AssertionError("predicate did not become true before deadline")
+        await asyncio.sleep(0.01)
+
+
+class _FakeController:
+    def __init__(
+        self,
+        *,
+        size: tuple[int, int] = (28, 12),
+        collapsed: bool = False,
+        animate: bool = False,
+        frames: tuple[str, ...] = ("BUDDY-A",),
+    ) -> None:
+        self.preferences = PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "persona-1"),
+            collapsed=collapsed,
+            geometry=PersonaBuddyGeometry(
+                x=1_000_000,
+                y=1_000_000,
+                width=size[0],
+                height=size[1],
+            ),
+        )
+        self.generation = 1
+        self.persisted: list[PersonaBuddyPreferences] = []
+        prepared = tuple(
+            SimpleNamespace(renderable=Text(label), duration_ms=20) for label in frames
+        )
+        self.visual = PersonaBuddyVisualSnapshot(
+            available=True,
+            reason=None,
+            source="local",
+            persona_id="persona-1",
+            persona_revision=1,
+            requested_state="idle",
+            resolved_state="idle",
+            animation_id="idle",
+            graph_identity=None,
+            cache_identity=None,
+            frames=prepared,  # type: ignore[arg-type]
+            frame_rate=50.0,
+            loop=True,
+            animate=animate,
+        )
+
+    def current_preferences(self) -> PersonaBuddyPreferences:
+        return self.preferences
+
+    def snapshot(self) -> PersonaBuddySnapshot:
+        self.generation += 1
+        return PersonaBuddySnapshot(
+            generation=self.generation,
+            selection=self.preferences.selection,
+            state="idle",
+            enabled=self.preferences.enabled,
+            open=self.preferences.open,
+            collapsed=self.preferences.collapsed,
+            preferences_generation=self.generation,
+            visual=self.visual,
+        )
+
+    async def update_preferences(
+        self, preferences: PersonaBuddyPreferences
+    ) -> PersonaBuddySnapshot:
+        self.preferences = preferences
+        self.persisted.append(preferences)
+        return self.snapshot()
+
+
+class _BuddyScreen(Screen):
+    def __init__(self, controller: _FakeController) -> None:
+        super().__init__()
+        self.controller = controller
+        self.buddy = PersonaBuddyWidget(
+            controller=controller,
+            view_generation=1,
+            reconcile=lambda: None,
+        )
+
+    def compose(self) -> ComposeResult:
+        with Container(id="buddy-flow-probe"):
+            yield Input(id="focus-probe")
+            yield Static("FLOW-END", id="flow-end")
+        yield self.buddy
+
+
+class _BuddyApp(ConsolidatedCSSApp):
+    CSS_PATH = BUNDLED_STYLESHEET
+    CSS = """
+    #buddy-flow-probe { height: 1fr; }
+    #flow-end { dock: bottom; height: 1; }
+    """
+
+    def __init__(self, controller: _FakeController) -> None:
+        super().__init__()
+        self.buddy_screen = _BuddyScreen(controller)
+
+    async def on_mount(self) -> None:
+        await self.push_screen(self.buddy_screen)
+
+
+def _compositor_text(screen: Screen) -> str:
+    return "\n".join(strip.text for strip in screen._compositor.render_strips())
+
+
+def _mouse(event_type, *, x: int, y: int, button: int = 1):
+    return event_type(
+        None,
+        x,
+        y,
+        0,
+        0,
+        button,
+        False,
+        False,
+        False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
+@pytest.mark.asyncio
+async def test_overlay_paints_without_flow_or_fr_budget():
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        flow = app.screen.query_one("#buddy-flow-probe")
+        await _wait_until(lambda: buddy.region.width == 28)
+        assert buddy.styles.position == "absolute"
+        assert buddy.styles.overlay == "screen"
+        assert flow.region.height == 24
+        assert app.screen.query_one("#flow-end").region.bottom == 24
+        assert "Persona Buddy" in _compositor_text(app.screen)
+        assert "BUDDY-A" in _compositor_text(app.screen)
+
+
+@pytest.mark.asyncio
+async def test_drag_and_resize_are_viewport_bounded_and_persist_once():
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.region.width == 28)
+        initial_geometry = buddy._clamped_geometry(controller.preferences.geometry)
+        assert initial_geometry.x + initial_geometry.width <= app.size.width
+        assert initial_geometry.y + initial_geometry.height <= app.size.height
+
+        buddy.on_mouse_down(
+            _mouse(events.MouseDown, x=buddy.region.x + 2, y=buddy.region.y)
+        )
+        await asyncio.sleep(0)
+        assert app.screen.focused is buddy
+        buddy.on_mouse_move(_mouse(events.MouseMove, x=-50, y=-50))
+        assert buddy.absolute_offset == Offset(0, 0)
+        assert controller.persisted == []
+        buddy.refresh_from_controller()
+        assert buddy.absolute_offset == Offset(0, 0)
+        buddy.on_mouse_up(_mouse(events.MouseUp, x=-50, y=-50))
+        await _wait_until(lambda: len(controller.persisted) == 1)
+
+        corner_x = buddy.region.right - 1
+        corner_y = buddy.region.bottom - 1
+        buddy.on_mouse_down(_mouse(events.MouseDown, x=corner_x, y=corner_y))
+        buddy.on_mouse_move(_mouse(events.MouseMove, x=500, y=500))
+        assert buddy.region.right <= app.size.width
+        assert buddy.region.bottom <= app.size.height
+        assert len(controller.persisted) == 1
+        buddy.on_mouse_up(_mouse(events.MouseUp, x=500, y=500))
+        await _wait_until(lambda: len(controller.persisted) == 2)
+        assert app.mouse_captured is None
+
+
+@pytest.mark.asyncio
+async def test_keyboard_move_resize_reset_collapse_close_exact_bindings():
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.region.width == 28)
+        buddy.focus(scroll_visible=False)
+        start = buddy.absolute_offset
+        await pilot.press("h")
+        assert buddy.absolute_offset.x == max(0, start.x - 1)
+        await pilot.press("j", "k", "l")
+        await pilot.press("H", "J", "K", "L")
+        await _wait_until(lambda: len(controller.persisted) >= 8)
+        await pilot.press("0")
+        assert buddy.absolute_offset == Offset(72, 18)
+        await pilot.press("c")
+        await _wait_until(lambda: controller.preferences.collapsed)
+        await _wait_until(lambda: "Buddy" in _compositor_text(app.screen))
+        await _wait_until(lambda: buddy.region.height == 3)
+        await pilot.press("x")
+        await _wait_until(lambda: not controller.preferences.open)
+
+        keys = {binding.key for binding in PersonaBuddyWidget.BINDINGS}
+        assert keys == {"h", "j", "k", "l", "H", "J", "K", "L", "0", "c", "x"}
+        assert not any(key.startswith("ctrl+") for key in keys)
+
+
+@pytest.mark.asyncio
+async def test_tiny_viewport_uses_labelled_compact_control():
+    controller = _FakeController(size=(28, 12))
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(12, 4)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.has_class("persona-buddy-compact"))
+        assert buddy.region.width <= 12
+        assert buddy.region.height <= 4
+        assert "Buddy" in _compositor_text(app.screen)
+
+
+@pytest.mark.asyncio
+async def test_state_repaint_never_steals_focus():
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        focus_probe = app.screen.query_one("#focus-probe", Input)
+        focus_probe.focus(scroll_visible=False)
+        assert app.screen.focused is focus_probe
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        buddy.refresh_from_controller()
+        await asyncio.sleep(0)
+        assert app.screen.focused is focus_probe
+
+
+@pytest.mark.asyncio
+async def test_animation_cells_change_then_freeze_hidden_collapsed():
+    controller = _FakeController(animate=True, frames=("FRAME-A", "FRAME-B"))
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: "FRAME-A" in _compositor_text(app.screen))
+        buddy.advance_frame()
+        await _wait_until(lambda: "FRAME-B" in _compositor_text(app.screen))
+
+        controller.preferences = replace(controller.preferences, collapsed=True)
+        buddy.refresh_from_controller()
+        frozen = buddy.frame_index
+        buddy.advance_frame()
+        assert buddy.frame_index == frozen
+        assert buddy.snapshot_polling_active
+
+        buddy.display = False
+        buddy.advance_frame()
+        assert buddy.frame_index == frozen
+
+
+@pytest.mark.asyncio
+async def test_reduced_motion_paints_static_frame():
+    controller = _FakeController(animate=False, frames=("STATIC-A", "STATIC-B"))
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: "STATIC-A" in _compositor_text(app.screen))
+        buddy.advance_frame()
+        assert buddy.frame_index == 0
+        assert "STATIC-A" in _compositor_text(app.screen)
+
+
+@pytest.mark.asyncio
+async def test_modal_covers_buddy_hit_target():
+    class _BlockingModal(ModalScreen):
+        def compose(self) -> ComposeResult:
+            yield Static("MODAL BLOCKER", id="modal-blocker")
+
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.region.width == 28)
+        point = (buddy.region.x + 1, buddy.region.y + 1)
+        await app.push_screen(_BlockingModal())
+        target, _region = app.screen.get_widget_at(*point)
+        assert not isinstance(target, PersonaBuddyWidget)
+        assert "MODAL BLOCKER" in _compositor_text(app.screen)
+
+
+@pytest.mark.asyncio
+async def test_capture_is_released_when_widget_unmounts_mid_drag():
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.region.width == 28)
+        buddy.on_mouse_down(
+            _mouse(events.MouseDown, x=buddy.region.x + 1, y=buddy.region.y)
+        )
+        assert app.mouse_captured is buddy
+        await buddy.remove()
+        assert app.mouse_captured is None

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -13,7 +13,7 @@ from textual.app import ComposeResult
 from textual.containers import Container
 from textual.geometry import Offset
 from textual.screen import ModalScreen, Screen
-from textual.widgets import Input, Static
+from textual.widgets import Button, Input, Static
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
 from tldw_chatbook.Persona_Buddy import (
@@ -47,6 +47,8 @@ class _FakeController:
         collapsed: bool = False,
         animate: bool = False,
         frames: tuple[str, ...] = ("BUDDY-A",),
+        durations: tuple[int, ...] | None = None,
+        loop: bool = True,
     ) -> None:
         self.preferences = PersonaBuddyPreferences(
             enabled=True,
@@ -61,8 +63,10 @@ class _FakeController:
         )
         self.generation = 1
         self.persisted: list[PersonaBuddyPreferences] = []
+        durations = durations or tuple(20 for _ in frames)
         prepared = tuple(
-            SimpleNamespace(renderable=Text(label), duration_ms=20) for label in frames
+            SimpleNamespace(renderable=Text(label), duration_ms=duration)
+            for label, duration in zip(frames, durations, strict=True)
         )
         self.visual = PersonaBuddyVisualSnapshot(
             available=True,
@@ -77,7 +81,7 @@ class _FakeController:
             cache_identity=None,
             frames=prepared,  # type: ignore[arg-type]
             frame_rate=50.0,
-            loop=True,
+            loop=loop,
             animate=animate,
         )
 
@@ -104,6 +108,10 @@ class _FakeController:
         self.persisted.append(preferences)
         return self.snapshot()
 
+    async def resolve_current_visual(self, *, cols: int, lines: int):
+        assert cols > 0 and lines > 0
+        return self.visual
+
 
 class _BuddyScreen(Screen):
     def __init__(self, controller: _FakeController) -> None:
@@ -120,6 +128,25 @@ class _BuddyScreen(Screen):
             yield Input(id="focus-probe")
             yield Static("FLOW-END", id="flow-end")
         yield self.buddy
+
+
+class _BlockingResolutionController(_FakeController):
+    def __init__(self) -> None:
+        super().__init__()
+        self.resolve_started = asyncio.Event()
+        self.resolve_release = asyncio.Event()
+        self.active_resolves = 0
+        self.max_active_resolves = 0
+
+    async def resolve_current_visual(self, *, cols: int, lines: int):
+        self.active_resolves += 1
+        self.max_active_resolves = max(self.max_active_resolves, self.active_resolves)
+        self.resolve_started.set()
+        try:
+            await self.resolve_release.wait()
+            return self.visual
+        finally:
+            self.active_resolves -= 1
 
 
 class _BuddyApp(ConsolidatedCSSApp):
@@ -141,9 +168,9 @@ def _compositor_text(screen: Screen) -> str:
     return "\n".join(strip.text for strip in screen._compositor.render_strips())
 
 
-def _mouse(event_type, *, x: int, y: int, button: int = 1):
+def _mouse(event_type, *, x: int, y: int, button: int = 1, widget=None):
     return event_type(
-        None,
+        widget,
         x,
         y,
         0,
@@ -180,12 +207,18 @@ async def test_drag_and_resize_are_viewport_bounded_and_persist_once():
     async with app.run_test(size=(80, 24)):
         buddy = app.screen.query_one(PersonaBuddyWidget)
         await _wait_until(lambda: buddy.region.width == 28)
+        drag_handle = buddy.query_one("#persona-buddy-drag-handle", Static)
         initial_geometry = buddy._clamped_geometry(controller.preferences.geometry)
         assert initial_geometry.x + initial_geometry.width <= app.size.width
         assert initial_geometry.y + initial_geometry.height <= app.size.height
 
         buddy.on_mouse_down(
-            _mouse(events.MouseDown, x=buddy.region.x + 2, y=buddy.region.y)
+            _mouse(
+                events.MouseDown,
+                x=drag_handle.region.x + 1,
+                y=drag_handle.region.y + 1,
+                widget=drag_handle,
+            )
         )
         await asyncio.sleep(0)
         assert app.screen.focused is buddy
@@ -250,6 +283,32 @@ async def test_tiny_viewport_uses_labelled_compact_control():
 
 
 @pytest.mark.asyncio
+async def test_labelled_buttons_click_without_starting_drag_and_reopen_collapsed():
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)) as pilot:
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.region.width == 28)
+        await pilot.click("#persona-buddy-collapse")
+        await _wait_until(lambda: controller.preferences.collapsed)
+        assert app.mouse_captured is None
+        reopen = buddy.query_one("#persona-buddy-collapse", Button)
+        assert str(reopen.label) == "Open Buddy"
+        assert reopen.display
+        await pilot.pause(0.25)
+        target, _ = app.screen.get_widget_at(
+            reopen.region.x + reopen.region.width // 2,
+            reopen.region.y + reopen.region.height // 2,
+        )
+        assert target is reopen
+        await pilot.click("#persona-buddy-collapse")
+        await _wait_until(lambda: not controller.preferences.collapsed)
+        await pilot.click("#persona-buddy-close")
+        await _wait_until(lambda: not controller.preferences.open)
+        assert app.mouse_captured is None
+
+
+@pytest.mark.asyncio
 async def test_state_repaint_never_steals_focus():
     controller = _FakeController()
     app = _BuddyApp(controller)
@@ -265,13 +324,23 @@ async def test_state_repaint_never_steals_focus():
 
 @pytest.mark.asyncio
 async def test_animation_cells_change_then_freeze_hidden_collapsed():
-    controller = _FakeController(animate=True, frames=("FRAME-A", "FRAME-B"))
+    controller = _FakeController(
+        animate=True,
+        frames=("FRAME-A", "FRAME-B"),
+        durations=(300, 200),
+        loop=False,
+    )
     app = _BuddyApp(controller)
     async with app.run_test(size=(80, 24)):
         buddy = app.screen.query_one(PersonaBuddyWidget)
         await _wait_until(lambda: "FRAME-A" in _compositor_text(app.screen))
+        buddy._next_frame_at = 0
         buddy.advance_frame()
         await _wait_until(lambda: "FRAME-B" in _compositor_text(app.screen))
+        assert buddy._next_frame_at - asyncio.get_running_loop().time() > 0.1
+        buddy._next_frame_at = 0
+        buddy.advance_frame()
+        assert buddy.frame_index == 1
 
         controller.preferences = replace(controller.preferences, collapsed=True)
         buddy.refresh_from_controller()
@@ -295,6 +364,22 @@ async def test_reduced_motion_paints_static_frame():
         buddy.advance_frame()
         assert buddy.frame_index == 0
         assert "STATIC-A" in _compositor_text(app.screen)
+
+
+@pytest.mark.asyncio
+async def test_resolution_is_single_owned_and_stale_completion_cannot_repaint():
+    controller = _BlockingResolutionController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await asyncio.wait_for(controller.resolve_started.wait(), timeout=1)
+        await asyncio.sleep(0.15)
+        assert controller.max_active_resolves == 1
+        previous = buddy._snapshot
+        buddy._current_view = lambda _candidate: False
+        controller.resolve_release.set()
+        await asyncio.sleep(0.05)
+        assert buddy._snapshot is previous
 
 
 @pytest.mark.asyncio
@@ -323,7 +408,12 @@ async def test_capture_is_released_when_widget_unmounts_mid_drag():
         buddy = app.screen.query_one(PersonaBuddyWidget)
         await _wait_until(lambda: buddy.region.width == 28)
         buddy.on_mouse_down(
-            _mouse(events.MouseDown, x=buddy.region.x + 1, y=buddy.region.y)
+            _mouse(
+                events.MouseDown,
+                x=buddy.query_one("#persona-buddy-drag-handle", Static).region.x + 1,
+                y=buddy.query_one("#persona-buddy-drag-handle", Static).region.y + 1,
+                widget=buddy.query_one("#persona-buddy-drag-handle", Static),
+            )
         )
         assert app.mouse_captured is buddy
         await buddy.remove()

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -149,6 +149,12 @@ class _BlockingResolutionController(_FakeController):
             self.active_resolves -= 1
 
 
+class _FreshEquivalentVisualController(_FakeController):
+    async def resolve_current_visual(self, *, cols: int, lines: int):
+        self.visual = replace(self.visual)
+        return self.visual
+
+
 class _BuddyApp(ConsolidatedCSSApp):
     CSS_PATH = BUNDLED_STYLESHEET
     CSS = """
@@ -380,6 +386,24 @@ async def test_resolution_is_single_owned_and_stale_completion_cannot_repaint():
         controller.resolve_release.set()
         await asyncio.sleep(0.05)
         assert buddy._snapshot is previous
+
+
+@pytest.mark.asyncio
+async def test_fresh_equivalent_snapshots_preserve_animation_deadline_and_progress():
+    controller = _FreshEquivalentVisualController(
+        animate=True,
+        frames=("POLL-A", "POLL-B"),
+        durations=(180, 260),
+        loop=False,
+    )
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        await _wait_until(lambda: "POLL-A" in _compositor_text(app.screen))
+        await _wait_until(lambda: "POLL-B" in _compositor_text(app.screen), timeout=0.5)
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await asyncio.sleep(0.25)
+        assert buddy.frame_index == 1
+        assert "POLL-B" in _compositor_text(app.screen)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -89,7 +89,6 @@ class _FakeController:
         return self.preferences
 
     def snapshot(self) -> PersonaBuddySnapshot:
-        self.generation += 1
         return PersonaBuddySnapshot(
             generation=self.generation,
             selection=self.preferences.selection,
@@ -105,7 +104,18 @@ class _FakeController:
         self, preferences: PersonaBuddyPreferences
     ) -> PersonaBuddySnapshot:
         self.preferences = preferences
+        self.generation += 1
         self.persisted.append(preferences)
+        return self.snapshot()
+
+    def apply_preferences_patch(self, **changes: object) -> int:
+        self.preferences = replace(self.preferences, **changes)
+        self.generation += 1
+        return self.generation
+
+    async def persist_preferences_revision(self, revision: int):
+        assert revision <= self.generation
+        self.persisted.append(self.preferences)
         return self.snapshot()
 
     async def resolve_current_visual(self, *, cols: int, lines: int):
@@ -152,6 +162,16 @@ class _BlockingResolutionController(_FakeController):
 class _FreshEquivalentVisualController(_FakeController):
     async def resolve_current_visual(self, *, cols: int, lines: int):
         self.visual = replace(self.visual)
+        return self.visual
+
+
+class _CountingResolutionController(_FakeController):
+    def __init__(self) -> None:
+        super().__init__()
+        self.resolve_calls = 0
+
+    async def resolve_current_visual(self, *, cols: int, lines: int):
+        self.resolve_calls += 1
         return self.visual
 
 
@@ -289,6 +309,48 @@ async def test_tiny_viewport_uses_labelled_compact_control():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("viewport", "compact"),
+    [((28, 12), False), ((18, 6), True), ((12, 4), True), ((10, 2), True)],
+)
+async def test_exact_cell_layouts_keep_complete_labelled_controls(
+    viewport: tuple[int, int], compact: bool
+):
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=viewport):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.region.width > 0 and buddy.region.height > 0)
+        assert buddy.has_class("persona-buddy-compact") is compact
+        assert buddy.region.right <= viewport[0]
+        assert buddy.region.bottom <= viewport[1]
+
+        text = _compositor_text(app.screen)
+        collapse = buddy.query_one("#persona-buddy-collapse", Button)
+        close = buddy.query_one("#persona-buddy-close", Button)
+        controls = (collapse, close) if viewport[0] >= 18 else (collapse,)
+        for control in controls:
+            assert control.display
+            assert control.region.width >= len(str(control.label))
+            assert buddy.region.contains_region(control.region)
+            target, _ = app.screen.get_widget_at(
+                control.region.x + control.region.width // 2,
+                control.region.y + control.region.height // 2,
+            )
+            assert target is control
+
+        if compact:
+            assert "Buddy" in text
+            assert close.display is (viewport[0] >= 18)
+            if close.display:
+                assert "Close" in text
+        else:
+            assert "Fold" in text
+            assert "Close" in text
+            assert "hjkl move · HJKL size" in text
+
+
+@pytest.mark.asyncio
 async def test_labelled_buttons_click_without_starting_drag_and_reopen_collapsed():
     controller = _FakeController()
     app = _BuddyApp(controller)
@@ -404,6 +466,44 @@ async def test_fresh_equivalent_snapshots_preserve_animation_deadline_and_progre
         await asyncio.sleep(0.25)
         assert buddy.frame_index == 1
         assert "POLL-B" in _compositor_text(app.screen)
+
+
+@pytest.mark.asyncio
+async def test_resolution_runs_once_until_semantic_authority_changes():
+    controller = _CountingResolutionController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)):
+        await _wait_until(lambda: controller.resolve_calls == 1)
+        await asyncio.sleep(0.62)
+        assert controller.resolve_calls == 1
+
+        controller.generation += 1
+        await _wait_until(lambda: controller.resolve_calls == 2, timeout=0.3)
+
+
+@pytest.mark.asyncio
+async def test_animation_uses_frame_deadline_one_shots_and_static_has_no_timer():
+    animated = _FakeController(
+        animate=True,
+        frames=("TIMER-A", "TIMER-B"),
+        durations=(180, 260),
+        loop=False,
+    )
+    app = _BuddyApp(animated)
+    async with app.run_test(size=(80, 24)):
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy._frame_timer is not None)
+        assert buddy._frame_timer._repeat == 0
+        assert buddy._frame_timer._interval >= 0.17
+        await _wait_until(lambda: buddy.frame_index == 1, timeout=0.4)
+        assert buddy._frame_timer is None
+
+    static = _FakeController(animate=False, frames=("STATIC-A", "STATIC-B"))
+    static_app = _BuddyApp(static)
+    async with static_app.run_test(size=(80, 24)):
+        buddy = static_app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: "STATIC-A" in _compositor_text(static_app.screen))
+        assert buddy._frame_timer is None
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -351,6 +351,80 @@ async def test_exact_cell_layouts_keep_complete_labelled_controls(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("viewport", [(18, 6), (12, 4), (10, 2)])
+async def test_compact_keyboard_move_preserves_preferred_size_on_restore(
+    viewport: tuple[int, int],
+):
+    controller = _FakeController(size=(28, 12))
+    app = _BuddyApp(controller)
+    async with app.run_test(size=viewport) as pilot:
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.has_class("persona-buddy-compact"))
+        start = buddy.absolute_offset
+        buddy.focus(scroll_visible=False)
+
+        await pilot.press("k")
+        await _wait_until(lambda: len(controller.persisted) == 1)
+
+        preferred = controller.preferences.geometry
+        assert (preferred.width, preferred.height) == (28, 12)
+        assert preferred.y == max(0, start.y - 1)
+        await pilot.resize_terminal(28, 12)
+        await _wait_until(lambda: not buddy.has_class("persona-buddy-compact"))
+        assert (buddy.region.width, buddy.region.height) == (28, 12)
+
+
+@pytest.mark.asyncio
+async def test_drag_while_viewport_becomes_compact_preserves_preferred_size():
+    controller = _FakeController(size=(28, 12))
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)) as pilot:
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.region.width == 28)
+        handle = buddy.query_one("#persona-buddy-drag-handle", Static)
+        buddy.on_mouse_down(
+            _mouse(
+                events.MouseDown,
+                x=handle.region.x + 1,
+                y=handle.region.y,
+                widget=handle,
+            )
+        )
+        assert app.mouse_captured is buddy
+
+        await pilot.resize_terminal(12, 4)
+        await _wait_until(lambda: buddy.has_class("persona-buddy-compact"))
+        buddy.on_mouse_move(_mouse(events.MouseMove, x=0, y=0))
+        buddy.on_mouse_up(_mouse(events.MouseUp, x=0, y=0))
+        await _wait_until(lambda: len(controller.persisted) == 1)
+
+        preferred = controller.preferences.geometry
+        assert (preferred.width, preferred.height) == (28, 12)
+        await pilot.resize_terminal(28, 12)
+        await _wait_until(lambda: not buddy.has_class("persona-buddy-compact"))
+        await _wait_until(
+            lambda: (buddy.region.width, buddy.region.height) == (28, 12)
+        )
+
+
+@pytest.mark.asyncio
+async def test_compact_keyboard_resize_intentionally_updates_preferred_size():
+    controller = _FakeController(size=(28, 12))
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(10, 2)) as pilot:
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: buddy.has_class("persona-buddy-compact"))
+        buddy.focus(scroll_visible=False)
+
+        await pilot.press("L")
+        await _wait_until(lambda: len(controller.persisted) == 1)
+
+        preferred = controller.preferences.geometry
+        assert (preferred.width, preferred.height) == (29, 12)
+        assert (buddy.region.width, buddy.region.height) == (10, 1)
+
+
+@pytest.mark.asyncio
 async def test_labelled_buttons_click_without_starting_drag_and_reopen_collapsed():
     controller = _FakeController()
     app = _BuddyApp(controller)

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -402,9 +402,7 @@ async def test_drag_while_viewport_becomes_compact_preserves_preferred_size():
         assert (preferred.width, preferred.height) == (28, 12)
         await pilot.resize_terminal(28, 12)
         await _wait_until(lambda: not buddy.has_class("persona-buddy-compact"))
-        await _wait_until(
-            lambda: (buddy.region.width, buddy.region.height) == (28, 12)
-        )
+        await _wait_until(lambda: (buddy.region.width, buddy.region.height) == (28, 12))
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -1,9 +1,7 @@
 """Mounted tests for the Personas inspector pane."""
 
-from dataclasses import FrozenInstanceError, is_dataclass
-
 import pytest
-from textual.app import App
+from textual.message import Message
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -41,9 +39,11 @@ class InspectorApp(ConsolidatedCSSApp):
 async def test_persona_buddy_action_message_is_typed_frozen_and_slotted():
     message_type = getattr(personas_messages, "PersonaBuddyActionRequested", None)
     assert message_type is not None
-    assert is_dataclass(message_type)
-    assert message_type.__dataclass_params__.frozen is True
+    assert message_type.__slots__ == ("_payload",)
     assert "__dict__" not in message_type.__slots__
+    assert message_type.set_sender is Message.set_sender
+    assert message_type.prevent_default is Message.prevent_default
+    assert message_type.stop is Message.stop
 
     message = message_type(
         action="use",
@@ -58,8 +58,25 @@ async def test_persona_buddy_action_message_is_typed_frozen_and_slotted():
         "persona-7",
         4,
     )
-    with pytest.raises(FrozenInstanceError):
+    with pytest.raises(AttributeError):
         message.action = "show"
+
+
+async def test_persona_buddy_action_message_uses_normal_textual_delivery():
+    app = InspectorApp()
+    async with app.run_test(size=(80, 24)) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        message = personas_messages.PersonaBuddyActionRequested(
+            action="use",
+            source="local",
+            persona_id="persona-7",
+            revision=4,
+        )
+
+        pane.post_message(message)
+        await pilot.pause()
+
+        assert app.buddy_messages == [message]
 
 
 @pytest.mark.parametrize(
@@ -88,6 +105,12 @@ async def test_active_local_persona_buddy_actions_are_explicit_and_typed(
             active=True,
             profile_current=True,
         )
+        pane.set_buddy_status(
+            source="local",
+            persona_id="persona-7",
+            enabled=True,
+            open=action != "show",
+        )
         await pilot.pause()
 
         button = pilot.app.query_one(button_id, Button)
@@ -97,7 +120,12 @@ async def test_active_local_persona_buddy_actions_are_explicit_and_typed(
         await pilot.pause()
 
         message = app.buddy_messages[-1]
-        assert (message.action, message.source, message.persona_id, message.revision) == (
+        assert (
+            message.action,
+            message.source,
+            message.persona_id,
+            message.revision,
+        ) == (
             action,
             "local",
             "persona-7",
@@ -129,6 +157,38 @@ async def test_server_persona_buddy_actions_are_disabled_with_exact_recovery_cop
             button = pilot.app.query_one(button_id, Button)
             assert button.disabled is True
             assert button.tooltip == "Save a local copy first"
+
+
+async def test_non_owner_highlight_only_enables_use_with_truthful_tooltip():
+    app = InspectorApp()
+    async with app.run_test(size=(170, 50)) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(
+            name="Navigator",
+            kind="persona",
+            source="local",
+            entity_id="persona-2",
+            revision=5,
+            active=True,
+            profile_current=True,
+        )
+        pane.set_buddy_status(
+            source="local",
+            persona_id="persona-1",
+            enabled=True,
+            open=True,
+        )
+        await pilot.pause()
+
+        assert pane.query_one("#personas-buddy-use", Button).disabled is False
+        for button_id in (
+            "#personas-buddy-show",
+            "#personas-buddy-close",
+            "#personas-buddy-disable",
+        ):
+            button = pane.query_one(button_id, Button)
+            assert button.disabled is True
+            assert button.tooltip == "Select the Persona currently used by Buddy"
 
 
 async def test_persona_highlight_alone_emits_no_buddy_action():
@@ -172,6 +232,12 @@ async def test_buddy_actions_keep_exact_labels_and_focus_without_keybindings(siz
             ("#personas-buddy-disable", "Disable Buddy"),
         )
         for button_id, label in expected:
+            pane.set_buddy_status(
+                source="local",
+                persona_id="persona-7",
+                enabled=True,
+                open=button_id != "#personas-buddy-show",
+            )
             button = pilot.app.query_one(button_id, Button)
             assert str(button.label) == label
             assert button.can_focus is True

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -86,6 +86,7 @@ async def test_active_local_persona_buddy_actions_are_explicit_and_typed(
             entity_id="persona-7",
             revision=4,
             active=True,
+            profile_current=True,
         )
         await pilot.pause()
 
@@ -115,6 +116,7 @@ async def test_server_persona_buddy_actions_are_disabled_with_exact_recovery_cop
             entity_id="persona-7",
             revision=4,
             active=True,
+            profile_current=True,
         )
         await pilot.pause()
 
@@ -140,6 +142,7 @@ async def test_persona_highlight_alone_emits_no_buddy_action():
             entity_id="persona-7",
             revision=4,
             active=True,
+            profile_current=True,
         )
         await pilot.pause()
 
@@ -158,6 +161,7 @@ async def test_buddy_actions_keep_exact_labels_and_focus_without_keybindings(siz
             entity_id="persona-7",
             revision=4,
             active=True,
+            profile_current=True,
         )
         await pilot.pause()
 
@@ -196,11 +200,35 @@ async def test_buddy_rejects_incomplete_or_inactive_local_persona(
             entity_id=entity_id,
             revision=revision,
             active=active,
+            profile_current=True,
         )
         await pilot.pause()
 
         for button in pilot.app.query(".persona-buddy-action").results(Button):
             assert button.disabled is True
+
+
+async def test_buddy_requires_current_complete_profile_not_cached_eligibility():
+    app = InspectorApp()
+    async with app.run_test(size=(170, 50)) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(
+            name="Cached Persona",
+            kind="persona",
+            source="local",
+            entity_id="persona-7",
+            revision=4,
+            active=True,
+            profile_current=False,
+        )
+        await pilot.pause()
+
+        for button in pilot.app.query(".persona-buddy-action").results(Button):
+            assert button.disabled is True
+            assert (
+                button.tooltip
+                == "Persona details are unavailable. Refresh and try again."
+            )
 
 
 async def test_default_state_shows_no_selection_and_disabled_actions():

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -1,5 +1,7 @@
 """Mounted tests for the Personas inspector pane."""
 
+from dataclasses import FrozenInstanceError, is_dataclass
+
 import pytest
 from textual.app import App
 
@@ -11,6 +13,7 @@ from textual.widgets import Button, Checkbox, ListItem, ListView, Static
 from tldw_chatbook.Widgets.Persona_Widgets.personas_inspector_pane import (
     PersonasInspectorPane,
 )
+from tldw_chatbook.Widgets.Persona_Widgets import personas_messages
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
     ConversationRowSelected,
 )
@@ -24,8 +27,180 @@ def _row_text(item: ListItem) -> str:
 
 
 class InspectorApp(ConsolidatedCSSApp):
+    def __init__(self):
+        super().__init__()
+        self.buddy_messages = []
+
     def compose(self):
         yield PersonasInspectorPane(id="personas-inspector-pane")
+
+    def on_persona_buddy_action_requested(self, message) -> None:
+        self.buddy_messages.append(message)
+
+
+async def test_persona_buddy_action_message_is_typed_frozen_and_slotted():
+    message_type = getattr(personas_messages, "PersonaBuddyActionRequested", None)
+    assert message_type is not None
+    assert is_dataclass(message_type)
+    assert message_type.__dataclass_params__.frozen is True
+    assert "__dict__" not in message_type.__slots__
+
+    message = message_type(
+        action="use",
+        source="local",
+        persona_id="persona-7",
+        revision=4,
+    )
+
+    assert (message.action, message.source, message.persona_id, message.revision) == (
+        "use",
+        "local",
+        "persona-7",
+        4,
+    )
+    with pytest.raises(FrozenInstanceError):
+        message.action = "show"
+
+
+@pytest.mark.parametrize(
+    ("button_id", "label", "action"),
+    (
+        ("#personas-buddy-use", "Use for Buddy", "use"),
+        ("#personas-buddy-show", "Show Buddy", "show"),
+        ("#personas-buddy-close", "Close Buddy", "close"),
+        ("#personas-buddy-disable", "Disable Buddy", "disable"),
+    ),
+)
+async def test_active_local_persona_buddy_actions_are_explicit_and_typed(
+    button_id: str,
+    label: str,
+    action: str,
+):
+    app = InspectorApp()
+    async with app.run_test(size=(170, 50)) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(
+            name="Archivist",
+            kind="persona",
+            source="local",
+            entity_id="persona-7",
+            revision=4,
+            active=True,
+        )
+        await pilot.pause()
+
+        button = pilot.app.query_one(button_id, Button)
+        assert str(button.label) == label
+        assert button.disabled is False
+        await pilot.click(button_id)
+        await pilot.pause()
+
+        message = app.buddy_messages[-1]
+        assert (message.action, message.source, message.persona_id, message.revision) == (
+            action,
+            "local",
+            "persona-7",
+            4,
+        )
+
+
+async def test_server_persona_buddy_actions_are_disabled_with_exact_recovery_copy():
+    app = InspectorApp()
+    async with app.run_test(size=(170, 50)) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(
+            name="Remote Archivist",
+            kind="persona",
+            source="server",
+            entity_id="persona-7",
+            revision=4,
+            active=True,
+        )
+        await pilot.pause()
+
+        for button_id in (
+            "#personas-buddy-use",
+            "#personas-buddy-show",
+            "#personas-buddy-close",
+            "#personas-buddy-disable",
+        ):
+            button = pilot.app.query_one(button_id, Button)
+            assert button.disabled is True
+            assert button.tooltip == "Save a local copy first"
+
+
+async def test_persona_highlight_alone_emits_no_buddy_action():
+    app = InspectorApp()
+    async with app.run_test(size=(80, 24)) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(
+            name="Archivist",
+            kind="persona",
+            source="local",
+            entity_id="persona-7",
+            revision=4,
+            active=True,
+        )
+        await pilot.pause()
+
+        assert app.buddy_messages == []
+
+
+@pytest.mark.parametrize("size", ((170, 50), (80, 24)))
+async def test_buddy_actions_keep_exact_labels_and_focus_without_keybindings(size):
+    app = InspectorApp()
+    async with app.run_test(size=size) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(
+            name="Archivist",
+            kind="persona",
+            source="local",
+            entity_id="persona-7",
+            revision=4,
+            active=True,
+        )
+        await pilot.pause()
+
+        expected = (
+            ("#personas-buddy-use", "Use for Buddy"),
+            ("#personas-buddy-show", "Show Buddy"),
+            ("#personas-buddy-close", "Close Buddy"),
+            ("#personas-buddy-disable", "Disable Buddy"),
+        )
+        for button_id, label in expected:
+            button = pilot.app.query_one(button_id, Button)
+            assert str(button.label) == label
+            assert button.can_focus is True
+            button.focus(scroll_visible=True)
+            await pilot.pause()
+            assert button.has_focus is True
+
+        await pilot.press("u", "s", "c", "d")
+        assert app.buddy_messages == []
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "revision", "active"),
+    ((None, 4, True), ("persona-7", None, True), ("persona-7", 4, False)),
+)
+async def test_buddy_rejects_incomplete_or_inactive_local_persona(
+    entity_id, revision, active
+):
+    app = InspectorApp()
+    async with app.run_test(size=(170, 50)) as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(
+            name="Archivist",
+            kind="persona",
+            source="local",
+            entity_id=entity_id,
+            revision=revision,
+            active=active,
+        )
+        await pilot.pause()
+
+        for button in pilot.app.query(".persona-buddy-action").results(Button):
+            assert button.disabled is True
 
 
 async def test_default_state_shows_no_selection_and_disabled_actions():

--- a/Tests/UI/test_personas_persona_visual_authoring.py
+++ b/Tests/UI/test_personas_persona_visual_authoring.py
@@ -26,6 +26,7 @@ from tldw_chatbook.Persona_Visual.publication import (
     PersonaVisualPublicationResult,
 )
 from tldw_chatbook.Persona_Visual.repository import PersonaVisualIdentity
+from tldw_chatbook.Persona_Buddy import PersonaBuddySelection
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 from tldw_chatbook.Utils.paths import get_user_data_dir
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
@@ -79,6 +80,15 @@ def _identity(version: int = 1) -> PersonaVisualIdentity:
         pack_version_id=13,
         version_number=version,
         manifest_sha256="a" * 64,
+    )
+
+
+def _buddy_snapshot(*, visual, persona_id: str = "p-1"):
+    return SimpleNamespace(
+        selection=PersonaBuddySelection("local", persona_id),
+        preferences_generation=7,
+        profile_generation=11,
+        visual=visual,
     )
 
 
@@ -253,8 +263,13 @@ async def test_visual_publication_invalidates_bound_buddy_old_and_new_identity_o
     invalidate_profile = Mock()
     reconcile = AsyncMock(return_value=True)
     buddy = SimpleNamespace(
-        snapshot=lambda: SimpleNamespace(
-            visual=SimpleNamespace(graph_identity=_identity())
+        snapshot=lambda: _buddy_snapshot(
+            visual=SimpleNamespace(
+                source="local",
+                persona_id="p-1",
+                persona_revision=2,
+                graph_identity=_identity(),
+            )
         ),
         invalidate_profile=invalidate_profile,
     )
@@ -286,14 +301,104 @@ async def test_visual_publication_invalidates_bound_buddy_old_and_new_identity_o
         invalidate_profile.assert_not_called()
         reconcile.assert_not_awaited()
 
-        buddy.snapshot = lambda: SimpleNamespace(
-            visual=SimpleNamespace(graph_identity=_identity(2))
+        buddy.snapshot = lambda: _buddy_snapshot(
+            visual=SimpleNamespace(
+                source="local",
+                persona_id="p-1",
+                persona_revision=2,
+                graph_identity=_identity(2),
+            )
         )
         await screen._invalidate_persona_visual_publication(
             PersonaVisualPublicationResult(_identity(), _identity(2), None)
         )
         invalidate_profile.assert_called_once_with()
         reconcile.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    "visual",
+    (
+        None,
+        SimpleNamespace(
+            source="local",
+            persona_id="p-1",
+            persona_revision=2,
+            graph_identity=None,
+        ),
+    ),
+)
+async def test_visual_publication_remounts_exact_selected_unavailable_buddy(
+    visual,
+    monkeypatch,
+    mock_app_instance,
+    stub_characters,
+    local_scope,
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    invalidate_profile = Mock()
+    reconcile = AsyncMock(return_value=True)
+    buddy = SimpleNamespace(
+        snapshot=lambda: _buddy_snapshot(visual=visual),
+        invalidate_profile=invalidate_profile,
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        mock_app_instance.persona_buddy_controller = buddy
+        mock_app_instance.reconcile_persona_buddy_view = reconcile
+
+        await screen._invalidate_persona_visual_publication(
+            PersonaVisualPublicationResult(_identity(), _identity(2), None)
+        )
+
+        invalidate_profile.assert_called_once_with()
+        reconcile.assert_awaited_once_with()
+
+
+async def test_visual_publication_rejects_stale_cached_actor_after_selection_change(
+    monkeypatch,
+    mock_app_instance,
+    stub_characters,
+    local_scope,
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    invalidate_profile = Mock()
+    buddy = SimpleNamespace(
+        snapshot=lambda: _buddy_snapshot(
+            persona_id="p-2",
+            visual=SimpleNamespace(
+                source="local",
+                persona_id="p-1",
+                persona_revision=2,
+                graph_identity=_identity(),
+            ),
+        ),
+        invalidate_profile=invalidate_profile,
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        local_scope.get_persona_profile = AsyncMock(
+            return_value={
+                **PROFILE,
+                "id": "p-2",
+                "version": 5,
+                "is_active": True,
+                "deleted": False,
+            }
+        )
+        mock_app_instance.persona_buddy_controller = buddy
+        mock_app_instance.reconcile_persona_buddy_view = AsyncMock(return_value=True)
+
+        await screen._invalidate_persona_visual_publication(
+            PersonaVisualPublicationResult(_identity(), _identity(2), None)
+        )
+
+        invalidate_profile.assert_not_called()
+        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
 
 
 async def test_failed_publication_keeps_draft_and_invalidates_nothing(
@@ -360,10 +465,22 @@ async def test_cancel_signals_active_operation_and_discards_only_draft(
     monkeypatch, mock_app_instance, stub_characters, local_scope
 ):
     monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    buddy_invalidation = Mock()
     app = PersonasTestApp(mock_app_instance)
 
     async with app.run_test() as pilot:
         screen = await _open_editor(pilot)
+        mock_app_instance.persona_buddy_controller = SimpleNamespace(
+            snapshot=lambda: _buddy_snapshot(
+                visual=SimpleNamespace(
+                    source="local",
+                    persona_id="p-1",
+                    persona_revision=2,
+                    graph_identity=_identity(),
+                )
+            ),
+            invalidate_profile=buddy_invalidation,
+        )
         state = screen._persona_visual_authoring
         assert state is not None
         state.dirty = True
@@ -385,6 +502,7 @@ async def test_cancel_signals_active_operation_and_discards_only_draft(
 
         assert screen._persona_visual_authoring is None
         assert screen._configure_persona_visual.await_count == 1
+        buddy_invalidation.assert_not_called()
 
 
 async def test_stale_import_is_cleaned_and_cannot_repaint(

--- a/Tests/UI/test_personas_persona_visual_authoring.py
+++ b/Tests/UI/test_personas_persona_visual_authoring.py
@@ -20,13 +20,19 @@ from Tests.UI.test_personas_workbench import (
     PersonasTestApp,
     _mounted,
 )
+from Tests.Persona_Buddy.test_persona_buddy_resolution import (
+    _runtime as _persona_buddy_runtime,
+)
 from tldw_chatbook.Persona_Visual.importer import PersonaVisualImportReview
 from tldw_chatbook.Persona_Visual.publication import (
     PersonaVisualPublicationError,
     PersonaVisualPublicationResult,
 )
-from tldw_chatbook.Persona_Visual.repository import PersonaVisualIdentity
-from tldw_chatbook.Persona_Buddy import PersonaBuddySelection
+from tldw_chatbook.Persona_Visual.repository import (
+    PersonaVisualIdentity,
+    PersonaVisualRepository,
+)
+from tldw_chatbook.Persona_Visual.runtime import PersonaVisualCacheIdentity
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 from tldw_chatbook.Utils.paths import get_user_data_dir
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
@@ -80,15 +86,6 @@ def _identity(version: int = 1) -> PersonaVisualIdentity:
         pack_version_id=13,
         version_number=version,
         manifest_sha256="a" * 64,
-    )
-
-
-def _buddy_snapshot(*, visual, persona_id: str = "p-1"):
-    return SimpleNamespace(
-        selection=PersonaBuddySelection("local", persona_id),
-        preferences_generation=7,
-        profile_generation=11,
-        visual=visual,
     )
 
 
@@ -257,187 +254,245 @@ async def test_save_publishes_once_then_invalidates_exact_old_and_new(
 
 
 async def test_visual_publication_invalidates_bound_buddy_old_and_new_identity_only(
-    monkeypatch, mock_app_instance, stub_characters, local_scope
+    monkeypatch, mock_app_instance, stub_characters, local_scope, tmp_path
 ):
     monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
-    invalidate_profile = Mock()
     reconcile = AsyncMock(return_value=True)
-    buddy = SimpleNamespace(
-        snapshot=lambda: _buddy_snapshot(
-            visual=SimpleNamespace(
-                source="local",
-                persona_id="p-1",
-                persona_revision=2,
-                graph_identity=_identity(),
-            )
-        ),
-        invalidate_profile=invalidate_profile,
-    )
+    buddy, db, graph = _persona_buddy_runtime(tmp_path)
+    assert graph is not None
     app = PersonasTestApp(mock_app_instance)
 
-    async with app.run_test() as pilot:
-        screen = await _open_editor(pilot)
-        mock_app_instance.persona_buddy_controller = buddy
-        mock_app_instance.reconcile_persona_buddy_view = reconcile
-
-        await screen._invalidate_persona_visual_publication(
-            PersonaVisualPublicationResult(_identity(), _identity(2), None)
-        )
-        invalidate_profile.assert_called_once_with()
-        reconcile.assert_awaited_once_with()
-
-        invalidate_profile.reset_mock()
-        reconcile.reset_mock()
-        unrelated = replace(
-            _identity(3),
-            persona_id="p-other",
-            binding_id=91,
-            pack_id=92,
-            pack_version_id=93,
-        )
-        await screen._invalidate_persona_visual_publication(
-            PersonaVisualPublicationResult(unrelated, unrelated, None)
-        )
-        invalidate_profile.assert_not_called()
-        reconcile.assert_not_awaited()
-
-        buddy.snapshot = lambda: _buddy_snapshot(
-            visual=SimpleNamespace(
-                source="local",
-                persona_id="p-1",
-                persona_revision=2,
-                graph_identity=_identity(2),
+    try:
+        visual = await buddy.resolve_current_visual(cols=80, lines=24)
+        assert visual.available is True
+        assert type(visual.cache_identity) is PersonaVisualCacheIdentity
+        assert visual.cache_identity.graph == graph.identity
+        async with app.run_test() as pilot:
+            screen = await _open_editor(pilot)
+            local_scope.get_persona_profile = AsyncMock(
+                return_value={
+                    **PROFILE,
+                    "id": "persona-local-1",
+                    "version": 7,
+                    "is_active": True,
+                    "deleted": False,
+                }
             )
-        )
-        await screen._invalidate_persona_visual_publication(
-            PersonaVisualPublicationResult(_identity(), _identity(2), None)
-        )
-        invalidate_profile.assert_called_once_with()
-        reconcile.assert_awaited_once_with()
+            mock_app_instance.persona_buddy_controller = buddy
+            mock_app_instance.reconcile_persona_buddy_view = reconcile
+            before = buddy.snapshot().profile_generation
+
+            await screen._invalidate_persona_visual_publication(
+                PersonaVisualPublicationResult(graph.identity, graph.identity, None)
+            )
+            assert buddy.snapshot().profile_generation == before + 1
+            reconcile.assert_awaited_once_with()
+
+            reconcile.reset_mock()
+            unrelated = replace(
+                graph.identity,
+                persona_id="p-other",
+                binding_id=91,
+                pack_id=92,
+                pack_version_id=93,
+            )
+            await screen._invalidate_persona_visual_publication(
+                PersonaVisualPublicationResult(unrelated, unrelated, None)
+            )
+            assert buddy.snapshot().profile_generation == before + 1
+            reconcile.assert_not_awaited()
+    finally:
+        await buddy.shutdown()
+        db.close_connection()
 
 
-@pytest.mark.parametrize(
-    "visual",
-    (
-        None,
-        SimpleNamespace(
-            source="local",
-            persona_id="p-1",
-            persona_revision=2,
-            graph_identity=None,
-        ),
-    ),
-)
-async def test_visual_publication_remounts_exact_selected_unavailable_buddy(
-    visual,
+async def test_visual_publication_rebounds_real_unavailable_buddy_to_available(
     monkeypatch,
     mock_app_instance,
     stub_characters,
     local_scope,
+    tmp_path,
 ):
     monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
-    invalidate_profile = Mock()
-    reconcile = AsyncMock(return_value=True)
-    buddy = SimpleNamespace(
-        snapshot=lambda: _buddy_snapshot(visual=visual),
-        invalidate_profile=invalidate_profile,
-    )
+    buddy, db, graph = _persona_buddy_runtime(tmp_path)
+    assert graph is not None
+    published = False
+
+    class PublicationGate:
+        def __init__(self, profile_db):
+            self._repository = PersonaVisualRepository(profile_db)
+
+        def get_active_persona_pack(self, persona_id):
+            if not published:
+                return None
+            return self._repository.get_active_persona_pack(persona_id)
+
+        def __getattr__(self, name):
+            return getattr(self._repository, name)
+
+    # The controller owns the real resolution and cache snapshots; only the
+    # publication boundary is gated so the first resolve sees no binding.
+    buddy._repository_factory = PublicationGate
+    mounted = []
+
+    async def reconcile():
+        mounted.append(await buddy.resolve_current_visual(cols=80, lines=24))
+        return True
+
     app = PersonasTestApp(mock_app_instance)
+    try:
+        unavailable = await buddy.resolve_current_visual(cols=80, lines=24)
+        assert unavailable.available is False
+        assert unavailable.source == "unavailable"
+        assert unavailable.persona_id == "persona-local-1"
+        assert unavailable.persona_revision == 7
+        assert unavailable.graph_identity is None
+        assert unavailable.cache_identity is None
 
-    async with app.run_test() as pilot:
-        screen = await _open_editor(pilot)
-        mock_app_instance.persona_buddy_controller = buddy
-        mock_app_instance.reconcile_persona_buddy_view = reconcile
+        async with app.run_test() as pilot:
+            screen = await _open_editor(pilot)
+            local_scope.get_persona_profile = AsyncMock(
+                return_value={
+                    **PROFILE,
+                    "id": "persona-local-1",
+                    "version": 7,
+                    "is_active": True,
+                    "deleted": False,
+                }
+            )
+            mock_app_instance.persona_buddy_controller = buddy
+            mock_app_instance.reconcile_persona_buddy_view = AsyncMock(
+                side_effect=reconcile
+            )
+            before = buddy.snapshot().profile_generation
+            published = True
 
-        await screen._invalidate_persona_visual_publication(
-            PersonaVisualPublicationResult(_identity(), _identity(2), None)
-        )
+            await screen._invalidate_persona_visual_publication(
+                PersonaVisualPublicationResult(graph.identity, graph.identity, None)
+            )
 
-        invalidate_profile.assert_called_once_with()
-        reconcile.assert_awaited_once_with()
+            assert buddy.snapshot().profile_generation == before + 1
+            assert len(mounted) == 1
+            assert mounted[0].available is True
+            assert mounted[0].graph_identity == graph.identity
+            assert type(mounted[0].cache_identity) is PersonaVisualCacheIdentity
+            assert buddy.snapshot().visual == mounted[0]
+    finally:
+        await buddy.shutdown()
+        db.close_connection()
 
 
-async def test_visual_publication_rejects_stale_cached_actor_after_selection_change(
+async def test_visual_publication_rejects_real_same_graph_stale_cache_and_actor(
     monkeypatch,
     mock_app_instance,
     stub_characters,
     local_scope,
+    tmp_path,
 ):
     monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
-    invalidate_profile = Mock()
-    buddy = SimpleNamespace(
-        snapshot=lambda: _buddy_snapshot(
-            persona_id="p-2",
-            visual=SimpleNamespace(
-                source="local",
-                persona_id="p-1",
-                persona_revision=2,
-                graph_identity=_identity(),
-            ),
-        ),
-        invalidate_profile=invalidate_profile,
-    )
+    buddy, db, graph = _persona_buddy_runtime(tmp_path)
+    assert graph is not None
     app = PersonasTestApp(mock_app_instance)
+    reduced_motion = [False]
+    buddy._reduced_motion = lambda: reduced_motion[0]
+    try:
+        original = await buddy.resolve_current_visual(cols=80, lines=24)
+        assert original.available is True
+        assert type(original.cache_identity) is PersonaVisualCacheIdentity
 
-    async with app.run_test() as pilot:
-        screen = await _open_editor(pilot)
-        local_scope.get_persona_profile = AsyncMock(
-            return_value={
+        async def change_cache(persona_id: str, *, mode: str):
+            assert persona_id == "persona-local-1"
+            assert mode == "local"
+            reduced_motion[0] = True
+            changed = await buddy.resolve_current_visual(cols=80, lines=24)
+            assert changed.graph_identity == original.graph_identity
+            assert changed.cache_identity != original.cache_identity
+            assert changed.cache_identity.reduced_motion is True
+            assert original.cache_identity.reduced_motion is False
+            return {
                 **PROFILE,
-                "id": "p-2",
-                "version": 5,
+                "id": "persona-local-1",
+                "version": 7,
                 "is_active": True,
                 "deleted": False,
             }
-        )
-        mock_app_instance.persona_buddy_controller = buddy
-        mock_app_instance.reconcile_persona_buddy_view = AsyncMock(return_value=True)
 
-        await screen._invalidate_persona_visual_publication(
-            PersonaVisualPublicationResult(_identity(), _identity(2), None)
-        )
+        async with app.run_test() as pilot:
+            screen = await _open_editor(pilot)
+            local_scope.get_persona_profile = AsyncMock(side_effect=change_cache)
+            mock_app_instance.persona_buddy_controller = buddy
+            mock_app_instance.reconcile_persona_buddy_view = AsyncMock(
+                return_value=True
+            )
+            before = buddy.snapshot().profile_generation
 
-        invalidate_profile.assert_not_called()
-        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+            await screen._invalidate_persona_visual_publication(
+                PersonaVisualPublicationResult(graph.identity, graph.identity, None)
+            )
+            assert buddy.snapshot().profile_generation == before
+            mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+            unrelated = replace(
+                graph.identity,
+                persona_id="p-other",
+                binding_id=91,
+                pack_id=92,
+                pack_version_id=93,
+            )
+            await screen._invalidate_persona_visual_publication(
+                PersonaVisualPublicationResult(unrelated, unrelated, None)
+            )
+            assert buddy.snapshot().profile_generation == before
+            mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+            buddy.select_local_persona("p-other")
+            after_selection = buddy.snapshot().profile_generation
+            await screen._invalidate_persona_visual_publication(
+                PersonaVisualPublicationResult(graph.identity, graph.identity, None)
+            )
+            assert buddy.snapshot().profile_generation == after_selection
+            mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+    finally:
+        await buddy.shutdown()
+        db.close_connection()
 
 
 async def test_failed_publication_keeps_draft_and_invalidates_nothing(
-    monkeypatch, mock_app_instance, stub_characters, local_scope
+    monkeypatch, mock_app_instance, stub_characters, local_scope, tmp_path
 ):
     monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    buddy, db, _graph = _persona_buddy_runtime(tmp_path)
     app = PersonasTestApp(mock_app_instance)
     invalidation = AsyncMock()
-    buddy_invalidation = Mock()
+    try:
+        async with app.run_test() as pilot:
+            screen = await _open_editor(pilot)
+            mock_app_instance.persona_buddy_controller = buddy
+            screen._session = SimpleNamespace(
+                invalidate_persona_visual_identities=invalidation
+            )
+            state = screen._persona_visual_authoring
+            assert state is not None
+            state.dirty = True
+            before = buddy.snapshot().profile_generation
+            monkeypatch.setattr(
+                personas_screen_module,
+                "persona_visual_draft_publication_snapshot",
+                lambda _draft: object(),
+            )
 
-    async with app.run_test() as pilot:
-        screen = await _open_editor(pilot)
-        mock_app_instance.persona_buddy_controller = SimpleNamespace(
-            snapshot=lambda: SimpleNamespace(
-                visual=SimpleNamespace(graph_identity=_identity())
-            ),
-            invalidate_profile=buddy_invalidation,
-        )
-        screen._session = SimpleNamespace(
-            invalidate_persona_visual_identities=invalidation
-        )
-        state = screen._persona_visual_authoring
-        assert state is not None
-        state.dirty = True
-        monkeypatch.setattr(
-            personas_screen_module,
-            "persona_visual_draft_publication_snapshot",
-            lambda _draft: object(),
-        )
+            def fail(*_args, **_kwargs):
+                raise PersonaVisualPublicationError("persona_visual_authority_changed")
 
-        def fail(*_args, **_kwargs):
-            raise PersonaVisualPublicationError("persona_visual_authority_changed")
+            monkeypatch.setattr(personas_screen_module, "publish_persona_visual", fail)
 
-        monkeypatch.setattr(personas_screen_module, "publish_persona_visual", fail)
-
-        assert await screen._save_persona_visual_pack() is False
-        assert screen._persona_visual_authoring is state
-        invalidation.assert_not_awaited()
-        buddy_invalidation.assert_not_called()
+            assert await screen._save_persona_visual_pack() is False
+            assert screen._persona_visual_authoring is state
+            invalidation.assert_not_awaited()
+            assert buddy.snapshot().profile_generation == before
+    finally:
+        await buddy.shutdown()
+        db.close_connection()
 
 
 async def test_persona_authority_guard_rejects_revision_and_eligibility_changes(
@@ -462,47 +517,41 @@ async def test_persona_authority_guard_rejects_revision_and_eligibility_changes(
 
 
 async def test_cancel_signals_active_operation_and_discards_only_draft(
-    monkeypatch, mock_app_instance, stub_characters, local_scope
+    monkeypatch, mock_app_instance, stub_characters, local_scope, tmp_path
 ):
     monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
-    buddy_invalidation = Mock()
+    buddy, db, _graph = _persona_buddy_runtime(tmp_path)
     app = PersonasTestApp(mock_app_instance)
+    try:
+        async with app.run_test() as pilot:
+            screen = await _open_editor(pilot)
+            mock_app_instance.persona_buddy_controller = buddy
+            state = screen._persona_visual_authoring
+            assert state is not None
+            state.dirty = True
+            before = buddy.snapshot().profile_generation
+            event = asyncio.Event()
 
-    async with app.run_test() as pilot:
-        screen = await _open_editor(pilot)
-        mock_app_instance.persona_buddy_controller = SimpleNamespace(
-            snapshot=lambda: _buddy_snapshot(
-                visual=SimpleNamespace(
-                    source="local",
-                    persona_id="p-1",
-                    persona_revision=2,
-                    graph_identity=_identity(),
-                )
-            ),
-            invalidate_profile=buddy_invalidation,
-        )
-        state = screen._persona_visual_authoring
-        assert state is not None
-        state.dirty = True
-        event = asyncio.Event()
+            async def blocked():
+                await event.wait()
 
-        async def blocked():
-            await event.wait()
+            task = asyncio.create_task(blocked())
+            screen._persona_visual_operation_task = task
+            screen._persona_visual_operation_event = threading.Event()
+            monkeypatch.setattr(screen, "_configure_persona_visual", AsyncMock())
 
-        task = asyncio.create_task(blocked())
-        screen._persona_visual_operation_task = task
-        screen._persona_visual_operation_event = threading.Event()
-        monkeypatch.setattr(screen, "_configure_persona_visual", AsyncMock())
+            cancel = asyncio.create_task(screen._cancel_persona_visual_authoring())
+            await asyncio.sleep(0)
+            assert screen._persona_visual_operation_event.is_set()
+            event.set()
+            await cancel
 
-        cancel = asyncio.create_task(screen._cancel_persona_visual_authoring())
-        await asyncio.sleep(0)
-        assert screen._persona_visual_operation_event.is_set()
-        event.set()
-        await cancel
-
-        assert screen._persona_visual_authoring is None
-        assert screen._configure_persona_visual.await_count == 1
-        buddy_invalidation.assert_not_called()
+            assert screen._persona_visual_authoring is None
+            assert screen._configure_persona_visual.await_count == 1
+            assert buddy.snapshot().profile_generation == before
+    finally:
+        await buddy.shutdown()
+        db.close_connection()
 
 
 async def test_stale_import_is_cleaned_and_cannot_repaint(

--- a/Tests/UI/test_personas_persona_visual_authoring.py
+++ b/Tests/UI/test_personas_persona_visual_authoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 import threading
 from io import BytesIO
 from types import SimpleNamespace
@@ -245,15 +246,72 @@ async def test_save_publishes_once_then_invalidates_exact_old_and_new(
         assert screen._persona_visual_authoring is None
 
 
+async def test_visual_publication_invalidates_bound_buddy_old_and_new_identity_only(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    invalidate_profile = Mock()
+    reconcile = AsyncMock(return_value=True)
+    buddy = SimpleNamespace(
+        snapshot=lambda: SimpleNamespace(
+            visual=SimpleNamespace(graph_identity=_identity())
+        ),
+        invalidate_profile=invalidate_profile,
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        mock_app_instance.persona_buddy_controller = buddy
+        mock_app_instance.reconcile_persona_buddy_view = reconcile
+
+        await screen._invalidate_persona_visual_publication(
+            PersonaVisualPublicationResult(_identity(), _identity(2), None)
+        )
+        invalidate_profile.assert_called_once_with()
+        reconcile.assert_awaited_once_with()
+
+        invalidate_profile.reset_mock()
+        reconcile.reset_mock()
+        unrelated = replace(
+            _identity(3),
+            persona_id="p-other",
+            binding_id=91,
+            pack_id=92,
+            pack_version_id=93,
+        )
+        await screen._invalidate_persona_visual_publication(
+            PersonaVisualPublicationResult(unrelated, unrelated, None)
+        )
+        invalidate_profile.assert_not_called()
+        reconcile.assert_not_awaited()
+
+        buddy.snapshot = lambda: SimpleNamespace(
+            visual=SimpleNamespace(graph_identity=_identity(2))
+        )
+        await screen._invalidate_persona_visual_publication(
+            PersonaVisualPublicationResult(_identity(), _identity(2), None)
+        )
+        invalidate_profile.assert_called_once_with()
+        reconcile.assert_awaited_once_with()
+
+
 async def test_failed_publication_keeps_draft_and_invalidates_nothing(
     monkeypatch, mock_app_instance, stub_characters, local_scope
 ):
     monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
     app = PersonasTestApp(mock_app_instance)
     invalidation = AsyncMock()
+    buddy_invalidation = Mock()
 
     async with app.run_test() as pilot:
         screen = await _open_editor(pilot)
+        mock_app_instance.persona_buddy_controller = SimpleNamespace(
+            snapshot=lambda: SimpleNamespace(
+                visual=SimpleNamespace(graph_identity=_identity())
+            ),
+            invalidate_profile=buddy_invalidation,
+        )
         screen._session = SimpleNamespace(
             invalidate_persona_visual_identities=invalidation
         )
@@ -274,6 +332,7 @@ async def test_failed_publication_keeps_draft_and_invalidates_nothing(
         assert await screen._save_persona_visual_pack() is False
         assert screen._persona_visual_authoring is state
         invalidation.assert_not_awaited()
+        buddy_invalidation.assert_not_called()
 
 
 async def test_persona_authority_guard_rejects_revision_and_eligibility_changes(

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -11830,14 +11830,71 @@ async def test_restore_reresolves_same_selection(
     mock_app_instance,
     stub_characters,
 ) -> None:
-    record = {**PROFILE, "version": 3, "is_active": True, "deleted": False}
+    record = {**PROFILE, "version": 3, "is_active": False, "deleted": False}
+    records = {"p-1": record}
     controller = _configure_persona_buddy(
         mock_app_instance,
-        {"p-1": record},
+        records,
         preferences=PersonaBuddyPreferences(
             enabled=True,
-            open=False,
+            open=True,
             collapsed=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    resolved = []
+
+    async def reconcile():
+        resolved.append(await controller.resolve_current_visual(cols=80, lines=24))
+        return True
+
+    mock_app_instance.reconcile_persona_buddy_view.side_effect = reconcile
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        before = controller.snapshot().profile_generation
+        await screen._refresh_persona_buddy_lifecycle("p-1")
+        records["p-1"] = {
+            **record,
+            "version": 4,
+            "is_active": True,
+            "deleted": False,
+        }
+        await screen._refresh_persona_buddy_lifecycle("p-1")
+
+        preferences = controller.current_preferences()
+        assert preferences.selection == PersonaBuddySelection("local", "p-1")
+        assert preferences.enabled is True
+        assert preferences.open is True
+        assert preferences.collapsed is True
+        assert controller.snapshot().profile_generation == before + 2
+        assert [visual.reason for visual in resolved] == [
+            "persona_buddy_persona_unavailable",
+            "persona_buddy_binding_unavailable",
+        ]
+
+
+async def test_buddy_action_fetch_aba_cannot_apply_or_reconcile(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    records = {
+        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False},
+        "p-2": {
+            **PROFILE,
+            "id": "p-2",
+            "name": "Navigator",
+            "version": 5,
+            "is_active": True,
+            "deleted": False,
+        },
+    }
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
             selection=PersonaBuddySelection("local", "p-1"),
         ),
     )
@@ -11845,13 +11902,57 @@ async def test_restore_reresolves_same_selection(
 
     async with app.run_test() as pilot:
         screen = await _mounted(pilot)
-        await screen._refresh_persona_buddy_lifecycle("p-1")
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
 
-        preferences = controller.current_preferences()
-        assert preferences.selection == PersonaBuddySelection("local", "p-1")
-        assert preferences.enabled is True
-        assert preferences.open is False
-        assert preferences.collapsed is True
+        async def fetch(persona_id: str, *, mode: str):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                started.set()
+                await release.wait()
+            return dict(records[persona_id])
+
+        mock_app_instance.character_persona_scope_service.get_persona_profile = fetch
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="close", source="local", persona_id="p-1", revision=2
+            )
+        )
+        await started.wait()
+        await screen._select_profile("p-2", "Navigator")
+        await screen._select_profile("p-1", "Archivist")
+        release.set()
+        await pilot.pause()
+
+        assert controller.current_preferences().open is True
+        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+
+async def test_incomplete_profile_fetch_disables_cached_buddy_actions(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    records = {
+        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    }
+    _configure_persona_buddy(mock_app_instance, records)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        mock_app_instance.character_persona_scope_service.get_persona_profile = (
+            AsyncMock(side_effect=RuntimeError("service unavailable"))
+        )
+        await screen._select_profile("p-1", "Archivist")
+
+        for button in screen.query(".persona-buddy-action").results(Button):
+            assert button.disabled is True
+            assert button.tooltip == "Persona details are unavailable. Refresh and try again."
 
 
 async def test_local_save_and_delete_refresh_only_the_same_buddy_selection(
@@ -11962,10 +12063,65 @@ async def test_stale_buddy_action_does_not_refresh_replaced_workbench_selection(
             await asyncio.sleep(0)
         assert controller.current_preferences().open is False
         await screen._select_profile("p-2", "Navigator")
+        await screen._select_profile("p-1", "Archivist")
         release.set()
         await pilot.pause()
 
         mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+
+async def test_newer_buddy_action_wins_serialized_persistence_and_reconcile(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    records = {
+        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    }
+    started = threading.Event()
+    release = threading.Event()
+    writes = []
+
+    def blocked_first_writer(preferences):
+        writes.append(preferences)
+        if len(writes) == 1:
+            started.set()
+            release.wait(timeout=5)
+        return True
+
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    controller._preference_writer = blocked_first_writer
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="close", source="local", persona_id="p-1", revision=2
+            )
+        )
+        while not started.is_set():
+            await asyncio.sleep(0)
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="show", source="local", persona_id="p-1", revision=2
+            )
+        )
+        await pilot.pause()
+        release.set()
+        await pilot.pause()
+
+        assert [preferences.open for preferences in writes] == [False, True]
+        assert controller.current_preferences().open is True
+        mock_app_instance.reconcile_persona_buddy_view.assert_awaited_once()
 
 
 async def test_persona_json_export_excludes_buddy_preferences(

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -27,6 +27,7 @@ import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_m
 import tldw_chatbook.UI.Persona_Modules.personas_conversations_controller as conversations_controller_module
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
 import tldw_chatbook.UI.Screens.personas_screen as personas_screen_module
+from tldw_chatbook.app import TldwCli
 from tldw_chatbook.Character_Chat.Character_Chat_Lib import (
     CharacterCardImportOutcome,
     CharacterCardTTSInspection,
@@ -75,6 +76,9 @@ from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 from tldw_chatbook.UI.tts_profile_recovery import dependency_recovery_actions
+from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+    PersonaBuddyWidget,
+)
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
     PersonaActionRequested,
@@ -249,6 +253,21 @@ class StyledPersonasTestApp(PersonasTestApp):
         / "css"
         / "tldw_cli_modular.tcss"
     )
+
+
+class PersonaBuddyWorkbenchApp(PersonasTestApp):
+    """Workbench harness using the real app-to-screen Buddy reconciliation."""
+
+    reconcile_persona_buddy_view = TldwCli.reconcile_persona_buddy_view
+    _persona_buddy_authority = staticmethod(TldwCli._persona_buddy_authority)
+    is_persona_buddy_confirmed_unavailable = (
+        TldwCli.is_persona_buddy_confirmed_unavailable
+    )
+    confirm_persona_buddy_unavailable = TldwCli.confirm_persona_buddy_unavailable
+
+    def __init__(self, mock_app_instance) -> None:
+        super().__init__(mock_app_instance)
+        self._persona_buddy_unavailable_authority = None
 
 
 def _row_text(item) -> str:
@@ -11679,6 +11698,78 @@ async def test_workbench_highlight_never_retargets_buddy(
 
         assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")
         mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+
+async def test_floating_buddy_close_refreshes_active_personas_inspector(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    records = {"p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}}
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            open=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    persisted: list[PersonaBuddyPreferences] = []
+    controller._preference_writer = lambda preferences: (
+        persisted.append(preferences) or True
+    )
+
+    async def unresolved_until_closed(*, cols: int, lines: int):
+        return None
+
+    controller.resolve_current_visual = unresolved_until_closed
+    app = PersonaBuddyWorkbenchApp(mock_app_instance)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        await app.reconcile_persona_buddy_view()
+        await pilot.pause()
+
+        assert screen.query_one(PersonaBuddyWidget).is_attached
+        assert screen.query_one("#personas-buddy-close", Button).disabled is False
+        assert screen.query_one("#personas-buddy-show", Button).disabled is True
+
+        await pilot.click("#persona-buddy-close")
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert controller.current_preferences().open is False
+        assert persisted[-1].open is False
+        assert not list(screen.query(PersonaBuddyWidget))
+        show = screen.query_one("#personas-buddy-show", Button)
+        close = screen.query_one("#personas-buddy-close", Button)
+        assert show.disabled is False
+        assert close.disabled is True
+        assert close.tooltip == "Buddy is already closed."
+
+
+async def test_stale_personas_screen_reconcile_skips_screen_local_buddy_hook(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    _configure_persona_buddy(
+        mock_app_instance,
+        {},
+        preferences=PersonaBuddyPreferences(open=False),
+    )
+    app = PersonaBuddyWorkbenchApp(mock_app_instance)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        stale = await _mounted(pilot)
+        await app.switch_screen(PersonasScreen(app))
+        hook = Mock(wraps=stale.sync_persona_buddy_reconciled_state)
+        stale.sync_persona_buddy_reconciled_state = hook
+
+        await stale.reconcile_persona_buddy_view()
+
+        hook.assert_not_called()
 
 
 @pytest.mark.parametrize("compact", (False, True), ids=("normal", "compact"))

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -11624,7 +11624,10 @@ def _configure_persona_buddy(
     scope = SimpleNamespace(
         local_service=SimpleNamespace(get_persona_profile=local_record),
         list_persona_profiles=AsyncMock(
-            return_value={"items": [dict(item) for item in records.values()], "total": len(records)}
+            return_value={
+                "items": [dict(item) for item in records.values()],
+                "total": len(records),
+            }
         ),
         get_persona_profile=AsyncMock(side_effect=scoped_record),
         delete_persona_profile=AsyncMock(
@@ -11678,6 +11681,66 @@ async def test_workbench_highlight_never_retargets_buddy(
         mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
 
 
+@pytest.mark.parametrize("compact", (False, True), ids=("normal", "compact"))
+async def test_real_80x24_workbench_scrolls_each_buddy_action_into_view_and_runs_it(
+    mock_app_instance,
+    stub_characters,
+    compact: bool,
+) -> None:
+    records = {"p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}}
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            open=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        workbench = screen.query_one("#personas-workbench")
+        workbench.set_class(compact, "personas-workbench-compact")
+        for pane_id in (
+            "#personas-library-pane",
+            "#personas-work-area",
+            "#personas-inspector-pane",
+        ):
+            screen.query_one(pane_id).set_class(
+                compact, "personas-workbench-compact-pane"
+            )
+        await pilot.pause()
+
+        inspector = screen.query_one("#personas-inspector-pane")
+        expectations = (
+            ("#personas-buddy-close", "Close Buddy", True, False),
+            ("#personas-buddy-show", "Show Buddy", True, True),
+            ("#personas-buddy-disable", "Disable Buddy", False, True),
+            ("#personas-buddy-use", "Use for Buddy", True, True),
+        )
+        for button_id, label, enabled, opened in expectations:
+            button = screen.query_one(button_id, Button)
+            assert str(button.label) == label
+            assert button.disabled is False
+            button.focus(scroll_visible=True)
+            await pilot.pause(0.5)
+
+            assert pilot.app.focused is button
+            assert button.region.y >= max(0, inspector.content_region.y)
+            assert button.region.bottom <= min(24, inspector.content_region.bottom)
+
+            await pilot.press("enter")
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            preferences = controller.current_preferences()
+            assert preferences.enabled is enabled
+            assert preferences.open is opened
+
+
 async def test_explicit_replacement_is_required(
     mock_app_instance,
     stub_characters,
@@ -11709,6 +11772,24 @@ async def test_explicit_replacement_is_required(
         await screen._select_profile("p-2", "Navigator")
         await pilot.pause()
         assert not screen.query_one("#personas-buddy-use", Button).disabled
+        for button_id in (
+            "#personas-buddy-show",
+            "#personas-buddy-close",
+            "#personas-buddy-disable",
+        ):
+            button = screen.query_one(button_id, Button)
+            assert button.disabled is True
+            assert button.tooltip == "Select the Persona currently used by Buddy"
+
+        await screen._select_profile("p-1", "Archivist")
+        assert screen.query_one("#personas-buddy-use", Button).disabled is False
+        assert screen.query_one("#personas-buddy-close", Button).disabled is False
+        assert screen.query_one("#personas-buddy-disable", Button).disabled is False
+        show = screen.query_one("#personas-buddy-show", Button)
+        assert show.disabled is True
+        assert show.tooltip == "Buddy is already open."
+
+        await screen._select_profile("p-2", "Navigator")
 
         screen.post_message(
             PersonaBuddyActionRequested(
@@ -11775,6 +11856,107 @@ async def test_buddy_visibility_actions_preserve_explicit_selection(
         assert preferences.selection == PersonaBuddySelection("local", "p-1")
         assert preferences.enabled is expected_enabled
         assert preferences.open is expected_open
+
+
+@pytest.mark.parametrize("failure", ("false", "raise", "cancel"))
+async def test_buddy_action_writer_failure_leaves_memory_and_durable_state_unchanged(
+    mock_app_instance,
+    stub_characters,
+    failure: str,
+) -> None:
+    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    initial = PersonaBuddyPreferences(
+        enabled=True,
+        open=True,
+        selection=PersonaBuddySelection("local", "p-1"),
+    )
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        {"p-1": record},
+        preferences=initial,
+    )
+    durable = initial
+
+    def writer(preferences: PersonaBuddyPreferences) -> bool:
+        nonlocal durable
+        if failure == "false":
+            return False
+        if failure == "raise":
+            raise RuntimeError("writer failed")
+        raise asyncio.CancelledError
+
+    controller._preference_writer = writer
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="close", source="local", persona_id="p-1", revision=2
+            )
+        )
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert durable == initial
+        assert controller.current_preferences() == initial
+        assert screen.state.has_unsaved_changes is False
+        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+
+async def test_buddy_action_persists_before_applying_memory_or_reconciling(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    initial = PersonaBuddyPreferences(
+        enabled=True,
+        open=True,
+        selection=PersonaBuddySelection("local", "p-1"),
+    )
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        {"p-1": record},
+        preferences=initial,
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    durable = initial
+
+    def writer(preferences: PersonaBuddyPreferences) -> bool:
+        nonlocal durable
+        entered.set()
+        release.wait(timeout=5)
+        durable = preferences
+        return True
+
+    controller._preference_writer = writer
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="close", source="local", persona_id="p-1", revision=2
+            )
+        )
+        assert await asyncio.to_thread(entered.wait, 2)
+
+        assert durable == initial
+        assert controller.current_preferences() == initial
+        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+        release.set()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert durable.open is False
+        assert controller.current_preferences() == durable
+        mock_app_instance.reconcile_persona_buddy_view.assert_awaited_once()
 
 
 async def test_disabled_deleted_missing_persona_hides_but_preserves_enabled_selection(
@@ -11936,9 +12118,7 @@ async def test_incomplete_profile_fetch_disables_cached_buddy_actions(
     mock_app_instance,
     stub_characters,
 ) -> None:
-    records = {
-        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}
-    }
+    records = {"p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}}
     _configure_persona_buddy(mock_app_instance, records)
     app = PersonasTestApp(mock_app_instance)
 
@@ -11952,7 +12132,10 @@ async def test_incomplete_profile_fetch_disables_cached_buddy_actions(
 
         for button in screen.query(".persona-buddy-action").results(Button):
             assert button.disabled is True
-            assert button.tooltip == "Persona details are unavailable. Refresh and try again."
+            assert (
+                button.tooltip
+                == "Persona details are unavailable. Refresh and try again."
+            )
 
 
 async def test_local_save_and_delete_refresh_only_the_same_buddy_selection(
@@ -12061,12 +12244,13 @@ async def test_stale_buddy_action_does_not_refresh_replaced_workbench_selection(
         )
         while not started.is_set():
             await asyncio.sleep(0)
-        assert controller.current_preferences().open is False
+        assert controller.current_preferences().open is True
         await screen._select_profile("p-2", "Navigator")
         await screen._select_profile("p-1", "Archivist")
         release.set()
         await pilot.pause()
 
+        assert controller.current_preferences().open is True
         mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
 
 
@@ -12074,9 +12258,7 @@ async def test_newer_buddy_action_wins_serialized_persistence_and_reconcile(
     mock_app_instance,
     stub_characters,
 ) -> None:
-    records = {
-        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}
-    }
+    records = {"p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}}
     started = threading.Event()
     release = threading.Event()
     writes = []

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -8,9 +8,10 @@ from datetime import UTC, datetime
 import inspect
 import json
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 from uuid import UUID
 
 import pytest
@@ -38,6 +39,11 @@ from tldw_chatbook.Constants import (
     LIBRARY_NAV_CONTEXT_CONVERSATION_ID,
     LIBRARY_NAV_CONTEXT_MODE,
     TAB_LIBRARY,
+)
+from tldw_chatbook.Persona_Buddy import (
+    PersonaBuddyController,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
 )
 from tldw_chatbook.tldw_api import PersonaProfileCreate
 from tldw_chatbook.TTS import (
@@ -72,6 +78,7 @@ from tldw_chatbook.UI.tts_profile_recovery import dependency_recovery_actions
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
     PersonaActionRequested,
+    PersonaBuddyActionRequested,
 )
 from tldw_chatbook.Widgets.Persona_Widgets.personas_inspector_pane import (
     PersonasInspectorPane,
@@ -11595,3 +11602,401 @@ async def test_character_soft_delete_never_detaches_tts_assignment(
         await pilot.app.workers.wait_for_complete()
 
         assert service.detach_calls == []
+
+
+def _configure_persona_buddy(
+    mock_app_instance,
+    records: dict[str, dict],
+    *,
+    preferences: PersonaBuddyPreferences | None = None,
+) -> PersonaBuddyController:
+    def local_record(persona_id: str):
+        record = records.get(str(persona_id))
+        return dict(record) if record is not None else None
+
+    async def scoped_record(persona_id: str, *, mode: str):
+        assert mode == "local"
+        record = local_record(persona_id)
+        if record is None:
+            raise ValueError("persona missing")
+        return record
+
+    scope = SimpleNamespace(
+        local_service=SimpleNamespace(get_persona_profile=local_record),
+        list_persona_profiles=AsyncMock(
+            return_value={"items": [dict(item) for item in records.values()], "total": len(records)}
+        ),
+        get_persona_profile=AsyncMock(side_effect=scoped_record),
+        delete_persona_profile=AsyncMock(
+            return_value={"status": "deleted", "persona_id": "p-1"}
+        ),
+    )
+    controller = PersonaBuddyController(
+        preferences=preferences,
+        local_persona_service=scope.local_service,
+        preference_writer=lambda _preferences: True,
+    )
+    mock_app_instance.runtime_backend = "local"
+    mock_app_instance.character_persona_scope_service = scope
+    mock_app_instance.persona_buddy_controller = controller
+    mock_app_instance.reconcile_persona_buddy_view = AsyncMock(return_value=True)
+    return controller
+
+
+async def test_workbench_highlight_never_retargets_buddy(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    records = {
+        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False},
+        "p-2": {
+            **PROFILE,
+            "id": "p-2",
+            "name": "Navigator",
+            "version": 5,
+            "is_active": True,
+            "deleted": False,
+        },
+    }
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-2", "Navigator")
+        await pilot.pause()
+
+        assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")
+        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+
+async def test_explicit_replacement_is_required(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    records = {
+        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False},
+        "p-2": {
+            **PROFILE,
+            "id": "p-2",
+            "name": "Navigator",
+            "version": 5,
+            "is_active": True,
+            "deleted": False,
+        },
+    }
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-2", "Navigator")
+        await pilot.pause()
+        assert not screen.query_one("#personas-buddy-use", Button).disabled
+
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="show", source="local", persona_id="p-2", revision=5
+            )
+        )
+        await pilot.pause()
+        assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")
+        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="use", source="local", persona_id="p-2", revision=5
+            )
+        )
+        await pilot.pause()
+
+        snapshot = controller.snapshot()
+        assert snapshot.selection == PersonaBuddySelection("local", "p-2")
+        assert snapshot.enabled is True
+        assert snapshot.open is True
+        mock_app_instance.reconcile_persona_buddy_view.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_enabled", "expected_open"),
+    (
+        ("show", True, True),
+        ("close", True, False),
+        ("disable", False, True),
+    ),
+)
+async def test_buddy_visibility_actions_preserve_explicit_selection(
+    mock_app_instance,
+    stub_characters,
+    action: str,
+    expected_enabled: bool,
+    expected_open: bool,
+) -> None:
+    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        {"p-1": record},
+        preferences=PersonaBuddyPreferences(
+            enabled=action != "show",
+            open=action != "show",
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action=action, source="local", persona_id="p-1", revision=2
+            )
+        )
+        await pilot.pause()
+
+        preferences = controller.current_preferences()
+        assert preferences.selection == PersonaBuddySelection("local", "p-1")
+        assert preferences.enabled is expected_enabled
+        assert preferences.open is expected_open
+
+
+async def test_disabled_deleted_missing_persona_hides_but_preserves_enabled_selection(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    records = {"p-1": record}
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    resolved = []
+
+    async def reconcile():
+        resolved.append(await controller.resolve_current_visual(cols=80, lines=24))
+        return True
+
+    mock_app_instance.reconcile_persona_buddy_view.side_effect = reconcile
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        before = controller.snapshot().profile_generation
+
+        for unavailable_record in (
+            {**record, "is_active": False},
+            {**record, "deleted": True},
+            None,
+        ):
+            if unavailable_record is None:
+                records.pop("p-1")
+            else:
+                records["p-1"] = unavailable_record
+            await screen._refresh_persona_buddy_lifecycle("p-1")
+
+        snapshot = controller.snapshot()
+        assert snapshot.profile_generation == before + 3
+        assert snapshot.enabled is True
+        assert snapshot.selection == PersonaBuddySelection("local", "p-1")
+        assert mock_app_instance.reconcile_persona_buddy_view.await_count == 3
+        assert [visual.available for visual in resolved] == [False, False, False]
+        assert {visual.reason for visual in resolved} == {
+            "persona_buddy_persona_unavailable"
+        }
+
+
+async def test_restore_reresolves_same_selection(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    record = {**PROFILE, "version": 3, "is_active": True, "deleted": False}
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        {"p-1": record},
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            open=False,
+            collapsed=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._refresh_persona_buddy_lifecycle("p-1")
+
+        preferences = controller.current_preferences()
+        assert preferences.selection == PersonaBuddySelection("local", "p-1")
+        assert preferences.enabled is True
+        assert preferences.open is False
+        assert preferences.collapsed is True
+
+
+async def test_local_save_and_delete_refresh_only_the_same_buddy_selection(
+    monkeypatch,
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        mock_app_instance.character_persona_scope_service.delete_persona_profile = (
+            AsyncMock()
+        )
+        refresh = AsyncMock()
+        monkeypatch.setattr(screen, "_refresh_persona_buddy_lifecycle", refresh)
+        monkeypatch.setattr(screen, "_after_delete", AsyncMock())
+        monkeypatch.setattr(
+            screen.persona_handler,
+            "refresh_persona_list",
+            AsyncMock(return_value=[]),
+        )
+
+        screen.state.active_mode = "characters"
+        await screen._after_profile_save(
+            {**PROFILE, "id": "p-1", "version": 3}, source="local"
+        )
+        await screen._delete_entity("persona", "p-1", 3)
+
+        assert refresh.await_args_list == [call("p-1"), call("p-1")]
+
+
+async def test_server_profile_durable_changes_never_refresh_local_buddy(
+    monkeypatch,
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        mock_app_instance.character_persona_scope_service.delete_persona_profile = (
+            AsyncMock()
+        )
+        refresh = AsyncMock()
+        monkeypatch.setattr(screen, "_refresh_persona_buddy_lifecycle", refresh)
+        monkeypatch.setattr(screen, "_after_delete", AsyncMock())
+        monkeypatch.setattr(
+            screen.persona_handler,
+            "refresh_persona_list",
+            AsyncMock(return_value=[]),
+        )
+        monkeypatch.setattr(screen.persona_handler, "current_mode", lambda: "server")
+
+        screen.state.active_mode = "characters"
+        await screen._after_profile_save(
+            {**PROFILE, "id": "p-1", "version": 3}, source="server"
+        )
+        await screen._delete_entity("persona", "p-1", 3)
+
+        refresh.assert_not_awaited()
+
+
+async def test_stale_buddy_action_does_not_refresh_replaced_workbench_selection(
+    mock_app_instance,
+    stub_characters,
+) -> None:
+    records = {
+        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False},
+        "p-2": {
+            **PROFILE,
+            "id": "p-2",
+            "name": "Navigator",
+            "version": 5,
+            "is_active": True,
+            "deleted": False,
+        },
+    }
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocked_writer(_preferences):
+        started.set()
+        release.wait(timeout=5)
+        return True
+
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        records,
+        preferences=PersonaBuddyPreferences(
+            enabled=True,
+            selection=PersonaBuddySelection("local", "p-1"),
+        ),
+    )
+    controller._preference_writer = blocked_writer
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="close", source="local", persona_id="p-1", revision=2
+            )
+        )
+        while not started.is_set():
+            await asyncio.sleep(0)
+        assert controller.current_preferences().open is False
+        await screen._select_profile("p-2", "Navigator")
+        release.set()
+        await pilot.pause()
+
+        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
+
+async def test_persona_json_export_excludes_buddy_preferences(
+    mock_app_instance,
+    stub_characters,
+    tmp_path,
+) -> None:
+    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    _configure_persona_buddy(mock_app_instance, {"p-1": record})
+    mock_app_instance.app_config = {
+        "persona_buddy": {
+            "enabled": True,
+            "source": "local",
+            "local_persona_id": "p-1",
+            "open": False,
+            "collapsed": True,
+            "x": 17,
+            "y": 9,
+            "width": 42,
+            "height": 14,
+        }
+    }
+    app = PersonasTestApp(mock_app_instance)
+    target = tmp_path / "persona.json"
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("p-1", "Archivist")
+        await screen._export_selected_character(str(target), fmt="json")
+
+    exported = json.loads(target.read_text(encoding="utf-8"))
+    assert exported == record
+    assert "persona_buddy" not in exported

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -25,11 +25,11 @@ code): construct a new screen, call ``restore_state`` on it, THEN push it -
 never mount a screen before its saved state has been seeded.
 """
 
-from unittest.mock import AsyncMock
+import tomllib
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
-from textual.app import App
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -43,11 +43,13 @@ from tldw_chatbook.Persona_Buddy import (
     PersonaBuddyPreferences,
     PersonaBuddySelection,
     parse_persona_buddy_preferences,
-    serialize_persona_buddy_preferences,
 )
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
     PersonasPreviewPane,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
+    PersonaBuddyActionRequested,
 )
 
 from Tests.UI.test_personas_dictionaries import (
@@ -59,7 +61,73 @@ from Tests.UI.test_personas_dictionaries import (
 pytestmark = pytest.mark.asyncio
 
 
-async def test_restart_restores_selection_open_collapsed_and_geometry():
+async def test_restart_restores_selection_open_collapsed_and_geometry(
+    mock_app_instance,
+    stub_characters,
+    monkeypatch,
+    tmp_path,
+):
+    config_path = tmp_path / "restart" / "config.toml"
+    config_path.parent.mkdir(mode=0o700)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    record = {
+        "id": "persona-7",
+        "name": "Archivist",
+        "version": 3,
+        "is_active": True,
+        "deleted": False,
+    }
+
+    def local_record(persona_id: str):
+        return dict(record) if persona_id == "persona-7" else None
+
+    async def scoped_record(persona_id: str, *, mode: str):
+        assert mode == "local"
+        found = local_record(persona_id)
+        if found is None:
+            raise ValueError("persona missing")
+        return found
+
+    scope = SimpleNamespace(
+        local_service=SimpleNamespace(get_persona_profile=local_record),
+        list_persona_profiles=AsyncMock(
+            return_value={"items": [dict(record)], "total": 1}
+        ),
+        get_persona_profile=AsyncMock(side_effect=scoped_record),
+    )
+    initial = PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "persona-7"),
+        open=True,
+        collapsed=True,
+        geometry=PersonaBuddyGeometry(x=17, y=9, width=42, height=14),
+    )
+    controller = PersonaBuddyController(
+        preferences=initial,
+        local_persona_service=scope.local_service,
+    )
+    mock_app_instance.runtime_backend = "local"
+    mock_app_instance.character_persona_scope_service = scope
+    mock_app_instance.persona_buddy_controller = controller
+    mock_app_instance.reconcile_persona_buddy_view = AsyncMock(return_value=True)
+
+    app = PersonasTestApp(mock_app_instance)
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("persona-7", "Archivist")
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="close",
+                source="local",
+                persona_id="persona-7",
+                revision=3,
+            )
+        )
+        await pilot.app.workers.wait_for_complete()
+    await controller.shutdown()
+
+    raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
     expected = PersonaBuddyPreferences(
         enabled=True,
         selection=PersonaBuddySelection("local", "persona-7"),
@@ -67,14 +135,38 @@ async def test_restart_restores_selection_open_collapsed_and_geometry():
         collapsed=True,
         geometry=PersonaBuddyGeometry(x=17, y=9, width=42, height=14),
     )
+    assert parse_persona_buddy_preferences(raw["persona_buddy"]) == expected
 
     restarted = PersonaBuddyController(
-        preferences=parse_persona_buddy_preferences(
-            serialize_persona_buddy_preferences(expected)
-        )
+        preferences=parse_persona_buddy_preferences(raw["persona_buddy"]),
+        local_persona_service=scope.local_service,
     )
+    assert restarted.current_preferences() == expected
+
+    durable_before = config_path.read_bytes()
+    restarted._preference_writer = lambda _preferences: False
+    mock_app_instance.persona_buddy_controller = restarted
+    mock_app_instance.reconcile_persona_buddy_view.reset_mock()
+    restarted_app = PersonasTestApp(mock_app_instance)
+    async with restarted_app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        await screen._select_profile("persona-7", "Archivist")
+        screen.post_message(
+            PersonaBuddyActionRequested(
+                action="show",
+                source="local",
+                persona_id="persona-7",
+                revision=3,
+            )
+        )
+        await pilot.app.workers.wait_for_complete()
+    await restarted.shutdown()
 
     assert restarted.current_preferences() == expected
+    assert config_path.read_bytes() == durable_before
+    mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
+
 
 CHARACTERS = [
     {

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -37,6 +37,14 @@ from Tests.UI.consolidated_css import ConsolidatedCSSApp
 
 import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+from tldw_chatbook.Persona_Buddy import (
+    PersonaBuddyController,
+    PersonaBuddyGeometry,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+    parse_persona_buddy_preferences,
+    serialize_persona_buddy_preferences,
+)
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
     PersonasPreviewPane,
@@ -49,6 +57,24 @@ from Tests.UI.test_personas_dictionaries import (
 )
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_restart_restores_selection_open_collapsed_and_geometry():
+    expected = PersonaBuddyPreferences(
+        enabled=True,
+        selection=PersonaBuddySelection("local", "persona-7"),
+        open=False,
+        collapsed=True,
+        geometry=PersonaBuddyGeometry(x=17, y=9, width=42, height=14),
+    )
+
+    restarted = PersonaBuddyController(
+        preferences=parse_persona_buddy_preferences(
+            serialize_persona_buddy_preferences(expected)
+        )
+    )
+
+    assert restarted.current_preferences() == expected
 
 CHARACTERS = [
     {

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1965,7 +1965,7 @@ def test_files_back_navigation_workspace_contract_matches_real_workspace():
     # ``_register_footer_shortcuts`` out, so probes never see it -- but the
     # real widget must still satisfy it.
     footer_contract = workspace_attribute_accesses(
-        LibraryScreen._library_footer_shortcuts_for_current_state
+        LibraryScreen._library_route_shortcuts_for_current_state
     )
     assert "reload_confirmation_active" in footer_contract
 
@@ -2547,6 +2547,7 @@ def test_action_show_workbench_help_includes_landing_footer_keys(monkeypatch):
     ``SettingsScreen.action_show_workbench_help`` reads its per-category
     shortcuts directly rather than through the footer widget).
     """
+    from tldw_chatbook.Library.library_rail_state import LibraryLifecycle
     from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
     from tldw_chatbook.UI.Workbench.help import WorkbenchHelpPanel
 
@@ -2554,6 +2555,10 @@ def test_action_show_workbench_help_includes_landing_footer_keys(monkeypatch):
     screen = LibraryScreen(app)
     # Landing: no row selected (the default -- see LibraryScreen.__init__).
     assert screen._library_selected_row_id == ""
+    # The full rail is visible after progressive disclosure, so `/` is a
+    # truthful shortcut here. Starter mode intentionally omits it because
+    # there is no rail search input yet.
+    screen._library_lifecycle = LibraryLifecycle.GRADUATED
 
     pushed = []
 
@@ -2833,11 +2838,16 @@ def test_action_library_list_focus_rail_focuses_search_input(monkeypatch):
     focused_widgets = []
 
     class _FakeInput:
-        def focus(self):
-            focused_widgets.append(self)
+        display = True
+        disabled = False
 
     fake_input = _FakeInput()
     monkeypatch.setattr(screen, "query_one", lambda *a, **k: fake_input)
+    monkeypatch.setattr(
+        screen,
+        "set_focus",
+        lambda widget, **_kwargs: focused_widgets.append(widget),
+    )
 
     screen.action_library_list_focus_rail()
 
@@ -3772,10 +3782,12 @@ def test_primary_routed_screens_use_base_app_screen():
 
 
 @pytest.mark.asyncio
-async def test_library_screen_round_trip_restores_rag_query_and_rail_selection():
-    """Select the Search/RAG rail row, type a query into the real Input
-    widget, hop to Home and back, and assert both the internal state and
-    the visible Input value survived on the freshly-composed instance.
+async def test_library_screen_round_trip_returns_to_landing_with_rag_draft():
+    """A generic Library return lands at the hub without losing a RAG draft.
+
+    The selected canvas is deliberately not restored automatically. After
+    reopening the disclosed Search/RAG canvas, the freshly-composed Input
+    must still contain the saved draft.
     """
     from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_SEARCH
 
@@ -3787,20 +3799,14 @@ async def test_library_screen_round_trip_restores_rag_query_and_rail_selection()
             if type(app.screen).__name__ != "Screen":
                 break
 
-        app.post_message(NavigateToScreen("library"))
+        app.post_message(NavigateToScreen("search"))
         for _ in range(150):
             await pilot.pause(0.02)
             if type(app.screen).__name__ == "LibraryScreen" and app.screen.query(
-                "#library-row-browse-search"
+                "#library-rag-query-input"
             ):
                 break
         assert type(app.screen).__name__ == "LibraryScreen"
-
-        app.screen.query_one("#library-row-browse-search").press()
-        for _ in range(150):
-            await pilot.pause(0.02)
-            if app.screen.query("#library-rag-query-input"):
-                break
 
         app.screen.query_one("#library-rag-query-input", Input).value = "roadmap notes"
         await pilot.pause()
@@ -3819,14 +3825,25 @@ async def test_library_screen_round_trip_restores_rag_query_and_rail_selection()
         app.post_message(NavigateToScreen("library"))
         for _ in range(150):
             await pilot.pause(0.02)
-            if type(app.screen).__name__ == "LibraryScreen" and app.screen.query(
-                "#library-rag-query-input"
+            if type(app.screen).__name__ == "LibraryScreen" and (
+                app.screen.query("#library-hub-explore-all")
+                or app.screen.query("#library-rail-explore-all")
+                or app.screen.query("#library-row-browse-search")
             ):
                 break
 
         restored_screen = app.screen
         assert type(restored_screen).__name__ == "LibraryScreen"
         assert restored_screen._library_rag_query == "roadmap notes"
+        assert restored_screen._library_selected_row_id == ""
+
+        await app.handle_screen_navigation(NavigateToScreen("search"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if app.screen.query("#library-rag-query-input"):
+                break
+
+        restored_screen = app.screen
         assert restored_screen._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH
         query_input = restored_screen.query_one("#library-rag-query-input", Input)
         assert query_input.value == "roadmap notes"
@@ -4203,11 +4220,9 @@ async def test_search_route_round_trips_to_the_library_rag_row():
     v2 PR-1, Task 1): the "search" route no longer has a runtime-state seam
     of its own, so this locks that the alias's rail-row selection survives a
     round trip through another screen and is not just a first-navigation
-    fluke of ``_LEGACY_ROUTE_LIBRARY_NAV_CONTEXT``. Unlike the "library" +
-    click entry point exercised by
-    ``test_library_screen_round_trip_restores_rag_query_and_rail_selection``,
-    entering via the bare "search" alias re-applies that legacy nav context
-    on every visit rather than relying solely on restored screen state.
+    fluke of ``_LEGACY_ROUTE_LIBRARY_NAV_CONTEXT``. The bare "search" alias
+    must reapply that context on every visit; the separate RAG-draft round
+    trip test pins generic Library re-entry to the returning landing.
     """
     from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_SEARCH
 
@@ -4858,11 +4873,12 @@ async def test_deep_link_library_route_lands_its_canvas_over_restored_state():
 
 
 @pytest.mark.asyncio
-async def test_generic_reentry_restores_last_visited_library_canvas():
-    """Core LIB-03 round trip: visit Search/RAG, leave to Home, then
-    re-enter Library GENERICALLY (bare ``NavigateToScreen``, no context --
-    the nav-bar tab button's own shape) -- the Search/RAG canvas must be
-    RESTORED, not reset back to the hub or any other canvas.
+async def test_generic_reentry_returns_to_library_landing():
+    """A bare Library route returns to the landing, not a prior canvas.
+
+    Explicit deep links still open their requested canvas. Generic re-entry
+    uses the returning-landing contract so the user chooses whether to
+    continue an authoritative prior scope.
     """
     from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_SEARCH
 
@@ -4881,11 +4897,11 @@ async def test_generic_reentry_restores_last_visited_library_canvas():
         await app.handle_screen_navigation(NavigateToScreen("home"))
         assert type(app.screen).__name__ == "HomeScreen"
 
-        # Generic re-entry must restore Search/RAG.
+        # Generic re-entry returns to the hub instead of reopening Search/RAG.
         await app.handle_screen_navigation(NavigateToScreen("library"))
 
         assert type(app.screen).__name__ == "LibraryScreen"
-        assert app.screen._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH
+        assert app.screen._library_selected_row_id == ""
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -3607,6 +3607,22 @@ def test_screen_lifecycle_methods():
 
 
 @pytest.mark.asyncio
+async def test_persona_buddy_app_reconcile_excludes_modal_screen():
+    """An active modal never becomes a Buddy mount target."""
+
+    from textual.screen import ModalScreen
+
+    from tldw_chatbook.app import TldwCli
+
+    class Modal(ModalScreen):
+        async def reconcile_persona_buddy_view(self) -> None:
+            raise AssertionError("modal must never receive Buddy reconciliation")
+
+    host = type("BuddyReconcileHost", (), {"screen": Modal()})()
+    await TldwCli.reconcile_persona_buddy_view(host)
+
+
+@pytest.mark.asyncio
 async def test_main_navigation_copy_and_order():
     expected_button_order = [
         ("nav-home", "\u23031 Home"),

--- a/Tests/UI/test_shell_chrome_contract.py
+++ b/Tests/UI/test_shell_chrome_contract.py
@@ -9,6 +9,9 @@ from Tests.UI.consolidated_css import ConsolidatedCSSApp
 
 from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
 from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
+from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+    PersonaBuddyWidget,
+)
 
 
 @pytest.mark.asyncio
@@ -26,6 +29,14 @@ async def test_base_app_screen_mounts_exactly_one_navigation_bar():
     async with app.run_test(size=(100, 20)) as pilot:
         await pilot.pause(0.1)
         assert len(list(pilot.app.screen.query(MainNavigationBar))) == 1
+
+
+def test_persona_buddy_shell_bindings_do_not_shadow_global_keys():
+    """Buddy's focused controls preserve terminal and shell-owned shortcuts."""
+
+    keys = {binding.key for binding in PersonaBuddyWidget.BINDINGS}
+    assert keys == {"h", "j", "k", "l", "H", "J", "K", "L", "0", "c", "x"}
+    assert keys.isdisjoint({"ctrl+p", "ctrl+q", "f1", "f6"})
 
 
 def test_navigation_contract_keeps_context_out_of_top_nav():

--- a/backlog/tasks/task-19055 - Add-opt-in-app-wide-floating-Persona-Buddy.md
+++ b/backlog/tasks/task-19055 - Add-opt-in-app-wide-floating-Persona-Buddy.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19055
 title: Add opt-in app-wide floating Persona Buddy
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-20 17:47'
 labels: []
@@ -32,3 +32,16 @@ Give users an explicitly enabled, app-wide floating visual companion for one sel
 - [ ] #7 No third-party window dependency, taskbar, snapping desktop, maximize system, model-directed state, or default Persona is introduced.
 - [ ] #8 Production-shaped Pilot tests cover normal, wide, and 80x24 layouts, compositor output, and zero flow/`fr` budget; isolated real-terminal verification covers mouse drag/resize, keyboard controls, focus, modal hit testing, navigation, viewport resize, and geometry restore. Evidence includes born-RED→GREEN tests at the actual seams, assigned-worktree import provenance, isolated HOME/XDG/config/data roots set before app import, and mutation proof for authority, lease, cancellation, geometry, and modal-input guards; real SQLite repository coverage is required only if persistence storage changes. Impeccable review follows the final visible change; scoped Ruff, format, compile, diff, and static checks plus diagnostic, privacy, architecture, and governance gates pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+ADR required: no
+ADR path: `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`
+Reason: ADR-074 already defines the app-owned Buddy controller, local-Persona authority, native Textual overlay, trusted-state, persistence, and async-lifetime boundaries; this task implements that accepted design without introducing another architectural choice.
+
+1. Add born-RED pure contracts for strict profile-local Buddy preferences, explicit local-Persona selection, state priority, source-scoped leases, and authority generations; implement the smallest app-owned controller that satisfies them.
+2. Add born-RED async controller tests for active Persona Visual resolution, fallback rendering, reduced motion, bounded frame preparation, serialization, shield-and-drain cancellation, stale-authority refusal, and lifecycle shutdown; integrate only the existing Persona Visual repository/runtime and image-rendering seams off the event loop.
+3. Add born-RED Textual tests for the lightweight floating view, native compositor placement, bounded drag/resize, keyboard controls, compact collapse, focus stability, animation pause, modal coverage, navigation replacement, and viewport re-clamping; mount it through the shared app-screen chrome without consuming flow or fractional layout budget.
+4. Add born-RED Personas Workbench tests and explicit actions to select, show, hide, and disable the Buddy; persist only local Persona identity and UI preferences, reject server-backed/inactive/deleted/missing Personas, and refresh through existing Persona and Persona Visual lifecycle seams without silent retargeting.
+5. Add born-RED trusted-lifecycle adapter tests for Console run, approval, realtime voice, wake, tool, error, explicit, and custom source-scoped states; keep adapters path-free, model-independent, and free of screen/widget retention.
+6. Run only touched-component verification in an isolated profile: focused unit/Pilot/architecture/privacy tests, mutation probes, a bounded real-terminal interaction harness, final Impeccable review/detector, scoped Ruff/format/compile/diff/CSS/governance checks, then document evidence and close TASK-19055.

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 from uuid import uuid4
 
 if TYPE_CHECKING:
+    from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
     from tldw_chatbook.UI.Screens.change_review_screen import (
         AgentRunsChangeReviewProvider,
     )
@@ -3205,12 +3206,14 @@ class ConsoleAgentBridge:
         skills_service: Any | None = None,
         native_tools_enabled: Callable[[], bool] | None = None,
         change_tracker: Any | None = None,
+        buddy_sink: "PersonaBuddyConsoleAdapter | None" = None,
     ) -> None:
         self._db = agent_runs_db
         # TASK-1971: optional Agent Change Review turn tracker. None (the
         # default, and every pre-existing construction site) disables
         # tracking entirely.
         self._change_tracker = change_tracker
+        self._buddy_sink = buddy_sink
         self._store = store
         self._gateway = provider_gateway
         self._clock = clock
@@ -4063,6 +4066,8 @@ class ConsoleAgentBridge:
         #: `live_steps` itself, so every existing reader of that local is
         #: unchanged.
         run_live_steps: dict[str, _LiveStepFeed] = {primary_live_key: live_steps}
+        buddy_tool_sequences: dict[str, deque[int]] = {}
+        primary_buddy_run_ids: set[str] = set()
         self._publish_live(
             conversation_id,
             primary_live_key,
@@ -4101,6 +4106,24 @@ class ConsoleAgentBridge:
                 # regresses for a step that cannot be attributed.
                 else (run_id or primary_live_key)
             )
+            buddy_run_id = run_id or live_key
+            buddy_sink = self._buddy_sink
+            if buddy_sink is not None:
+                if agent_kind == AGENT_KIND_PRIMARY:
+                    primary_buddy_run_ids.add(buddy_run_id)
+                if step.kind == STEP_TOOL_CALL:
+                    buddy_tool_sequences.setdefault(buddy_run_id, deque()).append(
+                        step.index
+                    )
+                    buddy_sink.tool_step(buddy_run_id, step.index, step.kind)
+                elif step.kind == STEP_TOOL_RESULT:
+                    sequences = buddy_tool_sequences.get(buddy_run_id)
+                    sequence = sequences.popleft() if sequences else step.index
+                    buddy_sink.tool_step(buddy_run_id, sequence, step.kind)
+                    if sequences is not None and not sequences:
+                        buddy_tool_sequences.pop(buddy_run_id, None)
+                elif step.kind == STEP_ERROR:
+                    buddy_sink.release_run(buddy_run_id)
             key_steps = run_live_steps.setdefault(live_key, _LiveStepFeed())
             key_steps.append(
                 # `time.monotonic()` HERE is the step's real start: this hook
@@ -4494,6 +4517,9 @@ class ConsoleAgentBridge:
             # `run_turn` raised, before any teardown below can block.
             with self._change_window_lock:
                 self._inflight_turn_message_ids.discard(assistant_message_id)
+            if self._buddy_sink is not None:
+                for buddy_run_id in primary_buddy_run_ids:
+                    self._buddy_sink.release_run(buddy_run_id)
             # PR2b Task 1: clear the published service in the SAME
             # teardown path that already tears this run down -- not a
             # second one. From this point `fleet_snapshot` reverts to `[]`
@@ -4909,6 +4935,8 @@ class ConsoleAgentBridge:
             run_id: The child's run row id, ``None`` if it never got one.
             status: The child's terminal status.
         """
+        if run_id is not None and self._buddy_sink is not None:
+            self._buddy_sink.release_run(run_id)
         with self._change_window_lock:
             # PR3a-2 Task 4: classify AT SETTLE TIME, per child, under the
             # same lock the window open/close uses -- a drain can carry a

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -181,6 +181,9 @@ from tldw_chatbook.Chat.console_skill_resolver import (
 )
 from tldw_chatbook.Chat.prompt_history import PromptHistory
 
+if TYPE_CHECKING:
+    from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
+
 from tldw_chatbook.Agents.builtin_tool_gate import (
     LOCAL_TOOLS_DEFAULT_ENABLED,
     build_builtin_gate,
@@ -1697,6 +1700,7 @@ class ConsoleChatController:
             Awaitable[tuple[Literal["select", "disable", "cancel"], str | None]],
         ]
         | None = None,
+        buddy_sink: "PersonaBuddyConsoleAdapter | None" = None,
     ) -> None:
         self.store = store
         self.provider_gateway = provider_gateway
@@ -1720,6 +1724,7 @@ class ConsoleChatController:
         self.streaming = streaming
         self.system_prompt = system_prompt
         self._agent_bridge = agent_bridge
+        self._buddy_sink = buddy_sink
         self._agent_runtime_enabled = agent_runtime_enabled
         self._skills_service = skills_service
         self._skill_substitution_enabled = skill_substitution_enabled
@@ -2621,6 +2626,8 @@ class ConsoleChatController:
             changed = round_id not in rounds
             rounds.add(round_id)
         if changed:
+            if self._buddy_sink is not None:
+                self._buddy_sink.approval_round(session_id, round_id, pending=True)
             self._advance_lifecycle_revision(session_id)
 
     def discard_pending_round(self, session_id: str, round_id: str) -> None:
@@ -2650,6 +2657,8 @@ class ConsoleChatController:
             if not rounds:
                 self._pending_approvals.pop(session_id, None)
         if changed:
+            if self._buddy_sink is not None:
+                self._buddy_sink.approval_round(session_id, round_id, pending=False)
             self._advance_lifecycle_revision(session_id)
 
     def has_pending_approval_round(self, session_id: str) -> bool:
@@ -6610,6 +6619,7 @@ class ConsoleChatController:
 
         self._disposed = True
         self._visit_open = False
+        self._fleet_wake.dispose()
         # The queue tombstone keeps its contract of running BEFORE any
         # teardown cancellation -- but it must never be able to SKIP that
         # cancellation. Its shutdown asserts queue-owner-thread affinity
@@ -13120,6 +13130,8 @@ class ConsoleChatController:
         previous_status = self.run_state_for(target).status
         self._run_states[target] = run_state
         self.run_state_history_for(target).append(run_state.status)
+        if self._buddy_sink is not None:
+            self._buddy_sink.run_state(target, run_state.status)
         self._advance_lifecycle_revision(target)
         terminal_notification_eligible = self.activity_for(
             target
@@ -13153,6 +13165,8 @@ class ConsoleChatController:
             # stays correct if a future caller ever moves this off-thread).
             with self._approval_state_lock:
                 self._pending_approvals.pop(target, None)
+            if self._buddy_sink is not None:
+                self._buddy_sink.release_session(target, sources={"approval"})
             # PR3a-2 Task 5: a terminal transition frees send capacity
             # (this session's own slot, possibly the global cap) -- retry
             # any deferred wake. Scheduled via the coordinator's loop hop,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+from contextvars import ContextVar
 import functools
 import hashlib
 import inspect
@@ -1796,6 +1797,9 @@ class ConsoleChatController:
         # OWNING session instead of whatever the user currently has open.
         self._run_states: dict[str, ConsoleRunState] = {}
         self._run_state_histories: dict[str, list[ConsoleRunStatus]] = {}
+        self._buddy_run_owner_context: ContextVar[dict[str, str] | None] = (
+            ContextVar("console_buddy_run_owners", default=None)
+        )
         # Parallel-agents spec §6: run-marker state (Task 7). Both maps are
         # keyed by session id like the run-state maps above, but track
         # marker-only bookkeeping that ``_run_states`` doesn't capture on
@@ -13131,7 +13135,27 @@ class ConsoleChatController:
         self._run_states[target] = run_state
         self.run_state_history_for(target).append(run_state.status)
         if self._buddy_sink is not None:
-            self._buddy_sink.run_state(target, run_state.status)
+            context_owners = self._buddy_run_owner_context.get() or {}
+            if run_state.status is ConsoleRunStatus.VALIDATING:
+                run_owner = self._buddy_sink.run_state(target, run_state.status)
+                if run_owner is not None:
+                    updated_owners = dict(context_owners)
+                    updated_owners[target] = run_owner
+                    self._buddy_run_owner_context.set(updated_owners)
+            else:
+                run_owner = context_owners.get(target)
+                self._buddy_sink.run_state(
+                    target, run_state.status, run_owner=run_owner
+                )
+                if run_state.status in {
+                    ConsoleRunStatus.BLOCKED,
+                    ConsoleRunStatus.COMPLETED,
+                    ConsoleRunStatus.STOPPED,
+                    ConsoleRunStatus.IDLE,
+                } and run_owner is not None:
+                    updated_owners = dict(context_owners)
+                    updated_owners.pop(target, None)
+                    self._buddy_run_owner_context.set(updated_owners or None)
         self._advance_lifecycle_revision(target)
         terminal_notification_eligible = self.activity_for(
             target

--- a/tldw_chatbook/Chat/console_fleet_wake.py
+++ b/tldw_chatbook/Chat/console_fleet_wake.py
@@ -299,6 +299,7 @@ class ConsoleFleetWakeCoordinator:
 
     def __init__(self, controller: "ConsoleChatController"):
         self._controller = controller
+        self.buddy_sink = getattr(controller, "_buddy_sink", None)
         self._app: Any | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._registry_lock = threading.Lock()
@@ -442,6 +443,11 @@ class ConsoleFleetWakeCoordinator:
                 for child in survivors:
                     bucket[str(child.run_id)] = str(
                         getattr(child, "status", "") or "done"
+                    )
+            if self.buddy_sink is not None:
+                for child in survivors:
+                    self.buddy_sink.wake(
+                        conversation_id, str(child.run_id), active=True
                     )
             self.retry_soon()
         except Exception as exc:  # noqa: BLE001 -- never raise into the fan-out
@@ -665,6 +671,9 @@ class ConsoleFleetWakeCoordinator:
                     if not bucket:
                         self._pending.pop(conversation_id, None)
                 nothing_undelivered = conversation_id not in self._pending
+            if self.buddy_sink is not None:
+                for run_id in delivered_run_ids:
+                    self.buddy_sink.wake(conversation_id, run_id, active=False)
             if nothing_undelivered and self._app is not None:
                 # task-15971 (the coordinator's design ruling): the mark's
                 # fate at commit depends on whether the user WATCHED the
@@ -780,8 +789,18 @@ class ConsoleFleetWakeCoordinator:
                     bucket.setdefault(
                         str(row.get("id")), str(row.get("status") or "done")
                     )
+            if self.buddy_sink is not None:
+                for row in rows:
+                    self.buddy_sink.wake(
+                        conversation_id, str(row.get("id")), active=True
+                    )
             seeded += 1
         return seeded
+
+    def dispose(self) -> None:
+        """Release all wake-owned Buddy state at permanent teardown."""
+        if self.buddy_sink is not None:
+            self.buddy_sink.clear_wakes()
 
     # -- internals ------------------------------------------------------------
 
@@ -871,5 +890,8 @@ class ConsoleFleetWakeCoordinator:
                         pending_bucket.pop(run_id, None)
                     if not pending_bucket:
                         self._pending.pop(conversation_id, None)
+            if self.buddy_sink is not None:
+                for run_id in stale:
+                    self.buddy_sink.wake(conversation_id, run_id, active=False)
         rows.sort(key=lambda r: str(r.get("updated_at") or ""))
         return rows

--- a/tldw_chatbook/Chat/console_fleet_wake.py
+++ b/tldw_chatbook/Chat/console_fleet_wake.py
@@ -457,11 +457,9 @@ class ConsoleFleetWakeCoordinator:
                     bucket[str(child.run_id)] = str(
                         getattr(child, "status", "") or "done"
                     )
-                if self.buddy_sink is not None:
-                    for child in survivors:
-                        self.buddy_sink.wake(
-                            conversation_id, str(child.run_id), active=True
-                        )
+            self._publish_active_wakes(
+                conversation_id, tuple(str(child.run_id) for child in survivors)
+            )
             self.retry_soon()
         except Exception as exc:  # noqa: BLE001 -- never raise into the fan-out
             logger.warning(
@@ -596,41 +594,62 @@ class ConsoleFleetWakeCoordinator:
             authorization = AgentWakeAuthorization(
                 self, session_id, _key=_WAKE_AUTHORIZATION_KEY
             )
-            # task-15862: tell the screen a wake turn is starting so it can arm
-            # the transcript poll. ``_delivering`` is already set, so a poll
-            # beat racing the delivery task's first run cannot self-stop in the
-            # gap. Never let a UI hook block the delivery itself.
             hook = self.delivery_ui_hook
-            try:
-                if callable(hook):
-                    hook(session_id)
-            except Exception as exc:  # noqa: BLE001 -- UI freshness is best-effort
-                logger.debug(
-                    "wake delivery UI hook raised (exception_type={})",
-                    type(exc).__name__,
-                )
-            # Qodo audit minor batch: `_delivering` must be set BEFORE the
-            # hook and task. A failed create must clear both flags.
-            try:
-                task = loop.create_task(
-                    self._deliver(
-                        conversation_id,
-                        session_id,
-                        delivered_run_ids,
-                        notice,
-                        authorization,
-                    )
-                )
-            except Exception as exc:  # noqa: BLE001 -- defer, never wedge
-                self._delivering = None
-                self._delivering_session = None
-                logger.warning(
-                    "wake delivery task could not be scheduled; deferring "
-                    "(exception_type={})",
-                    type(exc).__name__,
-                )
+        # The hook and scheduler are external callbacks: never invoke either
+        # while holding the registry lock. The exact in-flight identity is
+        # rechecked after each boundary.
+        try:
+            if callable(hook):
+                hook(session_id)
+        except Exception as exc:  # noqa: BLE001 -- UI freshness is best-effort
+            logger.debug(
+                "wake delivery UI hook raised (exception_type={})",
+                type(exc).__name__,
+            )
+        with self._registry_lock:
+            if (
+                self._disposed
+                or self._delivering != conversation_id
+                or self._delivering_session != session_id
+            ):
                 return
-            self._delivery_tasks.add(task)
+        try:
+            task = loop.create_task(
+                self._deliver(
+                    conversation_id,
+                    session_id,
+                    delivered_run_ids,
+                    notice,
+                    authorization,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 -- defer, never wedge
+            with self._registry_lock:
+                if (
+                    self._delivering == conversation_id
+                    and self._delivering_session == session_id
+                ):
+                    self._delivering = None
+                    self._delivering_session = None
+            logger.warning(
+                "wake delivery task could not be scheduled; deferring "
+                "(exception_type={})",
+                type(exc).__name__,
+            )
+            return
+        cancel_task = False
+        with self._registry_lock:
+            if (
+                self._disposed
+                or self._delivering != conversation_id
+                or self._delivering_session != session_id
+            ):
+                cancel_task = True
+            else:
+                self._delivery_tasks.add(task)
+        if cancel_task:
+            task.cancel()
+            return
         task.add_done_callback(self._delivery_tasks.discard)
 
     async def _deliver(
@@ -659,11 +678,11 @@ class ConsoleFleetWakeCoordinator:
         )
 
         with self._registry_lock:
-            if self._disposed:
-                self._release_exact_wakes(conversation_id, delivered_run_ids)
-                return
+            disposed = self._disposed
+        if disposed:
+            self._release_exact_wakes(conversation_id, delivered_run_ids)
+            return
         accepted = False
-        retry = False
         try:
             result = await self._controller.submit_draft(
                 notice,
@@ -678,43 +697,98 @@ class ConsoleFleetWakeCoordinator:
                 type(exc).__name__,
             )
         finally:
-            with self._registry_lock:
+            self._finish_delivery(
+                conversation_id,
+                session_id,
+                delivered_run_ids,
+                accepted=accepted,
+            )
+
+    def _finish_delivery(
+        self,
+        conversation_id: str,
+        session_id: str,
+        delivered_run_ids: tuple[str, ...],
+        *,
+        accepted: bool,
+    ) -> None:
+        """Commit one completed delivery without external calls under lock."""
+
+        with self._registry_lock:
+            exact_delivery = (
+                self._delivering == conversation_id
+                and self._delivering_session == session_id
+            )
+            bucket = self._pending.get(conversation_id) or {}
+            exact_membership = all(run_id in bucket for run_id in delivered_run_ids)
+            disposed = self._disposed
+            candidate = (
+                accepted and not disposed and exact_delivery and exact_membership
+            )
+            if not candidate:
+                if exact_delivery:
+                    self._delivering = None
+                    self._delivering_session = None
+
+        if disposed:
+            self._release_exact_wakes(conversation_id, delivered_run_ids)
+            return
+        if not candidate:
+            self.retry_soon()
+            return
+
+        # SQLite is external work and may reenter teardown. Keep the in-flight
+        # identity set while stamping, then revalidate it and membership before
+        # committing the in-memory registry transition.
+        runs_db = self._runs_db()
+        stamp = getattr(runs_db, "mark_wake_delivered", None)
+        if callable(stamp):
+            try:
+                stamp(delivered_run_ids)
+            except Exception as exc:  # noqa: BLE001 -- reannounce beats loss
+                logger.warning(
+                    "wake delivery ledger stamp failed (exception_type={})",
+                    type(exc).__name__,
+                )
+
+        with self._registry_lock:
+            exact_delivery = (
+                self._delivering == conversation_id
+                and self._delivering_session == session_id
+            )
+            bucket = self._pending.get(conversation_id)
+            exact_membership = bucket is not None and all(
+                run_id in bucket for run_id in delivered_run_ids
+            )
+            if self._disposed or not exact_delivery or not exact_membership:
+                disposed = self._disposed
+                if exact_delivery:
+                    self._delivering = None
+                    self._delivering_session = None
+                committed = False
+                nothing_undelivered = False
+            else:
+                for run_id in delivered_run_ids:
+                    bucket.pop(run_id, None)
+                if not bucket:
+                    self._pending.pop(conversation_id, None)
                 self._delivering = None
                 self._delivering_session = None
-                if self._disposed:
-                    self._release_exact_wakes(conversation_id, delivered_run_ids)
+                committed = True
+                nothing_undelivered = conversation_id not in self._pending
+
+        if disposed or committed:
+            self._release_exact_wakes(conversation_id, delivered_run_ids)
+        if committed and nothing_undelivered and self._app is not None:
+            in_view = self._conversation_in_view(conversation_id, session_id)
+            with self._registry_lock:
+                publish_mark = not self._disposed
+            if publish_mark:
+                if in_view:
+                    clear_fleet_unseen_completion(self._app, conversation_id)
                 else:
-                    retry = True
-                    if accepted:
-                        runs_db = self._runs_db()
-                        stamp = getattr(runs_db, "mark_wake_delivered", None)
-                        if callable(stamp):
-                            try:
-                                stamp(delivered_run_ids)
-                            except Exception as exc:  # noqa: BLE001
-                                # A lost stamp risks one re-announce, never a
-                                # lost result.
-                                logger.warning(
-                                    "wake delivery ledger stamp failed "
-                                    "(exception_type={})",
-                                    type(exc).__name__,
-                                )
-                        bucket = self._pending.get(conversation_id)
-                        if bucket is not None:
-                            for run_id in delivered_run_ids:
-                                bucket.pop(run_id, None)
-                            if not bucket:
-                                self._pending.pop(conversation_id, None)
-                        nothing_undelivered = conversation_id not in self._pending
-                        self._release_exact_wakes(conversation_id, delivered_run_ids)
-                        if nothing_undelivered and self._app is not None:
-                            if self._conversation_in_view(conversation_id, session_id):
-                                clear_fleet_unseen_completion(
-                                    self._app, conversation_id
-                                )
-                            else:
-                                set_fleet_unseen_completion(self._app, conversation_id)
-        if retry:
+                    set_fleet_unseen_completion(self._app, conversation_id)
+        if not disposed:
             self.retry_soon()
 
     def _conversation_in_view(
@@ -817,15 +891,12 @@ class ConsoleFleetWakeCoordinator:
                 if self._disposed:
                     return seeded
                 bucket = self._pending.setdefault(conversation_id, {})
+                run_ids: list[str] = []
                 for row in rows:
-                    bucket.setdefault(
-                        str(row.get("id")), str(row.get("status") or "done")
-                    )
-                if self.buddy_sink is not None:
-                    for row in rows:
-                        self.buddy_sink.wake(
-                            conversation_id, str(row.get("id")), active=True
-                        )
+                    run_id = str(row.get("id"))
+                    bucket.setdefault(run_id, str(row.get("status") or "done"))
+                    run_ids.append(run_id)
+            self._publish_active_wakes(conversation_id, tuple(run_ids))
             seeded += 1
         return seeded
 
@@ -838,8 +909,9 @@ class ConsoleFleetWakeCoordinator:
             self._pending.clear()
             self._delivering = None
             self._delivering_session = None
-            if self.buddy_sink is not None:
-                self.buddy_sink.clear_wakes()
+            sink = self.buddy_sink
+        if sink is not None:
+            sink.clear_wakes()
 
     # -- internals ------------------------------------------------------------
 
@@ -934,9 +1006,32 @@ class ConsoleFleetWakeCoordinator:
                         pending_bucket.pop(run_id, None)
                     if not pending_bucket:
                         self._pending.pop(conversation_id, None)
-                self._release_exact_wakes(conversation_id, stale)
+            self._release_exact_wakes(conversation_id, stale)
         rows.sort(key=lambda r: str(r.get("updated_at") or ""))
         return rows
+
+    def _publish_active_wakes(
+        self, conversation_id: str, run_ids: Sequence[str]
+    ) -> None:
+        """Publish active leases externally, then post-fence exact membership."""
+
+        sink = self.buddy_sink
+        if sink is None:
+            return
+        for run_id in run_ids:
+            with self._registry_lock:
+                live = not self._disposed and run_id in self._pending.get(
+                    conversation_id, {}
+                )
+            if not live:
+                continue
+            sink.wake(conversation_id, run_id, active=True)
+            with self._registry_lock:
+                still_live = not self._disposed and run_id in self._pending.get(
+                    conversation_id, {}
+                )
+            if not still_live:
+                sink.wake(conversation_id, run_id, active=False)
 
     def _release_exact_wakes(
         self, conversation_id: str, run_ids: Sequence[str]

--- a/tldw_chatbook/Chat/console_fleet_wake.py
+++ b/tldw_chatbook/Chat/console_fleet_wake.py
@@ -302,7 +302,11 @@ class ConsoleFleetWakeCoordinator:
         self.buddy_sink = getattr(controller, "_buddy_sink", None)
         self._app: Any | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._registry_lock = threading.Lock()
+        self._registry_lock = threading.RLock()
+        #: Permanent teardown fence. Set under ``_registry_lock`` before
+        #: pending membership or Buddy leases are cleared, so a producer
+        #: that began earlier cannot publish after disposal.
+        self._disposed = False
         #: conversation_id -> {run_id: terminal status}; the hot-path
         #: undelivered set (the durable mark is the restart-proof bit).
         self._pending: dict[str, dict[str, str]] = {}
@@ -365,12 +369,14 @@ class ConsoleFleetWakeCoordinator:
     ) -> bool:
         """Return whether ``authorization`` is this coordinator's live
         wake token for ``session_id``."""
-        return bool(
-            isinstance(authorization, AgentWakeAuthorization)
-            and authorization._coordinator is self
-            and authorization.session_id == session_id
-            and self._delivering is not None
-        )
+        with self._registry_lock:
+            return bool(
+                not self._disposed
+                and isinstance(authorization, AgentWakeAuthorization)
+                and authorization._coordinator is self
+                and authorization.session_id == session_id
+                and self._delivering is not None
+            )
 
     # -- inspection (tests / screen) -----------------------------------------
 
@@ -396,7 +402,8 @@ class ConsoleFleetWakeCoordinator:
         Returns:
             The conversation id being delivered, or ``None``.
         """
-        return self._delivering
+        with self._registry_lock:
+            return self._delivering
 
     def delivering_session_id(self) -> str | None:
         """The session a wake turn is delivering into right now.
@@ -410,7 +417,8 @@ class ConsoleFleetWakeCoordinator:
         Returns:
             The session id being delivered into, or ``None``.
         """
-        return self._delivering_session
+        with self._registry_lock:
+            return self._delivering_session
 
     # -- the drain half (child thread) ---------------------------------------
 
@@ -427,6 +435,9 @@ class ConsoleFleetWakeCoordinator:
         deliver what settled while it was off.
         """
         try:
+            with self._registry_lock:
+                if self._disposed:
+                    return
             survivors = [
                 child
                 for child in (getattr(event, "children", ()) or ())
@@ -439,16 +450,18 @@ class ConsoleFleetWakeCoordinator:
             if not conversation_id:
                 return
             with self._registry_lock:
+                if self._disposed:
+                    return
                 bucket = self._pending.setdefault(conversation_id, {})
                 for child in survivors:
                     bucket[str(child.run_id)] = str(
                         getattr(child, "status", "") or "done"
                     )
-            if self.buddy_sink is not None:
-                for child in survivors:
-                    self.buddy_sink.wake(
-                        conversation_id, str(child.run_id), active=True
-                    )
+                if self.buddy_sink is not None:
+                    for child in survivors:
+                        self.buddy_sink.wake(
+                            conversation_id, str(child.run_id), active=True
+                        )
             self.retry_soon()
         except Exception as exc:  # noqa: BLE001 -- never raise into the fan-out
             logger.warning(
@@ -468,7 +481,10 @@ class ConsoleFleetWakeCoordinator:
         poke, mount-claim seeding, and each delivery's own completion.
         No loop captured (sync harness) means nothing to schedule onto.
         """
-        loop = self._loop
+        with self._registry_lock:
+            if self._disposed:
+                return
+            loop = self._loop
         if loop is None or loop.is_closed():
             return
         try:
@@ -478,6 +494,8 @@ class ConsoleFleetWakeCoordinator:
 
     def _attempt_all(self) -> None:
         with self._registry_lock:
+            if self._disposed:
+                return
             conversations = tuple(self._pending)
         for conversation_id in conversations:
             self._attempt(conversation_id)
@@ -518,6 +536,12 @@ class ConsoleFleetWakeCoordinator:
         allowed before (no ``_shutdown_requested``) and is allowed now
         (``_disposed`` defaults False).
         """
+        with self._registry_lock:
+            if self._disposed:
+                return
+            if self._delivering is not None:
+                return
+            bucket = dict(self._pending.get(conversation_id) or {})
         if not autowake_enabled():
             return
         controller = self._controller
@@ -525,10 +549,6 @@ class ConsoleFleetWakeCoordinator:
             return
         if getattr(controller, "_disposed", False):
             return
-        if self._delivering is not None:
-            return
-        with self._registry_lock:
-            bucket = dict(self._pending.get(conversation_id) or {})
         if not bucket:
             return
         session_id = self._resolve_session_id(conversation_id)
@@ -558,55 +578,59 @@ class ConsoleFleetWakeCoordinator:
         notice = compose_wake_notice(rows)
         if not notice:
             return
+        delivered_run_ids = tuple(str(row.get("id")) for row in rows)
         loop = self._loop
         if loop is None or loop.is_closed():
             return
-        self._delivering = conversation_id
-        self._delivering_session = session_id
-        authorization = AgentWakeAuthorization(
-            self, session_id, _key=_WAKE_AUTHORIZATION_KEY
-        )
-        # task-15862: tell the screen a wake turn is starting so it can arm
-        # the transcript poll. ``_delivering`` is already set, so a poll
-        # beat racing the delivery task's first run cannot self-stop in the
-        # gap. Never let a UI hook block the delivery itself.
-        hook = self.delivery_ui_hook
-        if callable(hook):
+        with self._registry_lock:
+            # All gates above may invoke external code. Recheck the terminal
+            # fence and serializer after that work, immediately before the
+            # only enqueue/publication transition.
+            if self._disposed or self._delivering is not None:
+                return
+            current = self._pending.get(conversation_id) or {}
+            if not all(run_id in current for run_id in delivered_run_ids):
+                return
+            self._delivering = conversation_id
+            self._delivering_session = session_id
+            authorization = AgentWakeAuthorization(
+                self, session_id, _key=_WAKE_AUTHORIZATION_KEY
+            )
+            # task-15862: tell the screen a wake turn is starting so it can arm
+            # the transcript poll. ``_delivering`` is already set, so a poll
+            # beat racing the delivery task's first run cannot self-stop in the
+            # gap. Never let a UI hook block the delivery itself.
+            hook = self.delivery_ui_hook
             try:
-                hook(session_id)
+                if callable(hook):
+                    hook(session_id)
             except Exception as exc:  # noqa: BLE001 -- UI freshness is best-effort
                 logger.debug(
                     "wake delivery UI hook raised (exception_type={})",
                     type(exc).__name__,
                 )
-        # Qodo audit minor batch: `_delivering` must be set BEFORE the hook
-        # and the task (the poll-beat race above), so a `create_task` that
-        # raises -- the loop closing between the `is_closed()` check and
-        # this call is the live shape -- must CLEAR the flags on its way
-        # out. Leaving them set wedged every future `_attempt` in the
-        # process at the `self._delivering is not None` gate: no wake could
-        # ever fire again. The bucket is untouched, so the wake is
-        # deferred to the next attempt, not lost.
-        try:
-            task = loop.create_task(
-                self._deliver(
-                    conversation_id,
-                    session_id,
-                    tuple(bucket),
-                    notice,
-                    authorization,
+            # Qodo audit minor batch: `_delivering` must be set BEFORE the
+            # hook and task. A failed create must clear both flags.
+            try:
+                task = loop.create_task(
+                    self._deliver(
+                        conversation_id,
+                        session_id,
+                        delivered_run_ids,
+                        notice,
+                        authorization,
+                    )
                 )
-            )
-        except Exception as exc:  # noqa: BLE001 -- a failed wake defers, never wedges
-            self._delivering = None
-            self._delivering_session = None
-            logger.warning(
-                "wake delivery task could not be scheduled; deferring "
-                "(exception_type={})",
-                type(exc).__name__,
-            )
-            return
-        self._delivery_tasks.add(task)
+            except Exception as exc:  # noqa: BLE001 -- defer, never wedge
+                self._delivering = None
+                self._delivering_session = None
+                logger.warning(
+                    "wake delivery task could not be scheduled; deferring "
+                    "(exception_type={})",
+                    type(exc).__name__,
+                )
+                return
+            self._delivery_tasks.add(task)
         task.add_done_callback(self._delivery_tasks.discard)
 
     async def _deliver(
@@ -634,7 +658,12 @@ class ConsoleFleetWakeCoordinator:
             ConsoleSubmissionOrigin,
         )
 
+        with self._registry_lock:
+            if self._disposed:
+                self._release_exact_wakes(conversation_id, delivered_run_ids)
+                return
         accepted = False
+        retry = False
         try:
             result = await self._controller.submit_draft(
                 notice,
@@ -649,46 +678,44 @@ class ConsoleFleetWakeCoordinator:
                 type(exc).__name__,
             )
         finally:
-            self._delivering = None
-            self._delivering_session = None
-        if accepted:
-            runs_db = self._runs_db()
-            stamp = getattr(runs_db, "mark_wake_delivered", None)
-            if callable(stamp):
-                try:
-                    stamp(delivered_run_ids)
-                except Exception as exc:  # noqa: BLE001 -- a lost stamp risks one
-                    # re-announce at a later claim, never a lost result.
-                    logger.warning(
-                        "wake delivery ledger stamp failed (exception_type={})",
-                        type(exc).__name__,
-                    )
             with self._registry_lock:
-                bucket = self._pending.get(conversation_id)
-                if bucket is not None:
-                    for run_id in delivered_run_ids:
-                        bucket.pop(run_id, None)
-                    if not bucket:
-                        self._pending.pop(conversation_id, None)
-                nothing_undelivered = conversation_id not in self._pending
-            if self.buddy_sink is not None:
-                for run_id in delivered_run_ids:
-                    self.buddy_sink.wake(conversation_id, run_id, active=False)
-            if nothing_undelivered and self._app is not None:
-                # task-15971 (the coordinator's design ruling): the mark's
-                # fate at commit depends on whether the user WATCHED the
-                # delivery. In view -> the result is seen; clear through
-                # the named seam as always. Off view (a mounted-but-hidden
-                # Console delivering, or a non-active session tab) -> the
-                # delivery is real but unseen; the mark is SET so the ◈
-                # badge points at the delivered result until the user
-                # views it (view-clear then applies normally -- nothing
-                # is pending any more).
-                if self._conversation_in_view(conversation_id, session_id):
-                    clear_fleet_unseen_completion(self._app, conversation_id)
+                self._delivering = None
+                self._delivering_session = None
+                if self._disposed:
+                    self._release_exact_wakes(conversation_id, delivered_run_ids)
                 else:
-                    set_fleet_unseen_completion(self._app, conversation_id)
-        self.retry_soon()
+                    retry = True
+                    if accepted:
+                        runs_db = self._runs_db()
+                        stamp = getattr(runs_db, "mark_wake_delivered", None)
+                        if callable(stamp):
+                            try:
+                                stamp(delivered_run_ids)
+                            except Exception as exc:  # noqa: BLE001
+                                # A lost stamp risks one re-announce, never a
+                                # lost result.
+                                logger.warning(
+                                    "wake delivery ledger stamp failed "
+                                    "(exception_type={})",
+                                    type(exc).__name__,
+                                )
+                        bucket = self._pending.get(conversation_id)
+                        if bucket is not None:
+                            for run_id in delivered_run_ids:
+                                bucket.pop(run_id, None)
+                            if not bucket:
+                                self._pending.pop(conversation_id, None)
+                        nothing_undelivered = conversation_id not in self._pending
+                        self._release_exact_wakes(conversation_id, delivered_run_ids)
+                        if nothing_undelivered and self._app is not None:
+                            if self._conversation_in_view(conversation_id, session_id):
+                                clear_fleet_unseen_completion(
+                                    self._app, conversation_id
+                                )
+                            else:
+                                set_fleet_unseen_completion(self._app, conversation_id)
+        if retry:
+            self.retry_soon()
 
     def _conversation_in_view(
         self, conversation_id: str, session_id: str
@@ -755,6 +782,9 @@ class ConsoleFleetWakeCoordinator:
         Returns:
             How many conversations gained pending completions.
         """
+        with self._registry_lock:
+            if self._disposed:
+                return 0
         if not autowake_enabled():
             return 0
         app = self._app
@@ -784,23 +814,32 @@ class ConsoleFleetWakeCoordinator:
             if not rows:
                 continue
             with self._registry_lock:
+                if self._disposed:
+                    return seeded
                 bucket = self._pending.setdefault(conversation_id, {})
                 for row in rows:
                     bucket.setdefault(
                         str(row.get("id")), str(row.get("status") or "done")
                     )
-            if self.buddy_sink is not None:
-                for row in rows:
-                    self.buddy_sink.wake(
-                        conversation_id, str(row.get("id")), active=True
-                    )
+                if self.buddy_sink is not None:
+                    for row in rows:
+                        self.buddy_sink.wake(
+                            conversation_id, str(row.get("id")), active=True
+                        )
             seeded += 1
         return seeded
 
     def dispose(self) -> None:
-        """Release all wake-owned Buddy state at permanent teardown."""
-        if self.buddy_sink is not None:
-            self.buddy_sink.clear_wakes()
+        """Terminally fence producers, then clear membership and leases."""
+        with self._registry_lock:
+            if self._disposed:
+                return
+            self._disposed = True
+            self._pending.clear()
+            self._delivering = None
+            self._delivering_session = None
+            if self.buddy_sink is not None:
+                self.buddy_sink.clear_wakes()
 
     # -- internals ------------------------------------------------------------
 
@@ -837,6 +876,9 @@ class ConsoleFleetWakeCoordinator:
         wake-delivered (a redelivered drain, or a restart racing the
         in-memory commit) is DROPPED -- from the returned rows AND from
         the registry -- rather than re-announced."""
+        with self._registry_lock:
+            if self._disposed:
+                return []
         runs_db = self._runs_db()
         rows: list[dict] = []
         stale: list[str] = []
@@ -884,14 +926,23 @@ class ConsoleFleetWakeCoordinator:
             )
         if stale:
             with self._registry_lock:
+                if self._disposed:
+                    return []
                 pending_bucket = self._pending.get(conversation_id)
                 if pending_bucket is not None:
                     for run_id in stale:
                         pending_bucket.pop(run_id, None)
                     if not pending_bucket:
                         self._pending.pop(conversation_id, None)
-            if self.buddy_sink is not None:
-                for run_id in stale:
-                    self.buddy_sink.wake(conversation_id, run_id, active=False)
+                self._release_exact_wakes(conversation_id, stale)
         rows.sort(key=lambda r: str(r.get("updated_at") or ""))
         return rows
+
+    def _release_exact_wakes(
+        self, conversation_id: str, run_ids: Sequence[str]
+    ) -> None:
+        """Release only the wake owners named by a completed callback."""
+        if self.buddy_sink is None:
+            return
+        for run_id in run_ids:
+            self.buddy_sink.wake(conversation_id, run_id, active=False)

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -1013,7 +1013,7 @@ class ConsoleRuntime:
         # Controller shutdown begins by terminally fencing the fleet-wake
         # coordinator. Only after every trusted producer is tombstoned may
         # the shared Buddy sink release its remaining owner tokens.
-        self._persona_buddy_sink.release_all()
+        self._persona_buddy_sink.dispose()
         close = getattr(gateway, "aclose", None)
         if callable(close):
             try:

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -1001,7 +1001,6 @@ class ConsoleRuntime:
         """
         self._disposed = True
         self.detach_view(None)
-        self._persona_buddy_sink.release_all()
         controller, gateway = self._chat_controller, self._provider_gateway
         self.generation += 1
         if controller is not None:
@@ -1011,6 +1010,10 @@ class ConsoleRuntime:
                 logger.opt(exception=True).warning(
                     "Console runtime: controller shutdown failed at dispose."
                 )
+        # Controller shutdown begins by terminally fencing the fleet-wake
+        # coordinator. Only after every trusted producer is tombstoned may
+        # the shared Buddy sink release its remaining owner tokens.
+        self._persona_buddy_sink.release_all()
         close = getattr(gateway, "aclose", None)
         if callable(close):
             try:

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -122,6 +122,8 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
+from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
     from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
@@ -462,6 +464,9 @@ class ConsoleRuntime:
         self._provider_gateway: Any | None = None
         self._agent_bridge: Any | None = None
         self._chat_controller: Any | None = None
+        self._persona_buddy_sink = PersonaBuddyConsoleAdapter(
+            getattr(app, "persona_buddy_controller", None)
+        )
         #: The view (a `ChatScreen`) currently attached, or `None` while the
         #: runtime is VIEWLESS -- which is now a real, supported state, not
         #: a transient. Written only by `attach_view`/`detach_view`.
@@ -510,6 +515,14 @@ class ConsoleRuntime:
     def chat_controller(self) -> "ConsoleChatController | None":
         """The built chat controller, or `None`."""
         return self._chat_controller
+
+    @property
+    def persona_buddy_sink(self) -> PersonaBuddyConsoleAdapter:
+        """The app-owned, screen-free sink for trusted Console state."""
+        self._persona_buddy_sink.bind_controller(
+            getattr(self._app, "persona_buddy_controller", None)
+        )
+        return self._persona_buddy_sink
 
     # -- handle writes (the screen's properties, and 59 test sites) --------
 
@@ -691,6 +704,7 @@ class ConsoleRuntime:
                 else None
             ),
             change_tracker=change_tracker if change_tracker.available else None,
+            buddy_sink=self.persona_buddy_sink,
         )
         # PR3a-2 Task 4: the survivor-completion attention consumer (durable
         # unseen mark + app-wide toast + deep link), registered NEXT TO
@@ -723,6 +737,7 @@ class ConsoleRuntime:
             ConsoleChatController,
         )
 
+        kwargs.setdefault("buddy_sink", self.persona_buddy_sink)
         self._chat_controller = ConsoleChatController(**kwargs)
         if self.view is None:
             # task-15860 Task 4: a runtime can be VIEWLESS FROM BIRTH, not
@@ -986,6 +1001,7 @@ class ConsoleRuntime:
         """
         self._disposed = True
         self.detach_view(None)
+        self._persona_buddy_sink.release_all()
         controller, gateway = self._chat_controller, self._provider_gateway
         self.generation += 1
         if controller is not None:

--- a/tldw_chatbook/Persona_Buddy/__init__.py
+++ b/tldw_chatbook/Persona_Buddy/__init__.py
@@ -6,6 +6,7 @@ from .controller import (
     PersonaBuddySnapshot,
 )
 from .preferences import (
+    PERSONA_BUDDY_UNPOSITIONED_COORDINATE,
     PersonaBuddyGeometry,
     PersonaBuddyPreferences,
     PersonaBuddySelection,
@@ -15,6 +16,7 @@ from .preferences import (
 )
 
 __all__ = (
+    "PERSONA_BUDDY_UNPOSITIONED_COORDINATE",
     "PersonaBuddyController",
     "PersonaBuddyGeometry",
     "PersonaBuddyLeaseToken",

--- a/tldw_chatbook/Persona_Buddy/__init__.py
+++ b/tldw_chatbook/Persona_Buddy/__init__.py
@@ -1,9 +1,11 @@
 """App-owned Persona Buddy state and preference contracts."""
 
 from .controller import (
+    BuddyDrainResult,
     PersonaBuddyController,
     PersonaBuddyLeaseToken,
     PersonaBuddySnapshot,
+    PersonaBuddyVisualSnapshot,
 )
 from .preferences import (
     PERSONA_BUDDY_UNPOSITIONED_COORDINATE,
@@ -14,16 +16,28 @@ from .preferences import (
     persist_persona_buddy_preferences,
     serialize_persona_buddy_preferences,
 )
+from .rendering import (
+    PERSONA_BUDDY_FRAME_UNAVAILABLE,
+    PersonaBuddyFrameError,
+    PersonaBuddyPreparedFrame,
+    prepare_persona_buddy_frame,
+)
 
 __all__ = (
     "PERSONA_BUDDY_UNPOSITIONED_COORDINATE",
+    "PERSONA_BUDDY_FRAME_UNAVAILABLE",
+    "BuddyDrainResult",
     "PersonaBuddyController",
     "PersonaBuddyGeometry",
+    "PersonaBuddyFrameError",
     "PersonaBuddyLeaseToken",
     "PersonaBuddyPreferences",
+    "PersonaBuddyPreparedFrame",
     "PersonaBuddySelection",
     "PersonaBuddySnapshot",
+    "PersonaBuddyVisualSnapshot",
     "parse_persona_buddy_preferences",
+    "prepare_persona_buddy_frame",
     "persist_persona_buddy_preferences",
     "serialize_persona_buddy_preferences",
 )

--- a/tldw_chatbook/Persona_Buddy/__init__.py
+++ b/tldw_chatbook/Persona_Buddy/__init__.py
@@ -6,6 +6,7 @@ from .controller import (
     PersonaBuddyLeaseToken,
     PersonaBuddySnapshot,
     PersonaBuddyVisualSnapshot,
+    load_local_persona_portrait,
 )
 from .preferences import (
     PERSONA_BUDDY_UNPOSITIONED_COORDINATE,
@@ -36,6 +37,7 @@ __all__ = (
     "PersonaBuddySelection",
     "PersonaBuddySnapshot",
     "PersonaBuddyVisualSnapshot",
+    "load_local_persona_portrait",
     "parse_persona_buddy_preferences",
     "prepare_persona_buddy_frame",
     "persist_persona_buddy_preferences",

--- a/tldw_chatbook/Persona_Buddy/__init__.py
+++ b/tldw_chatbook/Persona_Buddy/__init__.py
@@ -1,0 +1,27 @@
+"""App-owned Persona Buddy state and preference contracts."""
+
+from .controller import (
+    PersonaBuddyController,
+    PersonaBuddyLeaseToken,
+    PersonaBuddySnapshot,
+)
+from .preferences import (
+    PersonaBuddyGeometry,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+    parse_persona_buddy_preferences,
+    persist_persona_buddy_preferences,
+    serialize_persona_buddy_preferences,
+)
+
+__all__ = (
+    "PersonaBuddyController",
+    "PersonaBuddyGeometry",
+    "PersonaBuddyLeaseToken",
+    "PersonaBuddyPreferences",
+    "PersonaBuddySelection",
+    "PersonaBuddySnapshot",
+    "parse_persona_buddy_preferences",
+    "persist_persona_buddy_preferences",
+    "serialize_persona_buddy_preferences",
+)

--- a/tldw_chatbook/Persona_Buddy/console_adapter.py
+++ b/tldw_chatbook/Persona_Buddy/console_adapter.py
@@ -107,11 +107,7 @@ class BuddyLifecycleEvent:
             and self.source not in _CUSTOM_STATE_SOURCES
         ):
             raise ValueError("persona_buddy_console_state_invalid")
-        if (
-            self.source == "explicit"
-            and not self.terminal
-            and (self.expires_at is None or self.expires_at <= time.monotonic())
-        ):
+        if self.source == "explicit" and not self.terminal and self.expires_at is None:
             raise ValueError("persona_buddy_console_expiry_invalid")
 
 
@@ -162,6 +158,12 @@ class PersonaBuddyConsoleAdapter:
             self._prune_expired_locked()
             controller = self._controller
             if controller is None:
+                return False
+            if (
+                event.source == "explicit"
+                and event.expires_at is not None
+                and event.expires_at <= self._clock()
+            ):
                 return False
             if event.terminal:
                 token = self._tokens.pop(key, None)

--- a/tldw_chatbook/Persona_Buddy/console_adapter.py
+++ b/tldw_chatbook/Persona_Buddy/console_adapter.py
@@ -1,0 +1,396 @@
+"""Content-free adapters from trusted Console lifecycle state to Buddy leases."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+import time
+from dataclasses import dataclass
+from threading import RLock
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from .controller import PersonaBuddyController, PersonaBuddyLeaseToken
+
+
+_SOURCES = frozenset(
+    {"console-run", "approval", "tool", "wake", "voice", "explicit", "authored"}
+)
+_BUILTIN_STATES = frozenset(
+    {
+        "idle",
+        "listening",
+        "thinking",
+        "speaking",
+        "approval_needed",
+        "tool_running",
+        "wake_armed",
+        "offline",
+        "error",
+    }
+)
+_CUSTOM_STATE_PATTERN = re.compile(r"[a-z][a-z0-9_.:-]{0,95}\Z")
+_OWNER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
+_CUSTOM_STATE_SOURCES = frozenset({"explicit", "authored"})
+_UNSAFE_STATE_PREFIXES = ("env:", "file:", "ftp:", "http:", "https:", "proc:", "ssh:")
+_UNSAFE_STATE_MARKERS = (
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth_token",
+    "authorization",
+    "bearer_token",
+    "client_secret",
+    "password",
+    "passwd",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "secret_key",
+)
+_RUN_STATES = {
+    "validating": "thinking",
+    "checking": "thinking",
+    "checking_citations": "thinking",
+    "retrying": "thinking",
+    "streaming": "speaking",
+    "failed": "error",
+}
+_RUN_RELEASE_STATES = frozenset({"idle", "completed", "stopped", "blocked"})
+_VOICE_STATES = {
+    "live": "listening",
+    "listening": "listening",
+    "thinking": "thinking",
+    "speaking": "speaking",
+    "connecting": "offline",
+    "reconnecting": "offline",
+}
+_TOOL_START = "tool_call"
+_TOOL_RELEASE = frozenset({"tool_result", "error", "cancelled", "terminal"})
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyLifecycleEvent:
+    """One trusted operational state transition with no user/model content."""
+
+    source: str
+    owner: str
+    state: str
+    terminal: bool = False
+    expires_at: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.source not in _SOURCES:
+            raise ValueError("persona_buddy_console_source_invalid")
+        if type(self.owner) is not str or _OWNER_PATTERN.fullmatch(self.owner) is None:
+            raise ValueError("persona_buddy_console_owner_invalid")
+        if type(self.state) is not str or not self.state:
+            raise ValueError("persona_buddy_console_state_invalid")
+        if type(self.terminal) is not bool:
+            raise ValueError("persona_buddy_console_terminal_invalid")
+        if self.expires_at is not None and (
+            type(self.expires_at) is not float or not math.isfinite(self.expires_at)
+        ):
+            raise ValueError("persona_buddy_console_expiry_invalid")
+        if _CUSTOM_STATE_PATTERN.fullmatch(self.state) is None:
+            raise ValueError("persona_buddy_console_state_invalid")
+        if self.state.startswith(_UNSAFE_STATE_PREFIXES):
+            raise ValueError("persona_buddy_console_state_invalid")
+        compact_state = re.sub(r"[._:-]+", "_", self.state)
+        if any(marker in compact_state for marker in _UNSAFE_STATE_MARKERS):
+            raise ValueError("persona_buddy_console_state_invalid")
+        if (
+            self.state not in _BUILTIN_STATES
+            and self.source not in _CUSTOM_STATE_SOURCES
+        ):
+            raise ValueError("persona_buddy_console_state_invalid")
+        if (
+            self.source == "explicit"
+            and not self.terminal
+            and (self.expires_at is None or self.expires_at <= time.monotonic())
+        ):
+            raise ValueError("persona_buddy_console_expiry_invalid")
+
+
+class PersonaBuddyConsoleAdapter:
+    """Thread-safe source/owner ledger for trusted Console producers."""
+
+    def __init__(self, controller: PersonaBuddyController | None) -> None:
+        self._controller = controller
+        self._lock = RLock()
+        self._tokens: dict[tuple[str, str], PersonaBuddyLeaseToken] = {}
+        self._run_generation: dict[str, int] = {}
+        self._run_owners: dict[str, str] = {}
+        self._approval_owners: dict[tuple[str, str], str] = {}
+        self._tool_owners: dict[tuple[str, int], str] = {}
+        self._wake_owners: dict[tuple[str, str], str] = {}
+        self._voice_owners: dict[tuple[str, int], str] = {}
+        self._voice_generation: dict[str, int] = {}
+
+    def bind_controller(self, controller: PersonaBuddyController | None) -> None:
+        """Bind the app controller once it exists during startup ordering."""
+        if controller is None:
+            return
+        with self._lock:
+            if self._controller is None:
+                self._controller = controller
+            elif self._controller is not controller:
+                raise RuntimeError("persona_buddy_console_controller_replacement")
+
+    @staticmethod
+    def _owner(kind: str, *parts: object) -> str:
+        digest = hashlib.sha256()
+        for part in parts:
+            encoded = str(part).encode("utf-8", errors="strict")
+            digest.update(len(encoded).to_bytes(4, "big"))
+            digest.update(encoded)
+        return f"{kind}:{digest.hexdigest()[:32]}"
+
+    def publish(self, event: BuddyLifecycleEvent) -> bool:
+        """Acquire, replace, or release one exact content-free event owner."""
+
+        controller = self._controller
+        if controller is None:
+            return False
+        key = (event.source, event.owner)
+        with self._lock:
+            if event.terminal:
+                token = self._tokens.pop(key, None)
+                return token is not None and controller.release_state(token=token)
+            token = controller.acquire_state(
+                source=event.source,
+                owner=event.owner,
+                state=event.state,
+                expires_at=event.expires_at,
+            )
+            self._tokens[key] = token
+            return True
+
+    def _release(self, source: str, owner: str) -> bool:
+        return self.publish(
+            BuddyLifecycleEvent(
+                source=source,
+                owner=owner,
+                state="idle",
+                terminal=True,
+            )
+        )
+
+    def run_state(self, session_id: str, status: object) -> str | None:
+        """Map one per-session run state, replacing on a new validation."""
+
+        if self._controller is None:
+            return None
+        normalized = str(getattr(status, "value", status)).strip().lower()
+        with self._lock:
+            owner = self._run_owners.get(session_id)
+            if normalized == "validating":
+                if owner is not None:
+                    self._release("console-run", owner)
+                generation = self._run_generation.get(session_id, 0) + 1
+                self._run_generation[session_id] = generation
+                owner = self._owner("run", session_id, generation)
+                self._run_owners[session_id] = owner
+            elif owner is None and normalized in _RUN_STATES:
+                generation = self._run_generation.get(session_id, 0) + 1
+                self._run_generation[session_id] = generation
+                owner = self._owner("run", session_id, generation)
+                self._run_owners[session_id] = owner
+            if normalized in _RUN_RELEASE_STATES:
+                if owner is not None:
+                    self._release("console-run", owner)
+                    self._run_owners.pop(session_id, None)
+                return None
+            state = _RUN_STATES.get(normalized)
+            if state is None or owner is None:
+                return owner
+            self.publish(
+                BuddyLifecycleEvent(
+                    source="console-run",
+                    owner=owner,
+                    state=state,
+                )
+            )
+            return owner
+
+    def approval_round(
+        self, session_id: str, round_id: str, *, pending: bool
+    ) -> str | None:
+        """Acquire or settle one exact approval round."""
+
+        if self._controller is None:
+            return None
+        key = (session_id, round_id)
+        with self._lock:
+            owner = self._approval_owners.get(key)
+            if not pending:
+                if owner is not None:
+                    self._release("approval", owner)
+                    self._approval_owners.pop(key, None)
+                return None
+            if owner is None:
+                owner = self._owner("approval", session_id, round_id)
+                self._approval_owners[key] = owner
+            self.publish(
+                BuddyLifecycleEvent(
+                    source="approval",
+                    owner=owner,
+                    state="approval_needed",
+                )
+            )
+            return owner
+
+    def tool_step(self, run_id: str, sequence: int, kind: str) -> str | None:
+        """Pair a tool-call start with its exact result or run cleanup."""
+
+        if self._controller is None:
+            return None
+        key = (run_id, sequence)
+        with self._lock:
+            if kind == _TOOL_START:
+                owner = self._tool_owners.get(key)
+                if owner is None:
+                    owner = self._owner("tool", run_id, sequence)
+                    self._tool_owners[key] = owner
+                self.publish(
+                    BuddyLifecycleEvent(
+                        source="tool",
+                        owner=owner,
+                        state="tool_running",
+                    )
+                )
+                return owner
+            if kind in _TOOL_RELEASE:
+                owner = self._tool_owners.pop(key, None)
+                if owner is not None:
+                    self._release("tool", owner)
+                return None
+            return self._tool_owners.get(key)
+
+    def release_run(self, run_id: str) -> None:
+        """Release every still-live tool owner for one terminal run."""
+
+        with self._lock:
+            for key, owner in tuple(self._tool_owners.items()):
+                if key[0] == run_id:
+                    self._release("tool", owner)
+                    self._tool_owners.pop(key, None)
+
+    def wake(self, conversation_id: str, run_id: str, *, active: bool) -> str | None:
+        """Mirror one pending or delivering fleet-wake membership."""
+
+        if self._controller is None:
+            return None
+        key = (conversation_id, run_id)
+        with self._lock:
+            owner = self._wake_owners.get(key)
+            if not active:
+                if owner is not None:
+                    self._release("wake", owner)
+                    self._wake_owners.pop(key, None)
+                return None
+            if owner is None:
+                owner = self._owner("wake", conversation_id, run_id)
+                self._wake_owners[key] = owner
+            self.publish(
+                BuddyLifecycleEvent(
+                    source="wake",
+                    owner=owner,
+                    state="wake_armed",
+                )
+            )
+            return owner
+
+    def clear_wakes(self, conversation_id: str | None = None) -> None:
+        """Release settled wake owners, optionally for one conversation."""
+
+        with self._lock:
+            for key, owner in tuple(self._wake_owners.items()):
+                if conversation_id is None or key[0] == conversation_id:
+                    self._release("wake", owner)
+                    self._wake_owners.pop(key, None)
+
+    def voice_state(self, session_id: str, generation: int, state: str) -> str | None:
+        """Publish one exact realtime-loop generation and fence replacements."""
+
+        if self._controller is None:
+            return None
+        key = (session_id, generation)
+        with self._lock:
+            current_generation = self._voice_generation.get(session_id)
+            if current_generation is not None and generation < current_generation:
+                return None
+            if current_generation is not None and generation > current_generation:
+                self.release_voice(session_id, current_generation)
+            self._voice_generation[session_id] = generation
+            owner = self._voice_owners.get(key)
+            if state == "idle":
+                self.release_voice(session_id, generation)
+                return None
+            mapped = _VOICE_STATES.get(state)
+            if mapped is None:
+                return owner
+            if owner is None:
+                owner = self._owner("voice", session_id, generation)
+                self._voice_owners[key] = owner
+            self.publish(BuddyLifecycleEvent(source="voice", owner=owner, state=mapped))
+            return owner
+
+    def release_voice(self, session_id: str, generation: int) -> None:
+        """Release only the named realtime-loop generation."""
+
+        key = (session_id, generation)
+        with self._lock:
+            owner = self._voice_owners.pop(key, None)
+            if owner is not None:
+                self._release("voice", owner)
+            if self._voice_generation.get(session_id) == generation:
+                self._voice_generation.pop(session_id, None)
+
+    def release_session(
+        self, session_id: str, *, sources: Iterable[str] | None = None
+    ) -> None:
+        """Release exact session-owned run, approval, and voice leases."""
+
+        allowed = set(sources or {"console-run", "approval", "voice"})
+        with self._lock:
+            if "console-run" in allowed:
+                owner = self._run_owners.pop(session_id, None)
+                if owner is not None:
+                    self._release("console-run", owner)
+            if "approval" in allowed:
+                for key, owner in tuple(self._approval_owners.items()):
+                    if key[0] == session_id:
+                        self._release("approval", owner)
+                        self._approval_owners.pop(key, None)
+            if "voice" in allowed:
+                generation = self._voice_generation.get(session_id)
+                if generation is not None:
+                    self.release_voice(session_id, generation)
+
+    def release_all(self) -> None:
+        """Release every adapter-owned token during terminal disposal."""
+
+        with self._lock:
+            for (source, _), token in tuple(self._tokens.items()):
+                controller = self._controller
+                if controller is not None:
+                    controller.release_state(token=token)
+            self._tokens.clear()
+            self._run_owners.clear()
+            self._approval_owners.clear()
+            self._tool_owners.clear()
+            self._wake_owners.clear()
+            self._voice_owners.clear()
+            self._voice_generation.clear()
+
+    def active_owner_count(self, source: str | None = None) -> int:
+        """Return a content-free owner count for focused lifecycle tests."""
+
+        with self._lock:
+            if source is None:
+                return len(self._tokens)
+            return sum(1 for token_source, _ in self._tokens if token_source == source)

--- a/tldw_chatbook/Persona_Buddy/console_adapter.py
+++ b/tldw_chatbook/Persona_Buddy/console_adapter.py
@@ -121,6 +121,8 @@ class PersonaBuddyConsoleAdapter:
     def __init__(self, controller: PersonaBuddyController | None) -> None:
         self._controller = controller
         self._lock = RLock()
+        self._clock = time.monotonic
+        self._disposed = False
         self._tokens: dict[tuple[str, str], PersonaBuddyLeaseToken] = {}
         self._run_generation: dict[str, int] = {}
         self._run_owners: dict[str, str] = {}
@@ -129,12 +131,13 @@ class PersonaBuddyConsoleAdapter:
         self._wake_owners: dict[tuple[str, str], str] = {}
         self._voice_owners: dict[tuple[str, int], str] = {}
         self._voice_generation: dict[str, int] = {}
+        self._next_voice_generation = 0
 
     def bind_controller(self, controller: PersonaBuddyController | None) -> None:
         """Bind the app controller once it exists during startup ordering."""
-        if controller is None:
-            return
         with self._lock:
+            if self._disposed or controller is None:
+                return
             if self._controller is None:
                 self._controller = controller
             elif self._controller is not controller:
@@ -152,13 +155,17 @@ class PersonaBuddyConsoleAdapter:
     def publish(self, event: BuddyLifecycleEvent) -> bool:
         """Acquire, replace, or release one exact content-free event owner."""
 
-        controller = self._controller
-        if controller is None:
-            return False
         key = (event.source, event.owner)
         with self._lock:
+            if self._disposed:
+                return False
+            self._prune_expired_locked()
+            controller = self._controller
+            if controller is None:
+                return False
             if event.terminal:
                 token = self._tokens.pop(key, None)
+                self._drop_owner_refs_locked(event.source, event.owner)
                 return token is not None and controller.release_state(token=token)
             token = controller.acquire_state(
                 source=event.source,
@@ -179,13 +186,15 @@ class PersonaBuddyConsoleAdapter:
             )
         )
 
-    def run_state(self, session_id: str, status: object) -> str | None:
+    def run_state(
+        self, session_id: str, status: object, *, run_owner: str | None = None
+    ) -> str | None:
         """Map one per-session run state, replacing on a new validation."""
 
-        if self._controller is None:
-            return None
         normalized = str(getattr(status, "value", status)).strip().lower()
         with self._lock:
+            if self._disposed or self._controller is None:
+                return None
             owner = self._run_owners.get(session_id)
             if normalized == "validating":
                 if owner is not None:
@@ -194,6 +203,10 @@ class PersonaBuddyConsoleAdapter:
                 self._run_generation[session_id] = generation
                 owner = self._owner("run", session_id, generation)
                 self._run_owners[session_id] = owner
+            elif run_owner is not None:
+                if owner != run_owner:
+                    return None
+                owner = run_owner
             elif owner is None and normalized in _RUN_STATES:
                 generation = self._run_generation.get(session_id, 0) + 1
                 self._run_generation[session_id] = generation
@@ -221,10 +234,10 @@ class PersonaBuddyConsoleAdapter:
     ) -> str | None:
         """Acquire or settle one exact approval round."""
 
-        if self._controller is None:
-            return None
         key = (session_id, round_id)
         with self._lock:
+            if self._disposed or self._controller is None:
+                return None
             owner = self._approval_owners.get(key)
             if not pending:
                 if owner is not None:
@@ -246,10 +259,10 @@ class PersonaBuddyConsoleAdapter:
     def tool_step(self, run_id: str, sequence: int, kind: str) -> str | None:
         """Pair a tool-call start with its exact result or run cleanup."""
 
-        if self._controller is None:
-            return None
         key = (run_id, sequence)
         with self._lock:
+            if self._disposed or self._controller is None:
+                return None
             if kind == _TOOL_START:
                 owner = self._tool_owners.get(key)
                 if owner is None:
@@ -274,6 +287,8 @@ class PersonaBuddyConsoleAdapter:
         """Release every still-live tool owner for one terminal run."""
 
         with self._lock:
+            if self._disposed:
+                return
             for key, owner in tuple(self._tool_owners.items()):
                 if key[0] == run_id:
                     self._release("tool", owner)
@@ -282,10 +297,10 @@ class PersonaBuddyConsoleAdapter:
     def wake(self, conversation_id: str, run_id: str, *, active: bool) -> str | None:
         """Mirror one pending or delivering fleet-wake membership."""
 
-        if self._controller is None:
-            return None
         key = (conversation_id, run_id)
         with self._lock:
+            if self._disposed or self._controller is None:
+                return None
             owner = self._wake_owners.get(key)
             if not active:
                 if owner is not None:
@@ -308,6 +323,8 @@ class PersonaBuddyConsoleAdapter:
         """Release settled wake owners, optionally for one conversation."""
 
         with self._lock:
+            if self._disposed:
+                return
             for key, owner in tuple(self._wake_owners.items()):
                 if conversation_id is None or key[0] == conversation_id:
                     self._release("wake", owner)
@@ -316,10 +333,10 @@ class PersonaBuddyConsoleAdapter:
     def voice_state(self, session_id: str, generation: int, state: str) -> str | None:
         """Publish one exact realtime-loop generation and fence replacements."""
 
-        if self._controller is None:
-            return None
         key = (session_id, generation)
         with self._lock:
+            if self._disposed or self._controller is None:
+                return None
             current_generation = self._voice_generation.get(session_id)
             if current_generation is not None and generation < current_generation:
                 return None
@@ -339,11 +356,23 @@ class PersonaBuddyConsoleAdapter:
             self.publish(BuddyLifecycleEvent(source="voice", owner=owner, state=mapped))
             return owner
 
+    def next_voice_generation(self, session_id: str) -> int | None:
+        """Mint one app-wide monotonic realtime-loop incarnation."""
+
+        del session_id  # the token is intentionally app-wide, not screen-local
+        with self._lock:
+            if self._disposed:
+                return None
+            self._next_voice_generation += 1
+            return self._next_voice_generation
+
     def release_voice(self, session_id: str, generation: int) -> None:
         """Release only the named realtime-loop generation."""
 
         key = (session_id, generation)
         with self._lock:
+            if self._disposed:
+                return
             owner = self._voice_owners.pop(key, None)
             if owner is not None:
                 self._release("voice", owner)
@@ -357,6 +386,8 @@ class PersonaBuddyConsoleAdapter:
 
         allowed = set(sources or {"console-run", "approval", "voice"})
         with self._lock:
+            if self._disposed:
+                return
             if "console-run" in allowed:
                 owner = self._run_owners.pop(session_id, None)
                 if owner is not None:
@@ -372,25 +403,80 @@ class PersonaBuddyConsoleAdapter:
                     self.release_voice(session_id, generation)
 
     def release_all(self) -> None:
-        """Release every adapter-owned token during terminal disposal."""
+        """Release every owner while keeping this adapter reusable."""
 
         with self._lock:
-            for (source, _), token in tuple(self._tokens.items()):
-                controller = self._controller
-                if controller is not None:
-                    controller.release_state(token=token)
-            self._tokens.clear()
-            self._run_owners.clear()
-            self._approval_owners.clear()
-            self._tool_owners.clear()
-            self._wake_owners.clear()
-            self._voice_owners.clear()
-            self._voice_generation.clear()
+            if self._disposed:
+                return
+            self._prune_expired_locked()
+            self._release_all_locked()
+
+    def dispose(self) -> None:
+        """Terminally fence producers before releasing every exact token."""
+
+        with self._lock:
+            if self._disposed:
+                return
+            self._disposed = True
+            self._release_all_locked()
+            self._run_generation.clear()
+            self._next_voice_generation = 0
+
+    def _release_all_locked(self) -> None:
+        """Release and clear all live owner maps. Caller holds ``_lock``."""
+
+        controller = self._controller
+        for token in tuple(self._tokens.values()):
+            if controller is not None:
+                controller.release_state(token=token)
+        self._tokens.clear()
+        self._run_owners.clear()
+        self._approval_owners.clear()
+        self._tool_owners.clear()
+        self._wake_owners.clear()
+        self._voice_owners.clear()
+        self._voice_generation.clear()
+
+    def _prune_expired_locked(self) -> None:
+        """Drop expired timed owners from token and source bookkeeping."""
+
+        now = self._clock()
+        controller = self._controller
+        for key, token in tuple(self._tokens.items()):
+            if token.expires_at is None or token.expires_at > now:
+                continue
+            self._tokens.pop(key, None)
+            self._drop_owner_refs_locked(token.source, token.owner)
+            if controller is not None:
+                controller.release_state(token=token)
+
+    def _drop_owner_refs_locked(self, source: str, owner: str) -> None:
+        """Remove one exact released owner from its source index."""
+
+        if source == "console-run":
+            indexed = self._run_owners
+        elif source == "approval":
+            indexed = self._approval_owners
+        elif source == "tool":
+            indexed = self._tool_owners
+        elif source == "wake":
+            indexed = self._wake_owners
+        elif source == "voice":
+            indexed = self._voice_owners
+        else:
+            return
+        for key, candidate in tuple(indexed.items()):
+            if candidate != owner:
+                continue
+            indexed.pop(key, None)
+            if source == "voice" and self._voice_generation.get(key[0]) == key[1]:
+                self._voice_generation.pop(key[0], None)
 
     def active_owner_count(self, source: str | None = None) -> int:
         """Return a content-free owner count for focused lifecycle tests."""
 
         with self._lock:
+            self._prune_expired_locked()
             if source is None:
                 return len(self._tokens)
             return sum(1 for token_source, _ in self._tokens if token_source == source)

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -1,0 +1,351 @@
+"""Screen-independent Persona Buddy state leases and priority resolution."""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from numbers import Real
+from threading import RLock
+from typing import Literal
+
+from .preferences import PersonaBuddySelection
+
+
+_BUILTIN_STATES = frozenset(
+    {
+        "idle",
+        "listening",
+        "thinking",
+        "speaking",
+        "approval_needed",
+        "tool_running",
+        "wake_armed",
+        "offline",
+        "error",
+    }
+)
+_CUSTOM_STATE_PATTERN = re.compile(r"[a-z][a-z0-9_.:-]{0,95}\Z")
+_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
+_UNSAFE_STATE_PREFIXES = (
+    "env:",
+    "file:",
+    "ftp:",
+    "http:",
+    "https:",
+    "proc:",
+    "ssh:",
+)
+_UNSAFE_STATE_MARKERS = (
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth_token",
+    "authorization",
+    "bearer_token",
+    "client_secret",
+    "password",
+    "passwd",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "secret_key",
+)
+_LIVE_STATES = frozenset({"idle", "listening", "thinking", "speaking"})
+_MAX_TTL_SECONDS = 3600.0
+
+_LeaseKind = Literal[
+    "error",
+    "approval",
+    "timed",
+    "authored",
+    "tool",
+    "wake",
+    "voice",
+    "offline",
+    "idle",
+]
+
+
+class PersonaBuddyStateError(ValueError):
+    """A fixed-category error for untrusted controller state input."""
+
+    __slots__ = ("category",)
+
+    def __init__(self, category: str = "persona_buddy_state_invalid") -> None:
+        self.category = category
+        super().__init__(category)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddyLeaseToken:
+    """Exact capability for one source-and-owner lease revision."""
+
+    source: str
+    owner: str
+    state: str
+    lease_id: int
+    expires_at: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddySnapshot:
+    """Immutable controller state safe for app-owned consumers."""
+
+    generation: int
+    selection: PersonaBuddySelection | None
+    state: str
+    state_source: str | None = None
+    state_owner: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _StateLease:
+    token: PersonaBuddyLeaseToken
+    kind: _LeaseKind
+
+
+def _require_identifier(value: object) -> str:
+    if type(value) is not str or _IDENTIFIER_PATTERN.fullmatch(value) is None:
+        raise PersonaBuddyStateError()
+    return value
+
+
+def _require_state(value: object) -> str:
+    if type(value) is not str or _CUSTOM_STATE_PATTERN.fullmatch(value) is None:
+        raise PersonaBuddyStateError()
+    if value in _BUILTIN_STATES:
+        return value
+    if value.startswith(_UNSAFE_STATE_PREFIXES):
+        raise PersonaBuddyStateError()
+    compact = re.sub(r"[._:-]+", "_", value)
+    if any(marker in compact for marker in _UNSAFE_STATE_MARKERS):
+        raise PersonaBuddyStateError()
+    return value
+
+
+def _require_expiration(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise PersonaBuddyStateError()
+    expiration = float(value)
+    if not math.isfinite(expiration):
+        raise PersonaBuddyStateError()
+    return expiration
+
+
+def _lease_kind(source: str, state: str, expires_at: float | None) -> _LeaseKind:
+    if state == "error":
+        return "error"
+    if state == "approval_needed":
+        return "approval"
+    if source == "timed" or expires_at is not None:
+        return "timed"
+    if source == "authored":
+        return "authored"
+    if state == "tool_running":
+        return "tool"
+    if state == "wake_armed":
+        return "wake"
+    if state in _LIVE_STATES:
+        return "voice" if state != "idle" else "idle"
+    if state == "offline":
+        return "offline"
+    return "authored"
+
+
+class PersonaBuddyController:
+    """Own one explicit selection and source-scoped operational-state leases."""
+
+    def __init__(
+        self,
+        *,
+        selection: PersonaBuddySelection | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if selection is not None and type(selection) is not PersonaBuddySelection:
+            raise PersonaBuddyStateError()
+        self._lock = RLock()
+        self._clock = clock
+        self._selection = selection
+        self._leases: dict[tuple[str, str], _StateLease] = {}
+        self._generation = 0
+        self._next_lease_id = 0
+
+    def snapshot(self) -> PersonaBuddySnapshot:
+        """Return the current immutable selection and resolved state."""
+
+        with self._lock:
+            self._discard_expired_locked()
+            lease = self._resolve_locked()
+            if lease is None:
+                return PersonaBuddySnapshot(
+                    generation=self._generation,
+                    selection=self._selection,
+                    state="idle",
+                )
+            token = lease.token
+            return PersonaBuddySnapshot(
+                generation=self._generation,
+                selection=self._selection,
+                state=token.state,
+                state_source=token.source,
+                state_owner=token.owner,
+            )
+
+    def select_local_persona(self, persona_id: str) -> int:
+        """Explicitly replace the selected local Persona and return generation."""
+
+        selection = PersonaBuddySelection("local", persona_id)
+        with self._lock:
+            if selection != self._selection:
+                self._selection = selection
+                self._generation += 1
+            return self._generation
+
+    def observe_persona(self, *, source: str, persona_id: object) -> int:
+        """Observe UI/runtime selection without changing Buddy authority."""
+
+        _require_identifier(source)
+        del persona_id
+        with self._lock:
+            return self._generation
+
+    def acquire_state(
+        self,
+        *,
+        source: str,
+        owner: str,
+        state: str,
+        expires_at: float | None = None,
+    ) -> PersonaBuddyLeaseToken:
+        """Acquire or replace one exact source-and-owner state lease."""
+
+        normalized_source = _require_identifier(source)
+        normalized_owner = _require_identifier(owner)
+        normalized_state = _require_state(state)
+        normalized_expiration = _require_expiration(expires_at)
+        with self._lock:
+            self._discard_expired_locked()
+            self._next_lease_id += 1
+            token = PersonaBuddyLeaseToken(
+                source=normalized_source,
+                owner=normalized_owner,
+                state=normalized_state,
+                lease_id=self._next_lease_id,
+                expires_at=normalized_expiration,
+            )
+            self._leases[(normalized_source, normalized_owner)] = _StateLease(
+                token=token,
+                kind=_lease_kind(
+                    normalized_source,
+                    normalized_state,
+                    normalized_expiration,
+                ),
+            )
+            self._generation += 1
+            return token
+
+    def release_state(
+        self,
+        *,
+        token: PersonaBuddyLeaseToken | None = None,
+        source: str | None = None,
+        owner: str | None = None,
+    ) -> bool:
+        """Release only an exact token or an exact source-and-owner pair."""
+
+        with self._lock:
+            self._discard_expired_locked()
+            if token is not None:
+                if type(token) is not PersonaBuddyLeaseToken:
+                    return False
+                key = (token.source, token.owner)
+                current = self._leases.get(key)
+                if current is None or current.token != token:
+                    return False
+            else:
+                if source is None or owner is None:
+                    return False
+                try:
+                    key = (_require_identifier(source), _require_identifier(owner))
+                except PersonaBuddyStateError:
+                    return False
+                current = self._leases.get(key)
+                if current is None:
+                    return False
+            del self._leases[key]
+            self._generation += 1
+            return True
+
+    def set_timed_state(
+        self,
+        *,
+        owner: str,
+        state: str,
+        ttl_seconds: float,
+    ) -> PersonaBuddyLeaseToken:
+        """Acquire a bounded explicit/custom state lease from the monotonic clock."""
+
+        if isinstance(ttl_seconds, bool) or not isinstance(ttl_seconds, Real):
+            raise PersonaBuddyStateError()
+        ttl = float(ttl_seconds)
+        if not math.isfinite(ttl) or not 0 < ttl <= _MAX_TTL_SECONDS:
+            raise PersonaBuddyStateError()
+        return self.acquire_state(
+            source="timed",
+            owner=owner,
+            state=state,
+            expires_at=self._clock() + ttl,
+        )
+
+    def set_authored_trigger(
+        self,
+        *,
+        owner: str,
+        state: str,
+    ) -> PersonaBuddyLeaseToken:
+        """Acquire or replace one authored Persona Visual trigger."""
+
+        return self.acquire_state(source="authored", owner=owner, state=state)
+
+    def _discard_expired_locked(self) -> None:
+        now = self._clock()
+        expired = [
+            key
+            for key, lease in self._leases.items()
+            if lease.token.expires_at is not None and lease.token.expires_at <= now
+        ]
+        if not expired:
+            return
+        for key in expired:
+            del self._leases[key]
+        self._generation += 1
+
+    def _resolve_locked(self) -> _StateLease | None:
+        leases = tuple(self._leases.values())
+        for kind in ("error", "approval", "timed", "authored", "tool"):
+            if match := _newest(leases, kind):
+                return match
+
+        non_idle_voice = tuple(
+            lease
+            for lease in leases
+            if lease.kind == "voice" and lease.token.state != "idle"
+        )
+        if non_idle_voice:
+            return max(non_idle_voice, key=lambda lease: lease.token.lease_id)
+        if wake := _newest(leases, "wake"):
+            return wake
+        for kind in ("voice", "idle", "offline"):
+            if match := _newest(leases, kind):
+                return match
+        return None
+
+
+def _newest(leases: tuple[_StateLease, ...], kind: str) -> _StateLease | None:
+    candidates = (lease for lease in leases if lease.kind == kind)
+    return max(candidates, key=lambda lease: lease.token.lease_id, default=None)

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -412,6 +412,54 @@ class PersonaBuddyController:
         with self._lock:
             return self._preferences
 
+    def apply_preferences_patch(self, **changes: object) -> int:
+        """Apply selected immutable fields immediately and return their revision.
+
+        Persistence is deliberately separate: interactive views can publish the
+        user's latest intent synchronously, then let an app-owned worker drain the
+        blocking writer without carrying a stale whole-preference snapshot.
+        """
+
+        allowed = {"enabled", "selection", "open", "collapsed", "geometry"}
+        if not changes or not set(changes) <= allowed:
+            raise PersonaBuddyStateError()
+        with self._lock:
+            candidate = replace(self._preferences, **changes)
+            self._apply_preferences_locked(candidate)
+            return self._preferences_generation
+
+    async def persist_preferences_revision(self, revision: int) -> bool:
+        """Persist current merged preferences once for one applied revision.
+
+        A failed write leaves the immediate in-memory intent authoritative; it is
+        not rolled back over newer interaction fields. A later revision writes the
+        then-current merged snapshot and converges durable state.
+        """
+
+        if type(revision) is not int or revision < 0:
+            raise PersonaBuddyStateError()
+        if self._shutdown_requested:
+            raise RuntimeError("persona_buddy_shutdown")
+
+        async def serialized() -> bool:
+            async with self._operation_lock:
+                with self._lock:
+                    if revision > self._preferences_generation:
+                        raise PersonaBuddyStateError()
+                    candidate = self._preferences
+                write = await self._drain_owned(
+                    asyncio.to_thread(self._preference_writer, candidate),
+                    name="preferences:patch-write",
+                )
+                return write.completed and write.value is True
+
+        outcome = await self._drain_owned(
+            serialized(), name=f"preferences:revision:{revision}"
+        )
+        if outcome.cancellation is not None:
+            raise outcome.cancellation
+        return outcome.completed and outcome.value is True
+
     def select_local_persona(self, persona_id: str) -> int:
         """Explicitly replace the selected local Persona and return generation."""
 

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -54,6 +54,7 @@ _UNSAFE_STATE_MARKERS = (
     "secret_key",
 )
 _LIVE_STATES = frozenset({"idle", "listening", "thinking", "speaking"})
+_TIMED_SOURCES = frozenset({"explicit", "timed"})
 _MAX_TTL_SECONDS = 3600.0
 
 _LeaseKind = Literal[
@@ -137,12 +138,12 @@ def _require_expiration(value: object) -> float | None:
     return expiration
 
 
-def _lease_kind(source: str, state: str, expires_at: float | None) -> _LeaseKind:
+def _lease_kind(source: str, state: str) -> _LeaseKind:
     if state == "error":
         return "error"
     if state == "approval_needed":
         return "approval"
-    if source == "timed" or expires_at is not None:
+    if source in _TIMED_SOURCES:
         return "timed"
     if source == "authored":
         return "authored"
@@ -240,11 +241,7 @@ class PersonaBuddyController:
             )
             self._leases[(normalized_source, normalized_owner)] = _StateLease(
                 token=token,
-                kind=_lease_kind(
-                    normalized_source,
-                    normalized_state,
-                    normalized_expiration,
-                ),
+                kind=_lease_kind(normalized_source, normalized_state),
             )
             self._generation += 1
             return token

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -1079,9 +1079,7 @@ class PersonaBuddyController:
                 prepared: list[PersonaBuddyPreparedFrame] = []
                 prepared_cells = 0
                 for frame in resolution.frames:
-                    remaining_cells = (
-                        MAX_PERSONA_BUDDY_PREPARED_CELLS - prepared_cells
-                    )
+                    remaining_cells = MAX_PERSONA_BUDDY_PREPARED_CELLS - prepared_cells
                     if remaining_cells < 1:
                         return None
                     painted = prepare_persona_buddy_frame(

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -55,6 +55,7 @@ _UNSAFE_STATE_MARKERS = (
 )
 _LIVE_STATES = frozenset({"idle", "listening", "thinking", "speaking"})
 _TIMED_SOURCES = frozenset({"explicit", "timed"})
+_CUSTOM_STATE_SOURCES = frozenset({"authored", *_TIMED_SOURCES})
 _MAX_TTL_SECONDS = 3600.0
 
 _LeaseKind = Literal[
@@ -158,6 +159,19 @@ def _lease_kind(source: str, state: str) -> _LeaseKind:
     return "authored"
 
 
+def _validate_state_authority(
+    *,
+    source: str,
+    state: str,
+    expires_at: float | None,
+    now: float,
+) -> None:
+    if source in _TIMED_SOURCES and (expires_at is None or expires_at <= now):
+        raise PersonaBuddyStateError()
+    if state not in _BUILTIN_STATES and source not in _CUSTOM_STATE_SOURCES:
+        raise PersonaBuddyStateError()
+
+
 class PersonaBuddyController:
     """Own one explicit selection and source-scoped operational-state leases."""
 
@@ -231,6 +245,12 @@ class PersonaBuddyController:
         normalized_expiration = _require_expiration(expires_at)
         with self._lock:
             self._discard_expired_locked()
+            _validate_state_authority(
+                source=normalized_source,
+                state=normalized_state,
+                expires_at=normalized_expiration,
+                now=self._clock(),
+            )
             self._next_lease_id += 1
             token = PersonaBuddyLeaseToken(
                 source=normalized_source,

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -1,17 +1,43 @@
-"""Screen-independent Persona Buddy state leases and priority resolution."""
+"""App-owned Persona Buddy state, resolution, and async lifetime."""
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import math
 import re
 import time
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field, replace
 from numbers import Real
+from pathlib import Path
 from threading import RLock
-from typing import Literal
+from typing import Generic, Literal, TypeVar
 
-from .preferences import PersonaBuddySelection
+from tldw_chatbook.Persona_Visual.repository import (
+    PersonaVisualGraph,
+    PersonaVisualIdentity,
+    PersonaVisualRepository,
+)
+from tldw_chatbook.Persona_Visual.runtime import (
+    PersonaVisualCacheIdentity,
+    PersonaVisualPortrait,
+    PersonaVisualResolution,
+    resolve_active_persona_visual,
+)
+
+from .preferences import (
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+    persist_persona_buddy_preferences,
+)
+from .rendering import (
+    PERSONA_BUDDY_FRAME_UNAVAILABLE,
+    PersonaBuddyFrameError,
+    PersonaBuddyPreparedFrame,
+    prepare_persona_buddy_frame,
+    prepare_persona_buddy_portrait,
+)
 
 
 _BUILTIN_STATES = frozenset(
@@ -58,6 +84,8 @@ _TIMED_SOURCES = frozenset({"explicit", "timed"})
 _CUSTOM_STATE_SOURCES = frozenset({"authored", *_TIMED_SOURCES})
 _MAX_TTL_SECONDS = 3600.0
 
+_T = TypeVar("_T")
+
 _LeaseKind = Literal[
     "error",
     "approval",
@@ -82,6 +110,16 @@ class PersonaBuddyStateError(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
+class BuddyDrainResult(Generic[_T]):
+    """Settlement of one retained child, including delayed outer cancellation."""
+
+    completed: bool
+    value: _T | None = None
+    error_category: str | None = None
+    cancellation: BaseException | None = field(default=None, repr=False, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
 class PersonaBuddyLeaseToken:
     """Exact capability for one source-and-owner lease revision."""
 
@@ -101,6 +139,54 @@ class PersonaBuddySnapshot:
     state: str
     state_source: str | None = None
     state_owner: str | None = None
+    enabled: bool = False
+    open: bool = True
+    collapsed: bool = False
+    preferences_generation: int = 0
+    profile_generation: int = 0
+    viewport_generation: int = 0
+    visual: PersonaBuddyVisualSnapshot | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddyVisualSnapshot:
+    """Path-free resolved visual state consumed by disposable views."""
+
+    available: bool
+    reason: str | None
+    source: str
+    persona_id: str | None
+    persona_revision: int | None
+    requested_state: str
+    resolved_state: str | None
+    animation_id: str | None
+    graph_identity: PersonaVisualIdentity | None
+    cache_identity: PersonaVisualCacheIdentity | None
+    frames: tuple[PersonaBuddyPreparedFrame, ...] = field(repr=False)
+    frame_rate: float | None = None
+    loop: bool = False
+    animate: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolutionTicket:
+    selection: PersonaBuddySelection
+    requested_state: str
+    controller_generation: int
+    preferences_generation: int
+    profile_generation: int
+    viewport_generation: int
+    enabled: bool
+    open: bool
+    collapsed: bool
+    reduced_motion: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _LocalPersona:
+    persona_id: str
+    revision: int
+    portrait: PersonaVisualPortrait | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,16 +265,58 @@ class PersonaBuddyController:
         self,
         *,
         selection: PersonaBuddySelection | None = None,
+        preferences: PersonaBuddyPreferences | None = None,
         clock: Callable[[], float] = time.monotonic,
+        local_persona_service: object | None = None,
+        profile_db: object | None = None,
+        profile_root: str | Path | None = None,
+        reduced_motion: bool | Callable[[], bool] = False,
+        repository_factory: Callable[[object], PersonaVisualRepository] = (
+            PersonaVisualRepository
+        ),
+        portrait_loader: (
+            Callable[[Mapping[str, object]], PersonaVisualPortrait | None] | None
+        ) = None,
+        preference_writer: Callable[[PersonaBuddyPreferences], bool] = (
+            persist_persona_buddy_preferences
+        ),
+        scheduler: Callable[[Callable[[], None]], object] | None = None,
+        phase_barrier: Callable[[str], Awaitable[None] | None] | None = None,
     ) -> None:
         if selection is not None and type(selection) is not PersonaBuddySelection:
             raise PersonaBuddyStateError()
+        if preferences is not None and type(preferences) is not PersonaBuddyPreferences:
+            raise PersonaBuddyStateError()
+        if preferences is not None and selection is not None:
+            raise PersonaBuddyStateError()
+        if type(reduced_motion) is not bool and not callable(reduced_motion):
+            raise PersonaBuddyStateError()
         self._lock = RLock()
         self._clock = clock
-        self._selection = selection
+        self._preferences = preferences or PersonaBuddyPreferences(selection=selection)
+        self._selection = self._preferences.selection
         self._leases: dict[tuple[str, str], _StateLease] = {}
         self._generation = 0
+        self._preferences_generation = 0
+        self._profile_generation = 0
+        self._viewport_generation = 0
         self._next_lease_id = 0
+        self._visual: PersonaBuddyVisualSnapshot | None = None
+        self._local_persona_service = local_persona_service
+        self._profile_db = profile_db
+        self._profile_root = (
+            Path(profile_root).resolve() if profile_root is not None else None
+        )
+        self._reduced_motion = reduced_motion
+        self._repository_factory = repository_factory
+        self._portrait_loader = portrait_loader
+        self._preference_writer = preference_writer
+        self._scheduler = scheduler
+        self._phase_barrier = phase_barrier
+        self._operation_lock = asyncio.Lock()
+        self._owned_tasks: set[asyncio.Task[object]] = set()
+        self._shutdown_requested = False
+        self._shutdown_task: asyncio.Task[None] | None = None
 
     def snapshot(self) -> PersonaBuddySnapshot:
         """Return the current immutable selection and resolved state."""
@@ -201,6 +329,13 @@ class PersonaBuddyController:
                     generation=self._generation,
                     selection=self._selection,
                     state="idle",
+                    enabled=self._preferences.enabled,
+                    open=self._preferences.open,
+                    collapsed=self._preferences.collapsed,
+                    preferences_generation=self._preferences_generation,
+                    profile_generation=self._profile_generation,
+                    viewport_generation=self._viewport_generation,
+                    visual=self._visual,
                 )
             token = lease.token
             return PersonaBuddySnapshot(
@@ -209,6 +344,13 @@ class PersonaBuddyController:
                 state=token.state,
                 state_source=token.source,
                 state_owner=token.owner,
+                enabled=self._preferences.enabled,
+                open=self._preferences.open,
+                collapsed=self._preferences.collapsed,
+                preferences_generation=self._preferences_generation,
+                profile_generation=self._profile_generation,
+                viewport_generation=self._viewport_generation,
+                visual=self._visual,
             )
 
     def select_local_persona(self, persona_id: str) -> int:
@@ -218,8 +360,29 @@ class PersonaBuddyController:
         with self._lock:
             if selection != self._selection:
                 self._selection = selection
+                self._preferences = replace(self._preferences, selection=selection)
+                self._preferences_generation += 1
                 self._generation += 1
             return self._generation
+
+    def invalidate_profile(self) -> int:
+        """Advance local Persona/graph authority without clearing preferences."""
+
+        with self._lock:
+            self._profile_generation += 1
+            self._generation += 1
+            return self._profile_generation
+
+    def set_viewport_generation(self, generation: int) -> int:
+        """Record a current viewport generation for late-frame fencing."""
+
+        if type(generation) is not int or generation < 0:
+            raise PersonaBuddyStateError()
+        with self._lock:
+            if generation != self._viewport_generation:
+                self._viewport_generation = generation
+                self._generation += 1
+            return self._viewport_generation
 
     def observe_persona(self, *, source: str, persona_id: object) -> int:
         """Observe UI/runtime selection without changing Buddy authority."""
@@ -328,6 +491,626 @@ class PersonaBuddyController:
         """Acquire or replace one authored Persona Visual trigger."""
 
         return self.acquire_state(source="authored", owner=owner, state=state)
+
+    async def _drain_owned(
+        self,
+        awaitable: Awaitable[_T],
+        *,
+        name: str,
+    ) -> BuddyDrainResult[_T]:
+        """Shield and settle one registered child despite repeated cancellation."""
+
+        async def runner() -> _T:
+            return await awaitable
+
+        task = asyncio.create_task(runner(), name=f"persona-buddy:{name}")
+        self._owned_tasks.add(task)  # registered before this method's first await
+        owner = asyncio.current_task()
+        seen_cancellations = owner.cancelling() if owner is not None else 0
+        outer_cancellation: asyncio.CancelledError | None = None
+        try:
+            while True:
+                try:
+                    value = await asyncio.shield(task)
+                except asyncio.CancelledError as error:
+                    cancellation_count = owner.cancelling() if owner is not None else 0
+                    if cancellation_count > seen_cancellations:
+                        outer_cancellation = outer_cancellation or error
+                        seen_cancellations = cancellation_count
+                        if not task.done():
+                            continue
+                    if task.cancelled():
+                        return BuddyDrainResult(
+                            completed=False,
+                            error_category="persona_buddy_operation_cancelled",
+                            cancellation=outer_cancellation,
+                        )
+                    if not task.done():
+                        outer_cancellation = outer_cancellation or error
+                        continue
+                    try:
+                        value = task.result()
+                    except asyncio.CancelledError:
+                        return BuddyDrainResult(
+                            completed=False,
+                            error_category="persona_buddy_operation_cancelled",
+                            cancellation=outer_cancellation,
+                        )
+                    except Exception:
+                        return BuddyDrainResult(
+                            completed=False,
+                            error_category="persona_buddy_operation_failed",
+                            cancellation=outer_cancellation,
+                        )
+                except Exception:
+                    return BuddyDrainResult(
+                        completed=False,
+                        error_category="persona_buddy_operation_failed",
+                        cancellation=outer_cancellation,
+                    )
+                return BuddyDrainResult(
+                    completed=True,
+                    value=value,
+                    cancellation=outer_cancellation,
+                )
+        finally:
+            if task.done():
+                self._owned_tasks.discard(task)
+
+    async def run_serialized(
+        self,
+        operation: Callable[[], _T],
+        *,
+        name: str,
+    ) -> _T:
+        """Run one blocking same-owner operation off-loop and drain cancellation."""
+
+        if self._shutdown_requested:
+            raise RuntimeError("persona_buddy_shutdown")
+
+        async def serialized() -> _T:
+            async with self._operation_lock:
+                outcome = await self._drain_owned(
+                    asyncio.to_thread(operation), name=f"{name}:thread"
+                )
+                if not outcome.completed:
+                    raise RuntimeError(outcome.error_category)
+                return outcome.value  # type: ignore[return-value]
+
+        outcome = await self._drain_owned(serialized(), name=name)
+        if outcome.cancellation is not None:
+            raise outcome.cancellation
+        if not outcome.completed:
+            raise RuntimeError(outcome.error_category)
+        return outcome.value  # type: ignore[return-value]
+
+    async def update_preferences(
+        self, preferences: PersonaBuddyPreferences
+    ) -> PersonaBuddySnapshot:
+        """Persist then apply one exact preference snapshot under owner serialization."""
+
+        if type(preferences) is not PersonaBuddyPreferences:
+            raise PersonaBuddyStateError()
+        if self._shutdown_requested:
+            raise RuntimeError("persona_buddy_shutdown")
+
+        async def serialized() -> PersonaBuddySnapshot:
+            async with self._operation_lock:
+                expected_authority = self._preference_authority()
+                written = await self._drain_owned(
+                    asyncio.to_thread(self._preference_writer, preferences),
+                    name="preferences:write",
+                )
+                if not written.completed or written.value is not True:
+                    return self.snapshot()
+                with self._lock:
+                    if expected_authority != self._preference_authority():
+                        return self.snapshot()
+                    self._preferences = preferences
+                    self._selection = preferences.selection
+                    self._preferences_generation += 1
+                    self._generation += 1
+                return self.snapshot()
+
+        outcome = await self._drain_owned(serialized(), name="preferences")
+        if outcome.cancellation is not None:
+            raise outcome.cancellation
+        if not outcome.completed or outcome.value is None:
+            return self.snapshot()
+        return outcome.value
+
+    async def resolve_current_visual(
+        self,
+        *,
+        cols: int,
+        lines: int,
+    ) -> PersonaBuddyVisualSnapshot:
+        """Resolve and prepare the selected local Persona's current state."""
+
+        if self._shutdown_requested:
+            return self._unavailable_snapshot(
+                "persona_buddy_shutdown", requested_state="idle"
+            )
+
+        async def serialized() -> PersonaBuddyVisualSnapshot:
+            async with self._operation_lock:
+                ticket = self._resolution_ticket()
+                if ticket is None:
+                    return self._apply_unavailable(
+                        "persona_buddy_persona_unavailable", requested_state="idle"
+                    )
+
+                persona_outcome = await self._drain_owned(
+                    asyncio.to_thread(self._read_local_persona, ticket.selection),
+                    name="resolve:persona-read",
+                )
+                if not self._is_current(ticket):
+                    return self._stale_snapshot(ticket)
+                if not persona_outcome.completed or persona_outcome.value is None:
+                    return self._apply_unavailable(
+                        "persona_buddy_persona_unavailable",
+                        requested_state=ticket.requested_state,
+                        ticket=ticket,
+                    )
+                persona = persona_outcome.value
+                if not await self._after_phase("persona_read", ticket):
+                    return self._stale_snapshot(ticket)
+
+                graph_outcome = await self._drain_owned(
+                    asyncio.to_thread(self._read_graph, persona.persona_id),
+                    name="resolve:graph-read",
+                )
+                if not self._is_current(ticket):
+                    return self._stale_snapshot(ticket)
+                graph = graph_outcome.value if graph_outcome.completed else None
+                if (
+                    type(graph) is not PersonaVisualGraph
+                    or graph.identity.persona_id != persona.persona_id
+                    or graph.identity.persona_revision != persona.revision
+                ):
+                    return self._apply_unavailable(
+                        "persona_buddy_binding_unavailable",
+                        requested_state=ticket.requested_state,
+                        ticket=ticket,
+                        persona=persona,
+                    )
+                graph_identity = graph.identity
+                if not await self._after_phase("graph_read", ticket):
+                    return self._stale_snapshot(ticket)
+
+                resolution_outcome = await self._drain_owned(
+                    asyncio.to_thread(
+                        self._resolve_runtime,
+                        persona,
+                        ticket.requested_state,
+                        ticket.reduced_motion,
+                    ),
+                    name="resolve:runtime",
+                )
+                if not self._is_current(ticket):
+                    return self._stale_snapshot(ticket)
+                resolution = (
+                    resolution_outcome.value if resolution_outcome.completed else None
+                )
+                if (
+                    type(resolution) is not PersonaVisualResolution
+                    or resolution.cache_identity.graph != graph_identity
+                    or resolution.requested_state != ticket.requested_state
+                    or resolution.cache_identity.requested_state
+                    != ticket.requested_state
+                    or resolution.cache_identity.reduced_motion != ticket.reduced_motion
+                ):
+                    return self._preserve_or_unavailable(
+                        ticket=ticket,
+                        persona=persona,
+                        reason=PERSONA_BUDDY_FRAME_UNAVAILABLE,
+                    )
+                cache_identity = resolution.cache_identity
+                if not await self._after_phase("runtime_resolve", ticket):
+                    return self._stale_snapshot(ticket)
+
+                prepared_outcome = await self._drain_owned(
+                    asyncio.to_thread(
+                        self._prepare_resolution,
+                        resolution,
+                        cols,
+                        lines,
+                    ),
+                    name="resolve:frame-prepare",
+                )
+                if not self._is_current(ticket):
+                    return self._stale_snapshot(ticket)
+                if not await self._after_phase("frame_prepare", ticket):
+                    return self._stale_snapshot(ticket)
+                frames = prepared_outcome.value if prepared_outcome.completed else None
+                if not self._prepared_matches(resolution, frames):
+                    return self._preserve_or_unavailable(
+                        ticket=ticket,
+                        persona=persona,
+                        reason=PERSONA_BUDDY_FRAME_UNAVAILABLE,
+                    )
+                if not frames:
+                    return self._preserve_or_unavailable(
+                        ticket=ticket,
+                        persona=persona,
+                        reason=PERSONA_BUDDY_FRAME_UNAVAILABLE,
+                    )
+
+                visual = PersonaBuddyVisualSnapshot(
+                    available=True,
+                    reason=resolution.reason,
+                    source=resolution.source,
+                    persona_id=persona.persona_id,
+                    persona_revision=persona.revision,
+                    requested_state=resolution.requested_state,
+                    resolved_state=resolution.resolved_state,
+                    animation_id=resolution.animation_id,
+                    graph_identity=graph_identity,
+                    cache_identity=cache_identity,
+                    frames=frames,
+                    frame_rate=resolution.frame_rate,
+                    loop=resolution.loop,
+                    animate=resolution.animate,
+                )
+                with self._lock:
+                    if not self._is_current(ticket):
+                        return self._stale_snapshot(ticket)
+                    self._visual = visual
+                return visual
+
+        outcome = await self._drain_owned(serialized(), name="resolve")
+        if outcome.cancellation is not None:
+            raise outcome.cancellation
+        if not outcome.completed or outcome.value is None:
+            return self._unavailable_snapshot(
+                "persona_buddy_operation_failed", requested_state="idle"
+            )
+        return outcome.value
+
+    async def shutdown(self) -> None:
+        """Stop admission and drain every registered operation exactly once."""
+
+        self._shutdown_requested = True
+        with self._lock:
+            self._generation += 1
+        task = self._shutdown_task
+        if task is None:
+            task = asyncio.create_task(
+                self._shutdown_runner(), name="shutdown_persona_buddy_controller"
+            )
+            self._shutdown_task = task
+        cancellation: asyncio.CancelledError | None = None
+        while True:
+            try:
+                await asyncio.shield(task)
+                break
+            except asyncio.CancelledError as error:
+                if task.done():
+                    if task.cancelled():
+                        raise
+                    task.result()
+                    cancellation = cancellation or error
+                    break
+                cancellation = cancellation or error
+                continue
+        if cancellation is not None:
+            raise cancellation
+
+    async def _shutdown_runner(self) -> None:
+        current = asyncio.current_task()
+        while True:
+            tasks = tuple(
+                task
+                for task in self._owned_tasks
+                if task is not current and not task.done()
+            )
+            if not tasks:
+                break
+            for task in tasks:
+                try:
+                    await asyncio.shield(task)
+                except BaseException:
+                    pass
+        async with self._operation_lock:
+            return
+
+    def _resolution_ticket(self) -> _ResolutionTicket | None:
+        reduced_motion = self._current_reduced_motion()
+        with self._lock:
+            self._discard_expired_locked()
+            selection = self._selection
+            if (
+                selection is None
+                or not self._preferences.enabled
+                or not self._preferences.open
+            ):
+                return None
+            lease = self._resolve_locked()
+            return _ResolutionTicket(
+                selection=selection,
+                requested_state=lease.token.state if lease else "idle",
+                controller_generation=self._generation,
+                preferences_generation=self._preferences_generation,
+                profile_generation=self._profile_generation,
+                viewport_generation=self._viewport_generation,
+                enabled=self._preferences.enabled,
+                open=self._preferences.open,
+                collapsed=self._preferences.collapsed,
+                reduced_motion=reduced_motion,
+            )
+
+    def _is_current(self, ticket: _ResolutionTicket) -> bool:
+        reduced_motion = self._current_reduced_motion()
+        with self._lock:
+            self._discard_expired_locked()
+            lease = self._resolve_locked()
+            return (
+                not self._shutdown_requested
+                and self._selection == ticket.selection
+                and self._generation == ticket.controller_generation
+                and self._preferences_generation == ticket.preferences_generation
+                and self._profile_generation == ticket.profile_generation
+                and self._viewport_generation == ticket.viewport_generation
+                and self._preferences.enabled == ticket.enabled
+                and self._preferences.open == ticket.open
+                and self._preferences.collapsed == ticket.collapsed
+                and (lease.token.state if lease else "idle") == ticket.requested_state
+                and reduced_motion == ticket.reduced_motion
+            )
+
+    def _current_reduced_motion(self) -> bool:
+        try:
+            value = (
+                self._reduced_motion()
+                if callable(self._reduced_motion)
+                else self._reduced_motion
+            )
+        except Exception:
+            return True
+        return value if type(value) is bool else True
+
+    def _preference_authority(self) -> tuple[object, ...]:
+        """Snapshot every controller authority relevant to a preference commit."""
+
+        with self._lock:
+            self._discard_expired_locked()
+            lease = self._resolve_locked()
+            return (
+                self._selection,
+                lease.token.state if lease else "idle",
+                self._generation,
+                self._preferences_generation,
+                self._profile_generation,
+                self._viewport_generation,
+                self._preferences,
+            )
+
+    async def _after_phase(self, phase: str, ticket: _ResolutionTicket) -> bool:
+        barrier = self._phase_barrier
+        if barrier is not None:
+            pending = barrier(phase)
+            if inspect.isawaitable(pending):
+                await pending
+            if not self._is_current(ticket):
+                return False
+        return self._is_current(ticket)
+
+    def _read_local_persona(
+        self, selection: PersonaBuddySelection
+    ) -> _LocalPersona | None:
+        service = self._local_persona_service
+        getter = getattr(service, "get_persona_profile", None)
+        if not callable(getter):
+            return None
+        try:
+            record = getter(selection.local_persona_id)
+            if not isinstance(record, Mapping):
+                return None
+            persona_id = record.get("id")
+            revision = record.get("version")
+            if (
+                type(persona_id) is not str
+                or persona_id != selection.local_persona_id
+                or type(revision) is not int
+                or revision < 1
+                or record.get("deleted", False) is not False
+                or record.get("is_active", True) is not True
+            ):
+                return None
+            portrait = self._portrait_loader(record) if self._portrait_loader else None
+            if portrait is not None and type(portrait) is not PersonaVisualPortrait:
+                portrait = None
+            return _LocalPersona(persona_id, revision, portrait)
+        except Exception:
+            return None
+
+    def _read_graph(self, persona_id: str) -> PersonaVisualGraph | None:
+        if self._profile_db is None:
+            return None
+        try:
+            return self._repository_factory(self._profile_db).get_active_persona_pack(
+                persona_id
+            )
+        except Exception:
+            return None
+
+    def _resolve_runtime(
+        self,
+        persona: _LocalPersona,
+        requested_state: str,
+        reduced_motion: bool,
+    ) -> PersonaVisualResolution | None:
+        if self._profile_db is None or self._profile_root is None:
+            return None
+        try:
+            return resolve_active_persona_visual(
+                self._repository_factory(self._profile_db),
+                persona.persona_id,
+                self._profile_root,
+                requested_state,
+                portrait=persona.portrait,
+                reduced_motion=reduced_motion,
+            )
+        except Exception:
+            return None
+
+    @staticmethod
+    def _prepare_resolution(
+        resolution: PersonaVisualResolution,
+        cols: int,
+        lines: int,
+    ) -> tuple[PersonaBuddyPreparedFrame, ...] | None:
+        try:
+            if resolution.frames:
+                return tuple(
+                    prepare_persona_buddy_frame(
+                        frame,
+                        resolution_cache_identity=resolution.cache_identity,
+                        cols=cols,
+                        lines=lines,
+                    )
+                    for frame in resolution.frames
+                )
+            if resolution.portrait is not None:
+                return (
+                    prepare_persona_buddy_portrait(
+                        resolution.portrait,
+                        resolution_cache_identity=resolution.cache_identity,
+                        cols=cols,
+                        lines=lines,
+                    ),
+                )
+            return ()
+        except PersonaBuddyFrameError:
+            return None
+
+    @staticmethod
+    def _prepared_matches(
+        resolution: PersonaVisualResolution,
+        frames: tuple[PersonaBuddyPreparedFrame, ...] | None,
+    ) -> bool:
+        if frames is None:
+            return False
+        if resolution.frames:
+            expected = tuple(
+                (
+                    frame.asset_id,
+                    frame.asset_key,
+                    frame.sha256,
+                    frame.manifest_frame_index,
+                    frame.selected_frame,
+                )
+                for frame in resolution.frames
+            )
+            actual = tuple(
+                (
+                    frame.asset_id,
+                    frame.asset_key,
+                    frame.asset_sha256,
+                    frame.manifest_frame_index,
+                    frame.selected_frame,
+                )
+                for frame in frames
+            )
+            return expected == actual and all(
+                frame.cache_identity == resolution.cache_identity for frame in frames
+            )
+        if resolution.portrait is not None:
+            return (
+                len(frames) == 1
+                and frames[0].asset_key == resolution.portrait.portrait_id
+                and frames[0].asset_sha256 == resolution.portrait.sha256
+                and frames[0].selected_frame == resolution.portrait.selected_frame
+                and frames[0].cache_identity == resolution.cache_identity
+            )
+        return frames == ()
+
+    def _preserve_or_unavailable(
+        self,
+        *,
+        ticket: _ResolutionTicket,
+        persona: _LocalPersona,
+        reason: str,
+    ) -> PersonaBuddyVisualSnapshot:
+        if not self._is_current(ticket):
+            return self._stale_snapshot(ticket)
+        with self._lock:
+            if not self._is_current(ticket):
+                return self._stale_snapshot(ticket)
+            previous = self._visual
+            if (
+                previous is not None
+                and previous.available
+                and previous.persona_id == persona.persona_id
+                and previous.frames
+            ):
+                retained = replace(previous, reason=reason)
+                self._visual = retained
+                return retained
+        return self._apply_unavailable(
+            reason,
+            requested_state=ticket.requested_state,
+            ticket=ticket,
+            persona=persona,
+        )
+
+    def _apply_unavailable(
+        self,
+        reason: str,
+        *,
+        requested_state: str,
+        ticket: _ResolutionTicket | None = None,
+        persona: _LocalPersona | None = None,
+    ) -> PersonaBuddyVisualSnapshot:
+        if ticket is not None and not self._is_current(ticket):
+            return self._stale_snapshot(ticket)
+        visual = self._unavailable_snapshot(
+            reason,
+            requested_state=requested_state,
+            persona=persona,
+        )
+        with self._lock:
+            if ticket is not None and not self._is_current(ticket):
+                return self._stale_snapshot(ticket)
+            self._visual = visual
+        return visual
+
+    @staticmethod
+    def _unavailable_snapshot(
+        reason: str,
+        *,
+        requested_state: str,
+        persona: _LocalPersona | None = None,
+    ) -> PersonaBuddyVisualSnapshot:
+        return PersonaBuddyVisualSnapshot(
+            available=False,
+            reason=reason,
+            source="unavailable",
+            persona_id=persona.persona_id if persona else None,
+            persona_revision=persona.revision if persona else None,
+            requested_state=requested_state,
+            resolved_state=None,
+            animation_id=None,
+            graph_identity=None,
+            cache_identity=None,
+            frames=(),
+        )
+
+    @staticmethod
+    def _stale_snapshot(ticket: _ResolutionTicket) -> PersonaBuddyVisualSnapshot:
+        return PersonaBuddyVisualSnapshot(
+            available=False,
+            reason="persona_buddy_resolution_stale",
+            source="unavailable",
+            persona_id=ticket.selection.local_persona_id,
+            persona_revision=None,
+            requested_state=ticket.requested_state,
+            resolved_state=None,
+            animation_id=None,
+            graph_identity=None,
+            cache_identity=None,
+            frames=(),
+        )
 
     def _discard_expired_locked(self) -> None:
         now = self._clock()

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -406,6 +406,12 @@ class PersonaBuddyController:
                 visual=self._visual,
             )
 
+    def current_preferences(self) -> PersonaBuddyPreferences:
+        """Return the exact immutable preference snapshot under the state lock."""
+
+        with self._lock:
+            return self._preferences
+
     def select_local_persona(self, persona_id: str) -> int:
         """Explicitly replace the selected local Persona and return generation."""
 

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -372,7 +372,11 @@ class PersonaBuddyController:
         self._shutdown_task: asyncio.Task[None] | None = None
 
     def snapshot(self) -> PersonaBuddySnapshot:
-        """Return the current immutable selection and resolved state."""
+        """Return the current immutable selection and resolved state.
+
+        Returns:
+            The current content-free Buddy state snapshot.
+        """
 
         with self._lock:
             self._discard_expired_locked()

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import math
 import re
@@ -256,6 +257,56 @@ def _validate_state_authority(
         raise PersonaBuddyStateError()
     if state not in _BUILTIN_STATES and source not in _CUSTOM_STATE_SOURCES:
         raise PersonaBuddyStateError()
+
+
+def load_local_persona_portrait(
+    local_persona_service: object,
+    persona_record: Mapping[str, object],
+) -> PersonaVisualPortrait | None:
+    """Load the linked local Character-card BLOB as a path-free portrait."""
+
+    try:
+        character_id = persona_record.get("character_card_id")
+        getter = getattr(local_persona_service, "get_character", None)
+        if type(character_id) is not int or character_id < 1 or not callable(getter):
+            return None
+        character = getter(character_id)
+        if not isinstance(character, Mapping):
+            return None
+        image = character.get("image")
+        revision = character.get("version")
+        if (
+            character.get("id") != character_id
+            or type(revision) is not int
+            or revision < 0
+            or type(image) is not bytes
+            or not image
+        ):
+            return None
+        mime_type = _portrait_mime_type(image)
+        if mime_type is None:
+            return None
+        return PersonaVisualPortrait(
+            portrait_id=f"local-character:{character_id}",
+            revision=revision,
+            mime_type=mime_type,
+            sha256=hashlib.sha256(image).hexdigest(),
+            data=image,
+        )
+    except Exception:
+        return None
+
+
+def _portrait_mime_type(data: bytes) -> str | None:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
 
 
 class PersonaBuddyController:

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -33,6 +33,8 @@ from .preferences import (
     persist_persona_buddy_preferences,
 )
 from .rendering import (
+    MAX_PERSONA_BUDDY_PREPARED_CELLS,
+    MAX_PERSONA_BUDDY_PREPARED_FRAMES,
     PERSONA_BUDDY_FRAME_UNAVAILABLE,
     PersonaBuddyFrameError,
     PersonaBuddyPreparedFrame,
@@ -648,20 +650,25 @@ class PersonaBuddyController:
         async def serialized() -> PersonaBuddySnapshot:
             async with self._operation_lock:
                 expected_authority = self._preference_authority()
-                written = await self._drain_owned(
-                    asyncio.to_thread(self._preference_writer, preferences),
-                    name="preferences:write",
-                )
-                if not written.completed or written.value is not True:
-                    return self.snapshot()
-                with self._lock:
-                    if expected_authority != self._preference_authority():
+                candidate = preferences
+                last_successful: PersonaBuddyPreferences | None = None
+                while True:
+                    written = await self._drain_owned(
+                        asyncio.to_thread(self._preference_writer, candidate),
+                        name="preferences:write",
+                    )
+                    if not written.completed or written.value is not True:
+                        if last_successful is not None:
+                            with self._lock:
+                                self._apply_preferences_locked(last_successful)
                         return self.snapshot()
-                    self._preferences = preferences
-                    self._selection = preferences.selection
-                    self._preferences_generation += 1
-                    self._generation += 1
-                return self.snapshot()
+                    last_successful = candidate
+                    with self._lock:
+                        if expected_authority == self._preference_authority():
+                            self._apply_preferences_locked(candidate)
+                            return self.snapshot()
+                        candidate = self._preferences
+                        expected_authority = self._preference_authority()
 
         outcome = await self._drain_owned(serialized(), name="preferences")
         if outcome.cancellation is not None:
@@ -920,21 +927,21 @@ class PersonaBuddyController:
             return True
         return value if type(value) is bool else True
 
-    def _preference_authority(self) -> tuple[object, ...]:
+    def _preference_authority(
+        self,
+    ) -> tuple[int, PersonaBuddyPreferences]:
         """Snapshot every controller authority relevant to a preference commit."""
 
         with self._lock:
-            self._discard_expired_locked()
-            lease = self._resolve_locked()
-            return (
-                self._selection,
-                lease.token.state if lease else "idle",
-                self._generation,
-                self._preferences_generation,
-                self._profile_generation,
-                self._viewport_generation,
-                self._preferences,
-            )
+            return self._preferences_generation, self._preferences
+
+    def _apply_preferences_locked(self, preferences: PersonaBuddyPreferences) -> None:
+        if preferences == self._preferences:
+            return
+        self._preferences = preferences
+        self._selection = preferences.selection
+        self._preferences_generation += 1
+        self._generation += 1
 
     async def _after_phase(self, phase: str, ticket: _ResolutionTicket) -> bool:
         barrier = self._phase_barrier
@@ -1013,15 +1020,26 @@ class PersonaBuddyController:
     ) -> tuple[PersonaBuddyPreparedFrame, ...] | None:
         try:
             if resolution.frames:
-                return tuple(
-                    prepare_persona_buddy_frame(
+                if len(resolution.frames) > MAX_PERSONA_BUDDY_PREPARED_FRAMES:
+                    return None
+                prepared: list[PersonaBuddyPreparedFrame] = []
+                prepared_cells = 0
+                for frame in resolution.frames:
+                    remaining_cells = (
+                        MAX_PERSONA_BUDDY_PREPARED_CELLS - prepared_cells
+                    )
+                    if remaining_cells < 1:
+                        return None
+                    painted = prepare_persona_buddy_frame(
                         frame,
                         resolution_cache_identity=resolution.cache_identity,
                         cols=cols,
                         lines=lines,
+                        max_cells=remaining_cells,
                     )
-                    for frame in resolution.frames
-                )
+                    prepared_cells += painted.width * painted.height
+                    prepared.append(painted)
+                return tuple(prepared)
             if resolution.portrait is not None:
                 return (
                     prepare_persona_buddy_portrait(

--- a/tldw_chatbook/Persona_Buddy/preferences.py
+++ b/tldw_chatbook/Persona_Buddy/preferences.py
@@ -191,6 +191,9 @@ def persist_persona_buddy_preferences(
         return save_settings_to_cli_config(
             {"persona_buddy": serialize_persona_buddy_preferences(preferences)}
         )
-    except Exception:
-        logger.error("persona_buddy_preferences_save_failed")
+    except Exception as error:
+        logger.error(
+            "persona_buddy_preferences_save_failed exception_type={}",
+            type(error).__name__,
+        )
         return False

--- a/tldw_chatbook/Persona_Buddy/preferences.py
+++ b/tldw_chatbook/Persona_Buddy/preferences.py
@@ -192,8 +192,10 @@ def persist_persona_buddy_preferences(
             {"persona_buddy": serialize_persona_buddy_preferences(preferences)}
         )
     except Exception as error:
-        logger.error(
-            "persona_buddy_preferences_save_failed exception_type={}",
-            type(error).__name__,
+        exception_type = type(error).__name__
+        if re.fullmatch(r"[A-Za-z][A-Za-z0-9_]{0,63}", exception_type) is None:
+            exception_type = "Exception"
+        logger.bind(exception_type=exception_type).error(
+            "persona_buddy_preferences_save_failed"
         )
         return False

--- a/tldw_chatbook/Persona_Buddy/preferences.py
+++ b/tldw_chatbook/Persona_Buddy/preferences.py
@@ -42,7 +42,11 @@ class PersonaBuddySelection:
     local_persona_id: str
 
     def __post_init__(self) -> None:
-        if self.source != "local" or not _valid_persona_id(self.local_persona_id):
+        if (
+            type(self.source) is not str
+            or self.source != "local"
+            or not _valid_persona_id(self.local_persona_id)
+        ):
             raise PersonaBuddyPreferenceError()
 
 
@@ -129,7 +133,7 @@ def parse_persona_buddy_preferences(
     source = section.get("source")
     persona_id = section.get("local_persona_id")
     selection = None
-    if source == "local" and _valid_persona_id(persona_id):
+    if type(source) is str and source == "local" and _valid_persona_id(persona_id):
         selection = PersonaBuddySelection("local", persona_id)
 
     default_geometry = defaults.geometry

--- a/tldw_chatbook/Persona_Buddy/preferences.py
+++ b/tldw_chatbook/Persona_Buddy/preferences.py
@@ -12,6 +12,8 @@ from loguru import logger
 _PERSONA_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
 _MAX_POSITION = 1_000_000
 _MAX_DIMENSION = 10_000
+PERSONA_BUDDY_UNPOSITIONED_COORDINATE = _MAX_POSITION
+"""Never-positioned coordinate that viewport clamping places bottom-right."""
 
 
 def save_settings_to_cli_config(
@@ -52,10 +54,15 @@ class PersonaBuddySelection:
 
 @dataclass(frozen=True, slots=True)
 class PersonaBuddyGeometry:
-    """Persisted floating-window geometry before viewport clamping."""
+    """Persisted floating-window geometry before viewport clamping.
 
-    x: int = 0
-    y: int = 0
+    The maximum-coordinate sentinel represents a Buddy that has never been
+    positioned and therefore clamps to the bottom-right. Zero remains an exact,
+    intentionally persisted top-left coordinate.
+    """
+
+    x: int = PERSONA_BUDDY_UNPOSITIONED_COORDINATE
+    y: int = PERSONA_BUDDY_UNPOSITIONED_COORDINATE
     width: int = 28
     height: int = 12
 

--- a/tldw_chatbook/Persona_Buddy/preferences.py
+++ b/tldw_chatbook/Persona_Buddy/preferences.py
@@ -1,0 +1,185 @@
+"""Strict profile-local preferences for the opt-in Persona Buddy."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from loguru import logger
+
+_PERSONA_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
+_MAX_POSITION = 1_000_000
+_MAX_DIMENSION = 10_000
+
+
+def save_settings_to_cli_config(
+    section_values: Mapping[str, Mapping[Any, Any]],
+) -> bool:
+    """Call the incumbent writer without loading global config during parsing."""
+
+    from tldw_chatbook.config import save_settings_to_cli_config as save
+
+    return save(section_values)
+
+
+class PersonaBuddyPreferenceError(ValueError):
+    """A bounded, path-free Persona Buddy preference error."""
+
+    __slots__ = ("category",)
+
+    def __init__(self, category: str = "persona_buddy_preferences_invalid") -> None:
+        self.category = category
+        super().__init__(category)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddySelection:
+    """One exact profile-local Persona selection."""
+
+    source: Literal["local"]
+    local_persona_id: str
+
+    def __post_init__(self) -> None:
+        if self.source != "local" or not _valid_persona_id(self.local_persona_id):
+            raise PersonaBuddyPreferenceError()
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddyGeometry:
+    """Persisted floating-window geometry before viewport clamping."""
+
+    x: int = 0
+    y: int = 0
+    width: int = 28
+    height: int = 12
+
+    def __post_init__(self) -> None:
+        if not _valid_position(self.x) or not _valid_position(self.y):
+            raise PersonaBuddyPreferenceError("persona_buddy_geometry_invalid")
+        if not _valid_dimension(self.width) or not _valid_dimension(self.height):
+            raise PersonaBuddyPreferenceError("persona_buddy_geometry_invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddyPreferences:
+    """One immutable snapshot of Buddy UI and selection preferences."""
+
+    enabled: bool = False
+    selection: PersonaBuddySelection | None = None
+    open: bool = True
+    collapsed: bool = False
+    geometry: PersonaBuddyGeometry = field(default_factory=PersonaBuddyGeometry)
+
+    def __post_init__(self) -> None:
+        if type(self.enabled) is not bool:
+            raise PersonaBuddyPreferenceError()
+        if (
+            self.selection is not None
+            and type(self.selection) is not PersonaBuddySelection
+        ):
+            raise PersonaBuddyPreferenceError()
+        if type(self.open) is not bool or type(self.collapsed) is not bool:
+            raise PersonaBuddyPreferenceError()
+        if type(self.geometry) is not PersonaBuddyGeometry:
+            raise PersonaBuddyPreferenceError()
+
+
+def _valid_persona_id(value: object) -> bool:
+    return type(value) is str and _PERSONA_ID_PATTERN.fullmatch(value) is not None
+
+
+def _valid_position(value: object) -> bool:
+    return type(value) is int and 0 <= value <= _MAX_POSITION
+
+
+def _valid_dimension(value: object) -> bool:
+    return type(value) is int and 1 <= value <= _MAX_DIMENSION
+
+
+def _boolean(value: object, default: bool) -> bool:
+    return value if type(value) is bool else default
+
+
+def _position(value: object, default: int) -> int:
+    return value if _valid_position(value) else default
+
+
+def _dimension(value: object, default: int) -> int:
+    return value if _valid_dimension(value) else default
+
+
+def parse_persona_buddy_preferences(
+    section: Mapping[str, object],
+) -> PersonaBuddyPreferences:
+    """Parse one config section with independent safe field fallbacks.
+
+    Args:
+        section: Raw ``[persona_buddy]`` configuration values.
+
+    Returns:
+        A strict immutable preference snapshot.
+    """
+
+    if not isinstance(section, Mapping):
+        return PersonaBuddyPreferences()
+
+    defaults = PersonaBuddyPreferences()
+    source = section.get("source")
+    persona_id = section.get("local_persona_id")
+    selection = None
+    if source == "local" and _valid_persona_id(persona_id):
+        selection = PersonaBuddySelection("local", persona_id)
+
+    default_geometry = defaults.geometry
+    geometry = PersonaBuddyGeometry(
+        x=_position(section.get("x"), default_geometry.x),
+        y=_position(section.get("y"), default_geometry.y),
+        width=_dimension(section.get("width"), default_geometry.width),
+        height=_dimension(section.get("height"), default_geometry.height),
+    )
+    return PersonaBuddyPreferences(
+        enabled=_boolean(section.get("enabled"), defaults.enabled),
+        selection=selection,
+        open=_boolean(section.get("open"), defaults.open),
+        collapsed=_boolean(section.get("collapsed"), defaults.collapsed),
+        geometry=geometry,
+    )
+
+
+def serialize_persona_buddy_preferences(
+    preferences: PersonaBuddyPreferences,
+) -> dict[str, object]:
+    """Serialize an exact preference snapshot for the incumbent config writer."""
+
+    if type(preferences) is not PersonaBuddyPreferences:
+        raise PersonaBuddyPreferenceError()
+    selection = preferences.selection
+    return {
+        "enabled": preferences.enabled,
+        "source": selection.source if selection is not None else "",
+        "local_persona_id": (
+            selection.local_persona_id if selection is not None else ""
+        ),
+        "open": preferences.open,
+        "collapsed": preferences.collapsed,
+        "x": preferences.geometry.x,
+        "y": preferences.geometry.y,
+        "width": preferences.geometry.width,
+        "height": preferences.geometry.height,
+    }
+
+
+def persist_persona_buddy_preferences(
+    preferences: PersonaBuddyPreferences,
+) -> bool:
+    """Persist one complete Buddy section through the incumbent config writer."""
+
+    try:
+        return save_settings_to_cli_config(
+            {"persona_buddy": serialize_persona_buddy_preferences(preferences)}
+        )
+    except Exception:
+        logger.error("persona_buddy_preferences_save_failed")
+        return False

--- a/tldw_chatbook/Persona_Buddy/rendering.py
+++ b/tldw_chatbook/Persona_Buddy/rendering.py
@@ -20,12 +20,11 @@ from tldw_chatbook.Persona_Visual.runtime import (
 
 
 PERSONA_BUDDY_FRAME_UNAVAILABLE = "persona_buddy_frame_unavailable"
+MAX_PERSONA_BUDDY_PREPARED_FRAMES = 128
+MAX_PERSONA_BUDDY_PREPARED_CELLS = 1_048_576
 _MAX_FRAME_BYTES = 100 * 1024 * 1024
 _MAX_COLS = 256
 _MAX_LINES = 128
-
-PersonaBuddyCell = tuple[int, int, int, int]
-PersonaBuddyCells = tuple[tuple[PersonaBuddyCell, ...], ...]
 
 
 class PersonaBuddyFrameError(ValueError):
@@ -52,7 +51,7 @@ class PersonaBuddyPreparedFrame:
     duration_ms: int | None
     width: int
     height: int
-    cells: PersonaBuddyCells = field(repr=False)
+    paint_digest: str
     renderable: Pixels = field(repr=False, compare=False, hash=False)
 
 
@@ -62,6 +61,7 @@ def prepare_persona_buddy_frame(
     resolution_cache_identity: PersonaVisualCacheIdentity,
     cols: int,
     lines: int,
+    max_cells: int | None = None,
 ) -> PersonaBuddyPreparedFrame:
     """Decode and scale the exact embedded frame into bounded Rich pixels.
 
@@ -77,6 +77,7 @@ def prepare_persona_buddy_frame(
             or type(lines) is not int
             or not 1 <= cols <= _MAX_COLS
             or not 1 <= lines <= _MAX_LINES
+            or (max_cells is not None and (type(max_cells) is not int or max_cells < 1))
         ):
             raise ValueError
         data = resolved_frame.data
@@ -127,12 +128,12 @@ def prepare_persona_buddy_frame(
             )
 
         image.thumbnail((cols, lines * 2), Image.Resampling.LANCZOS)
-        if image.width < 1 or image.height < 1:
+        if (
+            image.width < 1
+            or image.height < 1
+            or (max_cells is not None and image.width * image.height > max_cells)
+        ):
             raise ValueError
-        cells: PersonaBuddyCells = tuple(
-            tuple(image.getpixel((x, y)) for x in range(image.width))
-            for y in range(image.height)
-        )
         return PersonaBuddyPreparedFrame(
             cache_identity=resolution_cache_identity,
             graph_identity=resolution_cache_identity.graph,
@@ -144,7 +145,7 @@ def prepare_persona_buddy_frame(
             duration_ms=resolved_frame.duration_ms,
             width=image.width,
             height=image.height,
-            cells=cells,
+            paint_digest=hashlib.sha256(image.tobytes()).hexdigest(),
             renderable=Pixels.from_image(image),
         )
     except PersonaBuddyFrameError:
@@ -192,10 +193,6 @@ def prepare_persona_buddy_portrait(
             source.load()
             image = source.convert("RGBA")
         image.thumbnail((cols, lines * 2), Image.Resampling.LANCZOS)
-        cells: PersonaBuddyCells = tuple(
-            tuple(image.getpixel((x, y)) for x in range(image.width))
-            for y in range(image.height)
-        )
         return PersonaBuddyPreparedFrame(
             cache_identity=resolution_cache_identity,
             graph_identity=resolution_cache_identity.graph,
@@ -207,7 +204,7 @@ def prepare_persona_buddy_portrait(
             duration_ms=None,
             width=image.width,
             height=image.height,
-            cells=cells,
+            paint_digest=hashlib.sha256(image.tobytes()).hexdigest(),
             renderable=Pixels.from_image(image),
         )
     except PersonaBuddyFrameError:
@@ -217,6 +214,8 @@ def prepare_persona_buddy_portrait(
 
 
 __all__ = (
+    "MAX_PERSONA_BUDDY_PREPARED_CELLS",
+    "MAX_PERSONA_BUDDY_PREPARED_FRAMES",
     "PERSONA_BUDDY_FRAME_UNAVAILABLE",
     "PersonaBuddyFrameError",
     "PersonaBuddyPreparedFrame",

--- a/tldw_chatbook/Persona_Buddy/rendering.py
+++ b/tldw_chatbook/Persona_Buddy/rendering.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass, field
+from functools import lru_cache
 from io import BytesIO
-
-from PIL import Image
-from rich_pixels import Pixels
+from typing import TYPE_CHECKING, Any
 
 from tldw_chatbook.Persona_Visual.contracts import MAX_ASSET_DIMENSION
 from tldw_chatbook.Persona_Visual.repository import PersonaVisualIdentity
@@ -17,6 +16,9 @@ from tldw_chatbook.Persona_Visual.runtime import (
     PersonaVisualPortrait,
     PersonaVisualResolvedFrame,
 )
+
+if TYPE_CHECKING:
+    from rich_pixels import Pixels
 
 
 PERSONA_BUDDY_FRAME_UNAVAILABLE = "persona_buddy_frame_unavailable"
@@ -35,6 +37,19 @@ class PersonaBuddyFrameError(ValueError):
     def __init__(self) -> None:
         self.category = PERSONA_BUDDY_FRAME_UNAVAILABLE
         super().__init__(self.category)
+
+
+@lru_cache(maxsize=1)
+def _render_dependencies() -> tuple[Any, type[Any]]:
+    """Load required image modules only when Buddy rendering is used."""
+
+    from tldw_chatbook.Utils.optional_deps import require_dependency
+
+    require_dependency("PIL", "pillow")
+    pixels_module = require_dependency("rich_pixels")
+    from PIL import Image
+
+    return Image, pixels_module.Pixels
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,6 +85,7 @@ def prepare_persona_buddy_frame(
     """
 
     try:
+        Image, Pixels = _render_dependencies()
         if (
             type(resolved_frame) is not PersonaVisualResolvedFrame
             or type(resolution_cache_identity) is not PersonaVisualCacheIdentity
@@ -164,6 +180,7 @@ def prepare_persona_buddy_portrait(
     """Prepare the validated local Persona portrait fallback."""
 
     try:
+        Image, Pixels = _render_dependencies()
         if (
             type(portrait) is not PersonaVisualPortrait
             or type(resolution_cache_identity) is not PersonaVisualCacheIdentity

--- a/tldw_chatbook/Persona_Buddy/rendering.py
+++ b/tldw_chatbook/Persona_Buddy/rendering.py
@@ -1,0 +1,225 @@
+"""Bounded, Textual-independent Persona Buddy raster preparation."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from io import BytesIO
+
+from PIL import Image
+from rich_pixels import Pixels
+
+from tldw_chatbook.Persona_Visual.contracts import MAX_ASSET_DIMENSION
+from tldw_chatbook.Persona_Visual.repository import PersonaVisualIdentity
+from tldw_chatbook.Persona_Visual.runtime import (
+    PersonaVisualCacheAsset,
+    PersonaVisualCacheIdentity,
+    PersonaVisualPortrait,
+    PersonaVisualResolvedFrame,
+)
+
+
+PERSONA_BUDDY_FRAME_UNAVAILABLE = "persona_buddy_frame_unavailable"
+_MAX_FRAME_BYTES = 100 * 1024 * 1024
+_MAX_COLS = 256
+_MAX_LINES = 128
+
+PersonaBuddyCell = tuple[int, int, int, int]
+PersonaBuddyCells = tuple[tuple[PersonaBuddyCell, ...], ...]
+
+
+class PersonaBuddyFrameError(ValueError):
+    """A fixed, path-free Buddy frame preparation failure."""
+
+    __slots__ = ("category",)
+
+    def __init__(self) -> None:
+        self.category = PERSONA_BUDDY_FRAME_UNAVAILABLE
+        super().__init__(self.category)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddyPreparedFrame:
+    """One bounded painted frame with complete immutable cache identity."""
+
+    cache_identity: PersonaVisualCacheIdentity
+    graph_identity: PersonaVisualIdentity | None
+    asset_id: int
+    asset_key: str
+    asset_sha256: str
+    manifest_frame_index: int
+    selected_frame: int
+    duration_ms: int | None
+    width: int
+    height: int
+    cells: PersonaBuddyCells = field(repr=False)
+    renderable: Pixels = field(repr=False, compare=False, hash=False)
+
+
+def prepare_persona_buddy_frame(
+    resolved_frame: PersonaVisualResolvedFrame,
+    *,
+    resolution_cache_identity: PersonaVisualCacheIdentity,
+    cols: int,
+    lines: int,
+) -> PersonaBuddyPreparedFrame:
+    """Decode and scale the exact embedded frame into bounded Rich pixels.
+
+    Raises:
+        PersonaBuddyFrameError: If identity, decode, crop, or size validation fails.
+    """
+
+    try:
+        if (
+            type(resolved_frame) is not PersonaVisualResolvedFrame
+            or type(resolution_cache_identity) is not PersonaVisualCacheIdentity
+            or type(cols) is not int
+            or type(lines) is not int
+            or not 1 <= cols <= _MAX_COLS
+            or not 1 <= lines <= _MAX_LINES
+        ):
+            raise ValueError
+        data = resolved_frame.data
+        if (
+            type(data) is not bytes
+            or not data
+            or len(data) > _MAX_FRAME_BYTES
+            or hashlib.sha256(data).hexdigest() != resolved_frame.sha256
+        ):
+            raise ValueError
+        cache_asset = PersonaVisualCacheAsset(
+            asset_id=resolved_frame.asset_id,
+            asset_key=resolved_frame.asset_key,
+            sha256=resolved_frame.sha256,
+            manifest_frame_index=resolved_frame.manifest_frame_index,
+            selected_frame=resolved_frame.selected_frame,
+        )
+        if cache_asset not in resolution_cache_identity.assets:
+            raise ValueError
+
+        with Image.open(BytesIO(data)) as source:
+            if (
+                source.width < 1
+                or source.height < 1
+                or source.width > MAX_ASSET_DIMENSION
+                or source.height > MAX_ASSET_DIMENSION
+                or type(resolved_frame.selected_frame) is not int
+                or resolved_frame.selected_frame < 0
+            ):
+                raise ValueError
+            source.seek(resolved_frame.selected_frame)
+            source.load()
+            image = source.convert("RGBA")
+
+        region = resolved_frame.region
+        if region is not None:
+            if (
+                region.x < 0
+                or region.y < 0
+                or region.width < 1
+                or region.height < 1
+                or region.x + region.width > image.width
+                or region.y + region.height > image.height
+            ):
+                raise ValueError
+            image = image.crop(
+                (region.x, region.y, region.x + region.width, region.y + region.height)
+            )
+
+        image.thumbnail((cols, lines * 2), Image.Resampling.LANCZOS)
+        if image.width < 1 or image.height < 1:
+            raise ValueError
+        cells: PersonaBuddyCells = tuple(
+            tuple(image.getpixel((x, y)) for x in range(image.width))
+            for y in range(image.height)
+        )
+        return PersonaBuddyPreparedFrame(
+            cache_identity=resolution_cache_identity,
+            graph_identity=resolution_cache_identity.graph,
+            asset_id=resolved_frame.asset_id,
+            asset_key=resolved_frame.asset_key,
+            asset_sha256=resolved_frame.sha256,
+            manifest_frame_index=resolved_frame.manifest_frame_index,
+            selected_frame=resolved_frame.selected_frame,
+            duration_ms=resolved_frame.duration_ms,
+            width=image.width,
+            height=image.height,
+            cells=cells,
+            renderable=Pixels.from_image(image),
+        )
+    except PersonaBuddyFrameError:
+        raise
+    except Exception:
+        raise PersonaBuddyFrameError() from None
+
+
+def prepare_persona_buddy_portrait(
+    portrait: PersonaVisualPortrait,
+    *,
+    resolution_cache_identity: PersonaVisualCacheIdentity,
+    cols: int,
+    lines: int,
+) -> PersonaBuddyPreparedFrame:
+    """Prepare the validated local Persona portrait fallback."""
+
+    try:
+        if (
+            type(portrait) is not PersonaVisualPortrait
+            or type(resolution_cache_identity) is not PersonaVisualCacheIdentity
+            or resolution_cache_identity.portrait_id != portrait.portrait_id
+            or resolution_cache_identity.portrait_revision != portrait.revision
+            or resolution_cache_identity.portrait_sha256 != portrait.sha256
+            or type(cols) is not int
+            or type(lines) is not int
+            or not 1 <= cols <= _MAX_COLS
+            or not 1 <= lines <= _MAX_LINES
+            or type(portrait.data) is not bytes
+            or not portrait.data
+            or len(portrait.data) > _MAX_FRAME_BYTES
+            or hashlib.sha256(portrait.data).hexdigest() != portrait.sha256
+            or portrait.selected_frame != 0
+        ):
+            raise ValueError
+        with Image.open(BytesIO(portrait.data)) as source:
+            if (
+                source.width < 1
+                or source.height < 1
+                or source.width > MAX_ASSET_DIMENSION
+                or source.height > MAX_ASSET_DIMENSION
+            ):
+                raise ValueError
+            source.seek(0)
+            source.load()
+            image = source.convert("RGBA")
+        image.thumbnail((cols, lines * 2), Image.Resampling.LANCZOS)
+        cells: PersonaBuddyCells = tuple(
+            tuple(image.getpixel((x, y)) for x in range(image.width))
+            for y in range(image.height)
+        )
+        return PersonaBuddyPreparedFrame(
+            cache_identity=resolution_cache_identity,
+            graph_identity=resolution_cache_identity.graph,
+            asset_id=0,
+            asset_key=portrait.portrait_id,
+            asset_sha256=portrait.sha256,
+            manifest_frame_index=-1,
+            selected_frame=0,
+            duration_ms=None,
+            width=image.width,
+            height=image.height,
+            cells=cells,
+            renderable=Pixels.from_image(image),
+        )
+    except PersonaBuddyFrameError:
+        raise
+    except Exception:
+        raise PersonaBuddyFrameError() from None
+
+
+__all__ = (
+    "PERSONA_BUDDY_FRAME_UNAVAILABLE",
+    "PersonaBuddyFrameError",
+    "PersonaBuddyPreparedFrame",
+    "prepare_persona_buddy_frame",
+    "prepare_persona_buddy_portrait",
+)

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -57,7 +57,6 @@ class BaseAppScreen(Screen):
         self.nav_bar_active: str = screen_name
         self._persona_buddy_view = None
         self._persona_buddy_view_generation = 0
-        self._persona_buddy_unavailable_authority = None
         self._persona_buddy_reconcile_lock = asyncio.Lock()
 
         logger.debug(f"Initializing {self.__class__.__name__} screen: {screen_name}")
@@ -385,6 +384,29 @@ class BaseAppScreen(Screen):
 
         return self._persona_buddy_view_generation
 
+    def confirm_persona_buddy_unavailable(
+        self,
+        *,
+        view: Any,
+        controller: Any,
+        snapshot: Any,
+        visual: Any,
+    ) -> bool:
+        """Publish unavailable through the app's exact screen/view fence."""
+
+        confirm = getattr(self.app_instance, "confirm_persona_buddy_unavailable", None)
+        return bool(
+            callable(confirm)
+            and confirm(
+                screen=self,
+                view=view,
+                view_generation=view.view_generation,
+                controller=controller,
+                snapshot=snapshot,
+                visual=visual,
+            )
+        )
+
     def _schedule_persona_buddy_reconcile(self) -> None:
         """Schedule one idempotent mount reconciliation after screen paint."""
 
@@ -407,24 +429,13 @@ class BaseAppScreen(Screen):
             controller = getattr(self.app_instance, "persona_buddy_controller", None)
             active = self.is_attached and self.app.screen is self
             snapshot = controller.snapshot() if controller is not None else None
-            visual = getattr(snapshot, "visual", None)
-            authority = (
-                getattr(snapshot, "selection", None),
-                getattr(snapshot, "preferences_generation", None),
-                getattr(snapshot, "profile_generation", None),
+            unavailable = getattr(
+                self.app_instance, "is_persona_buddy_confirmed_unavailable", None
             )
-            if visual is not None and visual.available:
-                self._persona_buddy_unavailable_authority = None
-            elif (
-                self._persona_buddy_view is not None
-                and visual is not None
-                and not visual.available
-            ):
-                self._persona_buddy_unavailable_authority = authority
-            confirmed_unavailable = (
-                visual is not None
-                and not visual.available
-                and self._persona_buddy_unavailable_authority == authority
+            confirmed_unavailable = bool(
+                snapshot is not None
+                and callable(unavailable)
+                and unavailable(controller, snapshot)
             )
             desired = bool(
                 active

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -1,5 +1,6 @@
 """Base screen class for all application screens."""
 
+import asyncio
 from typing import TYPE_CHECKING, Optional, Dict, Any
 from loguru import logger
 
@@ -54,6 +55,9 @@ class BaseAppScreen(Screen):
         #: search aliases, screen routing) -- only this screen's OWN composed
         #: nav bar's highlight is affected.
         self.nav_bar_active: str = screen_name
+        self._persona_buddy_view = None
+        self._persona_buddy_view_generation = 0
+        self._persona_buddy_reconcile_lock = asyncio.Lock()
 
         logger.debug(f"Initializing {self.__class__.__name__} screen: {screen_name}")
 
@@ -162,6 +166,7 @@ class BaseAppScreen(Screen):
         self.release_mouse_capture_for_teardown()
         await super().recompose()
         self.sweep_stale_mouse_capture()
+        await self.reconcile_persona_buddy_view()
 
     def release_mouse_capture_for_teardown(self) -> None:
         """Release any mouse capture before removing widgets.
@@ -360,7 +365,87 @@ class BaseAppScreen(Screen):
         carries a legacy ``super().on_mount()`` call.
         """
         logger.info(f"Screen {self.screen_name} mounted")
+        self.call_after_refresh(self._schedule_persona_buddy_reconcile)
 
     def on_unmount(self) -> None:
         """Called when the screen is unmounted."""
+        self._persona_buddy_view_generation += 1
+        view = self._persona_buddy_view
+        self._persona_buddy_view = None
+        if view is not None:
+            view.release_interaction_capture()
         logger.info(f"Screen {self.screen_name} unmounted")
+
+    @property
+    def persona_buddy_view_generation(self) -> int:
+        """Return this screen's current disposable Buddy-view generation."""
+
+        return self._persona_buddy_view_generation
+
+    def _schedule_persona_buddy_reconcile(self) -> None:
+        """Schedule one idempotent mount reconciliation after screen paint."""
+
+        if not self.is_attached:
+            return
+        self.run_worker(
+            self.reconcile_persona_buddy_view(),
+            group="persona-buddy-view-reconcile",
+            exclusive=True,
+        )
+
+    async def reconcile_persona_buddy_view(self) -> None:
+        """Mount or remove one exact screen-local Buddy view generation."""
+
+        from ...Widgets.Persona_Widgets.persona_buddy_widget import (  # noqa: PLC0415
+            PersonaBuddyWidget,
+        )
+
+        async with self._persona_buddy_reconcile_lock:
+            self._persona_buddy_view_generation += 1
+            generation = self._persona_buddy_view_generation
+            controller = getattr(self.app_instance, "persona_buddy_controller", None)
+            active = self.is_attached and self.app.screen is self
+            snapshot = controller.snapshot() if controller is not None else None
+            visual = getattr(snapshot, "visual", None)
+            desired = bool(
+                active
+                and snapshot is not None
+                and snapshot.enabled
+                and snapshot.open
+                and snapshot.selection is not None
+                and not (visual is not None and not visual.available)
+            )
+
+            current = self._persona_buddy_view
+            if current is not None and not current.is_attached:
+                current = None
+                self._persona_buddy_view = None
+
+            if not desired:
+                if current is not None:
+                    current.release_interaction_capture()
+                    await current.remove()
+                    if self._persona_buddy_view is current:
+                        self._persona_buddy_view = None
+                return
+
+            if current is not None:
+                current.refresh_from_controller()
+                return
+
+            view = PersonaBuddyWidget(
+                controller=controller,
+                view_generation=generation,
+                reconcile=self.app_instance.reconcile_persona_buddy_view,
+            )
+            await self.mount(view)
+            still_current = bool(
+                generation == self._persona_buddy_view_generation
+                and self.is_attached
+                and self.app.screen is self
+            )
+            if not still_current:
+                view.release_interaction_capture()
+                await view.remove()
+                return
+            self._persona_buddy_view = view

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -369,6 +369,11 @@ class BaseAppScreen(Screen):
         logger.info(f"Screen {self.screen_name} mounted")
         self.call_after_refresh(self._schedule_persona_buddy_reconcile)
 
+    def on_screen_resume(self) -> None:
+        """Replay app-owned Buddy state after this screen is uncovered."""
+
+        self.call_after_refresh(self._schedule_persona_buddy_reconcile)
+
     def on_unmount(self) -> None:
         """Called when the screen is unmounted."""
         self._persona_buddy_view_generation += 1
@@ -423,7 +428,7 @@ class BaseAppScreen(Screen):
         if not self.is_attached:
             return
         self.run_worker(
-            self.reconcile_persona_buddy_view(),
+            self.reconcile_persona_buddy_view,
             group="persona-buddy-view-reconcile",
             exclusive=True,
         )
@@ -468,6 +473,7 @@ class BaseAppScreen(Screen):
 
             if current is not None:
                 current.refresh_from_controller()
+                current.resume_resolution()
                 return False
 
             self._persona_buddy_view_generation += 1

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -218,7 +218,9 @@ class BaseAppScreen(Screen):
         # defaults to ``screen_name``, see ``__init__``), not ``screen_name``
         # directly, so a screen can opt out of a misleading destination
         # highlight without touching every other screen's behavior.
-        yield MainNavigationBar(active=self.nav_bar_active, active_route=self.nav_bar_active)
+        yield MainNavigationBar(
+            active=self.nav_bar_active, active_route=self.nav_bar_active
+        )
 
         # Content area below navigation
         with Container(id="screen-content"):
@@ -401,19 +403,15 @@ class BaseAppScreen(Screen):
         )
 
         async with self._persona_buddy_reconcile_lock:
-            self._persona_buddy_view_generation += 1
-            generation = self._persona_buddy_view_generation
             controller = getattr(self.app_instance, "persona_buddy_controller", None)
             active = self.is_attached and self.app.screen is self
             snapshot = controller.snapshot() if controller is not None else None
-            visual = getattr(snapshot, "visual", None)
             desired = bool(
                 active
                 and snapshot is not None
                 and snapshot.enabled
                 and snapshot.open
                 and snapshot.selection is not None
-                and not (visual is not None and not visual.available)
             )
 
             current = self._persona_buddy_view
@@ -422,6 +420,7 @@ class BaseAppScreen(Screen):
                 self._persona_buddy_view = None
 
             if not desired:
+                self._persona_buddy_view_generation += 1
                 if current is not None:
                     current.release_interaction_capture()
                     await current.remove()
@@ -433,19 +432,39 @@ class BaseAppScreen(Screen):
                 current.refresh_from_controller()
                 return
 
+            self._persona_buddy_view_generation += 1
+            generation = self._persona_buddy_view_generation
             view = PersonaBuddyWidget(
                 controller=controller,
                 view_generation=generation,
                 reconcile=self.app_instance.reconcile_persona_buddy_view,
+                is_current=lambda candidate: bool(
+                    generation == self._persona_buddy_view_generation
+                    and self._persona_buddy_view is candidate
+                    and self.is_attached
+                    and self.app.screen is self
+                ),
             )
-            await self.mount(view)
+            self._persona_buddy_view = view
+            try:
+                await self.mount(view)
+            except BaseException:
+                if self._persona_buddy_view is view:
+                    self._persona_buddy_view = None
+                if view.is_attached:
+                    view.release_interaction_capture()
+                    await view.remove()
+                raise
             still_current = bool(
                 generation == self._persona_buddy_view_generation
+                and self._persona_buddy_view is view
                 and self.is_attached
                 and self.app.screen is self
             )
             if not still_current:
                 view.release_interaction_capture()
-                await view.remove()
+                if view.is_attached:
+                    await view.remove()
+                if self._persona_buddy_view is view:
+                    self._persona_buddy_view = None
                 return
-            self._persona_buddy_view = view

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -407,6 +407,16 @@ class BaseAppScreen(Screen):
             )
         )
 
+    def is_persona_buddy_confirmed_unavailable(
+        self, controller: Any, snapshot: Any
+    ) -> bool:
+        """Query the app-owned marker for this exact controller authority."""
+
+        unavailable = getattr(
+            self.app_instance, "is_persona_buddy_confirmed_unavailable", None
+        )
+        return bool(callable(unavailable) and unavailable(controller, snapshot))
+
     def _schedule_persona_buddy_reconcile(self) -> None:
         """Schedule one idempotent mount reconciliation after screen paint."""
 
@@ -418,8 +428,8 @@ class BaseAppScreen(Screen):
             exclusive=True,
         )
 
-    async def reconcile_persona_buddy_view(self) -> None:
-        """Mount or remove one exact screen-local Buddy view generation."""
+    async def reconcile_persona_buddy_view(self) -> bool:
+        """Reconcile one generation; return whether no current view remains."""
 
         from ...Widgets.Persona_Widgets.persona_buddy_widget import (  # noqa: PLC0415
             PersonaBuddyWidget,
@@ -429,13 +439,9 @@ class BaseAppScreen(Screen):
             controller = getattr(self.app_instance, "persona_buddy_controller", None)
             active = self.is_attached and self.app.screen is self
             snapshot = controller.snapshot() if controller is not None else None
-            unavailable = getattr(
-                self.app_instance, "is_persona_buddy_confirmed_unavailable", None
-            )
             confirmed_unavailable = bool(
                 snapshot is not None
-                and callable(unavailable)
-                and unavailable(controller, snapshot)
+                and self.is_persona_buddy_confirmed_unavailable(controller, snapshot)
             )
             desired = bool(
                 active
@@ -458,11 +464,11 @@ class BaseAppScreen(Screen):
                     await current.remove()
                     if self._persona_buddy_view is current:
                         self._persona_buddy_view = None
-                return
+                return True
 
             if current is not None:
                 current.refresh_from_controller()
-                return
+                return False
 
             self._persona_buddy_view_generation += 1
             generation = self._persona_buddy_view_generation
@@ -499,4 +505,5 @@ class BaseAppScreen(Screen):
                     await view.remove()
                 if self._persona_buddy_view is view:
                     self._persona_buddy_view = None
-                return
+                return True
+            return False

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -57,6 +57,7 @@ class BaseAppScreen(Screen):
         self.nav_bar_active: str = screen_name
         self._persona_buddy_view = None
         self._persona_buddy_view_generation = 0
+        self._persona_buddy_unavailable_authority = None
         self._persona_buddy_reconcile_lock = asyncio.Lock()
 
         logger.debug(f"Initializing {self.__class__.__name__} screen: {screen_name}")
@@ -406,12 +407,32 @@ class BaseAppScreen(Screen):
             controller = getattr(self.app_instance, "persona_buddy_controller", None)
             active = self.is_attached and self.app.screen is self
             snapshot = controller.snapshot() if controller is not None else None
+            visual = getattr(snapshot, "visual", None)
+            authority = (
+                getattr(snapshot, "selection", None),
+                getattr(snapshot, "preferences_generation", None),
+                getattr(snapshot, "profile_generation", None),
+            )
+            if visual is not None and visual.available:
+                self._persona_buddy_unavailable_authority = None
+            elif (
+                self._persona_buddy_view is not None
+                and visual is not None
+                and not visual.available
+            ):
+                self._persona_buddy_unavailable_authority = authority
+            confirmed_unavailable = (
+                visual is not None
+                and not visual.available
+                and self._persona_buddy_unavailable_authority == authority
+            )
             desired = bool(
                 active
                 and snapshot is not None
                 and snapshot.enabled
                 and snapshot.open
                 and snapshot.selection is not None
+                and not confirmed_unavailable
             )
 
             current = self._persona_buddy_view

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -433,6 +433,11 @@ class BaseAppScreen(Screen):
             exclusive=True,
         )
 
+    def sync_persona_buddy_reconciled_state(self) -> None:
+        """Refresh screen-local Buddy affordances after view reconciliation."""
+
+        return None
+
     async def reconcile_persona_buddy_view(self) -> bool:
         """Reconcile one generation; return whether no current view remains."""
 
@@ -469,11 +474,14 @@ class BaseAppScreen(Screen):
                     await current.remove()
                     if self._persona_buddy_view is current:
                         self._persona_buddy_view = None
+                if self.is_attached and self.app.screen is self:
+                    self.sync_persona_buddy_reconciled_state()
                 return True
 
             if current is not None:
                 current.refresh_from_controller()
                 current.resume_resolution()
+                self.sync_persona_buddy_reconciled_state()
                 return False
 
             self._persona_buddy_view_generation += 1
@@ -512,4 +520,5 @@ class BaseAppScreen(Screen):
                 if self._persona_buddy_view is view:
                     self._persona_buddy_view = None
                 return True
+            self.sync_persona_buddy_reconciled_state()
             return False

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5689,11 +5689,15 @@ class ChatScreen(BaseAppScreen):
         """
         session = getattr(self, "_session", None)
         prompts = getattr(self, "_prompts", None)
+        retrieval = getattr(self, "_retrieval", None)
+        skill = getattr(self, "_skill", None)
         return {
             # constructor-supplied callables
             "_chat_dictionary_applier": self._console_chat_dictionary_applier,
             "_world_info_applier": self._console_world_info_applier,
-            "_rag_capture_provider": self._retrieval._capture_console_staged_rag,
+            "_rag_capture_provider": getattr(
+                retrieval, "_capture_console_staged_rag", None
+            ),
             "_default_session_settings": getattr(
                 session, "_default_console_session_settings", None
             ),
@@ -5723,8 +5727,12 @@ class ChatScreen(BaseAppScreen):
             # task-2154.16 (FB-05): the ACTIVE session's own run failing --
             # one error toast carrying the run's visible copy.
             "notify_run_failure": self._notify_console_run_failure,
-            "set_pending_skill_install": self._skill._set_console_pending_skill_install,
-            "set_pending_skill_script": self._skill._set_console_pending_skill_script,
+            "set_pending_skill_install": getattr(
+                skill, "_set_console_pending_skill_install", None
+            ),
+            "set_pending_skill_script": getattr(
+                skill, "_set_console_pending_skill_script", None
+            ),
             # PR3a-2 Task 5, user-wins-ties.
             "wake_user_priority_probe": self._console_wake_user_priority,
             # task-15971: the delivery COMMIT's visibility probe -- a wake

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1041,7 +1041,7 @@ class ConsoleRealtimeSession:
             a tab switch mid-conversation must not scatter half a spoken
             exchange across two transcripts (the same discipline V3's
             `pending_session_id` enforces for its own send).
-        buddy_generation: Monotonic screen-local loop generation used only
+        buddy_generation: Monotonic app-owned loop generation used only
             to fence trusted Buddy lifecycle state from replaced loops.
         idle_timeout_seconds: The configured idle ceiling, kept here so the
             exit toast can name it without re-reading config at exit time.
@@ -3739,7 +3739,6 @@ class ChatScreen(BaseAppScreen):
         #: session is set. See `ConsoleRealtimeSession` and
         #: `_enter_console_realtime_loop`/`_release_console_realtime_state`.
         self._console_realtime: ConsoleRealtimeSession | None = None
-        self._console_realtime_generation = 0
         #: The worker releasing a just-exited realtime loop's tap/session/
         #: sink, or None. Retained only so `on_unmount` can wait for it --
         #: see `_teardown_console_realtime_loop`.
@@ -6823,7 +6822,12 @@ class ChatScreen(BaseAppScreen):
             return
 
         idle_timeout = realtime_idle_timeout_seconds()
-        self._console_realtime_generation += 1
+        buddy_generation = (
+            self._console_runtime()
+            .persona_buddy_sink.next_voice_generation(console_session_id)
+        )
+        if buddy_generation is None:
+            return
         controller = RealtimeLoopController(
             self._handle_console_realtime_intent,
             acoustic_barge_in=acoustic_barge_in_enabled(),
@@ -6833,7 +6837,7 @@ class ChatScreen(BaseAppScreen):
             controller=controller,
             console_session_id=console_session_id,
             idle_timeout_seconds=idle_timeout,
-            buddy_generation=self._console_realtime_generation,
+            buddy_generation=buddy_generation,
         )
         self._console_realtime = session
         session.tick_timer = self.set_interval(0.1, self._tick_console_realtime)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1041,6 +1041,8 @@ class ConsoleRealtimeSession:
             a tab switch mid-conversation must not scatter half a spoken
             exchange across two transcripts (the same discipline V3's
             `pending_session_id` enforces for its own send).
+        buddy_generation: Monotonic screen-local loop generation used only
+            to fence trusted Buddy lifecycle state from replaced loops.
         idle_timeout_seconds: The configured idle ceiling, kept here so the
             exit toast can name it without re-reading config at exit time.
         tap: The `RealtimeMicTap` streaming microphone PCM into the session.
@@ -1122,6 +1124,7 @@ class ConsoleRealtimeSession:
     controller: RealtimeLoopController
     console_session_id: str
     idle_timeout_seconds: float
+    buddy_generation: int = 0
     tap: Any = None
     session: Any = None
     sink: Any = None
@@ -3736,6 +3739,7 @@ class ChatScreen(BaseAppScreen):
         #: session is set. See `ConsoleRealtimeSession` and
         #: `_enter_console_realtime_loop`/`_release_console_realtime_state`.
         self._console_realtime: ConsoleRealtimeSession | None = None
+        self._console_realtime_generation = 0
         #: The worker releasing a just-exited realtime loop's tap/session/
         #: sink, or None. Retained only so `on_unmount` can wait for it --
         #: see `_teardown_console_realtime_loop`.
@@ -6819,6 +6823,7 @@ class ChatScreen(BaseAppScreen):
             return
 
         idle_timeout = realtime_idle_timeout_seconds()
+        self._console_realtime_generation += 1
         controller = RealtimeLoopController(
             self._handle_console_realtime_intent,
             acoustic_barge_in=acoustic_barge_in_enabled(),
@@ -6828,6 +6833,7 @@ class ChatScreen(BaseAppScreen):
             controller=controller,
             console_session_id=console_session_id,
             idle_timeout_seconds=idle_timeout,
+            buddy_generation=self._console_realtime_generation,
         )
         self._console_realtime = session
         session.tick_timer = self.set_interval(0.1, self._tick_console_realtime)
@@ -8392,6 +8398,11 @@ class ChatScreen(BaseAppScreen):
         session = self._console_realtime
         if session is None:
             return
+        self._console_runtime().persona_buddy_sink.voice_state(
+            session.console_session_id,
+            session.buddy_generation,
+            state,
+        )
         gated = session.controller.mic_gated
         session.mic_gated = gated
         tap = session.tap
@@ -8722,6 +8733,10 @@ class ChatScreen(BaseAppScreen):
         session = self._console_realtime
         if session is None:
             return None
+        self._console_runtime().persona_buddy_sink.release_voice(
+            session.console_session_id,
+            session.buddy_generation,
+        )
         self._console_realtime = None
         # Exiting mid-reply IS an interruption: close the row that way
         # rather than leaving a `pending` assistant message that nothing

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -19569,7 +19569,8 @@ class ChatScreen(BaseAppScreen):
             self.run_worker(
                 self._skill._refresh_console_skill_candidates(), exclusive=False
             )
-        # Note: BaseAppScreen doesn't have on_screen_resume, so no super() call
+        # Textual's MRO dispatch also invokes BaseAppScreen's shared reconciliation;
+        # this handler extends that resume event with Console-owned replay work.
 
     def set_task_resume_state(self, task_state: TaskResumeState) -> None:
         """Update native Console task-resume state and refresh its cards."""

--- a/tldw_chatbook/UI/Screens/mcp_screen.py
+++ b/tldw_chatbook/UI/Screens/mcp_screen.py
@@ -254,7 +254,8 @@ class MCPScreen(BaseAppScreen):
     def on_screen_resume(self) -> None:
         """Called when returning to this screen (e.g. after a pushed overlay pops)."""
         self._register_footer_shortcuts()
-        # Note: BaseAppScreen doesn't have on_screen_resume, so no super() call
+        # Textual's MRO dispatch also invokes BaseAppScreen's shared reconciliation;
+        # this handler extends that resume event with MCP-owned footer state.
 
     def on_screen_suspend(self) -> None:
         """Called when another screen is pushed on top of this one."""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3965,9 +3965,7 @@ class PersonasScreen(BaseAppScreen):
         record, complete = await self._fetch_profile_record_checked(entity_id)
         if (
             session_generation != self._persona_buddy_session_generation
-            or getattr(
-                self.app_instance, "character_persona_scope_service", None
-            )
+            or getattr(self.app_instance, "character_persona_scope_service", None)
             is not scope_service
             or self.state.active_mode != "personas"
             or self.state.runtime_source != source
@@ -5750,6 +5748,13 @@ class PersonasScreen(BaseAppScreen):
             open=getattr(snapshot, "open", True) is True,
         )
 
+    def sync_persona_buddy_reconciled_state(self) -> None:
+        """Refresh Inspector affordances for this mounted active Workbench."""
+
+        if not self.is_mounted or not self.is_active:
+            return
+        self._sync_inspector_buddy_status()
+
     async def _selection_handoff_body(self) -> str | None:
         """Readable card summary for the selected item, or ``None`` when stale."""
         kind = self.state.selected_entity_kind
@@ -5861,8 +5866,7 @@ class PersonasScreen(BaseAppScreen):
             is authority.scope_service
             and getattr(self.app, "persona_buddy_controller", None)
             is authority.controller
-            and self._persona_buddy_session_generation
-            == authority.session_generation
+            and self._persona_buddy_session_generation == authority.session_generation
             and self.state.active_mode == "personas"
             and self.state.runtime_source == authority.source
             and self.persona_handler.current_mode() == authority.source
@@ -7283,9 +7287,7 @@ class PersonasScreen(BaseAppScreen):
         latest = controller.snapshot()
         if (
             getattr(self.app, "persona_buddy_controller", None) is not controller
-            or getattr(
-                self.app_instance, "character_persona_scope_service", None
-            )
+            or getattr(self.app_instance, "character_persona_scope_service", None)
             is not scope_service
             or latest.selection != selection
             or latest.generation != snapshot.generation

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -108,7 +108,8 @@ from ...Persona_Visual.publication import (
     publish_persona_visual,
 )
 from ...Persona_Visual.repository import PersonaVisualIdentity, PersonaVisualRepository
-from ...Persona_Buddy import PersonaBuddySelection
+from ...Persona_Visual.runtime import PersonaVisualCacheIdentity
+from ...Persona_Buddy import PersonaBuddySelection, PersonaBuddyVisualSnapshot
 from ...TTS import (
     AssignedTTSProfileSnapshot,
     CharacterRef,
@@ -7241,23 +7242,43 @@ class PersonasScreen(BaseAppScreen):
             )
             is not scope_service
             or latest.selection != selection
+            or latest.generation != snapshot.generation
             or latest.preferences_generation != snapshot.preferences_generation
             or latest.profile_generation != snapshot.profile_generation
         ):
             return
         visual = latest.visual
-        if visual is not None:
+        if visual is not None and type(visual) is not PersonaBuddyVisualSnapshot:
+            return
+        if visual is not None and visual.available:
+            captured_visual = snapshot.visual
             if (
-                visual.source != "local"
+                type(captured_visual) is not PersonaBuddyVisualSnapshot
+                or not captured_visual.available
+                or visual.graph_identity != captured_visual.graph_identity
+                or visual.cache_identity != captured_visual.cache_identity
                 or visual.persona_id != selection.local_persona_id
                 or visual.persona_revision != revision
+                or type(visual.graph_identity) is not PersonaVisualIdentity
+                or visual.graph_identity not in actor_identities
+                or type(visual.cache_identity) is not PersonaVisualCacheIdentity
+                or visual.cache_identity.graph != visual.graph_identity
+                or visual.cache_identity.requested_state != visual.requested_state
+                or visual.cache_identity.resolved_state != visual.resolved_state
+                or visual.cache_identity.animation_id != visual.animation_id
             ):
                 return
+        elif visual is not None:
             if (
-                visual.graph_identity is not None
-                and visual.graph_identity not in actor_identities
+                visual != snapshot.visual
+                or visual.persona_id != selection.local_persona_id
+                or visual.persona_revision != revision
+                or visual.graph_identity is not None
+                or visual.cache_identity is not None
             ):
                 return
+        elif snapshot.visual is not None:
+            return
         controller.invalidate_profile()
         reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
         if callable(reconcile):

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -423,6 +423,19 @@ class _CharacterTTSControlSnapshot:
     )
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class _PersonaBuddyActionAuthority:
+    """Immutable Workbench and app-owner authority for one explicit action."""
+
+    action: str
+    source: str
+    persona_id: str
+    revision: int
+    session_generation: int
+    scope_service: object = dataclasses.field(repr=False, compare=False)
+    controller: object = dataclasses.field(repr=False, compare=False)
+
+
 class _CharacterTTSAuthorityUnavailable(RuntimeError):
     """Stable character authority could not be proved."""
 
@@ -957,6 +970,7 @@ class PersonasScreen(BaseAppScreen):
         self._persona_visual_publication_inflight = False
         self._profile_save_inflight: bool = False
         self._profile_save_operation_inflight: bool = False
+        self._persona_buddy_session_generation: int = 0
         # Mirrors _profile_save_inflight for the character editor: guards
         # against a re-entrant Save (double-click/Ctrl+S) while an earlier
         # save for this session is still persisting.
@@ -1267,6 +1281,7 @@ class PersonasScreen(BaseAppScreen):
         )
         if self._restored_from_saved_state:
             names = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
+            self._advance_persona_buddy_session()
             self.state = PersonasWorkbenchState(
                 **{k: v for k, v in wb.items() if k in names}
             )
@@ -1321,6 +1336,7 @@ class PersonasScreen(BaseAppScreen):
                 f"Could not restore Personas selection {kind}/{entity_id}; "
                 "clearing selection."
             )
+            self._advance_persona_buddy_session()
             self.state.clear_selection()
             self._restored_from_saved_state = False
             try:
@@ -1491,6 +1507,7 @@ class PersonasScreen(BaseAppScreen):
         normalized = str(runtime_backend or "").strip().lower()
         if normalized not in {"local", "server"}:
             return
+        self._advance_persona_buddy_session()
         self._next_character_page_generation()
         active_mode = self.state.active_mode
         self.runtime_backend = normalized
@@ -1521,6 +1538,7 @@ class PersonasScreen(BaseAppScreen):
             self._sync_title_and_console_actions()
 
     async def on_unmount(self) -> None:
+        self._advance_persona_buddy_session()
         self._character_tts_request_generation += 1
         self._character_tts_snapshot = None
         self._clear_character_tts_profile_suggestion()
@@ -3599,6 +3617,7 @@ class PersonasScreen(BaseAppScreen):
         self._sync_personas_rails()
 
     async def _apply_mode(self, mode: str) -> None:
+        self._advance_persona_buddy_session()
         if mode != "characters":
             self._clear_character_tts_profile_suggestion()
         self._cancel_search_debounce()
@@ -3772,6 +3791,12 @@ class PersonasScreen(BaseAppScreen):
 
     # ===== Selection =====
 
+    def _advance_persona_buddy_session(self) -> int:
+        """Invalidate every older Buddy action, including ABA transitions."""
+
+        self._persona_buddy_session_generation += 1
+        return self._persona_buddy_session_generation
+
     @on(PersonaEntitySelected)
     async def _handle_entity_selected(self, message: PersonaEntitySelected) -> None:
         message.stop()
@@ -3848,6 +3873,7 @@ class PersonasScreen(BaseAppScreen):
     async def _select_character(
         self, entity_id: str, entity_name: str, *, restore_preview: dict | None = None
     ) -> None:
+        self._advance_persona_buddy_session()
         server_record: dict | None = None
         if self.state.runtime_source == "server":
             fetched = await self._fetch_server_character(entity_id)
@@ -3922,6 +3948,11 @@ class PersonasScreen(BaseAppScreen):
         self._sync_local_character_actions()
 
     async def _select_profile(self, entity_id: str, entity_name: str) -> None:
+        session_generation = self._advance_persona_buddy_session()
+        source = self.persona_handler.current_mode()
+        scope_service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
         self.state.select_entity(
             entity_kind="persona",
             entity_id=entity_id,
@@ -3929,7 +3960,20 @@ class PersonasScreen(BaseAppScreen):
         )
         self._edit_mode = "view"
         self.query_one(PersonasLibraryPane).mark_active_row("persona", entity_id)
-        record = await self._fetch_profile_record(entity_id)
+        record, complete = await self._fetch_profile_record_checked(entity_id)
+        if (
+            session_generation != self._persona_buddy_session_generation
+            or getattr(
+                self.app_instance, "character_persona_scope_service", None
+            )
+            is not scope_service
+            or self.state.active_mode != "personas"
+            or self.state.runtime_source != source
+            or self.persona_handler.current_mode() != source
+            or self.state.selected_entity_kind != "persona"
+            or self.state.selected_entity_id != entity_id
+        ):
+            return
         self.query_one(PersonaProfileCardWidget).show_persona(record)
         self._show_center("#ccp-persona-card-view")
         inspector = self.query_one(PersonasInspectorPane)
@@ -3937,9 +3981,10 @@ class PersonasScreen(BaseAppScreen):
         inspector.show_selection(
             name=entity_name,
             kind="persona",
-            source=self.persona_handler.current_mode(),
+            source=source,
             entity_id=entity_id,
             revision=revision if type(revision) is int else None,
+            profile_current=complete,
             active=(
                 record.get("is_active", True) is True
                 and record.get("deleted", False) is False
@@ -3959,6 +4004,7 @@ class PersonasScreen(BaseAppScreen):
 
     async def _select_dictionary(self, entity_id: str, entity_name: str) -> None:
         """Load one dictionary into the center detail; inspector shows the selection."""
+        self._advance_persona_buddy_session()
         service = self._dictionary_scope_service()
         if service is None:
             self._notify("Dictionaries service is not configured.", "error")
@@ -4031,6 +4077,7 @@ class PersonasScreen(BaseAppScreen):
         return record, entries
 
     async def _select_lore_entry(self, entity_id: str, entity_name: str) -> None:
+        self._advance_persona_buddy_session()
         """Load one lore/world book into the center detail; inspector shows the selection."""
         manager = self._lore_manager()
         if manager is None:
@@ -5778,81 +5825,122 @@ class PersonasScreen(BaseAppScreen):
 
     def _persona_buddy_action_context_is_current(
         self,
-        message: PersonaBuddyActionRequested,
-        *,
-        scope_service: object,
-        controller: object,
+        authority: _PersonaBuddyActionAuthority,
     ) -> bool:
         """Revalidate every Workbench owner behind one explicit Buddy action."""
 
         return bool(
             self.is_mounted
             and getattr(self.app_instance, "character_persona_scope_service", None)
-            is scope_service
-            and getattr(self.app, "persona_buddy_controller", None) is controller
+            is authority.scope_service
+            and getattr(self.app, "persona_buddy_controller", None)
+            is authority.controller
+            and self._persona_buddy_session_generation
+            == authority.session_generation
             and self.state.active_mode == "personas"
-            and self.state.runtime_source == message.source
-            and self.persona_handler.current_mode() == message.source
+            and self.state.runtime_source == authority.source
+            and self.persona_handler.current_mode() == authority.source
             and self.state.selected_entity_kind == "persona"
-            and self.state.selected_entity_id == message.persona_id
+            and self.state.selected_entity_id == authority.persona_id
             and not self.state.has_unsaved_changes
         )
 
     @staticmethod
     def _persona_buddy_record_is_eligible(
-        record: Mapping[str, object], message: PersonaBuddyActionRequested
+        record: Mapping[str, object], authority: _PersonaBuddyActionAuthority
     ) -> bool:
         """Return whether a complete record still matches local action authority."""
 
         return bool(
-            message.source == "local"
-            and str(record.get("id") or "") == message.persona_id
+            authority.source == "local"
+            and str(record.get("id") or "") == authority.persona_id
             and type(record.get("version")) is int
-            and record.get("version") == message.revision
+            and record.get("version") == authority.revision
             and record.get("is_active", True) is True
             and record.get("deleted", False) is False
         )
 
+    @staticmethod
+    async def _fetch_persona_buddy_action_record(
+        authority: _PersonaBuddyActionAuthority,
+    ) -> Mapping[str, object] | None:
+        """Fetch a full record only through the request's captured service."""
+
+        getter = getattr(authority.scope_service, "get_persona_profile", None)
+        if not callable(getter):
+            return None
+        try:
+            record = await getter(authority.persona_id, mode=authority.source)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Persona Buddy action profile refresh failed "
+                "(category=profile_unavailable)."
+            )
+            return None
+        if hasattr(record, "model_dump"):
+            record = record.model_dump(mode="json")
+        return record if isinstance(record, Mapping) else None
+
     @on(PersonaBuddyActionRequested)
-    async def _handle_persona_buddy_action(
-        self, message: PersonaBuddyActionRequested
-    ) -> None:
-        """Persist one explicit local-Persona Buddy ownership or view command."""
+    def _handle_persona_buddy_action(self, message: PersonaBuddyActionRequested) -> None:
+        """Capture one action session and run it as a replaceable screen worker."""
 
         message.stop()
         scope_service = getattr(
             self.app_instance, "character_persona_scope_service", None
         )
         controller = getattr(self.app, "persona_buddy_controller", None)
+        authority = _PersonaBuddyActionAuthority(
+            action=message.action,
+            source=message.source,
+            persona_id=message.persona_id,
+            revision=message.revision,
+            session_generation=self._advance_persona_buddy_session(),
+            scope_service=scope_service,
+            controller=controller,
+        )
+        self.run_worker(
+            self._run_persona_buddy_action(authority),
+            group="personas-buddy-action",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    async def _run_persona_buddy_action(
+        self, authority: _PersonaBuddyActionAuthority
+    ) -> None:
+        """Persist one explicit action behind exact ABA-safe authority."""
+
+        scope_service = authority.scope_service
+        controller = authority.controller
         if (
-            message.source != "local"
+            authority.source != "local"
             or scope_service is None
             or controller is None
-            or not self._persona_buddy_action_context_is_current(
-                message, scope_service=scope_service, controller=controller
-            )
+            or not self._persona_buddy_action_context_is_current(authority)
         ):
             self._notify(
                 "Persona Buddy is available for active local Personas.", "warning"
             )
             return
 
-        record, complete = await self._fetch_profile_record_checked(message.persona_id)
+        record = await self._fetch_persona_buddy_action_record(authority)
         if (
-            not complete
-            or not self._persona_buddy_action_context_is_current(
-                message, scope_service=scope_service, controller=controller
-            )
-            or not self._persona_buddy_record_is_eligible(record, message)
+            record is None
+            or not self._persona_buddy_action_context_is_current(authority)
+            or not self._persona_buddy_record_is_eligible(record, authority)
         ):
-            self._notify(
-                "Persona Buddy is available for active local Personas.", "warning"
-            )
+            if self._persona_buddy_action_context_is_current(authority):
+                self._notify(
+                    "Persona Buddy is available for active local Personas.", "warning"
+                )
             return
 
         current = controller.current_preferences()
-        selection = PersonaBuddySelection("local", message.persona_id)
-        if message.action == "use":
+        selection = PersonaBuddySelection("local", authority.persona_id)
+        if authority.action == "use":
             changes: dict[str, object] = {
                 "selection": selection,
                 "enabled": True,
@@ -5861,9 +5949,9 @@ class PersonasScreen(BaseAppScreen):
         elif current.selection != selection:
             self._notify("Use this Persona for Buddy first.", "warning")
             return
-        elif message.action == "show":
+        elif authority.action == "show":
             changes = {"enabled": True, "open": True}
-        elif message.action == "close":
+        elif authority.action == "close":
             changes = {"open": False}
         else:
             changes = {"enabled": False}
@@ -5880,25 +5968,19 @@ class PersonasScreen(BaseAppScreen):
                 "Persona Buddy preference update failed "
                 "(category=preference_update_failed)."
             )
-            if self._persona_buddy_action_context_is_current(
-                message, scope_service=scope_service, controller=controller
-            ):
+            if self._persona_buddy_action_context_is_current(authority):
                 self._notify("Persona Buddy preference could not be saved.", "error")
             return
-        if not self._persona_buddy_action_context_is_current(
-            message, scope_service=scope_service, controller=controller
-        ):
+        if not self._persona_buddy_action_context_is_current(authority):
             return
         if not persisted:
             self._notify("Persona Buddy preference could not be saved.", "error")
             return
-        record, complete = await self._fetch_profile_record_checked(message.persona_id)
+        record = await self._fetch_persona_buddy_action_record(authority)
         if (
-            not complete
-            or not self._persona_buddy_action_context_is_current(
-                message, scope_service=scope_service, controller=controller
-            )
-            or not self._persona_buddy_record_is_eligible(record, message)
+            record is None
+            or not self._persona_buddy_action_context_is_current(authority)
+            or not self._persona_buddy_record_is_eligible(record, authority)
         ):
             return
         latest = controller.snapshot()
@@ -5917,13 +5999,13 @@ class PersonasScreen(BaseAppScreen):
                 logger.warning(
                     "Persona Buddy view refresh failed (category=view_refresh_failed)."
                 )
-                if self._persona_buddy_action_context_is_current(
-                    message, scope_service=scope_service, controller=controller
-                ):
+                if self._persona_buddy_action_context_is_current(authority):
                     self._notify(
                         "Persona Buddy was updated, but its view could not refresh.",
                         "warning",
                     )
+            if not self._persona_buddy_action_context_is_current(authority):
+                return
 
     @on(CharacterMessage.Loaded)
     async def _handle_character_loaded(self, message: CharacterMessage.Loaded) -> None:
@@ -6025,6 +6107,7 @@ class PersonasScreen(BaseAppScreen):
     async def _begin_create_character(self) -> None:
         if not self._local_character_actions_allowed():
             return
+        self._advance_persona_buddy_session()
         self._discard_visual_identity_authoring()
         self._character_editor_generation += 1
         # A picked image-gen style is scoped to the editor session that
@@ -6058,6 +6141,7 @@ class PersonasScreen(BaseAppScreen):
         self.call_after_refresh(self._focus_editor_name)
 
     async def _begin_create_profile(self) -> None:
+        self._advance_persona_buddy_session()
         await self._discard_persona_visual_authoring_async()
         self._persona_visual_generation += 1
         self._edit_mode = "create"
@@ -6402,6 +6486,7 @@ class PersonasScreen(BaseAppScreen):
         if str(message.persona_id) != (self.state.selected_entity_id or ""):
             self._notify("Selection out of sync; reselect the persona.", "warning")
             return
+        self._advance_persona_buddy_session()
         record = await self._fetch_profile_record(str(message.persona_id))
         self._edit_mode = "edit"
         # A new session starts unclaimed (see _begin_create_profile).
@@ -7109,9 +7194,70 @@ class PersonasScreen(BaseAppScreen):
         if controller is None:
             return
         snapshot = controller.snapshot()
-        visual = getattr(snapshot, "visual", None)
-        if getattr(visual, "graph_identity", None) not in identities:
+        selection = getattr(snapshot, "selection", None)
+        if type(selection) is not PersonaBuddySelection or selection.source != "local":
             return
+        actor_identities = tuple(
+            identity
+            for identity in identities
+            if identity.persona_id == selection.local_persona_id
+        )
+        if not actor_identities:
+            return
+        scope_service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        getter = getattr(scope_service, "get_persona_profile", None)
+        if not callable(getter):
+            return
+        try:
+            record = await getter(selection.local_persona_id, mode="local")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Persona Buddy publication authority refresh failed "
+                "(category=profile_unavailable)."
+            )
+            return
+        if hasattr(record, "model_dump"):
+            record = record.model_dump(mode="json")
+        revision = record.get("version") if isinstance(record, Mapping) else None
+        if (
+            not isinstance(record, Mapping)
+            or str(record.get("id") or "") != selection.local_persona_id
+            or type(revision) is not int
+            or record.get("is_active", True) is not True
+            or record.get("deleted", False) is not False
+            or result.new_identity.persona_id != selection.local_persona_id
+            or result.new_identity.persona_revision != revision
+        ):
+            return
+        latest = controller.snapshot()
+        if (
+            getattr(self.app, "persona_buddy_controller", None) is not controller
+            or getattr(
+                self.app_instance, "character_persona_scope_service", None
+            )
+            is not scope_service
+            or latest.selection != selection
+            or latest.preferences_generation != snapshot.preferences_generation
+            or latest.profile_generation != snapshot.profile_generation
+        ):
+            return
+        visual = latest.visual
+        if visual is not None:
+            if (
+                visual.source != "local"
+                or visual.persona_id != selection.local_persona_id
+                or visual.persona_revision != revision
+            ):
+                return
+            if (
+                visual.graph_identity is not None
+                and visual.graph_identity not in actor_identities
+            ):
+                return
         controller.invalidate_profile()
         reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
         if callable(reconcile):
@@ -11654,6 +11800,7 @@ class PersonasScreen(BaseAppScreen):
                     deleted_ids.add(str(entity_id))
             # Selection cleanup when the selection was among the deleted.
             if str(self.state.selected_entity_id or "") in deleted_ids:
+                self._advance_persona_buddy_session()
                 self.state.clear_selection()
                 self.state.has_unsaved_changes = False
                 try:
@@ -11901,6 +12048,7 @@ class PersonasScreen(BaseAppScreen):
                 )
                 self._notify(f"Delete failed: {exc}", "error")
                 return
+            self._advance_persona_buddy_session()
             self.state.clear_selection()
             self.state.has_unsaved_changes = False
             self._selected_dictionary_version = None
@@ -11940,6 +12088,7 @@ class PersonasScreen(BaseAppScreen):
             if not ok:
                 self._notify(conflict_copy.format(noun="lore book"), "error")
                 return
+            self._advance_persona_buddy_session()
             self.state.clear_selection()
             self.state.has_unsaved_changes = False
             self._selected_lore_book_version = None
@@ -12019,6 +12168,7 @@ class PersonasScreen(BaseAppScreen):
         expected_mode = "characters" if kind == "character" else "personas"
         stale = not self.is_mounted or self.state.active_mode != expected_mode
         if not stale:
+            self._advance_persona_buddy_session()
             self.state.clear_selection()
             self.state.has_unsaved_changes = False
             self._edit_mode = "view"
@@ -12391,6 +12541,7 @@ class PersonasScreen(BaseAppScreen):
             return
         self._profile_save_inflight = True
         self._profile_save_operation_inflight = True
+        self._advance_persona_buddy_session()
         # mode/persona_id are read INSIDE the try (rather than before it) so
         # a raise from either (e.g. current_mode()) is caught below, which
         # resets the inflight flag; reading them ahead of the try would let
@@ -12490,6 +12641,7 @@ class PersonasScreen(BaseAppScreen):
             # Leave the selection, inspector, and center pane alone.
             return
         self._edit_mode = "edit"  # create -> edit stays in the editor
+        self._advance_persona_buddy_session()
         self.state.has_unsaved_changes = False
         self._set_active_row_unsaved(False)
         name = str(saved.get("name") or "Saved persona")
@@ -12504,6 +12656,7 @@ class PersonasScreen(BaseAppScreen):
             source=self.persona_handler.current_mode(),
             entity_id=saved_id,
             revision=revision if type(revision) is int else None,
+            profile_current=True,
             active=(
                 saved.get("is_active", True) is True
                 and saved.get("deleted", False) is False
@@ -12576,6 +12729,7 @@ class PersonasScreen(BaseAppScreen):
         await self._run_guarded(_finish)
 
     def _finish_cancel_profile_edit(self) -> None:
+        self._advance_persona_buddy_session()
         self._discard_persona_visual_authoring()
         self._persona_visual_generation += 1
         self._edit_mode = "view"

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -108,6 +108,7 @@ from ...Persona_Visual.publication import (
     publish_persona_visual,
 )
 from ...Persona_Visual.repository import PersonaVisualIdentity, PersonaVisualRepository
+from ...Persona_Buddy import PersonaBuddySelection
 from ...TTS import (
     AssignedTTSProfileSnapshot,
     CharacterRef,
@@ -199,6 +200,7 @@ from ...Widgets.Persona_Widgets.personas_library_pane import (
 )
 from ...Widgets.Persona_Widgets.personas_messages import (
     PersonaActionRequested,
+    PersonaBuddyActionRequested,
     PersonaEntitySelected,
     PersonaMarksChanged,
     PersonaPageChanged,
@@ -3931,7 +3933,18 @@ class PersonasScreen(BaseAppScreen):
         self.query_one(PersonaProfileCardWidget).show_persona(record)
         self._show_center("#ccp-persona-card-view")
         inspector = self.query_one(PersonasInspectorPane)
-        inspector.show_selection(name=entity_name, kind="persona")
+        revision = record.get("version")
+        inspector.show_selection(
+            name=entity_name,
+            kind="persona",
+            source=self.persona_handler.current_mode(),
+            entity_id=entity_id,
+            revision=revision if type(revision) is int else None,
+            active=(
+                record.get("is_active", True) is True
+                and record.get("deleted", False) is False
+            ),
+        )
         # Drop any previous character's portrait: the rail must never show a
         # face that belongs to a different selection.
         inspector.set_avatar_thumbnail(None)
@@ -5763,6 +5776,155 @@ class PersonasScreen(BaseAppScreen):
         event.stop()
         await self._attach_selection_to_console(intent="start_chat")
 
+    def _persona_buddy_action_context_is_current(
+        self,
+        message: PersonaBuddyActionRequested,
+        *,
+        scope_service: object,
+        controller: object,
+    ) -> bool:
+        """Revalidate every Workbench owner behind one explicit Buddy action."""
+
+        return bool(
+            self.is_mounted
+            and getattr(self.app_instance, "character_persona_scope_service", None)
+            is scope_service
+            and getattr(self.app, "persona_buddy_controller", None) is controller
+            and self.state.active_mode == "personas"
+            and self.state.runtime_source == message.source
+            and self.persona_handler.current_mode() == message.source
+            and self.state.selected_entity_kind == "persona"
+            and self.state.selected_entity_id == message.persona_id
+            and not self.state.has_unsaved_changes
+        )
+
+    @staticmethod
+    def _persona_buddy_record_is_eligible(
+        record: Mapping[str, object], message: PersonaBuddyActionRequested
+    ) -> bool:
+        """Return whether a complete record still matches local action authority."""
+
+        return bool(
+            message.source == "local"
+            and str(record.get("id") or "") == message.persona_id
+            and type(record.get("version")) is int
+            and record.get("version") == message.revision
+            and record.get("is_active", True) is True
+            and record.get("deleted", False) is False
+        )
+
+    @on(PersonaBuddyActionRequested)
+    async def _handle_persona_buddy_action(
+        self, message: PersonaBuddyActionRequested
+    ) -> None:
+        """Persist one explicit local-Persona Buddy ownership or view command."""
+
+        message.stop()
+        scope_service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        controller = getattr(self.app, "persona_buddy_controller", None)
+        if (
+            message.source != "local"
+            or scope_service is None
+            or controller is None
+            or not self._persona_buddy_action_context_is_current(
+                message, scope_service=scope_service, controller=controller
+            )
+        ):
+            self._notify(
+                "Persona Buddy is available for active local Personas.", "warning"
+            )
+            return
+
+        record, complete = await self._fetch_profile_record_checked(message.persona_id)
+        if (
+            not complete
+            or not self._persona_buddy_action_context_is_current(
+                message, scope_service=scope_service, controller=controller
+            )
+            or not self._persona_buddy_record_is_eligible(record, message)
+        ):
+            self._notify(
+                "Persona Buddy is available for active local Personas.", "warning"
+            )
+            return
+
+        current = controller.current_preferences()
+        selection = PersonaBuddySelection("local", message.persona_id)
+        if message.action == "use":
+            changes: dict[str, object] = {
+                "selection": selection,
+                "enabled": True,
+                "open": True,
+            }
+        elif current.selection != selection:
+            self._notify("Use this Persona for Buddy first.", "warning")
+            return
+        elif message.action == "show":
+            changes = {"enabled": True, "open": True}
+        elif message.action == "close":
+            changes = {"open": False}
+        else:
+            changes = {"enabled": False}
+
+        try:
+            preferences_revision = controller.apply_preferences_patch(**changes)
+            persisted = await controller.persist_preferences_revision(
+                preferences_revision
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Persona Buddy preference update failed "
+                "(category=preference_update_failed)."
+            )
+            if self._persona_buddy_action_context_is_current(
+                message, scope_service=scope_service, controller=controller
+            ):
+                self._notify("Persona Buddy preference could not be saved.", "error")
+            return
+        if not self._persona_buddy_action_context_is_current(
+            message, scope_service=scope_service, controller=controller
+        ):
+            return
+        if not persisted:
+            self._notify("Persona Buddy preference could not be saved.", "error")
+            return
+        record, complete = await self._fetch_profile_record_checked(message.persona_id)
+        if (
+            not complete
+            or not self._persona_buddy_action_context_is_current(
+                message, scope_service=scope_service, controller=controller
+            )
+            or not self._persona_buddy_record_is_eligible(record, message)
+        ):
+            return
+        latest = controller.snapshot()
+        preferences = controller.current_preferences()
+        if latest.preferences_generation < preferences_revision or any(
+            getattr(preferences, field) != value for field, value in changes.items()
+        ):
+            return
+        reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
+        if callable(reconcile):
+            try:
+                await reconcile()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Persona Buddy view refresh failed (category=view_refresh_failed)."
+                )
+                if self._persona_buddy_action_context_is_current(
+                    message, scope_service=scope_service, controller=controller
+                ):
+                    self._notify(
+                        "Persona Buddy was updated, but its view could not refresh.",
+                        "warning",
+                    )
+
     @on(CharacterMessage.Loaded)
     async def _handle_character_loaded(self, message: CharacterMessage.Loaded) -> None:
         message.stop()
@@ -6942,6 +7104,25 @@ class PersonasScreen(BaseAppScreen):
                 logger.warning(
                     "Persona Visual invalidation failed "
                     "(category=cache_invalidation_failed)."
+                )
+        controller = getattr(self.app, "persona_buddy_controller", None)
+        if controller is None:
+            return
+        snapshot = controller.snapshot()
+        visual = getattr(snapshot, "visual", None)
+        if getattr(visual, "graph_identity", None) not in identities:
+            return
+        controller.invalidate_profile()
+        reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
+        if callable(reconcile):
+            try:
+                await reconcile()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Persona Buddy publication refresh failed "
+                    "(category=view_refresh_failed)."
                 )
 
     async def _save_persona_visual_pack(self) -> bool:
@@ -11519,13 +11700,16 @@ class PersonasScreen(BaseAppScreen):
                 raise ValueError("personas service is not configured")
             record = await self._fetch_profile_record(entity_id)
             raw_version = record.get("version")
+            mode = self.persona_handler.current_mode()
             await service.delete_persona_profile(
                 entity_id,
                 expected_version=(
                     int(raw_version) if raw_version is not None else None
                 ),
-                mode=self.persona_handler.current_mode(),
+                mode=mode,
             )
+            if mode == "local":
+                await self._refresh_persona_buddy_lifecycle(entity_id)
             return
         if kind == "dictionary":
             service = self._dictionary_scope_service()
@@ -11779,10 +11963,11 @@ class PersonasScreen(BaseAppScreen):
                 self._notify("Delete failed: personas are unavailable.", "error")
                 return
             try:
+                mode = self.persona_handler.current_mode()
                 await service.delete_persona_profile(
                     entity_id,
                     expected_version=version,
-                    mode=self.persona_handler.current_mode(),
+                    mode=mode,
                 )
             except Exception as exc:
                 logger.opt(exception=True).error(
@@ -11796,7 +11981,31 @@ class PersonasScreen(BaseAppScreen):
                 else:
                     self._notify(f"Delete failed: {exc}", "error")
                 return
+            if mode == "local":
+                await self._refresh_persona_buddy_lifecycle(entity_id)
         await self._after_delete(kind)
+
+    async def _refresh_persona_buddy_lifecycle(self, persona_id: str) -> None:
+        """Re-resolve the explicitly selected local Persona after a durable change."""
+
+        controller = getattr(self.app, "persona_buddy_controller", None)
+        if controller is None:
+            return
+        snapshot = controller.snapshot()
+        if snapshot.selection != PersonaBuddySelection("local", str(persona_id)):
+            return
+        controller.invalidate_profile()
+        reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
+        if not callable(reconcile):
+            return
+        try:
+            await reconcile()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Persona Buddy lifecycle refresh failed (category=view_refresh_failed)."
+            )
 
     async def _after_delete(self, kind: str) -> None:
         if kind == "character" and not self._local_character_actions_allowed():
@@ -12251,11 +12460,13 @@ class PersonasScreen(BaseAppScreen):
         saved = dict(result)
         saved.setdefault("id", persona_id)
         try:
-            await self._after_profile_save(saved)
+            await self._after_profile_save(saved, source=mode)
         finally:
             self._profile_save_operation_inflight = False
 
-    async def _after_profile_save(self, saved: dict) -> None:
+    async def _after_profile_save(
+        self, saved: dict, *, source: str | None = None
+    ) -> None:
         # Refresh the cached profile list tolerantly even when the user has
         try:
             profiles = await self.persona_handler.refresh_persona_list(
@@ -12270,6 +12481,9 @@ class PersonasScreen(BaseAppScreen):
         else:
             self._profile_lookup_recovery_state = None
         self._profiles = [dict(record) for record in (profiles or [])]
+        saved_id = str(saved.get("id") or "")
+        if saved_id and source == "local":
+            await self._refresh_persona_buddy_lifecycle(saved_id)
         self._update_purpose_line()
         self._update_purpose_line()
         if not self.is_mounted or self.state.active_mode != "personas":
@@ -12278,13 +12492,23 @@ class PersonasScreen(BaseAppScreen):
         self._edit_mode = "edit"  # create -> edit stays in the editor
         self.state.has_unsaved_changes = False
         self._set_active_row_unsaved(False)
-        saved_id = str(saved.get("id") or "")
         name = str(saved.get("name") or "Saved persona")
         self.state.select_entity(
             entity_kind="persona", entity_id=saved_id, entity_name=name
         )
         inspector = self.query_one(PersonasInspectorPane)
-        inspector.show_selection(name=name, kind="persona")
+        revision = saved.get("version")
+        inspector.show_selection(
+            name=name,
+            kind="persona",
+            source=self.persona_handler.current_mode(),
+            entity_id=saved_id,
+            revision=revision if type(revision) is int else None,
+            active=(
+                saved.get("is_active", True) is True
+                and saved.get("deleted", False) is False
+            ),
+        )
         inspector.set_unsaved(False)
         inspector.show_validation(())
         self._sync_inspector_console_actions()

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -972,6 +972,7 @@ class PersonasScreen(BaseAppScreen):
         self._profile_save_inflight: bool = False
         self._profile_save_operation_inflight: bool = False
         self._persona_buddy_session_generation: int = 0
+        self._persona_buddy_action_lock = asyncio.Lock()
         # Mirrors _profile_save_inflight for the character editor: guards
         # against a re-entrant Save (double-click/Ctrl+S) while an earlier
         # save for this session is still persisting.
@@ -3996,6 +3997,7 @@ class PersonasScreen(BaseAppScreen):
         inspector.set_avatar_thumbnail(None)
         inspector.set_unsaved(False)
         inspector.show_validation(())
+        self._sync_inspector_buddy_status()
         self._sync_inspector_console_actions()
         # Persona profiles have no conversation linkage in the local data.
         self.conversations.reset()
@@ -5725,6 +5727,29 @@ class PersonasScreen(BaseAppScreen):
             provider_block_reason=self._provider_send_block_reason(),
         )
 
+    def _sync_inspector_buddy_status(self) -> None:
+        """Push exact app-owned Buddy ownership and visibility into Inspector."""
+
+        try:
+            inspector = self.query_one(PersonasInspectorPane)
+        except QueryError:
+            return
+        controller = getattr(self.app, "persona_buddy_controller", None)
+        snapshot = controller.snapshot() if controller is not None else None
+        selection = getattr(snapshot, "selection", None)
+        inspector.set_buddy_status(
+            source=(
+                selection.source if type(selection) is PersonaBuddySelection else None
+            ),
+            persona_id=(
+                selection.local_persona_id
+                if type(selection) is PersonaBuddySelection
+                else None
+            ),
+            enabled=getattr(snapshot, "enabled", False) is True,
+            open=getattr(snapshot, "open", True) is True,
+        )
+
     async def _selection_handoff_body(self) -> str | None:
         """Readable card summary for the selected item, or ``None`` when stale."""
         kind = self.state.selected_entity_kind
@@ -5885,7 +5910,9 @@ class PersonasScreen(BaseAppScreen):
         return record if isinstance(record, Mapping) else None
 
     @on(PersonaBuddyActionRequested)
-    def _handle_persona_buddy_action(self, message: PersonaBuddyActionRequested) -> None:
+    def _handle_persona_buddy_action(
+        self, message: PersonaBuddyActionRequested
+    ) -> None:
         """Capture one action session and run it as a replaceable screen worker."""
 
         message.stop()
@@ -5939,55 +5966,74 @@ class PersonasScreen(BaseAppScreen):
                 )
             return
 
-        current = controller.current_preferences()
         selection = PersonaBuddySelection("local", authority.persona_id)
-        if authority.action == "use":
-            changes: dict[str, object] = {
-                "selection": selection,
-                "enabled": True,
-                "open": True,
-            }
-        elif current.selection != selection:
-            self._notify("Use this Persona for Buddy first.", "warning")
-            return
-        elif authority.action == "show":
-            changes = {"enabled": True, "open": True}
-        elif authority.action == "close":
-            changes = {"open": False}
-        else:
-            changes = {"enabled": False}
+        async with self._persona_buddy_action_lock:
+            if not self._persona_buddy_action_context_is_current(authority):
+                return
+            current = controller.current_preferences()
+            if authority.action == "use":
+                changes: dict[str, object] = {
+                    "selection": selection,
+                    "enabled": True,
+                    "open": True,
+                }
+            elif current.selection != selection:
+                self._notify("Use this Persona for Buddy first.", "warning")
+                return
+            elif authority.action == "show":
+                changes = {"enabled": True, "open": True}
+            elif authority.action == "close":
+                changes = {"open": False}
+            else:
+                changes = {"enabled": False}
 
-        try:
-            preferences_revision = controller.apply_preferences_patch(**changes)
-            persisted = await controller.persist_preferences_revision(
-                preferences_revision
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.warning(
-                "Persona Buddy preference update failed "
-                "(category=preference_update_failed)."
-            )
-            if self._persona_buddy_action_context_is_current(authority):
-                self._notify("Persona Buddy preference could not be saved.", "error")
-            return
-        if not self._persona_buddy_action_context_is_current(authority):
-            return
-        if not persisted:
-            self._notify("Persona Buddy preference could not be saved.", "error")
-            return
+            candidate = dataclasses.replace(current, **changes)
+            if candidate != current:
+
+                async def restore_previous_action_fields() -> None:
+                    latest_preferences = controller.current_preferences()
+                    rollback = dataclasses.replace(
+                        latest_preferences,
+                        **{field: getattr(current, field) for field in changes},
+                    )
+                    if rollback != latest_preferences:
+                        await controller.update_preferences(rollback)
+
+                try:
+                    await controller.update_preferences(candidate)
+                except asyncio.CancelledError:
+                    if not self._persona_buddy_action_context_is_current(authority):
+                        await restore_previous_action_fields()
+                    raise
+                except Exception:
+                    logger.warning(
+                        "Persona Buddy preference update failed "
+                        "(category=preference_update_failed)."
+                    )
+                    if self._persona_buddy_action_context_is_current(authority):
+                        self._notify(
+                            "Persona Buddy preference could not be saved.", "error"
+                        )
+                    return
+                if not self._persona_buddy_action_context_is_current(authority):
+                    await restore_previous_action_fields()
+                    return
+                preferences = controller.current_preferences()
+                if any(
+                    getattr(preferences, field) != value
+                    for field, value in changes.items()
+                ):
+                    self._notify(
+                        "Persona Buddy preference could not be saved.", "error"
+                    )
+                    return
+            self._sync_inspector_buddy_status()
+
         record = await self._fetch_persona_buddy_action_record(authority)
         if (
             record is None
             or not self._persona_buddy_action_context_is_current(authority)
             or not self._persona_buddy_record_is_eligible(record, authority)
-        ):
-            return
-        latest = controller.snapshot()
-        preferences = controller.current_preferences()
-        if latest.preferences_generation < preferences_revision or any(
-            getattr(preferences, field) != value for field, value in changes.items()
         ):
             return
         reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
@@ -12165,6 +12211,7 @@ class PersonasScreen(BaseAppScreen):
         if snapshot.selection != PersonaBuddySelection("local", str(persona_id)):
             return
         controller.invalidate_profile()
+        self._sync_inspector_buddy_status()
         reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
         if not callable(reconcile):
             return
@@ -12685,6 +12732,7 @@ class PersonasScreen(BaseAppScreen):
         )
         inspector.set_unsaved(False)
         inspector.show_validation(())
+        self._sync_inspector_buddy_status()
         self._sync_inspector_console_actions()
         await self._render_profile_rows()
         # Save-in-place: the returned ``saved`` dict already carries the

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -7,6 +7,7 @@ import inspect
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
+from functools import partial
 from typing import Any
 
 from textual import events
@@ -29,9 +30,12 @@ _DEFAULT_WIDTH = 28
 _DEFAULT_HEIGHT = 12
 _MIN_WIDTH = 18
 _MIN_HEIGHT = 6
-_COMPACT_HEIGHT = 3
+_FULL_CONTENT_HEIGHT = 8
+_OPERABLE_WIDTH = 10
+_DUAL_CONTROL_WIDTH = 14
+_COLLAPSED_HEIGHT = 3
+_COMPACT_HEIGHT = 1
 _POLL_SECONDS = 0.10
-_FRAME_SECONDS = 0.01
 
 
 class PersonaBuddyWidget(Widget, can_focus=True):
@@ -117,34 +121,57 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         text-align: center;
     }
 
-    PersonaBuddyWidget.persona-buddy-collapsed,
-    PersonaBuddyWidget.persona-buddy-compact {
+    PersonaBuddyWidget.persona-buddy-collapsed {
         height: 3;
         padding: 0;
+    }
+
+    PersonaBuddyWidget.persona-buddy-compact {
+        height: 1;
+        padding: 0;
+        border: none;
     }
 
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-frame,
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-status,
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-hints,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-close,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-close,
-    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-drag-handle,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-drag-handle {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-drag-handle {
         display: none;
     }
 
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-header,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
-    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-collapse,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-collapse {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-collapse {
         height: 1;
         width: 100%;
         padding: 0;
         content-align: center middle;
         text-align: center;
+    }
+
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-drag-handle {
+        display: none;
+    }
+
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
+    PersonaBuddyWidget.persona-buddy-compact .persona-buddy-control {
+        height: 1;
+        width: 1fr;
+        min-width: 5;
+        padding: 0;
+        content-align: center middle;
+        text-align: center;
+    }
+
+    PersonaBuddyWidget.persona-buddy-minimal #persona-buddy-close {
+        display: none;
+    }
+
+    PersonaBuddyWidget.persona-buddy-minimal #persona-buddy-collapse {
+        width: 100%;
     }
     """
 
@@ -171,12 +198,15 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self._poll_timer: Timer | None = None
         self._frame_timer: Timer | None = None
         self._resolution_worker: Worker[None] | None = None
+        self._resolved_authority: tuple[object, ...] | None = None
+        self._requested_authority: tuple[object, ...] | None = None
         self._interaction: tuple[str, int, int, PersonaBuddyGeometry] | None = None
         self._next_frame_at = 0.0
+        self._frame_was_frozen = True
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="persona-buddy-header"):
-            yield Static("Buddy · drag", id="persona-buddy-drag-handle")
+            yield Static("Drag", id="persona-buddy-drag-handle")
             yield Button(
                 "Fold", id="persona-buddy-collapse", classes="persona-buddy-control"
             )
@@ -185,7 +215,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             )
         yield Static("Visual pending", id="persona-buddy-frame")
         yield Static("State: idle", id="persona-buddy-status")
-        yield Static("h/j/k/l move · Shift resize · 0 reset", id="persona-buddy-hints")
+        yield Static("hjkl move · HJKL size", id="persona-buddy-hints")
 
     def on_mount(self) -> None:
         """Start bounded snapshot and frame polling without changing focus."""
@@ -197,12 +227,6 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self._poll_timer = self.set_interval(
             _POLL_SECONDS, self.refresh_from_controller
         )
-        self._frame_timer = self.set_interval(_FRAME_SECONDS, self.advance_frame)
-        self._resolution_worker = self.run_worker(
-            self._resolution_loop(),
-            group="persona-buddy-visual-resolution",
-            exclusive=True,
-        )
 
     def on_unmount(self) -> None:
         """Release capture and stop view-owned timers during any teardown path."""
@@ -211,10 +235,19 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self.release_interaction_capture()
         if self._poll_timer is not None:
             self._poll_timer.stop()
-        if self._frame_timer is not None:
-            self._frame_timer.stop()
+        self._stop_frame_timer()
         if self._resolution_worker is not None:
             self._resolution_worker.cancel()
+
+    def resume_resolution(self) -> None:
+        """Restart resolution when a covering modal returns to this view."""
+
+        if not self._is_current_view():
+            return
+        worker = self._resolution_worker
+        if worker is not None and not worker.is_finished:
+            return
+        self.refresh_from_controller()
 
     def _is_current_view(self) -> bool:
         if not self.is_attached:
@@ -222,59 +255,111 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         return self._current_view(self) if self._current_view is not None else True
 
     async def _resolution_loop(self) -> None:
-        """Resolve one production visual at a time while this exact view is current."""
+        """Resolve only changed semantic authority while this view is current."""
 
         while self._is_current_view():
             snapshot = self._controller.snapshot()
-            if snapshot.enabled and snapshot.open and snapshot.selection is not None:
-                region = self.content_region
-                visual = await self._controller.resolve_current_visual(
-                    cols=max(1, region.width),
-                    lines=max(1, region.height),
+            authority = self._resolution_authority(snapshot)
+            if authority is None or authority == self._resolved_authority:
+                return
+            region = self.content_region
+            visual = await self._controller.resolve_current_visual(
+                cols=max(1, region.width),
+                lines=max(1, region.height),
+            )
+            if not self._is_current_view():
+                return
+            current_snapshot = self._controller.snapshot()
+            if self._resolution_authority(current_snapshot) != authority:
+                continue
+            self.refresh_from_controller(schedule_resolution=False)
+            self._resolved_authority = authority
+            current_visual = current_snapshot.visual
+            if (
+                visual is not None
+                and not visual.available
+                and current_visual is visual
+            ):
+                confirm = getattr(
+                    self.screen, "confirm_persona_buddy_unavailable", None
                 )
-                if not self._is_current_view():
-                    return
-                self.refresh_from_controller()
-                current_visual = self._controller.snapshot().visual
-                if (
-                    visual is not None
-                    and not visual.available
-                    and current_visual is visual
+                if not callable(confirm) or not confirm(
+                    view=self,
+                    controller=self._controller,
+                    snapshot=current_snapshot,
+                    visual=visual,
                 ):
-                    confirm = getattr(
-                        self.screen, "confirm_persona_buddy_unavailable", None
-                    )
-                    if not callable(confirm) or not confirm(
-                        view=self,
-                        controller=self._controller,
-                        snapshot=self._controller.snapshot(),
-                        visual=visual,
-                    ):
-                        await asyncio.sleep(_POLL_SECONDS)
-                        continue
-                    pending = self._reconcile()
-                    removed = False
-                    if inspect.isawaitable(pending):
-                        reconcile_worker = self.app.run_worker(
-                            pending,
-                            group="persona-buddy-unavailable-reconcile",
-                            exclusive=True,
-                        )
-                        removed = bool(await asyncio.shield(reconcile_worker.wait()))
-                    else:
-                        removed = bool(pending)
-                    if removed or not self._is_current_view():
-                        return
-                    current_snapshot = self._controller.snapshot()
-                    confirmed = getattr(
-                        self.screen, "is_persona_buddy_confirmed_unavailable", None
-                    )
-                    if callable(confirmed) and confirmed(
-                        self._controller, current_snapshot
-                    ):
-                        return
+                    self._resolved_authority = None
+                    await asyncio.sleep(_POLL_SECONDS)
                     continue
-            await asyncio.sleep(_POLL_SECONDS)
+                pending = self._reconcile()
+                removed = False
+                if inspect.isawaitable(pending):
+                    reconcile_worker = self.app.run_worker(
+                        pending,
+                        group="persona-buddy-unavailable-reconcile",
+                        exclusive=True,
+                    )
+                    removed = bool(await asyncio.shield(reconcile_worker.wait()))
+                else:
+                    removed = bool(pending)
+                if removed or not self._is_current_view():
+                    return
+                current_snapshot = self._controller.snapshot()
+                confirmed = getattr(
+                    self.screen, "is_persona_buddy_confirmed_unavailable", None
+                )
+                if callable(confirmed) and confirmed(
+                    self._controller, current_snapshot
+                ):
+                    return
+                self._resolved_authority = None
+                continue
+            return
+
+    def _resolution_authority(self, snapshot: Any) -> tuple[object, ...] | None:
+        """Return the full semantic/cache/viewport key for one costly resolve."""
+
+        region = self.content_region
+        if (
+            not snapshot.enabled
+            or not snapshot.open
+            or snapshot.selection is None
+            or region.width < 1
+            or region.height < 1
+        ):
+            return None
+        return (
+            id(self._controller),
+            snapshot.generation,
+            snapshot.selection,
+            snapshot.state,
+            snapshot.state_source,
+            snapshot.state_owner,
+            snapshot.preferences_generation,
+            snapshot.profile_generation,
+            snapshot.viewport_generation,
+            region.width,
+            region.height,
+        )
+
+    def _ensure_resolution(self, snapshot: Any) -> None:
+        authority = self._resolution_authority(snapshot)
+        if authority is None or authority == self._resolved_authority:
+            return
+        worker = self._resolution_worker
+        if (
+            worker is not None
+            and not worker.is_finished
+            and authority == self._requested_authority
+        ):
+            return
+        self._requested_authority = authority
+        self._resolution_worker = self.run_worker(
+            partial(self._resolution_loop),
+            group="persona-buddy-visual-resolution",
+            exclusive=True,
+        )
 
     def on_resize(self, _event: events.Resize) -> None:
         """Re-clamp geometry whenever the terminal viewport changes."""
@@ -287,7 +372,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             setter(snapshot.viewport_generation + 1)
         self._apply_geometry(self._working_preferences.geometry)
 
-    def refresh_from_controller(self) -> None:
+    def refresh_from_controller(self, *, schedule_resolution: bool = True) -> None:
         """Refresh paint/state from an immutable snapshot without touching focus."""
 
         if not self._is_current_view():
@@ -331,18 +416,25 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             ),
         )
         if visual_identity != self._visual_identity:
+            self._stop_frame_timer()
             self._visual_identity = visual_identity
             self.frame_index = 0
             self._next_frame_at = time.monotonic() + self._frame_duration_seconds()
+            self._frame_was_frozen = False
 
-        self.query_one("#persona-buddy-drag-handle", Static).update("Buddy · drag")
+        self.query_one("#persona-buddy-drag-handle", Static).update("Drag")
         self.query_one("#persona-buddy-status", Static).update(
             f"State: {snapshot.state.replace('_', ' ')}"
         )
         self._paint_frame()
+        self._sync_frame_timer()
+        if schedule_resolution:
+            self._ensure_resolution(snapshot)
 
     def advance_frame(self) -> None:
         """Advance animation only while a full visible animated view is painted."""
+
+        self._stop_frame_timer()
 
         snapshot = self._snapshot
         if (
@@ -351,6 +443,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             or snapshot.collapsed
             or self.has_class("persona-buddy-compact")
         ):
+            self._frame_was_frozen = True
             return
         visual = snapshot.visual
         frames = getattr(visual, "frames", ()) if visual is not None else ()
@@ -358,12 +451,49 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             return
         now = time.monotonic()
         if now < self._next_frame_at:
+            self._sync_frame_timer()
             return
         if self.frame_index == len(frames) - 1 and not getattr(visual, "loop", False):
             return
         self.frame_index = (self.frame_index + 1) % len(frames)
         self._next_frame_at = now + self._frame_duration_seconds()
         self._paint_frame()
+        self._sync_frame_timer()
+
+    def _stop_frame_timer(self) -> None:
+        timer = self._frame_timer
+        self._frame_timer = None
+        if timer is not None:
+            timer.stop()
+
+    def _sync_frame_timer(self) -> None:
+        snapshot = self._snapshot
+        visual = getattr(snapshot, "visual", None) if snapshot is not None else None
+        frames = getattr(visual, "frames", ()) if visual is not None else ()
+        active = bool(
+            self._is_current_view()
+            and self.display
+            and not snapshot.collapsed
+            and not self.has_class("persona-buddy-compact")
+            and getattr(visual, "animate", False)
+            and len(frames) > 1
+            and (
+                self.frame_index < len(frames) - 1
+                or getattr(visual, "loop", False)
+            )
+        )
+        if not active:
+            self._stop_frame_timer()
+            self._frame_was_frozen = True
+            return
+        if self._frame_timer is not None:
+            return
+        now = time.monotonic()
+        if self._frame_was_frozen:
+            self._next_frame_at = now + self._frame_duration_seconds()
+            self._frame_was_frozen = False
+        delay = max(0.001, self._next_frame_at - now)
+        self._frame_timer = self.set_timer(delay, self.advance_frame)
 
     def _frame_duration_seconds(self) -> float:
         visual = getattr(self._snapshot, "visual", None)
@@ -391,24 +521,46 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         target.update("Visual unavailable" if reason else "Visual pending")
 
     def _sync_compact_state(self, collapsed: bool) -> None:
-        size = self.screen.size
-        tiny = size.width < _MIN_WIDTH or size.height < _MIN_HEIGHT
-        self.set_class(tiny, "persona-buddy-compact")
-        self.set_class(collapsed and not tiny, "persona-buddy-collapsed")
+        compact = self._compact_for_geometry(self._working_preferences.geometry)
+        available_width = min(
+            self._working_preferences.geometry.width,
+            max(1, self.screen.size.width),
+        )
+        self.set_class(compact, "persona-buddy-compact")
+        self.set_class(
+            compact and available_width < _DUAL_CONTROL_WIDTH,
+            "persona-buddy-minimal",
+        )
+        self.set_class(collapsed and not compact, "persona-buddy-collapsed")
         collapse = self.query_one("#persona-buddy-collapse", Button)
-        collapse.label = "Buddy" if tiny else ("Open Buddy" if collapsed else "Fold")
+        collapse.label = (
+            "Buddy" if compact else ("Open Buddy" if collapsed else "Fold")
+        )
         self._apply_geometry(self._working_preferences.geometry)
+
+    def _compact_for_geometry(self, geometry: PersonaBuddyGeometry) -> bool:
+        viewport = self.screen.size
+        available_width = min(geometry.width, max(1, viewport.width))
+        available_height = min(geometry.height, max(1, viewport.height))
+        return (
+            available_width < _DEFAULT_WIDTH
+            or available_height < _FULL_CONTENT_HEIGHT
+        )
 
     def _clamped_geometry(self, geometry: PersonaBuddyGeometry) -> PersonaBuddyGeometry:
         viewport = self.screen.size
-        tiny = viewport.width < _MIN_WIDTH or viewport.height < _MIN_HEIGHT
-        if tiny:
-            width = max(1, viewport.width)
+        compact = self._compact_for_geometry(geometry)
+        if compact:
+            available_width = min(geometry.width, max(1, viewport.width))
+            width = min(
+                max(1, viewport.width),
+                max(min(_OPERABLE_WIDTH, max(1, viewport.width)), available_width),
+            )
             height = min(_COMPACT_HEIGHT, max(1, viewport.height))
         else:
             width = min(max(_MIN_WIDTH, geometry.width), viewport.width)
             if self._snapshot and self._snapshot.collapsed:
-                height = min(_COMPACT_HEIGHT, viewport.height)
+                height = min(_COLLAPSED_HEIGHT, viewport.height)
             else:
                 height = min(max(_MIN_HEIGHT, geometry.height), viewport.height)
         max_x = max(0, viewport.width - width)
@@ -508,7 +660,10 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             return
         self._interaction = None
         self.release_interaction_capture()
-        self._schedule_preferences(self._working_preferences, reconcile=False)
+        self._apply_and_schedule_preferences(
+            geometry=self._working_preferences.geometry,
+            reconcile=False,
+        )
         event.stop()
 
     def release_interaction_capture(self) -> None:
@@ -537,7 +692,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         clamped = self._clamped_geometry(candidate)
         self._working_preferences = replace(self._working_preferences, geometry=clamped)
         self._apply_geometry(clamped)
-        self._schedule_preferences(self._working_preferences, reconcile=False)
+        self._apply_and_schedule_preferences(geometry=clamped, reconcile=False)
 
     def action_move_left(self) -> None:
         self._geometry_action(dx=-1)
@@ -570,7 +725,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         clamped = self._clamped_geometry(geometry)
         self._working_preferences = replace(self._working_preferences, geometry=clamped)
         self._apply_geometry(clamped)
-        self._schedule_preferences(self._working_preferences, reconcile=False)
+        self._apply_and_schedule_preferences(geometry=clamped, reconcile=False)
 
     def action_toggle_collapse(self) -> None:
         if not self._is_current_view():
@@ -580,12 +735,17 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             collapsed=not self._working_preferences.collapsed,
         )
         self._working_preferences = preferences
-        self._schedule_preferences(preferences, reconcile=False)
+        self._apply_and_schedule_preferences(
+            collapsed=preferences.collapsed,
+            reconcile=False,
+        )
 
     def action_close(self) -> None:
         if not self._is_current_view():
             return
-        self._schedule_awaitable(self.close_and_persist())
+        preferences = replace(self._working_preferences, open=False)
+        self._working_preferences = preferences
+        self._apply_and_schedule_preferences(open=False, reconcile=True)
 
     async def close_and_persist(self) -> None:
         """Persist the explicit close and reconcile only this app's active screen."""
@@ -594,7 +754,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             return
         preferences = replace(self._working_preferences, open=False)
         self._working_preferences = preferences
-        await self._controller.update_preferences(preferences)
+        revision = self._controller.apply_preferences_patch(open=False)
+        await self._controller.persist_preferences_revision(revision)
         if not self._is_current_view():
             return
         pending = self._reconcile()
@@ -610,16 +771,15 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             self.action_close()
         event.stop()
 
-    def _schedule_preferences(
-        self,
-        preferences: PersonaBuddyPreferences,
-        *,
-        reconcile: bool,
+    def _apply_and_schedule_preferences(
+        self, *, reconcile: bool, **changes: object
     ) -> None:
+        """Publish an exact field patch now and persist its revision on the app."""
+
+        revision = self._controller.apply_preferences_patch(**changes)
+
         async def update() -> None:
-            if not self._is_current_view():
-                return
-            await self._controller.update_preferences(preferences)
+            await self._controller.persist_preferences_revision(revision)
             if not self._is_current_view():
                 return
             self.refresh_from_controller()

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -610,11 +610,11 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         if not resize and not in_handle:
             return
         mode = "resize" if resize else "drag"
-        geometry = PersonaBuddyGeometry(
+        preferred = self._working_preferences.geometry
+        geometry = replace(
+            preferred,
             x=self.absolute_offset.x,
             y=self.absolute_offset.y,
-            width=region.width,
-            height=region.height,
         )
         self._interaction = (mode, screen_x, screen_y, geometry)
         self.focus(scroll_visible=False)
@@ -644,9 +644,11 @@ class PersonaBuddyWidget(Widget, can_focus=True):
                 width=max(1, original.width + dx),
                 height=max(1, original.height + dy),
             )
-        clamped = self._clamped_geometry(candidate)
-        self._working_preferences = replace(self._working_preferences, geometry=clamped)
-        self._apply_geometry(clamped)
+        preferred = self._preferred_geometry_at_clamped_position(candidate)
+        self._working_preferences = replace(
+            self._working_preferences, geometry=preferred
+        )
+        self._apply_geometry(preferred)
         event.stop()
 
     def on_mouse_up(self, event: events.MouseUp) -> None:
@@ -681,18 +683,29 @@ class PersonaBuddyWidget(Widget, can_focus=True):
     ) -> None:
         if not self._is_current_view():
             return
-        geometry = self._clamped_geometry(self._working_preferences.geometry)
+        geometry = self._working_preferences.geometry
+        displayed = self._clamped_geometry(geometry)
         candidate = replace(
             geometry,
-            x=max(0, geometry.x + dx),
-            y=max(0, geometry.y + dy),
+            x=max(0, displayed.x + dx),
+            y=max(0, displayed.y + dy),
             width=max(1, geometry.width + dw),
             height=max(1, geometry.height + dh),
         )
-        clamped = self._clamped_geometry(candidate)
-        self._working_preferences = replace(self._working_preferences, geometry=clamped)
-        self._apply_geometry(clamped)
-        self._apply_and_schedule_preferences(geometry=clamped, reconcile=False)
+        preferred = self._preferred_geometry_at_clamped_position(candidate)
+        self._working_preferences = replace(
+            self._working_preferences, geometry=preferred
+        )
+        self._apply_geometry(preferred)
+        self._apply_and_schedule_preferences(geometry=preferred, reconcile=False)
+
+    def _preferred_geometry_at_clamped_position(
+        self, geometry: PersonaBuddyGeometry
+    ) -> PersonaBuddyGeometry:
+        """Keep preferred dimensions while constraining the displayed position."""
+
+        displayed = self._clamped_geometry(geometry)
+        return replace(geometry, x=displayed.x, y=displayed.y)
 
     def action_move_left(self) -> None:
         self._geometry_action(dx=-1)
@@ -722,10 +735,12 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         if not self._is_current_view():
             return
         geometry = PersonaBuddyGeometry(width=_DEFAULT_WIDTH, height=_DEFAULT_HEIGHT)
-        clamped = self._clamped_geometry(geometry)
-        self._working_preferences = replace(self._working_preferences, geometry=clamped)
-        self._apply_geometry(clamped)
-        self._apply_and_schedule_preferences(geometry=clamped, reconcile=False)
+        preferred = self._preferred_geometry_at_clamped_position(geometry)
+        self._working_preferences = replace(
+            self._working_preferences, geometry=preferred
+        )
+        self._apply_geometry(preferred)
+        self._apply_and_schedule_preferences(geometry=preferred, reconcile=False)
 
     def action_toggle_collapse(self) -> None:
         if not self._is_current_view():

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -1,0 +1,483 @@
+"""Disposable terminal-native floating view for the app-owned Persona Buddy."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from typing import Any
+
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.geometry import Offset
+from textual.timer import Timer
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Persona_Buddy.preferences import (
+    PERSONA_BUDDY_UNPOSITIONED_COORDINATE,
+    PersonaBuddyGeometry,
+    PersonaBuddyPreferences,
+)
+
+_DEFAULT_WIDTH = 28
+_DEFAULT_HEIGHT = 12
+_MIN_WIDTH = 18
+_MIN_HEIGHT = 6
+_COMPACT_HEIGHT = 3
+_POLL_SECONDS = 0.10
+_FRAME_SECONDS = 0.02
+
+
+class PersonaBuddyWidget(Widget, can_focus=True):
+    """Paint one controller snapshot and own only disposable view mechanics."""
+
+    BINDINGS = [
+        Binding("h", "move_left", "Move left", show=False),
+        Binding("j", "move_down", "Move down", show=False),
+        Binding("k", "move_up", "Move up", show=False),
+        Binding("l", "move_right", "Move right", show=False),
+        Binding("H", "shrink_width", "Narrower", show=False),
+        Binding("L", "grow_width", "Wider", show=False),
+        Binding("J", "grow_height", "Taller", show=False),
+        Binding("K", "shrink_height", "Shorter", show=False),
+        Binding("0", "reset_geometry", "Reset", show=False),
+        Binding("c", "toggle_collapse", "Collapse", show=False),
+        Binding("x", "close", "Close", show=False),
+    ]
+
+    BUNDLED_CSS = """
+    PersonaBuddyWidget {
+        position: absolute;
+        overlay: screen;
+        layer: overlay;
+        width: 28;
+        height: 12;
+        min-width: 1;
+        min-height: 1;
+        padding: 0 1;
+        background: $panel;
+        color: $text;
+        border: round $accent;
+        overflow: hidden hidden;
+    }
+
+    PersonaBuddyWidget:focus {
+        outline: heavy $accent;
+    }
+
+    PersonaBuddyWidget #persona-buddy-header {
+        width: 100%;
+        height: 3;
+        layout: horizontal;
+        background: $surface;
+    }
+
+    PersonaBuddyWidget #persona-buddy-title {
+        width: 1fr;
+        height: 3;
+        padding: 1 0 0 1;
+        color: $text;
+        text-style: bold;
+    }
+
+    PersonaBuddyWidget .persona-buddy-control {
+        width: auto;
+        min-width: 7;
+        height: 3;
+        padding: 0 1;
+        margin: 0;
+        border: none;
+        background: $surface-darken-1;
+        color: $text-muted;
+    }
+
+    PersonaBuddyWidget .persona-buddy-control:focus {
+        outline: heavy $accent;
+        color: $text;
+    }
+
+    PersonaBuddyWidget #persona-buddy-frame {
+        width: 100%;
+        height: 1fr;
+        content-align: center middle;
+        color: $text;
+    }
+
+    PersonaBuddyWidget #persona-buddy-status,
+    PersonaBuddyWidget #persona-buddy-hints {
+        width: 100%;
+        height: 1;
+        color: $text-muted;
+        text-align: center;
+    }
+
+    PersonaBuddyWidget.persona-buddy-collapsed,
+    PersonaBuddyWidget.persona-buddy-compact {
+        height: 3;
+        padding: 0;
+    }
+
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-frame,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-status,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-hints,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
+    PersonaBuddyWidget.persona-buddy-collapsed .persona-buddy-control,
+    PersonaBuddyWidget.persona-buddy-compact .persona-buddy-control {
+        display: none;
+    }
+
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-header,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-title,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-title {
+        height: 1;
+        width: 100%;
+        padding: 0;
+        content-align: center middle;
+        text-align: center;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        controller: Any,
+        view_generation: int,
+        reconcile: Callable[[], Awaitable[None] | None],
+    ) -> None:
+        super().__init__(id="persona-buddy-widget")
+        self._controller = controller
+        self.view_generation = view_generation
+        self._reconcile = reconcile
+        self._snapshot: Any = None
+        self._visual_identity: object | None = None
+        self._working_preferences: PersonaBuddyPreferences = (
+            controller.current_preferences()
+        )
+        self.frame_index = 0
+        self.snapshot_polling_active = False
+        self._poll_timer: Timer | None = None
+        self._frame_timer: Timer | None = None
+        self._interaction: tuple[str, int, int, PersonaBuddyGeometry] | None = None
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="persona-buddy-header"):
+            yield Static("Buddy", id="persona-buddy-title")
+            yield Button(
+                "Fold", id="persona-buddy-collapse", classes="persona-buddy-control"
+            )
+            yield Button(
+                "Close", id="persona-buddy-close", classes="persona-buddy-control"
+            )
+        yield Static("Visual pending", id="persona-buddy-frame")
+        yield Static("State: idle", id="persona-buddy-status")
+        yield Static("h/j/k/l move · Shift resize · 0 reset", id="persona-buddy-hints")
+
+    def on_mount(self) -> None:
+        """Start bounded snapshot and frame polling without changing focus."""
+
+        self.snapshot_polling_active = True
+        self.border_title = "Persona Buddy"
+        self._apply_geometry(self._working_preferences.geometry)
+        self.refresh_from_controller()
+        self._poll_timer = self.set_interval(
+            _POLL_SECONDS, self.refresh_from_controller
+        )
+        self._frame_timer = self.set_interval(_FRAME_SECONDS, self.advance_frame)
+
+    def on_unmount(self) -> None:
+        """Release capture and stop view-owned timers during any teardown path."""
+
+        self.snapshot_polling_active = False
+        self.release_interaction_capture()
+        if self._poll_timer is not None:
+            self._poll_timer.stop()
+        if self._frame_timer is not None:
+            self._frame_timer.stop()
+
+    def on_resize(self, _event: events.Resize) -> None:
+        """Re-clamp geometry whenever the terminal viewport changes."""
+
+        setter = getattr(self._controller, "set_viewport_generation", None)
+        if callable(setter):
+            snapshot = self._controller.snapshot()
+            setter(snapshot.viewport_generation + 1)
+        self._apply_geometry(self._working_preferences.geometry)
+
+    def refresh_from_controller(self) -> None:
+        """Refresh paint/state from an immutable snapshot without touching focus."""
+
+        if not self.is_attached:
+            return
+        snapshot = self._controller.snapshot()
+        self._snapshot = snapshot
+        preferences = self._controller.current_preferences()
+        if self._interaction is not None:
+            preferences = replace(
+                preferences,
+                geometry=self._working_preferences.geometry,
+            )
+        self._working_preferences = preferences
+        self._sync_compact_state(snapshot.collapsed)
+
+        visual = snapshot.visual
+        visual_identity = (
+            id(visual),
+            getattr(visual, "requested_state", None),
+            getattr(visual, "resolved_state", None),
+        )
+        if visual_identity != self._visual_identity:
+            self._visual_identity = visual_identity
+            self.frame_index = 0
+
+        title = self.query_one("#persona-buddy-title", Static)
+        title.update("Buddy")
+        self.query_one("#persona-buddy-status", Static).update(
+            f"State: {snapshot.state.replace('_', ' ')}"
+        )
+        self._paint_frame()
+
+    def advance_frame(self) -> None:
+        """Advance animation only while a full visible animated view is painted."""
+
+        snapshot = self._snapshot
+        if (
+            snapshot is None
+            or not self.display
+            or snapshot.collapsed
+            or self.has_class("persona-buddy-compact")
+        ):
+            return
+        visual = snapshot.visual
+        frames = getattr(visual, "frames", ()) if visual is not None else ()
+        if not getattr(visual, "animate", False) or len(frames) < 2:
+            return
+        self.frame_index = (self.frame_index + 1) % len(frames)
+        self._paint_frame()
+
+    def _paint_frame(self) -> None:
+        if not self.is_attached:
+            return
+        target = self.query_one("#persona-buddy-frame", Static)
+        visual = getattr(self._snapshot, "visual", None)
+        frames = getattr(visual, "frames", ()) if visual is not None else ()
+        if frames:
+            self.frame_index = min(self.frame_index, len(frames) - 1)
+            target.update(frames[self.frame_index].renderable)
+            return
+        reason = getattr(visual, "reason", None)
+        target.update("Visual unavailable" if reason else "Visual pending")
+
+    def _sync_compact_state(self, collapsed: bool) -> None:
+        size = self.screen.size
+        tiny = size.width < _MIN_WIDTH or size.height < _MIN_HEIGHT
+        self.set_class(tiny, "persona-buddy-compact")
+        self.set_class(collapsed and not tiny, "persona-buddy-collapsed")
+        collapse = self.query_one("#persona-buddy-collapse", Button)
+        collapse.label = "Open" if collapsed else "Fold"
+        self._apply_geometry(self._working_preferences.geometry)
+
+    def _clamped_geometry(self, geometry: PersonaBuddyGeometry) -> PersonaBuddyGeometry:
+        viewport = self.screen.size
+        tiny = viewport.width < _MIN_WIDTH or viewport.height < _MIN_HEIGHT
+        if tiny:
+            width = max(1, viewport.width)
+            height = min(_COMPACT_HEIGHT, max(1, viewport.height))
+        else:
+            width = min(max(_MIN_WIDTH, geometry.width), viewport.width)
+            if self._snapshot and self._snapshot.collapsed:
+                height = min(_COMPACT_HEIGHT, viewport.height)
+            else:
+                height = min(max(_MIN_HEIGHT, geometry.height), viewport.height)
+        max_x = max(0, viewport.width - width)
+        max_y = max(0, viewport.height - height)
+        x = (
+            max_x
+            if geometry.x == PERSONA_BUDDY_UNPOSITIONED_COORDINATE
+            else min(geometry.x, max_x)
+        )
+        y = (
+            max_y
+            if geometry.y == PERSONA_BUDDY_UNPOSITIONED_COORDINATE
+            else min(geometry.y, max_y)
+        )
+        return PersonaBuddyGeometry(x=x, y=y, width=width, height=height)
+
+    def _apply_geometry(self, geometry: PersonaBuddyGeometry) -> None:
+        if not self.is_attached:
+            return
+        clamped = self._clamped_geometry(geometry)
+        self.styles.width = clamped.width
+        self.styles.height = clamped.height
+        self.absolute_offset = Offset(clamped.x, clamped.y)
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Arm header drag or lower-right resize for the real terminal event shape."""
+
+        if event.button != 1 or not self.is_attached:
+            return
+        screen_x = int(event.screen_x if event.screen_x is not None else event.x)
+        screen_y = int(event.screen_y if event.screen_y is not None else event.y)
+        region = self.region
+        resize = screen_x >= region.right - 2 and screen_y >= region.bottom - 1
+        if not resize and screen_y >= region.y + 3:
+            return
+        mode = "resize" if resize else "drag"
+        geometry = PersonaBuddyGeometry(
+            x=self.absolute_offset.x,
+            y=self.absolute_offset.y,
+            width=region.width,
+            height=region.height,
+        )
+        self._interaction = (mode, screen_x, screen_y, geometry)
+        self.focus(scroll_visible=False)
+        self.capture_mouse(True)
+        event.stop()
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Apply bounded working geometry without writing config per mouse move."""
+
+        if self._interaction is None:
+            return
+        mode, origin_x, origin_y, original = self._interaction
+        screen_x = int(event.screen_x if event.screen_x is not None else event.x)
+        screen_y = int(event.screen_y if event.screen_y is not None else event.y)
+        dx = screen_x - origin_x
+        dy = screen_y - origin_y
+        if mode == "drag":
+            candidate = replace(
+                original, x=max(0, original.x + dx), y=max(0, original.y + dy)
+            )
+        else:
+            candidate = replace(
+                original,
+                width=max(1, original.width + dx),
+                height=max(1, original.height + dy),
+            )
+        clamped = self._clamped_geometry(candidate)
+        self._working_preferences = replace(self._working_preferences, geometry=clamped)
+        self._apply_geometry(clamped)
+        event.stop()
+
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        """Finish one interaction, release capture, and persist exactly once."""
+
+        if self._interaction is None:
+            self.release_interaction_capture()
+            return
+        self._interaction = None
+        self.release_interaction_capture()
+        self._schedule_preferences(self._working_preferences, reconcile=False)
+        event.stop()
+
+    def release_interaction_capture(self) -> None:
+        """Release mouse capture safely for removal, recompose, and mouse-up."""
+
+        self._interaction = None
+        try:
+            self.release_mouse()
+        except Exception:
+            if self.is_attached:
+                self.app.capture_mouse(None)
+
+    def _geometry_action(
+        self, *, dx: int = 0, dy: int = 0, dw: int = 0, dh: int = 0
+    ) -> None:
+        geometry = self._clamped_geometry(self._working_preferences.geometry)
+        candidate = replace(
+            geometry,
+            x=max(0, geometry.x + dx),
+            y=max(0, geometry.y + dy),
+            width=max(1, geometry.width + dw),
+            height=max(1, geometry.height + dh),
+        )
+        clamped = self._clamped_geometry(candidate)
+        self._working_preferences = replace(self._working_preferences, geometry=clamped)
+        self._apply_geometry(clamped)
+        self._schedule_preferences(self._working_preferences, reconcile=False)
+
+    def action_move_left(self) -> None:
+        self._geometry_action(dx=-1)
+
+    def action_move_down(self) -> None:
+        self._geometry_action(dy=1)
+
+    def action_move_up(self) -> None:
+        self._geometry_action(dy=-1)
+
+    def action_move_right(self) -> None:
+        self._geometry_action(dx=1)
+
+    def action_shrink_width(self) -> None:
+        self._geometry_action(dw=-1)
+
+    def action_grow_width(self) -> None:
+        self._geometry_action(dw=1)
+
+    def action_grow_height(self) -> None:
+        self._geometry_action(dh=1)
+
+    def action_shrink_height(self) -> None:
+        self._geometry_action(dh=-1)
+
+    def action_reset_geometry(self) -> None:
+        geometry = PersonaBuddyGeometry(width=_DEFAULT_WIDTH, height=_DEFAULT_HEIGHT)
+        clamped = self._clamped_geometry(geometry)
+        self._working_preferences = replace(self._working_preferences, geometry=clamped)
+        self._apply_geometry(clamped)
+        self._schedule_preferences(self._working_preferences, reconcile=False)
+
+    def action_toggle_collapse(self) -> None:
+        preferences = replace(
+            self._working_preferences,
+            collapsed=not self._working_preferences.collapsed,
+        )
+        self._working_preferences = preferences
+        self._schedule_preferences(preferences, reconcile=False)
+
+    def action_close(self) -> None:
+        self._schedule_awaitable(self.close_and_persist())
+
+    async def close_and_persist(self) -> None:
+        """Persist the explicit close and reconcile only this app's active screen."""
+
+        preferences = replace(self._working_preferences, open=False)
+        self._working_preferences = preferences
+        await self._controller.update_preferences(preferences)
+        pending = self._reconcile()
+        if inspect.isawaitable(pending):
+            await pending
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "persona-buddy-collapse":
+            self.action_toggle_collapse()
+        elif event.button.id == "persona-buddy-close":
+            self.action_close()
+        event.stop()
+
+    def _schedule_preferences(
+        self,
+        preferences: PersonaBuddyPreferences,
+        *,
+        reconcile: bool,
+    ) -> None:
+        async def update() -> None:
+            await self._controller.update_preferences(preferences)
+            self.refresh_from_controller()
+            if reconcile:
+                pending = self._reconcile()
+                if inspect.isawaitable(pending):
+                    await pending
+
+        self._schedule_awaitable(update())
+
+    def _schedule_awaitable(self, awaitable: Awaitable[None]) -> None:
+        self.run_worker(awaitable, group="persona-buddy-preferences")
+
+
+__all__ = ["PersonaBuddyWidget"]

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -241,6 +241,17 @@ class PersonaBuddyWidget(Widget, can_focus=True):
                     and not visual.available
                     and current_visual is visual
                 ):
+                    confirm = getattr(
+                        self.screen, "confirm_persona_buddy_unavailable", None
+                    )
+                    if not callable(confirm) or not confirm(
+                        view=self,
+                        controller=self._controller,
+                        snapshot=self._controller.snapshot(),
+                        visual=visual,
+                    ):
+                        await asyncio.sleep(_POLL_SECONDS)
+                        continue
                     pending = self._reconcile()
                     if inspect.isawaitable(pending):
                         self.app.run_worker(
@@ -254,6 +265,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
     def on_resize(self, _event: events.Resize) -> None:
         """Re-clamp geometry whenever the terminal viewport changes."""
 
+        if not self._is_current_view():
+            return
         setter = getattr(self._controller, "set_viewport_generation", None)
         if callable(setter):
             snapshot = self._controller.snapshot()

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -253,13 +253,27 @@ class PersonaBuddyWidget(Widget, can_focus=True):
                         await asyncio.sleep(_POLL_SECONDS)
                         continue
                     pending = self._reconcile()
+                    removed = False
                     if inspect.isawaitable(pending):
-                        self.app.run_worker(
+                        reconcile_worker = self.app.run_worker(
                             pending,
                             group="persona-buddy-unavailable-reconcile",
                             exclusive=True,
                         )
-                    return
+                        removed = bool(await asyncio.shield(reconcile_worker.wait()))
+                    else:
+                        removed = bool(pending)
+                    if removed or not self._is_current_view():
+                        return
+                    current_snapshot = self._controller.snapshot()
+                    confirmed = getattr(
+                        self.screen, "is_persona_buddy_confirmed_unavailable", None
+                    )
+                    if callable(confirmed) and confirmed(
+                        self._controller, current_snapshot
+                    ):
+                        return
+                    continue
             await asyncio.sleep(_POLL_SECONDS)
 
     def on_resize(self, _event: events.Resize) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -228,13 +228,27 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             snapshot = self._controller.snapshot()
             if snapshot.enabled and snapshot.open and snapshot.selection is not None:
                 region = self.content_region
-                await self._controller.resolve_current_visual(
+                visual = await self._controller.resolve_current_visual(
                     cols=max(1, region.width),
                     lines=max(1, region.height),
                 )
                 if not self._is_current_view():
                     return
                 self.refresh_from_controller()
+                current_visual = self._controller.snapshot().visual
+                if (
+                    visual is not None
+                    and not visual.available
+                    and current_visual is visual
+                ):
+                    pending = self._reconcile()
+                    if inspect.isawaitable(pending):
+                        self.app.run_worker(
+                            pending,
+                            group="persona-buddy-unavailable-reconcile",
+                            exclusive=True,
+                        )
+                    return
             await asyncio.sleep(_POLL_SECONDS)
 
     def on_resize(self, _event: events.Resize) -> None:
@@ -263,10 +277,31 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self._sync_compact_state(snapshot.collapsed)
 
         visual = snapshot.visual
+        frames = getattr(visual, "frames", ()) if visual is not None else ()
         visual_identity = (
-            id(visual),
+            getattr(visual, "source", None),
+            getattr(visual, "persona_id", None),
+            getattr(visual, "persona_revision", None),
             getattr(visual, "requested_state", None),
             getattr(visual, "resolved_state", None),
+            getattr(visual, "animation_id", None),
+            getattr(visual, "graph_identity", None),
+            getattr(visual, "cache_identity", None),
+            getattr(visual, "frame_rate", None),
+            getattr(visual, "loop", None),
+            getattr(visual, "animate", None),
+            tuple(
+                (
+                    getattr(frame, "cache_identity", None),
+                    getattr(frame, "asset_id", None),
+                    getattr(frame, "asset_sha256", None),
+                    getattr(frame, "manifest_frame_index", None),
+                    getattr(frame, "selected_frame", None),
+                    getattr(frame, "duration_ms", None),
+                    getattr(frame, "paint_digest", None),
+                )
+                for frame in frames
+            ),
         )
         if visual_identity != self._visual_identity:
             self._visual_identity = visual_identity

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from typing import Any
@@ -13,6 +15,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.geometry import Offset
 from textual.timer import Timer
+from textual.worker import Worker
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -28,7 +31,7 @@ _MIN_WIDTH = 18
 _MIN_HEIGHT = 6
 _COMPACT_HEIGHT = 3
 _POLL_SECONDS = 0.10
-_FRAME_SECONDS = 0.02
+_FRAME_SECONDS = 0.01
 
 
 class PersonaBuddyWidget(Widget, can_focus=True):
@@ -75,7 +78,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         background: $surface;
     }
 
-    PersonaBuddyWidget #persona-buddy-title {
+    PersonaBuddyWidget #persona-buddy-drag-handle {
         width: 1fr;
         height: 3;
         padding: 1 0 0 1;
@@ -126,15 +129,17 @@ class PersonaBuddyWidget(Widget, can_focus=True):
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
-    PersonaBuddyWidget.persona-buddy-collapsed .persona-buddy-control,
-    PersonaBuddyWidget.persona-buddy-compact .persona-buddy-control {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-close,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-close,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-drag-handle,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-drag-handle {
         display: none;
     }
 
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-header,
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
-    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-title,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-title {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-collapse,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-collapse {
         height: 1;
         width: 100%;
         padding: 0;
@@ -149,11 +154,13 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         controller: Any,
         view_generation: int,
         reconcile: Callable[[], Awaitable[None] | None],
+        is_current: Callable[["PersonaBuddyWidget"], bool] | None = None,
     ) -> None:
         super().__init__(id="persona-buddy-widget")
         self._controller = controller
         self.view_generation = view_generation
         self._reconcile = reconcile
+        self._current_view = is_current
         self._snapshot: Any = None
         self._visual_identity: object | None = None
         self._working_preferences: PersonaBuddyPreferences = (
@@ -163,11 +170,13 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self.snapshot_polling_active = False
         self._poll_timer: Timer | None = None
         self._frame_timer: Timer | None = None
+        self._resolution_worker: Worker[None] | None = None
         self._interaction: tuple[str, int, int, PersonaBuddyGeometry] | None = None
+        self._next_frame_at = 0.0
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="persona-buddy-header"):
-            yield Static("Buddy", id="persona-buddy-title")
+            yield Static("Buddy · drag", id="persona-buddy-drag-handle")
             yield Button(
                 "Fold", id="persona-buddy-collapse", classes="persona-buddy-control"
             )
@@ -189,6 +198,11 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             _POLL_SECONDS, self.refresh_from_controller
         )
         self._frame_timer = self.set_interval(_FRAME_SECONDS, self.advance_frame)
+        self._resolution_worker = self.run_worker(
+            self._resolution_loop(),
+            group="persona-buddy-visual-resolution",
+            exclusive=True,
+        )
 
     def on_unmount(self) -> None:
         """Release capture and stop view-owned timers during any teardown path."""
@@ -199,6 +213,29 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             self._poll_timer.stop()
         if self._frame_timer is not None:
             self._frame_timer.stop()
+        if self._resolution_worker is not None:
+            self._resolution_worker.cancel()
+
+    def _is_current_view(self) -> bool:
+        if not self.is_attached:
+            return False
+        return self._current_view(self) if self._current_view is not None else True
+
+    async def _resolution_loop(self) -> None:
+        """Resolve one production visual at a time while this exact view is current."""
+
+        while self._is_current_view():
+            snapshot = self._controller.snapshot()
+            if snapshot.enabled and snapshot.open and snapshot.selection is not None:
+                region = self.content_region
+                await self._controller.resolve_current_visual(
+                    cols=max(1, region.width),
+                    lines=max(1, region.height),
+                )
+                if not self._is_current_view():
+                    return
+                self.refresh_from_controller()
+            await asyncio.sleep(_POLL_SECONDS)
 
     def on_resize(self, _event: events.Resize) -> None:
         """Re-clamp geometry whenever the terminal viewport changes."""
@@ -212,7 +249,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
     def refresh_from_controller(self) -> None:
         """Refresh paint/state from an immutable snapshot without touching focus."""
 
-        if not self.is_attached:
+        if not self._is_current_view():
             return
         snapshot = self._controller.snapshot()
         self._snapshot = snapshot
@@ -234,9 +271,9 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         if visual_identity != self._visual_identity:
             self._visual_identity = visual_identity
             self.frame_index = 0
+            self._next_frame_at = time.monotonic() + self._frame_duration_seconds()
 
-        title = self.query_one("#persona-buddy-title", Static)
-        title.update("Buddy")
+        self.query_one("#persona-buddy-drag-handle", Static).update("Buddy · drag")
         self.query_one("#persona-buddy-status", Static).update(
             f"State: {snapshot.state.replace('_', ' ')}"
         )
@@ -257,8 +294,26 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         frames = getattr(visual, "frames", ()) if visual is not None else ()
         if not getattr(visual, "animate", False) or len(frames) < 2:
             return
+        now = time.monotonic()
+        if now < self._next_frame_at:
+            return
+        if self.frame_index == len(frames) - 1 and not getattr(visual, "loop", False):
+            return
         self.frame_index = (self.frame_index + 1) % len(frames)
+        self._next_frame_at = now + self._frame_duration_seconds()
         self._paint_frame()
+
+    def _frame_duration_seconds(self) -> float:
+        visual = getattr(self._snapshot, "visual", None)
+        frames = getattr(visual, "frames", ()) if visual is not None else ()
+        if frames:
+            duration_ms = getattr(frames[self.frame_index], "duration_ms", None)
+            if type(duration_ms) is int and duration_ms > 0:
+                return duration_ms / 1000.0
+        frame_rate = getattr(visual, "frame_rate", None)
+        if isinstance(frame_rate, (int, float)) and frame_rate > 0:
+            return 1.0 / float(frame_rate)
+        return 0.1
 
     def _paint_frame(self) -> None:
         if not self.is_attached:
@@ -279,7 +334,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self.set_class(tiny, "persona-buddy-compact")
         self.set_class(collapsed and not tiny, "persona-buddy-collapsed")
         collapse = self.query_one("#persona-buddy-collapse", Button)
-        collapse.label = "Open" if collapsed else "Fold"
+        collapse.label = "Buddy" if tiny else ("Open Buddy" if collapsed else "Fold")
         self._apply_geometry(self._working_preferences.geometry)
 
     def _clamped_geometry(self, geometry: PersonaBuddyGeometry) -> PersonaBuddyGeometry:
@@ -319,13 +374,26 @@ class PersonaBuddyWidget(Widget, can_focus=True):
     def on_mouse_down(self, event: events.MouseDown) -> None:
         """Arm header drag or lower-right resize for the real terminal event shape."""
 
-        if event.button != 1 or not self.is_attached:
+        if event.button != 1 or not self._is_current_view():
             return
         screen_x = int(event.screen_x if event.screen_x is not None else event.x)
         screen_y = int(event.screen_y if event.screen_y is not None else event.y)
         region = self.region
         resize = screen_x >= region.right - 2 and screen_y >= region.bottom - 1
-        if not resize and screen_y >= region.y + 3:
+        for button in self.query(Button):
+            if (
+                button.display
+                and button.region.x <= screen_x < button.region.right
+                and button.region.y <= screen_y < button.region.bottom
+            ):
+                return
+        handle = self.query_one("#persona-buddy-drag-handle", Static)
+        in_handle = (
+            handle.display
+            and handle.region.x <= screen_x < handle.region.right
+            and handle.region.y <= screen_y < handle.region.bottom
+        )
+        if not resize and not in_handle:
             return
         mode = "resize" if resize else "drag"
         geometry = PersonaBuddyGeometry(
@@ -343,6 +411,9 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         """Apply bounded working geometry without writing config per mouse move."""
 
         if self._interaction is None:
+            return
+        if not self._is_current_view():
+            self.release_interaction_capture()
             return
         mode, origin_x, origin_y, original = self._interaction
         screen_x = int(event.screen_x if event.screen_x is not None else event.x)
@@ -370,6 +441,9 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         if self._interaction is None:
             self.release_interaction_capture()
             return
+        if not self._is_current_view():
+            self.release_interaction_capture()
+            return
         self._interaction = None
         self.release_interaction_capture()
         self._schedule_preferences(self._working_preferences, reconcile=False)
@@ -388,6 +462,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
     def _geometry_action(
         self, *, dx: int = 0, dy: int = 0, dw: int = 0, dh: int = 0
     ) -> None:
+        if not self._is_current_view():
+            return
         geometry = self._clamped_geometry(self._working_preferences.geometry)
         candidate = replace(
             geometry,
@@ -426,6 +502,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self._geometry_action(dh=-1)
 
     def action_reset_geometry(self) -> None:
+        if not self._is_current_view():
+            return
         geometry = PersonaBuddyGeometry(width=_DEFAULT_WIDTH, height=_DEFAULT_HEIGHT)
         clamped = self._clamped_geometry(geometry)
         self._working_preferences = replace(self._working_preferences, geometry=clamped)
@@ -433,6 +511,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self._schedule_preferences(self._working_preferences, reconcile=False)
 
     def action_toggle_collapse(self) -> None:
+        if not self._is_current_view():
+            return
         preferences = replace(
             self._working_preferences,
             collapsed=not self._working_preferences.collapsed,
@@ -441,19 +521,27 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self._schedule_preferences(preferences, reconcile=False)
 
     def action_close(self) -> None:
+        if not self._is_current_view():
+            return
         self._schedule_awaitable(self.close_and_persist())
 
     async def close_and_persist(self) -> None:
         """Persist the explicit close and reconcile only this app's active screen."""
 
+        if not self._is_current_view():
+            return
         preferences = replace(self._working_preferences, open=False)
         self._working_preferences = preferences
         await self._controller.update_preferences(preferences)
+        if not self._is_current_view():
+            return
         pending = self._reconcile()
         if inspect.isawaitable(pending):
             await pending
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        if not self._is_current_view():
+            return
         if event.button.id == "persona-buddy-collapse":
             self.action_toggle_collapse()
         elif event.button.id == "persona-buddy-close":
@@ -467,7 +555,11 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         reconcile: bool,
     ) -> None:
         async def update() -> None:
+            if not self._is_current_view():
+                return
             await self._controller.update_preferences(preferences)
+            if not self._is_current_view():
+                return
             self.refresh_from_controller()
             if reconcile:
                 pending = self._reconcile()
@@ -477,7 +569,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         self._schedule_awaitable(update())
 
     def _schedule_awaitable(self, awaitable: Awaitable[None]) -> None:
-        self.run_worker(awaitable, group="persona-buddy-preferences")
+        self.app.run_worker(awaitable, group="persona-buddy-preferences")
 
 
 __all__ = ["PersonaBuddyWidget"]

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -275,11 +275,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             self.refresh_from_controller(schedule_resolution=False)
             self._resolved_authority = authority
             current_visual = current_snapshot.visual
-            if (
-                visual is not None
-                and not visual.available
-                and current_visual is visual
-            ):
+            if visual is not None and not visual.available and current_visual is visual:
                 confirm = getattr(
                     self.screen, "confirm_persona_buddy_unavailable", None
                 )
@@ -477,10 +473,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             and not self.has_class("persona-buddy-compact")
             and getattr(visual, "animate", False)
             and len(frames) > 1
-            and (
-                self.frame_index < len(frames) - 1
-                or getattr(visual, "loop", False)
-            )
+            and (self.frame_index < len(frames) - 1 or getattr(visual, "loop", False))
         )
         if not active:
             self._stop_frame_timer()
@@ -533,9 +526,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         )
         self.set_class(collapsed and not compact, "persona-buddy-collapsed")
         collapse = self.query_one("#persona-buddy-collapse", Button)
-        collapse.label = (
-            "Buddy" if compact else ("Open Buddy" if collapsed else "Fold")
-        )
+        collapse.label = "Buddy" if compact else ("Open Buddy" if collapsed else "Fold")
         self._apply_geometry(self._working_preferences.geometry)
 
     def _compact_for_geometry(self, geometry: PersonaBuddyGeometry) -> bool:
@@ -543,8 +534,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         available_width = min(geometry.width, max(1, viewport.width))
         available_height = min(geometry.height, max(1, viewport.height))
         return (
-            available_width < _DEFAULT_WIDTH
-            or available_height < _FULL_CONTENT_HEIGHT
+            available_width < _DEFAULT_WIDTH or available_height < _FULL_CONTENT_HEIGHT
         )
 
     def _clamped_geometry(self, geometry: PersonaBuddyGeometry) -> PersonaBuddyGeometry:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -6,7 +6,7 @@ import re
 
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Container, Horizontal, Vertical
+from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.css.query import QueryError
 from textual.widgets import Button, Checkbox, ListItem, ListView, Static
 
@@ -53,7 +53,7 @@ _THUMB_BOX_COLS = 24
 _THUMB_BOX_LINES = 10
 
 
-class PersonasInspectorPane(Vertical):
+class PersonasInspectorPane(VerticalScroll):
     """Identity, validation, conversations, readiness, and actions."""
 
     # Structure only: colors come from the app stylesheet. The conversations
@@ -154,6 +154,10 @@ class PersonasInspectorPane(Vertical):
         self._buddy_revision: int | None = None
         self._buddy_active = False
         self._buddy_profile_current = False
+        self._buddy_owner_source: str | None = None
+        self._buddy_owner_persona_id: str | None = None
+        self._buddy_enabled = False
+        self._buddy_open = True
         # F-040: marked library rows drive bulk Delete/Export JSON affordances.
         self._marked_count = 0
 
@@ -349,6 +353,22 @@ class PersonasInspectorPane(Vertical):
 
     def set_unsaved(self, is_unsaved: bool) -> None:
         self._is_unsaved = is_unsaved
+        self._apply_action_state()
+
+    def set_buddy_status(
+        self,
+        *,
+        source: str | None,
+        persona_id: str | None,
+        enabled: bool,
+        open: bool,
+    ) -> None:
+        """Apply the screen-owned Buddy selection and visibility snapshot."""
+
+        self._buddy_owner_source = source
+        self._buddy_owner_persona_id = persona_id
+        self._buddy_enabled = enabled is True
+        self._buddy_open = open is True
         self._apply_action_state()
 
     def set_tts_export_available(self, available: bool) -> None:
@@ -654,10 +674,52 @@ class PersonasInspectorPane(Vertical):
             buddy_tooltip = "Activate this Persona first."
         else:
             buddy_tooltip = "Select a saved local Persona."
-        for button in self.query(".persona-buddy-action").results(Button):
+        use_button = self.query_one("#personas-buddy-use", Button)
+        use_button.display = buddy_applies
+        use_button.disabled = not buddy_eligible
+        use_button.tooltip = None if buddy_eligible else buddy_tooltip
+        owner = bool(
+            buddy_eligible
+            and self._buddy_owner_source == "local"
+            and self._buddy_owner_persona_id == self._buddy_persona_id
+        )
+        owner_tooltip = "Select the Persona currently used by Buddy"
+        if not buddy_eligible:
+            state = {
+                "personas-buddy-show": (False, buddy_tooltip),
+                "personas-buddy-close": (False, buddy_tooltip),
+                "personas-buddy-disable": (False, buddy_tooltip),
+            }
+        elif not owner:
+            state = {
+                "personas-buddy-show": (False, owner_tooltip),
+                "personas-buddy-close": (False, owner_tooltip),
+                "personas-buddy-disable": (False, owner_tooltip),
+            }
+        elif not self._buddy_enabled:
+            disabled_tooltip = "Buddy is disabled. Use for Buddy to enable it."
+            state = {
+                "personas-buddy-show": (False, disabled_tooltip),
+                "personas-buddy-close": (False, disabled_tooltip),
+                "personas-buddy-disable": (False, "Buddy is already disabled."),
+            }
+        elif self._buddy_open:
+            state = {
+                "personas-buddy-show": (False, "Buddy is already open."),
+                "personas-buddy-close": (True, None),
+                "personas-buddy-disable": (True, None),
+            }
+        else:
+            state = {
+                "personas-buddy-show": (True, None),
+                "personas-buddy-close": (False, "Buddy is already closed."),
+                "personas-buddy-disable": (True, None),
+            }
+        for button_id, (enabled, tooltip) in state.items():
+            button = self.query_one(f"#{button_id}", Button)
             button.display = buddy_applies
-            button.disabled = not buddy_eligible
-            button.tooltip = None if buddy_eligible else buddy_tooltip
+            button.disabled = not enabled
+            button.tooltip = tooltip
 
     @on(Button.Pressed, ".persona-buddy-action")
     def _buddy_action_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -153,6 +153,7 @@ class PersonasInspectorPane(Vertical):
         self._buddy_persona_id: str | None = None
         self._buddy_revision: int | None = None
         self._buddy_active = False
+        self._buddy_profile_current = False
         # F-040: marked library rows drive bulk Delete/Export JSON affordances.
         self._marked_count = 0
 
@@ -305,6 +306,7 @@ class PersonasInspectorPane(Vertical):
         entity_id: str | None = None,
         revision: int | None = None,
         active: bool = False,
+        profile_current: bool = False,
     ) -> None:
         """Reflect the selected library item in the inspector summary.
 
@@ -320,6 +322,7 @@ class PersonasInspectorPane(Vertical):
         self._buddy_persona_id = entity_id
         self._buddy_revision = revision
         self._buddy_active = active is True
+        self._buddy_profile_current = profile_current is True
         self._tts_export_available = False
         self.query_one("#personas-export-include-tts", Checkbox).value = False
         self.query_one("#personas-selected-name", Static).update(f"Selected: {name}")
@@ -334,6 +337,7 @@ class PersonasInspectorPane(Vertical):
         self._buddy_persona_id = None
         self._buddy_revision = None
         self._buddy_active = False
+        self._buddy_profile_current = False
         self._tts_export_available = False
         self.query_one("#personas-export-include-tts", Checkbox).value = False
         self.set_console_actions_enabled(False, reason="select an item")
@@ -572,12 +576,10 @@ class PersonasInspectorPane(Vertical):
         # CTA. When a profile IS assigned, the enabled/disabled-with-reason
         # gating below (and the F-041 legibility CSS) covers the shown case.
         tts_checkbox.display = (
-            (kind is None or kind == "character") and self._tts_export_available
-        )
+            kind is None or kind == "character"
+        ) and self._tts_export_available
         tts_checkbox.disabled = not (
-            export_enabled
-            and kind == "character"
-            and self._tts_export_available
+            export_enabled and kind == "character" and self._tts_export_available
         )
         tts_checkbox.tooltip = (
             export_tooltip
@@ -617,16 +619,12 @@ class PersonasInspectorPane(Vertical):
         json_button.display = export_json_applies
         json_button.disabled = (not export_enabled) and marked == 0
         json_button.tooltip = (
-            f"Export the {marked} marked items as JSON."
-            if marked
-            else export_tooltip
+            f"Export the {marked} marked items as JSON." if marked else export_tooltip
         )
         png_button = self.query_one("#personas-export-png", Button)
         png_button.display = export_png_applies
         png_button.disabled = marked > 0 or not (export_enabled and kind == "character")
-        png_button.tooltip = (
-            "Bulk export is JSON only." if marked else export_tooltip
-        )
+        png_button.tooltip = "Bulk export is JSON only." if marked else export_tooltip
         delete_button = self.query_one("#personas-delete", Button)
         delete_button.disabled = (not selected) and marked == 0
         delete_button.tooltip = (
@@ -639,6 +637,7 @@ class PersonasInspectorPane(Vertical):
         buddy_eligible = (
             buddy_applies
             and not unsaved
+            and self._buddy_profile_current
             and self._buddy_source == "local"
             and bool(self._buddy_persona_id)
             and type(self._buddy_revision) is int
@@ -649,6 +648,8 @@ class PersonasInspectorPane(Vertical):
             buddy_tooltip = "Save a local copy first"
         elif unsaved:
             buddy_tooltip = _UNSAVED_TOOLTIP
+        elif not self._buddy_profile_current:
+            buddy_tooltip = "Persona details are unavailable. Refresh and try again."
         elif not self._buddy_active:
             buddy_tooltip = "Activate this Persona first."
         else:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -12,6 +12,7 @@ from textual.widgets import Button, Checkbox, ListItem, ListView, Static
 
 from ..Console.console_image_viewer_modal import ClickableAvatarBox
 
+from .personas_messages import PersonaBuddyActionRequested
 from .personas_pane_messages import ConversationRowSelected
 
 _UNSAVED_TOOLTIP = "Save before using this action; the selection has unsaved edits."
@@ -148,6 +149,10 @@ class PersonasInspectorPane(Vertical):
         self._provider_block_reason: str | None = None
         self._conversation_lookup: dict[str, str] = {}
         self._tts_export_available = False
+        self._buddy_source: str | None = None
+        self._buddy_persona_id: str | None = None
+        self._buddy_revision: int | None = None
+        self._buddy_active = False
         # F-040: marked library rows drive bulk Delete/Export JSON affordances.
         self._marked_count = 0
 
@@ -235,6 +240,30 @@ class PersonasInspectorPane(Vertical):
                 classes="console-action-secondary",
                 tooltip=_NO_SELECTION_GUIDANCE,
             )
+            yield Button(
+                "Use for Buddy",
+                id="personas-buddy-use",
+                disabled=True,
+                classes="console-action-secondary persona-buddy-action",
+            )
+            yield Button(
+                "Show Buddy",
+                id="personas-buddy-show",
+                disabled=True,
+                classes="console-action-subdued persona-buddy-action",
+            )
+            yield Button(
+                "Close Buddy",
+                id="personas-buddy-close",
+                disabled=True,
+                classes="console-action-subdued persona-buddy-action",
+            )
+            yield Button(
+                "Disable Buddy",
+                id="personas-buddy-disable",
+                disabled=True,
+                classes="console-action-subdued persona-buddy-action",
+            )
             tts_checkbox = Checkbox(
                 "Include assigned voice profile",
                 id="personas-export-include-tts",
@@ -267,7 +296,16 @@ class PersonasInspectorPane(Vertical):
                 tooltip=_NO_SELECTION_DELETE_TOOLTIP,
             )
 
-    def show_selection(self, *, name: str, kind: str) -> None:
+    def show_selection(
+        self,
+        *,
+        name: str,
+        kind: str,
+        source: str | None = None,
+        entity_id: str | None = None,
+        revision: int | None = None,
+        active: bool = False,
+    ) -> None:
         """Reflect the selected library item in the inspector summary.
 
         Args:
@@ -278,6 +316,10 @@ class PersonasInspectorPane(Vertical):
         """
         self._has_selection = True
         self._selected_kind = kind
+        self._buddy_source = source
+        self._buddy_persona_id = entity_id
+        self._buddy_revision = revision
+        self._buddy_active = active is True
         self._tts_export_available = False
         self.query_one("#personas-export-include-tts", Checkbox).value = False
         self.query_one("#personas-selected-name", Static).update(f"Selected: {name}")
@@ -288,6 +330,10 @@ class PersonasInspectorPane(Vertical):
         self._has_selection = False
         self._is_unsaved = False
         self._selected_kind = None
+        self._buddy_source = None
+        self._buddy_persona_id = None
+        self._buddy_revision = None
+        self._buddy_active = False
         self._tts_export_available = False
         self.query_one("#personas-export-include-tts", Checkbox).value = False
         self.set_console_actions_enabled(False, reason="select an item")
@@ -587,6 +633,55 @@ class PersonasInspectorPane(Vertical):
             f"Delete the {marked} marked items."
             if marked
             else (None if selected else _NO_SELECTION_DELETE_TOOLTIP)
+        )
+
+        buddy_applies = selected and kind == "persona"
+        buddy_eligible = (
+            buddy_applies
+            and not unsaved
+            and self._buddy_source == "local"
+            and bool(self._buddy_persona_id)
+            and type(self._buddy_revision) is int
+            and self._buddy_revision >= 1
+            and self._buddy_active
+        )
+        if self._buddy_source == "server":
+            buddy_tooltip = "Save a local copy first"
+        elif unsaved:
+            buddy_tooltip = _UNSAVED_TOOLTIP
+        elif not self._buddy_active:
+            buddy_tooltip = "Activate this Persona first."
+        else:
+            buddy_tooltip = "Select a saved local Persona."
+        for button in self.query(".persona-buddy-action").results(Button):
+            button.display = buddy_applies
+            button.disabled = not buddy_eligible
+            button.tooltip = None if buddy_eligible else buddy_tooltip
+
+    @on(Button.Pressed, ".persona-buddy-action")
+    def _buddy_action_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        actions = {
+            "personas-buddy-use": "use",
+            "personas-buddy-show": "show",
+            "personas-buddy-close": "close",
+            "personas-buddy-disable": "disable",
+        }
+        action = actions.get(str(event.button.id or ""))
+        if (
+            action is None
+            or self._buddy_source not in {"local", "server"}
+            or not self._buddy_persona_id
+            or type(self._buddy_revision) is not int
+        ):
+            return
+        self.post_message(
+            PersonaBuddyActionRequested(
+                action=action,
+                source=self._buddy_source,
+                persona_id=self._buddy_persona_id,
+                revision=self._buddy_revision,
+            )
         )
 
     def set_avatar_thumbnail(self, renderable: object | None) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from dataclasses import dataclass
+from typing import Any, Literal, Self
 
 from textual.message import Message
 
@@ -34,6 +35,52 @@ PersonaAction = Literal[
     "cancel",
     "refresh",
 ]
+PersonaBuddyAction = Literal["use", "show", "close", "disable"]
+PersonaBuddySource = Literal["local", "server"]
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaBuddyActionRequested(Message):
+    """Request one explicit Buddy ownership or visibility change."""
+
+    action: PersonaBuddyAction
+    source: PersonaBuddySource
+    persona_id: str
+    revision: int
+
+    def __post_init__(self) -> None:
+        if (
+            self.action not in {"use", "show", "close", "disable"}
+            or self.source not in {"local", "server"}
+            or not self.persona_id
+            or type(self.revision) is not int
+            or self.revision < 1
+        ):
+            raise ValueError("invalid Persona Buddy action")
+        # Textual mutates Message's private delivery slots. Keep those slots
+        # operational while the public action payload remains frozen.
+        initialized = Message()
+        for attribute in Message.__slots__:
+            object.__setattr__(self, attribute, getattr(initialized, attribute))
+
+    def set_sender(self, sender: Any) -> Self:
+        object.__setattr__(self, "_sender", sender)
+        return self
+
+    def _set_forwarded(self) -> None:
+        object.__setattr__(self, "_forwarded", True)
+
+    def prevent_default(self, prevent: bool = True) -> Self:
+        object.__setattr__(self, "_no_default_action", prevent)
+        return self
+
+    def stop(self, stop: bool = True) -> Self:
+        object.__setattr__(self, "_stop_propagation", stop)
+        return self
+
+    def _bubble_to(self, widget: Any) -> None:
+        object.__setattr__(self, "_no_default_action", False)
+        widget.post_message(self)
 
 
 class PersonaModeChanged(Message):
@@ -118,6 +165,9 @@ class PersonaMarksChanged(Message):
 __all__ = [
     "PersonaAction",
     "PersonaActionRequested",
+    "PersonaBuddyAction",
+    "PersonaBuddyActionRequested",
+    "PersonaBuddySource",
     "PersonaEntityKind",
     "PersonaEntitySelected",
     "PersonaMarksChanged",

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, Self
+from typing import Literal
 
 from textual.message import Message
 
@@ -40,47 +40,57 @@ PersonaBuddySource = Literal["local", "server"]
 
 
 @dataclass(frozen=True, slots=True)
-class PersonaBuddyActionRequested(Message):
-    """Request one explicit Buddy ownership or visibility change."""
-
+class _PersonaBuddyActionPayload:
     action: PersonaBuddyAction
     source: PersonaBuddySource
     persona_id: str
     revision: int
 
-    def __post_init__(self) -> None:
+
+class PersonaBuddyActionRequested(Message):
+    """Request one explicit Buddy ownership or visibility change."""
+
+    __slots__ = ("_payload",)
+
+    def __init__(
+        self,
+        *,
+        action: PersonaBuddyAction,
+        source: PersonaBuddySource,
+        persona_id: str,
+        revision: int,
+    ) -> None:
+        super().__init__()
         if (
-            self.action not in {"use", "show", "close", "disable"}
-            or self.source not in {"local", "server"}
-            or not self.persona_id
-            or type(self.revision) is not int
-            or self.revision < 1
+            action not in {"use", "show", "close", "disable"}
+            or source not in {"local", "server"}
+            or not persona_id
+            or type(revision) is not int
+            or revision < 1
         ):
             raise ValueError("invalid Persona Buddy action")
-        # Textual mutates Message's private delivery slots. Keep those slots
-        # operational while the public action payload remains frozen.
-        initialized = Message()
-        for attribute in Message.__slots__:
-            object.__setattr__(self, attribute, getattr(initialized, attribute))
+        self._payload = _PersonaBuddyActionPayload(
+            action=action,
+            source=source,
+            persona_id=persona_id,
+            revision=revision,
+        )
 
-    def set_sender(self, sender: Any) -> Self:
-        object.__setattr__(self, "_sender", sender)
-        return self
+    @property
+    def action(self) -> PersonaBuddyAction:
+        return self._payload.action
 
-    def _set_forwarded(self) -> None:
-        object.__setattr__(self, "_forwarded", True)
+    @property
+    def source(self) -> PersonaBuddySource:
+        return self._payload.source
 
-    def prevent_default(self, prevent: bool = True) -> Self:
-        object.__setattr__(self, "_no_default_action", prevent)
-        return self
+    @property
+    def persona_id(self) -> str:
+        return self._payload.persona_id
 
-    def stop(self, stop: bool = True) -> Self:
-        object.__setattr__(self, "_stop_propagation", stop)
-        return self
-
-    def _bubble_to(self, widget: Any) -> None:
-        object.__setattr__(self, "_no_default_action", False)
-        widget.post_message(self)
+    @property
+    def revision(self) -> int:
+        return self._payload.revision
 
 
 class PersonaModeChanged(Message):

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -5791,6 +5791,7 @@ class TldwCli(
             reduced_motion=bool(get_cli_setting("appearance", "reduce_motion", False)),
             scheduler=self.call_after_refresh,
         )
+        self._persona_buddy_unavailable_authority = None
         self._persona_buddy_shutdown_task: asyncio.Task[None] | None = None
 
         # --- Initialize worker handler registry ---
@@ -8259,6 +8260,70 @@ class TldwCli(
     # Generous enough that a real save is never cut short, small enough that a
     # wedged one costs a few seconds instead of the session.
     NAVIGATION_FLUSH_TIMEOUT_SECONDS: float = 5.0
+
+    @staticmethod
+    def _persona_buddy_authority(controller: Any, snapshot: Any) -> tuple[Any, ...]:
+        """Return the exact app-lifetime authority for one visual decision."""
+
+        return (
+            id(controller),
+            snapshot.generation,
+            snapshot.selection,
+            snapshot.preferences_generation,
+            snapshot.profile_generation,
+        )
+
+    def is_persona_buddy_confirmed_unavailable(
+        self, controller: Any, snapshot: Any
+    ) -> bool:
+        """Query and clear the app-owned unavailable marker by exact authority."""
+
+        authority = self._persona_buddy_authority(controller, snapshot)
+        marker = getattr(self, "_persona_buddy_unavailable_authority", None)
+        if marker is not None and marker != authority:
+            self._persona_buddy_unavailable_authority = None
+            return False
+        return marker == authority
+
+    def confirm_persona_buddy_unavailable(
+        self,
+        *,
+        screen: Any,
+        view: Any,
+        view_generation: int,
+        controller: Any,
+        snapshot: Any,
+        visual: Any,
+    ) -> bool:
+        """Publish unavailable only for the exact current app/screen/view authority."""
+
+        current_controller = getattr(self, "persona_buddy_controller", None)
+        try:
+            current_screen = self.screen
+        except Exception:
+            return False
+        if (
+            controller is not current_controller
+            or current_screen is not screen
+            or not screen.is_attached
+            or screen._persona_buddy_view is not view
+            or screen.persona_buddy_view_generation != view_generation
+            or not view.is_attached
+        ):
+            return False
+        current = controller.snapshot()
+        if (
+            self._persona_buddy_authority(controller, current)
+            != self._persona_buddy_authority(controller, snapshot)
+            or current.visual is not visual
+            or visual is None
+            or visual.available
+        ):
+            return False
+        self._persona_buddy_unavailable_authority = self._persona_buddy_authority(
+            controller, current
+        )
+        return True
 
     async def reconcile_persona_buddy_view(self) -> None:
         """Reconcile Buddy only on the active ordinary application screen."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -8260,6 +8260,19 @@ class TldwCli(
     # wedged one costs a few seconds instead of the session.
     NAVIGATION_FLUSH_TIMEOUT_SECONDS: float = 5.0
 
+    async def reconcile_persona_buddy_view(self) -> None:
+        """Reconcile Buddy only on the active ordinary application screen."""
+
+        from .UI.Navigation.base_app_screen import BaseAppScreen
+
+        try:
+            screen = self.screen
+        except Exception:
+            return
+        if not isinstance(screen, BaseAppScreen) or not screen.is_active:
+            return
+        await screen.reconcile_persona_buddy_view()
+
     def _create_navigation_screen(self, screen_name: str, screen_class: type):
         """Build a FRESH screen instance for every navigation.
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -372,6 +372,10 @@ from .Character_Chat.server_chat_dictionary_service import ServerChatDictionaryS
 from .Character_Chat.server_character_persona_service import (
     ServerCharacterPersonaService,
 )
+from .Persona_Buddy import (
+    PersonaBuddyController,
+    parse_persona_buddy_preferences,
+)
 from .RAG_Admin.local_rag_admin_service import LocalRAGAdminService
 from .RAG_Admin.rag_admin_scope_service import RAGAdminScopeService
 from .RAG_Admin.server_rag_admin_service import ServerRAGAdminService
@@ -5772,6 +5776,17 @@ class TldwCli(
         self._wire_study_services()
         self._wire_research_services()
         self._wire_character_persona_services()
+        self.persona_buddy_controller = PersonaBuddyController(
+            preferences=parse_persona_buddy_preferences(
+                self.app_config.get("persona_buddy", {})
+            ),
+            local_persona_service=self.local_character_persona_service,
+            profile_db=self.chachanotes_db,
+            profile_root=get_user_data_dir(),
+            reduced_motion=bool(get_cli_setting("appearance", "reduce_motion", False)),
+            scheduler=self.call_after_refresh,
+        )
+        self._persona_buddy_shutdown_task: asyncio.Task[None] | None = None
 
         # --- Initialize worker handler registry ---
         self._init_worker_handlers()
@@ -11580,6 +11595,17 @@ class TldwCli(
             self._console_image_edit_shutdown_task = task
         await asyncio.shield(task)
 
+    async def _shutdown_persona_buddy(self) -> None:
+        """Drain the app-owned Buddy before profile database teardown."""
+        task = self._persona_buddy_shutdown_task
+        if task is None:
+            task = asyncio.create_task(
+                self.persona_buddy_controller.shutdown(),
+                name="shutdown_persona_buddy",
+            )
+            self._persona_buddy_shutdown_task = task
+        await asyncio.shield(task)
+
     async def _shutdown_console_runtime(self) -> None:
         """Destroy the app-owned Console runtime exactly once, at exit.
 
@@ -11601,6 +11627,7 @@ class TldwCli(
 
     async def _shutdown_app_owned_lifecycles(self) -> None:
         """Drain durable app-owned work before Textual closes screen state."""
+        await self._shutdown_persona_buddy()
         coordinator = getattr(self, "_audio_cpp_artifact_lease_coordinator", None)
         if coordinator is not None:
             await coordinator.shutdown()

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -374,6 +374,7 @@ from .Character_Chat.server_character_persona_service import (
 )
 from .Persona_Buddy import (
     PersonaBuddyController,
+    load_local_persona_portrait,
     parse_persona_buddy_preferences,
 )
 from .RAG_Admin.local_rag_admin_service import LocalRAGAdminService
@@ -5781,6 +5782,10 @@ class TldwCli(
                 self.app_config.get("persona_buddy", {})
             ),
             local_persona_service=self.local_character_persona_service,
+            portrait_loader=partial(
+                load_local_persona_portrait,
+                self.local_character_persona_service,
+            ),
             profile_db=self.chachanotes_db,
             profile_root=get_user_data_dir(),
             reduced_motion=bool(get_cli_setting("appearance", "reduce_motion", False)),

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -8325,18 +8325,18 @@ class TldwCli(
         )
         return True
 
-    async def reconcile_persona_buddy_view(self) -> None:
-        """Reconcile Buddy only on the active ordinary application screen."""
+    async def reconcile_persona_buddy_view(self) -> bool:
+        """Reconcile the active screen and report whether its Buddy is absent."""
 
         from .UI.Navigation.base_app_screen import BaseAppScreen
 
         try:
             screen = self.screen
         except Exception:
-            return
+            return False
         if not isinstance(screen, BaseAppScreen) or not screen.is_active:
-            return
-        await screen.reconcile_persona_buddy_view()
+            return False
+        return await screen.reconcile_persona_buddy_view()
 
     def _create_navigation_screen(self, screen_name: str, screen_class: type):
         """Build a FRESH screen instance for every navigation.

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -11710,13 +11710,15 @@ class TldwCli(
 
     async def _shutdown_app_owned_lifecycles(self) -> None:
         """Drain durable app-owned work before Textual closes screen state."""
+        # Console shutdown terminally fences every trusted Buddy producer
+        # before Buddy itself closes admission and drains owned work.
+        await self._shutdown_console_runtime()
         await self._shutdown_persona_buddy()
         coordinator = getattr(self, "_audio_cpp_artifact_lease_coordinator", None)
         if coordinator is not None:
             await coordinator.shutdown()
         await self.audio_cpp_model_install_owner.shutdown()
         await self._shutdown_console_image_edits()
-        await self._shutdown_console_runtime()
         await self._shutdown_file_notes_session_owner()
 
     async def _shutdown(self) -> None:

--- a/tldw_chatbook/css/screen_css_scoped.tcss
+++ b/tldw_chatbook/css/screen_css_scoped.tcss
@@ -11,7 +11,7 @@
 /* ===== WIDGET: NoteSelectionDialog (Widgets/Note_Widgets/note_selection_dialog.py) ===== */
 
 
-    
+
     NoteSelectionDialog #note-selection-container {
         width: 80;
         height: 50;
@@ -20,79 +20,80 @@
         border: thick $primary;
         padding: 1;
     }
-    
+
     NoteSelectionDialog .dialog-title {
         text-align: center;
         text-style: bold;
         margin-bottom: 1;
     }
-    
+
     NoteSelectionDialog .search-row {
         height: 3;
         margin-bottom: 1;
     }
-    
+
     NoteSelectionDialog #note-search-input {
         width: 100%;
     }
-    
+
     NoteSelectionDialog #notes-list-container {
         height: 1fr;
         border: solid $secondary;
         margin-bottom: 1;
     }
-    
+
     NoteSelectionDialog .note-item {
         padding: 1;
         margin-bottom: 1;
         border-bottom: dashed $secondary;
     }
-    
+
     NoteSelectionDialog .note-item:hover {
         background: $boost;
     }
-    
+
     NoteSelectionDialog .note-details {
         width: 1fr;
         margin-left: 1;
     }
-    
+
     NoteSelectionDialog .note-title {
         text-style: bold;
     }
-    
+
     NoteSelectionDialog .note-preview {
         color: $text-muted;
         text-style: italic;
         max-height: 2;
         overflow: hidden;
     }
-    
+
     NoteSelectionDialog .note-date {
         color: $text-disabled;
     }
-    
+
     NoteSelectionDialog .selection-info {
         height: 3;
         text-align: center;
         margin-bottom: 1;
     }
-    
+
     NoteSelectionDialog .button-row {
         dock: bottom;
         height: 3;
         align: center middle;
         margin-top: 1;
     }
-    
+
     NoteSelectionDialog .button-row Button {
         margin: 0 1;
     }
 
+
 /* ===== WIDGET: ConversationSelectionDialog (Widgets/conversation_selection_dialog.py) ===== */
 
 
-    
+
     ConversationSelectionDialog #conversation-selection-container {
         width: 80;
         height: 50;
@@ -101,146 +102,147 @@
         border: thick $primary;
         padding: 1;
     }
-    
+
     ConversationSelectionDialog .dialog-title {
         text-align: center;
         text-style: bold;
         margin-bottom: 1;
     }
-    
+
     ConversationSelectionDialog .search-row {
         height: 3;
         margin-bottom: 1;
     }
-    
+
     ConversationSelectionDialog #conversation-search-input {
         width: 100%;
     }
-    
+
     ConversationSelectionDialog #conversations-list-container {
         height: 1fr;
         border: solid $secondary;
         margin-bottom: 1;
     }
-    
+
     ConversationSelectionDialog .conversation-item {
         padding: 1;
         margin-bottom: 1;
         border-bottom: dashed $secondary;
     }
-    
+
     ConversationSelectionDialog .conversation-item:hover {
         background: $boost;
     }
-    
+
     ConversationSelectionDialog .conversation-details {
         width: 1fr;
         margin-left: 1;
     }
-    
+
     ConversationSelectionDialog .conversation-title {
         text-style: bold;
     }
-    
+
     ConversationSelectionDialog .conversation-info {
         color: $text-muted;
     }
-    
+
     ConversationSelectionDialog .conversation-date {
         color: $text-disabled;
     }
-    
+
     ConversationSelectionDialog .options-section {
         height: auto;
         margin-bottom: 1;
         padding: 1;
         border: solid $secondary;
     }
-    
+
     ConversationSelectionDialog .option-label {
         width: 20;
         margin-right: 1;
     }
-    
+
     ConversationSelectionDialog .button-row {
         dock: bottom;
         height: 3;
         align: center middle;
         margin-top: 1;
     }
-    
+
     ConversationSelectionDialog .button-row Button {
         margin: 0 1;
     }
+
 
 /* ===== WIDGET: EmojiPickerScreen (Widgets/emoji_picker.py) ===== */
 
 
 
-    EmojiPickerScreen #dialog { 
-        width: 80%; 
-        max-width: 120; 
-        height: 80%; 
+    EmojiPickerScreen #dialog {
+        width: 80%;
+        max-width: 120;
+        height: 80%;
         max-height: 40;
-        border: thick $primary; 
-        background: $surface; 
+        border: thick $primary;
+        background: $surface;
         padding: 1;
     }
-    EmojiPickerScreen #search-input { 
-        width: 100%; 
-        margin-bottom: 1; 
+    EmojiPickerScreen #search-input {
+        width: 100%;
+        margin-bottom: 1;
         border: tall $primary-background;
     }
     EmojiPickerScreen #search-input:focus {
         border: tall $primary;
     }
-    EmojiPickerScreen TabbedContent#emoji-tabs { 
-        height: 1fr; 
+    EmojiPickerScreen TabbedContent#emoji-tabs {
+        height: 1fr;
         border: none;
     }
-    EmojiPickerScreen TabPane { 
-        padding: 0 1; 
-        height: 100%; 
+    EmojiPickerScreen TabPane {
+        padding: 0 1;
+        height: 100%;
     }
-    EmojiPickerScreen EmojiGrid { 
-        width: 100%; 
-        height: 100%; 
+    EmojiPickerScreen EmojiGrid {
+        width: 100%;
+        height: 100%;
         padding: 0;
     }
-    EmojiPickerScreen .emoji_row { 
-        width: 100%; 
-        height: auto; 
-        align: left top; 
+    EmojiPickerScreen .emoji_row {
+        width: 100%;
+        height: auto;
+        align: left top;
         margin: 0;
     }
-    EmojiPickerScreen EmojiButton.emoji_button { 
-        width: 4; 
-        height: 3; 
-        border: none; 
-        background: transparent; 
-        color: $text; 
+    EmojiPickerScreen EmojiButton.emoji_button {
+        width: 4;
+        height: 3;
+        border: none;
+        background: transparent;
+        color: $text;
         padding: 0;
         text-align: center;
         content-align: center middle;
     }
-    EmojiPickerScreen EmojiButton.emoji_button:hover { 
-        background: $primary-background; 
+    EmojiPickerScreen EmojiButton.emoji_button:hover {
+        background: $primary-background;
     }
     /* EmojiButton :focus styling lives in css/components/_widgets.tcss
        (needs the bundle's $ds-focus-* tokens; TASK-16811). */
-    EmojiPickerScreen .no_emojis_message { 
-        width: 100%; 
-        content-align: center middle; 
-        padding: 2; 
-        color: $text-muted; 
+    EmojiPickerScreen .no_emojis_message {
+        width: 100%;
+        content-align: center middle;
+        padding: 2;
+        color: $text-muted;
         text-style: italic;
     }
-    EmojiPickerScreen #footer { 
-        height: auto; 
-        width: 100%; 
-        dock: bottom; 
-        padding-top: 1; 
-        align: right middle; 
+    EmojiPickerScreen #footer {
+        height: auto;
+        width: 100%;
+        dock: bottom;
+        padding-top: 1;
+        align: right middle;
     }
     EmojiPickerScreen .dialog-title {
         width: 100%;
@@ -250,12 +252,13 @@
         margin-bottom: 1;
     }
 
+
 /* ===== WIDGET: FileExtractionDialog (Widgets/file_extraction_dialog.py) ===== */
 
 
-    
 
-    
+
+
     FileExtractionDialog .dialog-title {
         text-align: center;
         text-style: bold;
@@ -263,39 +266,40 @@
         background: $boost;
         width: 100%;
     }
-    
+
     FileExtractionDialog #file-list {
         height: 15;
         margin: 1 0;
     }
-    
+
     FileExtractionDialog #file-preview {
         height: 15;
         border: solid $primary;
         padding: 1;
         margin: 1 0;
     }
-    
+
     FileExtractionDialog .dialog-buttons {
         dock: bottom;
         height: 3;
         align: center middle;
         padding: 1;
     }
-    
+
     FileExtractionDialog .dialog-buttons Button {
         margin: 0 1;
     }
-    
+
     FileExtractionDialog #filename-input {
         width: 100%;
         margin: 1 0;
     }
 
+
 /* ===== WIDGET: VoiceBlendDialog (Widgets/voice_blend_dialog.py) ===== */
 
 
-    
+
     VoiceBlendDialog #voice-blend-container {
         width: 60;
         height: auto;
@@ -304,53 +308,54 @@
         border: thick $primary;
         padding: 1;
     }
-    
+
     VoiceBlendDialog .dialog-title {
         text-align: center;
         text-style: bold;
         margin-bottom: 1;
     }
-    
+
     VoiceBlendDialog .form-row {
         height: 3;
         margin-bottom: 1;
     }
-    
+
     VoiceBlendDialog .form-label {
         width: 15;
         height: 1;
         margin-top: 1;
     }
-    
+
     VoiceBlendDialog #blend-name-input, VoiceBlendDialog #blend-description-input {
         width: 100%;
     }
-    
+
     VoiceBlendDialog .voice-blend-entry {
         height: 3;
         margin-bottom: 1;
     }
-    
+
     VoiceBlendDialog .weight-input {
         width: 15;
     }
-    
+
     VoiceBlendDialog .remove-btn {
         width: 3;
         min-width: 3;
     }
-    
+
     VoiceBlendDialog #add-voice-btn {
         margin: 1 0;
     }
-    
+
     VoiceBlendDialog .button-row {
         dock: bottom;
         height: 3;
         align: center middle;
         margin-top: 1;
     }
-    
+
     VoiceBlendDialog .button-row Button {
         margin: 0 1;
     }
+

--- a/tldw_chatbook/css/screen_css_self.tcss
+++ b/tldw_chatbook/css/screen_css_self.tcss
@@ -14,11 +14,71 @@
         align: center middle;
     }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /* ===== WIDGET: ConversationSelectionDialog (Widgets/conversation_selection_dialog.py) ===== */
 
     ConversationSelectionDialog {
         align: center middle;
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 /* ===== WIDGET: EmojiPickerScreen (Widgets/emoji_picker.py) ===== */
 
@@ -36,12 +96,16 @@
     /* EmojiButton :focus styling lives in css/components/_widgets.tcss
        (needs the bundle's $ds-focus-* tokens; TASK-16811). */
 
+
+
+
+
 /* ===== WIDGET: FileExtractionDialog (Widgets/file_extraction_dialog.py) ===== */
 
     FileExtractionDialog {
         align: center middle;
     }
-    
+
     FileExtractionDialog > Vertical {
         width: 80%;
         height: 80%;
@@ -52,8 +116,44 @@
         padding: 1;
     }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
 /* ===== WIDGET: VoiceBlendDialog (Widgets/voice_blend_dialog.py) ===== */
 
     VoiceBlendDialog {
         align: center middle;
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tldw_chatbook/css/widget_css.py
+++ b/tldw_chatbook/css/widget_css.py
@@ -916,15 +916,9 @@ def render_stylesheets(
         for stream, text in enumerate(split):
             if not text.strip():
                 continue
-            # A lifted block whose closing `"""` is indented ends with a
-            # whitespace-only line (the quote's own indentation). Emitting
-            # that verbatim put trailing whitespace in a GENERATED file,
-            # which any editor/linter with strip-on-save silently removes --
-            # desyncing the committed sheet from what this builder produces
-            # and failing the CSS Bundle Guard for everyone. (Happened on
-            # dev: `PersonaVisualCustomStateDialog`'s block, one 4-space
-            # line, red guard on every PR until regenerated.) Normalize the
-            # block's tail so generated output is canonical and cannot be
-            # "corrected" into a desync.
-            rendered[stream] += banner + text.rstrip() + "\n"
+            # Class-body indentation appears on otherwise blank lines before
+            # a closing triple quote. Never publish that Python indentation as
+            # trailing whitespace in generated CSS.
+            text = "\n".join(line.rstrip() for line in text.splitlines()) + "\n"
+            rendered[stream] += banner + text
     return rendered[0], rendered[1]

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -46,6 +46,9 @@
         padding: 0 1;
     }
 
+
+
+
 /* ===== WIDGET: LLMManagementWindow (UI/LLM_Management_Window.py) ===== */
 
 
@@ -68,32 +71,32 @@
         height: 100%;
         width: 100%;
     }
-    
+
     LLMManagementWindow .llm-view.-active {
         display: block;
     }
-    
+
     LLMManagementWindow .section-title {
         text-style: bold;
         margin: 1 0;
         color: $primary;
     }
-    
+
     LLMManagementWindow .section_label {
         text-style: bold;
         margin: 1 0;
         color: $secondary;
     }
-    
+
     LLMManagementWindow .description {
         margin: 0 0 1 0;
         color: $text-muted;
     }
-    
+
     LLMManagementWindow .label {
         margin: 1 0 0 0;
     }
-    
+
     LLMManagementWindow .input_container {
         layout: horizontal;
         height: 3;
@@ -109,120 +112,121 @@
         padding-right: 1;
         color: $text;
     }
-    
+
     LLMManagementWindow .input_container Input {
         width: 1fr;
         min-width: 16;
     }
-    
+
     LLMManagementWindow .input_container Button {
         width: auto;
         margin: 0 0 0 1;
     }
-    
+
     LLMManagementWindow .button_container {
         layout: horizontal;
         margin: 1 0;
         height: 3;
     }
-    
+
     LLMManagementWindow .button_container Button {
         margin: 0 1 0 0;
     }
-    
+
     LLMManagementWindow .log_output {
         height: 15;
         border: solid $primary;
         margin: 1 0;
     }
-    
+
     LLMManagementWindow .help-text-display {
         height: 10;
         border: solid $secondary;
         padding: 1;
     }
-    
+
     LLMManagementWindow .additional_args_textarea {
         height: 5;
         margin: 0 0 1 0;
     }
-    
+
     LLMManagementWindow .separator {
         height: 1;
         margin: 1 0;
         color: $primary;
     }
-    
+
     LLMManagementWindow .ollama-button-bar {
         layout: horizontal;
         height: 3;
         margin: 1 0;
     }
-    
+
     LLMManagementWindow .ollama-button-bar Button {
         margin: 0 1 0 0;
     }
-    
+
     LLMManagementWindow .ollama-actions-grid {
         layout: horizontal;
         margin: 1 0;
     }
-    
+
     LLMManagementWindow .ollama-actions-column {
         width: 50%;
         padding: 0 1;
     }
-    
+
     LLMManagementWindow .column-title {
         text-style: bold;
         margin: 0 0 1 0;
         color: $secondary;
     }
-    
+
     LLMManagementWindow .input_field_short {
         width: 40%;
     }
-    
+
     LLMManagementWindow .input_field_long {
         width: 100%;
     }
-    
+
     LLMManagementWindow .action_button_short {
         width: auto;
     }
-    
+
     LLMManagementWindow .full_width_button {
         width: 100%;
         margin: 1 0;
     }
-    
+
     LLMManagementWindow .delete_button {
         background: $error;
     }
-    
+
     LLMManagementWindow .embeddings_container {
         layout: horizontal;
         margin: 1 0;
     }
-    
+
     LLMManagementWindow .embeddings_inputs {
         width: 70%;
     }
-    
+
     LLMManagementWindow .action_button_tall {
         width: 30%;
         margin: 0 0 0 1;
     }
-    
+
     LLMManagementWindow .output_textarea_medium {
         height: 10;
         margin: 1 0;
     }
-    
+
     LLMManagementWindow .log_output_large {
         height: 20;
         margin: 1 0;
     }
+
 
 /* ===== WIDGET: LogsWindow (UI/Logs_Window.py) ===== */
 
@@ -233,6 +237,7 @@
     LogsWindow #logs-empty-state {
         display: none;
     }
+
 
 /* ===== WIDGET: MCPAuditMode (UI/MCP_Modules/mcp_audit_mode.py) ===== */
 
@@ -341,6 +346,7 @@
         height: auto;
         min-height: 0;
     }
+
 
 /* ===== WIDGET: MCPInspector (UI/MCP_Modules/mcp_inspector.py) ===== */
 
@@ -540,6 +546,7 @@
         min-height: 6;
     }
 
+
 /* ===== WIDGET: MCPPermissionsMode (UI/MCP_Modules/mcp_permissions_mode.py) ===== */
 
 
@@ -607,6 +614,7 @@
         min-height: 0;
     }
 
+
 /* ===== WIDGET: MCPRail (UI/MCP_Modules/mcp_rail.py) ===== */
 
 
@@ -637,6 +645,7 @@
         color: $text-muted;
         padding: 0 1;
     }
+
 
 /* ===== WIDGET: MCPServersMode (UI/MCP_Modules/mcp_servers_mode.py) ===== */
 
@@ -701,6 +710,7 @@
         min-height: 0;
         color: $text-muted;
     }
+
 
 /* ===== WIDGET: MCPToolsMode (UI/MCP_Modules/mcp_tools_mode.py) ===== */
 
@@ -772,6 +782,7 @@
         min-height: 0;
     }
 
+
 /* ===== WIDGET: MCPWorkbench (UI/MCP_Modules/mcp_workbench.py) ===== */
 
 
@@ -808,6 +819,7 @@
         min-width: 20;
     }
 
+
 /* ===== WIDGET: BaseAppScreen (UI/Navigation/base_app_screen.py) ===== */
 
 
@@ -818,6 +830,7 @@
         min-height: 0;
         padding-top: 0;
     }
+
 
 /* ===== WIDGET: MainNavigationBar (UI/Navigation/main_navigation.py) ===== */
 
@@ -1000,6 +1013,7 @@
         color: $text;
         text-style: bold underline;
     }
+
 
 /* ===== WIDGET: LibraryScreen (UI/Screens/library_screen.py) ===== */
 
@@ -1719,6 +1733,7 @@
         display: none;
     }
 
+
 /* ===== WIDGET: MCPScreen (UI/Screens/mcp_screen.py) ===== */
 
     MCPScreen Button.mcp-mode-chip {
@@ -1766,6 +1781,7 @@
         text-style: bold underline;
         outline: none;
     }
+
 
 /* ===== WIDGET: PersonasScreen (UI/Screens/personas_screen.py) ===== */
 
@@ -1922,6 +1938,7 @@
         width: 100%;
     }
 
+
 /* ===== WIDGET: ConflictsTab (UI/Screens/scheduling/conflicts_tab.py) ===== */
 
 
@@ -1947,6 +1964,7 @@
         color: $text-muted;
     }
 
+
 /* ===== WIDGET: SyncStatusWidget (UI/Screens/scheduling/sync_status_widget.py) ===== */
 
 
@@ -1969,6 +1987,7 @@
     SyncStatusWidget #scheduling-clear-error {
         width: auto;
     }
+
 
 /* ===== WIDGET: TaskDetail (UI/Screens/scheduling/task_detail.py) ===== */
 
@@ -1999,6 +2018,7 @@
         height: auto;
     }
 
+
 /* ===== WIDGET: PersonaProfileEditorWidget (Widgets/Persona_Widgets/persona_profile_editor_widget.py) ===== */
 
 
@@ -2012,6 +2032,8 @@
     /* Live per-field validation (Roleplay P3b Task 4): a literal color, not
        a $ds-* token - BUNDLED_CSS must resolve in bare-App test harnesses
        that never load the app stylesheet. */
+
+
 
 /* ===== WIDGET: PersonasCharacterEditorWidget (Widgets/Persona_Widgets/personas_character_editor_widget.py) ===== */
 
@@ -2128,6 +2150,8 @@
        a $ds-* token - BUNDLED_CSS must resolve in bare-App test harnesses
        that never load the app stylesheet. */
 
+
+
 /* ===== WIDGET: PersonasInspectorPane (Widgets/Persona_Widgets/personas_inspector_pane.py) ===== */
 
     /* Portrait box for the selected character. Sized like the editor's
@@ -2162,6 +2186,10 @@
        variables the ds-text-disabled/ds-surface-raised tokens alias; widget
        DEFAULT_CSS cannot see bundle-scoped ds-* names.) */
 
+
+
+
+
 /* ===== WIDGET: PersonasLibraryPane (Widgets/Persona_Widgets/personas_library_pane.py) ===== */
 
 
@@ -2188,3 +2216,7 @@
     /* F-030 narrow panes: stack each bar vertically so every action wraps
        onto its own full-width row (a Textual Horizontal never wraps, so one
        over-wide row would clip instead). */
+
+
+
+

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -1125,6 +1125,102 @@
         margin-top: 1;
     }
 
+/* ===== WIDGET: PersonaBuddyWidget (Widgets/Persona_Widgets/persona_buddy_widget.py) ===== */
+
+    PersonaBuddyWidget {
+        position: absolute;
+        overlay: screen;
+        layer: overlay;
+        width: 28;
+        height: 12;
+        min-width: 1;
+        min-height: 1;
+        padding: 0 1;
+        background: $panel;
+        color: $text;
+        border: round $accent;
+        overflow: hidden hidden;
+    }
+
+    PersonaBuddyWidget:focus {
+        outline: heavy $accent;
+    }
+
+    PersonaBuddyWidget #persona-buddy-header {
+        width: 100%;
+        height: 3;
+        layout: horizontal;
+        background: $surface;
+    }
+
+    PersonaBuddyWidget #persona-buddy-title {
+        width: 1fr;
+        height: 3;
+        padding: 1 0 0 1;
+        color: $text;
+        text-style: bold;
+    }
+
+    PersonaBuddyWidget .persona-buddy-control {
+        width: auto;
+        min-width: 7;
+        height: 3;
+        padding: 0 1;
+        margin: 0;
+        border: none;
+        background: $surface-darken-1;
+        color: $text-muted;
+    }
+
+    PersonaBuddyWidget .persona-buddy-control:focus {
+        outline: heavy $accent;
+        color: $text;
+    }
+
+    PersonaBuddyWidget #persona-buddy-frame {
+        width: 100%;
+        height: 1fr;
+        content-align: center middle;
+        color: $text;
+    }
+
+    PersonaBuddyWidget #persona-buddy-status,
+    PersonaBuddyWidget #persona-buddy-hints {
+        width: 100%;
+        height: 1;
+        color: $text-muted;
+        text-align: center;
+    }
+
+    PersonaBuddyWidget.persona-buddy-collapsed,
+    PersonaBuddyWidget.persona-buddy-compact {
+        height: 3;
+        padding: 0;
+    }
+
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-frame,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-status,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-hints,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
+    PersonaBuddyWidget.persona-buddy-collapsed .persona-buddy-control,
+    PersonaBuddyWidget.persona-buddy-compact .persona-buddy-control {
+        display: none;
+    }
+
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-header,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-title,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-title {
+        height: 1;
+        width: 100%;
+        padding: 0;
+        content-align: center middle;
+        text-align: center;
+    }
+    
+
 /* ===== WIDGET: PersonaProfileCardWidget (Widgets/Persona_Widgets/persona_profile_card_widget.py) ===== */
 
     PersonaProfileCardWidget {
@@ -1919,7 +2015,6 @@
         width: 1fr;
         min-width: 0;
     }
-
 /* ===== WIDGET: PersonasPersonaVisualPackWidget (Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py) ===== */
 
     PersonasPersonaVisualPackWidget {

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -1324,34 +1324,57 @@
         text-align: center;
     }
 
-    PersonaBuddyWidget.persona-buddy-collapsed,
-    PersonaBuddyWidget.persona-buddy-compact {
+    PersonaBuddyWidget.persona-buddy-collapsed {
         height: 3;
         padding: 0;
+    }
+
+    PersonaBuddyWidget.persona-buddy-compact {
+        height: 1;
+        padding: 0;
+        border: none;
     }
 
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-frame,
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-status,
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-hints,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-close,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-close,
-    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-drag-handle,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-drag-handle {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-drag-handle {
         display: none;
     }
 
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-header,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
-    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-collapse,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-collapse {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-collapse {
         height: 1;
         width: 100%;
         padding: 0;
         content-align: center middle;
         text-align: center;
+    }
+
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-drag-handle {
+        display: none;
+    }
+
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
+    PersonaBuddyWidget.persona-buddy-compact .persona-buddy-control {
+        height: 1;
+        width: 1fr;
+        min-width: 5;
+        padding: 0;
+        content-align: center middle;
+        text-align: center;
+    }
+
+    PersonaBuddyWidget.persona-buddy-minimal #persona-buddy-close {
+        display: none;
+    }
+
+    PersonaBuddyWidget.persona-buddy-minimal #persona-buddy-collapse {
+        width: 100%;
     }
 
 

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -20,21 +20,22 @@
         layer: overlay;
         display: none;
     }
-    
+
     CCPLoadingWidget.visible {
         display: block;
     }
-    
+
     CCPLoadingWidget.inline {
         layer: default;
         border: none;
         padding: 0;
     }
-    
+
     CCPLoadingWidget .loading-text {
         text-align: center;
         margin-left: 1;
     }
+
 
 /* ===== WIDGET: ConsolePromptQueueRegion (UI/Console_Modules/prompt_queue.py) ===== */
 
@@ -70,6 +71,7 @@
         display: none;
     }
 
+
 /* ===== WIDGET: LLMManagementWindow (UI/LLM_Management_Window.py) ===== */
 
     LLMManagementWindow {
@@ -83,27 +85,78 @@
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 
 
     /* Side-by-side form rows (UX-054): the label lives inside the input row
      * instead of stacked above it, so server forms fit the fold. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 /* ===== WIDGET: LogsWindow (UI/Logs_Window.py) ===== */
 
     LogsWindow {
         layout: vertical;
     }
+
+
+
 
 /* ===== WIDGET: MCPAuditMode (UI/MCP_Modules/mcp_audit_mode.py) ===== */
 
@@ -176,6 +229,10 @@
     `max-height: 70%` below resolves against a definite height, same
     percentage-inside-a-definite-not-auto-parent discipline the Select
     slot comment above documents for the filter bar. */
+
+
+
+
 
 /* ===== WIDGET: MCPInspector (UI/MCP_Modules/mcp_inspector.py) ===== */
 
@@ -301,6 +358,8 @@
     dominating the rest of the inspector pane, mirroring #mcp-inspector-
     audit-scroll's identical bounded-pretty-printed-JSON precedent above. */
 
+
+
 /* ===== WIDGET: MCPPermissionsMode (UI/MCP_Modules/mcp_permissions_mode.py) ===== */
 
     MCPPermissionsMode {
@@ -349,6 +408,8 @@
     listing (a handful of Static rows at most) -- hugs its own content,
     same rationale as #mcp-perm-preview immediately above. */
 
+
+
 /* ===== WIDGET: MCPRail (UI/MCP_Modules/mcp_rail.py) ===== */
 
     MCPRail {
@@ -364,6 +425,8 @@
     /* task-2243: the in-rail state legend decodes the rows' glyphs right
     under the "Servers" heading -- same quiet dim tier as the empty state,
     hugging its own (possibly wrapped) content. */
+
+
 
 /* ===== WIDGET: MCPServersMode (UI/MCP_Modules/mcp_servers_mode.py) ===== */
 
@@ -401,6 +464,8 @@
     raw `$text-muted` token rationale: this widget's unit tests mount it
     without the app bundle where the `$ds-*` aliases are defined. */
 
+
+
 /* ===== WIDGET: MCPToolsMode (UI/MCP_Modules/mcp_tools_mode.py) ===== */
 
     MCPToolsMode {
@@ -426,6 +491,9 @@
     1fr, so the table hugs its own row count instead of ballooning to fill
     the canvas. */
 
+
+
+
 /* ===== WIDGET: MCPWorkbench (UI/MCP_Modules/mcp_workbench.py) ===== */
 
     MCPWorkbench {
@@ -445,11 +513,18 @@
     DEFAULT_CSS on ties in this Textual version -- the established lockstep
     pattern documented there). */
 
+
+
+
+
 /* ===== WIDGET: BaseAppScreen (UI/Navigation/base_app_screen.py) ===== */
 
     BaseAppScreen {
         background: $background;
     }
+
+
+
 
 /* ===== WIDGET: MainNavigationBar (UI/Navigation/main_navigation.py) ===== */
 
@@ -561,6 +636,14 @@
        out rather than reworking every geometry read onto a different
        property. */
 
+
+
+
+
+
+
+
+
 /* ===== WIDGET: ChatScreen (UI/Screens/chat_screen.py) ===== */
 
     ChatScreen ToastRack {
@@ -569,6 +652,7 @@
         margin-top: 1;
         margin-bottom: 0;
     }
+
 
 /* ===== WIDGET: LabModeStrip (UI/Screens/lab_mode_strip.py) ===== */
 
@@ -599,6 +683,7 @@
         border: none;
         text-style: bold underline;
     }
+
 
 /* ===== WIDGET: LibraryScreen (UI/Screens/library_screen.py) ===== */
 
@@ -773,6 +858,28 @@
        (css/components/_agentic_terminal.tcss) carries the same rules and
        wins when loaded. */
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /* ===== WIDGET: MCPScreen (UI/Screens/mcp_screen.py) ===== */
 
 
@@ -794,6 +901,8 @@
     /* Active AND focused: still reads as "active" (bold underline, same
     background as non-focused .is-active) rather than picking up the
     reverse-video focus treatment above. */
+
+
 
 /* ===== WIDGET: CuratedView (UI/Screens/model_curated_view.py) ===== */
 
@@ -837,6 +946,7 @@
         width: auto;
         margin-right: 1;
     }
+
 
 /* ===== WIDGET: ExternalModelView (UI/Screens/model_external_view.py) ===== */
 
@@ -889,6 +999,7 @@
         margin-bottom: 1;
     }
 
+
 /* ===== WIDGET: InstalledView (UI/Screens/model_installed_view.py) ===== */
 
     InstalledView {
@@ -932,6 +1043,7 @@
         margin-right: 1;
     }
 
+
 /* ===== WIDGET: RemoteView (UI/Screens/model_remote_view.py) ===== */
 
     RemoteView {
@@ -964,6 +1076,8 @@
     RemoteView .remote-title {
         text-style: bold;
     }
+
+
 
 /* ===== WIDGET: PersonasScreen (UI/Screens/personas_screen.py) ===== */
 
@@ -1029,11 +1143,19 @@
        BUNDLED_CSS keeps every part height: auto, which the old cap existed
        to force). */
 
+
+
 /* ===== WIDGET: ConflictsTab (UI/Screens/scheduling/conflicts_tab.py) ===== */
 
     ConflictsTab {
         height: 1fr;
     }
+
+
+
+
+
+
 
 /* ===== WIDGET: SyncStatusWidget (UI/Screens/scheduling/sync_status_widget.py) ===== */
 
@@ -1045,11 +1167,16 @@
     /* task-2723: without margins these Statics render flush against each
        other — "Last pull: —Last push: —<error text>" read as one run. */
 
+
+
+
+
 /* ===== WIDGET: DestinationHeader (UI/Workbench/workbench_widgets.py) ===== */
 
     DestinationHeader {
         height: auto;
     }
+
 
 /* ===== WIDGET: AppFooterStatus (Widgets/AppFooterStatus.py) ===== */
 
@@ -1081,6 +1208,7 @@
         margin-left: 2;
     }
 
+
 /* ===== WIDGET: ConsoleTranscriptSurface (Widgets/Console/console_background_effect.py) ===== */
 
     ConsoleTranscriptSurface {
@@ -1101,6 +1229,7 @@
         height: 100%;
     }
 
+
 /* ===== WIDGET: ConsoleSessionTabButton (Widgets/Console/console_session_surface.py) ===== */
 
     ConsoleSessionTabButton {
@@ -1108,12 +1237,14 @@
         text-overflow: clip;
     }
 
+
 /* ===== WIDGET: ConsoleSetupBackdrop (Widgets/Console/console_setup_modal.py) ===== */
 
     ConsoleSetupBackdrop {
         width: 1fr;
         height: 1fr;
     }
+
 
 /* ===== WIDGET: ModelInstallProgress (Widgets/ModelArtifacts/install_progress.py) ===== */
 
@@ -1124,6 +1255,7 @@
     ModelInstallProgress ProgressBar {
         margin-top: 1;
     }
+
 
 /* ===== WIDGET: PersonaBuddyWidget (Widgets/Persona_Widgets/persona_buddy_widget.py) ===== */
 
@@ -1153,7 +1285,7 @@
         background: $surface;
     }
 
-    PersonaBuddyWidget #persona-buddy-title {
+    PersonaBuddyWidget #persona-buddy-drag-handle {
         width: 1fr;
         height: 3;
         padding: 1 0 0 1;
@@ -1204,22 +1336,24 @@
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-frame,
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-status,
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-hints,
-    PersonaBuddyWidget.persona-buddy-collapsed .persona-buddy-control,
-    PersonaBuddyWidget.persona-buddy-compact .persona-buddy-control {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-close,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-close,
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-drag-handle,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-drag-handle {
         display: none;
     }
 
     PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-header,
     PersonaBuddyWidget.persona-buddy-compact #persona-buddy-header,
-    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-title,
-    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-title {
+    PersonaBuddyWidget.persona-buddy-collapsed #persona-buddy-collapse,
+    PersonaBuddyWidget.persona-buddy-compact #persona-buddy-collapse {
         height: 1;
         width: 100%;
         padding: 0;
         content-align: center middle;
         text-align: center;
     }
-    
+
 
 /* ===== WIDGET: PersonaProfileCardWidget (Widgets/Persona_Widgets/persona_profile_card_widget.py) ===== */
 
@@ -1250,6 +1384,7 @@
         border: none;
         margin-right: 1;
     }
+
 
 /* ===== WIDGET: PersonaProfileEditorWidget (Widgets/Persona_Widgets/persona_profile_editor_widget.py) ===== */
 
@@ -1283,6 +1418,7 @@
     PersonaProfileEditorWidget .is-invalid {
         border: round red;
     }
+
 
 /* ===== WIDGET: PersonasCharacterCardWidget (Widgets/Persona_Widgets/personas_character_card_widget.py) ===== */
 
@@ -1320,6 +1456,7 @@
         margin-right: 1;
     }
 
+
 /* ===== WIDGET: PersonasCharacterDictionariesWidget (Widgets/Persona_Widgets/personas_character_dictionaries.py) ===== */
 
     PersonasCharacterDictionariesWidget {
@@ -1345,6 +1482,7 @@
     }
 
     PersonasCharacterDictionariesWidget #personas-char-dicts-table { height: auto; max-height: 8; }
+
 
 /* ===== WIDGET: PersonasCharacterEditorWidget (Widgets/Persona_Widgets/personas_character_editor_widget.py) ===== */
 
@@ -1611,6 +1749,7 @@
         border: round red;
     }
 
+
 /* ===== WIDGET: PersonasCharacterTTSWidget (Widgets/Persona_Widgets/personas_character_tts_widget.py) ===== */
 
     PersonasCharacterTTSWidget {
@@ -1664,6 +1803,7 @@
         margin-right: 0;
     }
 
+
 /* ===== WIDGET: PersonasCharacterWorldBooksWidget (Widgets/Persona_Widgets/personas_character_world_books.py) ===== */
 
     PersonasCharacterWorldBooksWidget {
@@ -1690,6 +1830,7 @@
 
     PersonasCharacterWorldBooksWidget #personas-char-worldbooks-table { height: auto; max-height: 8; }
 
+
 /* ===== WIDGET: PersonasConversationTranscriptWidget (Widgets/Persona_Widgets/personas_conversation_transcript_widget.py) ===== */
 
     PersonasConversationTranscriptWidget {
@@ -1704,6 +1845,7 @@
     PersonasConversationTranscriptWidget .personas-transcript-line {
         height: auto;
     }
+
 
 /* ===== WIDGET: PersonasDictionaryDetailWidget (Widgets/Persona_Widgets/personas_dictionary_detail.py) ===== */
 
@@ -1748,6 +1890,7 @@
         max-height: 8;
     }
 
+
 /* ===== WIDGET: PersonasDictionaryTryItWidget (Widgets/Persona_Widgets/personas_dictionary_tryit.py) ===== */
 
     PersonasDictionaryTryItWidget {
@@ -1777,6 +1920,7 @@
     PersonasDictionaryTryItWidget #personas-dict-tryit-nearmiss {
         height: auto;
     }
+
 
 /* ===== WIDGET: PersonasInspectorPane (Widgets/Persona_Widgets/personas_inspector_pane.py) ===== */
 
@@ -1857,6 +2001,7 @@
         color: $text;
     }
 
+
 /* ===== WIDGET: PersonasLibraryPane (Widgets/Persona_Widgets/personas_library_pane.py) ===== */
 
     PersonasLibraryPane #personas-library-rows ListItem {
@@ -1929,6 +2074,7 @@
         margin-right: 0;
     }
 
+
 /* ===== WIDGET: PersonasLoreDetailWidget (Widgets/Persona_Widgets/personas_lore_detail.py) ===== */
 
     PersonasLoreDetailWidget {
@@ -1956,6 +2102,7 @@
         height: auto;
         max-height: 8;
     }
+
 
 /* ===== WIDGET: PersonasLoreTryItWidget (Widgets/Persona_Widgets/personas_lore_tryit.py) ===== */
 
@@ -1990,6 +2137,7 @@
         height: auto;
     }
 
+
 /* ===== WIDGET: PersonaVisualCustomStateDialog (Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py) ===== */
 
     PersonaVisualCustomStateDialog {
@@ -2015,6 +2163,7 @@
         width: 1fr;
         min-width: 0;
     }
+
 /* ===== WIDGET: PersonasPersonaVisualPackWidget (Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py) ===== */
 
     PersonasPersonaVisualPackWidget {
@@ -2144,6 +2293,7 @@
         border: none;
         margin-right: 1;
     }
+
 
 /* ===== WIDGET: PersonasVisualIdentityPackWidget (Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py) ===== */
 


### PR DESCRIPTION
## Summary
- add an app-owned, opt-in floating Persona Buddy backed by local Persona Visual identity
- add native Textual drag, resize, compact, modal, navigation, persistence, and lifecycle behavior
- integrate explicit Workbench controls and trusted Console lifecycle state without model-directed emotes

## Verification
- 341 passed: full touched Personas Workbench file
- 575 passed: rebased broad touched-component gate, including the six former failures
- 6/6 focused regression nodes passed after the follow-up fix
- real POSIX PTY probe: 18/18 checks passed
- focused Buddy/CSS/architecture smoke: 24 passed
- Impeccable detector: `[]`
- fatal Ruff, compile, and diff checks passed
- full suite intentionally not run per task instruction

## Follow-up completed
Commit `62b44fda1` fixes the Console hook-enumeration safety gap and aligns stale Library navigation tests with the progressive-disclosure/returning-landing contract.

The persistent-diagnostic inventory check still detects a repository-wide stale inventory on current `dev` across unrelated Chat, database, Library, and Console owners as well as the new Buddy owner. It was reviewed but not folded into this focused regression commit.
