### PR TITLE
chore(backlog): file findings from the P0/P1 burn-down wave

### DIFF
--- a/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
+++ b/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
@@ -1,0 +1,125 @@
+---
+id: TASK-19733
+title: >-
+  Shared egress primitive does not strip x-api-key on cross-origin redirects
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:40'
+labels:
+  - security
+  - credentials
+  - http
+  - egress
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: surfaced while filing/reviewing **TASK-19557** (API-key headers survive
+cross-origin redirects in two clients). TASK-19557 fixes two *direct callers*
+(`tldw_api/client.py` and the Anthropic call sites) and deliberately does not
+touch the shared primitive. This task is that primitive. Re-verified at this
+branch base (`839819e1a`).
+
+`tldw_chatbook/Utils/egress.py:348`:
+
+```python
+_STRIP_HEADERS = ("authorization", "cookie", "proxy-authorization", "x-goog-api-key")
+```
+
+`x-api-key` is **not** in the tuple. `_hop_headers` (`egress.py:491-497`) is the
+single place every guarded fetch decides what a cross-origin redirect hop may
+carry; it lowercases and drops only what that tuple names. The same tuple is
+re-applied belt-and-braces at `egress.py:526-527`, `:588-589`, `:648` and
+`:710`.
+
+This matters more than the two callers TASK-19557 covers, because
+`Utils/egress.py` is the shared guarded-fetch primitive the review praised as
+well-built — roughly 25 call sites route through
+`guarded_fetch_httpx` / `guarded_fetch_httpx_async`, and everything that adopts
+the primitive inherits the gap.
+
+**Reachable today, with a user-supplied credential.** Feed/watchlist auth is
+user-configurable and lands in exactly this header:
+
+* `Subscriptions/monitoring_engine.py:1006-1009` —
+  `key_header = auth_config.get("header", "X-API-Key"); headers[key_header] =
+  auth_config.get("key", "")` — and those `headers` are handed straight to
+  `guarded_fetch_httpx_async` at `monitoring_engine.py:1024-1030` (same shape
+  again at `:1709-1714` for the single-URL fetch path).
+* `Subscriptions/site_config_manager.py:161-167` —
+  `key_name = self.auth_credentials.get("key_name", "X-API-Key")` — consumed by
+  every scraper's `self.get_headers()` (`generic_scraper.py:137`,
+  `custom_scraper.py:117`, `github_scraper.py:143,191`,
+  `reddit_scraper.py:152,199`, `hackernews_scraper.py:166,222,246,262,300`,
+  `youtube_scraper.py:181,218`), each of which passes them to
+  `guarded_fetch_httpx_async`.
+
+A feed that starts 302-ing to another host (compromised, sold, or hostile from
+the start) receives the user's feed API key verbatim.
+
+**The header name is user-supplied, which is the load-bearing design point.**
+Both producers above take the header NAME from user config and only *default*
+to `X-API-Key`. Adding one more literal to `_STRIP_HEADERS` closes the default
+and leaves every custom-named credential header open. Per the owner's standing
+ruling (durable/pragmatic over clever), the fix should be the one that cannot
+drift: on a cross-origin hop, drop **all caller-supplied headers except an
+explicit non-credential allowlist** (User-Agent / Accept / Accept-Language /
+Accept-Encoding and similar), rather than growing a denylist one incident at a
+time. `_STRIP_HEADERS` would then remain only as the client-default-header
+sweep it also performs at `:526`, `:588`, `:648`, `:710`.
+
+**Named siblings, still unfixed, all outside the primitive** (verified at this
+base; every one uses `requests` with default `allow_redirects=True` — grep for
+`allow_redirects` in `Web_Scraping/WebSearch_APIs.py` returns nothing):
+
+| site | header | call |
+| --- | --- | --- |
+| `LLM_Calls/LLM_API_Calls_Local.py:1011` (Kobold) | `X-Api-Key` | `session.post(...)` at `:1060` |
+| `Web_Scraping/WebSearch_APIs.py:2711` (Bing) | `Ocp-Apim-Subscription-Key` | `session.get(...)` |
+| `Web_Scraping/WebSearch_APIs.py:2964` (Brave) | `X-Subscription-Token` | `requests.get(...)` |
+| `Web_Scraping/WebSearch_APIs.py:3985` (Serper) | `X-API-KEY` | `requests.post(...)` |
+| `Web_Scraping/WebSearch_APIs.py:4055` (Exa) | `x-api-key` | `requests.post(...)` |
+
+(Kagi at `:3672` and Yandex at `:4228` use `Authorization`, which `requests`
+already strips cross-origin — record them as clean, not as fixes.)
+
+**Knock-on the fix must not miss:** `Model_Artifacts/fetch.py:26` keeps a
+hand-mirrored copy of the tuple, and
+`Tests/Model_Artifacts/test_stream_fetch.py:276` pins
+`set(fetch._STRIP_HEADERS) == set(egress._STRIP_HEADERS)`. Changing one without
+the other turns that guard red.
+
+## Acceptance Criteria
+
+- [ ] A credential header carrying a user-configured API key (default
+      `X-API-Key` **and** a custom header name the user chose) is absent from
+      the request when a guarded fetch follows a redirect to a different origin
+- [ ] The cross-origin rule is expressed so that a newly-introduced credential
+      header name is safe by default — a header the caller supplies is not
+      forwarded cross-origin unless it is on an explicit non-credential
+      allowlist — rather than by adding another literal to a denylist
+- [ ] Same-origin redirects still carry the header, so authenticated feeds that
+      redirect within their own origin keep working
+- [ ] Born-red tests drive an actual cross-origin redirect through both
+      `guarded_fetch_httpx` and `guarded_fetch_httpx_async` and assert the
+      credential header is absent on the second hop, including one case with a
+      non-default header name; each is mutation-checked (restoring the old
+      behaviour makes it red)
+- [ ] At least one test exercises the real producer path
+      (`monitoring_engine`'s `api_key` auth config or a `SiteConfig` scraper),
+      not only `_hop_headers` in isolation
+- [ ] `Model_Artifacts/fetch.py`'s mirrored tuple and
+      `Tests/Model_Artifacts/test_stream_fetch.py`'s drift guard are updated in
+      the same change and remain green
+- [ ] The five named non-egress siblings (Kobold, Bing, Brave, Serper, Exa) are
+      either fixed the same way or recorded — with the reason — as a separate
+      tracked item; the task is not closed with them silently unaddressed
+
+## Notes
+
+Deliberately scoped apart from TASK-19557: that task fixes two clients that do
+not use the primitive. Fixing the primitive does not fix them, and fixing them
+does not fix the ~25 call sites that route through `Utils/egress.py`. Both are
+needed; neither subsumes the other.

--- a/backlog/tasks/task-19734 - Chatbook import wizard reports success and per-type ticks it did not earn.md
+++ b/backlog/tasks/task-19734 - Chatbook import wizard reports success and per-type ticks it did not earn.md
@@ -1,0 +1,117 @@
+---
+id: TASK-19734
+title: >-
+  Chatbook import wizard reports success and per-type ticks it did not earn,
+  and two of its options are inert
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:40'
+labels:
+  - chatbooks
+  - honesty
+  - ux
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: surfaced during **TASK-19550** (the "Create backup" checkbox that wrote
+a success row and took no backup) and confirmed at exact line numbers by that
+task's reviewer. 19550 is Done and removed the fake backup control; these three
+are its siblings in the same wizard, all still present at this branch base
+(`839819e1a`). Same theme the holistic review named: *the app asserts outcomes
+it did not produce.*
+
+### (a) A fully-skipped import reports success, with per-type ✓ rows
+
+`Chatbooks/chatbook_importer.py:397-399`:
+
+```python
+success = (
+    status.successful_items + status.skipped_items
+) > 0 or status.total_items == 0
+```
+
+Skipped items count as success. The wizard then paints its per-type completion
+rows gated on **manifest counts, not results** —
+`UI/Wizards/ChatbookImportWizard.py:929-961` ticks
+`"✓ Imported conversations"`, `"✓ Imported notes"`, `"✓ Imported characters"`
+and `"✓ Imported media"` on `manifest.total_conversations > 0`,
+`manifest.total_notes > 0`, etc. — followed by `"✓ Updated indexes"`,
+`"✓ Import completed"` and the `"✅ Import Completed Successfully!"` banner
+(`:693`).
+
+Re-importing the same chatbook under the default conflict strategy (skip
+existing) therefore shows four green ✓ rows and "Import Completed
+Successfully!" directly above a summary panel reading **Imported: 0 /
+Skipped: N** (`:704-711`). The importer's own log line for that case is honest
+("Skipped N/M items due to conflicts", `:414`) — the UI is not.
+
+**A whole-import-granularity fix is not enough.** Making `success` mean "at
+least one item landed" only relocates the overstatement to the partial case: an
+import where notes landed and characters all failed would still tick
+"✓ Imported characters", because that row never consults a result. The ✓ rows
+have to be driven by **per-type result counts**, which means `ImportStatus`
+must carry them.
+
+### (b) Two collected options are consumed by nothing
+
+`ChatbookImportWizard.py:630-633` collects `preserve_timestamps` (checkbox at
+`:554-559`, default ON) and `import_tags` (checkbox at `:569-571`, default ON)
+into the options dict returned by `get_step_data`. A whole-tree grep finds
+**zero** other production consumers of either key —
+`import_chatbook` is called at `:790-800` and `:913-923` with neither. The user
+toggles them; nothing reads them. (`Media/local_media_reading_service.py`'s
+`_normalize_import_tags` / `_merge_import_tags` are unrelated — different
+feature, different key.)
+
+### (c) "Merge with existing tags" is default-ON and does not touch tags
+
+The checkbox at `ChatbookImportWizard.py:576-581` reads "Merge with existing
+tags", `value=True`. Its value is passed as
+`prefix_imported=options.get("merge_tags", False)` (`:796`, and again at
+`:918-920` with the comment `# Use merge_tags as prefix flag`).
+
+`prefix_imported` does exactly one thing, in four places — prepend
+`"[Imported] "` to a **name**: `chatbook_importer.py:506-507` (conversation
+name), `:1179-1180` (note title), `:1293-1294` (character name), `:1446-1447`
+(prompt name). It never reads or writes a tag. So a default-ON control labelled
+as tag behaviour silently renames every imported item instead, and the actual
+tag-merge behaviour the label promises does not exist.
+
+## Acceptance Criteria
+
+- [ ] An import in which every item was skipped does not present itself as a
+      successful import — neither the banner, nor the per-type rows, nor the
+      caller-visible return value asserts that items were imported
+- [ ] Each per-type completion row reflects that type's own **result count**,
+      not its manifest count: a type with zero successful items never shows an
+      "✓ Imported …" row, and a partially-failed type is distinguishable from a
+      fully-successful one
+- [ ] The wizard's headline and its Imported / Skipped / Failed summary can
+      never contradict each other for any combination of imported, skipped and
+      failed counts (covered by tests over those combinations, including
+      all-skipped and mixed partial-failure)
+- [ ] `preserve_timestamps` and `import_tags` are either implemented end-to-end
+      or their controls are removed — no control remains that the user can
+      toggle with no effect. Per the owner's standing ruling
+      (durable/pragmatic over clever), removing an inert control is preferred
+      over shipping a hurried implementation behind it; a disabled or
+      greyed-out control does not satisfy this, since it still reads as
+      "handled"
+- [ ] The "Merge with existing tags" control either performs tag merging or is
+      relabelled/removed to match what it actually does; the item-renaming
+      behaviour currently hidden behind it is exposed under a label that names
+      it, or dropped
+- [ ] Tests pin each of the above and are mutation-checked (restoring the old
+      wiring makes them red)
+
+## Notes
+
+Filed separately from TASK-19550 (Done) because that task's disposition was
+narrowly "remove the lying backup checkbox"; these three are different
+mechanisms in the same screen and (a) requires a change to `ImportStatus`'s
+shape, not just a UI edit. Related but distinct: TASK-279 (wrap chatbook import
+in a single transaction) — the import still has no rollback, which is part of
+why an over-claiming success banner is expensive here.

--- a/backlog/tasks/task-19735 - Tavily search carries its API key inside the request payload dict.md
+++ b/backlog/tasks/task-19735 - Tavily search carries its API key inside the request payload dict.md
@@ -1,0 +1,87 @@
+---
+id: TASK-19735
+title: >-
+  Tavily search carries its API key inside the request payload dict
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:40'
+labels:
+  - security
+  - credentials
+  - hardening
+  - websearch
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: surfaced while fixing **TASK-19552** (Google Search API key logged at
+INFO on the default search engine) and confirmed **latent** by that task's
+reviewer. Re-verified at this branch base (`839819e1a`).
+
+`Web_Scraping/WebSearch_APIs.py:4105-4110`, in `search_web_tavily`:
+
+```python
+tavily_api_key = loaded_config_data["search_engines"]["tavily_search_api_key"]
+
+payload = {
+    "api_key": tavily_api_key,
+    "query": search_query,
+    "max_results": result_count,
+}
+```
+
+The credential lives inside a plain dict alongside ordinary, log-worthy request
+parameters — the same smell as the Google leak TASK-19552 fixed, where a key
+sitting in a `params` dict was eventually rendered into a log line.
+
+**This one is latent, and the task should be sized accordingly:**
+
+1. Nothing in the current code logs `payload`. Grep at this base finds no log
+   statement in `search_web_tavily` at all.
+2. The key travels in the POST **body** (`requests.post(tavily_api_url,
+   headers=headers, data=json.dumps(payload), ...)`, `:4127-4129`), not in the
+   URL. So the exception path is clean too: the handler at `:4131-4132` returns
+   `f"There was an error searching for content. {str(e)}"`, and `str(e)` on a
+   `requests` exception carries the URL, not the body — unlike a query-string
+   credential, which would land in that string and then in the returned error
+   text.
+
+The risk is entirely prospective: a future maintainer adding
+`logger.debug(f"Tavily payload: {payload}")` while debugging — a one-line change
+with no local signal that it is dangerous — writes the key to disk. Every other
+credential in this module is at least kept in a `headers` dict, which reads as
+"do not log this"; this one does not.
+
+Per the owner's standing ruling (durable/pragmatic over clever), the preferred
+shape is the one that makes the hazard structurally impossible rather than one
+that relies on future reviewers noticing: keep the credential out of the
+loggable parameter object entirely (Tavily accepts `Authorization: Bearer
+<key>`, so it can move to `headers` like every sibling backend in this file), or
+— if it must stay in the body — assemble it only at the call and never bind it
+to a name that a debug log would naturally reach for.
+
+## Acceptance Criteria
+
+- [ ] The Tavily API key is not a member of any dict that also holds ordinary
+      request parameters, so a debug log of the request parameters cannot
+      disclose it
+- [ ] Tavily search still authenticates and returns results (the credential
+      reaches the service by whichever transport the fix chooses)
+- [ ] A test asserts that the object holding the request parameters contains no
+      credential value, and is mutation-checked (restoring the old payload
+      shape makes it red)
+- [ ] The already-clean properties are pinned, not just assumed: a test asserts
+      the error string returned on a request exception contains no credential
+- [ ] The other backends in `Web_Scraping/WebSearch_APIs.py` are checked for the
+      same shape and the result recorded (headers-based ones — Bing, Brave,
+      Serper, Exa, Kagi, Yandex — are expected clean; Google's `params["key"]`
+      at `:3428` is the one TASK-19552 addressed)
+
+## Notes
+
+Low priority on purpose. This is hardening against a plausible future edit, not
+a live disclosure — filing it as a live leak would misrepresent the evidence.
+The value is that the next person to debug this function finds the task instead
+of adding the log line.


### PR DESCRIPTION
Three findings from the 2026-08-21 holistic-review burn-down, filed as backlog
tasks. Every finding was **re-verified at this branch base (`839819e1a`)**
before filing; two candidates were dropped on that verification.

IDs claimed at MAX+30 (prior max across `git ls-remote` refs, `git branch -a`,
all `.worktrees/*/backlog/`, and `origin/dev`'s `backlog/tasks` + `drafts` was
**19703**). Re-swept immediately before commit — still 19703. Each id maps to
exactly one file; the Backlog Guard duplicate check passes locally (0 filename
dupes, 0 frontmatter dupes, 2328 task files).

## Filed

| id | pri | one-line rationale |
| --- | --- | --- |
| **TASK-19733** | high | `Utils/egress.py:348`'s `_STRIP_HEADERS` omits `x-api-key`, so the **shared** guarded-fetch primitive forwards a user-configured feed API key to whatever host a cross-origin redirect names. Reachable through `Subscriptions/monitoring_engine.py:1006-1009 → :1024` and `site_config_manager.py:161-167` via every scraper's `get_headers()`. TASK-19557 fixed two direct callers and deliberately left the primitive. Records the five named siblings still unfixed (Kobold `LLM_API_Calls_Local.py:1011`; Bing `:2711`, Brave `:2964`, Serper `:3985`, Exa `:4055` in `WebSearch_APIs.py` — all `requests` with default `allow_redirects=True`; grep for `allow_redirects` in that file returns nothing). Source: task-19557. |
| **TASK-19734** | high | Chatbook import wizard, three more "asserts an outcome it did not produce" instances: (a) `chatbook_importer.py:397-399` returns `success=True` when everything was skipped, and `ChatbookImportWizard.py:929-961` ticks four "✓ Imported …" rows off **manifest counts, not results**, over an "Imported: 0 / Skipped: N" panel; (b) `preserve_timestamps` (`:630`) and `import_tags` (`:633`) are collected and consumed by nothing; (c) default-ON "Merge with existing tags" (`:576-581`) passes `prefix_imported`, which only prepends `"[Imported] "` to **names** (`chatbook_importer.py:507,1180,1294,1447`) and never touches tags. Source: task-19550. |
| **TASK-19735** | low | Tavily embeds `api_key` in its request payload dict (`WebSearch_APIs.py:4105-4110`) — same smell as the Google key leak, filed as **hardening, not a live leak**: nothing logs that payload today, and because the key travels in the POST body rather than the URL, `str(e)` on a request exception does not carry it either. Source: task-19552. |

Each task encodes the owner's standing durable-over-clever ruling where a fix
choice exists:

* 19733 — the credential **header name is user-supplied** (`auth_config.get("header", "X-API-Key")`, `auth_credentials.get("key_name", "X-API-Key")`), so adding one literal to the denylist closes the default and leaves every custom-named header open. The AC requires a cross-origin rule that is safe by default (allowlist of non-credential headers) rather than a denylist grown one incident at a time. It also flags the knock-on: `Model_Artifacts/fetch.py:26` hand-mirrors the tuple and `Tests/Model_Artifacts/test_stream_fetch.py:276` pins the two as equal.
* 19734 — the ACs state explicitly that a **whole-import-granularity** fix just relocates the overstatement to the partial case, and require **per-type result counts** (which means `ImportStatus` has to carry them). For the inert options, removing a control is preferred over a hurried implementation, and a greyed-out control does not satisfy the AC.
* 19735 — prefers moving the credential out of the loggable parameter object entirely over relying on future reviewers noticing.

## Dropped

* **`play_current_audio` orphan pair** — **already fixed.** Merged **TASK-19190** ("Remove the orphaned play_current_audio pair (app wrapper + stts_events handler)") is `status: Done` at this base and removed both halves plus the caller-less `_current_playground_audio_path` helper. Verified: `grep -rn "play_current_audio" tldw_chatbook Tests` → **no hits**; `grep -n "current_audio" tldw_chatbook/app.py` → **no hits**. Nothing to file.
* **A third diagnostic-inventory task** — **covered.** TASK-19191 owns the per-row-reviewed regeneration; TASK-19572 owns the CI gate that would stop it recurring. Not duplicated. **But the recurrence count is now four and the pin is red again**: `scripts/check_persistent_diagnostic_inventory.py` exits **1** at this base (`839819e1a`) with "production diagnostic owners or persistent-sink topology changed", *despite TASK-19191 being Done*. Four separate tasks (19552, 19555, 19576, and one other) each had to independently decide not to bundle ~10 unrelated files' drift this session. **Both 19191 and 19572 should record this**: a one-shot regeneration does not hold, which is precisely the argument for 19572's install-free required check (the checker is stdlib-only and measured at 20.5 s).

Also checked for pre-existing equivalents before writing; 19632/19633 were not duplicated, and no existing task covers any of the three filed items (nearest neighbours — 19557, 19550, 19552 — are each cited as the source and scoped apart in the task Notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three backlog tasks from the P0/P1 burn-down to track a credential-forwarding gap in shared egress, misleading success in Chatbook import, and a latent Tavily credential handling risk. No runtime behavior changes; this PR only adds backlog items with acceptance criteria.

- TASK-19733: Shared egress forwards user-supplied API-key headers across cross-origin redirects. Requires allowlist-based cross-origin header forwarding, updates the mirrored tuple in Model Artifacts and its test, and records unfixed direct-call siblings (Kobold, Bing, Brave, Serper, Exa).
- TASK-19734: Chatbook import wizard overstates outcomes and includes inert options. Requires per-type result counts in `ImportStatus`, implements or removes `preserve_timestamps`/`import_tags`, and fixes or relabels “Merge with existing tags,” which currently renames items.
- TASK-19735: Tavily search places its API key in a request payload dict (latent risk). Moves the credential out of loggable parameter objects and adds tests to ensure params and error strings exclude credentials.
- Dropped items: `play_current_audio` orphan pair already removed; diagnostic-inventory recurrence is covered by existing tasks and should be recorded there.

<sup>Written for commit 58490002e0e168710304629b05cfc77740d6ca47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

