### PR TITLE
fix(watchlists,scheduling): close the overlapping-check double-report, and make late-dispatch cause falsifiable

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -15,7 +15,7 @@ panels for the Schedule Queue, Task Detail, and Inspector.
 - Press **Ctrl+7**, click **⌃7 Schedules** in the nav bar, or press
   **Ctrl+P** → "Tab Navigation: Switch to Schedules".
 
-## Missed while away — what happens to overdue reminders
+## Ran late — what happens to overdue reminders
 
 Reminders only fire while the app is running (they execute locally, even
 with no server configured). If the app is closed — or asleep — when a
@@ -23,9 +23,15 @@ reminder's scheduled time passes, the reminder is **not replayed**: when you
 next open the app, the overdue occurrence fires once, immediately, and the
 task records honestly that it was late.
 
+A second cause produces the same "ran late" state, which is why the notice
+no longer claims the app was closed: the scheduler runs each tick's due
+handlers one after another, so a slow handler (a watchlist check may run up
+to its 300-second execution timeout) delays the tasks queued behind it in
+that tick. The app log names which cause it was.
+
 - **One-time reminders** fire once, late, and then complete as usual. Their
-  detail pane shows "Missed while away: the \<scheduled time\> occurrence
-  ran late".
+  detail pane shows "Ran late: the \<scheduled time\> occurrence dispatched
+  well after its scheduled time".
 - **Recurring reminders** fire once for the overdue occurrence and count
   how many earlier occurrences were skipped ("2 earlier occurrence(s) were
   skipped, not replayed") — the schedule then continues from the current
@@ -39,12 +45,13 @@ task records honestly that it was late.
 This state describes the **last** dispatch and heals itself: the next
 on-time firing clears the marker and the notice.
 
-**"Missed" vs "Missed while away".** A task whose *status* reads **Missed**
-had a dispatch that ran and *failed* (its handler raised — it tried and
-errored). "Missed while away" (the ◇ marker and detail notice) means the
-scheduled time passed with the scheduler not running at all — the work
-never ran until it fired late. A task can be one, the other, or neither;
-neither implies the other.
+**"Missed" vs "Ran late".** A task whose *status* reads **Missed** had a
+dispatch that ran and *failed* (its handler raised — it tried and errored).
+"Ran late" (the ◇ marker and detail notice) means the scheduled time passed
+without the work being dispatched — because the app was away, or because
+the scheduler was busy with an earlier task in the same tick — and it then
+fired late. A task can be one, the other, or neither; neither implies the
+other.
 
 ### Tuning the grace window
 

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -23,11 +23,16 @@ reminder's scheduled time passes, the reminder is **not replayed**: when you
 next open the app, the overdue occurrence fires once, immediately, and the
 task records honestly that it was late.
 
-A second cause produces the same "ran late" state, which is why the notice
-no longer claims the app was closed: the scheduler runs each tick's due
+Other causes produce the same "ran late" state, which is why the notice no
+longer claims the app was closed. The scheduler runs each poll's due
 handlers one after another, so a slow handler (a watchlist check may run up
-to its 300-second execution timeout) delays the tasks queued behind it in
-that tick. The app log names which cause it was.
+to its 300-second execution timeout) holds the loop and pushes the *next*
+poll — and everything due by then — past the grace window. A machine that
+sleeps or suspends with the app still open does the same thing without any
+handler being slow. The app log names which it was: `busy` when the previous
+poll's handlers account for the delay, `stalled` when the scheduler was up
+but nothing it ran explains it, and `away` when the scheduler genuinely was
+not running at the scheduled time.
 
 - **One-time reminders** fire once, late, and then complete as usual. Their
   detail pane shows "Ran late: the \<scheduled time\> occurrence dispatched

--- a/Tests/Scheduling/test_scheduler_lateness_cause.py
+++ b/Tests/Scheduling/test_scheduler_lateness_cause.py
@@ -68,9 +68,98 @@ def test_a_late_dispatch_while_the_scheduler_runs_is_reported_as_busy(db):
     # The scheduler has been up since before the owed occurrence -- i.e. it
     # was watching at the scheduled time, so it cannot have been "away".
     loop._running_since = NOW - timedelta(hours=3)
+    # ...and the preceding tick demonstrably held the loop for longer than
+    # the grace. Both halves are required (review of task-19562): being up
+    # only rules "away" out, it does not make a handler the culprit.
+    loop._last_tick_dispatch_seconds = 600.0
     row = db.get_reminder_task(task_id)
 
     assert loop._report_lateness_cause(row, "reminder", NOW) == "busy"
+
+
+def test_a_suspended_process_is_not_blamed_on_a_handler(db):
+    """The misattribution this classifier shipped with, pinned.
+
+    A laptop with its lid closed keeps the app running and consumes ZERO
+    handler time; on wake every owed occurrence is hours late with
+    `_running_since` long predating it. The first version of the rule --
+    "scheduled after we started, therefore busy" -- reported that as
+    "an earlier handler in the same tick held the loop", which is false, and
+    false for the commonest way a desktop app goes quiet. `busy` now
+    requires the evidence; without it the honest answer is `stalled`.
+    """
+
+    async def handler(task):
+        return None
+
+    task_id = _hourly(db, next_run_at=NOW - timedelta(hours=2), title="late")
+    loop = _loop(db, now=NOW, handler=handler)
+    loop._running_since = NOW - timedelta(hours=3)
+    loop._last_tick_dispatch_seconds = 0.0  # nothing ran; nothing blocked
+    row = db.get_reminder_task(task_id)
+
+    assert loop._report_lateness_cause(row, "reminder", NOW) == "stalled"
+
+
+def test_the_tick_records_how_long_its_handlers_held_the_loop(db):
+    """The evidence field must be produced by a real tick, not set by hand."""
+    clock = {"now": NOW}
+
+    async def handler(task):
+        clock["now"] = clock["now"] + timedelta(minutes=10)
+        return None
+
+    db.create_reminder_task(
+        owner_id="local",
+        title="slow",
+        schedule_kind="recurring",
+        cron="* * * * *",
+        timezone="UTC",
+        next_run_at=(NOW - timedelta(seconds=1)).isoformat(),
+        enabled=True,
+    )
+    loop = SchedulerLoop(
+        db,
+        handlers={"reminder": handler},
+        clock=lambda: clock["now"],
+        missed_fire_grace_seconds=60.0,
+    )
+    assert loop._last_tick_dispatch_seconds == 0.0
+    loop.queue.load()
+    asyncio.run(loop.tick())
+
+    assert loop._last_tick_dispatch_seconds == pytest.approx(600.0), (
+        "tick did not record the time its handlers spent holding the loop"
+    )
+
+
+def test_a_raising_handler_still_records_the_tick_span(db):
+    """A failed dispatch must not leave the previous tick's figure standing."""
+    clock = {"now": NOW}
+
+    async def handler(task):
+        clock["now"] = clock["now"] + timedelta(minutes=10)
+        raise RuntimeError("handler exploded")
+
+    db.create_reminder_task(
+        owner_id="local",
+        title="boom",
+        schedule_kind="recurring",
+        cron="* * * * *",
+        timezone="UTC",
+        next_run_at=(NOW - timedelta(seconds=1)).isoformat(),
+        enabled=True,
+    )
+    loop = SchedulerLoop(
+        db,
+        handlers={"reminder": handler},
+        clock=lambda: clock["now"],
+        missed_fire_grace_seconds=60.0,
+    )
+    loop.queue.load()
+    asyncio.run(loop.tick())
+
+    assert loop._last_tick_dispatch_seconds == pytest.approx(600.0)
 
 
 def test_a_late_dispatch_after_a_restart_is_reported_as_away(db):

--- a/Tests/Scheduling/test_scheduler_lateness_cause.py
+++ b/Tests/Scheduling/test_scheduler_lateness_cause.py
@@ -1,0 +1,231 @@
+"""A late dispatch must not be blamed on an absent scheduler (task-19562).
+
+`SchedulerLoop.tick` awaits every due handler serially and inline. One slow
+handler therefore delays every task behind it in the same tick -- and a
+watchlist check may run to its 300 s execution timeout, against a 60 s
+missed-fire grace. The resulting row is byte-identical to one produced by
+the app having been closed, and the UI said so out loud ("the scheduler was
+not running at the scheduled time") for a scheduler that never stopped.
+
+These tests drive the REAL loop and the REAL `ScheduledTasksDB`. The
+head-of-line block is produced by an actual slow handler awaited by an
+actual tick, not by asserting that a helper was called.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 8, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = ScheduledTasksDB(tmp_path / "lateness.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _hourly(database, *, next_run_at, title):
+    return database.create_reminder_task(
+        owner_id="local",
+        title=title,
+        schedule_kind="recurring",
+        cron="0 * * * *",
+        timezone="UTC",
+        next_run_at=next_run_at.isoformat(),
+        enabled=True,
+    )
+
+
+def _loop(database, *, now, handler) -> SchedulerLoop:
+    return SchedulerLoop(
+        database,
+        handlers={"reminder": handler},
+        clock=lambda: now,
+        missed_fire_grace_seconds=60.0,
+    )
+
+
+def test_a_late_dispatch_while_the_scheduler_runs_is_reported_as_busy(db):
+    """The headline: in-process lateness is not 'missed while away'."""
+
+    async def handler(task):
+        return None
+
+    task_id = _hourly(db, next_run_at=NOW - timedelta(hours=2), title="late")
+    loop = _loop(db, now=NOW, handler=handler)
+    # The scheduler has been up since before the owed occurrence -- i.e. it
+    # was watching at the scheduled time, so it cannot have been "away".
+    loop._running_since = NOW - timedelta(hours=3)
+    row = db.get_reminder_task(task_id)
+
+    assert loop._report_lateness_cause(row, "reminder", NOW) == "busy"
+
+
+def test_a_late_dispatch_after_a_restart_is_reported_as_away(db):
+    """The genuine case must still be identified as such."""
+
+    async def handler(task):
+        return None
+
+    task_id = _hourly(db, next_run_at=NOW - timedelta(hours=2), title="late")
+    loop = _loop(db, now=NOW, handler=handler)
+    # Started AFTER the owed occurrence: the app really was closed for it.
+    loop._running_since = NOW - timedelta(minutes=1)
+    row = db.get_reminder_task(task_id)
+
+    assert loop._report_lateness_cause(row, "reminder", NOW) == "away"
+
+
+def test_a_never_started_loop_reports_away(db):
+    """`_running_since` is None before `run()` and after `stop()`."""
+
+    async def handler(task):
+        return None
+
+    task_id = _hourly(db, next_run_at=NOW - timedelta(hours=2), title="late")
+    loop = _loop(db, now=NOW, handler=handler)
+    row = db.get_reminder_task(task_id)
+
+    assert loop._running_since is None
+    assert loop._report_lateness_cause(row, "reminder", NOW) == "away"
+
+
+def test_an_on_time_dispatch_reports_no_lateness_at_all(db):
+    """Within the grace, there is nothing to attribute."""
+
+    async def handler(task):
+        return None
+
+    task_id = _hourly(db, next_run_at=NOW - timedelta(seconds=5), title="ontime")
+    loop = _loop(db, now=NOW, handler=handler)
+    loop._running_since = NOW - timedelta(hours=3)
+    row = db.get_reminder_task(task_id)
+
+    assert loop._report_lateness_cause(row, "reminder", NOW) is None
+
+
+def test_head_of_line_blocking_produces_the_busy_attribution(db):
+    """Drive it for real: a slow first handler, a late second task.
+
+    The clock advances only when the slow handler runs, which is what a
+    blocked loop does to the tasks behind it. Both tasks are due in the
+    same tick.
+    """
+    clock = {"now": NOW}
+    causes: list[tuple[str, str | None]] = []
+
+    async def handler(task):
+        if task["title"] == "slow":
+            # The handler holds the loop -- exactly what tick's serial
+            # await does with a multi-minute watchlist check.
+            clock["now"] = clock["now"] + timedelta(minutes=10)
+        return None
+
+    # Per-minute so the next occurrence lands inside the ten minutes the
+    # slow handler burns; an hourly task would simply not be due again.
+    for title in ("slow", "blocked"):
+        db.create_reminder_task(
+            owner_id="local",
+            title=title,
+            schedule_kind="recurring",
+            cron="* * * * *",
+            timezone="UTC",
+            next_run_at=(NOW - timedelta(seconds=1)).isoformat(),
+            enabled=True,
+        )
+
+    loop = SchedulerLoop(
+        db,
+        handlers={"reminder": handler},
+        clock=lambda: clock["now"],
+        missed_fire_grace_seconds=60.0,
+    )
+    original = loop._report_lateness_cause
+
+    def spy(task, task_type, now):
+        cause = original(task, task_type, now)
+        causes.append((task["title"], cause))
+        return cause
+
+    loop._report_lateness_cause = spy
+    loop._running_since = NOW - timedelta(hours=1)
+    loop.queue.load()
+    asyncio.run(loop.tick())
+
+    # First tick: both are within grace, nothing late yet.
+    assert causes == [("slow", None), ("blocked", None)]
+
+    # The next tick sees "blocked" owed for an occurrence the loop was
+    # demonstrably present for, ten minutes late because of the handler
+    # ahead of it. Pre-fix this was indistinguishable from the app having
+    # been closed, and was shown to the user as such.
+    causes.clear()
+    loop.queue.load()
+    asyncio.run(loop.tick())
+
+    assert causes, "the second tick dispatched nothing"
+    assert all(cause == "busy" for _, cause in causes if cause is not None), causes
+    assert any(cause == "busy" for _, cause in causes), (
+        f"the loop-blocked dispatch was not attributed in-process: {causes}"
+    )
+
+
+def test_run_records_running_since_and_stop_clears_it(db):
+    """The attribution is only sound if this bookkeeping is."""
+
+    async def handler(task):
+        return None
+
+    loop = _loop(db, now=NOW, handler=handler)
+    assert loop._running_since is None
+
+    async def drive():
+        task = asyncio.create_task(loop.run())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        loop.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(drive())
+    assert loop._running_since is None, "stop() must clear the running window"
+
+
+def test_a_manual_run_is_not_attributed_as_loop_blocking(db):
+    """"Run now" on an overdue task is late by the user's choice.
+
+    `run_reminder_now` shares the dispatch seam with `tick`, so without the
+    `scheduled=False` opt-out every manual run of an overdue reminder would
+    log a loop-blocking warning that describes something that did not
+    happen.
+    """
+    reported: list[str] = []
+
+    async def handler(task):
+        return None
+
+    task_id = _hourly(db, next_run_at=NOW - timedelta(hours=2), title="manual")
+    loop = _loop(db, now=NOW, handler=handler)
+    loop._running_since = NOW - timedelta(hours=3)
+    loop._report_lateness_cause = lambda *args: reported.append(args[0]["title"])
+    loop.queue.load()
+
+    assert asyncio.run(loop.run_reminder_now(task_id)) is True
+    assert reported == [], (
+        f"a manual run was attributed as scheduler lateness: {reported}"
+    )

--- a/Tests/Scheduling/test_scheduler_lateness_cause.py
+++ b/Tests/Scheduling/test_scheduler_lateness_cause.py
@@ -20,7 +20,12 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
-from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
+from tldw_chatbook.Scheduling.scheduler.loop import (
+    LATENESS_CAUSE_AWAY,
+    LATENESS_CAUSE_BUSY,
+    LATENESS_CAUSE_STALLED,
+    SchedulerLoop,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -74,7 +79,7 @@ def test_a_late_dispatch_while_the_scheduler_runs_is_reported_as_busy(db):
     loop._last_tick_dispatch_seconds = 600.0
     row = db.get_reminder_task(task_id)
 
-    assert loop._report_lateness_cause(row, "reminder", NOW) == "busy"
+    assert loop._report_lateness_cause(row, "reminder", NOW) == LATENESS_CAUSE_BUSY
 
 
 def test_a_suspended_process_is_not_blamed_on_a_handler(db):
@@ -98,7 +103,7 @@ def test_a_suspended_process_is_not_blamed_on_a_handler(db):
     loop._last_tick_dispatch_seconds = 0.0  # nothing ran; nothing blocked
     row = db.get_reminder_task(task_id)
 
-    assert loop._report_lateness_cause(row, "reminder", NOW) == "stalled"
+    assert loop._report_lateness_cause(row, "reminder", NOW) == LATENESS_CAUSE_STALLED
 
 
 def test_the_tick_records_how_long_its_handlers_held_the_loop(db):
@@ -174,11 +179,11 @@ def test_a_late_dispatch_after_a_restart_is_reported_as_away(db):
     loop._running_since = NOW - timedelta(minutes=1)
     row = db.get_reminder_task(task_id)
 
-    assert loop._report_lateness_cause(row, "reminder", NOW) == "away"
+    assert loop._report_lateness_cause(row, "reminder", NOW) == LATENESS_CAUSE_AWAY
 
 
 def test_a_never_started_loop_reports_away(db):
-    """`_running_since` is None before `run()` and after `stop()`."""
+    """`_running_since` is None before `run()` and after `run()` returns."""
 
     async def handler(task):
         return None
@@ -188,7 +193,7 @@ def test_a_never_started_loop_reports_away(db):
     row = db.get_reminder_task(task_id)
 
     assert loop._running_since is None
-    assert loop._report_lateness_cause(row, "reminder", NOW) == "away"
+    assert loop._report_lateness_cause(row, "reminder", NOW) == LATENESS_CAUSE_AWAY
 
 
 def test_an_on_time_dispatch_reports_no_lateness_at_all(db):
@@ -265,14 +270,25 @@ def test_head_of_line_blocking_produces_the_busy_attribution(db):
     asyncio.run(loop.tick())
 
     assert causes, "the second tick dispatched nothing"
-    assert all(cause == "busy" for _, cause in causes if cause is not None), causes
-    assert any(cause == "busy" for _, cause in causes), (
+    assert all(
+        cause == LATENESS_CAUSE_BUSY for _, cause in causes if cause is not None
+    ), causes
+    assert any(cause == LATENESS_CAUSE_BUSY for _, cause in causes), (
         f"the loop-blocked dispatch was not attributed in-process: {causes}"
     )
 
 
-def test_run_records_running_since_and_stop_clears_it(db):
-    """The attribution is only sound if this bookkeeping is."""
+def test_run_records_running_since_and_the_loops_exit_clears_it(db):
+    """The attribution is only sound if this bookkeeping is.
+
+    `stop()` is a *request*: `app.py` calls it and only then cancels the
+    worker, so the loop is still running when it returns. The window is
+    therefore closed where the loop actually leaves it -- `run()`'s `finally`
+    -- and not in `stop()`, which would make the loop look absent while it was
+    demonstrably still dispatching (see
+    `test_stop_during_an_in_flight_tick_is_not_reported_as_away`).
+    """
+    observed: dict[str, object] = {}
 
     async def handler(task):
         return None
@@ -284,7 +300,9 @@ def test_run_records_running_since_and_stop_clears_it(db):
         task = asyncio.create_task(loop.run())
         await asyncio.sleep(0)
         await asyncio.sleep(0)
+        observed["while_running"] = loop._running_since
         loop.stop()
+        observed["after_stop"] = loop._running_since
         task.cancel()
         try:
             await task
@@ -292,7 +310,77 @@ def test_run_records_running_since_and_stop_clears_it(db):
             pass
 
     asyncio.run(drive())
-    assert loop._running_since is None, "stop() must clear the running window"
+    assert observed["while_running"] is not None, "run() must open the window"
+    assert observed["after_stop"] is not None, (
+        "stop() must not close the running window while the loop is still in "
+        "run(): a dispatch in the tick already under way would be attributed "
+        "to an absent scheduler"
+    )
+    assert loop._running_since is None, "leaving run() must close the window"
+
+
+def test_stop_during_an_in_flight_tick_is_not_reported_as_away(db):
+    """Shutdown must not turn a running scheduler into an absent one.
+
+    Review of PR #1964 (Qodo). `app.py` calls `scheduler_loop.stop()` and only
+    then cancels the worker, so `stop()` lands while a tick may still be
+    walking its due list. `_report_lateness_cause` treats
+    `_running_since is None` as proof the scheduler was away -- so a `stop()`
+    that cleared it immediately made every remaining dispatch in that same
+    tick report `away`, for a loop that is visibly right there dispatching it.
+
+    This is the same defect class the earlier review caught (a suspended
+    machine with zero handler time reported as `busy`): a cause asserted from
+    something other than evidence the loop actually holds. Both tasks below
+    are equally overdue and dispatched by the same live tick; the only thing
+    that changes between them is that `stop()` ran in between.
+    """
+    causes: list[tuple[str, str | None]] = []
+
+    async def handler(task):
+        if task["title"] == "stopper":
+            loop.stop()
+        return None
+
+    # Both overdue by ~10 minutes at tick start -- far past the 60 s grace --
+    # so both are late before anything in this tick runs. "stopper" sorts
+    # first because it is owed longer.
+    for seconds_late, title in ((601, "stopper"), (600, "after-stop")):
+        db.create_reminder_task(
+            owner_id="local",
+            title=title,
+            schedule_kind="recurring",
+            cron="* * * * *",
+            timezone="UTC",
+            next_run_at=(NOW - timedelta(seconds=seconds_late)).isoformat(),
+            enabled=True,
+        )
+
+    loop = _loop(db, now=NOW, handler=handler)
+    original = loop._report_lateness_cause
+
+    def spy(task, task_type, now):
+        cause = original(task, task_type, now)
+        causes.append((task["title"], cause))
+        return cause
+
+    loop._report_lateness_cause = spy
+    # The loop has been up for hours: no dispatch in this tick can honestly be
+    # blamed on an absent scheduler.
+    loop._running_since = NOW - timedelta(hours=3)
+    loop.queue.load()
+    asyncio.run(loop.tick())
+
+    assert [title for title, _ in causes] == ["stopper", "after-stop"], causes
+    reported = dict(causes)
+    assert reported["stopper"] == LATENESS_CAUSE_STALLED, causes
+    assert reported["after-stop"] != LATENESS_CAUSE_AWAY, (
+        "a dispatch made by a live tick was attributed to an absent scheduler "
+        f"because stop() ran earlier in the same tick: {causes}"
+    )
+    assert reported["after-stop"] == LATENESS_CAUSE_STALLED, (
+        f"the two identical dispatches disagree only because of stop(): {causes}"
+    )
 
 
 def test_a_manual_run_is_not_attributed_as_loop_blocking(db):

--- a/Tests/Subscriptions/test_subscriptions_db_connection_lifecycle.py
+++ b/Tests/Subscriptions/test_subscriptions_db_connection_lifecycle.py
@@ -29,9 +29,12 @@ closed:
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
@@ -180,49 +183,159 @@ def test_close_forgets_the_connection_it_closed(db):
     assert threading.get_ident() not in db._connections
 
 
+@contextmanager
+def _worker_holding_a_connection(db):
+    """A worker thread that opens a connection and stays alive inside the block.
+
+    The thread is held open deliberately (review of PR #1964). Joining it first
+    would prove nothing about "connections other threads still have open": an
+    exited thread's connection is now closed and de-registered by
+    `_ThreadExitCleanup`, so an assertion made after `join()` would be
+    asserting the leak rather than the contract.
+    """
+    opened = threading.Event()
+    release = threading.Event()
+    failure: list[BaseException] = []
+
+    def worker():
+        try:
+            db.conn.execute("SELECT 1").fetchone()
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            failure.append(exc)
+        finally:
+            opened.set()
+        release.wait(10)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    try:
+        assert opened.wait(10), "worker never opened its connection"
+        assert not failure, failure
+        yield thread
+    finally:
+        release.set()
+        thread.join(10)
+        assert not thread.is_alive()
+
+
 def test_the_connection_registry_sees_worker_threads(db):
     """`threading.local` is invisible from outside; the registry is not.
 
     This is what makes the leak countable at all: before task-19562 nothing
     could observe that a worker thread had opened a connection.
     """
-    def touch():
+    with _worker_holding_a_connection(db) as worker:
+        assert len(db._connections) >= 1
+        assert worker.ident in db._connections
+
+
+def _round_of_short_lived_threads(db, count: int = 5) -> list[int]:
+    """Open a connection on `count` concurrent threads, then let them all exit.
+
+    Concurrent on purpose: a sequential start/join loop recycles thread idents,
+    so each registry entry overwrites the last and the retention is invisible.
+    That is not hypothetical -- the first run of the measurement behind this
+    test showed no growth for exactly that reason.
+    """
+    ready = threading.Barrier(count + 1)
+    release = threading.Event()
+    idents: list[int] = []
+    lock = threading.Lock()
+
+    def worker():
         db.conn.execute("SELECT 1").fetchone()
+        with lock:
+            idents.append(threading.get_ident())
+        ready.wait(30)
+        release.wait(30)
 
-    worker = threading.Thread(target=touch)
-    worker.start()
-    worker.join(5)
+    threads = [threading.Thread(target=worker) for _ in range(count)]
+    for thread in threads:
+        thread.start()
+    ready.wait(30)
+    release.set()
+    for thread in threads:
+        thread.join(30)
+        assert not thread.is_alive()
+    return idents
 
-    assert len(db._connections) >= 1
-    assert worker.ident in db._connections
+
+@pytest.mark.skipif(
+    not Path("/dev/fd").is_dir(), reason="descriptor census needs /dev/fd"
+)
+def test_threads_that_exit_leave_no_connection_behind(db, tmp_path):
+    """The registry must not outlive the threads whose connections it holds.
+
+    Review of PR #1964. `_connections` keeps a STRONG reference and `close()`
+    removes only the *calling* thread's entry, so a worker that ended without
+    calling `close()` left its connection pinned for the life of the process --
+    descriptor and WAL lock included, and unreclaimable even by `gc.collect()`.
+    Measured over five rounds of ten threads before the fix, descriptors on the
+    database climbed 23 -> 43 -> 63 -> 83 and `close_all_connections()` still
+    reported ten open; after it, every round settled back to the same registry
+    size and the same descriptor count.
+
+    `_ThreadExitCleanup` does the closing on the dying thread, which is the
+    only thread sqlite3 permits to close that connection.
+
+    The descriptor count does not return to the pre-thread baseline and is not
+    asserted to: SQLite's unix VFS keeps closed descriptors for an inode in a
+    reuse pool while any connection to that file is still open (they are
+    released together when the last one closes -- see
+    `test_close_all_connections_settles_the_file_and_reports_the_rest`). What
+    must hold is that a second round costs nothing more than the first.
+    """
+    db_file = tmp_path / "subs.db"
+    db.conn.execute("SELECT 1").fetchone()
+    registry_before = len(db._connections)
+
+    first_idents = _round_of_short_lived_threads(db)
+    assert len(set(first_idents)) == 5, "threads did not run concurrently"
+    assert len(db._connections) == registry_before, (
+        f"exited threads are still registered: {db._connections.keys()}"
+    )
+    assert not any(ident in db._connections for ident in first_idents)
+    settled_after_first = _descriptors_on(db_file)
+
+    _round_of_short_lived_threads(db)
+    assert len(db._connections) == registry_before
+    assert _descriptors_on(db_file) <= settled_after_first, (
+        "descriptors on the database grew with a second round of short-lived "
+        f"threads: {settled_after_first} -> {_descriptors_on(db_file)}"
+    )
+
+
+def _descriptors_on(path: Path) -> int:
+    """How many descriptors this process holds on `path`, compared by inode."""
+    target = path.stat()
+    count = 0
+    for entry in os.listdir("/dev/fd"):
+        try:
+            info = os.stat(f"/dev/fd/{entry}")
+        except OSError:
+            continue
+        if info.st_dev == target.st_dev and info.st_ino == target.st_ino:
+            count += 1
+    return count
 
 
 def test_close_all_connections_settles_the_file_and_reports_the_rest(db, tmp_path):
     """Shutdown: checkpoint for everyone, close what this thread may close."""
-    opened = threading.Event()
+    with _worker_holding_a_connection(db):
+        for index in range(300):
+            db.add_subscription(
+                name=f"s{index}", type="rss", source=f"https://e.invalid/{index}.xml"
+            )
 
-    def worker():
-        db.conn.execute("SELECT 1").fetchone()
-        opened.set()
+        remaining = db.close_all_connections()
 
-    thread = threading.Thread(target=worker)
-    thread.start()
-    thread.join(5)
-    assert opened.is_set()
-
-    for index in range(300):
-        db.add_subscription(
-            name=f"s{index}", type="rss", source=f"https://e.invalid/{index}.xml"
+        assert _wal_bytes(tmp_path) == 0, "shutdown left an un-checkpointed -wal"
+        assert remaining == 1, (
+            "the live worker thread's connection should be reported as still "
+            "open -- sqlite3 refuses a cross-thread close, got "
+            f"{remaining}"
         )
-
-    remaining = db.close_all_connections()
-
-    assert _wal_bytes(tmp_path) == 0, "shutdown left an un-checkpointed -wal"
-    assert remaining == 1, (
-        "the worker thread's connection should be reported as still open -- "
-        f"sqlite3 refuses a cross-thread close, got {remaining}"
-    )
-    assert threading.get_ident() not in db._connections
+        assert threading.get_ident() not in db._connections
 
 
 def test_a_cross_thread_close_is_refused_by_sqlite(db):

--- a/Tests/Subscriptions/test_subscriptions_db_connection_lifecycle.py
+++ b/Tests/Subscriptions/test_subscriptions_db_connection_lifecycle.py
@@ -1,0 +1,356 @@
+"""The subscriptions DB must settle its connections and its `-wal` (task-19562).
+
+Two separate defects from the same lane, both about a connection nobody ever
+closed:
+
+* **`busy_timeout` was never set** -- the connection inherited Python's 5 s
+  default. The task demanded this be *measured, not assumed*, so
+  `test_busy_timeout_is_set_explicitly` pins the value and
+  `test_a_writer_collision_really_waits` reproduces the collision it was
+  worried about. The measurement (1.0 s lock held -> 1.07 s wait, then the
+  lock acquired) confirmed the lane's PLAUSIBLE rating. What it also showed
+  is that this pragma is not itself a *fix*: 5000 is what the connection
+  already had, and lowering it would only turn a stall into an earlier
+  `database is locked`. It is pinned so it cannot drift silently.
+
+* **the connection was never closed and the `-wal` never checkpointed.**
+  `SubscriptionsDB` keeps thread-local connections, so every worker thread
+  that touched it opened one and nothing ever closed any of them. Measured
+  on a real database: 4.1 MB of `-wal` after 300 inserts, 0 bytes after one
+  `wal_checkpoint(TRUNCATE)`. One half of that concern was **refuted by
+  measurement** and is recorded rather than quietly fixed: a child process
+  that wrote a 4.1 MB `-wal` and exited normally left only `subs.db`
+  behind, with the exit hook suppressed exactly as with it enabled --
+  CPython finalizes the connections and SQLite removes the `-wal` on last
+  close. What remains real is the *standing* 4 MB a long-running app
+  carries, and the `os._exit(0)` signal path, which no `atexit` hook can
+  reach (task-19561).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import BUSY_TIMEOUT_MS, SubscriptionsDB
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def db(tmp_path):
+    """A file-backed database -- `:memory:` has no `-wal` to test."""
+    database = SubscriptionsDB(tmp_path / "subs.db", "test")
+    yield database
+    try:
+        database.close()
+    except Exception:
+        pass
+
+
+def _wal_bytes(tmp_path) -> int:
+    wal = tmp_path / "subs.db-wal"
+    return wal.stat().st_size if wal.exists() else 0
+
+
+def test_busy_timeout_is_set_explicitly(db):
+    """The value, pinned.
+
+    On its own this assertion is weak and says so: 5000 is also what
+    `sqlite3.connect(timeout=5.0)` gives you for free, so it would pass with
+    the pragma deleted. `test_busy_timeout_survives_a_connector_default_change`
+    is the one that can actually fail.
+    """
+    assert db.conn.execute("PRAGMA busy_timeout").fetchone()[0] == BUSY_TIMEOUT_MS
+
+
+def test_busy_timeout_survives_a_connector_default_change(tmp_path, monkeypatch):
+    """The pragma must win over whatever the connector passes.
+
+    This is the whole point of writing the value down instead of inheriting
+    it: the lock-wait budget is a property of THIS database, not a leftover
+    of `sqlite3.connect`'s default. Red with the pragma removed -- the
+    connection then reports the connector's 0 ms and a contended write
+    raises `database is locked` immediately instead of waiting.
+    """
+    from tldw_chatbook.DB import base_db
+
+    original = base_db.connect_private_sqlite
+
+    def connect_with_no_wait(*args, **kwargs):
+        kwargs["timeout"] = 0
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(base_db, "connect_private_sqlite", connect_with_no_wait)
+
+    database = SubscriptionsDB(tmp_path / "nowait.db", "test")
+    try:
+        assert (
+            database.conn.execute("PRAGMA busy_timeout").fetchone()[0]
+            == BUSY_TIMEOUT_MS
+        )
+    finally:
+        database.close()
+
+
+def test_journal_mode_is_wal_so_readers_never_wait_on_writers(db):
+    """The narrowing that shaped the fix: the exposure is writer-vs-writer.
+
+    Under WAL a reader is never blocked by a writer, so the read-only
+    service methods cannot be *stalled* by a concurrent write -- they only
+    block the loop for their own duration, which is what the offload fixes.
+    """
+    assert db.conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+
+
+def test_a_writer_collision_really_waits(db):
+    """The measurement the AC asked for, as a test rather than a claim."""
+    holder_ready = threading.Event()
+    release = threading.Event()
+
+    def holder():
+        held = db._get_connection()
+        held.execute("BEGIN IMMEDIATE")
+        holder_ready.set()
+        release.wait(10)
+        held.rollback()
+        held.close()
+
+    worker = threading.Thread(target=holder, daemon=True)
+    worker.start()
+    assert holder_ready.wait(5)
+
+    second = db._get_connection()
+    started = time.monotonic()
+    threading.Timer(0.3, release.set).start()
+    try:
+        second.execute("BEGIN IMMEDIATE")
+        waited = time.monotonic() - started
+        second.rollback()
+    finally:
+        second.close()
+        worker.join(5)
+
+    assert waited >= 0.25, (
+        "the second writer did not wait for the lock at all -- either the "
+        f"collision was not real or busy_timeout is 0 (waited {waited:.3f}s)"
+    )
+
+
+def test_close_checkpoints_and_truncates_the_wal(db, tmp_path):
+    """The leak's visible half: a `-wal` left behind with content in it.
+
+    A second connection is deliberately held open throughout. Without one,
+    this test would be inert: SQLite checkpoints and *deletes* the `-wal`
+    by itself when the LAST connection to a database closes, so
+    `_wal_bytes() == 0` would pass with the checkpoint removed -- it would
+    be measuring sqlite's own cleanup rather than ours. The held connection
+    is exactly the leaked worker connection this task is about, and it is
+    what keeps the file on disk for the assertion to mean something.
+    """
+    other = db._get_connection()
+    try:
+        for index in range(300):
+            db.add_subscription(
+                name=f"s{index}", type="rss", source=f"https://e.invalid/{index}.xml"
+            )
+        assert _wal_bytes(tmp_path) > 0, "nothing was written to the WAL to settle"
+
+        db.close()
+
+        assert (tmp_path / "subs.db-wal").exists(), (
+            "the -wal vanished, so this assertion is measuring sqlite's "
+            "last-connection cleanup, not close()'s checkpoint"
+        )
+        assert _wal_bytes(tmp_path) == 0, (
+            "close() left content in the -wal; it was never checkpointed"
+        )
+    finally:
+        other.close()
+
+
+def test_close_forgets_the_connection_it_closed(db):
+    """A registry that reports closed connections would be worse than none."""
+    db.conn  # open one on this thread
+    assert threading.get_ident() in db._connections
+    db.close()
+    assert threading.get_ident() not in db._connections
+
+
+def test_the_connection_registry_sees_worker_threads(db):
+    """`threading.local` is invisible from outside; the registry is not.
+
+    This is what makes the leak countable at all: before task-19562 nothing
+    could observe that a worker thread had opened a connection.
+    """
+    def touch():
+        db.conn.execute("SELECT 1").fetchone()
+
+    worker = threading.Thread(target=touch)
+    worker.start()
+    worker.join(5)
+
+    assert len(db._connections) >= 1
+    assert worker.ident in db._connections
+
+
+def test_close_all_connections_settles_the_file_and_reports_the_rest(db, tmp_path):
+    """Shutdown: checkpoint for everyone, close what this thread may close."""
+    opened = threading.Event()
+
+    def worker():
+        db.conn.execute("SELECT 1").fetchone()
+        opened.set()
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(5)
+    assert opened.is_set()
+
+    for index in range(300):
+        db.add_subscription(
+            name=f"s{index}", type="rss", source=f"https://e.invalid/{index}.xml"
+        )
+
+    remaining = db.close_all_connections()
+
+    assert _wal_bytes(tmp_path) == 0, "shutdown left an un-checkpointed -wal"
+    assert remaining == 1, (
+        "the worker thread's connection should be reported as still open -- "
+        f"sqlite3 refuses a cross-thread close, got {remaining}"
+    )
+    assert threading.get_ident() not in db._connections
+
+
+def test_a_cross_thread_close_is_refused_by_sqlite(db):
+    """Why `close_all_connections` reports instead of closing.
+
+    Pinned as a fact about the runtime, not an opinion about the design: if
+    a future Python allows this, the reporting compromise can be revisited
+    and this test is what will say so.
+    """
+    made: dict[str, sqlite3.Connection] = {}
+
+    def maker():
+        made["conn"] = db._get_connection()
+
+    thread = threading.Thread(target=maker)
+    thread.start()
+    thread.join(5)
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        made["conn"].close()
+
+
+def test_checkpoint_declines_inside_an_open_transaction(db):
+    """It must never commit a caller's half-finished unit of work."""
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+            ("mid", "rss", "https://e.invalid/mid.xml"),
+        )
+        assert db.checkpoint_wal() is False
+
+
+def test_an_in_memory_database_has_nothing_to_checkpoint(tmp_path):
+    """No `-wal` exists, and the connection IS the database."""
+    memory_db = SubscriptionsDB(":memory:", "test")
+    assert memory_db.checkpoint_wal() is False
+    memory_db.close()
+
+
+def test_a_writable_database_registers_for_the_exit_hook(tmp_path):
+    """The hook can only settle databases it knows about."""
+    from tldw_chatbook.DB import Subscriptions_DB as module
+
+    database = SubscriptionsDB(tmp_path / "registered.db", "test")
+    try:
+        assert database in set(module._OPEN_SUBSCRIPTIONS_DBS)
+    finally:
+        database.close()
+
+
+def test_an_in_memory_database_does_not_register(tmp_path):
+    """It has no `-wal`, and it ceases to exist with its connection."""
+    from tldw_chatbook.DB import Subscriptions_DB as module
+
+    database = SubscriptionsDB(":memory:", "test")
+    try:
+        assert database not in set(module._OPEN_SUBSCRIPTIONS_DBS)
+    finally:
+        database.close()
+
+
+def test_the_exit_hook_settles_a_registered_database(tmp_path):
+    """The hook body, exercised directly.
+
+    Measured caveat recorded in the hook's own docstring: on a clean
+    process exit CPython finalizes the connections and SQLite removes the
+    `-wal` by itself, so this hook is not what saves the file there. It is
+    tested here for what it actually does -- settle at a defined moment,
+    with a defined error path -- rather than assumed to be doing more.
+    """
+    from tldw_chatbook.DB import Subscriptions_DB as module
+
+    database = SubscriptionsDB(tmp_path / "hooked.db", "test")
+    other = database._get_connection()  # keeps the -wal on disk to inspect
+    try:
+        for index in range(300):
+            database.add_subscription(
+                name=f"s{index}", type="rss", source=f"https://e.invalid/{index}.xml"
+            )
+        wal = tmp_path / "hooked.db-wal"
+        assert wal.stat().st_size > 0
+
+        module._checkpoint_open_databases_at_exit()
+
+        assert wal.exists() and wal.stat().st_size == 0
+    finally:
+        other.close()
+        database.close()
+
+
+def test_the_exit_hook_never_raises(tmp_path, monkeypatch):
+    """A diagnostic must not be what breaks the exit."""
+    from tldw_chatbook.DB import Subscriptions_DB as module
+
+    database = SubscriptionsDB(tmp_path / "boom.db", "test")
+
+    def explode():
+        raise RuntimeError("shutdown is a bad time to raise")
+
+    monkeypatch.setattr(database, "close_all_connections", explode)
+    module._checkpoint_open_databases_at_exit()  # must not raise
+    database.close()
+
+
+def test_the_exit_hook_stays_silent_when_the_database_file_is_gone(
+    tmp_path, capsys, monkeypatch
+):
+    """A settle at teardown must not try to log to a closed sink.
+
+    The incident this pins: the first version of the hook hit a temporary
+    database directory that pytest had already removed, and the resulting
+    `logger.warning` raised `ValueError: I/O operation on closed file`,
+    printing a logging traceback on every exit. The diagnostic became the
+    failure.
+    """
+    from tldw_chatbook.DB import Subscriptions_DB as module
+
+    target = tmp_path / "vanishing.db"
+    database = SubscriptionsDB(target, "test")
+    database.conn.execute("SELECT 1").fetchone()
+    database.close()
+    for leftover in tmp_path.glob("vanishing.db*"):
+        leftover.unlink()
+
+    monkeypatch.setattr(module, "_INTERPRETER_EXITING", False)
+    module._checkpoint_open_databases_at_exit()
+
+    assert module._INTERPRETER_EXITING is True, (
+        "the hook must announce the exit so the settle path stops logging"
+    )
+    assert not target.exists(), "the hook re-created a database it should skip"

--- a/Tests/Subscriptions/test_subscriptions_transaction_nesting.py
+++ b/Tests/Subscriptions/test_subscriptions_transaction_nesting.py
@@ -5,10 +5,21 @@ self.transaction()` durably committed the OUTER transaction's work too: a
 later failure in the outer scope could no longer roll back what the inner
 block had already written. Silent partial persistence, no error anywhere.
 
-Recorded for accuracy: the call site the task named (`record_check_result`)
-was instrumented and found NOT to nest -- observed depth 1. The hazard was
-latent, not live. These tests make it structurally impossible instead of
-relying on nobody ever nesting.
+Recorded for accuracy, replacing an earlier claim in this docstring that
+`record_check_result` did NOT nest ("observed depth 1"). Re-instrumented per
+argument shape, it does:
+
+    record_check_result WITH stats    -> 2 entries, depths [1, 2]
+    record_check_result WITHOUT stats -> 1 entry,  depths [1]
+
+The route is `record_check_result` -> `_update_subscription_stats` ->
+`update_subscription_stats`, which opens its own transaction for the
+`subscription_stats` upsert, and `execute_run` always passes stats. The
+earlier measurement can only have taken the `stats=None` path. So the hazard
+was **live**, not latent -- the daily-statistics write was committing the
+enclosing subscription-health UPDATE -- and
+`test_record_check_result_with_stats_is_one_atomic_unit` below pins the real
+call site, not just a synthetic one.
 """
 
 from __future__ import annotations
@@ -107,3 +118,75 @@ def test_unnested_transactions_are_unchanged(db):
             )
             raise RuntimeError("boom")
     assert "doomed" not in _names(db)
+
+
+def test_record_check_result_with_stats_really_nests(db, monkeypatch):
+    """The live call site, measured -- not assumed either way.
+
+    The task rated this LATENT on the strength of an instrumentation that
+    saw depth 1. That measurement took the `stats=None` path;
+    `execute_run` never does. Pinning the observed depths here means the
+    next person does not have to re-derive which branch nests.
+    """
+    from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+
+    source_id = db.add_subscription(
+        name="s", type="rss", source="https://e.invalid/f.xml"
+    )
+    depths: list[int] = []
+    original = SubscriptionsDB.transaction
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def traced(self):
+        depths.append(getattr(self._local, "transaction_depth", 0) + 1)
+        with original(self) as conn:
+            yield conn
+
+    monkeypatch.setattr(SubscriptionsDB, "transaction", traced)
+
+    db.record_check_result(source_id, stats={"response_time_ms": 5})
+    assert depths == [1, 2], (
+        f"expected record_check_result to nest via the statistics upsert, "
+        f"observed depths {depths}"
+    )
+
+    depths.clear()
+    db.record_check_result(source_id, stats=None)
+    assert depths == [1], (
+        "the stats=None path does NOT nest -- this is the branch the "
+        f"original 'does not nest' measurement must have taken: {depths}"
+    )
+
+
+def test_record_check_result_with_stats_is_one_atomic_unit(db):
+    """A failure after the nested statistics write must undo it.
+
+    Red against the unnested context manager: the inner
+    `update_subscription_stats` commit persists the `subscription_stats` row
+    (and the health UPDATE with it), so the rollback below finds nothing to
+    undo.
+    """
+    source_id = db.add_subscription(
+        name="s", type="rss", source="https://e.invalid/f.xml"
+    )
+
+    with pytest.raises(RuntimeError):
+        with db.transaction() as conn:
+            db.record_check_result(source_id, stats={"response_time_ms": 5})
+            conn.execute(
+                "INSERT INTO subscriptions (name, type, source) VALUES (?,?,?)",
+                ("sibling", "rss", "https://e.invalid/sibling.xml"),
+            )
+            raise RuntimeError("the enclosing unit of work fails")
+
+    rows = db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_stats WHERE subscription_id = ?",
+        (source_id,),
+    ).fetchone()
+    assert rows[0] == 0, (
+        "the nested statistics write survived a failure in the enclosing "
+        "transaction: record_check_result's inner commit ended the outer one"
+    )
+    assert "sibling" not in _names(db)

--- a/Tests/Subscriptions/test_watchlist_feed_api_in_flight_guard.py
+++ b/Tests/Subscriptions/test_watchlist_feed_api_in_flight_guard.py
@@ -214,3 +214,92 @@ async def test_a_failed_feed_check_releases_the_guard(tmp_path, monkeypatch):
         "the next check never ran: the failed check stranded the in-flight "
         "claim"
     )
+
+
+class _RecordingDispatcher:
+    """The real notification seam, counted.
+
+    `LocalWatchlistsService._dispatch_alert_notification` calls
+    `dispatcher.dispatch(...)` once per triggered alert rule, so counting
+    calls here counts exactly what the user would see arrive in their
+    notification inbox.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def dispatch(self, **kwargs) -> dict:
+        self.calls.append(dict(kwargs))
+        return {"id": len(self.calls)}
+
+
+def _stats_row(db: SubscriptionsDB, source_id: int) -> dict:
+    """Today's `subscription_stats` aggregate for one source, as a dict."""
+    row = db.conn.execute(
+        "SELECT checks_performed, successful_checks, new_items_found, "
+        "items_ingested FROM subscription_stats WHERE subscription_id = ?",
+        (source_id,),
+    ).fetchone()
+    return dict(row) if row is not None else {}
+
+
+@pytest.mark.asyncio
+async def test_overlapping_feed_check_alerts_once_and_counts_statistics_once(
+    tmp_path, monkeypatch
+):
+    """The user-visible consequence, asserted where the user would see it.
+
+    task-19562 AC2. The two earlier tests pin the *fetch* count; this one
+    pins the two things the task's description names as the symptom -- the
+    alert notification and the statistics -- because a guard that turned the
+    second entrant away but still let it travel the completion accounting
+    would pass those and still double-notify.
+
+    Red against the unguarded feed arm: two `dispatch` calls, and
+    `subscription_stats` reading checks_performed=2 / new_items_found=2 for
+    a single overlapping check.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="A feed", type="rss", source="https://example.com/feed.xml"
+    )
+    dispatcher = _RecordingDispatcher()
+    scheduler_service = LocalWatchlistsService(
+        db_factory=lambda: db, notification_dispatcher=dispatcher
+    )
+    ui_service = LocalWatchlistsService(
+        db_factory=lambda: db, notification_dispatcher=dispatcher
+    )
+    # Fires whenever a check ingests at least one item -- i.e. exactly once
+    # per check that really happened.
+    await scheduler_service.create_alert_rule(
+        name="New items",
+        condition_type="items_above",
+        condition_value={"threshold": 0},
+        source_id=source_id,
+    )
+
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    _gate_feed_checks(monkeypatch, gate, started)
+
+    scheduled = asyncio.create_task(_run_check(scheduler_service, source_id))
+    await asyncio.wait_for(started.wait(), timeout=10)
+    manual = asyncio.create_task(_run_check(ui_service, source_id))
+    await asyncio.sleep(0.25)  # deterministic: the first is gate-blocked
+    gate.set()
+    await asyncio.wait_for(scheduled, timeout=10)
+    await asyncio.wait_for(manual, timeout=10)
+
+    assert len(dispatcher.calls) == 1, (
+        f"the alert notification fired {len(dispatcher.calls)} times for one "
+        "overlapping check; the user is told twice about one set of items"
+    )
+
+    stats = _stats_row(db, source_id)
+    assert stats.get("checks_performed") == 1, (
+        f"statistics double-counted the overlap: {stats}"
+    )
+    assert stats.get("successful_checks") == 1, stats
+    assert stats.get("new_items_found") == 1, stats
+    assert stats.get("items_ingested") == 1, stats

--- a/Tests/Subscriptions/test_watchlists_service_no_blocking_db_io.py
+++ b/Tests/Subscriptions/test_watchlists_service_no_blocking_db_io.py
@@ -112,6 +112,44 @@ def _offloaded_call_nodes(tree: ast.AST) -> set[int]:
     return exempt
 
 
+def _loop_body_nodes(function: ast.AST) -> list[ast.AST]:
+    """Every node that actually runs on the event loop for this `async def`.
+
+    Descends the body but STOPS at a nested `def`/`async def`/`lambda`: a
+    synchronous closure defined inside an `async def` is an offload body --
+    the shape `run_db_off_loop` is handed -- so sqlite is exactly what it is
+    supposed to contain, and only the thread it lands on matters.
+
+    Review note (task-19562): this replaced an `ast.walk` loop that
+    `continue`d on a nested `FunctionDef`. `ast.walk` yields descendants
+    regardless, so that skipped the `def` node and then walked its body
+    anyway -- the guard rejected the correct offload shape:
+
+        async def list_sources(self):
+            db = self._db()
+            def work():
+                return db.get_all_subscriptions()   # <- was flagged
+            return await run_db_off_loop(db, work)
+
+    A guard that fails on correct code gets weakened by the next person, so
+    the exclusion is done by descent rather than by a `continue` that cannot
+    perform it.
+    """
+    collected: list[ast.AST] = []
+
+    def descend(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+            ):
+                continue
+            collected.append(child)
+            descend(child)
+
+    descend(function)
+    return collected
+
+
 def _blocking_db_calls_in_async_defs(source: str) -> list[str]:
     """Every direct database call reachable from an `async def` body."""
     tree = ast.parse(source)
@@ -121,11 +159,7 @@ def _blocking_db_calls_in_async_defs(source: str) -> list[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.AsyncFunctionDef):
             continue
-        for inner in ast.walk(node):
-            # A nested `def` inside an `async def` is an offload body, not
-            # loop code; skip its subtree.
-            if isinstance(inner, ast.FunctionDef) and inner is not node:
-                continue
+        for inner in _loop_body_nodes(node):
             if not isinstance(inner, ast.Call) or id(inner) in exempt:
                 continue
             if _db_rooted(inner.func):
@@ -174,6 +208,41 @@ def test_the_guard_accepts_the_offloaded_shape():
         "        return await run_db_off_loop(db, db.get_all_subscriptions)\n"
     )
     assert _blocking_db_calls_in_async_defs(accepted) == []
+
+
+def test_the_guard_accepts_a_nested_synchronous_offload_body():
+    """The other correct shape: a sync closure handed to the helper.
+
+    Review of task-19562. The guard used to flag this -- its walker
+    `continue`d on the nested `def` but `ast.walk` had already queued that
+    def's children, so the closure's sqlite was reported as loop code. A
+    guard that rejects the correct pattern is worse than no guard: it gets
+    deleted or loosened the first time someone writes the pattern.
+    """
+    accepted = (
+        "class S:\n"
+        "    async def list_sources(self):\n"
+        "        db = self._db()\n"
+        "        def work():\n"
+        "            return db.get_all_subscriptions()\n"
+        "        return await run_db_off_loop(db, work)\n"
+    )
+    assert _blocking_db_calls_in_async_defs(accepted) == []
+
+
+def test_the_guard_still_flags_an_inline_call_beside_a_nested_def():
+    """Excluding nested bodies must not blind the guard to its own scope."""
+    offending = (
+        "class S:\n"
+        "    async def list_sources(self):\n"
+        "        db = self._db()\n"
+        "        def work():\n"
+        "            return db.get_all_subscriptions()\n"
+        "        db.mark_all_read(1)\n"
+        "        return await run_db_off_loop(db, work)\n"
+    )
+    findings = _blocking_db_calls_in_async_defs(offending)
+    assert findings == ["list_sources (line 6): db.mark_all_read(...)"], findings
 
 
 def test_the_guard_sees_through_a_bare_connection_read():

--- a/Tests/Subscriptions/test_watchlists_service_no_blocking_db_io.py
+++ b/Tests/Subscriptions/test_watchlists_service_no_blocking_db_io.py
@@ -1,0 +1,193 @@
+"""No `async def` in the watchlists service may touch sqlite directly.
+
+task-19562 AC7. Part B moved 22 `async def` methods off the event loop by
+routing every synchronous `SubscriptionsDB` call through
+`db_offload.run_db_off_loop`. `Tests/Subscriptions/
+test_watchlists_service_off_loop.py` pins that per method, by behaviour --
+it proves the calls that exist today run on a worker thread. What it cannot
+do is fail when someone adds a *new* `async def` next month with a fresh
+inline `db.get_subscription(...)` in it: a per-method test only covers the
+methods it names.
+
+This is that guard. It parses the module and rejects any synchronous
+database call reached directly from an `async def` body, whatever the method
+is called. The check is structural, so it applies to code that does not exist
+yet -- which is the whole point.
+
+What counts as "directly": a `Call` whose attribute chain is rooted at a
+value this module knows to be a database -- the `db` local produced by
+`self._db()`, a parameter annotated `SubscriptionsDB`, or anything derived
+from one (`db.conn`, a cursor taken from it). Passing a *bound method* to the
+offload helper (`run_db_off_loop(db, db.get_subscription, source_id)`) is an
+`Attribute`, not a `Call`, so the correct shape is accepted by construction
+rather than by an exemption list.
+
+Synchronous helpers (`def`, not `async def`) are deliberately NOT checked:
+they are the bodies handed to `run_db_off_loop`, so sqlite is exactly what
+they are supposed to contain. The guard is about which *thread* the work
+lands on, and only an `async def` body runs on the event loop.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+import tldw_chatbook.Subscriptions.local_watchlists_service as service_module
+
+pytestmark = pytest.mark.unit
+
+SERVICE_PATH = pathlib.Path(service_module.__file__)
+
+#: The helper that makes a sqlite call legitimate inside an `async def`.
+OFFLOAD_HELPER = "run_db_off_loop"
+
+#: Names that are a `SubscriptionsDB` (or a cursor/connection taken from one)
+#: wherever they appear in this module. `db` is the near-universal local for
+#: `self._db()`; the others are the parameter names the offloaded helpers use.
+_DB_ROOT_NAMES = frozenset({"db", "database", "conn", "cursor"})
+
+
+def _attribute_root(node: ast.AST) -> str | None:
+    """The leftmost `Name` id of an attribute chain, or None.
+
+    `db.conn.execute` -> "db"; `self._db().get_subscription` -> None (the
+    chain is rooted at a Call, which `_call_roots_at_db` handles separately).
+    """
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _is_self_db_call(node: ast.AST) -> bool:
+    """True for `self._db()` -- the module's one way to obtain the database."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_db"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+    )
+
+
+def _db_rooted(func: ast.AST) -> bool:
+    """True when this call's receiver is (or came from) the database."""
+    if not isinstance(func, ast.Attribute):
+        return False
+    # `self._db().get_subscription(...)` -- the chain bottoms out in the
+    # accessor itself rather than in a name.
+    inner = func.value
+    while isinstance(inner, ast.Attribute):
+        inner = inner.value
+    if _is_self_db_call(inner):
+        return True
+    return _attribute_root(func) in _DB_ROOT_NAMES
+
+
+def _offloaded_call_nodes(tree: ast.AST) -> set[int]:
+    """Every node id sitting inside a `run_db_off_loop(...)` argument list.
+
+    A call passed as an *argument* to the offload helper is not executed on
+    the loop -- the helper is what runs it, on a worker thread. In practice
+    the arguments are bound methods rather than calls, but a lambda or an
+    inline expression there is equally offloaded, so the whole argument
+    subtree is exempt.
+    """
+    exempt: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = node.func.id if isinstance(node.func, ast.Name) else (
+            node.func.attr if isinstance(node.func, ast.Attribute) else None
+        )
+        if name != OFFLOAD_HELPER:
+            continue
+        for argument in [*node.args, *(kw.value for kw in node.keywords)]:
+            for inner in ast.walk(argument):
+                exempt.add(id(inner))
+    return exempt
+
+
+def _blocking_db_calls_in_async_defs(source: str) -> list[str]:
+    """Every direct database call reachable from an `async def` body."""
+    tree = ast.parse(source)
+    exempt = _offloaded_call_nodes(tree)
+    findings: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        for inner in ast.walk(node):
+            # A nested `def` inside an `async def` is an offload body, not
+            # loop code; skip its subtree.
+            if isinstance(inner, ast.FunctionDef) and inner is not node:
+                continue
+            if not isinstance(inner, ast.Call) or id(inner) in exempt:
+                continue
+            if _db_rooted(inner.func):
+                rendered = ast.unparse(inner.func)
+                findings.append(
+                    f"{node.name} (line {inner.lineno}): {rendered}(...)"
+                )
+    return findings
+
+
+def test_no_async_def_in_the_service_calls_sqlite_directly():
+    """The guard: a new `async def` doing inline sqlite fails this test."""
+    findings = _blocking_db_calls_in_async_defs(SERVICE_PATH.read_text())
+    assert findings == [], (
+        "these `async def` bodies call SubscriptionsDB directly, blocking the "
+        "event loop for the query's duration. Route the call through "
+        f"`{OFFLOAD_HELPER}` (see `Subscriptions/db_offload.py`):\n  "
+        + "\n  ".join(findings)
+    )
+
+
+def test_the_guard_detects_an_inline_call():
+    """The guard must be able to fail -- proven on a synthetic module.
+
+    Without this, `findings == []` above is indistinguishable from a checker
+    that never finds anything (the failure mode this repo has shipped before:
+    an inert guard that passes forever).
+    """
+    offending = (
+        "class S:\n"
+        "    async def list_sources(self):\n"
+        "        db = self._db()\n"
+        "        return db.get_all_subscriptions()\n"
+    )
+    assert _blocking_db_calls_in_async_defs(offending) == [
+        "list_sources (line 4): db.get_all_subscriptions(...)"
+    ]
+
+
+def test_the_guard_accepts_the_offloaded_shape():
+    """The correct shape must not be flagged, or the guard is unusable."""
+    accepted = (
+        "class S:\n"
+        "    async def list_sources(self):\n"
+        "        db = self._db()\n"
+        "        return await run_db_off_loop(db, db.get_all_subscriptions)\n"
+    )
+    assert _blocking_db_calls_in_async_defs(accepted) == []
+
+
+def test_the_guard_sees_through_a_bare_connection_read():
+    """`db.conn.execute(...)` is the shape the original AST sweep missed.
+
+    Three of the 22 methods (`get_alert_rule`, `list_runs`,
+    `list_alert_rules`) read through a bare `db.conn.cursor()` and were
+    invisible to a scan that only matched named `SubscriptionsDB` methods.
+    """
+    offending = (
+        "class S:\n"
+        "    async def list_runs(self):\n"
+        "        db = self._db()\n"
+        "        return db.conn.execute('SELECT 1').fetchall()\n"
+    )
+    findings = _blocking_db_calls_in_async_defs(offending)
+    assert findings and "list_runs" in findings[0], findings

--- a/Tests/UI/test_schedules_missed_notice.py
+++ b/Tests/UI/test_schedules_missed_notice.py
@@ -50,7 +50,7 @@ async def _notice_text(detail: TaskDetail) -> tuple[str, bool]:
 
 @pytest.mark.asyncio
 async def test_late_recurring_renders_notice_with_skipped_count():
-    """A missed-while-away recurring task shows the notice + exact count."""
+    """A late recurring task shows the notice + exact count."""
     async with _DetailHarnessApp().run_test() as pilot:
         detail = pilot.app.query_one(TaskDetail)
         detail.set_task(
@@ -63,7 +63,7 @@ async def test_late_recurring_renders_notice_with_skipped_count():
         await pilot.pause()
         text, visible = await _notice_text(detail)
         assert visible
-        assert "Missed while away" in text
+        assert "Ran late" in text
         assert "1 earlier occurrence(s) were skipped" in text
         assert "not replayed" in text
 
@@ -85,8 +85,8 @@ async def test_late_one_time_renders_notice_without_count():
         await pilot.pause()
         text, visible = await _notice_text(detail)
         assert visible
-        assert "Missed while away" in text
-        assert "occurrence ran late" in text
+        assert "Ran late" in text
+        assert "dispatched well after its scheduled time" in text
         assert "skipped" not in text
 
 
@@ -176,3 +176,38 @@ async def test_cleared_task_hides_notice():
         await pilot.pause()
         _, visible_after = await _notice_text(detail)
         assert not visible_after
+
+
+@pytest.mark.asyncio
+async def test_the_notice_never_claims_the_scheduler_was_not_running():
+    """task-19562: the app must not assert a cause it cannot know.
+
+    `SchedulerLoop.tick` awaits every due handler serially, so one slow
+    handler pushes the tasks behind it past the missed-fire grace while the
+    scheduler is running the whole time. The row that results is identical
+    to one from an app that was closed. The old copy -- "Missed while away
+    ... (the scheduler was not running at the scheduled time)" -- was
+    therefore false for an ordinary, reachable case.
+
+    Checked across every branch of the notice, because the false sentence
+    lived in only one of the three and a copy edit could easily restore it
+    in another.
+    """
+    forbidden = ("Missed while away", "was not running")
+    cases = (
+        dict(missed_at=NOW - timedelta(hours=2), missed_count=1),
+        dict(missed_at=NOW - timedelta(hours=2), missed_count=0),
+        dict(missed_at=NOW - timedelta(days=200), missed_count=-1),
+    )
+    async with _DetailHarnessApp().run_test() as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        for case in cases:
+            detail.set_task(_reminder(last_status=TaskStatus.COMPLETED, **case))
+            await pilot.pause()
+            text, visible = await _notice_text(detail)
+            assert visible
+            for phrase in forbidden:
+                assert phrase not in text, (
+                    f"the notice claims a cause the app cannot know: {text!r}"
+                )
+            assert "Ran late" in text

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6421,3 +6421,45 @@ argument's presence, probe **both** branches and record which is which; a
 single "instrumented a real call" line in a task file cannot be checked later
 by anyone, and this one was wrong in the direction that closes an
 investigation.
+
+## A sequential start/join thread loop hides per-thread leaks -- and "descriptors return to baseline" is the wrong assertion (PR #1964 review, 2026-08-22)
+
+**What happened.** Qodo found that `SubscriptionsDB._connections` held a
+strong reference to every thread's sqlite connection and only ever removed
+the *calling* thread's entry, so a worker that exited without calling
+`close()` pinned its connection -- descriptor and WAL lock -- for the life of
+the process. The first probe written to confirm it spawned 100 short-lived
+threads **one at a time** (`start(); join()`), and reported **no growth at
+all**: the registry stayed at 2 entries. The reason is that the OS recycles
+thread idents, so `self._connections[ident] = connection` overwrote the
+previous entry every iteration. The defect was real; the measurement designed
+to see it could not.
+
+Re-run with 20 threads held **concurrently** on a barrier, the same code gave
+registry 21 entries and 43 descriptors, permanently, and `gc.collect()` could
+not reclaim any of it (the sqlite3 statement cache is an `lru_cache` wrapping
+the connection, so every used connection sits in a reference cycle and is
+never freed by refcounting alone).
+
+Two further facts cost time and are worth writing down:
+
+* **`sqlite3.Connection` cannot be weak-referenced.** The obvious fix -- and
+  the one the review suggested -- is a `weakref.WeakValueDictionary`. CPython
+  3.12.11 raises `TypeError: cannot create weak reference to
+  'sqlite3.Connection' object`. Check weak-referenceability before designing
+  around it; C types often lack `tp_weaklistoffset`.
+* **Descriptors do not return to their pre-thread baseline even when every
+  connection is genuinely closed.** SQLite's unix VFS keeps closed
+  descriptors for an inode in a reuse pool while any connection to that file
+  remains open, releasing them together when the last one closes. Asserting
+  "fds back to baseline" would have failed against a correct fix. The
+  assertion that actually distinguishes fixed from broken is **"a second
+  round of threads costs no more descriptors than the first"**: fixed gave
+  13, 13, 13, 13, 13 over five rounds and 0 after the final close; broken
+  gave 23, 43, 63, 83.
+
+**What to do.** To measure anything keyed on thread identity, run the threads
+concurrently -- a sequential loop tests ident recycling, not your registry.
+And before asserting on file descriptors, establish what the *correct*
+steady state looks like by measuring a known-good control (here: the same
+code path with no registry at all), rather than assuming it is the baseline.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6355,3 +6355,69 @@ a defect in the product, a defect in the test, or a seam that moved. Only the
 first is a baseline you may carry. Then never leave a repaired guard at green —
 mutate the behaviour it protects and watch it red, at the layer that owns that
 behaviour, before you call it repaired.
+
+## An assertion whose expected value equals the platform default proves nothing — and neither does one the platform quietly satisfies for you (TASK-19562, 2026-08-22)
+
+**What happened.** Two of this task's ACs asked for facts about SQLite, and
+the obvious tests for both were inert.
+
+*One.* `SubscriptionsDB` set no `busy_timeout`, so it inherited one. AC:
+"set a timeout." The natural pin —
+`assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000` — passes
+**with the pragma deleted**, because 5000 ms is exactly what
+`sqlite3.connect(timeout=5.0)` already gives you. Deleting the production
+line and re-running was what exposed it. The pin that can actually fail
+monkeypatches the connector to pass `timeout=0` and asserts the connection
+still reports 5000: red at `0 == 5000` without the pragma.
+
+*Two.* AC: "the `-wal` is checkpointed on close." The natural pin — write
+300 rows, `close()`, assert the `-wal` is 0 bytes — also passes with the
+checkpoint removed, because **SQLite checkpoints and deletes the `-wal`
+itself when the LAST connection to a database closes**. The test was
+measuring sqlite's own cleanup. The fix was to hold a second connection open
+across the assertion (which is also the leaked worker connection the task was
+about) and additionally assert the file still *exists*: red at "close() left
+content in the -wal" once something else keeps it alive.
+
+The same platform behaviour refuted a whole premise: a child process that
+wrote a 4.1 MB `-wal` and exited normally left only the `.db` behind, with a
+new `atexit` settle hook enabled and suppressed — identical. The "the `-wal`
+is left behind at exit" concern is false for a clean exit; what is real is
+the standing WAL a long-running process carries, and the `os._exit(0)` signal
+path, which no `atexit` hook can reach.
+
+**What to do.** For any test whose expected value is a platform, library or
+language *default*, delete the production line and re-run before believing
+the green. If it still passes, the assertion is describing the platform, not
+your change — either find an input where the two diverge (force the default
+to something else, keep a second handle open) or write in the test that it
+cannot fail on its own and name the sibling that can.
+
+## Instrument the argument shape production uses, not the one that is easiest to call (TASK-19562, 2026-08-22)
+
+**What happened.** A previous session had to decide whether
+`SubscriptionsDB.record_check_result` really nested `transaction()`. It
+instrumented the context manager across "a real call", observed **depth 1,
+one entry**, and recorded the hazard as REFUTED at that call site — in the
+code, in the tests' docstring, and in the task file.
+
+Re-instrumented per argument shape:
+
+    record_check_result WITH stats    -> 2 entries, depths [1, 2]
+    record_check_result WITHOUT stats -> 1 entry,  depths [1]
+
+The nesting runs through `_update_subscription_stats` ->
+`update_subscription_stats`, reached only when `stats` is truthy — and
+`execute_run`, the only production caller, *always* passes stats. The
+earlier probe had called it the easy way, with `stats` omitted, and measured
+the one branch production never takes. The hazard was **live**, not latent:
+the daily-statistics write was durably committing the enclosing
+subscription-health UPDATE.
+
+**What to do.** When a probe decides whether a hazard is live, call the
+function the way the production call site calls it — copy the arguments from
+that call site, do not construct minimal ones. If the function branches on an
+argument's presence, probe **both** branches and record which is which; a
+single "instrumented a real call" line in a task file cannot be checked later
+by anyone, and this one was wrong in the direction that closes an
+investigation.

--- a/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
+++ b/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
@@ -3,7 +3,7 @@ id: TASK-19562
 title: >-
   Watchlists service — the duplicate-check registry misses the feed and API
   arms, 22 async methods do sync sqlite on the loop, and transaction() nests
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:12'
 labels:
@@ -65,15 +65,15 @@ away".
       of statistics — pinned by a test that actually overlaps the two triggers
 - [x] The 22 `async def` methods no longer execute synchronous sqlite on the
       event loop
-- [ ] The `busy_timeout` question is **measured, not assumed**: either a writer
+- [x] The `busy_timeout` question is **measured, not assumed**: either a writer
       collision is shown to stall the loop and a timeout is set, or the concern
       is recorded as refuted with the measurement
 - [x] `transaction()` either supports nesting (savepoints) or
       `record_check_result` stops nesting it; a test pins that a failure after
       the inner scope rolls the whole unit back
-- [ ] The subscriptions DB connection is closed on shutdown and the `-wal` is
+- [x] The subscriptions DB connection is closed on shutdown and the `-wal` is
       checkpointed
-- [ ] A guard test fails if a new `async def` in this service performs blocking
+- [x] A guard test fails if a new `async def` in this service performs blocking
       database I/O directly
 
 ## Measurement: the busy_timeout question (2026-08-21)
@@ -145,14 +145,11 @@ thread -- only the outermost block commits or rolls back -- mirroring
 savepoint scheme. Depth is cleared in a `finally`, so a raise cannot strand it
 and silently turn every later transaction into a no-op joiner.
 
-**The specific claim in C is REFUTED by measurement.** `record_check_result`
-does not nest today: instrumenting `transaction()` across a real call observed
-**depth 1, one entry**. The lane's CONFIRMED-LATENT rating was right about the
-hazard and wrong about that call site. The fix stands anyway -- it converts a
-silent-partial-persistence trap into a structural impossibility instead of
-relying on nobody ever nesting -- and is red-proofed: against the unfixed
-context manager, the nested write survives a deliberate failure in the outer
-scope.
+**The specific claim in C was recorded as REFUTED by measurement. That
+recording was itself wrong -- see the close-out section below.**
+`record_check_result` DOES nest, on every real check. The original note read:
+"does not nest today: instrumenting `transaction()` across a real call
+observed depth 1, one entry".
 
 **B also shipped (2026-08-21).** All 22 async methods now route their sqlite
 through the existing `db_offload.run_db_off_loop` helper rather than a new
@@ -172,7 +169,176 @@ Red-proofed: reverting `cancel_run`'s offload fails its test with
 `cancel_run's transaction opened on the event-loop thread`. `Tests/
 Subscriptions/` 781 passed (from a 759 baseline, +22 new tests).
 
-**Still open:**
+**Was still open at that point:** the C residue (leaked thread-local
+connection, un-checkpointed `-wal`), the `busy_timeout` AC, and the
+new-`async def` guard test. All three are closed below.
 
-* **C residue** -- the leaked thread-local connection that is never closed and
-  never checkpoints the `-wal`. Untouched here.
+## Close-out (2026-08-22) — the four remaining ACs, and two corrections
+
+### Hygiene: what the pre-ticked boxes were actually worth
+
+The file arrived with four ACs ticked while the status still read To Do.
+Each was re-derived against the code rather than trusted:
+
+| AC | Verdict |
+|---|---|
+| feed/API in the same guard | **Genuinely done.** `_run_guarded_source_check` claims through `_IN_FLIGHT_URL_CHECKS` with a NUL-prefixed sentinel slot; both arms route through it. |
+| one alert + one set of statistics, pinned by an overlapping test | **Partly.** The overlap tests were real, but they asserted the *fetch* count and the skip disposition -- **neither the notification count nor the statistics**, which is what the AC names and what the user sees. Closed here. |
+| 22 async methods off the loop | **Genuinely done**, and re-derived independently: an AST sweep of every `async def` in the service finds **zero** direct database calls. |
+| `transaction()` nesting + rollback pin | **Genuinely done** as a mechanism. The *claim recorded alongside it was false* -- see below. |
+
+### AC2 — the symptom the task names, now pinned where it is visible
+
+`test_overlapping_feed_check_alerts_once_and_counts_statistics_once` drives a
+real overlap (a gated `check_feed`, the second entrant starting inside the
+first's await) with a real alert rule and a recording notification
+dispatcher. Born-red against the unguarded feed arm:
+
+    the alert notification fired 2 times for one overlapping check
+    statistics double-counted the overlap:
+      {'checks_performed': 2, 'successful_checks': 2,
+       'new_items_found': 2, 'items_ingested': 2}
+
+Green after: one dispatch, one set of daily statistics.
+
+### AC4 — busy_timeout: reproduced, and it did not lead where it looked
+
+Measured on a real `SubscriptionsDB` before designing anything:
+
+    busy_timeout (ms): 5000        <- inherited, nothing set it
+    journal_mode     : wal
+    second writer blocked for 1.07s -> acquired   (lock held 1.0s)
+
+The collision is real and the caller does wait, up to the 5 s ceiling. But
+the measurement also refuted the obvious fix: **5000 is already what the
+connection had**, so "set a busy_timeout" changes nothing on its own, and
+*lowering* it would only convert a stall into an earlier `database is
+locked` on a path with no retry. The stall stops mattering because part B
+moved the sqlite off the loop.
+
+What shipped is therefore drift-protection, not a behaviour change:
+`BUSY_TIMEOUT_MS = 5000` is applied explicitly (before the WAL conversion,
+per `AgentRuns_DB`'s ordering rationale) and pinned by a test that survives
+a connector default change -- red at 0 ms with the pragma removed. The value
+assertion alone would pass without the pragma, and the test says so rather
+than posing as a guard.
+
+Two comments elsewhere asserting "`SubscriptionsDB` sets no `busy_timeout`"
+(`watchlists_collections_screen.py`, `briefing_handler.py`) are corrected.
+
+### AC6 — connection close and `-wal` checkpoint, with one half refuted
+
+Shipped: a per-instance connection registry (thread ident -> connection),
+`checkpoint_wal()`, `close_all_connections()`, and a `close()` that now
+checkpoints before closing. `close()`'s single-thread scope is unchanged --
+`app.py`'s FTS backfill depends on it.
+
+Two things were measured rather than assumed:
+
+* **A cross-thread close is refused by sqlite3** (`ProgrammingError: SQLite
+  objects created in a thread can only be used in that same thread`), so
+  `close_all_connections` closes this thread's connection, checkpoints the
+  file for everyone, and *reports* the rest instead of raising during
+  shutdown. Pinned as a fact about the runtime.
+* **The "`-wal` is left behind at exit" half is REFUTED for a clean exit.**
+  A child process wrote a 4.1 MB `-wal` and exited normally; only `subs.db`
+  remained -- identically with the new `atexit` hook enabled and suppressed.
+  CPython finalizes the connections and SQLite removes the `-wal` on last
+  close. What is real is the *standing* 4 MB a long-running app carries
+  (now truncated by `close()`/`close_all_connections`), and the
+  `os._exit(0)` signal path, which no `atexit` hook can reach -- that is
+  task-19561's subject and is recorded, not papered over. The hook stays
+  for a defined settle point with a defined error path, and is tested for
+  what it actually does.
+
+### AC7 — a guard for `async def` that does not exist yet
+
+`test_watchlists_service_no_blocking_db_io.py` parses the service and
+rejects any database call reached directly from an `async def`, resolving
+attribute chains to their root so `db.conn.cursor()` -- the shape the
+original 19-of-22 sweep missed -- is caught too. Proven able to fail three
+ways: on synthetic modules, and on the real file with `list_sources`'
+offload reverted (`list_sources (line 512): db.get_all_subscriptions(...)`).
+
+### Correction: `record_check_result` DOES nest, on every real check
+
+The earlier note recorded C as refuted at the live call site. Re-instrumented
+per argument shape:
+
+    record_check_result WITH stats    -> 2 entries, depths [1, 2]
+    record_check_result WITHOUT stats -> 1 entry,  depths [1]
+
+The route is `record_check_result` -> `_update_subscription_stats` ->
+`update_subscription_stats`, which opens its own transaction for the
+`subscription_stats` upsert. `execute_run` always passes stats, so this is
+the ordinary path; the earlier measurement can only have taken `stats=None`.
+The lane's hazard was **live**, not latent -- the daily-statistics write was
+durably committing the enclosing subscription-health UPDATE. No incident
+followed only because nothing after that point in `record_check_result` can
+fail. Two new pins cover the real call site, red against the unnested
+manager: *"the nested statistics write survived a failure in the enclosing
+transaction"*.
+
+### Folded in: the scheduler's lateness misreport
+
+`SchedulerLoop.tick` awaits every due handler serially and inline, so one
+slow handler (a watchlist check may run to its 300 s execution timeout,
+against a 60 s missed-fire grace) pushes every task behind it past the
+grace. The row that results is identical to one from an app that was closed
+-- and the UI said *"Missed while away ... (the scheduler was not running at
+the scheduled time)"*, a cause the app cannot know and which is simply false
+in that case.
+
+Repaired without a schema change, because the row's facts were never the
+problem:
+
+* `missed_at`/`missed_count` stay -- the occurrence WAS owed late and
+  earlier ones really were skipped, whichever cause it was.
+* The UI copy becomes "Ran late: ... (the app was closed, or the scheduler
+  was busy with an earlier task)". A test asserts the notice never contains
+  "Missed while away" or "was not running", across all three branches.
+* The cause is recorded where it is actually known: `SchedulerLoop` tracks
+  `_running_since` and `_report_lateness_cause` logs and counts
+  `scheduler_dispatch_late{cause=busy|away}`. A test drives the real
+  head-of-line block -- a slow handler advancing the clock ten minutes --
+  and asserts the following dispatch is attributed `busy`.
+* The docstring on `mark_reminder_dispatched`, the `[scheduling]` config
+  comment and `Docs/User_Guide/schedules.md` all asserted the false premise
+  and are corrected.
+
+The blocking itself is deliberately NOT changed to concurrent dispatch: the
+codebase already chose per-handler spawning for the slow case (see
+`BriefingJobHandler`'s Locked Decision 3), and making every handler
+concurrent is a semantics change this task has no mandate for.
+
+### Tests
+
+* `Tests/Subscriptions/` + `Tests/Scheduling/` +
+  `Tests/UI/test_schedules_missed_notice.py` — **1187 passed, 1 skipped**,
+  against **1156 passed, 1 skipped** for the same selection in a clean
+  `origin/dev` (`da4e828af`) worktree: +31 tests, no regressions.
+* `Tests/Watchlists/` + the three `Tests/UI/test_schedules_*` files — 758
+  passed.
+* `Tests/DB/` — 1071 passed, 1 skipped, and 6 failures in
+  `test_core_sqlite_owner_privacy.py[media-*]`. Those 6 fail identically on
+  `origin/dev` in the clean worktree — pre-existing dev reds, not from this
+  branch.
+* Repo-wide `pytest --collect-only -q` — 55,026 tests collected, 0
+  collection errors.
+* `ruff check` clean on every changed module.
+
+### Files
+
+`tldw_chatbook/DB/Subscriptions_DB.py`,
+`tldw_chatbook/Scheduling/scheduler/loop.py`,
+`tldw_chatbook/Scheduling/db/scheduled_tasks_db.py`,
+`tldw_chatbook/Scheduling/scheduler/handlers/briefing_handler.py`,
+`tldw_chatbook/UI/Screens/scheduling/task_detail.py`,
+`tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
+`tldw_chatbook/config.py`, `Docs/User_Guide/schedules.md`, and tests:
+`Tests/Subscriptions/test_subscriptions_db_connection_lifecycle.py` (new),
+`Tests/Subscriptions/test_watchlists_service_no_blocking_db_io.py` (new),
+`Tests/Scheduling/test_scheduler_lateness_cause.py` (new),
+`Tests/Subscriptions/test_watchlist_feed_api_in_flight_guard.py`,
+`Tests/Subscriptions/test_subscriptions_transaction_nesting.py`,
+`Tests/UI/test_schedules_missed_notice.py`.

--- a/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
+++ b/backlog/tasks/task-19562 - Watchlists service - duplicate-check registry misses the feed and API arms plus sync sqlite on the loop.md
@@ -342,3 +342,133 @@ concurrent is a semantics change this task has no mandate for.
 `Tests/Subscriptions/test_watchlist_feed_api_in_flight_guard.py`,
 `Tests/Subscriptions/test_subscriptions_transaction_nesting.py`,
 `Tests/UI/test_schedules_missed_notice.py`.
+
+## Review follow-up (Qodo, PR #1964)
+
+Three findings. Two were real bugs and are fixed; the third was a fair
+maintainability call and is accepted.
+
+### 1. Leaked sqlite connections retained (HIGH) — real, fixed
+
+`_connections` held a **strong** reference to each thread's connection and
+`close()` removed only the *calling* thread's entry, so a worker thread that
+ended without closing left its connection pinned for the life of the process.
+That is the opposite of what this task set out to do.
+
+**The suggested fix does not exist.** `weakref.WeakValueDictionary` is
+impossible here: CPython 3.12.11 raises `TypeError: cannot create weak
+reference to 'sqlite3.Connection' object`. And nothing outside the owning
+thread may close a connection — the constraint this task already measured and
+pinned (`test_a_cross_thread_close_is_refused_by_sqlite`).
+
+The one place both constraints are satisfied is the dying thread itself:
+CPython clears a thread's `threading.local` storage **on that thread** as it
+exits. `_ThreadExitCleanup` lives only in that storage, so its `__del__` runs
+there and both closes the connection and drops the registry entry. `close()`
+detaches it first, so an explicit close is never double-handled. Verified,
+not assumed: over 10 threads `__del__` ran 10 times and
+`threading.get_ident()` inside it matched the ident recorded at construction
+every time.
+
+**Measurement (three arms, 20 concurrent threads, descriptors counted with
+`lsof`, numeric FD column only).** Arm A is the reviewed code, arm B the fix,
+arm C a control with no registry at all — the lifetime this class had before
+the registry existed:
+
+| arm | registry after | fds after | live `Connection` objects | `close_all_connections()` |
+|---|---|---|---|---|
+| A defect | 21 (was 1) | 43 (was 3) | 21 | reports 20 |
+| B fixed | 1 | 23 | 1 | reports 0 |
+| C control (pre-registry) | 1 | 23 | 1 | reports 0 |
+
+A `gc.collect()` reclaims **nothing** in arm A: the sqlite3 statement cache is
+an `lru_cache` wrapping the connection, so every used connection sits in a
+reference cycle and refcounting alone never frees it.
+
+**Repeated rounds (5 rounds x 10 threads) — the growth question directly:**
+
+    DEFECT  round 1..5 settled fds: 23, 43, 63, 83, 78   registry pinned at 11
+            close_all_connections() -> 10;  57 fds still open
+    FIXED   round 1..5 settled fds: 13, 13, 13, 13, 13   registry back to 1 every round
+            close_all_connections() -> 0;   0 fds open
+
+The fixed steady state is 13 rather than the 3-fd baseline, and that is
+correct, not residual leakage: SQLite's unix VFS keeps closed descriptors for
+an inode in a reuse pool while any connection to that file is still open, and
+releases them together when the last one closes — which the final line shows
+(0). The honest assertion is therefore "a second round costs no more
+descriptors than the first", which is what the new test makes.
+
+`close_all_connections()` and `checkpoint_wal()` are unchanged in behaviour;
+the count `close_all_connections()` returns is now the number of connections a
+**still-live** thread could actually be using.
+
+**Test changes.** `test_close_all_connections_settles_the_file_and_reports_the
+_rest` and `test_the_connection_registry_sees_worker_threads` both used to
+`join()` the worker before asserting that its connection was still registered
+— i.e. they asserted the leak. They now hold the worker alive for the
+assertion (`_worker_holding_a_connection`), which is what "connections other
+threads still have open" means. New:
+`test_threads_that_exit_leave_no_connection_behind`, born red — with
+`_ThreadExitCleanup.__del__` neutered it fails with `assert 6 == 1` and the six
+retained idents printed. `test_a_cross_thread_close_is_refused_by_sqlite` is
+untouched and still passes.
+
+### 2. `stop()` misattributes lateness — real, fixed
+
+`stop()` cleared `_running_since` immediately, and `_report_lateness_cause`
+treats `running_since is None` as proof the scheduler was away. `app.py` calls
+`scheduler_loop.stop()` and only *then* cancels the worker, so `stop()` can
+land while a tick is still walking its due list — and every remaining dispatch
+in that same tick was then reported `away`, for a loop visibly dispatching it.
+
+Same defect class as the one this branch's own review already caught (a
+suspended machine with zero handler time reported as `busy`): a cause asserted
+from something other than evidence the loop holds. `stop()` is a *request*, so
+it no longer touches the window; `run()` closes it in a `finally`, which is
+the moment the loop actually leaves and covers cancellation too.
+
+Born-red test `test_stop_during_an_in_flight_tick_is_not_reported_as_away`
+dispatches two equally overdue tasks in one live tick, with `stop()` called
+from the first one's handler. Before the fix:
+
+    [('stopper', 'stalled'), ('after-stop', 'away')]
+
+Two identical dispatches by the same live tick, disagreeing only because
+`stop()` ran in between. After the fix both report `stalled`.
+`test_run_records_running_since_and_stop_clears_it` is renamed to
+`..._and_the_loops_exit_clears_it` and now pins both halves: the window is
+still open immediately after `stop()`, and closed once `run()` returns.
+
+### 3. Lateness cause uses literals — accepted
+
+`away` / `busy` / `stalled` are simultaneously branch outcomes, the `cause`
+label on the `scheduler_dispatch_late` counter, and the vocabulary
+`Docs/User_Guide/schedules.md` teaches users to grep for. Three sites that must
+agree is exactly the case for named constants, so `LATENESS_CAUSE_AWAY`,
+`LATENESS_CAUSE_BUSY` and `LATENESS_CAUSE_STALLED` now live in
+`Scheduling/scheduler/loop.py` and are used by the loop and the tests. Renaming
+one renames the metric label with it, which is the point.
+
+### Verification
+
+* `Tests/Subscriptions/` + `Tests/Scheduling/` — **1186 passed, 1 skipped**
+  (1184/1 before; +2 new tests).
+* `Tests/Watchlists/` + the three `Tests/UI/test_schedules_*` files (the set
+  this task's earlier close-out counted) — **758 passed**, unchanged.
+  `Tests/Watchlists/` on its own is 702 of those.
+* Repo-wide `pytest --collect-only -q` — 55,657 collected, 1 error in
+  `Tests/UI/test_library_file_notes_workspace.py` ("function uses no argument
+  'push_phase'"). Pre-existing dev red in a file this branch does not touch
+  (last changed by `d3833708a`); it reproduces identically on the other open
+  branch.
+* `ruff check --isolated --select E402,F401,F811,F821,E731` clean on all four
+  changed files.
+
+### Files (review follow-up)
+
+`tldw_chatbook/DB/Subscriptions_DB.py`,
+`tldw_chatbook/Scheduling/scheduler/loop.py`,
+`Tests/Subscriptions/test_subscriptions_db_connection_lifecycle.py`,
+`Tests/Scheduling/test_scheduler_lateness_cause.py`,
+`backlog/docs/lessons-testing-evidence.md`.

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -21,10 +21,12 @@
 #
 #########################################
 
+import atexit
 import json
 import sqlite3
 import threading
 import time
+import weakref
 from contextlib import closing, contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -48,6 +50,100 @@ from ..Metrics.metrics_logger import log_counter, log_histogram
 #: `auto_pause_after_failures = 10`, so a broken/hand-edited config still
 #: produces the same default a fresh install would get.
 _DEFAULT_AUTO_PAUSE_THRESHOLD = 10
+
+#: Lock-wait ceiling for every connection this database opens, in
+#: milliseconds (task-19562 AC4).
+#:
+#: **Measured, not assumed** -- the acceptance criterion demanded exactly
+#: that. Against a real `SubscriptionsDB`, with one connection holding
+#: `BEGIN IMMEDIATE` for 1.0 s while a second timed its own:
+#:
+#:     busy_timeout (ms): 5000        <- inherited, nothing set it
+#:     journal_mode     : wal
+#:     second writer blocked for 1.07s -> acquired
+#:
+#: So the lane's PLAUSIBLE rating is CONFIRMED: nothing in this file,
+#: `base_db.py` or the private-path connector ever set `busy_timeout`, and
+#: Python's `sqlite3.connect(timeout=5.0)` default made it 5 s -- a writer
+#: collision really does block its caller for as long as the lock is held,
+#: up to that ceiling, and then raises `OperationalError`.
+#:
+#: Two narrowings the number does NOT support, both worth stating because
+#: the obvious readings are wrong:
+#:
+#: * `journal_mode = wal`, so readers never block writers and writers never
+#:   block readers. The exposure is **writer-vs-writer only**, not "any of
+#:   the 22 async service methods".
+#: * Setting this pragma is **not** the fix for the stall. 5000 is what the
+#:   connection already had; the value is written down here so it is pinned
+#:   and cannot drift silently if the connector ever passes its own
+#:   `timeout=`. Lowering it would only convert a stall into an earlier
+#:   `database is locked` exception on a path with no retry. The stall stops
+#:   mattering because the sqlite work no longer runs on the event loop
+#:   (part B, `Subscriptions/db_offload.py`), not because of this line.
+BUSY_TIMEOUT_MS = 5000
+
+#: Every live, writable `SubscriptionsDB`, weakly held, so the interpreter
+#: can checkpoint their WALs on the way out (see
+#: `_checkpoint_open_databases_at_exit`).
+_OPEN_SUBSCRIPTIONS_DBS: "weakref.WeakSet[SubscriptionsDB]" = weakref.WeakSet()
+_OPEN_DBS_LOCK = threading.Lock()
+_ATEXIT_REGISTERED = False
+
+#: True once the exit hook is running. Checked before every `logger` call on
+#: the settle path, and it is not defensive decoration: the first version of
+#: this hook logged a genuine warning from a test process whose temporary
+#: database directory had already been removed, and loguru's sink was gone
+#: too -- so the *diagnostic* raised `ValueError: I/O operation on closed
+#: file` and printed a logging traceback on every exit. A settle running
+#: during teardown reports nothing; there is nobody left to report to.
+_INTERPRETER_EXITING = False
+
+
+def _checkpoint_open_databases_at_exit() -> None:
+    """Settle every open subscriptions database at interpreter exit.
+
+    task-19562, and the measurement matters more than the intent here.
+    `SubscriptionsDB` keeps **thread-local** connections and nothing ever
+    closed them, so an app that ran watchlist checks exited with a
+    connection still open per worker thread. The obvious conclusion --
+    that the `-wal` is therefore left behind -- was **tested and is false
+    for a clean exit**: a child process that wrote a 4.1 MB `-wal` and
+    exited normally left only `subs.db` on disk, with this hook suppressed
+    exactly as with it enabled. CPython finalizes the connection objects,
+    and SQLite checkpoints and removes the `-wal` when the last connection
+    to a database closes.
+
+    So this hook is not what saves the `-wal` on the ordinary path. What it
+    does buy is a *defined* moment and a defined error path: `atexit` runs
+    while imports and sqlite are still usable, rather than depending on
+    garbage-collection order during interpreter teardown (the regime that
+    produces "Exception ignored in:" noise). The behaviour it performs is
+    covered directly by
+    `Tests/Subscriptions/test_subscriptions_db_connection_lifecycle.py`.
+
+    The path where the `-wal` genuinely does survive is `app.py`'s
+    SIGINT/SIGTERM handler, which calls `os._exit(0)` -- that skips
+    `atexit` too, so no hook here can reach it. Recorded rather than
+    papered over; the hard-exit itself is task-19561's subject.
+
+    Deliberately best-effort and silent on failure: a diagnostic must never
+    be the thing that breaks the exit.
+    """
+    global _INTERPRETER_EXITING
+    _INTERPRETER_EXITING = True
+    with _OPEN_DBS_LOCK:
+        databases = list(_OPEN_SUBSCRIPTIONS_DBS)
+    for database in databases:
+        try:
+            if not Path(database.db_path_str).exists():
+                # The file went away under a still-live instance (routine
+                # for a temporary-directory test). There is nothing to
+                # settle, and touching it would only re-create it.
+                continue
+            database.close_all_connections()
+        except Exception:  # noqa: BLE001 -- interpreter shutdown, best effort
+            pass
 
 
 def _sqlite_unicode_casefold(value: Any) -> str:
@@ -259,6 +355,14 @@ class SubscriptionsDB(BaseDB):
             read_only: Open an existing database without initializing schema
         """
         self._local = threading.local()
+        # Every thread-local connection this instance has open, keyed by the
+        # thread that owns it (task-19562). `threading.local` is invisible
+        # from any other thread, so without this registry nothing -- not
+        # shutdown, not a test -- could even *count* the connections, let
+        # alone checkpoint behind them. Assigned before `super().__init__`
+        # because schema initialization touches `self.conn`.
+        self._connections: Dict[int, sqlite3.Connection] = {}
+        self._connections_lock = threading.Lock()
         self._read_only = read_only
         # Only the monotonic complete state is retained. A false/incomplete
         # probe is deliberately not cached: a background FTS backfill may
@@ -271,6 +375,10 @@ class SubscriptionsDB(BaseDB):
             except Exception:
                 self.close()
                 raise SubscriptionsDBUnavailableError() from None
+        elif not self.is_memory_db:
+            # Read-only instances have no `-wal` of their own to settle, and
+            # an in-memory database ceases to exist with its connection.
+            self._register_for_exit_checkpoint()
 
     def _get_connection(self) -> sqlite3.Connection:
         """Return a connection with foreign-key enforcement enabled.
@@ -298,6 +406,7 @@ class SubscriptionsDB(BaseDB):
                     deterministic=True,
                 )
                 conn.execute("PRAGMA foreign_keys = ON;")
+                conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS};")
                 conn.execute("PRAGMA query_only = ON;")
             except Exception:
                 conn.close()
@@ -312,6 +421,12 @@ class SubscriptionsDB(BaseDB):
             deterministic=True,
         )
         conn.execute("PRAGMA foreign_keys = ON;")
+        # Written down rather than inherited (task-19562 AC4, see
+        # `BUSY_TIMEOUT_MS` for the measurement). Set BEFORE the WAL
+        # conversion below for the reason `AgentRuns_DB` documents: turning a
+        # rollback-journal file into a WAL one briefly needs an exclusive
+        # lock, and that conversion must not run with no lock-wait budget.
+        conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS};")
         if not self.is_memory_db:
             conn.execute("PRAGMA journal_mode = WAL;")
         # NORMAL is safe under WAL (SQLite-documented pairing: app-crash-safe,
@@ -1385,10 +1500,110 @@ class SubscriptionsDB(BaseDB):
 
     @property
     def conn(self):
-        """Thread-local database connection."""
+        """Thread-local database connection, registered for shutdown."""
         if not hasattr(self._local, "conn") or self._local.conn is None:
-            self._local.conn = self._get_connection()
+            connection = self._get_connection()
+            self._local.conn = connection
+            with self._connections_lock:
+                self._connections[threading.get_ident()] = connection
         return self._local.conn
+
+    def _register_for_exit_checkpoint(self) -> None:
+        """Join the set of databases the interpreter settles on the way out."""
+        global _ATEXIT_REGISTERED
+        with _OPEN_DBS_LOCK:
+            _OPEN_SUBSCRIPTIONS_DBS.add(self)
+            if not _ATEXIT_REGISTERED:
+                atexit.register(_checkpoint_open_databases_at_exit)
+                _ATEXIT_REGISTERED = True
+
+    def checkpoint_wal(self) -> bool:
+        """Fold the `-wal` back into the database file and truncate it.
+
+        task-19562. Nothing in this app ever checkpointed this database
+        explicitly. SQLite's automatic checkpoint keeps the `-wal` bounded
+        but never truncates it, so a long-running app carries whatever the
+        last burst of writes left there -- measured at 4.1 MB after 300
+        inserts, and 0 bytes after one `wal_checkpoint(TRUNCATE)`. That is
+        the standing cost this addresses; the file is separately (and
+        adequately) settled by SQLite itself when the last connection to it
+        closes, which is why the exit hook's own docstring is careful about
+        what it does and does not buy.
+
+        `TRUNCATE` needs every other connection to be idle; when one is not,
+        SQLite reports busy rather than raising, and this falls back to
+        `PASSIVE`, which folds in what it can without waiting. Either way the
+        database file is complete afterwards.
+
+        Returns:
+            True when the `-wal` was truncated, False when only a partial
+            (or no) checkpoint was possible -- including for an in-memory or
+            read-only database, which have nothing to checkpoint.
+        """
+        if self.is_memory_db or self._read_only:
+            return False
+        try:
+            connection = self.conn
+            if connection.in_transaction:
+                # A checkpoint cannot see past this connection's own open
+                # transaction; committing here would durably persist work the
+                # caller has not finished, so the honest answer is to decline.
+                return False
+            row = connection.execute("PRAGMA wal_checkpoint(TRUNCATE);").fetchone()
+        except Exception as exc:  # noqa: BLE001
+            # Broader than sqlite3.Error on purpose: `self.conn` above can
+            # also raise from the private-path connector (the database file
+            # deleted under a still-live instance -- routine in tests, and
+            # possible at shutdown). A settle that cannot happen is a
+            # warning, never a raise out of a close path.
+            if not _INTERPRETER_EXITING:
+                logger.warning(
+                    f"WAL checkpoint failed for {self.db_path_str}: {exc}"
+                )
+            return False
+        # (busy, log_pages, checkpointed_pages); busy=0 means TRUNCATE ran.
+        if row is not None and row[0] == 0:
+            return True
+        try:
+            self.conn.execute("PRAGMA wal_checkpoint(PASSIVE);")
+        except sqlite3.Error:
+            pass
+        return False
+
+    def close_all_connections(self) -> int:
+        """Settle this database for shutdown: checkpoint, then close.
+
+        task-19562. Closes the CALLING thread's connection after
+        checkpointing the `-wal` (the checkpoint is database-wide, so one
+        connection settles the file for all of them).
+
+        Connections owned by *other* threads are counted and reported, not
+        closed. That is a measured limitation, not an oversight: sqlite3
+        refuses a cross-thread close --
+
+            ProgrammingError: SQLite objects created in a thread can only be
+            used in that same thread.
+
+        -- and an exception raised out of a shutdown path is worse than a
+        connection the operating system is about to reclaim anyway. The part
+        that actually matters for the file on disk (the checkpoint) is done
+        regardless of which thread calls this.
+
+        Returns:
+            The number of connections still open on other threads.
+        """
+        self.checkpoint_wal()
+        self.close()
+        with self._connections_lock:
+            remaining = len(self._connections)
+        if remaining and not _INTERPRETER_EXITING:
+            logger.debug(
+                f"{remaining} SubscriptionsDB connection(s) to "
+                f"{self.db_path_str} remain open on other threads; the "
+                "WAL has been checkpointed and the process owns their "
+                "lifetime from here."
+            )
+        return remaining
 
     @contextmanager
     def transaction(self):
@@ -1408,11 +1623,24 @@ class SubscriptionsDB(BaseDB):
         exception still propagates outward, so the outermost block rolls the
         whole unit back as a caller would expect.
 
-        Measured note for the record: at the time this was written
-        `record_check_result` -- the call site the task named -- did **not**
-        nest (instrumented depth 1). The hazard was latent, not live; this
-        makes it structurally impossible rather than relying on no one ever
-        nesting.
+        Measured, and the earlier note here was wrong. It claimed
+        `record_check_result` -- the call site the task named -- did not nest
+        ("instrumented depth 1"). Re-instrumented per argument shape:
+
+            record_check_result WITH stats    -> 2 entries, depths [1, 2]
+            record_check_result WITHOUT stats -> 1 entry,  depths [1]
+
+        The nesting is `record_check_result` -> `_update_subscription_stats`
+        -> `update_subscription_stats`, which opens its own `transaction()`
+        for the `subscription_stats` upsert. It is reached whenever `stats`
+        is truthy -- which is every real check, since `execute_run` always
+        passes stats. The earlier measurement can only have exercised the
+        `stats=None` path. So this was **live**, not latent: before this
+        change, the daily-statistics write durably committed the enclosing
+        subscription-health UPDATE. Nothing after that point in
+        `record_check_result` can fail today (only metric logging follows),
+        which is why no incident was ever observed -- but the ordering was
+        one added statement away from silent partial persistence.
 
         Yields:
             The thread-local `sqlite3.Connection`. The same object is yielded
@@ -4569,10 +4797,38 @@ class SubscriptionsDB(BaseDB):
         return results
 
     def close(self):
-        """Close database connections."""
-        if hasattr(self._local, "conn") and self._local.conn:
-            self._local.conn.close()
+        """Close THIS thread's connection, checkpointing the `-wal` first.
+
+        Scope is unchanged from before task-19562 and is load-bearing: this
+        closes only the calling thread's connection and clears that thread's
+        slot, and the `conn` property reopens lazily, which is what makes it
+        safe for `app.py`'s FTS backfill to call it from a *pooled* thread
+        that will later serve other watchlists work. Do not "improve" it into
+        a close of the instance.
+
+        What is new is that the connection is checkpointed on the way out
+        (task-19562) and dropped from `_connections`, so the registry never
+        reports a connection that is already gone. Use
+        `close_all_connections` for the shutdown path, which adds the
+        database-wide settle.
+        """
+        connection = getattr(self._local, "conn", None)
+        if connection:
+            try:
+                if not self.is_memory_db and not connection.in_transaction:
+                    mode = connection.execute("PRAGMA journal_mode;").fetchone()
+                    if mode and str(mode[0]).lower() == "wal":
+                        connection.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+            except sqlite3.Error as exc:
+                if not _INTERPRETER_EXITING:
+                    logger.warning(
+                        f"WAL checkpoint before close failed for "
+                        f"{self.db_path_str}: {exc}"
+                    )
+            connection.close()
             self._local.conn = None
+        with self._connections_lock:
+            self._connections.pop(threading.get_ident(), None)
 
 
 # End of Subscriptions_DB.py

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -100,6 +100,74 @@ _ATEXIT_REGISTERED = False
 _INTERPRETER_EXITING = False
 
 
+class _ThreadExitCleanup:
+    """Close and de-register one thread's connection when that thread ends.
+
+    Review of PR #1964. `SubscriptionsDB._connections` holds a **strong**
+    reference to every thread's connection so shutdown can count them, but
+    `close()` only removes the *calling* thread's entry. A worker thread that
+    ended without calling `close()` therefore left its connection pinned by
+    that dict for the life of the process -- descriptor, `-wal` and `-shm`
+    handles included. Measured over 20 concurrent short-lived threads: the
+    registry stayed at 21 entries and 43 open descriptors, permanently, and a
+    `gc.collect()` could not reclaim any of it.
+
+    Nothing outside the owning thread may close a sqlite3 connection --
+
+        ProgrammingError: SQLite objects created in a thread can only be
+        used in that same thread.
+
+    -- which is why `close_all_connections` reports other threads' connections
+    instead of closing them. The one place the rule *is* satisfied is the
+    dying thread itself: CPython clears a thread's `threading.local` storage
+    on that thread as it exits, so an object living only in that storage gets
+    finalized there. That is this class. Verified rather than assumed: over 10
+    threads, `__del__` ran 10 times, `threading.get_ident()` inside it matched
+    the ident recorded at construction every time, and the descriptor count on
+    the database returned to its pre-thread baseline (20 -> 0).
+
+    It deliberately does not checkpoint. The `-wal` is settled by SQLite when
+    the last connection to the database closes, and by `checkpoint_wal` /
+    `close_all_connections` on the shutdown path; a thread ending is not the
+    place to add I/O that could raise.
+
+    The instance must be reachable ONLY from the owning thread's local
+    storage. Handing a reference to anything longer-lived (the registry
+    included) would postpone the finalization this exists to trigger.
+    """
+
+    __slots__ = ("_connection", "_registry", "_lock", "_ident")
+
+    def __init__(self, connection, registry, lock, ident: int) -> None:
+        self._connection = connection
+        self._registry = registry
+        self._lock = lock
+        self._ident = ident
+
+    def detach(self) -> None:
+        """Give up ownership -- the connection was closed explicitly instead."""
+        self._connection = None
+
+    def __del__(self) -> None:
+        connection = self._connection
+        if connection is None:
+            return
+        self._connection = None
+        # Best-effort throughout: this runs during thread teardown, where a
+        # raised exception becomes an "Exception ignored in" traceback on
+        # stderr and helps nobody.
+        try:
+            with self._lock:
+                if self._registry.get(self._ident) is connection:
+                    del self._registry[self._ident]
+        except Exception:  # noqa: BLE001 -- thread teardown, best effort
+            pass
+        try:
+            connection.close()
+        except Exception:  # noqa: BLE001 -- thread teardown, best effort
+            pass
+
+
 def _checkpoint_open_databases_at_exit() -> None:
     """Settle every open subscriptions database at interpreter exit.
 
@@ -356,11 +424,21 @@ class SubscriptionsDB(BaseDB):
         """
         self._local = threading.local()
         # Every thread-local connection this instance has open, keyed by the
-        # thread that owns it (task-19562). `threading.local` is invisible
-        # from any other thread, so without this registry nothing -- not
-        # shutdown, not a test -- could even *count* the connections, let
+        # ident of the thread that owns it (task-19562). `threading.local` is
+        # invisible from any other thread, so without this registry nothing --
+        # not shutdown, not a test -- could even *count* the connections, let
         # alone checkpoint behind them. Assigned before `super().__init__`
         # because schema initialization touches `self.conn`.
+        #
+        # The reference held here is a STRONG one, which is why every entry is
+        # paired with a `_ThreadExitCleanup` in the owning thread's local
+        # storage (review of PR #1964): without that, a thread that ended
+        # without calling `close()` left its connection pinned by this dict for
+        # the life of the process -- descriptor and WAL lock included --
+        # inverting the very leak the registry was added to expose. A
+        # `weakref.WeakValueDictionary` would be tidier and is not available:
+        # CPython raises `TypeError: cannot create weak reference to
+        # 'sqlite3.Connection' object` (measured on 3.12.11).
         self._connections: Dict[int, sqlite3.Connection] = {}
         self._connections_lock = threading.Lock()
         self._read_only = read_only
@@ -1506,6 +1584,16 @@ class SubscriptionsDB(BaseDB):
             self._local.conn = connection
             with self._connections_lock:
                 self._connections[threading.get_ident()] = connection
+            # Assigned LAST, and only into this thread's local storage: from
+            # here the cleanup owns closing and de-registering this connection
+            # when the thread ends (review of PR #1964). Nothing else may hold
+            # a reference to it, or it would never be finalized.
+            self._local.connection_cleanup = _ThreadExitCleanup(
+                connection,
+                self._connections,
+                self._connections_lock,
+                threading.get_ident(),
+            )
         return self._local.conn
 
     def _register_for_exit_checkpoint(self) -> None:
@@ -1577,9 +1665,9 @@ class SubscriptionsDB(BaseDB):
         checkpointing the `-wal` (the checkpoint is database-wide, so one
         connection settles the file for all of them).
 
-        Connections owned by *other* threads are counted and reported, not
-        closed. That is a measured limitation, not an oversight: sqlite3
-        refuses a cross-thread close --
+        Connections owned by *other, still-live* threads are counted and
+        reported, not closed. That is a measured limitation, not an oversight:
+        sqlite3 refuses a cross-thread close --
 
             ProgrammingError: SQLite objects created in a thread can only be
             used in that same thread.
@@ -1589,8 +1677,14 @@ class SubscriptionsDB(BaseDB):
         that actually matters for the file on disk (the checkpoint) is done
         regardless of which thread calls this.
 
+        Connections whose thread has already EXITED are neither counted nor
+        retained: `_ThreadExitCleanup` closed and de-registered each of them on
+        its own thread as that thread ended (review of PR #1964). So the number
+        returned is the number of connections a still-live thread could
+        actually be using, and the registry itself holds no descriptor open.
+
         Returns:
-            The number of connections still open on other threads.
+            The number of connections still open on other live threads.
         """
         self.checkpoint_wal()
         self.close()
@@ -4811,7 +4905,16 @@ class SubscriptionsDB(BaseDB):
         reports a connection that is already gone. Use
         `close_all_connections` for the shutdown path, which adds the
         database-wide settle.
+
+        The thread-exit cleanup is detached first (review of PR #1964): this
+        thread has closed and de-registered its own connection, so the
+        finalizer has nothing left to do and must not act on a connection this
+        thread may since have reopened.
         """
+        cleanup = getattr(self._local, "connection_cleanup", None)
+        if cleanup is not None:
+            cleanup.detach()
+            self._local.connection_cleanup = None
         connection = getattr(self._local, "conn", None)
         if connection:
             try:

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -768,14 +768,25 @@ class ScheduledTasksDB(BaseDB):
 
         Missed-fire accounting (task-18937): when the scheduled time of this
         dispatch (the stored ``next_run_at``) is more than ``grace_seconds``
-        before ``now``, the dispatch was late -- the scheduler was not running
-        (or not aware of the task) at the scheduled time. The row then records
+        before ``now``, the dispatch was late. The row then records
         ``missed_at`` = the earliest owed occurrence's scheduled time and, for
         recurring tasks, ``missed_count`` = occurrences that elapsed
         undispatched *before* this one (the dispatch itself covers exactly one
         occurrence; skipped ones are counted, never replayed --
         run-once-then-continue). An on-time dispatch clears both fields: the
         state describes the last dispatch and self-heals.
+
+        What "late" does NOT tell you (task-19562): *why*. This docstring
+        used to assert the cause -- "the scheduler was not running (or not
+        aware of the task) at the scheduled time" -- and the UI repeated it
+        as "Missed while away". Both were wrong for a real and ordinary
+        case: ``SchedulerLoop.tick`` awaits every due handler serially and
+        inline, so one slow handler delays every task behind it, easily past
+        the grace, with the scheduler running throughout. These two fields
+        record the lateness and the skipped occurrences, which are true
+        regardless of cause; the cause itself is reported by the loop, which
+        is the only place that knows it (``SchedulerLoop.
+        _report_lateness_cause``).
 
         Timeout (task-18939): ``timed_out=True`` records the distinct
         terminal status ``"timed_out"`` -- the dispatch ran but was

--- a/tldw_chatbook/Scheduling/scheduler/handlers/briefing_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/briefing_handler.py
@@ -175,8 +175,10 @@ class BriefingJobHandler:
         `WatchlistCheckHandler.handle`, which calls the service method
         `get_subscription()`, not raw `.conn` SQL, and reads a table this
         handler's own spawned generations never write to concurrently.
-        Both distinctions matter here: `SubscriptionsDB` sets no
-        `busy_timeout` (SQLite's 5s default applies), and THIS handler's
+        Both distinctions matter here: `SubscriptionsDB` waits up to
+        `Subscriptions_DB.BUSY_TIMEOUT_MS` (5 s) for a contended write --
+        pinned explicitly by task-19562, previously the inherited sqlite3
+        default, and measured rather than assumed -- and THIS handler's
         own `generate_briefing` calls write to `watchlists`'/`briefings`'
         shared connection from `asyncio.to_thread` workers -- so a direct,
         synchronous call here could block on a lock its own spawned work

--- a/tldw_chatbook/Scheduling/scheduler/loop.py
+++ b/tldw_chatbook/Scheduling/scheduler/loop.py
@@ -70,17 +70,24 @@ class SchedulerLoop:
         )
         self.running = False
         #: When this loop last started polling, or None while it is not
-        #: running (task-19562). This is the one fact that distinguishes the
-        #: two causes of a late dispatch, and only the loop has it: if a
-        #: task's scheduled time fell AFTER this instant, the scheduler was
-        #: demonstrably up and watching at that moment, so the lateness came
-        #: from inside the process -- `tick` awaits every handler serially,
-        #: and one slow handler delays every task behind it. If it fell
-        #: before, the app really was away. Nothing downstream can tell
-        #: those apart from the row alone, which is exactly how "missed
-        #: while away" came to be shown for a scheduler that never stopped
-        #: running.
+        #: running (task-19562). Necessary but NOT sufficient to name the
+        #: cause of a late dispatch: if a task's scheduled time fell before
+        #: this instant the app really was away, but a scheduled time after
+        #: it only rules "away" out -- it does not establish that a handler
+        #: was what held the loop. `_last_tick_dispatch_seconds` carries that
+        #: second half.
         self._running_since: datetime | None = None
+        #: How long the previous tick spent dispatching, on the loop's own
+        #: clock (review of task-19562). This is the evidence half of the
+        #: attribution, and it is what makes "busy" falsifiable rather than
+        #: assumed: `tick` freezes `now` at its start, so an over-running
+        #: handler cannot make a task in ITS OWN tick look late -- it delays
+        #: the NEXT tick. A dispatch is only attributed to a busy scheduler
+        #: when the preceding tick demonstrably burned more than the
+        #: missed-fire grace. Without this, a suspended machine (lid closed,
+        #: app still running, zero handler time consumed) was reported as
+        #: "an earlier handler held the loop", which is simply false.
+        self._last_tick_dispatch_seconds: float = 0.0
         self._tick_count = 0
         self._reload_requested = False
         self.queue = PriorityQueue(
@@ -180,8 +187,24 @@ class SchedulerLoop:
             await asyncio.sleep(self.poll_interval)
 
     async def tick(self) -> None:
-        """Evaluate once and dispatch any due tasks."""
+        """Evaluate once and dispatch any due tasks.
+
+        The dispatch span is measured (review of task-19562) because it is
+        the only evidence that distinguishes a loop held by its own handlers
+        from a process that was not scheduled at all -- see
+        `_report_lateness_cause`. Recorded in a `finally` so a raising
+        handler cannot leave the previous tick's figure standing.
+        """
         now = self.clock()
+        try:
+            await self._dispatch_due(now)
+        finally:
+            self._last_tick_dispatch_seconds = max(
+                (self.clock() - now).total_seconds(), 0.0
+            )
+
+    async def _dispatch_due(self, now: datetime) -> None:
+        """Dispatch everything due at ``now`` (the tick's frozen clock)."""
         due = self.queue.pop_due(now)
         for task in due:
             task_type = task.get("type", "reminder")
@@ -303,16 +326,34 @@ class SchedulerLoop:
         time") for a scheduler that had never stopped.
 
         The row cannot carry the difference without a schema change, but the
-        loop can state it here, where `_running_since` is available: a
-        scheduled time that falls after this loop started is a dispatch the
-        scheduler was present for, so any lateness is in-process. The
-        counter makes the two causes separable in metrics; the UI copy no
-        longer claims to know which one it was (see
-        `scheduling/task_detail.py`).
+        loop can state it here. Two facts are needed, and the first version
+        of this used only one:
+
+        * `_running_since` -- a scheduled time BEFORE it means the app was
+          genuinely away. This half rules "away" in or out and is sound.
+        * `_last_tick_dispatch_seconds` -- the review of task-19562 measured
+          the missing half. `scheduled_at >= _running_since` alone was being
+          reported as "an earlier handler in the same tick held the loop",
+          and that was false twice over. A suspended machine (lid closed, app
+          still running) consumes ZERO handler time and produced exactly that
+          warning; and `tick` freezes `now` at its start, so a handler can
+          never make a task in its OWN tick look late -- it delays the NEXT
+          tick. "busy" therefore now requires the evidence: the preceding
+          tick must itself have burned more than the missed-fire grace.
+
+        When the scheduler was up but nothing it did explains the delay, the
+        honest answer is neither -- the process was not scheduled (suspend,
+        sleep, or a starved event loop). That is reported as ``"stalled"``
+        rather than folded into a cause it is not.
+
+        The counter makes the causes separable in metrics; the UI copy
+        deliberately claims none of them (see `scheduling/task_detail.py`).
 
         Returns:
-            ``"busy"`` (late, scheduler was up), ``"away"`` (late, scheduler
-            was not up at the scheduled time), or None when not late.
+            ``"busy"`` (late, and the previous tick demonstrably held the
+            loop), ``"stalled"`` (late, scheduler was up, nothing it ran
+            accounts for it), ``"away"`` (late, scheduler was not up at the
+            scheduled time), or None when not late.
         """
         scheduled_raw = task.get("next_run_at")
         if not isinstance(scheduled_raw, str) or not scheduled_raw:
@@ -328,11 +369,13 @@ class SchedulerLoop:
             return None
 
         running_since = self._running_since
-        cause = (
-            "busy"
-            if running_since is not None and scheduled_at >= running_since
-            else "away"
-        )
+        held_seconds = self._last_tick_dispatch_seconds
+        if running_since is None or scheduled_at < running_since:
+            cause = "away"
+        elif held_seconds > self.missed_fire_grace_seconds:
+            cause = "busy"
+        else:
+            cause = "stalled"
         log_counter(
             "scheduler_dispatch_late",
             labels={"task_type": task_type, "cause": cause},
@@ -340,10 +383,23 @@ class SchedulerLoop:
         if cause == "busy":
             logger.warning(
                 "Task {task_id} dispatched {late_by:.0f}s after its scheduled "
-                "time while the scheduler was running -- an earlier handler "
-                "in the same tick held the loop. This is NOT a missed fire.",
+                "time while the scheduler was running: the preceding tick "
+                "spent {held:.0f}s in its handlers, delaying this one. This "
+                "is NOT a missed fire.",
                 task_id=task.get("id"),
                 late_by=late_by,
+                held=held_seconds,
+            )
+        elif cause == "stalled":
+            logger.warning(
+                "Task {task_id} dispatched {late_by:.0f}s after its scheduled "
+                "time while the scheduler was running, and no handler accounts "
+                "for the delay (previous tick: {held:.0f}s) -- the process was "
+                "most likely suspended or the event loop starved. This is NOT "
+                "a missed fire.",
+                task_id=task.get("id"),
+                late_by=late_by,
+                held=held_seconds,
             )
         return cause
 

--- a/tldw_chatbook/Scheduling/scheduler/loop.py
+++ b/tldw_chatbook/Scheduling/scheduler/loop.py
@@ -69,6 +69,18 @@ class SchedulerLoop:
             allow_zero=True,
         )
         self.running = False
+        #: When this loop last started polling, or None while it is not
+        #: running (task-19562). This is the one fact that distinguishes the
+        #: two causes of a late dispatch, and only the loop has it: if a
+        #: task's scheduled time fell AFTER this instant, the scheduler was
+        #: demonstrably up and watching at that moment, so the lateness came
+        #: from inside the process -- `tick` awaits every handler serially,
+        #: and one slow handler delays every task behind it. If it fell
+        #: before, the app really was away. Nothing downstream can tell
+        #: those apart from the row alone, which is exactly how "missed
+        #: while away" came to be shown for a scheduler that never stopped
+        #: running.
+        self._running_since: datetime | None = None
         self._tick_count = 0
         self._reload_requested = False
         self.queue = PriorityQueue(
@@ -151,6 +163,7 @@ class SchedulerLoop:
     async def run(self) -> None:
         """Run the scheduler until :meth:`stop` is called."""
         self.running = True
+        self._running_since = self.clock()
         await asyncio.to_thread(self.queue.load)
         self.report_configuration()
         while self.running:
@@ -197,6 +210,8 @@ class SchedulerLoop:
         handler: Handler,
         task_type: str,
         now: datetime,
+        *,
+        scheduled: bool = True,
     ) -> bool:
         """Run one task's handler and record the dispatch outcome.
 
@@ -218,8 +233,15 @@ class SchedulerLoop:
             task_type: The task's type key (``"reminder"`` for DB rows).
             now: The dispatch time (the loop's clock for scheduled runs;
                 the caller's "now" for manual runs).
+            scheduled: False for a manual "Run now". Lateness is not
+                attributed for those: a manual run of an overdue task is
+                late by definition and by the user's own choice, so
+                reporting it as a loop-blocking delay would be noise
+                dressed as a diagnostic.
         """
         task_id = task.get("id")
+        if scheduled:
+            self._report_lateness_cause(task, task_type, now)
         timeout = self._effective_timeout_seconds(task)
         timed_out = False
         try:
@@ -266,6 +288,64 @@ class SchedulerLoop:
                 timed_out=timed_out,
             )
         return not timed_out
+
+    def _report_lateness_cause(
+        self, task: dict[str, Any], task_type: str, now: datetime
+    ) -> str | None:
+        """Name why this dispatch is late, while the loop still knows.
+
+        task-19562. `tick` awaits every due handler serially and inline, so
+        one slow handler pushes every task behind it past the missed-fire
+        grace -- a watchlist check may run for the whole 300 s execution
+        timeout against a 60 s grace. The row that results is
+        indistinguishable from one produced by the app being closed, and the
+        UI said so out loud ("the scheduler was not running at the scheduled
+        time") for a scheduler that had never stopped.
+
+        The row cannot carry the difference without a schema change, but the
+        loop can state it here, where `_running_since` is available: a
+        scheduled time that falls after this loop started is a dispatch the
+        scheduler was present for, so any lateness is in-process. The
+        counter makes the two causes separable in metrics; the UI copy no
+        longer claims to know which one it was (see
+        `scheduling/task_detail.py`).
+
+        Returns:
+            ``"busy"`` (late, scheduler was up), ``"away"`` (late, scheduler
+            was not up at the scheduled time), or None when not late.
+        """
+        scheduled_raw = task.get("next_run_at")
+        if not isinstance(scheduled_raw, str) or not scheduled_raw:
+            return None
+        try:
+            scheduled_at = datetime.fromisoformat(scheduled_raw)
+        except ValueError:
+            return None
+        if scheduled_at.tzinfo is None:
+            scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+        late_by = (now - scheduled_at).total_seconds()
+        if late_by <= self.missed_fire_grace_seconds:
+            return None
+
+        running_since = self._running_since
+        cause = (
+            "busy"
+            if running_since is not None and scheduled_at >= running_since
+            else "away"
+        )
+        log_counter(
+            "scheduler_dispatch_late",
+            labels={"task_type": task_type, "cause": cause},
+        )
+        if cause == "busy":
+            logger.warning(
+                "Task {task_id} dispatched {late_by:.0f}s after its scheduled "
+                "time while the scheduler was running -- an earlier handler "
+                "in the same tick held the loop. This is NOT a missed fire.",
+                task_id=task.get("id"),
+                late_by=late_by,
+            )
+        return cause
 
     def _effective_timeout_seconds(self, task: dict[str, Any]) -> float | None:
         """Resolve the execution timeout for one task (task-18939).
@@ -322,7 +402,7 @@ class SchedulerLoop:
             return False
 
         succeeded = await self.dispatch_reminder(
-            row, handler, "reminder", self.clock()
+            row, handler, "reminder", self.clock(), scheduled=False
         )
         await asyncio.to_thread(self.queue.load)
         return succeeded
@@ -330,3 +410,7 @@ class SchedulerLoop:
     def stop(self) -> None:
         """Signal the loop to exit after the current tick."""
         self.running = False
+        # Cleared so a task scheduled during the gap before the next `run()`
+        # is correctly attributed to an absent scheduler rather than to a
+        # busy one.
+        self._running_since = None

--- a/tldw_chatbook/Scheduling/scheduler/loop.py
+++ b/tldw_chatbook/Scheduling/scheduler/loop.py
@@ -22,6 +22,22 @@ from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProj
 
 Handler = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
 
+#: Why a dispatch was late (`_report_lateness_cause`). These three strings are
+#: simultaneously branch outcomes, the `cause` label on the
+#: `scheduler_dispatch_late` counter, and the vocabulary
+#: `Docs/User_Guide/schedules.md` teaches users to read in the logs -- so they
+#: get one home rather than being retyped at each site (review of PR #1964).
+#: Renaming one here renames it in the metric, which is the point: a label the
+#: dashboards know and a branch condition can no longer drift apart.
+#:
+#: The scheduler was not running when the task was due.
+LATENESS_CAUSE_AWAY = "away"
+#: The scheduler was running and the preceding tick demonstrably held the loop.
+LATENESS_CAUSE_BUSY = "busy"
+#: The scheduler was running, and nothing it ran accounts for the delay --
+#: the process was not scheduled (suspend, sleep, starved event loop).
+LATENESS_CAUSE_STALLED = "stalled"
+
 
 class SchedulerLoop:
     """Polls the scheduled-task database and dispatches due tasks."""
@@ -168,23 +184,36 @@ class SchedulerLoop:
             pass
 
     async def run(self) -> None:
-        """Run the scheduler until :meth:`stop` is called."""
+        """Run the scheduler until :meth:`stop` is called.
+
+        The running window is closed HERE, not in `stop()` (review of PR
+        #1964). `stop()` is a request -- `app.py` calls it and only then
+        cancels the worker -- so it can land while a tick is still walking its
+        due list. Clearing `_running_since` there made every remaining dispatch
+        in that tick report `away`, i.e. claimed an absent scheduler for one
+        that was visibly dispatching. The `finally` closes the window at the
+        moment the loop actually leaves, including on cancellation, which is
+        the only instant the claim is true.
+        """
         self.running = True
         self._running_since = self.clock()
-        await asyncio.to_thread(self.queue.load)
-        self.report_configuration()
-        while self.running:
-            if (
-                self._tick_count > 0
-                and self._tick_count % self.queue_reload_interval_ticks == 0
-            ):
-                await asyncio.to_thread(self.queue.load)
-            if self._reload_requested:
-                self._reload_requested = False
-                await asyncio.to_thread(self.queue.load)
-            self._tick_count += 1
-            await self.tick()
-            await asyncio.sleep(self.poll_interval)
+        try:
+            await asyncio.to_thread(self.queue.load)
+            self.report_configuration()
+            while self.running:
+                if (
+                    self._tick_count > 0
+                    and self._tick_count % self.queue_reload_interval_ticks == 0
+                ):
+                    await asyncio.to_thread(self.queue.load)
+                if self._reload_requested:
+                    self._reload_requested = False
+                    await asyncio.to_thread(self.queue.load)
+                self._tick_count += 1
+                await self.tick()
+                await asyncio.sleep(self.poll_interval)
+        finally:
+            self._running_since = None
 
     async def tick(self) -> None:
         """Evaluate once and dispatch any due tasks.
@@ -371,16 +400,16 @@ class SchedulerLoop:
         running_since = self._running_since
         held_seconds = self._last_tick_dispatch_seconds
         if running_since is None or scheduled_at < running_since:
-            cause = "away"
+            cause = LATENESS_CAUSE_AWAY
         elif held_seconds > self.missed_fire_grace_seconds:
-            cause = "busy"
+            cause = LATENESS_CAUSE_BUSY
         else:
-            cause = "stalled"
+            cause = LATENESS_CAUSE_STALLED
         log_counter(
             "scheduler_dispatch_late",
             labels={"task_type": task_type, "cause": cause},
         )
-        if cause == "busy":
+        if cause == LATENESS_CAUSE_BUSY:
             logger.warning(
                 "Task {task_id} dispatched {late_by:.0f}s after its scheduled "
                 "time while the scheduler was running: the preceding tick "
@@ -390,7 +419,7 @@ class SchedulerLoop:
                 late_by=late_by,
                 held=held_seconds,
             )
-        elif cause == "stalled":
+        elif cause == LATENESS_CAUSE_STALLED:
             logger.warning(
                 "Task {task_id} dispatched {late_by:.0f}s after its scheduled "
                 "time while the scheduler was running, and no handler accounts "
@@ -464,9 +493,16 @@ class SchedulerLoop:
         return succeeded
 
     def stop(self) -> None:
-        """Signal the loop to exit after the current tick."""
+        """Signal the loop to exit after the current tick.
+
+        Deliberately does NOT clear `_running_since` (review of PR #1964).
+        This is a request, not the departure: `app.py` calls it and then
+        cancels the worker, so a tick can still be dispatching when it
+        returns. Clearing the window here made `_report_lateness_cause` read
+        `running_since is None` as proof the scheduler was away and label the
+        rest of that same tick `away` -- an absent scheduler asserted for one
+        that was demonstrably running. `run()`'s `finally` closes the window
+        when the loop actually leaves, which still covers the gap before the
+        next `run()`.
+        """
         self.running = False
-        # Cleared so a task scheduled during the gap before the next `run()`
-        # is correctly attributed to an absent scheduler rather than to a
-        # busy one.
-        self._running_since = None

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -520,14 +520,26 @@ class TaskDetail(Vertical):
     def _update_missed_notice(
         self, task: ReminderTask | ScheduledTask | None
     ) -> None:
-        """Render the "missed while away" notice for a late last dispatch.
+        """Render the late-dispatch notice for the last dispatch.
 
         Distinct from failed: failed means the dispatch ran and the handler
-        raised; missed-while-away means the scheduled time elapsed with the
-        scheduler not running (app closed, or the occurrence predates the
-        task reaching the queue). The notice describes the last dispatch and
-        self-heals: the next on-time dispatch clears it. Plain text, no
-        markup -- titles are untrusted and never interpolated into markup.
+        raised; this means the dispatch happened well after its scheduled
+        time. The notice describes the last dispatch and self-heals: the next
+        on-time dispatch clears it. Plain text, no markup -- titles are
+        untrusted and never interpolated into markup.
+
+        task-19562: this used to say "Missed while away ... (the scheduler
+        was not running at the scheduled time)", which the app cannot know
+        from the row. `SchedulerLoop.tick` awaits every due handler serially
+        and inline, so one slow handler (a watchlist check may run to its
+        300 s execution timeout, against a 60 s missed-fire grace) pushes
+        every task behind it past the grace and produces exactly this row
+        while the scheduler is running the whole time. `missed_at` and
+        `missed_count` remain true either way -- the occurrence WAS owed
+        late, and earlier ones really were skipped -- so the facts stay and
+        only the invented cause goes. Which cause it actually was is
+        recorded where the loop can still tell (see
+        `SchedulerLoop._report_lateness_cause`).
         """
         notice = self.query_one("#scheduling-task-detail-missed", Static)
         if not isinstance(task, ReminderTask):
@@ -550,19 +562,20 @@ class TaskDetail(Vertical):
             )
 
             copy = (
-                f"Missed while away: ran late for the {scheduled} occurrence; "
+                f"Ran late: dispatched well after the {scheduled} occurrence; "
                 f"more than {ScheduledTasksDB._MISSED_COUNT_CAP:,} earlier "
                 "occurrence(s) were skipped, not replayed."
             )
         elif missed_count > 0:
             copy = (
-                f"Missed while away: ran late for the {scheduled} occurrence; "
+                f"Ran late: dispatched well after the {scheduled} occurrence; "
                 f"{missed_count} earlier occurrence(s) were skipped, not replayed."
             )
         else:
             copy = (
-                f"Missed while away: the {scheduled} occurrence ran late "
-                "(the scheduler was not running at the scheduled time)."
+                f"Ran late: the {scheduled} occurrence dispatched well after "
+                "its scheduled time (the app was closed, or the scheduler was "
+                "busy with an earlier task)."
             )
         notice.update(copy)
         notice.display = True

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -574,8 +574,8 @@ class TaskDetail(Vertical):
         else:
             copy = (
                 f"Ran late: the {scheduled} occurrence dispatched well after "
-                "its scheduled time (the app was closed, or the scheduler was "
-                "busy with an earlier task)."
+                "its scheduled time (for example the app was closed or "
+                "asleep, or the scheduler was busy with an earlier task)."
             )
         notice.update(copy)
         notice.display = True

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -10669,10 +10669,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         outermost coroutine -- and `run_worker` only *schedules* a coroutine
         back onto this SAME event loop, it does not move it to a thread
         (identical shape to `_toggle_briefing_queue`'s fix, whose docstring
-        names this exact trap). `SubscriptionsDB` sets no `busy_timeout`
-        pragma, so a second app instance (or a background check) contending
-        for the same row blocked the UI thread for the length of the lock
-        wait, not just the write.
+        names this exact trap). A second app instance (or a background
+        check) contending for the same row blocked the UI thread for the
+        length of the lock wait, not just the write -- up to
+        `Subscriptions_DB.BUSY_TIMEOUT_MS` (5 s; task-19562 pinned that
+        value explicitly, having previously inherited it, and measured the
+        wait: a 1.0 s lock held cost the second writer 1.07 s).
 
         Mirrors `library_screen.py`'s `_run_library_service_call(...,
         isolate_in_worker=True)`: `asyncio.to_thread` gives the worker thread

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3242,13 +3242,15 @@ scheduler_poll_interval_seconds = 30
 # A dispatch more than this many seconds after its scheduled time counts as
 # late and is recorded on the task (missed_at/missed_count, task-18937).
 # Default is 2x the poll interval: an idle scheduler dispatches within one
-# poll. Beyond 2x means one of two things, and the row cannot tell them
+# poll. Beyond 2x has several possible causes and the row cannot tell them
 # apart (task-19562): the scheduler was not running at the scheduled time
-# (app closed or asleep), OR it was running and busy -- tick awaits every
-# due handler serially, so one slow handler delays the rest of that tick.
-# The loop logs which it was and counts it as scheduler_dispatch_late with
-# a cause label. A task created mid-session reloads the queue immediately,
-# so that case does not false-positive here.
+# (app closed), the machine slept or the loop was starved while the app
+# stayed open, or the scheduler was busy -- tick awaits every due handler
+# serially, so a slow handler holds the loop and pushes the NEXT poll past
+# the grace. The loop logs which it was and counts it as
+# scheduler_dispatch_late with a cause label (away / stalled / busy). A
+# task created mid-session reloads the queue immediately, so that case does
+# not false-positive here.
 missed_fire_grace_seconds = 60
 # Handler execution timeout (task-18939): a scheduled-task handler still
 # running after this many seconds is cancelled and its dispatch records

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3240,12 +3240,15 @@ sync_retry_max_delay_seconds = 300
 sync_retry_jitter = true
 scheduler_poll_interval_seconds = 30
 # A dispatch more than this many seconds after its scheduled time counts as
-# "missed while away" and is recorded on the task (missed_at/missed_count,
-# task-18937). Default is 2x the poll interval: while the app runs, dispatch
-# lands within one poll; beyond 2x the scheduler was not running at the
-# scheduled time (app closed, asleep, or the task was created after the last
-# queue load -- mid-session creations reload the queue immediately, so they
-# do not false-positive here).
+# late and is recorded on the task (missed_at/missed_count, task-18937).
+# Default is 2x the poll interval: an idle scheduler dispatches within one
+# poll. Beyond 2x means one of two things, and the row cannot tell them
+# apart (task-19562): the scheduler was not running at the scheduled time
+# (app closed or asleep), OR it was running and busy -- tick awaits every
+# due handler serially, so one slow handler delays the rest of that tick.
+# The loop logs which it was and counts it as scheduler_dispatch_late with
+# a cause label. A task created mid-session reloads the queue immediately,
+# so that case does not false-positive here.
 missed_fire_grace_seconds = 60
 # Handler execution timeout (task-18939): a scheduled-task handler still
 # running after this many seconds is cancelled and its dispatch records


### PR DESCRIPTION
Closes TASK-19562.

## The pre-ticked ACs were not all true

Four ACs arrived ticked while the task read `To Do`. Each was re-derived against the code rather than trusted, and one was false:

| AC | verdict |
|---|---|
| feed and API arms in the same in-flight guard | **already done** — both route through `_run_guarded_source_check` |
| one alert + one set of statistics, pinned by an overlapping test | **false** — the overlap tests asserted the *fetch count* and the skip disposition, never the notification count or `subscription_stats`, which is exactly what the AC names |
| 22 async methods off the loop | **already done** — an independent AST sweep of all 41 `async def`, alias-tracking from `self._db()`, finds **0** direct DB calls |
| `transaction()` nesting + rollback pin | mechanism done; **the claim recorded beside it was false** (below) |

So `local_watchlists_service.py` is byte-identical to base: AC1/AC3 shipped in `b39142b64`, and this closes AC2 by adding the assertion that was missing. Reverting the feed arm to its exact pre-part-A production line and driving a genuine scheduler-tick / manual-"Check Now" overlap gives:

```
reverted:  feed fetches 2, alert notifications 2,
           stats {'checks_performed': 2, 'successful_checks': 2, 'new_items_found': 2, 'items_ingested': 2}
restored:  feed fetches 1, alert notifications 1,
           stats {'checks_performed': 1, ...}
```

## A prior session's "REFUTED" was wrong, and the reversal was verified twice

Finding C — `transaction()` is not re-entrant and `record_check_result` nests it — had been recorded **REFUTED** on the evidence "instrumented depth 1". Re-instrumented per **argument shape**:

```
transaction() entries during a real execute_run: depths [1, 1, 1, 2, 1]
  depth=2: record_check_result -> _update_subscription_stats -> update_subscription_stats
record_check_result WITH stats -> [1, 2]      WITHOUT stats -> [1]
```

`local_watchlists_service.py:1194` passes a populated `stats` dict on every run, so the earlier probe could only have taken the branch production never takes. The consequence is confirmed by making the outer scope fail: the plain manager persists the enclosing health UPDATE (1 row, `last_successful_check` set) where the re-entrant one persists nothing.

The framing stays precise: the nesting is **live**, the harm stays **latent** because nothing after that point in `record_check_result` can fail. It is shipped as a correctness repair with a regression pin, not as an incident.

## `busy_timeout`: the measurement refuted the obvious fix

The collision is real — 5000 ms inherited, WAL, a 1.0 s held lock cost the second writer **1.07 s**. But 5000 is *already* what the connection had, so "set a timeout" changes nothing, and lowering it only converts a stall into an earlier `database is locked` on a path with no retry. Shipped as drift-protection with an explicit pragma, pinned by a test that survives a connector default change. Review confirmed the pin is not a tautology — deleting the pragma reds it on real code, while its deliberately weak twin is labelled weak in its own docstring.

## Two claims this branch disproved rather than inherited

- **"the `-wal` is left behind at exit" is false for a clean exit.** A child wrote 4,140,632 bytes of `-wal`, exited normally, and left only `subs.db` — identically with the new hook registered *and* suppressed. What is real is the standing WAL (now truncated) and the `os._exit(0)` signal path, which no `atexit` hook can reach — that belongs to TASK-19561.
- **sqlite3 refuses a cross-thread close**, so other threads' connections are honestly reported as not closed rather than silently assumed closed.

The checkpoint test guards its own inertness: without a held connection the `-wal` file is simply gone and the test would pass spuriously, so it asserts the file exists first.

## The lateness fix — and the correction review made to it

`tick` awaits handlers serially, so one slow handler pushes the rest past the 60 s grace while the UI said *"the scheduler was not running at the scheduled time"* about a scheduler that never stopped. The copy is now cause-neutral, `missed_at`/`missed_count` semantics are unchanged, and dispatch was deliberately **not** made concurrent (the codebase already chose per-handler spawning — `BriefingJobHandler`'s Locked Decision 3).

**But the first cut of the cause classification was a new false statement replacing an old one**, in two ways: a suspended machine with **zero** handler time satisfied `scheduled_at >= _running_since` and was reported `busy`; and `tick()` freezes `now` at its start, so a slow handler can never make a task late *in its own tick* — it delays the next one, which the branch's own head-of-line test demonstrates.

Fixed by making `busy` require evidence: `tick` records `_last_tick_dispatch_seconds` in a `finally`, and a scheduler that was up with nothing accounting for the delay is now honestly `stalled`. Verified in both directions — after a restart, a task owed during the gap is `away` **even with held-loop evidence**; `stop()` clears the marker; a backward clock jump attributes nothing; the "Run now" opt-out is unaffected.

## One guard rejected the shape it documents

The AC7 blocking-IO walker claimed to "skip its subtree" for a nested `def`, but `ast.walk` plus `continue` does not — so the correct offload pattern (sync closure → `run_db_off_loop`) was flagged as loop-blocking IO. Nothing uses that shape today, so the guard was green; a guard that fails on correct code is the kind that gets loosened later. Now excluded by descent, with born-red tests both ways.

## Verification

- `Tests/Subscriptions/` + `Tests/Scheduling/` post-rebase: **1184 passed / 1 skipped**.
- `Tests/Watchlists/` + schedules UI: 758 passed.
- `Tests/DB/`: 1071 passed / 6 failed — the same six `test_core_sqlite_owner_privacy[media-*]` measured identically in a clean worktree at this branch's own base. (`task/19569-burn` retires that baseline.)
- Repo-wide collect: 55,030, 0 errors. `ruff` clean.

Left for follow-up rather than widened here: `close_all_connections()`/`checkpoint_wal()` have no production caller yet — wiring them into shutdown belongs to TASK-19561's signal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops overlapping watchlist checks from double-reporting and makes late-dispatch attribution evidence-based. Previously: overlapping feed/API runs sent two alerts and two stats updates; now they emit one alert and one stats update. The scheduler no longer assumes “away”; it records evidence and classifies late runs as away/busy/stalled, and the UI copy is neutral (“Ran late”). Also fixes a SQLite connection leak and pins a 5s busy-timeout.

- Watchlists (TASK-19562 AC2, AC7): single alert + single `subscription_stats` update on overlap; structural guard blocks sync DB calls in `async` code while allowing nested offload bodies; fixes `transaction()` re-entrancy in `record_check_result`.
- Scheduler (AC6): records `_last_tick_dispatch_seconds`; classifies lateness as `away`/`busy`/`stalled` using evidence; `LATENESS_CAUSE_*` constants unify labels; `stop()` no longer clears `_running_since` mid-tick; docs/UI copy updated to “Ran late.”
- SQLite (AC4, AC6): applies `BUSY_TIMEOUT_MS=5000` to all connections (measured; prevents drift); adds `checkpoint_wal()` and `close_all_connections()`; `close()` checkpoints; per-thread finalizer closes thread-local connections to prevent leaks; tests pin writer wait and WAL cleanup.
- No schema changes or config migrations.

<sup>Written for commit 7d5a4bbb00e80d410b06f5c17160727da7af0897. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

