### PR TITLE
fix(tests): TASK-19602 final tranche — last 3 deterministic failures cleared

### DIFF
--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -11505,7 +11505,13 @@ async def test_library_prompt_copy_uses_live_unsaved_legacy_lane_markdown(tmp_pa
         screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         await _open_prompt_editor(screen, pilot, prompt_id)
+        # TASK-19602: each programmatic lane write fires the basic-lane
+        # publish whose preview sync reloads BOTH lanes -- writing both
+        # back-to-back makes the second publish revert the first. Settle
+        # each lane's publish before writing the next (the same pacing a
+        # user typing in one field at a time produces).
         screen.query_one("#library-prompt-system", TextArea).text = "Edited system"
+        await pilot.pause()
         screen.query_one("#library-prompt-user", TextArea).text = "Edited user"
         await pilot.pause()
 
@@ -12574,7 +12580,10 @@ async def test_library_prompt_copy_uses_unsaved_legacy_create_working_copy(tmp_p
         screen.query_one("#library-prompt-name", Input).value = "Unsaved create"
         screen.query_one("#library-prompt-author", Input).value = "Draft author"
         screen.query_one("#library-prompt-details", Input).value = "Draft details"
+        # TASK-19602: settle each lane's publish before the next (see the
+        # sibling copy test -- back-to-back writes race the preview sync).
         screen.query_one("#library-prompt-system", TextArea).text = "Draft system"
+        await pilot.pause()
         screen.query_one("#library-prompt-user", TextArea).text = "Draft user"
         screen.query_one("#library-prompt-keywords", Input).value = "draft, live"
         await pilot.pause()

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -720,6 +720,11 @@ class LibraryHarness(ConsolidatedCSSApp):
     )
 
     def __init__(self, app_instance, seen_routes=None, screen=None):
+        # TASK-19602: production readers hit ``app_instance.app_config``
+        # from workers (e.g. the Library source snapshot); a screen whose
+        # test swapped ``app_instance`` to this harness must not crash
+        # there. Share the real app's config mapping.
+        self.app_config = getattr(app_instance, "app_config", {})
         super().__init__()
         self.app_instance = app_instance
         self.seen_routes = seen_routes if seen_routes is not None else []


### PR DESCRIPTION
The last three: the cancelled-import retry Undo (root cause = snapshot worker crashing on the swapped harness lacking app_config; fixed by bridging the real app's config onto the harness), and the copy-lane pair (per-lane settle pacing — each programmatic write's publish must settle before the next, matching real typing order). Differential: the task's tracked failures 3 → 0. Two new-name failures surfaced during verification and reproduce identically on pristine dev — logged as separate dev-side fallout, not regressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the last three TASK-19602 deterministic UI test failures by pacing lane writes and preventing a snapshot worker crash in the test harness. Previously, back-to-back lane writes reverted each other and the harness swap removed `app_config`, crashing the snapshot worker; now each publish settles before the next write and the harness exposes the real app’s `app_config`.

- LibraryHarness: forward the real app’s `app_config` to the harness to keep background readers (snapshot worker) from crashing when tests swap the app instance.
- Prompt canvas copy tests: insert `await pilot.pause()` between programmatic lane writes so each publish settles before the next write, matching real typing and avoiding preview sync races.

<sup>Written for commit 6e92108f8280e54292f1bcdc77c2e4edec3b18cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

