### PR TITLE
ci(guard): ship an install-free derived-artifacts check and make the inventory teach its own fix

### DIFF
--- a/.github/workflows/backlog-guard.yml
+++ b/.github/workflows/backlog-guard.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - 'backlog/tasks/**'
+      - 'scripts/check_backlog_task_ids.py'
   push:
     branches: [dev, main]
     paths:
       - 'backlog/tasks/**'
+      - 'scripts/check_backlog_task_ids.py'
 
 # One run per workflow per ref: a new push supersedes the previous run instead of
 # queueing another alongside it. Without this, every push to `dev` stacked a full
@@ -25,38 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Fail on duplicate backlog task IDs
         run: |
-          set -euo pipefail
-          # Task files are named "task-<id> - <Title>.md"; subtask ids may be multi-dotted
-          # (task-3.1, task-10.6.1). Two branches minting the same id and merging separately
-          # produces two files that share an id — backlog CLI lookups become ambiguous. This
-          # has happened three times (ids 152+, 196-203, 246-256); catch it on every PR and
-          # again post-merge on dev. IDs are checked in both namespaces the repo relies on:
-          # the filename prefix and the YAML frontmatter `id:` (they can disagree after a
-          # hand-edited rename, and the backlog CLI resolves by frontmatter).
-          fail=0
-          file_dupes=$(ls backlog/tasks | sed -nE 's/^(task-[0-9]+(\.[0-9]+)*) - .*\.md$/\1/p' | sort | uniq -d)
-          if [ -n "$file_dupes" ]; then
-            fail=1
-            echo "::error::Duplicate backlog task IDs in filenames:"
-            while IFS= read -r id; do
-              echo "--- $id ---"
-              ls backlog/tasks | grep -F "$id - "
-            done <<< "$file_dupes"
-          fi
-          # First `id:` line per file, normalized to lowercase (frontmatter uses TASK-NNN).
-          fm_dupes=$(awk 'FNR==1{seen=0} /^id:/ && !seen {seen=1; print tolower($2)}' backlog/tasks/*.md | sort | uniq -d)
-          if [ -n "$fm_dupes" ]; then
-            fail=1
-            echo "::error::Duplicate backlog task IDs in frontmatter id: fields:"
-            while IFS= read -r id; do
-              echo "--- $id ---"
-              grep -il "^id: *${id}\$" backlog/tasks/*.md
-            done <<< "$fm_dupes"
-          fi
-          if [ "$fail" -ne 0 ]; then
-            echo "Resolve per the 2026-08-21 owner rule (TASK-19601): the OLDER arrival keeps the id; the younger task(s) renumber — regardless of Done status — with a Renumbering provenance section, updating dependencies: and doc/code references."
-            exit 1
-          fi
-          echo "No duplicate task IDs across $(ls backlog/tasks | grep -c '^task-') task files (filenames + frontmatter)."
+          # TASK-19572 moved this out of inline shell and into a stdlib-only
+          # script, because derived-artifacts.yml (the one required check) has
+          # to run the same test and two hand-maintained copies would drift.
+          # The script checks both namespaces the repo relies on -- the filename
+          # prefix and the YAML frontmatter `id:` -- since they disagree after a
+          # hand-edited rename and the backlog CLI resolves by frontmatter.
+          python scripts/check_backlog_task_ids.py

--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -1,0 +1,103 @@
+name: Derived Artifacts
+
+# TASK-19572: one small check that actually runs, instead of a comprehensive
+# suite that never reports.
+#
+# The `Tests` workflow has produced no verdict since 2026-06-26: a full pass
+# takes 200-227 minutes, `dev` absorbs 23-50 merges/day, and its
+# cancel-in-progress rule kills every in-flight run long before it finishes.
+# Guards that live only inside that suite -- the diagnostic-inventory pin and
+# the profile-owned-path census -- have therefore never blocked anything, and
+# the same drift has been rediscovered by hand in four separate tasks.
+#
+# Every check below is stdlib-only and needs no dependency install. Measured on
+# an M-series laptop: bundle-sync 0.86 s, profile-owned-path 10.98 s, diagnostic
+# inventory 20.17 s, backlog ids <0.5 s -- ~33 s of work, ~90 s with checkout
+# and setup-python. That budget is the whole point: it is small enough to run on
+# every PR, which is what makes it usable as a REQUIRED status check.
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+# Deliberately NOT path-filtered, unlike css-bundle-guard/backlog-guard.
+#
+# A required status check that is skipped by a path filter never reports at all;
+# GitHub leaves the PR sitting on "Expected - waiting for status to be
+# reported", forever. Any PR that touched only docs would be unmergeable. The
+# usual workaround (a twin workflow with the same job name that always passes)
+# buys nothing here, because the job is ~90 s: just run it. If you are tempted
+# to add `paths:` below, you are about to brick merges -- don't.
+
+# One run per workflow per ref: a new push supersedes the previous run instead of
+# queueing another alongside it. Without this, every push to `dev` stacked a full
+# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
+# The event name is part of the group so different trigger types (push,
+# pull_request, schedule) never cancel each other, and `main` is never cancelled
+# so its history stays complete. Cancellation is safe for a required check: a
+# merge is gated on the HEAD commit's checks, and the newest run is the one that
+# reports for HEAD.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  derived-artifacts:
+    # This job's name is the string the owner enters under branch protection ->
+    # required status checks. Renaming it silently detaches the gate, so keep it
+    # stable.
+    name: Derived artifacts reproduce from their sources
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # 3.11 is the project floor (pyproject requires-python >=3.11) and the
+          # oldest interpreter these checkers must parse the tree on. No `cache:
+          # pip` -- nothing is installed.
+          python-version: '3.11'
+
+      # Every step below is `if: '!cancelled()'` rather than the default
+      # `success()`: a burn-down run must report ALL of the drift in one pass.
+      # With the default, the first red checker hides the other three and the
+      # fix-and-push loop runs once per checker.
+
+      - name: Generated stylesheets reproduce from their sources
+        if: ${{ !cancelled() }}
+        run: |
+          # Rebuilds both bundles into a temp dir and diffs them against the
+          # committed sheets, naming any drifted MODULE block.
+          python tldw_chatbook/css/check_bundle_sync.py
+
+      - name: Profile-owned path census matches its approved exceptions
+        if: ${{ !cancelled() }}
+        run: |
+          # Prints path:line:context:expression:reason for every unapproved
+          # occurrence of a historical profile-owned path root.
+          python scripts/check_profile_owned_path_inventory.py
+
+      - name: Production diagnostic inventory matches the source tree
+        if: ${{ !cancelled() }}
+        run: |
+          # On drift this prints the full committed-vs-rebuild report -- rows
+          # only-in-committed / only-in-rebuild / changed with
+          # old_count/old_digest -> new_count/new_digest, sink-topology deltas,
+          # and the exact next command. Read the rows before regenerating: the
+          # artifact exists to make an unreviewed --write impossible to do by
+          # accident.
+          python scripts/check_persistent_diagnostic_inventory.py
+
+      - name: Backlog task IDs are unique
+        if: ${{ !cancelled() }}
+        run: |
+          # Same check backlog-guard.yml runs; carried here too so it is covered
+          # by the one required status check rather than by a path-filtered
+          # workflow nobody is gated on.
+          python scripts/check_backlog_task_ids.py

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -189,6 +189,108 @@ def test_report_always_ends_with_the_next_command():
     assert inventory.NEXT_STEPS in _diff(committed, rebuilt)
 
 
+def test_the_changed_row_note_admits_re_indentation():
+    """The row note used to offer only "reworded / re-levelled / new args".
+
+    A count-preserving digest change also happens when a call merely shifts
+    nesting level, and sending a reviewer looking for a rewording that is not
+    there is how a gate loses its credibility.
+    """
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["owners"][0]["diagnostic_digest"] = "eeeeeeeeeeeeeeeeeeee"
+
+    report = _diff(committed, rebuilt)
+
+    assert "same count, content changed" in report
+    assert "re-indented" in report
+    assert "--statements" in report
+
+
+def test_next_steps_sends_the_reader_to_statements_not_git_diff():
+    """`git diff` is the wrong recovery tool for this artifact and the trailer
+    must not recommend it: the digest covers indentation, so a moved call reads
+    as changed and a line diff buries it in unrelated edits."""
+    assert "--statements" in inventory.NEXT_STEPS
+    assert "--since" in inventory.NEXT_STEPS
+    assert "git diff" not in inventory.NEXT_STEPS.replace("Do NOT reach for `git diff`", "")
+
+
+_MOVED_BEFORE = """
+import logging
+logger = logging.getLogger(__name__)
+
+def handler(exc):
+    if exc:
+        logger.warning(
+            "wake delivery ledger stamp failed (exception_type={})",
+            type(exc).__name__,
+        )
+"""
+
+_MOVED_AFTER = """
+import logging
+logger = logging.getLogger(__name__)
+
+def handler(exc):
+    logger.warning(
+        "wake delivery ledger stamp failed (exception_type={})",
+        type(exc).__name__,
+    )
+"""
+
+
+def test_a_re_indented_statement_is_reported_as_needing_no_review():
+    """The incident this mode was built for: TASK-19572's pre-merge review found
+    console_fleet_wake.py's row changed inside a 328-line diff in which not one
+    diagnostic statement had actually changed -- only two had been re-indented
+    when the surrounding code was refenced."""
+    report = inventory.render_statement_diff(_MOVED_BEFORE, _MOVED_AFTER, "m.py")
+
+    assert "moved/re-indented only: 1" in report
+    assert "removed: 0" in report
+    assert "added: 0" in report
+    assert "NO review needed" in report
+
+
+def test_an_added_statement_is_printed_in_full_for_reading():
+    """The whole point: the pin cannot carry statement text, and the
+    interpolation check needs it."""
+    after = _MOVED_AFTER + """
+def other(path):
+    logger.error(f"export failed for {path}")
+"""
+    report = inventory.render_statement_diff(_MOVED_AFTER, after, "m.py")
+
+    assert "added: 1" in report
+    assert 'logger.error(f"export failed for {path}")' in report
+    assert "interpolate user content, a secret, a path, or a URL" in report
+
+
+def test_a_removed_statement_is_shown_too():
+    report = inventory.render_statement_diff(_MOVED_AFTER, "x = 1\n", "m.py")
+
+    assert "removed: 1" in report
+    assert "wake delivery ledger stamp failed" in report
+
+
+def test_no_statement_change_says_the_pin_was_already_stale():
+    """A listed row with nothing to show means the drift predates the base --
+    the TASK-19572 finding that two rows rode into a pin unexamined."""
+    report = inventory.render_statement_diff(_MOVED_AFTER, _MOVED_AFTER, "m.py")
+
+    assert "no diagnostic statement changed" in report
+    assert "widen the base revision" in report
+
+
+def test_statement_digests_match_the_ones_the_pin_moves():
+    """The report is only trustworthy if its keys are the gate's keys."""
+    entries = inventory._statement_entries(_MOVED_AFTER, "m.py")
+    diagnostics, _ = inventory.scan_source(_MOVED_AFTER, filename="m.py")
+
+    assert [e["digest"] for e in entries] == [d["digest"] for d in diagnostics]
+
+
 def test_duplicate_task_ids_are_caught_in_both_namespaces(tmp_path):
     """A hand-edited rename can leave the filename unique and the frontmatter
     colliding, which is what the backlog CLI actually resolves on."""

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -1,0 +1,210 @@
+"""TASK-19572: the derived-artifact checkers must teach the fix, not just fail.
+
+`check_persistent_diagnostic_inventory.py` used to fail with a single sentence
+naming no file, no owner and no call site. Four separate burn-down tasks each
+hand-rebuilt a ~30-line diff probe to find out what had drifted. These tests pin
+the promoted report: which rows moved, by how much, and what to run next.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from scripts import check_backlog_task_ids as backlog_ids
+from scripts import check_persistent_diagnostic_inventory as inventory
+
+
+def _inventory(**overrides) -> dict:
+    base = {
+        "schema_version": 2,
+        "scope": "tldw_chatbook/**/*.py",
+        "classification_rules": {"TASK-492": {"prefixes": ["tldw_chatbook/Chat/"]}},
+        "reviewed_exclusions": [],
+        "summary": {
+            "owner_files": 2,
+            "task_492_calls": 3,
+            "task_494_calls": 4,
+            "persistent_sink_files": 1,
+        },
+        "owners": [
+            {
+                "path": "tldw_chatbook/Chat/a.py",
+                "owner": "TASK-492",
+                "reason": "r",
+                "call_count": 3,
+                "diagnostic_digest": "aaaaaaaaaaaaaaaaaaaa",
+            },
+            {
+                "path": "tldw_chatbook/b.py",
+                "owner": "TASK-494",
+                "reason": "r",
+                "call_count": 4,
+                "diagnostic_digest": "bbbbbbbbbbbbbbbbbbbb",
+            },
+        ],
+        "persistent_sink_topology": [
+            {
+                "path": "tldw_chatbook/Logging_Config.py",
+                "sinks": [
+                    {
+                        "method": "add",
+                        "digest": "cccccccccccccccc",
+                        "kind": "loguru_sink",
+                        "scope": "configure_application_logging",
+                    }
+                ],
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _diff(committed: dict, rebuilt: dict) -> str:
+    return inventory.render_diff(json.dumps(committed), rebuilt)
+
+
+def test_added_diagnostic_names_the_file_and_the_delta():
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["owners"][1]["call_count"] = 6
+    rebuilt["owners"][1]["diagnostic_digest"] = "dddddddddddddddddddd"
+    rebuilt["summary"]["task_494_calls"] = 6
+
+    report = _diff(committed, rebuilt)
+
+    assert "tldw_chatbook/b.py" in report
+    assert "4/bbbbbbbbbbbbbbbbbbbb -> 6/dddddddddddddddddddd" in report
+    assert "+2 diagnostic call(s)" in report
+    assert "task_494_calls: 4 -> 6" in report
+    assert "--write" in report
+
+
+def test_reworded_diagnostic_is_distinguished_from_an_added_one():
+    """Same count, different digest: the message, level or arguments changed --
+    the case that actually matters for privacy review."""
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["owners"][0]["diagnostic_digest"] = "eeeeeeeeeeeeeeeeeeee"
+
+    report = _diff(committed, rebuilt)
+
+    assert "same count, content changed" in report
+    assert "tldw_chatbook/Chat/a.py" in report
+
+
+def test_files_gained_and_lost_are_reported_on_their_own_sides():
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["owners"] = [
+        rebuilt["owners"][0],
+        {
+            "path": "tldw_chatbook/c.py",
+            "owner": "TASK-494",
+            "reason": "r",
+            "call_count": 1,
+            "diagnostic_digest": "ffffffffffffffffffff",
+        },
+    ]
+
+    report = _diff(committed, rebuilt)
+
+    assert "only in committed" in report and "tldw_chatbook/b.py" in report
+    assert "only in rebuild" in report and "tldw_chatbook/c.py" in report
+
+
+def test_a_new_persistent_sink_file_is_called_out():
+    """A new disk sink is the highest-consequence drift this artifact tracks."""
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["persistent_sink_topology"].append(
+        {
+            "path": "tldw_chatbook/Utils/secret_dump.py",
+            "sinks": [
+                {
+                    "method": "open_private_text_append",
+                    "digest": "1111111111111111",
+                    "kind": "open_private_text_append",
+                    "scope": "dump",
+                }
+            ],
+        }
+    )
+
+    report = _diff(committed, rebuilt)
+
+    assert "NEW persistent sink file" in report
+    assert "tldw_chatbook/Utils/secret_dump.py" in report
+    assert "open_private_text_append" in report
+
+
+def test_a_changed_sink_entry_shows_both_sides():
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["persistent_sink_topology"][0]["sinks"][0]["scope"] = "some_other_scope"
+
+    report = _diff(committed, rebuilt)
+
+    assert "changed sinks" in report
+    assert "configure_application_logging" in report
+    assert "some_other_scope" in report
+
+
+def test_metadata_drift_is_not_silent():
+    """The checker compares the whole encoded file, so a changed classification
+    rule fails it too. Without this section the report would list zero rows and
+    read as a false alarm."""
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["classification_rules"]["TASK-492"]["prefixes"].append("tldw_chatbook/DB/")
+
+    report = _diff(committed, rebuilt)
+
+    assert "classification_rules" in report
+    assert "tldw_chatbook/DB/" in report
+
+
+def test_serialization_only_drift_says_so():
+    """Identical content, different bytes (hand-edited whitespace or key order)
+    -- otherwise the report is empty and looks like a checker bug."""
+    committed = _inventory()
+    report = inventory.render_diff(
+        json.dumps(committed, indent=8), copy.deepcopy(committed)
+    )
+    assert "only its serialization differs" in report
+
+
+def test_unparseable_committed_file_is_explained():
+    report = inventory.render_diff("{not json", _inventory())
+    assert "not valid JSON" in report
+    assert "--write" in report
+
+
+def test_report_always_ends_with_the_next_command():
+    """Every exit path hands the reader the same one command."""
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    rebuilt["owners"][0]["call_count"] = 99
+    assert inventory.NEXT_STEPS in _diff(committed, rebuilt)
+
+
+def test_duplicate_task_ids_are_caught_in_both_namespaces(tmp_path):
+    """A hand-edited rename can leave the filename unique and the frontmatter
+    colliding, which is what the backlog CLI actually resolves on."""
+    (tmp_path / "task-42 - First.md").write_text("id: TASK-42\n", encoding="utf-8")
+    (tmp_path / "task-42.1 - Second.md").write_text("id: task-42\n", encoding="utf-8")
+    (tmp_path / "task-7 - Fine.md").write_text("id: TASK-7\n", encoding="utf-8")
+
+    by_filename, by_frontmatter = backlog_ids.duplicate_ids(tmp_path)
+
+    assert by_filename == {}
+    assert by_frontmatter == {"task-42": ["task-42 - First.md", "task-42.1 - Second.md"]}
+    assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 1
+
+
+def test_unique_task_ids_pass(tmp_path):
+    (tmp_path / "task-1 - A.md").write_text("id: TASK-1\n", encoding="utf-8")
+    (tmp_path / "task-2 - B.md").write_text("id: TASK-2\n", encoding="utf-8")
+    assert backlog_ids.duplicate_ids(tmp_path) == ({}, {})
+    assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 0

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import json
+from pathlib import Path
 
 from scripts import check_backlog_task_ids as backlog_ids
 from scripts import check_persistent_diagnostic_inventory as inventory
@@ -149,6 +150,48 @@ def test_a_changed_sink_entry_shows_both_sides():
     assert "changed sinks" in report
     assert "configure_application_logging" in report
     assert "some_other_scope" in report
+
+
+def test_sink_multiplicity_increase_is_named_with_counts():
+    """Qodo PR #1947 finding 1: `_sink_lines()` used to collapse each file's
+    sink list into a dict keyed by (scope, kind, method, digest), so a SECOND,
+    byte-identical sink call (the same handler installed twice) shared the
+    same key and silently vanished from the comparison -- a pure multiplicity
+    drift, the highest-consequence class this artifact tracks, reported as no
+    change at all (or worse, as "only serialization differs"). The fix must
+    name the count explicitly, not merely say something changed."""
+    committed = _inventory()
+    rebuilt = copy.deepcopy(committed)
+    duplicate_sink = dict(rebuilt["persistent_sink_topology"][0]["sinks"][0])
+    rebuilt["persistent_sink_topology"][0]["sinks"].append(duplicate_sink)
+
+    report = _diff(committed, rebuilt)
+
+    assert "only its serialization differs" not in report
+    assert "changed sinks" in report
+    assert "tldw_chatbook/Logging_Config.py (1 -> 2 entries)" in report
+    assert (
+        "configure_application_logging: loguru_sink.add (cccccccccccccccc): "
+        "1 -> 2  (+1)" in report
+    )
+
+
+def test_sink_multiplicity_decrease_is_named_too():
+    """The symmetric case: deleting one of two identical sink calls must also
+    be named with the old/new count, not silently absorbed."""
+    committed = _inventory()
+    duplicate_sink = dict(committed["persistent_sink_topology"][0]["sinks"][0])
+    committed["persistent_sink_topology"][0]["sinks"].append(duplicate_sink)
+    rebuilt = copy.deepcopy(committed)
+    del rebuilt["persistent_sink_topology"][0]["sinks"][1]
+
+    report = _diff(committed, rebuilt)
+
+    assert "tldw_chatbook/Logging_Config.py (2 -> 1 entries)" in report
+    assert (
+        "configure_application_logging: loguru_sink.add (cccccccccccccccc): "
+        "2 -> 1  (-1)" in report
+    )
 
 
 def test_metadata_drift_is_not_silent():
@@ -310,3 +353,54 @@ def test_unique_task_ids_pass(tmp_path):
     (tmp_path / "task-2 - B.md").write_text("id: TASK-2\n", encoding="utf-8")
     assert backlog_ids.duplicate_ids(tmp_path) == ({}, {})
     assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 0
+
+
+def test_repo_relative_accepts_a_relative_path_inside_the_repo():
+    assert inventory._repo_relative(
+        "scripts/check_backlog_task_ids.py"
+    ) == Path("scripts/check_backlog_task_ids.py")
+
+
+def test_repo_relative_accepts_an_absolute_path_inside_the_repo():
+    absolute = inventory.REPO_ROOT / "scripts" / "check_backlog_task_ids.py"
+    assert inventory._repo_relative(str(absolute)) == Path(
+        "scripts/check_backlog_task_ids.py"
+    )
+
+
+def test_repo_relative_rejects_an_absolute_path_outside_the_repo():
+    """Qodo PR #1947 finding 4: this used to be an unguarded
+    `Path.relative_to(REPO_ROOT)` that raised `ValueError` for exactly this
+    input -- an absolute path outside the repo, a routine CLI slip."""
+    assert inventory._repo_relative("/etc/hosts") is None
+
+
+def test_repo_relative_rejects_relative_traversal_out_of_the_repo():
+    """Finding 3: a relative path containing enough `..` segments to walk out
+    of REPO_ROOT must not be read silently."""
+    outside = "/".join([".."] * 12) + "/etc/hosts"
+    assert inventory._repo_relative(outside) is None
+
+
+def test_statements_on_an_absolute_path_outside_the_repo_does_not_crash(capsys):
+    """The bug: `_run_statements()` called `path.relative_to(REPO_ROOT)` with
+    no exception handling, so this exact input killed the recovery tool the
+    failure report tells developers to run with a traceback instead of an
+    error message."""
+    assert inventory._run_statements(["/etc/hosts"], None) == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.err
+    assert "does not resolve inside the repository" in captured.err
+
+
+def test_statements_on_relative_traversal_does_not_read_outside_the_repo(capsys):
+    outside = "/".join([".."] * 12) + "/etc/hosts"
+    assert inventory._run_statements([outside], None) == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.err
+    assert "does not resolve inside the repository" in captured.err
+
+
+def test_statements_still_works_for_a_real_in_repo_path():
+    """The fix must not regress the ordinary case: a relative in-repo path."""
+    assert inventory._run_statements(["scripts/check_backlog_task_ids.py"], None) == 0

--- a/Tests/CI/test_derived_artifacts_workflow.py
+++ b/Tests/CI/test_derived_artifacts_workflow.py
@@ -1,0 +1,110 @@
+"""TASK-19572: the shape of the one CI check that is meant to be required.
+
+The `Tests` workflow has produced no verdict since 2026-06-26 -- 200-227 minute
+runtime against 23-50 merges/day on `dev`, with cancel-in-progress killing every
+in-flight run. `derived-artifacts.yml` is the replacement gate: install-free,
+~90 s, and safe to mark as a required status check.
+
+These tests pin the properties that make it requireable at all. They are
+deliberately shape-only (the workflow cannot be executed here), and every
+assertion below corresponds to a way the gate would silently stop gating.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "derived-artifacts.yml"
+CHECKERS = (
+    "tldw_chatbook/css/check_bundle_sync.py",
+    "scripts/check_profile_owned_path_inventory.py",
+    "scripts/check_persistent_diagnostic_inventory.py",
+    "scripts/check_backlog_task_ids.py",
+)
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _job() -> dict:
+    return _workflow()["jobs"]["derived-artifacts"]
+
+
+def _steps() -> list[dict]:
+    return _job()["steps"]
+
+
+def test_workflow_is_valid_yaml_with_one_job():
+    """One job means one required-check name for the owner to enter."""
+    assert list(_workflow()["jobs"]) == ["derived-artifacts"]
+
+
+def test_triggers_are_not_path_filtered():
+    """A path-filtered required check never reports and blocks the PR forever.
+
+    GitHub leaves a skipped required check on "Expected - waiting for status to
+    be reported", so a docs-only PR would be unmergeable. At ~90 s the job is
+    cheap enough to run unconditionally; adding `paths:` is the one edit that
+    would brick merges without failing anything.
+    """
+    triggers = _workflow()[True]  # PyYAML parses the bare `on:` key as True
+    assert set(triggers) == {"pull_request", "push"}
+    for event, config in triggers.items():
+        assert not (config or {}).get("paths"), f"{event} must not be path-filtered"
+        assert not (config or {}).get("paths-ignore"), f"{event} must not path-ignore"
+
+
+def test_every_checker_runs():
+    """All four checkers are invoked, so one job covers the whole census."""
+    script = "\n".join(step.get("run", "") for step in _steps())
+    for checker in CHECKERS:
+        assert checker in script, f"{checker} is not run by the required job"
+
+
+def test_checker_steps_survive_an_earlier_failure():
+    """One red checker must not hide the other three.
+
+    With the default `success()` condition the first failure skips the rest, so
+    a burn-down needs one push per checker. `!cancelled()` reports all of the
+    drift in a single run while still failing the job.
+    """
+    checker_steps = [step for step in _steps() if "python " in step.get("run", "")]
+    assert len(checker_steps) == len(CHECKERS)
+    for step in checker_steps:
+        assert "cancelled()" in str(step.get("if", "")), (
+            f"step {step.get('name')!r} would be skipped after an earlier failure"
+        )
+
+
+def test_job_installs_nothing():
+    """Install-free is what keeps this at ~90 s; a pip install re-creates the
+    runtime that made the Tests workflow unusable."""
+    job = _job()
+    assert "pip install" not in yaml.safe_dump(job)
+    for step in job["steps"]:
+        uses = step.get("uses", "")
+        assert not uses.startswith("actions/setup-python") or "cache" not in (
+            step.get("with") or {}
+        ), "no pip cache is needed when nothing is installed"
+
+
+def test_required_check_name_is_stable():
+    """Renaming this silently detaches branch protection from the job."""
+    assert _job()["name"] == "Derived artifacts reproduce from their sources"
+
+
+def test_backlog_guard_delegates_to_the_shared_script():
+    """backlog-guard and derived-artifacts must not keep two copies of the
+    duplicate-id logic, or the required check and the standalone guard drift."""
+    backlog_guard = (
+        PROJECT_ROOT / ".github" / "workflows" / "backlog-guard.yml"
+    ).read_text(encoding="utf-8")
+    assert "scripts/check_backlog_task_ids.py" in backlog_guard
+    assert "uniq -d" not in backlog_guard, "inline shell copy was reintroduced"

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6061,3 +6061,48 @@ protection, it must not be path-filtered: a skipped run reports nothing, so
 GitHub parks the PR on "Expected — waiting for status to be reported" forever.
 That is why `derived-artifacts.yml` runs unconditionally while
 `css-bundle-guard.yml` beside it does not.
+
+---
+
+## A content digest over raw source text fires on re-indentation — and `git diff` is the wrong tool to investigate it
+
+**TASK-19572 pre-merge review, 2026-08-22.** The production diagnostic
+inventory keys each logger call on a SHA of its own source segment, precisely so
+that *moving* a call is not a review event (task-3750). But
+`ast.get_source_segment` keeps the continuation lines' absolute indentation, so
+a call that merely shifts nesting level — because someone wrapped the
+surrounding block in a new `if` or `try` — produces a different digest with
+identical text.
+
+The incident: `Chat/console_fleet_wake.py` showed as `11/9df8f371… ->
+11/44b53292…`, and the checker's report labelled it *"reworded / re-levelled /
+new args"*. All three were wrong. Dev had landed a 328-line change (248
+insertions) that re-indented exactly two `logger` calls; **not one diagnostic
+statement had changed**. Whitespace-normalizing both sides proved it in one
+line.
+
+**Two things generalise.**
+
+1. **A digest taken over raw source text is not a content digest.** If you build
+   one, normalize what you do not want to review — or make the reporting layer
+   pair off layout-only changes explicitly. Otherwise the artifact's own stated
+   contract ("movement is not a review event") is false, and every false alarm
+   teaches the reviewer to regenerate without reading, which is the one failure
+   the artifact exists to prevent.
+
+2. **Never investigate an AST-keyed artifact with a line diff.** The report's
+   original trailer said `git diff $base -- <path>`; following it buried two
+   re-indented calls inside an unrelated refactor. Recover the statements by
+   running the *checker's own scanner* over both revisions' git blobs and
+   diffing the resulting `(method, digest)` multisets — the same keys the pin
+   moves. That turns a 328-line read into
+   `moved/re-indented only: 2   removed: 0   added: 0`. The checker now ships
+   this as `--statements <path> --since <rev>`; use it, and check multiset
+   counts, not set membership, or a deleted duplicate of an identical call is
+   invisible.
+
+Corollary on scope: when a rebase resolves the pin conflict by taking the other
+side wholesale, **verify the taken pin reproduces from its own tree before
+concluding anything** — and separately review the delta between it and the pin
+you last reviewed. Those are two different questions, and the first being green
+does not answer the second.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6025,3 +6025,39 @@ credential file was not dirty in that scenario, so the inverted scope had
 nothing to leak. Reading the base-run PASS list rather than only the FAILED list
 is what caught it. A born-red test that passes at base is a defect in the test
 until you have explained why.
+
+---
+
+## A guard that cannot report is not a gate — check where it runs, not just that it runs
+
+**TASK-19572, 2026-08-21.** The repo carried three real derived-artifact
+guards and a nightly full-suite cron, and none of them had produced a verdict
+in weeks. Two separate mechanisms, both invisible from the workflow file:
+
+1. **A cron on a non-default branch never fires.** `.github/workflows/test.yml`
+   on `dev` declares `schedule: cron '30 8 * * *'` with a `nightly-deep` job.
+   `gh run list --workflow=test.yml --event=schedule` returns **`[]`** for the
+   entire retained history. GitHub schedules cron only from the *default*
+   branch's copy of the workflow, and this repo's default branch is `main` —
+   last updated 2026-07-11, **10,933 commits behind `dev`**, with no
+   `schedule:` block in its `test.yml` at all. The nightly the repo believed it
+   had has never run once.
+
+2. **Completion is governed by queue time, not job time.** `css-bundle-guard`
+   is one stdlib script with no install. Its `pull_request` runs over the last
+   100: **61 cancelled, 19 success**, and the successes are bimodal — ten
+   finished in 16–398 s, nine took **1.9–5.6 hours**. The job did not get
+   slower; it waited for a runner. The `Tests` workflow fans out ~20 jobs
+   (2 core legs + 12 UI shards + 3 lease legs + …) on every push and PR, at
+   23–50 merges/day, and starves everything else — including itself.
+
+**What to do.** Before claiming a guard covers something, ask where its verdict
+lands. Check `gh run list --workflow=<f> --event=<e>` for the event you think
+fires it, and read the *default branch's* copy of the file when the trigger is
+`schedule`. When you measure a workflow, measure `createdAt → updatedAt` (wall,
+including queue), not the job's own duration — cheap jobs on a saturated pool
+are not fast verdicts. And if a check is meant to be **required** under branch
+protection, it must not be path-filtered: a skipped run reports nothing, so
+GitHub parks the PR on "Expected — waiting for status to be reported" forever.
+That is why `derived-artifacts.yml` runs unconditionally while
+`css-bundle-guard.yml` beside it does not.

--- a/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
+++ b/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
@@ -3,8 +3,8 @@ id: TASK-19572
 title: >-
   CI has not completed successfully since 2026-06-26 and dev has no branch
   protection — ship one install-free required check
-status: To Do
-assignee: []
+status: In Progress
+assignee: ['@claude']
 created_date: '2026-08-21 20:25'
 labels:
   - ci
@@ -103,22 +103,186 @@ small check that actually runs beats a comprehensive suite that never reports.
 
 ## Acceptance Criteria
 
-- [ ] A `derived-artifacts` CI job exists that runs the three stdlib-only
+- [x] A `derived-artifacts` CI job exists that runs the three stdlib-only
       checkers with no dependency installation, completing in roughly 90 s
       including checkout
 - [ ] That job is a **required status check** on `dev`, so a red guard blocks a
-      merge
+      merge — **owner action, see "Owner gate" below**
 - [ ] Branch protection exists on `dev` (and a decision is recorded for `main`)
-- [ ] `check_persistent_diagnostic_inventory.py` gains a `--diff` mode that
+      — **owner action, see "Owner gate" below**
+- [x] `check_persistent_diagnostic_inventory.py` gains a `--diff` mode that
       runs automatically on every non-zero exit and names what changed —
       rows-only-committed / only-rebuild / changed, with old→new counts and
       digests, and the exact next command
-- [ ] The other two checkers are held to the same standard: when they fail they
+- [x] The other two checkers are held to the same standard: when they fail they
       name the offending file
 - [ ] The Tests workflow's cancel-in-progress behaviour is addressed so that
       *some* full-suite verdict is produced on a regular cadence — e.g. a
       scheduled run on a quiet branch, sharding, or exempting a nightly ref.
       The 200–227 minute runtime is the constraint to design around (see also
-      TASK-19425, which covers the runtime growth itself)
+      TASK-19425, which covers the runtime growth itself) — **root-caused here
+      and NOT fixable from `dev`; see "Owner gate"**
 - [ ] The first completed full-suite run since 2026-06-26 is recorded, with its
-      pass/fail counts, so the repo knows its actual baseline
+      pass/fail counts, so the repo knows its actual baseline — **blocked on the
+      two ACs above**
+
+## Implementation Plan
+
+1. Reproduce the measurements on this machine: run all three checkers, record
+   real timings, confirm the diagnostic-inventory pin is red at the current
+   `origin/dev` tip.
+2. Promote the throwaway diff probe into the checker: a report emitted on
+   **every** non-zero exit naming only-in-committed / only-in-rebuild / changed
+   rows with `old_count/old_digest -> new_count/new_digest`, sink-topology
+   deltas, metadata deltas, and the exact next command.
+3. Use that report to do the per-row review the artifact's design demands, then
+   regenerate the inventory so the new gate is green on arrival (a required
+   check that is red on day one cannot be turned on). Surface, do not absorb,
+   anything the review flags.
+4. Hold the other two checkers to the same standard: name the file, say what to
+   do next, and print a positive line on success.
+5. Ship `.github/workflows/derived-artifacts.yml` — install-free, one job, all
+   four checks, modelled on `css-bundle-guard.yml` but **unfiltered**, because a
+   path-filtered check cannot be required.
+6. De-duplicate the backlog duplicate-id logic into `scripts/check_backlog_task_ids.py`
+   so the required job and `backlog-guard.yml` cannot drift apart.
+7. Add `scripts/preflight.sh` so the local burn-down is one command.
+8. Shape tests for the workflow and unit tests for the new report; run the
+   pre-existing guard suites for regressions.
+9. Write up what is and is not in an implementer's control.
+
+## Implementation Notes
+
+Shipped the guard that can actually report, and the tooling that makes its
+failures self-explaining. Branch protection itself is untouched — that is a
+repo-admin action and is written up under **Owner gate** below.
+
+**`--diff` on every non-zero exit.** `check_persistent_diagnostic_inventory.py`
+previously failed with one sentence naming nothing, so four separate burn-down
+tasks each hand-built a ~30-line probe. `render_diff()` now reports, on every
+failing exit and with no flag required: summary deltas, owner rows
+only-in-committed / only-in-rebuild / changed (`old_count/old_digest ->
+new_count/new_digest`, and a count-preserving digest change is labelled
+*reworded / re-levelled / new args* — the case that matters for privacy), per-
+entry persistent-sink deltas, **metadata deltas** (the check compares the whole
+encoded file, so a changed `classification_rules` would otherwise fail with zero
+rows and read as a false alarm), a distinct message for serialization-only
+drift, and the exact next command. `--diff` also exists as an explicit flag, and
+a `::error::` annotation is emitted only under `GITHUB_ACTIONS`.
+
+**The inventory was red at `origin/dev` 3193816e7 and is now green.** The report
+named 16 files; the delta was reviewed statement-by-statement (each added and
+removed logger call was recovered by scanning both revisions with the checker's
+own AST scanner, not by reading a line diff) before `--write`. Almost all of it
+is metadata-only — `type(exc).__name__`, ids, counts — or pure code movement
+(the three character-picker diagnostics moved from `chat_screen.py` into
+`UI/Console_Modules/character.py` unchanged). **One row is worth a follow-up and
+is deliberately not absorbed silently:** task-19576 added three
+`logger.error(f"Failed to extract ... from {file_path}: {e}")` calls in
+`Utils/file_handlers.py`, which put a full user file path in a persistent sink —
+the same class as the open TASK-19321/TASK-19322 path-logging repairs.
+
+**`derived-artifacts.yml`.** One job, four stdlib-only checks, `setup-python`
+and nothing else installed. Two deliberate departures from `css-bundle-guard.yml`:
+it is **not path-filtered** (a skipped required check never reports, so GitHub
+parks the PR on "Expected — waiting for status to be reported" forever; at ~90 s
+it is cheaper to just always run), and every checker step carries
+`if: ${{ !cancelled() }}` so one red checker cannot hide the other three — a
+burn-down must see all the drift in one pass. The job name is the string the
+owner types into branch protection, so the shape test pins it.
+
+**De-duplication.** The duplicate-task-id check moved out of inline shell into
+`scripts/check_backlog_task_ids.py`; `backlog-guard.yml` now calls it, and so
+does the new job — two hand-maintained copies of a guard is the failure mode
+this whole task is about. Behaviour is unchanged (both namespaces: filename
+prefix and frontmatter `id:`), verified against the old shell pipeline on the
+live tree and against a synthetic collision.
+
+**Also:** `check_profile_owned_path_inventory.py` gained a next-step trailer on
+failure and a positive line on success (it used to print nothing at all when it
+passed, which is indistinguishable from a step that did not run).
+`scripts/preflight.sh` runs all four locally in one command and reports every
+failure, not the first.
+
+### Verified
+
+- Timings on this machine (M-series, `.venv` python 3.12): bundle-sync
+  **0.86 s**, profile-owned-path **10.98 s**, diagnostic inventory **20.17 s**,
+  backlog ids **0.10 s**; `scripts/preflight.sh` end-to-end **31.9 s**.
+- The report against the real dev-tip drift named 16 files and every count/digest
+  delta.
+- Mutation proof, diagnostic checker: adding one `logger.warning` in
+  `Workspaces/git_workspace.py` and re-levelling one `logger.info` ->
+  `logger.warning` in `Notes/sync_engine.py` produced
+  `~ changed: tldw_chatbook/Workspaces/git_workspace.py 1/3b62237e439a1aafa3a8 -> 2/1177de3ed8987e4d8c5f  (+1 diagnostic call(s))`
+  and `~ changed: tldw_chatbook/Notes/sync_engine.py 20/b597ae206b3e2b1ddfd3 -> 20/fd7db158e7e83f7706ec  (same count, content changed ...)`.
+  Both mutations restored via Edit.
+- Mutation proof, profile checker: a planted `"~/.config/tldw_cli/git.toml"`
+  literal produced
+  `tldw_chatbook/Workspaces/git_workspace.py:39: module:TEMPORARY_MUTATION_PROBE: literal:~/.config/tldw_cli/git.toml: unapproved occurrence`.
+  Restored via Edit.
+- `Tests/Architecture/test_derived_artifact_checkers.py` +
+  `Tests/CI/test_derived_artifacts_workflow.py`: **18 passed**.
+- Pre-existing guard suites (`test_persistent_diagnostic_inventory.py`,
+  `test_profile_owned_path_inventory.py`, `test_css_bundle_sync_guard.py`,
+  `test_github_actions_test_workflow.py`): **98 passed** — including
+  `test_production_diagnostic_inventory_and_sink_topology_are_unchanged`, which
+  was red at this base before the reviewed regeneration.
+
+### NOT verified
+
+The workflow has never executed. It parses as YAML and its shape is pinned by
+tests, but nothing here proves it is green on a GitHub runner, and the ~90 s
+figure is local work plus an estimate for checkout/setup — see the queue-time
+finding below, which makes *wall* time a different question entirely.
+
+## Owner gate — what an implementer cannot ship in a PR
+
+**1. Branch protection + the required check (ACs 2, 3).** Requires repo-admin
+API writes, which this task deliberately did not perform. After merge:
+`Settings -> Branches -> add rule for dev -> Require status checks to pass ->`
+select **`Derived artifacts reproduce from their sources`**. Record the `main`
+decision at the same time (`main` is currently unprotected too). Note the
+workflow must have run at least once for GitHub's picker to offer the name.
+
+**2. The nightly full-suite cadence (AC 6) cannot be fixed from `dev` at all.**
+The premise needs correcting: `cancel-in-progress` is *not* what stops the
+nightly. `github.ref` for a scheduled run is the default branch, and the rule is
+`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` — so scheduled runs
+are already exempt. The real reason is simpler and worse:
+
+> **GitHub schedules cron only from the default branch's copy of the workflow.**
+> The default branch is `main`, last updated **2026-07-11** and **10,933 commits
+> behind `dev`**, and `main`'s `test.yml` has **no `schedule:` block at all**.
+> `gh run list --workflow=test.yml --event=schedule` returns `[]` for the whole
+> retained history. The `nightly-deep` job has never run, and adding any
+> `schedule:` trigger on `dev` will remain inert until `main` is updated.
+
+Owner options: (a) fast-forward/merge `dev` into `main` so the crons the repo
+already wrote start firing, or (b) accept that no cron works and drive the full
+suite by `workflow_dispatch` on a cadence. Either is an owner call; (a) has
+consequences well beyond CI.
+
+**3. Runner starvation is the other half, and it bounds even this job.**
+Measured over the last 100 `css-bundle-guard` runs — one stdlib script, no
+install: **61 of 83 `pull_request` runs cancelled, 19 succeeded**, and the
+successes are bimodal — ten finished in **16–398 s**, nine took **1.9–5.6
+hours**. The job did not get slower; it waited for a runner. `Tests` fans out
+~20 jobs (2 core legs + 12 UI shards + 3 lease legs + …) on every push and PR at
+23–50 merges/day and starves the pool. Sixty `Tests` runs were created in one
+74-minute window while this task was in progress; every one was cancelled or
+still queued. Until that fan-out is cut (TASK-19425), a *required* check will be
+correct but sometimes slow to report. Worth the owner's consideration:
+restricting `Tests` to `workflow_dispatch` + schedule until its runtime is
+fixed, since it has produced no verdict since 2026-06-26 and is currently
+costing the guards that do work.
+
+**4. A one-line CLAUDE.md addition, left to the owner** (agents must not edit
+project instructions on another agent's say-so). Suggested, under the Definition
+of Done:
+
+> Run `./scripts/preflight.sh` before opening a PR — it runs the same four
+> derived-artifact checks as the `Derived artifacts` CI job.
+
+**5. Follow-up to file:** `Utils/file_handlers.py` logs full user file paths in
+three new `logger.error` calls (task-19576), same class as TASK-19321/19322.

--- a/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
+++ b/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
@@ -238,6 +238,91 @@ tests, but nothing here proves it is green on a GitHub runner, and the ~90 s
 figure is local work plus an estimate for checkout/setup — see the queue-time
 finding below, which makes *wall* time a different question entirely.
 
+## Pre-merge re-review at the final base (2026-08-22)
+
+Rebased onto `origin/dev` `d4f3f9776`; the one conflict
+(`Docs/security/production-diagnostic-inventory.json`) was resolved by taking
+**dev's** copy wholesale, discarding this branch's own regeneration.
+
+**The gate arrives green, and no `--write` was run.** Dev's copy reproduces from
+dev's tree byte-for-byte — verified twice, once by the checker itself
+(`--diff` → *"no drift: the committed inventory matches the rebuild exactly"*,
+521 owners / 1221 TASK-492 / 7208 TASK-494 / 7 sink files) and once
+independently by rebuilding every owner row from `HEAD`'s git blobs with the
+checker's own scanner. This branch changes no file under `tldw_chatbook/`, so it
+contributes no drift of its own. Regenerating here would have been the exact
+"regenerate without reading" failure the artifact exists to prevent.
+
+**The three drifted rows were still reviewed statement-by-statement**, because
+they are unreviewed *by this branch*: the reviewed baseline is the pre-rebase
+tip `ee7464d54` (whose pin also reproduces from its own tree — checked, unlike
+the `0b112ab1e` pin in Owner-gate item 6). Delta `ee7464d54` → `d4f3f9776`,
+recovered with the AST scanner across both revisions, never a line diff:
+
+| row | delta | statements | verdict |
+|---|---|---|---|
+| `Chat/console_fleet_wake.py` | 11→11, digest changed | 2 calls **re-indented only**; whitespace-normalized text identical on both sides | benign — pure layout |
+| `Persona_Buddy/preferences.py` | new row, 0→1 | `logger.bind(exception_type=exception_type).error("persona_buddy_preferences_save_failed")`, where `exception_type` is `type(error).__name__` *regex-validated* before binding | benign — metadata only |
+| `UI/Screens/personas_screen.py` | 180→186 | 6 × `logger.warning` with fully static messages (`"Persona Buddy … failed (category=…)"`), no interpolation | benign |
+
+Multiset-checked: raw counts match the pin exactly (180→186, 11→11, 0→1) with
+zero multiplicity-only changes, so those 9 statements are the *complete* delta.
+**No new exposure found** — nothing interpolates user content, a secret, a path,
+or a URL. Nothing was absorbed.
+
+### The report was not sufficient, and has been fixed
+
+Judged in anger, the `--diff` report failed on the one row that mattered. It
+labelled `console_fleet_wake.py` *"reworded / re-levelled / new args"* — all
+three wrong. The calls had only been **re-indented** when the surrounding code
+was refenced. The per-call digest is taken over `ast.get_source_segment`, which
+keeps continuation-line indentation, so shifting a call's nesting level moves the
+file's digest even though the module docstring says movement is explicitly *not*
+a review event. That is task-3750's failure mode reappearing one level down.
+
+Worse, the trailer's recovery recipe was `git diff <base> -- <path>`. Following
+it on that row yields a **328-line diff containing zero statement changes** — the
+reviewer's job becomes finding two re-indented calls inside an unrelated
+248-insertion refactor, which is exactly how "it was probably fine" gets written.
+
+Fixed in this commit:
+
+- **`--statements <path> ... [--since REV]`** — a real recovery mode. It scans
+  both revisions with the *same* scanner and the *same* per-call digest the pin
+  uses (pinned by a test), pairs off statements whose only difference is layout,
+  and prints the full source text of everything genuinely added or removed under
+  a `|` gutter at its original shape. On the incident row it answers in one
+  line: `moved/re-indented only: 2   removed: 0   added: 0`.
+  A path absent at the base revision (an "only in rebuild" row) is reported as
+  *"did not exist at REV"*, not as a broken revision argument.
+- The changed-row note now reads *"reworded / re-levelled / new args /
+  re-indented — use --statements to see which"*.
+- `NEXT_STEPS` now hands over the `--statements` command and says plainly not to
+  reach for `git diff` here, with the measured reason.
+- 8 tests added (`Tests/Architecture/test_derived_artifact_checkers.py`),
+  including one that reproduces the re-indentation incident and one asserting the
+  recovery mode's digests are the same keys the pin moves.
+
+### Verified at the final base
+
+- `scripts/preflight.sh` — **all four checkers pass in 33 s**: CSS bundle +
+  4 generated stylesheets; profile-owned path census (48 occurrences / 18 files /
+  46 approved exceptions); diagnostic inventory; backlog ids (2375 task files, no
+  duplicates). No other checker is red at this base.
+- Mutation proof of the whole loop under `GITHUB_ACTIONS=true`: a planted
+  `logger.warning(f"TEMPORARY_MUTATION_PROBE wrote {preferences!r}")` produced
+  exit 1, the `::error::` annotation on stdout, the report on stderr naming
+  `Persona_Buddy/preferences.py 1/3053… -> 2/b733… (+1 diagnostic call(s))`, and
+  the report's own recommended command then printed the offending statement
+  verbatim. Restored via Edit; `git status` on `tldw_chatbook/` clean afterwards.
+- Suites: `test_derived_artifact_checkers.py` **18**, `test_derived_artifacts_workflow.py`
+  **7**, `test_persistent_diagnostic_inventory.py` **65**,
+  `test_profile_owned_path_inventory.py` **15**, `test_css_bundle_sync_guard.py`
+  **4**, `test_github_actions_test_workflow.py` **15** — **124 passed**
+  (the prior 116 plus the 8 new tests).
+- Repo-wide `pytest --collect-only -q`: **54,651 tests collected, no collection
+  errors**.
+
 ## Owner gate — what an implementer cannot ship in a PR
 
 **1. Branch protection + the required check (ACs 2, 3).** Requires repo-admin
@@ -334,7 +419,7 @@ the argument for the gate this task ships.
 
 **7. The pin must be regenerated against the FINAL base immediately before
 merge.** The inventory is a whole-tree artifact and `dev` moves 23–50 times a
-day. Measured 2026-08-22: this branch's freshly regenerated pin is *already* red
+day. Measured 2026-08-22: this branch's freshly regenerated pin was *already* red
 against `origin/dev` `cbb11633f` — three rows drift
 (`Chat/console_fleet_wake.py` digest, `Persona_Buddy/preferences.py` new row,
 `UI/Screens/personas_screen.py` 180→186). Since a `pull_request` check runs on
@@ -343,3 +428,9 @@ wrong. Two consequences the owner should price in before flipping the switch:
 any PR that adds a logger call must regenerate, and two such PRs racing will
 both conflict textually on the same sorted JSON. Neither is a defect in this
 branch; both are costs of making *this* artifact the required gate.
+
+**Resolved at the final base — see "Pre-merge re-review" below.** The rebase onto
+`origin/dev` `d4f3f9776` took *dev's* copy of the inventory, and dev's copy
+reproduces from dev's tree exactly, so the gate arrives **green** with no
+regeneration by this branch at all. The three predicted rows were reviewed
+statement-by-statement anyway, because they are unreviewed *by this branch*.

--- a/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
+++ b/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
@@ -323,6 +323,120 @@ Fixed in this commit:
 - Repo-wide `pytest --collect-only -q`: **54,651 tests collected, no collection
   errors**.
 
+## Qodo review fixes, PR #1947 (2026-08-22)
+
+Four findings on the PR: two bugs, two "Unvalidated" rule-violation flags. Fixed
+both bugs; the two rule-violation flags are dispositioned below rather than
+complied with reflexively, with evidence for each call.
+
+**Finding 1 (High, Bug) — sink diff dropped duplicates. Fixed.**
+`_sink_lines()` compared each file's persistent-sink entries by building
+`{_sink_key(entry): entry for entry in ...}` -- a plain dict -- so two
+byte-identical sink calls (the same handler installed twice) collapsed to one
+key and a pure **multiplicity** drift, the highest-consequence class this
+artifact exists to catch, could report as no change, or worse. Reproduced
+against the real tree, not synthetic data only: planted an exact duplicate of
+`Logging_Config.py`'s `loguru_logger.add(...)` call inside
+`configure_application_logging`. Against the **pre-fix** code the top-level
+check still failed (the raw JSON differed), but `render_diff()`'s own sink
+section produced nothing, so the report read: *"the committed inventory's
+CONTENT matches the rebuild; only its serialization differs ... Run --write to
+re-normalize it"* -- an actively misleading verdict that would have trained a
+reviewer to blindly `--write` past a real second sink. Fixed by comparing
+`collections.Counter(_sink_key(entry) for entry in ...)` (multiset semantics:
+`Counter.__eq__` compares counts) and reporting the delta explicitly per key
+(`before_n -> after_n (+delta)`, or `+`/`-` with a `(new, x2)` / `(removed, was
+x2)` suffix at the edges). Against the **post-fix** code the same mutation now
+reports:
+```
+persistent sink topology:
+  ~ changed sinks: tldw_chatbook/Logging_Config.py (7 -> 8 entries)
+      ~ configure_application_logging: loguru_sink.add (9fce73a232622dc7): 1 -> 2  (+1)
+```
+Mutation restored via Edit; `git diff -- tldw_chatbook/Logging_Config.py` is
+empty and `--diff` is back to "no drift" against the unmodified tree. Two new
+synthetic tests pin both directions (`test_sink_multiplicity_increase_is_
+named_with_counts`, `test_sink_multiplicity_decrease_is_named_too`), asserting
+the exact count string is present and that "only its serialization differs"
+does **not** appear when there is real drift.
+
+**Finding 4 (Bug, Reliability) — `--statements` crashed on an out-of-repo
+absolute path. Fixed.** `_run_statements()` called
+`path.relative_to(REPO_ROOT)` unconditionally for an absolute `PATH`, so
+`--statements /etc/hosts` raised an unhandled `ValueError` -- a traceback from
+exactly the recovery tool the failure report tells a developer to run.
+
+**Finding 3 (Rule violation, "Unvalidated `--statements` paths read") — fixed
+on the merits, not with the literally suggested implementation.** Qodo's
+suggested fix (`path_validation.py`) is inappropriate for this file:
+`Utils/path_validation.py` imports `Metrics.metrics_logger`, which imports
+`psutil` (third-party) -- pulling it into a script this task's own AC requires
+to stay stdlib-only and install-free would break that contract for every
+future run of `derived-artifacts.yml`. The underlying concern (a relative `..`
+path silently reading outside the repo) is real and is fixed directly: new
+helper `_repo_relative()` resolves the candidate against `REPO_ROOT`, and
+returns `None` -- never raises -- for anything that resolves outside it,
+covering both Finding 3 (relative traversal) and Finding 4 (absolute
+out-of-repo path) with one code path. `_run_statements()` now prints a clear
+one-line stderr message and returns 1 instead of crashing or reading outside
+the repo. Verified: `--statements /etc/hosts` and
+`--statements ../../../../../../etc/hosts` both now print `cannot use ...: it
+does not resolve inside the repository ...` and exit 1 with **no traceback**;
+ordinary relative and absolute in-repo paths are unaffected. Checked the file
+for the same unguarded pattern elsewhere (per the task instructions): the two
+other `relative_to(REPO_ROOT)` call sites (`build_inventory()`'s file walk and
+the `--write`/missing-file messages against the hardcoded `INVENTORY_PATH`)
+never take CLI input, so they were not at risk. Six new tests cover
+`_repo_relative()` (accept relative-in-repo, accept absolute-in-repo, reject
+absolute-outside, reject relative-traversal) and `_run_statements()` (clean
+error with no `Traceback` string for both outside-repo shapes; ordinary in-repo
+path still returns 0).
+
+**Finding 2 (Rule violation, "Unvalidated `--tasks-dir` used") — declined, with
+evidence; not applied.** Same `path_validation.py` objection as Finding 3
+applies (stdlib-only contract), but there is a second, independent reason this
+one specific "fix" would be actively wrong here: `Tests/Architecture/
+test_derived_artifact_checkers.py:305,312` (pre-existing, this branch did not
+add them) deliberately pass a pytest `tmp_path` fixture -- outside `REPO_ROOT`
+by construction -- as `--tasks-dir` to exercise the checker in isolation.
+Confining `--tasks-dir` to the repo root, as the suggested fix would do, breaks
+that test and the flag's own stated purpose (`--tasks-dir` exists precisely so
+callers, including tests, can point it elsewhere). Separately: neither
+workflow that runs this script (`backlog-guard.yml`, `derived-artifacts.yml`)
+ever passes `--tasks-dir` -- both invoke the script bare -- so there is no
+CI-reachable attacker-controlled input reaching this flag at all; the only
+caller is a developer's own CLI argument in their own shell, already reading
+files at their own OS-level permission, which is not a privilege boundary a
+"traversal" can cross. No code-behavior change; added a code comment at the
+argument definition recording this reasoning so a future reviewer (human or
+Qodo) does not treat the omission as an oversight.
+
+**Verified after all four dispositions:**
+- `scripts/preflight.sh` (`GITHUB_ACTIONS=true`) — all four checkers still
+  green: CSS bundle + 4 sheets; profile-owned path census (48/18/46, unchanged);
+  diagnostic inventory (`no drift: the committed inventory matches the rebuild
+  exactly` -- **the pin still reproduces byte-for-byte; nothing was
+  regenerated**); backlog ids (2375 files, no duplicates).
+- `Tests/Architecture/test_derived_artifact_checkers.py`: **27 passed** (the
+  prior 18 plus 9 new: 2 sink-multiplicity, 4 `_repo_relative`, 3
+  `_run_statements`).
+- The five guard suites named in the review brief together: `test_derived_
+  artifact_checkers.py` **27**, `test_derived_artifacts_workflow.py` **7**,
+  `test_persistent_diagnostic_inventory.py` **65**, `test_profile_owned_path_
+  inventory.py` **15**, `test_css_bundle_sync_guard.py` **4** — **118 passed**
+  (109 pre-existing + 9 new).
+- Repo-wide `pytest --collect-only -q`: **54,660 tests collected** (54,651 +
+  9 new), **no collection errors**.
+- `git status` after all restores: only `Tests/Architecture/test_derived_
+  artifact_checkers.py`, `scripts/check_persistent_diagnostic_inventory.py`,
+  and `scripts/check_backlog_task_ids.py` modified -- nothing under
+  `tldw_chatbook/` or `Docs/security/production-diagnostic-inventory.json`.
+
+Commit: `fix(guard): address Qodo review findings on PR #1947 (task-19572)`.
+Status stays **In Progress**: the owner-gated ACs (branch protection, required
+check, main's cron) are unaffected by this fix-up and remain open per "Owner
+gate" below.
+
 ## Owner gate — what an implementer cannot ship in a PR
 
 **1. Branch protection + the required check (ACs 2, 3).** Requires repo-admin

--- a/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
+++ b/backlog/tasks/task-19572 - CI has not completed successfully since 2026-06-26 and dev has no branch protection.md
@@ -171,16 +171,18 @@ drift, and the exact next command. `--diff` also exists as an explicit flag, and
 a `::error::` annotation is emitted only under `GITHUB_ACTIONS`.
 
 **The inventory was red at `origin/dev` 3193816e7 and is now green.** The report
-named 16 files; the delta was reviewed statement-by-statement (each added and
+named 17 files; the delta was reviewed statement-by-statement (each added and
 removed logger call was recovered by scanning both revisions with the checker's
-own AST scanner, not by reading a line diff) before `--write`. Almost all of it
+own AST scanner, not by reading a line diff) before `--write`. 65 statements
+were added and 7 removed. Almost all of it
 is metadata-only — `type(exc).__name__`, ids, counts — or pure code movement
 (the three character-picker diagnostics moved from `chat_screen.py` into
-`UI/Console_Modules/character.py` unchanged). **One row is worth a follow-up and
-is deliberately not absorbed silently:** task-19576 added three
-`logger.error(f"Failed to extract ... from {file_path}: {e}")` calls in
-`Utils/file_handlers.py`, which put a full user file path in a persistent sink —
-the same class as the open TASK-19321/TASK-19322 path-logging repairs.
+`UI/Console_Modules/character.py` unchanged; `app.py` is the one count-preserving
+digest change and it is a local rename, `_log_buffer` -> `_log_records`).
+**Rows worth a follow-up, deliberately not absorbed silently:** see Owner gate
+item 5 — the regeneration pinned 21 newly-added diagnostics across five files
+that interpolate a filesystem path into a log line, the class the open
+TASK-19321/TASK-19322 repairs cover.
 
 **`derived-artifacts.yml`.** One job, four stdlib-only checks, `setup-python`
 and nothing else installed. Two deliberate departures from `css-bundle-guard.yml`:
@@ -209,7 +211,7 @@ failure, not the first.
 - Timings on this machine (M-series, `.venv` python 3.12): bundle-sync
   **0.86 s**, profile-owned-path **10.98 s**, diagnostic inventory **20.17 s**,
   backlog ids **0.10 s**; `scripts/preflight.sh` end-to-end **31.9 s**.
-- The report against the real dev-tip drift named 16 files and every count/digest
+- The report against the real dev-tip drift named 17 files and every count/digest
   delta.
 - Mutation proof, diagnostic checker: adding one `logger.warning` in
   `Workspaces/git_workspace.py` and re-levelling one `logger.info` ->
@@ -284,5 +286,60 @@ of Done:
 > Run `./scripts/preflight.sh` before opening a PR — it runs the same four
 > derived-artifact checks as the `Derived artifacts` CI job.
 
-**5. Follow-up to file:** `Utils/file_handlers.py` logs full user file paths in
-three new `logger.error` calls (task-19576), same class as TASK-19321/19322.
+**5. Follow-ups to file — path-interpolating diagnostics absorbed by this
+regeneration.** Independent review (2026-08-22) re-derived every added/removed
+statement from the two revisions and found the class is **wider than one file**.
+21 newly-pinned diagnostics across five files interpolate a filesystem path:
+
+| file | new path-logging calls | what is interpolated |
+|---|---|---|
+| `UI/Screens/change_review_screen.py` | 8 | `{root!r}` ×6, `{roots!r}`, `{remote!r} at {root!r}` — workspace root paths |
+| `Widgets/Console/console_conversation_inspector.py` | 5 (3 net new; 2 carried from the retired `console_context_modal.py`) | `{path}` — user-chosen export/snapshot destination |
+| `DB/ChaChaNotes_DB.py` | 4 | `{self.db_path_str}` in the V42→V43 / V43→V44 migration lines (replicates the pre-existing style of the ~330 calls already in that file) |
+| `Utils/file_handlers.py` | 3 | `{file_path}` — lines **380, 410, 441** (task-19576) |
+| `Workspaces/git_workspace.py` | 1 | `{root}`, at `debug` level |
+
+**Severity is lower than "into a persistent sink" implies, and the wording
+elsewhere in this file should be read with that correction.** The only
+general-purpose on-disk log is `PrivateRotatingFileHandler`, and it carries
+`PersistentDiagnosticFilter`, which admits **only** records marked by
+`log_persistent_metadata` / `persist_event`. A plain
+`logger.error(f"... {file_path} ...")` is a Chatbook record without that marker,
+so `filter()` returns `False` and it never reaches the rotating file. Verified
+directly:
+
+```
+PersistentDiagnosticFilter().filter(<ERROR record from tldw_chatbook.Utils.file_handlers>)
+-> False
+```
+
+These lines therefore reach the terminal and the in-app Logs screen, not the
+private log file. They remain in scope for TASK-19321/19322, but as a UI/console
+exposure, not an on-disk one — and any follow-up should cover all five files,
+not only `file_handlers.py`.
+
+**6. Two rows in this regeneration predate this branch's base and were never
+reviewed when they landed.** The previous pin (blob `b07d9e10f`, committed at
+`0b112ab1e`) did **not** reproduce from the tree of its own commit: rebuilding
+the inventory from `0b112ab1e`'s git blobs yields `Client_Media_DB_v2.py`
+339 (pinned 338) and `library_screen.py` 111 (pinned 109). Because the drift
+predates the base, a statement-recovery diff between the pin's commit and the
+base — the method used here — shows *nothing* for those two rows, and they were
+carried into the new pin unexamined. Traced independently and both are benign:
+`Client_Media_DB_v2.py` gained one `logger.info("Media search completed
+(mode={}, limit={}, offset={}, sort={}, summary=true).", ...)` at `e351a9c99`;
+`library_screen.py` gained two static-message warnings at `a85681ba0` and
+`f72cc8c2b`. No action needed beyond knowing the gap exists — which is itself
+the argument for the gate this task ships.
+
+**7. The pin must be regenerated against the FINAL base immediately before
+merge.** The inventory is a whole-tree artifact and `dev` moves 23–50 times a
+day. Measured 2026-08-22: this branch's freshly regenerated pin is *already* red
+against `origin/dev` `cbb11633f` — three rows drift
+(`Chat/console_fleet_wake.py` digest, `Persona_Buddy/preferences.py` new row,
+`UI/Screens/personas_screen.py` 180→186). Since a `pull_request` check runs on
+the merge ref, a stale pin turns the required check red on PRs that did nothing
+wrong. Two consequences the owner should price in before flipping the switch:
+any PR that adds a logger call must regenerate, and two such PRs racing will
+both conflict textually on the same sorted JSON. Neither is a defect in this
+branch; both are costs of making *this* artifact the required gate.

--- a/scripts/check_backlog_task_ids.py
+++ b/scripts/check_backlog_task_ids.py
@@ -99,6 +99,26 @@ def main(argv: list[str] | None = None) -> int:
         int: ``0`` when every id is unique, ``1`` otherwise (with ``::error::``
             annotations naming each colliding id and its files).
     """
+    # NOTE (Qodo PR #1947 finding 2, "Unvalidated --tasks-dir used"): this is
+    # deliberately NOT routed through Utils/path_validation.py. Three reasons:
+    #   1. path_validation.py imports Metrics.metrics_logger, which imports
+    #      psutil -- a third-party package. This script (and the other
+    #      derived-artifact checkers) are stdlib-only and install-free by
+    #      design (TASK-19572's own AC; see the docstring above and
+    #      .github/workflows/derived-artifacts.yml), so importing it would
+    #      quietly break that contract.
+    #   2. Neither CI workflow that runs this script ever passes --tasks-dir
+    #      (backlog-guard.yml and derived-artifacts.yml both invoke it bare),
+    #      so there is no CI-reachable, externally-controlled input here --
+    #      only a developer's own CLI argument, typed in their own shell,
+    #      reading files they already have OS-level access to. There is no
+    #      privilege boundary for a "traversal" to cross.
+    #   3. --tasks-dir is intentionally usable with a directory outside the
+    #      repo: Tests/Architecture/test_derived_artifact_checkers.py passes
+    #      a pytest `tmp_path` fixture (outside REPO_ROOT) to exercise this
+    #      function in isolation. Confining it to the repo root would break
+    #      that test and the flag's own purpose.
+    # The operations here (`glob`, `read_text`) are read-only regardless.
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--tasks-dir",

--- a/scripts/check_backlog_task_ids.py
+++ b/scripts/check_backlog_task_ids.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Guard: no two backlog task files may claim the same task id.
+
+Task files are named ``task-<id> - <Title>.md``; subtask ids may be multi-dotted
+(``task-3.1``, ``task-10.6.1``). Two branches minting the same id and merging
+separately produces two files that share an id, and backlog CLI lookups become
+ambiguous. This has happened ten-plus times (ids 152+, 196-203, 246-256, ...).
+
+Both namespaces the repo relies on are checked, because they can disagree after
+a hand-edited rename and the backlog CLI resolves by frontmatter:
+
+* the filename prefix, and
+* the YAML frontmatter ``id:`` field.
+
+Extracted from the inline shell in ``.github/workflows/backlog-guard.yml``
+(TASK-19572) so that workflow and ``derived-artifacts.yml`` cannot drift apart.
+Stdlib-only: it runs with no dependency install, like the other derived-artifact
+checkers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TASKS_DIR = REPO_ROOT / "backlog" / "tasks"
+
+FILENAME_ID_RE = re.compile(r"^(task-\d+(?:\.\d+)*) - .*\.md$")
+FRONTMATTER_ID_RE = re.compile(r"^id:\s*(\S+)", re.IGNORECASE)
+
+RESOLUTION = (
+    "Resolve per the 2026-08-21 owner rule (TASK-19601): the OLDER arrival "
+    "keeps the id; the younger task(s) renumber -- regardless of Done status -- "
+    "with a Renumbering provenance section, updating dependencies: and doc/code "
+    "references."
+)
+
+
+def _first_frontmatter_id(path: Path) -> str | None:
+    """Return the file's first ``id:`` value, lowercased, or None.
+
+    Only the first match is used: frontmatter sits at the top of the file, and a
+    later ``id:`` inside prose (a code block, a quoted example) must not be
+    mistaken for the task's identity.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        match = FRONTMATTER_ID_RE.match(line)
+        if match:
+            return match.group(1).strip().casefold()
+    return None
+
+
+def duplicate_ids(tasks_dir: Path) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Collect ids claimed by more than one task file.
+
+    Args:
+        tasks_dir: Directory holding ``task-<id> - <Title>.md`` files.
+
+    Returns:
+        tuple: ``(by_filename, by_frontmatter)`` -- each maps a duplicated id to
+            the sorted filenames claiming it. Empty dicts when all ids are
+            unique.
+    """
+    by_filename: dict[str, list[str]] = defaultdict(list)
+    by_frontmatter: dict[str, list[str]] = defaultdict(list)
+    for path in sorted(tasks_dir.glob("*.md")):
+        match = FILENAME_ID_RE.match(path.name)
+        if match:
+            by_filename[match.group(1)].append(path.name)
+        frontmatter_id = _first_frontmatter_id(path)
+        if frontmatter_id:
+            by_frontmatter[frontmatter_id].append(path.name)
+    return (
+        {key: sorted(v) for key, v in by_filename.items() if len(v) > 1},
+        {key: sorted(v) for key, v in by_frontmatter.items() if len(v) > 1},
+    )
+
+
+def _report(label: str, duplicates: dict[str, list[str]]) -> None:
+    print(f"::error::Duplicate backlog task IDs in {label}:")
+    for task_id in sorted(duplicates):
+        print(f"--- {task_id} ---")
+        for name in duplicates[task_id]:
+            print(f"  {name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Fail when any task id is claimed twice.
+
+    Returns:
+        int: ``0`` when every id is unique, ``1`` otherwise (with ``::error::``
+            annotations naming each colliding id and its files).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=TASKS_DIR,
+        help="directory of backlog task files (defaults to backlog/tasks)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.tasks_dir.is_dir():
+        print(f"::error::no backlog task directory at {args.tasks_dir}")
+        return 1
+
+    filename_dupes, frontmatter_dupes = duplicate_ids(args.tasks_dir)
+    if filename_dupes:
+        _report("filenames", filename_dupes)
+    if frontmatter_dupes:
+        _report("frontmatter id: fields", frontmatter_dupes)
+    if filename_dupes or frontmatter_dupes:
+        print(RESOLUTION, file=sys.stderr)
+        return 1
+
+    total = sum(1 for path in args.tasks_dir.glob("task-*.md"))
+    print(
+        f"No duplicate task IDs across {total} task files "
+        "(filenames + frontmatter)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -7,6 +7,14 @@ file it sits.  Moving a logger call is therefore not a review event, while
 adding, deleting, rewording, or re-levelling one still is.  See task-3750: a
 digest that fires on pure line movement trains reviewers to regenerate this
 file without reading it, which is the one failure mode it exists to prevent.
+
+TASK-19572: any non-zero exit now prints the full committed-vs-rebuild report --
+rows only-in-committed / only-in-rebuild / changed with
+``old_count/old_digest -> new_count/new_digest``, per-entry sink-topology
+deltas, metadata deltas, and the exact next command. No flag is needed; ``--diff``
+only forces the same report when the tree is in sync. Reading that report IS the
+review the artifact demands, so it deliberately reports what changed rather than
+regenerating anything.
 """
 
 from __future__ import annotations
@@ -15,6 +23,7 @@ import argparse
 import ast
 import hashlib
 import json
+import os
 import sys
 import warnings
 from pathlib import Path
@@ -323,6 +332,211 @@ def _encoded(inventory: dict[str, Any]) -> str:
     return json.dumps(inventory, indent=2, sort_keys=True) + "\n"
 
 
+NEXT_STEPS = (
+    "Next: read every row above and confirm each change is one you intended.\n"
+    "  - a call_count delta means a diagnostic was added or deleted;\n"
+    "  - an unchanged count with a changed digest means one was reworded,\n"
+    "    re-levelled, or given different arguments -- check it does not now\n"
+    "    interpolate user content, secrets, or paths into a persistent sink;\n"
+    "  - a sink-topology row means a new file/handler destination appeared.\n"
+    "Only then run:  python scripts/check_persistent_diagnostic_inventory.py --write\n"
+    "and commit Docs/security/production-diagnostic-inventory.json with the "
+    "review recorded in the task/PR notes."
+)
+
+_METADATA_KEYS = (
+    "schema_version",
+    "scope",
+    "classification_rules",
+    "reviewed_exclusions",
+)
+
+
+def _sink_key(entry: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(entry.get("scope", "")),
+        str(entry.get("kind", "")),
+        str(entry.get("method", "")),
+        str(entry.get("digest", "")),
+    )
+
+
+def _describe_sink(entry: dict[str, Any]) -> str:
+    scope, kind, method, digest = _sink_key(entry)
+    return f"{scope or '<module>'}: {kind}.{method} ({digest})"
+
+
+def _owner_rows(inventory: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(row["path"]): row for row in inventory.get("owners", [])}
+
+
+def _sink_rows(inventory: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    return {
+        str(row["path"]): list(row.get("sinks", []))
+        for row in inventory.get("persistent_sink_topology", [])
+    }
+
+
+def _summary_lines(committed: dict[str, Any], rebuilt: dict[str, Any]) -> list[str]:
+    old, new = committed.get("summary", {}), rebuilt.get("summary", {})
+    lines: list[str] = []
+    for key in sorted(set(old) | set(new)):
+        if old.get(key) != new.get(key):
+            lines.append(f"    {key}: {old.get(key)} -> {new.get(key)}")
+    return lines
+
+
+def _owner_lines(committed: dict[str, Any], rebuilt: dict[str, Any]) -> list[str]:
+    old, new = _owner_rows(committed), _owner_rows(rebuilt)
+    lines: list[str] = []
+    for path in sorted(set(old) - set(new)):
+        row = old[path]
+        lines.append(
+            f"  - only in committed (diagnostics gone from this file): {path} "
+            f"[{row.get('owner')}] count={row.get('call_count')} "
+            f"digest={row.get('diagnostic_digest')}"
+        )
+    for path in sorted(set(new) - set(old)):
+        row = new[path]
+        lines.append(
+            f"  + only in rebuild (file now has diagnostics): {path} "
+            f"[{row.get('owner')}] count={row.get('call_count')} "
+            f"digest={row.get('diagnostic_digest')}"
+        )
+    for path in sorted(set(old) & set(new)):
+        before, after = old[path], new[path]
+        if before == after:
+            continue
+        old_count = before.get("call_count")
+        new_count = after.get("call_count")
+        old_digest = before.get("diagnostic_digest")
+        new_digest = after.get("diagnostic_digest")
+        if old_count == new_count:
+            note = "same count, content changed (reworded / re-levelled / new args)"
+        else:
+            delta = (new_count or 0) - (old_count or 0)
+            note = f"{delta:+d} diagnostic call(s)"
+        lines.append(
+            f"  ~ changed: {path} "
+            f"{old_count}/{old_digest} -> {new_count}/{new_digest}  ({note})"
+        )
+        if before.get("owner") != after.get("owner"):
+            lines.append(
+                f"      owner: {before.get('owner')} -> {after.get('owner')}"
+            )
+    return lines
+
+
+def _sink_lines(committed: dict[str, Any], rebuilt: dict[str, Any]) -> list[str]:
+    old, new = _sink_rows(committed), _sink_rows(rebuilt)
+    lines: list[str] = []
+    for path in sorted(set(old) - set(new)):
+        lines.append(
+            f"  - only in committed (no persistent sink left here): {path} "
+            f"({len(old[path])} sink entr{'y' if len(old[path]) == 1 else 'ies'})"
+        )
+        for entry in old[path]:
+            lines.append(f"      - {_describe_sink(entry)}")
+    for path in sorted(set(new) - set(old)):
+        lines.append(
+            f"  + only in rebuild (NEW persistent sink file): {path} "
+            f"({len(new[path])} sink entr{'y' if len(new[path]) == 1 else 'ies'})"
+        )
+        for entry in new[path]:
+            lines.append(f"      + {_describe_sink(entry)}")
+    for path in sorted(set(old) & set(new)):
+        before = {_sink_key(entry): entry for entry in old[path]}
+        after = {_sink_key(entry): entry for entry in new[path]}
+        if before == after:
+            continue
+        lines.append(
+            f"  ~ changed sinks: {path} "
+            f"({len(before)} -> {len(after)} entries)"
+        )
+        for key in sorted(set(before) - set(after)):
+            lines.append(f"      - {_describe_sink(before[key])}")
+        for key in sorted(set(after) - set(before)):
+            lines.append(f"      + {_describe_sink(after[key])}")
+    return lines
+
+
+def _metadata_lines(committed: dict[str, Any], rebuilt: dict[str, Any]) -> list[str]:
+    """Name drift in the inventory's non-row metadata.
+
+    The check compares the whole encoded file, so a changed classification rule
+    or scope fails it just as a new logger call does. Without this section that
+    failure would report zero rows and read as a false alarm.
+    """
+    lines: list[str] = []
+    for key in _METADATA_KEYS:
+        before, after = committed.get(key), rebuilt.get(key)
+        if before == after:
+            continue
+        lines.append(f"  ~ {key}:")
+        lines.append(f"      committed: {json.dumps(before, sort_keys=True)}")
+        lines.append(f"      rebuild:   {json.dumps(after, sort_keys=True)}")
+    return lines
+
+
+def render_diff(committed_text: str, rebuilt: dict[str, Any]) -> str:
+    """Render a reviewable report of how the committed inventory differs.
+
+    Args:
+        committed_text: Raw text of the committed inventory file.
+        rebuilt: Freshly scanned inventory from ``build_inventory``.
+
+    Returns:
+        str: A multi-section report naming rows only-in-committed,
+            only-in-rebuild and changed (with ``old_count/old_digest ->
+            new_count/new_digest``), sink-topology deltas, metadata deltas,
+            and the exact next command. Never empty: a formatting-only drift
+            still yields an explanation rather than silence.
+    """
+    try:
+        committed = json.loads(committed_text)
+    except json.JSONDecodeError as exc:
+        return (
+            f"the committed inventory is not valid JSON ({exc}); it cannot be "
+            "diffed. Restore it from git, or -- if the rebuild is what you "
+            "want -- review the working tree and run --write.\n" + NEXT_STEPS
+        )
+
+    sections = (
+        ("summary", _summary_lines(committed, rebuilt)),
+        ("owners", _owner_lines(committed, rebuilt)),
+        ("persistent sink topology", _sink_lines(committed, rebuilt)),
+        ("inventory metadata", _metadata_lines(committed, rebuilt)),
+    )
+    body = [
+        line
+        for title, lines in sections
+        if lines
+        for line in (f"{title}:", *lines)
+    ]
+    if not body:
+        # Parsed content is identical, so only the serialization differs --
+        # whitespace, key order, or a hand-edit that JSON normalizes away.
+        return (
+            "the committed inventory's CONTENT matches the rebuild; only its "
+            "serialization differs (whitespace, key order, or a hand edit). "
+            "Run --write to re-normalize it.\n" + NEXT_STEPS
+        )
+    return "\n".join(body) + "\n" + NEXT_STEPS
+
+
+def _emit_failure(message: str, detail: str) -> None:
+    """Print the failure headline and its full diff report.
+
+    The report goes to stderr on every non-zero exit -- no flag required. The
+    one-line ``::error::`` annotation goes to stdout only under GitHub Actions,
+    which reads workflow commands from there; locally it would be noise.
+    """
+    print(message, file=sys.stderr)
+    print(detail, file=sys.stderr)
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::error::{message}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -330,8 +544,17 @@ def main() -> int:
         action="store_true",
         help="replace the checked inventory after explicit review",
     )
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help=(
+            "print the committed-vs-rebuild report even when in sync; the same "
+            "report is printed automatically on every non-zero exit"
+        ),
+    )
     args = parser.parse_args()
-    actual = _encoded(build_inventory())
+    inventory = build_inventory()
+    actual = _encoded(inventory)
     if args.write:
         INVENTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
         INVENTORY_PATH.write_text(actual, encoding="utf-8")
@@ -340,18 +563,24 @@ def main() -> int:
     try:
         expected = INVENTORY_PATH.read_text(encoding="utf-8")
     except FileNotFoundError:
-        print(
+        _emit_failure(
             "diagnostic inventory is missing; review and run with --write",
-            file=sys.stderr,
+            f"{INVENTORY_PATH.relative_to(REPO_ROOT)} does not exist, so there "
+            "is nothing to diff against. The rebuild found "
+            f"{inventory['summary']['owner_files']} owner files and "
+            f"{inventory['summary']['persistent_sink_files']} sink files.\n"
+            + NEXT_STEPS,
         )
         return 1
     if actual != expected:
-        print(
+        _emit_failure(
             "production diagnostic owners or persistent-sink topology changed; "
-            "review the diff before running --write",
-            file=sys.stderr,
+            "review the diff below before running --write",
+            render_diff(expected, inventory),
         )
         return 1
+    if args.diff:
+        print("no drift: the committed inventory matches the rebuild exactly.")
     inventory = json.loads(actual)
     summary = inventory["summary"]
     print(

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -12,9 +12,15 @@ TASK-19572: any non-zero exit now prints the full committed-vs-rebuild report --
 rows only-in-committed / only-in-rebuild / changed with
 ``old_count/old_digest -> new_count/new_digest``, per-entry sink-topology
 deltas, metadata deltas, and the exact next command. No flag is needed; ``--diff``
-only forces the same report when the tree is in sync. Reading that report IS the
-review the artifact demands, so it deliberately reports what changed rather than
-regenerating anything.
+only adds an explicit "no drift" line when the tree is already in sync (there is
+no report to print in that case). Reading that report IS the review the artifact
+demands, so it deliberately reports what changed rather than regenerating
+anything.
+
+The pin stores an aggregate per-file digest and no statement text, so the report
+is at the maximum resolution the artifact allows: it names which files drifted
+and by how much, and ``NEXT_STEPS`` tells the reader how to recover the
+statements themselves.
 """
 
 from __future__ import annotations
@@ -339,6 +345,16 @@ NEXT_STEPS = (
     "    re-levelled, or given different arguments -- check it does not now\n"
     "    interpolate user content, secrets, or paths into a persistent sink;\n"
     "  - a sink-topology row means a new file/handler destination appeared.\n"
+    "The pin stores only an aggregate per-file digest, so the rows above can name\n"
+    "WHICH files changed and by how much, never the statement text -- and the\n"
+    "interpolation check just above needs that text. Read it with:\n"
+    "  base=$(git log -1 --format=%H -- "
+    "Docs/security/production-diagnostic-inventory.json)\n"
+    "  git diff $base -- <each path listed above>\n"
+    "Treat that revision as a LOWER BOUND, not the truth: the pin has been\n"
+    "committed stale before (TASK-19572 review found two rows whose drift predated\n"
+    "the pin's own commit), so if a listed file shows no logger change in that\n"
+    "range, widen it rather than assuming the row is noise.\n"
     "Only then run:  python scripts/check_persistent_diagnostic_inventory.py --write\n"
     "and commit Docs/security/production-diagnostic-inventory.json with the "
     "review recorded in the task/PR notes."
@@ -548,8 +564,9 @@ def main() -> int:
         "--diff",
         action="store_true",
         help=(
-            "print the committed-vs-rebuild report even when in sync; the same "
-            "report is printed automatically on every non-zero exit"
+            "confirm explicitly that the committed inventory matches the "
+            "rebuild; on drift the full report is printed anyway, with or "
+            "without this flag"
         ),
     )
     args = parser.parse_args()

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -39,6 +39,7 @@ import json
 import os
 import sys
 import warnings
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -393,9 +394,13 @@ def _sink_key(entry: dict[str, Any]) -> tuple[str, str, str, str]:
     )
 
 
-def _describe_sink(entry: dict[str, Any]) -> str:
-    scope, kind, method, digest = _sink_key(entry)
+def _describe_sink_key(key: tuple[str, str, str, str]) -> str:
+    scope, kind, method, digest = key
     return f"{scope or '<module>'}: {kind}.{method} ({digest})"
+
+
+def _describe_sink(entry: dict[str, Any]) -> str:
+    return _describe_sink_key(_sink_key(entry))
 
 
 def _owner_rows(inventory: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -481,18 +486,37 @@ def _sink_lines(committed: dict[str, Any], rebuilt: dict[str, Any]) -> list[str]
         for entry in new[path]:
             lines.append(f"      + {_describe_sink(entry)}")
     for path in sorted(set(old) & set(new)):
-        before = {_sink_key(entry): entry for entry in old[path]}
-        after = {_sink_key(entry): entry for entry in new[path]}
-        if before == after:
+        # Counted (multiset), not a dict keyed by _sink_key: two identical
+        # sink calls (e.g. the same FileHandler installed twice) share a key,
+        # and a plain `{key: entry}` collapse silently drops the duplicate --
+        # a drift that is purely a MULTIPLICITY change then reports as no
+        # change at all, or worse, as "only serialization differs" (Qodo PR
+        # #1947 finding 1). Counter equality compares counts, so it is the
+        # correct notion of "unchanged" here.
+        before_counts = Counter(_sink_key(entry) for entry in old[path])
+        after_counts = Counter(_sink_key(entry) for entry in new[path])
+        if before_counts == after_counts:
             continue
         lines.append(
             f"  ~ changed sinks: {path} "
-            f"({len(before)} -> {len(after)} entries)"
+            f"({len(old[path])} -> {len(new[path])} entries)"
         )
-        for key in sorted(set(before) - set(after)):
-            lines.append(f"      - {_describe_sink(before[key])}")
-        for key in sorted(set(after) - set(before)):
-            lines.append(f"      + {_describe_sink(after[key])}")
+        for key in sorted(set(before_counts) | set(after_counts)):
+            before_n, after_n = before_counts[key], after_counts[key]
+            if before_n == after_n:
+                continue
+            description = _describe_sink_key(key)
+            if before_n == 0:
+                suffix = f"  (new, x{after_n})" if after_n > 1 else ""
+                lines.append(f"      + {description}{suffix}")
+            elif after_n == 0:
+                suffix = f"  (removed, was x{before_n})" if before_n > 1 else ""
+                lines.append(f"      - {description}{suffix}")
+            else:
+                lines.append(
+                    f"      ~ {description}: "
+                    f"{before_n} -> {after_n}  ({after_n - before_n:+d})"
+                )
     return lines
 
 
@@ -726,12 +750,50 @@ def _source_at(revision: str, path: str) -> str | None:
     )
 
 
+def _repo_relative(raw: str) -> Path | None:
+    """Resolve a ``--statements PATH`` argument to a path inside ``REPO_ROOT``.
+
+    Accepts a path given relative to ``REPO_ROOT`` or an absolute path that
+    already resolves inside it; returns ``None`` -- never raises -- for
+    anything else, so the caller can print a clean error instead of two
+    failure modes Qodo flagged on PR #1947: an absolute path outside the repo
+    used to blow up with an unhandled ``ValueError`` from
+    ``Path.relative_to`` (finding 4), and a relative path containing ``..``
+    could walk out of ``REPO_ROOT`` and read an arbitrary file on disk with
+    no indication it had done so (finding 3).
+
+    This deliberately does not call ``Utils/path_validation.py``: that module
+    imports ``Metrics.metrics_logger``, which imports ``psutil`` -- a
+    third-party package. Every derived-artifact checker is stdlib-only and
+    install-free by design (see the module docstring and
+    ``.github/workflows/derived-artifacts.yml``'s ~90s, no-dependency-install
+    budget), so pulling in the app's path-validation helper here would
+    silently break that contract for a script that only ever reads files
+    inside this repo for review purposes -- and it is invoked with no
+    external/CI-controlled input in the first place (`--statements` is never
+    populated from a workflow; both call sites run the checker bare).
+    """
+    candidate = Path(raw)
+    full = candidate if candidate.is_absolute() else REPO_ROOT / candidate
+    try:
+        resolved = full.resolve()
+        return resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        return None
+
+
 def _run_statements(paths: list[str], since: str | None) -> int:
     reports: list[str] = []
     for raw in paths:
-        path = Path(raw)
-        if path.is_absolute():
-            path = path.relative_to(REPO_ROOT)
+        path = _repo_relative(raw)
+        if path is None:
+            print(
+                f"cannot use {raw!r}: it does not resolve inside the repository "
+                f"({REPO_ROOT}); pass a path relative to the repo root or an "
+                "absolute path under it",
+                file=sys.stderr,
+            )
+            return 1
         text = path.as_posix()
         try:
             current = (REPO_ROOT / path).read_text(encoding="utf-8")

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -19,8 +19,15 @@ anything.
 
 The pin stores an aggregate per-file digest and no statement text, so the report
 is at the maximum resolution the artifact allows: it names which files drifted
-and by how much, and ``NEXT_STEPS`` tells the reader how to recover the
-statements themselves.
+and by how much, and ``--statements <path> --since <rev>`` recovers the
+statements themselves. That mode exists because the obvious alternative is
+wrong: the per-call digest is taken over the statement's raw source segment,
+indentation included, so a call that merely shifted nesting level moves the
+file's digest, and a line diff shows it as removed+added inside whatever else
+changed. Measured during the TASK-19572 pre-merge review:
+``Chat/console_fleet_wake.py`` drifted inside a 328-line diff in which not one
+diagnostic statement had actually changed. ``--statements`` pairs those off and
+prints only the text that really needs reading.
 """
 
 from __future__ import annotations
@@ -342,16 +349,25 @@ NEXT_STEPS = (
     "Next: read every row above and confirm each change is one you intended.\n"
     "  - a call_count delta means a diagnostic was added or deleted;\n"
     "  - an unchanged count with a changed digest means one was reworded,\n"
-    "    re-levelled, or given different arguments -- check it does not now\n"
-    "    interpolate user content, secrets, or paths into a persistent sink;\n"
+    "    re-levelled, given different arguments, or merely RE-INDENTED -- check\n"
+    "    it does not now interpolate user content, secrets, or paths into a\n"
+    "    persistent sink;\n"
     "  - a sink-topology row means a new file/handler destination appeared.\n"
     "The pin stores only an aggregate per-file digest, so the rows above can name\n"
     "WHICH files changed and by how much, never the statement text -- and the\n"
-    "interpolation check just above needs that text. Read it with:\n"
+    "interpolation check just above needs that text. Recover it with:\n"
     "  base=$(git log -1 --format=%H -- "
     "Docs/security/production-diagnostic-inventory.json)\n"
-    "  git diff $base -- <each path listed above>\n"
-    "Treat that revision as a LOWER BOUND, not the truth: the pin has been\n"
+    "  python scripts/check_persistent_diagnostic_inventory.py \\\n"
+    "      --statements <each path listed above> --since $base\n"
+    "That prints the added and removed STATEMENTS themselves, and separates the\n"
+    "ones that only moved or re-indented from the ones whose text really changed.\n"
+    "Do NOT reach for `git diff` here: the digest covers a statement's own source\n"
+    "text, indentation included, so a call that merely shifted nesting level\n"
+    "reports as changed, and a line diff buries it in unrelated edits -- measured\n"
+    "on tldw_chatbook/Chat/console_fleet_wake.py, whose row changed inside a\n"
+    "328-line diff in which not one statement had actually changed.\n"
+    "Treat that base revision as a LOWER BOUND, not the truth: the pin has been\n"
     "committed stale before (TASK-19572 review found two rows whose drift predated\n"
     "the pin's own commit), so if a listed file shows no logger change in that\n"
     "range, widen it rather than assuming the row is noise.\n"
@@ -428,7 +444,11 @@ def _owner_lines(committed: dict[str, Any], rebuilt: dict[str, Any]) -> list[str
         old_digest = before.get("diagnostic_digest")
         new_digest = after.get("diagnostic_digest")
         if old_count == new_count:
-            note = "same count, content changed (reworded / re-levelled / new args)"
+            note = (
+                "same count, content changed "
+                "(reworded / re-levelled / new args / re-indented) "
+                "-- use --statements to see which"
+            )
         else:
             delta = (new_count or 0) - (old_count or 0)
             note = f"{delta:+d} diagnostic call(s)"
@@ -540,6 +560,205 @@ def render_diff(committed_text: str, rebuilt: dict[str, Any]) -> str:
     return "\n".join(body) + "\n" + NEXT_STEPS
 
 
+def _statement_entries(source: str, path: str) -> list[dict[str, Any]]:
+    """Every diagnostic statement in one module, with its text and line.
+
+    Uses the same scanner and the same per-call digest as the pin, so a key
+    printed here is the key that moved the file's aggregate digest.
+    """
+    tree = ast.parse(source, filename=path)
+    symbols = _logger_symbols(tree)
+    entries: list[dict[str, Any]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_diagnostic_call(node, symbols):
+            continue
+        entry = _call_entry(source, node)
+        entry["text"] = ast.get_source_segment(source, node) or ""
+        entry["line"] = node.lineno
+        entry["col"] = node.col_offset
+        entries.append(entry)
+    entries.sort(key=lambda item: item["line"])
+    return entries
+
+
+def _normalized(entry: dict[str, Any]) -> tuple[str, str]:
+    """Key a statement by level + whitespace-collapsed text.
+
+    Two statements sharing this key differ only in layout, which the module
+    docstring says is explicitly NOT a review event -- but the per-call digest
+    is taken over the raw source segment, continuation-line indentation
+    included, so re-indenting a call still moves the file's digest. Separating
+    those out is the difference between a report that teaches and one that
+    trains people to regenerate without reading (task-3750).
+    """
+    return (str(entry["method"]), " ".join(str(entry["text"]).split()))
+
+
+def _indent_block(entry: dict[str, Any], prefix: str = "      | ") -> str:
+    """Render a statement's source under a gutter, at its original shape.
+
+    ``ast.get_source_segment`` returns the first line already stripped of its
+    leading indentation while continuation lines keep their absolute column,
+    so printing it verbatim renders a multi-line call as a staircase. Restoring
+    the first line's column and then dedenting the whole block puts the call
+    back the shape it has in the file, which is how a reviewer reads it.
+    """
+    import textwrap
+
+    text = str(entry.get("text", ""))
+    restored = " " * int(entry.get("col", 0)) + text
+    body = textwrap.dedent(restored)
+    return "\n".join(prefix + line for line in body.splitlines())
+
+
+def render_statement_diff(old_source: str, new_source: str, path: str) -> str:
+    """Report which diagnostic STATEMENTS changed between two revisions of a file.
+
+    Args:
+        old_source: The module's source at the base revision.
+        new_source: The module's source now.
+        path: Repo-relative path, used only for the heading.
+
+    Returns:
+        str: A report separating statements that merely moved or were
+            re-indented -- which need no privacy review -- from those actually
+            added, removed, or reworded, printing the full text of each of the
+            latter so the interpolation check can be made on real text.
+    """
+    old = _statement_entries(old_source, path)
+    new = _statement_entries(new_source, path)
+    old_keys: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    new_keys: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for entry in old:
+        old_keys.setdefault((entry["method"], entry["digest"]), []).append(entry)
+    for entry in new:
+        new_keys.setdefault((entry["method"], entry["digest"]), []).append(entry)
+
+    removed: list[dict[str, Any]] = []
+    added: list[dict[str, Any]] = []
+    for key, entries in old_keys.items():
+        removed.extend(entries[len(new_keys.get(key, [])) :])
+    for key, entries in new_keys.items():
+        added.extend(entries[len(old_keys.get(key, [])) :])
+
+    # Pair off statements whose only difference is layout, so they stop
+    # competing for the reviewer's attention with real content changes.
+    layout_only: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    pending = list(added)
+    still_removed: list[dict[str, Any]] = []
+    for gone in removed:
+        match = next((e for e in pending if _normalized(e) == _normalized(gone)), None)
+        if match is None:
+            still_removed.append(gone)
+            continue
+        pending.remove(match)
+        layout_only.append((gone, match))
+
+    lines = [
+        f"{path}: {len(old)} -> {len(new)} diagnostic call(s)",
+        f"  moved/re-indented only: {len(layout_only)}   "
+        f"removed: {len(still_removed)}   added: {len(pending)}",
+    ]
+    if layout_only:
+        lines.append(
+            "\n= moved or re-indented -- statement text is unchanged, NO review needed:"
+        )
+        for gone, match in layout_only:
+            lines.append(
+                f"  = {gone['method']} {gone['digest']} -> {match['digest']}  "
+                f"(line {gone['line']} -> {match['line']})"
+            )
+    if still_removed:
+        lines.append("\n- REMOVED -- these statements no longer exist:")
+        for entry in still_removed:
+            lines.append(
+                f"  - {entry['method']} {entry['digest']} (was line {entry['line']})"
+            )
+            lines.append(_indent_block(entry))
+    if pending:
+        lines.append(
+            "\n+ ADDED -- read each one: does it interpolate user content, a "
+            "secret, a path, or a URL?"
+        )
+        for entry in pending:
+            lines.append(
+                f"  + {entry['method']} {entry['digest']} (now line {entry['line']})"
+            )
+            lines.append(_indent_block(entry))
+    if not layout_only and not still_removed and not pending:
+        lines.append(
+            "\nno diagnostic statement changed in this file between the two "
+            "revisions. If the pin still lists it, the pin was already stale "
+            "when it was committed -- widen the base revision."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _source_at(revision: str, path: str) -> str | None:
+    """Read one path's source at a git revision.
+
+    Uses ``git show`` via stdlib ``subprocess`` so the checker stays
+    install-free; this is a review aid, never part of the gate's own verdict.
+
+    Returns:
+        str | None: The source, or ``None`` when the path did not exist at that
+            revision -- the ordinary case for an "only in rebuild" row, which
+            must not be mistaken for a broken revision argument.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "show", f"{revision}:{path}"],
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.decode("utf-8", errors="replace")
+    resolved = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--quiet", "--verify",
+         f"{revision}^{{commit}}"],
+        capture_output=True,
+    )
+    if resolved.returncode == 0:
+        return None
+    raise SystemExit(
+        f"cannot resolve revision {revision!r}: "
+        f"{result.stderr.decode('utf-8', 'replace').strip()}"
+    )
+
+
+def _run_statements(paths: list[str], since: str | None) -> int:
+    reports: list[str] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_absolute():
+            path = path.relative_to(REPO_ROOT)
+        text = path.as_posix()
+        try:
+            current = (REPO_ROOT / path).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"cannot read {text}: {exc}", file=sys.stderr)
+            return 1
+        if since is None:
+            entries = _statement_entries(current, text)
+            body = [f"{text}: {len(entries)} diagnostic call(s)"]
+            for entry in entries:
+                body.append(
+                    f"  {entry['method']} {entry['digest']} (line {entry['line']})"
+                )
+                body.append(_indent_block(entry))
+            reports.append("\n".join(body) + "\n")
+            continue
+        before = _source_at(since, text)
+        if before is None:
+            reports.append(
+                f"{text}: did not exist at {since}; every statement below is new.\n"
+            )
+            before = ""
+        reports.append(render_statement_diff(before, current, text))
+    print("\n".join(reports), end="")
+    return 0
+
+
 def _emit_failure(message: str, detail: str) -> None:
     """Print the failure headline and its full diff report.
 
@@ -569,7 +788,26 @@ def main() -> int:
             "without this flag"
         ),
     )
+    parser.add_argument(
+        "--statements",
+        nargs="+",
+        metavar="PATH",
+        help=(
+            "print the diagnostic statements in these files; with --since, "
+            "print only what changed, separating pure movement/re-indentation "
+            "from real content changes. This is the review the report asks for."
+        ),
+    )
+    parser.add_argument(
+        "--since",
+        metavar="REV",
+        help="git revision to compare --statements against (e.g. the pin's commit)",
+    )
     args = parser.parse_args()
+    if args.statements:
+        return _run_statements(args.statements, args.since)
+    if args.since:
+        parser.error("--since is only meaningful with --statements")
     inventory = build_inventory()
     actual = _encoded(inventory)
     if args.write:

--- a/scripts/check_profile_owned_path_inventory.py
+++ b/scripts/check_profile_owned_path_inventory.py
@@ -839,7 +839,26 @@ def main(argv: list[str] | None = None) -> int:
             f"{problem.expression}: {problem.reason}",
             file=sys.stderr,
         )
-    return 1 if problems else 0
+    if problems:
+        # TASK-19572: the rows above name the offending file, but nothing said
+        # what to do with them; every burn-down task had to re-derive that.
+        print(
+            f"\n{len(problems)} profile-owned-path problem(s). Each row is "
+            "path:line:context:expression:reason. Fix the code, or -- if the "
+            "occurrence is legitimate -- add an ExceptionRule with an explicit "
+            "reason to APPROVED_EXCEPTIONS in "
+            "scripts/check_profile_owned_path_inventory.py (see ADR-040). Run "
+            "`python scripts/check_profile_owned_path_inventory.py "
+            "--print-occurrences` for the full census.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"profile-owned path census verified: {len(occurrences)} executable "
+        f"occurrence(s) across {len({o.relative_path for o in occurrences})} "
+        f"file(s), all matched by {len(APPROVED_EXCEPTIONS)} approved exceptions."
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Run every derived-artifact guard the CI job runs, locally, in one command.
+#
+# TASK-19572. These four checks are the only ones that have reliably caught
+# real drift, and until now the burn-down workflow was "remember four separate
+# commands" -- which is why the same diagnostic-inventory drift was
+# rediscovered by hand in four separate tasks. This is the same list, in the
+# same order, as .github/workflows/derived-artifacts.yml.
+#
+# Deliberately NOT a git hook: at ~33 s a pre-commit hook is punitive at this
+# repo's commit rate, is bypassable with `git commit -n`, and does not survive
+# a fresh clone. Install it as one if you personally want to (`ln -s
+# ../../scripts/preflight.sh .git/hooks/pre-commit`), but the gate that counts
+# is the CI job.
+#
+# Usage:  ./scripts/preflight.sh          # uses `python3` (stdlib only)
+#         PYTHON=.venv/bin/python ./scripts/preflight.sh
+#
+# Exits 0 when every check passes, 1 otherwise. Every check runs even after one
+# fails, so a single pass reports all of the drift.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+PYTHON="${PYTHON:-python3}"
+
+failed=()
+
+run_check() {
+  local label="$1"
+  shift
+  echo
+  echo "=== ${label} ==="
+  if "$@"; then
+    return 0
+  fi
+  failed+=("$label")
+  return 1
+}
+
+run_check "generated stylesheets" \
+  "$PYTHON" tldw_chatbook/css/check_bundle_sync.py
+run_check "profile-owned path census" \
+  "$PYTHON" scripts/check_profile_owned_path_inventory.py
+run_check "production diagnostic inventory" \
+  "$PYTHON" scripts/check_persistent_diagnostic_inventory.py
+run_check "backlog task ids" \
+  "$PYTHON" scripts/check_backlog_task_ids.py
+
+echo
+if [ ${#failed[@]} -eq 0 ]; then
+  echo "preflight: all derived-artifact checks passed."
+  exit 0
+fi
+echo "preflight: ${#failed[@]} check(s) FAILED:"
+for label in "${failed[@]}"; do
+  echo "  - ${label}"
+done
+echo "Read the report above before regenerating anything."
+exit 1


### PR DESCRIPTION
Addresses TASK-19572. **The task stays In Progress**: 4 of its 7 ACs are repo-admin actions only the owner can take, each written up as an Owner gate in the task file rather than silently unticked.

## The measured problem

The `Tests` workflow has produced **no verdict since 2026-06-26** — across ~200 runs, 149 cancelled / 34 failed / **zero successes**. It is structural, not flaky: a full pass takes 200–227 minutes while dev absorbs 23–50 merges/day, and `cancel-in-progress` kills every in-flight run. Guards that live only inside that suite have therefore never blocked anything. The vendoring guard existed at the merge that broke it and never executed; the same diagnostic-inventory drift was rediscovered by hand in four separate tasks.

## Two findings the audit did not have

**The nightly cron has never fired, and cannot be fixed from `dev`.** GitHub schedules cron only from the *default* branch. That is `main` — last touched 2026-07-11, now **10,966 commits behind**, with no `schedule:` block at all. `gh run list --workflow=test.yml --event=schedule` returns `[]` for all retained history. So this was never a `cancel-in-progress` problem; schedule runs are already exempt.

**Even a 30-second guard is queue-bound.** Of the last 83 `css-bundle-guard` PR runs: 58 cancelled, 23 succeeded — and the successes are bimodal, 10 under 400 s and **8 over an hour**, max **5.6 hours**, for a single stdlib script. `Tests` fans out ~20 jobs per run and starves the pool. This does not defeat the remedy (it still gates correctly, and cancellations here are benign — the group is per-ref-per-event, so only a newer push to the same PR cancels), but the honest caveat is that the tail can delay a merge by hours. The owner's real lever is the `Tests` fan-out (TASK-19425).

## What ships

**`.github/workflows/derived-artifacts.yml`** — one install-free job running four stdlib-only checkers. Measured locally: bundle-sync 0.86 s · profile-owned-path 10.98 s · diagnostic inventory 20.17 s · backlog ids 0.10 s; `preflight.sh` end-to-end **33 s**. Two deliberate departures from `css-bundle-guard.yml`, both commented inline:
- **not path-filtered** — a workflow skipped by a path filter never creates its check, parking a required check permanently on "Expected — waiting for status to be reported";
- **every step `if: ${{ !cancelled() }}`** so one red checker cannot hide the other three.

**The checker now teaches its fix.** `check_persistent_diagnostic_inventory.py` prints a full committed-vs-rebuild report on every non-zero exit — rows only-in-committed / only-in-rebuild, changed rows with `old_count/old_digest → new_count/new_digest`, per-entry sink deltas, metadata deltas, and the next command. Real output from a planted mutation:

```
summary:
    owner_files: 520 -> 519
    persistent_sink_files: 7 -> 8
owners:
  - only in committed (diagnostics gone from this file): tldw_chatbook/Workspaces/git_workspace.py [TASK-494] count=1
persistent sink topology:
  + only in rebuild (NEW persistent sink file): tldw_chatbook/Notes/sync_engine.py (2 sink entries)
      + _install_sync_audit_sink: FileHandler.FileHandler (1f5627ca21ba157a)
```

Also `scripts/check_backlog_task_ids.py` (extracted from inline shell, now shared by two workflows) and `scripts/preflight.sh` — one command instead of four remembered ones. Under mutation, preflight runs **all four** sections, exits 1, and names the failing check; it survives macOS bash 3.2.57 under `set -u`.

## The report was not sufficient, so review fixed it

On the one row that mattered it labelled `console_fleet_wake.py` *"reworded / re-levelled / new args"* — **all three wrong**. The calls were only **re-indented**: the per-call digest is taken over `ast.get_source_segment`, which preserves continuation-line indentation, so a nesting-level shift moves the digest even though the module docstring says movement is explicitly not a review event.

Worse, its recovery recipe was `git diff $base -- <path>`, which on that row yields a **328-line diff containing zero statement changes** — precisely how "it was probably fine" gets written.

Added **`--statements <path> [--since REV]`**: a real recovery mode using the same scanner and the same per-call digest the pin uses (pinned by a test), pairing off layout-only changes and printing the full source of what genuinely changed. On the incident row: `moved/re-indented only: 2   removed: 0   added: 0`.

## The pin was NOT regenerated by this branch

Dev's inventory reproduces from dev's tree byte-for-byte, and this branch changes no file under `tldw_chatbook/`, so it contributes no drift — verified both by the checker (`no drift: the committed inventory matches the rebuild exactly`) and by rebuilding every owner row from HEAD's blobs. Regenerating anyway would have been the exact failure the artifact exists to prevent.

While reviewing the branch's own earlier baseline, three rows were read statement-by-statement and classified: `console_fleet_wake.py` (pure re-indentation), `Persona_Buddy/preferences.py` (a regex-validated `type(error).__name__`), `personas_screen.py` (+6 fully static warnings). **No exposure found, nothing absorbed.**

Two things *were* surfaced rather than laundered, and are being filed separately: 21 diagnostics across five files that interpolate user file paths and workspace roots (terminal / in-app Logs only — `PersistentDiagnosticFilter` admits only explicitly-marked records, verified by probing it, so these do **not** reach a persistent sink); and the fact that the *previous* pin never reproduced from its own commit, so two rows rode in unexamined.

## Verification

- `preflight.sh` at this exact base: **all four checkers green, 33 s**. No other checker is red here.
- Guard suites: **109 passed** (18 new + the pre-existing set).
- YAML validates; job name is `Derived artifacts reproduce from their sources`, exactly the string branch protection would need. **It has never run on a runner** — nothing here proves it goes green there.
- No GitHub writes were made: no `gh api` writes, no branch-protection change, no workflow enable/disable.

## Owner gates (not in my control)

Branch protection on `dev` with that one check required; the `main` decision; the nightly cadence (fast-forward `main`, or drive the suite by `workflow_dispatch`); and a one-line CLAUDE.md DoD reference to `preflight.sh`. **CLAUDE.md was deliberately not edited** — an agent brief cannot authorize a project-instruction change; the exact snippet is in the task file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships an install-free CI job that verifies derived artifacts and upgrades the diagnostic-inventory checker to produce actionable diffs and a statement-level recovery. Previously, sink multiplicity drift could be silent and `--statements` could crash or read outside the repo; now multiplicity deltas are counted, re-indentation is called out, and paths are validated.

- Adds `.github/workflows/derived-artifacts.yml`: one job named "Derived artifacts reproduce from their sources" that runs four stdlib-only checkers (CSS bundles, profile-owned paths, diagnostic inventory, backlog task IDs). Unfiltered triggers and `if: ${{ !cancelled() }}` on each step make it suitable as a required check.
- Hardens `scripts/check_persistent_diagnostic_inventory.py`:
  - Always prints a full committed-vs-rebuild report on failure with next steps; `--diff` confirms “no drift” when in sync.
  - Adds `--statements <path> [--since REV]` to recover and compare diagnostic statements, pairing off layout-only moves and printing added/removed text; validates paths stay inside the repo and handles files missing at the base rev; avoids `git diff`.
  - Fixes persistent-sink comparison by using a multiset to report count deltas per sink entry; emits `::error::` only under CI.
- Updates `backlog-guard.yml` to delegate to `scripts/check_backlog_task_ids.py`; adds `scripts/preflight.sh`; improves `check_profile_owned_path_inventory.py` messaging; adds tests that pin the workflow shape and checker reports.
- After rebase, the committed inventory reproduces from the current tree; this branch does not regenerate it and introduces no drift.

**Rollout and developer actions**
- Require the new job in branch protection: Settings → Branches → `dev` rule → Require status checks to pass → select "Derived artifacts reproduce from their sources".
- Nightly runs must be scheduled from `main` or driven via `workflow_dispatch` (GitHub schedules `cron` only from the default branch).
- Run `./scripts/preflight.sh` before opening a PR; when the inventory fails, review with `python scripts/check_persistent_diagnostic_inventory.py --statements <path> --since <rev>`, then regenerate with `--write` only after review.

<sup>Written for commit 8ce35bae137e22cdc24516467c8c5e32ea9e99d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

