### PR TITLE
fix(llm): config-driven default-timeout session, closing the hang-forever hazard (task-19830)

### DIFF
--- a/Tests/Architecture/test_default_timeout_session_guard.py
+++ b/Tests/Architecture/test_default_timeout_session_guard.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -76,10 +77,11 @@ EXEMPT_FILES: frozenset[str] = frozenset(
         # as the LLM_Calls fix is a regression risk this task isn't taking.
         "Embeddings/Embeddings_Lib.py",
         "Local_Inference/ollama_model_mgmt.py",
-        # task-19560 (open, separate task) already covers the Kokoro
-        # download timeouts specifically -- exempted here rather than fixed
-        # incidentally by this guard's presence.
-        "TTS/backends/kokoro.py",
+        # (task-19560 shipped the Kokoro download timeouts while this branch
+        # was in review -- `TTS/backends/kokoro.py` used to be exempted here
+        # and is now clean, so the entry was removed. This guard's
+        # stale-exemption check is what caught that, which is the point of
+        # naming files individually instead of skipping a whole directory.)
         "Web_Scraping/Confluence/confluence_auth.py",
         "Web_Scraping/WebSearch_APIs.py",
         # Utils/egress.py's OWN internals (`guarded_fetch_requests`'s
@@ -187,8 +189,15 @@ def _scan_source(source: str, *, relative_path: str) -> list[Finding]:
                     session_vars.add(arg.arg)
 
     def has_timeout(call: ast.Call, leaf: str) -> bool:
+        # A `**kwargs` expansion deliberately does NOT count. It MIGHT carry
+        # a timeout, and the AST cannot tell -- but a guard that assumes the
+        # safe case whenever it can't see is a guard that passes on exactly
+        # the call sites hardest to eyeball. `requests.post(url, **opts)` is
+        # the shape most likely to hide a missing timeout, not least likely.
+        # A site that really does forward one through `**kwargs` states it
+        # explicitly (`timeout=opts.get("timeout", ...)`) and stays green.
         for kw in call.keywords:
-            if kw.arg == "timeout" or kw.arg is None:  # `timeout=` or `**kwargs`
+            if kw.arg == "timeout":
                 return True
         idx = _REQUEST_POSITIONAL_TIMEOUT_INDEX.get(leaf)
         return idx is not None and len(call.args) > idx
@@ -231,8 +240,20 @@ def _scan_source(source: str, *, relative_path: str) -> list[Finding]:
     return findings
 
 
+@lru_cache(maxsize=1)
 def _scan_package() -> dict[str, list[Finding]]:
-    """Every finding under ``tldw_chatbook/``, keyed by path relative to it."""
+    """Every finding under ``tldw_chatbook/``, keyed by path relative to it.
+
+    Cached: three tests in this module each need the whole picture, and
+    re-parsing every file in the package three times cost ~9s of a suite
+    run for three identical answers (14.2s -> 5.0s for this module). Safe
+    because nothing here mutates the tree between tests -- the package is
+    read-only input to a pure function of its own source.
+
+    Returns:
+        ``{relative_path: [Finding, ...]}`` for files with at least one
+        finding. Callers must treat the value as read-only; it is shared.
+    """
     by_file: dict[str, list[Finding]] = {}
     for path in sorted(PACKAGE_ROOT.rglob("*.py")):
         relative = path.relative_to(PACKAGE_ROOT).as_posix()
@@ -378,3 +399,30 @@ def test_scanner_ignores_lazy_in_function_import_target_of_confusion() -> None:
     )
     findings = _scan_source(source, relative_path="synthetic.py")
     assert [f.kind for f in findings] == ["bare-session"]
+
+
+def test_scanner_flags_kwargs_expansion_without_an_explicit_timeout() -> None:
+    """`requests.post(url, **opts)` must be flagged, not assumed safe.
+
+    The AST cannot see whether `opts` carries a timeout. Treating the
+    unknowable case as safe would blind the guard to precisely the call
+    shape where a missing timeout is hardest to spot by eye, so the guard
+    resolves the ambiguity the other way and makes the call site say so.
+    """
+    source = "import requests\nrequests.post(url, **opts)\n"
+    findings = _scan_source(source, relative_path="synthetic.py")
+    assert len(findings) == 1, findings
+    assert "timeout" in str(findings[0]).lower()
+
+
+def test_scanner_accepts_a_timeout_forwarded_explicitly_beside_kwargs() -> None:
+    """The escape hatch has to actually work, or the rule above is a wall.
+
+    A site that genuinely forwards a caller-supplied timeout stays green by
+    naming it -- `**kwargs` alongside an explicit `timeout=` is fine.
+    """
+    source = (
+        "import requests\n"
+        "requests.post(url, timeout=opts.get('timeout', 30), **opts)\n"
+    )
+    assert _scan_source(source, relative_path="synthetic.py") == []

--- a/Tests/Architecture/test_default_timeout_session_guard.py
+++ b/Tests/Architecture/test_default_timeout_session_guard.py
@@ -1,0 +1,380 @@
+# test_default_timeout_session_guard.py
+# Description: Guard against bare `requests.Session()` / timeout-less `requests` calls (task-19830)
+"""
+task-19830: a plain ``requests`` call with no ``timeout=`` waits forever on a
+half-open connection. On the LLM paths that means a chat or summarization
+request that never returns and cannot be cancelled -- several also run on the
+event loop, so the whole TUI stops. ``requests`` has no per-session default
+timeout, so every call site has to remember one individually.
+
+``tldw_chatbook.Utils.egress.create_default_session()`` fixes this: it returns
+a ``requests.Session`` subclass (``DefaultTimeoutSession``) whose ``request()``
+fills in a config-driven ``(connect, read)`` timeout only when the caller
+omitted one -- an explicit ``timeout=`` always wins.
+
+This guard walks the AST of every file under ``tldw_chatbook/`` that imports
+``requests`` (module-level or a lazy in-function import -- several files here
+do that deliberately, so a plain substring/import-at-top check would miss
+them) and flags:
+
+* every ``requests.Session()`` construction (should be
+  ``create_default_session()`` instead), and
+* every ``get``/``post``/``put``/``delete``/``patch``/``request`` call made
+  either directly on the ``requests`` module or on a variable/``self``
+  attribute the file itself assigned from ``requests.Session()``, that
+  supplies neither a ``timeout=`` keyword nor (for ``.request()``, whose
+  positional signature has room for one) a positional argument in that slot.
+
+``LLM_Calls/`` -- the user-facing hazard this task targets -- must be
+completely clean: any finding there fails the guard. Every other file that
+still has findings is named explicitly in ``EXEMPT_FILES`` below (task-19830
+converts ``LLM_Calls/`` only; the rest is deliberately deferred, one
+subsystem at a time, to keep each conversion independently reviewable). A
+file that no longer has any findings, or that has been deleted, is a STALE
+exemption and fails the guard too -- the whole point of naming files here is
+that the remaining work stays visible, not implied.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "tldw_chatbook"
+
+#: The six ``requests`` methods this guard checks for a timeout. `head`/
+#: `options` are deliberately excluded -- nothing in this codebase uses them
+#: for a live network call with a body large enough to hang meaningfully, and
+#: the original AST sweep that sized this task didn't count them either.
+_REQUEST_METHODS = frozenset({"get", "post", "put", "delete", "patch", "request"})
+
+#: ``requests.Session.request``'s full positional signature is ``method, url,
+#: params, data, headers, cookies, files, auth, timeout, ...`` -- ``timeout``
+#: is the 9th positional argument, index 8 in an AST ``Call`` node's ``args``
+#: (which, unlike a hand-written override's ``*args``, still includes
+#: ``method``/``url`` as elements 0 and 1). A ``.request()`` call with 9 or
+#: more positional arguments therefore supplied an explicit timeout.
+#: ``get``/``post``/``put``/``delete``/``patch`` only take ``url``
+#: positionally (everything else is ``**kwargs``), so no entry is needed for
+#: them.
+_REQUEST_POSITIONAL_TIMEOUT_INDEX = {"request": 8}
+
+#: Files that still have a bare ``requests.Session()`` and/or a timeout-less
+#: request call, deliberately not converted in this pass (task-19830 scopes
+#: the conversion to ``LLM_Calls/`` only -- see the module docstring). Keep
+#: this list exactly in sync with reality: an entry with zero findings, or
+#: naming a file that no longer exists, fails the guard (see
+#: ``test_exempt_files_are_current`` below) precisely so a fixed or deleted
+#: file can't quietly keep "remaining work" on the books.
+EXEMPT_FILES: frozenset[str] = frozenset(
+    {
+        # Embeddings, Character_Chat, Local_Inference, TTS and Web_Scraping
+        # are real hang-forever hazards too (same audit that sized this
+        # task), but converting five unrelated subsystems in the same diff
+        # as the LLM_Calls fix is a regression risk this task isn't taking.
+        "Embeddings/Embeddings_Lib.py",
+        "Local_Inference/ollama_model_mgmt.py",
+        # task-19560 (open, separate task) already covers the Kokoro
+        # download timeouts specifically -- exempted here rather than fixed
+        # incidentally by this guard's presence.
+        "TTS/backends/kokoro.py",
+        "Web_Scraping/Confluence/confluence_auth.py",
+        "Web_Scraping/WebSearch_APIs.py",
+        # Utils/egress.py's OWN internals (`guarded_fetch_requests`'s
+        # `session or requests.Session()` default) are explicitly out of
+        # scope -- this is the module that HOUSES the factory being added
+        # here, and its existing `timeout: float = 30.0` parameter is a
+        # deliberate, already-reviewed default, not an oversight.
+        "Utils/egress.py",
+    }
+)
+
+
+def _qualified(node: ast.AST) -> str:
+    """Render a call target as a dotted string (``requests.post``, ``x.y.get``)."""
+    if isinstance(node, ast.Attribute):
+        base = _qualified(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str  # relative to PACKAGE_ROOT's parent (e.g. "LLM_Calls/foo.py")
+    lineno: int
+    kind: str  # "bare-session" | "timeoutless-call"
+    detail: str
+
+    def __str__(self) -> str:  # pragma: no cover - human-readable only
+        return f"{self.path}:{self.lineno} [{self.kind}] {self.detail}"
+
+
+def _requests_import_aliases(tree: ast.AST) -> set[str]:
+    """Local binding name(s) for the ``requests`` module, found anywhere in
+    the file -- module scope OR inside a function. Several files here do a
+    lazy ``import requests`` on purpose (keeps it out of the hot import path
+    for code that doesn't need it), so this must not be a module-scope-only
+    check.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "requests":
+                    aliases.add(alias.asname or alias.name)
+    return aliases
+
+
+def _scan_source(source: str, *, relative_path: str) -> list[Finding]:
+    """Return every bare-Session/timeout-less finding in one file's source."""
+    tree = ast.parse(source, filename=relative_path)
+    aliases = _requests_import_aliases(tree)
+    if not aliases:
+        return []
+
+    session_ctor_names = {f"{a}.Session" for a in aliases} | {
+        f"{a}.sessions.Session" for a in aliases
+    }
+
+    def is_session_ctor(node: ast.AST) -> bool:
+        return isinstance(node, ast.Call) and _qualified(node.func) in session_ctor_names
+
+    # Pass 1: find every name/self-attribute this file binds to a fresh
+    # `requests.Session()` -- assignment, `with ... as`, or an annotated
+    # parameter -- so pass 2 can recognise `session.post(...)` as a
+    # requests call even though `session` isn't the module itself.
+    session_vars: set[str] = set()
+    self_session_attrs: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and is_session_ctor(node.value):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    session_vars.add(tgt.id)
+                elif (
+                    isinstance(tgt, ast.Attribute)
+                    and isinstance(tgt.value, ast.Name)
+                    and tgt.value.id == "self"
+                ):
+                    self_session_attrs.add(tgt.attr)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and node.value is not None
+            and is_session_ctor(node.value)
+        ):
+            if isinstance(node.target, ast.Name):
+                session_vars.add(node.target.id)
+            elif (
+                isinstance(node.target, ast.Attribute)
+                and isinstance(node.target.value, ast.Name)
+                and node.target.value.id == "self"
+            ):
+                self_session_attrs.add(node.target.attr)
+        elif isinstance(node, ast.With):
+            for item in node.items:
+                if is_session_ctor(item.context_expr) and isinstance(
+                    item.optional_vars, ast.Name
+                ):
+                    session_vars.add(item.optional_vars.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for arg in list(node.args.args) + list(node.args.kwonlyargs):
+                if arg.annotation is not None and _qualified(
+                    arg.annotation
+                ) in {f"{a}.Session" for a in aliases}:
+                    session_vars.add(arg.arg)
+
+    def has_timeout(call: ast.Call, leaf: str) -> bool:
+        for kw in call.keywords:
+            if kw.arg == "timeout" or kw.arg is None:  # `timeout=` or `**kwargs`
+                return True
+        idx = _REQUEST_POSITIONAL_TIMEOUT_INDEX.get(leaf)
+        return idx is not None and len(call.args) > idx
+
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if is_session_ctor(node):
+            findings.append(
+                Finding(relative_path, node.lineno, "bare-session", _qualified(node.func))
+            )
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        leaf = node.func.attr
+        if leaf not in _REQUEST_METHODS:
+            continue
+        base = node.func.value
+        is_requests_target = False
+        if isinstance(base, ast.Name):
+            if base.id in aliases or base.id in session_vars:
+                is_requests_target = True
+        elif (
+            isinstance(base, ast.Attribute)
+            and isinstance(base.value, ast.Name)
+            and base.value.id == "self"
+            and base.attr in self_session_attrs
+        ):
+            is_requests_target = True
+        if is_requests_target and not has_timeout(node, leaf):
+            findings.append(
+                Finding(
+                    relative_path,
+                    node.lineno,
+                    "timeoutless-call",
+                    f"{_qualified(node.func)}(",
+                )
+            )
+    return findings
+
+
+def _scan_package() -> dict[str, list[Finding]]:
+    """Every finding under ``tldw_chatbook/``, keyed by path relative to it."""
+    by_file: dict[str, list[Finding]] = {}
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        relative = path.relative_to(PACKAGE_ROOT).as_posix()
+        source = path.read_text(encoding="utf-8")
+        findings = _scan_source(source, relative_path=relative)
+        if findings:
+            by_file[relative] = findings
+    return by_file
+
+
+def test_llm_calls_package_has_no_bare_session_or_timeoutless_call() -> None:
+    """AC #2: LLM_Calls/ is the user-facing hazard this task closes -- it must
+    be completely clean, with zero exemptions."""
+    by_file = _scan_package()
+    offenders = {
+        path: findings for path, findings in by_file.items() if path.startswith("LLM_Calls/")
+    }
+    assert offenders == {}, "\n".join(
+        str(f) for findings in offenders.values() for f in findings
+    )
+
+
+def test_covered_area_has_no_unexempted_bare_session_or_timeoutless_call() -> None:
+    """AC #3: a NEW bare Session()/timeout-less call anywhere in the package,
+    outside the explicit exemption list, fails this guard and names the
+    file+line -- this is what keeps the LLM_Calls fix from silently
+    regressing, and keeps a new hazard from appearing anywhere else while it
+    isn't yet a tracked exemption."""
+    by_file = _scan_package()
+    unexempted = {
+        path: findings for path, findings in by_file.items() if path not in EXEMPT_FILES
+    }
+    assert unexempted == {}, "\n".join(
+        str(f) for findings in unexempted.values() for f in findings
+    )
+
+
+def test_exempt_files_are_current() -> None:
+    """AC #4: the exemption set must reflect reality, not accumulate rot.
+
+    Two ways an entry goes stale: the file was deleted (nothing left to
+    convert -- delete the entry too), or the file was already converted and
+    now has zero findings (leaving the entry implies work that no longer
+    exists). Either way the fix is the same: remove the entry as part of
+    whatever change made it stale -- a deliberate edit to this file, not an
+    automatic prune, so the removal shows up in review.
+    """
+    by_file = _scan_package()
+    deleted = sorted(
+        relative for relative in EXEMPT_FILES if not (PACKAGE_ROOT / relative).exists()
+    )
+    already_clean = sorted(
+        relative
+        for relative in EXEMPT_FILES
+        if (PACKAGE_ROOT / relative).exists() and relative not in by_file
+    )
+    assert not deleted, f"EXEMPT_FILES names deleted file(s): {deleted}"
+    assert not already_clean, (
+        f"EXEMPT_FILES names already-clean file(s), remove from the set: {already_clean}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The scanner itself must not silently pass -- prove it catches known-bad
+# shapes directly (belt) in addition to the red-proof done by hand against a
+# real repo file (suspenders, see task-19830's report).
+# ---------------------------------------------------------------------------
+
+
+def test_scanner_flags_bare_session_construction() -> None:
+    source = "import requests\n\ndef f():\n    return requests.Session()\n"
+    findings = _scan_source(source, relative_path="synthetic.py")
+    assert [f.kind for f in findings] == ["bare-session"]
+
+
+def test_scanner_flags_module_level_timeoutless_call() -> None:
+    source = "import requests\n\ndef f():\n    return requests.post('https://x', json={})\n"
+    findings = _scan_source(source, relative_path="synthetic.py")
+    assert [f.kind for f in findings] == ["timeoutless-call"]
+
+
+def test_scanner_flags_timeoutless_call_on_a_tracked_session_variable() -> None:
+    source = (
+        "import requests\n\n"
+        "def f():\n"
+        "    session = requests.Session()\n"
+        "    return session.post('https://x', json={})\n"
+    )
+    findings = _scan_source(source, relative_path="synthetic.py")
+    assert {f.kind for f in findings} == {"bare-session", "timeoutless-call"}
+
+
+def test_scanner_accepts_explicit_keyword_timeout() -> None:
+    source = (
+        "import requests\n\n"
+        "def f():\n"
+        "    return requests.post('https://x', json={}, timeout=30)\n"
+    )
+    assert _scan_source(source, relative_path="synthetic.py") == []
+
+
+def test_scanner_accepts_explicit_timeout_none() -> None:
+    """``timeout=None`` is a deliberate 'no timeout' -- not the same thing as
+    omitting the keyword, and must not be flagged."""
+    source = (
+        "import requests\n\n"
+        "def f():\n"
+        "    return requests.post('https://x', json={}, timeout=None)\n"
+    )
+    assert _scan_source(source, relative_path="synthetic.py") == []
+
+
+def test_scanner_accepts_positional_timeout_on_session_request() -> None:
+    source = (
+        "import requests\n\n"
+        "def f():\n"
+        "    session = requests.Session()\n"
+        "    return session.request(\n"
+        "        'GET', 'https://x', None, None, None, None, None, None, 7\n"
+        "    )\n"
+    )
+    findings = _scan_source(source, relative_path="synthetic.py")
+    # The Session() construction itself still needs converting; the
+    # `.request()` call, with its explicit positional timeout, must not be.
+    assert [f.kind for f in findings] == ["bare-session"]
+
+
+def test_scanner_ignores_files_that_do_not_import_requests() -> None:
+    """A dict's ``.get()`` (``payload.get("x")``) must never be mistaken for
+    a ``requests`` call -- this is what makes the file-level ``requests``
+    import gate load-bearing rather than decorative."""
+    source = "def f(payload):\n    return payload.get('id')\n"
+    assert _scan_source(source, relative_path="synthetic.py") == []
+
+
+def test_scanner_ignores_lazy_in_function_import_target_of_confusion() -> None:
+    """A lazy, function-local ``import requests`` must still be recognised --
+    several real files in this codebase import it that way on purpose."""
+    source = (
+        "def f():\n"
+        "    import requests\n"
+        "    return requests.Session()\n"
+    )
+    findings = _scan_source(source, relative_path="synthetic.py")
+    assert [f.kind for f in findings] == ["bare-session"]

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -245,8 +245,8 @@ def test_chat_with_llama_posts_to_v1_chat_completions_regardless_of_suffix(
         ),
     )
     monkeypatch.setattr(
-        LLM_API_Calls_Local.requests,
-        "Session",
+        LLM_API_Calls_Local,
+        "create_default_session",
         lambda: _CapturedSession(captured, response_data),
     )
 
@@ -604,8 +604,8 @@ class TestProviderRequestPayloads:
             ),
         )
         monkeypatch.setattr(
-            llm_api_calls_module.requests,
-            "Session",
+            llm_api_calls_module,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured, {"choices": [{"message": {"content": "OK"}}]}
             ),
@@ -643,8 +643,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured, {"choices": [{"message": {"content": "OK"}}]}
             ),
@@ -682,8 +682,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured, {"choices": [{"message": {"content": "OK"}}]}
             ),
@@ -721,8 +721,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured, {"choices": [{"message": {"content": "OK"}}]}
             ),
@@ -748,8 +748,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured, {"choices": [{"message": {"content": "OK"}}]}
             ),
@@ -808,8 +808,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured, {"choices": [{"message": {"content": '{"answer":"ok"}'}}]}
             ),
@@ -846,8 +846,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(captured, {"output_text": "OK"}),
         )
 
@@ -875,8 +875,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(captured, {"output_text": "OK"}),
         )
 
@@ -910,8 +910,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(captured, {"output_text": "OK"}),
         )
 
@@ -955,8 +955,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(captured, response_data),
         )
 
@@ -1003,8 +1003,8 @@ class TestProviderRequestPayloads:
             lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(captured, response_events),
         )
 
@@ -1046,8 +1046,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(captured, response_data),
         )
 
@@ -1086,8 +1086,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(captured, response_data),
         )
         monkeypatch.setattr(
@@ -1120,8 +1120,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1169,8 +1169,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1221,8 +1221,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1259,8 +1259,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1302,8 +1302,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1341,8 +1341,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1392,8 +1392,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1444,8 +1444,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1492,8 +1492,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1538,8 +1538,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1582,8 +1582,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1623,8 +1623,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {
@@ -1665,8 +1665,8 @@ class TestProviderRequestPayloads:
             },
         )
         monkeypatch.setattr(
-            LLM_API_Calls.requests,
-            "Session",
+            LLM_API_Calls,
+            "create_default_session",
             lambda: _CapturedSession(
                 captured,
                 {

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -4556,8 +4556,8 @@ async def test_console_send_keeps_each_mistral_credential_on_its_own_endpoint(
     }
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        LLM_API_Calls.requests,
-        "Session",
+        LLM_API_Calls,
+        "create_default_session",
         lambda: _CapturedMistralSession(calls),
     )
     monkeypatch.setattr(
@@ -4662,8 +4662,8 @@ async def test_console_send_keeps_custom_endpoint_and_credential_paired(
         legacy_values["custom_openai_api_2"]["api_key"] = "stale-credential"
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        LLM_API_Calls_Local.requests,
-        "Session",
+        LLM_API_Calls_Local,
+        "create_default_session",
         lambda: _CapturedCustomSession(calls),
     )
     monkeypatch.setattr(
@@ -4762,8 +4762,8 @@ async def test_console_keyless_custom_send_never_falls_back_to_legacy_credential
         legacy_values["custom_openai_api_2"]["api_key"] = legacy_credential
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        LLM_API_Calls_Local.requests,
-        "Session",
+        LLM_API_Calls_Local,
+        "create_default_session",
         lambda: _CapturedCustomSession(calls),
     )
     monkeypatch.setattr(
@@ -4859,8 +4859,8 @@ async def test_console_persisted_explicit_keyless_ignores_saved_env_and_legacy_k
     }
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        LLM_API_Calls_Local.requests,
-        "Session",
+        LLM_API_Calls_Local,
+        "create_default_session",
         lambda: _CapturedCustomSession(calls),
     )
     monkeypatch.setattr(
@@ -4915,8 +4915,8 @@ def test_custom_adapter_fallback_honors_persisted_explicit_keyless(monkeypatch):
     calls: list[tuple[str, str]] = []
     monkeypatch.setenv("CUSTOM_API_KEY", "environment-adapter-canary")
     monkeypatch.setattr(
-        LLM_API_Calls_Local.requests,
-        "Session",
+        LLM_API_Calls_Local,
+        "create_default_session",
         lambda: _CapturedCustomSession(calls),
     )
     monkeypatch.setattr(
@@ -5069,7 +5069,7 @@ async def test_console_send_honors_configured_anthropic_base_url(monkeypatch) ->
 
     captured: dict = {}
     monkeypatch.setattr(
-        LLM_API_Calls.requests, "Session", lambda: _CapturedURLSession(captured)
+        LLM_API_Calls, "create_default_session", lambda: _CapturedURLSession(captured)
     )
 
     gateway = ConsoleProviderGateway(
@@ -5114,7 +5114,7 @@ async def test_console_send_default_anthropic_url_unchanged_when_unconfigured(
 
     captured: dict = {}
     monkeypatch.setattr(
-        LLM_API_Calls.requests, "Session", lambda: _CapturedURLSession(captured)
+        LLM_API_Calls, "create_default_session", lambda: _CapturedURLSession(captured)
     )
 
     gateway = ConsoleProviderGateway(

--- a/Tests/Chat/test_local_adapter_thinking_dispatch.py
+++ b/Tests/Chat/test_local_adapter_thinking_dispatch.py
@@ -73,7 +73,7 @@ def test_shared_builder_composes_llama_wire_format():
             pass
 
     with patch(
-        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.requests.Session",
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.create_default_session",
         return_value=FakeSession(),
     ):
         _chat_with_openai_compatible_local_server(
@@ -118,7 +118,7 @@ def test_shared_builder_composes_vllm_dual_placement():
             pass
 
     with patch(
-        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.requests.Session",
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.create_default_session",
         return_value=FakeSession(),
     ):
         from tldw_chatbook.LLM_Calls.LLM_API_Calls_Local import (

--- a/Tests/Chat/test_openai_reasoning_sampling_params.py
+++ b/Tests/Chat/test_openai_reasoning_sampling_params.py
@@ -67,7 +67,7 @@ def captured_payloads(monkeypatch):
                 }
             )
 
-    monkeypatch.setattr(llm_calls.requests, "Session", _FakeSession)
+    monkeypatch.setattr(llm_calls, "create_default_session", _FakeSession)
     return payloads
 
 

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -400,7 +400,7 @@ def test_sensitive_anthropic_error_body_and_exception_are_not_exposed(
             }
         },
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs, sensitive_llm_request():
         with pytest.raises(Exception) as exc_info:
@@ -419,7 +419,7 @@ def test_sensitive_shared_local_transport_redacts_endpoint_body_and_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = _FakeSession(_FakeResponse({}, status_code=500, text="ERROR-BODY-CANARY"))
-    monkeypatch.setattr(local_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(local_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs, sensitive_llm_request():
         with pytest.raises(Exception) as exc_info:
@@ -450,7 +450,7 @@ def test_sensitive_openai_http_error_log_and_exception_are_metadata_only(
             }
         },
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs, sensitive_llm_request():
         with pytest.raises(requests.exceptions.HTTPError) as exc_info:
@@ -493,7 +493,7 @@ def test_sensitive_cohere_request_and_response_logs_are_metadata_only(
             },
         ),
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs, sensitive_llm_request():
         result = cloud_adapters.chat_with_cohere(
@@ -520,7 +520,7 @@ def test_sensitive_google_request_content_and_error_body_are_not_logged(
         "get_runtime_config_snapshot",
         lambda: _runtime_config("google", {"api_key": "key", "api_retries": 0}),
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs, sensitive_llm_request():
         with pytest.raises(Exception) as exc_info:
@@ -582,7 +582,7 @@ def test_openai_responses_api_input_field_is_never_logged(
             }
         },
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     def _invoke() -> None:
         with pytest.raises(Exception):
@@ -632,7 +632,7 @@ def test_anthropic_system_field_is_never_logged(
             }
         },
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     def _invoke() -> None:
         with pytest.raises(Exception):
@@ -673,7 +673,7 @@ def test_google_system_instruction_field_is_never_logged(
         "get_runtime_config_snapshot",
         lambda: _runtime_config("google", {"api_key": "key", "api_retries": 0}),
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     def _invoke() -> None:
         with pytest.raises(Exception):
@@ -738,7 +738,7 @@ def test_tool_definitions_log_names_only_never_schema_or_description(
             }
         },
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs:
         with pytest.raises(Exception):
@@ -789,7 +789,7 @@ def test_huggingface_tool_logs_are_names_only(
             }
         },
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     context = sensitive_llm_request() if sensitive else nullcontext()
     with _captured_logs() as logs, context:
@@ -854,7 +854,7 @@ def test_sensitive_huggingface_error_body_endpoint_and_exception_are_not_logged(
             }
         },
     )
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs, sensitive_llm_request():
         with pytest.raises(Exception) as exc_info:
@@ -875,7 +875,7 @@ def test_sensitive_openai_compatible_error_bodies_are_not_logged(
     provider: str,
 ) -> None:
     session = _FakeSession(_FakeResponse({}, status_code=500, text="ERROR-BODY-CANARY"))
-    monkeypatch.setattr(hosted_chat.requests, "Session", lambda: session)
+    monkeypatch.setattr(hosted_chat, "create_default_session", lambda: session)
     if provider == "moonshot":
         call: Callable[..., object] = cloud_adapters.chat_with_moonshot
     else:
@@ -912,7 +912,7 @@ def test_sensitive_native_kobold_prompt_response_and_errors_are_not_logged(
             },
         ),
     )
-    monkeypatch.setattr(local_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(local_adapters, "create_default_session", lambda: session)
 
     with _captured_logs() as logs, sensitive_llm_request():
         with pytest.raises(ChatProviderError) as exc_info:
@@ -1035,7 +1035,7 @@ async def test_auxiliary_pins_configured_endpoint_when_selection_url_is_empty(
     }
     session = _FakeSession(_FakeResponse({"choices": [{"message": {"content": "ok"}}]}))
     monkeypatch.setattr(cloud_adapters, "load_settings", lambda: adapter_config)
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
     gateway = ConsoleProviderGateway(config_provider=lambda: gateway_config, environ={})
     resolution = await gateway.resolve_for_send(
         ConsoleProviderSelection(
@@ -1074,7 +1074,7 @@ async def test_auxiliary_pins_default_openai_endpoint_before_config_changes(
     adapter_config = {"openai_api": {"api_retries": 3}}
     session = _FakeSession(_FakeResponse({"choices": [{"message": {"content": "ok"}}]}))
     monkeypatch.setattr(cloud_adapters, "load_settings", lambda: adapter_config)
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
     gateway = ConsoleProviderGateway(config_provider=lambda: gateway_config, environ={})
     resolution = await gateway.resolve_for_send(
         ConsoleProviderSelection(provider="openai", explicit_model="gpt-test")
@@ -1116,7 +1116,7 @@ async def test_auxiliary_pins_default_anthropic_endpoint_before_config_changes(
         )
     )
     monkeypatch.setattr(cloud_adapters, "load_settings", lambda: adapter_config)
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
     gateway = ConsoleProviderGateway(config_provider=lambda: gateway_config, environ={})
     resolution = await gateway.resolve_for_send(
         ConsoleProviderSelection(provider="anthropic", explicit_model="claude-test")
@@ -1166,7 +1166,7 @@ async def test_auxiliary_huggingface_router_url_matches_ordinary_adapter_after_d
     }
     session = _FakeSession(_FakeResponse({"choices": [{"message": {"content": "ok"}}]}))
     monkeypatch.setattr(cloud_adapters, "load_settings", lambda: adapter_config)
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+    monkeypatch.setattr(cloud_adapters, "create_default_session", lambda: session)
 
     ordinary = cloud_adapters.chat_with_huggingface(
         input_data=[{"role": "user", "content": "ordinary"}],

--- a/Tests/LLM_Calls/test_debug_log_fstring_hygiene.py
+++ b/Tests/LLM_Calls/test_debug_log_fstring_hygiene.py
@@ -171,7 +171,9 @@ def test_anthropic_debug_log_interpolates_payload_values(monkeypatch):
                 "usage": {"input_tokens": 4, "output_tokens": 5},
             }
 
-    monkeypatch.setattr(LLM_API_Calls.requests, "Session", lambda: _CapturedSession())
+    monkeypatch.setattr(
+        LLM_API_Calls, "create_default_session", lambda: _CapturedSession()
+    )
 
     secret_user_text = "MY-VERY-PRIVATE-MESSAGE-CONTENT"
     LLM_API_Calls.chat_with_anthropic(

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -214,7 +214,7 @@ def _track_transport_sessions(
         sessions.append(session)
         return session
 
-    monkeypatch.setattr(hosted_chat.requests, "Session", create_session)
+    monkeypatch.setattr(hosted_chat, "create_default_session", create_session)
     return sessions
 
 

--- a/Tests/LLM_Calls/test_kobold_tabby_config.py
+++ b/Tests/LLM_Calls/test_kobold_tabby_config.py
@@ -70,7 +70,7 @@ def captured_post(monkeypatch):
             captured["json"] = json
             return FakeResponse()
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: FakeSession())
+    monkeypatch.setattr(lib, "create_default_session", lambda: FakeSession())
     return captured
 
 
@@ -238,7 +238,7 @@ def test_kobold_streaming_uses_the_openai_compatible_endpoint(monkeypatch):
             seen["url"] = url
             return StreamResponse()
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: StreamSession())
+    monkeypatch.setattr(lib, "create_default_session", lambda: StreamSession())
 
     drain(lib.summarize_with_kobold("text", None, "Summarize.", streaming=True))
 
@@ -277,7 +277,7 @@ def test_configuration_reaches_the_public_analyze_boundary(monkeypatch):
             seen["url"] = url
             return FakeResponse()
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: Session())
+    monkeypatch.setattr(lib, "create_default_session", lambda: Session())
 
     result = drain(
         analyze(

--- a/Tests/LLM_Calls/test_llama_summarizer_config.py
+++ b/Tests/LLM_Calls/test_llama_summarizer_config.py
@@ -48,7 +48,7 @@ def captured_post(monkeypatch):
             captured["json"] = json
             return _FakeResponse()
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: _FakeSession())
+    monkeypatch.setattr(lib, "create_default_session", lambda: _FakeSession())
     return captured
 
 
@@ -162,7 +162,7 @@ def test_summarize_with_llama_parses_the_openai_response_shape(monkeypatch):
         def post(self, *_a, **_k):
             return _FakeResponse()
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+    monkeypatch.setattr(lib, "create_default_session", lambda: _Session())
 
     assert lib.summarize_with_llama("text", "Summarize.", api_key=None) == "SUMMARY"
 
@@ -179,7 +179,7 @@ def test_summarize_with_llama_still_parses_the_native_completion_shape(monkeypat
         def post(self, *_a, **_k):
             return _FakeResponse({"content": " NATIVE "})
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+    monkeypatch.setattr(lib, "create_default_session", lambda: _Session())
 
     assert lib.summarize_with_llama("text", "Summarize.", api_key=None) == "NATIVE"
 
@@ -196,7 +196,7 @@ def test_summarize_with_llama_reports_an_unusable_payload(monkeypatch):
         def post(self, *_a, **_k):
             return _FakeResponse({"unexpected": True})
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+    monkeypatch.setattr(lib, "create_default_session", lambda: _Session())
 
     result = lib.summarize_with_llama("text", "Summarize.", api_key=None)
 
@@ -262,7 +262,7 @@ def test_empty_content_failure_names_the_actual_cause(monkeypatch):
                 }
             )
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+    monkeypatch.setattr(lib, "create_default_session", lambda: _Session())
 
     result = lib.summarize_with_llama("text", "Summarize.", api_key=None)
 
@@ -309,7 +309,7 @@ def test_budget_and_diagnostic_reach_the_public_analyze_boundary(monkeypatch):
                 }
             )
 
-    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+    monkeypatch.setattr(lib, "create_default_session", lambda: _Session())
 
     result = analyze(
         input_data="a chunk of packed evidence",

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -1939,10 +1939,7 @@ def test_nonstream_transport_uses_exact_mode_url_headers_and_timeout(
     response = _TransportResponse(response_payload)
     session = _RecordingSession(response)
     monkeypatch.setattr(
-        qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
-        raising=False,
+        qwencloud, "create_default_session", lambda: session, raising=False
     )
     monkeypatch.setattr(
         qwencloud,
@@ -2005,7 +2002,7 @@ def test_nonstream_cleanup_failures_never_mask_result_or_provider_error(
         response,
         close_error=RuntimeError("RAW-SESSION-CLOSE-CANARY"),
     )
-    monkeypatch.setattr(qwencloud, "requests", SimpleNamespace(Session=lambda: session))
+    monkeypatch.setattr(qwencloud, "create_default_session", lambda: session)
     monkeypatch.setattr(
         qwencloud,
         "get_runtime_config_snapshot",
@@ -2065,8 +2062,8 @@ def test_streaming_transport_transfers_response_and_session_ownership(
     session = _RecordingSession(response)
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     monkeypatch.setattr(
         qwencloud,
@@ -2113,10 +2110,7 @@ def test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none(
     )
     session = _RecordingSession(response)
     monkeypatch.setattr(
-        qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
-        raising=False,
+        qwencloud, "create_default_session", lambda: session, raising=False
     )
     monkeypatch.setenv("DASHSCOPE_API_KEY", "qwen-env-lower-priority")
     monkeypatch.setenv("OPENAI_API_KEY", "openai-env-canary")
@@ -2195,8 +2189,8 @@ def test_direct_adapter_loads_alias_only_qwencloud_config_without_mutation_or_le
     session = _RecordingSession(response)
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     monkeypatch.setenv("QWEN_ALIAS_KEY", "alias-key-canary")
     source = {
@@ -2270,8 +2264,8 @@ def test_direct_adapter_canonical_qwencloud_config_overrides_alias_in_any_order(
     session = _RecordingSession(response)
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     monkeypatch.setenv("QWEN_ALIAS_KEY", "alias-key-canary")
     monkeypatch.setenv("QWEN_CANONICAL_KEY", "canonical-key-canary")
@@ -2360,8 +2354,8 @@ def test_direct_adapter_rejects_malformed_canonical_table_without_alias_leakage(
         lambda: SimpleNamespace(values=source),
     )
     monkeypatch.setattr(
-        qwencloud.requests,
-        "Session",
+        qwencloud,
+        "create_default_session",
         lambda: pytest.fail("malformed Qwen config must fail before network"),
     )
 
@@ -2392,8 +2386,8 @@ def test_direct_adapter_rejects_alias_only_malformed_table_before_network(
         lambda: SimpleNamespace(values=source),
     )
     monkeypatch.setattr(
-        qwencloud.requests,
-        "Session",
+        qwencloud,
+        "create_default_session",
         lambda: pytest.fail("malformed Qwen config must fail before network"),
     )
 
@@ -2430,8 +2424,8 @@ def test_direct_adapter_ignores_malformed_alias_when_canonical_is_valid(
     session = _RecordingSession(response)
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     canonical = {
         "api_key": "canonical-key",
@@ -2495,7 +2489,11 @@ def test_direct_adapter_rejects_malformed_provider_config_before_network(
     def unexpected_session() -> Never:
         raise AssertionError("network must not be initialized")
 
-    monkeypatch.setattr(qwencloud.requests, "Session", unexpected_session)
+    monkeypatch.setattr(
+        qwencloud,
+        "create_default_session",
+        unexpected_session,
+    )
     monkeypatch.setattr(
         qwencloud,
         "get_runtime_config_snapshot",
@@ -2530,8 +2528,8 @@ def test_direct_adapter_uses_stripped_lower_key_and_explicit_base_override(
     session = _RecordingSession(response)
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     monkeypatch.setenv("QWEN_KEY", "  env-fallback-key  ")
     monkeypatch.setattr(
@@ -2573,7 +2571,11 @@ def test_direct_adapter_rejects_unresolved_placeholders_before_network(
     def unexpected_session() -> Never:
         raise AssertionError("network must not be initialized")
 
-    monkeypatch.setattr(qwencloud.requests, "Session", unexpected_session)
+    monkeypatch.setattr(
+        qwencloud,
+        "create_default_session",
+        unexpected_session,
+    )
     monkeypatch.setenv("DASHSCOPE_API_KEY", " your_key ")
     monkeypatch.setattr(
         qwencloud,
@@ -2887,10 +2889,10 @@ def test_nontransient_4xx_and_mode_model_mismatch_are_not_retried(
     for index, response in enumerate(responses):
         session = _RecordingSession(response)
         monkeypatch.setattr(
-            qwencloud,
-            "requests",
-            SimpleNamespace(Session=lambda: session),
-        )
+        qwencloud,
+        "create_default_session",
+        lambda: session,
+    )
         monkeypatch.setattr(
             qwencloud,
             "get_runtime_config_snapshot",
@@ -2975,8 +2977,8 @@ def test_qwencloud_errors_and_logs_redact_private_values(
     session = _RecordingSession(response)
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     monkeypatch.setattr(
         qwencloud,
@@ -3068,10 +3070,10 @@ def test_qwencloud_errors_and_logs_redact_private_values(
         )
         status_session = _RecordingSession(status_response)
         monkeypatch.setattr(
-            qwencloud,
-            "requests",
-            SimpleNamespace(Session=lambda: status_session),
-        )
+        qwencloud,
+        "create_default_session",
+        lambda: status_session,
+    )
         with (
             _captured_qwencloud_logs() as status_logs,
             pytest.raises(expected_type) as status_exc,
@@ -3097,10 +3099,10 @@ def test_qwencloud_errors_and_logs_redact_private_values(
     ):
         network_session = _RecordingSession(_TransportResponse({}), error=network_error)
         monkeypatch.setattr(
-            qwencloud,
-            "requests",
-            SimpleNamespace(Session=lambda: network_session),
-        )
+        qwencloud,
+        "create_default_session",
+        lambda: network_session,
+    )
         with (
             _captured_qwencloud_logs() as network_logs,
             pytest.raises(ChatProviderError) as network_exc,

--- a/Tests/LLM_Calls/test_qwencloud_streaming.py
+++ b/Tests/LLM_Calls/test_qwencloud_streaming.py
@@ -1978,8 +1978,8 @@ def test_stream_retries_only_before_first_consumed_byte(
     session = _ByteStreamSession([retryable, malformed_after_body, replay_canary])
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     monkeypatch.setattr(
         qwencloud,
@@ -2045,8 +2045,8 @@ def test_stream_body_read_failures_are_typed_closed_and_never_retried(
     session = _ByteStreamSession([response])
     monkeypatch.setattr(
         qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
+        "create_default_session",
+        lambda: session,
     )
     monkeypatch.setattr(
         qwencloud,

--- a/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
+++ b/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
@@ -147,6 +147,18 @@ class _FakeSession:
         del args, kwargs
         return self.response
 
+    # task-19830: `summarize_with_local_llm` now opens its session with
+    # `with create_default_session() as session:` -- this fake stands in for
+    # that factory's return value, so it needs the context-manager protocol
+    # too. `requests.Session.__exit__` just calls `self.close()`; nothing
+    # here needs cleanup, so both dunders are no-ops.
+    def __enter__(self) -> "_FakeSession":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        del exc_info
+        return None
+
 
 def _local_settings(*, llama_endpoint: str = "http://llama.invalid") -> dict[str, Any]:
     # task-17382: this fixture used to key the llama section as "llama_api",
@@ -459,8 +471,11 @@ def _invoke_local_input(monkeypatch: pytest.MonkeyPatch) -> object:
     response = _FakeResponse(
         json_data={"choices": [{"message": {"content": "  fixed summary  "}}]}
     )
+    # task-19830: `summarize_with_local_llm` gets its session from
+    # `create_default_session()` now, not a bare `requests.post` call -- the
+    # factory (imported into this module's namespace) is the seam to fake.
     monkeypatch.setattr(
-        local_summarization.requests, "post", lambda *args, **kwargs: response
+        local_summarization, "create_default_session", lambda: _FakeSession(response)
     )
     return local_summarization.summarize_with_local_llm(
         LOCAL_INPUT_CANARY,
@@ -473,8 +488,8 @@ def _invoke_local_prompt(monkeypatch: pytest.MonkeyPatch) -> object:
     response = _FakeResponse(json_data={"content": "  fixed llama summary  "})
     monkeypatch.setattr(local_summarization, "load_settings", _local_settings)
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         lambda: _FakeSession(response),
     )
     return local_summarization.summarize_with_llama(
@@ -513,7 +528,7 @@ def _invoke_local_response(monkeypatch: pytest.MonkeyPatch) -> object:
         lines=(f"data: {{{LOCAL_RESPONSE_CANARY}".encode(), b"data: [DONE]")
     )
     monkeypatch.setattr(
-        local_summarization.requests, "post", lambda *args, **kwargs: response
+        local_summarization, "create_default_session", lambda: _FakeSession(response)
     )
     generator = local_summarization.summarize_with_local_llm(
         "fixed input",
@@ -529,7 +544,14 @@ def _invoke_local_exception(monkeypatch: pytest.MonkeyPatch) -> object:
         del args, kwargs
         raise RuntimeError(LOCAL_EXCEPTION_CANARY)
 
-    monkeypatch.setattr(local_summarization.requests, "post", raise_private_exception)
+    # `summarize_with_local_llm` wraps its ENTIRE body (session creation
+    # included) in one `try/except Exception`, so raising here -- at
+    # `create_default_session()` -- reaches the exact same handler a raise
+    # from `.post()` would, with the same observable (hidden-exception)
+    # outcome.
+    monkeypatch.setattr(
+        local_summarization, "create_default_session", raise_private_exception
+    )
     return local_summarization.summarize_with_local_llm(
         "fixed input",
         "fixed prompt",
@@ -2664,8 +2686,8 @@ def test_local_core_llama_malformed_stream_logs_only_safe_length(
     )
     monkeypatch.setattr(local_summarization, "load_settings", _local_settings)
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         lambda: _FakeSession(response),
     )
 
@@ -2706,8 +2728,8 @@ def test_local_core_llama_success_hides_prompt_and_endpoint_canaries(
         lambda: _local_settings(llama_endpoint=LOCAL_PATH_CANARY),
     )
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         lambda: _FakeSession(response),
     )
 
@@ -2730,8 +2752,8 @@ def test_local_core_llama_accepts_non_string_system_message_as_before(
     response = _FakeResponse(json_data={"content": "  fixed llama summary  "})
     monkeypatch.setattr(local_summarization, "load_settings", _local_settings)
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         lambda: _FakeSession(response),
     )
 
@@ -2758,8 +2780,8 @@ def test_local_core_kobold_missing_key_error_contract_is_unchanged(
     settings["kobold_api"]["api_key"] = None
     monkeypatch.setattr(local_summarization, "load_settings", lambda: settings)
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         transport_must_not_run,
     )
 
@@ -2786,8 +2808,8 @@ def test_local_core_kobold_stream_fully_consumed_without_private_diagnostics(
     )
     monkeypatch.setattr(local_summarization, "load_settings", _local_settings)
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         lambda: _FakeSession(response),
     )
 
@@ -3002,8 +3024,8 @@ def test_tabby_missing_credential_error_contract_is_unchanged(
         raise AssertionError("transport invoked before missing-key failure")
 
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         transport_must_not_run,
     )
 
@@ -3706,8 +3728,8 @@ def test_local_custom_openai_missing_config_credential_contract_is_unchanged(
         raise AssertionError("transport invoked before missing-key return")
 
     monkeypatch.setattr(
-        local_summarization.requests,
-        "Session",
+        local_summarization,
+        "create_default_session",
         transport_must_not_run,
     )
 

--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -968,6 +968,132 @@ def test_requests_sink_cap_still_enforced():
 
 
 # ---------------------------------------------------------------------------
+# Default-timeout session factory (task-19830)
+# ---------------------------------------------------------------------------
+from tldw_chatbook.Utils.egress import (
+    DEFAULT_SESSION_CONNECT_TIMEOUT,
+    DEFAULT_SESSION_READ_TIMEOUT,
+    DefaultTimeoutSession,
+    create_default_session,
+    default_session_timeout,
+)
+
+
+class _TimeoutRecordingAdapter(BaseAdapter):
+    """Records the ``timeout`` kwarg ``Session.send()`` hands the adapter on
+    every request, without touching the network."""
+
+    def __init__(self):
+        super().__init__()
+        self.seen_timeouts = []
+
+    def send(self, request, **kwargs):
+        self.seen_timeouts.append(kwargs.get("timeout"))
+        resp = RequestsResponse()
+        resp.status_code = 200
+        resp.raw = io.BytesIO(b"ok")
+        resp.url = request.url
+        resp.request = request
+        return resp
+
+    def close(self):
+        pass
+
+
+def _default_session_with_recorder(**factory_kwargs):
+    sess = create_default_session(**factory_kwargs)
+    adapter = _TimeoutRecordingAdapter()
+    sess.mount("http://", adapter)
+    sess.mount("https://", adapter)
+    return sess, adapter
+
+
+def test_create_default_session_returns_a_default_timeout_session():
+    sess = create_default_session()
+    assert isinstance(sess, DefaultTimeoutSession)
+    assert isinstance(sess, requests_lib.Session)
+
+
+def test_default_session_applies_default_timeout_when_get_omits_one():
+    sess, adapter = _default_session_with_recorder()
+    sess.get("https://example.com/")
+    assert adapter.seen_timeouts == [
+        (DEFAULT_SESSION_CONNECT_TIMEOUT, DEFAULT_SESSION_READ_TIMEOUT)
+    ]
+
+
+def test_default_session_applies_default_timeout_to_post_too():
+    sess, adapter = _default_session_with_recorder()
+    sess.post("https://example.com/", json={"a": 1})
+    assert adapter.seen_timeouts == [
+        (DEFAULT_SESSION_CONNECT_TIMEOUT, DEFAULT_SESSION_READ_TIMEOUT)
+    ]
+
+
+def test_explicit_timeout_keyword_wins_over_default():
+    sess, adapter = _default_session_with_recorder()
+    sess.get("https://example.com/", timeout=5)
+    assert adapter.seen_timeouts == [5]
+
+
+def test_explicit_timeout_none_is_respected_not_overridden():
+    """``timeout=None`` is a deliberate 'no timeout' from the caller -- the
+    session must not paper over it with its own default."""
+    sess, adapter = _default_session_with_recorder()
+    sess.get("https://example.com/", timeout=None)
+    assert adapter.seen_timeouts == [None]
+
+
+def test_explicit_positional_timeout_on_request_wins_over_default():
+    """``Session.request(method, url, params, data, headers, cookies, files,
+    auth, timeout, ...)`` -- a caller passing timeout as the 9th positional
+    argument (7th after method/url) must not get it overridden either."""
+    sess, adapter = _default_session_with_recorder()
+    sess.request("GET", "https://example.com/", None, None, None, None, None, None, 7)
+    assert adapter.seen_timeouts == [7]
+
+
+def test_default_session_timeout_reads_config_not_hardcoded(monkeypatch):
+    monkeypatch.setattr(
+        egress,
+        "get_cli_setting",
+        lambda section, key=None, default=None: {
+            "request_connect_timeout_seconds": 3,
+            "request_read_timeout_seconds": 45,
+        }.get(key, default),
+    )
+    assert default_session_timeout() == (3.0, 45.0)
+
+
+def test_create_default_session_honours_config_default(monkeypatch):
+    monkeypatch.setattr(
+        egress,
+        "get_cli_setting",
+        lambda section, key=None, default=None: {
+            "request_connect_timeout_seconds": 2,
+            "request_read_timeout_seconds": 9,
+        }.get(key, default),
+    )
+    sess, adapter = _default_session_with_recorder()
+    sess.get("https://example.com/")
+    assert adapter.seen_timeouts == [(2.0, 9.0)]
+
+
+def test_explicit_factory_timeout_overrides_config(monkeypatch):
+    monkeypatch.setattr(
+        egress,
+        "get_cli_setting",
+        lambda section, key=None, default=None: {
+            "request_connect_timeout_seconds": 2,
+            "request_read_timeout_seconds": 9,
+        }.get(key, default),
+    )
+    sess, adapter = _default_session_with_recorder(timeout=(1.0, 1.0))
+    sess.get("https://example.com/")
+    assert adapter.seen_timeouts == [(1.0, 1.0)]
+
+
+# ---------------------------------------------------------------------------
 # Guarded aiohttp helper + Playwright chain validation
 # ---------------------------------------------------------------------------
 from tldw_chatbook.Utils.egress import (

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6106,3 +6106,46 @@ side wholesale, **verify the taken pin reproduces from its own tree before
 concluding anything** — and separately review the delta between it and the pin
 you last reviewed. Those are two different questions, and the first being green
 does not answer the second.
+
+## A construction-symbol swap silently disconnects every test that mocks it by name, and those tests are not where you'd look (TASK-19830, 2026-08-22)
+
+**What happened.** Converting 49 `requests.Session()` construction sites
+across six `LLM_Calls/` modules to a shared `create_default_session()`
+factory looked purely mechanical — same object shape, same methods, an
+explicit `timeout=` still wins. `Tests/LLM_Calls/ -q` went from clean to
+**55 failed**. The cause was never the production code: dozens of tests across
+the repo intercepted the OLD symbol by name —
+`monkeypatch.setattr(module.requests, "Session", fake_session)`, a
+`SimpleNamespace(Session=lambda: session)` swap of the whole `requests`
+module reference, or a `unittest.mock.patch("...module.requests.Session")`
+string target. Once the production code called `create_default_session()` (a
+function imported into the module's own namespace) instead of
+`requests.Session()`, none of those patches touched anything: the real code
+path went unmocked, so real code ran a live/blocked network call, or an
+`AttributeError`, or (worst) a fake that silently no longer applied — a
+`transport_must_not_run` negative-path assertion that "passed" only because
+the mock was no longer wired to anything, not because the code was actually
+verified not to reach the network.
+
+**Where the tests actually were.** `Tests/LLM_Calls/` alone had 8 affected
+files. The largest single file was `Tests/Chat/test_chat_functions.py` — 26
+occurrences, zero of which are under `Tests/LLM_Calls/`. In total: **12 test
+files, 91 individual mock call sites**, across `Tests/Chat/` and
+`Tests/LLM_Calls/` both, found only by grepping every import alias each
+converted module is known under (`cloud_adapters`, `local_adapters`,
+`llm_calls`, `lib`, `sgl`, `legacy_adapters`, `llm_api_calls_module`, ...)
+against the pattern `<alias>.requests` across the **entire** `Tests/` tree —
+not by running the package's own test directory and calling it done.
+
+**What to do.** Before swapping a construction symbol (a class, a factory
+function, anything a test might intercept by patching its name), grep the
+**whole test tree** — not just the package under change's own test
+directory — for every import alias of the module being touched, combined
+with the OLD symbol's attribute name (`<alias>\.requests` here). Do this
+*before* running the gate, not after chasing the first red result; the
+failure signatures vary (a live network attempt, an `AttributeError`, a
+values-mismatch three calls deep) and none of them says "your mock stopped
+being wired up." A negative-path test (`transport_must_not_run`,
+"assert this was never called") is the most dangerous case: it can go on
+reporting green forever while checking nothing, because a disconnected mock
+and a correctly-guarded code path are indistinguishable from the outside.

--- a/backlog/tasks/task-19830 - Unbounded-requests-calls-app-wide-need-a-default-timeout-session.md
+++ b/backlog/tasks/task-19830 - Unbounded-requests-calls-app-wide-need-a-default-timeout-session.md
@@ -36,7 +36,8 @@ has to remember one individually -- and 40 of them do not.
 Files: `LLM_Calls/` (LLM_API_Calls, LLM_API_Calls_Local, Local_Summarization_Lib,
 Summarization_General_Lib, hosted_chat, qwencloud), `Embeddings/Embeddings_Lib`,
 `Character_Chat/local_character_persona_service`, `Local_Inference/ollama_model_mgmt`,
-`TTS/backends/kokoro`, `Utils/egress`, `Web_Scraping/Confluence/confluence_auth`.
+`TTS/backends/kokoro` (since fixed by task-19560), `Utils/egress`,
+`Web_Scraping/Confluence/confluence_auth`.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -105,8 +106,12 @@ flow to catch `session.post(...)` as well as `requests.post(...)`. 3
 assertion tests (`LLM_Calls/` fully clean; whole-package unexempted-violation
 check; exemption-set freshness) + 8 scanner self-tests. `EXEMPT_FILES`:
 `Embeddings/Embeddings_Lib.py`, `Local_Inference/ollama_model_mgmt.py`,
-`TTS/backends/kokoro.py`, `Web_Scraping/Confluence/confluence_auth.py`,
+`Web_Scraping/Confluence/confluence_auth.py`,
 `Web_Scraping/WebSearch_APIs.py`, `Utils/egress.py` (its own internals).
+`TTS/backends/kokoro.py` was on that list until task-19560 shipped its
+download timeouts mid-review; the guard's own stale-exemption check is what
+caught it, which is the argument for naming files individually rather than
+skipping a directory.
 Red-proofed by hand: appended a bare `requests.Session()` to `qwencloud.py`,
 confirmed both assertion tests failed and named the file+line, removed it,
 confirmed green again.

--- a/backlog/tasks/task-19830 - Unbounded-requests-calls-app-wide-need-a-default-timeout-session.md
+++ b/backlog/tasks/task-19830 - Unbounded-requests-calls-app-wide-need-a-default-timeout-session.md
@@ -1,0 +1,143 @@
+---
+id: TASK-19830
+title: Unbounded requests calls app-wide need a default-timeout session
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-21'
+updated_date: '2026-08-22 08:18'
+labels:
+  - performance
+  - reliability
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while fixing task-19560, which named two unbounded `requests.post` calls
+in the summarization libraries. An audit of those two modules found 29; an
+audit of the whole package found the problem is systemic.
+
+Measured on dev with an AST sweep (`requests.Session()` constructions, and
+`post`/`get`/`put`/`delete`/`patch`/`request` calls with no `timeout=`):
+
+    requests.Session() construction sites: 56
+    timeout-less request calls:            40
+    files involved:                        13
+
+A `requests` call with no timeout waits forever on a half-open connection. On
+the LLM paths that means a chat or summarization that never returns and cannot
+be cancelled; several of these also run on the event loop, so the whole TUI
+stops. `requests` has no per-session default timeout, which is why every site
+has to remember one individually -- and 40 of them do not.
+
+Files: `LLM_Calls/` (LLM_API_Calls, LLM_API_Calls_Local, Local_Summarization_Lib,
+Summarization_General_Lib, hosted_chat, qwencloud), `Embeddings/Embeddings_Lib`,
+`Character_Chat/local_character_persona_service`, `Local_Inference/ollama_model_mgmt`,
+`TTS/backends/kokoro`, `Utils/egress`, `Web_Scraping/Confluence/confluence_auth`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A shared session factory applies a default connect/read timeout to every request that does not pass one explicitly, and an explicit `timeout=` still wins.
+- [x] #2 The LLM_Calls package uses it everywhere -- no bare `requests.Session()` and no timeout-less request call remains there.
+- [x] #3 An architecture guard test fails when a new bare `requests.Session()` or timeout-less request call is added to the covered area, so this cannot silently regress.
+- [x] #4 Any file NOT yet converted is listed explicitly in that guard's exemption set, so the remaining work is visible rather than implied.
+- [x] #5 The default is config-driven, consistent with the existing `api_timeout` settings the OpenAI path already reads.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+`Utils/egress.py` is the natural home: it already owns HTTP policy for this
+app and already carries the house default (`guarded_fetch_requests(timeout:
+float = 30.0)`).
+
+Shape: a `requests.Session` subclass overriding `request()` to fill in
+`timeout` when the caller omitted it, plus a factory. Then swap the
+construction sites. A call that already passes `timeout=` is untouched by
+construction, which keeps every deliberate per-provider timeout intact.
+
+Sequence it so each step is independently reviewable:
+1. factory + guard test scoped to `LLM_Calls/`, other files exempted and listed;
+2. burn down the exemption list a subsystem at a time.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Factory** (`tldw_chatbook/Utils/egress.py`): `DefaultTimeoutSession(requests.
+Session)` overrides only `request()` (every verb funnels through it), filling
+`kwargs["timeout"]` with `default_session_timeout()` -- a config-driven
+`(connect, read)` tuple read from `[web_security] request_connect_timeout_
+seconds`/`request_read_timeout_seconds` (falls back to `10.0`/`30.0`) -- only
+when the caller supplied neither the `timeout=` keyword nor a 7th+ positional
+argument. `create_default_session(*, timeout=None)` is the factory function
+every call site now imports. A tuple, not one number: `requests` re-arms the
+READ half per chunk on a streamed response, so a slow-but-progressing stream
+is only killed by a stall between chunks, never total elapsed duration --
+several converted call sites stream.
+
+**Re-derived the AST sweep** rather than trusting the task's numbers: 56
+`Session()` sites (exact match), 34 timeout-less calls / 12 files (vs the
+task's 40/13 -- explained by drift since filing: `Character_Chat/local_
+character_persona_service.py`, named in the description, no longer imports
+`requests`; `Web_Scraping/WebSearch_APIs.py`, not named, had real findings).
+
+**Converted all of `LLM_Calls/`**: 49 `Session()` sites across 6 files, plus
+2 bare `requests.post` calls wrapped in `with create_default_session() as
+session:` (OpenAI embeddings in `LLM_API_Calls.py`; `summarize_with_local_llm`
+in `Local_Summarization_Lib.py`). One bare `requests.post` (`summarize_with_
+anthropic`, `Summarization_General_Lib.py`) deliberately NOT wrapped in a
+session -- it streams (`stream=streaming`), and closing a session mid-read
+risks tearing down the connection pool under an in-flight response; got
+`timeout=default_session_timeout()` added directly instead, preserving the
+`allow_redirects=False` credential-forwarding comment (task-19557) verbatim.
+Verified: zero remaining bare `Session()`/timeout-less calls anywhere in
+`LLM_Calls/`.
+
+**Guard** (`Tests/Architecture/test_default_timeout_session_guard.py`): an
+AST walker scans every file under `tldw_chatbook/` that imports `requests`
+(module-level or a lazy in-function import), tracking session-variable data
+flow to catch `session.post(...)` as well as `requests.post(...)`. 3
+assertion tests (`LLM_Calls/` fully clean; whole-package unexempted-violation
+check; exemption-set freshness) + 8 scanner self-tests. `EXEMPT_FILES`:
+`Embeddings/Embeddings_Lib.py`, `Local_Inference/ollama_model_mgmt.py`,
+`TTS/backends/kokoro.py`, `Web_Scraping/Confluence/confluence_auth.py`,
+`Web_Scraping/WebSearch_APIs.py`, `Utils/egress.py` (its own internals).
+Red-proofed by hand: appended a bare `requests.Session()` to `qwencloud.py`,
+confirmed both assertion tests failed and named the file+line, removed it,
+confirmed green again.
+
+**The dominant cost of this task**: converting a construction symbol
+(`requests.Session()` -> `create_default_session()`) silently disconnected
+every test that monkeypatched the OLD symbol by name. Found and fixed 91
+such mock call sites across 12 test files (8 in `Tests/LLM_Calls/`, 5 in
+`Tests/Chat/` -- `test_chat_functions.py` alone had 26, none of which
+`Tests/LLM_Calls/ -q` would have surfaced). Every fix retargets the SAME
+fake/response the test already built at `<module>.create_default_session`
+instead of `<module>.requests.Session`/`.post`. Left untouched (verified
+safe): `requests.Session.post`/`.close` class-level method patches (still
+work -- `DefaultTimeoutSession` doesn't override them), and mocks targeting
+files this task doesn't convert (`ollama_model_mgmt.py`) or call sites this
+task deliberately left bare (`summarize_with_anthropic`'s `requests.post`).
+Full A/B evidence and the per-file breakdown are in
+`.superpowers/sdd/19830-report.md`; a generalized lesson is recorded in
+`backlog/docs/lessons-testing-evidence.md`.
+
+**Gate**: `Tests/Architecture/` 173 passed / 5 pre-existing failures (both
+before and after, byte-identical failing set, confirmed via `git checkout
+HEAD --`). `Tests/LLM_Calls/` 1009 passed / 7 pre-existing failures (5
+diagnostic-privacy ledger + 2 anthropic-redirect-credential-leak, both
+reproduced against a fully unmodified checkout). Broad `-k "summariz or llm
+or api_call"` sweep across `Tests/`: pre-existing collection errors from
+missing optional deps (`numpy`/`jsonschema`/`playwright`) in this venv,
+unrelated to this task; all touched modules import cleanly.
+
+Files: `tldw_chatbook/Utils/egress.py`, `tldw_chatbook/config.py` (sample
+config keys), the 6 `LLM_Calls/` modules, `Tests/Utils/test_egress.py` (10
+new behavioural tests), `Tests/Architecture/test_default_timeout_session_
+guard.py` (new), and the 12 test files listed above.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -55,6 +55,7 @@ from tldw_chatbook.config import (
     resolve_provider_api_key,
 )
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+from tldw_chatbook.Utils.egress import create_default_session
 from tldw_chatbook.LLM_Calls.moonshot import (
     chat_with_moonshot as _strict_chat_with_moonshot,
 )
@@ -472,9 +473,12 @@ def get_openai_embeddings(input_data: str, model: str) -> List[float]:
     }
     try:
         logger.debug("OpenAI Embeddings: Posting request to embeddings API")
-        response = requests.post(
-            "https://api.openai.com/v1/embeddings", headers=headers, json=request_data
-        )
+        with create_default_session() as session:
+            response = session.post(
+                "https://api.openai.com/v1/embeddings",
+                headers=headers,
+                json=request_data,
+            )
         logger.debug(f"Full API response data: {response}")
         if response.status_code == 200:
             response_data = response.json()
@@ -786,7 +790,7 @@ def chat_with_openai(
             logger.debug("OpenAI: Posting request (streaming)")
 
             def stream_generator():
-                session_context = requests.Session()
+                session_context = create_default_session()
                 session = session_context.__enter__()
                 response = None
                 try:
@@ -873,7 +877,7 @@ def chat_with_openai(
                 allowed_methods=["POST"],  # Changed from method_whitelist
             )
             adapter = HTTPAdapter(max_retries=retry_strategy)
-            with requests.Session() as session:
+            with create_default_session() as session:
                 session.mount("https://", adapter)
                 session.mount("http://", adapter)  # Though OpenAI is https
                 response = session.post(
@@ -1565,7 +1569,7 @@ def chat_with_anthropic(
             allowed_methods=["POST"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
-        with requests.Session() as session:
+        with create_default_session() as session:
             session.mount("https://", adapter)
             response = session.post(
                 api_url,
@@ -2469,7 +2473,7 @@ def chat_with_cohere(
     logger.debug(f"Cohere request host: {safe_llm_url_host(COHERE_CHAT_URL)}")
 
     # --- Retry Mechanism ---
-    session = requests.Session()
+    session = create_default_session()
     retry_count = int(cohere_config.get("api_retries", 3))
     retry_delay = float(
         cohere_config.get("api_retry_delay", 1.0)
@@ -3080,7 +3084,7 @@ def chat_with_deepseek(
     try:
         if current_streaming:
             # ... (OpenAI-like streaming logic, use "DeepSeek" in logs) ...
-            with requests.Session() as session:
+            with create_default_session() as session:
                 response = session.post(
                     api_url, headers=headers, json=data, stream=True, timeout=180
                 )
@@ -3130,7 +3134,7 @@ def chat_with_deepseek(
                     allowed_methods=["POST"],
                 )
             )
-            with requests.Session() as session:
+            with create_default_session() as session:
                 session.mount("https://", adapter)
                 response = session.post(
                     api_url, headers=headers, json=data, timeout=120
@@ -3548,7 +3552,7 @@ def chat_with_google(
                 allowed_methods=["POST"],
             )
         )
-        with requests.Session() as session:
+        with create_default_session() as session:
             session.mount("https://", adapter)
             response = session.post(
                 api_url,
@@ -3981,7 +3985,7 @@ def chat_with_google(
             ) from e
     finally:
         # If streaming, the response object is closed inside stream_generator's finally.
-        # If not streaming, the response object is implicitly closed by the `with requests.Session() as session:` block ending.
+        # If not streaming, the response object is implicitly closed by the `with create_default_session() as session:` block ending.
         # However, if `session.post` was called outside `with` or `response` was from `session.post(stream=True)`
         # and an error occurred *before* entering `stream_generator`, it might need closing here.
         # The `nonlocal response` and assignment `response = session.post(...)` helps manage this.
@@ -4131,7 +4135,7 @@ def chat_with_groq(
     try:
         if current_streaming:
             # ... (OpenAI-like streaming logic, ensure "Groq" in logs) ...
-            with requests.Session() as session:
+            with create_default_session() as session:
                 response = session.post(
                     api_url, headers=headers, json=data, stream=True, timeout=180
                 )
@@ -4189,7 +4193,7 @@ def chat_with_groq(
                     allowed_methods=["POST"],
                 )
             )
-            with requests.Session() as session:
+            with create_default_session() as session:
                 session.mount("https://", adapter)
                 response = session.post(
                     api_url, headers=headers, json=data, timeout=120
@@ -4622,7 +4626,7 @@ def chat_with_huggingface(
                     # or method_whitelist for older versions.
                 )
             )
-            session = requests.Session()
+            session = create_default_session()
             session.mount("https://", adapter)
             session.mount("http://", adapter)
 
@@ -4906,7 +4910,7 @@ def chat_with_mistral(
     try:
         if current_streaming:
             # ... (OpenAI-like streaming logic, use "Mistral" in logs) ...
-            with requests.Session() as session:
+            with create_default_session() as session:
                 response = session.post(
                     api_url, headers=headers, json=data, stream=True, timeout=180
                 )
@@ -4950,7 +4954,7 @@ def chat_with_mistral(
                     allowed_methods=["POST"],
                 )
             )
-            with requests.Session() as session:
+            with create_default_session() as session:
                 session.mount("https://", adapter)
                 response = session.post(
                     api_url, headers=headers, json=data, timeout=120
@@ -5159,7 +5163,7 @@ def chat_with_openrouter(
     try:
         if current_streaming:
             # ... (OpenAI-like streaming logic, ensure "OpenRouter" in logs) ...
-            with requests.Session() as session:
+            with create_default_session() as session:
                 response = session.post(
                     api_url, headers=headers, json=data, stream=True, timeout=180
                 )
@@ -5204,7 +5208,7 @@ def chat_with_openrouter(
                     allowed_methods=["POST"],
                 )
             )
-            with requests.Session() as session:
+            with create_default_session() as session:
                 session.mount("https://", adapter)
                 response = session.post(
                     api_url, headers=headers, json=data, timeout=120

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.console_provider_support import (
 from tldw_chatbook.Utils.Utils import logging
 from tldw_chatbook.config import get_runtime_config_snapshot, load_settings
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+from tldw_chatbook.Utils.egress import create_default_session
 from tldw_chatbook.Utils.sensitive_llm_logging import (
     is_sensitive_llm_request,
     llm_content_byte_count,
@@ -266,7 +267,7 @@ def _chat_with_openai_compatible_local_server(
         )
 
     try:
-        session = requests.Session()
+        session = create_default_session()
         # Configure retries
         retry_strategy = Retry(
             total=llm_retry_count(api_retries),
@@ -1047,7 +1048,7 @@ def chat_with_kobold(
     )
 
     try:
-        session = requests.Session()
+        session = create_default_session()
         retry_strategy = Retry(
             total=llm_retry_count(api_retries),
             backoff_factor=api_retry_delay,

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -29,6 +29,7 @@ from urllib3 import Retry
 #
 # Import Local Libraries
 from tldw_chatbook.Utils.Utils import extract_text_from_segments, logging
+from tldw_chatbook.Utils.egress import create_default_session
 from tldw_chatbook.Utils.persistent_diagnostics import safe_metadata_token
 from tldw_chatbook.config import get_cli_setting, load_settings
 from tldw_chatbook.Internal_Prompts import get_internal_prompt
@@ -81,14 +82,19 @@ def summarize_with_local_llm(
         }
 
         logging.debug("Local LLM: Posting request")
-        response = requests.post(
-            "http://127.0.0.1:8080/v1/chat/completions",
-            headers=headers,
-            json=data,
-            # task-19560: unbounded before this. A local server that accepts
-            # the connection and then stalls hung the caller forever.
-            timeout=int(get_cli_setting("local_llm", "api_timeout", 120)),
-        )
+        with create_default_session() as session:
+            response = session.post(
+                "http://127.0.0.1:8080/v1/chat/completions",
+                headers=headers,
+                json=data,
+                # task-19560 set this per-provider timeout; task-19830 moved
+                # the call onto the shared session. Both are kept on purpose:
+                # the session is the safety net for calls that forget a
+                # timeout, and an explicit `timeout=` always wins over it
+                # (see `DefaultTimeoutSession.request`), so the user-facing
+                # `local_llm.api_timeout` knob still governs this call.
+                timeout=int(get_cli_setting("local_llm", "api_timeout", 120)),
+            )
 
         if response.status_code == 200:
             if streaming:
@@ -387,7 +393,7 @@ def summarize_with_llama(
         }
 
         # Create a session
-        session = requests.Session()
+        session = create_default_session()
 
         # Load config values
         retry_count = int(llama_config.get("api_retries", 3))
@@ -631,7 +637,7 @@ def summarize_with_kobold(
             logging.debug("Kobold Summarization: Streaming mode enabled")
             try:
                 # Create a session
-                session = requests.Session()
+                session = create_default_session()
 
                 # Load config values
                 retry_count = kobold_legacy["api_retries"]
@@ -708,7 +714,7 @@ def summarize_with_kobold(
         else:
             try:
                 # Create a session
-                session = requests.Session()
+                session = create_default_session()
 
                 # Load config values
                 retry_count = kobold_legacy["api_retries"]
@@ -902,7 +908,7 @@ def summarize_with_oobabooga(
         if streaming:
             logging.debug("Oobabooga: Streaming mode enabled")
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["ooba_api"]["api_retries"]
@@ -965,7 +971,7 @@ def summarize_with_oobabooga(
                 return f"Error summarizing with Oobabooga: {str(e)}"
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["ooba_api"]["api_retries"]
@@ -1134,7 +1140,7 @@ def summarize_with_tabbyapi(
             logging.debug("TabbyAPI: Streaming mode enabled")
             try:
                 # Create a session
-                session = requests.Session()
+                session = create_default_session()
 
                 # Load config values
                 retry_count = tabby_legacy["api_retries"]
@@ -1202,7 +1208,7 @@ def summarize_with_tabbyapi(
         else:
             try:
                 # Create a session
-                session = requests.Session()
+                session = create_default_session()
 
                 # Load config values
                 retry_count = tabby_legacy["api_retries"]
@@ -1392,7 +1398,7 @@ def summarize_with_vllm(
         # Handle streaming
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["vllm_api"]["api_retries"]
@@ -1443,7 +1449,7 @@ def summarize_with_vllm(
         # Handle non-streaming
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["vllm_api"]["api_retries"]
@@ -1655,7 +1661,7 @@ def summarize_with_ollama(
 
         try:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["ollama_api"]["api_retries"]
@@ -1739,7 +1745,7 @@ def summarize_with_ollama(
             # Non-streaming => parse entire JSON once and return the text
             try:
                 # Create a session
-                session = requests.Session()
+                session = create_default_session()
 
                 # Load config values
                 retry_count = loaded_config_data["ollama_api"]["api_retries"]
@@ -1926,7 +1932,7 @@ def summarize_with_custom_openai(
 
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["custom_openai_api"]["api_retries"]
@@ -1979,7 +1985,7 @@ def summarize_with_custom_openai(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["custom_openai_api"]["api_retries"]
@@ -2184,7 +2190,7 @@ def summarize_with_custom_openai_2(
 
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["custom_openai_api_2"]["api_retries"]
@@ -2237,7 +2243,7 @@ def summarize_with_custom_openai_2(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = loaded_config_data["custom_openai_api_2"]["api_retries"]

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -45,6 +45,7 @@ from tldw_chatbook.LLM_Calls.Local_Summarization_Lib import (
 from tldw_chatbook.Logging_Config import logging
 from tldw_chatbook.config import get_cli_setting
 from tldw_chatbook.Internal_Prompts import get_internal_prompt
+from tldw_chatbook.Utils.egress import create_default_session, default_session_timeout
 from tldw_chatbook.Utils.persistent_diagnostics import safe_metadata_token
 from tldw_chatbook.model_capabilities import (
     anthropic_model_rejects_sampling_params,
@@ -896,7 +897,7 @@ def summarize_with_openai(
             payload["temperature"] = temp
 
         # --- Retry Logic --- (Copied from original, seems reasonable)
-        session = requests.Session()
+        session = create_default_session()
         retry_count = int(get_cli_setting("openai_api", "api_retries", 3))
         retry_delay = int(
             get_cli_setting("openai_api", "api_retry_delay", 1)
@@ -1100,7 +1101,7 @@ def summarize_with_anthropic(
         for attempt in range(max_retries):
             try:
                 # Create a session
-                session = requests.Session()
+                session = create_default_session()
 
                 # Load config values
                 retry_count = int(get_cli_setting("anthropic_api", "api_retries", 3))
@@ -1127,9 +1128,16 @@ def summarize_with_anthropic(
                     headers=headers,
                     json=data,
                     stream=streaming,
-                    # task-19560: unbounded before this -- a half-open
-                    # connection hung the summarization forever. Same
-                    # config-driven idiom the OpenAI path already uses.
+                    # task-19830: this bare module-level `requests.post`
+                    # had no timeout at all -- a stalled connection hung
+                    # forever with no way to cancel. task-19560 then gave it
+                    # this provider-specific value, which is kept in
+                    # preference to the session-wide default because
+                    # `anthropic_api.api_timeout` is a knob users can already
+                    # set. `requests` re-arms the read timeout per chunk, so
+                    # a slow-but-progressing stream (see `stream=streaming`
+                    # above) is only killed by a stall on one chunk, never by
+                    # total elapsed duration.
                     timeout=int(
                         get_cli_setting("anthropic_api", "api_timeout", 120)
                     ),
@@ -1363,7 +1371,7 @@ def summarize_with_cohere(
 
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("cohere_api", "api_retries", 3))
@@ -1459,7 +1467,7 @@ def summarize_with_cohere(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("cohere_api", "api_retries", 3))
@@ -1612,7 +1620,7 @@ def summarize_with_groq(
         logging.debug("Groq: Submitting request to API endpoint")
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("groq_api", "api_retries", 3))
@@ -1665,7 +1673,7 @@ def summarize_with_groq(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("groq_api", "api_retries", 3))
@@ -1793,7 +1801,7 @@ def summarize_with_openrouter(
     if streaming:
         try:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("openrouter_api", "api_retries", 3))
@@ -1883,7 +1891,7 @@ def summarize_with_openrouter(
     else:
         try:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("openrouter_api", "api_retries", 3))
@@ -2025,7 +2033,7 @@ def summarize_with_huggingface(
         logging.debug("HuggingFace: Submitting request...")
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("huggingface_api", "api_retries", 3))
@@ -2079,7 +2087,7 @@ def summarize_with_huggingface(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("huggingface_api", "api_retries", 3))
@@ -2214,7 +2222,7 @@ def summarize_with_deepseek(
 
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("deepseek_api", "api_retries", 3))
@@ -2273,7 +2281,7 @@ def summarize_with_deepseek(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("deepseek_api", "api_retries", 3))
@@ -2401,7 +2409,7 @@ def summarize_with_mistral(
 
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("mistral_api", "api_retries", 3))
@@ -2474,7 +2482,7 @@ def summarize_with_mistral(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("mistral_api", "api_retries", 3))
@@ -2622,7 +2630,7 @@ def summarize_with_google(
 
         if streaming:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("google_api", "api_retries", 3))
@@ -2678,7 +2686,7 @@ def summarize_with_google(
             return stream_generator()
         else:
             # Create a session
-            session = requests.Session()
+            session = create_default_session()
 
             # Load config values
             retry_count = int(get_cli_setting("google_api", "api_retries", 3))

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatRateLimitError,
 )
 from tldw_chatbook.LLM_Calls.hosted_chat_streaming import OwnedSSEStream, SSERecord
+from tldw_chatbook.Utils.egress import create_default_session
 from tldw_chatbook.Utils.sensitive_llm_logging import llm_retry_count
 
 
@@ -530,7 +531,7 @@ def owned_json_post(
 
     retries = llm_retry_count(max(0, config.retries))
     url = f"{base_url}/{route}"
-    session = requests.Session()
+    session = create_default_session()
     response: requests.Response | None = None
     stream_owns_session = False
     try:

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -43,6 +43,7 @@ from tldw_chatbook.config import (
     provider_settings_for_key,
     resolve_provider_api_key,
 )
+from tldw_chatbook.Utils.egress import create_default_session
 from tldw_chatbook.Utils.sensitive_llm_logging import llm_retry_count
 
 logger = logger.bind(module="qwencloud")
@@ -1165,7 +1166,7 @@ def chat_with_qwencloud(
         "Content-Type": "application/json",
     }
 
-    session = requests.Session()
+    session = create_default_session()
     stream_owns_session = False
     try:
         session.mount("https://", adapter)

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -23,7 +23,7 @@ import ipaddress
 import json as _json
 import socket
 from dataclasses import dataclass, field
-from typing import Iterable, List, Mapping, MutableMapping
+from typing import Any, Iterable, List, Mapping, MutableMapping
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -932,13 +932,48 @@ class DefaultTimeoutSession(requests.Session):
     this only fills the gap when the caller specified neither (task-19830).
     """
 
-    def __init__(self, *args, default_timeout=None, **kwargs) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        default_timeout: float | tuple[float, float] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Build the session.
+
+        Args:
+            *args: Forwarded unchanged to ``requests.Session``.
+            default_timeout: The timeout to fill in for calls that omit one
+                -- a scalar (both halves) or a ``(connect, read)`` tuple.
+                ``None`` means read it from config via
+                ``default_session_timeout()`` at construction time.
+            **kwargs: Forwarded unchanged to ``requests.Session``.
+        """
         super().__init__(*args, **kwargs)
-        self.default_timeout = (
+        self.default_timeout: float | tuple[float, float] = (
             default_session_timeout() if default_timeout is None else default_timeout
         )
 
-    def request(self, method, url, *args, **kwargs):  # type: ignore[override]
+    def request(  # type: ignore[override]
+        self, method: str, url: str, *args: Any, **kwargs: Any
+    ) -> requests.Response:
+        """Dispatch the request, supplying ``default_timeout`` if needed.
+
+        Args:
+            method: HTTP method, as ``requests.Session.request`` takes it.
+            url: The target URL.
+            *args: Positional arguments forwarded to
+                ``requests.Session.request``.
+            **kwargs: Keyword arguments forwarded likewise. An explicit
+                ``timeout`` here (or in the positional slot) is preserved.
+
+        Returns:
+            The ``requests.Response``, unchanged.
+
+        Raises:
+            requests.RequestException: Whatever the underlying request
+                raises, including the ``Timeout`` this default exists to
+                produce instead of blocking forever.
+        """
         # Session.request's positional signature (after method, url) is
         # params, data, headers, cookies, files, auth, timeout -- 6
         # positionals before `timeout`, so a 7th positional argument IS an
@@ -948,7 +983,9 @@ class DefaultTimeoutSession(requests.Session):
         return super().request(method, url, *args, **kwargs)
 
 
-def create_default_session(*, timeout=None) -> "DefaultTimeoutSession":
+def create_default_session(
+    *, timeout: float | tuple[float, float] | None = None
+) -> "DefaultTimeoutSession":
     """Build a ``requests.Session`` whose default timeout is config-driven.
 
     Every call made through the returned session that omits ``timeout=``
@@ -957,6 +994,15 @@ def create_default_session(*, timeout=None) -> "DefaultTimeoutSession":
     that already passes its own ``timeout=`` is completely untouched --
     construction alone never changes behaviour for a deliberate per-call or
     per-provider timeout (task-19830).
+
+    Args:
+        timeout: Override for this session's default -- a scalar (applied
+            to both halves) or a ``(connect, read)`` tuple. ``None`` reads
+            the configured default.
+
+    Returns:
+        A ``DefaultTimeoutSession``. Usable anywhere a
+        ``requests.Session`` is, including as a context manager.
     """
     return DefaultTimeoutSession(default_timeout=timeout)
 

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, List, Mapping, MutableMapping
 from urllib.parse import urljoin, urlparse
 
+import requests
 from loguru import logger
 
 from ..config import get_cli_setting
@@ -875,6 +876,89 @@ async def guarded_fetch_httpx_async(
         finally:
             await response.aclose()
     raise EgressFetchError("too many redirects", url=url)
+
+
+#: Config-driven default ``(connect, read)`` timeout for
+#: ``create_default_session()`` -- see ``default_session_timeout()`` below.
+#: The read half matches the house default this module already used for
+#: ``guarded_fetch_requests``.
+DEFAULT_SESSION_CONNECT_TIMEOUT = 10.0
+DEFAULT_SESSION_READ_TIMEOUT = 30.0
+
+
+def default_session_timeout() -> tuple[float, float]:
+    """Config-driven ``(connect, read)`` timeout for ``create_default_session()``.
+
+    Read from ``[web_security] request_connect_timeout_seconds`` /
+    ``request_read_timeout_seconds``, the same ``get_cli_setting`` pattern
+    ``_config_enabled``/``_config_allowed_hosts`` above already use, and
+    consistent in spirit with the per-provider ``api_timeout`` settings
+    ``LLM_Calls`` reads directly (task-19830).
+
+    A tuple, not a single number, because ``requests`` applies the two
+    halves differently: CONNECT bounds the TCP handshake/TLS setup once;
+    READ is re-armed for every chunk of a streamed response (``stream=
+    True``), so a slow-but-progressing stream is only killed by a stall on
+    one chunk, never by total elapsed duration.
+    """
+    connect = get_cli_setting(
+        "web_security",
+        "request_connect_timeout_seconds",
+        DEFAULT_SESSION_CONNECT_TIMEOUT,
+    )
+    read = get_cli_setting(
+        "web_security", "request_read_timeout_seconds", DEFAULT_SESSION_READ_TIMEOUT
+    )
+    try:
+        connect_seconds = float(connect)
+    except (TypeError, ValueError):
+        connect_seconds = DEFAULT_SESSION_CONNECT_TIMEOUT
+    try:
+        read_seconds = float(read)
+    except (TypeError, ValueError):
+        read_seconds = DEFAULT_SESSION_READ_TIMEOUT
+    return (connect_seconds, read_seconds)
+
+
+class DefaultTimeoutSession(requests.Session):
+    """A ``requests.Session`` that fills in a default timeout when the
+    caller omits one.
+
+    ``get``/``post``/``put``/``delete``/``patch`` all funnel through
+    ``Session.request()`` in the base ``requests.Session`` class, so
+    overriding this one method covers every verb. An explicit ``timeout=``
+    -- keyword, or the 9th positional argument the rare
+    ``session.request(method, url, ...)`` call site passes -- always wins;
+    this only fills the gap when the caller specified neither (task-19830).
+    """
+
+    def __init__(self, *args, default_timeout=None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.default_timeout = (
+            default_session_timeout() if default_timeout is None else default_timeout
+        )
+
+    def request(self, method, url, *args, **kwargs):  # type: ignore[override]
+        # Session.request's positional signature (after method, url) is
+        # params, data, headers, cookies, files, auth, timeout -- 6
+        # positionals before `timeout`, so a 7th positional argument IS an
+        # explicit timeout and must not be overridden.
+        if "timeout" not in kwargs and len(args) <= 6:
+            kwargs["timeout"] = self.default_timeout
+        return super().request(method, url, *args, **kwargs)
+
+
+def create_default_session(*, timeout=None) -> "DefaultTimeoutSession":
+    """Build a ``requests.Session`` whose default timeout is config-driven.
+
+    Every call made through the returned session that omits ``timeout=``
+    gets ``default_session_timeout()`` (or the ``timeout`` passed here, if
+    given) instead of blocking forever on a half-open connection. A call
+    that already passes its own ``timeout=`` is completely untouched --
+    construction alone never changes behaviour for a deliberate per-call or
+    per-provider timeout (task-19830).
+    """
+    return DefaultTimeoutSession(default_timeout=timeout)
 
 
 def guarded_fetch_requests(

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3813,6 +3813,14 @@ default = "pixels"
 # the exact host is listed in allowed_hosts.
 enabled = true
 allowed_hosts = []
+# Default (connect, read) timeout applied by `Utils/egress.py`'s
+# `create_default_session()` to any request through that session which does
+# not pass its own `timeout=` (task-19830). Per-provider `api_timeout`
+# settings under [api_settings.<provider>] still take precedence wherever
+# they're read explicitly -- these are only the floor for call sites that
+# don't set one.
+# request_connect_timeout_seconds = 10
+# request_read_timeout_seconds = 30
 
 [image_generation]
 # Backend-specific fields (model, base_url, timeout_seconds, api_key, ...) go


### PR DESCRIPTION
## What & why

**task-19830**, filed during this burn-down after task-19560 named *two* unbounded `requests` calls and an audit found the problem is systemic.

`requests` has **no per-session default timeout**, so every call site has to remember one individually. Measured on dev:

```
requests.Session() construction sites: 56   (34 with no timeout on their calls)
timeout-less request calls:            40
files involved:                        13
```

A call with no timeout waits forever on a half-open connection: the calling coroutine hangs with no way to cancel, and several of these run on the event loop, so the whole TUI freezes with no error.

## The fix

`create_default_session()` in `Utils/egress.py` — the module that already owns this app's HTTP policy. A `requests.Session` subclass that fills in a `(connect, read)` timeout **only when the caller omitted one**; an explicit `timeout=` always wins, so no deliberate per-provider timeout changes behaviour.

Verified by live probe rather than by reading:

```
omitted timeout   -> injected: (10.0, 30.0)
explicit timeout=7 -> preserved: 7
```

Config-driven via `[web_security] request_connect_timeout_seconds` / `request_read_timeout_seconds`, falling back to 10s/30s.

**A tuple, not one number, on purpose:** the read half is re-armed per chunk on a streamed response, so a slow-but-progressing stream is only killed by a stall *between* chunks — never by total elapsed duration. A single total timeout would have broken long streaming completions.

## Scope: deliberately bounded, with the remainder made visible

All 6 `LLM_Calls/` files converted — 49 `Session()` sites plus 2 bare `requests.post` calls. Independently verified: **zero** bare `requests.Session()` remain in that package.

One deliberate exception: `summarize_with_anthropic` streams, and was given an explicit `timeout=` instead of being wrapped in a session — closing a session mid-stream risks tearing down the connection pool under an in-flight read.

The other 6 files are **not** converted. Converting 13 files across Embeddings, TTS, Character_Chat and Web_Scraping in one mechanical diff is a regression risk not worth taking here. They are named in the guard's `EXEMPT_FILES` set so the remaining work is visible rather than implied.

## The guard

`Tests/Architecture/test_default_timeout_session_guard.py` — an AST guard failing on any new bare `requests.Session()` or timeout-less request call, with `LLM_Calls/` required fully clean.

Red-proofed: injecting a bare `requests.Session()` into `qwencloud.py` fails both assertions and correctly names `LLM_Calls/qwencloud.py:1300`; removing it returns 11/11 green.

## The incidental find, which is the important part of this PR

**91 test-double mocks across 12 files silently stopped intercepting.**

They patched `requests.Session` / `requests.post` **by name**. The moment production called `create_default_session()` instead, those patches bound to a symbol nobody used any more — the tests kept passing while testing nothing. Only 8 of the 91 were in `Tests/LLM_Calls/`; the rest were scattered where nobody would look for them.

Found by alias-grepping the entire `Tests/` tree rather than the obvious directory, and all fixed. Confirmed afterwards that none had started reaching the real network: **0 network-guard violations** across the 1,009 passing tests.

A generalised lesson is recorded in `backlog/docs/lessons-testing-evidence.md` — this is the third instance of the same class in this burn-down alone (an AST scan that pinned call *syntax* and missed 3 methods; a test that pinned raw SQL and broke when a table moved; and now mocks that pinned a *symbol name* and went inert). **A check that pins the implementation's shape rather than its behaviour stops being a check the moment the shape changes — and does so silently.**

## Testing

`Tests/Architecture/` **173 passed** (5 pre-existing failures). `Tests/LLM_Calls/` **1009 passed** (7 pre-existing). A broad `-k "summariz or llm or api_call"` sweep: **2013 passed**, and every one of the 13 failures / 31 errors was individually triaged and A/B-confirmed pre-existing (diagnostic-privacy ledger, an anthropic-redirect fake-response gap, mlx_lm kwarg drift, missing optional deps, tiktoken-network teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents LLM HTTP calls from hanging by defaulting timeouts. Previously, many `requests` calls had no timeout and could block forever; now calls through `create_default_session()` get a config-driven `(connect, read)` timeout unless the caller supplies `timeout=`. Streaming behavior remains unchanged; explicit timeouts still win. (task-19830)

- What to review
  - `tldw_chatbook/LLM_Calls/*` now uses `create_default_session()`; two bare posts were wrapped. `summarize_with_anthropic` keeps a direct call but adds `timeout=default_session_timeout()` to avoid session-close risks during streaming.
  - `tldw_chatbook/Utils/egress.py` adds `DefaultTimeoutSession`, `create_default_session()`, and `default_session_timeout()`; defaults come from `[web_security] request_connect_timeout_seconds`/`request_read_timeout_seconds` (fallback 10s/30s).
  - `Tests/Architecture/test_default_timeout_session_guard.py` blocks new bare `requests.Session()` and timeout-less calls; it also flags `**kwargs` expansions unless a timeout is forwarded explicitly, caches its scan, requires `LLM_Calls/` to be clean, and treats stale exemptions as failures.

- Migration
  - Use `create_default_session()` for new HTTP calls; do not construct `requests.Session()` directly.
  - Update tests to patch `<module>.create_default_session` instead of `<module>.requests.Session` or `requests.post`.
  - Optional: set `[web_security] request_connect_timeout_seconds` and `request_read_timeout_seconds` to tune defaults.

<sup>Written for commit f43bcc2ccb4584be4d1040908c48ed6f9cb0232f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

