### PR TITLE
fix(db): restore the media connect cause chain, and repair three guards that stopped guarding

### DIFF
--- a/Tests/Agents/test_tool_catalog_concurrency.py
+++ b/Tests/Agents/test_tool_catalog_concurrency.py
@@ -51,6 +51,7 @@ def test_invoke_by_name_takes_exactly_one_catalog_snapshot():
 
     registry._ensure_catalog_cache = counting
 
+    assert snapshots == []  # nothing but invoke_by_name may be counted
     registry.invoke_by_name(name, {})
 
     assert len(snapshots) == 1  # pre-fix: 2

--- a/Tests/MCP/test_gateway_runtime_tools.py
+++ b/Tests/MCP/test_gateway_runtime_tools.py
@@ -41,6 +41,7 @@ from tldw_chatbook.MCP.permission_store import (  # noqa: E402
     MCPPermissionStore,
     definition_hash,
 )
+from tldw_chatbook.runtime_policy.types import RuntimeSourceState  # noqa: E402
 from tldw_chatbook.MCP.server import (  # noqa: E402
     TldwMCPServer,
     _describe_local_tools,
@@ -1054,17 +1055,10 @@ async def test_real_watchlists_provider_preserves_structured_domain_outcomes(
     mutable.close()
     source = {"value": "local"}
 
-    class RuntimeStore:
-        def __init__(self, _path):
-            pass
-
-        def load(self):
-            return source["value"]
-
     monkeypatch.setattr(
         local_server_tools, "get_subscriptions_db_path", lambda: db_path
     )
-    monkeypatch.setattr(local_server_tools, "RuntimeSourceStateStore", RuntimeStore)
+    _pin_runtime_source(monkeypatch, lambda: source["value"])
     store = MCPPermissionStore(tmp_path / "mcp_permissions.json")
     provider = build_server_local_provider(workspace, store)
     _grant_local_tool(store, provider, "watchlists_search_items")
@@ -1149,18 +1143,11 @@ async def test_real_watchlists_gateway_permission_failures_precede_storage(
 
 @pytest.mark.asyncio
 async def test_real_watchlists_provider_scrubs_unexpected_failures(
-    monkeypatch, tmp_path, capsys
+    monkeypatch, tmp_path, capsys, caplog
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     sentinel = "SENTINEL /private/db.sqlite API_KEY=secret"
-
-    class RuntimeStore:
-        def __init__(self, _path):
-            pass
-
-        def load(self):
-            return "local"
 
     def fail_database(*_args, **_kwargs):
         raise RuntimeError(sentinel)
@@ -1168,7 +1155,7 @@ async def test_real_watchlists_provider_scrubs_unexpected_failures(
     monkeypatch.setattr(
         local_server_tools, "get_subscriptions_db_path", lambda: tmp_path / "db.sqlite"
     )
-    monkeypatch.setattr(local_server_tools, "RuntimeSourceStateStore", RuntimeStore)
+    _pin_runtime_source(monkeypatch, "local")
     monkeypatch.setattr(local_server_tools, "SubscriptionsDB", fail_database)
     store = MCPPermissionStore(tmp_path / "mcp_permissions.json")
     provider = build_server_local_provider(workspace, store)
@@ -1192,6 +1179,15 @@ async def test_real_watchlists_provider_scrubs_unexpected_failures(
     assert sentinel not in captured.out
     assert sentinel not in captured.err
     assert all(sentinel not in record for record in records)
+    # TASK-19569: the stdlib-`logging` channel was NOT covered here, and
+    # `WatchlistsToolService._raise_unexpected` -- the scrubber on this very
+    # path -- logs through `logging.getLogger(__name__)`, not loguru. Adding
+    # `detail=%s` to that call leaked the sentinel into the captured log and
+    # this test still passed; the loguru sink and capsys never see stdlib
+    # records. The sibling guard in `Tests/MCP/test_local_server_tools.py`
+    # (`..._blocks_replacement_until_failed_close_succeeds`) already asserts
+    # against `caplog.text`; this one now does too.
+    assert sentinel not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1202,13 +1198,6 @@ async def test_real_watchlists_database_resolution_runs_off_event_loop(
     workspace.mkdir()
     entered = threading.Event()
     release = threading.Event()
-
-    class RuntimeStore:
-        def __init__(self, _path):
-            pass
-
-        def load(self):
-            return "local"
 
     class BlockingDatabase:
         def __init__(self):
@@ -1233,7 +1222,7 @@ async def test_real_watchlists_database_resolution_runs_off_event_loop(
     monkeypatch.setattr(
         local_server_tools, "get_subscriptions_db_path", lambda: tmp_path / "db.sqlite"
     )
-    monkeypatch.setattr(local_server_tools, "RuntimeSourceStateStore", RuntimeStore)
+    _pin_runtime_source(monkeypatch, "local")
     monkeypatch.setattr(
         local_server_tools,
         "SubscriptionsDB",
@@ -1267,6 +1256,30 @@ async def test_real_watchlists_database_resolution_runs_off_event_loop(
     result = await call_task
     await heartbeat_task
     assert json.loads(result)["status"] == "ok"
+
+
+def _pin_runtime_source(monkeypatch, source) -> None:
+    """Pin the runtime source the composed watchlists service will read.
+
+    The seam is ``local_server_tools.load_default_runtime_source_state`` --
+    the owner-module loader ``build_server_local_provider`` injects as
+    ``runtime_source_loader=`` (TASK-18609). These tests kept patching the
+    ``RuntimeSourceStateStore`` name it replaced, which no longer exists on
+    the module, so all three errored at the monkeypatch line (TASK-19569).
+
+    ``source`` may be a literal ``"local"``/``"server"`` or a zero-arg
+    callable, so a test can flip the source between gateway calls. The
+    loader returns a real ``RuntimeSourceState`` -- production's shape.
+
+    Deliberately NOT ``raising=False``: a renamed seam must fail loudly at
+    the patch line rather than silently install a never-read attribute.
+    """
+    resolve = source if callable(source) else (lambda: source)
+    monkeypatch.setattr(
+        local_server_tools,
+        "load_default_runtime_source_state",
+        lambda: RuntimeSourceState(active_source=resolve()),
+    )
 
 
 def _grant_local_tool(

--- a/Tests/MCP/test_gateway_runtime_tools.py
+++ b/Tests/MCP/test_gateway_runtime_tools.py
@@ -2,50 +2,64 @@
 
 from __future__ import annotations
 
+# `mcp-unified` ships in the optional `[mcp]` extra, so a plain checkout can
+# legitimately lack it. The skip has to run before the import section below --
+# both `mcp_unified.gateway` and `tldw_chatbook.MCP.gateway_runtime` resolve the
+# extra at module scope -- so it sits here, ahead of the three import groups,
+# rather than between them. The `pytest.importorskip` form used by the sibling
+# gateway modules splits third-party from local and forces E402 suppressions on
+# every import below it; this probe-and-skip keeps the groups contiguous while
+# producing the same module-level skip.
+try:
+    # Probe only; the symbols this module actually uses are imported below.
+    import mcp_unified.gateway  # noqa: F401
+except ImportError:  # pragma: no cover - only reachable without the extra
+    import pytest
+
+    pytest.skip("mcp-unified extra not installed", allow_module_level=True)
+
 import asyncio
 import copy
-from functools import partial
 import json
 import threading
+from functools import partial
 from typing import Any
 
 import pytest
 from loguru import logger
-
-gateway = pytest.importorskip(
-    "mcp_unified.gateway", reason="mcp-unified extra not installed"
+from mcp_unified.gateway import (
+    PROTOCOL_PROFILES,
+    GatewayLimits,
+    GatewayProtocolConnection,
+    GatewayRequestContext,
+    GatewayToolExecutionError,
 )
-GatewayRequestContext = gateway.GatewayRequestContext
-GatewayToolExecutionError = gateway.GatewayToolExecutionError
-GatewayProtocolConnection = gateway.GatewayProtocolConnection
-GatewayLimits = gateway.GatewayLimits
-PROTOCOL_PROFILES = gateway.PROTOCOL_PROFILES
 
-from tldw_chatbook.MCP.gateway_runtime import ChatbookGatewayRuntime  # noqa: E402
-from tldw_chatbook.Agents.agent_models import ToolResult  # noqa: E402
-from tldw_chatbook.Agents.local_tool_provider import (  # noqa: E402
+from tldw_chatbook.Agents.agent_models import ToolResult
+from tldw_chatbook.Agents.local_tool_provider import (
     LOCAL_DENY_REFUSAL,
     LOCAL_GATE_ERROR_REFUSAL,
     LOCAL_KILL_SWITCH_REFUSAL,
     LOCAL_TIMEOUT_REFUSAL,
 )
-from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB  # noqa: E402
-import tldw_chatbook.MCP.local_server_tools as local_server_tools  # noqa: E402
-from tldw_chatbook.MCP.local_server_tools import (  # noqa: E402
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.MCP import local_server_tools
+from tldw_chatbook.MCP.gateway_runtime import ChatbookGatewayRuntime
+from tldw_chatbook.MCP.local_server_tools import (
     EXTERNAL_NO_CALLBACK_REFUSAL,
     LocalToolRegistration,
     _local_agent_tool_registrations,
     build_server_local_provider,
 )
-from tldw_chatbook.MCP.permission_store import (  # noqa: E402
+from tldw_chatbook.MCP.permission_store import (
     MCPPermissionStore,
     definition_hash,
 )
-from tldw_chatbook.runtime_policy.types import RuntimeSourceState  # noqa: E402
-from tldw_chatbook.MCP.server import (  # noqa: E402
+from tldw_chatbook.MCP.server import (
     TldwMCPServer,
     _describe_local_tools,
 )
+from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 
 
 BUILTIN_TOOL_NAMES = [

--- a/Tests/MCP/test_local_server_tools.py
+++ b/Tests/MCP/test_local_server_tools.py
@@ -35,10 +35,40 @@ from tldw_chatbook.MCP.local_server_tools import (
 )
 from tldw_chatbook.MCP.permission_store import MCPPermissionStore, definition_hash
 from tldw_chatbook.MCP.server import TldwMCPServer, _describe_local_tools
+from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 
 
 BUILTIN_TOOL_NAMES = [descriptor["name"] for descriptor in _describe_local_tools()]
 TASK_TOOL_NAMES = {"todo_create", "todo_update", "todo_get", "todo_list"}
+
+
+def _pin_runtime_source(monkeypatch, source):
+    """Pin the runtime source the composed watchlists service will read.
+
+    The seam is ``local_server_tools.load_default_runtime_source_state`` --
+    the owner-module loader that ``build_server_local_provider`` injects as
+    ``runtime_source_loader=`` (TASK-18609). It used to be a
+    ``RuntimeSourceStateStore`` constructed in-module, and these tests went
+    on patching that vanished name for weeks (TASK-19569): four of them
+    errored at the monkeypatch line, and the two that passed
+    ``raising=False`` installed a never-read attribute and failed
+    downstream on a scrubbed ``ToolResult`` instead.
+
+    ``source`` may be a literal ``"local"``/``"server"`` or a zero-arg
+    callable, so a test can flip the source between calls. The loader
+    returns a real ``RuntimeSourceState`` -- the production shape, which
+    exercises ``WatchlistsToolService._runtime_source``'s attribute branch
+    rather than the bare-string convenience branch the old fakes used.
+
+    Deliberately NOT ``raising=False``: if this name is renamed or removed
+    again, every caller must fail loudly at the patch line.
+    """
+    resolve = source if callable(source) else (lambda: source)
+    monkeypatch.setattr(
+        local_server_tools,
+        "load_default_runtime_source_state",
+        lambda: RuntimeSourceState(active_source=resolve()),
+    )
 
 
 def _context():
@@ -190,22 +220,12 @@ def test_watchlists_registration_is_storage_lazy_and_server_mode_never_resolves_
         path_calls += 1
         raise AssertionError("server mode must not resolve the subscriptions path")
 
-    class ServerRuntimeStore:
-        def __init__(self, _path):
-            pass
-
-        def load(self):
-            return "server"
-
     monkeypatch.setattr(
         local_server_tools,
         "get_subscriptions_db_path",
         fail_path_resolution,
-        raising=False,
     )
-    monkeypatch.setattr(
-        local_server_tools, "RuntimeSourceStateStore", ServerRuntimeStore, raising=False
-    )
+    _pin_runtime_source(monkeypatch, "server")
     provider = build_server_local_provider(workspace, store)
     provider.list_catalog()
     provider.load_schema("local:watchlists_search_items")
@@ -236,13 +256,6 @@ def test_watchlists_first_local_call_opens_one_read_only_database(
     path_calls = 0
     constructions = []
 
-    class LocalRuntimeStore:
-        def __init__(self, _path):
-            pass
-
-        def load(self):
-            return "local"
-
     real_database = SubscriptionsDB
 
     def resolve_path():
@@ -254,15 +267,9 @@ def test_watchlists_first_local_call_opens_one_read_only_database(
         constructions.append((path, client_id, read_only))
         return real_database(path, client_id, read_only=read_only)
 
-    monkeypatch.setattr(
-        local_server_tools, "get_subscriptions_db_path", resolve_path, raising=False
-    )
-    monkeypatch.setattr(
-        local_server_tools, "RuntimeSourceStateStore", LocalRuntimeStore, raising=False
-    )
-    monkeypatch.setattr(
-        local_server_tools, "SubscriptionsDB", construct_database, raising=False
-    )
+    monkeypatch.setattr(local_server_tools, "get_subscriptions_db_path", resolve_path)
+    _pin_runtime_source(monkeypatch, "local")
+    monkeypatch.setattr(local_server_tools, "SubscriptionsDB", construct_database)
 
     provider = build_server_local_provider(workspace, store)
     assert path_calls == 0
@@ -303,11 +310,8 @@ def test_watchlists_lazy_resolver_closes_failure_and_retries(monkeypatch, tmp_pa
         local_server_tools,
         "get_subscriptions_db_path",
         lambda: tmp_path / "subscriptions.db",
-        raising=False,
     )
-    monkeypatch.setattr(
-        local_server_tools, "SubscriptionsDB", construct_database, raising=False
-    )
+    monkeypatch.setattr(local_server_tools, "SubscriptionsDB", construct_database)
     resolver = local_server_tools._LazyWatchlistsDBResolver()
 
     with pytest.raises(SubscriptionsDBReadError):
@@ -360,22 +364,13 @@ def test_watchlists_lazy_resolver_blocks_replacement_until_failed_close_succeeds
         constructions.append(candidate)
         return candidate
 
-    class LocalRuntimeStore:
-        def __init__(self, _path):
-            pass
-
-        def load(self):
-            return "local"
-
     monkeypatch.setattr(
         local_server_tools,
         "get_subscriptions_db_path",
         lambda: tmp_path / "subscriptions.db",
     )
     monkeypatch.setattr(local_server_tools, "SubscriptionsDB", construct_database)
-    monkeypatch.setattr(
-        local_server_tools, "RuntimeSourceStateStore", LocalRuntimeStore
-    )
+    _pin_runtime_source(monkeypatch, "local")
     provider = build_server_local_provider(workspace, store)
     _grant(store, provider, "watchlists_search_items")
     records: list[str] = []
@@ -430,11 +425,8 @@ def test_watchlists_lazy_resolver_concurrent_first_calls_retain_one_instance(
         local_server_tools,
         "get_subscriptions_db_path",
         lambda: tmp_path / "subscriptions.db",
-        raising=False,
     )
-    monkeypatch.setattr(
-        local_server_tools, "SubscriptionsDB", construct_database, raising=False
-    )
+    monkeypatch.setattr(local_server_tools, "SubscriptionsDB", construct_database)
     resolver = local_server_tools._LazyWatchlistsDBResolver()
 
     with ThreadPoolExecutor(max_workers=8) as pool:
@@ -458,22 +450,12 @@ def test_watchlists_unready_database_is_bounded_and_keeps_other_tools(
     else:
         before = None
 
-    class LocalRuntimeStore:
-        def __init__(self, _path):
-            pass
-
-        def load(self):
-            return "local"
-
     monkeypatch.setattr(
         local_server_tools,
         "get_subscriptions_db_path",
         lambda: database_path,
-        raising=False,
     )
-    monkeypatch.setattr(
-        local_server_tools, "RuntimeSourceStateStore", LocalRuntimeStore, raising=False
-    )
+    _pin_runtime_source(monkeypatch, "local")
     provider = build_server_local_provider(workspace, store)
     _grant(store, provider, "watchlists_search_items")
 
@@ -498,7 +480,6 @@ def test_watchlists_external_ask_refuses_before_storage_resolution(
         local_server_tools,
         "get_subscriptions_db_path",
         lambda: (_ for _ in ()).throw(AssertionError("must not resolve storage")),
-        raising=False,
     )
     provider = build_server_local_provider(workspace, store)
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6307,3 +6307,51 @@ The mismatch first recurred in TASK-19579 and then made the Skills import flow
 look broken because the expected Skills row was absent. Choose the factory whose
 profile posture matches the destination contract; do not redefine a truthful
 fresh-profile factory merely to satisfy returning-user tests.
+
+## A red guard protects nothing, and `raising=False` is how a stale monkeypatch hides (TASK-19569, 2026-08-22)
+
+**What happened.** Three guards had been red on `dev` for weeks. None of them
+was red because the thing it guards was broken:
+
+- `Tests/Agents/test_tool_catalog_concurrency.py` asserted `2 == 1` on every
+  run since it installed its `_ensure_catalog_cache` counter and *then* called
+  `registry.list_catalog()` itself, counting its own setup call. Production was
+  correct the whole time. Hoisting one line made it green — and a mutation
+  restoring the historical two-snapshot `name -> id -> provider` shape in
+  `_owner_record_for_name` made it red again with the same `assert 2 == 1`. For
+  the whole period, a real TOCTOU guard could not detect its own regression.
+- Five `Tests/MCP/` watchlists tests patched
+  `local_server_tools.RuntimeSourceStateStore`, a name TASK-18609 had replaced
+  with an injected `load_default_runtime_source_state`. Four errored at the
+  monkeypatch line. **The other two passed `raising=False`** — so `monkeypatch`
+  cheerfully created a brand-new attribute nobody reads, the test fell through
+  to the real loader, and one of them *passed for an accidental reason* (the
+  real loader happens to return `"local"`, which is what the fake wanted).
+- Six `Tests/DB/test_core_sqlite_owner_privacy.py` failures were the only
+  honest reds in the set: a genuine product defect (a `from None` severing the
+  cause chain the privacy contract walks).
+
+**Two traps worth naming.** First, `monkeypatch.setattr(..., raising=False)` on
+a *seam* is never a convenience — it converts "this seam was renamed" from a
+loud error into a silent no-op, and the resulting green tells you nothing.
+Reserve it for genuinely-optional attributes; on an injection seam, let it
+raise.
+
+Second, mutation-testing a scrubbing guard has to hit the layer the guard
+actually watches. `test_real_watchlists_provider_scrubs_unexpected_failures`
+survived *three* separate leak mutations before biting, because the scrub is
+layered (service `_raise_unexpected` -> provider `ToolResult.error` -> gateway
+fixed-message mapping) and any one layer alone re-scrubs. The mutation that
+finally exposed a real hole was the smallest one: adding `detail=%s` to
+`WatchlistsToolService._raise_unexpected`'s `_LOGGER.error` leaked the sentinel
+into the captured log **and the test still passed** — it asserted against
+capsys and a loguru sink, and neither sees stdlib `logging` records. Its
+sibling in `test_local_server_tools.py` had asserted `sentinel not in
+caplog.text` all along. If a "no secrets leak" test names some output channels,
+check that it names the one the code under test actually writes to.
+
+**What to do.** When you inherit a red test, first establish *why* it is red:
+a defect in the product, a defect in the test, or a seam that moved. Only the
+first is a baseline you may carry. Then never leave a repaired guard at green —
+mutate the behaviour it protects and watch it red, at the layer that owns that
+behaviour, before you call it repaired.

--- a/backlog/tasks/task-19569 - Guards that no longer guard - an inert concurrency test five stale MCP patches and a severed cause chain.md
+++ b/backlog/tasks/task-19569 - Guards that no longer guard - an inert concurrency test five stale MCP patches and a severed cause chain.md
@@ -297,3 +297,69 @@ drains into whichever test happens to be tearing down. Count is stable (2 in
 `Tests/MCP/test_local_server_tools.py`,
 `Tests/MCP/test_gateway_runtime_tools.py`,
 `backlog/docs/lessons-testing-evidence.md`.
+
+## Review follow-up (Qodo, PR #1961)
+
+Qodo raised one finding — a rule violation, "Non-contiguous imports in the
+gateway test": `Tests/MCP/test_gateway_runtime_tools.py` split its import
+section with `gateway = pytest.importorskip("mcp_unified.gateway")` plus five
+attribute assignments, so the third-party and local groups were not contiguous
+and every local import carried `# noqa: E402`. The new `RuntimeSourceState`
+import had been added into that already-split section.
+
+The guard cannot simply be deleted — `mcp-unified` really is optional
+(`[mcp]` extra in `pyproject.toml`) and both `mcp_unified.gateway` and
+`tldw_chatbook.MCP.gateway_runtime` resolve it at module scope, so the skip has
+to run before the imports. It is now a probe-and-skip preamble placed *ahead of*
+the three import groups rather than between them:
+
+```python
+try:
+    import mcp_unified.gateway  # noqa: F401
+except ImportError:
+    import pytest
+
+    pytest.skip("mcp-unified extra not installed", allow_module_level=True)
+```
+
+`try`/`except` lines are exempt from pycodestyle's import-position rule and the
+handler body is indented, so nothing below is flagged: the file now has three
+contiguous blocks (stdlib / third-party incl. the direct `mcp_unified.gateway`
+symbol imports / local, alphabetised) and zero `# noqa: E402`. Confirmed with
+`ruff check --isolated --select E402,F401,F811` → "All checks passed!".
+
+**A conftest `collect_ignore` was tried first and rejected on evidence.** With
+`Tests/MCP/conftest.py` holding the guard, a directory run skipped the module
+correctly, but `pytest Tests/MCP/test_gateway_runtime_tools.py` — a path named
+explicitly on the command line — is *not* subject to `collect_ignore` or to
+`pytest_ignore_collect`, and produced `ModuleNotFoundError: No module named
+'mcp_unified'` → "1 error during collection". That is strictly worse than the
+`importorskip` it replaced, so the conftest was removed.
+
+**Guard proven to still guard.** Verified with a `-p` plugin that installs a
+`sys.meta_path` finder raising `ModuleNotFoundError` for `mcp_unified`:
+explicit-file run → `SKIPPED [1] ...:19: mcp-unified extra not installed`,
+`1 skipped`; directory run (`Tests/MCP/`) → same skip line, no collection error.
+Every `monkeypatch.setattr` target was re-resolved after the reorder
+(`local_server_tools.get_subscriptions_db_path`, `.SubscriptionsDB`,
+`.load_default_runtime_source_state`, and `runtime_policy.types.
+RuntimeSourceState`), and `import tldw_chatbook.MCP.local_server_tools as
+local_server_tools` was rewritten as `from tldw_chatbook.MCP import
+local_server_tools` — asserted to bind the identical module object, so the
+patches land where they did before.
+
+**Counts (unchanged by the fix).** `Tests/MCP/test_local_server_tools.py` +
+`Tests/MCP/test_gateway_runtime_tools.py` → 98 passed;
+`Tests/DB/test_core_sqlite_owner_privacy.py` +
+`Tests/Agents/test_tool_catalog_concurrency.py` → 92 passed; all four together
+→ 190 passed. Repo-wide `--collect-only -q` → 55619 collected, 1 error in
+`Tests/UI/test_library_file_notes_workspace.py`
+("function uses no argument 'push_phase'") — a pre-existing dev red in a file
+this branch does not touch (last changed by `d3833708a`).
+
+Noted, not fixed (out of scope, untouched file): under the same blocker,
+`Tests/MCP/test_tools_resources_prompts_real_methods.py` fails rather than skips
+— it does a bare in-test `from mcp_unified.gateway import GatewayRequestContext`
+with no guard, in two tests.
+
+**Modified files (review follow-up).** `Tests/MCP/test_gateway_runtime_tools.py`.

--- a/backlog/tasks/task-19569 - Guards that no longer guard - an inert concurrency test five stale MCP patches and a severed cause chain.md
+++ b/backlog/tasks/task-19569 - Guards that no longer guard - an inert concurrency test five stale MCP patches and a severed cause chain.md
@@ -136,16 +136,49 @@ reason>"` and every `reason=` in `Utils/private_paths.py` is a fixed token
 (`shared_writable_parent`, `missing_parent`, ...), never a path. The scrubbed
 message is unchanged.
 
+Audited exhaustively (AST scan of all 65 `PrivatePathResult(...)` constructions
+repo-wide — the only way a `PrivatePathError` can be built): 60 pass a string
+literal, 4 a ternary between two literals, and 1 is `_failure()` in
+`private_sqlite.py`, whose 26 call sites are 25 literals plus one
+`type(exc).__name__`. The only non-literal shape anywhere is
+`type(exc).__name__` (3 sites), which yields an exception *class name* raised by
+a syscall — never a path, filename, or user value.
+
+**Scope caveat on that rationale.** The handler catches `(sqlite3.Error,
+PrivatePathError)`, so `from error` chains the `sqlite3.Error` branch too, which
+the argument above does not cover. Measured directly by rendering the real
+failure through `traceback`, stdlib `logging(exc_info=True)` and loguru: on the
+`PrivatePathError` branch chaining adds exactly one line — `PrivatePathError:
+unsafe_parent: shared_writable_parent` — and leaks nothing. On the
+`sqlite3.Error` branch it does make raw driver text traceback-renderable again,
+which `a189533c1` had removed from the *message*. Five realistic connect/PRAGMA
+failures were probed and every SQLite message is path-free (`unable to open
+database file`, `file is not a database`, ...), so no path or user content can
+escape; both app sinks are `diagnose=False` (`Logging_Config.py:438`,
+`__init__.py:68`), so no frame locals are dumped either; and the two public read
+paths re-sever with `from None`. If tighter containment is wanted later, the
+one-line narrowing `from (error if isinstance(error, PrivatePathError) else
+None)` satisfies the privacy contract exactly while keeping driver text severed.
+
 **Does the shape recur? No — this was the only affected connect site.** The
 four sibling owners (`base`, `chachanotes`, `prompts`, `evals`) either never
 catch `PrivatePathError` or already chain with `from e`
 (`ChaChaNotes_DB.py:3086`, `Prompts_DB.py:459`), which is why the identical
-parametrizations passed for them. The other `from None` raises in
-`Client_Media_DB_v2.py` (`:2290` media search, `:6746` distinct media types)
-catch bare `Exception`/`sqlite3.Error`, not `PrivatePathError`, and are not on
-the privacy contract's path. `DB/private_sqlite.py`'s many `from None` raises
-are the *producers* of `PrivatePathError` — deliberate `OSError`-detail scrubs
-where the boundary error is the `PrivatePathError` itself — and were left alone.
+parametrizations passed for them. Verified by an AST sweep over every
+`connect_private_sqlite()` call site in `tldw_chatbook/`: exactly three of the
+~46 sites sit in a `try` whose handler can catch a `PrivatePathError` and
+re-raises, and after this change all three chain. The other `from None` raises
+in `Client_Media_DB_v2.py` (`:2302` media search, `:6758` distinct media types)
+catch bare `Exception` — which *does* catch `PrivatePathError`, so the earlier
+wording here was wrong. They are nonetheless correctly left alone, for a
+stronger reason: `Tests/DB/test_client_media_debug_logging.py:229`
+(`test_connection_open_failure_is_wrapped_without_private_diagnostics`)
+explicitly asserts `raised.value.__cause__ is None` at those two sites. They
+are deliberately, guardedly severed — and they re-contain the inner
+`DatabaseError` on both public read paths. `DB/private_sqlite.py`'s many
+`from None` raises are the *producers* of `PrivatePathError` — deliberate
+`OSError`-detail scrubs where the boundary error is the `PrivatePathError`
+itself — and were left alone.
 
 **B — test fix.** The counter install and the test's own `list_catalog()` call
 were swapped, plus an `assert snapshots == []` precondition so the counter can
@@ -163,6 +196,19 @@ flip local→server→local between gateway calls. All **12** `raising=False`
 arguments were removed (all of them in `test_local_server_tools.py`;
 `test_gateway_runtime_tools.py` had none) — not just the 3 sitting on the stale
 name: on an injection seam, a rename must fail loudly at the patch line.
+
+**The `raising=False` cases were worse than "fail downstream" — two of them
+were GREEN.** Re-measured individually at `da4e828af`:
+`test_watchlists_first_local_call_opens_one_read_only_database` (`:261`) and
+`test_watchlists_unready_database_is_bounded_and_keeps_other_tools` (`:450`)
+both **passed** while patching the vanished `RuntimeSourceStateStore` — the
+never-read attribute was installed, the service fell through to the real
+loader, and the real loader happens to return `"local"`, which is exactly what
+their fakes wanted. Only `:207` failed downstream on a scrubbed `ToolResult`.
+So this change repairs **seven** tests, not five: the five reds plus two that
+were green while asserting nothing about the seam they patched. The
+green-and-hollow pair is the more dangerous half, and neither would ever have
+been noticed from a test report.
 
 **What the five tests were actually asserting, and whether that needed
 updating.** The runtime-source patch was setup in all five, never the
@@ -207,9 +253,44 @@ test_application_state_ownership.py test_remaining_diagnostic_sentinel_matrix.py
 (`test_reading_progress_reopens_through_versioned_migration` — a v5→v6
 `duplicate column name` migration bug; `test_legacy_server_client_builder_matches
 _are_listed_in_migration_audit`; and 6 huggingface-egress fixture errors whose
-blamed test ids shuffle run to run). Pre-existing, untouched. `ruff check` and
-`ruff format --check` clean on all four changed files; the 5 `ruff check` errors
-elsewhere under `Tests/MCP/` are pre-existing at the merge base.
+blamed test ids shuffle run to run). Pre-existing, untouched. `ruff check` clean
+on all four changed files; the 5 `ruff check` errors elsewhere under
+`Tests/MCP/` are pre-existing at the merge base. **Correction:** `ruff format
+--check` is *not* clean on `Client_Media_DB_v2.py` — it reports "would
+reformat", but identically at the merge base, and every hunk it wants is in
+untouched code (lines 733, 970, 987, 2238, 2289, 3946); the changed region
+(769–787) is correctly formatted. The other three files are clean.
+
+`test_reading_progress_reopens_through_versioned_migration` is a **test**
+defect, not a shipped migration bug — see the characterisation below.
+
+**Characterisation of the pre-existing media-migration red (for filing).**
+`test_reading_progress_reopens_through_versioned_migration` dies with
+`DatabaseError: Migration v5->v6 failed: duplicate column name:
+chunk_engine_version`, thrown out of `MediaDatabase.__init__`, so the database
+cannot be opened at all. **It does not brick a real upgrade.** Probed against
+the real `MediaDatabase`: a genuine v2 database upgrades cleanly to v6, and so
+does a genuine v5 database (the actual shipped path). The migration is also
+atomic — poisoning the version bump after the `ALTER` leaves `version=5` with
+the column *absent* and a retry succeeds — so no partial-apply state is
+reachable. The failing state is manufactured by the test itself: it fakes a
+"v2" database by dropping v3's `ReadingProgress` table and v5's
+`transcription_provenance_json` column but **not** v6's
+`chunk_engine_version` column, which task-11 added after this test was written.
+The consequence is the same class as the three findings above: the media DB's
+whole v2→v6 migration chain has been unguarded since v6 landed, because the one
+test that walks the chain dies on its last hop. Worth noting separately: any
+such schema drift is *unrecoverable* (the second open fails identically, with no
+tolerance or repair path), so an idempotent `ADD COLUMN` would be cheap
+hardening.
+
+The 6 egress errors are one root cause, not six: something on this path loads
+`sentence-transformers/all-MiniLM-L6-v2`, `huggingface_hub` issues a real
+`HEAD https://huggingface.co/...` , the network guard blocks it, and
+`huggingface_hub` **retries with backoff** — so the blocked-attempt record
+drains into whichever test happens to be tearing down. Count is stable (2 in
+`Tests/Tools/test_document_expansion_tool.py`, 4 in
+`Tests/Tools/test_file_tools_workspace_roots.py`); the blamed ids are not.
 
 **Modified files.** `tldw_chatbook/DB/Client_Media_DB_v2.py`,
 `Tests/Agents/test_tool_catalog_concurrency.py`,

--- a/backlog/tasks/task-19569 - Guards that no longer guard - an inert concurrency test five stale MCP patches and a severed cause chain.md
+++ b/backlog/tasks/task-19569 - Guards that no longer guard - an inert concurrency test five stale MCP patches and a severed cause chain.md
@@ -3,7 +3,7 @@ id: TASK-19569
 title: >-
   Guards that no longer guard — an inert concurrency test, five stale MCP
   monkeypatches, and a severed cause chain
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:19'
 labels:
@@ -82,19 +82,137 @@ The five tests: `test_watchlists_registration_is_storage_lazy_and_server_mode_ne
 
 ## Acceptance Criteria
 
-- [ ] `Client_Media_DB_v2.py:775` preserves the cause chain (`from error`), so
+- [x] `Client_Media_DB_v2.py:775` preserves the cause chain (`from error`), so
       a `PrivatePathError` remains identifiable to the privacy contract; the 6
       media reds go green for the right reason, not by relaxing the assertion
-- [ ] `test_tool_catalog_concurrency` is repaired in the **test** (its own
+- [x] `test_tool_catalog_concurrency` is repaired in the **test** (its own
       `list_catalog()` call moved before the counter is installed) and left
       able to detect a real regression — verified by mutating the production
       snapshot behaviour and seeing it go red
-- [ ] The five MCP watchlists tests are re-pointed at the current seam
+- [x] The five MCP watchlists tests are re-pointed at the current seam
       (`runtime_source_loader` / `load_default_runtime_source_state`) and pass
-- [ ] `monkeypatch.setattr(..., raising=False)` is removed wherever it is
+- [x] `monkeypatch.setattr(..., raising=False)` is removed wherever it is
       masking a renamed or removed attribute in these files — a patch that
       installs a never-read attribute must fail loudly
-- [ ] Each repaired guard is mutation-checked: it goes red when the behaviour
+- [x] Each repaired guard is mutation-checked: it goes red when the behaviour
       it protects is broken. A green test that cannot fail is the defect being
       fixed here
-- [ ] The watchlists local-server tool contract is demonstrably guarded again
+- [x] The watchlists local-server tool contract is demonstrably guarded again
+
+## Implementation Plan
+
+1. Reproduce all three reds at the merge base with a pinned runner (isolated
+   HOME/XDG, `tldw_chatbook.__file__` assert) and record exact counts.
+2. **A** — restore the cause chain in `Client_Media_DB_v2._get_thread_connection`
+   and audit the other DB owners' connect sites for the same `from None` shape.
+3. **B** — hoist the test's own `list_catalog()` above the counter install; add
+   an explicit `snapshots == []` precondition so the counter can only ever
+   observe `invoke_by_name`.
+4. **C** — re-point every stale `RuntimeSourceStateStore` patch at the live
+   `load_default_runtime_source_state` seam via one shared helper per file; drop
+   every `raising=False` in the two files.
+5. Mutation-check each repaired guard against the production behaviour it
+   protects; Edit-restore and confirm `git diff` is clean.
+6. Run `Tests/DB/`, `Tests/Agents/`, `Tests/MCP/`, the related suites, and a
+   repo-wide `--collect-only`; baseline anything else red against the merge base.
+
+## Implementation Notes
+
+All three guards repaired and each proven to bite. **These reds are no longer
+available as a baseline**: the 6 `test_core_sqlite_owner_privacy` media
+failures and the `test_tool_catalog_concurrency` failure have been carried as
+"known pre-existing dev reds" by several merged PRs this week, and they are
+gone. Any PR that lists them from here on is either stale or has introduced
+them.
+
+**A — product fix (the only production change).**
+`DB/Client_Media_DB_v2.py:775` now raises `from error` instead of `from None`.
+The severing arrived in `a189533c1` ("fix(library): contain media database
+diagnostics"), which correctly scrubbed the *message* — the path and driver
+text are gone — but also dropped `from e`, and the privacy contract identifies
+its boundary failure by walking `__cause__` to a `PrivatePathError`. Chaining
+is privacy-safe here: `PrivatePathError.__str__` is `"<status>: <symbolic
+reason>"` and every `reason=` in `Utils/private_paths.py` is a fixed token
+(`shared_writable_parent`, `missing_parent`, ...), never a path. The scrubbed
+message is unchanged.
+
+**Does the shape recur? No — this was the only affected connect site.** The
+four sibling owners (`base`, `chachanotes`, `prompts`, `evals`) either never
+catch `PrivatePathError` or already chain with `from e`
+(`ChaChaNotes_DB.py:3086`, `Prompts_DB.py:459`), which is why the identical
+parametrizations passed for them. The other `from None` raises in
+`Client_Media_DB_v2.py` (`:2290` media search, `:6746` distinct media types)
+catch bare `Exception`/`sqlite3.Error`, not `PrivatePathError`, and are not on
+the privacy contract's path. `DB/private_sqlite.py`'s many `from None` raises
+are the *producers* of `PrivatePathError` — deliberate `OSError`-detail scrubs
+where the boundary error is the `PrivatePathError` itself — and were left alone.
+
+**B — test fix.** The counter install and the test's own `list_catalog()` call
+were swapped, plus an `assert snapshots == []` precondition so the counter can
+only ever observe `invoke_by_name`. Production was correct throughout.
+
+**C — seam repair.** Each file gained a `_pin_runtime_source(monkeypatch,
+source)` helper that patches `local_server_tools.load_default_runtime_source_state`
+(the owner-module loader TASK-18609 injects as `runtime_source_loader=`) and
+returns a **real `RuntimeSourceState`** rather than the old fakes' bare
+`"local"`/`"server"` string — that is production's shape, so the tests now
+exercise `WatchlistsToolService._runtime_source`'s attribute branch instead of
+its bare-string convenience branch. `source` accepts a callable so
+`test_real_watchlists_provider_preserves_structured_domain_outcomes` can still
+flip local→server→local between gateway calls. All **12** `raising=False`
+arguments were removed (all of them in `test_local_server_tools.py`;
+`test_gateway_runtime_tools.py` had none) — not just the 3 sitting on the stale
+name: on an injection seam, a rename must fail loudly at the patch line.
+
+**What the five tests were actually asserting, and whether that needed
+updating.** The runtime-source patch was setup in all five, never the
+assertion, so four needed only the re-point: server-mode must short-circuit
+before any storage resolution; the lazy resolver must not replace a failed
+candidate until its `close()` succeeds; the gateway must pass the provider's
+structured domain outcomes through byte-for-byte; database resolution must run
+off the event loop. **One did need updating.**
+`test_real_watchlists_provider_scrubs_unexpected_failures` asserted no sentinel
+in `str(exc)`, capsys, and a loguru sink — but the scrubber it guards
+(`WatchlistsToolService._raise_unexpected`) logs through
+`logging.getLogger(__name__)`, and none of those three channels sees stdlib
+records. Adding `detail=%s` to that log call leaked the sentinel into the
+captured log **and the test still passed**. It now also asserts
+`sentinel not in caplog.text`, matching its sibling in
+`test_local_server_tools.py`, and reds on that mutation.
+
+**Bite-proofs (mutate production → guard reds → Edit-restore → `git diff` clean).**
+
+| # | Mutation | Guard that red |
+|---|---|---|
+| A | `from error` → `from None` at `Client_Media_DB_v2.py:775` | 6 media parametrizations, `6 failed / 83 passed` |
+| B | `_owner_record_for_name` takes two `_ensure_catalog_cache()` snapshots (the historical TOCTOU shape) | `test_invoke_by_name_takes_exactly_one_catalog_snapshot`, `assert 2 == 1` |
+| C1 | `WatchlistsToolService._runtime_source` ignores the loaded state (always `"local"`) | `..._server_mode_never_resolves_path` **and** `..._preserves_structured_domain_outcomes` — proving the repaired seam is load-bearing |
+| C2 | `_LazyWatchlistsDBResolver` replaces a failed candidate even when `close()` raises | `..._blocks_replacement_until_failed_close_succeeds` |
+| C3 | `_raise_unexpected` logs `detail=%s` (the raw exception) | `..._scrubs_unexpected_failures` — **only after** the `caplog` assertion was added; it survived this and two other leak mutations before that |
+| C4 | gateway calls the local handler inline instead of `asyncio.to_thread` | `..._database_resolution_runs_off_event_loop` (+ the generic `test_blocking_local_handler_runs_off_event_loop`) |
+
+**Counts (merge base `da4e828af` → this branch).**
+
+| File | Before | After |
+|---|---|---|
+| `Tests/DB/test_core_sqlite_owner_privacy.py` | 6 failed / 83 passed | **89 passed** |
+| `Tests/Agents/test_tool_catalog_concurrency.py` | 1 failed / 2 passed | **3 passed** |
+| `Tests/MCP/test_local_server_tools.py` + `test_gateway_runtime_tools.py` | 5 failed / 93 passed | **98 passed** |
+
+Suite gates: `Tests/DB/` 1077 passed / 1 skipped; `Tests/Agents/` 1793 passed;
+`Tests/MCP/` 1042 passed; repo-wide `--collect-only -q` 54996 collected, exit 0
+(identical to the merge base). `Tests/Media_DB/ Tests/RuntimePolicy/ Tests/Tools/
+test_application_state_ownership.py test_remaining_diagnostic_sentinel_matrix.py`
+= 2 failed / 1211 passed / 6 errors on **both** this branch and the merge base
+(`test_reading_progress_reopens_through_versioned_migration` — a v5→v6
+`duplicate column name` migration bug; `test_legacy_server_client_builder_matches
+_are_listed_in_migration_audit`; and 6 huggingface-egress fixture errors whose
+blamed test ids shuffle run to run). Pre-existing, untouched. `ruff check` and
+`ruff format --check` clean on all four changed files; the 5 `ruff check` errors
+elsewhere under `Tests/MCP/` are pre-existing at the merge base.
+
+**Modified files.** `tldw_chatbook/DB/Client_Media_DB_v2.py`,
+`Tests/Agents/test_tool_catalog_concurrency.py`,
+`Tests/MCP/test_local_server_tools.py`,
+`Tests/MCP/test_gateway_runtime_tools.py`,
+`backlog/docs/lessons-testing-evidence.md`.

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -951,7 +951,19 @@ class MediaDatabase:
                     type(error).__name__,
                 )
                 self._local.conn = None
-                raise DatabaseError("Failed to connect to media database.") from None
+                # `from error`, NOT `from None` (TASK-19569): the raised
+                # message stays scrubbed (no path, no driver text), but the
+                # private-path contract identifies its boundary failure by
+                # walking `__cause__` to a `PrivatePathError`. Severing the
+                # chain here made this owner the only one of five whose
+                # unsafe-namespace rejection was unidentifiable to callers --
+                # the log line above already records the type, so the
+                # information was being thrown away, not withheld. Chaining is
+                # privacy-safe: `PrivatePathError.__str__` is
+                # `"<status>: <symbolic reason>"` with no path in it (see
+                # `Utils/private_paths.py`), matching the `from e` chaining
+                # the ChaChaNotes and Prompts owners already do.
+                raise DatabaseError("Failed to connect to media database.") from error
         self._local.conn_last_used = time.monotonic()
         return self._local.conn
 


### PR DESCRIPTION
Closes TASK-19569.

Calibration first, because it frames the task: the lane that filed this found **no hollow guard** — 15 of 16 injected defects were caught, several with real precision. These three are the exceptions, each with a specific small cause. The theme is that a guard red for reasons unrelated to what it protects leaves the thing it protects **unguarded**.

## A — a product defect hiding behind 6 test failures

`DB/Client_Media_DB_v2.py:775` raised `DatabaseError(...) from None`, severing the cause chain the privacy contract requires, so `isinstance(err, PrivatePathError)` failed. The log line one statement earlier already recorded `error_type=PrivatePathError` — the code knew what it caught and threw the information away. Six `media-*` parametrizations failed while the identical ones passed for `base`, `chachanotes`, `prompts` and `evals`.

Traced to `a189533c1` ("contain media database diagnostics"), which correctly scrubbed the *message* but also dropped the `from e` its sibling owners kept. So `from error` restores what the guard was written against, rather than loosening it.

**Chaining is privacy-safe, audited exhaustively rather than argued.** An AST scan of all **65** `PrivatePathResult(...)` constructions repo-wide — the only way a `PrivatePathError` can be built, since it takes a frozen result object with no `replace()` or alias import — found 60 string literals, 4 ternaries between literals, and one `_failure()` helper covering 26 call sites. The only non-literal shape anywhere is `type(exc).__name__`, an exception *class name*, never a path or user value. An empirical probe rendered a real failure through `traceback`, stdlib `logging(exc_info=True)`, and loguru at both `diagnose=False` (the app's actual sink) and `diagnose=True`: the `PrivatePathError` branch adds exactly one line, `PrivatePathError: unsafe_parent: shared_writable_parent`, and leaks nothing.

Review noted the handler also catches `sqlite3.Error`, so chaining makes raw driver text traceback-renderable again. Probed across five realistic connect/PRAGMA failures: every SQLite message is path-free, both app sinks are `diagnose=False` so no frame locals are dumped, and the two public read paths re-sever with `from None`. Non-blocking.

**The shape does not recur.** An independent AST sweep of all ~46 `connect_private_sqlite()` call sites found exactly 3 whose handler can catch `PrivatePathError` and re-raise — ChaChaNotes, Prompts, Media. All three now chain; zero severed sites remain. The other two `from None` in this file stay severed because `test_client_media_debug_logging.py:229` explicitly asserts `__cause__ is None` there.

## B — an inert concurrency guard, with the bug entirely in the test

`test_tool_catalog_concurrency.py` failed unconditionally with `assert 2 == 1`: it installed its counter, then called `registry.list_catalog()` itself and counted its own call. Production was correct all along. Hoisting the call above the counter turns it green — but green is not the deliverable, so the guard was bite-proved by reintroducing the historical two-snapshot TOCTOU in `_owner_record_for_name`, which reds it.

## C — five MCP tests patching a name that no longer exists

Production now imports `load_default_runtime_source_state` and injects it as `runtime_source_loader=`; the tests patched `RuntimeSourceStateStore`, gone. In all five the patch was **setup, never the assertion**, so re-pointing it does not change what they assert — verified per test, each bite-proved by a distinct mutation (server-mode short-circuit, failed-close replacement blocking, structured-outcome passthrough, off-loop execution).

All **12** `raising=False` arguments were dropped, not just the 3 on the stale name, and the fakes now use a real `RuntimeSourceState` rather than a bare string, so the object branch of `_runtime_source` is actually exercised.

**Review found this repairs seven tests, not five.** Measured individually at the merge base, two of the `raising=False` cases were **green while patching a vanished name**, because the real loader happens to return `"local"`. The green-and-hollow pair is the more dangerous half.

## The best catch: a scrubber test that was hollow across an entire channel

`test_real_watchlists_provider_scrubs_unexpected_failures` asserted no sentinel in `str(exc)`, capsys, and a loguru sink — but the scrubber it guards logs through **stdlib** `logging.getLogger(__name__)`, which none of those channels observes. Review built a 2×4 matrix and confirmed it was hollow across the whole stdlib channel, not one formatting style:

| leak vector | before | after |
|---|---|---|
| lazy `%`-arg `detail=%s` | survived | caught |
| eager f-string `{exc}` | survived | caught |
| `exc_info=exc` traceback | survived | caught |

A one-line `caplog` assertion closes all three. A static sweep found 88 leak-shaped tests asserting only on capsys/loguru; a dynamic probe over 665 tests in the changed and related privacy-guard files found no genuine recurrence (a full-repo dynamic sweep was killed at 42%, so this is well-supported rather than exhaustive).

## Counts

| file | merge base | branch |
|---|---|---|
| `test_core_sqlite_owner_privacy.py` | 6 failed / 83 passed | **89 passed** |
| `test_tool_catalog_concurrency.py` | 1 failed / 2 passed | **3 passed** |
| MCP pair | 5 failed / 93 passed | **98 passed** |
| all four guard files | 12 failed / 178 passed | **190 passed** |

`Tests/DB/` + `Tests/Agents/` + `Tests/MCP/`: 3912 passed / 1 skipped. Repo-wide `--collect-only`: 54,996, identical to base. Post-rebase spot check: 199 passed.

**These reds are no longer available as a baseline.** Several PRs merged this week carried the 6 media failures and the catalog failure as "known pre-existing dev reds"; from here on, any PR listing them is stale or has introduced them.

Filed separately from this work: a media `v5→v6` migration test defect (the real upgrade path is clean and atomic — probed from genuine v2 and v5 databases — but the whole `v2→v6` chain has been unguarded since v6 landed), a migration-audit drift naming two new legacy-builder call sites in `app.py`, six huggingface-egress fixture errors that are one root cause with a shuffling blame id, and an incidental full-DB-path log at `Client_Media_DB_v2.py:676`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores cause chaining for media DB connect failures and repairs three guards so they protect real behavior (TASK-19569). Old: media raised DatabaseError from None, breaking privacy detection of PrivatePathError. New: media raises from the caught error; tests now target the live seams and cover stdlib logging.

- Production: in `tldw_chatbook/DB/Client_Media_DB_v2.py` `_get_thread_connection`, raise `DatabaseError("...") from error`. Message stays scrubbed; two public read sites that tests assert severed remain `from None`.
- MCP tests: replace stale `RuntimeSourceStateStore` patches with `_pin_runtime_source` that targets `load_default_runtime_source_state` and returns `RuntimeSourceState`; remove all `raising=False`; add a `caplog` assertion for the scrubber path. For optional `mcp` installs, switch to a top‑of‑file probe‑and‑skip preamble for `mcp_unified.gateway` to keep imports contiguous and avoid `# noqa: E402`.
- Agents test: hoist `list_catalog()` before installing the counter and assert `snapshots == []`, so only `invoke_by_name` is counted.
- Rollout: no migrations. Do not carry the prior six media privacy reds or the catalog red as baseline; treat any reappearance as regressions.

<sup>Written for commit 6f3ea68e2b1908be83f0d758444d2ec8cb7d557a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

