### PR TITLE
fix/perf: watchlists duplicate-alert guard, off-loop sqlite, nesting-safe transaction (task-19562 A, B, C)

### DIFF
--- a/Tests/Subscriptions/test_subscriptions_transaction_nesting.py
+++ b/Tests/Subscriptions/test_subscriptions_transaction_nesting.py
@@ -1,0 +1,109 @@
+"""`SubscriptionsDB.transaction()` must be safe to nest (TASK-19562 part C).
+
+It used to commit unconditionally on exit, so an INNER `with
+self.transaction()` durably committed the OUTER transaction's work too: a
+later failure in the outer scope could no longer roll back what the inner
+block had already written. Silent partial persistence, no error anywhere.
+
+Recorded for accuracy: the call site the task named (`record_check_result`)
+was instrumented and found NOT to nest -- observed depth 1. The hazard was
+latent, not live. These tests make it structurally impossible instead of
+relying on nobody ever nesting.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(tmp_path / "subs.db", "test")
+
+
+def _names(database: SubscriptionsDB) -> set[str]:
+    with database.transaction() as conn:
+        return {
+            row["name"]
+            for row in conn.execute("SELECT name FROM subscriptions").fetchall()
+        }
+
+
+def test_failure_after_a_nested_block_rolls_the_whole_unit_back(db):
+    """The defect, stated as behaviour: the inner write must not survive."""
+    with pytest.raises(RuntimeError):
+        with db.transaction() as conn:
+            conn.execute(
+                "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+                ("outer", "rss", "https://e.invalid/outer.xml"),
+            )
+            with db.transaction() as inner:
+                inner.execute(
+                    "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+                    ("inner", "rss", "https://e.invalid/inner.xml"),
+                )
+            # Fails AFTER the inner block exited. Pre-fix, the inner exit had
+            # already committed both rows, so this rollback did nothing.
+            raise RuntimeError("outer scope fails")
+
+    surviving = _names(db)
+    assert "inner" not in surviving, (
+        "the nested block's write survived a failure in the outer scope: its "
+        "exit committed the outer transaction early"
+    )
+    assert "outer" not in surviving
+
+
+def test_nested_success_still_commits_once_the_outer_block_exits(db):
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+            ("outer", "rss", "https://e.invalid/outer.xml"),
+        )
+        with db.transaction() as inner:
+            inner.execute(
+                "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+                ("inner", "rss", "https://e.invalid/inner.xml"),
+            )
+
+    assert {"outer", "inner"} <= _names(db)
+
+
+def test_depth_returns_to_zero_after_a_raise(db):
+    """A stranded depth would make every later transaction a no-op joiner."""
+    with pytest.raises(RuntimeError):
+        with db.transaction():
+            raise RuntimeError("boom")
+
+    assert getattr(db._local, "transaction_depth", 0) == 0
+
+    # And the connection is still usable as an outermost transaction.
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+            ("after", "rss", "https://e.invalid/after.xml"),
+        )
+    assert "after" in _names(db)
+
+
+def test_unnested_transactions_are_unchanged(db):
+    """AC: no behaviour change for the ordinary single-level case."""
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+            ("solo", "rss", "https://e.invalid/solo.xml"),
+        )
+    assert "solo" in _names(db)
+
+    with pytest.raises(RuntimeError):
+        with db.transaction() as conn:
+            conn.execute(
+                "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+                ("doomed", "rss", "https://e.invalid/doomed.xml"),
+            )
+            raise RuntimeError("boom")
+    assert "doomed" not in _names(db)

--- a/Tests/Subscriptions/test_watchlist_feed_api_in_flight_guard.py
+++ b/Tests/Subscriptions/test_watchlist_feed_api_in_flight_guard.py
@@ -1,0 +1,216 @@
+"""task-19562 part A: the feed and API arms must share the in-flight guard.
+
+`_check_url_guarded` (task-16838) serializes concurrent checks of the same
+source -- but only for the url-family arms (`url`, `url_list`, `sitemap`).
+The **feed** arm (`FeedMonitor().check_feed`) and the **API** arm never
+registered a claim at all, and feeds are the commonest source type. A
+scheduler tick overlapping a manual "Check Now" therefore ran the check
+TWICE: the alert notification fired twice and statistics double-counted.
+
+The tests below force the overlap for real -- the check is gated on an
+`asyncio.Event`, the second entrant starts while the first is still inside
+its await -- rather than asserting that a guard function was called.
+
+The skip must also carry a `DISPOSITION_SKIPPED_IN_FLIGHT` disposition, not
+just return zero items. That is load-bearing: `_entirely_skipped_
+dispositions` -> `execute_run` reads it to SKIP source-health accounting, so
+a turned-away check cannot take `record_check_result`'s SUCCESS branch and
+reset the auto-pause breaker, clear `last_error` and stamp
+`last_successful_check` for a run that never contacted the source. Zero items
+with `None` dispositions would have looked exactly like a clean "nothing new"
+check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.local_watchlists_service import (
+    LocalWatchlistsService,
+)
+
+pytestmark = pytest.mark.unit
+
+
+async def _run_check(service: LocalWatchlistsService, source_id: int) -> dict:
+    """One full check the way every real entrant does it: launch + execute."""
+    launched = await service.launch_run(source_id=source_id)
+    return await service.execute_run(launched["run_id"])
+
+
+def _gate_feed_checks(monkeypatch, gate: asyncio.Event, started: asyncio.Event):
+    """Make FeedMonitor.check_feed block on `gate`, counting entries."""
+    from tldw_chatbook.Subscriptions import monitoring_engine
+
+    calls: list[int] = []
+
+    async def gated_check_feed(self, config, *args, **kwargs):
+        calls.append(1)
+        started.set()
+        await gate.wait()
+        return [
+            {
+                "title": "Item",
+                "url": "https://example.com/feed/1",
+                "content": "body",
+            }
+        ]
+
+    monkeypatch.setattr(
+        monitoring_engine.FeedMonitor, "check_feed", gated_check_feed
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_overlapping_feed_checks_run_the_check_once(tmp_path, monkeypatch):
+    """The headline: a scheduler tick and a Check Now must not both fetch."""
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="A feed", type="rss", source="https://example.com/feed.xml"
+    )
+    scheduler_service = LocalWatchlistsService(db_factory=lambda: db)
+    ui_service = LocalWatchlistsService(db_factory=lambda: db)
+
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    calls = _gate_feed_checks(monkeypatch, gate, started)
+
+    scheduled = asyncio.create_task(_run_check(scheduler_service, source_id))
+    await asyncio.wait_for(started.wait(), timeout=10)
+
+    # The manual entrant arrives while the scheduled fetch is still gated.
+    manual = asyncio.create_task(_run_check(ui_service, source_id))
+    # The scheduled entrant is blocked on `gate` and CANNOT progress, so this
+    # wait is deterministic, not a race: it only gives the manual entrant loop
+    # time to get through launch_run's DB work and reach the guard.
+    await asyncio.sleep(0.25)
+    gate.set()
+
+    scheduled_result = await asyncio.wait_for(scheduled, timeout=10)
+    manual_result = await asyncio.wait_for(manual, timeout=10)
+
+    assert len(calls) == 1, (
+        f"the feed was fetched {len(calls)} times for one overlap; the "
+        "second entrant was not turned away"
+    )
+
+    dispositions = [
+        (result["stats"] or {}).get("dispositions") for result in
+        (scheduled_result, manual_result)
+    ]
+    skipped_counts = [
+        int((d or {}).get("skipped", 0) or 0) for d in dispositions
+    ]
+    assert sum(skipped_counts) == 1, (
+        f"expected exactly one run to record a skip, got {dispositions}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skipped_feed_check_does_not_count_as_a_successful_check(
+    tmp_path, monkeypatch
+):
+    """The skip must not reset source health for a check that never ran."""
+    from tldw_chatbook.Subscriptions.local_watchlists_service import (
+        _entirely_skipped_dispositions,
+    )
+
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="A feed", type="rss", source="https://example.com/feed.xml"
+    )
+    scheduler_service = LocalWatchlistsService(db_factory=lambda: db)
+    ui_service = LocalWatchlistsService(db_factory=lambda: db)
+
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    _gate_feed_checks(monkeypatch, gate, started)
+
+    scheduled = asyncio.create_task(_run_check(scheduler_service, source_id))
+    await asyncio.wait_for(started.wait(), timeout=10)
+    manual = asyncio.create_task(_run_check(ui_service, source_id))
+    await asyncio.sleep(0.25)  # deterministic: the first is gate-blocked
+    gate.set()
+    results = [
+        await asyncio.wait_for(scheduled, timeout=10),
+        await asyncio.wait_for(manual, timeout=10),
+    ]
+
+    skipped_runs = [
+        r for r in results
+        if _entirely_skipped_dispositions((r["stats"] or {}).get("dispositions"))
+    ]
+    assert len(skipped_runs) == 1, (
+        "the turned-away run must match _entirely_skipped_dispositions, or "
+        "execute_run will run the SUCCESS health path for a check that never "
+        "contacted the source"
+    )
+
+
+@pytest.mark.asyncio
+async def test_distinct_feed_sources_still_check_concurrently(
+    tmp_path, monkeypatch
+):
+    """The guard is per-source: two different feeds must not block each other."""
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    first = db.add_subscription(
+        name="Feed one", type="rss", source="https://example.com/one.xml"
+    )
+    second = db.add_subscription(
+        name="Feed two", type="rss", source="https://example.com/two.xml"
+    )
+    service_a = LocalWatchlistsService(db_factory=lambda: db)
+    service_b = LocalWatchlistsService(db_factory=lambda: db)
+
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    calls = _gate_feed_checks(monkeypatch, gate, started)
+
+    task_a = asyncio.create_task(_run_check(service_a, first))
+    await asyncio.wait_for(started.wait(), timeout=10)
+    task_b = asyncio.create_task(_run_check(service_b, second))
+    await asyncio.sleep(0.25)  # deterministic: task_a is gate-blocked
+    gate.set()
+    await asyncio.wait_for(task_a, timeout=10)
+    await asyncio.wait_for(task_b, timeout=10)
+
+    assert len(calls) == 2, (
+        "two DIFFERENT feed sources must both check; the guard is keyed per "
+        f"source, but only {len(calls)} check(s) ran"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_feed_check_releases_the_guard(tmp_path, monkeypatch):
+    """A raise must not strand the source as permanently in flight."""
+    from tldw_chatbook.Subscriptions import monitoring_engine
+
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="A feed", type="rss", source="https://example.com/feed.xml"
+    )
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    async def boom(self, config, *args, **kwargs):
+        raise RuntimeError("feed exploded")
+
+    monkeypatch.setattr(monitoring_engine.FeedMonitor, "check_feed", boom)
+    await _run_check(service, source_id)
+
+    calls: list[int] = []
+
+    async def ok(self, config, *args, **kwargs):
+        calls.append(1)
+        return []
+
+    monkeypatch.setattr(monitoring_engine.FeedMonitor, "check_feed", ok)
+    await _run_check(service, source_id)
+
+    assert calls == [1], (
+        "the next check never ran: the failed check stranded the in-flight "
+        "claim"
+    )

--- a/Tests/Subscriptions/test_watchlists_service_off_loop.py
+++ b/Tests/Subscriptions/test_watchlists_service_off_loop.py
@@ -1,0 +1,434 @@
+"""task-19562 part B: `LocalWatchlistsService` sqlite calls must not run on the loop.
+
+22 `async def` methods on `LocalWatchlistsService` used to call `SubscriptionsDB`
+synchronously inline, each blocking the event loop -- the whole TUI -- for its
+own query duration. They now hop through `db_offload.run_db_off_loop`
+(`asyncio.to_thread` under the hood), mirroring the pattern task-15463 already
+established for `launch_run`/`execute_run`/`record_run_result` in this same
+service.
+
+The work order this task started from enumerated 19 of the 22 by an AST scan
+that matched calls to *named* `SubscriptionsDB` methods (`db.get_subscription`,
+`db.delete_subscription`, ...). `get_alert_rule`, `list_runs` and
+`list_alert_rules` read through a bare `db.conn.cursor()` instead, so that
+scan missed them -- but all three are exactly the same class of loop-blocking
+read, and `get_alert_rule` is directly embedded in two of the 19
+(`create_alert_rule`/`update_alert_rule` both end by awaiting it), so leaving
+it inline would have left those two still blocking on their last statement.
+19 + 3 = 22, which is exactly the count task-19562's own description names.
+
+Threading note, same reasoning as `test_watchlists_db_instance_and_off_loop.py`:
+every database here MUST be file-backed (`tmp_path`), never `:memory:`.
+`run_db_off_loop` deliberately runs its callable INLINE, on the calling
+thread, when `db.is_memory_db is True` -- `SubscriptionsDB` keeps thread-local
+connections and builds its schema on the constructing thread, so an
+in-memory database handed to a worker thread would be a private, empty
+database nobody else can see. That carve-out means an in-memory DB here would
+make every assertion below vacuously pass whether or not the offload actually
+happened -- proving nothing. A file-backed database is what actually exercises
+the `asyncio.to_thread` branch.
+
+Two probes are used, matching the two shapes the service's edited call sites
+take:
+
+* Most methods call a *named* `SubscriptionsDB` method directly
+  (`db.get_subscription`, `db.delete_subscription`, ...). `_spy` patches that
+  bound method on the instance and records `threading.get_ident()` per call.
+* The four methods that used to hold a `db.transaction()` block open
+  (`cancel_run`, `create_alert_rule`, `update_alert_rule`,
+  `delete_alert_rule`) were rewritten so the WHOLE transaction hops as one
+  synchronous helper (per `run_db_off_loop`'s own contract: it must not be
+  handed a callable that holds a transaction open across the await boundary).
+  `_spy_transaction` patches `db.transaction` itself so entering it is what
+  gets timestamped, regardless of how many statements run inside.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
+from tldw_chatbook.Subscriptions.local_watchlists_service import (
+    LocalWatchlistsService,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _build_service_and_seed(tmp_path):
+    """A file-backed `SubscriptionsDB` with one subscription and one item.
+
+    Returns:
+        ``(service, db, source_id, item_id)``.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    source_id = db.add_subscription(
+        name="Feed", type="rss", source="https://example.com/feed.xml"
+    )
+    with db.transaction() as conn:
+        item_id = persist_subscription_item(
+            conn,
+            source_id,
+            {
+                "url": "https://example.com/one/",
+                "title": "One",
+                "content_hash": "hash-off-loop",
+            },
+            run_id=None,
+            now="2026-08-21T09:00:00+00:00",
+        )
+    return service, db, source_id, item_id
+
+
+def _spy(db: SubscriptionsDB, name: str) -> list[int]:
+    """Patch `db.<name>` to record the thread id of every call.
+
+    Instance-attribute assignment shadows the class method, same technique
+    `test_watchlists_db_instance_and_off_loop.py` and
+    `test_local_watchlists_service.py` already use to spy on `SubscriptionsDB`.
+    """
+    threads: list[int] = []
+    real = getattr(db, name)
+
+    def wrapper(*args, **kwargs):
+        threads.append(threading.get_ident())
+        return real(*args, **kwargs)
+
+    setattr(db, name, wrapper)
+    return threads
+
+
+def _spy_transaction(db: SubscriptionsDB) -> list[int]:
+    """Patch `db.transaction` to record the thread id it is ENTERED on.
+
+    The four rewritten methods hop the entire `with db.transaction():` block
+    as one synchronous helper, so the meaningful timestamp is "what thread
+    opened the transaction", not any one statement inside it.
+    """
+    threads: list[int] = []
+    real_transaction = db.transaction
+
+    @contextmanager
+    def wrapper():
+        threads.append(threading.get_ident())
+        with real_transaction() as conn:
+            yield conn
+
+    db.transaction = wrapper
+    return threads
+
+
+# --- simple reads/writes: one db-method call per service call ---------------
+
+_SIMPLE_CASES = [
+    pytest.param(
+        "get_all_subscriptions",
+        lambda service, ctx: service.list_sources(),
+        id="list_sources",
+    ),
+    pytest.param(
+        "get_subscription",
+        lambda service, ctx: service.get_source(ctx["source_id"]),
+        id="get_source",
+    ),
+    pytest.param(
+        "get_new_items",
+        lambda service, ctx: service.list_items(),
+        id="list_items",
+    ),
+    pytest.param(
+        "get_item_status",
+        lambda service, ctx: service.get_item_status(ctx["item_id"]),
+        id="get_item_status",
+    ),
+    pytest.param(
+        "get_item_content",
+        lambda service, ctx: service.get_item_content(ctx["item_id"]),
+        id="get_item_content",
+    ),
+    pytest.param(
+        "get_url_snapshots",
+        lambda service, ctx: service.get_url_snapshots(
+            ctx["source_id"], "https://example.com/one/"
+        ),
+        id="get_url_snapshots",
+    ),
+    pytest.param(
+        "mark_item_status",
+        lambda service, ctx: service.update_item(
+            item_id=ctx["item_id"], status="ingested"
+        ),
+        id="update_item",
+    ),
+    pytest.param(
+        "mark_all_read",
+        lambda service, ctx: service.mark_all_read(),
+        id="mark_all_read",
+    ),
+    pytest.param(
+        "restore_items_new",
+        lambda service, ctx: service.restore_items_new(item_ids=[ctx["item_id"]]),
+        id="restore_items_new",
+    ),
+    pytest.param(
+        "set_item_flagged",
+        lambda service, ctx: service.set_item_flagged(
+            item_id=ctx["item_id"], flagged=True
+        ),
+        id="set_item_flagged",
+    ),
+    pytest.param(
+        "get_subscription_id_by_source",
+        lambda service, ctx: service.find_source_id_by_url(
+            "https://example.com/feed.xml"
+        ),
+        id="find_source_id_by_url",
+    ),
+    pytest.param(
+        "delete_subscription",
+        lambda service, ctx: service.delete_source(ctx["source_id"]),
+        id="delete_source",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("db_method_name", "call"), _SIMPLE_CASES)
+async def test_simple_db_calls_run_off_the_event_loop_thread(
+    tmp_path, db_method_name, call
+):
+    """Each of these service methods' single db call must hop to a worker thread.
+
+    Mutation: revert any one of these methods' `run_db_off_loop` wrapping back
+    to a bare inline call and its own case reddens, naming the db method that
+    ran on the loop thread.
+    """
+    service, db, source_id, item_id = _build_service_and_seed(tmp_path)
+    ctx = {"source_id": source_id, "item_id": item_id}
+    threads = _spy(db, db_method_name)
+    loop_thread = threading.get_ident()
+
+    await call(service, ctx)
+
+    assert threads, f"SubscriptionsDB.{db_method_name} must have been called"
+    assert all(thread_id != loop_thread for thread_id in threads), (
+        f"SubscriptionsDB.{db_method_name} ran on the event-loop thread: "
+        f"{threads}"
+    )
+
+
+# --- multi-call methods -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_source_both_db_calls_run_off_the_event_loop_thread(tmp_path):
+    """`create_source` does an INSERT then a re-read; both must hop."""
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    add_threads = _spy(db, "add_subscription")
+    get_threads = _spy(db, "get_subscription")
+    loop_thread = threading.get_ident()
+
+    created = await service.create_source(
+        {"name": "New Feed", "url": "https://example.com/new.xml"}
+    )
+
+    assert created["title"] == "New Feed"
+    assert add_threads and all(t != loop_thread for t in add_threads)
+    assert get_threads and all(t != loop_thread for t in get_threads)
+
+
+@pytest.mark.asyncio
+async def test_update_source_both_db_calls_run_off_the_event_loop_thread(tmp_path):
+    """`update_source` does an UPDATE then a re-read; both must hop."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    update_threads = _spy(db, "update_subscription")
+    get_threads = _spy(db, "get_subscription")
+    loop_thread = threading.get_ident()
+
+    updated = await service.update_source(source_id, {"name": "Renamed"})
+
+    assert updated["title"] == "Renamed"
+    assert update_threads and all(t != loop_thread for t in update_threads)
+    assert get_threads and all(t != loop_thread for t in get_threads)
+
+
+@pytest.mark.asyncio
+async def test_resume_source_both_db_calls_run_off_the_event_loop_thread(tmp_path):
+    """`resume_source`'s reset-then-read pair must both hop, in order."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    reset_threads = _spy(db, "reset_subscription_errors")
+    get_threads = _spy(db, "get_subscription")
+    loop_thread = threading.get_ident()
+
+    await service.resume_source(source_id)
+
+    assert reset_threads and all(t != loop_thread for t in reset_threads)
+    assert get_threads and all(t != loop_thread for t in get_threads)
+
+
+# --- the four rewritten `db.transaction()` blocks ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_transaction_block_runs_off_the_event_loop_thread(tmp_path):
+    """`cancel_run`'s whole transaction must hop as one unit."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    launched = await service.launch_run(source_id=source_id)
+    run_id = launched["run_id"]
+    txn_threads = _spy_transaction(db)
+    loop_thread = threading.get_ident()
+
+    cancelled = await service.cancel_run(run_id)
+
+    assert cancelled["status"] == "cancelled"
+    assert txn_threads, "db.transaction() must have been entered"
+    assert all(t != loop_thread for t in txn_threads), (
+        f"cancel_run's transaction opened on the event-loop thread: {txn_threads}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_alert_rule_transaction_block_runs_off_the_event_loop_thread(
+    tmp_path,
+):
+    """`create_alert_rule`'s whole transaction must hop as one unit."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    txn_threads = _spy_transaction(db)
+    loop_thread = threading.get_ident()
+
+    rule = await service.create_alert_rule(
+        name="No items", condition_type="no_items", source_id=source_id
+    )
+
+    assert rule["name"] == "No items"
+    assert txn_threads, "db.transaction() must have been entered"
+    assert all(t != loop_thread for t in txn_threads), (
+        f"create_alert_rule's transaction opened on the event-loop thread: "
+        f"{txn_threads}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_alert_rule_transaction_block_runs_off_the_event_loop_thread(
+    tmp_path,
+):
+    """`update_alert_rule`'s whole transaction must hop as one unit."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    rule = await service.create_alert_rule(
+        name="No items", condition_type="no_items", source_id=source_id
+    )
+    txn_threads = _spy_transaction(db)
+    loop_thread = threading.get_ident()
+
+    updated = await service.update_alert_rule(rule["rule_id"], name="Renamed rule")
+
+    assert updated["name"] == "Renamed rule"
+    assert txn_threads, "db.transaction() must have been entered"
+    assert all(t != loop_thread for t in txn_threads), (
+        f"update_alert_rule's transaction opened on the event-loop thread: "
+        f"{txn_threads}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_alert_rule_transaction_block_runs_off_the_event_loop_thread(
+    tmp_path,
+):
+    """`delete_alert_rule`'s whole transaction must hop as one unit."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    rule = await service.create_alert_rule(
+        name="No items", condition_type="no_items", source_id=source_id
+    )
+    txn_threads = _spy_transaction(db)
+    loop_thread = threading.get_ident()
+
+    result = await service.delete_alert_rule(rule["rule_id"])
+
+    assert result["deleted"] is True
+    assert txn_threads, "db.transaction() must have been entered"
+    assert all(t != loop_thread for t in txn_threads), (
+        f"delete_alert_rule's transaction opened on the event-loop thread: "
+        f"{txn_threads}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_alert_rule_reads_off_the_event_loop_thread(tmp_path):
+    """`get_alert_rule` was added to the offload sweep (not on the original
+    enumerated list -- see the module docstring in `local_watchlists_service.py`
+    at `get_alert_rule`) because `create_alert_rule`/`update_alert_rule` both
+    end by awaiting it; leaving it inline would have left those two methods
+    still blocking the loop on their last statement.
+    """
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    rule = await service.create_alert_rule(
+        name="No items", condition_type="no_items", source_id=source_id
+    )
+    # `get_alert_rule` reads via a bare `db.conn.cursor()`, not a named
+    # SubscriptionsDB method, so it is not spy-able the way the simple cases
+    # above are. Use the thread-local `set_trace_callback` probe instead
+    # (same technique as `test_a_scheduled_check_runs_no_sqlite_on_the_
+    # event_loop` in `test_watchlists_db_instance_and_off_loop.py`): any SQL
+    # seen on the loop thread's OWN connection is, by construction, SQL that
+    # ran inline -- `SubscriptionsDB` connections are thread-local, so a
+    # worker thread's statements are invisible to this callback.
+    loop_statements: list[str] = []
+    db.conn.set_trace_callback(loop_statements.append)
+    try:
+        rule_again = await service.get_alert_rule(rule["rule_id"])
+    finally:
+        db.conn.set_trace_callback(None)
+
+    assert rule_again["rule_id"] == rule["rule_id"]
+    assert not loop_statements, (
+        "get_alert_rule ran SQL on the event-loop thread: "
+        f"{loop_statements[:3]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_runs_reads_off_the_event_loop_thread(tmp_path):
+    """`list_runs` also reads via a bare `db.conn.cursor()` -- the trace probe."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    await service.launch_run(source_id=source_id)
+
+    loop_statements: list[str] = []
+    db.conn.set_trace_callback(loop_statements.append)
+    try:
+        runs = await service.list_runs()
+    finally:
+        db.conn.set_trace_callback(None)
+
+    assert len(runs) == 1, "the seeded run must have been read, or this proves nothing"
+    assert not loop_statements, (
+        f"list_runs ran SQL on the event-loop thread: {loop_statements[:3]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_alert_rules_reads_off_the_event_loop_thread(tmp_path):
+    """`list_alert_rules` also reads via a bare `db.conn.cursor()` -- the trace probe."""
+    service, db, source_id, _ = _build_service_and_seed(tmp_path)
+    await service.create_alert_rule(
+        name="No items", condition_type="no_items", source_id=source_id
+    )
+
+    loop_statements: list[str] = []
+    db.conn.set_trace_callback(loop_statements.append)
+    try:
+        rules = await service.list_alert_rules(source_id=source_id)
+    finally:
+        db.conn.set_trace_callback(None)
+
+    assert len(rules) == 1, (
+        "the seeded alert rule must have been read, or this proves nothing"
+    )
+    assert not loop_statements, (
+        f"list_alert_rules ran SQL on the event-loop thread: {loop_statements[:3]}"
+    )

--- a/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
+++ b/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
@@ -68,7 +68,7 @@ away".
 - [ ] The `busy_timeout` question is **measured, not assumed**: either a writer
       collision is shown to stall the loop and a timeout is set, or the concern
       is recorded as refuted with the measurement
-- [ ] `transaction()` either supports nesting (savepoints) or
+- [x] `transaction()` either supports nesting (savepoints) or
       `record_check_result` stops nesting it; a test pins that a failure after
       the inner scope rolls the whole unit back
 - [ ] The subscriptions DB connection is closed on shutdown and the `-wal` is
@@ -139,12 +139,26 @@ Red-proofed on behaviour, not vocabulary: against the unfixed code the forced
 interleave fetches the feed **2 times for one overlap**. `Tests/Subscriptions/`
 755 passed.
 
+**C also shipped (2026-08-21).** `transaction()` now tracks nesting depth per
+thread -- only the outermost block commits or rolls back -- mirroring
+`ChaChaNotes_DB`'s `TransactionContextManager` rather than inventing a
+savepoint scheme. Depth is cleared in a `finally`, so a raise cannot strand it
+and silently turn every later transaction into a no-op joiner.
+
+**The specific claim in C is REFUTED by measurement.** `record_check_result`
+does not nest today: instrumenting `transaction()` across a real call observed
+**depth 1, one entry**. The lane's CONFIRMED-LATENT rating was right about the
+hazard and wrong about that call site. The fix stands anyway -- it converts a
+silent-partial-persistence trap into a structural impossibility instead of
+relying on nobody ever nesting -- and is red-proofed: against the unfixed
+context manager, the nested write survives a deliberate failure in the outer
+scope.
+
 **Still open:**
 
 * **B** -- the 22 `async def` methods doing synchronous sqlite on the loop.
   See this task's own busy_timeout measurement above: the 5s stall exposure is
   writer-vs-writer only (WAL), but every one of the 22 still blocks the loop
   for its own query duration.
-* **C** -- `transaction()` is not re-entrant and `record_check_result` nests
-  it, so the inner `commit()` durably commits the outer transaction early;
-  plus the leaked thread-local connection that never checkpoints the `-wal`.
+* **C residue** -- the leaked thread-local connection that is never closed and
+  never checkpoints the `-wal`. Untouched here.

--- a/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
+++ b/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
@@ -58,10 +58,10 @@ away".
 
 ## Acceptance Criteria
 
-- [ ] The feed and API arms register in the same in-flight guard the URL arm
+- [x] The feed and API arms register in the same in-flight guard the URL arm
       uses, so a scheduler tick overlapping a manual "Check Now" runs the check
       once
-- [ ] An overlapping check produces exactly one alert notification and one set
+- [x] An overlapping check produces exactly one alert notification and one set
       of statistics — pinned by a test that actually overlaps the two triggers
 - [ ] The 22 `async def` methods no longer execute synchronous sqlite on the
       event loop
@@ -115,3 +115,36 @@ bundling a user-visible correctness bug (duplicate alert notifications), the
 `record_check_result` nests, and a leaked thread-local connection. Recommend
 splitting: (A) the in-flight guard + duplicate-alert test, (B) the sqlite
 offload, (C) transaction nesting + connection close.
+
+## Part A shipped (2026-08-21) — B and C still open
+
+**A (feed/API in-flight guard) is done.** Both arms now claim through the same
+`_IN_FLIGHT_URL_CHECKS` registry the url-family arms use, scoped to the whole
+source with a NUL-prefixed sentinel in the URL slot (no real URL can contain
+NUL, so it cannot collide with a url-family claim for the same subscription).
+
+The skip returns a `DISPOSITION_SKIPPED_IN_FLIGHT` disposition rather than the
+arm's usual `None`. That turned out to be the load-bearing half: without it,
+`_entirely_skipped_dispositions` would not match, `execute_run` would run the
+ordinary health path, and a turned-away check would take
+`record_check_result`'s SUCCESS branch -- resetting the auto-pause breaker,
+clearing `last_error` and stamping `last_successful_check` for a run that
+never contacted the source. Returning `[]` items with `None` dispositions
+would have been indistinguishable from a clean "nothing new" check.
+
+Two comments in the file asserted the old invariant ("feed/API runs can never
+skip", "`None` for the feed and API arms") and are corrected, not left to rot.
+
+Red-proofed on behaviour, not vocabulary: against the unfixed code the forced
+interleave fetches the feed **2 times for one overlap**. `Tests/Subscriptions/`
+755 passed.
+
+**Still open:**
+
+* **B** -- the 22 `async def` methods doing synchronous sqlite on the loop.
+  See this task's own busy_timeout measurement above: the 5s stall exposure is
+  writer-vs-writer only (WAL), but every one of the 22 still blocks the loop
+  for its own query duration.
+* **C** -- `transaction()` is not re-entrant and `record_check_result` nests
+  it, so the inner `commit()` durably commits the outer transaction early;
+  plus the leaked thread-local connection that never checkpoints the `-wal`.

--- a/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
+++ b/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
@@ -63,7 +63,7 @@ away".
       once
 - [x] An overlapping check produces exactly one alert notification and one set
       of statistics — pinned by a test that actually overlaps the two triggers
-- [ ] The 22 `async def` methods no longer execute synchronous sqlite on the
+- [x] The 22 `async def` methods no longer execute synchronous sqlite on the
       event loop
 - [ ] The `busy_timeout` question is **measured, not assumed**: either a writer
       collision is shown to stall the loop and a timeout is set, or the concern
@@ -154,11 +154,25 @@ relying on nobody ever nesting -- and is red-proofed: against the unfixed
 context manager, the nested write survives a deliberate failure in the outer
 scope.
 
+**B also shipped (2026-08-21).** All 22 async methods now route their sqlite
+through the existing `db_offload.run_db_off_loop` helper rather than a new
+mechanism. The four `transaction()` sites were handled differently on purpose:
+that helper's contract forbids holding a transaction open across the thread
+boundary, so each block was extracted whole into an offloaded function rather
+than offloading statements inside an open transaction.
+
+Count note: an AST sweep for `db.<method>()` / `self._db().<method>()` found
+19 methods; three more (`get_alert_rule`, `list_runs`, `list_alert_rules`)
+reach the database through a bare `db.conn.cursor()` and were invisible to
+that pattern. Adding them gives 22 -- matching this task's original figure,
+which the narrower scan would have under-reported. Verified after the change:
+**zero** inline db calls remain in any `async def` in the file.
+
+Red-proofed: reverting `cancel_run`'s offload fails its test with
+`cancel_run's transaction opened on the event-loop thread`. `Tests/
+Subscriptions/` 781 passed (from a 759 baseline, +22 new tests).
+
 **Still open:**
 
-* **B** -- the 22 `async def` methods doing synchronous sqlite on the loop.
-  See this task's own busy_timeout measurement above: the 5s stall exposure is
-  writer-vs-writer only (WAL), but every one of the 22 still blocks the loop
-  for its own query duration.
 * **C residue** -- the leaked thread-local connection that is never closed and
   never checkpoints the `-wal`. Untouched here.

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1392,14 +1392,51 @@ class SubscriptionsDB(BaseDB):
 
     @contextmanager
     def transaction(self):
-        """Context manager for database transactions."""
+        """Context manager for database transactions, safe to nest.
+
+        task-19562 part C. This used to commit unconditionally on exit. A
+        nested `with self.transaction()` therefore had its INNER exit
+        durably commit the OUTER transaction's work as well, so a later
+        failure in the outer scope could no longer roll back what the inner
+        block had already written -- silent partial persistence, with no
+        error anywhere.
+
+        Nesting is now tracked per thread (the connection is thread-local,
+        so the depth must be too), mirroring `ChaChaNotes_DB`'s
+        `TransactionContextManager`: only the OUTERMOST block commits or
+        rolls back, and an inner block simply yields the same connection. An
+        exception still propagates outward, so the outermost block rolls the
+        whole unit back as a caller would expect.
+
+        Measured note for the record: at the time this was written
+        `record_check_result` -- the call site the task named -- did **not**
+        nest (instrumented depth 1). The hazard was latent, not live; this
+        makes it structurally impossible rather than relying on no one ever
+        nesting.
+        """
         conn = self.conn
+        if not hasattr(self._local, "transaction_depth"):
+            self._local.transaction_depth = 0
+
+        if self._local.transaction_depth > 0:
+            # Inner block: join the outer transaction. No commit, no
+            # rollback -- the outermost owns both.
+            self._local.transaction_depth += 1
+            try:
+                yield conn
+            finally:
+                self._local.transaction_depth -= 1
+            return
+
+        self._local.transaction_depth = 1
         try:
             yield conn
             conn.commit()
         except Exception:
             conn.rollback()
             raise
+        finally:
+            self._local.transaction_depth = 0
 
     # --- Core Subscription Management ---
 

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1413,6 +1413,16 @@ class SubscriptionsDB(BaseDB):
         nest (instrumented depth 1). The hazard was latent, not live; this
         makes it structurally impossible rather than relying on no one ever
         nesting.
+
+        Yields:
+            The thread-local `sqlite3.Connection`. The same object is yielded
+            to a nested block, so an inner `with` shares the outer's
+            transaction rather than starting its own.
+
+        Raises:
+            Exception: Whatever the body raises, re-raised unchanged after the
+                OUTERMOST block rolls back. An inner block does not roll back;
+                the exception propagates so the outermost can.
         """
         conn = self.conn
         if not hasattr(self._local, "transaction_depth"):

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -10,7 +10,7 @@ import sqlite3
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Any, Callable, Mapping
+from typing import Any, Awaitable, Callable, Mapping
 
 from loguru import logger
 
@@ -274,7 +274,11 @@ def _entirely_skipped_dispositions(
     Args:
         dispositions_counts: The run's `_disposition_counts()` output, or
             `None`/absent for source types with no dispositions (feed/API
-            runs, which can never skip and always return False here).
+            runs, whose dispositions are ``None`` on the ordinary path).
+            task-19562: feed/API runs CAN now skip -- when they do they carry
+            a single `DISPOSITION_SKIPPED_IN_FLIGHT` disposition precisely so
+            they match here and `execute_run` skips the health accounting,
+            exactly like an entirely-skipped url-family run.
 
     Returns:
         True only for a non-empty counts mapping that is all zeros except
@@ -1745,11 +1749,19 @@ class LocalWatchlistsService:
 
         subscription_config = self._subscription_execution_config(subscription)
         source_type = str(subscription_config.get("type") or "").strip()
-        # `None` for the feed and API arms, which have no dispositions at all
-        # (spec §4) -- distinguished from `[]`, which would record four zeros.
+        # `None` for the feed and API arms on the ordinary path, which have
+        # no dispositions at all (spec §4) -- distinguished from `[]`, which
+        # would record four zeros. task-19562: those arms now REASSIGN this
+        # to a one-element skip list when the in-flight guard turns them
+        # away, so a skipped check is not mistaken for a clean zero-item run.
         dispositions: list[dict[str, Any]] | None = None
         if source_type in _FEED_SOURCE_TYPES:
-            items = await FeedMonitor().check_feed(subscription_config)
+            items, dispositions = await self._run_guarded_source_check(
+                db,
+                subscription_config,
+                "feed",
+                lambda: FeedMonitor().check_feed(subscription_config),
+            )
         elif source_type == "url":
             result, disposition = await self._check_url_guarded(
                 URLMonitor(db),
@@ -1789,7 +1801,12 @@ class LocalWatchlistsService:
                 if result:
                     items.append(result)
         elif source_type == "api":
-            items = await self._items_for_api_source(subscription_config)
+            items, dispositions = await self._run_guarded_source_check(
+                db,
+                subscription_config,
+                "api",
+                lambda: self._items_for_api_source(subscription_config),
+            )
         else:
             raise ValueError(
                 f"Unsupported local watchlist source type for execution: {source_type}"
@@ -1815,6 +1832,79 @@ class LocalWatchlistsService:
                 run_stats["max_withheld_pct"] = max_withheld
             result_payload["stats"] = run_stats
         return result_payload
+
+    async def _run_guarded_source_check(
+        self,
+        db: Any,
+        subscription_config: Mapping[str, Any],
+        claim_kind: str,
+        check: "Callable[[], Awaitable[list[Any]]]",
+    ) -> tuple[list[Any], list[dict[str, Any]] | None]:
+        """A whole-source check behind the same in-flight guard the URL arms use.
+
+        task-19562 part A: only the url-family arms went through
+        `_check_url_guarded`. The **feed** and **API** arms -- and feeds are
+        the commonest source type -- ran unguarded, so a scheduler tick
+        overlapping a manual "Check Now" ran the check twice: the alert
+        notification fired twice and statistics double-counted.
+
+        These arms have no per-URL granularity, so the claim is scoped to the
+        whole source with a ``claim_kind`` sentinel in the URL slot. The
+        sentinel is NUL-prefixed, which no real URL can contain, so it can
+        never collide with a url-family claim for the same subscription.
+
+        A skip returns a single `DISPOSITION_SKIPPED_IN_FLIGHT` disposition
+        rather than the arm's usual ``None``. That is load-bearing, not
+        cosmetic: `_entirely_skipped_dispositions` -> `execute_run` uses it to
+        short-circuit source-health accounting, so a skipped check cannot take
+        `record_check_result`'s SUCCESS branch and reset the auto-pause
+        breaker, clear `last_error` and stamp `last_successful_check` for a
+        run that never contacted the source. Returning ``[]`` items with
+        ``None`` dispositions would have reported "nothing new" for a check
+        that never happened.
+
+        ``db`` is taken as a parameter and held in THIS frame across the
+        await on purpose: the claim key stores ``id(db)`` and no reference to
+        it, so it is the live parameter that stops the object being collected
+        and its id reused while the claim is registered (see
+        `_IN_FLIGHT_URL_CHECKS`).
+
+        Args:
+            db: The database this run writes to; part of the claim key.
+            subscription_config: The source's execution config; must carry ``id``.
+            claim_kind: Short arm name (``"feed"``/``"api"``) used to build
+                the sentinel claim slot.
+            check: Zero-arg coroutine factory performing the actual check.
+
+        Returns:
+            ``(items, dispositions)`` -- the check's items with ``None``
+            dispositions when this entrant won the claim, or ``([], [skip])``
+            when a concurrent check of the same source already held it.
+        """
+        from .monitoring_engine import DISPOSITION_SKIPPED_IN_FLIGHT
+
+        subscription_id = subscription_config.get("id")
+        claim_slot = f"\x00{claim_kind}"
+        key = (id(db), subscription_id, claim_slot)
+        if key in _IN_FLIGHT_URL_CHECKS:
+            logger.info(
+                f"watchlist check skipped: subscription {subscription_id} "
+                f"already has a {claim_kind} check in flight"
+            )
+            return [], [
+                {
+                    "kind": DISPOSITION_SKIPPED_IN_FLIGHT,
+                    "reason": None,
+                    "withheld_percentage": None,
+                }
+            ]
+        _IN_FLIGHT_URL_CHECKS.add(key)
+        try:
+            return await check(), None
+        finally:
+            # `finally` so a raise or a cancellation (the user navigating away
+            # mid-check) can never strand the source as permanently in flight.
+            _IN_FLIGHT_URL_CHECKS.discard(key)
 
     async def _check_url_guarded(
         self,

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -508,7 +508,10 @@ class LocalWatchlistsService:
             if not q
             else max(normalized_limit + normalized_offset, 1000)
         )
-        rows = self._db().get_all_subscriptions(
+        db = self._db()
+        rows = await run_db_off_loop(
+            db,
+            db.get_all_subscriptions,
             include_inactive=True,
             limit=fetch_limit,
             offset=0 if q else normalized_offset,
@@ -526,7 +529,8 @@ class LocalWatchlistsService:
         return filtered[normalized_offset : normalized_offset + normalized_limit]
 
     async def get_source(self, source_id: Any) -> dict[str, Any]:
-        row = self._db().get_subscription(int(source_id))
+        db = self._db()
+        row = await run_db_off_loop(db, db.get_subscription, int(source_id))
         if row is None:
             raise KeyError(f"Subscription not found: {source_id}")
         return normalize_local_subscription_row(row)
@@ -603,7 +607,9 @@ class LocalWatchlistsService:
         subscription_id = int(source_id) if source_id is not None else None
         status_filter = status if status else None
         fetch_limit = int(limit) + int(offset)
-        rows = db.get_new_items(
+        rows = await run_db_off_loop(
+            db,
+            db.get_new_items,
             subscription_id=subscription_id,
             status=status_filter,
             limit=fetch_limit,
@@ -627,7 +633,9 @@ class LocalWatchlistsService:
             or self._first_configured_url(payload)
             or ""
         )
-        source_id = db.add_subscription(
+        source_id = await run_db_off_loop(
+            db,
+            db.add_subscription,
             name=str(payload.get("name") or "Untitled subscription"),
             type=local_type,
             source=source,
@@ -636,7 +644,8 @@ class LocalWatchlistsService:
             is_active=bool(payload.get("active", True)),
             **self._subscription_config_fields(payload),
         )
-        return normalize_local_subscription_row(db.get_subscription(source_id))
+        row = await run_db_off_loop(db, db.get_subscription, source_id)
+        return normalize_local_subscription_row(row)
 
     async def update_source(
         self, source_id: Any, payload: Mapping[str, Any]
@@ -663,8 +672,11 @@ class LocalWatchlistsService:
             changes["type"] = self._local_type_for_source_type(payload["source_type"])
         changes.update(self._subscription_config_fields(payload))
         if changes:
-            db.update_subscription(int(source_id), **changes)
-        return normalize_local_subscription_row(db.get_subscription(int(source_id)))
+            await run_db_off_loop(
+                db, db.update_subscription, int(source_id), **changes
+            )
+        row = await run_db_off_loop(db, db.get_subscription, int(source_id))
+        return normalize_local_subscription_row(row)
 
     #: Statuses a watchlist item may be moved to from the UI. Mirrors
     #: `ItemsPane._STATUS_OPTIONS` minus its "all" filter entry.
@@ -695,7 +707,8 @@ class LocalWatchlistsService:
             row_id = int(item_id)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
-        return self._db().get_item_status(row_id)
+        db = self._db()
+        return await run_db_off_loop(db, db.get_item_status, row_id)
 
     async def get_item_content(self, item_id: Any) -> str | None:
         """Read one item's full body text -- the reader's DETAIL fetch.
@@ -722,7 +735,8 @@ class LocalWatchlistsService:
             row_id = int(item_id)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
-        return self._db().get_item_content(row_id)
+        db = self._db()
+        return await run_db_off_loop(db, db.get_item_content, row_id)
 
     async def get_url_snapshots(
         self, source_id: Any, url: str, *, limit: int = 2
@@ -733,11 +747,10 @@ class LocalWatchlistsService:
         normalization needed on the way out; the three columns it returns
         (`id`, `extracted_content`, `created_at`) are exactly what the
         screen's `ViewSnapshotRequested` handler and `SnapshotViewModal`
-        read. Not wrapped in `asyncio.to_thread`: no read on this service
-        is (see `list_items`/`get_source`/`get_item_status` above) --
-        `SubscriptionsDB`'s SQLite reads are fast enough that this service
-        has never paid for a thread hop on one, and adding it just for this
-        method would be an inconsistency, not a fix.
+        read. task-19562 B: now hops through `run_db_off_loop` like every
+        other read on this service -- the comment that used to justify
+        leaving this one inline (every other read already did) no longer
+        applies, since none of them are inline anymore either.
 
         Args:
             source_id: Owning subscription id (bare, not namespaced) --
@@ -750,7 +763,10 @@ class LocalWatchlistsService:
             Up to `limit` dicts, newest first; empty when the (source, url)
             pair has no snapshot yet.
         """
-        return self._db().get_url_snapshots(int(source_id), str(url), limit=limit)
+        db = self._db()
+        return await run_db_off_loop(
+            db, db.get_url_snapshots, int(source_id), str(url), limit=limit
+        )
 
     async def update_item(self, *, item_id: Any, status: str) -> dict[str, Any]:
         """Move one watchlist item to a new status.
@@ -784,7 +800,11 @@ class LocalWatchlistsService:
             row_id = int(item_id)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
-        if not self._db().mark_item_status(row_id, normalized_status):
+        db = self._db()
+        updated = await run_db_off_loop(
+            db, db.mark_item_status, row_id, normalized_status
+        )
+        if not updated:
             raise KeyError(f"Watchlist item not found: {item_id}")
         return {
             "success": True,
@@ -820,7 +840,10 @@ class LocalWatchlistsService:
         Returns:
             The local row ids moved to ``reviewed``.
         """
-        return self._db().mark_all_read(
+        db = self._db()
+        return await run_db_off_loop(
+            db,
+            db.mark_all_read,
             subscription_id=int(source_id) if source_id is not None else None,
             watchlist_id=int(watchlist_id) if watchlist_id is not None else None,
             unassigned_only=bool(unassigned_only),
@@ -849,7 +872,8 @@ class LocalWatchlistsService:
                 row_ids.append(int(item_id))
             except (TypeError, ValueError) as exc:
                 raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
-        return self._db().restore_items_new(row_ids)
+        db = self._db()
+        return await run_db_off_loop(db, db.restore_items_new, row_ids)
 
     async def set_item_flagged(self, *, item_id: Any, flagged: bool) -> None:
         """Star or unstar one item (TASK-3072 plan task 7).
@@ -871,7 +895,8 @@ class LocalWatchlistsService:
             row_id = int(item_id)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
-        self._db().set_item_flagged(row_id, bool(flagged))
+        db = self._db()
+        await run_db_off_loop(db, db.set_item_flagged, row_id, bool(flagged))
 
     async def find_source_id_by_url(self, url: str) -> int | None:
         """The id of the source carrying exactly this URL, or `None`.
@@ -887,7 +912,8 @@ class LocalWatchlistsService:
         Returns:
             The subscription's id, or `None` when no row carries it.
         """
-        return self._db().get_subscription_id_by_source(str(url))
+        db = self._db()
+        return await run_db_off_loop(db, db.get_subscription_id_by_source, str(url))
 
     async def resolve_or_create_watchlist(self, name: str) -> tuple[dict[str, Any], bool]:
         """The watchlist named `name` (case-insensitive), creating it if missing.
@@ -959,7 +985,8 @@ class LocalWatchlistsService:
         ]
 
     async def delete_source(self, source_id: Any) -> dict[str, Any]:
-        success = self._db().delete_subscription(int(source_id))
+        db = self._db()
+        success = await run_db_off_loop(db, db.delete_subscription, int(source_id))
         return {
             "success": success,
             "id": f"local:subscription:{source_id}",
@@ -998,8 +1025,8 @@ class LocalWatchlistsService:
             KeyError: `source_id` does not name a subscription.
         """
         db = self._db()
-        db.reset_subscription_errors(int(source_id))
-        row = db.get_subscription(int(source_id))
+        await run_db_off_loop(db, db.reset_subscription_errors, int(source_id))
+        row = await run_db_off_loop(db, db.get_subscription, int(source_id))
         if row is None:
             raise KeyError(f"Subscription not found: {source_id}")
         return normalize_local_subscription_row(row)
@@ -1340,6 +1367,20 @@ class LocalWatchlistsService:
             values.append(int(resolved_source_id))
         where_clause = f"WHERE {' AND '.join(filters)}" if filters else ""
         values.extend([int(limit), int(offset)])
+        # task-19562 B: not one of the originally enumerated 19 methods (same
+        # reason as `get_alert_rule` -- it reads through a bare
+        # `db.conn.cursor()`, not a named `SubscriptionsDB` method), but it is
+        # exactly the same class of loop-blocking read as everything else in
+        # this sweep.
+        rows = await run_db_off_loop(
+            db, self._select_run_rows, db, where_clause, values
+        )
+        return [self._normalize_run_row(row) for row in rows]
+
+    def _select_run_rows(
+        self, db: SubscriptionsDB, where_clause: str, values: list[Any]
+    ) -> list[Any]:
+        """Read a page of run rows (task-19562 B hop body)."""
         cursor = db.conn.cursor()
         cursor.execute(
             f"""
@@ -1350,7 +1391,7 @@ class LocalWatchlistsService:
             """,
             values,
         )
-        return [self._normalize_run_row(row) for row in cursor.fetchall()]
+        return cursor.fetchall()
 
     def list_home_run_snapshot(self, *, limit: int = 20) -> list[dict[str, Any]]:
         """Return recent local watchlist runs from a synchronous Home-safe path."""
@@ -1420,6 +1461,21 @@ class LocalWatchlistsService:
     async def cancel_run(self, run_id: Any) -> dict[str, Any]:
         db = self._db()
         now = self._utc_now()
+        # task-19562 B: the whole `db.transaction()` block hops as one unit
+        # -- `run_db_off_loop` must not be handed a callable that holds a
+        # transaction open across the await boundary, so the UPDATE and its
+        # commit/rollback happen entirely inside `_cancel_run_row`, on the
+        # worker thread.
+        updated_rows = await run_db_off_loop(
+            db, self._cancel_run_row, db, int(run_id), now
+        )
+        if updated_rows == 0:
+            raise KeyError(f"Watchlist run not found: {run_id}")
+        return await self.get_run(run_id)
+
+    @staticmethod
+    def _cancel_run_row(db: SubscriptionsDB, run_id: int, now: str) -> int:
+        """Mark one run cancelled; returns rows updated (task-19562 B hop body)."""
         with db.transaction() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -1428,11 +1484,9 @@ class LocalWatchlistsService:
                 SET status = ?, finished_at = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                ("cancelled", now, now, int(run_id)),
+                ("cancelled", now, now, run_id),
             )
-            if cursor.rowcount == 0:
-                raise KeyError(f"Watchlist run not found: {run_id}")
-        return await self.get_run(run_id)
+            return cursor.rowcount
 
     async def record_run_result(
         self,
@@ -1509,8 +1563,20 @@ class LocalWatchlistsService:
     ) -> list[dict[str, Any]]:
         db = self._db()
         resolved_job_id = job_id if job_id is not None else source_id
+        # task-19562 B: same reasoning as `list_runs`/`get_alert_rule` above --
+        # a bare `db.conn.cursor()` read, now hopped off the loop.
+        rows = await run_db_off_loop(
+            db, self._select_alert_rule_rows, db, resolved_job_id
+        )
+        return [
+            normalize_watchlist_alert_rule("local", self._alert_rule_row_to_dict(row))
+            for row in rows
+        ]
+
+    def _select_alert_rule_rows(self, db: SubscriptionsDB, job_id: Any) -> list[Any]:
+        """Read every alert rule, optionally scoped to one job (task-19562 B hop body)."""
         cursor = db.conn.cursor()
-        if resolved_job_id is None:
+        if job_id is None:
             cursor.execute(
                 "SELECT * FROM local_watchlist_alert_rules ORDER BY created_at DESC"
             )
@@ -1521,25 +1587,35 @@ class LocalWatchlistsService:
                 WHERE job_id = ? OR job_id IS NULL
                 ORDER BY created_at DESC
                 """,
-                (int(resolved_job_id),),
+                (int(job_id),),
             )
-        return [
-            normalize_watchlist_alert_rule("local", self._alert_rule_row_to_dict(row))
-            for row in cursor.fetchall()
-        ]
+        return cursor.fetchall()
 
     async def get_alert_rule(self, rule_id: Any) -> dict[str, Any]:
         db = self._db()
-        cursor = db.conn.cursor()
-        cursor.execute(
-            "SELECT * FROM local_watchlist_alert_rules WHERE id = ?", (int(rule_id),)
+        # task-19562 B: not one of the originally enumerated 19 methods --
+        # the AST scan that produced that list only matched calls to named
+        # `SubscriptionsDB` methods, and this reads through a bare
+        # `db.conn.cursor()` -- but `create_alert_rule` and
+        # `update_alert_rule` both end by awaiting this method, so leaving
+        # it inline would have left those two still blocking the loop on
+        # their last statement.
+        row = await run_db_off_loop(
+            db, self._select_alert_rule_row, db, int(rule_id)
         )
-        row = cursor.fetchone()
         if row is None:
             raise KeyError(f"Watchlist alert rule not found: {rule_id}")
         return normalize_watchlist_alert_rule(
             "local", self._alert_rule_row_to_dict(row)
         )
+
+    def _select_alert_rule_row(self, db: SubscriptionsDB, rule_id: int) -> Any:
+        """Read one alert rule row (task-19562 B hop body)."""
+        cursor = db.conn.cursor()
+        cursor.execute(
+            "SELECT * FROM local_watchlist_alert_rules WHERE id = ?", (rule_id,)
+        )
+        return cursor.fetchone()
 
     async def create_alert_rule(
         self,
@@ -1551,15 +1627,45 @@ class LocalWatchlistsService:
         source_id: Any = None,
         severity: str = "warning",
     ) -> dict[str, Any]:
+        db = self._db()
         normalized_condition_type = self._validate_condition_type(condition_type)
         resolved_job_id = job_id if job_id is not None else source_id
-        if (
-            resolved_job_id is not None
-            and self._db().get_subscription(int(resolved_job_id)) is None
-        ):
-            raise KeyError(f"Subscription not found: {resolved_job_id}")
-        db = self._db()
+        if resolved_job_id is not None:
+            subscription = await run_db_off_loop(
+                db, db.get_subscription, int(resolved_job_id)
+            )
+            if subscription is None:
+                raise KeyError(f"Subscription not found: {resolved_job_id}")
         now = self._utc_now()
+        # task-19562 B: the whole `db.transaction()` block hops as one unit
+        # -- `run_db_off_loop` must not be handed a callable that holds a
+        # transaction open across the await boundary, so the INSERT and its
+        # commit/rollback happen entirely inside `_insert_alert_rule`, on the
+        # worker thread.
+        rule_id = await run_db_off_loop(
+            db,
+            self._insert_alert_rule,
+            db,
+            int(resolved_job_id) if resolved_job_id is not None else None,
+            name,
+            normalized_condition_type,
+            self._serialize_condition_value(condition_value),
+            severity,
+            now,
+        )
+        return await self.get_alert_rule(rule_id)
+
+    @staticmethod
+    def _insert_alert_rule(
+        db: SubscriptionsDB,
+        job_id: int | None,
+        name: str,
+        condition_type: str,
+        condition_value_json: str | None,
+        severity: str,
+        now: str,
+    ) -> int:
+        """Insert one alert rule row and return its id (task-19562 B hop body)."""
         with db.transaction() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -1570,18 +1676,17 @@ class LocalWatchlistsService:
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    int(resolved_job_id) if resolved_job_id is not None else None,
+                    job_id,
                     name,
                     1,
-                    normalized_condition_type,
-                    self._serialize_condition_value(condition_value),
+                    condition_type,
+                    condition_value_json,
                     severity,
                     now,
                     now,
                 ),
             )
-            rule_id = cursor.lastrowid
-        return await self.get_alert_rule(rule_id)
+            return cursor.lastrowid
 
     async def update_alert_rule(self, rule_id: Any, **fields: Any) -> dict[str, Any]:
         db = self._db()
@@ -1603,13 +1708,21 @@ class LocalWatchlistsService:
             updates["severity"] = fields["severity"]
         if "job_id" in fields:
             job_id = fields["job_id"]
-            if job_id is not None and db.get_subscription(int(job_id)) is None:
-                raise KeyError(f"Subscription not found: {job_id}")
+            if job_id is not None:
+                subscription = await run_db_off_loop(
+                    db, db.get_subscription, int(job_id)
+                )
+                if subscription is None:
+                    raise KeyError(f"Subscription not found: {job_id}")
             updates["job_id"] = int(job_id) if job_id is not None else None
         if "source_id" in fields:
             source_id = fields["source_id"]
-            if source_id is not None and db.get_subscription(int(source_id)) is None:
-                raise KeyError(f"Subscription not found: {source_id}")
+            if source_id is not None:
+                subscription = await run_db_off_loop(
+                    db, db.get_subscription, int(source_id)
+                )
+                if subscription is None:
+                    raise KeyError(f"Subscription not found: {source_id}")
             updates["job_id"] = int(source_id) if source_id is not None else None
         if not updates:
             return current
@@ -1617,24 +1730,35 @@ class LocalWatchlistsService:
         updates["updated_at"] = self._utc_now()
         assignments = ", ".join(f"{field} = ?" for field in updates)
         values = list(updates.values()) + [int(rule_id)]
+        # task-19562 B: whole transaction block hops as one unit, same
+        # reasoning as `create_alert_rule` above.
+        updated_rows = await run_db_off_loop(
+            db, self._update_alert_rule_row, db, assignments, values
+        )
+        if updated_rows == 0:
+            raise KeyError(f"Watchlist alert rule not found: {rule_id}")
+        return await self.get_alert_rule(rule_id)
+
+    @staticmethod
+    def _update_alert_rule_row(
+        db: SubscriptionsDB, assignments: str, values: list[Any]
+    ) -> int:
+        """Apply one alert rule UPDATE; returns rows updated (task-19562 B hop body)."""
         with db.transaction() as conn:
             cursor = conn.cursor()
             cursor.execute(
                 f"UPDATE local_watchlist_alert_rules SET {assignments} WHERE id = ?",
                 values,
             )
-            if cursor.rowcount == 0:
-                raise KeyError(f"Watchlist alert rule not found: {rule_id}")
-        return await self.get_alert_rule(rule_id)
+            return cursor.rowcount
 
     async def delete_alert_rule(self, rule_id: Any) -> dict[str, Any]:
         db = self._db()
-        with db.transaction() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "DELETE FROM local_watchlist_alert_rules WHERE id = ?", (int(rule_id),)
-            )
-            deleted = cursor.rowcount > 0
+        # task-19562 B: whole transaction block hops as one unit, same
+        # reasoning as `create_alert_rule` above.
+        deleted = await run_db_off_loop(
+            db, self._delete_alert_rule_row, db, int(rule_id)
+        )
         if not deleted:
             raise KeyError(f"Watchlist alert rule not found: {rule_id}")
         return {
@@ -1644,6 +1768,16 @@ class LocalWatchlistsService:
             "entity_kind": "watchlist_alert_rule",
             "rule_id": int(rule_id),
         }
+
+    @staticmethod
+    def _delete_alert_rule_row(db: SubscriptionsDB, rule_id: int) -> bool:
+        """Delete one alert rule row (task-19562 B hop body)."""
+        with db.transaction() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM local_watchlist_alert_rules WHERE id = ?", (rule_id,)
+            )
+            return cursor.rowcount > 0
 
     @staticmethod
     def _local_type_for_source_type(source_type: Any) -> str:


### PR DESCRIPTION
## What & why

Fourth efficiency batch: **parts A and C of task-19562**. One user-visible correctness bug fixed, one silent-data-loss hazard closed — and one of the task's own claims refuted by measurement.

## Part A — overlapping feed checks fired the alert twice

`_check_url_guarded` (task-16838) serializes concurrent checks of the same source, but only for the url-family arms (`url`, `url_list`, `sitemap`). The **feed** arm and the **API** arm registered no claim at all — and feeds are the commonest source type. A scheduler tick overlapping a manual "Check Now" therefore ran the check **twice**: the alert notification fired twice and statistics double-counted.

Both arms now claim through the same registry, scoped to the whole source with a NUL-prefixed sentinel in the URL slot — no real URL can contain NUL, so it cannot collide with a url-family claim for the same subscription.

### The load-bearing part is the disposition, not the skip

A skipped feed check returns a `DISPOSITION_SKIPPED_IN_FLIGHT` disposition rather than the arm's usual `None`. That is not cosmetic. `_entirely_skipped_dispositions` → `execute_run` reads it to **skip source-health accounting**. Without it, a turned-away check takes `record_check_result`'s SUCCESS branch and resets the auto-pause breaker, clears `last_error`, and stamps `last_successful_check` — recording a successful check for a run that never contacted the source. Returning `[]` items with `None` dispositions would have been indistinguishable from a clean "nothing new" result.

Two comments in the file asserted the old invariant (*"feed/API runs can never skip"*, *"`None` for the feed and API arms"*). Both are corrected rather than left to rot into folklore.

One trap avoided deliberately: the claim key stores `id(db)` and holds **no reference** to it, so the file's own comment warns that extracting the claim into a helper taking only a precomputed key silently drops the liveness guarantee. The new helper therefore takes `db` and holds it in its own frame across the await.

## Part C — a nested transaction committed the outer one early

`SubscriptionsDB.transaction()` committed unconditionally on exit, so a nested `with self.transaction()` had its **inner** exit durably commit the **outer** transaction's work. A later failure in the outer scope could no longer roll back what the inner block had already written — silent partial persistence, no error anywhere.

Nesting is now tracked per thread (the connection is thread-local, so the depth must be too), mirroring `ChaChaNotes_DB`'s `TransactionContextManager` rather than inventing a savepoint scheme. Depth is cleared in a `finally`, so a raise cannot strand it and turn every later transaction into a no-op joiner.

### The task's named call site is refuted

The task states `record_check_result` nests `transaction()`. It **does not**. Instrumenting `transaction()` across a real call observed **depth 1, one entry**. The lane's CONFIRMED-LATENT rating was right about the hazard and wrong about that call site.

The fix stands anyway — it converts a silent-partial-persistence trap into a structural impossibility instead of relying on nobody ever nesting — but the claim is corrected in the task rather than quietly satisfied.

## Part B — 22 async methods did synchronous sqlite on the event loop

Every one blocked the loop (the whole TUI) for its query duration. They now route through `db_offload.run_db_off_loop`, the helper this codebase **already had** and already used in several methods — not a new mechanism.

The four `transaction()` sites were handled differently on purpose: that helper's contract forbids holding a transaction open across the thread boundary, so each block was extracted whole into an offloaded function rather than offloading statements inside an open transaction.

**A counting note worth recording.** My AST sweep for `db.<method>()` / `self._db().<method>()` found 19 methods. Three more — `get_alert_rule`, `list_runs`, `list_alert_rules` — reach the database through a bare `db.conn.cursor()` and were invisible to that pattern. Adding them gives **22**, which matches this task's original figure; the narrower scan would have quietly under-reported and left three methods blocking the loop. Verified after the change: **zero** inline db calls remain in any `async def` in the file.

Red-proofed: reverting `cancel_run`'s offload fails its test with `cancel_run's transaction opened on the event-loop thread`.

Note for anyone extending these tests: `run_db_off_loop` deliberately runs **inline** when `is_memory_db is True`, so a test DB must be file-backed or the offload correctly won't happen and the test proves nothing.

## Red-proof evidence

Both fixes were verified against the real unfixed code, on behaviour rather than vocabulary:

| Change | Reverted → |
|---|---|
| feed/API guard | `the feed was fetched 2 times for one overlap; the second entrant was not turned away` |
| nesting-safe transaction | `the nested block's write survived a failure in the outer scope: its exit committed the outer transaction early` |
| sqlite offload | `cancel_run's transaction opened on the event-loop thread: [8692277440]` |

The interleave is forced for real — the check blocks on an `asyncio.Event` and the second entrant starts while the first is still inside its await. The wait is deterministic rather than a race: the first entrant is gate-blocked and *cannot* progress, so the sleep only gives the second one loop time to reach the guard. (My first attempt used `sleep(0)`, which yielded once and let the second arrive too late — that produced a false pass, and is why the timing is spelled out in the test.)

## Testing

`Tests/Subscriptions/` **781 passed, 3 skipped** (from a 759 baseline, +22 new tests). Subscription-related DB tests **133 passed**. The pre-existing `Tests/UI/test_watchlists_check_now_skipped.py` still passes.

## Still open on task-19562

* **C residue** — the leaked thread-local connection that is never closed and never checkpoints the `-wal`. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
