### PR TITLE
perf: efficiency burn-down batch 1 (task-692, task-19324, task-19573 AC, task-13158)

### DIFF
--- a/Tests/CI/test_backlog_task_id_uniqueness.py
+++ b/Tests/CI/test_backlog_task_id_uniqueness.py
@@ -38,10 +38,24 @@ _FILENAME_ID = re.compile(r"^(task-[0-9]+(?:\.[0-9]+)*) - .*\.md$")
 
 
 def _task_files() -> list[Path]:
+    """Return every backlog task file, sorted for stable failure output.
+
+    Returns:
+        Sorted ``backlog/tasks/task-*.md`` paths.
+    """
     return sorted(TASKS_DIR.glob("task-*.md"))
 
 
 def _format(dupes: dict[str, list[str]]) -> str:
+    """Render duplicate ids and their files as an actionable failure message.
+
+    Args:
+        dupes: Task id -> the file names that claim it.
+
+    Returns:
+        A multi-line message naming every colliding file plus the owner rule
+        for resolving it.
+    """
     lines = []
     for task_id, names in sorted(dupes.items()):
         lines.append(f"--- {task_id} ---")
@@ -57,6 +71,11 @@ def _format(dupes: dict[str, list[str]]) -> str:
 
 @pytest.fixture(scope="module")
 def task_files() -> list[Path]:
+    """Every task file, with a guard against a mis-resolved project root.
+
+    Returns:
+        Sorted ``backlog/tasks/task-*.md`` paths.
+    """
     files = _task_files()
     # Guard the guard: a wrong PROJECT_ROOT would make every assertion below
     # vacuously true, which is how a green gate hides a real collision.
@@ -65,6 +84,11 @@ def task_files() -> list[Path]:
 
 
 def test_no_duplicate_task_ids_in_filenames(task_files: list[Path]) -> None:
+    """Fail when two task files share an id in their FILENAME prefix.
+
+    Args:
+        task_files: Every ``backlog/tasks/task-*.md`` file, from the fixture.
+    """
     by_id: dict[str, list[str]] = defaultdict(list)
     for path in task_files:
         match = _FILENAME_ID.match(path.name)
@@ -75,6 +99,14 @@ def test_no_duplicate_task_ids_in_filenames(task_files: list[Path]) -> None:
 
 
 def test_no_duplicate_task_ids_in_frontmatter(task_files: list[Path]) -> None:
+    """Fail when two task files share an id in their frontmatter.
+
+    Checked separately from the filename because the two can disagree after a
+    hand-edited rename, and the backlog CLI resolves by frontmatter.
+
+    Args:
+        task_files: Every ``backlog/tasks/task-*.md`` file, from the fixture.
+    """
     by_id: dict[str, list[str]] = defaultdict(list)
     for path in task_files:
         for line in path.read_text(encoding="utf-8", errors="replace").splitlines():

--- a/Tests/CI/test_backlog_task_id_uniqueness.py
+++ b/Tests/CI/test_backlog_task_id_uniqueness.py
@@ -1,0 +1,108 @@
+"""Local gate for duplicate backlog task ids (TASK-19573's last AC).
+
+Two branches minting the same id and merging separately produce two task
+files that share an id; `backlog` CLI lookups then resolve ambiguously.
+This has happened repeatedly -- ids 152+, 196-203, 246-256, `task-3401`
+(TASK-13158), and most recently a batch of seven (TASK-19573).
+
+`.github/workflows/backlog-guard.yml` already fails on this, but only
+*after* a push: the collision costs a CI cycle and a PR round-trip to
+discover, and the workflow's output is the only place it is visible.
+TASK-19573 shipped its renumbering with this AC open:
+
+    "A **local** gate exists -- a pytest that fails on duplicate ids -- so
+     a collision is caught before push rather than by a workflow nobody
+     can run."
+
+This is that gate. It checks BOTH namespaces the guard checks, because
+they can disagree after a hand-edited rename and the backlog CLI resolves
+by frontmatter:
+
+* the filename prefix (``task-<id> - <Title>.md``, ids may be multi-dotted)
+* the first ``id:`` line of the frontmatter (stored as ``TASK-NNN``)
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TASKS_DIR = PROJECT_ROOT / "backlog" / "tasks"
+
+#: Mirrors the workflow's `sed -nE 's/^(task-[0-9]+(\.[0-9]+)*) - .*\.md$/\1/p'`.
+_FILENAME_ID = re.compile(r"^(task-[0-9]+(?:\.[0-9]+)*) - .*\.md$")
+
+
+def _task_files() -> list[Path]:
+    return sorted(TASKS_DIR.glob("task-*.md"))
+
+
+def _format(dupes: dict[str, list[str]]) -> str:
+    lines = []
+    for task_id, names in sorted(dupes.items()):
+        lines.append(f"--- {task_id} ---")
+        lines.extend(f"    {name}" for name in sorted(names))
+    lines.append(
+        "Resolve per the owner rule (TASK-19601): the OLDER arrival keeps the "
+        "id; the younger task(s) renumber -- regardless of Done status -- with "
+        "a Renumbering provenance section, updating dependencies: and "
+        "doc/code references."
+    )
+    return "\n".join(lines)
+
+
+@pytest.fixture(scope="module")
+def task_files() -> list[Path]:
+    files = _task_files()
+    # Guard the guard: a wrong PROJECT_ROOT would make every assertion below
+    # vacuously true, which is how a green gate hides a real collision.
+    assert files, f"no task files found under {TASKS_DIR}"
+    return files
+
+
+def test_no_duplicate_task_ids_in_filenames(task_files: list[Path]) -> None:
+    by_id: dict[str, list[str]] = defaultdict(list)
+    for path in task_files:
+        match = _FILENAME_ID.match(path.name)
+        if match:
+            by_id[match.group(1)].append(path.name)
+    dupes = {k: v for k, v in by_id.items() if len(v) > 1}
+    assert not dupes, "Duplicate backlog task IDs in filenames:\n" + _format(dupes)
+
+
+def test_no_duplicate_task_ids_in_frontmatter(task_files: list[Path]) -> None:
+    by_id: dict[str, list[str]] = defaultdict(list)
+    for path in task_files:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("id:"):
+                by_id[line.split(":", 1)[1].strip().lower()].append(path.name)
+                break  # first `id:` only, matching the workflow's awk
+    dupes = {k: v for k, v in by_id.items() if len(v) > 1}
+    assert not dupes, (
+        "Duplicate backlog task IDs in frontmatter id: fields:\n" + _format(dupes)
+    )
+
+
+def test_every_task_file_declares_a_frontmatter_id(task_files: list[Path]) -> None:
+    """A file with no ``id:`` is invisible to the frontmatter check above.
+
+    Without this, deleting an id line would *silence* a collision rather
+    than surface it -- the failure mode the guard exists to prevent.
+    """
+    missing = [
+        path.name
+        for path in task_files
+        if not any(
+            line.startswith("id:")
+            for line in path.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines()
+        )
+    ]
+    assert not missing, "Task files with no frontmatter id:\n" + "\n".join(
+        f"    {name}" for name in sorted(missing)
+    )

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -6664,8 +6664,8 @@ class TestLlamaCppExchangeCapture:
 
     @pytest.mark.asyncio
     async def test_llamacpp_stream_to_complete_fallback_gets_its_own_capture(
-        self, monkeypatch
-    ):
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """task-19324: the stream->complete retry is a SECOND HTTP request.
 
         It is issued inside ``stream_llamacpp_chat``, below the seam that

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -6663,6 +6663,84 @@ class TestLlamaCppExchangeCapture:
         assert "local-secret" not in _json.dumps(captures[0].request)
 
     @pytest.mark.asyncio
+    async def test_llamacpp_stream_to_complete_fallback_gets_its_own_capture(
+        self, monkeypatch
+    ):
+        """task-19324: the stream->complete retry is a SECOND HTTP request.
+
+        It is issued inside ``stream_llamacpp_chat``, below the seam that
+        captures ``stream_chat``'s own call, so before this it never got a
+        capture and the Inspector showed one row for a turn that really
+        made two calls -- understating what was sent on exactly the
+        degraded turn a user opens the Inspector to look at.
+
+        Drives the REAL ``stream_llamacpp_chat`` (only the HTTP layer and
+        the non-streaming retry are faked) so the fallback genuinely fires.
+        """
+        import json as _json
+
+        class _EmptyStreamResponse:
+            def raise_for_status(self):
+                return None
+
+            async def aiter_lines(self):
+                # A stream that opens fine and yields no content is exactly
+                # what triggers the non-streaming retry.
+                return
+                yield  # pragma: no cover - generator marker
+
+        class _StreamCtx:
+            async def __aenter__(self):
+                return _EmptyStreamResponse()
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _FakeClient:
+            def stream(self, *args, **kwargs):
+                return _StreamCtx()
+
+        gateway = ConsoleProviderGateway()
+        monkeypatch.setattr(
+            ConsoleProviderGateway,
+            "_active_http_client",
+            lambda self: _FakeClient(),
+        )
+
+        async def fake_complete(self, **kwargs):
+            return "recovered text"
+
+        monkeypatch.setattr(
+            ConsoleProviderGateway, "complete_llamacpp_chat", fake_complete
+        )
+
+        aggregate = ConsoleProviderStreamSignals(exchange_capture_enabled=True)
+        resolution = self._resolution(streaming=True)
+        out = [
+            c
+            async for c in gateway.stream_chat(
+                resolution, [{"role": "user", "content": "q"}], signals=aggregate
+            )
+        ]
+        assert out == ["recovered text"]
+
+        captures = aggregate.exchange_captures()
+        assert len(captures) == 2, (
+            "the streaming call and its non-streaming retry are two HTTP "
+            f"requests and must be two captures, got {len(captures)}"
+        )
+        retry = [c for c in captures if "retry_of" in c.request]
+        assert len(retry) == 1
+        retry_capture = retry[0]
+        assert retry_capture.request["wire_payload"]["stream"] is False
+        assert (
+            retry_capture.request["wire_payload"]["messages"][-1]["content"] == "q"
+        )
+        assert retry_capture.response["content"] == "recovered text"
+        # Same keyless guarantee the sibling captures hold.
+        assert "local-secret" not in _json.dumps(retry_capture.request)
+
+    @pytest.mark.asyncio
     async def test_llamacpp_non_streaming_abort_after_first_item_keeps_recorded_content(
         self, monkeypatch
     ):

--- a/Tests/Tools/test_note_tool_user_id.py
+++ b/Tests/Tools/test_note_tool_user_id.py
@@ -39,6 +39,22 @@ class _FakeNotesService:
         return True
 
 
+@pytest.fixture(autouse=True)
+def _clear_notes_service_cache():
+    """Drop the module-global service cache around every test (task-692).
+
+    ``_notes_service()`` caches the built service so the tool path stops
+    re-opening the DB per call. That cache is module state: without this,
+    a real service built by one test could be served to a later test that
+    monkeypatches ``NotesInteropService``, and the fake would never be
+    used. Today each test happens to get its own config path, so the key
+    differs -- this does not rely on that accident.
+    """
+    nmt._reset_notes_service_cache()
+    yield
+    nmt._reset_notes_service_cache()
+
+
 @pytest.fixture
 def fake_service(monkeypatch):
     monkeypatch.setattr(nmt, "NotesInteropService", _FakeNotesService)
@@ -188,3 +204,62 @@ def test_a_reload_does_not_leak_a_patched_binding(reloadable_module):
 
     assert nmt.get_chachanotes_db_path is config_module.get_chachanotes_db_path
     assert "/fake" not in str(nmt._notes_db_base_dir())
+
+
+@pytest.mark.asyncio
+async def test_note_tools_reuse_one_service_across_calls(monkeypatch, fake_service):
+    """task-692: the service (and therefore its per-user CharactersRAGDB
+    cache) is built once, not once per tool call.
+
+    Before this, every ``execute()`` constructed its own service, whose
+    ``_db_instances`` cache is an INSTANCE attribute -- so ``_get_db``
+    missed every time and opened a fresh ``CharactersRAGDB`` (a real DB
+    open plus schema-version check) on each call, then threw it away.
+    """
+    monkeypatch.setattr(nmt, "_resolve_user_id", lambda: "alice")
+    built = []
+    real_init = _FakeNotesService.__init__
+
+    def counting_init(self, **kwargs):
+        built.append(kwargs)
+        real_init(self, **kwargs)
+
+    monkeypatch.setattr(_FakeNotesService, "__init__", counting_init)
+
+    await nmt.CreateNoteTool().execute(title="a", content="c")
+    await nmt.CreateNoteTool().execute(title="b", content="c")
+    await nmt.SearchNotesTool().execute(query="q")
+
+    assert len(built) == 1, f"expected one service build, got {len(built)}"
+
+
+@pytest.mark.asyncio
+async def test_service_cache_rebuilds_when_the_db_path_changes(
+    monkeypatch, fake_service, tmp_path
+):
+    """The cache is keyed on the resolved DB path, so re-pointing the data
+    dir must NOT serve a service bound to the previous database."""
+    monkeypatch.setattr(nmt, "_resolve_user_id", lambda: "alice")
+    built = []
+    real_init = _FakeNotesService.__init__
+
+    def counting_init(self, **kwargs):
+        built.append(kwargs)
+        real_init(self, **kwargs)
+
+    monkeypatch.setattr(_FakeNotesService, "__init__", counting_init)
+
+    first = tmp_path / "one" / "chachanotes.db"
+    second = tmp_path / "two" / "chachanotes.db"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+
+    monkeypatch.setattr(nmt, "get_chachanotes_db_path", lambda: first)
+    monkeypatch.setattr(nmt, "_notes_db_base_dir", lambda: first.parent)
+    await nmt.CreateNoteTool().execute(title="a", content="c")
+    assert len(built) == 1
+
+    monkeypatch.setattr(nmt, "get_chachanotes_db_path", lambda: second)
+    monkeypatch.setattr(nmt, "_notes_db_base_dir", lambda: second.parent)
+    await nmt.CreateNoteTool().execute(title="b", content="c")
+    assert len(built) == 2, "a new DB path must rebuild the cached service"

--- a/Tests/Tools/test_note_tool_user_id.py
+++ b/Tests/Tools/test_note_tool_user_id.py
@@ -254,12 +254,14 @@ async def test_service_cache_rebuilds_when_the_db_path_changes(
     first.parent.mkdir(parents=True)
     second.parent.mkdir(parents=True)
 
+    # Only `get_chachanotes_db_path` is patched: `_notes_service` now resolves
+    # the path ONCE and derives the base directory from it (Qodo #5), so
+    # patching `_notes_db_base_dir` here would be inert and would imply a
+    # coupling that no longer exists.
     monkeypatch.setattr(nmt, "get_chachanotes_db_path", lambda: first)
-    monkeypatch.setattr(nmt, "_notes_db_base_dir", lambda: first.parent)
     await nmt.CreateNoteTool().execute(title="a", content="c")
     assert len(built) == 1
 
     monkeypatch.setattr(nmt, "get_chachanotes_db_path", lambda: second)
-    monkeypatch.setattr(nmt, "_notes_db_base_dir", lambda: second.parent)
     await nmt.CreateNoteTool().execute(title="b", content="c")
     assert len(built) == 2, "a new DB path must rebuild the cached service"

--- a/backlog/tasks/task-13158 - Duplicate-backlog-id-task-3401-blocks-the-duplicate-ID-CI-gate-on-every-PR.md
+++ b/backlog/tasks/task-13158 - Duplicate-backlog-id-task-3401-blocks-the-duplicate-ID-CI-gate-on-every-PR.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13158
 title: Duplicate backlog id task-3401 blocks the duplicate-ID CI gate on every PR
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-09 20:28'
 labels: []
@@ -17,8 +17,33 @@ Two unrelated task files share id task-3401 on origin/dev: 'Make-Console-rail-la
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Owner decides which of the two task-3401 files is renumbered
-- [ ] #2 The chosen file is renumbered past the current max id with headroom, including its frontmatter id and any subtask/parent references
-- [ ] #3 Any branch or docs references to the renumbered id are updated
-- [ ] #4 The 'No duplicate backlog task IDs' check passes on dev
+- [x] #1 Owner decides which of the two task-3401 files is renumbered
+- [x] #2 The chosen file is renumbered past the current max id with headroom, including its frontmatter id and any subtask/parent references
+- [x] #3 Any branch or docs references to the renumbered id are updated
+- [x] #4 The 'No duplicate backlog task IDs' check passes on dev
 <!-- AC:END -->
+
+## Implementation Notes
+
+Resolved upstream, not by this task: the `task-3401` collision was cleared in
+PR #1465, which renumbered the Console-rail task to `TASK-14650` (its file
+carries the provenance line). The remaining six duplicate ids were then
+cleared under TASK-19573, whose own notes record the 2026-08-21 owner rule
+(TASK-19601): the older arrival keeps the id, the younger renumbers.
+
+Verified by running the workflow's own check verbatim (`.github/workflows/
+backlog-guard.yml`, "Fail on duplicate backlog task IDs") against this
+branch's `backlog/tasks/`, both namespaces it tests:
+
+    exact-CI-check fail=0  over 2325 task files
+
+AC #1-#3 were satisfied by that renumbering; #4 is the check above.
+
+**Left open for an owner call (not fixed here):** `task-13262` and
+`task-14650` are the same task — identical title, identical created_date,
+identical body except that only 14650 carries the renumber provenance — and
+BOTH are still `In Progress`. They hold different ids, so the duplicate-ID
+guard cannot see them, but a person picking up the work sees two live
+copies. 14650 is the canonical one (referenced by task-3793, task-4000 and
+`Docs/superpowers/plans/2026-08-08-console-rail-label-setting.md`); 13262 is
+referenced only by TASK-19573. Deliberately not archived unilaterally.

--- a/backlog/tasks/task-19324 - llama.cpp-stream-to-complete-fallback-makes-a-second-uncaptured-HTTP-request.md
+++ b/backlog/tasks/task-19324 - llama.cpp-stream-to-complete-fallback-makes-a-second-uncaptured-HTTP-request.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19324
 title: llama.cpp stream-to-complete fallback makes a second uncaptured HTTP request
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 06:03'
 labels:
@@ -19,6 +19,32 @@ The Console Conversation Inspector's exchange-capture feature (task-18300 and it
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The llama.cpp stream-to-complete fallback path's second HTTP request is captured with its own ExchangeCapture (or the existing capture is amended to reflect both calls), so the Exchange tab shows every HTTP request a turn actually made.
-- [ ] #2 A test exercises the fallback path (streaming request fails mid-stream, retried as non-streaming) and asserts the retry's request/response appears in exchange_captures().
+- [x] #1 The llama.cpp stream-to-complete fallback path's second HTTP request is captured with its own ExchangeCapture (or the existing capture is amended to reflect both calls), so the Exchange tab shows every HTTP request a turn actually made.
+- [x] #2 A test exercises the fallback path (streaming request fails mid-stream, retried as non-streaming) and asserts the retry's request/response appears in exchange_captures().
 <!-- AC:END -->
+
+## Implementation Notes
+
+`stream_llamacpp_chat` gained an optional `on_fallback_retry` hook, invoked
+only when the non-streaming retry actually runs. `stream_chat` supplies a
+callback that opens a SECOND call-scoped exchange off the aggregate, so the
+retry lands as its own Inspector row rather than being folded into the
+streaming call it replaced. The capture carries the retry's real wire payload
+(`stream=false`) and a `retry_of` marker explaining why it exists.
+
+Chose AC #1's primary clause (its own ExchangeCapture) over the "amend the
+existing capture" alternative: the user-facing promise is that the Exchange
+tab shows every HTTP request a turn made, and one row carrying two requests
+does not show that.
+
+The hook is best-effort and swallows its own failures -- capture must never
+break a send (task-18300's contract), and this path is already the degraded
+one.
+
+Test drives the REAL `stream_llamacpp_chat`, faking only the HTTP client (a
+stream that opens and yields nothing) and the retry, so the fallback genuinely
+fires rather than being simulated. Red-proofed: removing the wiring drops the
+capture count from 2 to 1.
+
+Files: `tldw_chatbook/Chat/console_provider_gateway.py`,
+`Tests/Chat/test_console_provider_gateway.py`.

--- a/backlog/tasks/task-19573 - Seven duplicate backlog task ids on dev with one live In Progress ambiguity.md
+++ b/backlog/tasks/task-19573 - Seven duplicate backlog task ids on dev with one live In Progress ambiguity.md
@@ -72,7 +72,7 @@ more than 14 days and three carry no date at all.
 - [x] Renumbering updates every inbound reference (dependencies, branch names,
       PR bodies where practical), not just the filenames
 - [x] Backlog Guard is green on `dev`
-- [ ] A **local** gate exists — a pytest that fails on duplicate ids — so a
+- [x] A **local** gate exists — a pytest that fails on duplicate ids — so a
       collision is caught before push rather than by a workflow nobody can
       block on
 - [x] The id-claiming protocol is revised to survive concurrent sessions: the
@@ -133,3 +133,17 @@ rather than reopening it unilaterally, since the task's core defect (red
 guard, live ambiguity) is genuinely resolved and closed elsewhere
 (TASK-19601); the three open items above should be tracked as their own
 follow-up rather than reopening this one.
+
+## Follow-up: the local gate (2026-08-21)
+
+`Tests/CI/test_backlog_task_id_uniqueness.py` closes the last AC. It checks
+both namespaces the workflow checks -- the filename prefix and the first
+frontmatter `id:` line -- and adds a third assertion the workflow does not
+have: every task file must *declare* an id, so deleting an `id:` line
+silences nothing.
+
+Red-proofed against all three defects it claims to catch (a filename
+collision, a frontmatter-only collision, and a missing `id:`); each fails
+the matching assertion and only that one. A module fixture asserts the task
+directory is non-empty, so a wrong PROJECT_ROOT cannot make the gate
+vacuously green.

--- a/backlog/tasks/task-692 - Note-tools-construct-a-fresh-CharactersRAGDB-per-call-instead-of-reusing-the-app-singleton.md
+++ b/backlog/tasks/task-692 - Note-tools-construct-a-fresh-CharactersRAGDB-per-call-instead-of-reusing-the-app-singleton.md
@@ -3,7 +3,7 @@ id: TASK-692
 title: >-
   Note tools construct a fresh CharactersRAGDB per call instead of reusing the
   app singleton
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 06:06'
 labels:
@@ -27,6 +27,35 @@ The related import-time seam in this file (`USER_DB_BASE_DIR` computed at module
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Note tools reuse a shared/cached CharactersRAGDB connection instead of opening a fresh one on every call
-- [ ] #2 No behavior change to note CRUD semantics or the resolved writing user
+- [x] #1 Note tools reuse a shared/cached CharactersRAGDB connection instead of opening a fresh one on every call
+- [x] #2 No behavior change to note CRUD semantics or the resolved writing user
 <!-- AC:END -->
+
+## Implementation Notes
+
+`_notes_service()` builds the service lazily once and reuses it, keyed on the
+resolved chachanotes DB path so re-pointing the data dir still rebuilds.
+
+The premise was real but understated in the original write-up. The three
+tools already passed `global_db_to_use=chachanotes_db`, so it looked like the
+singleton was reused -- but that only supplies the *path template*. The
+service's `_db_instances` cache is an INSTANCE attribute, so a per-call
+service missed it every time and `_get_db` constructed a fresh
+`CharactersRAGDB(db_path=..., client_id=user_id)` -- a real DB open plus
+schema-version check -- then discarded it when the call returned. Measured at
+~1.8 ms per construction on an already-created DB, plus a
+`verify_trusted_directory` filesystem check per call.
+
+Kept the per-user `client_id` semantics exactly: caching the *service*
+preserves `_get_db`'s attribution behaviour, whereas reusing `chachanotes_db`
+directly would have silently changed the `client_id` written into rows.
+
+Also adds an autouse cache-reset fixture to the covering tests: the cache is
+module state, and without it a real service built by one test could be served
+to a later test that monkeypatches `NotesInteropService`. Today each test
+happens to get its own config path so the key differs -- the fixture removes
+that accident. Red-proofed: reverting the cache makes the reuse test see
+three service builds instead of one.
+
+Files: `tldw_chatbook/Tools/note_management_tools.py`,
+`Tests/Tools/test_note_tool_user_id.py`.

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -2031,6 +2031,7 @@ class ConsoleProviderGateway:
         reasoning_effort: str | None = None,
         thinking_budget_tokens: int | None = None,
         api_key: str | None = None,
+        on_fallback_retry: "Callable[[dict[str, Any], str], None] | None" = None,
     ) -> AsyncIterator[str]:
         """Stream OpenAI-compatible chat completion chunks from llama.cpp.
 
@@ -2117,6 +2118,33 @@ class ConsoleProviderGateway:
             thinking_budget_tokens=thinking_budget_tokens,
             api_key=api_key,
         )
+        # task-19324: this retry is a SECOND HTTP request to the server. It
+        # is made below the Console capture seam (which wraps stream_chat's
+        # one call), so without this hook a turn that really made two calls
+        # showed only one in the Inspector -- understating what was sent, on
+        # exactly the degraded turn a user opens the Inspector to inspect.
+        if on_fallback_retry is not None:
+            try:
+                on_fallback_retry(
+                    build_llamacpp_chat_payload(
+                        model=model,
+                        messages=messages,
+                        stream=False,
+                        temperature=temperature,
+                        top_p=top_p,
+                        min_p=min_p,
+                        top_k=top_k,
+                        max_tokens=max_tokens,
+                        reasoning_effort=reasoning_effort,
+                        thinking_budget_tokens=thinking_budget_tokens,
+                    ),
+                    fallback or "",
+                )
+            except Exception:
+                # Capture must never break a send (task-18300 contract).
+                logger.opt(exception=False).warning(
+                    "exchange_capture_fallback_failed"
+                )
         if fallback:
             yield fallback
             return
@@ -2546,6 +2574,45 @@ class ConsoleProviderGateway:
                         yield completion
                     completed = True
                     return
+                def _capture_llamacpp_fallback(
+                    wire_payload: dict[str, Any], text: str
+                ) -> None:
+                    """Give the stream->complete retry its own capture (task-19324).
+
+                    The retry is a second HTTP request issued *inside*
+                    ``stream_llamacpp_chat``, below the seam that captures
+                    ``stream_chat``'s own call. It gets a fresh call-scoped
+                    signals view off the aggregate so it lands as its own
+                    row rather than being folded into the streaming call it
+                    replaced. Needs the aggregate: a caller that handed us
+                    an already-scoped view has no second call to open.
+                    """
+                    if signals is None or isinstance(
+                        signals, ConsoleProviderCallSignals
+                    ):
+                        return
+                    retry_signals = signals.new_usage_call()
+                    capture_request, omitted = build_request_capture(
+                        {"model": resolution.model}
+                    )
+                    capture_request["wire_payload"] = stub_binary_strings(
+                        wire_payload
+                    )
+                    capture_request["retry_of"] = (
+                        "llama.cpp stream produced no content; "
+                        "retried non-streaming"
+                    )
+                    retry_signals.begin_exchange(
+                        provider=str(resolution.provider or ""),
+                        model=str(resolution.model or ""),
+                        endpoint=normalize_llamacpp_base_url(resolution.base_url),
+                        request=capture_request,
+                        omitted_keys=omitted,
+                    )
+                    if text:
+                        retry_signals.record_exchange_content(text)
+                    retry_signals.close_exchange(status="complete")
+
                 try:
                     async for chunk in self.stream_llamacpp_chat(
                         base_url=resolution.base_url,
@@ -2559,6 +2626,7 @@ class ConsoleProviderGateway:
                         reasoning_effort=resolution.reasoning_effort,
                         thinking_budget_tokens=resolution.thinking_budget_tokens,
                         api_key=resolution.api_key,
+                        on_fallback_retry=_capture_llamacpp_fallback,
                     ):
                         if call_signals is not None:
                             call_signals.record_exchange_content(chunk)

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -2140,10 +2140,15 @@ class ConsoleProviderGateway:
                     ),
                     fallback or "",
                 )
-            except Exception:
-                # Capture must never break a send (task-18300 contract).
-                logger.opt(exception=False).warning(
-                    "exchange_capture_fallback_failed"
+            except Exception as exc:
+                # Capture must never break a send (task-18300 contract) -- but
+                # a constant message made the degraded path this exists to
+                # EXPLAIN undiagnosable (Qodo #6). The type name is enough to
+                # act on and, unlike a traceback, cannot carry payload from
+                # the frame's locals.
+                logger.warning(
+                    "exchange_capture_fallback_failed: "
+                    f"{type(exc).__name__}"
                 )
         if fallback:
             yield fallback
@@ -2612,6 +2617,14 @@ class ConsoleProviderGateway:
                     if text:
                         retry_signals.record_exchange_content(text)
                     retry_signals.close_exchange(status="complete")
+                    # Qodo #4: `new_usage_call()` registers this call in the
+                    # aggregate's `_active_usage_payloads`; without the
+                    # matching close it stays there forever. Harmless while
+                    # the retry records no usage, but the moment one is added
+                    # the stuck entry is billed by `usage_payloads()`'s
+                    # in-flight tail. Closing here keeps the pairing local and
+                    # obvious instead of load-bearing on a future reader.
+                    retry_signals.close_usage_call()
 
                 try:
                     async for chunk in self.stream_llamacpp_chat(

--- a/tldw_chatbook/Tools/note_management_tools.py
+++ b/tldw_chatbook/Tools/note_management_tools.py
@@ -4,7 +4,9 @@ Note Management Tools for LLM function calling.
 These tools allow LLMs to create, search, update, and manage notes.
 """
 
-from typing import Dict, Any
+import threading
+from typing import Dict, Any, Optional, Tuple
+
 from loguru import logger
 
 from . import Tool
@@ -33,6 +35,64 @@ def _notes_db_base_dir():
     """
     return get_chachanotes_db_path().parent
 
+
+#: Cached ``NotesInteropService`` for the tool path (task-692).
+#:
+#: Each note tool used to build its own service per ``execute()``. That is
+#: not just object churn: the service's ``_db_instances`` cache is an
+#: INSTANCE attribute, so a per-call service always missed it and
+#: ``_get_db`` constructed a fresh ``CharactersRAGDB`` -- a real DB open
+#: plus schema-version check (~1.8 ms measured on an existing DB) -- on
+#: every single call, and the instance was then discarded. ``TASK-545 P2``
+#: put these tools on the agent worker thread, where one run can invoke
+#: them many times.
+#:
+#: Keyed on the resolved DB path so a config change (or a test that
+#: repoints the data dir) still rebuilds rather than serving a service
+#: bound to the previous database.
+_SERVICE_LOCK = threading.Lock()
+_SERVICE_CACHE: Optional[Tuple[str, NotesInteropService]] = None
+
+
+def _notes_service() -> NotesInteropService:
+    """Return the shared notes service for the tool path.
+
+    Built lazily on first use and reused afterwards, so the service's own
+    per-user ``CharactersRAGDB`` cache survives across tool calls instead
+    of being rebuilt for each one.
+
+    Returns:
+        A ``NotesInteropService`` bound to the current chachanotes DB.
+    """
+    global _SERVICE_CACHE
+
+    from ..config import chachanotes_db
+
+    base_dir = _notes_db_base_dir()
+    key = str(get_chachanotes_db_path())
+
+    cached = _SERVICE_CACHE
+    if cached is not None and cached[0] == key:
+        return cached[1]
+
+    with _SERVICE_LOCK:
+        cached = _SERVICE_CACHE
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        service = NotesInteropService(
+            base_db_directory=base_dir,
+            api_client_id="tool_executor",
+            global_db_to_use=chachanotes_db,
+        )
+        _SERVICE_CACHE = (key, service)
+        return service
+
+
+def _reset_notes_service_cache() -> None:
+    """Drop the cached service (tests, and any deliberate re-point)."""
+    global _SERVICE_CACHE
+    with _SERVICE_LOCK:
+        _SERVICE_CACHE = None
 
 #: Matches config.py's own `default_users_name_fallback`, so an
 #: unconfigured user sees no change from the previously hardcoded value.
@@ -120,13 +180,7 @@ class CreateNoteTool(Tool):
             return {"error": "No content provided"}
 
         try:
-            from ..config import chachanotes_db
-
-            notes_service = NotesInteropService(
-                base_db_directory=_notes_db_base_dir(),
-                api_client_id="tool_executor",
-                global_db_to_use=chachanotes_db,
-            )
+            notes_service = _notes_service()
 
             note_id = notes_service.add_note(
                 user_id=_resolve_user_id(),
@@ -196,13 +250,7 @@ class SearchNotesTool(Tool):
 
         try:
             # Get the notes service
-            from ..config import chachanotes_db
-
-            notes_service = NotesInteropService(
-                base_db_directory=_notes_db_base_dir(),
-                api_client_id="tool_executor",
-                global_db_to_use=chachanotes_db,
-            )
+            notes_service = _notes_service()
 
             # Search notes
             results = notes_service.search_notes(
@@ -300,13 +348,7 @@ class UpdateNoteTool(Tool):
             return {"error": "No updates provided (need title or content)"}
 
         try:
-            from ..config import chachanotes_db
-
-            notes_service = NotesInteropService(
-                base_db_directory=_notes_db_base_dir(),
-                api_client_id="tool_executor",
-                global_db_to_use=chachanotes_db,
-            )
+            notes_service = _notes_service()
 
             user_id = _resolve_user_id()
 

--- a/tldw_chatbook/Tools/note_management_tools.py
+++ b/tldw_chatbook/Tools/note_management_tools.py
@@ -68,8 +68,14 @@ def _notes_service() -> NotesInteropService:
 
     from ..config import chachanotes_db
 
-    base_dir = _notes_db_base_dir()
-    key = str(get_chachanotes_db_path())
+    # Resolved ONCE and derived from that single value (Qodo #5): calling
+    # `get_chachanotes_db_path()` twice -- once inside `_notes_db_base_dir()`
+    # and once for the key -- lets a profile switch or config rewrite between
+    # them cache a service under a key that does not describe the database it
+    # was actually bound to.
+    db_path = get_chachanotes_db_path()
+    base_dir = db_path.parent
+    key = str(db_path)
 
     cached = _SERVICE_CACHE
     if cached is not None and cached[0] == key:


### PR DESCRIPTION
## What & why

First burn-down batch from the efficiency backlog. Four small, independently reviewable changes; each one verified against real code before being touched, and each behaviour change red-proofed.

## task-692 — note tools re-opened the DB on every call

The three note tools built a fresh `NotesInteropService` per `execute()`.

The original write-up said this paid "a full DB-open and schema-check cost per call", and the code looked like it did *not* — all three already pass `global_db_to_use=chachanotes_db`. But that only supplies the **path template**. `NotesInteropService._db_instances` is an *instance* attribute, so a per-call service missed its own cache every time and `_get_db` constructed a brand-new `CharactersRAGDB(db_path=…, client_id=user_id)` — a real DB open plus schema-version check — then threw it away when the call returned.

Measured: **~1.8 ms per construction** on an already-created DB, plus a `verify_trusted_directory` filesystem check per call. `TASK-545 P2` put these tools on the agent worker thread, where one run can invoke them many times.

Now built lazily once and reused, keyed on the resolved DB path so re-pointing the data dir still rebuilds. **Attribution semantics preserved deliberately**: caching the *service* keeps `_get_db`'s per-user `client_id` behaviour, whereas reusing `chachanotes_db` directly would have silently changed the `client_id` written into rows.

## task-19324 — the llama.cpp retry was invisible in the Inspector

When a llama.cpp stream opens fine but yields nothing, `stream_llamacpp_chat` retries non-streaming. That retry is a **second HTTP request**, issued below the seam that captures `stream_chat`'s call — so the Conversation Inspector showed one row for a turn that really made two, understating what was sent on exactly the degraded turn a user opens the Inspector to look at.

The retry now gets its own `ExchangeCapture` carrying its real wire payload (`stream=false`) and a `retry_of` marker. Chose AC #1's primary clause (a separate capture) over "amend the existing one": the promise is that the tab shows every request a turn made, and one row carrying two requests doesn't show that. The hook is best-effort — capture must never break a send, and this path is already degraded.

## task-19573's last AC — duplicate task ids now fail locally

`Tests/CI/test_backlog_task_id_uniqueness.py`. The Backlog Guard workflow already rejects duplicate ids, but only *after* a push — a collision costs a CI cycle and a PR round-trip to find, and the workflow log is the only place it's visible. This has recurred at ids 152+, 196-203, 246-256, `task-3401`, and most recently a batch of seven.

Checks both namespaces the workflow does (filename prefix and first frontmatter `id:`, which can disagree after a hand-edited rename), plus one it doesn't: **every task file must declare an id**, so deleting an `id:` line can't silence a collision. A module fixture asserts the tasks directory is non-empty, so a wrong `PROJECT_ROOT` can't make the gate vacuously green.

## task-13158 — closed, resolved upstream

Its `task-3401` collision was cleared in PR #1465 (Console-rail renumbered to `TASK-14650`); the remaining six went under TASK-19573. Verified by running the workflow's own check **verbatim** against this branch: `fail=0 over 2325 task files`.

## Red-proof evidence

Every behaviour claim was verified by breaking it first:

| Change | Reverted → |
|---|---|
| notes service cache | reuse test sees **3** service builds instead of 1 |
| llama.cpp retry capture | capture count drops **2 → 1** |
| duplicate-id gate | each of the three defects (filename collision, frontmatter-only collision, missing `id:`) fails its own assertion and only that one |

## Testing

`Tests/Tools/` + the new gate: **625 passed**. Full `test_console_provider_gateway.py`: **264 passed** (263 on dev + the one added here).

Pre-existing on clean `origin/dev`, confirmed in a throwaway worktree — **not** from this branch: 2 failures in `test_glob_grep_files.py`, and a tiktoken-download teardown error in `test_console_provider_gateway.py` (25 errors on dev, 25 here).

## Left for an owner call (not touched)

`task-13262` and `task-14650` are the **same task** — identical title, identical `created_date`, identical body except only 14650 carries the renumber provenance — and **both are still `In Progress`**. Different ids, so the duplicate-id guard cannot see them, but someone picking up the work sees two live copies. 14650 is canonical (referenced by task-3793, task-4000, and its own design plan); 13262 is referenced only by TASK-19573. Not archived unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up note tools, improves Inspector accuracy for llama.cpp fallbacks, and adds a local test gate to block duplicate backlog IDs before push.

- Notes tools: Previously reopened the DB on each call; now reuse a single `NotesInteropService` cached by the resolved chachanotes DB path. Per-user client_id attribution is unchanged. Adds `_reset_notes_service_cache()` and an autouse test reset.
- llama.cpp fallback capture: The non-streaming retry now gets its own ExchangeCapture with `stream=false` and a `retry_of` marker. Implemented via an internal `on_fallback_retry` hook; closes the call-scoped signals and logs only the exception type. Best-effort and non-blocking.
- Backlog guard: Adds `Tests/CI/test_backlog_task_id_uniqueness.py` to fail locally on duplicate IDs in filenames or frontmatter, and on missing `id:` lines. Run pytest locally to catch collisions before pushing.

<sup>Written for commit d3e4253b8feb730d714d620c7a38a88ea863f17c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

