### PR TITLE
Change review: explain an empty review instead of implying nothing changed (TASK-19702)

### DIFF
--- a/Tests/UI/test_change_review_current_mode.py
+++ b/Tests/UI/test_change_review_current_mode.py
@@ -429,7 +429,10 @@ async def test_pseudo_entry_absent_without_candidate_roots(
         await _wait_for_detection(pilot, screen)
 
         assert _select_values(screen) == []
-        assert "No file changes recorded" in screen.diff_pane_text()
+        # TASK-19702: with no tracked roots the empty state now names the
+        # CAUSE rather than asserting nothing changed. This test's subject
+        # (no pseudo-entry without candidate roots) is unchanged.
+        assert "No folder is bound" in screen.diff_pane_text()
 
 
 @pytest.mark.asyncio
@@ -1166,3 +1169,109 @@ async def test_unborn_head_renders_a_STAGED_add_through_the_preview_path(
     assert diff_calls == [], (
         f"`git diff HEAD` must never run on an unborn HEAD; got {diff_calls}"
     )
+
+
+# ---------------------------------------------------------------------------
+# TASK-19702: an empty Change Review must say WHY, not imply "nothing changed".
+#
+# A Default-workspace conversation can never bind a folder — verified against
+# the real registry: `add_folder_binding(DEFAULT_WORKSPACE_ID, ...)` raises
+# "Default workspace does not allow runtime bindings." (folder bindings
+# delegate to `save_runtime_binding`). With no bound folder there are no
+# tracked roots, so the bridge records no snapshots and this screen has
+# nothing to show — but the old copy, "No file changes recorded for this
+# conversation.", reads as a REPORT that the agent changed nothing, which is
+# a claim the app cannot support. That is the honesty rule (spec §8) applied
+# to the empty state.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_review_without_tracked_roots_explains_why(
+    monkeypatch, tmp_path
+):
+    _patch_git_actions(monkeypatch, True)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="unbound-conv"
+    )
+    app = _Harness(provider)  # no workspace_roots -> nothing is tracked
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _open_screen(pilot, app)
+        await _wait_for_detection(pilot, screen)
+        text = screen.diff_pane_text()
+
+    assert "no folder" in text.lower(), (
+        f"the empty state must name the CAUSE, not just the absence: {text!r}"
+    )
+    assert "No file changes recorded" not in text, (
+        "that copy asserts the agent changed nothing, which is not known here"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_review_with_tracked_roots_still_reports_no_changes(
+    monkeypatch, tmp_path
+):
+    """The honest inverse: a tracked root with no recorded turns genuinely
+    DOES mean nothing was changed, and must keep saying so."""
+    _patch_git_actions(monkeypatch, True)
+    repo = _init_repo(tmp_path / "bound_repo")
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="bound-conv"
+    )
+    app = _Harness(provider, workspace_roots=[str(repo)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _open_screen(pilot, app)
+        await _wait_for_detection(pilot, screen)
+        text = screen.diff_pane_text()
+
+    assert "No file changes recorded" in text, text
+
+
+@pytest.mark.asyncio
+async def test_untracked_agent_writable_root_is_disclosed(
+    monkeypatch, tmp_path
+):
+    """TASK-19702 AC #3: `[console] workspace_root` is the agent's tool
+    confinement root (`console_chat_controller` reads it, falling back to
+    the process CWD), while change tracking follows BOUND folders. When
+    they disagree, an agent writes files this screen will never show — and
+    the user must be told rather than left with a silent gap.
+    """
+    _patch_git_actions(monkeypatch, True)
+    writable = tmp_path / "agent_can_write_here"
+    writable.mkdir()
+    tracked = _init_repo(tmp_path / "tracked_repo")
+
+    import tldw_chatbook.UI.Screens.change_review_screen as crs
+
+    real_get = crs.__dict__.get("get_cli_setting")
+    monkeypatch.setattr(
+        "tldw_chatbook.config.get_cli_setting",
+        lambda section, key, default=None: (
+            str(writable)
+            if (section, key) == ("console", "workspace_root")
+            else (real_get(section, key, default) if real_get else default)
+        ),
+    )
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="mismatch-conv"
+    )
+    app = _Harness(provider, workspace_roots=[str(tracked)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _open_screen(pilot, app)
+        await _wait_for_detection(pilot, screen)
+        banner = screen.query_one("#change-review-banner", Static)
+        text = str(banner.renderable)
+
+    assert "agent_can_write_here" in text, (
+        f"the writable-but-untracked root must be named: {text!r}"
+    )
+    assert "not tracked" in text.lower(), text

--- a/Tests/UI/test_change_review_current_mode.py
+++ b/Tests/UI/test_change_review_current_mode.py
@@ -1190,6 +1190,13 @@ async def test_unborn_head_renders_a_STAGED_add_through_the_preview_path(
 async def test_empty_review_without_tracked_roots_explains_why(
     monkeypatch, tmp_path
 ):
+    """With nothing tracked, the empty state must name the CAUSE.
+
+    "No file changes recorded for this conversation." is a claim the app
+    can only support when the conversation HAS tracked roots; with none it
+    never watched anything, so asserting the stronger thing is the same
+    dishonest-empty-state class spec §8 forbids elsewhere on this screen.
+    """
     _patch_git_actions(monkeypatch, True)
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     service = ShadowRepoService(data_dir=tmp_path / "appdata")
@@ -1275,3 +1282,68 @@ async def test_untracked_agent_writable_root_is_disclosed(
         f"the writable-but-untracked root must be named: {text!r}"
     )
     assert "not tracked" in text.lower(), text
+
+
+@pytest.mark.asyncio
+async def test_untracked_cwd_is_disclosed_when_workspace_root_is_unset(
+    monkeypatch, tmp_path
+):
+    """Qodo #3 (PR #1941): with `[console] workspace_root` UNSET the agent's
+    file tools fall back to `os.getcwd()` — which is precisely the case the
+    first version of this banner returned early on, omitting the disclosure
+    exactly where it was needed. The PR text described that fallback while
+    the code skipped it.
+    """
+    _patch_git_actions(monkeypatch, True)
+    loose = tmp_path / "process_cwd"
+    loose.mkdir()
+    tracked = _init_repo(tmp_path / "tracked_repo_cwd")
+    monkeypatch.chdir(loose)
+    monkeypatch.setattr(
+        "tldw_chatbook.config.get_cli_setting",
+        lambda section, key, default=None: (
+            "" if (section, key) == ("console", "workspace_root") else default
+        ),
+    )
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="cwd-conv"
+    )
+    app = _Harness(provider, workspace_roots=[str(tracked)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _open_screen(pilot, app)
+        await _wait_for_detection(pilot, screen)
+        text = str(screen.query_one("#change-review-banner", Static).renderable)
+
+    assert "process_cwd" in text, (
+        f"an untracked CWD an agent can write to must be disclosed: {text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_tracked_cwd_is_not_disclosed(monkeypatch, tmp_path):
+    """Control: when the fallback root IS tracked there is no gap to warn
+    about, and a spurious warning would train users to ignore the banner."""
+    _patch_git_actions(monkeypatch, True)
+    tracked = _init_repo(tmp_path / "tracked_and_cwd")
+    monkeypatch.chdir(tracked)
+    monkeypatch.setattr(
+        "tldw_chatbook.config.get_cli_setting",
+        lambda section, key, default=None: (
+            "" if (section, key) == ("console", "workspace_root") else default
+        ),
+    )
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="cwd-tracked-conv"
+    )
+    app = _Harness(provider, workspace_roots=[str(tracked)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _open_screen(pilot, app)
+        await _wait_for_detection(pilot, screen)
+        text = str(screen.query_one("#change-review-banner", Static).renderable)
+
+    assert "not tracked here" not in text, text

--- a/backlog/tasks/task-19702 - Default-workspace-never-sees-change-review.md
+++ b/backlog/tasks/task-19702 - Default-workspace-never-sees-change-review.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19702
 title: 'Default workspace never sees change review or git modes'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21'
 labels:
@@ -44,8 +44,57 @@ review surface will never show the user.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A Default-workspace conversation either sees its changes in Change Review, or the screen explains why it cannot, rather than rendering an empty state that reads as "nothing changed"
-- [ ] #2 Any root that becomes reviewable is a root the workspace actually binds — no fallback to CWD or to a bare config key that bypasses workspace binding
-- [ ] #3 The `[console] workspace_root` write/visibility mismatch is resolved or explicitly documented: a directory an agent can write must not be invisible to change review without the user being told
-- [ ] #4 Tests cover a Default-workspace conversation end to end, asserting the chosen behaviour rather than the current silent emptiness
+- [x] #1 A Default-workspace conversation either sees its changes in Change Review, or the screen explains why it cannot, rather than rendering an empty state that reads as "nothing changed"
+- [x] #2 Any root that becomes reviewable is a root the workspace actually binds — no fallback to CWD or to a bare config key that bypasses workspace binding
+- [x] #3 The `[console] workspace_root` write/visibility mismatch is resolved or explicitly documented: a directory an agent can write must not be invisible to change review without the user being told
+- [x] #4 Tests cover a Default-workspace conversation end to end, asserting the chosen behaviour rather than the current silent emptiness
 <!-- AC:END -->
+
+## Implementation Notes
+
+Chose disclosure over fabrication. The screen now distinguishes the two
+things an empty history can mean, and names the writable-but-untracked
+directory when one exists.
+
+**Premise verified before building** (the task was traced during a review,
+so I re-checked it against the real registry rather than trusting the
+write-up). `add_folder_binding(DEFAULT_WORKSPACE_ID, ...)` raises
+`WorkspaceRegistryServiceError: Default workspace does not allow runtime
+bindings.` — folder bindings delegate to `save_runtime_binding`, which
+refuses Default — while the same call on a non-Default workspace succeeds.
+So a Default-workspace conversation genuinely can never have a tracked root.
+
+**AC #1 — the empty state now states its cause.** "No file changes recorded
+for this conversation." is a claim the app can only support when the
+conversation HAS tracked roots; with none, nothing was ever watched. With no
+roots the copy now says no folder is bound, says explicitly that this is not
+a report that nothing changed, and points at Settings ▸ Workspaces plus the
+Default-workspace limitation. With roots present the original copy is
+unchanged, because there it is true. This is the same honesty rule the
+working-tree pane already follows by saying "unavailable" rather than
+"clean" when every root fails (TASK-16801).
+
+**AC #2 — no fabricated root.** Deliberately does NOT fall back to
+`[console] workspace_root` or the process CWD to manufacture something
+reviewable. That was rejected in TASK-16801's whole-branch review and is
+worth restating: it would offer confirmed commit and push against a
+repository the workspace never bound.
+
+**AC #3 — the write/visibility mismatch is disclosed.** Confirmed in
+`Chat/console_chat_controller.py`: the agent's file-tool confinement root
+comes from `tool_configuration["workspace_root"]` or `[console]
+workspace_root`, **falling back to `os.getcwd()`**, while change tracking
+follows bound folders. Nothing keeps them in agreement. When a configured
+root is not covered by a tracked root, the banner now names it and says
+changes made there will not appear in this review.
+
+**Not changed:** the Default workspace's inability to bind folders. That is
+a deliberate registry rule with its own rationale; this task's remit was
+that the user must not be left with a silent gap, not that the rule should
+be relaxed.
+
+**Files:** `tldw_chatbook/UI/Screens/change_review_screen.py`,
+`Tests/UI/test_change_review_current_mode.py` (one pre-existing assertion
+updated: `test_pseudo_entry_absent_without_candidate_roots` asserted the old
+copy in exactly this scenario; its subject — no pseudo-entry without
+candidate roots — is unchanged).

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -15,6 +15,8 @@ line by line with diff coloring, never markup-parsed: file content is data
 
 from __future__ import annotations
 
+import os
+
 import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Sequence
@@ -3279,18 +3281,24 @@ class ChangeReviewScreen(Screen):
     def _refresh_untracked_writable_banner(self) -> None:
         """Disclose an agent-writable root that change review cannot see.
 
-        TASK-19702 AC #3. `[console] workspace_root` is the CONFINEMENT
-        root for the agent's file tools (`console_chat_controller` reads
-        it, and falls back to the process CWD when it is unset), while
-        change tracking follows the workspace's BOUND folders. Nothing
-        keeps those two in agreement, so an agent can edit files that this
-        screen will never show — a silent gap exactly where the user comes
-        to check what the agent did.
+        TASK-19702 AC #3. The agent's file tools confine to
+        `tool_configuration["workspace_root"]` or `[console]
+        workspace_root`, and **fall back to the process CWD when neither is
+        set** (`Chat/console_chat_controller.py`), while change tracking
+        follows the workspace's BOUND folders. Nothing keeps those in
+        agreement, so an agent can edit files this screen will never show —
+        a silent gap exactly where the user comes to check what it did.
 
-        Rather than paper over it by treating the configured root as
-        reviewable (AC #2 forbids that: it would offer confirmed commit
-        and push against a repository the workspace never bound), the
-        mismatch is stated.
+        Qodo #3 (PR #1941): the first version returned early when the
+        config key was unset, which is PRECISELY when the CWD fallback
+        applies — omitting the disclosure in the case that needed it most.
+        The effective root is resolved the same way the controller resolves
+        it, so the two cannot drift.
+
+        Rather than paper the gap over by treating that root as reviewable
+        (AC #2 forbids it: that would offer confirmed commit and push
+        against a repository the workspace never bound), the mismatch is
+        stated.
         """
         self._untracked_writable_banners = []
         try:
@@ -3300,17 +3308,35 @@ class ChangeReviewScreen(Screen):
                 get_cli_setting("console", "workspace_root", "") or ""
             ).strip()
         except Exception:  # noqa: BLE001 -- a bad config never breaks review
+            # Qodo #4 (PR #1941): a swallowed failure here silently drops a
+            # disclosure, which is the same masking class this screen is
+            # meant to prevent. Log it rather than vanish.
+            logger.opt(exception=True).debug(
+                "change_review: could not read [console] workspace_root for "
+                "the untracked-writable disclosure"
+            )
             return
-        if not configured:
-            return
-        from pathlib import Path as _Path
 
+        # Mirrors the controller's own resolution, CWD fallback included.
+        raw = configured or os.getcwd()
         try:
-            target = _Path(configured).expanduser().resolve()
+            # Qodo #2 (PR #1941): route through the shared boundary rather
+            # than an ad-hoc `Path(...).resolve()`. `validate_path_simple`
+            # is the base-less member of that family -- there is no
+            # confinement root to check against here (the whole point is
+            # that this directory may legitimately sit anywhere), only a
+            # path to normalise safely before comparing.
+            from tldw_chatbook.Utils.path_validation import validate_path_simple
+
+            target = validate_path_simple(raw)
             tracked = {
-                _Path(r).expanduser().resolve() for r in self._workspace_roots
+                validate_path_simple(root) for root in self._workspace_roots
             }
-        except (OSError, RuntimeError, ValueError):
+        except (ValueError, OSError, RuntimeError) as exc:
+            logger.debug(
+                f"change_review: skipping untracked-writable disclosure "
+                f"for {raw!r}: {exc}"
+            )
             return
         if any(target == root or root in target.parents for root in tracked):
             return

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -1501,6 +1501,8 @@ class ChangeReviewScreen(Screen):
         #: Banner lines for detection refusals (root inside a repository).
         #: Live truth about the workspace, so they survive turn switches.
         self._git_refusal_banners: list[str] = []
+        #: TASK-19702: the agent-writable root this screen cannot see.
+        self._untracked_writable_banners: list[str] = []
         #: TASK-16801 arc B (spec §5): a git ACTION (the commit preflight or
         #: the commit itself) is in flight. Every git affordance is disabled
         #: while it is True, so nothing can be double-dispatched. Task 8's
@@ -1636,7 +1638,9 @@ class ChangeReviewScreen(Screen):
             # every turn twice -- doubled git work per open).
             select.value = wanted or self._turns[0].run_id
         else:
-            self._show_empty("No file changes recorded for this conversation.")
+            self._show_empty(self._empty_history_copy())
+        self._refresh_untracked_writable_banner()
+        self._update_banner()
         self._refresh_mode_affordances()
         # TASK-16801 arc B: the `current` mode is OFFERED (never opened on)
         # -- so detection runs AFTER the turn view is already up, keeping
@@ -2101,6 +2105,7 @@ class ChangeReviewScreen(Screen):
             *self._turn_banner_lines,
             *self._current_root_errors,
             *self._git_refusal_banners,
+            *self._untracked_writable_banners,
         ):
             if line and line not in seen:
                 seen.add(line)
@@ -3270,6 +3275,87 @@ class ChangeReviewScreen(Screen):
                 "  ⚠ changed outside direct file tools", style="dim"
             )
         return label
+
+    def _refresh_untracked_writable_banner(self) -> None:
+        """Disclose an agent-writable root that change review cannot see.
+
+        TASK-19702 AC #3. `[console] workspace_root` is the CONFINEMENT
+        root for the agent's file tools (`console_chat_controller` reads
+        it, and falls back to the process CWD when it is unset), while
+        change tracking follows the workspace's BOUND folders. Nothing
+        keeps those two in agreement, so an agent can edit files that this
+        screen will never show — a silent gap exactly where the user comes
+        to check what the agent did.
+
+        Rather than paper over it by treating the configured root as
+        reviewable (AC #2 forbids that: it would offer confirmed commit
+        and push against a repository the workspace never bound), the
+        mismatch is stated.
+        """
+        self._untracked_writable_banners = []
+        try:
+            from tldw_chatbook.config import get_cli_setting
+
+            configured = str(
+                get_cli_setting("console", "workspace_root", "") or ""
+            ).strip()
+        except Exception:  # noqa: BLE001 -- a bad config never breaks review
+            return
+        if not configured:
+            return
+        from pathlib import Path as _Path
+
+        try:
+            target = _Path(configured).expanduser().resolve()
+            tracked = {
+                _Path(r).expanduser().resolve() for r in self._workspace_roots
+            }
+        except (OSError, RuntimeError, ValueError):
+            return
+        if any(target == root or root in target.parents for root in tracked):
+            return
+        self._untracked_writable_banners = [
+            f"⚠ agents can write in {target} — it is not tracked here, so "
+            f"changes made there will not appear in this review"
+        ]
+
+    def _empty_history_copy(self) -> str:
+        """What an empty history actually means, distinguished (TASK-19702).
+
+        "No file changes recorded for this conversation." reads as a REPORT
+        that the agent changed nothing. That is only true when this
+        conversation HAS tracked roots. With none, the app simply never
+        watched anything, and asserting the stronger claim is the same
+        dishonest-empty-state class spec §8 forbids elsewhere in this
+        screen (the working-tree pane says "unavailable", not "clean", when
+        every root failed).
+
+        A conversation has no tracked roots whenever its workspace binds no
+        folder -- which the built-in Default workspace can NEVER do:
+        `add_folder_binding` delegates to `save_runtime_binding`, which
+        raises "Default workspace does not allow runtime bindings"
+        (verified against the real registry). Change tracking only records
+        snapshots when it has roots, so both sources this screen reads stay
+        empty and the feature is invisible in Default.
+
+        Deliberately does NOT fall back to `[console] workspace_root` or
+        the process CWD to manufacture a root: that would offer confirmed
+        commit and push against a repository the workspace never bound,
+        which is worse than showing nothing (TASK-16801 whole-branch review
+        ruling, restated in this task's AC #2).
+
+        Returns:
+            The empty-state copy matching what is actually known.
+        """
+        if self._workspace_roots:
+            return "No file changes recorded for this conversation."
+        return (
+            "No folder is bound to this conversation's workspace, so file "
+            "changes are not tracked here — this is not a report that "
+            "nothing changed. Bind a folder in Settings ▸ Workspaces; the "
+            "built-in Default workspace cannot bind folders, so use or "
+            "create another workspace."
+        )
 
     def _show_empty(self, copy: str) -> None:
         self.query_one("#change-review-diff-content", Static).update(copy)


### PR DESCRIPTION
## The problem

A Default-workspace conversation shows an empty Change Review screen reading **"No file changes recorded for this conversation."** — copy that asserts the agent changed nothing. The app cannot know that, because it never watched anything.

Premise re-verified against the real registry rather than taken from the filing:

```
add_folder_binding(DEFAULT_WORKSPACE_ID, ...) -> WorkspaceRegistryServiceError:
    "Default workspace does not allow runtime bindings."
add_folder_binding("ws-x", ...)               -> OK, bindings = 1
```

Folder bindings delegate to `save_runtime_binding`, which refuses Default. No bound folder ⇒ no tracked roots ⇒ the bridge records no snapshots ⇒ empty screen. Same honesty rule the working-tree pane already follows by saying *unavailable* rather than *clean* when every root fails (TASK-16801).

## What changed

**The empty state now distinguishes the two things it can mean.** With no tracked roots it names the cause, states explicitly that this is *not* a report that nothing changed, and points at Settings ▸ Workspaces plus the Default limitation. With roots present the original copy is untouched — there it is true.

**The write/visibility mismatch is disclosed** (AC #3). Confirmed in `console_chat_controller.py`: the agent's file-tool confinement root comes from `tool_configuration["workspace_root"]` or `[console] workspace_root`, **falling back to `os.getcwd()`** — while change tracking follows bound folders, with nothing keeping them in agreement. An agent can therefore edit files this screen will never show, precisely where the user comes to check what it did. When a configured root isn't covered by a tracked one, the banner now names it.

## What deliberately did NOT change

No fallback to `[console] workspace_root` or the CWD to manufacture a reviewable root (AC #2). That was rejected in TASK-16801's whole-branch review and is worth restating: it would offer confirmed **commit and push** against a repository the workspace never bound — worse than showing nothing.

The Default workspace's inability to bind folders is also untouched. That's a deliberate registry rule; the remit here was that the user must not be left with a silent gap, not that the rule should be relaxed.

## Verification

- **533 passed** across the change-review suites + `Tests/Workspaces/`; ruff clean.
- Both new behaviours **mutation-proven**: collapsing the empty-state discrimination fails the new test (and the pre-existing one), and emptying the disclosure list fails the banner test.
- One pre-existing assertion updated: `test_pseudo_entry_absent_without_candidate_roots` asserted the old copy in exactly this scenario. Its subject — no pseudo-entry without candidate roots — is unchanged.

Follows TASK-16801 (#1914).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explains why Change Review is empty instead of implying nothing changed, and discloses agent‑writable but untracked directories (including the CWD fallback) to prevent silent gaps in Default-workspace conversations.

- Empty state: when no tracked roots, the copy names the cause and states it is not a “nothing changed” report; when roots exist, the original “No file changes recorded” copy remains.
- Disclosure banner: identifies an agent-writable root from `[console] workspace_root` or the process CWD when it is not covered by a tracked root; normalizes paths via `tldw_chatbook.Utils.path_validation.validate_path_simple`; logs and skips on config read errors; does not fabricate roots or relax the Default workspace rule (satisfies TASK-19702 AC #1–#3).
- Tests: new cases for untracked CWD disclosure and a control ensuring a tracked CWD yields no warning; existing assertion updated for the new empty-state copy (AC #4).

<sup>Written for commit 82fe5c42abeea367df9a57a447bb6caa4ec49ca0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

