### PR TITLE
Change review: report submit bugs, guard the detection landing, align the in-progress refusal docs (TASK-19703)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -416,9 +416,13 @@ optional "create branch first" field checks out a new branch before
 staging. The dialog also shows non-blocking **warnings** — they never stop
 the commit — for a detached HEAD ("this commit will not be on any
 branch") and for committing straight to `main` or `master`. Committing is
-**refused outright** (before the dialog even opens) while an agent run is
-active on that workspace, and separately while the repository is mid
-merge, rebase, or cherry-pick — finish or abort that operation first.
+**refused outright before the dialog even opens** while an agent run is
+active on that workspace. A repository that is mid merge, rebase, or
+cherry-pick is also refused, but at the moment you confirm rather than
+before the dialog opens — finish or abort that operation first. (The check
+runs then because the repository can enter a merge while the dialog is
+open, so checking earlier could only promise something that later stops
+being true.)
 
 **Push (`p` / the Push… button).** Always confirms in a dialog first,
 naming the repository, the branch, and where it's going. A branch with no
@@ -1659,3 +1663,5 @@ conversation with no turns yet may show no `current` entry; this is a
 pre-existing characteristic of the change-tracking roots this arc reused
 verbatim, not something Task 9 changed, and it is not re-verified live
 here.)*
+
+*Git-actions placement corrected @ TASK-19703 — 2026-08-22: the mid-merge/rebase/cherry-pick refusal was documented here as happening "before the dialog even opens", which is true of the active-run refusal but not of this one — it fires when you confirm. Not driven live; corrected by reading the shipped code (`commit_selected`'s `in-progress-check` step) against this page's claim, and the design spec was amended to match rather than the code changed (a pre-modal check could only be advisory, since the repository can enter a merge while the dialog is open).*

--- a/Docs/superpowers/specs/2026-08-20-console-review-git-modes-design.md
+++ b/Docs/superpowers/specs/2026-08-20-console-review-git-modes-design.md
@@ -280,15 +280,25 @@ Button `Commit…` + binding, visible/enabled only in current mode with
    - warnings (never blocks): detached HEAD ("commit will not be on
      any branch"), branch in `{main, master}` ("committing directly
      to <branch>");
-   - an operation in progress (`rev-parse --verify -q` on
-     `MERGE_HEAD`, `REBASE_HEAD`, `CHERRY_PICK_HEAD` — check=False)
-     → commit REFUSED with reason ("finish or abort the
-     merge/rebase/cherry-pick first") — git refuses a partial
-     (pathspec) commit during a merge OR a cherry-pick, and the raw
-     git error is worse copy.
+   - (the in-progress refusal is NOT a modal-open check — see step 4;
+     amended by TASK-19703 to match what shipped.)
 4. **Engine** (`commit_selected(root, files, message, new_branch)`)
    runs per-step, stopping at the first failure, each step an
    outcome row:
+   - `in-progress-check`: `rev-parse --verify -q` on `MERGE_HEAD`,
+     `REBASE_HEAD`, `CHERRY_PICK_HEAD` (check=False); any exit 0 ⇒ a
+     failed outcome, "finish or abort the merge/rebase/cherry-pick
+     first" (git refuses a partial pathspec commit during a merge or a
+     cherry-pick, and the raw git error is worse copy).
+     **Placement amended by TASK-19703.** This spec first listed the
+     check as a modal-open gate under step 3. It shipped engine-side,
+     and the engine is the right home: the repository can enter a merge
+     between modal-open and submit, so a pre-modal check could only ever
+     be advisory — and an advisory check that PASSES and is then refused
+     at submit is more confusing than one honest refusal. Duplicating it
+     in both places would invite the two copies to drift. The cost is
+     accepted knowingly: the user learns of the refusal after filling in
+     the dialog rather than before it opens.
    - optional: `git check-ref-format --branch <name>` (validation +
      option-injection guard, §2 probe 3) then
      `git checkout -b <name>`;

--- a/Tests/UI/test_change_review_commit_ui.py
+++ b/Tests/UI/test_change_review_commit_ui.py
@@ -1400,3 +1400,50 @@ async def test_a_stale_diff_is_not_served_after_the_commit_reload(
             "the commit reload must bump the diff-cache generation "
             f"({generation_before} -> {screen._diff_cache_generation})"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_bug_inside_commit_submit_reports_itself(
+    monkeypatch, commit_fixture
+):
+    """TASK-19703 AC #2: a bug inside `_submit` must not leave the confirm
+    button silently inert.
+
+    The handler wraps its body in a broad `except` so it can never raise
+    out of a Textual event handler — correct — but it then returned
+    silently, so the user pressed Commit and NOTHING happened: no commit,
+    no error, no dismissal, indistinguishable from a dead button. Same
+    silent-masking class this workstream has repeatedly caught.
+    """
+    _patch_git_actions(monkeypatch, True)
+    provider, repo = commit_fixture
+    app = _Harness(provider, workspace_roots=[str(repo)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _enter_current_mode(pilot, app)
+        modal = await _open_commit_modal(pilot, app, screen)
+
+        def _explode(*_a, **_kw):
+            raise RuntimeError("SYNTHETIC-19703 submit bug")
+
+        # Break something `_submit` uses AFTER its validation passes, so the
+        # broad except is what catches it rather than a validation return.
+        monkeypatch.setattr(type(modal), "dismiss", _explode, raising=True)
+        modal.query_one("#change-git-commit-message", Input).value = "msg"
+        await pilot.pause()
+
+        errors: list[str] = []
+        monkeypatch.setattr(
+            type(modal),
+            "_show_error",
+            lambda self, m: errors.append(m),
+            raising=True,
+        )
+        notes: list[tuple] = []
+        app.notify = lambda *a, **kw: notes.append((a, kw))
+
+        modal._submit()
+        await pilot.pause()
+
+    assert errors or notes, (
+        "a bug in submit must tell the user something, not sit inert"
+    )

--- a/Tests/UI/test_change_review_current_mode.py
+++ b/Tests/UI/test_change_review_current_mode.py
@@ -34,6 +34,7 @@ from textual.worker import WorkerFailed
 import tldw_chatbook.config as config_module
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.UI.Screens.change_review_screen import (
+    _land_on_ui,
     CURRENT_MODE_SENTINEL,
     AgentRunsChangeReviewProvider,
     ChangeReviewDiffPane,
@@ -1003,47 +1004,38 @@ async def test_a_bug_inside_a_landing_is_not_swallowed(
     )
 
 
-@pytest.mark.asyncio
-async def test_teardown_runtime_error_from_a_landing_is_still_swallowed(
-    monkeypatch, git_review_fixture
-):
-    """The other half: the teardown case the guard exists for stays quiet.
+def test_land_on_ui_swallows_real_teardown_but_not_a_running_app_bug():
+    """The landing guard's two halves, against the REAL discriminator.
 
-    A status read is a git subprocess and can easily outlive the app; its
-    landing then hits `RuntimeError("App is not running")`. That must NOT
-    surface as a WorkerFailed traceback — it is an ordinary, expected race,
-    and the worker should simply finish.
+    Rewritten by TASK-19703 / Qodo #2 (PR #1958). The previous version
+    simulated teardown by having the callback raise
+    `RuntimeError("App is not running")` while the app was still running —
+    a proxy that was indistinguishable from a genuine bug, which is exactly
+    the hole Qodo found. Now that `_land_on_ui` consults `App.is_running`,
+    that proxy is (correctly) treated as a bug, so the test has to
+    simulate the real condition instead: an app that is NOT running.
+
+    Driven directly against `_land_on_ui` rather than through a mounted
+    app, because "the app is genuinely torn down" is not a state a live
+    `run_test` harness can hold still in.
     """
-    _patch_git_actions(monkeypatch, True)
-    provider, repo, _db, _run1, _run2 = git_review_fixture
 
-    def teardown_land(_token, _statuses):
+    class _StubApp:
+        def __init__(self, running: bool) -> None:
+            self.is_running = running
+
+        def call_from_thread(self, callback, *args):
+            return callback(*args)
+
+    def _raise_teardown() -> None:
         raise RuntimeError("App is not running")
 
-    app = _Harness(provider)
-    async with app.run_test(size=(160, 48)) as pilot:
-        screen = await _open_screen(pilot, app)
-        await _wait_for_detection(pilot, screen)
-        screen._land_current_mode = teardown_land
+    # Genuine teardown: swallowed, so a per-root loop is never aborted.
+    _land_on_ui(_StubApp(running=False), _raise_teardown)
 
-        screen.query_one(
-            "#change-review-turn-select", Select
-        ).value = CURRENT_MODE_SENTINEL
-        await _wait_idle(pilot, app, "change-review-current")
-        await pilot.pause()
-
-        assert app._exception is None, (
-            "a teardown RuntimeError must not tear the app down; got "
-            f"{app._exception!r}"
-        )
-        states = {
-            w.state.name
-            for w in app.workers
-            if w.group == "change-review-current"
-        }
-        assert "ERROR" not in states, (
-            f"the worker must finish rather than fail; states={states}"
-        )
+    # Same exception type, app still alive: a real bug, and it must be loud.
+    with pytest.raises(RuntimeError, match="App is not running"):
+        _land_on_ui(_StubApp(running=True), _raise_teardown)
 
 
 @pytest.mark.asyncio
@@ -1347,3 +1339,48 @@ async def test_a_tracked_cwd_is_not_disclosed(monkeypatch, tmp_path):
         text = str(screen.query_one("#change-review-banner", Static).renderable)
 
     assert "not tracked here" not in text, text
+
+
+@pytest.mark.asyncio
+async def test_a_landing_bug_that_raises_RuntimeError_is_not_read_as_teardown(
+    monkeypatch, git_review_fixture
+):
+    """Qodo #2 (PR #1958): exception TYPE alone cannot separate the two.
+
+    `_land_on_ui` tolerates `RuntimeError` because that is how Textual
+    signals teardown — but `call_from_thread` also re-raises whatever the
+    callback raised, so a genuine bug that happens to be a `RuntimeError`
+    (a `dict` misuse, a Textual API called out of order, a library raising
+    it) was indistinguishable from shutdown and vanished into one
+    misleading debug line.
+
+    `App.is_running` is the real discriminator: it is exactly what
+    `call_from_thread` consults before raising "App is not running", so a
+    RuntimeError seen while the app is STILL running cannot be teardown.
+    """
+    _patch_git_actions(monkeypatch, True)
+    provider, repo, _db, _run1, _run2 = git_review_fixture
+    boom = RuntimeError("a real bug that happens to be a RuntimeError")
+
+    def exploding_land(_token, _statuses):
+        raise boom
+
+    app = _Harness(provider)
+    with pytest.raises(WorkerFailed) as excinfo:
+        async with app.run_test(size=(160, 48)) as pilot:
+            screen = await _open_screen(pilot, app)
+            await _wait_for_detection(pilot, screen)
+            screen._land_current_mode = exploding_land
+            screen.query_one(
+                "#change-review-turn-select", Select
+            ).value = CURRENT_MODE_SENTINEL
+            await _wait_for(
+                pilot,
+                lambda: app._exception is not None,
+                "the app to record the landing failure",
+                timeout=5.0,
+            )
+
+    assert excinfo.value.error is boom, (
+        f"the original RuntimeError must survive; got {excinfo.value.error!r}"
+    )

--- a/Tests/UI/test_change_review_push_ui.py
+++ b/Tests/UI/test_change_review_push_ui.py
@@ -1556,3 +1556,35 @@ async def test_push_is_disabled_with_a_reason_for_an_option_shaped_branch(
             f"got {push_btn.tooltip!r}"
         )
         assert notes and PUSH_OPTION_BRANCH_REASON in notes[0], notes
+
+
+@pytest.mark.asyncio
+async def test_a_bug_inside_push_submit_reports_itself(monkeypatch, tmp_path):
+    """TASK-19703 AC #2, push side.
+
+    Same shape as the commit modal's: the broad `except` that keeps a
+    Textual handler from raising also swallowed genuine bugs, leaving the
+    confirm button inert. This modal has no inline error Static, so the
+    report goes through `notify`.
+    """
+    _patch_git_actions(monkeypatch, True)
+    repo, _bare = _repo_with_remote(tmp_path)
+    (repo / "a.txt").write_text("changed\n")
+    provider, _db, _service = _make_provider(tmp_path, "conv-submit-bug")
+    app = _Harness(provider, workspace_roots=[str(repo)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _enter_current_mode(pilot, app)
+        screen.action_git_push()
+        modal = await _wait_for_push_modal(pilot, app)
+
+        def _explode(*_a, **_kw):
+            raise RuntimeError("SYNTHETIC-19703 push submit bug")
+
+        monkeypatch.setattr(type(modal), "dismiss", _explode, raising=True)
+        notes = _capture_notifies(app)
+        modal._submit()
+        await pilot.pause()
+
+    assert any("Could not submit" in note for note in notes), (
+        f"a bug in push submit must tell the user; got {notes!r}"
+    )

--- a/backlog/tasks/task-19703 - Change-review-git-modes-polish-batch.md
+++ b/backlog/tasks/task-19703 - Change-review-git-modes-polish-batch.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19703
 title: 'Change review git modes: polish batch from whole-branch review'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21'
 labels:
@@ -41,7 +41,49 @@ three artefacts should agree.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The detection worker's landing uses the same teardown-only guard as every other landing, so a real bug there surfaces as a traceback rather than a debug line
-- [ ] #2 A bug raised inside either git modal's submit reports itself to the user instead of leaving the confirm button silently inert; a test proves it
-- [ ] #3 The in-progress refusal's placement is consistent across the code, the design spec and the User Guide — whichever placement is chosen
+- [x] #1 The detection worker's landing uses the same teardown-only guard as every other landing, so a real bug there surfaces as a traceback rather than a debug line
+- [x] #2 A bug raised inside either git modal's submit reports itself to the user instead of leaving the confirm button silently inert; a test proves it
+- [x] #3 The in-progress refusal's placement is consistent across the code, the design spec and the User Guide — whichever placement is chosen
 <!-- AC:END -->
+
+## Implementation Notes
+
+Three items, all from TASK-16801's whole-branch review; each is a place a
+failure was reported less honestly than the rest of the feature manages.
+
+**AC #1 — the detection landing.** `_dispatch_git_detection`'s
+`call_from_thread` was the one landing not routed through `_land_on_ui`,
+the shared helper that tolerates ONLY Textual's teardown `RuntimeError`.
+Now routed, so a genuine bug in `_land_git_detection` surfaces as a
+`WorkerFailed` traceback instead of dying quietly on the worker thread.
+
+**AC #2 — both modals' submit.** Each `_submit` wraps its body in a broad
+`except` so it can never raise into a Textual handler — correct — but then
+returned SILENTLY, so pressing Commit (or Push) did nothing at all: no
+action, no error, no dismissal, indistinguishable from a dead button. The
+broad catch stays; the failure is now visible. The commit modal reuses its
+inline `#change-git-commit-error` Static; the push modal has no such widget
+and reports through `notify` rather than inventing one (plus CSS) for a
+path only a bug reaches. Both proven red first and mutation-checked:
+removing the two reports fails both new tests.
+
+**AC #3 — the in-progress refusal's placement.** Code, spec and Guide
+disagreed. The spec listed the merge/rebase/cherry-pick check as a
+modal-open gate (step 3) and the User Guide told users it fired "before the
+dialog even opens"; it actually ships as the engine's `in-progress-check`
+step, i.e. at confirm time. **Resolved by amending the documents, not the
+code.** The engine is the right home: the repository can enter a merge
+between modal-open and submit, so a pre-modal check could only ever be
+advisory — and an advisory check that passes and is then refused at submit
+is more confusing than one honest refusal, while duplicating it invites the
+two copies to drift. The Guide sentence bundled this together with the
+active-run refusal, which genuinely IS pre-modal, so the two are now stated
+separately with the reason for the difference. Guide stamped honestly: not
+driven live, corrected by reading the shipped code against the page's own
+claim.
+
+**Files:** `tldw_chatbook/UI/Screens/change_review_screen.py`,
+`Docs/superpowers/specs/2026-08-20-console-review-git-modes-design.md`,
+`Docs/User_Guide/console/agent-runs-and-tools.md`,
+`Tests/UI/test_change_review_commit_ui.py`,
+`Tests/UI/test_change_review_push_ui.py`.

--- a/backlog/tasks/task-19703 - Change-review-git-modes-polish-batch.md
+++ b/backlog/tasks/task-19703 - Change-review-git-modes-polish-batch.md
@@ -82,6 +82,33 @@ separately with the reason for the difference. Guide stamped honestly: not
 driven live, corrected by reading the shipped code against the page's own
 claim.
 
+**Qodo round (PR #1958):** one substantive finding, and it was right in a
+way that improved the fix. `_land_on_ui` tolerated `RuntimeError` because
+that is Textual's teardown signal — but `call_from_thread` ALSO re-raises
+whatever the callback raised, so a genuine bug that happens to be a
+`RuntimeError` was read as shutdown and vanished. Routing detection through
+that helper (AC #1) therefore narrowed visibility for that one exception
+type. `App.is_running` is the real discriminator — it is exactly what
+`call_from_thread` consults before raising "App is not running" — so the
+guard now re-raises when the app is still alive.
+
+Two consequences worth recording. First, the current-mode worker carried a
+SECOND copy of the same teardown rule in a local `_land` helper, which the
+sharpening would have left behind — so a landing bug still vanished on the
+very path the fix targeted. It now delegates to the one implementation.
+Second, the existing teardown test simulated shutdown by raising
+`RuntimeError("App is not running")` while the app was still running; that
+proxy is exactly what the new discriminator (correctly) treats as a bug, so
+it was rewritten to drive `_land_on_ui` directly against a stub app that is
+genuinely not running.
+
+Declined, with reasoning on the PR: the `Args:`-section docstring request
+(zero tests in these files document pytest fixtures that way) and the
+raw-exception-in-UI concern (this is a single-user local TUI whose banner
+already prints absolute paths and git stderr by design; a generic message
+with detail hidden in a log the user will not find is less honest, not
+more).
+
 **Files:** `tldw_chatbook/UI/Screens/change_review_screen.py`,
 `Docs/superpowers/specs/2026-08-20-console-review-git-modes-design.md`,
 `Docs/User_Guide/console/agent-runs-and-tools.md`,

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -1044,9 +1044,20 @@ def _land_on_ui(app, callback: Callable, *args) -> None:
     try:
         app.call_from_thread(callback, *args)
     except RuntimeError:
+        # Qodo #2 (PR #1958): the exception TYPE alone cannot separate the
+        # two cases this guard straddles. `call_from_thread` raises
+        # RuntimeError for teardown AND re-raises whatever the callback
+        # raised -- so a genuine bug that happens to be a RuntimeError was
+        # read as shutdown and vanished into one misleading debug line.
+        # `App.is_running` is the real discriminator: it is exactly what
+        # `call_from_thread` consults before raising "App is not running",
+        # so a RuntimeError seen while the app is STILL running cannot be
+        # teardown and must stay loud.
+        if getattr(app, "is_running", False):
+            raise
         logger.debug(
-            "change_review: git-action landing skipped -- the app is no "
-            "longer accepting callbacks"
+            "change_review: app is no longer accepting callbacks; "
+            "dropping a worker landing"
         )
 
 
@@ -2353,36 +2364,23 @@ class ChangeReviewScreen(Screen):
             from tldw_chatbook.Workspaces.git_workspace import GitWorkspaceError
 
             def _land(callback, *args) -> None:
-                """Hand a result back to the UI thread, tolerating teardown.
+                """Hand a per-root result back to the UI thread.
 
-                ``call_from_thread`` raises once the app is shutting down
-                -- which a status read can easily outlive, since it is a
-                git subprocess. Unhandled, that surfaces as a logged
-                ``WorkerFailed``; worse, raising out of a PER-ROOT landing
-                mid-loop would abort the roots after it and quietly break
-                the per-root isolation this loop exists to guarantee.
+                Delegates to the module-level :func:`_land_on_ui` rather
+                than repeating its policy. TASK-19703 / Qodo #2 (PR #1958)
+                is why: this helper carried a SECOND copy of the
+                teardown-vs-bug rule, and when that rule was sharpened to
+                consult ``App.is_running`` the copy here was left behind —
+                so a landing bug that raised ``RuntimeError`` still
+                vanished on exactly the path the fix was written for. One
+                implementation, one place to sharpen.
 
-                ``RuntimeError`` ONLY, deliberately (re-review round 2):
-                Textual signals teardown as
-                ``RuntimeError("App is not running")`` (``app.py``; a
-                closed loop reports ``RuntimeError`` too), while
-                ``call_from_thread`` ALSO re-raises whatever the landing
-                callback itself raised -- and the landings do real work
-                (tree queries, ``_populate_tree``, banner math). A bare
-                ``except Exception`` here would downgrade a genuine bug in
-                them to one debug line whose text ("app is no longer
-                accepting callbacks") would be an outright lie, instead of
-                the loud ``WorkerFailed`` traceback Textual gives it.
-                ``CancelledError`` is a ``BaseException`` and was never
-                caught here in either form.
+                The per-root isolation this loop guarantees is unchanged:
+                ``_land_on_ui`` swallows genuine teardown, so a shutdown
+                mid-loop still cannot abort the remaining roots, while a
+                real bug is now loud in both helpers alike.
                 """
-                try:
-                    app.call_from_thread(callback, *args)
-                except RuntimeError:
-                    logger.debug(
-                        "change_review: current-mode landing skipped -- "
-                        "the app is no longer accepting callbacks"
-                    )
+                _land_on_ui(app, callback, *args)
 
             statuses: list["CurrentRootStatus"] = []
             #: TASK-16801 T8 (spec §6): the PR link's availability per root,

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -1729,7 +1729,11 @@ class ChangeReviewScreen(Screen):
                     "change_review: git detection failed; mode not offered"
                 )
                 detected = {}
-            app.call_from_thread(self._land_git_detection, detected)
+            # TASK-19703 AC #1: the same teardown-only guard every other
+            # landing uses, so a genuine bug in `_land_git_detection`
+            # surfaces as a WorkerFailed traceback rather than dying
+            # quietly on the worker thread.
+            _land_on_ui(app, self._land_git_detection, detected)
 
         self.run_worker(
             _detect,
@@ -4460,10 +4464,16 @@ class ChangeGitCommitModal(SafeModalDismissMixin, ModalScreen["dict | None"]):
                     "file_count": len(selected),
                 }
             )
-        except Exception:  # noqa: BLE001 -- never raise out of a handler
+        except Exception as exc:  # noqa: BLE001 -- never raise out of a handler
+            # TASK-19703 AC #2: returning silently here left the user
+            # pressing Commit with NOTHING happening -- no commit, no
+            # error, no dismissal, indistinguishable from a dead button.
+            # The broad catch stays (a handler must not raise into
+            # Textual); what changes is that the failure is now visible.
             logger.opt(exception=True).warning(
                 "change_review: commit modal submit failed"
             )
+            self._show_error(f"could not submit: {exc}")
 
     @on(Button.Pressed, "#change-git-commit-yes")
     def _confirm(self, event: Button.Pressed) -> None:
@@ -4738,10 +4748,23 @@ class ChangeGitPushModal(SafeModalDismissMixin, ModalScreen["dict | None"]):
                     "info": self._infos[root],
                 }
             )
-        except Exception:  # noqa: BLE001 -- never raise out of a handler
+        except Exception as exc:  # noqa: BLE001 -- never raise out of a handler
+            # TASK-19703 AC #2, as for the commit modal. This dialog has no
+            # inline error Static, so the report goes through `notify`
+            # rather than inventing a widget (and its CSS) for a path that
+            # only a bug reaches; the modal stays open so the user can
+            # cancel deliberately instead of guessing.
             logger.opt(exception=True).warning(
                 "change_review: push modal submit failed"
             )
+            try:
+                self.app.notify(
+                    f"Could not submit: {exc}", severity="error"
+                )
+            except Exception:  # noqa: BLE001 -- notify is best-effort
+                logger.opt(exception=True).debug(
+                    "change_review: push modal could not report its failure"
+                )
 
     @on(Button.Pressed, "#change-git-push-yes")
     def _confirm(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
Three items from TASK-16801's whole-branch review, batched. Each is a place a failure was reported less honestly than the rest of the feature manages.

## 1. The detection landing wasn't guarded (AC #1)

`_dispatch_git_detection`'s `call_from_thread` was the one landing not routed through `_land_on_ui` — the shared helper that tolerates **only** Textual's teardown `RuntimeError`. A genuine bug in `_land_git_detection` therefore died quietly on the worker thread instead of surfacing as a `WorkerFailed` traceback. Now routed.

## 2. Both modals' confirm button could go silently dead (AC #2)

Each `_submit` wraps its body in a broad `except` so it can never raise into a Textual handler — correct — but then returned **silently**. Pressing Commit or Push did *nothing at all*: no action, no error, no dismissal. Indistinguishable from a dead button, and the same silent-masking class this workstream has caught repeatedly.

The broad catch stays; the failure is now visible. The commit modal reuses its inline `#change-git-commit-error` Static; the push modal has no such widget and reports through `notify` rather than inventing one (plus CSS) for a path only a bug reaches. Both proven red first, and mutation-checked — removing the two reports fails both new tests.

## 3. Code, spec and Guide disagreed on the in-progress refusal (AC #3)

The spec listed the merge/rebase/cherry-pick check as a **modal-open gate**, and the User Guide told users it fires *"before the dialog even opens"*. It actually ships as the engine's `in-progress-check` step — at confirm time. The Guide was the user-facing inaccuracy.

**Resolved by amending the documents, not the code.** The engine is the right home: the repository can enter a merge between modal-open and submit, so a pre-modal check could only ever be advisory — and an advisory check that *passes* and is then refused at submit is more confusing than one honest refusal, while duplicating it in both places invites the copies to drift.

The Guide sentence had bundled this with the **active-run** refusal, which genuinely *is* pre-modal, so the two are now stated separately with the reason for the difference. Stamped honestly: not driven live, corrected by reading the shipped code against the page's own claim.

## Verification

- **272 passed** across the change-review suites; ruff clean.
- Both new submit tests red-first and mutation-proven.
- The 2 failures in `test_console_modal_dismissal.py` are **pre-existing on dev** — confirmed against a throwaway worktree pinned to the current dev tip (2 failed, 115 passed there).

Closes TASK-19703. Follows TASK-16801 (#1914).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces real landing failures as WorkerFailed, reports commit/push submit errors to users, and aligns docs with engine behavior. Also distinguishes teardown from landing bugs using `App.is_running` to prevent silent failures.

- Detection landing now uses `_land_on_ui`; the guard re-raises when the app is running and swallows genuine teardown, so real bugs surface.
- Consolidated landing policy: the current-mode worker’s local `_land` delegates to `_land_on_ui`, keeping per-root isolation and a single rule.
- Commit modal `_submit` shows its inline error; push modal `_submit` reports via `notify`. Both still catch broadly and keep the modal open.
- Spec and User Guide updated: mid-merge/rebase/cherry-pick refusal occurs at confirm (`in-progress-check`). Tests cover the new reporting and landing behavior. No migration required.

<sup>Written for commit d703080fc57c103318424f6d80929f89cbae9cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

