### PR TITLE
fix(tests): repair six pre-existing dev test reds (four of them Python-version drift)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2560,6 +2560,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "86a8bc66a943d2aef621",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/model_remote_view.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 186,
       "diagnostic_digest": "abf6fdc6c9eef6dd4f9c",
       "owner": "TASK-494",
@@ -3225,6 +3232,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "01bf025ed01c65569ea6",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Widgets/Console/console_run_inspector.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 2,
       "diagnostic_digest": "fd3c40d9f3d798e91fc4",
       "owner": "TASK-494",
@@ -3840,9 +3854,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 519,
+    "owner_files": 521,
     "persistent_sink_files": 8,
     "task_492_calls": 1222,
-    "task_494_calls": 7187
+    "task_494_calls": 7189
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1980,7 +1980,7 @@
     },
     {
       "call_count": 70,
-      "diagnostic_digest": "04c4f3f8a3dc9eeadbdd",
+      "diagnostic_digest": "c8c97abdd441f878754e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/kokoro.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2557,13 +2557,6 @@
       "diagnostic_digest": "eb735f3bcd9aea1fcade",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/model_installed_view.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
-      "call_count": 1,
-      "diagnostic_digest": "86a8bc66a943d2aef621",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/UI/Screens/model_remote_view.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -3847,9 +3840,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 520,
+    "owner_files": 519,
     "persistent_sink_files": 8,
     "task_492_calls": 1222,
-    "task_494_calls": 7188
+    "task_494_calls": 7187
   }
 }

--- a/Tests/Agents/test_tool_catalog_concurrency.py
+++ b/Tests/Agents/test_tool_catalog_concurrency.py
@@ -34,6 +34,14 @@ def test_invoke_by_name_takes_exactly_one_catalog_snapshot():
     registry.register_provider(BuiltinToolProvider())
     registry._ensure_catalog_cache()  # warm the cache first
 
+    # Resolve the name BEFORE the counter is installed. `list_catalog()`
+    # routes through `_ensure_catalog_cache()` itself, so taking the name
+    # inside the counting window charges the test's own setup to the
+    # subject and the assertion reads 2 no matter how `invoke_by_name`
+    # behaves -- it stopped measuring anything the moment `list_catalog`
+    # was refactored onto the shared snapshot helper.
+    name = registry.list_catalog()[0].name
+
     real_ensure = registry._ensure_catalog_cache
     snapshots = []
 
@@ -43,7 +51,6 @@ def test_invoke_by_name_takes_exactly_one_catalog_snapshot():
 
     registry._ensure_catalog_cache = counting
 
-    name = registry.list_catalog()[0].name
     registry.invoke_by_name(name, {})
 
     assert len(snapshots) == 1  # pre-fix: 2

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -182,7 +182,6 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Failed to restore a Library media item in bulk-delete undo": (
             "type(exc).__name__",
         ),
-        "Failed to persist a Library notes setting": (),
         "Failed to persist the Library ingest backend": (),
         "Failed to persist Library ingest options": (),
         "Failed to restore a Library note": (),

--- a/Tests/LLM_Calls/summarization_diagnostic_guard.py
+++ b/Tests/LLM_Calls/summarization_diagnostic_guard.py
@@ -6,6 +6,7 @@ import ast
 from collections import defaultdict
 from dataclasses import dataclass
 
+from Tests.ast_shape import stable_dump
 from scripts.check_persistent_diagnostic_inventory import (
     LOG_METHODS,
     _is_diagnostic_call,
@@ -622,7 +623,7 @@ def discover_diagnostic_calls(source: str, *, module: str) -> list[DiagnosticCal
                 event=event,
                 occurrence=occurrences[occurrence_key],
                 message_shape=(
-                    ast.dump(first, include_attributes=False)
+                    stable_dump(first, include_attributes=False)
                     if first is not None
                     else "<missing>"
                 ),

--- a/Tests/LLM_Calls/test_anthropic_redirect_credential_leak.py
+++ b/Tests/LLM_Calls/test_anthropic_redirect_credential_leak.py
@@ -64,6 +64,7 @@ def _fake_response(
     body: bytes = b"",
     *,
     close_calls: list[int] | None = None,
+    request: requests.PreparedRequest | None = None,
 ) -> requests.Response:
     """Build a bare ``requests.Response`` double that ``close()`` safely.
 
@@ -104,6 +105,16 @@ def _fake_response(
     resp._content = body
     resp._content_consumed = True
     resp.encoding = "utf-8"
+    # A real adapter sets this in `HTTPAdapter.build_response`; a hand-rolled
+    # `send` double has to do it explicitly. Not cosmetic: `Session.send`
+    # peeks ahead through `resolve_redirects` -> `rebuild_auth`, which
+    # dereferences `response.request.url` to decide whether to strip
+    # `Authorization` across a host change. With `.request` left as None that
+    # raises `AttributeError` INSIDE requests, before the production refusal
+    # can be observed -- and the production code's own `except Exception`
+    # then swallows it and reports it as a generic failure, so the test
+    # appears to exercise the redirect path while actually never reaching it.
+    resp.request = request
     if close_calls is not None:
         original_close = resp.close
 
@@ -149,9 +160,15 @@ def _install_redirecting_adapter(
                 302,
                 {"Location": "https://evil.example/steal"},
                 close_calls=redirect_close_calls,
+                request=request,
             )
         if host == "evil.example":
-            return _fake_response(200, {"Content-Type": "application/json"}, ok_body)
+            return _fake_response(
+                200,
+                {"Content-Type": "application/json"},
+                ok_body,
+                request=request,
+            )
         raise AssertionError(f"unexpected host in test transport: {host}")
 
     monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", _fake_send)

--- a/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
+++ b/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Iterator
 import pytest
 from loguru import logger as loguru_logger
 
+from Tests.ast_shape import stable_dump
 from scripts import check_persistent_diagnostic_inventory as diagnostic_inventory
 from tldw_chatbook.LLM_Calls import Local_Summarization_Lib as local_summarization
 from tldw_chatbook.LLM_Calls import (
@@ -988,7 +989,7 @@ def _message_shape(expression: str) -> str:
     node = ast.parse(f"logger.info({expression})").body[0]
     assert isinstance(node, ast.Expr)
     assert isinstance(node.value, ast.Call)
-    return ast.dump(node.value.args[0], include_attributes=False)
+    return stable_dump(node.value.args[0], include_attributes=False)
 
 
 def _single_call(source: str):

--- a/Tests/TTS/test_profile_store_lock.py
+++ b/Tests/TTS/test_profile_store_lock.py
@@ -78,7 +78,16 @@ def _source_executable_lines(
             {
                 line
                 for _, line in dis.findlinestarts(function.__code__)
-                if start_line <= line <= end_line
+                # `line` is Optional: an instruction may carry no source
+                # position, and CPython emits more of those as it evolves --
+                # measured on this function, 3.11 yields 0 such entries and
+                # 3.14 yields 12, which turned this comprehension into a
+                # module-level `TypeError: '<=' not supported between
+                # instances of 'int' and 'NoneType'` and took the whole file
+                # out at COLLECTION. A positionless instruction cannot be
+                # inside a source-line boundary, so skipping it is also the
+                # semantically right answer, not just the safe one.
+                if line is not None and start_line <= line <= end_line
             }
         )
     )

--- a/Tests/ast_shape.py
+++ b/Tests/ast_shape.py
@@ -1,0 +1,76 @@
+# ast_shape.py
+# Description: Version-stable `ast.dump()` for frozen-shape inventories
+"""A single ``ast.dump()`` wrapper for tests that FREEZE dumped shapes.
+
+Several guards in this suite record ``ast.dump()`` output in a committed,
+individually-reviewed inventory (the summarization diagnostic ledger, the
+persistent-diagnostic inventory, the Console wave-6 inventory) and compare
+later runs against it. That only works if the dump is a pure function of
+the source -- and by default it is not: it is also a function of the
+interpreter.
+
+The incident: Python 3.13 added ``show_empty`` to ``ast.dump()`` and
+defaulted it to ``False``, so an empty field stopped being rendered.
+``Call(func=..., args=[...], keywords=[])`` on <=3.12 became
+``Call(func=..., args=[...])`` on >=3.13. Every frozen shape containing a
+no-keyword call therefore stopped matching, and five tests in
+``test_summarization_diagnostic_privacy.py`` failed on a 3.14 interpreter
+while passing on the 3.12 venv the ledger was generated with -- a red that
+looked like a product regression and was really a toolchain difference.
+
+Measured on this repo, digesting all 229 diagnostic shapes in
+``LLM_Calls/Local_Summarization_Lib.py`` with four real interpreters:
+
+    3.11  digest=92a85a3a989ffd13   <- what the committed ledger holds
+    3.12  digest=92a85a3a989ffd13
+    3.13  digest=cd27a1b6c1fdf001   <- diverges exactly where show_empty landed
+    3.14  digest=cd27a1b6c1fdf001
+
+and with ``show_empty=True`` forced on >=3.13, all four produce
+``92a85a3a989ffd13``. So pinning the OLD rendering (rather than
+regenerating the ledger against the new one) is what makes the inventory
+portable across the versions this project supports -- ``requires-python``
+is ``>=3.11`` -- and it leaves the reviewed ledger rows untouched, which
+matters because those rows are a privacy review, not a checksum.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from typing import Any
+
+#: ``show_empty`` exists from 3.13 on. Below that, empty fields are always
+#: rendered, which IS the behaviour this module pins -- so no argument is
+#: passed there and the call keeps working on the 3.11 floor.
+_SUPPORTS_SHOW_EMPTY = sys.version_info >= (3, 13)
+
+
+def stable_dump(node: ast.AST, **kwargs: Any) -> str:
+    """``ast.dump(node, **kwargs)``, rendered the same on every version.
+
+    Use this instead of ``ast.dump()`` anywhere the result is compared
+    against a committed value. For a dump that is only ever produced and
+    consumed within one process (an error message, a same-run comparison),
+    plain ``ast.dump()`` is fine.
+
+    Args:
+        node: The node to dump.
+        **kwargs: Passed through to ``ast.dump`` (e.g.
+            ``include_attributes=False``). Passing ``show_empty`` yourself
+            defeats the point and is rejected.
+
+    Returns:
+        The dump, with empty fields rendered on every supported version.
+
+    Raises:
+        TypeError: If ``show_empty`` is passed explicitly.
+    """
+    if "show_empty" in kwargs:
+        raise TypeError(
+            "stable_dump() pins show_empty itself -- passing it defeats the "
+            "cross-version stability this wrapper exists to provide"
+        )
+    if _SUPPORTS_SHOW_EMPTY:
+        return ast.dump(node, show_empty=True, **kwargs)
+    return ast.dump(node, **kwargs)

--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "888f11ffcc5403bb95f596f441af697b84e7399147527553d8d4d41b4c66efe2",
-        "origin_dev_generated_normalized_inventory_sha256": "888f11ffcc5403bb95f596f441af697b84e7399147527553d8d4d41b4c66efe2",
+        "checked_normalized_inventory_sha256": "c051677247dde3c59e08101181c581a1ead9464832573f8ccaacc969d7107c34",
+        "origin_dev_generated_normalized_inventory_sha256": "c051677247dde3c59e08101181c581a1ead9464832573f8ccaacc969d7107c34",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",

--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "c051677247dde3c59e08101181c581a1ead9464832573f8ccaacc969d7107c34",
-        "origin_dev_generated_normalized_inventory_sha256": "c051677247dde3c59e08101181c581a1ead9464832573f8ccaacc969d7107c34",
+        "checked_normalized_inventory_sha256": "c4d9b71142061fd2cf5b53418526ef5ebcb5ee93fb71713dd45c659f56f885b0",
+        "origin_dev_generated_normalized_inventory_sha256": "c4d9b71142061fd2cf5b53418526ef5ebcb5ee93fb71713dd45c659f56f885b0",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",

--- a/Tests/test_ast_shape.py
+++ b/Tests/test_ast_shape.py
@@ -1,0 +1,61 @@
+# test_ast_shape.py
+# Description: Pins the cross-version stability of `Tests.ast_shape.stable_dump`
+"""Guard the wrapper that keeps frozen `ast.dump()` inventories portable.
+
+Without this, the failure mode is silent and delayed: someone runs the suite
+on the interpreter the ledger was generated with, everything passes, and the
+break only shows up for whoever upgrades Python -- which is exactly how five
+tests in `test_summarization_diagnostic_privacy.py` came to fail on 3.14
+while passing on the repo's 3.12 venv.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from Tests.ast_shape import stable_dump
+
+
+def _call_node() -> ast.AST:
+    """A call with no keyword arguments -- the shape whose rendering moved."""
+    return ast.parse("type(data)").body[0].value
+
+
+def test_stable_dump_renders_empty_fields_on_every_supported_version() -> None:
+    """The load-bearing assertion.
+
+    `ast.dump()` gained `show_empty` in 3.13 and defaulted it to False, so a
+    no-keyword call renders as `Call(func=..., args=[...])` there and
+    `Call(func=..., args=[...], keywords=[])` on 3.11/3.12. Committed
+    inventories hold the latter. This fails on >=3.13 the moment the wrapper
+    stops pinning it, and passes on 3.11/3.12 either way -- so it is the
+    check that actually travels.
+    """
+    assert "keywords=[]" in stable_dump(_call_node())
+
+
+def test_stable_dump_matches_plain_dump_where_nothing_is_empty() -> None:
+    """The wrapper must not otherwise alter the rendering.
+
+    A node with no empty fields has to dump identically through either path,
+    or the wrapper would be silently rewriting shapes rather than pinning one
+    version's rendering of them.
+    """
+    node = ast.parse("x + 1").body[0].value
+    assert stable_dump(node) == ast.dump(node)
+
+
+def test_stable_dump_forwards_its_keyword_arguments() -> None:
+    """Callers pass `include_attributes=False`; it has to reach `ast.dump`."""
+    node = _call_node()
+    assert stable_dump(node, include_attributes=False) == stable_dump(node)
+    with_attrs = stable_dump(node, include_attributes=True)
+    assert "lineno=" in with_attrs
+
+
+def test_stable_dump_rejects_an_explicit_show_empty() -> None:
+    """Passing it back in would defeat the point, so it is refused loudly."""
+    with pytest.raises(TypeError, match="show_empty"):
+        stable_dump(_call_node(), show_empty=False)

--- a/backlog/tasks/task-19936 - change-review-debug-line-interpolates-the-raw-console-workspace-root-path.md
+++ b/backlog/tasks/task-19936 - change-review-debug-line-interpolates-the-raw-console-workspace-root-path.md
@@ -1,0 +1,48 @@
+---
+id: TASK-19936
+title: change_review debug line interpolates the raw [console] workspace_root path
+status: To Do
+assignee: []
+created_date: '2026-08-22 10:30'
+labels:
+  - privacy
+  - diagnostics
+  - change-review
+dependencies: []
+priority: low
+---
+
+## Description
+
+`UI/Screens/change_review_screen.py` logs the raw, unredacted `[console]
+workspace_root` configuration value when the untracked-writable disclosure
+cannot normalise it:
+
+    logger.debug(
+        f"change_review: skipping untracked-writable disclosure "
+        f"for {raw!r}: {exc}"
+    )
+
+`raw` is a user-configured filesystem path, so this writes the location of
+the user's project tree — commonly including their home directory and
+therefore their account name — into a diagnostic. That is the class of
+diagnostic TASK-15103 removed 49 instances of, and the same class the
+persistent-diagnostic inventory exists to catch on the way in.
+
+Surfaced during the TASK-19572 inventory review while repairing unrelated
+test failures. Left unfixed deliberately: it arrived with PR #1941 and
+belongs to that change's author, not to the test-repair branch that found
+it. Severity is low — `debug` level, and the path is the user's own
+workspace rather than third-party content — which is why this is filed
+rather than hotfixed.
+
+## Acceptance Criteria
+
+- [ ] The diagnostic no longer interpolates the raw path value; it reports
+      the failure with metadata only (e.g. `type(exc).__name__`), matching
+      the convention the neighbouring repaired call sites use.
+- [ ] A reviewer can still tell WHICH disclosure was skipped and why, so the
+      line keeps its debugging value rather than being deleted outright.
+- [ ] `Docs/security/production-diagnostic-inventory.json` is regenerated
+      and the row for `change_review_screen.py` reflects the new text.
+- [ ] `Tests/Architecture/test_persistent_diagnostic_inventory.py` passes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,11 @@ dev = [
     "pytest-timeout",  # For handling hanging tests
     "pytest-xdist",  # Parallel test execution: pytest -n auto --dist loadscope
     "pytest-mock",  # Used throughout Tests/; was only in requirements-test.txt
+    # Tests/Agents/test_local_tool_provider.py imports Draft202012Validator at
+    # module level. It reached environments only TRANSITIVELY (chromadb,
+    # docling-core, mcp-unified -- all optional extras), so a plain
+    # `.[dev]` install could not collect that module at all.
+    "jsonschema",
     "pytest-cov",  # Coverage runs documented in Tests/README.md
     "textual-dev", # For Textual development tools
     "hypothesis",

--- a/tldw_chatbook/TTS/backends/kokoro.py
+++ b/tldw_chatbook/TTS/backends/kokoro.py
@@ -158,8 +158,18 @@ def _kokoro_stream_download(
         try:
             if os.path.exists(partial):
                 os.remove(partial)
-        except OSError:
-            logger.debug(f"{label}: could not remove partial file {partial}")
+        except OSError as cleanup_exc:
+            # No path here on purpose. `partial` is `destination + ".part"`,
+            # and two of this function's four call sites pass the user's
+            # CONFIGURED model/voice directory, so the path is user data.
+            # The two diagnostics this file lost in the same change
+            # ("Downloaded model to {self.model_path}") were removed for
+            # exactly that reason; the label identifies the download without
+            # naming where it lives.
+            logger.debug(
+                f"{label}: could not remove the partial file; "
+                f"error_type={type(cleanup_exc).__name__}"
+            )
         raise
 
 


### PR DESCRIPTION
Eleven tests were failing on dev before this branch, from three unrelated causes. **None was a product defect** — but two were tests that had quietly stopped being able to observe the thing they guard, which is worse than a plain red.

## 1. `ast.dump()` is not a pure function of the source (5 tests)

Python 3.13 added `show_empty` to `ast.dump()` and defaulted it to `False`, so empty fields stopped rendering: `Call(func=..., args=[...], keywords=[])` on ≤3.12 became `Call(func=..., args=[...])` on ≥3.13. The summarization diagnostic ledger **freezes** dumped shapes, so every reviewed row containing a no-keyword call stopped matching — on a 3.14 interpreter, while still passing on the repo's own 3.12 venv that generated the ledger.

Measured on four real interpreters, digesting all 229 diagnostic shapes in `Local_Summarization_Lib.py`:

| Python | digest |
|---|---|
| 3.11 | `92a85a3a989ffd13` ← what the committed ledger holds |
| 3.12 | `92a85a3a989ffd13` |
| 3.13 | `cd27a1b6c1fdf001` ← diverges exactly where `show_empty` landed |
| 3.14 | `cd27a1b6c1fdf001` |

New `Tests/ast_shape.stable_dump()` pins the pre-3.13 rendering; all four then produce `92a85a3a989ffd13`.

Pinning the **old** rendering rather than regenerating against the new one is deliberate: those ledger rows are a privacy review, not a checksum. Regenerating would invalidate all of them at once *and* break the 3.11 floor (`requires-python = ">=3.11"`) instead of fixing anything.

## 2. A response double `requests` can no longer drive (2 tests)

`test_anthropic_redirect_credential_leak.py` installs a fake `HTTPAdapter.send` but never set `response.request` — a real adapter sets it in `build_response`. requests 2.34.2's `Session.send` peeks ahead through `resolve_redirects` → `rebuild_auth`, which dereferences `response.request.url`. So the double raised `AttributeError` **inside requests**, before the production refusal path ran, and the production `except Exception` re-reported it as a generic failure. The tests looked like they exercised the redirect refusal and never reached it.

Fixed by giving the double its `.request` — then **red-proofed**, because a credential-leak test that merely stops failing is worth nothing:

* `allow_redirects=False` → `True`: fails, printing the sentinel `x-api-key` arriving at `evil.example`.
* refusal-path `response.close()` removed: fails on the close count.

## 3. Reviewed-inventory drift (4 tests)

The persistent-diagnostic inventory had drifted after a Notes sync refactor and several merges (`owner_files` 521→519, sinks 7→8, 11 changed files). Regenerated **only after reading every row** via the artifact's own `--statements --since` review, not a blind `--write`. What that review found:

* The new sink `Notes/notes_sync_coordinator.py` **writes nothing** — zero write calls in the file; the handle is used only for `portalocker`, and the lock filename is a SHA-256 of `(st_dev, st_ino)`, not a path. Clean.
* `library_screen.py` is a net **privacy improvement**: three warnings that interpolated import paths were replaced with `type(exc).__name__`.
* **One real regression, mine, from #1935**: kokoro's partial-file cleanup logged `{partial}`, and two of that function's four call sites pass the user's *configured* model/voice directory — the same class of leak as the two `Downloaded model to {self.model_path}` lines removed in that very change. Now logs the label and error type. Fixed here.
* `change_review_screen.py` interpolates the raw `[console] workspace_root` into a debug line. Not mine and not in scope — **filed as TASK-19936** rather than absorbed.

Also dropped a curated `REVIEWED_METADATA_ONLY_DIAGNOSTICS` entry naming a diagnostic dev's Notes-import refactor deleted, and re-pinned the manifest-boundary digest (both halves agree — the committed and freshly-generated inventories project to the same SHA).

## Verification

`257` privacy + `65` inventory + `2` redirect + `4` new `ast_shape` + `5` kokoro — all pass. The `ast_shape` guard is version-travelling by construction: it asserts the rendering that fails on ≥3.13 without the wrapper and passes on 3.11/3.12 either way.

Out of scope: the `chat_screen.py` size ratchet, which is a separate pre-existing red the owner asked to leave alone.

---

## Update: three more reds found while verifying

Sweeping wider turned up three additional pre-existing failures, all now fixed in this branch.

### 4. A `None` line number took 98 TTS tests out at collection

`Tests/TTS/test_profile_store_lock.py` builds a module-level constant from `dis.findlinestarts()`, comparing each line against a source boundary. That generator's line is **Optional** — an instruction may carry no source position, and CPython emits more of those as it evolves. Measured on the very function the file inspects (`ProfileStoreLease.acquire`): **3.11 yields 0 positionless entries, 3.14 yields 12**.

So on a newer interpreter it raised `TypeError: '<=' not supported between instances of 'int' and 'NoneType'` while building a module-level constant — not a test failure but a **collection error**, so the entire file (98 tests) silently stopped running. Skipping positionless instructions is also semantically right: an instruction with no source line cannot be inside a source-line boundary.

### 5. A concurrency guard that had stopped measuring its subject

`test_invoke_by_name_takes_exactly_one_catalog_snapshot` was failing `assert 2 == 1`. **The production code is correct.** Tracing both calls:

```
call 1  tool_catalog.py:1118  list_catalog      -> _ensure_catalog_cache()
call 2  tool_catalog.py:1209  invoke_by_name    -> _owner_record_for_name -> _ensure_catalog_cache()
```

Call 1 is the *test's own* `name = registry.list_catalog()[0].name`, taken after the counter was installed. `list_catalog` was since refactored onto the shared `_ensure_catalog_cache()` helper — good for consistent locking — and from that moment the assertion read 2 regardless of how `invoke_by_name` behaved. Fixed by resolving the name before installing the counter; red-proofed by reintroducing a second snapshot, which fails with the original `assert 2 == 1`.

### 6. `jsonschema` was never declared

`Tests/Agents/test_local_tool_provider.py` imports `Draft202012Validator` at module level, but `jsonschema` reached environments only **transitively** — via `chromadb`, `docling-core`, `mcp-unified`, all *optional* extras. A plain `pip install -e ".[dev]"` could not collect that module at all. Now declared in the `dev` extra.

## Cross-version verification

Every repair was checked on **both** interpreters, which matters because four of the six causes were version drift:

* Python 3.14: **434 passed, 0 failed** across all touched suites.
* Python 3.12 (the repo's own venv): **322 passed** for the ledger suites, plus 104 for the rest.

## Not fixed, and why

* **`chat_screen.py` size ratchet** — excluded by the owner.
* **Five TTS collection errors** (`numpy`/`torch`/`soundfile`) — these are a thin worktree venv, not a repo red: all pass under the full main venv. Unlike `jsonschema`, these deps *are* declared under real extras.
* **A full-suite run was not completed.** The suite is large enough that a whole-repo `pytest Tests/` was killed at 9% after 26 minutes, so "no other reds exist anywhere" is not a claim this PR makes — the sweep covered `Tests/LLM_Calls`, `Tests/Architecture`, `Tests/Agents`, `Tests/TTS`, `Tests/DB`, `Tests/Subscriptions`, and `Tests/Utils`.
