### PR TITLE
test(library): reconcile modal inventory

### DIFF
--- a/Tests/UI/test_library_modal_dismissal.py
+++ b/Tests/UI/test_library_modal_dismissal.py
@@ -612,8 +612,8 @@ LIBRARY_MODAL_LAUNCH_EDGES = (
     _edge(
         _LIBRARY_SCREEN_FILE,
         "LibraryScreen",
-        "handle_library_notes_sync_browse",
-        SelectDirectory,
+        "handle_library_notes_lasting_folder_requested",
+        FileOpen,
     ),
     _edge(
         _LIBRARY_SCREEN_FILE,

--- a/backlog/tasks/task-19013 - Declare-WorkspaceCreateModal-in-the-Library-modal-inventory.md
+++ b/backlog/tasks/task-19013 - Declare-WorkspaceCreateModal-in-the-Library-modal-inventory.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-19013
 title: Declare WorkspaceCreateModal in the Library modal inventory
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-21 01:23'
+updated_date: '2026-08-22 17:32'
 labels:
   - library
   - testing
@@ -20,8 +22,27 @@ Restore the Library modal inventory gate so it resolves and declares the existin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The Library modal inventory resolves `create_local_workspace` to `WorkspaceCreateModal`.
-- [ ] #2 The `WorkspaceCreateModal` contract and any transitive modal edge are declared or explicitly excluded with a recorded reason.
-- [ ] #3 The full Library modal-dismissal suite reaches and passes its bidirectional inventory assertions.
-- [ ] #4 No production modal behavior changes.
+- [x] #1 The Library modal inventory resolves `create_local_workspace` to `WorkspaceCreateModal`.
+- [x] #2 The `WorkspaceCreateModal` contract and any transitive modal edge are declared or explicitly excluded with a recorded reason.
+- [x] #3 The full Library modal-dismissal suite reaches and passes its bidirectional inventory assertions.
+- [x] #4 No production modal behavior changes.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the full Library modal-inventory failure on current dev and confirm WorkspaceCreateModal is already declared.
+2. Replace the single retired Notes sync modal edge with the exact current lasting-sync FileOpen edge; make no production changes.
+3. Run the exact inventory node, full modal-dismissal suite, Ruff/format/diff checks, and verify the production tree is unchanged.
+4. Record evidence, check all acceptance criteria, and mark the task Done.
+
+ADR required: no
+ADR path: N/A
+Reason: this is a test-inventory correction for existing modal behavior and introduces no architecture or runtime contract.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified that current dev already declares `LibraryScreen.create_local_workspace -> WorkspaceCreateModal`, includes the exact WorkspaceCreateModal dismissal contract, and discovers no undeclared transitive edge. The full inventory gate exposed one adjacent stale declaration left by the lasting Notes cutover, so the test inventory now declares `handle_library_notes_lasting_folder_requested -> FileOpen` and removes the retired legacy Sync browse edge; production code is unchanged. Verification: the exact bidirectional inventory node passed; the full `Tests/UI/test_library_modal_dismissal.py` suite passed 170 tests with one pre-existing requests dependency warning; Ruff check, Ruff format check, and `git diff --check` passed. No new ADR or lesson was required because this only reconciles a test inventory with existing runtime behavior.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- preserve the existing `create_local_workspace -> WorkspaceCreateModal` inventory contract
- replace the retired Notes Sync browse declaration with the current lasting-sync folder picker edge
- complete TASK-19013 without changing production modal behavior

## Test plan
- [x] `pytest Tests/UI/test_library_modal_dismissal.py` (170 passed)
- [x] Ruff check and format check
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the Library modal inventory in tests to match current behavior. Replaces the retired Notes Sync browse edge (`handle_library_notes_sync_browse -> SelectDirectory`) with the lasting-sync folder picker (`handle_library_notes_lasting_folder_requested -> FileOpen`) while keeping `create_local_workspace -> WorkspaceCreateModal`. Completes TASK-19013 without changing production behavior.

- Review focus: Only `Tests/UI/test_library_modal_dismissal.py` and the task doc changed; confirm the new handler and modal names match runtime.
- Rollout: No migrations or config changes; the modal-dismissal suite passes (170 tests).

<sup>Written for commit 7dca9a8892f9b7f7401e6303435e2b5fdaa211b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

