### PR TITLE
fix(security): allowlist, not denylist, for cross-origin redirect headers

### DIFF
--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -268,12 +268,83 @@ async def test_max_bytes_bounds_final_size(tmp_path):
                 )
 
 
-def test_strip_headers_mirror_matches_egress():
-    """Drift guard: our local strip tuple must equal egress's."""
+def test_cross_origin_header_policy_is_shared_not_mirrored():
+    """Drift guard, task-19733: the mirror is gone; the policy is imported.
+
+    This module used to keep its own copy of egress's strip tuple, and this
+    test compared the two SETS -- which only detects drift after someone
+    edits one side and runs the suite. It now asserts the stronger property:
+    there is one object, so divergence is not expressible. The
+    ``hasattr`` assertion is the anti-regression -- re-introducing a local
+    ``_STRIP_HEADERS`` copy fails here.
+    """
     from tldw_chatbook.Utils import egress
     from tldw_chatbook.Model_Artifacts import fetch
 
-    assert set(fetch._STRIP_HEADERS) == set(egress._STRIP_HEADERS)
+    assert fetch.CROSS_ORIGIN_SAFE_HEADERS is egress.CROSS_ORIGIN_SAFE_HEADERS
+    assert not hasattr(fetch, "_STRIP_HEADERS")
+
+
+@pytest.mark.asyncio
+async def test_cross_origin_hop_keeps_range_but_drops_custom_credential(
+    tmp_path, monkeypatch
+):
+    """Catalog -> CDN is the normal artifact download, and it is cross-origin.
+
+    Two things must hold on that second hop at once (task-19733):
+    ``Range``/``If-Range`` MUST survive or resume silently stops working,
+    while a credential under a name nobody denylisted (``X-Artifact-Token``)
+    must NOT. A rule that only drops four known names fails the second half;
+    a rule that drops everything fails the first.
+    """
+    seen: list[httpx.Request] = []
+    body = b"tail-bytes-after-resume"
+
+    async def allow_egress(_url: str, *, trusted_origins: frozenset[str]) -> None:
+        """Keep this transport-only test independent of DNS/egress policy."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.host == "catalog.example":
+            return httpx.Response(
+                302,
+                headers={"Location": "https://cdn.example/model.gguf"},
+                request=request,
+            )
+        return httpx.Response(
+            206,
+            headers={
+                "content-range": f"bytes 100-{100 + len(body) - 1}/{100 + len(body)}",
+                "etag": '"v1"',
+            },
+            content=body,
+            request=request,
+        )
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.fetch.check_url_or_raise_async", allow_egress
+    )
+    dest = tmp_path / "model.gguf"
+    dest.write_bytes(b"x" * 100)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await stream_fetch(
+            "https://catalog.example/model.gguf",
+            dest,
+            client=client,
+            max_bytes=100 + len(body),
+            resume_from=100,
+            validators=FetchValidators(etag='"v1"', last_modified=None),
+            headers={"X-Artifact-Token": "sentinel-not-a-real-key-19733"},
+        )
+
+    assert len(seen) == 2
+    first, second = seen
+    assert first.headers.get("x-artifact-token") == "sentinel-not-a-real-key-19733"
+    assert "cdn.example" in str(second.url)
+    assert "x-artifact-token" not in second.headers
+    assert second.headers.get("range") == "bytes=100-"
+    assert second.headers.get("if-range") == '"v1"'
+    assert dest.read_bytes() == b"x" * 100 + body
 
 
 @pytest.mark.asyncio

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -296,14 +296,32 @@ async def test_cross_origin_hop_keeps_range_but_drops_custom_credential(
     while a credential under a name nobody denylisted (``X-Artifact-Token``)
     must NOT. A rule that only drops four known names fails the second half;
     a rule that drops everything fails the first.
+
+    Args:
+        tmp_path: pytest fixture -- destination directory for the download.
+        monkeypatch: pytest fixture -- neutralises the egress DNS check so
+            this stays a transport-only test.
     """
     seen: list[httpx.Request] = []
     body = b"tail-bytes-after-resume"
 
     async def allow_egress(_url: str, *, trusted_origins: frozenset[str]) -> None:
-        """Keep this transport-only test independent of DNS/egress policy."""
+        """Keep this transport-only test independent of DNS/egress policy.
+
+        Args:
+            _url: The URL ``stream_fetch`` is about to fetch; ignored.
+            trusted_origins: Passed through by the caller; ignored.
+        """
 
     def handler(request: httpx.Request) -> httpx.Response:
+        """Record every request, then answer catalog with a redirect to the CDN.
+
+        Args:
+            request: The request the MockTransport was handed.
+
+        Returns:
+            A 302 for the catalog origin, a 206 partial response otherwise.
+        """
         seen.append(request)
         if request.url.host == "catalog.example":
             return httpx.Response(
@@ -394,14 +412,32 @@ async def test_client_level_auth_not_applied_on_cross_origin_hop(
     route because httpx applies a client-level ``auth`` inside ``send()``,
     after ``build_request`` produced the request the guard filtered. The
     same-origin first hop must still authenticate.
+
+    Args:
+        tmp_path: pytest fixture -- destination directory for the download.
+        monkeypatch: pytest fixture -- neutralises the egress DNS check so
+            this stays a transport-only test.
     """
     seen: list[httpx.Request] = []
     body = b"cdn-bytes"
 
     async def allow_egress(_url: str, *, trusted_origins: frozenset[str]) -> None:
-        """Keep this transport-only test independent of DNS/egress policy."""
+        """Keep this transport-only test independent of DNS/egress policy.
+
+        Args:
+            _url: The URL ``stream_fetch`` is about to fetch; ignored.
+            trusted_origins: Passed through by the caller; ignored.
+        """
 
     def handler(request: httpx.Request) -> httpx.Response:
+        """Record every request, then answer catalog with a redirect to the CDN.
+
+        Args:
+            request: The request the MockTransport was handed.
+
+        Returns:
+            A 302 for the catalog origin, the artifact bytes otherwise.
+        """
         seen.append(request)
         if request.url.host == "catalog.example":
             return httpx.Response(

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -382,3 +382,51 @@ async def test_https_redirect_downgrade_stops_before_second_request(tmp_path, mo
             )
 
     assert requests == ["https://catalog.example/model.gguf"]
+
+
+@pytest.mark.asyncio
+async def test_client_level_auth_not_applied_on_cross_origin_hop(
+    tmp_path, monkeypatch
+):
+    """A client-level ``auth=`` must not follow the catalog -> CDN hop.
+
+    Independent review of task-19733: header stripping cannot reach this
+    route because httpx applies a client-level ``auth`` inside ``send()``,
+    after ``build_request`` produced the request the guard filtered. The
+    same-origin first hop must still authenticate.
+    """
+    seen: list[httpx.Request] = []
+    body = b"cdn-bytes"
+
+    async def allow_egress(_url: str, *, trusted_origins: frozenset[str]) -> None:
+        """Keep this transport-only test independent of DNS/egress policy."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.host == "catalog.example":
+            return httpx.Response(
+                302,
+                headers={"Location": "https://cdn.example/model.gguf"},
+                request=request,
+            )
+        return httpx.Response(200, content=body, request=request)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.fetch.check_url_or_raise_async", allow_egress
+    )
+    dest = tmp_path / "model.gguf"
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        auth=("alice", "sentinel-not-a-real-key-19733"),
+    ) as client:
+        await stream_fetch(
+            "https://catalog.example/model.gguf",
+            dest,
+            client=client,
+            max_bytes=len(body),
+        )
+
+    assert len(seen) == 2
+    assert "authorization" in seen[0].headers
+    assert "authorization" not in seen[1].headers
+    assert dest.read_bytes() == body

--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -597,14 +597,24 @@ def test_httpx_cross_origin_hop_strips_credentials(monkeypatch):
             "https://a.example/start",
             client=client,
             max_bytes=1024,
-            headers={"Authorization": "Bearer secret", "Cookie": "sid=1", "X-Keep": "y"},
+            headers={
+                "Authorization": "Bearer secret",
+                "Cookie": "sid=1",
+                "X-Keep": "y",
+                "Accept": "text/html",
+            },
         )
     assert resp.content == b"done"
     first, second = seen[0], seen[1]
     assert first.headers.get("authorization") == "Bearer secret"
     assert "authorization" not in second.headers
     assert "cookie" not in second.headers
-    assert second.headers.get("x-keep") == "y"
+    # task-19733: "X-Keep" used to be asserted PRESENT here, encoding the old
+    # denylist rule (drop four known names, forward everything else). The
+    # credential header name is user-supplied in this app, so that rule could
+    # never be safe; the hop now carries only the explicit allowlist.
+    assert "x-keep" not in second.headers
+    assert second.headers.get("accept") == "text/html"
 
 
 def test_httpx_same_host_scheme_downgrade_strips_credentials(monkeypatch):
@@ -1146,10 +1156,16 @@ def test_hop_headers_strips_x_goog_api_key_cross_origin():
     # host would forward the real API key verbatim.
     from tldw_chatbook.Utils.egress import _hop_headers
 
-    headers = {"x-goog-api-key": "secret-key", "X-Keep": "y"}
+    headers = {"x-goog-api-key": "secret-key", "X-Keep": "y", "Accept": "*/*"}
     stripped = _hop_headers(headers, False)
     assert "x-goog-api-key" not in stripped
-    assert stripped.get("X-Keep") == "y"
+    # task-19733 inverted the rule: an unrecognised custom header ("X-Keep")
+    # no longer survives a cross-origin hop either, because nothing here can
+    # tell a user-named credential from a user-named non-credential. What
+    # survives is the explicit allowlist -- see
+    # Tests/Utils/test_egress_cross_origin_header_allowlist.py.
+    assert "X-Keep" not in stripped
+    assert stripped.get("Accept") == "*/*"
 
 
 def test_hop_headers_keeps_x_goog_api_key_same_origin():

--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -586,6 +586,12 @@ def test_httpx_same_origin_redirect_allowed_and_followed():
 
 
 def test_httpx_cross_origin_hop_strips_credentials(monkeypatch):
+    """Credentials do not follow a redirect off the original origin.
+
+    Args:
+        monkeypatch: pytest fixture -- pins DNS resolution to a public IP so
+            this stays a transport-only test.
+    """
     _resolve_to(monkeypatch, ["93.184.216.34"])
     seen = []
     routes = {

--- a/Tests/Utils/test_egress_cross_origin_header_allowlist.py
+++ b/Tests/Utils/test_egress_cross_origin_header_allowlist.py
@@ -1,0 +1,446 @@
+"""Cross-origin redirect hops carry an allowlist, not a denylist (task-19733).
+
+The credential header NAME in this app is user-supplied: a subscription's
+``auth_config`` picks it (``monitoring_engine._fetch_and_parse_feed``, which
+only *defaults* to ``X-API-Key``), and so does a ``SiteConfig``
+(``site_config_manager.SiteConfig.get_headers``, same default). A denylist of
+literal header names therefore cannot be correct -- it closes whichever names
+someone thought of and forwards every other one verbatim to whatever host the
+feed decides to redirect to.
+
+These tests pin the inverted rule: on a hop that leaves the original origin,
+a caller-supplied header is dropped unless it is explicitly known to be safe
+to forward. They are deliberately written so the DEFAULT name and a CUSTOM
+name are separate cases -- appending ``"x-api-key"`` to the old denylist
+passes the default case and still leaks the custom one.
+
+All transports are in-process (``httpx.MockTransport`` / a fake aiohttp
+session); nothing here opens a socket. Every credential value is a synthetic
+sentinel.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from tldw_chatbook.Utils import egress
+from tldw_chatbook.Utils.egress import (
+    guarded_fetch_httpx,
+    guarded_fetch_httpx_async,
+    guarded_fetch_requests,
+)
+
+# Synthetic sentinels -- never a real credential.
+SENTINEL = "sentinel-not-a-real-key-19733"
+CUSTOM_HEADER = "X-Feed-Token"
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Keep these transport tests independent of DNS/egress policy."""
+    monkeypatch.setattr(egress, "_resolve", lambda host: ["93.184.216.34"])
+
+    async def _resolve_async(host):
+        return ["93.184.216.34"]
+
+    monkeypatch.setattr(egress, "_resolve_async", _resolve_async)
+
+
+def _transport(routes, seen):
+    """MockTransport recording every request it is handed."""
+
+    def handler(request):
+        seen.append(request)
+        for prefix, (status, headers, body) in routes.items():
+            if str(request.url).startswith(prefix):
+                return httpx.Response(status, headers=headers, content=body)
+        return httpx.Response(404)
+
+    return httpx.MockTransport(handler)
+
+
+CROSS_ORIGIN_ROUTES = {
+    "https://feed.example/": (302, {"location": "https://evil.example/x"}, b""),
+    "https://evil.example/": (200, {"content-type": "text/plain"}, b"done"),
+}
+
+SAME_ORIGIN_ROUTES = {
+    "https://feed.example/start": (302, {"location": "/moved"}, b""),
+    "https://feed.example/moved": (200, {"content-type": "text/plain"}, b"done"),
+}
+
+
+# ---------------------------------------------------------------------------
+# The custom header name -- the case a longer denylist cannot reach
+# ---------------------------------------------------------------------------
+
+
+def test_sync_custom_named_credential_header_dropped_cross_origin():
+    """A user-chosen credential header name must not reach a second origin.
+
+    ``X-Feed-Token`` is on no denylist anywhere in the codebase. If the rule
+    is name-based, this leaks.
+    """
+    seen = []
+    with httpx.Client(transport=_transport(CROSS_ORIGIN_ROUTES, seen)) as client:
+        resp = guarded_fetch_httpx(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers={CUSTOM_HEADER: SENTINEL},
+        )
+    assert resp.content == b"done"
+    first, second = seen[0], seen[1]
+    assert first.headers.get(CUSTOM_HEADER.lower()) == SENTINEL
+    assert "evil.example" in str(second.url)
+    assert CUSTOM_HEADER.lower() not in second.headers
+    assert SENTINEL not in "".join(second.headers.values())
+
+
+@pytest.mark.asyncio
+async def test_async_custom_named_credential_header_dropped_cross_origin():
+    """Async guarded fetch, same rule (the subscriptions path uses this one)."""
+    seen = []
+    transport = _transport(CROSS_ORIGIN_ROUTES, seen)
+    async with httpx.AsyncClient(transport=transport) as client:
+        resp = await guarded_fetch_httpx_async(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers={CUSTOM_HEADER: SENTINEL},
+        )
+    assert resp.content == b"done"
+    first, second = seen[0], seen[1]
+    assert first.headers.get(CUSTOM_HEADER.lower()) == SENTINEL
+    assert CUSTOM_HEADER.lower() not in second.headers
+    assert SENTINEL not in "".join(second.headers.values())
+
+
+def test_sync_custom_client_default_header_dropped_cross_origin():
+    """The same name set as an httpx client DEFAULT header also must not leak.
+
+    ``_hop_headers`` never sees client-default headers -- httpx merges them
+    onto the built request -- so this is a separate escape route.
+    """
+    seen = []
+    with httpx.Client(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen),
+        headers={CUSTOM_HEADER: SENTINEL},
+    ) as client:
+        resp = guarded_fetch_httpx(
+            "https://feed.example/start", client=client, max_bytes=1024
+        )
+    assert resp.content == b"done"
+    assert seen[0].headers.get(CUSTOM_HEADER.lower()) == SENTINEL
+    assert CUSTOM_HEADER.lower() not in seen[1].headers
+
+
+@pytest.mark.asyncio
+async def test_async_custom_client_default_header_dropped_cross_origin():
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen),
+        headers={CUSTOM_HEADER: SENTINEL},
+    ) as client:
+        resp = await guarded_fetch_httpx_async(
+            "https://feed.example/start", client=client, max_bytes=1024
+        )
+    assert resp.content == b"done"
+    assert seen[0].headers.get(CUSTOM_HEADER.lower()) == SENTINEL
+    assert CUSTOM_HEADER.lower() not in seen[1].headers
+
+
+# ---------------------------------------------------------------------------
+# The default header name -- the case the filing named
+# ---------------------------------------------------------------------------
+
+
+def test_sync_default_x_api_key_dropped_cross_origin():
+    seen = []
+    with httpx.Client(transport=_transport(CROSS_ORIGIN_ROUTES, seen)) as client:
+        guarded_fetch_httpx(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers={"X-API-Key": SENTINEL},
+        )
+    assert seen[0].headers.get("x-api-key") == SENTINEL
+    assert "x-api-key" not in seen[1].headers
+
+
+@pytest.mark.asyncio
+async def test_async_default_x_api_key_dropped_cross_origin():
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen)
+    ) as client:
+        await guarded_fetch_httpx_async(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers={"X-API-Key": SENTINEL},
+        )
+    assert seen[0].headers.get("x-api-key") == SENTINEL
+    assert "x-api-key" not in seen[1].headers
+
+
+def test_requests_path_drops_custom_credential_header_cross_origin():
+    """``guarded_fetch_requests`` shares the rule (article/audio/Confluence)."""
+    requests = pytest.importorskip("requests")
+
+    seen = []
+
+    class _Adapter(requests.adapters.BaseAdapter):
+        def send(self, request, **kwargs):
+            seen.append(request)
+            resp = requests.Response()
+            resp.request = request
+            resp.url = request.url
+            if request.url.startswith("https://feed.example/"):
+                resp.status_code = 302
+                resp.headers["location"] = "https://evil.example/x"
+                resp.raw = _Raw(b"")
+            else:
+                resp.status_code = 200
+                resp.raw = _Raw(b"done")
+            return resp
+
+        def close(self):
+            pass
+
+    class _Raw:
+        def __init__(self, body):
+            self._body = body
+
+        def stream(self, chunk_size, decode_content=True):
+            yield self._body
+
+        def read(self, *a, **k):
+            return self._body
+
+        def release_conn(self):
+            pass
+
+        def close(self):
+            pass
+
+    session = requests.Session()
+    session.mount("https://", _Adapter())
+    try:
+        guarded_fetch_requests(
+            "https://feed.example/start",
+            session=session,
+            max_bytes=1024,
+            headers={CUSTOM_HEADER: SENTINEL},
+        )
+    finally:
+        session.close()
+
+    assert len(seen) == 2
+    assert seen[0].headers.get(CUSTOM_HEADER) == SENTINEL
+    assert CUSTOM_HEADER not in seen[1].headers
+
+
+# ---------------------------------------------------------------------------
+# The rule must not be "drop everything"
+# ---------------------------------------------------------------------------
+
+FORWARDABLE = {
+    "User-Agent": "tldw-chatbook/1.0",
+    "Accept": "application/rss+xml, application/xml",
+    "Accept-Encoding": "gzip, deflate",
+    "Accept-Language": "en-US,en;q=0.9",
+    "If-None-Match": '"etag-abc"',
+    "If-Modified-Since": "Wed, 21 Oct 2015 07:28:00 GMT",
+    "Range": "bytes=100-",
+}
+
+
+def test_sync_forwardable_headers_still_cross_origin():
+    """Content negotiation / conditional / range headers keep working.
+
+    A CDN redirect (the normal case for feeds and artifact downloads) must
+    still receive these, or resume and conditional GET break.
+    """
+    seen = []
+    with httpx.Client(transport=_transport(CROSS_ORIGIN_ROUTES, seen)) as client:
+        guarded_fetch_httpx(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers=dict(FORWARDABLE),
+        )
+    second = seen[1]
+    for name, value in FORWARDABLE.items():
+        assert second.headers.get(name.lower()) == value, name
+
+
+@pytest.mark.asyncio
+async def test_async_forwardable_headers_still_cross_origin():
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen)
+    ) as client:
+        await guarded_fetch_httpx_async(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers=dict(FORWARDABLE),
+        )
+    second = seen[1]
+    for name, value in FORWARDABLE.items():
+        assert second.headers.get(name.lower()) == value, name
+
+
+# ---------------------------------------------------------------------------
+# Same-origin redirects keep authenticating
+# ---------------------------------------------------------------------------
+
+
+def test_sync_same_origin_redirect_keeps_custom_credential_header():
+    seen = []
+    with httpx.Client(transport=_transport(SAME_ORIGIN_ROUTES, seen)) as client:
+        resp = guarded_fetch_httpx(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers={CUSTOM_HEADER: SENTINEL, "X-API-Key": SENTINEL},
+        )
+    assert resp.content == b"done"
+    assert len(seen) == 2
+    for request in seen:
+        assert request.headers.get(CUSTOM_HEADER.lower()) == SENTINEL
+        assert request.headers.get("x-api-key") == SENTINEL
+
+
+@pytest.mark.asyncio
+async def test_async_same_origin_redirect_keeps_custom_credential_header():
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(SAME_ORIGIN_ROUTES, seen)
+    ) as client:
+        resp = await guarded_fetch_httpx_async(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers={CUSTOM_HEADER: SENTINEL},
+        )
+    assert resp.content == b"done"
+    assert len(seen) == 2
+    assert all(r.headers.get(CUSTOM_HEADER.lower()) == SENTINEL for r in seen)
+
+
+# ---------------------------------------------------------------------------
+# The allowlist itself
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_never_admits_a_credential_shaped_name():
+    """Guard on future edits to CROSS_ORIGIN_SAFE_HEADERS.
+
+    The allowlist is the whole safety property now, so an addition to it is a
+    security decision. Everything the old denylist named, plus anything whose
+    name reads like a secret, must stay off it. The ``_STRIP_HEADERS`` half is
+    enforced by construction (both exemption sets subtract it) -- this asserts
+    the enforcement is actually wired up, not just intended.
+    """
+    for name in egress._STRIP_HEADERS:
+        assert name not in egress.CROSS_ORIGIN_SAFE_HEADERS, name
+    for name in egress.CROSS_ORIGIN_SAFE_HEADERS:
+        assert name == name.lower(), f"{name} must be lowercase to match lookups"
+        for marker in ("key", "token", "secret", "auth", "cookie", "password", "sig"):
+            assert marker not in name, f"{name} looks credential-bearing"
+
+
+def test_transport_headers_are_disjoint_from_the_allowlist():
+    """The two exemption sets must not overlap -- one reason per header."""
+    assert not (egress.CROSS_ORIGIN_SAFE_HEADERS & egress._TRANSPORT_HEADERS)
+    for name in egress._STRIP_HEADERS:
+        assert name not in egress._TRANSPORT_HEADERS, name
+
+
+# ---------------------------------------------------------------------------
+# Producer path: a real subscription auth_config, not _hop_headers in isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscription_api_key_auth_does_not_survive_cross_origin_redirect(
+    monkeypatch,
+):
+    """``FeedMonitor`` with a custom-named ``api_key`` auth config.
+
+    This is the reachable production path: feed auth is user-configurable and
+    the header name comes straight from ``auth_config["header"]``.
+    """
+    from tldw_chatbook.Subscriptions import monitoring_engine
+
+    seen = []
+    routes = {
+        "https://feed.example/": (302, {"location": "https://evil.example/x"}, b""),
+        "https://evil.example/": (
+            200,
+            {"content-type": "application/xml"},
+            b"<rss><channel></channel></rss>",
+        ),
+    }
+    transport = _transport(routes, seen)
+
+    real_async_client = httpx.AsyncClient
+
+    def _client_factory(*args, **kwargs):
+        kwargs.pop("verify", None)
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(monitoring_engine.httpx, "AsyncClient", _client_factory)
+
+    monitor = monitoring_engine.FeedMonitor()
+    subscription = {
+        "id": 1,
+        "source": "https://feed.example/start",
+        "type": "rss",
+        "auth_config": json.dumps(
+            {"type": "api_key", "header": CUSTOM_HEADER, "key": SENTINEL}
+        ),
+    }
+
+    await monitor._fetch_and_parse_feed(subscription)
+
+    assert len(seen) == 2, [str(r.url) for r in seen]
+    assert seen[0].headers.get(CUSTOM_HEADER.lower()) == SENTINEL
+    assert "evil.example" in str(seen[1].url)
+    assert CUSTOM_HEADER.lower() not in seen[1].headers
+    assert SENTINEL not in "".join(seen[1].headers.values())
+
+
+@pytest.mark.asyncio
+async def test_site_config_scraper_headers_do_not_survive_cross_origin_redirect():
+    """``SiteConfig.get_headers()`` is the other producer of the same shape."""
+    from tldw_chatbook.Subscriptions.site_config_manager import SiteConfig
+
+    config = SiteConfig(
+        "feed.example",
+        {
+            "auth_type": "api_key",
+            "auth_credentials": {"key_name": CUSTOM_HEADER, "key_value": SENTINEL},
+        },
+    )
+    headers = config.get_headers({"User-Agent": "tldw-chatbook/1.0"})
+    assert headers[CUSTOM_HEADER] == SENTINEL  # the producer really emits it
+
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen)
+    ) as client:
+        await guarded_fetch_httpx_async(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            headers=headers,
+        )
+    assert CUSTOM_HEADER.lower() not in seen[1].headers
+    assert seen[1].headers.get("user-agent") == "tldw-chatbook/1.0"

--- a/Tests/Utils/test_egress_cross_origin_header_allowlist.py
+++ b/Tests/Utils/test_egress_cross_origin_header_allowlist.py
@@ -40,19 +40,49 @@ CUSTOM_HEADER = "X-Feed-Token"
 
 @pytest.fixture(autouse=True)
 def _public_dns(monkeypatch):
-    """Keep these transport tests independent of DNS/egress policy."""
+    """Keep these transport tests independent of DNS/egress policy.
+
+    Args:
+        monkeypatch: pytest fixture -- pins both the sync and async resolvers
+            to a public IP so no test here touches the network.
+    """
     monkeypatch.setattr(egress, "_resolve", lambda host: ["93.184.216.34"])
 
     async def _resolve_async(host):
+        """Stand in for the async resolver.
+
+        Args:
+            host: Hostname being resolved; ignored.
+
+        Returns:
+            A single public IP, always.
+        """
         return ["93.184.216.34"]
 
     monkeypatch.setattr(egress, "_resolve_async", _resolve_async)
 
 
 def _transport(routes, seen):
-    """MockTransport recording every request it is handed."""
+    """MockTransport recording every request it is handed.
+
+    Args:
+        routes: Mapping of URL prefix -> ``(status, headers, body)`` to answer
+            with; the first matching prefix wins.
+        seen: List the handler appends each received request to, in order.
+
+    Returns:
+        An ``httpx.MockTransport`` -- in-process, never opens a socket.
+    """
 
     def handler(request):
+        """Record the request and answer from ``routes``.
+
+        Args:
+            request: The request the MockTransport was handed.
+
+        Returns:
+            The routed response, or a 404 when no prefix matches.
+        """
         seen.append(request)
         for prefix, (status, headers, body) in routes.items():
             if str(request.url).startswith(prefix):
@@ -195,6 +225,15 @@ def test_requests_path_drops_custom_credential_header_cross_origin():
 
     class _Adapter(requests.adapters.BaseAdapter):
         def send(self, request, **kwargs):
+            """Record the prepared request, then answer feed with a redirect.
+
+            Args:
+                request: The ``requests.PreparedRequest`` about to go out.
+                **kwargs: Transport options from ``Session.send``; ignored.
+
+            Returns:
+                A 302 for the feed origin, a 200 with a body otherwise.
+            """
             seen.append(request)
             resp = requests.Response()
             resp.request = request
@@ -356,10 +395,249 @@ def test_allowlist_never_admits_a_credential_shaped_name():
 
 
 def test_transport_headers_are_disjoint_from_the_allowlist():
-    """The two exemption sets must not overlap -- one reason per header."""
+    """The three exemption sets must not overlap -- one reason per header."""
     assert not (egress.CROSS_ORIGIN_SAFE_HEADERS & egress._TRANSPORT_HEADERS)
+    assert not (egress.CROSS_ORIGIN_SAFE_HEADERS & egress._BODY_DESCRIBING_HEADERS)
+    assert not (egress._TRANSPORT_HEADERS & egress._BODY_DESCRIBING_HEADERS)
     for name in egress._STRIP_HEADERS:
         assert name not in egress._TRANSPORT_HEADERS, name
+        assert name not in egress._BODY_DESCRIBING_HEADERS, name
+
+
+# ---------------------------------------------------------------------------
+# Content-Type describes a BODY, so it crosses origin only with one
+# (Qodo review of PR #1942)
+# ---------------------------------------------------------------------------
+
+#: A Content-Type value whose *parameter* is the secret. This is the whole
+#: point: Content-Type is not a fixed vocabulary, it carries arbitrary
+#: caller-controlled text, and a multipart boundary is the ready-made carrier.
+LEAKY_CONTENT_TYPE = f"multipart/form-data; boundary={SENTINEL}"
+
+
+def test_sync_client_default_content_type_does_not_cross_origin_without_a_body():
+    """A client-default ``Content-Type`` must not reach a second origin.
+
+    ``guarded_fetch_httpx`` issues a GET with no body, so nothing on that hop
+    has a content type to describe -- forwarding one only hands the attacker
+    origin whatever text the caller put in it (here, the boundary parameter).
+    """
+    seen = []
+    with httpx.Client(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen),
+        headers={"Content-Type": LEAKY_CONTENT_TYPE},
+    ) as client:
+        resp = guarded_fetch_httpx(
+            "https://feed.example/start", client=client, max_bytes=1024
+        )
+    assert resp.content == b"done"
+    assert len(seen) == 2
+    assert seen[0].headers.get("content-type") == LEAKY_CONTENT_TYPE
+    assert "evil.example" in str(seen[1].url)
+    assert "content-type" not in seen[1].headers
+    assert SENTINEL not in "".join(seen[1].headers.values())
+
+
+@pytest.mark.asyncio
+async def test_async_client_default_content_type_does_not_cross_origin_without_a_body():
+    """Async guarded fetch, same rule (the subscriptions path uses this one)."""
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen),
+        headers={"Content-Type": LEAKY_CONTENT_TYPE},
+    ) as client:
+        resp = await guarded_fetch_httpx_async(
+            "https://feed.example/start", client=client, max_bytes=1024
+        )
+    assert resp.content == b"done"
+    assert len(seen) == 2
+    assert seen[0].headers.get("content-type") == LEAKY_CONTENT_TYPE
+    assert "content-type" not in seen[1].headers
+    assert SENTINEL not in "".join(seen[1].headers.values())
+
+
+def test_requests_session_default_content_type_does_not_cross_origin():
+    """A ``requests.Session`` default ``Content-Type`` leaks by the same route."""
+    requests = pytest.importorskip("requests")
+
+    seen = []
+
+    class _Raw:
+        def __init__(self, body):
+            self._body = body
+
+        def stream(self, chunk_size, decode_content=True):
+            yield self._body
+
+        def read(self, *a, **k):
+            return self._body
+
+        def release_conn(self):
+            pass
+
+        def close(self):
+            pass
+
+    class _Adapter(requests.adapters.BaseAdapter):
+        def send(self, request, **kwargs):
+            """Record the prepared request, then answer feed with a redirect.
+
+            Args:
+                request: The ``requests.PreparedRequest`` about to go out.
+                **kwargs: Transport options from ``Session.send``; ignored.
+
+            Returns:
+                A 302 for the feed origin, a 200 with a body otherwise.
+            """
+            seen.append(request)
+            resp = requests.Response()
+            resp.request = request
+            resp.url = request.url
+            if request.url.startswith("https://feed.example/"):
+                resp.status_code = 302
+                resp.headers["location"] = "https://evil.example/x"
+                resp.raw = _Raw(b"")
+            else:
+                resp.status_code = 200
+                resp.raw = _Raw(b"done")
+            return resp
+
+        def close(self):
+            pass
+
+    session = requests.Session()
+    session.mount("https://", _Adapter())
+    session.headers["Content-Type"] = LEAKY_CONTENT_TYPE
+    try:
+        guarded_fetch_requests(
+            "https://feed.example/start", session=session, max_bytes=1024
+        )
+    finally:
+        session.close()
+
+    assert len(seen) == 2
+    assert seen[0].headers.get("Content-Type") == LEAKY_CONTENT_TYPE
+    assert "Content-Type" not in seen[1].headers
+
+
+def test_bodied_cross_origin_httpx_request_keeps_its_content_type():
+    """The other half of the rule: a hop that HAS a body keeps its type.
+
+    Dropping ``Content-Type`` off a request that carries a body corrupts it,
+    so the strip keys off the outgoing request itself -- a body is present
+    (``Content-Length``/``Transfer-Encoding`` say so) exactly when the type is
+    describing something real. A credential header on the same request is
+    still dropped, and so are the framing headers' neighbours.
+    """
+    with httpx.Client() as client:
+        request = client.build_request(
+            "POST",
+            "https://evil.example/x",
+            content=b'{"payload": 1}',
+            headers={"Content-Type": "application/json", CUSTOM_HEADER: SENTINEL},
+        )
+    assert request.headers.get("content-length") == "14"
+    egress.strip_cross_origin_request_headers(request.headers)
+    assert request.headers.get("content-type") == "application/json"
+    assert request.headers.get("content-length") == "14"
+    assert CUSTOM_HEADER.lower() not in request.headers
+
+
+def test_bodied_cross_origin_streamed_request_keeps_its_content_type():
+    """A chunked (unknown-length) body counts as a body too."""
+
+    def _chunks():
+        yield b"streamed"
+
+    with httpx.Client() as client:
+        request = client.build_request(
+            "POST",
+            "https://evil.example/x",
+            content=_chunks(),
+            headers={"Content-Type": LEAKY_CONTENT_TYPE, CUSTOM_HEADER: SENTINEL},
+        )
+    assert request.headers.get("transfer-encoding") == "chunked"
+    egress.strip_cross_origin_request_headers(request.headers)
+    assert request.headers.get("content-type") == LEAKY_CONTENT_TYPE
+    assert CUSTOM_HEADER.lower() not in request.headers
+
+
+def test_bodied_cross_origin_prepared_request_keeps_its_content_type():
+    """Same rule on the ``requests`` side, which uses a different header type."""
+    requests = pytest.importorskip("requests")
+
+    session = requests.Session()
+    try:
+        prepared = session.prepare_request(
+            requests.Request(
+                "POST",
+                "https://evil.example/x",
+                data=b'{"payload": 1}',
+                headers={"Content-Type": "application/json", CUSTOM_HEADER: SENTINEL},
+            )
+        )
+    finally:
+        session.close()
+    assert prepared.headers.get("Content-Length") == "14"
+    egress.strip_cross_origin_request_headers(prepared.headers)
+    assert prepared.headers.get("Content-Type") == "application/json"
+    assert CUSTOM_HEADER not in prepared.headers
+
+
+def test_zero_length_body_is_not_a_body():
+    """``Content-Length: 0`` describes nothing, so the type must not cross.
+
+    httpx puts ``Content-Length: 0`` on a bodyless POST. Treating "the header
+    exists" as "there is a body" would re-open the leak through any POST.
+    """
+    with httpx.Client() as client:
+        request = client.build_request(
+            "POST",
+            "https://evil.example/x",
+            headers={"Content-Type": LEAKY_CONTENT_TYPE},
+        )
+    assert request.headers.get("content-length") == "0"
+    egress.strip_cross_origin_request_headers(request.headers)
+    assert "content-type" not in request.headers
+
+
+def test_framing_headers_survive_the_strip_on_a_real_built_request():
+    """The strip must not break the request it is protecting.
+
+    ``Host`` is the one that would fail loudly; ``Connection`` and
+    ``Content-Length`` would fail quietly. All three are the client library's
+    own framing, never a caller credential.
+    """
+    with httpx.Client(headers={CUSTOM_HEADER: SENTINEL}) as client:
+        request = client.build_request("GET", "https://evil.example/x")
+    egress.strip_cross_origin_request_headers(request.headers)
+    assert request.headers.get("host") == "evil.example"
+    assert request.headers.get("connection") == "keep-alive"
+    assert request.headers.get("accept-encoding") == "gzip, deflate"
+    assert CUSTOM_HEADER.lower() not in request.headers
+
+
+def test_both_layers_agree_on_content_type():
+    """The caller layer and the built-request layer apply one rule, not two.
+
+    Before this fix they disagreed: ``filter_cross_origin_headers`` dropped a
+    caller-supplied ``Content-Type`` while ``strip_cross_origin_request_headers``
+    exempted a client-default one unconditionally. Both now key off the same
+    question -- does this hop carry a body?
+    """
+    caller = {"Content-Type": LEAKY_CONTENT_TYPE, "Accept": "text/plain"}
+    bodyless = egress.filter_cross_origin_headers(caller)
+    assert "Content-Type" not in bodyless
+    assert bodyless["Accept"] == "text/plain"
+
+    bodied = egress.filter_cross_origin_headers(caller, has_body=True)
+    assert bodied["Content-Type"] == LEAKY_CONTENT_TYPE
+    assert bodied["Accept"] == "text/plain"
+
+    # ...and neither ``has_body`` value ever re-admits a credential.
+    assert CUSTOM_HEADER not in egress.filter_cross_origin_headers(
+        {CUSTOM_HEADER: SENTINEL}, has_body=True
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +653,10 @@ async def test_subscription_api_key_auth_does_not_survive_cross_origin_redirect(
 
     This is the reachable production path: feed auth is user-configurable and
     the header name comes straight from ``auth_config["header"]``.
+
+    Args:
+        monkeypatch: pytest fixture -- swaps ``httpx.AsyncClient`` in the
+            monitoring engine for one bound to an in-process MockTransport.
     """
     from tldw_chatbook.Subscriptions import monitoring_engine
 
@@ -392,6 +674,16 @@ async def test_subscription_api_key_auth_does_not_survive_cross_origin_redirect(
     real_async_client = httpx.AsyncClient
 
     def _client_factory(*args, **kwargs):
+        """Build an ``AsyncClient`` bound to the in-process MockTransport.
+
+        Args:
+            *args: Positional arguments the production code passed.
+            **kwargs: Keyword arguments the production code passed; ``verify``
+                is dropped because it conflicts with an explicit transport.
+
+        Returns:
+            A real ``httpx.AsyncClient`` that never opens a socket.
+        """
         kwargs.pop("verify", None)
         kwargs["transport"] = transport
         return real_async_client(*args, **kwargs)

--- a/Tests/Utils/test_egress_cross_origin_header_allowlist.py
+++ b/Tests/Utils/test_egress_cross_origin_header_allowlist.py
@@ -444,3 +444,82 @@ async def test_site_config_scraper_headers_do_not_survive_cross_origin_redirect(
         )
     assert CUSTOM_HEADER.lower() not in seen[1].headers
     assert seen[1].headers.get("user-agent") == "tldw-chatbook/1.0"
+
+
+# ---------------------------------------------------------------------------
+# The other route a credential reaches the wire: a CLIENT-level auth=
+# ---------------------------------------------------------------------------
+
+
+def test_sync_client_level_auth_not_applied_cross_origin():
+    """``httpx.Client(auth=...)`` must not re-attach on a cross-origin hop.
+
+    Header stripping cannot reach this one: httpx applies a client-level
+    ``auth`` inside ``send()``, AFTER ``build_request`` produced the request
+    the guard filtered. Found by independent review of task-19733 -- the
+    allowlist closed the ``headers=``/client-default-header routes and this
+    third route still put ``Authorization: Basic ...`` on the wire to the
+    second origin.
+    """
+    seen = []
+    with httpx.Client(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen),
+        auth=("alice", SENTINEL),
+    ) as client:
+        resp = guarded_fetch_httpx(
+            "https://feed.example/start", client=client, max_bytes=1024
+        )
+    assert resp.content == b"done"
+    assert len(seen) == 2
+    assert "authorization" in seen[0].headers  # same-origin hop still authenticates
+    assert "authorization" not in seen[1].headers
+    assert SENTINEL not in "".join(seen[1].headers.values())
+
+
+@pytest.mark.asyncio
+async def test_async_client_level_auth_not_applied_cross_origin():
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(CROSS_ORIGIN_ROUTES, seen),
+        auth=("alice", SENTINEL),
+    ) as client:
+        resp = await guarded_fetch_httpx_async(
+            "https://feed.example/start", client=client, max_bytes=1024
+        )
+    assert resp.content == b"done"
+    assert len(seen) == 2
+    assert "authorization" in seen[0].headers
+    assert "authorization" not in seen[1].headers
+
+
+@pytest.mark.asyncio
+async def test_async_same_origin_redirect_still_applies_client_level_auth():
+    """The suppression is per-hop, not permanent: same-origin still authenticates."""
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(SAME_ORIGIN_ROUTES, seen),
+        auth=("alice", SENTINEL),
+    ) as client:
+        resp = await guarded_fetch_httpx_async(
+            "https://feed.example/start", client=client, max_bytes=1024
+        )
+    assert resp.content == b"done"
+    assert len(seen) == 2
+    assert all("authorization" in r.headers for r in seen)
+
+
+@pytest.mark.asyncio
+async def test_async_explicit_auth_argument_still_applies_same_origin():
+    """The function's own ``auth=`` parameter keeps working on same-origin hops."""
+    seen = []
+    async with httpx.AsyncClient(
+        transport=_transport(SAME_ORIGIN_ROUTES, seen)
+    ) as client:
+        await guarded_fetch_httpx_async(
+            "https://feed.example/start",
+            client=client,
+            max_bytes=1024,
+            auth=httpx.BasicAuth("alice", SENTINEL),
+        )
+    assert len(seen) == 2
+    assert all("authorization" in r.headers for r in seen)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5958,3 +5958,25 @@ deleting the mirror and importing the one object; the guard became an
 identity assertion plus `assert not hasattr(fetch, "_STRIP_HEADERS")`, so a
 re-introduced mirror fails. **A test that pins a duplicated constant is
 evidence the duplication should not exist, not evidence that it is safe.**
+
+**Third half, found by the independent review of the same task.** The fix
+above filtered the *built request object* — `request.headers` after
+`client.build_request(...)` — and its docstring then claimed cross-origin hops
+carry nothing but the allowlist "whether the header came from the `headers`
+argument or from the client object's own defaults". A probe with
+`httpx.Client(auth=("alice", <sentinel>))` put `Authorization: Basic …` on the
+wire to the second origin anyway. `httpx` applies a client-level `auth` inside
+`send()`, *after* `build_request` returns — so it is structurally invisible to
+anything that inspects the request object. (The docstring did carry a residual
+note, but scoped to an auth *callable*; a plain tuple leaked the same way.)
+
+**Generalises to:** "I filtered the request" is not the same as "I filtered
+what goes on the wire". Before trusting a strip, ask what the client library
+adds *between* the object you hold and the socket — auth flows, cookie jars,
+proxy headers, retry/redirect middleware. Prove it by constructing the
+credential through each injection route the API offers (per-call arg, client
+default header, cookie jar, `auth=`), not just the one the code under review
+happens to use. Three of those four routes were already closed here; the
+fourth was the one no test had ever expressed. The fix was
+`send(..., auth=None)` — explicit `None`, because *omitting* the argument
+leaves httpx's `USE_CLIENT_DEFAULT` sentinel in play and changes nothing.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5913,3 +5913,48 @@ Then mutate the fix: a negative-space assertion that stays green under the
 mutation is not a test. And in this codebase specifically: **`loguru` uses
 brace formatting**; a `%s` template is a silent no-op that drops your payload,
 while stdlib `logging` calls on the same page take `%s` correctly.
+
+## A denylist over USER-NAMED values, and the mirror test that made it look guarded (TASK-19733, 2026-08-22)
+
+`Utils/egress.py`'s cross-origin redirect rule was
+`_STRIP_HEADERS = ("authorization", "cookie", "proxy-authorization",
+"x-goog-api-key")` — drop those four on a hop that leaves the origin, forward
+everything else. The obvious repair for the filed defect was "append
+`x-api-key`". It would have been wrong, and the test suite would have gone
+green on it.
+
+The reason is one line in `Subscriptions/monitoring_engine.py`:
+
+```python
+key_header = auth_config.get("header", "X-API-Key")
+headers[key_header] = auth_config.get("key", "")
+```
+
+The header NAME is user config. `X-API-Key` is only the default. So the
+denylist was being asked to enumerate a set the user gets to extend at
+runtime — unfixable by extending the list, whatever names you add. Written as
+a born-red test with a header the user picked (`X-Feed-Token`), the base
+failure showed the key arriving at the redirect target:
+
+```
+assert 'x-feed-token' not in Headers({'host': 'evil.example', ...,
+    'x-feed-token': 'sentinel-not-a-real-key-19733'})
+```
+
+**Generalises to:** whenever a security filter matches on a value the user
+supplies (header name, param name, filename, env var, tool name), a denylist
+is not a weaker allowlist — it is not a control at all. Invert it. And write
+the born-red test with a name nobody would have thought to denylist: had the
+test used `X-API-Key`, the one-literal fix would have passed it and the real
+hole would have shipped.
+
+**Second half, same task.** `Model_Artifacts/fetch.py` kept a hand-mirrored
+copy of that tuple, and `Tests/Model_Artifacts/test_stream_fetch.py` pinned
+`set(fetch._STRIP_HEADERS) == set(egress._STRIP_HEADERS)`. That guard reads
+like the drift is handled. It is not: it detects divergence only *after*
+someone edits one side, and only if they run that suite — and it actively
+rewards re-synchronising the copy, which preserves the defect shape. Fixed by
+deleting the mirror and importing the one object; the guard became an
+identity assertion plus `assert not hasattr(fetch, "_STRIP_HEADERS")`, so a
+re-introduced mirror fails. **A test that pins a duplicated constant is
+evidence the duplication should not exist, not evidence that it is safe.**

--- a/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
+++ b/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
@@ -159,13 +159,15 @@ negotiation (`accept`, `accept-charset`, `accept-encoding`,
 `accept-language`), cache validators (`cache-control`, `pragma`, `if-match`,
 `if-none-match`, `if-modified-since`, `if-unmodified-since`), partial content
 (`range`, `if-range`), and `user-agent`. A second, separate frozenset
-`_TRANSPORT_HEADERS` (`host`, `connection`, `content-length`, `content-type`,
+`_TRANSPORT_HEADERS` (`host`, `connection`, `content-length`,
 `transfer-encoding`, …) is exempt: those are framing owned by the HTTP client,
 and stripping `host` off a built request would break the very request the
-guard protects. `_STRIP_HEADERS` is retained but demoted — it is no longer the
-rule, it is the never-cross FLOOR: both exemption sets are constructed by
+guard protects. A third, `_BODY_DESCRIBING_HEADERS` (`content-type`), is
+exempt only *conditionally* — see the Qodo section below. `_STRIP_HEADERS` is
+retained but demoted — it is no longer the
+rule, it is the never-cross FLOOR: all three exemption sets are constructed by
 subtracting it (`frozenset({...}) - frozenset(_STRIP_HEADERS)`), so a careless
-future edit that adds `authorization` to either list cannot take effect.
+future edit that adds `authorization` to any of them cannot take effect.
 `test_allowlist_never_admits_a_credential_shaped_name` asserts that wiring is
 live, and additionally rejects any allowlist entry whose name reads like a
 secret (`key`/`token`/`secret`/`auth`/`cookie`/`password`/`sig`).
@@ -207,11 +209,11 @@ earlier claim that this client downloads *release assets* was wrong, all four
 of its guarded call sites are `api.github.com` JSON endpoints);
 `Model_Artifacts` resume (`Range`, `If-Range`) is allowlisted, which matters
 because catalog→CDN is the normal artifact download. `Confluence` passes
-`Content-Type: application/json` as a CALLER header, and caller headers are
-filtered by `filter_cross_origin_headers`, which does **not** consult
-`_TRANSPORT_HEADERS` — so it is dropped off-origin, not preserved as first
-claimed. Harmless (these are bodyless GETs), but the two layers are
-deliberately asymmetric and the note was wrong about which one applies.
+`Content-Type: application/json` as a CALLER header, and it is dropped
+off-origin. Harmless — these are bodyless GETs, so the type describes
+nothing. (Until the Qodo section below, the two layers reached that same
+outcome by *different* rules — the caller layer dropped it, the built-request
+layer exempted it — which is the asymmetry Qodo's finding closed.)
 Same-origin redirects are untouched — the same-origin
 branch returns the caller's headers verbatim, so authenticated feeds that
 redirect within their own origin keep authenticating (pinned by two tests).
@@ -339,13 +341,13 @@ trustworthy, and the surrounding docstring asserted it was already covered.
    Fetch spec removes the header permanently once an origin boundary is
    crossed. The recipient here is still the credential's own origin, so this
    is hardening, not disclosure to a third party; low severity.
-2. *`content-type` is exempt on the BUILT-request layer.* It is the only
-   exempted header that can carry arbitrary caller text, and a client-default
+2. *`content-type` is exempt on the BUILT-request layer.* **FIXED — see the
+   Qodo section below.** It is the only exempted header that can carry
+   arbitrary caller text, and a client-default
    `Content-Type: application/json; boundary=<secret>` was measured arriving
-   cross-origin. Every guarded helper is GET-only, so nothing needs it today;
-   the code comment keeps it for a hypothetical future body-carrying helper.
-   Low severity, no live exposure — but it is the answer to "construct a leak
-   using only exempted headers".
+   cross-origin. Recorded here as a LOW residual; Qodo independently raised
+   the same thing as a bug on PR #1942, and that convergence is why it was
+   fixed rather than filed.
 
 **Verified independently:** born-red at base reproduces with the defect
 signature; `4012 passed / 4 skipped / 0 failed` across the eight suites and
@@ -361,3 +363,115 @@ Yandex (`:4228`/`:4235`) are genuinely clean because `requests` strips
 `tldw_chatbook/Model_Artifacts/fetch.py`,
 `Tests/Utils/test_egress_cross_origin_header_allowlist.py` (new),
 `Tests/Utils/test_egress.py`, `Tests/Model_Artifacts/test_stream_fetch.py`.
+
+## Qodo review of PR #1942 — `Content-Type` now travels only with a body
+
+Qodo raised as a Bug/Security finding exactly what the review addendum above
+had recorded as LOW residual #2: `strip_cross_origin_request_headers` exempted
+`content-type` via `_TRANSPORT_HEADERS`, so a **client-default** `Content-Type`
+still crossed the origin boundary. `Content-Type` is the one exempted header
+whose value is arbitrary caller-controlled text — a multipart `boundary=`
+parameter is the ready-made carrier — so it violated this branch's own
+"only the allowlist crosses origin" policy. Two independent reviewers
+converging is why it was fixed here rather than filed.
+
+**The rule, exactly.** `Content-Type` describes a body, so it may cross an
+origin boundary **only on a hop that actually carries one**:
+
+* no body on the cross-origin hop → `content-type` is dropped like any other
+  non-allowlisted header;
+* body present → it is preserved, because dropping it corrupts the request.
+
+The in-code comment that argued for the old exemption ("the day one of them
+grows a body, silently dropping Content-Type would corrupt the request") was
+sound reasoning with too broad a conclusion: it protected a hypothetical body
+by leaking on every bodyless request. The conditional form protects both.
+
+**How "has a body" is decided — off the outgoing request, not the status
+code.** `_built_request_carries_body()` reads the request's own framing:
+`Transfer-Encoding` present, or `Content-Length` parsing to > 0. Redirect
+semantics say 301/302/303 convert to GET and drop the body (so `Content-Type`
+must go) while 307/308 preserve both (so it must stay) — but keying off the
+status code would only re-derive what the client library has already decided.
+By the time the guard runs, the client has *built* the request for this hop,
+so its framing is ground truth however it got here. Probe evidence that this
+is safe to rely on (`scratchpad/probe_body_framing.out`): httpx 0.28.1 and
+requests 2.32.5 both emit `Content-Length` for a known-length body and
+`Transfer-Encoding: chunked` for a streamed one at *build* time
+(`Client.build_request` / `Session.prepare_request`), a bodyless GET gets
+neither, and a bodyless POST gets `Content-Length: 0` — which is why the
+value is checked and not merely the header's presence
+(`test_zero_length_body_is_not_a_body`). Anything unparseable is treated as
+"no body": deny-by-default, since a header that describes a body it cannot
+prove exists has no business crossing an origin.
+
+**The asymmetry is gone.** Both layers now call one predicate,
+`_may_cross_origin(name, *, has_body)`. The only difference left is where
+`has_body` comes from, and that difference is structural rather than
+accidental: `strip_cross_origin_request_headers` **infers** it from the built
+request, while `filter_cross_origin_headers` takes it as an explicit keyword
+(default `False`) because a bare `headers` mapping says nothing about a body.
+Every `guarded_fetch_*` helper and `Model_Artifacts.stream_fetch` issue a
+bodyless GET, so they all take the default; a future body-carrying caller must
+pass `has_body=True` or lose its `Content-Type`.
+`test_both_layers_agree_on_content_type` pins both halves.
+
+**Born-red evidence** (run at this branch's HEAD *before* the fix,
+`Tests/Utils/test_egress_cross_origin_header_allowlist.py`: **6 failed, 22
+passed**). The leak, verbatim:
+
+```
+assert 'content-type' not in Headers({'host': 'evil.example', ...,
+    'content-type': 'multipart/form-data; boundary=sentinel-not-a-real-key-19733'})
+```
+
+— i.e. a client-default `Content-Type` carrying the sentinel in its boundary
+parameter arriving at the attacker origin, reproduced on all three transports
+(`httpx.Client`, `httpx.AsyncClient`, `requests.Session`). The bodied-hop
+pins (`test_bodied_cross_origin_{httpx,streamed,prepared}_request_keeps_its_content_type`)
+and `test_framing_headers_survive_the_strip_on_a_real_built_request` **passed**
+before the fix — they are the non-regression half, and they are what stops the
+fix from being "just delete the exemption".
+
+**Mutation-checked, both directions** (Edit-based; no mutation residue —
+`grep MUTATION` clean afterwards):
+
+| mutation | red |
+| --- | --- |
+| A: `return True` for `_BODY_DESCRIBING_HEADERS` (pre-fix, unconditional exemption) | the 3 client-default leak tests, `test_zero_length_body_is_not_a_body`, `test_both_layers_agree_on_content_type` — **5 failed, 136 passed** |
+| B: `return False` (naive "just delete the exemption") | the 3 bodied-hop pins + `test_both_layers_agree_on_content_type` — **4 failed, 137 passed** |
+| C: drop `host` from `_TRANSPORT_HEADERS` | `test_framing_headers_survive_the_strip_on_a_real_built_request` only (`assert None == 'evil.example'`) — **1 failed, 27 passed** |
+
+The two red sets under A and B are disjoint except for the layer-agreement
+test, which is the point: neither the old behaviour nor the naive deletion
+satisfies both halves of the rule. C confirms `host` (and with it the framing
+set) is still genuinely exempt — stripping it breaks the request the guard
+exists to protect.
+
+**Also in this review round** (Qodo findings 1 and 2, both repo-rule
+violations): `filter_cross_origin_headers` and
+`strip_cross_origin_request_headers` were untyped. They are now
+`filter_cross_origin_headers(headers: Mapping[str, str] | None, *, has_body:
+bool = False) -> dict[str, str]` and
+`strip_cross_origin_request_headers(request_headers: MutableMapping[str, str])
+-> None`. `Mapping`/`MutableMapping` is the honest shape rather than `dict`:
+every mapping these are actually called with — plain `dict`, `httpx.Headers`,
+`requests.structures.CaseInsensitiveDict`, `multidict.CIMultiDict` — subclasses
+`typing.MutableMapping[str, str]`, while `dict` would have excluded three of
+the four. `_hop_headers` got the same treatment. Google-style `Args:` sections
+were added to the branch's own new/modified test functions that take
+parameters (`test_stream_fetch.py`'s two new tests and their nested doubles,
+`test_egress.py`'s modified `test_httpx_cross_origin_hop_strips_credentials`,
+and the new allowlist file's fixture/helpers); pre-existing tests this branch
+did not touch were deliberately left alone.
+
+**Verification.** venv `../../.venv/bin/python`, `PYTHONPATH` pinned with a
+`tldw_chatbook.__file__` assert; in-process transports only (`httpx.MockTransport`,
+a `requests` `BaseAdapter` double), no sockets; every credential value is the
+synthetic sentinel `sentinel-not-a-real-key-19733`. Utils + Model_Artifacts +
+Subscriptions + Web_Scraping + Local_Ingestion + Scheduling + tldw_api + Media:
+**4026 passed / 4 skipped / 0 failed** — exactly the pre-fix 4017 plus the 9
+tests this round adds. Repo-wide `--collect-only -q`: **54656 collected, 0
+errors**. `ruff check` on the four changed files reports 9 findings, all
+byte-identical to what `origin/dev` already reports for the same files (1 F821
+in `egress.py`, 8 E402 in `Tests/Utils/test_egress.py`) — no new lint.

--- a/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
+++ b/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
@@ -2,8 +2,9 @@
 id: TASK-19733
 title: >-
   Shared egress primitive does not strip x-api-key on cross-origin redirects
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-21 23:40'
 labels:
   - security
@@ -93,27 +94,27 @@ the other turns that guard red.
 
 ## Acceptance Criteria
 
-- [ ] A credential header carrying a user-configured API key (default
+- [x] A credential header carrying a user-configured API key (default
       `X-API-Key` **and** a custom header name the user chose) is absent from
       the request when a guarded fetch follows a redirect to a different origin
-- [ ] The cross-origin rule is expressed so that a newly-introduced credential
+- [x] The cross-origin rule is expressed so that a newly-introduced credential
       header name is safe by default — a header the caller supplies is not
       forwarded cross-origin unless it is on an explicit non-credential
       allowlist — rather than by adding another literal to a denylist
-- [ ] Same-origin redirects still carry the header, so authenticated feeds that
+- [x] Same-origin redirects still carry the header, so authenticated feeds that
       redirect within their own origin keep working
-- [ ] Born-red tests drive an actual cross-origin redirect through both
+- [x] Born-red tests drive an actual cross-origin redirect through both
       `guarded_fetch_httpx` and `guarded_fetch_httpx_async` and assert the
       credential header is absent on the second hop, including one case with a
       non-default header name; each is mutation-checked (restoring the old
       behaviour makes it red)
-- [ ] At least one test exercises the real producer path
+- [x] At least one test exercises the real producer path
       (`monitoring_engine`'s `api_key` auth config or a `SiteConfig` scraper),
       not only `_hop_headers` in isolation
-- [ ] `Model_Artifacts/fetch.py`'s mirrored tuple and
+- [x] `Model_Artifacts/fetch.py`'s mirrored tuple and
       `Tests/Model_Artifacts/test_stream_fetch.py`'s drift guard are updated in
       the same change and remain green
-- [ ] The five named non-egress siblings (Kobold, Bing, Brave, Serper, Exa) are
+- [x] The five named non-egress siblings (Kobold, Bing, Brave, Serper, Exa) are
       either fixed the same way or recorded — with the reason — as a separate
       tracked item; the task is not closed with them silently unaddressed
 
@@ -123,3 +124,163 @@ Deliberately scoped apart from TASK-19557: that task fixes two clients that do
 not use the primitive. Fixing the primitive does not fix them, and fixing them
 does not fix the ~25 call sites that route through `Utils/egress.py`. Both are
 needed; neither subsumes the other.
+
+## Implementation Plan
+
+1. Write the born-red tests first, against unmodified `origin/dev`: a
+   custom-named credential header (`X-Feed-Token` — on no denylist anywhere)
+   and the default `X-API-Key`, each driven through a real cross-origin
+   redirect in `guarded_fetch_httpx`, `guarded_fetch_httpx_async` and
+   `guarded_fetch_requests`, plus the two real producer paths.
+2. Invert `_hop_headers`'s cross-origin branch from a name denylist to an
+   explicit allowlist, and apply the same allowlist to the BUILT request so
+   client-default headers are covered too.
+3. Delete `Model_Artifacts/fetch.py`'s hand-mirrored tuple; import the one
+   policy object instead, and re-point the drift guard at identity.
+4. Run egress / Model_Artifacts / subscriptions / web-scraping suites and a
+   repo-wide `--collect-only`; baseline anything red against `origin/dev`.
+5. Record the five non-egress siblings for separate filing.
+
+## Implementation Notes
+
+Inverted the cross-origin redirect rule in `Utils/egress.py` from a denylist
+of credential header names to an allowlist of headers that may cross an
+origin boundary. `x-api-key` was never added — adding it would have been the
+wrong fix, because both producers take the header NAME from user config
+(`monitoring_engine._fetch_and_parse_feed` and `SiteConfig.get_headers` only
+*default* to `X-API-Key`), so any literal list closes one name and forwards
+every other one verbatim.
+
+**The rule.** New `CROSS_ORIGIN_SAFE_HEADERS` in `Utils/egress.py`: on a hop
+that leaves the original origin, a header survives only if it is on that
+frozenset. Membership test — forwarding it off-origin must be both *needed by
+a real caller* and *incapable of carrying a secret*. That admits content
+negotiation (`accept`, `accept-charset`, `accept-encoding`,
+`accept-language`), cache validators (`cache-control`, `pragma`, `if-match`,
+`if-none-match`, `if-modified-since`, `if-unmodified-since`), partial content
+(`range`, `if-range`), and `user-agent`. A second, separate frozenset
+`_TRANSPORT_HEADERS` (`host`, `connection`, `content-length`, `content-type`,
+`transfer-encoding`, …) is exempt: those are framing owned by the HTTP client,
+and stripping `host` off a built request would break the very request the
+guard protects. `_STRIP_HEADERS` is retained but demoted — it is no longer the
+rule, it is the never-cross FLOOR: both exemption sets are constructed by
+subtracting it (`frozenset({...}) - frozenset(_STRIP_HEADERS)`), so a careless
+future edit that adds `authorization` to either list cannot take effect.
+`test_allowlist_never_admits_a_credential_shaped_name` asserts that wiring is
+live, and additionally rejects any allowlist entry whose name reads like a
+secret (`key`/`token`/`secret`/`auth`/`cookie`/`password`/`sig`).
+
+Applied at both layers, because they leak independently:
+- `_hop_headers()` filters what the CALLER passed (`filter_cross_origin_headers`).
+- `strip_cross_origin_request_headers()` filters the BUILT request in
+  `guarded_fetch_httpx`, `guarded_fetch_httpx_async` and
+  `guarded_fetch_requests` — that is the only layer that sees the client
+  object's DEFAULT headers (`httpx.Client(headers=...)`, a `requests.Session`'s
+  `headers`/`auth`/cookies), which `_hop_headers` never sees. The old code
+  popped a fixed four names here; it now applies the same allowlist, so a
+  user-named credential set as a client default is covered too (proved by two
+  of the born-red tests). Range/conditional headers are unaffected because they
+  are on the allowlist.
+
+`guarded_fetch_aiohttp` gets the allowlist through `_hop_headers` only; it has
+no built-request object to post-filter, so a credential set as an
+`aiohttp.ClientSession(headers=...)` default remains a documented residual —
+unchanged by this task, and no live caller does that.
+
+**What this might break — stated plainly.** A *non-credential* custom header a
+user configured for a feed (`custom_headers` on a subscription, `custom_headers`
+on a `SiteConfig`) also stops being forwarded once that feed redirects
+off-origin. Nothing at this layer can tell `X-Feed-Token` from
+`X-Client-Version` by name, and that is precisely why the denylist could not
+work; being wrong in this direction costs a redirected request some optional
+metadata, being wrong in the other direction hands a user's API key to whoever
+bought the domain. Concretely reviewed against every live caller: the
+subscriptions/watchlists header build (`User-Agent`, `Accept`,
+`Accept-Encoding`, `If-None-Match`, `If-Modified-Since`) is entirely
+allowlisted; `github_api_client` (`Accept: application/vnd.github.v3+json`,
+`User-Agent`) is allowlisted, which matters because release-asset downloads
+redirect to `objects.githubusercontent.com`; `Model_Artifacts` resume
+(`Range`, `If-Range`) is allowlisted, which matters because catalog→CDN is the
+normal artifact download; `Confluence`'s `Content-Type: application/json` is in
+`_TRANSPORT_HEADERS`. Same-origin redirects are untouched — the same-origin
+branch returns the caller's headers verbatim, so authenticated feeds that
+redirect within their own origin keep authenticating (pinned by two tests).
+
+**The hand-mirrored constant: removed, not re-synced.** `Model_Artifacts/fetch.py`
+kept its own copy of `_STRIP_HEADERS` with `test_stream_fetch.py` pinning
+`set(...) == set(...)`. Re-synchronising the copy would have preserved the
+defect shape — a duplicated security constant whose correctness depends on
+someone remembering a test. `fetch.py` now imports `CROSS_ORIGIN_SAFE_HEADERS`,
+`filter_cross_origin_headers` and `strip_cross_origin_request_headers` from
+`egress` and has no local copy; the guard became
+`test_cross_origin_header_policy_is_shared_not_mirrored`, asserting object
+IDENTITY (`fetch.CROSS_ORIGIN_SAFE_HEADERS is egress.CROSS_ORIGIN_SAFE_HEADERS`)
+plus `not hasattr(fetch, "_STRIP_HEADERS")` so re-introducing a mirror fails.
+Divergence is now not expressible rather than merely detected late.
+
+**Born-red evidence.** `Tests/Utils/test_egress_cross_origin_header_allowlist.py`
+was written and run FIRST against unmodified `origin/dev` (`3193816e7`):
+**9 failed, 4 passed**. The failures show the sentinel arriving at the second
+origin, e.g.
+
+```
+assert 'x-feed-token' not in Headers({'host': 'evil.example', ...,
+    'user-agent': 'tldw-chatbook/1.0 (+https://github.com/tld...',
+    'x-feed-token': 'sentinel-not-a-real-key-19733'})
+```
+
+— that particular one is the **producer** test, driving
+`FeedMonitor._fetch_and_parse_feed` with a real `auth_config`
+`{"type": "api_key", "header": "X-Feed-Token", ...}` (the feed's own
+`User-Agent` in the dump is the tell that this is the production header
+build, not a hand-made dict). The default-name case failed identically with
+`'x-api-key': 'sentinel-...'`; the `requests` path failed with
+`'X-Feed-Token'` present on the second prepared request. The 4 that passed at
+base are the deliberate non-regression pins — same-origin redirect keeps the
+header, and `User-Agent`/`Accept`/`Accept-Encoding`/`Accept-Language`/
+`If-None-Match`/`If-Modified-Since`/`Range` still forward cross-origin — so the
+fix could not be "drop everything".
+
+Mutation re-check after implementation (patch saved, `git apply -R`, re-run,
+`git apply`, checksums verified byte-identical): **13 failed, 17 passed**,
+which additionally covers the two tests written after the fix
+(`test_cross_origin_hop_keeps_range_but_drops_custom_credential`, the
+identity drift guard). All in-process transports (`httpx.MockTransport`, a
+`requests` `BaseAdapter` double); no sockets; every credential value is the
+synthetic sentinel `sentinel-not-a-real-key-19733`.
+
+**Two pre-existing tests changed on purpose.**
+`test_httpx_cross_origin_hop_strips_credentials` and
+`test_hop_headers_strips_x_goog_api_key_cross_origin` both asserted that an
+arbitrary custom header (`X-Keep`) SURVIVES a cross-origin hop — they encoded
+the old denylist rule as intended behaviour. Each now asserts `X-Keep` is
+dropped and an allowlisted header (`Accept`) survives, with a comment naming
+this task. These were the only two reds in the whole verified set.
+
+**The five named non-egress siblings: recorded, not fixed** (re-verified at
+this base; all still `requests` with default `allow_redirects=True`, and
+`requests` strips only `Authorization`/`Cookie` cross-origin):
+
+| site | header | call | why not fixed here |
+| --- | --- | --- | --- |
+| `LLM_Calls/LLM_API_Calls_Local.py:1010` (Kobold) | `X-Api-Key` | `session.post` `:1060` | POST; `guarded_fetch_*` is GET-only. **Highest risk of the five — `current_api_base_url` is user-configured.** |
+| `Web_Scraping/WebSearch_APIs.py:2711` (Bing) | `Ocp-Apim-Subscription-Key` | `session.get` | GET, but re-routing it changes its `Retry`/`HTTPAdapter` session behaviour; user-configurable `bing_search_api_url`. |
+| `Web_Scraping/WebSearch_APIs.py:2961` (Brave) | `X-Subscription-Token` | `requests.get` | hard-coded vendor endpoint. |
+| `Web_Scraping/WebSearch_APIs.py:3985` (Serper) | `X-API-KEY` | `requests.post` | POST; hard-coded `google.serper.dev`. |
+| `Web_Scraping/WebSearch_APIs.py:4055` (Exa) | `x-api-key` | `requests.post` | POST; hard-coded `api.exa.ai`. |
+
+None of them touch `Utils/egress.py`, so fixing the primitive cannot reach
+them and folding them in here would mix a shared-primitive change with five
+per-call-site rewrites in one diff. Their minimal fix is `allow_redirects=False`
+(none of these APIs legitimately redirects), which is a different, testable
+change. They were already listed as residue in TASK-19557's notes (items 2 and
+3) and remain unfiled — **they need a task of their own; this one is closed
+having named them, not having fixed them.**
+
+Kagi (`:3672`) and Yandex (`:4228`) use `Authorization` and are clean, as the
+filing said.
+
+**Modified files.** `tldw_chatbook/Utils/egress.py`,
+`tldw_chatbook/Model_Artifacts/fetch.py`,
+`Tests/Utils/test_egress_cross_origin_header_allowlist.py` (new),
+`Tests/Utils/test_egress.py`, `Tests/Model_Artifacts/test_stream_fetch.py`.

--- a/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
+++ b/backlog/tasks/task-19733 - Shared egress primitive does not strip x-api-key on cross-origin redirects.md
@@ -197,12 +197,22 @@ metadata, being wrong in the other direction hands a user's API key to whoever
 bought the domain. Concretely reviewed against every live caller: the
 subscriptions/watchlists header build (`User-Agent`, `Accept`,
 `Accept-Encoding`, `If-None-Match`, `If-Modified-Since`) is entirely
-allowlisted; `github_api_client` (`Accept: application/vnd.github.v3+json`,
-`User-Agent`) is allowlisted, which matters because release-asset downloads
-redirect to `objects.githubusercontent.com`; `Model_Artifacts` resume
-(`Range`, `If-Range`) is allowlisted, which matters because catalog→CDN is the
-normal artifact download; `Confluence`'s `Content-Type: application/json` is in
-`_TRANSPORT_HEADERS`. Same-origin redirects are untouched — the same-origin
+allowlisted; `github_api_client`'s client-DEFAULT headers
+(`Accept: application/vnd.github.v3+json`, `User-Agent`) are allowlisted, so
+its calls keep working across a redirect off `api.github.com` (independent
+review drove `GitHubAPIClient.get_file_content` through a real
+`api.github.com` → `objects.githubusercontent.com` 302 on a MockTransport:
+both headers arrive on hop 2, `Authorization: token …` does not — note the
+earlier claim that this client downloads *release assets* was wrong, all four
+of its guarded call sites are `api.github.com` JSON endpoints);
+`Model_Artifacts` resume (`Range`, `If-Range`) is allowlisted, which matters
+because catalog→CDN is the normal artifact download. `Confluence` passes
+`Content-Type: application/json` as a CALLER header, and caller headers are
+filtered by `filter_cross_origin_headers`, which does **not** consult
+`_TRANSPORT_HEADERS` — so it is dropped off-origin, not preserved as first
+claimed. Harmless (these are bodyless GETs), but the two layers are
+deliberately asymmetric and the note was wrong about which one applies.
+Same-origin redirects are untouched — the same-origin
 branch returns the caller's headers verbatim, so authenticated feeds that
 redirect within their own origin keep authenticating (pinned by two tests).
 
@@ -220,8 +230,14 @@ Divergence is now not expressible rather than merely detected late.
 
 **Born-red evidence.** `Tests/Utils/test_egress_cross_origin_header_allowlist.py`
 was written and run FIRST against unmodified `origin/dev` (`3193816e7`):
-**9 failed, 4 passed**. The failures show the sentinel arriving at the second
-origin, e.g.
+**9 failed, 4 passed** on the behaviour tests. (Independent review re-ran the
+committed file at that same base and measured **11 failed, 4 passed** — the
+two extra reds are `test_allowlist_never_admits_a_credential_shaped_name` and
+`test_transport_headers_are_disjoint_from_the_allowlist`, which fail at base
+with `AttributeError: module … has no attribute 'CROSS_ORIGIN_SAFE_HEADERS'`,
+i.e. an introspection failure rather than the defect signature. The 9/4 split
+is the right count of *behavioural* born-red evidence.) The failures show the
+sentinel arriving at the second origin, e.g.
 
 ```
 assert 'x-feed-token' not in Headers({'host': 'evil.example', ...,
@@ -279,6 +295,67 @@ having named them, not having fixed them.**
 
 Kagi (`:3672`) and Yandex (`:4228`) use `Authorization` and are clean, as the
 filing said.
+
+## Independent review addendum
+
+Adversarial review re-ran every claim above (born-red at `3193816e7`, the
+mutation of the real `CROSS_ORIGIN_SAFE_HEADERS` literal, both suites) and
+probed four escape routes the branch had not covered. Three were already
+closed: a `requests.Session`'s `auth=`, its cookie jar, and its default
+`headers` are all applied by `prepare_request` and therefore reached by
+`strip_cross_origin_request_headers`; an `httpx.Client(cookies=…)` jar
+likewise. The fourth was open, and is fixed here.
+
+**Found and fixed: a client-level `httpx` `auth=` still crossed the origin
+boundary.** `httpx` applies a client-level `auth` inside `send()` — *after*
+`build_request` produced the object the guard filters — so no amount of header
+stripping could see it. An `httpx.Client(auth=("alice", <secret>))` put
+`Authorization: Basic …` on the wire to `evil.example` on the redirect hop.
+The pre-existing docstring described this residual as applying only to a
+client-level auth *callable*; a plain tuple leaked identically, and the
+sibling paragraph simultaneously claimed cross-origin hops carry "only
+`CROSS_ORIGIN_SAFE_HEADERS` … or the client object's own defaults", which was
+not true of this route. Fix: pass an explicit `auth=None` (not omission, which
+leaves httpx's `USE_CLIENT_DEFAULT` sentinel in play) on the cross-origin hop
+in `guarded_fetch_httpx`, `guarded_fetch_httpx_async` and
+`Model_Artifacts.fetch.stream_fetch`. Four born-red tests
+(`test_{sync,async}_client_level_auth_not_applied_cross_origin` plus a
+`Model_Artifacts` one); mutation-checked — reverting the three lines turns
+exactly those red with `authorization` present at `host: evil.example`, while
+`test_async_same_origin_redirect_still_applies_client_level_auth` and
+`test_async_explicit_auth_argument_still_applies_same_origin` stay green, so
+the fix is not "never authenticate".
+
+No live caller constructs a client that way today, so this is hardening rather
+than a shipped leak — but it sat on the one code path this task exists to make
+trustworthy, and the surrounding docstring asserted it was already covered.
+
+**Two residuals recorded, not fixed (need their own task):**
+
+1. *The strip is not sticky.* `same_origin(url, current)` compares each hop to
+   the ORIGINAL url, so a chain `feed → evil → feed` re-attaches the
+   credential on hop 3 — measured, with the attacker choosing the return
+   path/query (`https://feed.example/logs?leak=1` received the sentinel). The
+   Fetch spec removes the header permanently once an origin boundary is
+   crossed. The recipient here is still the credential's own origin, so this
+   is hardening, not disclosure to a third party; low severity.
+2. *`content-type` is exempt on the BUILT-request layer.* It is the only
+   exempted header that can carry arbitrary caller text, and a client-default
+   `Content-Type: application/json; boundary=<secret>` was measured arriving
+   cross-origin. Every guarded helper is GET-only, so nothing needs it today;
+   the code comment keeps it for a hypothetical future body-carrying helper.
+   Low severity, no live exposure — but it is the answer to "construct a leak
+   using only exempted headers".
+
+**Verified independently:** born-red at base reproduces with the defect
+signature; `4012 passed / 4 skipped / 0 failed` across the eight suites and
+`54178 collected` repo-wide both reproduce exactly; the five siblings are real
+at the lines named (Kobold's header is `LLM_API_Calls_Local.py:1011`, call
+`:1061`; Bing `:2711`/`:2728` with `search_url` genuinely user-configurable
+from `search_engines.bing_search_api_url` at `:2672`; Brave `:2964`/`:2980`;
+Serper `:3985`/`:3992`; Exa `:4055`/`:4062`), and Kagi (`:3672`/`:3678`) and
+Yandex (`:4228`/`:4235`) are genuinely clean because `requests` strips
+`Authorization` on a host change.
 
 **Modified files.** `tldw_chatbook/Utils/egress.py`,
 `tldw_chatbook/Model_Artifacts/fetch.py`,

--- a/tldw_chatbook/Model_Artifacts/fetch.py
+++ b/tldw_chatbook/Model_Artifacts/fetch.py
@@ -191,8 +191,15 @@ async def stream_fetch(
         request = client.build_request("GET", current, headers=send_headers)
         if not is_same_origin:
             strip_cross_origin_request_headers(request.headers)
+        send_kwargs: dict[str, object] = {"stream": True, "follow_redirects": False}
+        if not is_same_origin:
+            # httpx applies a CLIENT-level ``auth=`` inside send(), after
+            # build_request -- invisible to the header strip above. Explicit
+            # None (not omission, which leaves USE_CLIENT_DEFAULT in play)
+            # suppresses it for this hop. Mirrors egress.guarded_fetch_httpx.
+            send_kwargs["auth"] = None
         try:
-            response = await client.send(request, stream=True, follow_redirects=False)
+            response = await client.send(request, **send_kwargs)
         except httpx.HTTPError as exc:
             raise FetchTransportError(type(exc).__name__) from exc
         try:

--- a/tldw_chatbook/Model_Artifacts/fetch.py
+++ b/tldw_chatbook/Model_Artifacts/fetch.py
@@ -16,14 +16,19 @@ from typing import Callable, Mapping
 import httpx
 from loguru import logger
 
-from tldw_chatbook.Utils.egress import (
+# task-19733: this module used to hand-MIRROR egress's strip tuple, kept
+# honest only by a drift-guard test that had to be remembered. The mirror is
+# gone -- the cross-origin header policy is now IMPORTED, one object, so the
+# two cannot diverge in the first place. ``CROSS_ORIGIN_SAFE_HEADERS`` is
+# imported (not just used) so the guard in Tests/Model_Artifacts can assert
+# identity with egress's object rather than equality with a copy of it.
+from tldw_chatbook.Utils.egress import (  # noqa: F401
+    CROSS_ORIGIN_SAFE_HEADERS,
     MAX_REDIRECT_HOPS,
     check_url_or_raise_async,
+    filter_cross_origin_headers,
+    strip_cross_origin_request_headers,
 )
-
-# Mirrors egress._STRIP_HEADERS (private there); the drift-guard test in
-# test_stream_fetch.py fails if the two sets ever diverge.
-_STRIP_HEADERS = ("authorization", "cookie", "proxy-authorization", "x-goog-api-key")
 
 _CHUNK_BYTES = 1024 * 1024
 
@@ -167,11 +172,15 @@ async def stream_fetch(
     for _hop in range(MAX_REDIRECT_HOPS + 1):
         await check_url_or_raise_async(str(current), trusted_origins=trusted_origins)
         is_same_origin = _same_origin(origin, current)
-        send_headers = dict(request_headers)
-        if not is_same_origin:
-            for name in list(send_headers):
-                if name.lower() in _STRIP_HEADERS:
-                    del send_headers[name]
+        # Cross-origin hops carry only egress's CROSS_ORIGIN_SAFE_HEADERS.
+        # Range/If-Range are on that allowlist precisely because THIS module
+        # needs them: a catalog host redirecting to its CDN is the normal
+        # artifact download, and resume dies without them.
+        send_headers = (
+            dict(request_headers)
+            if is_same_origin
+            else filter_cross_origin_headers(request_headers)
+        )
         # Built explicitly (not passed straight to client.stream/client.get)
         # so cross-origin credential stripping can also reach headers the
         # CALLER attached at the client-construction level (e.g.
@@ -181,8 +190,7 @@ async def stream_fetch(
         # never sees them. Mirrors egress.py's guarded_fetch_httpx_async.
         request = client.build_request("GET", current, headers=send_headers)
         if not is_same_origin:
-            for _h in _STRIP_HEADERS:
-                request.headers.pop(_h, None)
+            strip_cross_origin_request_headers(request.headers)
         try:
             response = await client.send(request, stream=True, follow_redirects=False)
         except httpx.HTTPError as exc:

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -650,7 +650,16 @@ def guarded_fetch_httpx(
             # client-default header named by the user leaks identically to a
             # per-call one.
             strip_cross_origin_request_headers(request.headers)
-        response = client.send(request, stream=True, follow_redirects=False)
+        send_kwargs = {"stream": True, "follow_redirects": False}
+        if not is_same_origin:
+            # httpx applies a CLIENT-level ``auth=`` inside ``send()``, AFTER
+            # build_request -- so header stripping above cannot see it and an
+            # ``httpx.Client(auth=("u", "p"))`` re-attached ``Authorization``
+            # on the very hop this guard exists to protect. Passing an
+            # explicit ``auth=None`` (rather than the USE_CLIENT_DEFAULT
+            # sentinel) suppresses it for this hop only.
+            send_kwargs["auth"] = None
+        response = client.send(request, **send_kwargs)
         try:
             if response.is_redirect and response.status_code != 304:
                 location = response.headers.get("location")
@@ -691,12 +700,13 @@ async def guarded_fetch_httpx_async(
 
     ``auth`` is applied on same-origin hops only (credential-stripping rule).
     Cross-origin hops carry only :data:`CROSS_ORIGIN_SAFE_HEADERS`, whether the
-    header came from the ``headers`` argument or from the client object's own
-    defaults (e.g. an ``httpx.AsyncClient(headers=...)``). A
-    client-level ``auth=`` CALLABLE (set on the ``httpx.Client``/``AsyncClient``
-    itself, as opposed to the ``auth`` parameter of this function) is NOT
-    suppressed by this guard — no live caller uses that flow today; this is a
-    documented residual risk.
+    header came from the ``headers`` argument, from the client object's own
+    default headers (e.g. an ``httpx.AsyncClient(headers=...)``), or from a
+    client-level ``auth=`` (set on the ``httpx.Client``/``AsyncClient`` itself,
+    as opposed to the ``auth`` parameter of this function) — the last of those
+    is applied by httpx inside ``send()``, so it is suppressed by passing an
+    explicit ``auth=None`` on the cross-origin hop rather than by header
+    stripping.
     """
     current = url
     for hop in range(MAX_REDIRECT_HOPS + 1):
@@ -713,7 +723,13 @@ async def guarded_fetch_httpx_async(
             # level — see guarded_fetch_httpx for the rationale.
             strip_cross_origin_request_headers(request.headers)
         send_kwargs = {"stream": True, "follow_redirects": False}
-        if auth is not None and is_same_origin:
+        if not is_same_origin:
+            # Explicit None, not "omit": omitting leaves httpx's
+            # USE_CLIENT_DEFAULT sentinel in play, which re-applies a
+            # CLIENT-level ``auth=`` inside send() -- after the header strip
+            # above. See guarded_fetch_httpx for the full rationale.
+            send_kwargs["auth"] = None
+        elif auth is not None:
             send_kwargs["auth"] = auth
         response = await client.send(request, **send_kwargs)
         try:

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -345,7 +345,127 @@ async def check_url_or_raise_async(url: str, *, trusted_origins=frozenset()) -> 
 #: forward the real API key verbatim; every ``Authorization``-based adapter
 #: is already protected by this tuple. There is no legitimate cross-origin
 #: use of this header, so adding it is strictly tightening.
+#:
+#: NOTE (task-19733): this tuple is no longer the cross-origin RULE -- the rule
+#: is :data:`CROSS_ORIGIN_SAFE_HEADERS` below, an allowlist. It survives as the
+#: never-cross floor: both exemption sets below are constructed by SUBTRACTING
+#: it, so a careless future edit that adds one of these names to an exemption
+#: list cannot take effect.
 _STRIP_HEADERS = ("authorization", "cookie", "proxy-authorization", "x-goog-api-key")
+
+#: Request headers that MAY be forwarded across an origin boundary on a
+#: redirect hop. Everything else the caller (or the client's own default
+#: headers) supplied is dropped.
+#:
+#: This is an ALLOWLIST on purpose (task-19733). A denylist of credential
+#: header names cannot be correct in this app, because the credential header
+#: NAME is user-supplied: a subscription's ``auth_config`` chooses it
+#: (``Subscriptions/monitoring_engine.py`` only *defaults* to ``X-API-Key``),
+#: and so does a per-site config (``site_config_manager.SiteConfig.get_headers``,
+#: same default). Growing ``_STRIP_HEADERS`` one incident at a time closes the
+#: name someone happened to think of and forwards every other one verbatim to
+#: whatever host the feed redirects to.
+#:
+#: Membership test: a header is listed here only when forwarding it to a
+#: DIFFERENT origin is both (a) needed by a real caller and (b) incapable of
+#: carrying a secret. That admits content negotiation, cache validators, and
+#: range/partial-content headers -- a CDN redirect (feeds, model artifacts)
+#: genuinely needs those or conditional GET and download resume break.
+#:
+#: Consequence to know about: a NON-credential custom header a user configured
+#: for a feed (``custom_headers``) also stops being forwarded once that feed
+#: redirects off-origin. That is deliberate -- nothing at this layer can tell
+#: ``X-Feed-Token`` from ``X-Client-Version`` by name -- and it is the safe
+#: direction to be wrong in.
+CROSS_ORIGIN_SAFE_HEADERS = frozenset(
+    {
+        # Content negotiation
+        "accept",
+        "accept-charset",
+        "accept-encoding",
+        "accept-language",
+        # Caching / conditional requests
+        "cache-control",
+        "pragma",
+        "if-match",
+        "if-modified-since",
+        "if-none-match",
+        "if-unmodified-since",
+        # Partial content (Model_Artifacts resume; HF -> CDN is cross-origin)
+        "if-range",
+        "range",
+        # Client identity (not a credential)
+        "user-agent",
+    }
+) - frozenset(_STRIP_HEADERS)
+
+#: Framing/connection headers owned by the HTTP client library itself, never a
+#: caller credential. They are exempt from the allowlist so that stripping a
+#: BUILT request cannot break the request it is protecting (dropping ``host``
+#: would be fatal; dropping ``connection`` would silently change keep-alive).
+_TRANSPORT_HEADERS = frozenset(
+    {
+        "host",
+        "connection",
+        "keep-alive",
+        "content-length",
+        # Describes the request BODY, never a credential. Every guarded helper
+        # is GET-only today so this is inert, but it belongs with the framing
+        # headers rather than the allowlist: the day one of them grows a body,
+        # silently dropping Content-Type would corrupt the request.
+        "content-type",
+        "transfer-encoding",
+        "te",
+        "trailer",
+        "upgrade",
+        "proxy-connection",
+    }
+) - frozenset(_STRIP_HEADERS)
+
+
+def filter_cross_origin_headers(headers) -> dict:
+    """Caller-supplied headers reduced to the ones safe to send off-origin.
+
+    Deny-by-default: a name absent from :data:`CROSS_ORIGIN_SAFE_HEADERS` is
+    dropped, whatever it is called. Use this for the ``headers`` mapping a
+    caller passed in, before it is handed to the transport.
+
+    Args:
+        headers: Any mapping of header name -> value (may be ``None``).
+
+    Returns:
+        A new plain ``dict`` containing only the allowlisted entries,
+        preserving the caller's casing.
+    """
+    return {
+        str(k): v
+        for k, v in dict(headers or {}).items()
+        if str(k).lower() in CROSS_ORIGIN_SAFE_HEADERS
+    }
+
+
+def strip_cross_origin_request_headers(request_headers) -> None:
+    """In place, drop every non-forwardable header from a BUILT request.
+
+    The complement of :func:`filter_cross_origin_headers`: that one filters
+    what the caller passed, this one filters what the transport actually
+    assembled -- which additionally contains the client object's DEFAULT
+    headers (``httpx.Client(headers=...)``, a ``requests.Session``'s
+    ``headers``/``auth``/cookies). Those are invisible to the caller-side
+    filter, and a credential set there leaks exactly the same way.
+
+    Transport/framing headers (:data:`_TRANSPORT_HEADERS`) are left alone;
+    everything else must be on :data:`CROSS_ORIGIN_SAFE_HEADERS` to survive.
+
+    Args:
+        request_headers: A mutable, case-insensitive header mapping
+            (``httpx.Headers`` or ``requests.structures.CaseInsensitiveDict``).
+    """
+    for name in list(request_headers.keys()):
+        lowered = str(name).lower()
+        if lowered in CROSS_ORIGIN_SAFE_HEADERS or lowered in _TRANSPORT_HEADERS:
+            continue
+        request_headers.pop(name, None)
 
 
 class EgressFetchError(Exception):
@@ -489,12 +609,16 @@ def same_origin(url_a: str, url_b: str) -> bool:
 
 
 def _hop_headers(headers, same_origin: bool) -> dict:
-    hop = {str(k): v for k, v in dict(headers or {}).items()}
-    if not same_origin:
-        for key in list(hop):
-            if key.lower() in _STRIP_HEADERS:
-                hop.pop(key)
-    return hop
+    """Caller headers for one hop: everything same-origin, allowlist otherwise.
+
+    task-19733 inverted the cross-origin branch from a denylist of credential
+    names to :func:`filter_cross_origin_headers`. Same-origin hops are
+    untouched, so an authenticated feed that redirects within its own origin
+    keeps working exactly as before.
+    """
+    if same_origin:
+        return {str(k): v for k, v in dict(headers or {}).items()}
+    return filter_cross_origin_headers(headers)
 
 
 def guarded_fetch_httpx(
@@ -522,9 +646,10 @@ def guarded_fetch_httpx(
             # level (e.g. httpx.Client(headers={"Authorization": ...})) —
             # these are merged onto the built request by httpx and are
             # invisible to _hop_headers, which only sees the per-call
-            # `headers` argument.
-            for _h in _STRIP_HEADERS:
-                request.headers.pop(_h, None)
+            # `headers` argument. Allowlist, not denylist (task-19733): a
+            # client-default header named by the user leaks identically to a
+            # per-call one.
+            strip_cross_origin_request_headers(request.headers)
         response = client.send(request, stream=True, follow_redirects=False)
         try:
             if response.is_redirect and response.status_code != 304:
@@ -565,8 +690,9 @@ async def guarded_fetch_httpx_async(
     """Async capped GET via httpx.AsyncClient with per-hop re-validation.
 
     ``auth`` is applied on same-origin hops only (credential-stripping rule).
-    Client-default sensitive headers (e.g. an ``httpx.AsyncClient(headers=...)``
-    default ``Authorization``) are also stripped on cross-origin hops. A
+    Cross-origin hops carry only :data:`CROSS_ORIGIN_SAFE_HEADERS`, whether the
+    header came from the ``headers`` argument or from the client object's own
+    defaults (e.g. an ``httpx.AsyncClient(headers=...)``). A
     client-level ``auth=`` CALLABLE (set on the ``httpx.Client``/``AsyncClient``
     itself, as opposed to the ``auth`` parameter of this function) is NOT
     suppressed by this guard — no live caller uses that flow today; this is a
@@ -585,8 +711,7 @@ async def guarded_fetch_httpx_async(
         if not is_same_origin:
             # Strip credentials the client attaches at the transport-object
             # level — see guarded_fetch_httpx for the rationale.
-            for _h in _STRIP_HEADERS:
-                request.headers.pop(_h, None)
+            strip_cross_origin_request_headers(request.headers)
         send_kwargs = {"stream": True, "follow_redirects": False}
         if auth is not None and is_same_origin:
             send_kwargs["auth"] = auth
@@ -649,10 +774,11 @@ def guarded_fetch_requests(
                 )
             )
             if not is_same_origin:
-                # prepare_request applies session.auth/cookies into headers;
-                # a cross-origin hop must not carry them.
-                for key in ("Authorization", "Cookie", "Proxy-Authorization"):
-                    prepared.headers.pop(key, None)
+                # prepare_request applies session.auth/cookies AND the
+                # session's default headers into the prepared request; a
+                # cross-origin hop must not carry any of them unless they are
+                # explicitly forwardable (task-19733).
+                strip_cross_origin_request_headers(prepared.headers)
             response = sess.send(
                 prepared, stream=True, timeout=timeout, allow_redirects=False
             )
@@ -698,7 +824,14 @@ async def guarded_fetch_aiohttp(
     headers: dict | None = None,
     timeout=None,
 ) -> GuardedResponse:
-    """Capped GET via aiohttp.ClientSession with per-hop re-validation."""
+    """Capped GET via aiohttp.ClientSession with per-hop re-validation.
+
+    Cross-origin hops carry only :data:`CROSS_ORIGIN_SAFE_HEADERS` out of the
+    ``headers`` argument. Unlike the httpx/requests helpers there is no built
+    request object to post-filter here, so a credential set as an
+    ``aiohttp.ClientSession(headers=...)`` DEFAULT is not suppressed — a
+    documented residual, unchanged by task-19733; no live caller does that.
+    """
     from multidict import CIMultiDict
 
     current = url

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -23,7 +23,7 @@ import ipaddress
 import json as _json
 import socket
 from dataclasses import dataclass, field
-from typing import Iterable, List
+from typing import Iterable, List, Mapping, MutableMapping
 from urllib.parse import urljoin, urlparse
 
 from loguru import logger
@@ -403,17 +403,17 @@ CROSS_ORIGIN_SAFE_HEADERS = frozenset(
 #: caller credential. They are exempt from the allowlist so that stripping a
 #: BUILT request cannot break the request it is protecting (dropping ``host``
 #: would be fatal; dropping ``connection`` would silently change keep-alive).
+#:
+#: Every name here has a value drawn from a fixed vocabulary the client library
+#: generates -- none of them can carry arbitrary caller text. That is the
+#: membership test, and it is why ``content-type`` is NOT in this set (see
+#: :data:`_BODY_DESCRIBING_HEADERS`).
 _TRANSPORT_HEADERS = frozenset(
     {
         "host",
         "connection",
         "keep-alive",
         "content-length",
-        # Describes the request BODY, never a credential. Every guarded helper
-        # is GET-only today so this is inert, but it belongs with the framing
-        # headers rather than the allowlist: the day one of them grows a body,
-        # silently dropping Content-Type would corrupt the request.
-        "content-type",
         "transfer-encoding",
         "te",
         "trailer",
@@ -422,8 +422,93 @@ _TRANSPORT_HEADERS = frozenset(
     }
 ) - frozenset(_STRIP_HEADERS)
 
+#: Headers that describe a request BODY. They may cross an origin boundary
+#: only on a hop that actually carries one.
+#:
+#: ``content-type`` sat in :data:`_TRANSPORT_HEADERS` until Qodo's review of
+#: PR #1942 (task-19733) pointed out that it is the one exempted header whose
+#: value is arbitrary caller-controlled text: ``multipart/form-data;
+#: boundary=<anything>`` is a ready-made carrier, and a client-DEFAULT
+#: ``Content-Type`` therefore crossed to the attacker origin on every bodyless
+#: redirect hop. Deleting the exemption outright is also wrong -- dropping
+#: ``Content-Type`` off a request that HAS a body corrupts it. The precise
+#: rule is the conditional one: it describes a body, so it travels with a body.
+_BODY_DESCRIBING_HEADERS = frozenset({"content-type"}) - frozenset(_STRIP_HEADERS)
 
-def filter_cross_origin_headers(headers) -> dict:
+#: Framing headers whose presence on a BUILT request proves it carries a body.
+#: Verified against both clients this module drives: httpx and ``requests``
+#: each emit ``Content-Length`` for a known-length body and
+#: ``Transfer-Encoding: chunked`` for a streamed one, at BUILD time
+#: (``Client.build_request`` / ``Session.prepare_request``), i.e. before this
+#: module inspects the request. A bodyless GET gets neither; a bodyless POST
+#: gets ``Content-Length: 0``, which is why the value is checked, not just the
+#: name.
+_BODY_FRAMING_HEADERS = frozenset({"content-length", "transfer-encoding"})
+
+
+def _built_request_carries_body(request_headers: Mapping[str, str]) -> bool:
+    """Whether a BUILT request actually has a body attached.
+
+    Keys off the outgoing request's own framing headers rather than off the
+    redirect status code. That is the durable form: 301/302/303 convert the
+    method to GET and drop the body while 307/308 preserve both, but by the
+    time this runs the client has already built the request for THIS hop, so
+    its framing is the ground truth regardless of how it got here.
+
+    Deny-by-default on anything unparseable: an unreadable ``Content-Length``
+    is treated as "no body", so a header that describes a body it cannot prove
+    exists does not cross an origin boundary. Neither client library emits
+    such a value.
+
+    Args:
+        request_headers: Header mapping of a request the transport has
+            already assembled (``httpx.Request.headers``,
+            ``requests.PreparedRequest.headers``).
+
+    Returns:
+        ``True`` if the request carries a non-empty body.
+    """
+    for name, value in request_headers.items():
+        lowered = str(name).lower()
+        if lowered not in _BODY_FRAMING_HEADERS:
+            continue
+        text = str(value).strip()
+        if lowered == "transfer-encoding":
+            if text:
+                return True
+            continue
+        try:
+            if int(text) > 0:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def _may_cross_origin(name: str, *, has_body: bool) -> bool:
+    """The single cross-origin rule, shared by both filtering layers.
+
+    Args:
+        name: Header name, any casing.
+        has_body: Whether the hop this header would travel on carries a
+            request body. Only :data:`_BODY_DESCRIBING_HEADERS` consult it.
+
+    Returns:
+        ``True`` if the header may be sent to a different origin.
+    """
+    lowered = name.lower()
+    if lowered in CROSS_ORIGIN_SAFE_HEADERS or lowered in _TRANSPORT_HEADERS:
+        return True
+    if lowered in _BODY_DESCRIBING_HEADERS:
+        return has_body
+    return False
+
+
+def filter_cross_origin_headers(
+    headers: Mapping[str, str] | None,
+    *,
+    has_body: bool = False,
+) -> dict[str, str]:
     """Caller-supplied headers reduced to the ones safe to send off-origin.
 
     Deny-by-default: a name absent from :data:`CROSS_ORIGIN_SAFE_HEADERS` is
@@ -431,20 +516,31 @@ def filter_cross_origin_headers(headers) -> dict:
     caller passed in, before it is handed to the transport.
 
     Args:
-        headers: Any mapping of header name -> value (may be ``None``).
+        headers: Any mapping of header name -> value (a plain ``dict``,
+            ``httpx.Headers``, ``requests.structures.CaseInsensitiveDict`` and
+            ``multidict.CIMultiDict`` all satisfy this). May be ``None``.
+        has_body: Whether the request being described will carry a body. This
+            is the same question :func:`strip_cross_origin_request_headers`
+            answers by inspecting the built request; here it must be declared,
+            because a ``headers`` mapping on its own says nothing about a
+            body. Every guarded helper in this module issues a bodyless GET,
+            hence the default. A body-carrying caller must pass ``True`` or
+            its ``Content-Type`` will be dropped off-origin.
 
     Returns:
-        A new plain ``dict`` containing only the allowlisted entries,
+        A new plain ``dict`` containing only the forwardable entries,
         preserving the caller's casing.
     """
     return {
         str(k): v
         for k, v in dict(headers or {}).items()
-        if str(k).lower() in CROSS_ORIGIN_SAFE_HEADERS
+        if _may_cross_origin(str(k), has_body=has_body)
     }
 
 
-def strip_cross_origin_request_headers(request_headers) -> None:
+def strip_cross_origin_request_headers(
+    request_headers: MutableMapping[str, str],
+) -> None:
     """In place, drop every non-forwardable header from a BUILT request.
 
     The complement of :func:`filter_cross_origin_headers`: that one filters
@@ -454,16 +550,23 @@ def strip_cross_origin_request_headers(request_headers) -> None:
     ``headers``/``auth``/cookies). Those are invisible to the caller-side
     filter, and a credential set there leaks exactly the same way.
 
+    Both layers apply the same rule (:func:`_may_cross_origin`); the only
+    difference is where ``has_body`` comes from. Here it is INFERRED from the
+    request's own framing headers, so the answer describes the actual outgoing
+    hop rather than being taken on trust.
+
     Transport/framing headers (:data:`_TRANSPORT_HEADERS`) are left alone;
-    everything else must be on :data:`CROSS_ORIGIN_SAFE_HEADERS` to survive.
+    ``Content-Type`` survives only if the request carries a body; everything
+    else must be on :data:`CROSS_ORIGIN_SAFE_HEADERS`.
 
     Args:
-        request_headers: A mutable, case-insensitive header mapping
-            (``httpx.Headers`` or ``requests.structures.CaseInsensitiveDict``).
+        request_headers: A mutable, case-insensitive header mapping belonging
+            to an already-built request (``httpx.Headers`` or
+            ``requests.structures.CaseInsensitiveDict``). Mutated in place.
     """
+    has_body = _built_request_carries_body(request_headers)
     for name in list(request_headers.keys()):
-        lowered = str(name).lower()
-        if lowered in CROSS_ORIGIN_SAFE_HEADERS or lowered in _TRANSPORT_HEADERS:
+        if _may_cross_origin(str(name), has_body=has_body):
             continue
         request_headers.pop(name, None)
 
@@ -608,13 +711,26 @@ def same_origin(url_a: str, url_b: str) -> bool:
     return origin_a is not None and origin_a == origin_of(url_b)
 
 
-def _hop_headers(headers, same_origin: bool) -> dict:
+def _hop_headers(
+    headers: Mapping[str, str] | None, same_origin: bool
+) -> dict[str, str]:
     """Caller headers for one hop: everything same-origin, allowlist otherwise.
 
     task-19733 inverted the cross-origin branch from a denylist of credential
     names to :func:`filter_cross_origin_headers`. Same-origin hops are
     untouched, so an authenticated feed that redirects within its own origin
     keeps working exactly as before.
+
+    ``has_body`` is left at its default: every ``guarded_fetch_*`` helper in
+    this module issues a bodyless GET, so a caller-supplied ``Content-Type``
+    describes nothing and does not cross an origin boundary.
+
+    Args:
+        headers: The ``headers`` mapping the caller passed to a guarded fetch.
+        same_origin: Whether this hop stays on the original request's origin.
+
+    Returns:
+        A new plain ``dict`` of the headers this hop may carry.
     """
     if same_origin:
         return {str(k): v for k, v in dict(headers or {}).items()}
@@ -699,14 +815,17 @@ async def guarded_fetch_httpx_async(
     """Async capped GET via httpx.AsyncClient with per-hop re-validation.
 
     ``auth`` is applied on same-origin hops only (credential-stripping rule).
-    Cross-origin hops carry only :data:`CROSS_ORIGIN_SAFE_HEADERS`, whether the
-    header came from the ``headers`` argument, from the client object's own
-    default headers (e.g. an ``httpx.AsyncClient(headers=...)``), or from a
-    client-level ``auth=`` (set on the ``httpx.Client``/``AsyncClient`` itself,
-    as opposed to the ``auth`` parameter of this function) — the last of those
-    is applied by httpx inside ``send()``, so it is suppressed by passing an
-    explicit ``auth=None`` on the cross-origin hop rather than by header
-    stripping.
+    A cross-origin hop carries :data:`CROSS_ORIGIN_SAFE_HEADERS` plus the
+    client library's own framing (:data:`_TRANSPORT_HEADERS`) and nothing
+    else — no matter whether the header came from the ``headers`` argument,
+    from the client object's own default headers (e.g. an
+    ``httpx.AsyncClient(headers=...)``), or from a client-level ``auth=`` (set
+    on the ``httpx.Client``/``AsyncClient`` itself, as opposed to the ``auth``
+    parameter of this function). That last one is applied by httpx inside
+    ``send()``, so it is suppressed by passing an explicit ``auth=None`` on the
+    cross-origin hop rather than by header stripping. ``Content-Type`` would
+    be the one conditional exception (:data:`_BODY_DESCRIBING_HEADERS`), but
+    this helper only ever issues a bodyless GET, so it never applies here.
     """
     current = url
     for hop in range(MAX_REDIRECT_HOPS + 1):


### PR DESCRIPTION
Closes TASK-19733. Residue of TASK-19557, which fixed two direct callers and deliberately left this shared gap.

## Why a longer denylist was not the fix

`_STRIP_HEADERS` was `("authorization", "cookie", "proxy-authorization", "x-goog-api-key")` and did not include `x-api-key`. But appending it would have closed exactly one case: **the credential header's name is user-supplied.** `monitoring_engine.py` does `key_header = auth_config.get("header", "X-API-Key")` — it merely *defaults*. A denylist over a set the user extends at runtime is unbounded by construction.

So the rule is inverted for cross-origin hops:

- **`CROSS_ORIGIN_SAFE_HEADERS`** — a hop leaving the origin carries only `accept*`, `cache-control`, `pragma`, the conditional/range headers, and `user-agent`. Membership test: needed by a real caller *and* incapable of carrying a secret.
- **`_TRANSPORT_HEADERS`** — framing owned by the client (`host`, `connection`, `content-length`, …), exempt because stripping `host` off a built request breaks the request the guard protects.
- **`_STRIP_HEADERS` retained as a never-cross floor**: both exempt sets are built as `frozenset({…}) - frozenset(_STRIP_HEADERS)`, so a later edit cannot allowlist `authorization` by accident. Verified by mutation — adding the credential names to the real literal leaves all 10 credential tests green.

## Applied at two layers, because one was never enough

`_hop_headers()` only sees what the *caller* passed. A new `strip_cross_origin_request_headers()` filters the **built** request in `guarded_fetch_httpx` / `_async` / `_requests` — the only layer that sees the client object's own defaults (`httpx.Client(headers=…)`, a `requests.Session`'s headers, auth and cookies).

Review then found a third route the header layer structurally cannot reach: **httpx applies a client-level `auth=` inside `send()`, after `build_request`**. A plain `auth=("alice", secret)` tuple leaked `Authorization: Basic …` to the attacker origin. Fixed with an explicit `auth=None` on the cross-origin hop (not omission — `USE_CLIENT_DEFAULT` would still apply it) in both httpx helpers and `Model_Artifacts/fetch.py:stream_fetch`. No live caller does this today; this is hardening, not a shipped leak.

## Born-red

At base, the new suite fails with the sentinel present on hop 2 — driven through the production producer, not a hand-made dict:

```
assert 'x-feed-token' not in Headers({'host': 'evil.example', …,
       'user-agent': 'tldw-chatbook/1.0 (+https://github.com/tld…',
       'x-feed-token': 'sentinel-not-a-real-key-19733'})
```

The test deliberately uses `X-Feed-Token`, **not** `X-API-Key` — a born-red written with the default name would have passed the one-literal fix and shipped the hole. Non-regression pins (same-origin keeps the header; `User-Agent`/`Accept`/`Range`/conditionals still forward cross-origin) pass at base, so the fix could not be "drop everything".

Independently verified end-to-end: a real `GitHubAPIClient` call through `api.github.com` → 302 → `objects.githubusercontent.com` keeps `Accept: application/vnd.github.v3+json` and drops the token; a real `stream_fetch` catalog→CDN resume keeps `Range`/`If-Range`, lands the right bytes, and drops both `Authorization` and a client-default token.

## The hand-mirrored constant was deleted, not re-synced

`Model_Artifacts/fetch.py` held a copy of `_STRIP_HEADERS` with a test pinning the two sets equal — a test that *rewards* keeping the mirror. It now imports the shared policy, and the guard asserts object identity plus `not hasattr(fetch, "_STRIP_HEADERS")`. Drift is inexpressible rather than detected late.

## Known cost, stated plainly

A **non-credential** custom feed header also stops being forwarded once that feed redirects off-origin. Nothing at this layer can tell `X-Feed-Token` from `X-Client-Version` by name — which is precisely why the denylist could not work. All ~30 guarded call sites were read; only `monitoring_engine`'s `custom_headers` is affected. Same-origin redirects are untouched.

Two pre-existing tests asserted an arbitrary `X-Keep` *survives* a cross-origin hop. Their history was checked independently: `X-Keep` entered as an incidental control proving the strip was selective, with no docstring, commit rationale, AC, or decision record. It was not a requirement.

## Verification

- New suite: born-red 11F/4P at base → 15 pass. Mutation re-check with the implementation reverted: 13F/17P.
- Utils + Model_Artifacts + Subscriptions + Web_Scraping + Local_Ingestion + Scheduling + tldw_api + Media: **4017 passed / 4 skipped / 0 failed**. Repo-wide collect: 54,183.
- In-process transports only; synthetic sentinels only; no sockets.

Five sibling `requests` sites still carry API keys through default redirects (Kobold, Bing, Brave, Serper, Exa) — none touch this primitive, so fixing it cannot reach them. Being filed separately with exact lines and severities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents credential leaks on cross-origin redirects by switching to an explicit allowlist and suppressing client-level `httpx` auth on off-origin hops. `Content-Type` now forwards only when the hop has a body; same-origin behavior is unchanged. Addresses TASK-19733.

- Introduces `CROSS_ORIGIN_SAFE_HEADERS`, applied to both caller headers (`filter_cross_origin_headers`) and the built request (`strip_cross_origin_request_headers`). `_STRIP_HEADERS` remains a never-cross floor; `_TRANSPORT_HEADERS` stay exempt to avoid breaking framing.
- Treats `Content-Type` as body-describing: forward only when the built request carries a body (detected via `Content-Length > 0` or `Transfer-Encoding`); drop otherwise.
- Suppresses client-level `httpx` auth on cross-origin hops by passing `auth=None` in `guarded_fetch_httpx`, `guarded_fetch_httpx_async`, and `Model_Artifacts.stream_fetch`. Same-origin hops and per-call `auth` still apply.
- Deduplicates policy: `Model_Artifacts/fetch.py` imports the shared policy and helpers; adds typed public helpers. Note for `aiohttp`: only caller headers are filtered; session default headers are not post-filtered.

- Rollout
  - Custom feed headers no longer forward off-origin. If you rely on them, ensure same-origin redirects or move secrets to supported auth config.
  - Call sites that bypass these helpers (e.g., direct `requests` usage) should set `allow_redirects=False` per site.

<sup>Written for commit 163473cb9db2c7f6192fc7f5f873ea7aeb0e5023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

