### PR TITLE
fix(security): stop git_diff leaking denylisted file content, and cover dotfile credentials

### DIFF
--- a/Tests/Tools/test_git_tool_sensitive_paths.py
+++ b/Tests/Tools/test_git_tool_sensitive_paths.py
@@ -1,0 +1,627 @@
+"""Sensitive-path coverage for the workspace-local ``git_*`` family.
+
+TASK-19632. TASK-19551 made ``resolve_workspace_path`` enforce the
+sensitive-path denylist for every path a model NAMES, and made the three
+enumerating ``fs_*`` tools filter the entries they present but the model
+never named. The ``git_*`` tools share that choke point for their path
+ARGUMENT -- but ``path`` is OPTIONAL on ``git_status``/``git_log``/
+``git_diff``, and with it omitted nothing but the repository root ever
+reaches the denylist: git enumerates the repository on the tool's behalf
+and the tool returns what comes back.
+
+Measured before the fix, with the workspace root set to ``$HOME`` (exactly
+what the shipped ``workspace_root`` default -- the app's cwd at startup --
+produces when the app is launched from the user's home directory) and
+``$HOME`` a git repository containing a synthetic ``.ssh/id_rsa``:
+
+* ``git_diff(commit_range="HEAD~1..HEAD")`` returned the key's CONTENT
+  from a CLEAN worktree -- no write primitive and no dirty tree needed.
+* ``git_diff(stat=True)`` and ``git_status`` returned its NAME.
+* ``git_log`` leaked nothing, and is deliberately left unfiltered.
+
+Plus one vector found while building the fix: pathspec MAGIC in a
+repository FILENAME. ``:(exclude)notes.txt`` is a legal POSIX filename, so
+``git_diff(path=":(exclude)notes.txt")`` passed the choke point as an
+ordinary confined path and then inverted the diff's scope, returning the
+rest of the repository -- ``~/.ssh/id_rsa``'s content included -- while
+nominally scoping to one file. ``--`` does not stop that: it ends OPTION
+parsing, not magic parsing.
+
+The fix constrains git's INPUT (``:(exclude)`` pathspecs computed per call
+from the live denylist) rather than filtering its OUTPUT, so the negative
+half of this file matters as much as the positive half: an ordinary diff,
+stat, status and log must come back untouched, byte for byte.
+
+``Tests/conftest.py``'s autouse ``isolate_test_environment`` fixture
+redirects HOME/XDG/``TLDW_CONFIG_PATH`` to per-test tmp directories, so
+every "credential" below is a synthetic marker under an isolated home --
+no real credential file is ever created or read.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Tools.git_tool_impls import (
+    _denylist_pathspecs,
+    _glob_escape,
+    git_diff,
+    git_log,
+    git_status,
+    prepare_repository,
+)
+from tldw_chatbook.Tools.local_tool_impls import LocalToolError
+
+GIT_AVAILABLE = shutil.which("git") is not None
+pytestmark = pytest.mark.skipif(
+    not GIT_AVAILABLE, reason="git is not available on this system"
+)
+
+SSH_MARKER = "SYNTHETIC-NOT-A-REAL-PRIVATE-KEY-19632"
+NETRC_MARKER = "SYNTHETIC-NOT-A-REAL-PASSWORD-19632"
+#: A legal POSIX filename that is ALSO a git pathspec meaning "everything
+#: except notes.txt". The whole point of the injection case below.
+MAGIC_NAME = ":(exclude)notes.txt"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+
+def _home() -> Path:
+    return Path(os.environ["HOME"]).resolve()
+
+
+def _raw_git(repo: Path, *args: str) -> str:
+    """Run git directly, so a tool's output can be compared against it."""
+    completed = subprocess.run(
+        ["git", "--no-pager", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+@pytest.fixture
+def home_repo() -> Path:
+    """``$HOME`` as both workspace root AND git repo, holding a synthetic key.
+
+    Three commits, so the negative pins have something to hold onto:
+
+    * ``initial``  -- ``notes.txt`` v1, ``.ssh/id_rsa`` v1, ``MAGIC_NAME``
+    * ``second``   -- ``notes.txt`` v2 AND ``.ssh/id_rsa`` v2 (the range
+      used for the content-leak cases: an ordinary file and a denylisted
+      one change together, so "the secret is gone" and "the diff is not
+      truncated" are asserted on the SAME output)
+    * ``third``    -- ``.ssh/id_rsa`` v3 only (a commit touching NOTHING
+      but a denylisted path -- what ``git_log`` must still list)
+    """
+    home = _home()
+    _init(home)
+    key = home / ".ssh" / "id_rsa"
+    key.parent.mkdir(parents=True, exist_ok=True)
+    key.write_text(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\n")
+    (home / "notes.txt").write_text("hello\n")
+    (home / MAGIC_NAME).write_text("magic-filename\n")
+    _git(home, "add", "-A", "-f")
+    _git(home, "commit", "-m", "initial")
+
+    key.write_text(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nROTATED\n")
+    (home / "notes.txt").write_text("hello\nworld\n")
+    _git(home, "add", "-A", "-f")
+    _git(home, "commit", "-m", "second")
+
+    key.write_text(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nAGAIN\n")
+    _git(home, "add", "-A", "-f")
+    _git(home, "commit", "-m", "third")
+    return home
+
+
+def _assert_no_leak(output: str, label: str) -> None:
+    """Born-red evidence: at base each of these prints the leaked bytes."""
+    assert SSH_MARKER not in output, (
+        f"{label} leaked the private key's CONTENT -- it returned:\n{output}"
+    )
+    assert "id_rsa" not in output, (
+        f"{label} leaked the private key's NAME -- it returned:\n{output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The leaks, one test per measured case (TASK-19632 AC1/AC2/AC4).
+# ---------------------------------------------------------------------------
+
+
+def test_git_diff_commit_range_never_returns_denylisted_content_on_a_clean_worktree(
+    home_repo: Path,
+) -> None:
+    """The headline: a read-only agent on a CLEAN checkout was enough.
+
+    ``commit_range`` reads the credential out of HISTORY, so neither a
+    write primitive nor a dirty worktree is required -- which is what makes
+    this reachable by prompt injection from fetched web content: the model
+    only has to call a ``reads``-tagged git tool with no path.
+    """
+    assert _raw_git(home_repo, "status", "--porcelain").strip() == "", (
+        "the worktree must be CLEAN for this case to mean what it claims"
+    )
+
+    out = git_diff(home_repo, commit_range="HEAD~2..HEAD~1")
+
+    _assert_no_leak(out, "git_diff(commit_range=..., no path)")
+    # ... and the ordinary file that changed in the SAME range is intact.
+    assert "notes.txt" in out
+    assert "+world" in out
+
+
+def test_git_diff_stat_never_names_a_denylisted_path(home_repo: Path) -> None:
+    """``stat=True`` disclosed the NAME (and the change size) only."""
+    out = git_diff(home_repo, commit_range="HEAD~2..HEAD~1", stat=True)
+
+    _assert_no_leak(out, "git_diff(stat=True, no path)")
+    assert "notes.txt" in out
+
+
+def test_git_diff_worktree_never_returns_denylisted_content(home_repo: Path) -> None:
+    """The dirty-worktree case (the one the original draft over-claimed)."""
+    (home_repo / ".ssh" / "id_rsa").write_text(
+        f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nDIRTY\n"
+    )
+    (home_repo / "notes.txt").write_text("hello\nworld\ndirty\n")
+
+    _assert_no_leak(git_diff(home_repo), "git_diff() dirty")
+    _assert_no_leak(git_diff(home_repo, stat=True), "git_diff(stat=True) dirty")
+    assert "notes.txt" in git_diff(home_repo)
+
+
+def test_git_diff_index_never_returns_denylisted_content(home_repo: Path) -> None:
+    """The INDEX scope (``staged=True``) -- AC1 names it explicitly."""
+    (home_repo / ".ssh" / "id_rsa").write_text(
+        f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nSTAGED\n"
+    )
+    (home_repo / "notes.txt").write_text("hello\nworld\nstaged\n")
+    _git(home_repo, "add", "-A", "-f")
+
+    out = git_diff(home_repo, staged=True)
+
+    _assert_no_leak(out, "git_diff(staged=True)")
+    assert "notes.txt" in out
+
+
+def test_git_status_never_names_a_denylisted_path(home_repo: Path) -> None:
+    """``git_status`` disclosed existence + name on a dirty tree."""
+    (home_repo / ".ssh" / "id_rsa").write_text(
+        f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nDIRTY\n"
+    )
+    (home_repo / "notes.txt").write_text("hello\nworld\ndirty\n")
+    (home_repo / ".ssh" / "untracked_key").write_text(SSH_MARKER)
+
+    out = git_status(home_repo)
+
+    _assert_no_leak(out, "git_status()")
+    assert "untracked_key" not in out, (
+        f"git_status leaked an UNTRACKED denylisted path:\n{out}"
+    )
+    assert "notes.txt" in out
+
+
+def test_git_diff_still_refuses_a_denylisted_path_argument(home_repo: Path) -> None:
+    """The TASK-19551 behaviour is unchanged: naming the path is refused."""
+    with pytest.raises(LocalToolError, match="protected path"):
+        git_diff(home_repo, commit_range="HEAD~2..HEAD~1", path=".ssh/id_rsa")
+
+
+# ---------------------------------------------------------------------------
+# Pathspec magic in a repository FILENAME -- a pathspec is not a path.
+# ---------------------------------------------------------------------------
+
+
+def test_pathspec_magic_in_the_path_argument_cannot_invert_the_scope(
+    home_repo: Path,
+) -> None:
+    """``path=":(exclude)notes.txt"`` returned the rest of the repository.
+
+    The file genuinely exists, so it resolves, stays inside the workspace
+    and is not denylisted -- the choke point has no reason to refuse it.
+    git then read it as MAGIC rather than as a name. Before the fix this
+    call returned ``.ssh/id_rsa``'s content; after it, the pathspec is
+    rendered ``:(literal)`` and scopes to the one real file.
+    """
+    (home_repo / MAGIC_NAME).write_text("magic-filename\nchanged\n")
+    (home_repo / "notes.txt").write_text("hello\nworld\nalso changed\n")
+    # The key must be dirty too, or the injected ":(exclude)notes.txt"
+    # scope would have nothing to leak and this test would pass at base
+    # for the wrong reason (caught while checking the born-red run).
+    (home_repo / ".ssh" / "id_rsa").write_text(
+        f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nINJECTED\n"
+    )
+
+    out = git_diff(home_repo, path=MAGIC_NAME)
+
+    _assert_no_leak(out, f"git_diff(path={MAGIC_NAME!r})")
+    # Positive half: it scopes to the named file, and ONLY to it.
+    assert "changed" in out, (
+        f"the literal pathspec stopped matching its own file:\n{out}"
+    )
+    assert "also changed" not in out, (
+        f"the scope leaked past the named file into notes.txt:\n{out}"
+    )
+
+
+def test_every_pathspec_this_family_builds_carries_explicit_magic() -> None:
+    """Structural pin: no bare pathspec may be spliced after ``--``.
+
+    ``--`` ends OPTION parsing, not pathspec-magic parsing, so a bare
+    value in a pathspec position is a repository-supplied injection point.
+    Every argv element this module places after ``--`` must therefore
+    start with an explicit magic prefix -- except ``git_blame``'s, which
+    takes a plain PATH and rejects magic outright (verified: ``fatal: no
+    such path ':(literal)a.txt' in HEAD``).
+    """
+    import ast
+
+    from tldw_chatbook.Tools import git_tool_impls
+
+    source = Path(git_tool_impls.__file__).read_text()
+    tree = ast.parse(source)
+    offenders: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if node.name == "git_blame":
+            continue  # plain path, see the docstring above
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            if not (isinstance(call.func, ast.Attribute) and call.func.attr == "extend"):
+                continue
+            for arg in call.args:
+                if not isinstance(arg, (ast.List, ast.Tuple)):
+                    continue
+                elements = list(arg.elts)
+                if not elements:
+                    continue
+                first = elements[0]
+                if not (isinstance(first, ast.Constant) and first.value == "--"):
+                    continue
+                for element in elements[1:]:
+                    if isinstance(element, ast.Starred):
+                        continue  # _denylist_pathspecs' own output, pinned below
+                    if isinstance(element, ast.Call) and isinstance(
+                        element.func, ast.Name
+                    ):
+                        if element.func.id in {"_literal_pathspec"}:
+                            continue
+                    offenders.append(f"{node.name}: {ast.dump(element)[:120]}")
+    assert not offenders, (
+        "these values are spliced into a pathspec position without explicit "
+        "magic, so a repository file named ':(exclude)x' can invert the "
+        f"command's scope: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The negative side: the fix must not truncate a legitimate result.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ordinary_repo(tmp_path: Path) -> Path:
+    """A repo with nothing denylisted anywhere near it."""
+    repo = (tmp_path / "project").resolve()
+    _init(repo)
+    (repo / "pkg").mkdir()
+    for name in ("a.txt", "b.txt", "pkg/c.txt"):
+        (repo / name).write_text(f"{name} v1\n")
+    (repo / ".github").mkdir()
+    (repo / ".github" / "ci.yml").write_text("name: ci\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "initial")
+    for name in ("a.txt", "b.txt", "pkg/c.txt"):
+        (repo / name).write_text(f"{name} v1\n{name} v2\n")
+    (repo / ".github" / "ci.yml").write_text("name: ci\njobs: {}\n")
+    return repo
+
+
+def test_an_ordinary_multi_file_diff_is_byte_identical_to_raw_git(
+    ordinary_repo: Path,
+) -> None:
+    """The whole risk of an input-side fix: over-exclusion.
+
+    Compared against git run directly with the same flags, not against a
+    hand-written expectation, so a pathspec that quietly drops one file
+    cannot pass by matching a stale literal.
+    """
+    expected = _raw_git(
+        ordinary_repo,
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        "--unified=3",
+    )
+    assert git_diff(ordinary_repo) == expected
+    for name in ("a.txt", "b.txt", "pkg/c.txt", ".github/ci.yml"):
+        assert name in expected, "fixture drifted"
+
+
+def test_an_ordinary_stat_and_status_are_unchanged(ordinary_repo: Path) -> None:
+    stat = git_diff(ordinary_repo, stat=True)
+    assert stat == _raw_git(
+        ordinary_repo,
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        "--stat",
+    )
+
+    status = git_status(ordinary_repo)
+    for name in ("a.txt", "b.txt", "pkg/c.txt", ".github/ci.yml"):
+        assert name in status, f"{name} vanished from git_status:\n{status}"
+
+
+def test_an_ordinary_scoped_diff_is_unchanged(ordinary_repo: Path) -> None:
+    """A ``path`` argument still scopes exactly as it did (file AND dir)."""
+    out = git_diff(ordinary_repo, path="pkg")
+    assert "pkg/c.txt" in out
+    assert "a.txt" not in out
+
+    out = git_diff(ordinary_repo, path="a.txt")
+    assert "a.txt" in out
+    assert "b.txt" not in out
+
+
+def test_git_log_is_unfiltered_including_commits_that_touch_only_denied_paths(
+    home_repo: Path,
+) -> None:
+    """AC5: ``git_log`` leaks nothing, so it must not be filtered either.
+
+    The ``third`` commit touches NOTHING but ``.ssh/id_rsa``. Excluding
+    denylisted paths from ``git log`` would delete it from the history the
+    model sees while protecting nothing -- the format below emits commit
+    metadata only, no paths and no content.
+    """
+    out = git_log(home_repo)
+
+    assert "third" in out, f"a commit disappeared from git_log:\n{out}"
+    assert "second" in out
+    assert "initial" in out
+    _assert_no_leak(out, "git_log()")
+
+
+def test_git_log_scoped_by_path_is_unchanged(ordinary_repo: Path) -> None:
+    out = git_log(ordinary_repo, path="pkg")
+    assert "initial" in out
+
+
+# ---------------------------------------------------------------------------
+# Rule fidelity: each denial kind must be expressed as EXACTLY that rule.
+# ---------------------------------------------------------------------------
+
+
+def test_the_container_rule_hides_direct_child_files_and_nothing_deeper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``direct_children`` must not become a subtree exclusion.
+
+    ``is_sensitive_path``'s container rule refuses loose FILES sitting
+    directly inside one of this app's state directories while leaving the
+    directories nested in them (``tool_sandbox``, ``skills``, ...) fully
+    reachable. The pathspec has to draw the same line: ``:(exclude,glob)``
+    is used precisely because ``*`` does not cross ``/`` under glob magic.
+
+    The effective config directory is the container here, relocated into
+    the repository through ``TLDW_CONFIG_PATH`` -- the same override the
+    denylist itself honors, so nothing is stubbed.
+    """
+    repo = (tmp_path / "project").resolve()
+    _init(repo)
+    container = repo / "appstate"
+    (container / "nested").mkdir(parents=True)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(container / "config.toml"))
+
+    (repo / "keep.txt").write_text("v1\n")
+    (container / "loose.txt").write_text("secret v1\n")
+    (container / "nested" / "deep.txt").write_text("ordinary v1\n")
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-m", "initial")
+    (repo / "keep.txt").write_text("v1\nv2\n")
+    (container / "loose.txt").write_text("secret v1\nsecret v2\n")
+    (container / "nested" / "deep.txt").write_text("ordinary v1\nordinary v2\n")
+
+    out = git_diff(repo)
+
+    assert "appstate/loose.txt" not in out, (
+        f"a loose file inside a protected container leaked:\n{out}"
+    )
+    assert "secret v2" not in out
+    assert "appstate/nested/deep.txt" in out, (
+        "the container exclusion swallowed a nested directory the denylist "
+        f"deliberately leaves reachable:\n{out}"
+    )
+    assert "keep.txt" in out
+
+
+def test_the_name_rule_is_excluded_at_every_depth(tmp_path: Path) -> None:
+    """TASK-19633's name rule must reach git too, wherever the file sits."""
+    repo = (tmp_path / "project").resolve()
+    _init(repo)
+    (repo / "sub" / "deeper").mkdir(parents=True)
+    for rel in (".netrc", "sub/.netrc", "sub/deeper/.netrc"):
+        (repo / rel).write_text(f"machine example.invalid password {NETRC_MARKER}\n")
+    (repo / "sub" / "keep.txt").write_text("v1\n")
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-m", "initial")
+    for rel in (".netrc", "sub/.netrc", "sub/deeper/.netrc"):
+        (repo / rel).write_text(f"machine example.invalid password {NETRC_MARKER}2\n")
+    (repo / "sub" / "keep.txt").write_text("v1\nv2\n")
+
+    out = git_diff(repo)
+
+    assert NETRC_MARKER not in out, f".netrc content leaked through git_diff:\n{out}"
+    assert ".netrc" not in out
+    assert "sub/keep.txt" in out
+
+
+def test_glob_escaping_confines_a_container_exclusion_to_its_own_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A container whose NAME contains a glob metacharacter.
+
+    Unescaped, ``:(exclude,glob)co*ntainer/*`` also swallows
+    ``coXntainer/``. Verified against git 2.39 while building the fix; the
+    escaping is what keeps the exclusion to the directory it names.
+    """
+    assert _glob_escape("co*ntainer") == "co\\*ntainer"
+    assert _glob_escape("a?b[c]\\d") == "a\\?b\\[c]\\\\d"
+
+    repo = (tmp_path / "project").resolve()
+    _init(repo)
+    container = repo / "co*ntainer"
+    container.mkdir()
+    (repo / "coXntainer").mkdir()
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(container / "config.toml"))
+    (container / "loose.txt").write_text("v1\n")
+    (repo / "coXntainer" / "loose.txt").write_text("v1\n")
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-m", "initial")
+    (container / "loose.txt").write_text("v1\nv2\n")
+    (repo / "coXntainer" / "loose.txt").write_text("v1\nv2\n")
+
+    out = git_diff(repo)
+
+    assert "co*ntainer/loose.txt" not in out
+    assert "coXntainer/loose.txt" in out, (
+        f"an unescaped glob exclusion swallowed a lookalike directory:\n{out}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift pins between the denylist and its git rendering.
+# ---------------------------------------------------------------------------
+
+
+def test_exclusions_survive_a_case_variant_spelling(tmp_path: Path) -> None:
+    """The git side must fold case exactly as the denylist does (TASK-19800).
+
+    git records whatever spelling a path was added under, and on a
+    case-insensitive filesystem that need not match the denylist's. An
+    exclusion that misses ``.NETRC`` because the rule says ``.netrc``
+    is a leak, so every exclusion carries ``icase``. The SCOPING pathspec
+    deliberately does not -- folding it would add files to the output.
+    """
+    repo = (tmp_path / "project").resolve()
+    _init(repo)
+    (repo / "sub").mkdir()
+    (repo / "sub" / ".NETRC").write_text(f"password {NETRC_MARKER}\n")
+    (repo / "keep.txt").write_text("v1\n")
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-m", "initial")
+    (repo / "sub" / ".NETRC").write_text(f"password {NETRC_MARKER}2\n")
+    (repo / "keep.txt").write_text("v1\nv2\n")
+
+    out = git_diff(repo)
+
+    assert NETRC_MARKER not in out, (
+        f"a case-variant spelling of a name-rule credential leaked:\n{out}"
+    )
+    assert ".NETRC" not in out
+    assert "keep.txt" in out
+
+
+def test_every_exclusion_kind_the_denylist_emits_can_be_rendered(
+    tmp_path: Path,
+) -> None:
+    """A new denial kind must fail loudly here, not pass through silently."""
+    from tldw_chatbook.Utils.sensitive_paths import (
+        SensitiveExclusion,
+        sensitive_exclusions_under,
+    )
+
+    repo = (tmp_path / "project").resolve()
+    repo.mkdir()
+    kinds = {kind for kind, _ in sensitive_exclusions_under(repo)}
+    assert "name" in kinds, "the name rule must always apply"
+
+    specs = _denylist_pathspecs(repo)
+    assert specs, "an empty exclusion list would mean no protection at all"
+    assert all(spec.startswith(":(exclude,") for spec in specs), specs
+
+    import tldw_chatbook.Utils.sensitive_paths as sp
+
+    original = sp.sensitive_exclusions_under
+    try:
+        sp.sensitive_exclusions_under = lambda root, context=None: (
+            SensitiveExclusion("a_kind_from_the_future", "x"),
+        )
+        import tldw_chatbook.Tools.git_tool_impls as gti
+
+        gti.sensitive_exclusions_under = sp.sensitive_exclusions_under
+        with pytest.raises(LocalToolError, match="unsupported sensitive-path"):
+            _denylist_pathspecs(repo)
+    finally:
+        sp.sensitive_exclusions_under = original
+        import tldw_chatbook.Tools.git_tool_impls as gti
+
+        gti.sensitive_exclusions_under = original
+
+
+def test_the_runner_environment_never_sets_a_pathspec_mode() -> None:
+    """``GIT_LITERAL_PATHSPECS=1`` would disable every exclusion, silently.
+
+    TASK-16801's lesson recommends exactly that variable as blanket
+    hardening for git argv, and it is the natural thing for a future
+    reader to add here. Under it ``:(exclude,literal)<path>`` is read as a
+    literal FILENAME, matches nothing, and ``git_diff``/``git_status``
+    return "(no changes)"/"(working tree clean)" with exit 0 -- a total
+    functional break AND a total protection break, with no error anywhere.
+    Verified on git 2.39 while writing this.
+
+    ``_git_environment`` builds its environment from scratch, so an
+    ambient one never reaches git either; this pins that neither direction
+    changes.
+    """
+    from tldw_chatbook.Tools.git_tool_impls import _git_environment
+
+    env = _git_environment()
+    leaked = {key for key in env if key.endswith("_PATHSPECS")}
+    assert not leaked, (
+        "a pathspec-mode variable in the git runner's environment silently "
+        f"disables the sensitive-path exclusions: {sorted(leaked)}"
+    )
+
+
+def test_prepare_repository_refuses_a_protected_repository_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Excluding denied paths from a repo that is ITSELF denied is nonsense.
+
+    The repo root is DISCOVERED by git rather than supplied by the model,
+    so it is the one path in this family the choke point never sees.
+    """
+    repo = (tmp_path / "project").resolve()
+    _init(repo)
+    (repo / "x.txt").write_text("v1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "initial")
+
+    import tldw_chatbook.Tools.git_tool_impls as gti
+
+    monkeypatch.setattr(gti, "is_sensitive_path", lambda candidate: True)
+    with pytest.raises(LocalToolError, match="protected path"):
+        prepare_repository(repo, ".")

--- a/Tests/Tools/test_git_tool_sensitive_paths.py
+++ b/Tests/Tools/test_git_tool_sensitive_paths.py
@@ -740,6 +740,75 @@ def test_prepare_repository_refuses_a_protected_repository_root(
 
     import tldw_chatbook.Tools.git_tool_impls as gti
 
-    monkeypatch.setattr(gti, "is_sensitive_path", lambda candidate: True)
+    # TASK-19632 review fix: `prepare_repository` now accepts an optional
+    # `context` it threads into this exact call (see `_denylist_pathspecs`
+    # sharing one `SensitivePathContext` per tool call instead of
+    # re-resolving it) -- the stub must accept that keyword too.
+    monkeypatch.setattr(
+        gti, "is_sensitive_path", lambda candidate, context=None: True
+    )
     with pytest.raises(LocalToolError, match="protected path"):
         prepare_repository(repo, ".")
+
+
+# ---------------------------------------------------------------------------
+# Qodo review of PR #1948 (TASK-19632/19633): the denylist context is
+# resolved ONCE per call, not once per check.
+# ---------------------------------------------------------------------------
+
+
+def test_git_status_and_git_diff_resolve_the_denylist_context_exactly_once(
+    ordinary_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One ``SensitivePathContext`` per tool call, not one per denylist check.
+
+    Before this fix, ``prepare_repository``'s own ``is_sensitive_path(repo_root)``
+    call (no ``context`` argument) forced ``resolve_sensitive_context()`` to
+    run, and ``_denylist_pathspecs()`` -- called separately by
+    ``git_status``/``git_diff`` right after -- resolved it AGAIN, even
+    though its own ``context`` parameter existed and simply was never
+    passed by either caller. With ``path="."`` (the default), the full
+    chain (``_prepare_for_path``'s own ``resolve_workspace_path`` call, the
+    ``resolve_workspace_path`` call inside ``prepare_repository``, that
+    function's ``is_sensitive_path`` check on the discovered repo root, and
+    ``_denylist_pathspecs``) resolved it FOUR times over. Measured cost of
+    one resolution on this machine: ~4-5ms (11 config accessors), so this
+    was not free -- see the TASK-19632/19633 task files' Implementation
+    Notes for a before/after timing comparison on a 1000-file repo.
+
+    Pattern follows ``Tests/Agents/test_tool_catalog_concurrency.py``'s
+    ``test_invoke_by_name_takes_exactly_one_catalog_snapshot``: count calls
+    to the real resolver via a counting wrapper, deterministic, no timing
+    dependence.
+    """
+    import tldw_chatbook.Tools.git_tool_impls as gti
+
+    real_resolve = gti.resolve_sensitive_context
+    calls: list[int] = []
+
+    def _counting() -> object:
+        calls.append(1)
+        return real_resolve()
+
+    monkeypatch.setattr(gti, "resolve_sensitive_context", _counting)
+
+    calls.clear()
+    git_status(ordinary_repo, ".")
+    assert len(calls) == 1, (
+        f"git_status resolved the sensitive-path context {len(calls)} "
+        "times in one call; expected exactly 1"
+    )
+
+    calls.clear()
+    git_diff(ordinary_repo)
+    assert len(calls) == 1, (
+        f"git_diff resolved the sensitive-path context {len(calls)} times "
+        "in one call; expected exactly 1"
+    )
+
+    calls.clear()
+    git_log(ordinary_repo)
+    assert len(calls) == 1, (
+        f"git_log resolved the sensitive-path context {len(calls)} times "
+        "in one call; expected exactly 1"
+    )

--- a/Tests/Tools/test_git_tool_sensitive_paths.py
+++ b/Tests/Tools/test_git_tool_sensitive_paths.py
@@ -263,14 +263,26 @@ def test_pathspec_magic_in_the_path_argument_cannot_invert_the_scope(
 
 
 def test_every_pathspec_this_family_builds_carries_explicit_magic() -> None:
-    """Structural pin: no bare pathspec may be spliced after ``--``.
+    """Structural pin: no bare value may reach a pathspec position.
 
     ``--`` ends OPTION parsing, not pathspec-magic parsing, so a bare
-    value in a pathspec position is a repository-supplied injection point.
-    Every argv element this module places after ``--`` must therefore
-    start with an explicit magic prefix -- except ``git_blame``'s, which
-    takes a plain PATH and rejects magic outright (verified: ``fatal: no
-    such path ':(literal)a.txt' in HEAD``).
+    value after it is a repository-supplied injection point: a file
+    legitimately named ``:(exclude)notes.txt`` inverts the scope of
+    whatever command it lands in. Only two shapes are allowed through --
+    ``_literal_pathspec(...)``, which disables magic for one value, and a
+    splat of ``_denylist_pathspecs(...)``, which renders its own.
+
+    Checked over EVERY list literal in the module that contains ``"--"``,
+    and THROUGH a local list that is splatted into one. An earlier form of
+    this test only inspected ``.extend([...])`` arguments and waved every
+    ``*splat`` through, which post-fix left both leaking tools uncovered:
+    ``git_status`` builds its whole argv as one literal handed to
+    ``_run_git_checked``, and ``git_diff`` accumulates into a local
+    ``pathspecs`` list and splats that. Measured: splicing a bare
+    model-supplied value into either left the old test green. ``git_blame``
+    stays exempt -- it takes a plain PATH, not a pathspec, and rejects
+    magic outright (verified: ``fatal: no such path ':(literal)a.txt' in
+    HEAD``).
     """
     import ast
 
@@ -278,39 +290,86 @@ def test_every_pathspec_this_family_builds_carries_explicit_magic() -> None:
 
     source = Path(git_tool_impls.__file__).read_text()
     tree = ast.parse(source)
-    offenders: list[str] = []
-    for node in tree.body:
-        if not isinstance(node, ast.FunctionDef):
-            continue
-        if node.name == "git_blame":
-            continue  # plain path, see the docstring above
-        for call in ast.walk(node):
-            if not isinstance(call, ast.Call):
-                continue
-            if not (isinstance(call.func, ast.Attribute) and call.func.attr == "extend"):
-                continue
-            for arg in call.args:
-                if not isinstance(arg, (ast.List, ast.Tuple)):
-                    continue
-                elements = list(arg.elts)
-                if not elements:
-                    continue
-                first = elements[0]
-                if not (isinstance(first, ast.Constant) and first.value == "--"):
-                    continue
-                for element in elements[1:]:
-                    if isinstance(element, ast.Starred):
-                        continue  # _denylist_pathspecs' own output, pinned below
-                    if isinstance(element, ast.Call) and isinstance(
-                        element.func, ast.Name
+
+    def _is_call_to(node: ast.AST, names: set[str]) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in names
+        )
+
+    def _local_list_is_safe(func: ast.FunctionDef, name: str) -> list[str]:
+        """Every value that can reach the local list ``name``."""
+        bad: list[str] = []
+        for node in ast.walk(func):
+            # Rebinding it to anything but a fresh empty list hides the flow.
+            targets: list[ast.AST] = []
+            if isinstance(node, ast.Assign):
+                targets = list(node.targets)
+            elif isinstance(node, ast.AnnAssign):
+                targets = [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    value = node.value  # type: ignore[union-attr]
+                    if value is not None and not (
+                        isinstance(value, ast.List) and not value.elts
                     ):
-                        if element.func.id in {"_literal_pathspec"}:
-                            continue
-                    offenders.append(f"{node.name}: {ast.dump(element)[:120]}")
+                        bad.append(f"{name} = {ast.dump(value)[:100]}")
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == name
+            ):
+                continue
+            allowed = (
+                {"_literal_pathspec"}
+                if node.func.attr == "append"
+                else {"_denylist_pathspecs"}
+            )
+            if node.func.attr not in {"append", "extend"}:
+                bad.append(f"{name}.{node.func.attr}(...)")
+                continue
+            for arg in node.args:
+                if not _is_call_to(arg, allowed):
+                    bad.append(f"{name}.{node.func.attr}({ast.dump(arg)[:100]})")
+        return bad
+
+    offenders: list[str] = []
+    for func in tree.body:
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if func.name == "git_blame":
+            continue  # plain path, see the docstring above
+        for literal in ast.walk(func):
+            if not isinstance(literal, (ast.List, ast.Tuple)):
+                continue
+            elements = list(literal.elts)
+            separators = [
+                index
+                for index, element in enumerate(elements)
+                if isinstance(element, ast.Constant) and element.value == "--"
+            ]
+            if not separators:
+                continue
+            for element in elements[separators[0] + 1 :]:
+                if _is_call_to(element, {"_literal_pathspec"}):
+                    continue
+                if isinstance(element, ast.Starred):
+                    if _is_call_to(element.value, {"_denylist_pathspecs"}):
+                        continue
+                    if isinstance(element.value, ast.Name):
+                        offenders.extend(
+                            f"{func.name}: via *{element.value.id} -- {reason}"
+                            for reason in _local_list_is_safe(func, element.value.id)
+                        )
+                        continue
+                offenders.append(f"{func.name}: {ast.dump(element)[:120]}")
+
     assert not offenders, (
-        "these values are spliced into a pathspec position without explicit "
-        "magic, so a repository file named ':(exclude)x' can invert the "
-        f"command's scope: {offenders}"
+        "these values reach a pathspec position without explicit magic, so a "
+        "repository file named ':(exclude)x' can invert the command's scope: "
+        f"{offenders}"
     )
 
 
@@ -542,6 +601,65 @@ def test_exclusions_survive_a_case_variant_spelling(tmp_path: Path) -> None:
     )
     assert ".NETRC" not in out
     assert "keep.txt" in out
+
+
+def test_a_location_exclusion_survives_a_case_variant_directory_spelling() -> None:
+    """The same fold, on the LOCATION rules -- the case that was unpinned.
+
+    The test above covers the name rule's ``:(exclude,glob,icase)**/<name>``
+    form. Nothing covered ``:(exclude,literal,icase)<rel>``, which renders
+    ``_SENSITIVE_DIRS`` and the resolved single-file denials -- and that is
+    the form the module docstring's own headline example depends on:
+    the rule is spelled ``~/.ssh``, git records whatever spelling the path
+    was ADDED under, and on the case-insensitive filesystems this app ships
+    on ``~/.SSH/id_rsa`` opens the very same file. ``is_sensitive_path``
+    folds and refuses that spelling (TASK-19800); the pathspec rendered
+    from it has to reach the same verdict or the denial is decorative.
+
+    Found by mutation while reviewing TASK-19632: dropping ``icase`` from
+    the ``subtree``/``file`` branch of ``_denylist_pathspecs`` left the
+    whole suite GREEN while ``git_diff`` returned the key's content and
+    ``stat``/``status`` returned its name. This test is what reds instead.
+    """
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    home = _home()
+    _init(home)
+    # `.SSH`, not `.ssh`: the denylist's spelling and git's must differ.
+    key = home / ".SSH" / "id_rsa"
+    key.parent.mkdir(parents=True, exist_ok=True)
+    key.write_text(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\n")
+    (home / "keep.txt").write_text("v1\n")
+    _git(home, "add", "-A", "-f")
+    _git(home, "commit", "-m", "initial")
+    key.write_text(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nROTATED\n")
+    (home / "keep.txt").write_text("v1\nv2\n")
+    _git(home, "add", "-A", "-f")
+    _git(home, "commit", "-m", "second")
+
+    # The premise: the denylist itself already refuses this spelling, so
+    # any disclosure below is the git rendering disagreeing with it.
+    assert is_sensitive_path(key), (
+        "premise broken: the denylist must already refuse the case variant "
+        "(TASK-19800) for this test to be about the pathspec rendering"
+    )
+
+    _assert_no_leak(
+        git_diff(home, commit_range="HEAD~1..HEAD"),
+        "git_diff(commit_range) on a case-variant location",
+    )
+    _assert_no_leak(
+        git_diff(home, commit_range="HEAD~1..HEAD", stat=True),
+        "git_diff(stat) on a case-variant location",
+    )
+    key.write_text(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_MARKER}\nAGAIN\n")
+    (home / "keep.txt").write_text("v1\nv2\nv3\n")
+    _assert_no_leak(git_diff(home), "git_diff(worktree) on a case-variant location")
+    _assert_no_leak(git_status(home), "git_status on a case-variant location")
+
+    # Not vacuous: the ordinary file beside it is still reported.
+    assert "keep.txt" in git_diff(home)
+    assert "keep.txt" in git_status(home)
 
 
 def test_every_exclusion_kind_the_denylist_emits_can_be_rendered(

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -366,16 +366,23 @@ def _denylisted_candidates() -> list[tuple[str, Path]]:
     refusal comes from confinement, not the denylist -- a distinction the
     assertions below keep rather than paper over.
 
-    Read that distinction accurately (review round): it is not purely a
-    design difference. Because the second family rejects dotted components
-    at confinement, it ALSO refuses dotted credential files the denylist
-    does not enumerate at all (``~/.netrc``, ``~/.git-credentials``,
-    ``~/.npmrc``, ...), which the ``fs_*`` family -- passing
-    ``allow_hidden=True`` -- returns in full. For dotted paths the ``fs_*``
-    family is therefore strictly the weaker of the two, and part of what
-    looks like an honest difference of mechanism is residue. Tracked as
-    TASK-19633; the candidates below are all genuinely denylisted, so this
-    test is unaffected either way.
+    That distinction is now an honest one, and TASK-19633 is what made it
+    so -- the phrase used to carry a caveat, because it was describing
+    residue as well as design. When TASK-19551 shipped, the second
+    family's dotted-component rejection ALSO refused credential files the
+    denylist did not enumerate at all (``~/.netrc``,
+    ``~/.git-credentials``, ``~/.npmrc``, ``~/.pypirc``,
+    ``~/.cargo/credentials.toml``, ``~/.config/gh/hosts.yml``), every one
+    of which the ``fs_*`` family returned in full: for those paths the
+    ``fs_*`` family was strictly the weaker of the two, by accident rather
+    than by decision. TASK-19633 closed that in the shared oracle -- a
+    name rule for unambiguous credential FILENAMES plus ``~/.config/gh``
+    as a location -- so both families now refuse all six, and
+    ``test_both_families_refuse_the_TASK_19633_credential_paths`` below
+    pins it in configurations where confinement cannot be what does the
+    work. What remains is only the mechanism difference described above:
+    a deliberate ADR-032 policy split about DOTTED NAMES, not a gap in
+    what the denylist knows.
     """
     from tldw_chatbook import config as app_config
 
@@ -906,3 +913,260 @@ def test_binding_gate_still_allows_an_unrelated_root():
     plain = _home() / "projects" / "myapp"
     plain.mkdir(parents=True, exist_ok=True)
     assert find_root_binding_conflict(plain) is None
+
+
+# ---------------------------------------------------------------------------
+# TASK-19633: credential files the denylist did not cover.
+#
+# TASK-19551 kept `allow_hidden=True` (ADR-032) on the argument that "starts
+# with a dot" is a name heuristic while `is_sensitive_path` answers the
+# question properly, by resolved ancestry. That decision is right, but
+# resolved-ancestry matching is only as strong as what the denylist knows:
+# `_SENSITIVE_DIRS` listed seven locations and nothing else, so every file
+# below returned its BODY through `fs_read` (measured, isolated $HOME).
+#
+# The fix is in the denylist's CONTENT: a NAME rule for filenames that are
+# credential stores wherever they appear, plus `~/.config/gh` as a location
+# where the filename (`hosts.yml`) is far too generic to be one. See
+# `Utils/sensitive_paths.py`'s docstring for why both instruments exist.
+# ---------------------------------------------------------------------------
+
+CREDENTIAL_MARKER = "SYNTHETIC-NOT-A-REAL-CREDENTIAL-19633"
+
+#: (label, path relative to $HOME, which rule refuses it). Exactly the six
+#: paths measured in the task; the rule column is asserted, not decorative.
+_TASK_19633_CREDENTIALS = (
+    ("netrc", ".netrc", "name"),
+    ("git credential store", ".git-credentials", "name"),
+    ("npm auth token", ".npmrc", "name"),
+    ("pypi upload credentials", ".pypirc", "name"),
+    ("cargo registry token", ".cargo/credentials.toml", "name"),
+    ("github cli oauth tokens", ".config/gh/hosts.yml", "location"),
+)
+
+
+def _plant_credential(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"machine example.invalid password {CREDENTIAL_MARKER}\n")
+    return path
+
+
+@pytest.mark.parametrize(
+    ("label", "relative", "rule"),
+    _TASK_19633_CREDENTIALS,
+    ids=[relative for _label, relative, _rule in _TASK_19633_CREDENTIALS],
+)
+def test_fs_read_refuses_each_TASK_19633_credential_path(label, relative, rule):
+    """One born-red case per added path shape.
+
+    The workspace root is the file's OWN directory, so the relative
+    portion carries no dotted component and ``allow_hidden=True`` is not
+    what lets it through -- only the denylist can refuse it. At base every
+    one of these returned the file's body.
+    """
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    path = _plant_credential(_home() / relative)
+    assert is_sensitive_path(path), f"{label}: the shared oracle must refuse it"
+
+    message = _refused(
+        lambda: read_file(path.name, workspace_root=path.parent),
+        f"fs_read({relative})",
+    )
+    assert "protected path" in message, label
+    assert CREDENTIAL_MARKER not in message, label
+
+
+def test_the_name_rule_and_the_location_rule_each_do_their_own_work():
+    """Which instrument refuses which path, asserted rather than assumed.
+
+    A name-rule path must still be refused after being MOVED (that is the
+    whole reason a name rule was chosen for it); a location-rule path must
+    NOT be, because its filename is generic on purpose -- ``hosts.yml`` is
+    just as often an Ansible inventory, and refusing it everywhere would
+    be exactly the over-refusal the module docstring rules out.
+    """
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    elsewhere = _home() / "projects" / "repo"
+    for label, relative, rule in _TASK_19633_CREDENTIALS:
+        moved = _plant_credential(elsewhere / Path(relative).name)
+        assert is_sensitive_path(moved) is (rule == "name"), (
+            f"{label}: expected the {rule} rule to decide, and it did not"
+        )
+        moved.unlink()
+
+
+def test_the_name_rule_is_case_insensitive():
+    """macOS and Windows filesystems are case-insensitive.
+
+    ``.NETRC`` opens the same file an exact-case comparison would wave
+    through, so the check is case-folded.
+    """
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    assert is_sensitive_path(_plant_credential(_home() / ".NETRC"))
+    assert is_sensitive_path(_plant_credential(_home() / "Credentials.TOML"))
+
+
+def test_the_name_rule_does_not_refuse_near_misses_or_containers():
+    """The cost of a name rule is over-refusal; this is where it is bounded.
+
+    A container DIRECTORY carrying one of the names stays reachable (the
+    same ``is_dir()`` gate the direct-child-file rule uses), and names that
+    merely resemble a credential file are ordinary files. ``.env`` is the
+    deliberate omission recorded in the module docstring.
+    """
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    workspace = _home() / "projects" / "repo"
+    (workspace / "credentials").mkdir(parents=True)
+    (workspace / "credentials" / "README.md").write_text("docs\n")
+    for name in (".npmrc.example", "netrc", "my.netrc", ".env", "credentials.json"):
+        (workspace / name).write_text("ordinary\n")
+
+    assert not is_sensitive_path(workspace / "credentials")
+    assert "README.md" in list_directory("credentials", workspace_root=workspace)
+    for name in (".npmrc.example", "netrc", "my.netrc", ".env", "credentials.json"):
+        assert "ordinary" in read_file(name, workspace_root=workspace), name
+
+
+def test_both_families_refuse_the_TASK_19633_credential_paths(monkeypatch):
+    """AC1: BOTH families, in configurations confinement cannot explain.
+
+    Constructing that configuration takes deliberate care, because the two
+    families disagree about dotted names on purpose:
+
+    * The NAME-rule paths are planted at a NON-dotted location under a
+      NON-dotted root (``projects/repo/_netrc``, ``credentials.toml``,
+      ``credentials``). Nothing in either family's confinement can object,
+      so a refusal is the denylist's -- and that a moved credential is
+      still refused is the name rule's whole point.
+    * The LOCATION-rule path keeps its location, since that is what
+      identifies it -- but rooted at ``~/.config/gh`` the relative portion
+      is a plain ``hosts.yml`` and the root's own basename (``gh``) is not
+      dotted either, so family 1's ``allow_hidden=False`` has nothing to
+      reject.
+    """
+    from tldw_chatbook.Tools import file_operation_tools as fot
+    from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+    def _raise():
+        raise RuntimeError("no workspace registry in this test")
+
+    monkeypatch.setattr(wfr, "_registry_factory", _raise)
+
+    neutral = _home() / "projects" / "repo"
+    cases: list[tuple[str, Path]] = [
+        (f"moved name-rule credential ({name})", _plant_credential(neutral / name))
+        for name in ("_netrc", "credentials.toml", "credentials")
+    ]
+    cases.append(
+        ("github cli oauth tokens", _plant_credential(_home() / ".config/gh/hosts.yml"))
+    )
+
+    for label, path in cases:
+        relative_parts = (path.name,)
+        assert not any(part.startswith(".") for part in relative_parts), label
+        assert not path.parent.name.startswith("."), label
+
+        # Family A: fs_* (allow_hidden=True), root = the file's directory.
+        message = _refused(
+            lambda p=path: read_file(p.name, workspace_root=p.parent),
+            f"fs_read({label})",
+        )
+        assert "protected path" in message, label
+        assert CREDENTIAL_MARKER not in message, label
+
+        # Family B: file_operation_tools, sandbox root = the same directory.
+        monkeypatch.setattr(fot, "_tool_sandbox_root", lambda p=path: p.parent.resolve())
+        legacy = asyncio.run(fot.ReadFileTool().execute(file_path=path.name))
+        assert "error" in legacy, label
+        assert "protected path" in legacy["error"], label
+        assert CREDENTIAL_MARKER not in str(legacy), label
+
+
+def test_family_b_hides_the_dotted_credential_names_by_denylist_not_confinement(
+    monkeypatch,
+):
+    """The four inherently-dotted names, for family B, with the denylist alone.
+
+    ``.netrc`` cannot be spelled without a dot, so ``ReadFileTool`` will
+    always refuse it at confinement and prove nothing about the denylist.
+    ``ListDirectoryTool`` with ``include_hidden=True`` is the seam where
+    that is not true: it lists dotted entries by request, and the ONLY
+    thing that can then withhold one is ``is_sensitive_path``. Before
+    TASK-19633 all four were listed by name; ``.gitignore`` is the control
+    proving ``include_hidden`` is honored and the listing itself works.
+    """
+    from tldw_chatbook.Tools import file_operation_tools as fot
+    from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+    def _raise():
+        raise RuntimeError("no workspace registry in this test")
+
+    monkeypatch.setattr(wfr, "_registry_factory", _raise)
+
+    workspace = _home() / "projects" / "repo"
+    dotted = (".netrc", ".git-credentials", ".npmrc", ".pypirc")
+    for name in dotted:
+        _plant_credential(workspace / name)
+    (workspace / ".gitignore").write_text("*.pyc\n")
+
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: workspace.resolve())
+    listing = asyncio.run(
+        fot.ListDirectoryTool().execute(directory_path=".", include_hidden=True)
+    )
+
+    names = {entry["name"] for entry in listing.get("entries", [])}
+    assert ".gitignore" in names, (
+        f"the listing itself is broken or include_hidden was ignored: {listing}"
+    )
+    for name in dotted:
+        assert name not in names, (
+            f"ListDirectoryTool(include_hidden=True) disclosed {name}: {sorted(names)}"
+        )
+
+
+def test_fs_grep_never_reads_a_name_rule_credential(monkeypatch):
+    """The sharpest ``fs_*`` tool, on the newly-covered shape.
+
+    ``grep_files`` READS every file it walks and prints matching lines, so
+    a home-rooted workspace and a pattern as bland as ``password`` emitted
+    ``~/.netrc``'s body verbatim into the transcript.
+    """
+    _plant_credential(_home() / ".netrc")
+    (_home() / "notes.txt").write_text(f"decoy password {CREDENTIAL_MARKER}\n")
+
+    out = grep_files("password", workspace_root=_home())
+
+    assert "notes.txt" in out
+    assert ".netrc" not in out
+    assert out.count(CREDENTIAL_MARKER) == 1  # the decoy line only
+
+
+def test_the_name_rule_uses_the_modules_one_folding_rule(monkeypatch):
+    """TASK-19633 must not open a SECOND normalization path (TASK-19800).
+
+    ``_compare_key`` is this module's single definition of how two path
+    spellings are compared. If the name rule ever grows its own
+    ``.casefold()`` beside it, the two can drift -- so this pins the
+    dependency by MUTATION: with folding removed from ``_compare_key``
+    (and only from there), a case-variant credential name must stop being
+    refused. It does not, if the name rule folds on its own.
+
+    The mutation keeps ``_compare_key``'s SHAPE (a tuple of components) so
+    the other rules keep working normally and this test isolates the one
+    it is about.
+    """
+    import tldw_chatbook.Utils.sensitive_paths as sp
+
+    variant = _plant_credential(_home() / "projects" / "repo" / "Credentials.TOML")
+    assert sp.is_sensitive_path(variant)
+
+    monkeypatch.setattr(sp, "_compare_key", lambda p: tuple(p.parts))
+    assert not sp.is_sensitive_path(variant), (
+        "the name rule still folded case after folding was removed from "
+        "_compare_key, so it normalizes independently of the module's one "
+        "folding rule"
+    )

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5980,3 +5980,48 @@ happens to use. Three of those four routes were already closed here; the
 fourth was the one no test had ever expressed. The fix was
 `send(..., auth=None)` — explicit `None`, because *omitting* the argument
 leaves httpx's `USE_CLIENT_DEFAULT` sentinel in play and changes nothing.
+
+## The pathspec-magic vector reappears wherever a FILENAME reaches argv — and the blanket fix for it breaks exclusions (task-19632, 2026-08-21)
+
+The lesson above (task-16801) recorded pathspec magic as vector 4 in Change
+Review's git modes and recommended `GIT_LITERAL_PATHSPECS=1` as the blanket
+hardening. The agent-facing `git_*` tools are a *different* module with a
+*different* entry point, and the same vector was live there, reached from the
+other direction: not a repository filename the UI carried into a commit, but
+the model's own `path` ARGUMENT.
+
+`git_diff(path=":(exclude)notes.txt")` — a legal POSIX filename, a real file in
+the repo, so `resolve_workspace_path` resolves it, confines it, and finds it
+un-denylisted, exactly as designed. git then read it as MAGIC and inverted the
+diff's scope, returning the rest of the repository including `~/.ssh/id_rsa`'s
+content. The tool's *own* denylist refusal for `path=".ssh/id_rsa"` still
+worked; the model simply asked a different question. Measured before the fix,
+with an isolated `$HOME`.
+
+Two things generalise:
+
+- **Trace the argv slot per module, not per repository.** The 16801 audit was
+  correct and complete for the module it audited. "This class was fixed" is not
+  a property of a codebase; a second module building the same argv from a
+  different source needs its own slot table. Here the source was the model, and
+  the choke point every reviewer trusts (`resolve_workspace_path`) is a PATH
+  validator — it has no opinion about pathspec syntax, and correctly so.
+- **`GIT_LITERAL_PATHSPECS=1` and `:(exclude)` are mutually exclusive, and the
+  conflict is SILENT.** With it set, `:(exclude,literal)<path>` is taken as a
+  literal filename, matches nothing, and `git diff`/`git status` return **empty
+  output with exit 0** (verified, git 2.39). Applying the previous lesson's
+  blanket recommendation to this module would therefore have broken the feature
+  *and* every credential exclusion at once, with no error to notice. The
+  per-pathspec form (`:(literal)` on values that SCOPE, `:(exclude,literal)` /
+  `:(exclude,glob)` on values that DENY) is the compatible equivalent. There is
+  now a test asserting no `*_PATHSPECS` variable appears in that runner's
+  environment, because the comment alone would not survive a future hardening
+  pass.
+
+One test-craft note from the same session: the born-red run for the injection
+case **passed at base**, which looked like the vector was already closed. It was
+not — the assertions happened to align with the injected behaviour, because the
+credential file was not dirty in that scenario, so the inverted scope had
+nothing to leak. Reading the base-run PASS list rather than only the FAILED list
+is what caught it. A born-red test that passes at base is a defect in the test
+until you have explained why.

--- a/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
+++ b/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
@@ -2,7 +2,7 @@
 id: TASK-19632
 title: >-
   git_diff leaks denylisted file content when path is omitted
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 12:05'
 labels:
@@ -66,21 +66,21 @@ should not be described or built as "the three git tools leak".
 
 ## Acceptance Criteria
 
-- [ ] `git_diff` never returns the content of a path `is_sensitive_path` refuses,
+- [x] `git_diff` never returns the content of a path `is_sensitive_path` refuses,
       whether that path is reached via the worktree, the index, or a
       `commit_range`, and whether or not the caller supplied `path`
-- [ ] `git_status` never names such a path
-- [ ] The behaviour is enforced by construction (e.g. denylisted paths inside the
+- [x] `git_status` never names such a path
+- [x] The behaviour is enforced by construction (e.g. denylisted paths inside the
       repository are excluded from git's own output via pathspec, or the output
       is filtered before it is returned) rather than by asking the model to pass
       `path`
-- [ ] A born-red test reproduces the clean-worktree `commit_range` content leak
+- [x] A born-red test reproduces the clean-worktree `commit_range` content leak
       and the `stat=True`/`git_status` name leaks, and each is refused after
       the fix
-- [ ] A test pins that `git_log` output is unchanged, and that ordinary
+- [x] A test pins that `git_log` output is unchanged, and that ordinary
       (non-denylisted) diffs, stats and statuses are unchanged — the fix must not
       silently truncate legitimate multi-file diffs
-- [ ] `Utils/sensitive_paths.py`'s module docstring and
+- [x] `Utils/sensitive_paths.py`'s module docstring and
       `Tools/local_tool_impls.py`'s drop the TASK-19632 exception once it no
       longer applies (both currently state it explicitly)
 
@@ -102,3 +102,106 @@ test_every_workspace_rooted_function_uses_the_choke_point` already covers
 `git_tool_impls` structurally and carries a NOTE that reaching the choke point
 proves the path ARGUMENT is checked, not that output is filtered — that note
 points here.
+
+
+## Implementation Plan
+
+1. Reproduce all five measured cases against an isolated `$HOME` that is a git
+   repository, and confirm which of them actually leak (the table in the
+   description, re-measured on this branch).
+2. Choose between pathspec exclusion and output filtering, and record the
+   argument.
+3. Give `Utils/sensitive_paths.py` a structural accessor for its own denials so
+   the git renderer cannot become a second, hand-maintained copy of the
+   denylist.
+4. Render those denials as git exclude pathspecs in `git_tool_impls`, one
+   pathspec form per denial rule so no rule is widened or narrowed in
+   translation.
+5. Prove the pathspec-injection case is closed rather than assuming `--`
+   handles it.
+6. Born-red tests for every leak; hard negative pins for `git_log` and for
+   ordinary diffs/stats/statuses.
+7. Remove the TASK-19632 exception paragraphs from both module docstrings.
+
+## Implementation Notes
+
+**Chosen: pathspec exclusion.** git stays the authority on what matches, no
+unified-diff or porcelain text is ever parsed, and the exclusions are
+recomputed from the live denylist on every call (so a `TLDW_CONFIG_PATH`
+switch or a relocated database is observed immediately). Output filtering was
+rejected on the task's own grounds -- a half-parsed diff is worse than none --
+and it would have had to parse two unrelated formats, one of them NUL-delimited
+porcelain v2.
+
+The seam matters as much as the mechanism. `Utils/sensitive_paths.py` gained
+`sensitive_exclusions_under(root)`, which returns this module's denials as
+structured `SensitiveExclusion(kind, value)` entries relative to a root;
+`git_tool_impls._denylist_pathspecs` renders them. So the denylist stays the
+one place that knows WHAT is denied and the git module the one place that knows
+HOW to say it to git. Each kind maps to the pathspec form that expresses
+exactly that rule: a container's `direct_children` becomes
+`:(exclude,glob,icase)<dir>/*`, where `*` does not cross `/` under glob magic,
+so `tool_sandbox/` stays diffable while a loose file beside it does not -- the
+same line `is_sensitive_path`'s own container rule draws. An unrecognized kind
+raises rather than being skipped.
+
+**Argv injection: found live, and closed.** While building the fix I measured a
+vector the task did not list. `:(exclude)notes.txt` is a legal POSIX filename,
+so `git_diff(path=":(exclude)notes.txt")` passes the choke point as an ordinary
+confined path -- and git then reads it as MAGIC and inverts the diff's scope,
+returning the rest of the repository with `~/.ssh/id_rsa`'s content in it. `--`
+does NOT stop this: `--` ends OPTION parsing, not magic parsing. Every pathspec
+this family builds is now rendered with explicit magic. The proof is
+`test_pathspec_magic_in_the_path_argument_cannot_invert_the_scope` (red at base
+with the key's content in the failure message) plus an AST tripwire,
+`test_every_pathspec_this_family_builds_carries_explicit_magic`, which fails on
+any bare value spliced after `--` (red at base, naming `git_log` and
+`git_diff`).
+
+`git_blame` is deliberately untouched: `git blame` takes a plain PATH, not a
+pathspec, and rejects magic outright (`fatal: no such path ':(literal)a.txt' in
+HEAD`, verified) -- so it never interprets a magic-shaped filename either.
+
+**Deliberate non-changes.** `git_log` is not given exclusions: its `--format`
+emits commit metadata only, it was measured leaking nothing, and excluding
+denied paths would delete commits from a legitimate history while protecting
+nothing. A test asserts a commit touching ONLY `~/.ssh/id_rsa` still appears.
+And nothing announces that an exclusion took effect: the only honest note would
+state that this repository contains a protected path, which is the same
+disclosure `stat=True`/`git_status` were leaking. A model that NAMES the path
+still gets the "protected path" refusal, which is the actionable case.
+
+**Case folding (composed with TASK-19800, merged mid-task).** Every exclusion
+carries `icase`, for the reason 19800 gives for folding the denylist itself:
+git records whatever spelling a path was added under, and a denial that misses
+`.SSH/id_rsa` is a leak. Folding an exclusion only ever removes more, so it
+fails in the cheap direction -- unlike the SCOPING pathspec, which is
+deliberately left case-sensitive because folding it would ADD files to what the
+model gets back. `_relative_within` decides containment through 19800's
+`_is_within` rather than `Path.relative_to`'s exact-case parts, so the git side
+has no second, differently-normalized comparison path.
+
+**A trap left for the next reader.** TASK-16801's lesson recommends
+`GIT_LITERAL_PATHSPECS=1` as blanket hardening for git argv. It is incompatible
+with this fix and fails SILENTLY: under it `:(exclude,literal)<path>` is taken
+as a literal filename, matches nothing, and every `git_diff`/`git_status`
+returns empty output with exit 0 (verified, git 2.39) -- breaking the feature
+and every exclusion at once. `_git_environment` carries a comment and
+`test_the_runner_environment_never_sets_a_pathspec_mode` asserts no
+`*_PATHSPECS` variable appears there.
+
+**Evidence.** Born-red at `origin/dev` (`d4f3f9776`, i.e. including TASK-19800):
+10 of the 19 tests in the new file fail, each failure message carrying the
+leaked bytes -- `git_diff(commit_range=..., no path)`, `stat=True`,
+`staged=True`, dirty worktree, `git_status` (including an UNTRACKED denylisted
+file), the pathspec injection, the AST tripwire, the container rule, the name
+rule, and the case variant. The remaining 9 pass at base and after, which is
+the point: they are the negative pins (`git_log` unfiltered; ordinary diff and
+stat byte-identical to raw git run with the same flags; ordinary status and
+scoped diffs unchanged). All 19 pass on this branch.
+
+Modified: `tldw_chatbook/Utils/sensitive_paths.py`,
+`tldw_chatbook/Tools/git_tool_impls.py`,
+`tldw_chatbook/Tools/local_tool_impls.py` (docstring),
+`backlog/docs/lessons-testing-evidence.md`. Added:
+`Tests/Tools/test_git_tool_sensitive_paths.py`.

--- a/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
+++ b/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
@@ -205,3 +205,57 @@ Modified: `tldw_chatbook/Utils/sensitive_paths.py`,
 `tldw_chatbook/Tools/local_tool_impls.py` (docstring),
 `backlog/docs/lessons-testing-evidence.md`. Added:
 `Tests/Tools/test_git_tool_sensitive_paths.py`.
+
+## Independent review addendum (2026-08-22)
+
+Reviewed adversarially against `d4f3f9776`. The fix itself held everywhere it
+was attacked: 22 pathspec-magic forms (`:(exclude)`, `:!`, `:^`, `:(icase)`,
+`:(glob)*`/`**`, `:(attr:)`, `:(top)`, bare `:`, `:/`, `:(exclude,literal)`,
+nested `:(literal):(exclude)`, and glob/newline filenames) were driven through
+`git_diff`/`git_log`/`git_blame`/`git_status`, each with and without a
+`commit_range`; **every one leaked at base and none leaks on this branch**. An
+oracle probe planting 40 files and comparing `is_sensitive_path`'s verdict
+against what git actually emitted found **0 disagreements in either direction**
+(base: 8 leaks) — covering nesting under a subtree rule, nesting 1 and 2 levels
+under a `direct_children` container, untracked and ignored files, a merge
+commit, rename detection in both directions, binaries, submodules (both as
+parent and as workspace root), and the name-rule near misses. `git blame`'s
+plain-PATH claim was verified directly (`fatal: no such path
+':(literal)notes.txt' in HEAD`), as was the `GIT_LITERAL_PATHSPECS` silent mode
+(exit 0, branch header only) — with the additional finding that
+`_git_environment` building from scratch means an AMBIENT setting cannot reach
+git at all, and that adding one reds 15 tests, not just the env pin.
+
+Two mutation survivors were found and fixed here:
+
+1. **`icase` on the LOCATION exclusions was load-bearing but unpinned.**
+   `test_exclusions_survive_a_case_variant_spelling` only exercises the NAME
+   rule's `**/<name>` form; dropping `icase` from the `subtree`/`file` branch of
+   `_denylist_pathspecs` left the whole suite GREEN while a repo recording
+   `.SSH/id_rsa` — which `is_sensitive_path` refuses via TASK-19800 — returned
+   its CONTENT through `git_diff` and its NAME through `stat`/`status`
+   (measured). Added
+   `test_a_location_exclusion_survives_a_case_variant_directory_spelling`.
+2. **The AST tripwire covered only `git_log` after the fix.** It inspected
+   `.extend([...])` arguments only and waved every `*splat` through, so
+   `git_status` (whole argv as one literal passed to `_run_git_checked`) and
+   `git_diff` (splats a local `pathspecs` list) were both uncovered — splicing a
+   bare model-supplied value into either left it green. It now walks every list
+   literal containing `"--"` and follows a splatted local list back to its
+   `append`/`extend` sources. Verified red against six evasions: bare value in
+   `git_diff`, bare value in `git_status`'s literal, an f-string, a different
+   helper, a bare `git_log` splice, and the original base shape.
+
+Neither survivor was exploitable as shipped (the exclusions still apply even
+when the scoping pathspec is bare, so the tripwire is defence in depth); the
+`icase` one was a live leak the moment anyone touched that line.
+
+Still unpinned, judged acceptable and recorded rather than fixed: the
+fail-closed `("subtree", "")` return for an unresolvable root, and
+`_relative_within` using `_is_within` rather than `Path.relative_to` — both
+correct as written, neither reachable through `prepare_repository` today.
+
+Evidence note for the record: the new test module imports `_denylist_pathspecs`
+at module scope, so at `d4f3f9776` it does not COLLECT at all — "10 of the 19
+fail at base" is only reproducible with those imports shimmed (13 fail, 7 pass
+that way). The behavioural failures do each carry the leaked bytes, as claimed.

--- a/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
+++ b/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
@@ -259,3 +259,91 @@ Evidence note for the record: the new test module imports `_denylist_pathspecs`
 at module scope, so at `d4f3f9776` it does not COLLECT at all — "10 of the 19
 fail at base" is only reproducible with those imports shimmed (13 fail, 7 pass
 that way). The behavioural failures do each carry the leaked bytes, as claimed.
+
+## PR #1948 Qodo review fixes (2026-08-22)
+
+Two findings on the merged PR, both scoped to `git_tool_impls.py`; neither
+touches `Utils/sensitive_paths.py`.
+
+**Finding 1 (redundant denylist context resolve).** `prepare_repository`
+called `is_sensitive_path(repo_root)` with no `context`, forcing a fresh
+`resolve_sensitive_context()` — and `git_status`/`git_diff` then called
+`_denylist_pathspecs(repo_root)` right after with no `context` either, even
+though that function already had a `context` parameter nobody was passing.
+Traced the FULL chain rather than just the two call sites Qodo named: with
+`path="."` (the default), `_prepare_for_path`'s own `resolve_workspace_path`
+call, the `resolve_workspace_path` call inside `prepare_repository`, that
+function's `is_sensitive_path` check on the discovered repo root, and
+`_denylist_pathspecs` each re-resolved independently — **4 resolutions for
+`git_status`, 3 for `git_diff`, 2 for `git_log`** (measured directly by
+counting real `resolve_sensitive_context` calls against the pre-fix code
+loaded from this commit's own blob, not assumed).
+
+Ordering check (the task's own caveat): the context is a snapshot of
+config-derived state only (files/dirs/db_paths/user_data_dir) — it does not
+depend on `repo_root`, which `prepare_repository` DISCOVERS. So resolving it
+once at the top of `git_status`/`git_diff`/`git_log`/`git_blame`/
+`git_branches`, before repo discovery even runs, and threading it through
+`_prepare_for_path` → `prepare_repository` → `resolve_workspace_path` /
+`is_sensitive_path` → `_denylist_pathspecs` is correct, not just faster:
+nothing in that chain can make the context stale mid-call, since this is
+synchronous, single-threaded code with no `await` between resolution and
+use. `prepare_repository`, `_prepare_for_path` and `_repo_relative_path` each
+gained an optional keyword-only `context: SensitivePathContext | None`
+(mirroring `resolve_workspace_path`'s existing parameter), defaulting to
+`None` so every other caller (`Agents/local_tool_provider.py`'s
+`path_targets`, the existing test suite) is unaffected.
+
+Measured on a synthetic 1000-tracked-file repo (120 dirty), isolated HOME,
+before (this commit's blob) vs. after, averaged over 30 calls with 3
+warm-up calls discarded, two independent runs:
+
+| call | before | after | before | after |
+| --- | --- | --- | --- | --- |
+| `git_status` | 48.7ms | 31.0ms | 46.5ms | 34.5ms |
+| `git_diff` | 54.7ms | 43.6ms | 56.3ms | 48.4ms |
+
+`resolve_sensitive_context()` alone costs ~4.7-5.1ms (11 config accessors).
+Not negligible — collapsing 4→1 resolutions accounts for essentially all of
+`git_status`'s ~15-18ms improvement. A new regression test,
+`test_git_status_and_git_diff_resolve_the_denylist_context_exactly_once` in
+`Tests/Tools/test_git_tool_sensitive_paths.py`, counts real
+`resolve_sensitive_context` calls the same way (pattern borrowed from
+`Tests/Agents/test_tool_catalog_concurrency.py`'s
+`test_invoke_by_name_takes_exactly_one_catalog_snapshot`) and pins exactly 1
+per `git_status`/`git_diff`/`git_log` call; confirmed non-vacuous by running
+the same counting logic against the pre-fix module (4/3/2 respectively).
+
+**Required mutation check re-run**: dropped `icase` from the
+`subtree`/`file` branch of `_denylist_pathspecs` again;
+`test_a_location_exclusion_survives_a_case_variant_directory_spelling`
+reds with the synthetic key's content in the failure message, exactly as
+the original review documented. Restored via `Edit`, re-verified green
+(never `git checkout` over uncommitted work — see
+`lessons-backlog-hygiene.md`/mutation-restores-must-be-edit-based).
+
+**Finding 2 (docstrings).** `git_status`, `git_log` and `git_diff` gained
+Google-style `Args:`/`Returns:` sections. `git_status`'s `path` Args entry
+states the discrepancy Qodo asked about rather than papering over it:
+`path` is used ONLY for repository discovery (walking up to find which repo
+to report on) and is NEVER applied as a scoping pathspec — the tool's argv
+carries no positive pathspec for it, unlike `git_diff`/`git_log`. Asking for
+a subdirectory's status still returns the WHOLE repository's changes. This
+is pre-existing behavior, not something introduced here; **filing a
+follow-up is warranted** to decide whether `git_status` should gain a real
+scoping pathspec (mirroring `git_diff`/`git_log`'s `_repo_relative_path`/
+`_literal_pathspec` pattern) or whether the docstring fix (making the
+limitation legible to the model) is the whole fix.
+
+**Evidence.** `Tests/Tools/test_git_tool_sensitive_paths.py` (23 tests,
+including the new one) and `Tests/Tools/test_git_tool_impls.py` (25 tests)
+both green under an isolated HOME. `Tests/Tools/` + `Tests/Agents/`:
+2480 passed, 1 failed
+(`test_tool_catalog_concurrency.py::test_invoke_by_name_takes_exactly_one_catalog_snapshot`,
+confirmed identical on `origin/dev` — unrelated to this change). Repo-wide
+`--collect-only -q`: 54660 tests collected, no collection errors.
+
+Modified: `tldw_chatbook/Tools/git_tool_impls.py`,
+`Tests/Tools/test_git_tool_sensitive_paths.py` (one existing monkeypatch
+signature updated for the new `context` keyword, plus the new regression
+test).

--- a/backlog/tasks/task-19633 - Denylist does not enumerate common dotfile credentials.md
+++ b/backlog/tasks/task-19633 - Denylist does not enumerate common dotfile credentials.md
@@ -2,7 +2,7 @@
 id: TASK-19633
 title: >-
   Denylist does not enumerate common dotfile credentials
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 12:05'
 labels:
@@ -63,21 +63,21 @@ supplementary rule the team wants for high-signal credential filenames.
 
 ## Acceptance Criteria
 
-- [ ] The paths measured above are refused by BOTH file-tool families, in a
+- [x] The paths measured above are refused by BOTH file-tool families, in a
       configuration where confinement alone does not explain the refusal (root
       set so no dotted component appears in the relative portion)
-- [ ] The additions are expressed the way the rest of the module already
+- [x] The additions are expressed the way the rest of the module already
       prefers — a rule or accessor where one exists, a literal only where the
       location genuinely is fixed — and the module docstring says which
       choice was made and why
-- [ ] A born-red test per added path shape, showing the accept before and the
+- [x] A born-red test per added path shape, showing the accept before and the
       refusal after
-- [ ] The asymmetry is resolved deliberately and recorded: either both families
+- [x] The asymmetry is resolved deliberately and recorded: either both families
       apply the same hidden-component policy, or the module docstring states
       which family is stricter and why that is acceptable
-- [ ] `Utils/sensitive_paths.py`'s docstring paragraph naming this task
+- [x] `Utils/sensitive_paths.py`'s docstring paragraph naming this task
       (added by TASK-19551) is updated or removed to match the new state
-- [ ] TASK-19551's drift-pin comment in
+- [x] TASK-19551's drift-pin comment in
       `Tests/Tools/test_local_tool_sensitive_paths.py` is re-read: the phrase
       "an honest distinction" must still be true after this change
 
@@ -90,3 +90,104 @@ location-based rules. The module deliberately prefers rules over
 enumerations because enumerations trail reality — that reasoning applies to
 this gap too, and an enumeration of six filenames will itself be stale within
 a year.
+
+
+## Implementation Plan
+
+1. Re-measure the six paths on this branch, with an isolated `$HOME`.
+2. Decide rule vs enumeration for each of them and record the reasoning in the
+   module docstring rather than in a commit message.
+3. Add the chosen instrument(s), composed with -- not duplicating -- the
+   module's existing comparison normalization.
+4. Construct, deliberately, a configuration in which each family's refusal
+   cannot be explained by confinement, and pin it.
+5. Bound the cost: pin the near-misses and container shapes that must stay
+   readable.
+6. Update the docstring paragraph naming this task, and re-read TASK-19551's
+   drift-pin comment against the result.
+
+## Implementation Notes
+
+**Decision: BOTH instruments, chosen per case, and the docstring says so.**
+
+* A **name rule** (`_SENSITIVE_FILE_NAMES`) for filenames that identify a
+  credential store wherever they appear: `.netrc`, `_netrc` (the Windows
+  spelling -- also the one non-dotted probe that makes the AC's "confinement
+  cannot explain it" configuration constructible for that family of names),
+  `.git-credentials`, `.npmrc`, `.pypirc`, `credentials`, `credentials.toml`.
+* A **location rule** for `~/.config/gh`, added to `_SENSITIVE_DIRS`, because
+  there the LOCATION is the unambiguous part and the filename is not --
+  `hosts.yml` is just as often an Ansible inventory.
+
+The argument, in short: both instruments are enumerations and both trail
+reality, names no less than locations. The name rule wins where it applies
+because one entry covers unbounded locations while one location entry covers
+exactly one, and because a tool's config DIRECTORY migrates between XDG/legacy/
+OS conventions far more often than its credential FILENAME ever changes. A
+location rule could not have covered most of this set at all: a project-local
+`.npmrc`/`.pypirc` carries an auth token exactly like the home one, and
+refusing all of `~/.cargo` or `~/.config/git` would take down things an agent
+legitimately reads.
+
+The cost is real and is stated rather than hidden: an agent cannot read a test
+fixture named `credentials`, and the refusal names it as protected. `.env` is
+the deliberate omission -- as often build configuration as secrets, and
+refusing it would break the ADR-032 coding-agent use case this module exists to
+keep working. Directory-shaped matches are exempted by the same `is_dir()` gate
+the direct-child-file rule uses, so a container named `credentials/` stays
+listable.
+
+**The asymmetry, resolved deliberately (AC4).** The two families'
+hidden-component policies still differ and that difference is now design
+throughout: family 1 (`file_operation_tools`) refuses any dotted component at
+confinement; family 2 (`fs_*`) passes `allow_hidden=True` per ADR-032. Family 1
+is stricter for dotted NAMES, which is acceptable because the roots are
+different kinds of place -- family 1's sandbox root is app-owned storage where
+a dotfile has no legitimate purpose, family 2's is a user source tree where
+dotfiles are the point. What is no longer allowed to differ is the shared
+oracle's ANSWER, and it does not: all six measured paths are refused by the
+denylist itself under either family. The residue is gone; the policy split
+remains.
+
+**Constructing "confinement alone does not explain it".** Family 2 is easy
+(`allow_hidden=True`, root at the file's own directory). Family 1 took care,
+and is done three ways: the two name-rule paths that can be spelled without a
+dot are planted at a NON-dotted location under a NON-dotted root
+(`projects/repo/_netrc`, `credentials.toml`, `credentials`) -- which is also
+the name rule's whole point, that a moved credential is still a credential; the
+location-rule path keeps its location but is rooted at `~/.config/gh`, whose
+own basename is not dotted and whose relative portion is a plain `hosts.yml`;
+and the four inherently-dotted names go through `ListDirectoryTool` with
+`include_hidden=True`, the one family-1 seam that lists dotted entries by
+request, so `is_sensitive_path` is the only thing that can withhold them
+(`.gitignore` is the control proving the listing works).
+
+**Composed with TASK-19800, which merged mid-task.** 19800 made every denylist
+comparison go through one folded key, `_compare_key`. The name rule reads
+through it via a new `_name_key` rather than growing its own `.casefold()` --
+a security primitive with two independently-normalized comparison paths is how
+they drift. `test_the_name_rule_uses_the_modules_one_folding_rule` pins that by
+mutation: with folding removed from `_compare_key` and nowhere else, a
+case-variant credential name must stop being refused. For the record, 19800
+did NOT already refuse any of the six -- re-measured at `d4f3f9776`, all six
+still returned their body through `fs_read`; 19800 fixed how the paths it
+already knew were compared, not which paths it knew.
+
+**Evidence.** Born-red at `origin/dev` (`d4f3f9776`): 12 failures -- the six
+parametrized shapes, the rule-attribution test, case-insensitivity, the
+both-families test, the family-1 listing test, `fs_grep`, and the folding
+composition pin. The over-refusal bound
+(`test_the_name_rule_does_not_refuse_near_misses_or_containers`) passes at base
+AND after, deliberately. All pass on this branch. Blast radius checked across
+`Tests/Tools/`, `Tests/Agents/`, `Tests/Utils/`, `Tests/Workspaces/`,
+`Tests/MCP/`, `Tests/Notes/` git suites and `Tests/UI/` navigation.
+
+**Housekeeping.** The module docstring's "the denylist is an ENUMERATION ...
+(TASK-19633, open)" paragraph is replaced by the two-instruments decision and
+the asymmetry record. TASK-19551's drift-pin comment in
+`Tests/Tools/test_local_tool_sensitive_paths.py` was re-read and rewritten: "an
+honest distinction" is now TRUE without its caveat, and the comment says why it
+used to carry one.
+
+Modified: `tldw_chatbook/Utils/sensitive_paths.py`,
+`Tests/Tools/test_local_tool_sensitive_paths.py`.

--- a/tldw_chatbook/Tools/git_tool_impls.py
+++ b/tldw_chatbook/Tools/git_tool_impls.py
@@ -50,6 +50,21 @@ from the reference (deliberate, per the phase-3b-ii plan):
     silently drops those lines.
 (d) ``git_blame``'s ``-L`` range is optional (the reference always passes
     one); the range is capped at ``GIT_BLAME_MAX_LINES`` lines.
+
+TASK-19632 adds one thing the reference has no equivalent of: these tools
+enumerate a repository on the model's behalf, so ``path`` being optional
+meant no candidate ever reached the sensitive-path denylist and
+``git_diff`` returned ``~/.ssh/id_rsa``'s CONTENT from a CLEAN worktree.
+The fix constrains git's INPUT rather than filtering its OUTPUT -- see
+``_denylist_pathspecs`` for the mechanism and ``Utils/sensitive_paths.py``
+for why that direction was chosen. Two properties of pathspecs are
+load-bearing there and are easy to lose in a later edit: an exclude-only
+pathspec list applies to the whole tree (no positive pathspec is needed),
+and pathspec MAGIC is honoured after ``--``, so every pathspec built here
+carries explicit magic -- ``:(literal)`` for the one that SCOPES output,
+``:(exclude,literal,icase)``/``:(exclude,glob,icase)`` for the ones that
+DENY from it. The ``icase`` asymmetry is deliberate; see
+``_literal_pathspec`` and ``_denylist_pathspecs``.
 """
 
 from __future__ import annotations
@@ -67,6 +82,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tldw_chatbook.Tools.local_tool_impls import LocalToolError, resolve_workspace_path
+from tldw_chatbook.Utils.sensitive_paths import (
+    SensitivePathContext,
+    is_sensitive_path,
+    sensitive_exclusions_under,
+)
 
 GIT_TIMEOUT_SECONDS = 30.0
 GIT_MAX_OUTPUT_BYTES = 1_000_000
@@ -108,6 +128,16 @@ def _git_environment() -> dict[str, str]:
         value = os.environ.get(key)
         if value:
             env[key] = value
+    # Built from scratch, so ambient GIT_*_PATHSPECS never reaches git --
+    # and nothing here may ever ADD one. TASK-16801's lesson recommends
+    # `GIT_LITERAL_PATHSPECS=1` as blanket hardening for git argv; it is
+    # incompatible with this module's denylist exclusions and fails
+    # SILENTLY, not loudly: under it, `:(exclude,literal)<path>` is taken
+    # as a literal FILENAME, matches nothing, and every `git_diff` /
+    # `git_status` returns "(no changes)" / "(working tree clean)" with
+    # exit 0 (verified on git 2.39). The per-pathspec `:(literal)` magic
+    # in `_literal_pathspec` is this module's equivalent, and it composes
+    # with exclusions instead of disabling them.
     env.update(
         {
             "GIT_TERMINAL_PROMPT": "0",
@@ -277,6 +307,131 @@ def _kill_process(process: subprocess.Popen) -> None:
         process.kill()
 
 
+#: Characters wildmatch (git's glob engine) treats as metacharacters. A
+#: backslash escapes the next character, so escaping these renders a real
+#: filename literally inside a ``:(exclude,glob)`` pathspec. Verified
+#: against git 2.39: a container directory literally named ``co*ntainer``
+#: excluded ``coXntainer/`` too until its ``*`` was escaped.
+_GLOB_METACHARACTERS = "\\*?["
+
+
+def _glob_escape(value: str) -> str:
+    """Escape ``value`` so a ``:(...,glob)`` pathspec matches it literally."""
+    return "".join(
+        f"\\{char}" if char in _GLOB_METACHARACTERS else char for char in value
+    )
+
+
+def _literal_pathspec(relative_posix: str) -> str:
+    """Render a repo-relative path as a pathspec that CANNOT carry magic.
+
+    A pathspec is not a path. ``--`` ends git's OPTION parsing, not its
+    pathspec-magic parsing, so a repository file legitimately named
+    ``:(exclude)notes.txt`` -- resolved, confined and denylist-checked by
+    the choke point exactly like any other filename -- inverted the scope
+    of the diff it was spliced into and returned the rest of the
+    repository, ``~/.ssh/id_rsa`` included (measured; TASK-19632).
+    ``:(literal)`` disables magic AND wildcard interpretation for the
+    remainder of the element, so the value is matched as the byte string
+    it is.
+
+    ``:(literal).`` behaves identically to a bare ``.`` (verified), so the
+    repo-root case needs no special handling.
+
+    Deliberately NOT given the ``icase`` magic the EXCLUSIONS carry. This
+    pathspec SCOPES the output; theirs DENY from it, and the two fail in
+    opposite directions -- exactly the asymmetry TASK-19800 records for
+    ``_compare_key`` versus confinement. Folding case here would ADD files
+    to what the model gets back (a ``README`` alongside the ``readme`` it
+    asked for); folding it there only ever removes more.
+    """
+    return f":(literal){relative_posix}"
+
+
+def _denylist_pathspecs(
+    repo_root: Path, context: SensitivePathContext | None = None
+) -> tuple[str, ...]:
+    """Render the sensitive-path denylist as git exclude pathspecs.
+
+    The TASK-19632 fix, in one place. ``git_status``/``git_diff`` hand a
+    whole repository to git and return what comes back, so a path the
+    model never named -- ``~/.ssh/id_rsa`` under a ``$HOME``-rooted
+    workspace -- never reached ``Utils/sensitive_paths.py`` at all.
+
+    Excluding by PATHSPEC rather than filtering git's output is the
+    deliberate choice: git stays the authority on what matches, the
+    exclusions are recomputed from the live denylist on every call (so a
+    ``TLDW_CONFIG_PATH`` switch or a relocated database is observed
+    immediately), and no unified-diff or porcelain text is ever parsed to
+    decide what to withhold -- a half-parsed diff is worse than none.
+
+    Each :class:`~tldw_chatbook.Utils.sensitive_paths.SensitiveExclusion`
+    kind maps to the pathspec form that expresses exactly that rule and
+    no more, which is what keeps a legitimate diff intact:
+
+    * ``subtree``/``file`` -> ``:(exclude,literal,icase)<rel>``. Literal
+      magic, so a real filename containing ``*`` excludes only itself.
+    * ``direct_children`` -> ``:(exclude,glob,icase)<rel>/*``. Under
+      ``glob`` magic ``*`` does not cross ``/``, so this refuses the
+      container's direct child FILES and leaves its subdirectories fully
+      visible -- the same distinction ``is_sensitive_path``'s own
+      container rule draws (``tool_sandbox/`` stays diffable; a loose file
+      beside it does not).
+    * ``name`` -> ``:(exclude,glob,icase)**/<name>``, which matches at
+      every depth INCLUDING the repository root (verified).
+
+    Every one of them carries ``icase``, for the reason TASK-19800 gives
+    for folding the denylist itself: macOS and Windows filesystems are
+    case-insensitive by default, git records whatever spelling a path was
+    added under, and a denial that misses ``.SSH/id_rsa`` because the
+    denylist says ``.ssh`` is a leak. Folding an EXCLUSION only ever
+    removes more from the output, so it fails in the cheap direction --
+    unlike folding a scoping pathspec (see ``_literal_pathspec``) or a
+    confinement check.
+
+    An unrecognized kind raises rather than being skipped: a denial added
+    to the denylist that this renderer does not understand must fail the
+    call, not silently pass through.
+
+    Args:
+        repo_root: The already-resolved repository root; every pathspec
+            is rendered relative to it, which is what ``-C <repo_root>``
+            makes correct (git resolves pathspecs against the process's
+            working directory).
+        context: Optional pre-resolved ``SensitivePathContext``, so one
+            tool call resolves the denylist once.
+
+    Returns:
+        Exclude pathspecs, possibly empty of location-based entries but
+        never empty overall (the name rule always applies). They may be
+        passed as the ONLY pathspecs after ``--``: git applies an
+        exclude-only list to the whole tree (verified).
+
+    Raises:
+        LocalToolError: The repository root is itself a protected path,
+            or the denylist produced an exclusion kind this renderer does
+            not know how to express.
+    """
+    specs: list[str] = []
+    for kind, value in sensitive_exclusions_under(repo_root, context=context):
+        if kind in {"subtree", "file"}:
+            if not value:
+                raise LocalToolError(
+                    f"repository root ({repo_root}) is a protected path; refusing"
+                )
+            specs.append(f":(exclude,literal,icase){value}")
+        elif kind == "direct_children":
+            prefix = f"{_glob_escape(value)}/" if value else ""
+            specs.append(f":(exclude,glob,icase){prefix}*")
+        elif kind == "name":
+            specs.append(f":(exclude,glob,icase)**/{_glob_escape(value)}")
+        else:  # pragma: no cover - defensive; see the docstring
+            raise LocalToolError(
+                f"unsupported sensitive-path exclusion kind: {kind!r}"
+            )
+    return tuple(specs)
+
+
 def prepare_repository(workspace_root: Path, path: str = ".") -> Path:
     """Resolve the git repo root for ``path``, confined to ``workspace_root``.
 
@@ -316,6 +471,16 @@ def prepare_repository(workspace_root: Path, path: str = ".") -> Path:
     if not (repo_root == workspace_root or workspace_root in repo_root.parents):
         raise LocalToolError(
             f"repository root ({repo_root}) is outside the workspace root ({workspace_root}); refusing"
+        )
+    # The repo root is DISCOVERED by git, not supplied by the model, so it
+    # is the one path in this family the choke point never sees. Today it
+    # can only be the workspace root or below it, and both are already
+    # denylist-checked -- this is here so that stays true if either
+    # relationship is ever relaxed: excluding denied paths from a
+    # repository that is ITSELF denied would leave nothing honest to show.
+    if is_sensitive_path(repo_root):
+        raise LocalToolError(
+            f"repository root ({repo_root}) is a protected path; refusing"
         )
     return repo_root
 
@@ -387,6 +552,11 @@ def git_status(workspace_root: Path, path: str = ".") -> str:
     Sync adaptation of the reference's ``_execute_status`` (:570): porcelain
     v2 ``-z`` output with the ``--branch`` header, parsed and rendered as
     ``category: XY path`` lines capped at ``GIT_STATUS_MAX_ENTRIES``.
+
+    Denylisted paths are excluded by pathspec (``_denylist_pathspecs``):
+    this tool named ``~/.ssh/id_rsa`` on a dirty ``$HOME``-rooted
+    workspace (TASK-19632). Existence and a name are all a status entry
+    carries, so excluding them is the whole refusal.
     """
     repo_root = _prepare_for_path(workspace_root, path)
     result = _run_git_checked(
@@ -400,6 +570,8 @@ def git_status(workspace_root: Path, path: str = ".") -> str:
             "-z",
             "--branch",
             "--untracked-files=all",
+            "--",
+            *_denylist_pathspecs(repo_root),
         ],
         subcommand="status",
     )
@@ -568,6 +740,15 @@ def git_log(
     Sync adaptation of the reference's ``_execute_log`` (:831). Deviation:
     ``count`` defaults to 20 here (the reference has no default and falls
     back to its max-100 when no limit is given).
+
+    Deliberately NOT given the denylist exclusions ``git_status``/
+    ``git_diff`` carry: the ``--format`` below emits commit metadata only
+    -- no paths, no content -- so this tool was measured leaking nothing,
+    and excluding denied paths here would silently drop commits from a
+    legitimate history instead of protecting anything (TASK-19632). Its
+    ``path`` pathspec IS rendered literally, for the same reason
+    ``git_diff``'s is: the value is a model-supplied filename and a bare
+    one would be parsed as pathspec magic.
     """
     count = min(max(int(count), 1), GIT_LOG_MAX_COUNT)
     repo_root = _prepare_for_path(workspace_root, path)
@@ -582,7 +763,9 @@ def git_log(
         str(count),
     ]
     if path is not None:
-        argv.extend(["--", _repo_relative_path(workspace_root, repo_root, path)])
+        argv.extend(
+            ["--", _literal_pathspec(_repo_relative_path(workspace_root, repo_root, path))]
+        )
     result = _run_git_checked(argv, subcommand="log")
     lines: list[str] = []
     for record in result.stdout.split("\x1e"):
@@ -611,6 +794,20 @@ def git_diff(
     ``--no-color`` ported). Disclosed deviations: adds ``commit_range``
     (regex-validated before entering argv) and ``stat`` modes; the
     reference's third ``working_tree`` scope is omitted.
+
+    Denylisted paths are excluded by pathspec (``_denylist_pathspecs``)
+    in every mode — worktree, index and ``commit_range`` alike, since the
+    leak this closes was reachable from a CLEAN worktree by reading the
+    credential out of history (TASK-19632). Exclusions apply whether or
+    not the caller supplied ``path``: a denylisted ``path`` is refused by
+    the choke point, but the leak was in the no-``path`` case, where the
+    model names nothing and git enumerates the repository.
+
+    Nothing announces that an exclusion took effect, deliberately. The
+    only honest note would state that this repository contains a protected
+    path — which is the same disclosure ``stat=True``/``git_status`` were
+    leaking. A model that names the path still gets a "protected path"
+    refusal, which is the case where the information is actionable.
     """
     if commit_range is not None:
         # Leading-dash values are FLAGS, not refnames (git refnames cannot
@@ -646,8 +843,16 @@ def git_diff(
         argv.append("--cached")
     if commit_range is not None:
         argv.append(commit_range)
+    pathspecs: list[str] = []
     if path is not None:
-        argv.extend(["--", _repo_relative_path(workspace_root, repo_root, path)])
+        pathspecs.append(
+            _literal_pathspec(_repo_relative_path(workspace_root, repo_root, path))
+        )
+    # Exclusions come LAST and are never empty (the name rule always
+    # applies), so `--` is always present: an exclude-only pathspec list
+    # is applied to the whole tree, which is exactly the no-`path` case.
+    pathspecs.extend(_denylist_pathspecs(repo_root))
+    argv.extend(["--", *pathspecs])
     result = _run_git_checked(argv, subcommand="diff")
     return result.stdout if result.stdout.strip() else "(no changes)"
 
@@ -695,6 +900,14 @@ def git_blame(
             raise LocalToolError(f"end_line ({end}) is before start_line ({start})")
         end = min(end, start + GIT_BLAME_MAX_LINES - 1)
         argv.extend(["-L", f"{start},{end}"])
+    # NOT wrapped in `:(literal)` like the diff/log pathspecs above:
+    # `git blame` takes a plain PATH here, not a pathspec, and rejects
+    # magic outright (`fatal: no such path ':(literal)a.txt' in HEAD`,
+    # verified on git 2.39). It therefore never interprets a magic-shaped
+    # filename either -- blaming a repository file literally named
+    # `:(exclude)notes.txt` blames that file, checked the same way as any
+    # other path: `resolve_workspace_path` above already denylist-checked
+    # it, and `resolved.is_file()` means it must genuinely exist.
     argv.extend(["--", repo_relative])
 
     result = _run_git_checked(argv, subcommand="blame")

--- a/tldw_chatbook/Tools/git_tool_impls.py
+++ b/tldw_chatbook/Tools/git_tool_impls.py
@@ -85,6 +85,7 @@ from tldw_chatbook.Tools.local_tool_impls import LocalToolError, resolve_workspa
 from tldw_chatbook.Utils.sensitive_paths import (
     SensitivePathContext,
     is_sensitive_path,
+    resolve_sensitive_context,
     sensitive_exclusions_under,
 )
 
@@ -432,7 +433,12 @@ def _denylist_pathspecs(
     return tuple(specs)
 
 
-def prepare_repository(workspace_root: Path, path: str = ".") -> Path:
+def prepare_repository(
+    workspace_root: Path,
+    path: str = ".",
+    *,
+    context: SensitivePathContext | None = None,
+) -> Path:
     """Resolve the git repo root for ``path``, confined to ``workspace_root``.
 
     Refuses (LocalToolError) when git is unavailable, ``path`` escapes the
@@ -441,13 +447,27 @@ def prepare_repository(workspace_root: Path, path: str = ".") -> Path:
     it — a workspace nested inside a repo is refused so the model cannot
     read repo state outside the confinement).
 
+    Args:
+        workspace_root: The confinement root ``path`` must resolve inside.
+        path: The workspace-relative (or absolute-but-confined) location to
+            discover a repository from; ``"."`` (the default) discovers
+            from ``workspace_root`` itself.
+        context: Optional pre-resolved ``SensitivePathContext``. Passed
+            through to both denylist checks this function makes (the
+            ``path`` argument, via ``resolve_workspace_path``, and the
+            DISCOVERED repo root below) so a caller that also needs the
+            same context for e.g. ``_denylist_pathspecs`` resolves the
+            ~11 config accessors behind the denylist once per tool call
+            instead of once per check. ``None`` resolves fresh each time —
+            still enforces the denylist, just not shared.
+
     Returns:
         The resolved repository root path.
     """
     if shutil.which("git") is None:
         raise LocalToolError("git is not available on this system")
     workspace_root = Path(workspace_root).resolve()
-    target = resolve_workspace_path(path, workspace_root)
+    target = resolve_workspace_path(path, workspace_root, context=context)
     result = run_git(
         ["git", "-C", str(target), "rev-parse", "--show-toplevel"],
         timeout=REPOSITORY_DISCOVERY_TIMEOUT_SECONDS,
@@ -478,7 +498,7 @@ def prepare_repository(workspace_root: Path, path: str = ".") -> Path:
     # denylist-checked -- this is here so that stays true if either
     # relationship is ever relaxed: excluding denied paths from a
     # repository that is ITSELF denied would leave nothing honest to show.
-    if is_sensitive_path(repo_root):
+    if is_sensitive_path(repo_root, context=context):
         raise LocalToolError(
             f"repository root ({repo_root}) is a protected path; refusing"
         )
@@ -516,9 +536,25 @@ def _run_git_checked(argv: list[str], *, subcommand: str) -> GitCommandResult:
     return result
 
 
-def _repo_relative_path(workspace_root: Path, repo_root: Path, path: str) -> str:
-    """Resolve ``path`` confined to the workspace, rendered repo-relative."""
-    resolved = resolve_workspace_path(path, Path(workspace_root).resolve())
+def _repo_relative_path(
+    workspace_root: Path,
+    repo_root: Path,
+    path: str,
+    *,
+    context: SensitivePathContext | None = None,
+) -> str:
+    """Resolve ``path`` confined to the workspace, rendered repo-relative.
+
+    Args:
+        workspace_root: The confinement root ``path`` must resolve inside.
+        repo_root: The already-discovered repository root.
+        path: The workspace-relative (or absolute-but-confined) path.
+        context: Optional pre-resolved ``SensitivePathContext``, threaded
+            through to ``resolve_workspace_path`` so a caller that has
+            already resolved one for the same tool call does not pay for
+            it again here.
+    """
+    resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
     try:
         relative = resolved.relative_to(repo_root)
     except ValueError:
@@ -528,14 +564,31 @@ def _repo_relative_path(workspace_root: Path, repo_root: Path, path: str) -> str
     return relative.as_posix() or "."
 
 
-def _prepare_for_path(workspace_root: Path, path: str | None) -> Path:
-    """Repo discovery that tolerates ``path`` being a file (uses its parent)."""
+def _prepare_for_path(
+    workspace_root: Path,
+    path: str | None,
+    *,
+    context: SensitivePathContext | None = None,
+) -> Path:
+    """Repo discovery that tolerates ``path`` being a file (uses its parent).
+
+    Args:
+        workspace_root: The confinement root ``path`` must resolve inside.
+        path: The workspace-relative (or absolute-but-confined) path to
+            discover a repository from, or ``None`` to discover from
+            ``workspace_root`` itself.
+        context: Optional pre-resolved ``SensitivePathContext``, threaded
+            through to every denylist check this function (and
+            ``prepare_repository`` beneath it) makes, so a caller that
+            resolves one per tool call — rather than letting each check
+            resolve its own — pays the ~11 config-accessor cost once.
+    """
     if path is None:
-        return prepare_repository(workspace_root, ".")
-    resolved = resolve_workspace_path(path, Path(workspace_root).resolve())
+        return prepare_repository(workspace_root, ".", context=context)
+    resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
     discovery = resolved if resolved.is_dir() else resolved.parent
     relative = os.path.relpath(discovery, Path(workspace_root).resolve())
-    return prepare_repository(workspace_root, relative)
+    return prepare_repository(workspace_root, relative, context=context)
 
 
 def _sanitize_author_name(value: str) -> str:
@@ -557,8 +610,26 @@ def git_status(workspace_root: Path, path: str = ".") -> str:
     this tool named ``~/.ssh/id_rsa`` on a dirty ``$HOME``-rooted
     workspace (TASK-19632). Existence and a name are all a status entry
     carries, so excluding them is the whole refusal.
+
+    Args:
+        workspace_root: The confinement root ``path`` must resolve inside.
+        path: Used ONLY to discover which repository to report on (a file
+            or directory anywhere inside the target repo works, since
+            discovery walks up to the repo root). It is NOT applied as a
+            scoping pathspec: unlike ``git_diff``/``git_log``, this
+            function's argv carries no positive pathspec for ``path``, so
+            the status returned always covers the WHOLE repository —
+            asking for a subdirectory's status still returns every
+            changed file in the repo, not just that subdirectory's.
+
+    Returns:
+        The branch header line, one ``category: XY path`` (or
+        ``untracked: path``) line per entry up to ``GIT_STATUS_MAX_ENTRIES``,
+        ``"(working tree clean)"`` when there are none, and a truncation
+        note appended if the repository has more entries than the cap.
     """
-    repo_root = _prepare_for_path(workspace_root, path)
+    context = resolve_sensitive_context()
+    repo_root = _prepare_for_path(workspace_root, path, context=context)
     result = _run_git_checked(
         [
             "git",
@@ -571,7 +642,7 @@ def git_status(workspace_root: Path, path: str = ".") -> str:
             "--branch",
             "--untracked-files=all",
             "--",
-            *_denylist_pathspecs(repo_root),
+            *_denylist_pathspecs(repo_root, context=context),
         ],
         subcommand="status",
     )
@@ -697,7 +768,7 @@ def git_branches(workspace_root: Path) -> str:
 
     Sync adaptation of the reference's ``_execute_branches`` (:621).
     """
-    repo_root = prepare_repository(workspace_root, ".")
+    repo_root = prepare_repository(workspace_root, ".", context=resolve_sensitive_context())
     result = _run_git_checked(
         [
             "git",
@@ -749,9 +820,23 @@ def git_log(
     ``path`` pathspec IS rendered literally, for the same reason
     ``git_diff``'s is: the value is a model-supplied filename and a bare
     one would be parsed as pathspec magic.
+
+    Args:
+        workspace_root: The confinement root ``path`` must resolve inside.
+        count: Maximum number of commits to return, clamped to 1..100.
+        path: When given, scopes the log to commits touching this file or
+            directory (rendered as a literal pathspec — see the note
+            above); ``None`` (the default) returns the log for the whole
+            repository ``path`` (or ``workspace_root`` when ``path`` is
+            also omitted) discovers.
+
+    Returns:
+        One ``short_hash date author: subject`` line per commit, newest
+        first, or ``"(no commits)"`` when there are none.
     """
     count = min(max(int(count), 1), GIT_LOG_MAX_COUNT)
-    repo_root = _prepare_for_path(workspace_root, path)
+    context = resolve_sensitive_context()
+    repo_root = _prepare_for_path(workspace_root, path, context=context)
     argv = [
         "git",
         "--no-pager",
@@ -764,7 +849,12 @@ def git_log(
     ]
     if path is not None:
         argv.extend(
-            ["--", _literal_pathspec(_repo_relative_path(workspace_root, repo_root, path))]
+            [
+                "--",
+                _literal_pathspec(
+                    _repo_relative_path(workspace_root, repo_root, path, context=context)
+                ),
+            ]
         )
     result = _run_git_checked(argv, subcommand="log")
     lines: list[str] = []
@@ -808,6 +898,25 @@ def git_diff(
     path — which is the same disclosure ``stat=True``/``git_status`` were
     leaking. A model that names the path still gets a "protected path"
     refusal, which is the case where the information is actionable.
+
+    Args:
+        workspace_root: The confinement root ``path`` must resolve inside.
+        staged: When True, diff the index against ``HEAD`` (``--cached``)
+            instead of the worktree.
+        commit_range: When given, diff across this ref/range instead of
+            against the worktree or index (validated against
+            ``^[A-Za-z0-9._/~^-]+$`` and refused if it starts with ``-``).
+        path: When given, scopes the diff to this file or directory
+            (rendered as a literal pathspec, so a magic-shaped filename is
+            matched literally); ``None`` (the default) diffs the whole
+            repository ``path`` (or ``workspace_root`` when ``path`` is
+            also omitted) discovers.
+        stat: When True, return a ``--stat`` summary instead of a unified
+            patch.
+
+    Returns:
+        The unified diff (or ``--stat`` summary) text, or ``"(no
+        changes)"`` when the diff is empty.
     """
     if commit_range is not None:
         # Leading-dash values are FLAGS, not refnames (git refnames cannot
@@ -822,7 +931,8 @@ def git_diff(
                 f"invalid commit_range {commit_range!r}: "
                 "must be a ref/range matching [A-Za-z0-9._/~^-] and not start with '-'"
             )
-    repo_root = _prepare_for_path(workspace_root, path)
+    context = resolve_sensitive_context()
+    repo_root = _prepare_for_path(workspace_root, path, context=context)
     argv = [
         "git",
         "--no-pager",
@@ -846,12 +956,14 @@ def git_diff(
     pathspecs: list[str] = []
     if path is not None:
         pathspecs.append(
-            _literal_pathspec(_repo_relative_path(workspace_root, repo_root, path))
+            _literal_pathspec(
+                _repo_relative_path(workspace_root, repo_root, path, context=context)
+            )
         )
     # Exclusions come LAST and are never empty (the name rule always
     # applies), so `--` is always present: an exclude-only pathspec list
     # is applied to the whole tree, which is exactly the no-`path` case.
-    pathspecs.extend(_denylist_pathspecs(repo_root))
+    pathspecs.extend(_denylist_pathspecs(repo_root, context=context))
     argv.extend(["--", *pathspecs])
     result = _run_git_checked(argv, subcommand="diff")
     return result.stdout if result.stdout.strip() else "(no changes)"
@@ -871,10 +983,11 @@ def git_blame(
     neither bound is given) and the range is capped at
     ``GIT_BLAME_MAX_LINES`` lines.
     """
-    resolved = resolve_workspace_path(path, Path(workspace_root).resolve())
+    context = resolve_sensitive_context()
+    resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
     if not resolved.is_file():
         raise LocalToolError(f"file not found: {path}")
-    repo_root = _prepare_for_path(workspace_root, path)
+    repo_root = _prepare_for_path(workspace_root, path, context=context)
     try:
         repo_relative = resolved.relative_to(repo_root).as_posix()
     except ValueError:

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -33,11 +33,17 @@ per candidate. ``grep_files`` is the sharpest of the three — it READS every
 file it walks and prints matching lines — so its check runs before the
 read, not after.
 
-``Tools/git_tool_impls.py`` shares this choke point for its path arguments
-but has NO such output filter, and ``path`` is optional on ``git_status``/
-``git_log``/``git_diff``: with it omitted, ``git_diff`` returns the CONTENT
-of a denylisted file (TASK-19632, open). Do not extend that family assuming
-the choke point alone makes its output safe.
+``Tools/git_tool_impls.py`` shares this choke point for its path arguments,
+and ``path`` is optional on ``git_status``/``git_log``/``git_diff``: with
+it omitted the choke point sees only the repository root, and ``git_diff``
+returned the CONTENT of a denylisted file from a CLEAN worktree
+(TASK-19632). That family solves the same problem a third way -- it cannot
+filter candidates it never sees, because git enumerates the repository for
+it, so it instead excludes denylisted paths from git's INPUT by pathspec
+(``git_tool_impls._denylist_pathspecs``). Do not extend that family
+assuming the choke point alone makes its output safe: whichever of the
+three mechanisms fits, a tool that PRESENTS paths the model never named
+needs one.
 """
 
 from __future__ import annotations

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -23,18 +23,38 @@ TWO independent agent file-tool families enforce this, and both must:
      so each additionally filters its own walked candidates against
      :func:`is_sensitive_path` -- the choke point only ever sees their
      root.
-   * **The ``git_*`` tools do NOT have that filtering, and one of them
-     leaks (TASK-19632, open).** ``path`` is OPTIONAL on ``git_status``/
-     ``git_log``/``git_diff``, and when it is omitted nothing reaches this
-     module at all (``Agents/local_tool_provider.py``'s ``path_targets``
-     returns the repo root and stops). Measured on a ``$HOME``-rooted
-     workspace containing ``~/.ssh/id_rsa``: ``git_diff`` returns the
-     file's CONTENT (a clean worktree is enough -- ``commit_range=
-     "HEAD~1..HEAD"`` reads it out of history, no write primitive needed);
-     ``git_diff(stat=True)`` and ``git_status`` on a dirty tree return the
-     NAME; ``git_log`` returns commit metadata only and leaks nothing. Do
-     not read item 2 as "the git tools are covered" -- their path
-     ARGUMENT is, their output is not.
+   * The ``git_*`` tools present entries the model never named too --
+     ``path`` is OPTIONAL on ``git_status``/``git_log``/``git_diff``, and
+     with it omitted nothing but the repository root reaches this module
+     (``Agents/local_tool_provider.py``'s ``path_targets`` returns the
+     repo root and stops). They do not filter git's OUTPUT; they
+     constrain its INPUT, translating this module's denials into
+     ``:(exclude)`` PATHSPECS computed per call from
+     :func:`sensitive_exclusions_under` (see ``Tools/git_tool_impls.py``'s
+     ``_denylist_pathspecs``). git stays the authority on what matches,
+     and no diff or porcelain text is ever parsed to decide what to
+     withhold -- a half-parsed diff is worse than none. TASK-19632, which
+     that closed: on a ``$HOME``-rooted workspace containing
+     ``~/.ssh/id_rsa``, ``git_diff`` with no ``path`` returned the file's
+     CONTENT from a CLEAN worktree (``commit_range="HEAD~1..HEAD"`` reads
+     it out of history -- no write primitive and no dirty tree needed),
+     and ``git_diff(stat=True)`` / ``git_status`` returned its NAME.
+     ``git_log`` leaked nothing (commit metadata only -- no paths, no
+     content) and is deliberately left unfiltered, so its output is
+     unchanged by any of this.
+
+   One consequence of using pathspecs belongs here, where the denials are
+   defined: **a pathspec is not a path**. A repository file whose NAME is
+   itself pathspec magic (``:(exclude)notes.txt`` is a legal POSIX
+   filename) inverts the scope of whatever argv it is spliced into --
+   ``git_diff(path=":(exclude)notes.txt")`` was measured returning the
+   whole-repo diff, ``~/.ssh/id_rsa``'s content included, while nominally
+   scoping to that one file, and it did so THROUGH the choke point, since
+   the string is a real filename that resolves inside the workspace. The
+   ``--`` separator does not stop it: ``--`` ends OPTIONS, and everything
+   after it is parsed as a pathspec, magic and all. Every pathspec those
+   tools build is therefore rendered with explicit ``:(literal)`` /
+   ``:(exclude,literal)`` magic, the model-supplied ``path`` included.
 
    This family was added AFTER this contract was written and, until
    TASK-19551, called none of this: it confined paths to ``[console]
@@ -54,14 +74,54 @@ TWO independent agent file-tool families enforce this, and both must:
    modules) and pins the two families' agreement on the denylist, so they
    cannot drift apart again.
 
-Also worth knowing before relying on this module: the denylist is an
-ENUMERATION (``_SENSITIVE_DIRS`` plus the accessor-resolved paths below),
-so its coverage is exactly what it lists. Credential files it does not
-enumerate -- ``~/.netrc``, ``~/.git-credentials``, ``~/.npmrc``,
-``~/.pypirc``, ``~/.cargo/credentials.toml``, ``~/.config/gh/hosts.yml`` --
-are NOT refused by it, and family 2 passes ``allow_hidden=True`` while
-family 1 does not, so for dotted paths family 2 is strictly the weaker of
-the two (TASK-19633, open).
+Two instruments express what is denied, and the choice between them is
+made per case rather than by taste (TASK-19633):
+
+* **Location rules** -- ``_SENSITIVE_DIRS`` plus the accessor-resolved
+  paths further down -- for anything whose LOCATION is the unambiguous
+  part. ``~/.ssh``, ``~/.aws``, ``~/.config/gh``: everything under them is
+  credential material, and their filenames are NOT self-identifying
+  (``hosts.yml`` is just as often an Ansible inventory).
+* **A name rule** (``_SENSITIVE_FILE_NAMES``) for the handful of
+  filenames that identify a credential store wherever they appear.
+  Adopted after ``~/.netrc``, ``~/.git-credentials``, ``~/.npmrc``,
+  ``~/.pypirc``, ``~/.cargo/credentials.toml`` and
+  ``~/.config/gh/hosts.yml`` were each measured returning their body
+  through ``fs_read``. A location rule cannot cover most of that set: the
+  credential is not confined to one directory (a project-local
+  ``.npmrc``/``.pypirc`` carries an auth token exactly like the home one,
+  and a copy of ``credentials.toml`` is a credential wherever it lands),
+  and refusing the whole of ``~/.cargo`` or ``~/.config/git`` would take
+  down things an agent legitimately reads.
+
+BOTH are enumerations and both trail reality -- names no less than
+locations. The name rule is preferred where it applies because one entry
+covers unbounded locations while one location entry covers exactly one,
+and because a tool's config DIRECTORY migrates between XDG/legacy/OS
+conventions far more often than its credential FILENAME ever changes. It
+is kept deliberately small and biased toward names that are credential
+stores by definition; a name is added only when a false refusal would be
+a curiosity rather than routine obstruction -- which is why ``.env`` is
+deliberately NOT here (as often build configuration as secrets, and
+refusing it would break the ADR-032 coding-agent use case this module
+must not break). The cost is real and accepted: an agent cannot read a
+test fixture named ``credentials``, and the refusal names it as protected
+rather than failing silently.
+
+The two families' HIDDEN-COMPONENT policies still differ, and that
+difference is design, not residue. Family 1 confines through
+``validate_path_multi``, which defaults ``allow_hidden=False`` and so
+refuses any dotted component before this module is consulted; family 2
+passes ``allow_hidden=True`` (ADR-032 -- a coding agent that cannot read
+``.github/`` or ``.gitignore`` is useless). Family 1 is therefore
+strictly stricter for dotted NAMES, which is acceptable because the two
+roots are different kinds of place: family 1's sandbox root is app-owned
+storage where a dotfile has no legitimate purpose, while family 2's root
+is a user source tree where dotfiles are the point. What must not differ
+is THIS module's answer -- and since TASK-19633 it does not: every
+credential path measured above is refused by the denylist itself, under
+either family, so the part of the gap that was weaker-by-accident is
+gone and only the deliberate difference remains.
 
 This is *not* wired into
 ``Utils/path_validation.validate_path``/``validate_path_multi`` themselves:
@@ -144,11 +204,17 @@ track is the real answer for shell execution.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from loguru import logger
 
 #: Directory prefixes that are refused along with everything beneath them.
+#: The LOCATION rule (see the module docstring): used where the directory
+#: is unambiguously a credential store and its filenames are not
+#: self-identifying. ``~/.config/gh`` joined in TASK-19633 for exactly
+#: that reason -- it holds the GitHub CLI's OAuth tokens in
+#: ``hosts.yml``, a filename far too generic to put in the name rule
+#: below.
 _SENSITIVE_DIRS = (
     "~/.ssh",
     "~/.aws",
@@ -157,6 +223,32 @@ _SENSITIVE_DIRS = (
     "~/.docker",
     "~/.kube",
     "~/.local/share/keyrings",
+    "~/.config/gh",
+)
+
+#: The NAME rule (TASK-19633): filenames that identify a credential store
+#: WHEREVER they appear, refused by name in addition to every location
+#: rule. Compared case-folded, because the macOS and Windows filesystems
+#: this app runs on are case-insensitive -- ``.NETRC`` opens the same file
+#: an exact-case check would wave through. See the module docstring for
+#: why a name rule earns its place here (and why ``.env`` does not).
+#:
+#: Matching is skipped for an existing DIRECTORY, mirroring the
+#: direct-child-file rule's own ``is_dir()`` gate below: a directory named
+#: ``credentials`` is a container, not a credential, and refusing it would
+#: make everything under it unlistable. A path that does not exist is not
+#: a directory either, so it still fails closed.
+_SENSITIVE_FILE_NAMES = frozenset(
+    name.casefold()
+    for name in (
+        ".netrc",  # curl/ftp/python-netrc credentials
+        "_netrc",  # the same file's Windows spelling (and it is NOT dotted)
+        ".git-credentials",  # git credential-store default
+        ".npmrc",  # npm `_authToken` -- per-project as often as per-user
+        ".pypirc",  # PyPI upload credentials
+        "credentials",  # cargo (legacy), git credential-store under XDG
+        "credentials.toml",  # cargo's current registry-token file
+    )
 )
 
 #: NOTE: this app's own ``config.toml`` and the MCP-permission-store family
@@ -608,6 +700,19 @@ def _is_within(child: Path, ancestor: Path) -> bool:
     return child_key[: len(ancestor_key)] == ancestor_key
 
 
+def _name_key(path: Path) -> str:
+    """The final component of ``path``, in the same folded form (TASK-19633).
+
+    The name rule's half of :func:`_compare_key`. Kept here rather than
+    spelled ``path.name.casefold()`` at the one call site so this module
+    has exactly ONE definition of how two path spellings are compared --
+    the property TASK-19800 established and the reason a name rule could
+    be added without opening a second normalization path.
+    """
+    key = _compare_key(path)
+    return key[-1] if key else ""
+
+
 def is_sensitive_path(
     candidate: Path, context: SensitivePathContext | None = None
 ) -> bool:
@@ -632,9 +737,10 @@ def is_sensitive_path(
       choke point the workspace-local ``fs_*``/``git_*`` family resolves
       its path ARGUMENTS through -- plus the per-candidate filters in
       ``list_directory``/``glob_files``/``grep_files`` there (TASK-19551).
-      The ``git_*`` tools have no output filter and ``git_diff`` leaks
-      content for a denylisted path when ``path`` is omitted; see this
-      module's docstring and TASK-19632.
+      The ``git_*`` tools additionally translate this function's denials
+      into git ``:(exclude)`` pathspecs, via
+      :func:`sensitive_exclusions_under`, so git never reports a denied
+      path in the first place (TASK-19632); see this module's docstring.
 
     Args:
         candidate: The path a tool intends to touch.
@@ -674,6 +780,20 @@ def is_sensitive_path(
         if _is_within(resolved, root):
             return True
 
+    # TASK-19633: the NAME rule, applied wherever the file sits. See the
+    # module docstring for why this instrument exists alongside the
+    # location rules above and why it is kept small. `is_dir()` exempts a
+    # container directory that happens to carry one of these names; a
+    # path that does not exist yet is not a directory, so it still fails
+    # closed.
+    #
+    # Normalized through `_compare_key` like every comparison above, NOT
+    # through a second casefold of its own: TASK-19800 made this module's
+    # folding rule one function on purpose, and a security primitive with
+    # two independently-normalized comparison paths is how they drift.
+    if _name_key(resolved) in _SENSITIVE_FILE_NAMES and not resolved.is_dir():
+        return True
+
     # Finding 2 (substrate review), generalized beyond `get_user_data_dir()`
     # to every container directory `_direct_child_rule_container_dirs()`
     # resolves (also the effective config directory, the ChromaDB persist
@@ -709,6 +829,138 @@ def is_sensitive_path(
             return True
 
     return False
+
+
+class SensitiveExclusion(NamedTuple):
+    """One denial of :func:`is_sensitive_path`, expressed relative to a root.
+
+    Produced by :func:`sensitive_exclusions_under` for callers that cannot
+    ask this module about each candidate one at a time because they never
+    see the candidates -- the ``git_*`` tools, which hand a whole
+    repository to ``git`` and get finished output back. Such a caller
+    translates these into whatever exclusion syntax its own subprocess
+    speaks (git pathspecs, in the only current case) instead of parsing
+    that output to decide what to withhold.
+
+    Attributes:
+        kind: Which rule produced this denial.
+
+            * ``"subtree"`` -- ``value`` and everything beneath it.
+            * ``"file"`` -- exactly ``value``.
+            * ``"direct_children"`` -- the direct, non-recursive child
+              FILES of the directory ``value`` (never anything deeper,
+              and never the subdirectories themselves): the
+              container-directory rule in :func:`is_sensitive_path`.
+            * ``"name"`` -- any file named ``value`` at ANY depth under
+              the root: the TASK-19633 name rule.
+        value: For every kind but ``"name"``, a POSIX path RELATIVE to
+            the root passed to :func:`sensitive_exclusions_under`, and
+            the empty string when it IS that root (possible only for
+            ``"subtree"`` -- the whole root is denied, which a caller
+            must treat as "refuse outright", there being nothing left to
+            show -- and for ``"direct_children"``). For ``"name"``, a
+            bare filename, not a path.
+    """
+
+    kind: Literal["subtree", "file", "direct_children", "name"]
+    value: str
+
+
+def _relative_within(root: Path, candidate: Path) -> str | None:
+    """POSIX path of ``candidate`` relative to ``root``, or ``None`` if outside.
+
+    Returns ``""`` when ``candidate`` IS ``root`` (both already resolved).
+
+    Containment is decided by :func:`_is_within`, i.e. through the SAME
+    folded key every other denylist comparison uses (TASK-19800), not by
+    ``Path.relative_to``'s exact-case parts. ``root`` here is a repository
+    root the caller resolved from git's own output while the candidates
+    come from config accessors and ``$HOME``; on a case-insensitive
+    filesystem those two chains can legitimately disagree about the
+    spelling of a shared ancestor, and an exclusion that silently decides
+    "outside the repository" for that reason would be a hole, not a
+    no-op.
+
+    The RETURNED value is built from the candidate's own components, not
+    the folded ones -- the folding decides the relationship, never what
+    gets rendered.
+    """
+    if _same_path(candidate, root):
+        return ""
+    if not _is_within(candidate, root):
+        return None
+    return Path(*candidate.parts[len(root.parts) :]).as_posix()
+
+
+def sensitive_exclusions_under(
+    root: Path, context: SensitivePathContext | None = None
+) -> tuple[SensitiveExclusion, ...]:
+    """Every denial that could match something inside ``root``.
+
+    The bridge for callers that delegate enumeration to a subprocess and
+    therefore cannot consult :func:`is_sensitive_path` per candidate --
+    today only ``Tools/git_tool_impls.py``, which renders these as git
+    ``:(exclude)`` pathspecs so ``git diff``/``git status`` never emit a
+    denied path's name or content (TASK-19632).
+
+    This function is deliberately the ONE place that enumerates the
+    module's rules for that purpose, so a denial added to
+    :func:`is_sensitive_path` flows into those tools by being added here
+    rather than by someone remembering to update a second list in a
+    different package. ``Tests/Tools/test_git_tool_sensitive_paths.py``
+    pins the two against each other.
+
+    Args:
+        root: The directory the exclusions will be expressed relative to
+            (a repository root, in the current caller). Resolved here.
+        context: Optional pre-resolved ``SensitivePathContext``; see
+            ``resolve_sensitive_context``.
+
+    Returns:
+        Deduplicated ``SensitiveExclusion`` entries, in a deterministic
+        order. Location-based denials that fall entirely OUTSIDE ``root``
+        are omitted (nothing under the root can match them); the name
+        rule is always present, since it can match at any depth.
+    """
+    ctx = context if context is not None else resolve_sensitive_context()
+    resolved_root = _resolved(str(root))
+    if resolved_root is None:
+        # Fail closed the same way `is_sensitive_path` does: a root we
+        # cannot resolve gets the most restrictive answer available.
+        return (SensitiveExclusion("subtree", ""),)
+
+    found: list[SensitiveExclusion] = []
+    seen: set[SensitiveExclusion] = set()
+
+    def _record(kind: str, value: str) -> None:
+        entry = SensitiveExclusion(kind, value)  # type: ignore[arg-type]
+        if entry not in seen:
+            seen.add(entry)
+            found.append(entry)
+
+    for denied_dir in ctx.dirs:
+        relative = _relative_within(resolved_root, denied_dir)
+        if relative is not None:
+            _record("subtree", relative)
+
+    denied_files: list[Path] = list(ctx.files)
+    for db_path in ctx.db_paths:
+        denied_files.append(db_path)
+        denied_files.extend(_db_sidecar_paths(db_path))
+    for denied_file in denied_files:
+        relative = _relative_within(resolved_root, denied_file)
+        if relative:  # "" would mean the root itself is a file -- not possible
+            _record("file", relative)
+
+    for container in ctx.direct_child_denied_dirs:
+        relative = _relative_within(resolved_root, container)
+        if relative is not None:
+            _record("direct_children", relative)
+
+    for name in sorted(_SENSITIVE_FILE_NAMES):
+        _record("name", name)
+
+    return tuple(found)
 
 
 def find_root_binding_conflict(


### PR DESCRIPTION
Closes TASK-19632 and TASK-19633. Both are residue of TASK-19551, which closed the same class for the `fs_*` tools; they ship together because they share files.

## TASK-19632 — `git_diff` returned the CONTENT of denylisted files

The `git_*` tools share `resolve_workspace_path` for their path *argument*, but have no output filter — and on three of them `path` is **optional**. When it is omitted, no candidate path reaches the denylist at all: `path_targets` returns the repository root and stops, git enumerates the whole repository on the tool's behalf, and the output is returned verbatim.

Two properties make it worse than the `fs_grep` gap 19551 closed: the `commit_range` form reads the credential **out of history**, so a read-only agent on a **clean** checkout is enough — no write primitive, no dirty worktree — and it is reachable by **prompt injection** from fetched web content, since the model only has to call a read-only `reads`-tagged tool with no arguments.

**Implementation: pathspec exclusion.** git stays the authority; no unified-diff or porcelain text is ever parsed (a half-parsed diff is worse than none). `Utils/sensitive_paths.py` gained `sensitive_exclusions_under(root)` returning structured `SensitiveExclusion(kind, value)`; `git_tool_impls._denylist_pathspecs` renders each kind into the pathspec form expressing exactly that rule. A container's `direct_children` becomes `:(exclude,glob,icase)<dir>/*` — `*` does not cross `/`, so `tool_sandbox/` stays diffable while a loose file beside it does not. Unknown kind raises. `git_log` is deliberately unfiltered (it discloses commit metadata only, and was clean as filed).

### A vector neither task listed: pathspec magic in the `path` argument

`:(exclude)notes.txt` is a legal POSIX filename, so `git_diff(path=":(exclude)notes.txt")` passes the confinement choke point as an ordinary path — and git then reads it as **magic**, inverting the scope. Measured pre-fix: it returned `~/.ssh/id_rsa`'s content while nominally scoping to a single file. **`--` does not stop this**; it ends *option* parsing, not magic parsing.

Review widened the battery to 22 forms × 5 tools: **9 leaked key content at base** (`:(exclude)`, `:!`, `:^`, `:(glob)**`, bare `:`, `:/`, `*`, `:(exclude,literal)`, `:(exclude).ssh`) — wider than documented, because `resolve_workspace_path` never requires existence, so any magic string that confines is accepted. **On the branch: zero leaks across all forms.** Closed with explicit `:(literal)` on every pathspec plus an AST tripwire failing on any bare value spliced after `--`. `git_blame` was verified directly to take a plain path and reject magic, so it is untouched.

This is the fifth member of the argv-injection family TASK-16801 documented.

### A trap left for the next reader

TASK-16801's own lesson recommends `GIT_LITERAL_PATHSPECS=1`. It is **incompatible with this fix and fails silently** — `:(exclude,literal)<path>` becomes a literal filename, matches nothing, and every `git_diff`/`git_status` returns empty with exit 0 (verified, git 2.39). An empty diff reading as "no changes" is the dangerous shape. `_git_environment` builds from scratch so an ambient setting cannot reach git; the residual risk is a future edit, and introducing one reds 15 tests.

## TASK-19633 — the denylist enumerated 7 locations and nothing else

`~/.netrc`, `~/.git-credentials`, `~/.npmrc`, `~/.pypirc`, `~/.cargo/credentials.toml` and `~/.config/gh/hosts.yml` all returned their body through `fs_read`. Fixed with **both instruments, chosen per case**: a name rule (`.netrc`, `_netrc`, `.git-credentials`, `.npmrc`, `.pypirc`, `credentials`, `credentials.toml`) because one entry covers unbounded locations and a credential *filename* is far more stable than a tool's config *directory*; and one location addition (`~/.config/gh`) because `hosts.yml` is too generic to be a name. Accepted cost stated in the docstring: an agent cannot read a fixture named `credentials`. `.env` deliberately excluded.

`allow_hidden=True` is **not** reversed — that would contradict ADR-032, break the coding-agent use case, and still not refuse a non-dotted credential file.

The both-families requirement (refusal in a configuration where confinement alone does not explain it) was constructed three ways: name-rule paths at a non-dotted location under a non-dotted root; the location rule rooted at `~/.config/gh`; and the inherently-dotted names via family B's `ListDirectoryTool(include_hidden=True)`, the one seam that lists dotted entries on request.

**Composition with TASK-19800**, which merged into these files mid-implementation: independently verified that 19800 fixed *how* known paths are compared (case folding), not *which* paths are known — all six still leaked at `d4f3f9776`. The name rule reads through the module's single folding rule via `_name_key`/`_compare_key` rather than its own `.casefold()`, pinned by mutation; `_relative_within` decides containment via `_is_within`, so the git side introduces no second normalization path.

## Evidence

- Born-red at base: 22 failed / 44 passed, each failure carrying the leaked bytes.
- A 40-file oracle probe comparing `is_sensitive_path` against what git actually emits: **0 disagreements in both directions** (base: 8 leaks). Covers nesting under subtree and container rules, untracked, ignored, merge commits, rename detection both ways, binaries, submodules, case variants.
- Negative pins: `git_log` still lists a commit touching only `~/.ssh/id_rsa`; ordinary diffs and `--stat` are byte-identical to raw git with the same flags; scoped diffs unchanged; near-misses (`.npmrc.example`, `netrc`, `my.netrc`, `credentials.json`, a `credentials/` directory) still readable.
- `Tests/Tools/` + `Tests/Agents/` post-rebase: **2480 passed / 1 failed** — that one failure is present identically on `origin/dev`.

Review committed two fixes for **mutation survivors** (neither exploitable as shipped): `icase` on location exclusions was load-bearing but unpinned — dropping it left the whole suite green while a repo recording `.SSH/id_rsa` leaked content; and the AST tripwire inspected `.extend([...])` only, skipping every `*splat`, so `git_status` and `git_diff` were both uncovered. It is now verified red against six distinct evasions.

One honest correction to the notes: the new git test module imports `_denylist_pathspecs` at module scope, so at base it does not collect at all — the "10 of 19 fail at base" figure is reproducible only with imports shimmed (13 fail / 7 pass).

## Housekeeping

Both tasks' exception paragraphs in `Utils/sensitive_paths.py` are replaced with the new contracts, `local_tool_impls.py`'s is rewritten, and **TASK-19551's drift-pin comment is rewritten** — "an honest distinction" is now true *without* its caveat, and the comment records why it used to carry one.

Separately filed from this work: migration `.sql` files are enumerated one-by-one in `pyproject.toml` and `MANIFEST.in` rather than globbed, so **20 of 31 are missing from the wheel** and a PyPI install cannot initialize its main database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `git_diff` and `git_status` from exposing denylisted content or names and adds common dotfile credentials to the denylist (TASK-19632, TASK-19633). Previously, omitting `path` or injecting pathspec magic could leak repository content; now we exclude denylisted paths via explicit literal pathspecs, block magic, and resolve the sensitive-path context once per call.

- Enforces exclusions with git pathspecs: scoping uses `:(literal)`, exclusions use `:(exclude,...,icase)`; applies to worktree, index, and `commit_range`. `git_log` remains unfiltered; ordinary diffs and `--stat` are byte-identical to raw git.
- Blocks pathspec magic injection with an AST tripwire that covers list literals and `*splat` sources; all argv pathspecs are explicit `:(literal)` forms.
- Expands the denylist: blocks `.netrc`, `_netrc`, `.git-credentials`, `.npmrc`, `.pypirc`, `credentials`, `credentials.toml` anywhere, plus `~/.config/gh/hosts.yml` by location. `.env` stays allowed; `allow_hidden=True` unchanged.
- Resolves the denylist context once per call to avoid redundant work.

- Migration
  - Do not set `GIT_LITERAL_PATHSPECS=1` for these tools; it empties results.
  - Rename any test or fixture named `credentials` you need to read.

<sup>Written for commit c50d70006d0ccf3322a97b215bc2168639e390b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

