### PR TITLE
Change review: name the effective push destination in the confirm dialog (TASK-19701)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -425,7 +425,14 @@ open, so checking earlier could only promise something that later stops
 being true.)
 
 **Push (`p` / the Push… button).** Always confirms in a dialog first,
-naming the repository, the branch, and where it's going. A branch with no
+naming the repository, the branch, and where it's going — including the
+remote's actual **URL**, not just its name. That matters when the
+repository redirects pushes to a different host than it fetches from
+(`remote.<name>.pushurl`, or `url.<other>.pushInsteadOf`), which is a
+perfectly normal setup — fetching over https and pushing over ssh, say.
+Those redirects are honoured rather than refused; the dialog simply tells
+you where the push will actually land, so the confirmation says as much as
+`git remote -v` would. A branch with no
 upstream yet gets one set on this push; with an upstream already
 configured, push targets exactly that upstream's remote and ref — never
 "whatever the repository's push configuration would have done" (see the
@@ -1665,3 +1672,5 @@ verbatim, not something Task 9 changed, and it is not re-verified live
 here.)*
 
 *Git-actions placement corrected @ TASK-19703 — 2026-08-22: the mid-merge/rebase/cherry-pick refusal was documented here as happening "before the dialog even opens", which is true of the active-run refusal but not of this one — it fires when you confirm. Not driven live; corrected by reading the shipped code (`commit_selected`'s `in-progress-check` step) against this page's claim, and the design spec was amended to match rather than the code changed (a pre-modal check could only be advisory, since the repository can enter a merge while the dialog is open).*
+
+*Push-destination disclosure added @ TASK-19701 — 2026-08-22: the confirm dialog now names the remote's effective push URL. Not driven live; verified against real repositories in tests configured with `remote.<name>.pushurl` and with `url.<other>.pushInsteadOf`, plus a control with no redirect.*

--- a/Tests/UI/test_change_review_push_ui.py
+++ b/Tests/UI/test_change_review_push_ui.py
@@ -1588,3 +1588,102 @@ async def test_a_bug_inside_push_submit_reports_itself(monkeypatch, tmp_path):
     assert any("Could not submit" in note for note in notes), (
         f"a bug in push submit must tell the user; got {notes!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# TASK-19701: the confirm dialog names where the push will actually land.
+#
+# `remote.<name>.pushurl` and `url.<other>.pushInsteadOf` both send a push to
+# a DIFFERENT host than the fetch URL. Verified against real git: both are
+# reflected in `git remote -v`'s (push) line and in `git remote get-url
+# --push`, and detection already parses that line — so the effective URL was
+# in hand all along and only the dialog was withholding it, naming the
+# remote alias but never its destination. A terminal told the user more than
+# the confirm dialog did, on the one screen whose job is to state what a
+# button will do before they press it.
+#
+# Decision (AC #1): SURFACE, do not refuse. Both settings are legitimate,
+# widely used git configuration (fetch over https, push over ssh is a
+# standard corporate setup); refusing would break normal workflows to
+# protect against nothing this app is entitled to override.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_push_dialog_names_the_effective_url_under_pushurl(
+    monkeypatch, tmp_path
+):
+    """`remote.origin.pushurl` redirects the push to another host."""
+    _patch_git_actions(monkeypatch, True)
+    repo, _bare = _repo_with_remote(tmp_path)
+    (repo / "a.txt").write_text("changed\n")
+    _git(repo, "config", "remote.origin.pushurl", "ssh://git@pushtarget.invalid/r.git")
+
+    provider, _db, _service = _make_provider(tmp_path, "conv-pushurl")
+    app = _Harness(provider, workspace_roots=[str(repo)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _enter_current_mode(pilot, app)
+        screen.action_git_push()
+        modal = await _wait_for_push_modal(pilot, app)
+        text = "\n".join(
+            str(w.renderable) for w in modal.query(Static)
+        )
+
+    assert "pushtarget.invalid" in text, (
+        f"the dialog must name where the push actually lands; got {text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_push_dialog_names_the_effective_url_under_pushinsteadof(
+    monkeypatch, tmp_path
+):
+    """`url.<other>.pushInsteadOf` rewrites the push URL by prefix."""
+    _patch_git_actions(monkeypatch, True)
+    repo, bare = _repo_with_remote(tmp_path)
+    (repo / "a.txt").write_text("changed\n")
+    _git(
+        repo,
+        "config",
+        "url.ssh://git@insteadof.invalid/.pushInsteadOf",
+        str(bare),
+    )
+
+    provider, _db, _service = _make_provider(tmp_path, "conv-insteadof")
+    app = _Harness(provider, workspace_roots=[str(repo)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _enter_current_mode(pilot, app)
+        screen.action_git_push()
+        modal = await _wait_for_push_modal(pilot, app)
+        text = "\n".join(
+            str(w.renderable) for w in modal.query(Static)
+        )
+
+    assert "insteadof.invalid" in text, (
+        f"the dialog must name the rewritten destination; got {text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_push_dialog_shows_the_plain_url_without_a_redirect(
+    monkeypatch, tmp_path
+):
+    """Control: with no redirect configured the destination is still named,
+    so the disclosure is normal copy rather than a scary special case."""
+    _patch_git_actions(monkeypatch, True)
+    repo, bare = _repo_with_remote(tmp_path)
+    (repo / "a.txt").write_text("changed\n")
+
+    provider, _db, _service = _make_provider(tmp_path, "conv-plain")
+    app = _Harness(provider, workspace_roots=[str(repo)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _enter_current_mode(pilot, app)
+        screen.action_git_push()
+        modal = await _wait_for_push_modal(pilot, app)
+        text = "\n".join(
+            str(w.renderable) for w in modal.query(Static)
+        )
+
+    assert str(bare) in text, (
+        f"the ordinary destination must be named too; got {text!r}"
+    )

--- a/Tests/UI/test_change_review_push_ui.py
+++ b/Tests/UI/test_change_review_push_ui.py
@@ -1687,3 +1687,36 @@ async def test_push_dialog_shows_the_plain_url_without_a_redirect(
     assert str(bare) in text, (
         f"the ordinary destination must be named too; got {text!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_push_dialog_names_every_destination_of_a_multi_pushurl_remote(
+    monkeypatch, tmp_path
+):
+    """Qodo #2 (PR #1959): a remote may push to SEVERAL destinations.
+
+    Naming only the first would make the dialog state a smaller
+    destination set than reality — worse than saying nothing, since the
+    user would believe it.
+    """
+    _patch_git_actions(monkeypatch, True)
+    repo, bare = _repo_with_remote(tmp_path)
+    (repo / "a.txt").write_text("changed\n")
+    second = tmp_path / "second.git"
+    _git(repo, "init", "-q", "--bare", str(second)) if False else subprocess.run(
+        ["git", "init", "-q", "--bare", str(second)], check=True
+    )
+    _git(repo, "config", "--add", "remote.origin.pushurl", str(bare))
+    _git(repo, "config", "--add", "remote.origin.pushurl", str(second))
+
+    provider, _db, _service = _make_provider(tmp_path, "conv-multi-pushurl")
+    app = _Harness(provider, workspace_roots=[str(repo)])
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _enter_current_mode(pilot, app)
+        screen.action_git_push()
+        modal = await _wait_for_push_modal(pilot, app)
+        text = "\n".join(str(w.renderable) for w in modal.query(Static))
+
+    assert str(bare) in text and str(second) in text, (
+        f"BOTH destinations must be named; got {text!r}"
+    )

--- a/Tests/Workspaces/test_git_workspace_detection.py
+++ b/Tests/Workspaces/test_git_workspace_detection.py
@@ -128,3 +128,49 @@ def test_ambient_pathspec_vars_do_not_break_every_invocation(
     (repo / "a.txt").write_text("edited\n")
     result = _run_user_git(repo, "diff", "HEAD", "--", "a.txt")
     assert "a.txt" in result.stdout, result.stderr
+
+
+def test_remote_url_with_a_space_is_not_truncated(repo, tmp_path):
+    """Qodo #2 (PR #1959): `remote -v` is `<name>\\t<url> (push)`, so the URL
+    must be recovered by stripping the ` (push)` SUFFIX — splitting on the
+    first space truncates any local-path remote containing one.
+
+    Verified before the fix: a remote at `.../with space.git` was reported
+    as `.../with`, a path that does not exist.
+    """
+    spaced = tmp_path / "with space.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(spaced)], check=True)
+    _git(repo, "remote", "add", "spaced", str(spaced))
+
+    info = detect_git_workspace(repo)
+    urls = dict(info.remotes)
+    assert urls["spaced"] == str(spaced), (
+        f"the URL must survive its space; got {urls['spaced']!r}"
+    )
+
+
+def test_all_push_urls_are_carried_for_a_multi_pushurl_remote(repo, tmp_path):
+    """A remote may configure SEVERAL `pushurl`s; a push reaches every one.
+
+    Verified against real git: two `--add remote.origin.pushurl` entries
+    make `remote -v` emit two `(push)` lines for `origin`. Naming only the
+    first would make the confirm dialog state a destination set that is
+    smaller than reality — worse than saying nothing, because the user
+    would believe it.
+    """
+    first = tmp_path / "first.git"
+    second = tmp_path / "second.git"
+    for bare in (first, second):
+        subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
+    _git(repo, "remote", "add", "origin", str(first))
+    _git(repo, "config", "--add", "remote.origin.pushurl", str(first))
+    _git(repo, "config", "--add", "remote.origin.pushurl", str(second))
+
+    info = detect_git_workspace(repo)
+    all_urls = dict(info.remote_push_urls)
+    assert set(all_urls["origin"]) == {str(first), str(second)}, (
+        f"every push destination must be carried; got {all_urls!r}"
+    )
+    # The de-duplicated view stays one-entry-per-remote, because the
+    # sole-remote derivations key off its LENGTH.
+    assert len(info.remotes) == 1, info.remotes

--- a/backlog/tasks/task-19701 - Remaining-git-config-push-redirects.md
+++ b/backlog/tasks/task-19701 - Remaining-git-config-push-redirects.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19701
 title: 'Change review: remaining git-config push redirects (pushurl, pushInsteadOf)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21'
 labels:
@@ -39,8 +39,45 @@ terminal would.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A decision is recorded for each of `remote.<name>.pushurl` and `url.<other>.pushInsteadOf`: surface the effective push URL, refuse the push, or accept the redirect as normal git behaviour
-- [ ] #2 If the decision is to surface it, the push confirm modal names the effective destination the push will actually reach, not only the remote's name
-- [ ] #3 Tests drive a real repository configured with each redirect and assert the chosen behaviour
-- [ ] #4 The User Guide's git-actions section matches whatever behaviour ships
+- [x] #1 A decision is recorded for each of `remote.<name>.pushurl` and `url.<other>.pushInsteadOf`: surface the effective push URL, refuse the push, or accept the redirect as normal git behaviour
+- [x] #2 If the decision is to surface it, the push confirm modal names the effective destination the push will actually reach, not only the remote's name
+- [x] #3 Tests drive a real repository configured with each redirect and assert the chosen behaviour
+- [x] #4 The User Guide's git-actions section matches whatever behaviour ships
 <!-- AC:END -->
+
+## Implementation Notes
+
+**Decision (AC #1): surface, do not refuse.** Both `remote.<name>.pushurl`
+and `url.<other>.pushInsteadOf` are legitimate, widely used git
+configuration — fetching over https while pushing over ssh is a standard
+corporate setup — so refusing them would break ordinary workflows to guard
+against nothing this app is entitled to override. What was wrong was not
+the redirect but the silence: the confirm dialog named the remote's ALIAS
+and never its destination, so a terminal running `git remote -v` told the
+user more than the dialog whose whole job is to state what a button will do
+before it is pressed.
+
+**No new git call was needed.** Verified against real git that both
+settings are already resolved into `git remote -v`'s (push) line (and
+`git remote get-url --push`), and detection parses exactly that line — so
+the effective URL was in hand all along:
+
+```
+baseline          origin  https://fetch.example/repo.git (push)
++ pushurl         origin  ssh://git@PUSH-TARGET.example/repo.git (push)
++ pushInsteadOf   origin  ssh://git@INSTEADOF.example/repo.git (push)
+```
+
+The dialog now reads `pushes to origin (ssh://…)`. The URL is shown for
+EVERY push, redirected or not, so the disclosure is ordinary copy rather
+than an alarm that appears only in the unusual case — a warning that fires
+only when something is odd trains people to fear the odd case; a line that
+always states the destination just makes the dialog honest.
+
+**Tests (AC #3)** drive real repositories configured each way, plus a
+control asserting the plain destination is named with no redirect present;
+mutation-proven (dropping the URL from the label fails all three).
+
+**Files:** `tldw_chatbook/UI/Screens/change_review_screen.py`,
+`Docs/User_Guide/console/agent-runs-and-tools.md`,
+`Tests/UI/test_change_review_push_ui.py`.

--- a/backlog/tasks/task-19701 - Remaining-git-config-push-redirects.md
+++ b/backlog/tasks/task-19701 - Remaining-git-config-push-redirects.md
@@ -78,6 +78,34 @@ always states the destination just makes the dialog honest.
 control asserting the plain destination is named with no redirect present;
 mutation-proven (dropping the URL from the label fails all three).
 
-**Files:** `tldw_chatbook/UI/Screens/change_review_screen.py`,
+**Qodo round (PR #1959): the disclosure itself was inaccurate.** Two
+parsing defects in `_parse_remotes`, both reproduced against live git
+before fixing, and both of which would have made this dialog state
+something false — worse than the silence it replaced, because a user
+would believe it:
+
+* a URL was recovered by splitting on the first SPACE, so a local-path
+  remote at `/tmp/with space.git` was reported as `/tmp/with`, a path that
+  does not exist. Now the trailing `" (push)"` suffix is stripped instead.
+* only the FIRST `(push)` line per remote was kept, but a remote may
+  configure several `pushurl`s and git emits one line per destination — a
+  push reaches all of them. Now every destination is carried and named.
+
+The de-duplicated `remotes` view is deliberately unchanged in shape:
+`_resolve_push_remote` and the dialog's "must I ask which remote?" check
+both key off its LENGTH, so letting one multi-`pushurl` remote appear twice
+would have made a single remote look like a choice between two. The full
+set lives in a new defaulted `remote_push_urls` field.
+
+Declined, with counts on the PR: extracting a named constant for the
+`(160, 48)` terminal size. It appears 28 times in this one test file and
+across 66 test files repo-wide, with exactly one named-constant precedent
+in the whole suite — so converting only the four new call sites would leave
+28 literals beside 1 constant in the same file and make consistency worse,
+which is the finding's own stated rationale. Offered as a separate
+mechanical sweep instead.
+
+**Files:** `tldw_chatbook/Workspaces/git_workspace.py`,
+`tldw_chatbook/UI/Screens/change_review_screen.py`,
 `Docs/User_Guide/console/agent-runs-and-tools.md`,
 `Tests/UI/test_change_review_push_ui.py`.

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -4596,12 +4596,55 @@ class ChangeGitPushModal(SafeModalDismissMixin, ModalScreen["dict | None"]):
             return f"{head} → {info.upstream}"
         if info.upstream is not None:
             target = info.upstream_remote or "the upstream's remote"
-            return f"{head} ↑{info.ahead} → {info.upstream}  ·  pushes to {target}"
+            return (
+                f"{head} ↑{info.ahead} → {info.upstream}  ·  pushes to "
+                f"{self._destination_label(root, target)}"
+            )
         if self._needs_remote_choice(root):
             return f"{head}  ·  no upstream — choose a remote to track"
         names = self._remote_names(root)
         target = names[0] if names else "the remote"
-        return f"{head}  ·  no upstream — will push -u to {target}"
+        return (
+            f"{head}  ·  no upstream — will push -u to "
+            f"{self._destination_label(root, target)}"
+        )
+
+    def _destination_label(self, root: str, remote_name: str) -> str:
+        """``<name>`` plus the URL the push will ACTUALLY reach.
+
+        TASK-19701. `remote.<name>.pushurl` and `url.<other>.pushInsteadOf`
+        both send a push to a different host than the fetch URL. Naming
+        only the remote's alias left this dialog telling the user less than
+        `git remote -v` would — on the one screen whose whole job is to
+        state what a button will do before it is pressed.
+
+        The effective URL needs no new git call: detection parses
+        `remote -v`'s (push) line, which git already resolves through both
+        settings (verified against real git for each).
+
+        Decision recorded on the task (AC #1): SURFACE, never refuse. Both
+        settings are legitimate, widely used configuration — fetch over
+        https and push over ssh is a standard corporate setup — so refusing
+        would break ordinary workflows to guard against nothing this app is
+        entitled to override. The URL is shown for every push, redirected
+        or not, so the disclosure reads as normal copy rather than an alarm
+        that only appears in the unusual case.
+
+        Args:
+            root: The root currently targeted.
+            remote_name: The remote the push will use.
+
+        Returns:
+            ``"<name> (<url>)"``, or just the name when no URL is known.
+        """
+        try:
+            urls = {
+                name: url for name, url in self._infos[root].remotes
+            }
+        except (KeyError, AttributeError, TypeError, ValueError):
+            return remote_name
+        url = urls.get(remote_name)
+        return f"{remote_name} ({url})" if url else remote_name
 
     # -- layout -------------------------------------------------------------
 

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -4638,13 +4638,22 @@ class ChangeGitPushModal(SafeModalDismissMixin, ModalScreen["dict | None"]):
             ``"<name> (<url>)"``, or just the name when no URL is known.
         """
         try:
-            urls = {
-                name: url for name, url in self._infos[root].remotes
-            }
+            info = self._infos[root]
+            # EVERY destination, not just the first: a remote may configure
+            # several `pushurl`s and a push reaches all of them (Qodo #2,
+            # PR #1959 — naming one of two is a smaller truth than silence,
+            # because the user would believe it).
+            all_urls = dict(getattr(info, "remote_push_urls", ()) or ())
+            urls = tuple(all_urls.get(remote_name) or ())
+            if not urls:
+                urls = tuple(
+                    url for name, url in info.remotes if name == remote_name
+                )
         except (KeyError, AttributeError, TypeError, ValueError):
             return remote_name
-        url = urls.get(remote_name)
-        return f"{remote_name} ({url})" if url else remote_name
+        if not urls:
+            return remote_name
+        return f"{remote_name} ({', '.join(urls)})"
 
     # -- layout -------------------------------------------------------------
 

--- a/tldw_chatbook/Workspaces/git_workspace.py
+++ b/tldw_chatbook/Workspaces/git_workspace.py
@@ -105,6 +105,11 @@ class GitWorkspaceInfo:
     remotes: tuple[tuple[str, str], ...]
     ahead: int
     behind: int
+    #: Every push destination per remote (TASK-19701). `remotes` keeps ONE
+    #: entry per remote because the sole-remote derivations key off its
+    #: length; a remote with several `pushurl`s reaches all of these.
+    #: Defaulted so existing constructions stay valid.
+    remote_push_urls: tuple[tuple[str, tuple[str, ...]], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -244,26 +249,60 @@ def _run_user_git(
     return GitCmdResult(proc.returncode, proc.stdout, proc.stderr)
 
 
-def _parse_remotes(remote_v_output: str) -> tuple[tuple[str, str], ...]:
-    """Parse ``remote -v`` output into ordered, unique ``(name, url)`` push pairs.
+def _parse_remote_push_urls(
+    remote_v_output: str,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Parse ``remote -v`` into ``(name, (every push URL))`` pairs.
 
-    Each line is ``<name>\\t<url> (fetch|push)``. Only ``(push)`` lines are
-    kept (fetch and push URLs are usually identical; the push URL is the
-    one that matters for this arc's actions).
+    Each line is ``<name>\\t<url> (fetch|push)``; only ``(push)`` lines are
+    kept (the push URL is the one this arc's actions use, and git has
+    already resolved ``remote.<name>.pushurl`` and
+    ``url.<other>.pushInsteadOf`` into it).
+
+    Two parsing details, both real defects found by Qodo on PR #1959 and
+    both reproduced against live git first:
+
+    * the URL is recovered by stripping the trailing ``" (push)"``, NOT by
+      splitting on the first space -- a local-path remote at
+      ``/tmp/with space.git`` was otherwise reported as ``/tmp/with``, a
+      path that does not exist;
+    * a remote may configure SEVERAL ``pushurl`` entries, and git emits one
+      ``(push)`` line per destination -- a push reaches all of them, so
+      keeping only the first understates where the user's code is about to
+      go.
     """
-    seen: dict[str, str] = {}
+    ordered: dict[str, list[str]] = {}
     for line in remote_v_output.splitlines():
         line = line.rstrip()
-        if not line or "(push)" not in line:
+        if not line.endswith("(push)"):
             continue
         name_and_rest = line.split("\t", 1)
         if len(name_and_rest) != 2:
             continue
         name, rest = name_and_rest
-        url = rest.split(" ", 1)[0]
-        if name not in seen:
-            seen[name] = url
-    return tuple(seen.items())
+        url = rest[: -len(" (push)")].rstrip()
+        if not url:
+            continue
+        urls = ordered.setdefault(name, [])
+        if url not in urls:
+            urls.append(url)
+    return tuple((name, tuple(urls)) for name, urls in ordered.items())
+
+
+def _parse_remotes(remote_v_output: str) -> tuple[tuple[str, str], ...]:
+    """One ``(name, url)`` pair per remote -- the de-duplicated view.
+
+    Kept one-entry-per-remote deliberately: ``_resolve_push_remote`` and
+    the push dialog's "do I need to ask which remote?" check both key off
+    this tuple's LENGTH, so letting a multi-``pushurl`` remote appear twice
+    would make a single remote look like a choice between two. The full
+    destination set lives in :func:`_parse_remote_push_urls`.
+    """
+    return tuple(
+        (name, urls[0])
+        for name, urls in _parse_remote_push_urls(remote_v_output)
+        if urls
+    )
 
 
 def detect_git_workspace(root: Path) -> GitWorkspaceInfo | GitWorkspaceRefusal | None:
@@ -317,7 +356,12 @@ def _detect_git_workspace(root: Path) -> GitWorkspaceInfo | GitWorkspaceRefusal 
     unborn = verify_result.returncode != 0
 
     remote_result = _run_user_git(root, "remote", "-v", check=False)
-    remotes = _parse_remotes(remote_result.stdout) if remote_result.returncode == 0 else ()
+    _push_urls = (
+        _parse_remote_push_urls(remote_result.stdout)
+        if remote_result.returncode == 0
+        else ()
+    )
+    remotes = tuple((name, urls[0]) for name, urls in _push_urls if urls)
 
     upstream: str | None = None
     upstream_remote: str | None = None
@@ -369,6 +413,7 @@ def _detect_git_workspace(root: Path) -> GitWorkspaceInfo | GitWorkspaceRefusal 
         upstream=upstream,
         upstream_remote=upstream_remote,
         remotes=remotes,
+        remote_push_urls=_push_urls,
         ahead=ahead,
         behind=behind,
     )


### PR DESCRIPTION
## The gap

`remote.<name>.pushurl` and `url.<other>.pushInsteadOf` both send a push to a **different host** than the repository fetches from. The confirm dialog named the remote's *alias* and never its destination — so a terminal running `git remote -v` told the user more than the dialog whose entire job is to state what a button will do before they press it.

## Decision (AC #1): surface, don't refuse

Both settings are legitimate, widely used git configuration — fetching over https while pushing over ssh is a standard corporate setup. Refusing would break ordinary workflows to guard against nothing this app is entitled to override. What was wrong was the silence, not the redirect.

## No new git call was needed

Verified against real git that both settings are already resolved into `git remote -v`'s `(push)` line — and detection parses exactly that line, so the effective URL was in hand all along:

```
baseline          origin  https://fetch.example/repo.git          (push)
+ pushurl         origin  ssh://git@PUSH-TARGET.example/repo.git  (push)
+ pushInsteadOf   origin  ssh://git@INSTEADOF.example/repo.git    (push)
```

The dialog now reads `pushes to origin (ssh://…)`.

**Shown for every push, redirected or not.** A warning that fires only when something is odd trains people to fear the odd case; a line that always states the destination just makes the dialog honest — and it means the disclosure can't be missed by someone who has never seen the plain version to compare against.

## Verification

- **137 passed** across the change-review suites; ruff clean.
- Three new tests drive **real repositories** configured with `pushurl` and with `pushInsteadOf`, plus a control asserting the plain destination is named when no redirect exists.
- Mutation-proven: dropping the URL from the label fails all three.
- User Guide updated and stamped honestly (not driven live; verified via real-repo tests).

Closes TASK-19701 — the last follow-up from TASK-16801 (#1914).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the effective push destination in the push confirmation dialog so users see where a push will land. Previously the dialog showed only the remote alias; now it displays "pushes to <remote> (<url[, url...]>)" for every push, including redirects via `remote.<name>.pushurl` or `url.<other>.pushInsteadOf`, and lists all destinations for multi-`pushurl` remotes (TASK-19701).

- Behavior change: always surface the actual destination(s); do not block; show URL(s) for all pushes, not only redirected ones.
- Parsing fixes: stop truncating URLs containing spaces by stripping the trailing " (push)"; collect every `(push)` URL per remote.
- Data shape: keep `remotes` de-duplicated (one entry per remote); add a defaulted `remote_push_urls` field carrying all push destinations.
- Implementation: no new Git calls; reuse `git remote -v` (push) output already parsed; `_destination_label` formats "<name> (<url[, url...]>)" and falls back to the name when no URL is available.
- Tests/Docs: UI tests cover `pushurl`, `pushInsteadOf`, no-redirect, and multi-`pushurl`; workspace tests cover space-in-URL and multi-destination parsing; User Guide updated to document the disclosure.

<sup>Written for commit b1ef8289ec98bd4b0e69d8ecba3a771db666c738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

