### PR TITLE
docs(lessons): record interpreter drift as a test-evidence class

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6463,3 +6463,61 @@ concurrently -- a sequential loop tests ident recycling, not your registry.
 And before asserting on file descriptors, establish what the *correct*
 steady state looks like by measuring a known-good control (here: the same
 code path with no registry at all), rather than assuming it is the baseline.
+
+---
+
+## The interpreter is an input to your test, and this repo spans four of them (PR #1960, 2026-08-22)
+
+**The trap.** A test can be correct, deterministic, and still pass or fail purely on
+which Python ran it. This repo makes that routine rather than exotic: the declared
+floor is **3.11** (`requires-python = ">=3.11"`), the maintainer's `.venv` is **3.12**,
+worktree venvs get **3.14**, and a contributor may have **3.13**. Four of six reds
+found on dev in one sweep were this, by three unrelated mechanisms — each invisible on
+whichever interpreter its author happened to use.
+
+**What happened.**
+
+- **`ast.dump()` stopped rendering empty fields.** Python 3.13 added `show_empty`,
+  defaulting to `False`, so `Call(func=..., args=[...], keywords=[])` became
+  `Call(func=..., args=[...])`. The summarization diagnostic ledger FREEZES dumped
+  shapes, so every reviewed row holding a no-keyword call stopped matching. Measured by
+  digesting all 229 shapes in `Local_Summarization_Lib.py` on four real interpreters:
+  3.11 and 3.12 gave `92a85a3a989ffd13`; 3.13 and 3.14 gave `cd27a1b6c1fdf001`. The
+  split is exactly where `show_empty` landed.
+- **`dis.findlinestarts()` began yielding `None` lines.** On
+  `ProfileStoreLease.acquire`, 3.11 yields 0 positionless entries and 3.14 yields 12.
+  Comparing those against an int boundary raised `TypeError` while building a
+  *module-level* constant — a COLLECTION error, so all 98 tests in the file stopped
+  running rather than failing.
+- **A nested same-quote f-string is a 3.11 `SyntaxError`.** PEP 701 legalised quote
+  reuse in 3.12. `TTS/backends/kokoro.py` therefore could not be imported *at all* on
+  the project's own floor, while every local test passed on 3.14. Note that
+  `ast.parse(feature_version=(3, 11))` does **not** catch this — it does not downgrade
+  the tokenizer. Only a real 3.11 interpreter does.
+
+**A recorded diagnosis is not a fix.** The `findlinestarts` case was already written up
+here nine days earlier ("Run source-inspection tests on a supported interpreter before
+changing them", TASK-15706, 2026-08-13). That entry was accurate and correctly told the
+reader how to tell interpreter drift from a product regression — and the 98 tests stayed
+uncollectable the whole time, because diagnosing is not the same as repairing. When an
+entry lands here describing something still broken, it needs a task, not just a
+paragraph.
+
+**What to do.**
+
+1. **Verify a version-sensitive fix on both ends of the supported range**, not on the
+   one you are sitting at. `uv python find 3.11` / `3.12` / `3.13` are all available on
+   this machine, and running the same digest under each is a few seconds of work.
+2. **An artifact that freezes interpreter output must pin the rendering, not chase it.**
+   `Tests/ast_shape.stable_dump()` forces the pre-3.13 rendering (`show_empty=True`
+   where supported, nothing below 3.13 where empty fields always rendered), so all four
+   interpreters reproduce the committed digest. Regenerating the ledger against the new
+   rendering was the tempting alternative and the wrong one: it invalidates a large set
+   of individually reviewed privacy rows at once, and breaks the 3.11 floor instead of
+   fixing anything.
+3. **Treat an Optional in an introspection API as load-bearing.** `findlinestarts`
+   documents its line as optional; the failure was assuming otherwise.
+4. **A module-level computation turns drift into a collection error**, which reports as
+   an error rather than a failure and can be skipped past with
+   `--continue-on-collection-errors`. Grep for `ERROR` as well as `FAILED` when
+   surveying a suite, or an entire file's worth of tests will read as "not failing".

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6505,11 +6505,15 @@ paragraph.
 
 **What to do.**
 
-1. **Verify a version-sensitive fix on both ends of the supported range**, not on the
-   one you are sitting at. `uv python find 3.11` / `3.12` / `3.13` are all available on
-   this machine, and running the same digest under each is a few seconds of work.
+1. **Verify a version-sensitive fix across the whole supported range**, not on the one
+   you are sitting at, and not only at the two ends. All four matter here: the `ast.dump`
+   split falls **between 3.12 and 3.13**, so an ends-only check (3.11 and 3.14) would
+   have seen two disagreeing answers without locating the boundary, while the f-string
+   break is visible **only at the floor**. `uv python find 3.11` / `3.12` / `3.13`
+   resolve the three you are not running; re-running the same digest under each is
+   seconds of work.
 2. **An artifact that freezes interpreter output must pin the rendering, not chase it.**
-   `Tests/ast_shape.stable_dump()` forces the pre-3.13 rendering (`show_empty=True`
+   `stable_dump()` in `Tests/ast_shape.py` forces the pre-3.13 rendering (`show_empty=True`
    where supported, nothing below 3.13 where empty fields always rendered), so all four
    interpreters reproduce the committed digest. Regenerating the ledger against the new
    rendering was the tempting alternative and the wrong one: it invalidates a large set


### PR DESCRIPTION
Docs only. Records the class of failure behind four of the six dev reds fixed in #1960, in `backlog/docs/lessons-testing-evidence.md`.

## Why this is a class, not three coincidences

A test can be correct, deterministic, and still pass or fail purely on which Python ran it. This repo makes that routine rather than exotic — floor **3.11** (`requires-python = ">=3.11"`), maintainer venv **3.12**, worktree venvs **3.14**, and a contributor may well be on 3.13. Three unrelated mechanisms hit in a single sweep, each invisible on whichever interpreter its author happened to use:

| Mechanism | Landed in | Effect |
|---|---|---|
| `ast.dump()` gained `show_empty`, default off | 3.13 | Frozen dumped shapes stop matching |
| `dis.findlinestarts()` yields `None` lines | progressive | `TypeError` at module level → **collection** error |
| PEP 701 quote reuse in f-strings | 3.12 | Module is a `SyntaxError` on the floor |

Every number in the entry is measured, not asserted. Digesting all 229 diagnostic shapes in `Local_Summarization_Lib.py` on four real interpreters gives `92a85a3a989ffd13` on 3.11/3.12 and `cd27a1b6c1fdf001` on 3.13/3.14 — the split is exactly where `show_empty` landed. `ProfileStoreLease.acquire` yields 0 positionless bytecode entries on 3.11 and 12 on 3.14. And the f-string claim is demonstrated both ways:

```
3.11 compile: SyntaxError -> f-string: unmatched '['
3.12 compile: accepted
ast.parse(feature_version=(3,11)): ACCEPTED   <- does NOT catch it
```

That last line is the one most likely to mislead someone: `feature_version` does not downgrade the tokenizer, so the obvious guard against this doesn't work. Only a real floor interpreter finds it.

## The part I'd most want a reviewer to weigh

The `findlinestarts` case was **already written up in this same file nine days earlier** (TASK-15706, 2026-08-13). That entry is accurate and correctly explains how to tell interpreter drift from a product regression — and the 98 tests in that file stayed uncollectable the entire time, because diagnosing is not repairing.

So the entry says plainly: when something lands here describing a thing that is still broken, it needs a task, not just a paragraph. I've written that as a rule rather than a criticism of the earlier entry, which did its job.

## Relationship to the existing entry

Complements, doesn't duplicate. TASK-15706's entry covers **how to diagnose** drift when you hit it. This one covers **the class**, how to verify a fix across the supported range (`uv python find 3.11/3.12/3.13` are all present on this machine — running the same digest under each is seconds of work), and why an artifact that freezes interpreter output must **pin** the rendering rather than chase it. Regenerating the ledger against the new rendering was the tempting alternative and the wrong one: it invalidates a large set of individually reviewed privacy rows at once and breaks the 3.11 floor instead of fixing anything.

One practical note included for suite surveys: a module-level computation turns drift into a collection *error*, which reports differently from a failure and is skippable with `--continue-on-collection-errors`. Grep for `ERROR` as well as `FAILED`, or an entire file's worth of tests reads as "not failing".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents interpreter drift as a repeatable test‑evidence class and why it caused four dev reds fixed in #1960. Explains behavior differences across Python 3.11–3.14 and how to verify and pin outputs to keep digests stable.

- Docs only; no code or test behavior changes.
- Captures three drift mechanisms and effects: `ast.dump()` `show_empty=False` in 3.13 splits frozen digests; `dis.findlinestarts()` yielding None lines caused module‑level collection errors; nested same‑quote f‑strings are a 3.11 `SyntaxError` not caught by `ast.parse(feature_version=(3, 11))`.
- Contributor guidance and policy: verify on 3.11, 3.12, 3.13, and 3.14 (why all four matter); pin AST rendering with `stable_dump()` in `Tests/ast_shape.py`; treat optional line numbers as valid; watch for collection errors (grep ERROR as well as FAILED); when a lesson documents an unresolved issue, open a task (complements TASK-15706).

<sup>Written for commit 9adf3127c8f23272d928bb918ef3e59f03f2cdd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

