### PR TITLE
Security: refuse agent writes into a repository's .git metadata (TASK-19700)

### DIFF
--- a/Tests/Tools/test_file_tool_sandbox.py
+++ b/Tests/Tools/test_file_tool_sandbox.py
@@ -409,3 +409,58 @@ def test_default_sandbox_configuration_still_works_end_to_end():
     grep_result = asyncio.run(fot.GrepFiles().execute(pattern="hi there"))
     assert "error" not in grep_result, grep_result
     assert any(m["path"].endswith("hello.txt") for m in grep_result["matches"])
+
+
+# ---------------------------------------------------------------------------
+# TASK-19700: `.git/` metadata and THIS family.
+#
+# Verified by mutation while writing these: this family does NOT have the
+# gap. `validate_path_multi` refuses EVERY hidden component ("Access to
+# hidden files/directories is not allowed"), so `.git/config` was already
+# unreachable here -- disabling the new `is_git_metadata_write` check leaves
+# the refusal test passing. The real gap was in the OTHER family
+# (`local_tool_impls`), which sets `allow_hidden=True` per ADR-032 so a
+# coding agent can read dotfiles; that is where the guard is load-bearing
+# and mutation-proven (see `Tests/Tools/test_local_tool_sensitive_paths.py`).
+#
+# The check is still wired here as defense-in-depth -- if this family ever
+# adopts `allow_hidden` the way ADR-032 drove the other one to, the guard is
+# already in place -- but these tests are honest about which mechanism does
+# the work today, rather than crediting the new one for a refusal it did not
+# produce.
+# ---------------------------------------------------------------------------
+
+
+def test_write_file_tool_refuses_git_config_today_via_the_hidden_rule(
+    monkeypatch, tmp_path
+):
+    """Regression pin, NOT red-first: the hidden-component rule is what
+    refuses this today. Pinned so a future `allow_hidden` adoption here
+    cannot silently open `.git/` writes without a test noticing."""
+    sandbox = tmp_path / "sandbox"
+    (sandbox / ".git").mkdir(parents=True)
+    (sandbox / ".git" / "config").write_text("[core]\n")
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox.resolve())
+
+    result = asyncio.run(
+        fot.WriteFileTool().execute(
+            file_path=".git/config", content='[remote "--force"]\n'
+        )
+    )
+    assert "error" in result, f"the write was allowed: {result}"
+    assert (sandbox / ".git" / "config").read_text() == "[core]\n"
+
+
+def test_is_git_metadata_write_predicate_is_exact_on_components():
+    """The shared predicate itself -- the part that IS load-bearing in the
+    other family. Prefix lookalikes must stay writable."""
+    from tldw_chatbook.Utils.sensitive_paths import is_git_metadata_write
+
+    assert is_git_metadata_write(Path("/repo/.git"))
+    assert is_git_metadata_write(Path("/repo/.git/config"))
+    assert is_git_metadata_write(Path("/repo/.git/hooks/pre-commit"))
+    assert is_git_metadata_write(Path("/repo/nested/.git/config"))
+    assert not is_git_metadata_write(Path("/repo/.gitignore"))
+    assert not is_git_metadata_write(Path("/repo/.gitattributes"))
+    assert not is_git_metadata_write(Path("/repo/.github/workflows/ci.yml"))
+    assert not is_git_metadata_write(Path("/repo/src/git/config"))

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -613,3 +613,159 @@ def test_resolve_workspace_path_still_confines_and_still_allows_hidden(tmp_path)
     assert resolve_workspace_path(".github", ws) == (ws / ".github").resolve()
     with pytest.raises(LocalToolError, match="outside the workspace root"):
         resolve_workspace_path("../x", ws)
+
+
+# ---------------------------------------------------------------------------
+# Shape 5: writes into a repository's own `.git/` metadata (TASK-19700).
+#
+# Surfaced by TASK-16801's git-modes arc, where a repository-supplied
+# `.git/config` or `.git/HEAD` was the precondition for FOUR proven
+# data-destruction vectors (an option-shaped remote or branch name reaching
+# git's argv; `remote.push`/`mirror`/`push.default` turning an ordinary push
+# into a forced update or a ref deletion). Those are all fixed defensively
+# inside the git engine; this is the upstream cause -- an agent that can
+# write `.git/` reconfigures git for EVERY feature that shells out to it.
+#
+# `.git` is a dotted component under the root, which ADR-032's
+# `allow_hidden=True` deliberately lets past confinement, so this depends
+# entirely on the write guard.
+# ---------------------------------------------------------------------------
+
+
+def _plant_repo(tmp_path: Path) -> Path:
+    """A workspace root that is a real-looking git repo (no git binary needed)."""
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "config").write_text("[core]\n\trepositoryformatversion = 0\n")
+    (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    return root
+
+
+def test_fs_write_refuses_rewriting_git_config(tmp_path):
+    root = _plant_repo(tmp_path)
+    before = (root / ".git" / "config").read_text()
+    message = _refused(
+        lambda: write_file(
+            ".git/config",
+            "[remote \"--force\"]\n\turl = https://example.invalid/x.git\n",
+            workspace_root=root,
+        ),
+        "fs_write(.git/config)",
+    )
+    assert ".git" in message
+    assert (root / ".git" / "config").read_text() == before, "config was rewritten"
+
+
+def test_fs_write_refuses_rewriting_git_head(tmp_path):
+    root = _plant_repo(tmp_path)
+    before = (root / ".git" / "HEAD").read_text()
+    message = _refused(
+        lambda: write_file(
+            ".git/HEAD", "ref: refs/heads/--mirror\n", workspace_root=root
+        ),
+        "fs_write(.git/HEAD)",
+    )
+    assert ".git" in message
+    assert (root / ".git" / "HEAD").read_text() == before, "HEAD was rewritten"
+
+
+def test_fs_write_refuses_a_nested_path_under_git(tmp_path):
+    """The guard is on ANY `.git` component, not just its direct children."""
+    root = _plant_repo(tmp_path)
+    (root / ".git" / "hooks").mkdir()
+    _refused(
+        lambda: write_file(
+            ".git/hooks/pre-commit", "#!/bin/sh\nexit 1\n", workspace_root=root
+        ),
+        "fs_write(.git/hooks/pre-commit)",
+    )
+    assert not (root / ".git" / "hooks" / "pre-commit").exists()
+
+
+def test_fs_write_refuses_the_dot_git_FILE_of_a_linked_worktree(tmp_path):
+    """A linked worktree carries `.git` as a FILE; rewriting it redirects the
+    whole repository, so the guard must not assume `.git` is a directory."""
+    root = tmp_path / "linked"
+    root.mkdir()
+    (root / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n")
+    before = (root / ".git").read_text()
+    _refused(
+        lambda: write_file(".git", "gitdir: /attacker\n", workspace_root=root),
+        "fs_write(.git as a file)",
+    )
+    assert (root / ".git").read_text() == before
+
+
+def test_fs_edit_refuses_git_config(tmp_path):
+    """The guard sits at the shared boundary, so edit is covered too."""
+    root = _plant_repo(tmp_path)
+    _refused(
+        lambda: edit_file(
+            ".git/config",
+            "repositoryformatversion = 0",
+            "repositoryformatversion = 0\n\tfsmonitor = /tmp/evil",
+            workspace_root=root,
+        ),
+        "fs_edit(.git/config)",
+    )
+    assert "fsmonitor" not in (root / ".git" / "config").read_text()
+
+
+def test_fs_patch_refuses_git_config(tmp_path):
+    root = _plant_repo(tmp_path)
+    # A REAL unified diff -- the "*** Begin Patch" envelope is a different
+    # tool's format and this parser rejects it as `invalid_diff`, which
+    # would make this test pass without ever reaching the guard.
+    patch = "--- /dev/null\n+++ b/.git/hooks/pre-commit\n@@ -0,0 +1,1 @@\n+evil\n"
+    try:
+        result = patch_files(patch, workspace_root=root)
+    except LocalToolError as exc:
+        result = str(exc)
+    assert "invalid_diff" not in str(result), (
+        f"the patch payload never reached the guard: {result}"
+    )
+    assert ".git" in str(result), f"expected a .git refusal, got: {result}"
+    assert not (root / ".git" / "hooks" / "pre-commit").exists(), (
+        f"patch_files wrote into .git/: {result}"
+    )
+
+
+def test_fs_patch_control_the_same_shape_succeeds_outside_git(tmp_path):
+    """Proves the patch payload above is well-formed: the identical shape
+    aimed at an ordinary path must APPLY, so the refusal is the guard's
+    doing and not a malformed diff."""
+    root = _plant_repo(tmp_path)
+    patch = "--- /dev/null\n+++ b/notes.txt\n@@ -0,0 +1,1 @@\n+hello\n"
+    patch_files(patch, workspace_root=root)
+    assert (root / "notes.txt").read_text() == "hello\n"
+
+
+# -- the deliberate exceptions: ordinary tracked dotfiles stay writable ------
+
+
+def test_fs_write_still_allows_gitignore(tmp_path):
+    """`.gitignore` is an ordinary tracked file; refusing it would break
+    normal coding work. It only shares a name PREFIX with `.git`."""
+    root = tmp_path / "repo2"
+    (root / ".git").mkdir(parents=True)
+    write_file(".gitignore", "build/\n", workspace_root=root)
+    assert (root / ".gitignore").read_text() == "build/\n"
+
+
+def test_fs_write_still_allows_gitattributes_and_github_dir(tmp_path):
+    root = tmp_path / "repo3"
+    (root / ".git").mkdir(parents=True)
+    (root / ".github" / "workflows").mkdir(parents=True)
+    write_file(".gitattributes", "* text=auto\n", workspace_root=root)
+    write_file(".github/workflows/ci.yml", "name: ci\n", workspace_root=root)
+    assert (root / ".gitattributes").read_text() == "* text=auto\n"
+    assert (root / ".github" / "workflows" / "ci.yml").read_text() == "name: ci\n"
+
+
+def test_reads_under_git_are_unchanged_by_this_guard(tmp_path):
+    """Scope pin: TASK-19700 governs WRITES. Read behaviour is deliberately
+    untouched here so the change cannot quietly break an agent inspecting
+    repository state; the read-side question is tracked separately."""
+    root = _plant_repo(tmp_path)
+    out = read_file(".git/HEAD", workspace_root=root)
+    assert "refs/heads/main" in out

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -769,3 +769,29 @@ def test_reads_under_git_are_unchanged_by_this_guard(tmp_path):
     root = _plant_repo(tmp_path)
     out = read_file(".git/HEAD", workspace_root=root)
     assert "refs/heads/main" in out
+
+
+def test_fs_write_refuses_a_case_variant_of_git(tmp_path):
+    """Qodo #1 (PR #1934): macOS and Windows filesystems are
+    case-insensitive by default, so `.GIT/config` IS `.git/config`.
+
+    Verified before the fix: `write_file(".GIT/config", ...)` succeeded and
+    the hostile remote landed in the REAL `.git/config`.
+    """
+    root = _plant_repo(tmp_path)
+    before = (root / ".git" / "config").read_text()
+    for spelling in (".GIT/config", ".Git/config", ".gIt/HEAD"):
+        _refused(
+            lambda s=spelling: write_file(s, "[remote \"--force\"]\n", workspace_root=root),
+            f"fs_write({spelling})",
+        )
+    assert (root / ".git" / "config").read_text() == before
+
+
+def test_case_variants_do_not_over_refuse_gitignore(tmp_path):
+    """The case-insensitive match must still be COMPONENT-exact: `.GITIGNORE`
+    is an ordinary file, not repository metadata."""
+    root = tmp_path / "repo_ci"
+    (root / ".git").mkdir(parents=True)
+    write_file(".GITIGNORE", "build/\n", workspace_root=root)
+    assert (root / ".GITIGNORE").read_text() == "build/\n"

--- a/backlog/tasks/task-19700 - Agent-writable-git-directory-inside-workspace-roots.md
+++ b/backlog/tasks/task-19700 - Agent-writable-git-directory-inside-workspace-roots.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19700
 title: 'Security: agent write tools can modify .git/ inside a workspace root'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21'
 labels:
@@ -45,9 +45,86 @@ answer rather than an accidental one.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A policy decision is recorded (in the task or an ADR) for whether agent write tools may modify anything under `.git/`, and for `.gitattributes`, with the reasoning for legitimate exceptions
-- [ ] #2 The chosen policy is enforced at the path-resolution boundary shared by the write tools, not per-tool
-- [ ] #3 A write attempt that the policy refuses fails with an explanation naming the path, never silently
-- [ ] #4 Tests cover: a refused `.git/config` write, a refused `.git/HEAD` write, and whatever exceptions the policy deliberately allows
-- [ ] #5 The audit states which other features shell out to git against agent-writable roots, so the blast radius of this gap is recorded rather than assumed
+- [x] #1 A policy decision is recorded (in the task or an ADR) for whether agent write tools may modify anything under `.git/`, and for `.gitattributes`, with the reasoning for legitimate exceptions
+- [x] #2 The chosen policy is enforced at the path-resolution boundary shared by the write tools, not per-tool
+- [x] #3 A write attempt that the policy refuses fails with an explanation naming the path, never silently
+- [x] #4 Tests cover: a refused `.git/config` write, a refused `.git/HEAD` write, and whatever exceptions the policy deliberately allows
+- [x] #5 The audit states which other features shell out to git against agent-writable roots, so the blast radius of this gap is recorded rather than assumed
 <!-- AC:END -->
+
+## Policy decision (AC #1)
+
+**Writes to anything under a `.git` component: REFUSED.** No legitimate
+agent flow needs them. The two candidate exceptions named when this task was
+filed both dissolve on inspection: a user asking an agent to "fix the
+gitignore" edits `.gitignore`, an ordinary tracked file at the repository
+root, not `.git/`; and the app's own tooling that writes `.git/info/exclude`
+is the shadow tracker, which owns a private `GIT_DIR` under the app data
+directory and never routes through these tools.
+
+**`.gitignore`, `.gitattributes` and `.github/`: ALLOWED.** They are ordinary
+tracked files that share only a name prefix with `.git`, and refusing them
+would break routine coding work. `.gitattributes` is the one with a security
+history — it can assign a textconv/diff driver — but that vector was closed
+defensively in TASK-16801 by passing `--no-ext-diff --no-textconv
+--no-color` at every `git diff` site, so blocking the file as well would cost
+real usability for no remaining gain.
+
+**Reads are deliberately UNCHANGED.** ADR-032 adopted `allow_hidden` so a
+coding agent can read a repository's dotfile configuration; making the guard
+read-side too would undo that for no benefit against this threat, which is
+about reconfiguring git rather than observing it. One read-side question is
+worth separating rather than smuggling in here: `.git/config` can embed a
+credential in a remote URL (`https://user:TOKEN@host/...`), so an agent
+reading it can see a token. That is a disclosure question with a different
+shape and a different fix, and it is NOT addressed by this task.
+
+## Blast-radius audit (AC #5)
+
+Every feature that shells out to git against a root an agent can write:
+
+| Feature | Reads the user's `.git/config`? | Status |
+|---|---|---|
+| `Workspaces/git_workspace.py` (change-review git modes) | Yes, by design | Hardened in TASK-16801: option-shaped remote/branch names refused, explicit fully-qualified push refspec, `GIT_LITERAL_PATHSPECS=1`, machine-safe diff flags |
+| `Tools/git_tool_impls.py` (read-only agent git tools) | Yes | Fixed-argv allowlist, sanitized env, and already passes `--no-ext-diff --no-textconv --no-color` |
+| `Workspaces/change_tracking.py` (shadow tracker) | **No** — explicit `--git-dir` to an app-owned directory and every `GIT_*` scrubbed | Residual, narrow: it diffs the user's WORKING TREE without machine-safe diff flags, so a worktree `.gitattributes` naming a driver defined in the user's GLOBAL `~/.gitconfig` could still colour its output. Not reachable through this gap (an agent cannot write `~/.gitconfig`), recorded for completeness |
+| `Notes/file_notes_git_*` | Operates on the Notes sync repository, not an agent workspace root | Out of scope |
+
+`UI/CodeRepoCopyPasteWindow.py` and `Media/local_media_reading_service.py`
+match on the string "git" but shell out to no git binary (the former uses the
+GitHub HTTP API, the latter names a `git_repository` source type).
+
+With this task's guard in place, an agent can no longer plant the
+`.git/config` or `.git/HEAD` that every one of TASK-16801's four vectors
+depended on — the defensive fixes there are now belt to this braces.
+
+## Implementation Notes
+
+Adds `is_git_metadata_write(path)` to `Utils/sensitive_paths.py` — the module
+both write families already import — matching `.git` as an exact path
+COMPONENT so prefix lookalikes stay writable, and covering the `.git` FILE a
+linked worktree carries as well as the directory.
+
+**The gap was in one family, not two.** The task text assumed both. Verified
+by mutation while implementing: `Tools/file_operation_tools.py` refuses every
+hidden component outright ("Access to hidden files/directories is not
+allowed"), so `.git/` was already unreachable there — disabling the new check
+leaves its test passing. The real gap was `Tools/local_tool_impls.py`, whose
+`resolve_workspace_path` sets `allow_hidden=True` per ADR-032 precisely so a
+coding agent can read dotfiles; that is where the guard is load-bearing, and
+where the five refusal tests are red-first. The check is still wired into the
+other family as defense-in-depth against a future `allow_hidden` adoption
+there, and its tests say plainly which mechanism does the work today rather
+than crediting the new one for a refusal it did not produce.
+
+One test-quality note worth recording: the first version of the `patch_files`
+test used a different tool's `*** Begin Patch` envelope, which this parser
+rejects as `invalid_diff` — so it passed without ever reaching the guard. It
+now uses a real unified diff and is paired with a control proving the same
+payload APPLIES to an ordinary path, so the refusal is the guard's doing.
+
+**Files:** `tldw_chatbook/Utils/sensitive_paths.py`,
+`tldw_chatbook/Tools/local_tool_impls.py`,
+`tldw_chatbook/Tools/file_operation_tools.py`,
+`Tests/Tools/test_local_tool_sensitive_paths.py`,
+`Tests/Tools/test_file_tool_sandbox.py`.

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -20,6 +20,7 @@ from loguru import logger
 from . import Tool
 from ..Utils.path_validation import validate_path_multi
 from ..Utils.sensitive_paths import (
+    is_git_metadata_write,
     SensitivePathContext,
     is_sensitive_path,
     refuses_new_directory_chain,
@@ -628,6 +629,21 @@ class WriteFileTool(Tool):
                 return {
                     "file_path": file_path,
                     "error": f"Refused: '{file_path}' is a protected path and cannot be written",
+                }
+
+            # TASK-19700: the OTHER write family enforces this at
+            # `local_tool_impls.resolve_workspace_path`; this family has its
+            # own boundary, and the two drifting apart is exactly how the
+            # denylist came to be missing from all seven `fs_*` tools
+            # (TASK-19551). Write-only: reading repository state stays
+            # legitimate.
+            if is_git_metadata_write(path):
+                return {
+                    "file_path": file_path,
+                    "error": (
+                        f"Refused: '{file_path}' is inside a repository's "
+                        f".git metadata and cannot be written"
+                    ),
                 }
 
             # Check if we're overwriting an existing file

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -49,6 +49,7 @@ from typing import Literal
 
 from tldw_chatbook.Utils.path_validation import validate_path
 from tldw_chatbook.Utils.sensitive_paths import (
+    is_git_metadata_write,
     SensitivePathContext,
     is_sensitive_path,
     refuses_new_directory_chain,
@@ -157,6 +158,15 @@ def resolve_workspace_path(
     if is_sensitive_path(resolved, context=context):
         raise LocalToolError(
             f"Refused: '{path}' is a protected path and cannot be {verb}"
+        )
+    if intent == "write" and is_git_metadata_write(resolved):
+        # TASK-19700: the upstream cause of TASK-16801's four
+        # repository-supplied argv vectors. Write-only and checked here
+        # rather than folded into `is_sensitive_path`, which also governs
+        # reads -- reading repository state stays legitimate.
+        raise LocalToolError(
+            f"Refused: '{path}' is inside a repository's .git metadata and "
+            f"cannot be {verb}"
         )
     if intent == "write" and refuses_new_directory_chain(
         resolved.parent, context=context

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -835,3 +835,48 @@ def refuses_new_directory_chain(
         if parent == node:
             return False
         node = parent
+
+
+#: The one directory (or, in a linked worktree, FILE) name that holds a
+#: repository's own metadata. Matched as an exact path COMPONENT, never as a
+#: prefix: `.gitignore`, `.gitattributes` and `.github/` are ordinary tracked
+#: files and stay writable (TASK-19700 policy).
+GIT_METADATA_COMPONENT = ".git"
+
+
+def is_git_metadata_write(path: Path) -> bool:
+    """Whether writing ``path`` would modify a repository's own git metadata.
+
+    TASK-19700. Surfaced by TASK-16801's git-modes arc: a repository-supplied
+    ``.git/config`` or ``.git/HEAD`` was the precondition for four proven
+    data-destruction vectors -- an option-shaped remote or branch name
+    reaching git's argv, and ``remote.push``/``remote.mirror``/
+    ``push.default=matching`` turning an ordinary push into a forced update
+    or a ref deletion. Each is fixed defensively inside the git engine, but
+    an agent that can write ``.git/`` reconfigures git for EVERY feature
+    that shells out to it, so the upstream cause is denied here.
+
+    Deliberately WRITE-only and deliberately NOT part of
+    :func:`is_sensitive_path`: that denylist governs reads as well, and an
+    agent reading repository state is legitimate (ADR-032 adopted
+    ``allow_hidden`` precisely so a coding agent can see dotfiles). The
+    read-side question -- ``.git/config`` can embed a credential in a remote
+    URL -- is tracked separately rather than smuggled in here.
+
+    Matching is on an exact path component, so the near-miss names that
+    share the prefix stay writable:
+
+    * refused: ``.git``, ``.git/config``, ``.git/hooks/pre-commit``, and the
+      ``.git`` FILE a linked worktree carries (rewriting it redirects the
+      whole repository, so a directory-only check would miss it);
+    * allowed: ``.gitignore``, ``.gitattributes``, ``.github/workflows/``.
+
+    Args:
+        path: An already-resolved absolute path (the callers resolve before
+            calling, so a symlink cannot smuggle a ``.git`` component past
+            this check).
+
+    Returns:
+        True when any component of ``path`` is exactly ``.git``.
+    """
+    return GIT_METADATA_COMPONENT in path.parts

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -866,7 +866,10 @@ def is_git_metadata_write(path: Path) -> bool:
     Matching is on an exact path component, so the near-miss names that
     share the prefix stay writable:
 
-    * refused: ``.git``, ``.git/config``, ``.git/hooks/pre-commit``, and the
+    Matching is case-insensitive (a case-insensitive filesystem makes
+    ``.GIT`` the same directory), but still component-exact:
+
+    * refused: ``.git``, ``.GIT``, ``.git/config``, ``.git/hooks/pre-commit``, and the
       ``.git`` FILE a linked worktree carries (rewriting it redirects the
       whole repository, so a directory-only check would miss it);
     * allowed: ``.gitignore``, ``.gitattributes``, ``.github/workflows/``.
@@ -879,4 +882,11 @@ def is_git_metadata_write(path: Path) -> bool:
     Returns:
         True when any component of ``path`` is exactly ``.git``.
     """
-    return GIT_METADATA_COMPONENT in path.parts
+    # Case-INSENSITIVE component match (Qodo, PR #1934): macOS and Windows
+    # filesystems are case-insensitive by default, so `.GIT/config` opens the
+    # very same file as `.git/config`. Verified before this fix: a
+    # `.GIT/config` write sailed past an exact-match guard and landed a
+    # hostile remote in the real config. Still COMPONENT-exact, so
+    # `.GITIGNORE` stays writable.
+    folded = GIT_METADATA_COMPONENT.casefold()
+    return any(part.casefold() == folded for part in path.parts)


### PR DESCRIPTION
## What this fixes

An agent's write tools could create or rewrite `.git/config` and `.git/HEAD` inside a workspace root. That is the **upstream cause** of the four repository-supplied argv vectors fixed defensively in TASK-16801 (PR #1914) — with a hostile `.git/config`, an ordinary `git push` became a forced update or a ref deletion, and an option-shaped remote or branch name reached git's argv without any dangerous flag appearing in our own code.

Adds `is_git_metadata_write()` to `Utils/sensitive_paths.py` — the module both write families already import — matching `.git` as an exact path **component**, and covering the `.git` *file* a linked worktree carries as well as the directory.

## Policy (AC #1)

| | |
|---|---|
| Writes under any `.git` component | **Refused** |
| `.gitignore`, `.gitattributes`, `.github/` | **Allowed** — ordinary tracked files sharing only a name prefix |
| Reads | **Unchanged** — ADR-032 adopted `allow_hidden` so a coding agent can read dotfile config |

Both exceptions named when the task was filed dissolve on inspection: "fix the gitignore" edits `.gitignore`, not `.git/`; and the app tooling that writes `.git/info/exclude` is the shadow tracker, which owns a private `GIT_DIR` and never routes through these tools. `.gitattributes` has a security history (textconv drivers) but that vector was closed in TASK-16801 with machine-safe diff flags, so blocking the file would cost usability for no remaining gain.

## The task's premise was half wrong — verified, not assumed

The task said neither write family excluded `.git/`. **Only one did.** Mutation testing while implementing showed `Tools/file_operation_tools.py` refuses *every* hidden component already ("Access to hidden files/directories is not allowed"), so `.git/` was unreachable there — disabling the new check leaves its test green.

The real gap was `Tools/local_tool_impls.py`, whose `resolve_workspace_path` sets `allow_hidden=True` per ADR-032 precisely so a coding agent can read dotfiles. That is where the guard is load-bearing and where the five refusal tests are red-first. The check is still wired into the other family as defense-in-depth against a future `allow_hidden` adoption, and its tests **name the mechanism actually doing the work today** rather than crediting the new one for a refusal it didn't produce.

## Test-quality note

The first `patch_files` test used another tool's `*** Begin Patch` envelope, which this parser rejects as `invalid_diff` — so it passed without ever reaching the guard. It now uses a real unified diff, paired with a control proving the same payload *applies* to an ordinary path.

## Verification

- **682 passed** across `Tests/Tools/` + `Tests/Utils/test_sensitive_paths.py`; ruff clean.
- Refusal tests proven red before the fix; the not-load-bearing check proven not-load-bearing by mutation.
- Blast-radius audit (AC #5) in the task file: which features shell out to git against agent-writable roots, and one residual recorded honestly — the shadow tracker diffs the working tree without machine-safe flags, reachable only via a driver in the user's *global* gitconfig, which an agent cannot write.

Follows TASK-16801 (PR #1914). Read-side question deliberately **not** addressed: `.git/config` can embed a credential in a remote URL, which is a disclosure problem with a different shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses agent writes into a repository’s .git metadata within workspace roots. Previously `local_tool_impls` could create or edit `.git/config` and `.git/HEAD`; now writes to any path with a `.git` component are rejected (component-exact, case-insensitive), preventing repo reconfiguration that could turn safe pushes into destructive operations.

- Adds `is_git_metadata_write` in `tldw_chatbook/Utils/sensitive_paths.py`, matching `.git` as an exact path component case-insensitively and covering the `.git` file used by linked worktrees.
- Enforces the guard in `tldw_chatbook/Tools/local_tool_impls.py` for write intent; also applied in `tldw_chatbook/Tools/file_operation_tools.py` as defense-in-depth (that family already blocks hidden components).
- Keeps `.gitignore`, `.gitattributes`, and `.github/` writable; reads unchanged per ADR-032.
- Tests refuse writes to `.git/config`, `.git/HEAD`, hooks under `.git/`, the worktree `.git` file, and case-variant paths; a control proves the same patch applies outside `.git`. Errors name the refused path.
- No migration required; satisfies TASK-19700 acceptance criteria with policy and blast-radius audit recorded in the task.

<sup>Written for commit 2dbf5b2a8878c021be82653eea9ee5d360da0ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

