### PR TITLE
docs: file 15 findings from the holistic-review batch-3 burn-down

### DIFF
--- a/backlog/tasks/task-19860 - Migration SQL files are missing from the built wheel and sdist.md
+++ b/backlog/tasks/task-19860 - Migration SQL files are missing from the built wheel and sdist.md
@@ -1,0 +1,85 @@
+---
+id: TASK-19860
+title: >-
+  Migration SQL files are missing from the built wheel and sdist
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - packaging
+  - bug
+  - database
+  - release-blocker
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: surfaced by the reviewer of **TASK-19632/19633**, who found
+`Tests/Packaging/test_mcp_unified_distribution.py` red on dev for a reason
+unrelated to that branch. Re-verified at `3605bd52d`.
+
+A user who installs `tldw_chatbook` from PyPI cannot start the application. The
+main conversations/notes/characters database refuses to initialize, because the
+migration scripts it needs were never packaged.
+
+The cause is that the migration scripts are listed **one file at a time** in
+both `pyproject.toml`'s `package-data` map and `MANIFEST.in`, rather than being
+matched by a glob. Every new migration since the lists were last touched is
+therefore absent from the artifact. Measured at `3605bd52d`:
+
+- 31 `.sql` files exist under `tldw_chatbook/DB/migrations/`
+- 11 are enumerated in `pyproject.toml` → **20 missing from the wheel**
+- 9 are enumerated in `MANIFEST.in` → **22 missing from the sdist**
+
+The current schema version is 44 (`ChaChaNotes_DB.py:450`). Three of the
+missing files sit directly on the fresh-install upgrade chain:
+
+- `chachanotes_v40_to_v41_persona_visual.sql`
+- `chachanotes_v41_to_v42_console_project_context.sql`
+- `chachanotes_v43_to_v44_sync_conflict_preservation.sql`
+
+A PyPI install dies at the first of them with
+`SchemaError: Migration from V40 to V41 failed ... No such file or directory:
+chachanotes_v40_to_v41_persona_visual.sql`. The existing packaging test only
+ever reports that one, because the migration chain aborts there and the two
+later gaps are never reached — so the visible symptom badly under-reports the
+size of the hole.
+
+This compounds the holistic review's standing finding that migrations brick the
+DB on a partial apply (TASK-19551 family): here the partial apply is caused by
+the packaging step itself, on a completely ordinary install.
+
+The mechanical fix is a `*.sql` glob in both files. That is necessary but not
+sufficient as a task outcome: **enumeration trailing reality is the root
+cause**, and the same trap will re-form for any other asset directory that is
+listed by hand. What is missing is a check that the *built artifact* — not the
+source tree, and not the config file — contains every migration the code can
+ask for.
+
+## Acceptance Criteria
+
+- [ ] A wheel built from a clean checkout contains every `.sql` file present
+      under `tldw_chatbook/DB/migrations/`
+- [ ] An sdist built from a clean checkout contains every `.sql` file present
+      under `tldw_chatbook/DB/migrations/`
+- [ ] Installing the built wheel into an empty environment and initializing the
+      ChaChaNotes database from scratch reaches the current schema version
+      without a `SchemaError`
+- [ ] A test fails when a migration file exists in the source tree but is
+      absent from the built artifact, and it reports **all** missing files
+      rather than aborting at the first — mutation-checked by removing one
+      migration from the packaging config and confirming the test names it
+- [ ] The test asserts against the contents of the built artifact, not against
+      the text of `pyproject.toml` / `MANIFEST.in`, so a future packaging
+      mechanism change cannot make it vacuously pass
+- [ ] Other hand-enumerated asset lists in `pyproject.toml` / `MANIFEST.in` are
+      audited for the same enumeration-trails-reality shape and the result is
+      recorded (either globbed, or documented as deliberately explicit)
+
+## Notes
+
+Rate this as a release blocker rather than a defect: the failure mode is "the
+application does not start after a normal install", and it has been shippable
+for as long as the enumeration has been stale.

--- a/backlog/tasks/task-19861 - Chatbook import conflict step tells every user there are no conflicts.md
+++ b/backlog/tasks/task-19861 - Chatbook import conflict step tells every user there are no conflicts.md
@@ -1,0 +1,84 @@
+---
+id: TASK-19861
+title: >-
+  Chatbook import conflict step tells every user there are no conflicts
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - ux
+  - honesty
+  - chatbooks
+  - bug
+priority: high
+dependencies:
+  - TASK-19550
+  - TASK-19734
+---
+
+## Description
+
+Source: surfaced by the reviewer of **TASK-19734**, who drove awkward import
+cases through the real wizard against real SQLite. Re-verified at `3605bd52d`
+(after 19734 merged as `cf38ee6f8`).
+
+Step 3 of the chatbook import wizard asks the user to choose how conflicts
+should be resolved — Skip, Rename, Replace, or Merge. Directly beneath that
+choice, the step displays:
+
+> ✅ No conflicts detected - all content is new
+
+This message is **unconditional**. It is a plain `Static` yielded in
+`compose()` (`UI/Wizards/ChatbookImportWizard.py:639-644`) with no condition
+attached, `display=True` on every render, and no code anywhere ever hides it.
+**No conflict check exists anywhere in the wizard or the importer.** Driven
+against a destination where all four of the chatbook's items were already
+present and would all be skipped, it still says "all content is new".
+
+Every import passes through this step, so every user picks their conflict
+strategy on a premise the application invented. A user who reads it and leaves
+the default in place has been told that their choice does not matter, which is
+exactly backwards in the case that matters most.
+
+The lesser half of the same defect: `#conflict-container`
+(`:635-637`), the "Potential Conflicts Detected:" panel and its
+`#conflict-list`, carries the `hidden` class in `compose()` and is never
+unhidden — no Python outside `compose()` references either id. So the wizard
+ships both the true panel (permanently invisible) and the false one
+(permanently visible).
+
+This is the same family as **TASK-19550** (a "Create backup" checkbox that
+writes a ✓ and does nothing) and **TASK-19734** (per-type ticks the import did
+not earn): *the app asserts an outcome it did not produce*. Given that the
+false claim here is what the user's next decision is based on, it is arguably
+higher-impact than either.
+
+Either half is a valid fix — perform a real conflict check and drive both
+elements from it, or say nothing at all about conflicts — but shipping a
+reassurance nothing computed is not.
+
+## Acceptance Criteria
+
+- [ ] The conflict step never claims that no conflicts were detected unless a
+      check actually ran and actually found none
+- [ ] When the destination already contains items the chatbook would import,
+      the step either names them or says nothing — it does not assert that all
+      content is new
+- [ ] No element in the step is rendered permanently-hidden with no code path
+      that can reveal it (either `#conflict-container` becomes reachable, or it
+      is removed)
+- [ ] A test drives the step against a destination pre-loaded with every item
+      in the chatbook and asserts the "no conflicts" copy is absent, and is
+      mutation-checked (restoring the unconditional `Static` makes it red)
+- [ ] A test drives the step against a genuinely empty destination and asserts
+      whatever the step now says is true of that case
+- [ ] The user-facing documentation page for chatbook import matches whatever
+      the step now claims
+
+## Notes
+
+Scope note for the implementer: if a real conflict check is out of scope for
+this task, removing the false claim is a complete and shippable outcome on its
+own — an honest silence is strictly better than a confident lie, and the
+strategy selector still works. Do not close this by making the claim *more
+specific* without computing it.

--- a/backlog/tasks/task-19862 - Five outbound API sites leak their key through default redirect following.md
+++ b/backlog/tasks/task-19862 - Five outbound API sites leak their key through default redirect following.md
@@ -1,0 +1,94 @@
+---
+id: TASK-19862
+title: >-
+  Five outbound API sites leak their key through default redirect following
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - security
+  - credentials
+  - websearch
+  - llm-providers
+priority: medium
+dependencies:
+  - TASK-19557
+  - TASK-19733
+---
+
+## Description
+
+Source: unfiled residue in **TASK-19557**'s implementation notes, with exact
+lines and per-site severities confirmed by **TASK-19733**'s reviewer.
+Re-verified at `3605bd52d`: neither
+`Web_Scraping/WebSearch_APIs.py` nor `LLM_Calls/LLM_API_Calls_Local.py`
+contains the string `allow_redirects` anywhere, so all five sites take the
+`requests` default of `allow_redirects=True`.
+
+Five outbound call sites send an API key in a **custom header** and follow
+redirects automatically. `requests` strips only `Authorization` and `Cookie`
+when a redirect crosses origins; a vendor-specific header such as
+`X-Api-Key`, `Ocp-Apim-Subscription-Key`, `X-Subscription-Token` or
+`X-API-KEY` survives the hop and is delivered to whatever host the redirect
+names.
+
+None of these sites route through `Utils/egress.py`, so the per-hop
+re-validation and cross-origin allowlist that **TASK-19733** built cannot reach
+them — that fix hardened the shared primitive, and these five bypass it
+entirely.
+
+Sites, with the severities the reviewer assigned:
+
+| Site | Header | Request | Severity |
+| --- | --- | --- | --- |
+| KoboldAI | `LLM_API_Calls_Local.py:1011` (`X-Api-Key`) | `:1061` `session.post` | **medium** |
+| Bing | `WebSearch_APIs.py:2711` (`Ocp-Apim-Subscription-Key`) | `:2728` `session.get` | **medium** |
+| Brave | `:2964` (`X-Subscription-Token`) | `:2980` `requests.get` | low |
+| Serper | `:3985` (`X-API-KEY`) | `:3992` `requests.post` | low |
+| Exa | `:4055` (`x-api-key`) | `:4062` `requests.post` | low |
+
+Kobold is the worst of the five on two counts. Its destination,
+`current_api_base_url`, is **user-configured** — a redirect-serving endpoint is
+reachable by ordinary misconfiguration or by a hostile local-server URL, not
+only by a compromised vendor. And it is a POST: on a 302 or 303 `requests`
+converts the method to GET and re-issues to the new host, still carrying the
+key header.
+
+Bing is medium because `bing_search_api_url` is likewise read from config
+(`WebSearch_APIs.py:2672`) and the credential is a paid Azure subscription key.
+Brave, Serper and Exa are low because their endpoints are hard-coded vendor
+URLs — only a vendor-side compromise or DNS attack reaches them.
+
+Kagi and Yandex were checked and are genuinely clean.
+
+Minimal fix is `allow_redirects=False` at each site: none of these APIs
+legitimately redirects, so refusing a redirect is a behaviour-preserving change
+that turns a silent credential disclosure into a visible error.
+
+## Acceptance Criteria
+
+- [ ] None of the five sites follows a redirect while carrying its API key
+      header
+- [ ] A redirect response at each site produces a clear, non-silent failure
+      rather than a second request to the redirect target
+- [ ] A test per site drives a redirect from a stubbed server and asserts the
+      key header is never sent to the second host, and each is mutation-checked
+      (restoring default redirect following makes it red)
+- [ ] The Kobold POST case is covered specifically for a 302/303, where the
+      method converts to GET — a test that only exercises a 307 does not
+      demonstrate the fix
+- [ ] Every redirect response that is refused is closed, so the connection is
+      not leaked (the defect TASK-19557's Qodo round found on its own refusal
+      paths)
+- [ ] The refusal message does not echo the raw attacker-controlled `Location`
+      header (consistent with the exception-text rule applied in TASK-19321 /
+      TASK-19552 / TASK-19557)
+- [ ] The remaining `requests` call sites in both modules are swept for the same
+      shape and the result recorded, so this residue does not have to be
+      rediscovered a third time
+
+## Notes
+
+This residue has now been reported by two separate reviewers (TASK-19557's
+notes, then TASK-19733's) without ever being filed. That is the reason for the
+sweep criterion: the point is to close the class, not the five known members.

--- a/backlog/tasks/task-19863 - Cross-origin credential strip re-arms when a redirect chain returns home.md
+++ b/backlog/tasks/task-19863 - Cross-origin credential strip re-arms when a redirect chain returns home.md
@@ -1,0 +1,76 @@
+---
+id: TASK-19863
+title: >-
+  Cross-origin credential strip re-arms when a redirect chain returns home
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - security
+  - credentials
+  - egress
+priority: low
+dependencies:
+  - TASK-19733
+---
+
+## Description
+
+Source: residual finding from **TASK-19733**'s reviewer, recorded in that
+task's notes and left unfiled. Re-verified at `3605bd52d`.
+
+`Utils/egress.py` strips credential-bearing headers once a redirect takes a
+request off its original origin. The decision is made per hop by
+`same_origin(url, current)` — and both arguments are wrong for the job:
+`url` is the **original** request URL, held constant for the whole chain, so
+each hop is compared against the starting point rather than against the
+previous hop. All four guarded-fetch loops do this
+(`egress.py:753`, `:833`, `:905`, `:975`).
+
+The consequence is that the strip is not sticky. A chain of
+`feed.example → evil.example → feed.example` strips on hop 2 and then
+**re-attaches** the credential on hop 3, because hop 3's URL is same-origin
+with the original. The attacker does not receive the credential directly, but
+they choose the path and query string of the request that carries it, so they
+control which endpoint on the credential's own origin gets called with the
+user's key.
+
+The Fetch specification removes a credential **permanently** once it has been
+stripped, precisely so that a redirect chain cannot launder its way back into
+an authenticated state. This implementation does not.
+
+Severity is genuinely low — the recipient is always the credential's own origin,
+so this is not a disclosure — but the shape is wrong, and the cost of an
+attacker-chosen authenticated request against the legitimate origin is not
+zero.
+
+A second, smaller residual from the same review belongs here: on the
+built-request layer, `Content-Type` is the only exempted header that can carry
+arbitrary caller-supplied text across an origin boundary. TASK-19733's Qodo
+round already narrowed it to hops that actually carry a body; what remains is
+that the *value* is caller-controlled text on a cross-origin hop, which is
+worth a deliberate decision rather than an inherited exemption.
+
+## Acceptance Criteria
+
+- [ ] Once a credential header has been stripped on any hop of a redirect
+      chain, it is not re-attached on any later hop, regardless of that hop's
+      origin
+- [ ] A test drives an `A → B → A` redirect chain and asserts the credential is
+      absent on the third request, and is mutation-checked (restoring the
+      compare-against-original behaviour makes it red)
+- [ ] Same-origin chains that never leave the original origin still carry their
+      credentials on every hop (no regression for the ordinary case)
+- [ ] All four guarded-fetch loops in `Utils/egress.py` share one stickiness
+      rule rather than each implementing it, so the next loop added inherits it
+- [ ] The `Content-Type` cross-origin exemption is either justified in a
+      comment with the reason it is safe, or narrowed — the decision is
+      recorded either way
+
+## Notes
+
+Filed as low deliberately. Reporting this as a credential leak would
+misrepresent the evidence: the credential never reaches the attacker's origin.
+The finding is that the guard's rule does not match the specification it is
+implementing, which is the kind of drift that becomes a real leak the next time
+someone extends the loop.

--- a/backlog/tasks/task-19864 - Diagnostics interpolate user file paths and workspace roots into log text.md
+++ b/backlog/tasks/task-19864 - Diagnostics interpolate user file paths and workspace roots into log text.md
@@ -1,0 +1,93 @@
+---
+id: TASK-19864
+title: >-
+  Diagnostics interpolate user file paths and workspace roots into log text
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - privacy
+  - diagnostics
+  - logging
+priority: medium
+dependencies:
+  - TASK-19321
+  - TASK-19322
+  - TASK-19555
+---
+
+## Description
+
+Source: surfaced during **TASK-19572**'s review round, whose reviewer corrected
+an earlier over-statement of the same finding. Re-measured at `3605bd52d`.
+Same class as the open **TASK-19321** / **TASK-19322**.
+
+Production diagnostics interpolate the user's absolute file paths, workspace
+roots and database locations directly into log message text. A path is not
+inert: it names projects, clients, employers and directory structures the user
+never chose to disclose.
+
+**The scope of this finding has been corrected twice, so record it precisely
+rather than re-deriving it from folklore:**
+
+1. These calls do **not** reach a persistent on-disk sink.
+   `PersistentDiagnosticFilter` (`Utils/persistent_diagnostics.py:257`) admits
+   only records explicitly marked by `log_persistent_metadata` / `persist_event`;
+   probing `filter(<record>)` for one of these calls returns `False`. An earlier
+   report in this programme claimed they were writing to a persistent sink.
+   They are not.
+2. "Copy all" in the Logs window is **no longer** an exposure path. TASK-19555
+   converted it to the metadata-only form (`UI/Logs_Window.py:533`) — timestamps,
+   loggers, levels and exception types, no message bodies.
+
+What remains, and is the actual reason to fix this:
+
+- Terminal output, where the paths appear verbatim.
+- The in-app Logs pane, which renders message bodies.
+- **"Copy visible logs"** (`UI/Logs_Window.py:507`), which copies message text
+  to the clipboard and whose own notification tells the user the truth:
+  *"Recognised key formats and your account name were removed; file names and
+  search terms were not."* `redact_user_paths` collapses the home prefix and
+  the account name; a workspace root outside `$HOME` survives intact, and every
+  leaf directory and file name survives in all cases.
+
+Census at `3605bd52d` (larger than the 21-call sample the reviewer took — this
+is a class, not a list):
+
+| File | Interpolated value | Calls |
+| --- | --- | --- |
+| `Utils/file_handlers.py` | `{file_path}` | 10 |
+| `DB/ChaChaNotes_DB.py` | `{self.db_path_str}` | 82 |
+| `UI/Screens/change_review_screen.py` | `{root!r}` ×6, `{roots!r}`, `{remote!r} at {root!r}` | 8 |
+| `Widgets/Console/console_conversation_inspector.py` | path arguments | ~5 |
+| `Workspaces/git_workspace.py` | `{root}` | 1 |
+
+Because the census keeps coming out different depending on who counts, the
+outcome this task needs is a **rule plus a check**, not a list of edits.
+
+## Acceptance Criteria
+
+- [ ] Production diagnostics do not place a user's absolute path, workspace root
+      or database location into log message text where a less-identifying form
+      (basename, extension, path depth, a stable hash) carries the same
+      diagnostic value
+- [ ] Where a full path genuinely is the diagnostic — a "file not found" the
+      user must act on — it goes through the redaction seam rather than being
+      interpolated raw
+- [ ] "Copy visible logs" no longer needs to warn that file names were not
+      removed, or its warning is still accurate after the change
+- [ ] A guard detects a newly-added diagnostic that interpolates a path-shaped
+      value, so the census does not have to be retaken by hand a fourth time —
+      mutation-checked by adding one such call and confirming it goes red
+- [ ] The guard reports the whole set rather than aborting at the first hit
+- [ ] The corrected scope is recorded in the implementation notes: these calls
+      do NOT reach a persistent sink, and "Copy all" is metadata-only since
+      TASK-19555 — so nobody re-rates this as a persistent-disclosure defect
+
+## Notes
+
+Medium, not high: the exposure is a live terminal, an in-app pane, and a
+clipboard action the user takes deliberately and is warned about. It is filed
+because it is the same untracked class as TASK-19321/19322 and because the
+count has now been wrong in both directions — once too small (three calls, one
+file), once too severe (persistent sink).

--- a/backlog/tasks/task-19865 - Detect a diagnostic-inventory pin that does not reproduce when it is committed.md
+++ b/backlog/tasks/task-19865 - Detect a diagnostic-inventory pin that does not reproduce when it is committed.md
@@ -1,0 +1,76 @@
+---
+id: TASK-19865
+title: >-
+  Detect a diagnostic-inventory pin that does not reproduce when it is committed
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - process
+  - tooling
+  - diagnostics
+priority: medium
+dependencies:
+  - TASK-19191
+  - TASK-19572
+---
+
+## Description
+
+Source: surfaced during **TASK-19572**'s work on the persistent diagnostic
+inventory checker.
+
+The persistent diagnostic inventory is a committed pin: a per-file census of
+production diagnostic calls that a checker rebuilds and compares against, so
+that a newly-added diagnostic has to be looked at by a human before it lands.
+The whole method rests on one assumption — that the committed pin is what the
+scanner actually produces from the tree it was committed against.
+
+That assumption has been violated at least once, and it was silent. Rebuilding
+the inventory from the blobs of the pin's own commit `0b112ab1e` does not
+reproduce the pin:
+
+- `Client_Media_DB_v2.py` — rebuild says 339, the pin says 338
+- `library_screen.py` — rebuild says 111, the pin says 109
+
+A recovery diff bounded at the pin's own commit shows **nothing** for those two
+rows. That is the damaging part: the rows differ, the diff that is supposed to
+explain the difference is empty, and so the calls behind them entered the
+codebase without ever being reviewed — which is the single thing the pin exists
+to prevent. Both were later traced by hand and found benign, but "benign after
+the fact" is not the same as "reviewed", and nothing in the process
+distinguished them.
+
+The checker gained a warning about this after the fact (TASK-19572 added
+`--statements <path> [--since REV]` to recover what actually changed). That
+helps whoever is standing in front of a confusing report *later*. It does not
+help at the moment the damage is done, which is when a pin is written that does
+not describe the tree it is being committed with.
+
+The outcome wanted here is a check that runs **at pin time**: rebuild from the
+tree being committed, and refuse a pin that does not reproduce from it.
+
+## Acceptance Criteria
+
+- [ ] Committing a diagnostic-inventory pin that does not reproduce from the
+      tree it is committed against is detected and reported, not silently
+      accepted
+- [ ] The detection names which rows fail to reproduce and by how much, so the
+      operator can act without re-deriving it
+- [ ] The check is reachable from `scripts/preflight.sh` and from the CI
+      derived-artifacts job, so it is not a command someone has to remember
+- [ ] The check is mutation-verified: hand-editing one count in the committed
+      inventory makes it red, and restoring the value makes it green
+- [ ] The historical non-reproducing pin at `0b112ab1e` is used as the
+      regression case, or the reason it cannot be is recorded
+- [ ] The check does not require an installed environment (the install-free
+      contract TASK-19572's workflow establishes)
+
+## Notes
+
+The incident, stated plainly so this does not decay into a rule nobody believes:
+two inventory rows rode into the codebase unexamined because the pin that was
+supposed to gate them did not describe the tree it shipped with, and the
+recovery tooling — asked afterwards what had changed — answered "nothing". The
+review method has a lower bound, and this task is about making that bound
+visible at the moment it is crossed rather than months later.

--- a/backlog/tasks/task-19866 - No guard prevents reintroducing a mid-body version short-circuit in migration tests.md
+++ b/backlog/tasks/task-19866 - No guard prevents reintroducing a mid-body version short-circuit in migration tests.md
@@ -1,0 +1,73 @@
+---
+id: TASK-19866
+title: >-
+  No guard prevents reintroducing a mid-body version short-circuit in migration tests
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - testing
+  - test-integrity
+  - database
+priority: medium
+dependencies:
+  - TASK-19568
+---
+
+## Description
+
+Source: **TASK-19568**'s reviewer, and independently recommended by Qodo on
+that task's PR (#1940). Re-verified at `3605bd52d`.
+
+A migration test that opens with `assert db.schema_version == N` before any
+substantive assertion is not a test — it is a switch that turns the rest of the
+body off. Once the schema moves past `N`, the equality fails (or the guard
+skips), and the columns, indexes and row-survival assertions below it stop
+running. The suite stays green because the file still "passes"; the migration
+it was written to protect is simply no longer checked by anything.
+
+TASK-19568 removed the offending assertions. It did not ship a guard, and its
+own review is the proof that one is needed: the reviewer found the same shape
+**already latent in the newest migration test file**
+(`Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py`), which
+held three version equalities rather than the one the task had accounted for,
+two of them positioned mid-body ahead of the `NEW_COLUMNS` and row-survival
+assertions. A simulated v45 bump turned three of those files red where one
+should have been. Nothing would have surfaced this until the next schema bump,
+by which point the assertions had already been silently inert for a release
+cycle.
+
+Both the human reviewer and Qodo independently proposed the same remedy, which
+is a reasonable signal that it is the right one: a meta-test over the migration
+test modules that flags a literal version-equality assertion positioned before
+the substantive assertions in its function body.
+
+At `3605bd52d` there are 26 modules matching `Tests/**/test_*migration*.py` and
+no guard of any kind over them.
+
+## Acceptance Criteria
+
+- [ ] A test fails when any module under `Tests/**/test_*migration*.py`
+      contains a literal schema-version equality assertion positioned before
+      the substantive assertions in the same function body
+- [ ] The guard is structural (AST) rather than a text grep, so reformatting,
+      line wrapping or an intervening comment does not evade it
+- [ ] The guard is mutation-verified against at least three distinct evasion
+      shapes — for example a version equality inside a helper called from the
+      body, one wrapped in a `pytest.skip` guard, and one expressed as
+      `!=`/`<=` rather than `==`
+- [ ] The guard reports every offending file and line, not just the first
+- [ ] Version assertions that are legitimately the *subject* of a test (a test
+      whose whole purpose is that the version advanced) remain possible, and
+      the mechanism by which they are distinguished is documented
+- [ ] The guard is green against the current tree at the time it lands, with
+      any allowlisted entry carrying a written reason
+
+## Notes
+
+The incident, kept with the rule: TASK-19568 was dispatched to remove exactly
+this shape. Its reviewer then found the shape sitting in the newest migration
+test file the task had just walked past — because a check scoped to "the file
+we know about" structurally cannot see the file added last week. That is what a
+guard is for, and it is why the acceptance criteria here demand mutation
+evidence rather than a passing run.

--- a/backlog/tasks/task-19867 - VALID_TABLES media and prompts entries have drifted with no guard test.md
+++ b/backlog/tasks/task-19867 - VALID_TABLES media and prompts entries have drifted with no guard test.md
@@ -1,0 +1,88 @@
+---
+id: TASK-19867
+title: >-
+  VALID_TABLES media and prompts entries have drifted with no guard test
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - testing
+  - test-integrity
+  - database
+  - hygiene
+priority: low
+dependencies:
+  - TASK-19568
+---
+
+## Description
+
+Source: reported by **TASK-19568**'s implementer and upheld in both directions
+by that task's reviewer. Re-measured at `3605bd52d` by initializing a real
+`MediaDatabase` and `PromptsDatabase` and diffing `sqlite_master` against the
+allowlist.
+
+`DB/sql_validation.py`'s `VALID_TABLES` is a hand-maintained allowlist of table
+names, keyed by database. TASK-19568 added a guard test for the `chachanotes`
+entry, after that entry went stale. The `media` and `prompts` entries have
+drifted just as far and have **no guard test at all**.
+
+Measured drift (FTS shadow tables `*_config` / `*_data` / `*_docsize` /
+`*_idx` and `sqlite_sequence` excluded):
+
+**`media`** — 6 real tables are not allowlisted
+(`ChunkingTemplates`, `MediaReadItLaterState`, `ReadingProgress`,
+`keyword_fts`, `media_fts`, `schema_version`) and 6 allowlisted names no longer
+exist (`IngestionTriggerTracking`, `Keywords_fts`, `MediaChunks_fts`,
+`MediaModifications`, `MediaVersion`, `Media_fts`). The FTS tables were renamed
+— `Keywords_fts` → `keyword_fts`, `Media_fts` → `media_fts` — and
+`MediaChunks_fts` is simply gone.
+
+**`prompts`** — only `Prompts` and `sync_log` still match reality. The
+allowlist names `Keywords`, `Keywords_fts`, `PromptKeywords` and `Prompts_fts`,
+none of which exist; the live schema has `PromptKeywordLinks`,
+`PromptKeywordsTable`, `prompt_keywords_fts`, `prompts_fts` and
+`schema_version`, none of which are allowlisted.
+
+**This is hygiene, not a live defect, and it should not be re-rated. State the
+verification plainly so nobody does:**
+
+1. The two `_get_next_version` methods that could take an arbitrary table name
+   (`Client_Media_DB_v2.py:1549`, `Prompts_DB.py:1040`) have **no callers
+   anywhere** in `tldw_chatbook/` or `Tests/`. There is no reachable path that
+   feeds a caller-chosen name into the validator for these two databases.
+2. The residual drift fails **closed** in both directions: an allowlisted name
+   that no longer exists validates and then fails at SQLite; a real table that
+   is not allowlisted is rejected. Neither direction admits an unvalidated
+   identifier.
+
+The value of fixing it is that the next person who *does* add a caller inherits
+an allowlist that describes reality, and that the guard makes the drift visible
+the moment a table is added or renamed — which is the whole reason the
+`chachanotes` entry got a guard.
+
+## Acceptance Criteria
+
+- [ ] `VALID_TABLES['media']` matches the tables a freshly initialized media
+      database actually contains
+- [ ] `VALID_TABLES['prompts']` matches the tables a freshly initialized
+      prompts database actually contains
+- [ ] A guard test fails when either entry drifts from the live schema, in both
+      directions (a real table missing from the allowlist, and an allowlisted
+      name that no longer exists), mirroring the `chachanotes` guard TASK-19568
+      added
+- [ ] The guard builds the live set from a real database rather than from a
+      hand-written second list, so the guard cannot drift alongside what it
+      guards
+- [ ] The treatment of FTS shadow tables and `sqlite_sequence` is explicit and
+      documented, not incidental
+- [ ] The implementation notes state the currently-unexploitable finding
+      explicitly — no callers on either `_get_next_version`, and the drift fails
+      closed — so this is not later re-reported as a live injection defect
+
+## Notes
+
+Filed low on purpose. Calling this a SQL-injection exposure would misrepresent
+the evidence twice over: there is no reachable caller, and the failure mode is
+closed. The finding is that a safety allowlist has quietly stopped describing
+the thing it allows, and only one of its three entries has a test.

--- a/backlog/tasks/task-19868 - Chatbook Import embeddings control is inert in local mode and defaults on.md
+++ b/backlog/tasks/task-19868 - Chatbook Import embeddings control is inert in local mode and defaults on.md
@@ -1,0 +1,85 @@
+---
+id: TASK-19868
+title: >-
+  Chatbook Import embeddings control is inert in local mode and defaults on
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - ux
+  - honesty
+  - chatbooks
+priority: medium
+dependencies:
+  - TASK-19734
+---
+
+## Description
+
+Source: surfaced by the reviewer of **TASK-19734**, as the third inert control
+in the same options box — missed by that task's own sweep because it is not
+fully dead. Re-verified at `3605bd52d` (after 19734 merged as `cf38ee6f8`).
+
+The import wizard's options step offers:
+
+> ☑ Import embeddings
+> *Import vector embeddings for RAG search (if available)*
+
+(`UI/Wizards/ChatbookImportWizard.py:722-730`.) It is **checked by default**
+(`value=True`), so the user is told, on every single import, that vector
+embeddings are being brought across for RAG search.
+
+In local mode nothing of the kind happens. The value is collected at `:795`,
+passed through `local_chatbook_service.py:946` into
+`ChatbookImporter.import_chatbook`, accepted as a parameter
+(`chatbook_importer.py:506`), written into a debug log line (`:528`) — and
+never read again. There is no code path in the local importer that imports an
+embedding.
+
+The other half of the capability does not exist either: the **exporter** never
+writes embeddings. `include_embeddings` in `chatbook_creator.py` reaches only
+the manifest field (`chatbook_models.py:128`); no embedding data is ever
+written into a chatbook. So even a local importer that wanted to honour the
+option would find nothing to import.
+
+Why TASK-19734's sweep of this same box did not catch it: the control is not
+inert everywhere. It feeds `_update_server_mode_availability` (`:753`, `:759`)
+and is genuinely consumed on the server path
+(`server_chatbook_service.py:105` filters `ContentType.EMBEDDING` on it). A
+"has no consumers" search finds consumers. The defect is narrower and worse to
+find: a control that is real in one mode and decorative in the other, with the
+default set to the decorative-and-affirmative position.
+
+One further correction belongs with this: the comment added at `:789-791`
+during TASK-19734 —
+
+> Every key here is consumed by the import call below.
+
+— is **false** as written. `import_embeddings` is one of the four keys in that
+return, and the local import call does not consume it. A comment that asserts
+an invariant the code does not hold is worse than no comment, because the next
+sweep will trust it.
+
+## Acceptance Criteria
+
+- [ ] In local mode the user is not told that vector embeddings will be
+      imported, whether by the control's presence, its label, or its default
+      state
+- [ ] The control's behaviour matches the mode it is shown in — it is either
+      absent, disabled with a reason, or honoured
+- [ ] The capability gap is recorded: chatbooks do not contain embeddings
+      because the exporter never writes them, so the import side has nothing to
+      consume even in principle
+- [ ] A test asserts that the local import path's collected options contain no
+      key that the local import call ignores, and is mutation-checked
+      (re-adding an ignored key makes it red)
+- [ ] The comment at `:789-791` is either true of the code or removed
+- [ ] The server-mode path continues to filter embeddings on this value (no
+      regression to the half that works)
+
+## Notes
+
+The reason to fix the *default* and not only the wiring: a control that is off
+by default and does nothing is clutter, while a control that is **on** by
+default and does nothing is a claim. This one is a claim, made on every import,
+about a feature neither end of the pipeline implements.

--- a/backlog/tasks/task-19869 - Chatbook import non-happy paths understate what was written.md
+++ b/backlog/tasks/task-19869 - Chatbook import non-happy paths understate what was written.md
@@ -1,0 +1,93 @@
+---
+id: TASK-19869
+title: >-
+  Chatbook import non-happy paths understate what was written
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - ux
+  - honesty
+  - chatbooks
+priority: medium
+dependencies:
+  - TASK-279
+  - TASK-19734
+---
+
+## Description
+
+Source: surfaced by the reviewer of **TASK-19734**, which corrected the
+chatbook import wizard's *successful* paths. These are the two remaining paths
+where the wizard still tells the user less than it knows. Re-verified at
+`3605bd52d`.
+
+**1. A fatal error hides a completed write.**
+
+When the import worker raises, the handler at
+`UI/Wizards/ChatbookImportWizard.py:1116-1119` calls `_show_error` (`:1203`),
+which updates only the finalize row and retitles the panel "❌ Import Failed".
+The per-type rows that had already been set to `⟳ Preparing notes…` /
+`⟳ Preparing characters…` / `⟳ Preparing media…` (`:1065-1073`) are never
+updated again and freeze there, and **no stats panel renders at all**.
+
+Meanwhile the items the run had already written are permanently in the
+database. There is no rollback (TASK-279). So the screen reads as "nothing
+happened, it failed while preparing", and the truth is "an unknown number of
+items were committed and will still be there when you retry". A user who then
+retries the import gets duplicates or conflicts they were given no reason to
+expect.
+
+**2. Server mode reports a 4-item chatbook as empty.**
+
+At `:1017-1028` the server path builds a fresh `ImportStatus` from the job
+payload:
+
+- `successful_items` defaults to `0` when the key is absent
+- `failed_items` defaults to `0`
+- `total_items` is their sum
+- `skipped_items` is **hard-set to 0**, regardless of what the server did
+
+A payload that omits `successful_items` therefore yields `attempted_items == 0`
+with `left_out_items == 0`, which `ImportStatus.outcome`
+(`chatbook_importer.py:293-309`) resolves to `IMPORT_OUTCOME_EMPTY`, and the
+panel says:
+
+> ⊘ Nothing was imported — this chatbook contained no items.
+
+…about a chatbook whose four-item manifest the wizard is holding in memory at
+that moment. The hard-set `skipped_items = 0` is a second, independent false
+claim: it is not something the server reported, it is a value the client
+invented.
+
+Both belong to the family TASK-19550, TASK-19734 and TASK-19861 are in — *the
+app asserts an outcome it did not produce* — and both are on the paths where a
+user most needs the truth, because both are paths where they are about to
+decide whether to retry.
+
+## Acceptance Criteria
+
+- [ ] When the import fails partway through, the completion surface states that
+      items may already have been written and cannot be rolled back
+- [ ] Per-type rows do not remain frozen on a "preparing" state after a fatal
+      error — each row says what is known about that type, including "unknown"
+- [ ] The wizard never reports "this chatbook contained no items" for a
+      chatbook whose manifest it holds and which lists items
+- [ ] Server mode does not invent a `skipped_items` value the server did not
+      report; an unreported count is presented as unknown, not as zero
+- [ ] A server payload missing `successful_items` produces a message that
+      distinguishes "the server told us nothing" from "there was nothing to
+      import"
+- [ ] Tests drive both paths — a fatal error raised after at least one item is
+      committed, and a server payload with no counts — and assert the rendered
+      text; both are mutation-checked against the current behaviour
+- [ ] The one-vocabulary rule TASK-19734 established (empty = a claim about the
+      file, excluded = a claim about the run) is extended to cover these two
+      cases rather than bypassed
+
+## Notes
+
+Filed as one task because both are the same surface's remaining non-happy-path
+claims and a fix for either will touch the same completion-panel code. The
+rollback gap itself is TASK-279 and is not in scope here — what is in scope is
+that the UI currently conceals it at exactly the moment it matters.

--- a/backlog/tasks/task-19870 - Mutation workers refresh inline instead of dispatching into the loader group.md
+++ b/backlog/tasks/task-19870 - Mutation workers refresh inline instead of dispatching into the loader group.md
@@ -1,0 +1,71 @@
+---
+id: TASK-19870
+title: >-
+  Mutation workers refresh inline instead of dispatching into the loader group
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - workers
+  - concurrency
+  - scheduling
+  - watchlists
+priority: low
+dependencies:
+  - TASK-19559
+---
+
+## Description
+
+Source: surfaced by **TASK-19559**'s reviewer while verifying that task's
+worker-group census.
+
+**Precondition, stated up front: this does not reproduce on `dev` today.** The
+worker groups it names — `schedules-load-tasks` and `wc_notifications` — are
+introduced by TASK-19559, which is still in flight (its first review returned
+do-not-ship). At `3605bd52d` every schedules worker is `exclusive=True` with no
+group at all, which is the larger defect TASK-19559 exists to fix. This task is
+the follow-up that becomes live the moment that one lands, and it is filed now
+so the observation is not lost between a fix round and a merge.
+
+The shape: once a loader has its own worker group, a mutation worker that wants
+the list refreshed afterwards should dispatch the refresh **into that group**,
+so the group's exclusivity governs it. Instead these mutation workers `await`
+the loader inline, inside their own worker:
+
+- `UI/Screens/scheduling/schedules_workbench.py` — the delete / save / run /
+  update / bulk-delete / bulk-toggle workers each `await self.load_tasks()`
+  inline (`:496`, `:579`, `:666`, `:693`, `:913`, `:1002` at `3605bd52d`),
+  while the standalone refresh calls dispatch into `schedules-load-tasks`
+- the watchlists notification mark-read and dismiss handlers do the same
+  outside `wc_notifications`
+
+The consequence is that an inline refresh is invisible to the group that is
+supposed to serialize refreshes. A mutation-triggered refresh and a
+user-triggered refresh can interleave over the same list, and the group's
+cancel-the-previous guarantee does not apply to the one that was never
+dispatched into it — the exact class of list corruption TASK-19559's reviewer
+found in the Study pane (blocker R2), reached by a different route.
+
+Low severity: both paths render from the same query, so the visible outcome is
+a redundant or briefly out-of-order repaint rather than a lost write.
+
+## Acceptance Criteria
+
+- [ ] A refresh triggered by a mutation worker is subject to the same worker
+      group as a refresh triggered directly by the user
+- [ ] Two refreshes that overlap — one from a mutation, one from a user action —
+      cannot interleave their writes to the same list
+- [ ] A test drives a mutation and a concurrent user refresh and asserts the
+      resulting list contents, and is mutation-checked (restoring the inline
+      `await` makes it red)
+- [ ] The schedules workbench and the watchlists notification handlers are both
+      covered
+- [ ] TASK-19559's worker-group guard is extended to notice an inline loader
+      call inside a worker body, or the reason it cannot is recorded
+
+## Notes
+
+Do not start this before TASK-19559 merges — the group names this task refers
+to do not exist until then, and the pre-19559 code has a bigger problem (no
+groups at all) that this fix would sit on top of incoherently.

--- a/backlog/tasks/task-19871 - Watchlists day-header tests read the real clock and fail before 02-00 local.md
+++ b/backlog/tasks/task-19871 - Watchlists day-header tests read the real clock and fail before 02-00 local.md
@@ -1,0 +1,88 @@
+---
+id: TASK-19871
+title: >-
+  Watchlists day-header tests read the real clock and fail before 02:00 local
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - testing
+  - flaky-test
+  - watchlists
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: a residual red observed during **TASK-19559**'s work, initially taken
+for a code regression. It is a timezone flake: the same commit passes under
+`TZ=UTC` and fails at machine-local time. First seen failing at 00:38 PDT.
+Re-derived at `3605bd52d`.
+
+The tests stamp their fixture items relative to the **real** clock and then
+assert on the day-bucket headers the pane renders:
+
+- `Tests/Watchlists/test_watchlists_pane_filter_in_place.py:40-41` defines
+  `_now()` as `datetime.now(timezone.utc)`, and `:52` stamps every item as
+  `_now() - timedelta(hours=published_offset_hours)`
+- `test_article_search_hides_a_day_header_whose_whole_group_is_filtered_out`
+  (`:200`) uses offsets of 1h and 26h, then asserts
+  `_visible_headers(pane) == ["Today", "Yesterday"]` (`:211`) and
+  `== ["Today"]` (`:216`)
+
+The headers come from `day_bucket()`
+(`tldw_chatbook/Subscriptions/item_dates.py:140-160`), which buckets in the
+**viewer's local zone** via `astimezone()`. So:
+
+- the `now − 1h` item only buckets as "Today" once the local clock is at or
+  past 01:00
+- the `now − 26h` item only buckets as "Yesterday" once the local clock is at
+  or past 02:00 — before that it lands two days back and renders as a full
+  date
+
+Net: the assertions are red for any run between local **00:00 and 01:59**, in
+any timezone, and the boundary shifts by an hour across a DST transition. Both
+assertions break in that window.
+
+The same defect sits in four sibling tests in
+`Tests/Watchlists/test_watchlists_article_list.py`, which copies the same
+`_now()` helper (`:37-38`, `:51-52`) with no TZ pin:
+`test_rows_group_under_day_headers_in_effective_date_order` (`:222`),
+`test_future_dated_item_lands_under_today` (`:248`),
+`test_displayed_items_excludes_headers_and_preserves_order` (`:262`) and
+`test_headers_are_not_highlightable` (`:276`).
+
+**The fix wanted is an injected clock, not a `TZ` pin.** Both `day_bucket` and
+`relative_time` already accept an optional `now=` keyword; neither the
+production pane (`UI/Watchlists_Modules/article_list.py:89`, `:465`) nor these
+tests passes one. A `TZ=UTC` fixture — as used by
+`Tests/Watchlists/test_humane_time.py:29-43` — makes the suite green while
+leaving the tests unable to exercise the boundary behaviour that is the actual
+subject of `day_bucket`, and leaves the next timezone-sensitive test to
+rediscover this.
+
+## Acceptance Criteria
+
+- [ ] The affected tests produce the same result at every local wall-clock
+      time and in every timezone
+- [ ] The tests control the reference instant explicitly rather than depending
+      on when they happen to run
+- [ ] A test exercises the day-boundary transitions deliberately — an item just
+      before and just after local midnight — which the current tests cannot do
+- [ ] All five affected tests are covered (one in
+      `test_watchlists_pane_filter_in_place.py`, four in
+      `test_watchlists_article_list.py`)
+- [ ] The fix is verified by running the affected tests with the process clock
+      or `TZ` set to a value inside the previously-failing window and observing
+      a pass
+- [ ] Any remaining reliance on the ambient clock in `Tests/Watchlists/` is
+      either removed or recorded with a reason
+
+## Notes
+
+The incident: this red was carried for part of a task as a suspected code
+regression before anyone re-ran it under `TZ=UTC`. A flake that only fires in a
+two-hour window each night is expensive precisely because it is usually green —
+the cost is not the failure, it is the investigation it triggers in whichever
+unrelated branch happens to run at 00:38.

--- a/backlog/tasks/task-19872 - Double-pressing Settings Load Backup reports edits were kept that never existed.md
+++ b/backlog/tasks/task-19872 - Double-pressing Settings Load Backup reports edits were kept that never existed.md
@@ -1,0 +1,73 @@
+---
+id: TASK-19872
+title: >-
+  Double-pressing Settings Load Backup reports edits were kept that never existed
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - ux
+  - settings
+  - concurrency
+priority: low
+dependencies:
+  - TASK-19559
+---
+
+## Description
+
+Source: surfaced by **TASK-19559**'s reviewer while checking the arrival-time
+guards that task introduces.
+
+**Precondition, stated up front: this does not reproduce on `dev` today.** The
+copy it describes ("unsaved edits were kept") and the comparison that produces
+it are introduced by TASK-19559, which is still in flight. At `3605bd52d`
+`_advanced_load_backup_worker` (`UI/Screens/settings_screen.py:8601`) is a plain
+`@work(exclusive=True, thread=True)` with no such guard. This is filed now so
+the observation survives that task's fix round.
+
+The shape: TASK-19559 replaces the worker's exclusivity with an arrival-time
+guard — before applying a loaded backup, the callback compares the editor's
+current text against what it expects, and declines to overwrite if the user has
+typed something in the meantime. That is the right instinct. But the guard
+compares against the editor's *live* content, and the first callback's own
+write into the config `TextArea` is indistinguishable from a user edit.
+
+So on a rapid double-press of "Load Backup":
+
+1. two workers are dispatched
+2. the first completes and writes the backup text into the editor
+3. the second completes, compares, sees text it did not expect, and declines —
+   reporting that the user's unsaved edits were preserved
+
+The user had no unsaved edits. The application invented a reason for declining,
+and told the user about work it protected that never existed.
+
+**Reasoned from the code, not driven.** The sequence above follows from reading
+the callback and the worker dispatch; it has not been reproduced in a running
+app. Whoever picks this up should confirm the interleaving before fixing it.
+
+No data is at risk — declining is the safe direction, and the backup text is
+already in the editor from the first callback. The defect is that the message
+is false, which is the same family as TASK-19550 / TASK-19861 / TASK-19869:
+*the app describes an outcome it did not produce.*
+
+## Acceptance Criteria
+
+- [ ] Pressing "Load Backup" twice in quick succession does not report that
+      unsaved edits were kept when the user made none
+- [ ] The guard distinguishes a write the application itself made from a genuine
+      user edit
+- [ ] A real unsaved user edit is still protected — a backup load that would
+      overwrite typed-but-unsaved config text still declines and still says so
+- [ ] A test drives both cases (double-press with no user edit; single press
+      with a pending user edit) and asserts the message, and is
+      mutation-checked
+- [ ] The interleaving is reproduced before the fix is written, and what was
+      observed is recorded — this task was reasoned from code, not driven
+
+## Notes
+
+Low severity and deliberately so: the outcome is correct, only the explanation
+is wrong. It is worth fixing because a spurious "we protected your edits"
+teaches users to distrust the message on the occasion when it is true.

--- a/backlog/tasks/task-19873 - Decide the fate of two CCP handlers that have never been able to run.md
+++ b/backlog/tasks/task-19873 - Decide the fate of two CCP handlers that have never been able to run.md
@@ -1,0 +1,84 @@
+---
+id: TASK-19873
+title: >-
+  Decide the fate of two CCP handlers that have never been able to run
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - dead-code
+  - owner-decision
+  - personas
+priority: medium
+dependencies:
+  - TASK-19559
+  - TASK-19563
+---
+
+## Description
+
+Source: **TASK-19559**'s reviewer, correcting that task's blast-radius claim.
+Re-verified at `3605bd52d`.
+
+`CCPConversationHandler` (`UI/CCP_Modules/ccp_conversation_handler.py:39`) and
+`CCPDictionaryHandler` (`ccp_dictionary_handler.py:16`) are exported from
+`UI/CCP_Modules/__init__.py` and **never constructed in production**.
+`PersonasScreen` builds only `character_handler` and `persona_handler`
+(`UI/Screens/personas_screen.py:1026-1027`). Nothing else instantiates either
+class.
+
+That they are dead is not a guess — it is provable from the code, because
+neither could ever have executed. Both contain the same two independent
+`run_worker` defects, either of which raises on the first call:
+
+1. `self.window.run_worker(self._search_conversations_sync, search_term,
+   search_type, thread=True, exclusive=True, name="conversation_search")`
+   (`ccp_conversation_handler.py:111-118`; same shape at
+   `ccp_dictionary_handler.py:79-85`). The extra positional arguments bind onto
+   `run_worker`'s **own** `name` and `group` parameters, not onto the callable
+   → `TypeError`.
+2. The target methods carry `@work(thread=True)`
+   (`ccp_conversation_handler.py:120`, `:276`;
+   `ccp_dictionary_handler.py:87`, `:430`, `:459`), whose decorator asserts
+   `isinstance(self, DOMNode)` — and these handlers are plain objects, not
+   widgets → `AssertionError`.
+
+So conversation search, dictionary load, conversation refresh and conversation
+load in these two handlers have never worked and cannot have. This is the
+corpse of a feature, not a regression.
+
+Five further dispatches of the same shape sit in
+`UI/Tools_Settings_Window.py` (`:6685`, `:6747`, `:6894`, `:7000`, `:7325`).
+That surface is nav-unreachable: `UI/Navigation/screen_registry.py:122-123`
+routes `tools_settings` to `MCPScreen`, so the window is never mounted.
+
+**This wants a decision, not a silent repair.** Quietly fixing the `run_worker`
+misuse would resurrect four code paths that no one has exercised, tested, or
+reviewed for correctness against the current schema and screen structure — a
+larger and riskier change than it looks, dressed as a bug fix. Deleting them is
+equally a decision: it removes the last trace of whatever these were meant to
+become. The corpse trap runs in both directions, and the owner should choose.
+
+## Acceptance Criteria
+
+- [ ] An explicit decision is recorded for `CCPConversationHandler` and
+      `CCPDictionaryHandler`: delete, or wire up and fix
+- [ ] Whichever is chosen is carried out completely — if deleted, the exports in
+      `UI/CCP_Modules/__init__.py` go with them; if wired up, each restored
+      path has a test that would have caught the original `TypeError` and
+      `AssertionError`
+- [ ] The five `UI/Tools_Settings_Window.py` dispatches get the same explicit
+      decision, taken together with the standing question of whether that
+      nav-unreachable surface survives at all (TASK-3240)
+- [ ] Nothing is left in a state where a `run_worker` call is known-broken and
+      merely unreachable
+- [ ] The evidence that these paths never ran is preserved in the
+      implementation notes, so a future reader does not mistake the deletion
+      for a feature removal
+
+## Notes
+
+Recorded because it corrects a claim made in flight: TASK-19559 reported the
+CCP conversation-search fix as a headline find. It is a correct fix to dead
+code. The only genuinely live CCP defect that task touched is the character
+load, which it rated as the lesser of the two.

--- a/backlog/tasks/task-19874 - git_status advertises a path scope it does not apply.md
+++ b/backlog/tasks/task-19874 - git_status advertises a path scope it does not apply.md
@@ -1,0 +1,80 @@
+---
+id: TASK-19874
+title: >-
+  git_status advertises a path scope it does not apply
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - tools
+  - agents
+  - owner-decision
+priority: low
+dependencies:
+  - TASK-19632
+---
+
+## Description
+
+Source: a pre-existing minor finding noted by **TASK-19632**'s reviewer while
+verifying the pathspec-exclusion work. Re-verified at `3605bd52d`.
+
+The `git_status` agent tool takes a `path` argument. It is used **only** to
+discover which repository to report on — `_prepare_for_path` walks up to the
+repository root and the argv that follows carries no positive pathspec for it
+(`Tools/git_tool_impls.py:632-648`). Asking for one subdirectory's status
+therefore returns every changed file in the whole repository.
+
+The Python docstring is now accurate: TASK-19632 rewrote it to say so
+explicitly (`git_tool_impls.py:614-624`, "It is NOT applied as a scoping
+pathspec … asking for a subdirectory's status still returns every changed file
+in the repo"). But that docstring is not what the model reads. The tool schema
+handed to the model still says:
+
+> "path": "Path inside the repository, relative to the workspace root
+> (default: the workspace root)."
+
+(`Agents/local_tool_provider.py:1258-1261`.) To a model, that reads as a scope
+— particularly next to `git_diff` and `git_log`, whose `path` argument on the
+same surface **is** applied as a literal pathspec. An agent narrowing to a
+subdirectory to keep its context small silently receives the whole repository
+instead, and has no signal that it did.
+
+This is not a correctness or safety problem post-TASK-19632: the denylist
+exclusions are applied to `git_status` regardless of `path`, so no sensitive
+file becomes reachable through the gap. It is a truthfulness problem in the
+interface the model plans against.
+
+**This wants a decision rather than a default.** Either is defensible:
+
+- **Give it real scoping** — mirror `git_diff` / `git_log` and append a
+  `:(literal)` positive pathspec, so the parameter means what both its name and
+  its description suggest. Note that TASK-19632's headline finding applies
+  directly here: a bare value spliced after `--` is read as pathspec *magic*,
+  so any positive pathspec must be `:(literal)`-prefixed and covered by that
+  task's AST tripwire.
+- **Keep the current behaviour** and make the model-facing description say what
+  the docstring now says, so the parameter is honestly advertised as
+  repository-discovery only.
+
+## Acceptance Criteria
+
+- [ ] A decision is recorded: `git_status`'s `path` either scopes the output or
+      is described to the model as discovery-only
+- [ ] The model-facing tool description in `Agents/local_tool_provider.py`
+      matches the implementation's actual behaviour
+- [ ] The description no longer implies a scoping contract that `git_diff` and
+      `git_log` honour and `git_status` does not
+- [ ] If scoping is added, the positive pathspec is `:(literal)`-prefixed and
+      covered by TASK-19632's AST tripwire, and a test proves a
+      pathspec-magic filename cannot invert the scope
+- [ ] If scoping is added, the denylist exclusions still apply and a test pins
+      that they are not weakened by the new positive pathspec
+- [ ] A test asserts the tool description and the implementation agree, so the
+      two cannot drift again
+
+## Notes
+
+Worth doing precisely because the docstring was already fixed. Half the drift
+was closed and the half the model actually reads was not — which is the version
+of this problem that still costs an agent a wasted turn.


### PR DESCRIPTION
Files tasks **19860-19874** for findings surfaced while implementing and reviewing the holistic-review batch-3 queue (19568 / 19572 / 19632 / 19633 / 19733 / 19734 / 19559). No code changes — task files only.

Every finding was **re-verified against `origin/dev` 3605bd52d** before filing, after today's five merges (`aaec11812`, `ac0af7e0a`, `cf38ee6f8`, `647132758`, `3605bd52d`). Line numbers were re-derived at that base. Nothing was filed that no longer reproduces; three findings were re-scoped and the correction is recorded in the task rather than quietly dropped.

## Headline

**TASK-19860 (high) — a real shipped packaging bug.** Migration `.sql` files are enumerated one file at a time in `pyproject.toml`'s `package-data` and `MANIFEST.in` instead of globbed. Measured at this base: 31 migrations exist, 11 are listed in `pyproject.toml` (**20 missing from the wheel**) and 9 in `MANIFEST.in` (**22 missing from the sdist**). Three of the missing files sit on the fresh-install chain to the current schema v44, so a PyPI install dies with `SchemaError: Migration from V40 to V41 failed … No such file or directory` and the main database never initializes. The existing packaging test only ever reports the first, because the chain aborts there.

## Filed

| id | title | priority |
| --- | --- | --- |
| 19860 | Migration SQL files are missing from the built wheel and sdist | **high** |
| 19861 | Chatbook import conflict step tells every user there are no conflicts | **high** |
| 19862 | Five outbound API sites leak their key through default redirect following | medium |
| 19863 | Cross-origin credential strip re-arms when a redirect chain returns home | low |
| 19864 | Diagnostics interpolate user file paths and workspace roots into log text | medium |
| 19865 | Detect a diagnostic-inventory pin that does not reproduce when it is committed | medium |
| 19866 | No guard prevents reintroducing a mid-body version short-circuit in migration tests | medium |
| 19867 | VALID_TABLES media and prompts entries have drifted with no guard test | low |
| 19868 | Chatbook Import embeddings control is inert in local mode and defaults on | medium |
| 19869 | Chatbook import non-happy paths understate what was written | medium |
| 19870 | Mutation workers refresh inline instead of dispatching into the loader group | low |
| 19871 | Watchlists day-header tests read the real clock and fail before 02:00 local | medium |
| 19872 | Double-pressing Settings Load Backup reports edits were kept that never existed | low |
| 19873 | Decide the fate of two CCP handlers that have never been able to run | medium |
| 19874 | git_status advertises a path scope it does not apply | low |

## Corrections carried in the task files

- **19864** — the path-logging diagnostics do **not** reach a persistent sink; `PersistentDiagnosticFilter` admits only records marked by `log_persistent_metadata` / `persist_event`. And "Copy all" stopped being an exposure path when TASK-19555 made it metadata-only. The residual exposure is the terminal, the in-app Logs pane, and "Copy visible logs" — whose own notification already says file names are not removed. An earlier report in this programme overstated this as a persistent-sink leak; the task says so explicitly so it is not re-rated.
- **19870 / 19872** — these do **not** reproduce on dev. They describe worker groups (`schedules-load-tasks`, `wc_notifications`) and copy ("unsaved edits were kept") that TASK-19559 introduces and which is still in flight. Both carry the precondition in their first paragraph and depend on 19559.
- **19874** — TASK-19632 already corrected the Python docstring. What is still wrong is the model-facing tool description in `local_tool_provider.py`, which still reads as a scope. The task is scoped to the half that was missed.
- **19867** — verified currently unexploitable in both directions (no callers on either `_get_next_version`; the drift fails closed) and filed **low** with that stated, so it is not re-reported as an injection defect.

## ID claiming

MAX task id swept across every remote branch, every local ref and all 170 worktrees (filenames **and** `id:` frontmatter, case-insensitive) = **19830**. Claimed **19860-19874** (MAX+30). Re-verified at commit time with the exact `task-<id> - ` delimiter: zero collisions on filenames, zero on frontmatter.

## Verification

`scripts/preflight.sh` — all four checks green, including the duplicate-task-id guard:

```
=== generated stylesheets ===        CSS bundle reproduces from its source modules.
=== profile-owned path census ===    48 executable occurrence(s) across 18 file(s)
=== production diagnostic inventory === 521 owners, 1221/7208 calls, 7 sink files
=== backlog task ids ===             No duplicate task IDs across 2390 task files
preflight: all derived-artifact checks passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 15 backlog task files documenting findings from holistic-review batch-3. No code changes. This queues fixes and guards, including a release-blocking packaging issue that breaks fresh installs.

- Highlights for review
  - Only new backlog entries under `backlog/tasks/`; skim for scope and priority.
  - 19860 high: migration `.sql` files are missing from built wheel/sdist, so a PyPI install fails to initialize the database; follow-ups require globbing in packaging and an artifact-level check.
  - 19862–19863: outbound requests follow redirects with API-key headers and credential strip re-arms on A→B→A chains; tasks call for `allow_redirects=False` and a sticky strip rule.
  - 19866–19867, 19871: add a structural guard against mid-body schema-version assertions in migration tests, realign `VALID_TABLES` with live schemas, and fix timezone-dependent watchlists tests.
  - 19861, 19868–19869, 19872: correct import wizard claims (conflicts, embeddings, non-happy path outcomes) and a backup load message; note 19870/19872 depend on worker-group changes tracked in TASK-19559 and do not reproduce on current dev.
  - 19864–19865: narrow diagnostics path exposure (non-persistent; Logs pane/terminal/Copy visible logs) and add a pin-repro check for the diagnostic inventory.
  - 19874: `git_status` path parameter advertises scoping it does not apply; task records a decision to either implement literal scoping or update the model-facing description.

<sup>Written for commit 1a08829e0e15b3cdf87b2d33f24743a11a7d7931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

