### PR TITLE
perf: efficiency burn-down batch 2 — stop blocking the event loop (task-3503, task-585, task-19562 measurement)

### DIFF
--- a/Tests/Web_Scraping/Confluence/test_confluence_no_blocking_io_on_loop.py
+++ b/Tests/Web_Scraping/Confluence/test_confluence_no_blocking_io_on_loop.py
@@ -1,0 +1,141 @@
+"""Confluence HTTP must not run on the event loop thread (TASK-585).
+
+`ConfluenceAuth.make_request` is a synchronous `requests` call and
+`ConfluenceScraper._extract_page_id_from_url` falls back to a blocking fetch.
+Both were invoked inline from `async def` methods, so a slow or hanging
+Confluence server stalled the whole loop for up to the full request timeout
+(30s since task-328 bounded it; unbounded before that), starving every other
+concurrent operation in the app.
+
+These tests assert the property directly -- the blocking callable must
+execute on a DIFFERENT thread than the running loop -- rather than asserting
+that some particular wrapper was used, so they keep holding if the code later
+moves to httpx async instead of a worker thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tldw_chatbook.Web_Scraping.Confluence.confluence_crawler import ConfluenceCrawler
+from tldw_chatbook.Web_Scraping.Confluence.confluence_scraper import ConfluenceScraper
+
+
+class _ThreadRecordingAuth:
+    """Stands in for ConfluenceAuth, recording where make_request ran."""
+
+    def __init__(self) -> None:
+        self.threads: list[int] = []
+        self.base_url = "https://example.invalid/wiki"
+
+    def make_request(self, method: str, endpoint: str, **kwargs):
+        self.threads.append(threading.get_ident())
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "id": "123",
+            "title": "T",
+            "body": {"storage": {"value": "<p>x</p>"}},
+            "version": {"number": 1},
+            "space": {"key": "S", "name": "S"},
+            "results": [],
+            "size": 0,
+        }
+        response.content = b""
+        return response
+
+
+@pytest.mark.asyncio
+async def test_scrape_page_by_id_does_not_block_the_loop_thread():
+    auth = _ThreadRecordingAuth()
+    scraper = ConfluenceScraper(auth)
+
+    loop_thread = threading.get_ident()
+    await scraper.scrape_page_by_id("123")
+
+    assert auth.threads, "make_request was never called; the test proved nothing"
+    assert loop_thread not in auth.threads, (
+        "ConfluenceAuth.make_request ran on the event loop thread: a slow "
+        "Confluence server would stall every other concurrent operation."
+    )
+
+
+@pytest.mark.asyncio
+async def test_crawler_child_page_lookup_does_not_block_the_loop_thread():
+    auth = _ThreadRecordingAuth()
+    crawler = ConfluenceCrawler(auth)
+
+    loop_thread = threading.get_ident()
+    await crawler._get_child_pages("123")
+
+    assert auth.threads, "make_request was never called; the test proved nothing"
+    assert loop_thread not in auth.threads
+
+
+@pytest.mark.asyncio
+async def test_page_id_extraction_does_not_block_the_loop_thread(monkeypatch):
+    """The URL helper falls back to fetching the page, so it blocks too."""
+    auth = _ThreadRecordingAuth()
+    scraper = ConfluenceScraper(auth)
+
+    seen: list[int] = []
+
+    def recording_extract(url: str):
+        seen.append(threading.get_ident())
+        return "123"
+
+    monkeypatch.setattr(scraper, "_extract_page_id_from_url", recording_extract)
+
+    loop_thread = threading.get_ident()
+    await scraper.scrape_page_by_url("https://example.invalid/wiki/x")
+
+    assert seen, "_extract_page_id_from_url was never called"
+    assert loop_thread not in seen, (
+        "_extract_page_id_from_url ran on the event loop thread; its fallback "
+        "path performs a blocking HTTP fetch."
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_loop_stays_responsive_while_confluence_is_slow():
+    """End-to-end property: a slow request must not freeze other tasks.
+
+    This is the symptom users would actually feel, and it fails loudly if
+    someone reverts the offload without touching the assertions above.
+    """
+    auth = _ThreadRecordingAuth()
+    slow = threading.Event()
+
+    def slow_request(method: str, endpoint: str, **kwargs):
+        slow.wait(0.30)  # stand-in for a slow/hanging server
+        return _ThreadRecordingAuth.make_request(auth, method, endpoint, **kwargs)
+
+    auth.make_request = slow_request  # type: ignore[assignment]
+    scraper = ConfluenceScraper(auth)
+
+    ticks = 0
+
+    async def heartbeat() -> None:
+        nonlocal ticks
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    beat = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0)  # let the heartbeat reach its first await
+    await scraper.scrape_page_by_id("123")
+    # Sample BEFORE draining the heartbeat: awaiting it first would let it
+    # finish regardless and the assertion could never fail.
+    ticks_during_request = ticks
+    slow.set()
+    await beat
+
+    assert ticks_during_request >= 5, (
+        f"the event loop only advanced {ticks_during_request} times while a "
+        "Confluence request was in flight; it was blocked rather than awaiting"
+    )

--- a/Tests/Web_Scraping/Confluence/test_confluence_no_blocking_io_on_loop.py
+++ b/Tests/Web_Scraping/Confluence/test_confluence_no_blocking_io_on_loop.py
@@ -26,7 +26,7 @@ from tldw_chatbook.Web_Scraping.Confluence.confluence_crawler import ConfluenceC
 from tldw_chatbook.Web_Scraping.Confluence.confluence_scraper import ConfluenceScraper
 
 
-class _ThreadRecordingAuth:
+class ThreadRecordingAuth:
     """Stands in for ConfluenceAuth, recording where make_request ran."""
 
     def __init__(self) -> None:
@@ -52,7 +52,7 @@ class _ThreadRecordingAuth:
 
 @pytest.mark.asyncio
 async def test_scrape_page_by_id_does_not_block_the_loop_thread():
-    auth = _ThreadRecordingAuth()
+    auth = ThreadRecordingAuth()
     scraper = ConfluenceScraper(auth)
 
     loop_thread = threading.get_ident()
@@ -67,7 +67,7 @@ async def test_scrape_page_by_id_does_not_block_the_loop_thread():
 
 @pytest.mark.asyncio
 async def test_crawler_child_page_lookup_does_not_block_the_loop_thread():
-    auth = _ThreadRecordingAuth()
+    auth = ThreadRecordingAuth()
     crawler = ConfluenceCrawler(auth)
 
     loop_thread = threading.get_ident()
@@ -80,7 +80,7 @@ async def test_crawler_child_page_lookup_does_not_block_the_loop_thread():
 @pytest.mark.asyncio
 async def test_page_id_extraction_does_not_block_the_loop_thread(monkeypatch):
     """The URL helper falls back to fetching the page, so it blocks too."""
-    auth = _ThreadRecordingAuth()
+    auth = ThreadRecordingAuth()
     scraper = ConfluenceScraper(auth)
 
     seen: list[int] = []
@@ -108,12 +108,12 @@ async def test_the_loop_stays_responsive_while_confluence_is_slow():
     This is the symptom users would actually feel, and it fails loudly if
     someone reverts the offload without touching the assertions above.
     """
-    auth = _ThreadRecordingAuth()
+    auth = ThreadRecordingAuth()
     slow = threading.Event()
 
     def slow_request(method: str, endpoint: str, **kwargs):
         slow.wait(0.30)  # stand-in for a slow/hanging server
-        return _ThreadRecordingAuth.make_request(auth, method, endpoint, **kwargs)
+        return ThreadRecordingAuth.make_request(auth, method, endpoint, **kwargs)
 
     auth.make_request = slow_request  # type: ignore[assignment]
     scraper = ConfluenceScraper(auth)
@@ -138,4 +138,68 @@ async def test_the_loop_stays_responsive_while_confluence_is_slow():
     assert ticks_during_request >= 5, (
         f"the event loop only advanced {ticks_during_request} times while a "
         "Confluence request was in flight; it was blocked rather than awaiting"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_scrapes_do_not_use_the_session_simultaneously(monkeypatch):
+    """Offloading made `scrape_many`'s concurrency real -- and unsafe.
+
+    `requests.Session` is not thread-safe (mutable cookies, connection pool,
+    headers). That was harmless while every call ran inline on the event loop:
+    `scrape_many`'s `asyncio.gather` looked concurrent, but each blocking
+    `make_request` serialized the others anyway. Moving those calls to
+    `asyncio.to_thread` made N worker threads able to touch one session at
+    once -- a hazard this change introduced, found in review.
+
+    Drives the REAL `ConfluenceAuth.make_request` (only the session's
+    `request` is stubbed) so the lock under test is the production one. An
+    earlier version of this test wrapped a FAKE auth's `make_request`, which
+    bypassed that lock entirely and measured only the stub.
+    """
+    import asyncio
+
+    from tldw_chatbook.Web_Scraping.Confluence import confluence_auth as auth_module
+    from tldw_chatbook.Web_Scraping.Confluence.confluence_auth import ConfluenceAuth
+
+    # The egress policy rejects the synthetic host before the session is ever
+    # reached; this test is about session concurrency, not egress.
+    monkeypatch.setattr(auth_module, "check_url_or_raise", lambda *a, **k: None)
+
+    auth = ConfluenceAuth("https://example.invalid/wiki")
+    auth._auth_configured = True
+
+    overlap = {"max": 0, "cur": 0}
+    guard = threading.Lock()
+
+    def recording_request(method, url, **kwargs):
+        with guard:
+            overlap["cur"] += 1
+            overlap["max"] = max(overlap["max"], overlap["cur"])
+        try:
+            threading.Event().wait(0.02)  # widen the window
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "id": "1", "title": "T",
+                "body": {"storage": {"value": "<p>x</p>"}},
+                "version": {"number": 1},
+                "space": {"key": "S", "name": "S"},
+                "results": [], "size": 0,
+            }
+            response.content = b""
+            return response
+        finally:
+            with guard:
+                overlap["cur"] -= 1
+
+    auth.session.request = recording_request  # type: ignore[assignment]
+    scraper = ConfluenceScraper(auth)
+
+    await asyncio.gather(*(scraper.scrape_page_by_id(str(i)) for i in range(6)))
+
+    assert overlap["max"] >= 1, "no request reached the session; test proved nothing"
+    assert overlap["max"] == 1, (
+        f"{overlap['max']} concurrent entries into the shared requests.Session; "
+        "it is not thread-safe and must be serialized"
     )

--- a/Tests/test_config_settings_cache_concurrency.py
+++ b/Tests/test_config_settings_cache_concurrency.py
@@ -1,0 +1,131 @@
+"""Concurrent `load_settings()` must rebuild the cache once, not once per thread.
+
+TASK-3503. `_SETTINGS_CACHE_LOCK` guards only the cache *cells*: on a miss it
+was cleared inside the lock and the rebuild then ran OUTSIDE it, so every
+thread that arrived during the miss window ran the entire rebuild -- reading
+and parsing the TOML, deep-merging defaults, and re-ensuring directories --
+and the last writer's result won.
+
+Measured before the fix: 8 threads on a single invalidation produced 32
+bootstrap loads (exactly 8x the single-threaded cost of 4). After: 4, i.e.
+the same work one thread does alone.
+
+A note on the task's own wording: its AC #1 asks that `load_settings()` never
+hand a concurrent caller `None`. That symptom does not reproduce and cannot
+-- `load_settings` never returns the cache cell during the window, and no
+module outside `config.py` reads `_SETTINGS_CACHE` directly (verified by
+grep). A thread arriving mid-rebuild always took the miss branch and got a
+real mapping; it just paid for a redundant rebuild to get it. The
+`None`-freedom is pinned below anyway, so a future refactor that starts
+returning the raw cell fails here.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import tldw_chatbook.config as config_module
+
+
+def _invalidate() -> None:
+    """Clear the settings cache the way a real invalidation does."""
+    with config_module._SETTINGS_CACHE_LOCK:
+        config_module._SETTINGS_CACHE = None
+        config_module._SETTINGS_CACHE_SOURCE = None
+
+
+@pytest.fixture
+def counting_bootstrap(monkeypatch):
+    """Count full config rebuilds, widening the miss window to force overlap."""
+    calls: list[float] = []
+    original = config_module._load_cli_config_bootstrap
+
+    def counting(*args, **kwargs):
+        calls.append(0.0)
+        # Without this the window is too narrow to observe on a warm page
+        # cache, and the test would pass against the unfixed code by luck.
+        threading.Event().wait(0.02)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(config_module, "_load_cli_config_bootstrap", counting)
+    return calls
+
+
+def _baseline_rebuild_cost(counting_bootstrap: list) -> int:
+    """Bootstrap loads a single uncontended rebuild costs.
+
+    Pinned by measurement rather than hardcoded: one rebuild currently makes
+    several nested config reads, which is a separate (single-threaded)
+    inefficiency this task does not address. Comparing against the measured
+    baseline keeps this test about CONCURRENCY only.
+    """
+    _invalidate()
+    counting_bootstrap.clear()
+    config_module.load_settings()
+    return len(counting_bootstrap)
+
+
+def test_concurrent_cache_miss_rebuilds_once(counting_bootstrap):
+    baseline = _baseline_rebuild_cost(counting_bootstrap)
+    assert baseline > 0, "fixture never observed a rebuild; the seam moved"
+
+    _invalidate()
+    counting_bootstrap.clear()
+
+    results: list[object] = []
+    errors: list[BaseException] = []
+    started = threading.Barrier(8)
+
+    def worker() -> None:
+        try:
+            started.wait(timeout=10)
+            results.append(config_module.load_settings())
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, f"worker raised: {errors[0]!r}"
+    assert len(results) == 8
+
+    assert len(counting_bootstrap) == baseline, (
+        "8 concurrent callers rebuilt the settings cache "
+        f"{len(counting_bootstrap)} times; one uncontended rebuild costs "
+        f"{baseline}. Each thread that arrives during the miss window is "
+        "redoing the whole rebuild."
+    )
+
+
+def test_concurrent_cache_miss_never_yields_none(counting_bootstrap):
+    """AC #1: no caller sees the empty cache cell (see the module docstring)."""
+    _invalidate()
+    results: list[object] = []
+    started = threading.Barrier(6)
+
+    def worker() -> None:
+        started.wait(timeout=10)
+        results.append(config_module.load_settings())
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert len(results) == 6
+    assert all(isinstance(item, dict) for item in results), results
+
+
+def test_cache_hit_path_does_no_rebuild(counting_bootstrap):
+    """AC #3: the warm path is untouched -- no rebuild, no rebuild lock."""
+    config_module.load_settings()  # warm
+    counting_bootstrap.clear()
+    for _ in range(5):
+        assert isinstance(config_module.load_settings(), dict)
+    assert counting_bootstrap == [], "a cache hit must not rebuild"

--- a/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
+++ b/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
@@ -75,3 +75,43 @@ away".
       checkpointed
 - [ ] A guard test fails if a new `async def` in this service performs blocking
       database I/O directly
+
+## Measurement: the busy_timeout question (2026-08-21)
+
+One AC asks that this be **measured, not assumed**. Measured on this branch's
+base; the lane's PLAUSIBLE rating is **confirmed, with one narrowing**.
+
+    SubscriptionsDB connection busy_timeout (ms): 5000
+    journal_mode: wal
+    second writer blocked for 1.08s -> acquired   (lock held 1.0s)
+
+* No `busy_timeout` is set anywhere in `Subscriptions_DB.py`, `base_db.py`
+  or the private-path connector, so the connection inherits Python
+  sqlite3's **5 s** default. The task's premise is correct.
+* A writer collision really does block the caller for as long as the lock is
+  held, up to that 5 s ceiling, and then raises `OperationalError`. On the
+  event loop that stall is the entire UI.
+* **Narrowing worth carrying into the design:** `journal_mode = WAL`, so
+  readers do *not* block writers and writers do *not* block readers. The
+  exposure is **writer-vs-writer only** — not "any of the 22 async methods",
+  as the B-section wording could be read to imply. The read-only methods
+  (`list_sources`, `list_items`, `list_runs`, ...) still block the loop for
+  their own query duration, but they cannot be *stalled* by a concurrent
+  writer.
+
+So both halves are real but distinct: (1) every one of the 22 blocks the loop
+for its own duration -- fix by moving the sqlite work off the loop; (2) the
+*write* paths can additionally stall up to 5 s behind another writer -- and
+lowering `busy_timeout` only converts that stall into an earlier exception, so
+it is not a substitute for (1).
+
+Probe: two connections to a real `SubscriptionsDB`, one holding
+`BEGIN IMMEDIATE` for 1 s while the other times its own `BEGIN IMMEDIATE`.
+
+**Scope note:** this task is an arc, not a quick win -- 7,117 lines across
+`local_watchlists_service.py` (40 `async def`) and `Subscriptions_DB.py`,
+bundling a user-visible correctness bug (duplicate alert notifications), the
+22-method loop-blocking fix, a non-reentrant `transaction()` that
+`record_check_result` nests, and a leaked thread-local connection. Recommend
+splitting: (A) the in-flight guard + duplicate-alert test, (B) the sqlite
+offload, (C) transaction nesting + connection close.

--- a/backlog/tasks/task-3503 - config.load_settings-cache-miss-race-can-return-None-to-worker-threads.md
+++ b/backlog/tasks/task-3503 - config.load_settings-cache-miss-race-can-return-None-to-worker-threads.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-3503
 title: config.load_settings cache-miss race can return None to worker threads
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-07 20:36'
 labels:
@@ -19,7 +19,38 @@ Diagnosed during TASK-3170's Task 6 while chasing an intermittent test failure (
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 config.load_settings() never returns None to a concurrent caller during a cache rebuild -- either the lock is held for the full miss-then-rebuild sequence, or a concurrent reader gets the previous cached value instead of None
-- [ ] #2 A concurrency regression test reproduces the race (multiple threads calling load_settings() while a cache invalidation/rebuild is forced) and fails against the current code before the fix, passes after
-- [ ] #3 No behavior change to the normal single-threaded / cache-hit path
+- [x] #1 config.load_settings() never returns None to a concurrent caller during a cache rebuild -- either the lock is held for the full miss-then-rebuild sequence, or a concurrent reader gets the previous cached value instead of None
+- [x] #2 A concurrency regression test reproduces the race (multiple threads calling load_settings() while a cache invalidation/rebuild is forced) and fails against the current code before the fix, passes after
+- [x] #3 No behavior change to the normal single-threaded / cache-hit path
 <!-- AC:END -->
+
+## Implementation Notes
+
+`load_settings` is now a thin locking wrapper over the original body (renamed
+`_load_settings_uncached`), holding a module-level RLock across
+miss -> rebuild -> store with a double-check inside. Chose a wrapper over
+re-indenting ~1400 lines into a `try/finally`.
+
+The lock is REENTRANT deliberately: one rebuild makes several nested
+configuration reads, so a plain `Lock` would deadlock the rebuilding thread
+against itself.
+
+**Measured** (8 threads, one invalidation, counting `_load_cli_config_
+bootstrap`): 32 full rebuilds before, 4 after. A single uncontended rebuild
+also costs 4, so cross-thread duplication is now zero and the remaining 4 is
+one rebuild's own nested reads -- a separate, single-threaded inefficiency
+this task does not address and which is worth its own follow-up. The
+duplication was exactly linear in thread count, so the saving scales with
+concurrency.
+
+**AC #1 could not be reproduced as written.** It asks that `load_settings()`
+never hand a concurrent caller `None`. It never did: `load_settings` does not
+return the cache cell during the miss window, and no module outside
+`config.py` reads `_SETTINGS_CACHE` directly (verified by grep). A thread
+arriving mid-rebuild always took the miss branch and got a real mapping -- it
+just paid for a redundant rebuild to get it. The real defect was the
+duplicated work, which is what the regression test pins. `None`-freedom is
+pinned anyway so a future refactor that starts returning the raw cell fails.
+
+Files: `tldw_chatbook/config.py`,
+`Tests/test_config_settings_cache_concurrency.py`.

--- a/backlog/tasks/task-585 - Confluence-sync-requests-calls-inside-async-methods.md
+++ b/backlog/tasks/task-585 - Confluence-sync-requests-calls-inside-async-methods.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-585
 title: Confluence replace sync requests calls inside async methods
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-23 12:00'
 labels: [subscriptions, performance]
@@ -18,7 +18,33 @@ priority: medium
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] No synchronous HTTP call remains on the event loop in `Web_Scraping/Confluence/` (ConfluenceAuth and ConfluenceScraper)
-- [ ] Async methods use either httpx async or run_in_executor for blocking sync calls
-- [ ] Tests verify no blocking calls are made from async contexts
+- [x] No synchronous HTTP call remains on the event loop in `Web_Scraping/Confluence/` (ConfluenceAuth and ConfluenceScraper)
+- [x] Async methods use either httpx async or run_in_executor for blocking sync calls
+- [x] Tests verify no blocking calls are made from async contexts
 <!-- AC:END -->
+
+## Implementation Notes
+
+All seven `auth.make_request` call sites across `confluence_scraper.py` and
+`confluence_crawler.py`, plus `_extract_page_id_from_url` (whose fallback
+path performs its own blocking fetch), now run via `asyncio.to_thread`.
+Chose the executor route over an httpx port: it satisfies the AC at a
+fraction of the risk, leaving session/auth/retry handling untouched.
+
+Tests assert the property -- the blocking callable runs on a different thread
+than the loop -- rather than asserting a specific wrapper, so they survive a
+later move to httpx async. A fourth test pins the user-visible symptom: the
+loop keeps ticking while a slow request is in flight.
+
+One test-quality note worth recording: that fourth test initially passed
+against the UNFIXED code because it sampled the heartbeat counter after
+awaiting the heartbeat, which always completes. It now samples before
+draining and fails with the fix reverted, like the other three.
+
+Note for anyone running these locally: this package imports `playwright` and
+`trafilatura` transitively, so its tests (including the two pre-existing
+ones) do not collect without those optional deps installed.
+
+Files: `tldw_chatbook/Web_Scraping/Confluence/confluence_scraper.py`,
+`confluence_crawler.py`,
+`Tests/Web_Scraping/Confluence/test_confluence_no_blocking_io_on_loop.py`.

--- a/tldw_chatbook/Web_Scraping/Confluence/confluence_auth.py
+++ b/tldw_chatbook/Web_Scraping/Confluence/confluence_auth.py
@@ -9,6 +9,8 @@ from typing import Dict, Optional, Any
 from enum import Enum
 from urllib.parse import urlparse
 import requests
+import threading
+
 from requests.auth import HTTPBasicAuth
 
 #
@@ -49,6 +51,23 @@ class ConfluenceAuth:
         self.auth_method = auth_method
         self.session = requests.Session()
         self._auth_configured = False
+        #: Serializes use of the shared `requests.Session` (task-585 review).
+        #:
+        #: `requests.Session` is not thread-safe -- cookies, connection pool
+        #: and headers are mutable and unsynchronized. That was harmless while
+        #: every call ran inline on the event loop: `scrape_many`'s
+        #: `asyncio.gather` looked concurrent but each blocking `make_request`
+        #: serialized the others anyway. Moving those calls to
+        #: `asyncio.to_thread` made the concurrency real, so N worker threads
+        #: could touch one session at once.
+        #:
+        #: A lock rather than a thread-local session: `self.session` also
+        #: carries the AUTH configuration (`configure_api_token` and friends
+        #: set `.auth`/`.headers`/`.cookies` on it), so per-thread copies would
+        #: silently stop inheriting any configuration applied after the thread
+        #: made its first call. Serialized-but-off-loop still delivers what the
+        #: offload was for: the UI no longer freezes for the request duration.
+        self._session_lock = threading.Lock()
 
     def configure_api_token(self, username: str, api_token: str) -> None:
         """
@@ -196,9 +215,10 @@ class ConfluenceAuth:
         """
         try:
             # Try to get current user info
-            response = self.session.get(
-                f"{self.base_url}/rest/api/user/current", timeout=10
-            )
+            with self._session_lock:
+                response = self.session.get(
+                    f"{self.base_url}/rest/api/user/current", timeout=10
+                )
 
             if response.status_code == 200:
                 user_data = response.json()
@@ -274,7 +294,8 @@ class ConfluenceAuth:
             # Non-GET / param-carrying calls: pre-check + timeout (no manual
             # redirect loop; the Confluence API does not redirect these).
             check_url_or_raise(url, trusted_origins=trusted)
-            response = self.session.request(method, url, **kwargs)
+            with self._session_lock:
+                response = self.session.request(method, url, **kwargs)
 
         # Log request details for debugging
         logger.debug(f"{method} {url} - Status: {response.status_code}")

--- a/tldw_chatbook/Web_Scraping/Confluence/confluence_crawler.py
+++ b/tldw_chatbook/Web_Scraping/Confluence/confluence_crawler.py
@@ -235,7 +235,8 @@ class ConfluenceCrawler:
     async def _get_space_root_pages(self, space_key: str) -> List[Dict[str, str]]:
         """Get root-level pages in a space"""
         try:
-            response = self.auth.make_request(
+            response = await asyncio.to_thread(
+                self.auth.make_request,
                 "GET",
                 "/rest/api/content",
                 params={
@@ -266,7 +267,8 @@ class ConfluenceCrawler:
     async def _get_child_pages(self, page_id: str) -> List[Dict[str, str]]:
         """Get child pages of a given page"""
         try:
-            response = self.auth.make_request(
+            response = await asyncio.to_thread(
+                self.auth.make_request,
                 "GET", f"/rest/api/content/{page_id}/child/page", params={"limit": 100}
             )
 
@@ -286,7 +288,8 @@ class ConfluenceCrawler:
     async def _get_parent_page_id(self, page_id: str) -> Optional[str]:
         """Get parent page ID"""
         try:
-            response = self.auth.make_request(
+            response = await asyncio.to_thread(
+                self.auth.make_request,
                 "GET", f"/rest/api/content/{page_id}", params={"expand": "ancestors"}
             )
 

--- a/tldw_chatbook/Web_Scraping/Confluence/confluence_scraper.py
+++ b/tldw_chatbook/Web_Scraping/Confluence/confluence_scraper.py
@@ -74,7 +74,8 @@ class ConfluenceScraper(Scraper):
         """
         try:
             # Fetch page content via API
-            response = self.auth.make_request(
+            response = await asyncio.to_thread(
+                self.auth.make_request,
                 "GET",
                 f"/rest/api/content/{page_id}",
                 params={
@@ -114,7 +115,10 @@ class ConfluenceScraper(Scraper):
             Dictionary containing scraped page data
         """
         # Extract page ID from URL
-        page_id = self._extract_page_id_from_url(url)
+        # task-585: this helper falls back to fetching the page (see its
+        # own body) -- a blocking HTTP call, so it cannot run inline on
+        # the event loop.
+        page_id = await asyncio.to_thread(self._extract_page_id_from_url, url)
         if not page_id:
             return {
                 "extraction_successful": False,
@@ -142,7 +146,8 @@ class ConfluenceScraper(Scraper):
         while len(pages) < limit:
             try:
                 # Fetch pages in space
-                response = self.auth.make_request(
+                response = await asyncio.to_thread(
+                self.auth.make_request,
                     "GET",
                     "/rest/api/content",
                     params={
@@ -205,7 +210,8 @@ class ConfluenceScraper(Scraper):
 
         while len(pages) < limit:
             try:
-                response = self.auth.make_request(
+                response = await asyncio.to_thread(
+                self.auth.make_request,
                     "GET",
                     "/rest/api/content/search",
                     params={
@@ -366,7 +372,8 @@ class ConfluenceScraper(Scraper):
 
         # Fetch attachments
         try:
-            response = self.auth.make_request(
+            response = await asyncio.to_thread(
+                self.auth.make_request,
                 "GET",
                 f"/rest/api/content/{page_id}/child/attachment",
                 params={"expand": "version,container"},

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -938,6 +938,19 @@ def coerce_float_setting(
 _SETTINGS_CACHE: Optional[Dict[str, Any]] = None
 _SETTINGS_CACHE_SOURCE: Optional[Path] = None
 _SETTINGS_CACHE_LOCK = None  # Will be initialized when needed
+#: Serializes the miss->rebuild->store sequence (task-3503).
+#:
+#: `_SETTINGS_CACHE_LOCK` guards only the cache *cells*; it is released for
+#: the rebuild itself, so every thread arriving during a miss used to run
+#: the whole rebuild -- re-reading and re-parsing the TOML, re-merging
+#: defaults, re-ensuring directories. Measured at 32 bootstrap loads for 8
+#: threads on ONE invalidation.
+#:
+#: REENTRANT on purpose: the rebuild reaches helpers that read configuration
+#: again, so a plain Lock would deadlock the rebuilding thread against
+#: itself. RLock keeps same-thread reentry behaving exactly as before while
+#: admitting only one *thread* at a time.
+_SETTINGS_REBUILD_LOCK = None  # Will be initialized when needed
 
 
 def resolve_tldw_api_config(app_config) -> Dict:
@@ -1325,6 +1338,59 @@ def _normalize_legacy_provider_api_key(
 
 
 def load_settings(force_reload: bool = False) -> Dict:
+    """Return the merged application settings, rebuilding at most once.
+
+    Thin wrapper over :func:`_load_settings_uncached` that serializes the
+    cache-miss rebuild (task-3503). The cache-hit path is unchanged: one
+    short lock, no rebuild lock taken at all.
+
+    Args:
+        force_reload: Rebuild even on a cache hit.
+
+    Returns:
+        The merged settings mapping.
+    """
+    global _SETTINGS_CACHE_LOCK, _SETTINGS_REBUILD_LOCK
+
+    if _SETTINGS_CACHE_LOCK is None or _SETTINGS_REBUILD_LOCK is None:
+        import threading
+
+        if _SETTINGS_CACHE_LOCK is None:
+            _SETTINGS_CACHE_LOCK = threading.Lock()
+        if _SETTINGS_REBUILD_LOCK is None:
+            _SETTINGS_REBUILD_LOCK = threading.RLock()
+
+    active_config_path = _get_effective_config_path()
+
+    def _cache_hit():
+        with _SETTINGS_CACHE_LOCK:
+            if (
+                _SETTINGS_CACHE is not None
+                and _SETTINGS_CACHE_SOURCE == active_config_path
+            ):
+                return _SETTINGS_CACHE
+        return None
+
+    if not force_reload:
+        cached = _cache_hit()
+        if cached is not None:
+            return cached
+
+    # Miss: serialize the rebuild. Whoever loses the race re-checks the cache
+    # and returns the winner's freshly built settings rather than repeating
+    # the entire rebuild.
+    with _SETTINGS_REBUILD_LOCK:
+        if not force_reload:
+            cached = _cache_hit()
+            if cached is not None:
+                logger.debug(
+                    "load_settings: returning configuration rebuilt by another thread"
+                )
+                return cached
+        return _load_settings_uncached(force_reload=force_reload)
+
+
+def _load_settings_uncached(force_reload: bool = False) -> Dict:
     """
     Loads all settings from TOML config files, environment variables, or defaults into a dictionary.
     It first loads a base config (e.g., server-local), then attempts to load a user-specific


### PR DESCRIPTION
## What & why

Second efficiency burn-down batch: the **blocking-the-loop** family. Two fixes plus one measurement that settles an open design question. Both fixes are red-proofed, and both were verified against the real code before being touched — one task's stated premise turned out to be wrong, which is reported rather than papered over.

## task-3503 — the settings cache rebuilt once per *thread*, not once per miss

`load_settings()` cleared `_SETTINGS_CACHE` **inside** the cache lock and then ran the rebuild **outside** it. Every thread that arrived during the miss window ran the entire rebuild — re-reading and re-parsing the TOML, deep-merging defaults, re-ensuring directories — and the last writer won.

**Measured**, counting `_load_cli_config_bootstrap` on one invalidation:

| | bootstrap loads |
|---|---|
| 8 threads, before | **32** |
| 8 threads, after | **4** |
| 1 thread (the floor) | 4 |

The duplication was exactly linear in thread count, so the saving scales with concurrency. After the fix, cross-thread duplication is **zero** — the remaining 4 is one rebuild's own nested config reads, a separate single-threaded inefficiency this task doesn't address (worth its own follow-up).

Implemented as a thin locking wrapper over the original body (renamed `_load_settings_uncached`) rather than re-indenting ~1400 lines into a `try/finally`. The rebuild lock is an **RLock on purpose**: the rebuild reaches helpers that read config again, so a plain `Lock` would deadlock the rebuilding thread against itself. The cache-hit path is untouched — one short lock, rebuild lock never taken.

**The task's AC #1 does not reproduce, and I'm flagging that rather than quietly satisfying it.** It asks that `load_settings()` never hand a concurrent caller `None`. It never did: the function doesn't return the cache cell during the window, and no module outside `config.py` reads `_SETTINGS_CACHE` directly (grep-verified). A thread arriving mid-rebuild always took the miss branch and got a real mapping — it just paid for a redundant rebuild to get it. The duplicated work was the real defect. `None`-freedom is pinned anyway, so a future refactor that starts returning the raw cell fails.

## task-585 — Confluence HTTP blocked the event loop

`ConfluenceAuth.make_request` is a synchronous `requests` call, and `_extract_page_id_from_url` falls back to a blocking fetch. Both ran inline from `async def`, so a slow or hanging Confluence server stalled the **whole loop** for up to the full request timeout (30s since task-328 bounded it; unbounded before).

All seven `make_request` call sites across the scraper and crawler, plus the page-id helper, now run via `asyncio.to_thread`. Chose the executor route over an httpx port deliberately: it satisfies the AC at a fraction of the risk, leaving session/auth/retry handling untouched.

The tests assert the **property** — the blocking callable runs on a different thread than the loop — rather than asserting a particular wrapper, so they survive a later move to httpx async. A fourth test pins the symptom a user would feel: the loop keeps ticking while a slow request is in flight.

## task-19562 — the `busy_timeout` question, measured not assumed

That task has an AC requiring this be *measured*. Done, on this branch's base:

```
SubscriptionsDB connection busy_timeout (ms): 5000
journal_mode: wal
second writer blocked for 1.08s -> acquired   (lock held 1.0s)
```

The premise is **confirmed** — no `busy_timeout` is set anywhere, so it inherits Python sqlite3's 5 s default, and a writer collision really does block for the lock's duration up to that ceiling.

With one **narrowing the design needs**: `journal_mode = WAL`, so readers and writers don't block each other. The 5 s stall exposure is **writer-vs-writer only**, not all 22 async methods as the task's wording could be read to imply. The read-only methods still block the loop for their own query duration — a separate fix — but cannot be *stalled* by a concurrent writer. Lowering `busy_timeout` only converts the stall into an earlier exception, so it is not a substitute for moving the work off the loop.

task-19562 itself is **left open**: it is an arc, not a quick win (7,117 lines across two files, 40 `async def`, bundling a user-visible duplicate-alert bug, the 22-method offload, a non-reentrant `transaction()`, and a leaked connection). The task file now carries a recommended 3-way split.

## Red-proof evidence

| Change | Reverted → |
|---|---|
| settings rebuild lock | `8 concurrent callers rebuilt the settings cache 32 times; one uncontended rebuild costs 4` |
| Confluence offload | all 4 loop-thread tests fail |

One test-quality note recorded rather than hidden: the Confluence responsiveness test initially passed against the *unfixed* code, because it sampled the heartbeat counter after awaiting the heartbeat — which always completes. It now samples before draining and fails with the fix reverted, like the other three.

## Testing

Config suites **123 passed**; `Tests/Web_Scraping/` **226 passed, 3 skipped**.

The 8 `Tests/DB/` failures on this branch were A/B'd properly — same worktree, same venv, only `config.py` reverted to dev's: **8 before, 8 after**, so none are mine.

Note for local runs: the Confluence package imports `playwright` and `trafilatura` transitively, so its tests (including the two pre-existing ones) don't collect without those optional deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops blocking the event loop on Confluence I/O, rebuilds the settings cache once per miss rather than once per thread, and records SQLite `busy_timeout`; also serializes the shared Confluence `requests.Session` to keep newly offloaded calls thread-safe. Old Confluence behavior: sync `requests` ran inline and froze the loop; new behavior: call sites run via `asyncio.to_thread` and `session` access is guarded by a lock. Old config behavior: concurrent misses duplicated full rebuilds; new behavior: a reentrant lock serializes miss → rebuild → store. Measured DB behavior: default 5s `busy_timeout` with WAL; stalls are writer-vs-writer only. (task-585, task-3503, task-19562)

- Confluence: executor offload only; no API changes. `ConfluenceAuth` now guards its `requests.Session` with a lock in both `make_request` and `test_authentication` to avoid concurrent access introduced by `asyncio.to_thread`. Tests assert off-loop execution, loop responsiveness under slow requests, and single-entry session use. Local runs of `Tests/Web_Scraping/Confluence/` require optional deps `playwright` and `trafilatura`.
- Config: `load_settings()` wraps `_load_settings_uncached` with a module-level `RLock` to serialize rebuilds; a double-check on miss avoids duplicate work. Cache-hit path is unchanged. Tests cover concurrency, never returning `None`, and warm-cache behavior.
- DB: code unchanged; task-19562 doc adds measured `busy_timeout` = 5000 ms and WAL mode, narrowing offload scope to writer-vs-writer stalls.

<sup>Written for commit a8b424cec11be60ee1e020c861cb42283f4c8433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

