### PR TITLE
Security: sensitive-path denylist bypassable by path case (TASK-19800)

### DIFF
--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -795,3 +795,81 @@ def test_case_variants_do_not_over_refuse_gitignore(tmp_path):
     (root / ".git").mkdir(parents=True)
     write_file(".GITIGNORE", "build/\n", workspace_root=root)
     assert (root / ".GITIGNORE").read_text() == "build/\n"
+
+
+# ---------------------------------------------------------------------------
+# Shape 6: case-variant spellings of a denylisted path (TASK-19800).
+#
+# Found while fixing TASK-19700's `.git` guard for the same weakness. macOS
+# and Windows filesystems are case-insensitive by DEFAULT, and
+# `Path.resolve()` does NOT canonicalise case there (it resolves symlinks
+# and `..`, but preserves what the caller typed) -- so `~/.SSH/id_rsa` opens
+# the same file as `~/.ssh/id_rsa` while comparing unequal to every
+# denylist entry.
+#
+# Reproduced end-to-end before the fix against the app's OWN config file:
+#   tldw_cli/config.toml -> refused
+#   TLDW_CLI/config.toml -> ALLOWED, returned 32782 chars
+# i.e. the user's provider API keys, read straight through the denylist by
+# changing the case of one path component. The same shape reaches `~/.ssh`,
+# `~/.aws` and `mcp_permissions.json` -- and bypassing that last one turns
+# every `ask` into `allow`, which is the permission-gate bypass TASK-19551
+# exists to prevent.
+# ---------------------------------------------------------------------------
+
+
+def test_is_sensitive_path_matches_case_variants_of_a_denied_directory():
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    _plant_ssh_key()
+    home = _home()
+    for spelling in (".ssh", ".SSH", ".Ssh", ".sSh"):
+        assert is_sensitive_path(home / spelling / "id_rsa"), (
+            f"~/{spelling}/id_rsa must be denied: on a case-insensitive "
+            f"filesystem it IS ~/.ssh/id_rsa"
+        )
+
+
+def test_is_sensitive_path_matches_a_case_variant_of_a_denied_file():
+    from tldw_chatbook import config as app_config
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    real = app_config._get_effective_config_path()
+    real.parent.mkdir(parents=True, exist_ok=True)
+    real.write_text("[API]\nopenai_api_key = \"SYNTHETIC-19800\"\n")
+    variant = real.parent.parent / real.parent.name.upper() / real.name
+    assert is_sensitive_path(real)
+    assert is_sensitive_path(variant), (
+        f"{variant} must be denied: it is the same file on a "
+        f"case-insensitive filesystem"
+    )
+
+
+def test_fs_read_refuses_a_case_variant_of_this_apps_config():
+    """End-to-end through the tool, not just the predicate."""
+    from tldw_chatbook import config as app_config
+
+    real = app_config._get_effective_config_path()
+    real.parent.mkdir(parents=True, exist_ok=True)
+    real.write_text("[API]\nopenai_api_key = \"SYNTHETIC-19800\"\n")
+    root = real.parent.parent
+    message = _refused(
+        lambda: read_file(
+            f"{real.parent.name.upper()}/{real.name}", workspace_root=root
+        ),
+        "fs_read(CASE-VARIANT config.toml)",
+    )
+    assert "protected path" in message
+    assert "SYNTHETIC-19800" not in message
+
+
+def test_case_folding_does_not_deny_an_unrelated_lookalike():
+    """The match stays ancestry-based, not substring-based: `~/.sshfoo` is a
+    genuinely different directory and must remain readable."""
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    home = _home()
+    (home / ".sshfoo").mkdir(parents=True, exist_ok=True)
+    (home / ".sshfoo" / "notes.txt").write_text("ordinary\n")
+    assert not is_sensitive_path(home / ".sshfoo" / "notes.txt")
+    assert not is_sensitive_path(home / ".SSHFOO" / "notes.txt")

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -873,3 +873,36 @@ def test_case_folding_does_not_deny_an_unrelated_lookalike():
     (home / ".sshfoo" / "notes.txt").write_text("ordinary\n")
     assert not is_sensitive_path(home / ".sshfoo" / "notes.txt")
     assert not is_sensitive_path(home / ".SSHFOO" / "notes.txt")
+
+
+def test_binding_gate_detects_a_case_variant_conflict():
+    """Qodo #1 (PR #1936): `find_root_binding_conflict` enforces the SAME
+    protected-path policy at folder-bind time, and was still comparing
+    case-sensitively — so a case-variant spelling could bind a workspace
+    root that overlaps a protected directory, widening tool reachability
+    into it.
+
+    Not a confinement check: this is the denylist's own overlap gate, so
+    folding it fails safe (more conflicts reported) exactly as elsewhere.
+    """
+    from tldw_chatbook.Utils.sensitive_paths import find_root_binding_conflict
+
+    _plant_ssh_key()
+    home = _home()
+
+    # (1) the root IS a protected directory, spelled differently
+    assert find_root_binding_conflict(home / ".SSH") is not None
+
+    # (3) the root CONTAINS a protected path, reached by a cased ancestor
+    upper_home = Path(str(home).upper())
+    assert find_root_binding_conflict(upper_home) is not None, (
+        "a cased spelling of an ancestor still contains the protected paths"
+    )
+
+
+def test_binding_gate_still_allows_an_unrelated_root():
+    from tldw_chatbook.Utils.sensitive_paths import find_root_binding_conflict
+
+    plain = _home() / "projects" / "myapp"
+    plain.mkdir(parents=True, exist_ok=True)
+    assert find_root_binding_conflict(plain) is None

--- a/backlog/tasks/task-19800 - Sensitive-path-denylist-bypassable-by-path-case.md
+++ b/backlog/tasks/task-19800 - Sensitive-path-denylist-bypassable-by-path-case.md
@@ -1,0 +1,86 @@
+---
+id: TASK-19800
+title: 'Security: sensitive-path denylist bypassable by changing path case'
+status: Done
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - security
+  - tools
+dependencies:
+  - TASK-19551
+  - TASK-19700
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The credential/gate-state denylist (`Utils/sensitive_paths.py`, added by
+TASK-19551) compared resolved paths with exact, case-sensitive equality. On
+macOS and Windows — where filesystems are case-insensitive by default, and
+where `Path.resolve()` does NOT canonicalise case — a case-variant spelling
+reaches the same file while comparing unequal to every denylist entry.
+
+Found while fixing TASK-19700's `.git` write guard for exactly this
+weakness, which Qodo flagged on PR #1934; checking whether the older
+denylist shared it showed that it did.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 A case-variant spelling of a denylisted path receives the same verdict as the canonical spelling, for denied files, denied directories, database sidecars, and the direct-child container rule
+- [x] #2 Ancestry and lookalike behaviour are unchanged: `~/.sshfoo` is still not `~/.ssh`
+- [x] #3 The end-to-end tool path (`fs_read`) refuses a case-variant of a denylisted file, not just the predicate
+- [x] #4 Confinement checks are explicitly NOT case-folded, with the reasoning recorded, since folding those would admit paths rather than refuse them
+<!-- AC:END -->
+
+## Implementation Notes
+
+Routes every denylist comparison through `_compare_key`, which casefolds
+path components; `_same_path` and `_is_within` replace the previous `==` and
+`in .parents` checks for denied files, DB paths and their sidecars, denied
+directories, and the direct-child container rule.
+
+**Evidence this was live, not theoretical.** Before the fix, end-to-end
+through `fs_read` against the app's own denylisted config:
+
+```
+tldw_cli/config.toml   -> refused (Refused: '...' is a protected path...)
+TLDW_CLI/config.toml   -> ALLOWED, returned 32782 chars
+```
+
+That is the real config file — the one holding provider API keys — read
+through the denylist by changing the case of one path component. The same
+shape reaches `~/.ssh`, `~/.aws`, and `mcp_permissions.json`; bypassing that
+last one turns every `ask` into `allow`, which is the permission-gate bypass
+TASK-19551 exists to prevent. Reachable by prompt injection on the two
+platforms where case-insensitive filesystems are the default.
+
+**Casefolding is unconditional, not platform-gated or probed.** Platform is
+only a proxy for the real question (macOS can be configured case-sensitive,
+Linux can mount a case-insensitive volume), a per-path probe would add I/O
+to a check that runs on every candidate, and the two error directions are
+not symmetric: over-refusing a genuinely distinct `~/.SSH` on a
+case-sensitive filesystem costs one explained refusal of a very unusual
+path, while under-refusing leaks a credential.
+
+**Confinement is deliberately left case-sensitive** (AC #4). The two checks
+fail in opposite directions: for a denylist, folding produces extra
+refusals and fails safe; for confinement ("is this inside the allowed
+root?"), folding produces extra ADMISSIONS — on a case-sensitive filesystem
+`/Root/evil` would begin counting as inside `/root`. `is_within` in
+`Tools/file_operation_tools.py` is left alone for that reason, and the
+asymmetry is documented in `_compare_key` so a later "consistency" pass does
+not apply it there.
+
+**Not addressed, deliberately:** Windows also normalises trailing dots and
+spaces (`.ssh.` → `.ssh`). That is a real second normalization, but it is
+Windows-only — on POSIX `.ssh.` is a genuinely different directory, so
+stripping there would over-refuse for no security gain — and it wants a
+platform-gated rule of its own rather than being folded into the
+case-comparison change.
+
+**Files:** `tldw_chatbook/Utils/sensitive_paths.py`,
+`Tests/Tools/test_local_tool_sensitive_paths.py`.

--- a/backlog/tasks/task-19800 - Sensitive-path-denylist-bypassable-by-path-case.md
+++ b/backlog/tasks/task-19800 - Sensitive-path-denylist-bypassable-by-path-case.md
@@ -34,6 +34,7 @@ denylist shared it showed that it did.
 - [x] #2 Ancestry and lookalike behaviour are unchanged: `~/.sshfoo` is still not `~/.ssh`
 - [x] #3 The end-to-end tool path (`fs_read`) refuses a case-variant of a denylisted file, not just the predicate
 - [x] #4 Confinement checks are explicitly NOT case-folded, with the reasoning recorded, since folding those would admit paths rather than refuse them
+- [x] #5 The folder-binding overlap gate (`find_root_binding_conflict`) uses the same folded comparison, since it enforces the same protected-path policy at bind time
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -81,6 +82,16 @@ Windows-only — on POSIX `.ssh.` is a genuinely different directory, so
 stripping there would over-refuse for no security gain — and it wants a
 platform-gated rule of its own rather than being folded into the
 case-comparison change.
+
+**Qodo round (PR #1936):** one High, correct and missed by me —
+`find_root_binding_conflict()` enforces the same protected-path policy at
+folder-bind time and was still comparing case-sensitively, so a case-variant
+spelling could bind a workspace root overlapping a protected directory and
+widen tool reachability into it. All three of its cases (root IS protected,
+root nested inside protected, root contains protected) now compare through
+the same folded key, with equality excluded from the two ancestry cases so
+the "most specific match" reporting is unchanged. Qodo also explicitly
+agreed confinement should stay unfolded.
 
 **Files:** `tldw_chatbook/Utils/sensitive_paths.py`,
 `Tests/Tools/test_local_tool_sensitive_paths.py`.

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -786,15 +786,23 @@ def find_root_binding_conflict(
     # (1) `root` IS a protected path itself -- the most direct, most
     # actionable case, checked before either containment direction so it
     # always wins when several apply at once.
+    # TASK-19800 / Qodo (PR #1936): this gate enforces the same
+    # protected-path policy as `is_sensitive_path`, so it compares through
+    # the same case-folded key. It is NOT a confinement check -- folding
+    # here reports MORE conflicts (fails safe); see `_compare_key`.
     for protected in tuple(protected_dirs) + tuple(protected_files):
-        if root == protected:
+        if _same_path(root, protected):
             return protected
 
     # (2) `root` is nested INSIDE a protected directory. Several enclosing
     # directories can match at once (e.g. the skill-trust subtree nested
     # inside `get_user_data_dir()`); the one with the MOST path parts is
     # the deepest/closest enclosing directory, hence the most specific.
-    nested_inside = [protected for protected in protected_dirs if protected in root.parents]
+    nested_inside = [
+        protected
+        for protected in protected_dirs
+        if _is_within(root, protected) and not _same_path(root, protected)
+    ]
     if nested_inside:
         return max(nested_inside, key=lambda candidate: len(candidate.parts))
 
@@ -804,8 +812,16 @@ def find_root_binding_conflict(
     # inside it); the one with the FEWEST path parts is the shallowest/
     # nearest contained path, hence the most immediate, least obscure one
     # to report.
-    contains = [protected for protected in protected_dirs if root in protected.parents]
-    contains.extend(protected for protected in protected_files if root in protected.parents)
+    contains = [
+        protected
+        for protected in protected_dirs
+        if _is_within(protected, root) and not _same_path(protected, root)
+    ]
+    contains.extend(
+        protected
+        for protected in protected_files
+        if _is_within(protected, root) and not _same_path(protected, root)
+    )
     if contains:
         return min(contains, key=lambda candidate: len(candidate.parts))
 

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -553,6 +553,61 @@ def resolve_sensitive_context() -> SensitivePathContext:
     )
 
 
+def _compare_key(path: Path) -> tuple[str, ...]:
+    """The form two paths are compared in by the denylist (TASK-19800).
+
+    macOS and Windows filesystems are case-insensitive by DEFAULT, and
+    ``Path.resolve()`` does NOT canonicalise case on them -- it resolves
+    symlinks and ``..`` but preserves whatever spelling the caller typed.
+    So ``~/.SSH/id_rsa`` opens the very same file as ``~/.ssh/id_rsa``
+    while comparing unequal to every entry in the denylist. Verified
+    end-to-end before this fix: reading ``TLDW_CLI/config.toml`` through
+    ``fs_read`` returned the user's real config -- the file holding their
+    provider API keys -- while the lowercase spelling was refused.
+
+    Casefolding is applied UNCONDITIONALLY rather than gated on the
+    platform or probed per volume. Platform is only a proxy for the real
+    question (macOS can be configured case-sensitive; Linux can mount a
+    case-insensitive volume), a per-path probe would add I/O to a check
+    that runs on every candidate, and the two error directions are not
+    symmetric: over-refusing a genuinely distinct ``~/.SSH`` on a
+    case-sensitive filesystem costs one explained refusal of a very
+    unusual path, while under-refusing leaks a credential. A denylist
+    should fail in the cheap direction.
+
+    Comparison stays COMPONENT-wise, so ancestry and lookalike behaviour
+    are unchanged: ``~/.sshfoo`` is still not ``~/.ssh``.
+
+    **Do not reuse this for CONFINEMENT checks.** The two fail in opposite
+    directions. For a denylist ("is this path forbidden?") folding produces
+    extra refusals -- it fails safe. For confinement ("is this path inside
+    the allowed root?") folding produces extra ADMISSIONS: on a
+    case-sensitive filesystem ``/Root/evil`` would start counting as inside
+    ``/root``, which is a loosening, not a hardening. ``is_within`` in
+    ``Tools/file_operation_tools.py`` is deliberately left case-sensitive
+    for exactly that reason.
+
+    Args:
+        path: An already-resolved absolute path.
+
+    Returns:
+        The path's components, each casefolded.
+    """
+    return tuple(part.casefold() for part in path.parts)
+
+
+def _same_path(a: Path, b: Path) -> bool:
+    """Whether two resolved paths denote the same file (see :func:`_compare_key`)."""
+    return _compare_key(a) == _compare_key(b)
+
+
+def _is_within(child: Path, ancestor: Path) -> bool:
+    """Whether ``child`` is ``ancestor`` or below it (see :func:`_compare_key`)."""
+    child_key = _compare_key(child)
+    ancestor_key = _compare_key(ancestor)
+    return child_key[: len(ancestor_key)] == ancestor_key
+
+
 def is_sensitive_path(
     candidate: Path, context: SensitivePathContext | None = None
 ) -> bool:
@@ -602,18 +657,21 @@ def is_sensitive_path(
 
     ctx = context if context is not None else resolve_sensitive_context()
 
+    # Every comparison below goes through `_compare_key` (TASK-19800): a
+    # case-variant spelling reaches the same file on a case-insensitive
+    # filesystem and must reach the same verdict.
     for target in ctx.files:
-        if resolved == target:
+        if _same_path(resolved, target):
             return True
 
     for db_path in ctx.db_paths:
-        if resolved == db_path:
+        if _same_path(resolved, db_path):
             return True
-        if resolved in _db_sidecar_paths(db_path):
+        if any(_same_path(resolved, s) for s in _db_sidecar_paths(db_path)):
             return True
 
     for root in ctx.dirs:
-        if resolved == root or root in resolved.parents:
+        if _is_within(resolved, root):
             return True
 
     # Finding 2 (substrate review), generalized beyond `get_user_data_dir()`
@@ -647,7 +705,7 @@ def is_sensitive_path(
     # never by loosening this check's own "is a directory" gate (which
     # would break every legitimate container above).
     for denied_parent in ctx.direct_child_denied_dirs:
-        if resolved.parent == denied_parent and not resolved.is_dir():
+        if _same_path(resolved.parent, denied_parent) and not resolved.is_dir():
             return True
 
     return False


### PR DESCRIPTION
## A live credential-disclosure bypass in the existing denylist

The credential/gate-state denylist added by TASK-19551 compared resolved paths with **exact, case-sensitive equality**. macOS and Windows filesystems are case-insensitive by default, and `Path.resolve()` does **not** canonicalise case on them — it resolves symlinks and `..` but preserves whatever spelling the caller typed. So a case-variant reaches the same file while matching no denylist entry.

Verified end-to-end before the fix, through `fs_read`, against this app's own denylisted config:

```
tldw_cli/config.toml   -> refused (Refused: '...' is a protected path...)
TLDW_CLI/config.toml   -> ALLOWED, returned 32782 chars    <-- BYPASS
```

That is the real config file — the one holding provider API keys — read straight through the denylist by changing the case of one path component. The predicate agrees:

```
~/.ssh/id_ed25519   -> sensitive=True      ~/.SSH/id_ed25519   -> sensitive=False
~/.aws/credentials  -> sensitive=True      ~/.AWS/credentials  -> sensitive=False
```

The same shape reaches `~/.ssh`, `~/.aws` and `mcp_permissions.json`. Bypassing that last one turns every `ask` into `allow` — the permission-gate bypass TASK-19551 exists to prevent — and it is reachable by prompt injection on the two platforms where case-insensitive filesystems are the default.

**How it was found:** Qodo flagged the identical weakness in TASK-19700's brand-new `.git` write guard (PR #1934). Checking whether the older, shipped denylist shared it showed that it did.

## The fix

Every denylist comparison now goes through `_compare_key` — casefolded, component-wise — via `_same_path`/`_is_within`, covering denied files, database paths and their WAL/SHM/journal sidecars, denied directories, and the direct-child container rule.

**Casefolding is unconditional**, not platform-gated or probed. Platform is only a proxy for the real question (macOS can be configured case-sensitive; Linux can mount a case-insensitive volume), a per-path probe would add I/O to a check that runs on every candidate, and the error directions are not symmetric: over-refusing a genuinely distinct `~/.SSH` costs one explained refusal of a very unusual path, while under-refusing leaks a credential.

## Confinement is deliberately NOT folded

The two checks fail in **opposite directions**, so applying this "consistently" would be a security regression:

| Check | Folding produces | Direction |
|---|---|---|
| Denylist — "is this forbidden?" | extra refusals | fails **safe** |
| Confinement — "is this inside the root?" | extra **admissions** (`/Root/evil` counts as inside `/root`) | fails **open** |

`is_within` in `Tools/file_operation_tools.py` is left case-sensitive for that reason, and the asymmetry is documented at `_compare_key` so a later consistency pass doesn't undo it.

## Verification

- **688 passed** across `Tests/Tools/` + `Tests/Utils/test_sensitive_paths.py`; ruff clean.
- Three bypass tests proven **red first**; removing the casefold turns them red again (mutation-proven).
- Ancestry and lookalike behaviour pinned unchanged: `~/.sshfoo` is still not `~/.ssh`.

## Deliberately not addressed

Windows also normalises trailing dots and spaces (`.ssh.` → `.ssh`). That is a real second normalization, but it is Windows-only — on POSIX `.ssh.` is a genuinely different directory, so stripping there would over-refuse for no gain — and it wants a platform-gated rule of its own rather than being folded into this change.

Follows TASK-19700 (#1934) and TASK-19551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Case-variant paths could bypass the sensitive-path denylist on case-insensitive filesystems. Previously we compared resolved paths case-sensitively; now we compare component-wise with unconditional casefolding across denylist checks and the folder-binding overlap gate to prevent credential and permission-gate leaks.

- Routes all denylist comparisons through `_compare_key`/`_same_path`/`_is_within` for denied files, DB paths and sidecars, denied directories, and the direct-child container rule in `tldw_chatbook/Utils/sensitive_paths.py`.
- Applies the folded comparison to `find_root_binding_conflict` so binding a case-variant root that overlaps a protected path is rejected; equality is excluded in ancestry cases to preserve most-specific reporting.
- Keeps confinement checks case-sensitive by design; do not refactor them to use these helpers.
- Adds tests that fail red without the fix, including end-to-end `fs_read` refusal of a case-variant config; lookalikes like `~/.sshfoo` remain allowed. No migrations; expect added refusals for case-only-distinct paths on case-sensitive volumes. Linear: TASK-19800.

<sup>Written for commit c89038e06e602f387aba328dff30b04683ab89f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

