### PR TITLE
fix(workers): name every exclusive worker group, and guard the 146th

### DIFF
--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -486,7 +486,7 @@ state: "Last validated: not validated" / "current text" / "stale after edits".
 | Button | What it does |
 |---|---|
 | **Validate Raw TOML** | Checks the editor text. |
-| **Load Backup** | Loads the backup copy into the editor **without saving it** — a preview you still have to validate. |
+| **Load Backup** | Loads the backup copy into the editor **without saving it** — a preview you still have to validate. Reading the backup happens in the background, and if you carry on typing while it loads, your edits win: the result line reads "not applied — the editor changed while the backup was loading; unsaved edits were kept". Press **Load Backup** again once you have finished typing. |
 | **Save Raw TOML** | Blocked until the text you are looking at is the exact text that last validated. Writes atomically, keeping a `.bak` backup of the previous file, then reloads. |
 
 ### Domain Defaults — Image Gen
@@ -708,3 +708,12 @@ list, verified by mounted-settings tests driving `kimi-k2.6` and `glm-5.3`;
 preserved thinking is documented for the versioned Kimi family per wire
 probes, with `kimi-latest` excluded; the rest of this page's content
 unchanged from the prior stamp).*
+*Advanced Config — Load Backup's row updated against TASK-19559 —
+2026-08-22 (the backup read is a background thread worker whose completion
+callback used to overwrite the editor unconditionally; it now compares the
+editor text against what it saw at dispatch and refuses to clobber typing
+that arrived in between, reporting "not applied … unsaved edits were kept".
+Verified by a mounted-settings test that holds the off-loop read open,
+types into the live `TextArea`, and asserts the keystroke survives — the
+same test reds with the exact clobbering diff when the check is removed;
+the rest of this page's content unchanged from the prior stamp).*

--- a/Tests/Architecture/test_worker_exclusive_group_inventory.py
+++ b/Tests/Architecture/test_worker_exclusive_group_inventory.py
@@ -1,0 +1,383 @@
+# test_worker_exclusive_group_inventory.py
+# Description: Guard against exclusive workers scheduled into the shared
+#              "default" group (task-19559)
+"""task-19559: In Textual (verified against the installed 8.2.8), a worker
+scheduled with ``exclusive=True`` and no ``group=`` lands in the group
+literally named ``"default"`` -- ``Worker.__init__``'s signature is
+``group: str = "default"``, and so is ``work()``'s. ``WorkerManager.add_worker``
+then calls ``cancel_group(worker.node, worker.group)``, and ``cancel_group``
+filters on ``(worker.group, worker.node)`` alone::
+
+    workers = [
+        worker
+        for worker in self._workers
+        if (worker.group == group and worker.node == node)
+    ]
+
+It **never consults ``name=``**. So every ungrouped exclusive worker on a node
+mutually cancels every other one, no matter how distinct their ``name=`` values
+are, and ``name=`` scopes nothing at all.
+
+Two facts make this quietly destructive rather than merely surprising:
+
+* ``asyncio.CancelledError`` derives from ``BaseException``, so the
+  ``except Exception:`` blocks these handlers use cannot observe it. A
+  cancelled save does not log, does not toast, does not raise -- it vanishes.
+* ``Worker.cancel()`` does **not** stop a thread worker. Its body runs to
+  completion in the executor and its ``call_from_thread`` callbacks still land,
+  so for thread workers grouping alone is not even sufficient -- the result
+  must additionally be refused at arrival (see task-19563).
+
+**Counting.** A naive ``grep exclusive=True | grep -v group=`` over the package
+over-counts by roughly 4x (523 vs 133 at this task's branch base), because a
+multi-line call carries ``group=`` on a following line. This guard walks the
+AST instead, which is also what produced the census in the task notes.
+
+**The contract.** Every ``@work(...)`` decorator and every ``run_worker(...)``
+call inside ``tldw_chatbook/`` that requests exclusivity must name its group,
+so the blast radius of the cancellation is written down at the call site. The
+group name should describe the *work*, not the caller: two call sites that
+start the same load belong in the same group (a refresh supersedes a refresh),
+two different operations do not (a section load must not kill a save).
+
+An exclusive worker that genuinely wants the shared ``"default"`` group is
+allowed, but only through ``DEFAULT_GROUP_ALLOWLIST`` -- an entry there is a
+recorded decision with a reason, not a silent one.
+
+**Relationship to the existing guard.**
+``Tests/UI/test_chat_screen_worker_groups.py`` (TASK-228) enforces the same
+rule over ``chat_screen.py`` plus ``UI/Console_Modules/``, and additionally
+pins that the Console run and sync workers use *disjoint* groups. This sweep
+generalises the first half to the whole package; the Console-specific
+disjointness check stays where it is.
+
+Born red: at the branch base this sweep reported **133 sites across 32 files**
+(the four user-visible instances task-19559 names among them: Study rating
+submission, Media analysis generation, four of the six Watchlists section
+loaders, and the Settings advanced-config backup load).
+``test_multiline_ungrouped_exclusive_is_flagged`` pins the multi-line form the
+naive grep is blind to, and ``test_ungrouped_exclusive_decorator_is_flagged``
+pins the decorator form.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+
+#: Callables that schedule a Textual worker. ``work`` is the decorator factory
+#: (``@work(...)``); ``run_worker`` is ``DOMNode.run_worker``.
+SCHEDULER_NAMES = {"work", "run_worker"}
+
+#: ``DOMNode.run_worker``'s positional parameter order, so a ``group`` or
+#: ``exclusive`` passed positionally is still seen. ``work()`` takes everything
+#: after ``method`` as keyword-only, so it needs no equivalent.
+RUN_WORKER_POSITIONAL = (
+    "work",
+    "name",
+    "group",
+    "description",
+    "exit_on_error",
+    "start",
+    "exclusive",
+    "thread",
+)
+
+#: task-19559: sites that deliberately want default-group mutual exclusion, or
+#: that this repo does not own. Keyed by ``"<path>::<owning function>"`` -- a
+#: qualified name rather than a line number, so the entry survives edits above
+#: it. The value is the reason the exemption is correct; adding a row here is a
+#: decision to accept that *every* other ungrouped exclusive worker on the same
+#: node cancels this one, and vice versa.
+DEFAULT_GROUP_ALLOWLIST: dict[str, str] = {
+    "tldw_chatbook/Third_Party/textual_fspicker/parts/directory_navigation.py"
+    "::DirectoryNavigation._load": (
+        "Vendored upstream code (textual-fspicker), kept byte-compatible with "
+        "its source tree so it can be re-synced. It is also benign: `_load` is "
+        "the only exclusive worker on that widget, so the default group "
+        "degenerates to self-exclusion, which is exactly what it wants."
+    ),
+}
+
+
+def _call_name(node: ast.Call) -> str | None:
+    """Return the bare callee name for ``f()``, ``a.f()`` and ``f[T]()``."""
+    func = node.func
+    if isinstance(func, ast.Subscript):
+        func = func.value
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _keyword(node: ast.Call, name: str) -> ast.expr | None:
+    for keyword in node.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _owner_index(tree: ast.Module) -> dict[int, str]:
+    """Map every line to the qualified name of the function that owns it.
+
+    A ``@work(...)`` decorator is attributed to the function it decorates (the
+    decorator's own line falls outside that function's ``lineno`` range), which
+    is the name a reader would use to talk about the worker.
+    """
+    owners: dict[int, str] = {}
+    stack: list[str] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def _visit_function(self, node: ast.AST) -> None:
+            stack.append(node.name)  # type: ignore[attr-defined]
+            qualname = ".".join(stack)
+            start = min(
+                [node.lineno]  # type: ignore[attr-defined]
+                + [d.lineno for d in node.decorator_list]  # type: ignore[attr-defined]
+            )
+            end = node.end_lineno or node.lineno  # type: ignore[attr-defined]
+            for line in range(start, end + 1):
+                owners[line] = qualname
+            self.generic_visit(node)
+            stack.pop()
+
+        visit_FunctionDef = _visit_function  # type: ignore[assignment]
+        visit_AsyncFunctionDef = _visit_function  # type: ignore[assignment]
+
+    _Visitor().visit(tree)
+    return owners
+
+
+def _violations_in_tree(tree: ast.Module) -> list[tuple[int, str, str]]:
+    """Return ``(lineno, owner_qualname, detail)`` for every ungrouped
+    exclusive worker schedule in an already-parsed module.
+
+    Path-free, so tests can drive it with synthetic source rather than only
+    with real package files.
+    """
+    owners = _owner_index(tree)
+    violations: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        scheduler = _call_name(node)
+        if scheduler not in SCHEDULER_NAMES:
+            continue
+
+        exclusive = _keyword(node, "exclusive")
+        group = _keyword(node, "group")
+        # A `**kwargs` spread can carry `exclusive=` and can equally fail to
+        # carry `group=`, so neither can be proved from the AST. Fail CLOSED,
+        # as `Tests/UI/test_chat_screen_worker_groups.py` (TASK-228) does: a
+        # guard that skips what it cannot prove certifies nothing.
+        has_spread = any(keyword.arg is None for keyword in node.keywords)
+        if scheduler == "run_worker":
+            for index, arg in enumerate(node.args):
+                if index >= len(RUN_WORKER_POSITIONAL):
+                    break
+                if RUN_WORKER_POSITIONAL[index] == "group":
+                    group = arg
+                elif RUN_WORKER_POSITIONAL[index] == "exclusive":
+                    exclusive = arg
+
+        if exclusive is None and not has_spread:
+            continue
+        # `exclusive=False` is not exclusive; anything else (including a
+        # variable or an expression) may be, so it must still name a group.
+        if isinstance(exclusive, ast.Constant) and exclusive.value is False:
+            continue
+        if group is not None:
+            continue
+
+        shown = "**kwargs" if exclusive is None else ast.unparse(exclusive)
+        violations.append(
+            (
+                node.lineno,
+                owners.get(node.lineno, "<module>"),
+                f"{scheduler}(exclusive={shown}) with no group=",
+            )
+        )
+    return violations
+
+
+def _violations_in_file(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    relative = path.relative_to(PACKAGE_ROOT.parent)
+    reported: list[str] = []
+    for lineno, owner, detail in _violations_in_tree(tree):
+        if f"{relative}::{owner}" in DEFAULT_GROUP_ALLOWLIST:
+            continue
+        reported.append(f"{relative}:{lineno} ({owner}): {detail}")
+    return reported
+
+
+def _all_site_keys() -> set[str]:
+    keys: set[str] = set()
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        relative = path.relative_to(PACKAGE_ROOT.parent)
+        for _lineno, owner, _detail in _violations_in_tree(tree):
+            keys.add(f"{relative}::{owner}")
+    return keys
+
+
+def test_no_ungrouped_exclusive_workers() -> None:
+    """Every exclusive worker in the package names the group it may cancel."""
+    assert PACKAGE_ROOT.is_dir(), f"package root not found: {PACKAGE_ROOT}"
+    violations: list[str] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        violations.extend(_violations_in_file(path))
+    assert not violations, (
+        "exclusive=True scheduled without an explicit group= lands in the "
+        'shared "default" group, where it cancels every other ungrouped '
+        "exclusive worker on the same node (cancel_group filters on "
+        "(node, group) and never on name=). Name the group after the WORK "
+        "being done, or -- if default-group mutual exclusion really is what "
+        "the site wants -- add it to DEFAULT_GROUP_ALLOWLIST with the reason:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_ungrouped_exclusive_decorator_is_flagged() -> None:
+    """The ``@work(exclusive=True)`` decorator form must be caught.
+
+    Born red against the branch base, where `settings_screen.py`'s twelve
+    thread workers were written exactly like this.
+    """
+    tree = ast.parse(
+        "from textual import work\n"
+        "from textual.widget import Widget\n\n"
+        "class ScratchWidget(Widget):\n"
+        "    @work(exclusive=True, thread=True)\n"
+        "    def _save(self) -> None:\n"
+        "        pass\n"
+    )
+    violations = _violations_in_tree(tree)
+    assert len(violations) == 1
+    lineno, owner, detail = violations[0]
+    assert lineno == 5
+    assert owner == "ScratchWidget._save"
+    assert "no group=" in detail
+
+
+def test_multiline_ungrouped_exclusive_is_flagged() -> None:
+    """The multi-line call form -- the one a line-oriented grep gets wrong.
+
+    A naive ``grep exclusive=True | grep -v group=`` reports this site twice
+    over (once for the ``exclusive=True`` line of the flagged call, once for
+    the grouped call's ``exclusive=True`` line whose ``group=`` sits on the
+    NEXT line). The AST sees one violation and one clean site.
+    """
+    tree = ast.parse(
+        "from textual.widget import Widget\n\n"
+        "class ScratchWidget(Widget):\n"
+        "    def _start(self) -> None:\n"
+        "        self.run_worker(\n"
+        "            self._flagged(),\n"
+        "            exclusive=True,\n"
+        "        )\n"
+        "        self.run_worker(\n"
+        "            self._clean(),\n"
+        "            exclusive=True,\n"
+        "            group='scratch-clean',\n"
+        "        )\n"
+    )
+    violations = _violations_in_tree(tree)
+    assert len(violations) == 1
+    lineno, owner, _detail = violations[0]
+    assert lineno == 5
+    assert owner == "ScratchWidget._start"
+
+
+def test_positional_group_is_not_a_violation() -> None:
+    """``run_worker(work, name, group, ...)`` takes group positionally too.
+
+    A site that passes it that way has named its group, even though no
+    ``group=`` string appears on the line.
+    """
+    tree = ast.parse(
+        "from textual.widget import Widget\n\n"
+        "class ScratchWidget(Widget):\n"
+        "    def _start(self) -> None:\n"
+        "        self.run_worker(\n"
+        "            self._work, 'worker-name', 'scratch-group', exclusive=True\n"
+        "        )\n"
+    )
+    assert _violations_in_tree(tree) == []
+
+
+def test_name_keyword_does_not_satisfy_the_guard() -> None:
+    """``name=`` is the exact confusion this guard exists to catch.
+
+    ``cancel_group`` never reads ``name``; a site that passes one and believes
+    it is scoped is still in the shared ``"default"`` group.
+    """
+    tree = ast.parse(
+        "from textual.widget import Widget\n\n"
+        "class ScratchWidget(Widget):\n"
+        "    def _start(self) -> None:\n"
+        "        self.run_worker(\n"
+        "            self._work, thread=True, exclusive=True, name='my_search'\n"
+        "        )\n"
+    )
+    assert len(_violations_in_tree(tree)) == 1
+
+
+def test_non_exclusive_worker_needs_no_group() -> None:
+    """A worker that is not exclusive cancels nothing, so it is unconstrained."""
+    tree = ast.parse(
+        "from textual.widget import Widget\n\n"
+        "class ScratchWidget(Widget):\n"
+        "    def _start(self) -> None:\n"
+        "        self.run_worker(self._work())\n"
+        "        self.run_worker(self._other(), exclusive=False)\n"
+    )
+    assert _violations_in_tree(tree) == []
+
+
+def test_allowlisted_site_is_not_flagged() -> None:
+    """An allowlisted owner is exempt, and the exemption is keyed by name."""
+    tree = ast.parse(
+        "from textual import work\n"
+        "from textual.widget import Widget\n\n"
+        "class DirectoryNavigation(Widget):\n"
+        "    @work(exclusive=True)\n"
+        "    def _load(self) -> None:\n"
+        "        pass\n"
+    )
+    violations = _violations_in_tree(tree)
+    assert len(violations) == 1
+    _lineno, owner, _detail = violations[0]
+    assert (
+        "tldw_chatbook/Third_Party/textual_fspicker/parts/directory_navigation.py"
+        f"::{owner}"
+    ) in DEFAULT_GROUP_ALLOWLIST
+
+
+def test_allowlist_has_no_stale_entries() -> None:
+    """Every allowlist row must still describe a real site.
+
+    Without this, an entry outlives the code it excused and quietly widens the
+    exemption for whatever function later takes that name.
+    """
+    live = _all_site_keys()
+    stale = sorted(key for key in DEFAULT_GROUP_ALLOWLIST if key not in live)
+    assert not stale, (
+        "DEFAULT_GROUP_ALLOWLIST entries that no longer match an ungrouped "
+        "exclusive worker -- delete them:\n" + "\n".join(stale)
+    )
+
+
+def test_allowlist_entries_state_a_reason() -> None:
+    """An allowlist row without reasoning is folklore; require prose."""
+    for key, reason in DEFAULT_GROUP_ALLOWLIST.items():
+        assert len(reason.split()) >= 10, f"{key}: reason is too thin to review"

--- a/Tests/Architecture/test_worker_exclusive_group_inventory.py
+++ b/Tests/Architecture/test_worker_exclusive_group_inventory.py
@@ -195,15 +195,41 @@ def _violations_in_tree(tree: ast.Module) -> list[tuple[int, str, str]]:
         # variable or an expression) may be, so it must still name a group.
         if isinstance(exclusive, ast.Constant) and exclusive.value is False:
             continue
-        if group is not None:
+        # A `group=` whose value cannot be read from the AST (a constant, an
+        # f-string, an attribute) is accepted: the site has named *something*,
+        # and the name is the reviewable artefact. But three literal values are
+        # NOT names, and each defeats the guard while looking like it satisfies
+        # it, so they are reported as if no group had been given at all:
+        #
+        # * `group="default"` IS the shared bucket this whole guard exists to
+        #   keep sites out of -- it is byte-for-byte what omitting `group=`
+        #   produces (`Worker.__init__`/`work()`/`run_worker` all default to
+        #   the string "default"). It is the likeliest wrong "fix" for a guard
+        #   failure, and this repo already spells that shape by hand at
+        #   `UI/Console_Modules/agent.py` (non-exclusive there, so benign).
+        # * `group=""` / `group=None` are falsy, and `WorkerManager.add_worker`
+        #   reads `if exclusive and worker.group:` -- a falsy group skips
+        #   `cancel_group` entirely, so the site silently gets NO exclusivity
+        #   despite asking for it. That is a different bug, not a fix.
+        group_is_a_name = group is not None and not (
+            isinstance(group, ast.Constant) and group.value in ("default", "", None)
+        )
+        if group_is_a_name:
             continue
 
         shown = "**kwargs" if exclusive is None else ast.unparse(exclusive)
+        if group is None:
+            detail = f"{scheduler}(exclusive={shown}) with no group="
+        else:
+            detail = (
+                f"{scheduler}(exclusive={shown}, group={ast.unparse(group)}) "
+                "-- that is not a group name"
+            )
         violations.append(
             (
                 node.lineno,
                 owners.get(node.lineno, "<module>"),
-                f"{scheduler}(exclusive={shown}) with no group=",
+                detail,
             )
         )
     return violations
@@ -330,6 +356,64 @@ def test_name_keyword_does_not_satisfy_the_guard() -> None:
         "        )\n"
     )
     assert len(_violations_in_tree(tree)) == 1
+
+
+def test_group_default_does_not_satisfy_the_guard() -> None:
+    """`group="default"` is the shared bucket, not an escape from it.
+
+    Found in review: the guard originally accepted any `group=` node without
+    reading its value, so the likeliest wrong "fix" for a guard failure --
+    pasting in `group="default"` -- silenced the guard while changing the
+    runtime behaviour not at all. `Worker`, `work()` and `run_worker` all
+    default `group` to the literal string `"default"`, so this call is
+    byte-for-byte the ungrouped one.
+    """
+    tree = ast.parse(
+        "from textual.widget import Widget\n\n"
+        "class ScratchWidget(Widget):\n"
+        "    def _start(self) -> None:\n"
+        "        self.run_worker(self._work, exclusive=True, group='default')\n"
+    )
+    violations = _violations_in_tree(tree)
+    assert len(violations) == 1
+    assert "not a group name" in violations[0][2]
+
+
+def test_falsy_group_does_not_satisfy_the_guard() -> None:
+    """`group=""`/`group=None` silently disable exclusivity altogether.
+
+    `WorkerManager.add_worker` reads ``if exclusive and worker.group:`` before
+    calling ``cancel_group``, so a falsy group means the site asked for
+    exclusivity and received none -- a different bug wearing the fix's clothes.
+    """
+    for literal in ("''", "None"):
+        tree = ast.parse(
+            "from textual.widget import Widget\n\n"
+            "class ScratchWidget(Widget):\n"
+            "    def _start(self) -> None:\n"
+            f"        self.run_worker(self._work, exclusive=True, group={literal})\n"
+        )
+        violations = _violations_in_tree(tree)
+        assert len(violations) == 1, literal
+        assert "not a group name" in violations[0][2], literal
+
+
+def test_non_literal_group_is_accepted() -> None:
+    """A constant or f-string group is a name; the guard must not reject it.
+
+    33 real sites name their group through a module constant or an f-string
+    (`f"console-run-{session_id}"`). Those are named groups and stay clean --
+    only the three literals above are rejected.
+    """
+    tree = ast.parse(
+        "from textual.widget import Widget\n"
+        "GROUP = 'scratch-load'\n\n"
+        "class ScratchWidget(Widget):\n"
+        "    def _start(self, key) -> None:\n"
+        "        self.run_worker(self._a, exclusive=True, group=GROUP)\n"
+        "        self.run_worker(self._b, exclusive=True, group=f'scratch-{key}')\n"
+    )
+    assert _violations_in_tree(tree) == []
 
 
 def test_non_exclusive_worker_needs_no_group() -> None:

--- a/Tests/Architecture/test_worker_exclusive_group_inventory.py
+++ b/Tests/Architecture/test_worker_exclusive_group_inventory.py
@@ -63,6 +63,8 @@ pins the decorator form.
 from __future__ import annotations
 
 import ast
+import functools
+import re
 from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
@@ -70,6 +72,20 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
 #: Callables that schedule a Textual worker. ``work`` is the decorator factory
 #: (``@work(...)``); ``run_worker`` is ``DOMNode.run_worker``.
 SCHEDULER_NAMES = {"work", "run_worker"}
+
+#: Qodo review of PR #1951: the sweep parsed all ~1,780 package modules twice.
+#: It is now a single cached pass over the files that could possibly contain a
+#: scheduler call, which is a cost fix and NOT a coverage fix -- the set of
+#: sites reported is byte-identical (``test_prefilter_admits_every_flagged_form``
+#: pins that, and ``test_scan_is_a_single_cached_pass`` pins that the cache does
+#: not quietly re-read).
+#:
+#: The prefilter is sound because ``_call_name`` only ever returns an
+#: ``ast.Name.id`` or an ``ast.Attribute.attr``: both are identifiers that must
+#: appear verbatim as a token in the source. A file with neither token cannot
+#: contain a call this guard would flag. (``\b`` boundaries mean ``workspace``
+#: and ``workflow`` do not match, while ``x.work()`` and ``run_worker`` do.)
+_SCHEDULER_TOKEN = re.compile(r"\b(?:work|run_worker)\b")
 
 #: ``DOMNode.run_worker``'s positional parameter order, so a ``group`` or
 #: ``exclusive`` passed positionally is still seen. ``work()`` takes everything
@@ -164,7 +180,7 @@ def _violations_in_tree(tree: ast.Module) -> list[tuple[int, str, str]]:
     Path-free, so tests can drive it with synthetic source rather than only
     with real package files.
     """
-    owners = _owner_index(tree)
+    owners: dict[int, str] | None = None
     violations: list[tuple[int, str, str]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -225,6 +241,12 @@ def _violations_in_tree(tree: ast.Module) -> list[tuple[int, str, str]]:
                 f"{scheduler}(exclusive={shown}, group={ast.unparse(group)}) "
                 "-- that is not a group name"
             )
+        # Built only once a violation exists. Attributing every line in the
+        # package to its owning function is the single most expensive step in
+        # the sweep, and the overwhelming majority of files have nothing to
+        # attribute.
+        if owners is None:
+            owners = _owner_index(tree)
         violations.append(
             (
                 node.lineno,
@@ -235,33 +257,37 @@ def _violations_in_tree(tree: ast.Module) -> list[tuple[int, str, str]]:
     return violations
 
 
-def _violations_in_file(path: Path) -> list[str]:
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    relative = path.relative_to(PACKAGE_ROOT.parent)
-    reported: list[str] = []
-    for lineno, owner, detail in _violations_in_tree(tree):
-        if f"{relative}::{owner}" in DEFAULT_GROUP_ALLOWLIST:
+@functools.lru_cache(maxsize=1)
+def _scan_package() -> tuple[tuple[Path, int, str, str], ...]:
+    """Every flagged site in the package, found in one cached pass.
+
+    Returns ``(relative_path, lineno, owner_qualname, detail)`` rows *before*
+    the allowlist is applied, so both the guard and the allowlist-staleness
+    check can be answered from the same scan.
+    """
+    rows: list[tuple[Path, int, str, str]] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if not _SCHEDULER_TOKEN.search(source):
             continue
-        reported.append(f"{relative}:{lineno} ({owner}): {detail}")
-    return reported
+        relative = path.relative_to(PACKAGE_ROOT.parent)
+        for lineno, owner, detail in _violations_in_tree(ast.parse(source)):
+            rows.append((relative, lineno, owner, detail))
+    return tuple(rows)
 
 
 def _all_site_keys() -> set[str]:
-    keys: set[str] = set()
-    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        relative = path.relative_to(PACKAGE_ROOT.parent)
-        for _lineno, owner, _detail in _violations_in_tree(tree):
-            keys.add(f"{relative}::{owner}")
-    return keys
+    return {f"{relative}::{owner}" for relative, _l, owner, _d in _scan_package()}
 
 
 def test_no_ungrouped_exclusive_workers() -> None:
     """Every exclusive worker in the package names the group it may cancel."""
     assert PACKAGE_ROOT.is_dir(), f"package root not found: {PACKAGE_ROOT}"
-    violations: list[str] = []
-    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
-        violations.extend(_violations_in_file(path))
+    violations = [
+        f"{relative}:{lineno} ({owner}): {detail}"
+        for relative, lineno, owner, detail in _scan_package()
+        if f"{relative}::{owner}" not in DEFAULT_GROUP_ALLOWLIST
+    ]
     assert not violations, (
         "exclusive=True scheduled without an explicit group= lands in the "
         'shared "default" group, where it cancels every other ungrouped '
@@ -465,3 +491,87 @@ def test_allowlist_entries_state_a_reason() -> None:
     """An allowlist row without reasoning is folklore; require prose."""
     for key, reason in DEFAULT_GROUP_ALLOWLIST.items():
         assert len(reason.split()) >= 10, f"{key}: reason is too thin to review"
+
+
+def test_prefilter_admits_every_flagged_form() -> None:
+    """The cheap text prefilter must never hide a form the AST would flag.
+
+    Qodo's third finding on PR #1951 asked for a speed-up. Making a guard fast
+    by making it blind is the failure mode, so the prefilter is pinned here
+    against every shape the other tests in this file assert on -- decorator,
+    multi-line, positional, ``name=``-only, ``group="default"``, falsy group,
+    and the ``**kwargs`` spread the guard fails closed on. Each source is
+    checked twice: the AST must flag it, and the prefilter must admit it for
+    parsing in the first place.
+    """
+    flagged_sources = [
+        # decorator form
+        "from textual import work\n"
+        "class W:\n"
+        "    @work(exclusive=True, thread=True)\n"
+        "    def _save(self): ...\n",
+        # multi-line call form
+        "class W:\n"
+        "    def _s(self):\n"
+        "        self.run_worker(\n"
+        "            self._f(),\n"
+        "            exclusive=True,\n"
+        "        )\n",
+        # name= mistaken for scoping
+        "class W:\n"
+        "    def _s(self):\n"
+        "        self.run_worker(self._f, exclusive=True, name='search')\n",
+        # group='default' is the shared bucket
+        "class W:\n"
+        "    def _s(self):\n"
+        "        self.run_worker(self._f, exclusive=True, group='default')\n",
+        # falsy group silently disables exclusivity
+        "class W:\n"
+        "    def _s(self):\n"
+        "        self.run_worker(self._f, exclusive=True, group=None)\n",
+        # **kwargs spread: unprovable, so failed closed
+        "class W:\n    def _s(self, **kw):\n        self.run_worker(self._f, **kw)\n",
+        # positional exclusive, no group
+        "class W:\n"
+        "    def _s(self):\n"
+        "        self.run_worker(self._f, 'nm', None, 'desc', True, True, True)\n",
+    ]
+    for source in flagged_sources:
+        assert _violations_in_tree(ast.parse(source)), f"AST missed:\n{source}"
+        assert _SCHEDULER_TOKEN.search(source), (
+            "the prefilter would have skipped a file the AST flags:\n" + source
+        )
+
+
+def test_prefilter_only_skips_files_with_no_scheduler_token() -> None:
+    """Every package file the prefilter skips really has no scheduler call.
+
+    Re-parses the *skipped* files -- the ones the fast path never looks at --
+    and asserts the AST finds nothing there either. This is the check that
+    would catch a prefilter regex that got too clever.
+    """
+    skipped_with_violations: list[str] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if _SCHEDULER_TOKEN.search(source):
+            continue
+        if _violations_in_tree(ast.parse(source)):
+            skipped_with_violations.append(str(path))
+    assert not skipped_with_violations, (
+        "the prefilter skipped files that do contain flagged worker sites:\n"
+        + "\n".join(skipped_with_violations)
+    )
+
+
+def test_scan_is_a_single_cached_pass() -> None:
+    """The package is read once per session, not once per assertion.
+
+    The sweep used to walk and parse all of ``tldw_chatbook/`` twice -- once in
+    ``test_no_ungrouped_exclusive_workers`` and again in ``_all_site_keys()``
+    for the allowlist-staleness check. Both now answer from one cached scan.
+    """
+    first = _scan_package()
+    assert _scan_package() is first, "the scan is being recomputed per call"
+    # Deliberately no `cache_clear()`: forcing a rebuild here would spend the
+    # very seconds this change exists to save.
+    assert _scan_package.cache_info().misses <= 1, _scan_package.cache_info()

--- a/Tests/UI/test_ccp_handlers.py
+++ b/Tests/UI/test_ccp_handlers.py
@@ -1,5 +1,6 @@
 """Focused CCP handler tests for dual character/persona management."""
 
+import asyncio
 from functools import partial
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -169,8 +170,16 @@ class TestCCPConversationHandler:
 
         mock_window.run_worker.assert_called_once()
         call_args = mock_window.run_worker.call_args
-        assert call_args[0][0] == handler._load_conversation_sync
-        assert call_args[0][1] == "conv-1"
+        # TASK-19563: worker args travel with the callable. Passing them as
+        # extra positional `run_worker` arguments bound them to `run_worker`'s
+        # own name/group parameters and then collided with the explicit
+        # `name=` keyword -- a guaranteed TypeError that this assertion used
+        # to pin in place, because a Mock window never raised it.
+        worker_callable = call_args[0][0]
+        assert isinstance(worker_callable, partial)
+        assert worker_callable.func == handler._load_conversation_sync
+        assert worker_callable.args == ("conv-1",)
+        assert len(call_args[0]) == 1
 
     def test_search_excludes_workspace_scoped_conversations_from_general_results(
         self, mock_window
@@ -198,9 +207,15 @@ class TestCCPConversationHandler:
         mock_window.state.selected_persona_id = None
         handler = CCPConversationHandler(mock_window)
 
-        CCPConversationHandler._search_conversations_sync.__wrapped__(
-            handler, "Alpha", "title"
-        )
+        handler._search_conversations_sync("Alpha", "title")
+
+        # TASK-19563: results are handed to the event loop rather than written
+        # straight onto the handler, so the arrival-time generation check gets
+        # a say. Drive that hop the way `call_from_thread` would.
+        mock_window.call_from_thread.assert_called_once()
+        callback, generation, results = mock_window.call_from_thread.call_args[0]
+        assert callback == handler._apply_search_results
+        asyncio.run(handler._apply_search_results(generation, results))
 
         assert [row["id"] for row in handler.search_results] == ["conv-global-1"]
 
@@ -221,7 +236,9 @@ class TestCCPCharacterHandler:
         worker_callable = call_args[0][0]
         assert isinstance(worker_callable, partial)
         assert worker_callable.func == handler._load_character_sync
-        assert worker_callable.args == ("char.local.alice",)
+        # TASK-19563: the dispatch generation rides along with the id, so the
+        # arrival callback can reject a superseded load.
+        assert worker_callable.args == ("char.local.alice", 1)
 
     @pytest.mark.asyncio
     async def test_list_chat_greetings_routes_via_scope_service(self, mock_window):
@@ -472,3 +489,106 @@ class TestCCPMessageManager:
 
         mock_fetch.assert_called_with("conv-1")
         assert manager.current_messages[0]["id"] == "msg-1"
+
+
+class _TitleSearchDb:
+    """Return exactly one row per query, named after the query itself."""
+
+    def search_conversations_by_title(self, title_query, limit=100):
+        return [
+            {
+                "id": f"conv-{title_query}",
+                "title": title_query,
+                "discovery_owner": "general_chat",
+                "scope_type": "global",
+            }
+        ]
+
+
+@pytest.mark.asyncio
+async def test_ccp_conversation_search_discards_out_of_order_stale_results(
+    mock_window,
+):
+    """TASK-19563: the slower `"a"` read must not overwrite the `"ab"` list.
+
+    These are *thread* workers. `Worker.cancel()` does not stop a thread
+    worker -- its body runs to completion in the executor and its
+    `call_from_thread` callback still lands -- so grouping alone cannot help.
+    The test therefore runs BOTH worker bodies and then delivers their results
+    **newest first**, which is precisely the interleaving that leaves the list
+    showing results for a prefix of what the search box now reads.
+
+    Born red against the branch base twice over: the dispatch raised
+    `TypeError: run_worker() got multiple values for argument 'name'` (so the
+    search never ran at all), and there was no generation to compare on
+    arrival.
+    """
+    mock_window.app_instance.chachanotes_db = _TitleSearchDb()
+    mock_window.state.selected_character_id = None
+    mock_window.state.selected_persona_id = None
+    handler = CCPConversationHandler(mock_window)
+
+    rendered: list[list[str]] = []
+
+    async def _record_render():
+        rendered.append([row["id"] for row in handler.search_results])
+
+    handler._update_search_results_ui = _record_render
+
+    # The user types "a", then "ab" before the first read has come back.
+    await handler.handle_search("a", "title")
+    await handler.handle_search("ab", "title")
+    assert mock_window.run_worker.call_count == 2
+
+    # Both bodies run to completion -- a thread worker cannot be cancelled.
+    for call in mock_window.run_worker.call_args_list:
+        worker_callable = call[0][0]
+        assert isinstance(worker_callable, partial)
+        worker_callable()
+
+    deliveries = [call[0] for call in mock_window.call_from_thread.call_args_list]
+    assert len(deliveries) == 2, "both reads should have produced a delivery"
+
+    # Deliver OUT OF ORDER: the newest result first, the stale one second.
+    for callback, generation, results in reversed(deliveries):
+        await callback(generation, results)
+
+    assert rendered == [["conv-ab"]], (
+        "a superseded search result was rendered; renders=" f"{rendered}"
+    )
+    assert [row["id"] for row in handler.search_results] == ["conv-ab"]
+
+
+@pytest.mark.asyncio
+async def test_ccp_character_load_discards_out_of_order_stale_results(mock_window):
+    """TASK-19563: a superseded character card must never be displayed.
+
+    Display corruption only -- the modern save path carries its own generation
+    guard, so stored character data is not at risk either way.
+    """
+    handler = CCPCharacterHandler(mock_window)
+    displayed: list[str] = []
+    handler._display_character_card = lambda: displayed.append(
+        str(handler.current_character_id)
+    )
+
+    await handler.load_character("char.local.alice")
+    await handler.load_character("char.local.bob")
+    assert mock_window.run_worker.call_count == 2
+
+    first_generation, second_generation = (
+        call[0][0].args[1] for call in mock_window.run_worker.call_args_list
+    )
+    assert second_generation > first_generation
+
+    # Newest arrives first, then the stale one.
+    handler._apply_loaded_character(
+        second_generation, "char.local.bob", {"name": "Bob"}
+    )
+    handler._apply_loaded_character(
+        first_generation, "char.local.alice", {"name": "Alice"}
+    )
+
+    assert displayed == ["char.local.bob"]
+    assert handler.current_character_id == "char.local.bob"
+    assert handler.current_character_data == {"name": "Bob"}

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -1403,8 +1403,11 @@ async def test_media_analysis_llm_failure_surfaces_error_not_sentinel():
 
     captured = {}
 
-    def _run_worker(coro, exclusive=True):
+    # TASK-19559: analysis generation now names its own group, so a
+    # sibling media worker cannot cancel it mid-flight.
+    def _run_worker(coro, exclusive=True, group=None):
         captured["coro"] = coro
+        captured["group"] = group
 
     window.run_worker = _run_worker
 
@@ -1474,8 +1477,11 @@ async def test_media_analysis_missing_response_text_clears_stale_analysis_state(
 
     captured = {}
 
-    def _run_worker(coro, exclusive=True):
+    # TASK-19559: analysis generation now names its own group, so a
+    # sibling media worker cannot cancel it mid-flight.
+    def _run_worker(coro, exclusive=True, group=None):
         captured["coro"] = coro
+        captured["group"] = group
 
     window.run_worker = _run_worker
 

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -2681,7 +2681,9 @@ def test_forced_refresh_queues_behind_an_inflight_inventory_load(
         None,
     )
 
-    view._load_inventory.assert_called_once_with()
+    # TASK-19563: the dispatch generation rides with the read so
+    # `_apply_inventory` can refuse a superseded one.
+    view._load_inventory.assert_called_once_with(view._inventory_generation)
     assert view._loading is True
 
 
@@ -3283,3 +3285,40 @@ def test_models_rail_lists_surviving_destinations_without_a_downloader() -> None
     models_section = dict(MODELS_RAIL_SECTIONS)["Models"]
     keys = [key for key, _label in models_section]
     assert keys == ["curated", "installed", "external", "remote"]
+
+
+def test_superseded_inventory_read_is_discarded_on_arrival(tmp_path: Path) -> None:
+    """TASK-19563: a slow first inventory read cannot overwrite a newer one.
+
+    `_load_inventory` is a *thread* worker. `Worker.cancel()` does not stop a
+    thread worker -- the body finishes in the executor and its
+    `call_from_thread` callback lands regardless -- so the group on that
+    decorator cannot help. The generation captured at dispatch and compared on
+    arrival is what actually refuses the stale rows.
+
+    Born red against the branch base, where `_apply_inventory` took no
+    generation at all and applied whichever result arrived last.
+    """
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    view.refresh = MagicMock()
+    view._load_inventory = MagicMock()
+
+    view.ensure_loaded()
+    # Pretend the first read has left the dispatcher but not yet come back.
+    view._loading = False
+    view._loaded = True
+    view.ensure_loaded(force=True)
+
+    first_generation, second_generation = (
+        call.args[0] for call in view._load_inventory.call_args_list
+    )
+    assert second_generation > first_generation
+
+    # The stale read lands after the fresh one was dispatched.
+    view._apply_inventory(("stale",), None, None, None, first_generation)
+    assert view._rows == (), "a superseded inventory read was applied"
+
+    view._apply_inventory(("fresh",), None, None, None, second_generation)
+    assert view._rows == ("fresh",)

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -1267,8 +1267,13 @@ def test_settings_library_rag_save_uses_exclusive_thread_worker():
     source = inspect.getsource(SettingsScreen)
 
     assert getattr(worker, "__wrapped__", None) is not None
+    # TASK-19559: the group is now explicit, so this worker cancels only
+    # its own predecessor rather than every other exclusive worker on the
+    # Settings screen (Textual puts an ungrouped exclusive worker in the
+    # shared "default" group).
     assert (
-        "@work(exclusive=True, thread=True)\n    def _settings_save_library_rag_worker"
+        '@work(exclusive=True, group="settings-save-library-rag", thread=True)\n'
+        "    def _settings_save_library_rag_worker"
     ) in source
 
 
@@ -1506,8 +1511,13 @@ def test_settings_appearance_save_uses_exclusive_thread_worker():
     source = inspect.getsource(SettingsScreen)
 
     assert getattr(worker, "__wrapped__", None) is not None
+    # TASK-19559: the group is now explicit, so this worker cancels only
+    # its own predecessor rather than every other exclusive worker on the
+    # Settings screen (Textual puts an ungrouped exclusive worker in the
+    # shared "default" group).
     assert (
-        "@work(exclusive=True, thread=True)\n    def _settings_save_appearance_worker"
+        '@work(exclusive=True, group="settings-save-appearance", thread=True)\n'
+        "    def _settings_save_appearance_worker"
     ) in source
 
 
@@ -1777,8 +1787,13 @@ def test_settings_storage_save_uses_exclusive_thread_worker():
     source = inspect.getsource(SettingsScreen)
 
     assert getattr(worker, "__wrapped__", None) is not None
+    # TASK-19559: the group is now explicit, so this worker cancels only
+    # its own predecessor rather than every other exclusive worker on the
+    # Settings screen (Textual puts an ungrouped exclusive worker in the
+    # shared "default" group).
     assert (
-        "@work(exclusive=True, thread=True)\n    def _settings_save_storage_worker"
+        '@work(exclusive=True, group="settings-save-storage", thread=True)\n'
+        "    def _settings_save_storage_worker"
     ) in source
 
 
@@ -9105,8 +9120,11 @@ def test_settings_advanced_config_load_backup_handler_uses_worker(monkeypatch):
     def fail_direct_load():
         raise AssertionError("backup loading should not run in the button handler")
 
-    def fake_worker():
-        calls.append("worker")
+    def fake_worker(dispatch_text):
+        # TASK-19559: the handler must hand the worker the editor text as it
+        # stands at dispatch, so the arrival callback can refuse to clobber
+        # typing that happened while the backup was being read.
+        calls.append(("worker", dispatch_text))
 
     monkeypatch.setattr(screen, "_load_advanced_backup_preview", fail_direct_load)
     monkeypatch.setattr(
@@ -9117,7 +9135,7 @@ def test_settings_advanced_config_load_backup_handler_uses_worker(monkeypatch):
 
     screen.handle_advanced_load_backup(event)
 
-    assert calls == ["stop", "worker"]
+    assert calls == ["stop", ("worker", "")]
 
 
 @pytest.mark.asyncio
@@ -10178,3 +10196,77 @@ async def test_settings_manual_sync_run_token_guards_stale_worker_finally():
     # The current worker's finally clears it.
     await wrapped(screen, 2)
     assert screen._manual_sync_run_in_flight is False
+
+
+@pytest.mark.asyncio
+async def test_settings_advanced_config_backup_load_never_clobbers_unsaved_typing(
+    monkeypatch, tmp_path
+):
+    """TASK-19559: a background backup read must not overwrite live typing.
+
+    `_advanced_load_backup_worker` is a *thread* worker. `Worker.cancel()`
+    cannot stop a thread worker -- the body finishes in the executor and its
+    `call_from_thread` callback lands regardless -- so the only place the
+    result can be refused is on arrival. This test holds the off-loop read
+    open, types into the editor while it is blocked, then releases it.
+
+    Born red against the branch base, where `_apply_advanced_backup_preview_
+    result` assigned `TextArea.text = backup_text` unconditionally: the user's
+    unsaved edit was silently replaced by the backup.
+    """
+    import threading
+
+    config_path = tmp_path / "config.toml"
+    backup_path = tmp_path / "config.toml.bak"
+    current_text = '[chat_defaults]\nprovider = "OpenAI"\n'
+    backup_text = '[chat_defaults]\nprovider = "Ollama"\nmodel = "llama3"\n'
+    config_path.write_text(current_text, encoding="utf-8")
+    backup_path.write_text(backup_text, encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    release = threading.Event()
+    original_read = SettingsScreen._read_advanced_backup_preview
+
+    def gated_read(self):
+        # Runs on the worker thread, so blocking here does not stall the loop.
+        release.wait(10)
+        return original_read(self)
+
+    monkeypatch.setattr(
+        SettingsScreen, "_read_advanced_backup_preview", gated_read
+    )
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-advanced-config")
+        screen = _active_destination_screen(host)
+        editor = screen.query_one("#settings-advanced-config-editor", TextArea)
+        assert editor.text == current_text
+
+        await pilot.click("#settings-advanced-load-backup")
+        await pilot.pause(0.1)
+        assert not release.is_set()
+
+        # The user keeps typing while the backup is still being read.
+        editor.focus()
+        await pilot.pause()
+        editor.move_cursor(editor.document.end)
+        await pilot.press("z")
+        await pilot.pause()
+        typed_text = editor.text
+        assert typed_text != current_text, "the simulated keystroke did not land"
+
+        release.set()
+        # Wait on the neutral prefix, so a regression reds on the editor
+        # assertion below (the behaviour) rather than on a wait timeout.
+        await _wait_for_settings_text(screen, pilot, "Advanced config recovery:")
+        await pilot.pause(0.2)
+
+        assert editor.text == typed_text, (
+            "the background backup load overwrote unsaved typing"
+        )
+        assert backup_text not in editor.text
+        assert "not applied" in screen._advanced_config_result
+        assert "unsaved edits were kept" in screen._advanced_config_result

--- a/Tests/UI/test_study_flashcards_screen.py
+++ b/Tests/UI/test_study_flashcards_screen.py
@@ -1369,6 +1369,28 @@ async def test_start_review_blocks_when_pending_session_teardown_keeps_failing()
         assert controller._pending_review_session_teardown is not None
 
 
+
+def _review_candidates(count: int = 6) -> list[dict]:
+    """`count` distinct due cards, so a review queue can actually advance."""
+    return [
+        {
+            "card": {
+                "record_id": f"local:study_flashcard:card-local-{index}",
+                "backing_id": f"card-local-{index}",
+                "deck_record_id": "local:study_deck:deck-local-1",
+                "front": f"Question {index}",
+                "back": f"Answer {index}",
+                "queue_state": "new",
+            },
+            "selection_reason": "new",
+            "next_intervals": {"again": "10m", "good": "1d"},
+            "review_session": {"review_session_id": 41},
+            "detail_available": True,
+        }
+        for index in range(1, count + 1)
+    ]
+
+
 class GatedReviewStudyScopeService(FakeStudyScopeService):
     """A scope service whose review save can be held open mid-flight.
 
@@ -1381,25 +1403,8 @@ class GatedReviewStudyScopeService(FakeStudyScopeService):
     def __init__(self):
         super().__init__()
         self.gate = asyncio.Event()
-        self.entered: list[tuple[str | None, int]] = []
         self.persisted: list[tuple[str | None, int]] = []
-        self.candidates = [
-            {
-                "card": {
-                    "record_id": f"local:study_flashcard:card-local-{index}",
-                    "backing_id": f"card-local-{index}",
-                    "deck_record_id": "local:study_deck:deck-local-1",
-                    "front": f"Question {index}",
-                    "back": f"Answer {index}",
-                    "queue_state": "new",
-                },
-                "selection_reason": "new",
-                "next_intervals": {"again": "10m", "good": "1d"},
-                "review_session": {"review_session_id": 41},
-                "detail_available": True,
-            }
-            for index in range(1, 6)
-        ]
+        self.candidates = _review_candidates()
 
     async def submit_flashcard_review(
         self,
@@ -1412,7 +1417,6 @@ class GatedReviewStudyScopeService(FakeStudyScopeService):
         current_card=None,
         answer_time_ms=None,
     ):
-        self.entered.append((card_id, rating))
         await self.gate.wait()
         self.persisted.append((card_id, rating))
         return {
@@ -1428,23 +1432,36 @@ class GatedReviewStudyScopeService(FakeStudyScopeService):
         }
 
 
-@pytest.mark.asyncio
-async def test_fast_consecutive_flashcard_ratings_all_persist():
-    """TASK-19559: a second rating press must not destroy the first save.
+class GatedCardListStudyScopeService(FakeStudyScopeService):
+    """Holds `list_flashcards` open so two card-list rebuilds can interleave."""
 
-    Born red against the branch base, where `handle_review_rating` scheduled
-    `submit_rating` with `exclusive=True` and no `group=`. That put every
-    rating in the shared "default" group, so `add_worker` cancelled the
-    in-flight save the moment the next press arrived -- and because
-    `CancelledError` is a `BaseException`, `submit_rating`'s `except
-    Exception:` could not even see it happen. The first rating simply
-    vanished. Pre-fix this asserts `persisted == [(card, 5)]`; post-fix both
-    ratings are present.
+    def __init__(self):
+        super().__init__()
+        self.gate = asyncio.Event()
+        self.list_calls = 0
+        self.candidates = _review_candidates()
 
-    Driven through the real rating buttons -- two consecutive presses with the
-    save held open in between -- not by inspecting the dispatch keywords.
-    """
-    scope = GatedReviewStudyScopeService()
+    async def list_flashcards(
+        self,
+        *,
+        mode=None,
+        scope_type=None,
+        workspace_id=None,
+        deck_id=None,
+        q=None,
+        limit=100,
+        offset=0,
+    ):
+        self.list_calls += 1
+        await self.gate.wait()
+        return [
+            card
+            for card in self.cards
+            if deck_id is None or card["deck_record_id"].endswith(str(deck_id))
+        ]
+
+
+def _study_app_for(scope):
     app_instance = SimpleNamespace(
         study_scope_service=scope,
         current_runtime_backend="local",
@@ -1452,49 +1469,255 @@ async def test_fast_consecutive_flashcard_ratings_all_persist():
         app_config={},
         notify=lambda *args, **kwargs: None,
     )
-    app = _build_full_study_app(app_instance)
+    return _build_full_study_app(app_instance)
+
+
+async def _enter_review(pilot, app):
+    """Open Flashcards, pick the deck, start a review and reveal the answer."""
+    await pilot.pause(0.2)
+    await pilot.click("#view-flashcards-btn")
+    await pilot.pause(0.3)
+    app.screen.query_one("#deck-select", Select).value = "deck-local-1"
+    # Let the deck-change refresh settle before starting a review, so nothing
+    # tears the card down underneath the test.
+    await pilot.pause(0.5)
+    window = app.screen.query_one(StudyWindow)
+    controller = window.flashcards_controller
+    await controller.start_review()
+    await pilot.pause(0.2)
+    controller.show_answer()
+    await pilot.pause(0.1)
+    return window, controller
+
+
+@pytest.mark.asyncio
+async def test_flashcard_rating_survives_a_sibling_study_worker():
+    """TASK-19559(a): the named bug -- a sibling Study worker ate the save.
+
+    `Study_Window.py:1007/1011` (create deck, refresh cards) and the
+    `initialize_view` refresh at `914` were all `exclusive=True` with no
+    `group=`, which put them in the shared "default" group alongside the
+    rating submission. Pressing any of them while a rating was in flight
+    cancelled the save, and `CancelledError` is a `BaseException` that
+    `submit_rating`'s `except Exception:` cannot observe -- the rating simply
+    vanished.
+
+    Born red against the branch base: `persisted == []`.
+    """
+    scope = GatedReviewStudyScopeService()
+    app = _study_app_for(scope)
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        window, _controller = await _enter_review(pilot, app)
+
+        window.query_one("#review-rating-3", Button).press()
+        await pilot.pause(0.2)
+        assert scope.persisted == [], "the gate should still be holding the save"
+
+        # A sibling Study worker starts while the save is in flight.
+        window.query_one("#flashcard-refresh-button", Button).press()
+        await pilot.pause(0.2)
+
+        scope.gate.set()
+        await pilot.pause(0.5)
+
+        assert scope.persisted == [("card-local-1", 3)], (
+            "a sibling Study worker cancelled the in-flight rating save; "
+            f"persisted={scope.persisted}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_consecutive_ratings_on_distinct_cards_all_persist():
+    """TASK-19559: rating card after card in quick succession loses nothing.
+
+    This is the acceptance criterion's real content: *distinct* cards all
+    persist. (Two presses on one card are a double-submit, not two reviews --
+    see `test_double_press_on_one_card_applies_sm2_once`.)
+    """
+    scope = GatedReviewStudyScopeService()
+    scope.gate.set()  # saves complete immediately; the user never waits
+    app = _study_app_for(scope)
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        window, controller = await _enter_review(pilot, app)
+
+        for _ in range(3):
+            assert controller.current_review_card is not None
+            window.query_one("#review-rating-4", Button).press()
+            await pilot.pause(0.3)
+            controller.show_answer()
+            await pilot.pause(0.05)
+
+        assert len(scope.persisted) == 3, f"persisted={scope.persisted}"
+        assert [card_id for card_id, _rating in scope.persisted] == [
+            "card-local-1",
+            "card-local-2",
+            "card-local-3",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_rating_in_flight_survives_leaving_the_flashcards_sub_view():
+    """TASK-19559 review R1: switching sub-view mid-save must not crash.
+
+    `StudyWindow.watch_current_view` calls `remove_children()` on the view
+    container, destroying every widget `_set_review_status` /
+    `_set_next_intervals` query with a bare `query_one`. Exclusivity used to
+    hide this by cancelling the save first. Removing it exposed an unhandled
+    `WorkerFailed(NoMatches(...))`, and the tail also re-assigned
+    `current_review_session_id` for a session teardown had just ended.
+
+    Base vs branch, identical probe -- base lost the rating and raised
+    nothing; the pre-fix branch raised `WorkerFailed` and resurrected session
+    41. The fix keeps the write *and* stays quiet.
+    """
+    scope = GatedReviewStudyScopeService()
+    app = _study_app_for(scope)
+    captured: list[str] = []
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        app._handle_exception = lambda error: captured.append(repr(error))
+        window, controller = await _enter_review(pilot, app)
+
+        window.query_one("#review-rating-3", Button).press()
+        await pilot.pause(0.2)
+
+        # The user leaves Flashcards while the save is still in flight.
+        window.current_view = "quizzes"
+        await pilot.pause(0.4)
+
+        scope.gate.set()
+        await pilot.pause(0.6)
+
+        assert captured == [], f"unhandled worker exception: {captured}"
+        assert scope.persisted == [("card-local-1", 3)], (
+            f"the rating did not survive the sub-view switch: {scope.persisted}"
+        )
+        assert controller.current_review_session_id is None, (
+            "an ended review session was resurrected by the rating's tail"
+        )
+
+
+@pytest.mark.asyncio
+async def test_deck_change_and_refresh_do_not_interleave_the_card_list():
+    """TASK-19559 review R2: two card-list rebuilds must not interleave.
+
+    `handle_deck_select_changed` was left ungrouped *and* non-exclusive, so it
+    sat in the shared "default" group while `handle_refresh_cards` moved to
+    `study-refresh-cards`. Base's ungrouped-exclusive refresh used to cancel
+    the deck-change rebuild; afterwards both `refresh_cards()` bodies appended
+    into `#card-list` together and the visible row count no longer matched
+    `current_cards`.
+    """
+    scope = GatedCardListStudyScopeService()
+    app = _study_app_for(scope)
 
     async with app.run_test(size=(180, 60)) as pilot:
         await pilot.pause(0.2)
         await pilot.click("#view-flashcards-btn")
         await pilot.pause(0.3)
-
-        app.screen.query_one("#deck-select", Select).value = "deck-local-1"
-        # Let the deck-change refresh (and its review-session teardown) finish
-        # before starting a review, so nothing tears the card down underneath us.
-        await pilot.pause(0.5)
-        controller = app.screen.query_one(StudyWindow).flashcards_controller
-
-        await controller.start_review()
-        await pilot.pause(0.2)
-        controller.show_answer()
-        await pilot.pause(0.1)
-
-        # `Button.press()` posts the real `Button.Pressed` message through the
-        # real `@on` handler; it just does not need the button to be within the
-        # visible viewport the way `pilot.click` does.
-        rating_three = app.screen.query_one("#review-rating-3", Button)
-        rating_five = app.screen.query_one("#review-rating-5", Button)
-        assert not rating_three.disabled, (
-            f"rating buttons should be live after Show; card="
-            f"{controller.current_review_card}; calls={scope.calls}"
-        )
-
-        # First press: the save enters the service and blocks on the gate.
-        rating_three.press()
-        await pilot.pause(0.2)
-        assert len(scope.entered) == 1, "first rating never reached the service"
-        assert scope.persisted == [], "the gate should still be holding the save"
-
-        # Second press while the first save is still in flight.
-        rating_five.press()
-        await pilot.pause(0.2)
-
+        window = app.screen.query_one(StudyWindow)
+        controller = window.flashcards_controller
         scope.gate.set()
-        await pilot.pause(0.4)
+        await pilot.pause(0.3)
 
-        assert len(scope.persisted) == 2, (
-            "a fast consecutive rating cancelled the previous save; persisted="
-            f"{scope.persisted}"
+        # Hold both rebuilds open together.
+        scope.gate.clear()
+        app.screen.query_one("#deck-select", Select).value = "deck-local-1"
+        await pilot.pause(0.1)
+        window.query_one("#flashcard-refresh-button", Button).press()
+        await pilot.pause(0.1)
+        scope.gate.set()
+        await pilot.pause(0.6)
+
+        rows = len(window.query_one("#card-list", ListView).children)
+        assert rows == len(controller.current_cards), (
+            f"#card-list holds {rows} rows against "
+            f"{len(controller.current_cards)} cards -- two rebuilds interleaved"
         )
-        assert sorted(rating for _card_id, rating in scope.persisted) == [3, 5]
+
+
+@pytest.mark.asyncio
+async def test_double_press_on_one_card_applies_sm2_once(tmp_path):
+    """TASK-19559 review R3: SM-2 is compounding, so a double-submit doubles it.
+
+    `ChaChaNotes_DB.update_flashcard_review` runs SM-2, which is *not*
+    idempotent: applying it twice to one card moves `repetitions` 0 -> 1 -> 2
+    and `interval` 1d -> 6d. Removing exclusivity turned a lost write into a
+    doubled schedule, which is a different data defect, not a fix.
+
+    Real DB, real Textual workers, two rapid presses on one card. Expected
+    `repetitions=1, interval=1` (SM-2 applied exactly once, matching base);
+    the pre-fix branch recorded `repetitions=2, interval=6`.
+    """
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    from tldw_chatbook.Study_Interop.local_study_service import LocalStudyService
+
+    db = CharactersRAGDB(str(tmp_path / "study.db"), "study-review-probe")
+    deck_id = db.create_deck("Doubling deck")
+    card_id = db.create_flashcard(
+        {"deck_id": deck_id, "front": "Q", "back": "A"}
+    )
+    local = LocalStudyService(db)
+
+    class RealDbStudyScopeService(FakeStudyScopeService):
+        def __init__(self):
+            super().__init__()
+            self.gate = asyncio.Event()
+            self.candidates = [
+                {
+                    "card": {
+                        "record_id": f"local:study_flashcard:{card_id}",
+                        "backing_id": card_id,
+                        "deck_record_id": f"local:study_deck:{deck_id}",
+                        "front": "Q",
+                        "back": "A",
+                        "queue_state": "new",
+                    },
+                    "selection_reason": "new",
+                    "next_intervals": {"again": "10m", "good": "1d"},
+                    "review_session": {"review_session_id": 41},
+                    "detail_available": True,
+                }
+            ] * 4
+
+        async def submit_flashcard_review(
+            self,
+            *,
+            mode=None,
+            scope_type=None,
+            workspace_id=None,
+            card_id=None,
+            rating,
+            current_card=None,
+            answer_time_ms=None,
+        ):
+            await self.gate.wait()
+            outcome = local.submit_flashcard_review(card_id, rating=rating)
+            return {
+                "card": outcome["card"],
+                "rating": rating,
+                "next_intervals": {"good": "3d"},
+                "review_session": {"review_session_id": 41},
+                "detail_available": True,
+            }
+
+    scope = RealDbStudyScopeService()
+    app = _study_app_for(scope)
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        window, _controller = await _enter_review(pilot, app)
+
+        window.query_one("#review-rating-3", Button).press()
+        await pilot.pause(0.2)
+        window.query_one("#review-rating-5", Button).press()
+        await pilot.pause(0.2)
+        scope.gate.set()
+        await pilot.pause(0.8)
+
+    row = db.get_flashcard(card_id)
+    assert (row["repetitions"], row["interval"]) == (1, 1), (
+        "SM-2 was applied more than once for a single card presentation: "
+        f"repetitions={row['repetitions']} interval={row['interval']}"
+    )

--- a/Tests/UI/test_study_flashcards_screen.py
+++ b/Tests/UI/test_study_flashcards_screen.py
@@ -1721,3 +1721,203 @@ async def test_double_press_on_one_card_applies_sm2_once(tmp_path):
         "SM-2 was applied more than once for a single card presentation: "
         f"repetitions={row['repetitions']} interval={row['interval']}"
     )
+
+
+class RealDbReviewScopeService(FakeStudyScopeService):
+    """Deals one real flashcard repeatedly and writes real SM-2 through it.
+
+    The `gate` is a genuine suspension point *in front of* the SM-2 write. It
+    stands in for the server backend, which is the only one where a rating can
+    be cancelled with the write's fate unknown: the local backend reaches
+    `ChaChaNotes_DB.update_flashcard_review` through `_maybe_await` without ever
+    yielding to the loop, so a `CancelledError` delivered at that await means
+    the write had not begun. Holding this gate open lets a test cancel the
+    rating worker at a point where nothing has been written yet -- the case a
+    retry must be able to recover.
+    """
+
+    def __init__(self, local, *, card_id: str, deck_id: str, deals: int = 4):
+        super().__init__()
+        self.local = local
+        self.gate = asyncio.Event()
+        self.submissions: list[tuple[str, int]] = []
+        self.candidates = [
+            {
+                "card": {
+                    "record_id": f"local:study_flashcard:{card_id}",
+                    "backing_id": card_id,
+                    "deck_record_id": f"local:study_deck:{deck_id}",
+                    "front": "Q",
+                    "back": "A",
+                    "queue_state": "new",
+                },
+                "selection_reason": "relearn",
+                "next_intervals": {"again": "10m", "good": "1d"},
+                "review_session": {"review_session_id": 41},
+                "detail_available": True,
+            }
+            for _ in range(deals)
+        ]
+
+    async def submit_flashcard_review(
+        self,
+        *,
+        mode=None,
+        scope_type=None,
+        workspace_id=None,
+        card_id=None,
+        rating,
+        current_card=None,
+        answer_time_ms=None,
+    ):
+        await self.gate.wait()
+        self.submissions.append((card_id, rating))
+        outcome = self.local.submit_flashcard_review(card_id, rating=rating)
+        return {
+            "card": outcome["card"],
+            "rating": rating,
+            "next_intervals": {"good": "3d"},
+            "review_session": {"review_session_id": 41},
+            "detail_available": True,
+        }
+
+
+def _real_db_review_fixture(tmp_path, name: str):
+    """A real ChaChaNotes DB holding one deck with one brand-new card."""
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    from tldw_chatbook.Study_Interop.local_study_service import LocalStudyService
+
+    db = CharactersRAGDB(str(tmp_path / f"{name}.db"), f"study-{name}")
+    deck_id = db.create_deck(f"{name} deck")
+    card_id = db.create_flashcard({"deck_id": deck_id, "front": "Q", "back": "A"})
+    return db, LocalStudyService(db), deck_id, card_id
+
+
+def _rating_buttons_enabled(window) -> bool:
+    return not any(
+        window.query_one(f"#review-rating-{rating}", Button).disabled
+        for rating in range(6)
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_rating_leaves_the_card_retryable(tmp_path):
+    """Qodo #1 on PR #1951: a cancelled rating locked the card out for good.
+
+    `submit_rating` used to claim `_reviewed_presentation` and disable the
+    rating buttons *before* awaiting the save. The `except asyncio.CancelledError:`
+    branch -- added by this very branch, because `CancelledError` is a
+    `BaseException` the `except Exception:` cannot see -- re-raised without
+    undoing either. So a cancelled save left the panel frozen: buttons disabled,
+    the presentation permanently marked reviewed, and no way to retry.
+
+    Born red at 738bd6179: after the cancellation the rating buttons are still
+    disabled, so the second press cannot even fire (`Button.press()` is a no-op
+    on a disabled button) and the DB still shows `repetitions=0` -- the review
+    the user made vanished with no way to make it again.
+    """
+    db, local, deck_id, card_id = _real_db_review_fixture(tmp_path, "cancel-retry")
+    scope = RealDbReviewScopeService(local, card_id=card_id, deck_id=deck_id)
+    app = _study_app_for(scope)
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        window, controller = await _enter_review(pilot, app)
+
+        window.query_one("#review-rating-3", Button).press()
+        await pilot.pause(0.2)
+        assert scope.submissions == [], "the gate should still hold the save"
+
+        # Cancel the in-flight rating exactly as an exclusive sibling would.
+        app.workers.cancel_group(window, "study-flashcard-rating")
+        await pilot.pause(0.3)
+
+        assert _rating_buttons_enabled(window), (
+            "a cancelled rating left the panel frozen: the rating buttons are "
+            "still disabled while the review panel is mounted, so the user "
+            "cannot retry the save that was just thrown away"
+        )
+
+        # The user rates the same card again. It must land exactly once.
+        scope.gate.set()
+        window.query_one("#review-rating-3", Button).press()
+        await pilot.pause(0.6)
+
+    row = db.get_flashcard(card_id)
+    assert (row["repetitions"], row["interval"]) == (1, 1), (
+        "the retry after a cancelled rating did not apply SM-2 exactly once: "
+        f"repetitions={row['repetitions']} interval={row['interval']} "
+        f"submissions={scope.submissions}"
+    )
+    assert scope.submissions == [(card_id, 3)], f"submissions={scope.submissions}"
+
+
+@pytest.mark.asyncio
+async def test_direct_submit_rating_call_cannot_double_apply_sm2(tmp_path):
+    """Review property 2: the durable gate holds for callers that skip the UI.
+
+    Disabling the rating buttons stops a second *press*, but the once-per-
+    presentation check is the backstop that has to hold when something calls
+    `submit_rating` directly. Here a real button press is in flight at the gate
+    and a direct call queues behind it on the same presentation; SM-2 must
+    still be applied once.
+    """
+    db, local, deck_id, card_id = _real_db_review_fixture(tmp_path, "direct-call")
+    scope = RealDbReviewScopeService(local, card_id=card_id, deck_id=deck_id)
+    app = _study_app_for(scope)
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        window, controller = await _enter_review(pilot, app)
+
+        window.query_one("#review-rating-3", Button).press()
+        await pilot.pause(0.2)
+        # Bypass the (now disabled) buttons entirely.
+        bypass = asyncio.ensure_future(controller.submit_rating(5))
+        await pilot.pause(0.1)
+
+        scope.gate.set()
+        await pilot.pause(0.6)
+        await bypass
+
+    row = db.get_flashcard(card_id)
+    assert (row["repetitions"], row["interval"]) == (1, 1), (
+        "a direct submit_rating() call compounded SM-2 for one presentation: "
+        f"repetitions={row['repetitions']} interval={row['interval']} "
+        f"submissions={scope.submissions}"
+    )
+    assert scope.submissions == [(card_id, 3)], f"submissions={scope.submissions}"
+
+
+@pytest.mark.asyncio
+async def test_re_dealt_card_records_every_genuine_re_review(tmp_path):
+    """Review property 3: the gate is per-*presentation*, never per-card.
+
+    A relearn queue deals the same card again a few minutes later, and that
+    second showing is a real recall event that must reach SM-2. Two sequential
+    reviews of one re-dealt card therefore have to move it 0 -> 1 -> 2
+    repetitions (interval 1d -> 6d) -- the exact state the double-press test
+    forbids for a single presentation.
+    """
+    db, local, deck_id, card_id = _real_db_review_fixture(tmp_path, "re-deal")
+    scope = RealDbReviewScopeService(local, card_id=card_id, deck_id=deck_id)
+    scope.gate.set()  # saves complete immediately; the user never waits
+    app = _study_app_for(scope)
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        window, controller = await _enter_review(pilot, app)
+
+        for _ in range(2):
+            assert controller.current_review_card is not None
+            window.query_one("#review-rating-3", Button).press()
+            await pilot.pause(0.4)
+            controller.show_answer()
+            await pilot.pause(0.05)
+
+    row = db.get_flashcard(card_id)
+    assert (row["repetitions"], row["interval"]) == (2, 6), (
+        "a re-dealt card lost one of its two genuine re-reviews: "
+        f"repetitions={row['repetitions']} interval={row['interval']} "
+        f"submissions={scope.submissions}"
+    )
+    assert scope.submissions == [(card_id, 3), (card_id, 3)], (
+        f"submissions={scope.submissions}"
+    )

--- a/Tests/UI/test_study_flashcards_screen.py
+++ b/Tests/UI/test_study_flashcards_screen.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -1366,3 +1367,134 @@ async def test_start_review_blocks_when_pending_session_teardown_keeps_failing()
         assert len(end_review_calls) == 2
         assert not any(call[0] == "get_next_review_candidate" for call in scope.calls)
         assert controller._pending_review_session_teardown is not None
+
+
+class GatedReviewStudyScopeService(FakeStudyScopeService):
+    """A scope service whose review save can be held open mid-flight.
+
+    `submit_flashcard_review` records the write only *after* the gate opens,
+    so a submission that is cancelled at its await never appears in
+    `persisted` -- which is exactly what "the rating did not reach the
+    database" looks like from the user's side.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.gate = asyncio.Event()
+        self.entered: list[tuple[str | None, int]] = []
+        self.persisted: list[tuple[str | None, int]] = []
+        self.candidates = [
+            {
+                "card": {
+                    "record_id": f"local:study_flashcard:card-local-{index}",
+                    "backing_id": f"card-local-{index}",
+                    "deck_record_id": "local:study_deck:deck-local-1",
+                    "front": f"Question {index}",
+                    "back": f"Answer {index}",
+                    "queue_state": "new",
+                },
+                "selection_reason": "new",
+                "next_intervals": {"again": "10m", "good": "1d"},
+                "review_session": {"review_session_id": 41},
+                "detail_available": True,
+            }
+            for index in range(1, 6)
+        ]
+
+    async def submit_flashcard_review(
+        self,
+        *,
+        mode=None,
+        scope_type=None,
+        workspace_id=None,
+        card_id=None,
+        rating,
+        current_card=None,
+        answer_time_ms=None,
+    ):
+        self.entered.append((card_id, rating))
+        await self.gate.wait()
+        self.persisted.append((card_id, rating))
+        return {
+            "card": {
+                **(current_card or {}),
+                "interval_days": 3,
+                "queue_state": "review",
+            },
+            "rating": rating,
+            "next_intervals": {"again": "10m", "good": "3d"},
+            "review_session": {"review_session_id": 41},
+            "detail_available": True,
+        }
+
+
+@pytest.mark.asyncio
+async def test_fast_consecutive_flashcard_ratings_all_persist():
+    """TASK-19559: a second rating press must not destroy the first save.
+
+    Born red against the branch base, where `handle_review_rating` scheduled
+    `submit_rating` with `exclusive=True` and no `group=`. That put every
+    rating in the shared "default" group, so `add_worker` cancelled the
+    in-flight save the moment the next press arrived -- and because
+    `CancelledError` is a `BaseException`, `submit_rating`'s `except
+    Exception:` could not even see it happen. The first rating simply
+    vanished. Pre-fix this asserts `persisted == [(card, 5)]`; post-fix both
+    ratings are present.
+
+    Driven through the real rating buttons -- two consecutive presses with the
+    save held open in between -- not by inspecting the dispatch keywords.
+    """
+    scope = GatedReviewStudyScopeService()
+    app_instance = SimpleNamespace(
+        study_scope_service=scope,
+        current_runtime_backend="local",
+        runtime_backend=None,
+        app_config={},
+        notify=lambda *args, **kwargs: None,
+    )
+    app = _build_full_study_app(app_instance)
+
+    async with app.run_test(size=(180, 60)) as pilot:
+        await pilot.pause(0.2)
+        await pilot.click("#view-flashcards-btn")
+        await pilot.pause(0.3)
+
+        app.screen.query_one("#deck-select", Select).value = "deck-local-1"
+        # Let the deck-change refresh (and its review-session teardown) finish
+        # before starting a review, so nothing tears the card down underneath us.
+        await pilot.pause(0.5)
+        controller = app.screen.query_one(StudyWindow).flashcards_controller
+
+        await controller.start_review()
+        await pilot.pause(0.2)
+        controller.show_answer()
+        await pilot.pause(0.1)
+
+        # `Button.press()` posts the real `Button.Pressed` message through the
+        # real `@on` handler; it just does not need the button to be within the
+        # visible viewport the way `pilot.click` does.
+        rating_three = app.screen.query_one("#review-rating-3", Button)
+        rating_five = app.screen.query_one("#review-rating-5", Button)
+        assert not rating_three.disabled, (
+            f"rating buttons should be live after Show; card="
+            f"{controller.current_review_card}; calls={scope.calls}"
+        )
+
+        # First press: the save enters the service and blocks on the gate.
+        rating_three.press()
+        await pilot.pause(0.2)
+        assert len(scope.entered) == 1, "first rating never reached the service"
+        assert scope.persisted == [], "the gate should still be holding the save"
+
+        # Second press while the first save is still in flight.
+        rating_five.press()
+        await pilot.pause(0.2)
+
+        scope.gate.set()
+        await pilot.pause(0.4)
+
+        assert len(scope.persisted) == 2, (
+            "a fast consecutive rating cancelled the previous save; persisted="
+            f"{scope.persisted}"
+        )
+        assert sorted(rating for _card_id, rating in scope.persisted) == [3, 5]

--- a/backlog/tasks/task-19559 - exclusive=True without group= makes every worker on a node cancel its siblings.md
+++ b/backlog/tasks/task-19559 - exclusive=True without group= makes every worker on a node cancel its siblings.md
@@ -3,7 +3,7 @@ id: TASK-19559
 title: >-
   exclusive=True without group= makes every worker on a node cancel its
   siblings (145 sites)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:09'
 labels:
@@ -68,21 +68,101 @@ hand-edits: a failing lint/test is what stops the 146th.
 
 ## Acceptance Criteria
 
-- [ ] A lint or test fails on `exclusive=True` scheduled without an explicit
+- [x] A lint or test fails on `exclusive=True` scheduled without an explicit
       `group=`, covering both `@work(...)` decorators and `run_worker(...)`
       calls, including multi-line forms
-- [ ] The guard has an explicit, documented allowlist mechanism for any site
+- [x] The guard has an explicit, documented allowlist mechanism for any site
       that genuinely wants default-group mutual exclusion, so suppressing it is
       a deliberate recorded choice rather than a silent one
-- [ ] The four named user-visible instances are fixed: Study rating submission,
+- [x] The four named user-visible instances are fixed: Study rating submission,
       Media analysis generation, the four unfixed Watchlists section loaders,
       and the Settings advanced-config backup load
-- [ ] Fast consecutive flashcard ratings all persist — pinned by a test that
+- [x] Fast consecutive flashcard ratings all persist — pinned by a test that
       drives consecutive submissions, not by inspection
-- [ ] The Settings advanced-config editor is never overwritten by a background
+- [x] The Settings advanced-config editor is never overwritten by a background
       load while the user has unsaved typing in it
-- [ ] Handlers in this family no longer rely on `except Exception:` to observe
+- [x] Handlers in this family no longer rely on `except Exception:` to observe
       cancellation, given `CancelledError` is a `BaseException`
-- [ ] The remaining sites are triaged with the user-visible ones fixed and the
+- [x] The remaining sites are triaged with the user-visible ones fixed and the
       rest either grouped or allowlisted — the count is driven to a number the
       guard can hold
+
+## Implementation Plan
+
+1. Re-confirm the framework mechanism against the installed Textual 8.2.8
+   (`Worker.__init__` default group, `WorkerManager.add_worker`/`cancel_group`
+   source, `Worker.cancel` on a thread worker).
+2. Census the real site count with an AST walk, not a grep, and record both
+   numbers so the over-count is documented rather than repeated.
+3. Land the durable remedy first: an `Tests/Architecture/` inventory guard with
+   a documented, reason-carrying allowlist, proven to bite on both the
+   decorator form and the multi-line call form.
+4. Fix the four named user-visible instances.
+5. Triage every remaining site to an explicit group named after the *work*.
+
+## Implementation Notes
+
+**The guard is the deliverable.** `Tests/Architecture/test_worker_exclusive_group_inventory.py`
+walks the AST of every module under `tldw_chatbook/` and fails on any
+`@work(...)` or `run_worker(...)` that requests exclusivity without naming a
+group. It handles the multi-line form, the positional `run_worker(work, name,
+group, ...)` form, and fails **closed** on a `**kwargs` spread or a non-literal
+`exclusive=` (the stance `Tests/UI/test_chat_screen_worker_groups.py` already
+took for Console). `DEFAULT_GROUP_ALLOWLIST` is keyed by
+`"<path>::<owning function>"` — a name, not a line number, so an entry survives
+edits above it — and carries the reasoning that earns it; two further tests
+assert no entry is stale and no entry ships without prose.
+
+**Measured, not estimated.** At the branch base the AST census found **133
+sites across 32 files**. The naive `grep exclusive=True | grep -v group=` the
+task warned about reported **523** — a ~4x over-count, because a multi-line call
+carries `group=` on a following line (`chat_screen.py` alone accounts for 29 of
+the phantom hits while having zero real ones). After this change: **1 site**,
+the vendored `textual-fspicker` widget, allowlisted with its reasoning.
+
+**Group naming rule.** A group is named after the *work*, not the caller. Two
+call sites that start the same load share a group (a refresh supersedes a
+refresh: `wc_rules` is used by all four `_load_rules()` dispatchers); two
+different operations do not (a section load must never kill a save). That rule
+drove all 131 mechanical edits and is stated in the guard's docstring.
+
+**The four named instances.**
+
+- **(a) Study ratings.** Grouping alone is *not* sufficient here and the born-red
+  test proves it: with an explicit group but `exclusive=True` still set, the
+  second press still destroys the first save. A spaced-repetition rating is a
+  durable write, so `handle_review_rating` now dispatches into
+  `group="study-flashcard-rating"` with **no exclusivity at all**, and
+  `FlashcardsHandler.submit_rating` serialises presses behind an `asyncio.Lock`,
+  capturing the card under review synchronously before its first `await` so a
+  fast second press rates the card the user was looking at. It also grows an
+  explicit `except asyncio.CancelledError:` that logs and re-raises — the
+  `except Exception:` beneath it is a `BaseException` blind spot by construction.
+- **(b) Media analysis.** `perform_analysis` and its four siblings each name
+  their own group, so generating an analysis can no longer be cancelled by a
+  save/overwrite/delete/read-it-later toggle.
+- **(c) Watchlists.** `wc_rules` / `wc_runs` / `wc_sources` / `wc_notifications`
+  join the two already-fixed branches, matching the adjacent `wc_items`
+  convention; the method docstring now records that the hazard comment sat
+  directly above four siblings it did not protect.
+- **(d) Settings backup load.** Grouping is again insufficient: the worker is a
+  *thread* worker, whose body `Worker.cancel()` cannot stop. The editor text is
+  now captured at dispatch and compared on arrival; if the user typed while the
+  backup was being read the write is refused and the refusal is reported
+  ("unsaved edits were kept") instead of silently replacing their work.
+
+**Born-red evidence.** Both behavioural tests were driven, then re-run against a
+neutered fix and observed to fail with the exact production symptom:
+`persisted=[('card-local-1', 5)]` (the rating-3 save gone) and a
+`provider = "OpenAI"` → `provider = "Ollama"` editor diff. The guard was proven
+to bite by injecting one single-line decorator violation and one multi-line
+`name=`-only call into real package files; both were reported, and the files
+restored to byte-identical SHA-256.
+
+**Modified:** `Tests/Architecture/test_worker_exclusive_group_inventory.py`
+(new); `UI/Study_Window.py`, `UI/Study_Modules/flashcards_handler.py`,
+`UI/MediaWindow_v2.py`, `UI/Screens/watchlists_collections_screen.py`,
+`UI/Screens/settings_screen.py`, plus 26 further modules taking mechanical
+`group=` additions; `Tests/UI/test_settings_configuration_hub.py`,
+`Tests/UI/test_media_window_v2_parity.py`,
+`Tests/UI/test_study_flashcards_screen.py`.

--- a/backlog/tasks/task-19559 - exclusive=True without group= makes every worker on a node cancel its siblings.md
+++ b/backlog/tasks/task-19559 - exclusive=True without group= makes every worker on a node cancel its siblings.md
@@ -257,3 +257,135 @@ test_article_search_hides_a_day_header_whose_whole_group_is_filtered_out` is a
 `TZ=UTC` and fails under `America/Los_Angeles`. The other two residual
 failures (`test_persistent_diagnostic_inventory`, `test_screen_size_ratchet
 [chat_screen.py]`) were confirmed pre-existing at that same base.
+
+## Qodo review response (PR #1951)
+
+Three findings, all accepted. Baselines below are the PR head `738bd6179`.
+
+**Q1 (High) — a cancelled rating locked the card out permanently. Real, and
+the independent review of this branch missed it.** The review checked the
+re-enable paths and cleared them, but it read the generic `except Exception:`
+branch, which *does* reset `_reviewed_presentation` before re-enabling. The
+`except asyncio.CancelledError:` branch is separate — it exists precisely
+because `CancelledError` is a `BaseException` that `except Exception` cannot
+observe, which is this task's own headline — and it never got the same
+treatment. The branch's signature mechanism created the gap.
+
+Probe at `738bd6179`, real Textual workers + real ChaChaNotes DB, cancelling
+the in-flight rating with `app.workers.cancel_group(window,
+"study-flashcard-rating")` (exactly what an ungrouped exclusive sibling did):
+
+```
+panel_live=True  buttons_enabled=False  _reviewed_presentation=3
+_review_presentation=3  submissions=[]  repetitions=0  interval=0
+```
+
+The panel is still mounted, every rating button is disabled, the presentation
+is marked reviewed forever, and nothing was ever written — a direct
+`submit_rating()` bypass is refused too. The user's review is gone with no way
+to make it again.
+
+**Fix — Qodo's option B, not option A.** The marker is no longer claimed before
+the await; it is claimed the instant the write *returns*, before the arrival
+guard can return early. That costs nothing, because the lock is held across the
+await: a queued second submission cannot reach the duplicate check until the
+first has either recorded its marker or failed. So cancellation has nothing to
+roll back — it only hands the buttons back (guarded by `_review_panel_is_live()`
+and by its own `try/except`, so a restore failure can never replace the
+`CancelledError` on its way out) and re-raises.
+
+**The unknown, and which way it is erred.** A cancellation cannot say whether
+the write landed. For the *local* backend it can:
+`StudyScopeService.submit_flashcard_review` reaches `LocalStudyService` through
+`_maybe_await`, which never suspends for a synchronous result, so a
+`CancelledError` delivered at that await must have arrived before the DB call —
+nothing was written. For the *server* backend the await is a real HTTP
+round-trip and a cancellation can lose the response to a review the server
+already applied. The code does **not** branch on the backend for this (that
+reasoning depends on a collaborator's internal await structure, which is not
+ours to pin). It errs toward **retryable**: the marker is not claimed, so the
+user can rate the card again. Erring this way risks one re-application of SM-2
+in server mode; erring the other way guarantees a frozen panel holding a review
+that was never written and can never be written. The retry is made an informed
+one — the status line and a toast say the save may not have landed, instead of
+leaving the panel looking untouched.
+
+**Born red** (`test_cancelled_rating_leaves_the_card_retryable`): at
+`738bd6179` it fails on `_rating_buttons_enabled(window)` — the buttons are
+still disabled, so the second press cannot even fire (`Button.press()` is a
+no-op on a disabled button) — and the DB still reads `repetitions=0`. After the
+fix the retry lands exactly once: `repetitions=1, interval=1`.
+
+**The three review properties, re-verified and mutation-tested** (each drives
+real Textual workers against a real DB and reads persisted state):
+
+| property | test | mutation | result under mutation |
+|---|---|---|---|
+| two rapid presses ⇒ one SM-2 | `..._double_press_on_one_card_applies_sm2_once` | delete the UI disable | still **passes** — the durable gate alone holds it |
+| bypassing the buttons ⇒ one SM-2 | `..._direct_submit_rating_call_cannot_double_apply_sm2` (new) | `if False and self._reviewed_presentation == presentation` | **fails**: `repetitions=2 interval=6` |
+| re-dealt card ⇒ each re-review recorded | `..._re_dealt_card_records_every_genuine_re_review` (new) | `presentation = 0` (per-card, not per-presentation) | **fails**: `repetitions=1 interval=1`, one review lost |
+
+The middle row is the one that matters for this change: moving the marker to
+after the write could have opened a double-apply window for a programmatic
+caller, and it does not — the lock, not the ordering, is what closes it. The
+top row shows the two defences are genuinely independent.
+
+**Q2 (Medium) — the new error log had no context.** `submit_rating` now binds
+`operation="study.flashcard.submit_review"`, `card_id`, `deck_id`, `mode`,
+`rating`, `scope_type`, `presentation` (the repo's established
+`logger.bind(...).opt(exception=True)` idiom, as in
+`personas_preview_controller`), and additionally spells `card_id`/`deck_id`/
+`mode` into the message text — the shipped loguru sink format in
+`Logging_Config.py` renders `{message}` and not `{extra}`, so bound-only fields
+would not reach the log file a human actually greps. **Metadata only.**
+`card_id`/`deck_id` are `CharactersRAGDB._generate_uuid()` values, not anything
+the user typed. **Rejected as user content:** the card's `front` and `back`
+(the user's own study material), the deck *name*, and the review status text —
+TASK-19864 is open on diagnostics that interpolate user content and paths into
+log text, and none of them are needed to correlate a failure.
+
+**Q3 (Moderate) — "worker guard test too heavy". Accepted, and fixed without
+narrowing anything.** The guard still walks the whole package, still catches
+decorators, calls, multi-line and positional forms, and still fails closed on
+`**kwargs` spreads and non-literal `exclusive=`. Three cost changes, none of
+them a coverage change:
+
+1. **One cached pass.** `_scan_package()` is `@lru_cache(maxsize=1)`;
+   `test_no_ungrouped_exclusive_workers` and the allowlist-staleness check both
+   read it, where they used to walk and parse all ~1,780 modules independently.
+2. **Lazy owner index.** `_owner_index` — attributing every line to its owning
+   function — is the most expensive step and was run for every file. It is now
+   built only once a file actually has a violation to attribute.
+3. **Text prefilter before parse.** `\b(?:work|run_worker)\b` admits 311 of
+   1,779 files. Sound by construction: `_call_name` only ever returns an
+   `ast.Name.id` or `ast.Attribute.attr`, both of which must appear verbatim as
+   a token in the source, so a file without either token cannot contain a call
+   this guard would flag. (`\b` means `workspace`/`workflow` do not match.)
+
+Proven equivalent, not argued: an A/B in-process run of the prefiltered scan
+against a no-prefilter scan of every file returned **`IDENTICAL: True`**, and
+`test_prefilter_only_skips_files_with_no_scheduler_token` re-parses the 1,468
+*skipped* files every run and asserts the AST finds nothing there either.
+`test_prefilter_admits_every_flagged_form` pins the prefilter against all seven
+flagged shapes.
+
+| | before | after |
+|---|---|---|
+| `test_no_ungrouped_exclusive_workers` | 6.23s | 2.55s |
+| `test_allowlist_has_no_stale_entries` | 5.97s | <1s (cache hit) |
+| both guard suites, wall clock | 14.97s / 16 passed | 7.32s / 19 passed |
+
+**Census unchanged after the optimisation:** 1,779 package files, **1 flagged
+site** (`Third_Party/textual_fspicker/.../DirectoryNavigation._load`), 1
+allowlist entry, **0 violations**, 0 stale allowlist rows.
+
+**Counts at this commit:** branch-touched test files + `Tests/Study_Interop`
+**654 passed / 0 failed**; the architecture guard **15 passed**;
+`Tests/UI/test_chat_screen_worker_groups.py` **4 passed**. Reconciling with the
+prior 663: 654 − 3 new Study tests = 651, and 651 + the guard file's former 12
+= 663. The two guard suites go 16 → 19. Repo-wide `--collect-only -q`:
+**54,905 tests collected, 0 collection errors**.
+
+**Modified by this response:** `UI/Study_Modules/flashcards_handler.py`,
+`Tests/UI/test_study_flashcards_screen.py`,
+`Tests/Architecture/test_worker_exclusive_group_inventory.py`.

--- a/backlog/tasks/task-19559 - exclusive=True without group= makes every worker on a node cancel its siblings.md
+++ b/backlog/tasks/task-19559 - exclusive=True without group= makes every worker on a node cancel its siblings.md
@@ -166,3 +166,94 @@ restored to byte-identical SHA-256.
 `group=` additions; `Tests/UI/test_settings_configuration_hub.py`,
 `Tests/UI/test_media_window_v2_parity.py`,
 `Tests/UI/test_study_flashcards_screen.py`.
+
+## Review response (do-not-ship findings R1/R2/R3)
+
+Independent review confirmed the guard, the allowlist and the census (133
+sites / 32 files; the task's own "145 / 35" header is wrong) but returned
+**do-not-ship** on the Study path: removing exclusivity there was correct, and
+was not paired with the arrival-time guard this same change applies everywhere
+else. All three findings reproduced, were fixed, and are now pinned.
+
+Evidence is a single probe run identically against base `e98076411`, the
+pre-fix branch `3f539c2d4`, and the fix — real Textual workers, real DB,
+reading persisted state:
+
+| | base | pre-fix branch | fixed |
+|---|---|---|---|
+| R1 `_handle_exception` | `[]` | `WorkerFailed(NoMatches('#review-status'))` | `[]` |
+| R1 rating persisted | `[]` (lost) | `[('card-local-1', 3)]` | `[('card-local-1', 3)]` |
+| R1 `current_review_session_id` | `None` | `41` (resurrected) | `None` |
+| R2 `#card-list` rows / `current_cards` | 2 / 2 | 4 / 2 | 2 / 2 |
+| R3 `repetitions` / `interval` | 1 / 1d | 2 / 6d | 1 / 1d |
+
+**R1 — arrival guard.** `StudyWindow.watch_current_view` calls
+`remove_children()`, so leaving the sub-view mid-save destroys the widgets
+every `_set_review_*` helper reaches with a bare `query_one`. Exclusivity used
+to swallow this by cancelling the save first. `StudyFlashcardsController` now
+carries a `_review_presentation` token, bumped wherever the presented card
+changes or the panel is torn down (`reset_review_panel`,
+`_load_next_review_candidate`, `end_review_session_if_needed`).
+`submit_rating` captures it before its first `await` and re-checks it — plus
+`_review_panel_is_live()` — after the write lands, before touching session
+state or UI. Note the fixed column beats base on the row that matters: the
+rating **persists** where base lost it, and nothing raises.
+
+**R2 — the missed writer.** `handle_deck_select_changed` was left ungrouped
+*and* non-exclusive, so it sat in `"default"` while `handle_refresh_cards`
+moved to `study-refresh-cards`; base's ungrouped-exclusive refresh had been
+cancelling it. Both rebuild `#card-list`, so by this task's own rule (group
+after the *work*) they now share `study-refresh-cards`, exclusive.
+
+**R3 — SM-2 is compounding; semantic choice flagged for the owner.**
+`ChaChaNotes_DB.update_flashcard_review` is not idempotent: two reviews of one
+card move it `repetitions` 0->1->2 and `interval` 1d->6d. Converting a lost
+write into a doubled schedule is a different data defect, not a fix, and the
+old gated test *pinned* the doubling by holding one card fixed.
+
+Resolved as **one review per card presentation**: `submit_rating` records the
+presentation it has written for and drops a second submission for the same
+one, and rating buttons are now disabled the moment a press is accepted (re-
+enabled on the failure path), so the UI cannot produce the second press at all.
+
+The controller proposed "apply the **latest** rating once"; this ships
+**first-press-wins**, and the difference needs an owner call. Reasoning: by the
+time a second press arrives the first write is already awaiting the service, so
+the only ways to honour "latest" are to un-apply SM-2 (no such API) or to
+debounce the first write, which adds latency to *every* rating on the hot path.
+Anki, the reference implementation for this interaction, also disables the
+answer buttons on press and routes the next press to the *next* card — which is
+what disabling the buttons now reproduces. Both options agree on the part that
+matters (SM-2 applied exactly once); only the tie-break differs, and it is only
+reachable programmatically now. If the owner prefers latest-wins, the mechanism
+is a short debounce window and it should be filed as its own task.
+
+**Tests.** The doubling-pinning test is gone. Five now stand, each red at the
+baseline that owns it: `..._survives_a_sibling_study_worker` (red at base —
+this is the AC's actual named bug, `Study_Window.py:1007/1011` eating the
+save), `..._on_distinct_cards_all_persist` (the AC as-meant), `..._survives_
+leaving_the_flashcards_sub_view` (red at **both** baselines: lost write at
+base, `WorkerFailed` pre-fix), `..._do_not_interleave_the_card_list` (red
+pre-fix, 4 vs 2), `..._applies_sm2_once` (red pre-fix, real DB, 2/6d).
+
+**Guard hole closed by the reviewer (`3f539c2d4`, kept):** the walk checked
+only that a `group=` node was *present*. `group="default"` is byte-identical to
+omitting it, and `group=""`/`None` are falsy so `add_worker`'s
+`if exclusive and worker.group:` skips `cancel_group` entirely — the site asks
+for exclusivity and silently gets none.
+
+**Residuals to file, not fixed here** (both are the inverse shape — work that
+should be inside an existing group running outside it):
+1. `schedules_workbench` mutation workers (`_delete_and_refresh`,
+   `_save_and_refresh`, `_run_and_refresh`, `_update_and_refresh`,
+   `_bulk_delete`, `_bulk_toggle`) `await load_tasks()` inline, so that reload
+   runs outside `schedules-load-tasks` and cannot be superseded by a newer one.
+2. Watchlists notification mark-read/dismiss reload notifications inline,
+   outside `wc_notifications`.
+
+**Also recorded:** `Tests/Watchlists/test_watchlists_pane_filter_in_place.py::
+test_article_search_hides_a_day_header_whose_whole_group_is_filtered_out` is a
+**timezone flake**, not a regression — at base `e98076411` it passes under
+`TZ=UTC` and fails under `America/Los_Angeles`. The other two residual
+failures (`test_persistent_diagnostic_inventory`, `test_screen_size_ratchet
+[chat_screen.py]`) were confirmed pre-existing at that same base.

--- a/backlog/tasks/task-19563 - Three surfaces show stale search results because name= was mistaken for worker scoping.md
+++ b/backlog/tasks/task-19563 - Three surfaces show stale search results because name= was mistaken for worker scoping.md
@@ -3,7 +3,7 @@ id: TASK-19563
 title: >-
   Three surfaces show stale results because name= was mistaken for worker
   scoping and no generation guard exists
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:13'
 labels:
@@ -68,16 +68,81 @@ instances touched by this work; do not open a 42-site sweep on its own account.
 
 ## Acceptance Criteria
 
-- [ ] Each of the three surfaces discards results that no longer match the
+- [x] Each of the three surfaces discards results that no longer match the
       current input, using the generation-counter pattern already established
       in `chat_screen.py`
-- [ ] The guard is applied at **result arrival**, not only at dispatch — thread
+- [x] The guard is applied at **result arrival**, not only at dispatch — thread
       worker bodies cannot be cancelled, so arrival-time rejection is required
-- [ ] Typing quickly in CCP conversation search never leaves the list showing
+- [x] Typing quickly in CCP conversation search never leaves the list showing
       results for a prefix of the current query — pinned by a test that
       interleaves two dispatches and delivers them out of order
-- [ ] The Personas character load no longer renders a superseded character
-- [ ] `model_installed_view` toasts cannot land on an unrelated screen
-- [ ] Any `is_mounted` post-await guard touched by this change is corrected to
+- [x] The Personas character load no longer renders a superseded character
+- [x] `model_installed_view` toasts cannot land on an unrelated screen
+- [x] Any `is_mounted` post-await guard touched by this change is corrected to
       `is_attached`; the remaining instances are left for separate triage
       rather than swept blind
+
+## Implementation Plan
+
+1. Copy `chat_screen.py`'s generation counter rather than inventing a mechanism:
+   bump at dispatch, carry the value with the work, compare on arrival.
+2. Put the comparison at **result arrival** on each of the three surfaces,
+   because a thread worker's body cannot be cancelled.
+3. Correct only the `is_mounted` guards this change actually touches.
+
+## Implementation Notes
+
+**Headline: CCP conversation search never ran at all.** Reading the named site
+closely turned up two independent defects underneath the stale-results
+symptom, neither observable from the handler:
+
+* `run_worker(self._search_conversations_sync, search_term, search_type,
+  thread=True, exclusive=True, name="conversation_search")` binds
+  `search_term` to `run_worker`'s own `name` parameter and `search_type` to its
+  `group`, then collides with the explicit `name=` keyword —
+  `TypeError: run_worker() got multiple values for argument 'name'`. Proved by
+  binding the real `DOMNode.run_worker` signature, not by reading.
+* `_search_conversations_sync` carried `@work(thread=True)`, and Textual's
+  decorator does `assert isinstance(self, DOMNode)`. `CCPConversationHandler`
+  is a plain object that merely *holds* a window, so the decorator could only
+  ever have raised `AssertionError`. Proved by running a two-line repro.
+
+The same `run_worker` misuse was present in `refresh_conversation_list`,
+`load_conversation`, and `ccp_dictionary_handler.load_dictionary` — all now use
+the `functools.partial` shape `CCPCharacterHandler.load_character` already used,
+and the two `@work` decorators on non-DOMNode helpers are gone. **An AST sweep
+found five more sites of this exact shape in `UI/Tools_Settings_Window.py`
+(6685, 6747, 6894, 7000, 7325); left untouched as that screen is
+`DEPRECATED (TASK-1346)` and nav-unreachable, and it is outside this task.**
+
+**The three surfaces.** Each gained a monotonic counter bumped at dispatch and
+compared in an arrival callback that runs on the event loop:
+
+- **(a) CCP conversation search** — the worker no longer writes
+  `self.search_results` from the worker thread. It hands rows to
+  `_apply_search_results(generation, results)`, which adopts them only while the
+  generation is current.
+- **(b) Personas character load** — `_load_character_sync` no longer mutates
+  handler state or posts messages from the thread; `_apply_loaded_character`
+  does both, behind the generation check. Display corruption only, as the task
+  states: the modern save path has its own guard.
+- **(c) Model install view** — `ensure_loaded` bumps `_inventory_generation` and
+  passes it to `_load_inventory`; `_apply_inventory` drops a superseded read
+  outright, and gates the UI-driving branch (recompose, observation refresh,
+  focus restoration) on `is_attached` so a read that lands after the user
+  navigated away cannot drive another screen.
+
+**`is_mounted`:** the one guard added here uses `is_attached`, which is the
+check that can actually be `False`; no 42-site sweep was opened.
+
+**Born-red evidence.** Both new arrival-guard tests were re-run against a
+neutered guard and failed with the exact production symptom: the CCP list
+rendered `[['conv-ab'], ['conv-a']]` (the stale prefix winning) and the
+character surface displayed `['char.local.bob', 'char.local.alice']`. The
+inventory test failed with `('stale',) == ()`.
+
+**Modified:** `UI/CCP_Modules/ccp_conversation_handler.py`,
+`UI/CCP_Modules/ccp_character_handler.py`,
+`UI/CCP_Modules/ccp_dictionary_handler.py`,
+`UI/Screens/model_installed_view.py`, `Tests/UI/test_ccp_handlers.py`,
+`Tests/UI/test_model_installed_view.py`.

--- a/backlog/tasks/task-19563 - Three surfaces show stale search results because name= was mistaken for worker scoping.md
+++ b/backlog/tasks/task-19563 - Three surfaces show stale search results because name= was mistaken for worker scoping.md
@@ -92,7 +92,16 @@ instances touched by this work; do not open a 42-site sweep on its own account.
 
 ## Implementation Notes
 
-**Headline: CCP conversation search never ran at all.** Reading the named site
+**Note on severity, corrected in review: surface (a) is dead code.**
+`PersonasScreen` (1008-1009) only ever builds `character_handler` and
+`persona_handler` -- `CCPConversationHandler` and `CCPDictionaryHandler` are
+never instantiated in production. The conversation-search and dictionary fixes
+below are correct but unreachable, so **the live fix in this task is the
+Personas character load (b)**, and (a) must not be described as the headline.
+The findings are kept because the handlers are still imported, exported and
+tested, and would be reached the moment either is wired up.
+
+**What reading the named site turned up.** Reading the named site
 closely turned up two independent defects underneath the stale-results
 symptom, neither observable from the handler:
 

--- a/backlog/tasks/task-19563 - Three surfaces show stale search results because name= was mistaken for worker scoping.md
+++ b/backlog/tasks/task-19563 - Three surfaces show stale search results because name= was mistaken for worker scoping.md
@@ -155,3 +155,24 @@ inventory test failed with `('stale',) == ()`.
 `UI/CCP_Modules/ccp_dictionary_handler.py`,
 `UI/Screens/model_installed_view.py`, `Tests/UI/test_ccp_handlers.py`,
 `Tests/UI/test_model_installed_view.py`.
+
+## Qodo review response (PR #1951)
+
+Qodo returned three findings on the shared PR; **none of them landed on this
+task's surfaces** (CCP conversation search, Personas character load, Model
+install view). All three are recorded in full in task-19559's notes:
+
+1. **High — cancelled rating locks the card out** (`Study_Modules/
+   flashcards_handler.py`). The arrival-guard *pattern* this task established
+   is unaffected; the defect was in the once-per-presentation write gate that
+   sits beside it, where the presentation marker was claimed before the await
+   and never given back on `CancelledError`. Fixed by claiming the marker only
+   once the write returns.
+2. **Medium — error log without context**, same file.
+3. **Moderate — the worker-group guard test is too heavy.** Made ~4.8× cheaper
+   on the scan (6.23s → 2.55s) with no reduction in what it checks; proven
+   output-identical against an unfiltered scan.
+
+`Tests/UI/test_ccp_handlers.py` and `Tests/UI/test_model_installed_view.py` —
+this task's evidence — were re-run at the fix commit and are green inside the
+**654 passed / 0 failed** branch-touched battery.

--- a/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
@@ -200,6 +200,8 @@ class CCPCharacterHandler:
         self.current_character_data: Dict[str, Any] = {}
         self.character_list: List[Dict[str, Any]] = []
         self.pending_image_data: Optional[str] = None
+        # TASK-19563: monotonic dispatch counter; see `_apply_loaded_character`.
+        self._character_load_generation: int = 0
 
         logger.debug("CCPCharacterHandler initialized")
 
@@ -454,19 +456,30 @@ class CCPCharacterHandler:
         """
         logger.info(f"Starting character load for {character_id}")
 
+        self._character_load_generation += 1
+
         # Run the sync database operation in a worker thread
         self.window.run_worker(
-            partial(self._load_character_sync, character_id),
+            partial(
+                self._load_character_sync,
+                character_id,
+                self._character_load_generation,
+            ),
             thread=True,
             exclusive=True,
+            group="ccp-load-character",
             name=f"load_character_{character_id}",
         )
 
-    def _load_character_sync(self, character_id: CharacterId) -> None:
+    def _load_character_sync(
+        self, character_id: CharacterId, generation: Optional[int] = None
+    ) -> None:
         """Sync method to load character data in a worker thread.
 
         Args:
             character_id: The ID of the character to load
+            generation: The dispatch generation this read belongs to; a
+                superseded generation is discarded when it arrives.
         """
         logger.info(f"Loading character {character_id}")
 
@@ -474,27 +487,11 @@ class CCPCharacterHandler:
             card_data = fetch_character_by_id(character_id)
 
             if card_data:
-                self.current_character_id = character_id
-                self.current_character_data = card_data
-
-                # Post messages from worker thread using call_from_thread
+                # Everything that mutates handler state or the UI happens on
+                # the event loop, behind the generation check.
                 self._call_from_thread(
-                    self.window.post_message,
-                    CharacterMessage.Loaded(character_id, card_data),
+                    self._apply_loaded_character, generation, character_id, card_data
                 )
-
-                # Switch view to show character card
-                self._call_from_thread(
-                    self.window.post_message,
-                    ViewChangeMessage.Requested(
-                        "character_card", {"character_id": character_id}
-                    ),
-                )
-
-                # Update UI on main thread
-                self._call_from_thread(self._display_character_card)
-
-                logger.info(f"Character {character_id} loaded successfully")
             else:
                 logger.error(f"Failed to load character {character_id}")
 
@@ -502,6 +499,45 @@ class CCPCharacterHandler:
             logger.opt(exception=True).error(
                 f"Error loading character {character_id}: {e}"
             )
+
+    def _apply_loaded_character(
+        self,
+        generation: Optional[int],
+        character_id: CharacterId,
+        card_data: Dict[str, Any],
+    ) -> None:
+        """Display a loaded character only while it is still the current one.
+
+        TASK-19563: selecting characters quickly dispatches one *thread* worker
+        per selection, and `Worker.cancel()` does not stop a thread worker --
+        its body finishes in the executor and its `call_from_thread` callbacks
+        still land. Without this arrival-time check the slower of two reads can
+        win and render a superseded character card. This is display corruption
+        only; the modern save path carries its own generation guard, so stored
+        data is not at risk.
+        """
+        if generation is not None and generation != self._character_load_generation:
+            logger.debug(
+                "Dropping superseded CCP character load "
+                f"(generation {generation} != {self._character_load_generation})"
+            )
+            return
+
+        self.current_character_id = character_id
+        self.current_character_data = card_data
+
+        self.window.post_message(CharacterMessage.Loaded(character_id, card_data))
+
+        # Switch view to show character card
+        self.window.post_message(
+            ViewChangeMessage.Requested(
+                "character_card", {"character_id": character_id}
+            )
+        )
+
+        self._display_character_card()
+
+        logger.info(f"Character {character_id} loaded successfully")
 
     def _display_character_card(self) -> None:
         """Display character card in the UI."""
@@ -779,6 +815,7 @@ class CCPCharacterHandler:
                     ),
                     thread=True,
                     exclusive=True,
+                    group="ccp-update-character",
                     name=f"update_character_{self.current_character_id}",
                 )
             else:
@@ -787,6 +824,7 @@ class CCPCharacterHandler:
                     partial(self._create_character, character_data),
                     thread=True,
                     exclusive=True,
+                    group="ccp-create-character",
                     name="create_character",
                 )
 

--- a/tldw_chatbook/UI/CCP_Modules/ccp_conversation_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_conversation_handler.py
@@ -1,8 +1,8 @@
 """Handler for conversation-related operations in the Personas screen."""
 
+from functools import partial
 from typing import TYPE_CHECKING, Optional, List, Dict, Any, Tuple, Union
 from loguru import logger
-from textual import work
 from textual.widgets import ListView, ListItem, Input, Static
 
 from ...config import get_chachanotes_db_lazy
@@ -50,6 +50,8 @@ class CCPConversationHandler:
         self.current_conversation_id: Optional[ConversationId] = None
         self.current_conversation_data: Dict[str, Any] = {}
         self.search_results: List[Dict[str, Any]] = []
+        # TASK-19563: monotonic dispatch counter; see `_apply_search_results`.
+        self._conversation_search_generation: int = 0
 
         logger.debug("CCPConversationHandler initialized")
 
@@ -96,6 +98,16 @@ class CCPConversationHandler:
         normalized = [normalize_conversation_row(row) for row in conversations]
         return [row for row in normalized if self._matches_active_scope(row)]
 
+    def _next_search_generation(self) -> int:
+        """Claim the newest conversation-search generation.
+
+        TASK-19563: the generation-counter pattern from
+        `UI/Screens/chat_screen.py` -- bumped once per dispatch, captured by
+        the worker, and compared again when the result arrives.
+        """
+        self._conversation_search_generation += 1
+        return self._conversation_search_generation
+
     async def handle_search(self, search_term: str, search_type: str = "title") -> None:
         """Handle conversation search (async wrapper).
 
@@ -107,25 +119,45 @@ class CCPConversationHandler:
             f"Starting conversation search: term='{search_term}', type={search_type}"
         )
 
-        # Run the sync search in a worker thread
+        # TASK-19563: worker arguments travel with the callable, as a
+        # `functools.partial` (the pattern `CCPCharacterHandler.load_character`
+        # already uses). Two bugs lived in the previous spelling, and neither
+        # was observable from the handler:
+        #   * the arguments were passed positionally to `run_worker`, where
+        #     they bound to its own `name`/`group` parameters and then collided
+        #     with the explicit `name=` keyword -- `TypeError: run_worker() got
+        #     multiple values for argument 'name'`;
+        #   * `_search_conversations_sync` carried a `@work` decorator, which
+        #     asserts `isinstance(self, DOMNode)`. `CCPConversationHandler` is
+        #     a plain object that merely *holds* a window, so the decorator
+        #     could only ever have raised `AssertionError`.
+        # Between them, CCP conversation search never ran at all.
         self.window.run_worker(
-            self._search_conversations_sync,
-            search_term,
-            search_type,
+            partial(
+                self._search_conversations_sync,
+                search_term,
+                search_type,
+                self._next_search_generation(),
+            ),
             thread=True,
             exclusive=True,
+            group="ccp-conversation-search",
             name="conversation_search",
         )
 
-    @work(thread=True)
     def _search_conversations_sync(
-        self, search_term: str, search_type: str = "title"
+        self,
+        search_term: str,
+        search_type: str = "title",
+        generation: Optional[int] = None,
     ) -> None:
         """Sync method to perform conversation search in a worker thread.
 
         Args:
             search_term: The term to search for
             search_type: Type of search ("title", "content", "tags")
+            generation: The dispatch generation this read belongs to; results
+                whose generation is no longer current are dropped on arrival.
         """
         logger.debug(
             f"Searching conversations: term='{search_term}', type={search_type}"
@@ -134,8 +166,7 @@ class CCPConversationHandler:
         try:
             db = self._conversation_db()
             if db is None:
-                self.search_results = []
-                self.window.call_from_thread(self._update_search_results_ui)
+                self._deliver_search_results(generation, [])
                 logger.warning(
                     "Conversation DB unavailable; returning empty CCP results"
                 )
@@ -161,19 +192,45 @@ class CCPConversationHandler:
             else:
                 results = []
 
-            self.search_results = self._filter_conversations_for_scope(
-                list(results or [])
-            )
+            filtered = self._filter_conversations_for_scope(list(results or []))
 
-            # Update the search results list on main thread
-            self.window.call_from_thread(self._update_search_results_ui)
+            # Hand the rows to the event loop; the loop decides whether this
+            # generation is still the one the user is waiting for.
+            self._deliver_search_results(generation, filtered)
 
             logger.info(
-                f"Found {len(self.search_results)} conversations matching '{search_term}'"
+                f"Found {len(filtered)} conversations matching '{search_term}'"
             )
 
         except Exception as e:
             logger.opt(exception=True).error(f"Error searching conversations: {e}")
+
+    def _deliver_search_results(
+        self, generation: Optional[int], results: List[Dict[str, Any]]
+    ) -> None:
+        """Hop one search result set back to the Textual event loop."""
+        self.window.call_from_thread(self._apply_search_results, generation, results)
+
+    async def _apply_search_results(
+        self, generation: Optional[int], results: List[Dict[str, Any]]
+    ) -> None:
+        """Adopt a search result set only while it is still the current one.
+
+        TASK-19563: this is a *thread* worker, so `Worker.cancel()` does not
+        stop its body -- it runs to completion in the executor and this
+        callback still lands. Rejecting at arrival is therefore the only
+        guard that actually works; without it the list renders the results
+        for `"a"` while the search box already reads `"ab"`.
+        """
+        current = self._conversation_search_generation
+        if generation is not None and generation != current:
+            logger.debug(
+                "Dropping superseded CCP conversation search results "
+                f"(generation {generation} != {current})"
+            )
+            return
+        self.search_results = results
+        await self._update_search_results_ui()
 
     def _search_by_title_sync(self, search_term: str) -> List[Dict[str, Any]]:
         """Search conversations by title (sync version for worker).
@@ -264,16 +321,22 @@ class CCPConversationHandler:
         """
         logger.info(f"Loading conversation {conversation_id}")
 
-        # Run the sync database operation in a worker thread
+        # Run the sync database operation in a worker thread.
+        # TASK-19563: worker arguments travel with the callable (a
+        # `functools.partial`, as in `CCPCharacterHandler.load_character`) --
+        # passing them positionally to `run_worker` binds them to
+        # `run_worker`'s own `name`/`group` parameters instead, which then
+        # collides with the explicit `name=` keyword and raises `TypeError`.
+        # The `@work` decorator is likewise gone: it asserts
+        # `isinstance(self, DOMNode)`, and this handler is a plain object.
         self.window.run_worker(
-            self._load_conversation_sync,
-            conversation_id,
+            partial(self._load_conversation_sync, conversation_id),
             thread=True,
             exclusive=True,
+            group="ccp-load-conversation",
             name=f"load_conversation_{conversation_id}",
         )
 
-    @work(thread=True)
     def _load_conversation_sync(self, conversation_id: ConversationId) -> None:
         """Sync method to load conversation data in a worker thread.
 
@@ -478,13 +541,17 @@ class CCPConversationHandler:
         try:
             search_input = self.window.query_one("#conv-char-search-input", Input)
             if search_input.value:
+                # TASK-19563: `handle_search` is a coroutine function, so it
+                # must be *called* and the coroutine handed to `run_worker`.
+                # The previous spelling passed the bound method plus arguments
+                # positionally, which bound them to `run_worker`'s own
+                # `name`/`group` parameters and then collided with the explicit
+                # `name=` keyword -- a `TypeError` swallowed by the `except`
+                # below, so refresh silently did nothing.
                 self.window.run_worker(
-                    self.handle_search,
-                    search_input.value,
-                    "title",
-                    thread=True,
+                    self.handle_search(search_input.value, "title"),
                     exclusive=True,
-                    name="refresh_search",
+                    group="ccp-conversation-search-refresh",
                 )
         except Exception as e:
             logger.error(f"Error refreshing conversation list: {e}")

--- a/tldw_chatbook/UI/CCP_Modules/ccp_dictionary_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_dictionary_handler.py
@@ -1,5 +1,6 @@
 """Handler for dictionary/world book operations in the Personas screen."""
 
+from functools import partial
 from typing import TYPE_CHECKING, Optional, Dict, Any, List
 from loguru import logger
 from textual import work
@@ -75,16 +76,23 @@ class CCPDictionaryHandler:
         """
         logger.info(f"Starting dictionary load for {dictionary_id}")
 
-        # Run the sync database operation in a worker thread
+        # Run the sync database operation in a worker thread.
+        # TASK-19563: worker arguments travel with the callable (a
+        # `functools.partial`, as in `CCPCharacterHandler.load_character`) --
+        # passing them positionally to `run_worker` binds them to
+        # `run_worker`'s own `name`/`group` parameters instead, which then
+        # collides with the explicit `name=` keyword and raises `TypeError`.
         self.window.run_worker(
-            self._load_dictionary_sync,
-            dictionary_id,
+            partial(self._load_dictionary_sync, dictionary_id),
             thread=True,
             exclusive=True,
+            group="ccp-load-dictionary",
             name=f"load_dictionary_{dictionary_id}",
         )
 
-    @work(thread=True)
+    # TASK-19563: no `@work` decorator -- it asserts `isinstance(self,
+    # DOMNode)` and this handler is a plain object that merely holds a window.
+    # The worker is started by `load_dictionary` through `window.run_worker`.
     def _load_dictionary_sync(self, dictionary_id: int) -> None:
         """Sync method to load dictionary data in a worker thread.
 

--- a/tldw_chatbook/UI/CCP_Modules/ccp_loading_indicators.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_loading_indicators.py
@@ -384,7 +384,7 @@ class InlineLoadingIndicator(Static):
         self._loading = False
         self._dots = 0
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="ccp-loading-indicator-animate")
     async def animate(self):
         """Animate the loading dots."""
         import asyncio

--- a/tldw_chatbook/UI/CodeRepoCopyPasteWindow.py
+++ b/tldw_chatbook/UI/CodeRepoCopyPasteWindow.py
@@ -877,7 +877,11 @@ class CodeRepoCopyPasteWindow(ModalScreen):
             return
 
         # Run export in a worker to avoid blocking UI
-        self.run_worker(self._export_to_zip_worker(selected_files), exclusive=True)
+        self.run_worker(
+            self._export_to_zip_worker(selected_files),
+            exclusive=True,
+            group="coderepo-export-to-zip",
+        )
 
     @on(Button.Pressed, "#generate-compilation-btn")
     async def generate_compilation(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -1552,7 +1552,11 @@ class MediaWindow(Container):
     def handle_read_it_later_toggle(self, event: MediaReadItLaterToggleEvent) -> None:
         """Handle viewer save/remove actions in a worker."""
         event.stop()
-        self.run_worker(self._handle_read_it_later_toggle_async(event), exclusive=True)
+        self.run_worker(
+            self._handle_read_it_later_toggle_async(event),
+            exclusive=True,
+            group="media-read-it-later-toggle",
+        )
 
     async def _handle_read_it_later_toggle_async(
         self, event: MediaReadItLaterToggleEvent
@@ -1981,14 +1985,20 @@ class MediaWindow(Container):
                 await self._reset_analysis_failure_state(event.media_id)
 
         # Run the analysis in a worker
-        self.run_worker(perform_analysis(), exclusive=True)
+        self.run_worker(
+            perform_analysis(), exclusive=True, group="media-analysis-generate"
+        )
 
     @on(MediaAnalysisSaveEvent)
     def handle_analysis_save(self, event: MediaAnalysisSaveEvent) -> None:
         """Handle saving new analysis."""
         event.stop()
         event.type_slug = self.active_media_type or ""
-        self.run_worker(self._handle_analysis_save_async(event), exclusive=True)
+        self.run_worker(
+            self._handle_analysis_save_async(event),
+            exclusive=True,
+            group="media-analysis-save",
+        )
 
     async def _handle_analysis_save_async(self, event: MediaAnalysisSaveEvent) -> None:
         """Persist a new analysis version via the shared seam."""
@@ -2077,7 +2087,11 @@ class MediaWindow(Container):
         """Handle overwriting existing analysis."""
         event.stop()
         event.type_slug = self.active_media_type or ""
-        self.run_worker(self._handle_analysis_overwrite_async(event), exclusive=True)
+        self.run_worker(
+            self._handle_analysis_overwrite_async(event),
+            exclusive=True,
+            group="media-analysis-overwrite",
+        )
 
     async def _handle_analysis_overwrite_async(
         self, event: MediaAnalysisOverwriteEvent
@@ -2128,7 +2142,11 @@ class MediaWindow(Container):
         """Handle deleting an analysis version."""
         event.stop()
         event.type_slug = self.active_media_type or ""
-        self.run_worker(self._handle_analysis_delete_async(event), exclusive=True)
+        self.run_worker(
+            self._handle_analysis_delete_async(event),
+            exclusive=True,
+            group="media-analysis-delete",
+        )
 
     async def _handle_analysis_delete_async(
         self, event: MediaAnalysisDeleteEvent

--- a/tldw_chatbook/UI/Outputs_Panel.py
+++ b/tldw_chatbook/UI/Outputs_Panel.py
@@ -306,7 +306,9 @@ class OutputsPanel(ScrollableContainer):
             )
 
     def on_mount(self) -> None:
-        self.run_worker(self.refresh_for_mode(), exclusive=True)
+        self.run_worker(
+            self.refresh_for_mode(), exclusive=True, group="outputs-refresh-for-mode"
+        )
 
     @staticmethod
     def _clean_string(value: Any) -> str:
@@ -509,48 +511,84 @@ class OutputsPanel(ScrollableContainer):
 
     @on(Button.Pressed, "#outputs-list-templates-btn")
     def handle_list_output_templates(self) -> None:
-        self.run_worker(self.list_output_templates(), exclusive=True)
+        self.run_worker(
+            self.list_output_templates(),
+            exclusive=True,
+            group="outputs-list-output-templates",
+        )
 
     @on(Button.Pressed, "#outputs-create-template-btn")
     def handle_create_output_template(self) -> None:
-        self.run_worker(self.create_output_template(), exclusive=True)
+        self.run_worker(
+            self.create_output_template(),
+            exclusive=True,
+            group="outputs-create-output-template",
+        )
 
     @on(Button.Pressed, "#outputs-get-template-btn")
     def handle_get_output_template(self) -> None:
-        self.run_worker(self.get_output_template(), exclusive=True)
+        self.run_worker(
+            self.get_output_template(),
+            exclusive=True,
+            group="outputs-get-output-template",
+        )
 
     @on(Button.Pressed, "#outputs-update-template-btn")
     def handle_update_output_template(self) -> None:
-        self.run_worker(self.update_output_template(), exclusive=True)
+        self.run_worker(
+            self.update_output_template(),
+            exclusive=True,
+            group="outputs-update-output-template",
+        )
 
     @on(Button.Pressed, "#outputs-delete-template-btn")
     def handle_delete_output_template(self) -> None:
-        self.run_worker(self.delete_output_template(), exclusive=True)
+        self.run_worker(
+            self.delete_output_template(),
+            exclusive=True,
+            group="outputs-delete-output-template",
+        )
 
     @on(Button.Pressed, "#outputs-preview-template-btn")
     def handle_preview_output_template(self) -> None:
-        self.run_worker(self.preview_output_template(), exclusive=True)
+        self.run_worker(
+            self.preview_output_template(),
+            exclusive=True,
+            group="outputs-preview-output-template",
+        )
 
     @on(Button.Pressed, "#outputs-list-artifacts-btn")
     def handle_list_outputs(self) -> None:
-        self.run_worker(self.list_outputs(), exclusive=True)
+        self.run_worker(
+            self.list_outputs(), exclusive=True, group="outputs-list-outputs"
+        )
 
     @on(Button.Pressed, "#outputs-list-deleted-btn")
     def handle_list_deleted_outputs(self) -> None:
-        self.run_worker(self.list_deleted_outputs(), exclusive=True)
+        self.run_worker(
+            self.list_deleted_outputs(),
+            exclusive=True,
+            group="outputs-list-deleted-outputs",
+        )
 
     @on(Button.Pressed, "#outputs-get-output-btn")
     def handle_get_output(self) -> None:
-        self.run_worker(self.get_output(), exclusive=True)
+        self.run_worker(self.get_output(), exclusive=True, group="outputs-get-output")
 
     @on(Button.Pressed, "#outputs-create-output-btn")
     def handle_create_output(self) -> None:
-        self.run_worker(self.create_output(), exclusive=True)
+        self.run_worker(
+            self.create_output(), exclusive=True, group="outputs-create-output"
+        )
 
     @on(Button.Pressed, "#outputs-update-output-btn")
     def handle_update_output(self) -> None:
-        self.run_worker(self.update_output(), exclusive=True)
+        self.run_worker(
+            self.update_output(), exclusive=True, group="outputs-update-output"
+        )
 
     @on(Button.Pressed, "#outputs-delete-output-btn")
     def handle_delete_output(self) -> None:
-        self.run_worker(self.delete_output(), exclusive=True)
+        self.run_worker(
+            self.delete_output(), exclusive=True, group="outputs-delete-output"
+        )

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -2499,20 +2499,40 @@ class STTSWindow(Container):
             event.stop()
             self.post_message(SpeechDestinationBackRequested())
         elif event.button.id == "view-playground-btn":
-            self.run_worker(self.request_view("playground"), exclusive=True)
+            self.run_worker(
+                self.request_view("playground"),
+                exclusive=True,
+                group="stts-request-view",
+            )
         elif event.button.id == "view-profiles-btn":
-            self.run_worker(self.request_view("profiles"), exclusive=True)
+            self.run_worker(
+                self.request_view("profiles"),
+                exclusive=True,
+                group="stts-request-view",
+            )
         elif event.button.id == "view-settings-btn":
-            self.run_worker(self.request_view("settings"), exclusive=True)
+            self.run_worker(
+                self.request_view("settings"),
+                exclusive=True,
+                group="stts-request-view",
+            )
         elif event.button.id == "view-audiobook-btn":
-            self.run_worker(self.request_view("audiobook"), exclusive=True)
+            self.run_worker(
+                self.request_view("audiobook"),
+                exclusive=True,
+                group="stts-request-view",
+            )
         elif event.button.id == "view-voice-cloning-btn":
             # Import and push the Voice Cloning window
             from tldw_chatbook.UI.Voice_Cloning_Window import VoiceCloningWindow
 
             self.app.push_screen(VoiceCloningWindow())
         elif event.button.id == "view-stt-btn":
-            self.run_worker(self.request_view("dictation"), exclusive=True)
+            self.run_worker(
+                self.request_view("dictation"),
+                exclusive=True,
+                group="stts-request-view",
+            )
         else:
             # Try to delegate to the active content widget
             try:

--- a/tldw_chatbook/UI/Screens/acp_screen.py
+++ b/tldw_chatbook/UI/Screens/acp_screen.py
@@ -448,7 +448,7 @@ class ACPScreen(BaseAppScreen):
         event.stop()
         self._launch_acp_runtime_worker("ACP agent session")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="acp-launch-runtime", thread=True)
     def _launch_acp_runtime_worker(self, title: str) -> None:
         manager = getattr(self.app_instance, "acp_runtime_process_manager", None)
         launcher = getattr(manager, "start_session", None)
@@ -489,7 +489,7 @@ class ACPScreen(BaseAppScreen):
         event.stop()
         self._stop_acp_runtime_worker()
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="acp-stop-runtime", thread=True)
     def _stop_acp_runtime_worker(self) -> None:
         manager = getattr(self.app_instance, "acp_runtime_process_manager", None)
         stopper = getattr(manager, "stop", None)

--- a/tldw_chatbook/UI/Screens/artifacts_screen.py
+++ b/tldw_chatbook/UI/Screens/artifacts_screen.py
@@ -156,7 +156,7 @@ class ArtifactsScreen(BaseAppScreen):
                 type(exc).__name__,
             )
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="artifacts-refresh-chatbook-context", thread=True)
     def _refresh_chatbook_context(
         self,
         generation: int,

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -276,7 +276,7 @@ class HomeScreen(BaseAppScreen):
         self._refresh_home_content_snapshot()
         self._refresh_home_active_work_cache()
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="home-refresh-chatbook-artifact-snapshot", thread=True)
     def _refresh_home_chatbook_artifact_snapshot(self) -> None:
         adapter = getattr(self.app_instance, "home_active_work_adapter", None)
         refresh_flashcards_due = getattr(

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -283,6 +283,8 @@ class InstalledView(Widget):
         self._restore_header_focus_id: str | None = None
         self._observation_generation = 0
         self._observation_focus_locator: ModelLibraryFocusLocator | None = None
+        # TASK-19563: monotonic inventory-read counter; see `_apply_inventory`.
+        self._inventory_generation = 0
         super().__init__(id=id)
 
     def _non_import_lifecycle_pending(self) -> bool:
@@ -641,10 +643,11 @@ class InstalledView(Widget):
         if self._loaded and not force:
             return
         self._observation_generation += 1
+        self._inventory_generation += 1
         self._loading = True
         self._load_error = None
         self.refresh(recompose=True)
-        self._load_inventory()
+        self._load_inventory(self._inventory_generation)
 
     def _service_for_worker(self) -> ModelArtifactService:
         """Create the managed service lazily on a worker thread."""
@@ -655,8 +658,14 @@ class InstalledView(Widget):
     @work(
         thread=True, group="installed_models_load", exclusive=True, exit_on_error=False
     )
-    def _load_inventory(self) -> None:
-        """Read managed inventory, disk totals, and legacy files off-loop."""
+    def _load_inventory(self, generation: int | None = None) -> None:
+        """Read managed inventory, disk totals, and legacy files off-loop.
+
+        TASK-19563: the generation captured at dispatch travels with the read.
+        This is a *thread* worker, so `Worker.cancel()` cannot stop the body --
+        it finishes in the executor and the `call_from_thread` callbacks below
+        still land, potentially on a view the user has already left.
+        """
         try:
             service = self._service_for_worker()
             installed = service.list_installed()
@@ -683,9 +692,13 @@ class InstalledView(Widget):
                 (),
                 None,
                 "The local model inventory could not be loaded.",
+                None,
+                generation,
             )
             return
-        self.app.call_from_thread(self._apply_inventory, rows, usage, None, audio_cpp)
+        self.app.call_from_thread(
+            self._apply_inventory, rows, usage, None, audio_cpp, generation
+        )
 
     def _apply_inventory(
         self,
@@ -693,8 +706,27 @@ class InstalledView(Widget):
         usage: ArtifactDiskUsage | None,
         error: str | None,
         audio_cpp: dict[ArtifactRef, AudioCppPackageProjection] | None = None,
+        generation: int | None = None,
     ) -> None:
-        """Apply a completed inventory read on the Textual event loop."""
+        """Apply a completed inventory read on the Textual event loop.
+
+        TASK-19563: this is the arrival end of a *thread* worker, which
+        `Worker.cancel()` cannot stop -- the body finishes in the executor and
+        this callback lands regardless. Two refusals therefore live here:
+
+        * a read a newer `ensure_loaded()` has already superseded is dropped
+          outright, so a slow first read can never overwrite a fast second one;
+        * a read that arrives after the view has left the DOM records its state
+          but drives no UI. Everything below the `is_attached` check recomposes,
+          re-drives the observation pass, and restores focus -- work that lands
+          on whatever screen happens to be current, not on this one.
+
+        `is_attached` is the check that can actually be `False`; `is_mounted`
+        is never reset once set (see `UI/Screens/library_screen.py`), which is
+        why it is useless as a post-hop detach guard.
+        """
+        if generation is not None and generation != self._inventory_generation:
+            return
         self._rows = rows
         self._usage = usage
         self._loading = False
@@ -706,7 +738,7 @@ class InstalledView(Widget):
         self._reload_after_load = False
         if reload_after_load:
             self.ensure_loaded(force=True)
-        else:
+        elif self.is_attached:
             self.refresh(recompose=True)
             if error is None and self._observation_provider is not None:
                 self.refresh_observations()

--- a/tldw_chatbook/UI/Screens/schedules_screen.py
+++ b/tldw_chatbook/UI/Screens/schedules_screen.py
@@ -65,7 +65,7 @@ class SchedulesScreen(BaseAppScreen):
         )
         self._refresh_latest_console_context(has_recent_work)
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="schedules-refresh-console-context", thread=True)
     def _refresh_latest_console_context(self, has_recent_work: bool) -> None:
         latest_console_item = self._latest_console_follow_item_from_adapter(
             has_recent_work

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -201,7 +201,11 @@ class SchedulesWorkbench(BaseAppScreen):
         self._refresh_conflicts_tab()
         table = self.query_one("#scheduling-task-table", DataTable)
         table.add_columns("Title", "Type", "Status", "Next Run")
-        self.run_worker(self.load_tasks, exclusive=True)  # type: ignore[arg-type]
+        self.run_worker(
+            self.load_tasks,
+            exclusive=True,
+            group="schedules-load-tasks",
+        )  # type: ignore[arg-type]
 
     def _sync_responsive_workbench(self) -> None:
         """Keep the primary queue and detail action visible at narrow widths."""
@@ -495,7 +499,11 @@ class SchedulesWorkbench(BaseAppScreen):
                 )
             await self.load_tasks()
 
-        self.run_worker(_delete_and_refresh, exclusive=True)  # type: ignore[arg-type]
+        self.run_worker(
+            _delete_and_refresh,
+            exclusive=True,
+            group="schedules-delete-task",
+        )  # type: ignore[arg-type]
 
     @on(Button.Pressed, "#schedules-follow-in-console")
     def follow_latest_schedule_run_in_console(self, event: Button.Pressed) -> None:
@@ -578,7 +586,11 @@ class SchedulesWorkbench(BaseAppScreen):
                 )
             await self.load_tasks()
 
-        self.run_worker(_save_and_refresh, exclusive=True)  # type: ignore[arg-type]
+        self.run_worker(
+            _save_and_refresh,
+            exclusive=True,
+            group="schedules-save-reminder",
+        )  # type: ignore[arg-type]
 
     @on(EditTaskRequested)
     def _on_edit_task_requested(self, event: EditTaskRequested) -> None:
@@ -665,7 +677,11 @@ class SchedulesWorkbench(BaseAppScreen):
                 )
             await self.load_tasks()
 
-        self.run_worker(_run_and_refresh, exclusive=True)  # type: ignore[arg-type]
+        self.run_worker(
+            _run_and_refresh,
+            exclusive=True,
+            group="schedules-run-reminder-now",
+        )  # type: ignore[arg-type]
 
     def _set_reminder_enabled(self, task: ReminderTask, enabled: bool) -> None:
         """Update a reminder's enabled state and refresh the queue."""
@@ -692,7 +708,11 @@ class SchedulesWorkbench(BaseAppScreen):
                 )
             await self.load_tasks()
 
-        self.run_worker(_update_and_refresh, exclusive=True)  # type: ignore[arg-type]
+        self.run_worker(
+            _update_and_refresh,
+            exclusive=True,
+            group="schedules-set-reminder-enabled",
+        )  # type: ignore[arg-type]
 
     def _refresh_owner_select(self) -> None:
         status = self.query_one("#scheduling-sync-status", SyncStatusWidget)
@@ -806,7 +826,7 @@ class SchedulesWorkbench(BaseAppScreen):
             app_config=self.app_instance.app_config,
         )
         self._refresh_owner_select()
-        self.run_worker(self.load_tasks, exclusive=True)
+        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
         self._refresh_conflicts_tab()
 
     @on(Button.Pressed, "#scheduling-clear-error")
@@ -822,7 +842,7 @@ class SchedulesWorkbench(BaseAppScreen):
         self._sync_running = False
         self.app_instance.notify("Sync completed.", severity="information")
         self._refresh_owner_select()
-        self.run_worker(self.load_tasks, exclusive=True)
+        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
         self._refresh_conflicts_tab()
 
     @on(SyncFailed)
@@ -830,12 +850,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self._sync_running = False
         self.app_instance.notify(f"Sync failed: {event.error}", severity="error")
         self._refresh_owner_select()
-        self.run_worker(self.load_tasks, exclusive=True)
+        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
         self._refresh_conflicts_tab()
 
     @on(ConflictsTab.ConflictResolved)
     def _on_conflict_resolved(self, event: ConflictsTab.ConflictResolved) -> None:
-        self.run_worker(self.load_tasks, exclusive=True)
+        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
         self._refresh_conflicts_tab()
 
     def _refresh_conflicts_tab(self) -> None:
@@ -912,7 +932,11 @@ class SchedulesWorkbench(BaseAppScreen):
             self._marked_ids.clear()
             await self.load_tasks()
 
-        self.run_worker(_bulk_delete, exclusive=True)  # type: ignore[arg-type]
+        self.run_worker(
+            _bulk_delete,
+            exclusive=True,
+            group="schedules-bulk-delete",
+        )  # type: ignore[arg-type]
 
     def _selected_task(self) -> ReminderTask | ScheduledTask | None:
         """Return the task under the queue cursor, if any."""
@@ -1001,7 +1025,11 @@ class SchedulesWorkbench(BaseAppScreen):
                 self._marked_ids.clear()
                 await self.load_tasks()
 
-            self.run_worker(_bulk_toggle, exclusive=True)  # type: ignore[arg-type]
+            self.run_worker(
+                _bulk_toggle,
+                exclusive=True,
+                group="schedules-bulk-toggle",
+            )  # type: ignore[arg-type]
             return
 
         task = self._selected_task()
@@ -1039,7 +1067,7 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             return
         self._sync_running = True
-        self.run_worker(self._run_sync, exclusive=True)
+        self.run_worker(self._run_sync, exclusive=True, group="schedules-sync-now")
 
     async def _run_sync(self) -> None:
         service = self._service()

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -5354,7 +5354,7 @@ class SettingsScreen(BaseAppScreen):
         )
         self._settings_save_image_gen_worker(draft_values, warnings)
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-save-image-gen", thread=True)
     def _settings_save_image_gen_worker(
         self, draft_values: ImageGenDraftValues, warnings: list[str]
     ) -> None:
@@ -5765,7 +5765,7 @@ class SettingsScreen(BaseAppScreen):
         )
         self._settings_save_video_gen_worker(draft_values, warnings)
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-save-video-gen", thread=True)
     def _settings_save_video_gen_worker(
         self, draft_values: VideoGenDraftValues, warnings: list[str]
     ) -> None:
@@ -8195,7 +8195,7 @@ class SettingsScreen(BaseAppScreen):
         self._update_storage_check_widgets()
         self.app.notify("Storage check finished.", severity="information")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-storage-check", thread=True)
     def _storage_check_worker(
         self, values: SettingsStorageDefaults | None = None
     ) -> None:
@@ -8292,7 +8292,7 @@ class SettingsScreen(BaseAppScreen):
         self._update_privacy_check_widgets()
         self.app.notify("Privacy check finished.", severity="information")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-privacy-check", thread=True)
     def _privacy_check_worker(self, app_config: object) -> None:
         rows = self._privacy_check_results(app_config)
         self.app.call_from_thread(self._apply_privacy_check_result, rows)
@@ -8416,7 +8416,7 @@ class SettingsScreen(BaseAppScreen):
             "Diagnostics validation and reload finished.", severity="information"
         )
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-diagnostics-validate-reload", thread=True)
     def _diagnostics_validation_and_reload_worker(self) -> None:
         validation_result, reload_result, loaded_config = (
             self._diagnostics_validation_and_reload_results()
@@ -8551,7 +8551,7 @@ class SettingsScreen(BaseAppScreen):
         self._update_advanced_validation_status()
         return result
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-advanced-validate-config", thread=True)
     def _advanced_validate_config_worker(self, text: str) -> None:
         validation = SettingsConfigAdapter().validate_raw_toml(text)
         status = "valid" if validation.valid else "invalid"
@@ -8573,7 +8573,7 @@ class SettingsScreen(BaseAppScreen):
         )
         self._update_advanced_validation_status()
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-advanced-save-config", thread=True)
     def _advanced_save_config_worker(self, text: str) -> None:
         result = self._save_advanced_config_text(text)
         loaded_config: dict | None = None
@@ -8599,22 +8599,49 @@ class SettingsScreen(BaseAppScreen):
         )
         self._update_advanced_validation_status()
 
-    @work(exclusive=True, thread=True)
-    def _advanced_load_backup_worker(self) -> None:
+    @work(exclusive=True, group="settings-advanced-load-backup", thread=True)
+    def _advanced_load_backup_worker(self, dispatch_text: str) -> None:
+        """Read the backup off-loop, carrying the editor text seen at dispatch.
+
+        TASK-19559: this is a *thread* worker, so `Worker.cancel()` does not
+        stop it -- the body runs to completion in the executor and the
+        `call_from_thread` callback below still lands. The only place the
+        result can be refused is on arrival, which is why the editor text the
+        user had when they pressed the button travels with it.
+        """
         result, backup_text = self._read_advanced_backup_preview()
         self.app.call_from_thread(
             self._apply_advanced_backup_preview_result,
             result,
             backup_text,
+            dispatch_text,
         )
 
     def _apply_advanced_backup_preview_result(
         self,
         result: str,
         backup_text: str | None,
+        dispatch_text: str | None = None,
     ) -> None:
+        """Apply a backup preview only if the editor is untouched since dispatch.
+
+        TASK-19559: the editor is a live `TextArea`. If the user kept typing
+        while the backup was being read off-loop, writing the backup over the
+        top silently destroys their unsaved edits, so the write is refused and
+        the refusal is reported instead of being swallowed.
+        """
         final_result = result
         if backup_text is not None:
+            current_text = self._advanced_editor_text()
+            if dispatch_text is not None and current_text != dispatch_text:
+                self._advanced_config_result = (
+                    "Advanced config recovery: not applied - the editor changed "
+                    "while the backup was loading; unsaved edits were kept"
+                )
+                self._set_static_text(
+                    "#settings-advanced-config-result", self._advanced_config_result
+                )
+                return
             try:
                 self.query_one(
                     "#settings-advanced-config-editor", TextArea
@@ -20747,7 +20774,10 @@ class SettingsScreen(BaseAppScreen):
         self._set_static_text(
             "#settings-advanced-config-result", self._advanced_config_result
         )
-        self._advanced_load_backup_worker()
+        # TASK-19559: carry the editor text as it stands right now, so the
+        # arrival callback can tell "nothing changed" from "the user typed
+        # while we were reading the backup".
+        self._advanced_load_backup_worker(self._advanced_editor_text())
 
     @on(Button.Pressed, ".settings-advanced-guided-path-button")
     def handle_advanced_guided_path(self, event: Button.Pressed) -> None:
@@ -22032,7 +22062,7 @@ class SettingsScreen(BaseAppScreen):
         )
         self.app.notify(self._appearance_result, severity="error")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-save-appearance", thread=True)
     def _settings_save_appearance_worker(
         self, section_values: Mapping[str, object]
     ) -> None:
@@ -22288,7 +22318,7 @@ class SettingsScreen(BaseAppScreen):
         )
         self.app.notify(self._library_rag_result, severity="error")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-save-library-rag", thread=True)
     def _settings_save_library_rag_worker(
         self,
         values: SettingsLibraryRagDefaults,
@@ -22327,7 +22357,7 @@ class SettingsScreen(BaseAppScreen):
         self._set_static_text("#settings-storage-save-result", self._storage_result)
         self.app.notify(self._storage_result, severity="error")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-save-storage", thread=True)
     def _settings_save_storage_worker(
         self, section_values: Mapping[str, object]
     ) -> None:
@@ -22389,7 +22419,7 @@ class SettingsScreen(BaseAppScreen):
         )
         self.app.notify("Failed to save Console behavior settings.", severity="error")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="settings-save-console-behavior", thread=True)
     def _settings_save_console_behavior_worker(
         self,
         console_values: Mapping[str, object],

--- a/tldw_chatbook/UI/Screens/skills_screen.py
+++ b/tldw_chatbook/UI/Screens/skills_screen.py
@@ -319,7 +319,7 @@ class SkillsScreen(BaseAppScreen):
         # BaseAppScreen.on_mount separately for this Mount event.
         self._refresh_local_skills_context()
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="skills-refresh-local-context")
     async def _refresh_local_skills_context(self) -> None:
         records, lookup_error, recovery_state = await self._list_local_skills()
         self._apply_local_skills_context(records, lookup_error, recovery_state)

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -1529,6 +1529,7 @@ class StudyScreen(BaseAppScreen):
                         scope_context, study_window=study_window
                     ),
                     exclusive=True,
+                    group="study-apply-scope-context",
                 )
                 return
         open_study = getattr(self.app_instance, "open_study_screen", None)
@@ -1564,6 +1565,7 @@ class StudyScreen(BaseAppScreen):
                         scope_context, study_window=study_window
                     ),
                     exclusive=True,
+                    group="study-apply-scope-context",
                 )
                 return
         open_study = getattr(self.app_instance, "open_study_screen", None)
@@ -1612,7 +1614,11 @@ class StudyScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#study-generate-source-pack")
     def handle_generate_source_pack(self) -> None:
-        self.run_worker(self._generate_source_study_pack(), exclusive=True)
+        self.run_worker(
+            self._generate_source_study_pack(),
+            exclusive=True,
+            group="study-generate-source-pack",
+        )
 
     @on(Button.Pressed, "#study-resume-last")
     def handle_resume_last_session(self) -> None:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -4383,20 +4383,32 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self.set_timer(0.05, self._open_sources_import_opml)
 
     def _load_active_section_data(self) -> None:
-        """Start the loader owned by the currently visible section."""
+        """Start the loader owned by the currently visible section.
+
+        Every branch names its own group. TASK-19559: for four releases only
+        the `items` and `artifacts` branches did -- the hazard comment below
+        sat directly above four siblings it did not actually protect, so
+        switching to Rules/Runs/Sources/Notifications cancelled whatever
+        default-group worker was in flight (a source create, a rule save, a
+        run cancellation, ...).
+        """
         if self.active_section == "items":
             # Own group (task-2513), as in `watch_tree_scope`:
             # `exclusive=True` in the default group would cancel every
             # in-flight default-group worker (`_create_source`, ...).
             self.run_worker(self._load_items(), exclusive=True, group="wc_items")
         elif self.active_section == "rules":
-            self.run_worker(self._load_rules(), exclusive=True)
+            self.run_worker(self._load_rules(), exclusive=True, group="wc_rules")
         elif self.active_section == "runs":
-            self.run_worker(self._load_runs(), exclusive=True)
+            self.run_worker(self._load_runs(), exclusive=True, group="wc_runs")
         elif self.active_section == "sources":
-            self.run_worker(self._load_sources(), exclusive=True)
+            self.run_worker(self._load_sources(), exclusive=True, group="wc_sources")
         elif self.active_section == "notifications":
-            self.run_worker(self._load_notifications(), exclusive=True)
+            self.run_worker(
+                self._load_notifications(),
+                exclusive=True,
+                group="wc_notifications",
+            )
         elif self.active_section == "artifacts":
             # Own group (TASK-1362): `exclusive=True` without one cancels
             # every other worker in the default group, which here would
@@ -5000,7 +5012,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # THEN, not at the one this submission happened to use.
         self._source_create_draft_type = None
         self._source_create_draft_destination = None
-        self.run_worker(self._create_source(event.payload), exclusive=True)
+        self.run_worker(
+            self._create_source(event.payload),
+            exclusive=True,
+            group="wc_create_source",
+        )
 
     async def _create_source(self, payload: dict[str, Any]) -> None:
         # TASK-2302: the destination is not part of the source record -- it
@@ -5096,7 +5112,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @on(CancelRunRequested)
     def handle_cancel_run_requested(self, event: CancelRunRequested) -> None:
         event.stop()
-        self.run_worker(self._cancel_run(event.run_id), exclusive=True)
+        self.run_worker(
+            self._cancel_run(event.run_id),
+            exclusive=True,
+            group="wc_cancel_run",
+        )
 
     async def _cancel_run(self, run_id: Any) -> None:
         try:
@@ -5120,7 +5140,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # A coroutine worker, never thread=True — this launches a check, so
         # the in-flight guard's single-loop invariant applies (see
         # `handle_check_now_requested`'s launch site).
-        self.run_worker(self._rerun_run(event.source_id), exclusive=True)
+        self.run_worker(
+            self._rerun_run(event.source_id),
+            exclusive=True,
+            group="wc_rerun_run",
+        )
 
     async def _rerun_run(self, source_id: Any) -> None:
         try:
@@ -5144,7 +5168,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         entity = event.entity
         if entity is None:
             return
-        self.run_worker(self._preview_source(entity), exclusive=True)
+        self.run_worker(
+            self._preview_source(entity),
+            exclusive=True,
+            group="wc_preview_source",
+        )
 
     async def _preview_source(self, source: dict[str, Any]) -> None:
         notify = getattr(self.app_instance, "notify", None)
@@ -5569,7 +5597,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 f"kind={entity.get('entity_kind')!r}); refusing."
             )
             return
-        self.run_worker(self._resume_source(entity), exclusive=True)
+        self.run_worker(
+            self._resume_source(entity),
+            exclusive=True,
+            group="wc_resume_source",
+        )
 
     async def _resume_source(self, source: dict[str, Any]) -> None:
         """Clear an auto-paused source's pause via the real service (AC#2/#3).
@@ -5661,7 +5693,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @on(ExportOpmlRequested)
     def handle_export_opml_requested(self, event: ExportOpmlRequested) -> None:
         event.stop()
-        self.run_worker(self._export_opml(), exclusive=True)
+        self.run_worker(self._export_opml(), exclusive=True, group="wc_export_opml")
 
     async def _export_opml(self) -> None:
         notify = getattr(self.app_instance, "notify", None)
@@ -5958,7 +5990,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self, event: RefreshNotificationsRequested
     ) -> None:
         event.stop()
-        self.run_worker(self._load_notifications(), exclusive=True)
+        self.run_worker(
+            self._load_notifications(),
+            exclusive=True,
+            group="wc_notifications",
+        )
 
     @on(MarkNotificationReadRequested)
     def handle_mark_notification_read_requested(
@@ -5966,7 +6002,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         event.stop()
         self.run_worker(
-            self._mark_notification_read(event.notification_id), exclusive=True
+            self._mark_notification_read(event.notification_id),
+            exclusive=True,
+            group="wc_mark_notification_read",
         )
 
     async def _mark_notification_read(self, notification_id: int) -> None:
@@ -5982,7 +6020,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         event.stop()
         self.run_worker(
-            self._dismiss_notification(event.notification_id), exclusive=True
+            self._dismiss_notification(event.notification_id),
+            exclusive=True,
+            group="wc_dismiss_notification",
         )
 
     async def _dismiss_notification(self, notification_id: int) -> None:
@@ -10156,7 +10196,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @on(RefreshRulesRequested)
     def handle_refresh_rules_requested(self, event: RefreshRulesRequested) -> None:
         event.stop()
-        self.run_worker(self._load_rules(), exclusive=True)
+        self.run_worker(self._load_rules(), exclusive=True, group="wc_rules")
 
     @on(SaveRuleRequested)
     def handle_save_rule_requested(self, event: SaveRuleRequested) -> None:
@@ -10173,7 +10213,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # chain that can recompose.
         self._rule_form_open = False
         self._rule_form_editing = None
-        self.run_worker(self._save_rule(event.payload), exclusive=True)
+        self.run_worker(
+            self._save_rule(event.payload),
+            exclusive=True,
+            group="wc_save_rule",
+        )
 
     @on(EditRuleRequested)
     def handle_edit_rule_requested(self, event: EditRuleRequested) -> None:
@@ -10694,7 +10738,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             logger.opt(exception=True).warning("Failed to save alert rule.")
             if callable(notify):
                 notify("Failed to save alert rule.", severity="error")
-        self.run_worker(self._load_rules(), exclusive=True)
+        self.run_worker(self._load_rules(), exclusive=True, group="wc_rules")
         self._refresh_overview_data()
 
     @on(DeleteRequested)
@@ -10744,11 +10788,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             return
         entity_type = InspectorPane._entity_type(entity)
         if entity_type == "source":
-            self.run_worker(self._delete_source(entity.get("id")), exclusive=True)
+            self.run_worker(
+                self._delete_source(entity.get("id")),
+                exclusive=True,
+                group="wc_delete_source",
+            )
         elif entity_type == "run":
-            self.run_worker(self._delete_run(entity.get("id")), exclusive=True)
+            self.run_worker(
+                self._delete_run(entity.get("id")),
+                exclusive=True,
+                group="wc_delete_run",
+            )
         elif entity_type == "rule":
-            self.run_worker(self._delete_rule(entity.get("id")), exclusive=True)
+            self.run_worker(
+                self._delete_rule(entity.get("id")),
+                exclusive=True,
+                group="wc_delete_rule",
+            )
         # No `item` branch: items never reach this dialog any more -- see the
         # Minor 2 note in `handle_delete_requested`.
 
@@ -10825,7 +10881,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             notify = getattr(self.app_instance, "notify", None)
             if callable(notify):
                 notify("Failed to delete alert rule.", severity="error")
-        self.run_worker(self._load_rules(), exclusive=True)
+        self.run_worker(self._load_rules(), exclusive=True, group="wc_rules")
         self._refresh_overview_data()
 
     def action_switch_section(self, section_id: str) -> None:

--- a/tldw_chatbook/UI/Screens/workflows_screen.py
+++ b/tldw_chatbook/UI/Screens/workflows_screen.py
@@ -55,7 +55,7 @@ class WorkflowsScreen(BaseAppScreen):
         )
         self._refresh_latest_console_context(has_recent_work)
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="workflows-refresh-console-context", thread=True)
     def _refresh_latest_console_context(self, has_recent_work: bool) -> None:
         latest_console_item = self._latest_console_follow_item_from_adapter(
             has_recent_work

--- a/tldw_chatbook/UI/Sharing_Panel.py
+++ b/tldw_chatbook/UI/Sharing_Panel.py
@@ -251,7 +251,9 @@ class SharingPanel(ScrollableContainer):
             )
 
     def on_mount(self) -> None:
-        self.run_worker(self.refresh_for_mode(), exclusive=True)
+        self.run_worker(
+            self.refresh_for_mode(), exclusive=True, group="sharing-refresh-for-mode"
+        )
 
     @staticmethod
     def _clean_string(value: Any) -> str:
@@ -310,67 +312,125 @@ class SharingPanel(ScrollableContainer):
 
     @on(Button.Pressed, "#sharing-create-workspace-share-btn")
     def handle_create_workspace_share(self) -> None:
-        self.run_worker(self.create_workspace_share(), exclusive=True)
+        self.run_worker(
+            self.create_workspace_share(),
+            exclusive=True,
+            group="sharing-create-workspace-share",
+        )
 
     @on(Button.Pressed, "#sharing-list-workspace-shares-btn")
     def handle_list_workspace_shares(self) -> None:
-        self.run_worker(self.list_workspace_shares(), exclusive=True)
+        self.run_worker(
+            self.list_workspace_shares(),
+            exclusive=True,
+            group="sharing-list-workspace-shares",
+        )
 
     @on(Button.Pressed, "#sharing-update-share-btn")
     def handle_update_share(self) -> None:
-        self.run_worker(self.update_share(), exclusive=True)
+        self.run_worker(
+            self.update_share(), exclusive=True, group="sharing-update-share"
+        )
 
     @on(Button.Pressed, "#sharing-revoke-share-btn")
     def handle_revoke_share(self) -> None:
-        self.run_worker(self.revoke_share(), exclusive=True)
+        self.run_worker(
+            self.revoke_share(), exclusive=True, group="sharing-revoke-share"
+        )
 
     @on(Button.Pressed, "#sharing-list-shared-with-me-btn")
     def handle_list_shared_with_me(self) -> None:
-        self.run_worker(self.list_shared_with_me(), exclusive=True)
+        self.run_worker(
+            self.list_shared_with_me(),
+            exclusive=True,
+            group="sharing-list-shared-with-me",
+        )
 
     @on(Button.Pressed, "#sharing-get-shared-workspace-btn")
     def handle_get_shared_workspace(self) -> None:
-        self.run_worker(self.get_shared_workspace(), exclusive=True)
+        self.run_worker(
+            self.get_shared_workspace(),
+            exclusive=True,
+            group="sharing-get-shared-workspace",
+        )
 
     @on(Button.Pressed, "#sharing-clone-btn")
     def handle_clone(self) -> None:
-        self.run_worker(self.clone_shared_workspace(), exclusive=True)
+        self.run_worker(
+            self.clone_shared_workspace(),
+            exclusive=True,
+            group="sharing-clone-shared-workspace",
+        )
 
     @on(Button.Pressed, "#sharing-list-sources-btn")
     def handle_list_sources(self) -> None:
-        self.run_worker(self.list_shared_workspace_sources(), exclusive=True)
+        self.run_worker(
+            self.list_shared_workspace_sources(),
+            exclusive=True,
+            group="sharing-list-workspace-sources",
+        )
 
     @on(Button.Pressed, "#sharing-get-media-btn")
     def handle_get_media(self) -> None:
-        self.run_worker(self.get_shared_workspace_media(), exclusive=True)
+        self.run_worker(
+            self.get_shared_workspace_media(),
+            exclusive=True,
+            group="sharing-get-workspace-media",
+        )
 
     @on(Button.Pressed, "#sharing-chat-btn")
     def handle_chat(self) -> None:
-        self.run_worker(self.chat_with_shared_workspace(), exclusive=True)
+        self.run_worker(
+            self.chat_with_shared_workspace(),
+            exclusive=True,
+            group="sharing-chat-with-workspace",
+        )
 
     @on(Button.Pressed, "#sharing-create-token-btn")
     def handle_create_token(self) -> None:
-        self.run_worker(self.create_share_token(), exclusive=True)
+        self.run_worker(
+            self.create_share_token(),
+            exclusive=True,
+            group="sharing-create-share-token",
+        )
 
     @on(Button.Pressed, "#sharing-list-tokens-btn")
     def handle_list_tokens(self) -> None:
-        self.run_worker(self.list_share_tokens(), exclusive=True)
+        self.run_worker(
+            self.list_share_tokens(), exclusive=True, group="sharing-list-share-tokens"
+        )
 
     @on(Button.Pressed, "#sharing-revoke-token-btn")
     def handle_revoke_token(self) -> None:
-        self.run_worker(self.revoke_share_token(), exclusive=True)
+        self.run_worker(
+            self.revoke_share_token(),
+            exclusive=True,
+            group="sharing-revoke-share-token",
+        )
 
     @on(Button.Pressed, "#sharing-preview-public-btn")
     def handle_preview_public(self) -> None:
-        self.run_worker(self.preview_public_share(), exclusive=True)
+        self.run_worker(
+            self.preview_public_share(),
+            exclusive=True,
+            group="sharing-preview-public-share",
+        )
 
     @on(Button.Pressed, "#sharing-verify-password-btn")
     def handle_verify_password(self) -> None:
-        self.run_worker(self.verify_public_share_password(), exclusive=True)
+        self.run_worker(
+            self.verify_public_share_password(),
+            exclusive=True,
+            group="sharing-verify-public-password",
+        )
 
     @on(Button.Pressed, "#sharing-import-public-btn")
     def handle_import_public(self) -> None:
-        self.run_worker(self.import_public_share(), exclusive=True)
+        self.run_worker(
+            self.import_public_share(),
+            exclusive=True,
+            group="sharing-import-public-share",
+        )
 
     async def create_workspace_share(self) -> None:
         await self._run_operation(

--- a/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
+++ b/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
@@ -946,6 +946,16 @@ class StudyFlashcardsController:
           destroys the widgets every `_set_review_*` helper queries, and the
           tail below would otherwise resurrect a review session that teardown
           had just ended. The presentation token is re-checked after the await.
+
+        Qodo review of PR #1951 caught the corollary of rule two: the marker
+        used to be claimed *before* the await, and the `CancelledError` branch
+        re-raised without giving it back, so a cancelled save froze the panel
+        for good -- buttons disabled, presentation marked reviewed, nothing
+        written. The marker is now claimed only once the write has *returned*,
+        which costs nothing: the lock is held across the await, so a queued
+        second submission cannot reach the check until the first has either
+        recorded its marker or failed. Cancellation therefore needs no rollback
+        at all -- it only has to hand the buttons back (see below).
         """
         service = self._scope_service()
         card = self.current_review_card
@@ -956,14 +966,37 @@ class StudyFlashcardsController:
         # press is judged against the card the user was actually looking at.
         presentation = self._review_presentation
 
+        card_id = str(card.get("backing_id") or "")
+        mode = self._current_mode()
+        deck_id = self._selected_deck_id()
+        # Qodo review of PR #1951: an error line with no context cannot be
+        # correlated with anything. Ids and enum-ish values ONLY -- never the
+        # card's `front`/`back`, which are the user's own study material, and
+        # never a path (TASK-19864 is open on diagnostics that interpolate user
+        # content into log text). `card_id`/`deck_id` are generated UUIDs
+        # (`CharactersRAGDB._generate_uuid`), not anything the user typed.
+        # The bound fields are the structured record; the same two ids are also
+        # spelled into the message text below, because the shipped loguru sink
+        # format (`Logging_Config.py`) renders `{message}` and not `{extra}`.
+        log = logger.bind(
+            operation="study.flashcard.submit_review",
+            card_id=card_id,
+            deck_id=deck_id,
+            mode=mode,
+            rating=rating,
+            scope_type=self._scope_type(),
+            presentation=presentation,
+        )
+        log_subject = f"card_id={card_id!r} deck_id={deck_id!r} mode={mode}"
+
         async with self._review_submit_lock:
             if self._reviewed_presentation == presentation:
-                logger.info(
+                log.info(
                     "Ignoring a duplicate flashcard rating: this card has "
-                    "already been reviewed once and SM-2 would compound it."
+                    "already been reviewed once and SM-2 would compound it "
+                    f"({log_subject})."
                 )
                 return
-            self._reviewed_presentation = presentation
 
             # Stop the UI producing a second press for this same card.
             if self._review_panel_is_live():
@@ -973,9 +1006,9 @@ class StudyFlashcardsController:
 
             try:
                 outcome = await service.submit_flashcard_review(
-                    mode=self._current_mode(),
+                    mode=mode,
                     **self._scope_arguments(),
-                    card_id=str(card.get("backing_id") or ""),
+                    card_id=card_id,
                     rating=rating,
                     current_card=card,
                 )
@@ -984,22 +1017,70 @@ class StudyFlashcardsController:
                 # Exception` below can never see it. Log it explicitly rather
                 # than letting a lost review vanish silently, then re-raise so
                 # the worker still unwinds (TASK-19559).
-                logger.warning(
+                #
+                # The write's fate here is only knowable for the local backend:
+                # `StudyScopeService.submit_flashcard_review` reaches
+                # `LocalStudyService` through `_maybe_await`, which never
+                # suspends for a synchronous result, so a cancellation cannot
+                # be delivered between the SM-2 write and the return -- it must
+                # have arrived before the call. The server backend awaits a
+                # real HTTP round-trip, and a cancellation there can lose a
+                # response for a review the server has already applied.
+                #
+                # We do not branch on the backend for that (the reasoning
+                # depends on a collaborator's internal await structure, which
+                # is not ours to pin). We err instead toward *retryable*: the
+                # marker is not claimed, so the user can rate the card again.
+                # The cost of erring this way is one possible re-application of
+                # SM-2 in server mode; the cost of erring the other way is a
+                # frozen panel holding a review that was never written and can
+                # never be written. The retry is also made an informed one --
+                # the status line and a toast say the save may not have landed
+                # rather than letting the panel look untouched.
+                log.warning(
                     "Flashcard review submission was cancelled before it "
-                    "completed; the rating may not have been saved."
+                    "completed; the rating may not have been saved "
+                    f"({log_subject})."
                 )
+                try:
+                    if self._review_panel_is_live():
+                        self._set_review_status(
+                            "Review save was interrupted -- it may not have "
+                            "been saved. Rate the card again to be sure."
+                        )
+                        self._set_review_controls(
+                            show_answer_enabled=False, ratings_enabled=True
+                        )
+                        self._notify("Review save was interrupted.", severity="warning")
+                except Exception:
+                    # A cancellation usually means the app is going away, and
+                    # nothing here may replace the CancelledError on its way
+                    # out -- swallowing it would leave the worker looking like
+                    # it finished normally.
+                    log.opt(exception=True).warning(
+                        "Could not restore the review panel after a cancelled "
+                        f"rating ({log_subject})"
+                    )
                 raise
             except Exception:
-                logger.opt(exception=True).error("Failed to submit flashcard review")
+                log.opt(exception=True).error(
+                    f"Failed to submit flashcard review ({log_subject})"
+                )
                 self._notify("Failed to save review.", severity="error")
-                # The write did not land, so this presentation is reviewable
-                # again and the user needs the buttons back to retry.
-                self._reviewed_presentation = None
+                # The write did not land, so the marker below was never
+                # claimed and this presentation is still reviewable -- the user
+                # just needs the buttons back to retry.
                 if self._review_panel_is_live():
                     self._set_review_controls(
                         show_answer_enabled=False, ratings_enabled=True
                     )
                 return
+
+            # The write has returned, so SM-2 has been applied exactly once for
+            # this presentation. Claim the marker BEFORE the arrival guard
+            # below can return early, or a panel that moved on mid-save would
+            # leave the presentation submittable a second time.
+            self._reviewed_presentation = presentation
 
             # ARRIVAL GUARD. The write has landed; everything below only
             # touches UI and session state, and both are wrong to touch if the
@@ -1008,7 +1089,7 @@ class StudyFlashcardsController:
                 presentation != self._review_presentation
                 or not self._review_panel_is_live()
             ):
-                logger.info(
+                log.info(
                     "Flashcard review saved, but the review panel moved on "
                     "before the result arrived; leaving the current view alone."
                 )

--- a/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
+++ b/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Optional
 
 from loguru import logger
+from textual.css.query import NoMatches, QueryError
 from textual.widgets import (
     Button,
     Input,
@@ -54,6 +55,16 @@ class StudyFlashcardsController:
         # TASK-19559: rating submissions are serialised, never cancelled --
         # see `submit_rating`.
         self._review_submit_lock = asyncio.Lock()
+        # TASK-19559 review: a monotonic token for "which card is on screen
+        # right now". It is bumped every time the presented card changes and
+        # every time the panel is torn down, so a rating that finishes saving
+        # can tell whether the panel it was started from is still the one in
+        # front of the user. See `submit_rating`.
+        self._review_presentation: int = 0
+        # The presentation a review has already been written for. SM-2 is
+        # compounding, so a second submission for the SAME presentation is a
+        # double-submit, not a second review -- see `submit_rating`.
+        self._reviewed_presentation: Optional[int] = None
 
     def _current_mode(self) -> str:
         getter = getattr(self.app_instance, "get_authoritative_runtime_source", None)
@@ -482,7 +493,35 @@ class StudyFlashcardsController:
             button = self.window.query_one(f"#review-rating-{rating}", Button)
             button.disabled = not ratings_enabled
 
+    def _bump_review_presentation(self) -> int:
+        """Claim a new "card on screen" token.
+
+        TASK-19559 review: called every time the presented card changes or the
+        review panel is torn down. `submit_rating` captures the token before it
+        awaits and re-checks it afterwards, which is the arrival-time guard the
+        rest of this change already applies in `ccp_character_handler`,
+        `model_installed_view` and the Settings backup load.
+        """
+        self._review_presentation += 1
+        return self._review_presentation
+
+    def _review_panel_is_live(self) -> bool:
+        """Is the review panel still mounted?
+
+        `StudyWindow.watch_current_view` calls `remove_children()` on the view
+        container, so switching sub-view destroys these widgets outright while
+        a rating save is still in flight. Every `_set_review_*` helper does a
+        bare `query_one`, so touching them afterwards raises `NoMatches` out of
+        the worker.
+        """
+        try:
+            self.window.query_one("#review-status", Static)
+        except (NoMatches, QueryError):
+            return False
+        return True
+
     def reset_review_panel(self, message: str) -> None:
+        self._bump_review_presentation()
         self.current_review_card = None
         self.current_review_session_id = None
         self.current_review_session_mode = None
@@ -885,22 +924,53 @@ class StudyFlashcardsController:
         self._set_review_controls(show_answer_enabled=False, ratings_enabled=True)
 
     async def submit_rating(self, rating: int) -> None:
-        """Persist one rating, serialised behind any rating already in flight.
+        """Write exactly one review for the card currently on screen.
 
-        TASK-19559: this is a durable write, so it must never be raced away by
-        the next press. The card under review is captured **synchronously**,
-        before the first ``await``, so a second press that arrives while the
-        first save is still running rates the card the user was actually
-        looking at rather than whatever card has since been loaded. The lock
-        then serialises the two saves instead of cancelling either, so every
-        press reaches the database in press order.
+        TASK-19559: a spaced-repetition rating is a durable write, so it must
+        not be raced away by the next press -- exclusivity used to cancel the
+        in-flight save, and `CancelledError` is a `BaseException` that the
+        `except Exception` below cannot even observe. Three rules replace it:
+
+        * **Serialised, never cancelled.** The lock queues a second press
+          behind the first instead of destroying it.
+        * **Once per presentation.** `update_flashcard_review` runs SM-2, which
+          is *compounding and non-idempotent*: applying two reviews to one card
+          moves it from `repetitions=1, interval=1d` to `repetitions=2,
+          interval=6d`. Two rapid presses on the same card are a double-submit,
+          not two recall events, so the second is dropped rather than
+          compounded. (Ratings are also disabled the moment a press is
+          accepted, so the UI cannot produce the second press at all; this
+          check is the durable backstop for any programmatic caller.)
+        * **Guarded at arrival.** `StudyWindow.watch_current_view` calls
+          `remove_children()`, so leaving the flashcards sub-view mid-save
+          destroys the widgets every `_set_review_*` helper queries, and the
+          tail below would otherwise resurrect a review session that teardown
+          had just ended. The presentation token is re-checked after the await.
         """
         service = self._scope_service()
         card = self.current_review_card
         if service is None or not card or not self._scope_is_available():
             return
 
+        # Captured synchronously, before the first await, so a queued second
+        # press is judged against the card the user was actually looking at.
+        presentation = self._review_presentation
+
         async with self._review_submit_lock:
+            if self._reviewed_presentation == presentation:
+                logger.info(
+                    "Ignoring a duplicate flashcard rating: this card has "
+                    "already been reviewed once and SM-2 would compound it."
+                )
+                return
+            self._reviewed_presentation = presentation
+
+            # Stop the UI producing a second press for this same card.
+            if self._review_panel_is_live():
+                self._set_review_controls(
+                    show_answer_enabled=False, ratings_enabled=False
+                )
+
             try:
                 outcome = await service.submit_flashcard_review(
                     mode=self._current_mode(),
@@ -922,6 +992,26 @@ class StudyFlashcardsController:
             except Exception:
                 logger.opt(exception=True).error("Failed to submit flashcard review")
                 self._notify("Failed to save review.", severity="error")
+                # The write did not land, so this presentation is reviewable
+                # again and the user needs the buttons back to retry.
+                self._reviewed_presentation = None
+                if self._review_panel_is_live():
+                    self._set_review_controls(
+                        show_answer_enabled=False, ratings_enabled=True
+                    )
+                return
+
+            # ARRIVAL GUARD. The write has landed; everything below only
+            # touches UI and session state, and both are wrong to touch if the
+            # panel this rating came from is gone or has already moved on.
+            if (
+                presentation != self._review_presentation
+                or not self._review_panel_is_live()
+            ):
+                logger.info(
+                    "Flashcard review saved, but the review panel moved on "
+                    "before the result arrived; leaving the current view alone."
+                )
                 return
 
             review_session = outcome.get("review_session") or {}
@@ -965,6 +1055,7 @@ class StudyFlashcardsController:
             )
             return
 
+        self._bump_review_presentation()
         self.current_review_card = card
         review_session = candidate.get("review_session") or {}
         session_id = review_session.get("review_session_id")
@@ -1002,6 +1093,7 @@ class StudyFlashcardsController:
 
         self._pending_review_session_teardown = None
         if self.current_review_session_id == teardown_request.get("review_session_id"):
+            self._bump_review_presentation()
             self.current_review_session_id = None
             self.current_review_card = None
             self.current_review_session_mode = None

--- a/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
+++ b/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
@@ -51,6 +51,9 @@ class StudyFlashcardsController:
         self.selected_card_record: Optional[dict[str, Any]] = None
         self._scope_service_cache: Optional[StudyScopeService] = None
         self.has_decks: bool = False
+        # TASK-19559: rating submissions are serialised, never cancelled --
+        # see `submit_rating`.
+        self._review_submit_lock = asyncio.Lock()
 
     def _current_mode(self) -> str:
         getter = getattr(self.app_instance, "get_authoritative_runtime_source", None)
@@ -882,36 +885,54 @@ class StudyFlashcardsController:
         self._set_review_controls(show_answer_enabled=False, ratings_enabled=True)
 
     async def submit_rating(self, rating: int) -> None:
+        """Persist one rating, serialised behind any rating already in flight.
+
+        TASK-19559: this is a durable write, so it must never be raced away by
+        the next press. The card under review is captured **synchronously**,
+        before the first ``await``, so a second press that arrives while the
+        first save is still running rates the card the user was actually
+        looking at rather than whatever card has since been loaded. The lock
+        then serialises the two saves instead of cancelling either, so every
+        press reaches the database in press order.
+        """
         service = self._scope_service()
-        if (
-            service is None
-            or not self.current_review_card
-            or not self._scope_is_available()
-        ):
+        card = self.current_review_card
+        if service is None or not card or not self._scope_is_available():
             return
 
-        try:
-            outcome = await service.submit_flashcard_review(
-                mode=self._current_mode(),
-                **self._scope_arguments(),
-                card_id=str(self.current_review_card.get("backing_id") or ""),
-                rating=rating,
-                current_card=self.current_review_card,
-            )
-        except Exception:
-            logger.opt(exception=True).error("Failed to submit flashcard review")
-            self._notify("Failed to save review.", severity="error")
-            return
+        async with self._review_submit_lock:
+            try:
+                outcome = await service.submit_flashcard_review(
+                    mode=self._current_mode(),
+                    **self._scope_arguments(),
+                    card_id=str(card.get("backing_id") or ""),
+                    rating=rating,
+                    current_card=card,
+                )
+            except asyncio.CancelledError:
+                # `CancelledError` is a `BaseException`, so the `except
+                # Exception` below can never see it. Log it explicitly rather
+                # than letting a lost review vanish silently, then re-raise so
+                # the worker still unwinds (TASK-19559).
+                logger.warning(
+                    "Flashcard review submission was cancelled before it "
+                    "completed; the rating may not have been saved."
+                )
+                raise
+            except Exception:
+                logger.opt(exception=True).error("Failed to submit flashcard review")
+                self._notify("Failed to save review.", severity="error")
+                return
 
-        review_session = outcome.get("review_session") or {}
-        session_id = review_session.get("review_session_id")
-        if session_id is not None:
-            self.current_review_session_id = int(session_id)
-            self.current_review_session_mode = self._current_mode()
+            review_session = outcome.get("review_session") or {}
+            session_id = review_session.get("review_session_id")
+            if session_id is not None:
+                self.current_review_session_id = int(session_id)
+                self.current_review_session_mode = self._current_mode()
 
-        self._set_review_status("Review saved.")
-        self._set_next_intervals(outcome.get("next_intervals"))
-        await self._load_next_review_candidate(deck_id=self._selected_deck_id())
+            self._set_review_status("Review saved.")
+            self._set_next_intervals(outcome.get("next_intervals"))
+            await self._load_next_review_candidate(deck_id=self._selected_deck_id())
 
     async def _load_next_review_candidate(self, *, deck_id: Optional[str]) -> None:
         service = self._scope_service()

--- a/tldw_chatbook/UI/Study_Window.py
+++ b/tldw_chatbook/UI/Study_Window.py
@@ -781,6 +781,7 @@ class StudyWindow(Container):
             self.run_worker(
                 self.flashcards_controller.end_review_session_if_needed(),
                 exclusive=True,
+                group="study-end-review-session",
             )
 
         # Remove old content
@@ -911,12 +912,20 @@ class StudyWindow(Container):
         delete_deck_note.display = server_mode
 
     def _schedule_flashcards_refresh(self) -> None:
-        self.run_worker(self.flashcards_controller.initialize_view(), exclusive=True)
+        self.run_worker(
+            self.flashcards_controller.initialize_view(),
+            exclusive=True,
+            group="study-flashcards-initialize-view",
+        )
         self.call_after_refresh(self._configure_flashcards_lifecycle_controls)
         self.call_after_refresh(self._notify_shell_state_changed)
 
     def _schedule_quizzes_refresh(self) -> None:
-        self.run_worker(self.quizzes_controller.initialize_view(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.initialize_view(),
+            exclusive=True,
+            group="study-quizzes-initialize-view",
+        )
         self.call_after_refresh(self._configure_quizzes_lifecycle_controls)
         self.call_after_refresh(self._notify_shell_state_changed)
 
@@ -1004,15 +1013,27 @@ class StudyWindow(Container):
 
     @on(Button.Pressed, "#create-deck-button")
     def handle_create_deck(self) -> None:
-        self.run_worker(self.flashcards_controller.create_deck(), exclusive=True)
+        self.run_worker(
+            self.flashcards_controller.create_deck(),
+            exclusive=True,
+            group="study-create-deck",
+        )
 
     @on(Button.Pressed, "#flashcard-refresh-button")
     def handle_refresh_cards(self) -> None:
-        self.run_worker(self.flashcards_controller.refresh_cards(), exclusive=True)
+        self.run_worker(
+            self.flashcards_controller.refresh_cards(),
+            exclusive=True,
+            group="study-refresh-cards",
+        )
 
     @on(Button.Pressed, "#create-card-btn")
     def handle_create_card(self) -> None:
-        self.run_worker(self.flashcards_controller.create_card(), exclusive=True)
+        self.run_worker(
+            self.flashcards_controller.create_card(),
+            exclusive=True,
+            group="study-create-card",
+        )
 
     @on(Button.Pressed, "#delete-deck-button")
     async def handle_delete_deck(self) -> None:
@@ -1036,7 +1057,11 @@ class StudyWindow(Container):
 
     @on(Button.Pressed, "#start-review-btn")
     def handle_start_review(self) -> None:
-        self.run_worker(self.flashcards_controller.start_review(), exclusive=True)
+        self.run_worker(
+            self.flashcards_controller.start_review(),
+            exclusive=True,
+            group="study-start-review",
+        )
 
     @on(Button.Pressed, "#show-answer-button")
     def handle_show_answer(self) -> None:
@@ -1050,8 +1075,19 @@ class StudyWindow(Container):
     @on(Button.Pressed, "#review-rating-5")
     def handle_review_rating(self, event: Button.Pressed) -> None:
         rating = int(str(event.button.id).rsplit("-", 1)[-1])
+        # TASK-19559: a spaced-repetition rating is a DURABLE WRITE, so it is
+        # deliberately NOT `exclusive=True`. Exclusivity cancels the previous
+        # worker in the same group, and `submit_rating` awaits the review save
+        # -- a second fast press would kill the first press's save before it
+        # reached the database, and `CancelledError` is a `BaseException` that
+        # the handler's `except Exception:` cannot even observe. Ratings are
+        # instead serialised inside `StudyFlashcardsController.submit_rating`
+        # (an `asyncio.Lock`), so presses queue and every one persists.
+        # The explicit group also keeps these workers out of `"default"`, where
+        # any other Study worker would cancel them.
         self.run_worker(
-            self.flashcards_controller.submit_rating(rating), exclusive=True
+            self.flashcards_controller.submit_rating(rating),
+            group="study-flashcard-rating",
         )
 
     @on(Select.Changed, "#deck-select")
@@ -1060,31 +1096,59 @@ class StudyWindow(Container):
 
     @on(Button.Pressed, "#create-quiz-button")
     def handle_create_quiz(self) -> None:
-        self.run_worker(self.quizzes_controller.create_quiz(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.create_quiz(),
+            exclusive=True,
+            group="study-create-quiz",
+        )
 
     @on(Button.Pressed, "#delete-quiz-button")
     def handle_delete_quiz(self) -> None:
-        self.run_worker(self.quizzes_controller.delete_quiz(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.delete_quiz(),
+            exclusive=True,
+            group="study-delete-quiz",
+        )
 
     @on(Button.Pressed, "#create-quiz-question-button")
     def handle_create_quiz_question(self) -> None:
-        self.run_worker(self.quizzes_controller.create_question(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.create_question(),
+            exclusive=True,
+            group="study-create-quiz-question",
+        )
 
     @on(Button.Pressed, "#delete-quiz-question-button")
     def handle_delete_quiz_question(self) -> None:
-        self.run_worker(self.quizzes_controller.delete_question(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.delete_question(),
+            exclusive=True,
+            group="study-delete-quiz-question",
+        )
 
     @on(Button.Pressed, "#start-quiz-attempt-button")
     def handle_start_quiz_attempt(self) -> None:
-        self.run_worker(self.quizzes_controller.start_attempt(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.start_attempt(),
+            exclusive=True,
+            group="study-start-quiz-attempt",
+        )
 
     @on(Button.Pressed, "#submit-quiz-answer-button")
     def handle_submit_quiz_answer(self) -> None:
-        self.run_worker(self.quizzes_controller.submit_current_answer(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.submit_current_answer(),
+            exclusive=True,
+            group="study-submit-quiz-answer",
+        )
 
     @on(Button.Pressed, "#load-quiz-attempt-history-button")
     def handle_load_quiz_attempt_history(self) -> None:
-        self.run_worker(self.quizzes_controller.load_selected_attempt(), exclusive=True)
+        self.run_worker(
+            self.quizzes_controller.load_selected_attempt(),
+            exclusive=True,
+            group="study-load-quiz-attempt-history",
+        )
 
     @on(Select.Changed, "#quiz-select")
     async def handle_quiz_select_changed(self, event: Select.Changed) -> None:

--- a/tldw_chatbook/UI/Study_Window.py
+++ b/tldw_chatbook/UI/Study_Window.py
@@ -1092,7 +1092,18 @@ class StudyWindow(Container):
 
     @on(Select.Changed, "#deck-select")
     def handle_deck_select_changed(self, event: Select.Changed) -> None:
-        self.run_worker(self.flashcards_controller.handle_deck_changed())
+        # TASK-19559 review: `handle_deck_changed` ends the review session and
+        # then rebuilds `#card-list` -- the same list `handle_refresh_cards`
+        # rebuilds. Both writers must share one exclusive group so the newer
+        # rebuild supersedes the older one; ungrouped and non-exclusive, this
+        # one sat in "default" and interleaved with the grouped refresh,
+        # leaving `#card-list` holding one row per interleaved append while
+        # `current_cards` held the true count.
+        self.run_worker(
+            self.flashcards_controller.handle_deck_changed(),
+            exclusive=True,
+            group="study-refresh-cards",
+        )
 
     @on(Button.Pressed, "#create-quiz-button")
     def handle_create_quiz(self) -> None:

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -4165,7 +4165,7 @@ class ToolsSettingsWindow(Container):
                     streaming=False,
                 ),
                 thread=True,
-                exclusive=True,
+                exclusive=True, group="tools-settings-test-chat-connection",
             )
             test_response = extract_response_content(raw)
 
@@ -4302,7 +4302,7 @@ class ToolsSettingsWindow(Container):
                             streaming=False,
                         ),
                         thread=True,
-                        exclusive=True,
+                        exclusive=True, group="tools-settings-test-all-api-keys",
                     )
 
                     if extract_response_content(raw):

--- a/tldw_chatbook/UI/Voice_Cloning_Window.py
+++ b/tldw_chatbook/UI/Voice_Cloning_Window.py
@@ -315,7 +315,7 @@ class VoiceCloningWindow(DataTableClickSelectMixin, Vertical):
             logger.error(f"Error initializing backends: {e}")
             self.notify(f"Failed to initialize backends: {e}", severity="error")
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="voice-cloning-load-profiles")
     async def _load_profiles(self) -> None:
         """Load profiles for the current backend"""
         if self._loading:

--- a/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
@@ -509,7 +509,7 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
     def _start_run_poll(self, run: dict[str, Any]) -> None:
         self.run_poll(run)
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="watchlists-runs-poll")
     async def run_poll(self, run: dict[str, Any]) -> None:
         """Poll the selected run while it is running.
 

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -2015,7 +2015,7 @@ class MediaViewerPanel(Container):
         if 0 <= self.current_analysis_index < len(self.all_analyses):
             self._run_delete_confirmation()
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="media-viewer-delete-confirmation")
     async def _run_delete_confirmation(self) -> None:
         """Show confirmation dialog and handle deletion."""
         if not self.media_data or len(self.all_analyses) == 0:

--- a/tldw_chatbook/Widgets/audio_troubleshooting_dialog.py
+++ b/tldw_chatbook/Widgets/audio_troubleshooting_dialog.py
@@ -221,7 +221,7 @@ class AudioTroubleshootingDialog(ModalScreen[bool]):
         """Initialize when dialog is shown."""
         self.run_worker(self._initialize_audio())
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="audio-troubleshooting-initialize")
     async def _initialize_audio(self):
         """Initialize audio system and enumerate devices."""
         log = self.query_one("#diagnostic-log", RichLog)

--- a/tldw_chatbook/Widgets/dictation_performance_widget.py
+++ b/tldw_chatbook/Widgets/dictation_performance_widget.py
@@ -162,7 +162,7 @@ class DictationPerformanceWidget(Widget):
         """Load metrics on mount."""
         self.refresh_metrics()
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="dictation-performance-refresh-metrics")
     async def refresh_metrics(self):
         """Refresh performance metrics."""
         monitor = get_performance_monitor()

--- a/tldw_chatbook/Widgets/enhanced_sidebar.py
+++ b/tldw_chatbook/Widgets/enhanced_sidebar.py
@@ -77,7 +77,7 @@ class SidebarSection(Container):
             if self.content:
                 self.content.remove_class("loading-fade")
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="enhanced-sidebar-load-content")
     async def load_content(self, loader: Callable) -> None:
         """Load content asynchronously with loading indicator.
 

--- a/tldw_chatbook/Widgets/lazy_widgets.py
+++ b/tldw_chatbook/Widgets/lazy_widgets.py
@@ -162,7 +162,7 @@ class VirtualListView(ListView):
         if len(self._items) <= self._rendered_range[1]:
             self.mount(self._item_factory(item))
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="lazy-widgets-update-visible-items")
     async def _update_visible_items(self) -> None:
         """Update which items are rendered based on scroll position."""
         if self._pending_update:

--- a/tldw_chatbook/Widgets/loading_states.py
+++ b/tldw_chatbook/Widgets/loading_states.py
@@ -79,7 +79,7 @@ class LoadingState(Container):
         if self.auto_start and self.loader:
             self.start_loading()
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="loading-states-start-loading")
     async def start_loading(self) -> None:
         """Start the loading process."""
         self.is_loading = True

--- a/tldw_chatbook/Widgets/project_skills_import_modal.py
+++ b/tldw_chatbook/Widgets/project_skills_import_modal.py
@@ -326,7 +326,11 @@ class ProjectSkillsImportModal(SafeModalDismissMixin, ModalScreen[ImportDecision
             except Exception:  # noqa: BLE001 - purely cosmetic, never fatal
                 pass
         selected = self._selected_entries()
-        self.run_worker(self._run_import(selected), exclusive=True)
+        self.run_worker(
+            self._run_import(selected),
+            exclusive=True,
+            group="project-skills-run-import",
+        )
 
     async def _run_import(self, entries: tuple[ProjectSkillEntry, ...]) -> None:
         outcomes: list[ImportOutcome] = []

--- a/tldw_chatbook/Widgets/voice_input_widget.py
+++ b/tldw_chatbook/Widgets/voice_input_widget.py
@@ -273,7 +273,7 @@ class VoiceInputWidget(Widget):
                 self.dictation_service.set_audio_device(event.value)
                 logger.info(f"Changed audio device to: {event.value}")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="voice-input-start-recording", thread=True)
     def start_recording(self):
         """Start voice recording and dictation."""
         try:
@@ -322,7 +322,7 @@ class VoiceInputWidget(Widget):
             logger.error(f"Failed to start recording: {e}")
             self._call_from_worker_or_now(self._set_error, f"Recording error: {str(e)}")
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="voice-input-stop-recording", thread=True)
     def stop_recording(self):
         """Stop voice recording and get final transcript."""
         if not self.dictation_service:
@@ -445,11 +445,14 @@ class VoiceInputWidget(Widget):
             return "Processing..."
         return ""
 
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True, group="voice-input-start-level-monitoring", thread=True)
     def _start_level_monitoring(self):
         """Start monitoring audio levels."""
         self.level_monitor_worker = self.run_worker(
-            self._monitor_audio_levels, exclusive=True, thread=True
+            self._monitor_audio_levels,
+            exclusive=True,
+            group="voice-input-monitor-levels",
+            thread=True,
         )
 
     def _stop_level_monitoring(self):
@@ -557,7 +560,9 @@ class VoiceInputWidget(Widget):
         """Start audio level monitoring."""
         if not hasattr(self, "level_monitor_worker") or not self.level_monitor_worker:
             self.level_monitor_worker = self.run_worker(
-                self._monitor_audio_levels, exclusive=True
+                self._monitor_audio_levels,
+                exclusive=True,
+                group="voice-input-monitor-levels",
             )
 
     def _set_audio_level(self, level: float):


### PR DESCRIPTION
Closes TASK-19559 and TASK-19563. They ship together because they share a root cause and overlapping files.

## The mechanism

`exclusive=True` with no `group=` lands the worker in the group literally named `"default"`. `cancel_group` filters on `(node, group)` and **never consults `name=`**. So every ungrouped exclusive worker on a node mutually cancels every sibling, and the `name=` several authors passed believing it scoped exclusivity scopes nothing. `CancelledError` derives from `BaseException`, so the `except Exception:` blocks these handlers use cannot catch it — the work vanishes silently. And `Worker.cancel()` does **not** stop a thread worker: the body runs to completion in an executor and its `call_from_thread` callbacks still land.

## The guard is the deliverable

Measured by AST walk (independently reproduced in review): **133 sites across 32 files → 1**, the allowlisted vendored `textual-fspicker` widget. The task file's "145 sites / 35 files" is wrong; a naive `grep exclusive=True | grep -v group=` reports **523**, a ~4× over-count — `chat_screen.py` alone contributes 29 phantom hits while having zero real ones.

`Tests/Architecture/test_worker_exclusive_group_inventory.py` covers `@work(...)` decorators, `run_worker(...)` calls, multi-line forms and the positional `run_worker(work, name, group, …)` shape, and **fails closed** on a `**kwargs` spread or a non-literal `exclusive=`. The allowlist is keyed by `"<path>::<owning function>"` — a name, not a line number, so entries survive edits above them — with a prose reason per row, plus tests rejecting stale entries and thin reasons.

Review closed a hole in it worth calling out: **`group="default"` is byte-identical to omitting `group=`**, and `group=""`/`None` are falsy, so `add_worker`'s `if exclusive and worker.group:` skips `cancel_group` entirely — the site asks for exclusivity and silently gets none. The guard checked only that the node was *present*, never its value. That is also the likeliest wrong fix someone reaches for when the guard fails, and one file already spells it by hand.

## The four named instances

Media analysis, the four unfixed Watchlists loaders (whose hazard comment sat directly above them), and the Settings advanced-config backup load (now an arrival-time guard: editor text captured at dispatch, compared on arrival, refusal reported).

**Study ratings needed more than a group.** Grouping alone is provably insufficient here and the born-red shows it: with an explicit group *and* `exclusive=True`, the second press still destroys the first save, because cancelling a thread worker doesn't stop its body. The rating is a durable write, so it now dispatches non-exclusively into `study-flashcard-rating`, serialised behind an `asyncio.Lock`, with the card captured synchronously before the first `await`, and an explicit `except asyncio.CancelledError:` that logs and re-raises.

The remaining 129 sites are grouped by the *work*, so same-work sites share one group (`wc_rules` ×4 all dispatch `_load_rules`, `schedules-load-tasks` ×5, `stts-request-view` ×5) and different operations never cross-cancel. Verified in review that no load/save pair shares a group.

## Review found three regressions the first pass introduced — all fixed

Removing exclusivity from the Study path removed protection it had been providing incidentally.

| | base | pre-fix | fixed |
|---|---|---|---|
| rating in flight + sub-view switch: exception | `[]` | `WorkerFailed(NoMatches '#review-status')` | `[]` |
| …rating persisted | `[]` **(lost)** | `[('card-local-1', 3)]` | `[('card-local-1', 3)]` |
| …`current_review_session_id` | `None` | `41` **(resurrected)** | `None` |
| deck-change + refresh: `#card-list` rows / `current_cards` | 2 / 2 | 3 / 2 | 2 / 2 |
| two presses: SM-2 applications | 1 | **2** | 1 |

The third is the subtle one: `update_flashcard_review` runs **SM-2, which is compounding and non-idempotent**, so the fix had converted a lost write into a *doubled schedule* (`repetitions=2, interval=6d`), and the new test held the card fixed and therefore **pinned** the doubling. Fixed by one review per card *presentation* — not per card, so a re-dealt relearn card still records each genuine re-review.

## An owner call, escalated rather than decided silently

For a same-card double press this ships **first-press-wins** plus disabling the rating buttons on press, not latest-wins. By the time the second press arrives the first write is already awaiting the service, so honouring "latest" needs either an un-apply for SM-2 (no such API) or a debounce on every rating, on the hot path; Anki disables answer buttons on press and routes the next press to the next card. Both designs agree on what matters — SM-2 applied exactly once.

Note base's behaviour *was* latest-wins, so the tie-break does change — but only in a scenario the UI can no longer produce. Review attacked the button-disable four ways (`enter`, `space`, direct `.press()`, real `pilot.click`) and the service received exactly one submission where base received three; there are no `BINDINGS` in `Study_Window` and no other caller of `submit_rating`. A once-per-presentation gate backstops it even when the buttons are bypassed programmatically.

## TASK-19563 — severity corrected in review

Three surfaces dispatched per keystroke and rendered whatever arrived last. All three now compare a generation counter **at arrival**, copying `chat_screen.py` — necessary because thread bodies cannot be cancelled, so dispatch-time guarding is not sufficient.

**The filed headline was wrong about impact, and the PR should not repeat it.** CCP conversation search did not merely show stale results — it could never run at all (`run_worker(bound_method, term, type, …, name=…)` binds the search term onto `run_worker`'s own `name` and the type onto `group`, raising `TypeError`; and `_search_conversations_sync` carried `@work`, which asserts `isinstance(self, DOMNode)` on a plain object). But `CCPConversationHandler` and `CCPDictionaryHandler` are **never instantiated in production** — `PersonasScreen` builds only `character_handler` and `persona_handler`. So that surface is a correct fix to dead code, and the live TASK-19563 fix is the **Personas character load**, which the task rated lesser. Five more dispatches of the same shape sit in `Tools_Settings_Window`, confirmed nav-unreachable; left alone and filed.

## Verification

- Branch-touched test files + Study interop, post-rebase: **663 passed / 0 failed**.
- Five tests replace the deleted doubling-pinner, each red at the baseline that owns it, every failure behavioural rather than an import error — assertion texts carry the production symptoms (`"a sibling Study worker cancelled the in-flight rating save; persisted=[]"`, `"#card-list holds 4 rows against 2 cards — two rebuilds interleaved"`, `"SM-2 was applied more than once: repetitions=2 interval=6"`). One of the five is a sequential characterisation test and is labelled as such.
- Guard suites 16 passed, including the three `group="default"` additions. Census re-run independently: 1 allowlisted site.
- `Docs/User_Guide/settings.md` updated for the Load Backup refusal.

Filed rather than fixed: two mutation workers that refresh inline outside their loader's group, a spurious double-press refusal message on Load Backup, the dead CCP handlers' disposition, and a timezone-dependent watchlists test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names every exclusive worker group and enforces a repo-wide guard; previously, ungrouped exclusive workers canceled each other in the shared "default" group. Adds arrival-time generation checks so stale thread results are dropped, and reworks Study rating to serialize without exclusivity; first-press-wins and canceled saves no longer lock the panel. Addresses TASK-19559 and TASK-19563.

- Guard and migration: An architecture test fails on `exclusive=True` without a concrete `group` and rejects `group="default"`, `""`, or `None`. One vendored widget is allowlisted; all other groups are named after the work. Required: when adding an exclusive worker, set a real `group`; do not rely on `name=`. For thread workers whose results can be superseded, add arrival-time guards.
- Arrival guards: Personas character load, CCP conversation search, and Model Installed inventory compare a dispatch counter at result arrival and discard superseded reads. Settings “Load Backup” keeps edits made while the backup loads; docs updated.
- Study ratings: remove exclusivity; serialize with an `asyncio.Lock`; capture the active card before the first await; drop duplicate presses per presentation; disable rating buttons on press. On cancellation, restore buttons and record success only after a save; tie-break is first-press-wins.

<sup>Written for commit 72235f02430ad62a94c89e8d9d582a33af53c0cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

