### PR TITLE
feat: enable Shared Visual Identity for Persona actors

### DIFF
--- a/Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
+++ b/Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
@@ -196,11 +196,8 @@
 
 - Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py`
 - Modify: `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py`
-- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`
 - Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
 - Create: `Tests/UI/test_personas_persona_visual_identity_pack.py`
-- Modify: `Tests/UI/test_personas_visual_identity_pack.py`
-- Modify: `Tests/UI/test_personas_workbench.py`
 
 - [ ] **Step 1: Write widget/eligibility REDs**
 
@@ -255,7 +252,7 @@
 - [ ] **Step 8: Commit Task 3**
 
   ```bash
-  git add tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_persona_visual_identity_pack.py Tests/UI/test_personas_visual_identity_pack.py Tests/UI/test_personas_workbench.py
+  git add tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_persona_visual_identity_pack.py Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
   git commit -m "feat: author Persona expression packs"
   ```
 

--- a/Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
+++ b/Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
@@ -1,0 +1,415 @@
+# Persona Shared Visual Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan sequentially. Every production behavior starts with `superpowers:test-driven-development`; use `superpowers:verification-before-completion` before each commit and completion claim.
+
+**Goal:** Make the already-declared `actor_kind = "persona"` Shared Visual Identity path operational for eligible local Personas, including immutable authoring/publication, deterministic resolution, Workbench controls, and Console rendering, while keeping Persona Visual/Buddy operational states completely separate.
+
+**Architecture:** Retain one Shared Visual Identity model and repository. Add a small local-Persona authority adapter that snapshots the exact local source, Persona ID/revision/eligibility, and linked Character portrait identity. Refactor the existing Character-only resolver and candidate publisher around actor-generic pack selection plus actor-specific fallback/authority; do not duplicate the repository, schema, manifest validator, asset loader, or publication filesystem state machine. Personas Workbench owns draft/UI lifetime and passes a read-only exact Persona guard into the existing in-transaction publication guard. Console extends its existing actor-scoped cache/controller seam to local Persona sessions; Persona Buddy and Persona Visual receive no Shared Visual Identity expressions or state mappings.
+
+**Tech Stack:** Python 3.11+, Textual 8, SQLite, existing `VisualIdentityRepository`, Pillow/Rich Pixels, local Persona JSON service, pytest/Pilot.
+
+**ADR required:** no
+
+**ADR path:** Existing [ADR-067](../../../backlog/decisions/067-bundled-samira-visual-identity-pack.md) and [ADR-074](../../../backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md)
+
+**Reason:** ADR-067 already declares Persona bindings and the immutable Shared Visual Identity contract; ADR-074 explicitly requires Shared Visual Identity expressions to remain separate from Persona Visual/Buddy operational states. This task implements those accepted boundaries without a new architectural decision.
+
+---
+
+## Fixed contracts and file map
+
+- `tldw_chatbook/DB/VisualIdentity_DB.py` is already actor-generic. Change it only if a born-RED exact-CAS test proves the existing `activate_pack`/`publish_version` guard cannot express required Persona authority.
+- `tldw_chatbook/Character_Chat/visual_identity.py` remains the single manifest, asset, immutable version, resolver, candidate, publication, and cleanup engine. Extract only bounded actor-specific helpers; do not create a second Persona visual-identity runtime.
+- Create `tldw_chatbook/Character_Chat/persona_visual_identity.py` for exact local-Persona authority capture/revalidation and linked Character portrait loading. It may depend on the local Persona/Character service contract, but never on Textual, Persona Buddy, or Persona Visual.
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py` remains the path-free Shared Visual Identity browser. Add actor-mode copy/allowed actions rather than clone the widget.
+- `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py` mounts the Shared Visual Identity browser beside (not inside) `PersonasPersonaVisualPackWidget`; their IDs, messages, state vocabularies, drafts, and Save/Cancel ownership remain distinct.
+- `tldw_chatbook/UI/Screens/personas_screen.py` owns weak editor/browser references, source/profile/editor generations, one unpublished candidate, cancellation/drain, and post-publication targeted invalidation.
+- `tldw_chatbook/UI/Console_Modules/session.py`, `character.py`, and `wiring.py` keep the existing actor-scoped reaction/cache controller. Extend actor scope and display naming to eligible local Persona sessions; do not route expressions into `PersonaBuddyConsoleAdapter` or `PersonaBuddyController`.
+- Server-backed Personas always show exactly `Save a local copy first`; they never read/write local bindings in place.
+- Existing Character resolver order, legacy-expression fallback, four operational states, authoring, publication, cache keys, and Console behavior are non-regression contracts.
+- No Actor Pack archive, Persona Visual schema/runtime, Buddy state, server write/sync, or new image-generation provider work is authorized.
+- User instruction: run the complete touched/modified component surface and governance gates, not full-repository pytest.
+
+## Task 1: Freeze local Persona authority and actor-generic resolution
+
+**Files:**
+
+- Create: `tldw_chatbook/Character_Chat/persona_visual_identity.py`
+- Modify: `tldw_chatbook/Character_Chat/visual_identity.py`
+- Create: `Tests/Character_Chat/test_persona_visual_identity_resolution.py`
+- Modify: `Tests/Character_Chat/test_visual_identity_resolution.py`
+
+- [ ] **Step 1: Write authority-adapter REDs**
+
+  Add named tests:
+
+  - `test_capture_requires_exact_local_persona_id_revision_and_active_state`
+  - `test_capture_rejects_deleted_disabled_missing_and_server_records`
+  - `test_linked_character_portrait_is_bounded_and_path_free`
+  - `test_authority_revalidation_detects_revision_aba_and_linked_portrait_change`
+
+  Pin frozen/slotted public values with no record dictionaries or paths in repr:
+
+  ```python
+  authority = capture_local_persona_visual_identity(service, "p-1")
+  assert authority.source == "local"
+  assert authority.persona_id == "p-1"
+  assert authority.persona_revision == 4
+  assert authority.portrait is not None
+  assert local_persona_visual_identity_is_current(service, authority) is True
+  ```
+
+- [ ] **Step 2: Run the authority RED**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Character_Chat/test_persona_visual_identity_resolution.py -k 'capture or authority or portrait'
+  ```
+
+  Expected: collection fails because `persona_visual_identity` does not exist.
+
+- [ ] **Step 3: Implement the minimal authority adapter**
+
+  Implement exact-type validation for source/ID/revision/deleted/active fields. Reuse the linked local Character-card portrait contract (ID, Character revision, bounded bytes, MIME, SHA-256) without importing Persona Buddy. Revalidation reloads the same Persona and linked Character and compares the complete frozen authority; it never logs record contents, paths, or bytes.
+
+- [ ] **Step 4: Write actor-generic resolver REDs**
+
+  Add:
+
+  - `test_persona_bound_pack_resolves_manual_requested_default_and_neutral_order`
+  - `test_persona_missing_pack_asset_falls_back_to_linked_portrait`
+  - `test_persona_unavailable_or_changed_authority_returns_actor_unavailable`
+  - `test_persona_cache_identity_contains_full_actor_binding_version_asset_and_portrait_identity`
+  - `test_persona_resolution_does_not_read_character_legacy_expression_rows`
+  - `test_character_resolution_cache_and_fallback_contract_is_byte_unchanged`
+
+  The public Persona entry point is synchronous for `to_thread` callers:
+
+  ```python
+  result = resolve_persona_visual_identity(
+      db,
+      local_service,
+      persona_id="p-1",
+      requested_state="speaking",
+      manual_expression_key=None,
+      user_data_dir=profile_root,
+  )
+  assert result.actor_kind == "persona"
+  assert "persona_revision=4" in result.cache_identity
+  ```
+
+- [ ] **Step 5: Run the resolver RED**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Character_Chat/test_persona_visual_identity_resolution.py Tests/Character_Chat/test_visual_identity_resolution.py
+  ```
+
+  Expected: Persona cases fail on missing resolver/Character-only rejection; all pre-existing Character cases remain green.
+
+- [ ] **Step 6: Refactor the resolver without changing Character behavior**
+
+  Extract the bounded active-pack candidate query so both actor kinds use the same binding/version/assets/fallback walk. Character keeps legacy-expression and card-portrait fallback. Persona uses no legacy-expression table and falls back only to its exact linked portrait, then placeholder. Persona results include exact source, Persona revision, linked portrait identity, binding ID/version, pack ID/revision, immutable version ID/number/manifest digest, selected asset ID/digest, request/manual/resolved keys, and fallback source in `cache_identity`. Revalidate Persona authority after pack/asset reads before returning bytes.
+
+- [ ] **Step 7: Run GREEN and mutations**
+
+  Run Step 5. Then independently remove the post-read Persona revalidation, omit binding version from the cache identity, and permit a Character legacy row for Persona; each named test must fail before restoration.
+
+- [ ] **Step 8: Commit Task 1**
+
+  ```bash
+  git add tldw_chatbook/Character_Chat/persona_visual_identity.py tldw_chatbook/Character_Chat/visual_identity.py Tests/Character_Chat/test_persona_visual_identity_resolution.py Tests/Character_Chat/test_visual_identity_resolution.py
+  git commit -m "feat: resolve Persona Shared Visual Identity"
+  ```
+
+## Task 2: Support unbound Persona creation and authority-fenced publication
+
+**Files:**
+
+- Modify: `tldw_chatbook/Character_Chat/visual_identity.py`
+- Modify only if RED requires: `tldw_chatbook/DB/VisualIdentity_DB.py`
+- Create: `Tests/Character_Chat/test_persona_visual_identity_publication.py`
+- Modify: `Tests/Character_Chat/test_visual_identity_publication.py`
+- Modify: `Tests/ChaChaNotesDB/test_visual_identity_repository.py`
+
+- [ ] **Step 1: Write candidate REDs**
+
+  Add:
+
+  - `test_unbound_local_persona_can_create_empty_canonical_candidate`
+  - `test_bound_persona_candidate_snapshots_exact_binding_and_actor_authority`
+  - `test_persona_candidate_rejects_server_deleted_disabled_missing_and_stale_actor`
+  - `test_candidate_replace_clear_and_cancel_leave_active_version_unchanged`
+
+  Extend `VisualIdentityCandidate` only as needed to represent `old_* = None` for a new binding and a frozen Persona authority token. Preserve the existing Character constructor behavior and errors.
+
+- [ ] **Step 2: Run candidate REDs**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Character_Chat/test_persona_visual_identity_publication.py -k 'candidate or replace or clear or cancel'
+  ```
+
+  Expected: Persona candidate creation is rejected as `visual_identity_actor_kind_invalid`.
+
+- [ ] **Step 3: Implement actor-generic candidates**
+
+  Bound Persona candidates clone the active immutable graph exactly. Unbound Persona candidates start from the canonical approved expression metadata with no asset bytes and can stage replacements; publication requires a valid default/neutral resolution and at least one validated asset. Do not invent a Persona-only manifest or state catalog. Candidate methods remain in-memory and cancellation discards only unpublished state.
+
+- [ ] **Step 4: Write publication/CAS REDs**
+
+  Add real-SQLite tests:
+
+  - `test_unbound_persona_publish_creates_one_pack_version_assets_and_binding`
+  - `test_bound_persona_publish_appends_immutable_version_and_preserves_old_rows`
+  - `test_persona_revision_source_binding_version_and_portrait_change_fail_closed`
+  - `test_persona_authority_is_rechecked_inside_reserved_sqlite_transaction`
+  - `test_failed_cancelled_or_stale_publish_keeps_prior_binding_and_cleans_owned_staging`
+  - `test_character_publication_contract_remains_unchanged`
+
+  Use an injected read-only actor guard alongside the existing filesystem `publication_guard`. The final repository guard must check both while the SQLite write reservation is held.
+
+- [ ] **Step 5: Run publication REDs**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Character_Chat/test_persona_visual_identity_publication.py Tests/Character_Chat/test_visual_identity_publication.py Tests/ChaChaNotesDB/test_visual_identity_repository.py
+  ```
+
+  Expected: new Persona cases fail; existing Character/repository cases pass.
+
+- [ ] **Step 6: Implement publication through the existing state machine**
+
+  For an unbound Persona call `VisualIdentityRepository.activate_pack` with no expected binding and the combined actor/filesystem guard. For a bound candidate keep the existing copy-on-write/single-binding decisions and exact binding/version CAS. Run the optional actor guard early and again inside the repository transaction; false/raise maps to a fixed `visual_identity_actor_changed` category. Preserve owned staging cleanup/capability behavior and immutable old versions.
+
+- [ ] **Step 7: Run GREEN and mutations**
+
+  Run Step 5. Mutate away the in-transaction actor guard, permit publication after Persona revision ABA, and overwrite rather than append an immutable version; each dedicated test must fail before restoration.
+
+- [ ] **Step 8: Commit Task 2**
+
+  ```bash
+  git add tldw_chatbook/Character_Chat/visual_identity.py tldw_chatbook/DB/VisualIdentity_DB.py Tests/Character_Chat/test_persona_visual_identity_publication.py Tests/Character_Chat/test_visual_identity_publication.py Tests/ChaChaNotesDB/test_visual_identity_repository.py
+  git commit -m "feat: publish Persona expression packs"
+  ```
+
+## Task 3: Add the Persona Workbench Shared Visual Identity editor
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Create: `Tests/UI/test_personas_persona_visual_identity_pack.py`
+- Modify: `Tests/UI/test_personas_visual_identity_pack.py`
+- Modify: `Tests/UI/test_personas_workbench.py`
+
+- [ ] **Step 1: Write widget/eligibility REDs**
+
+  Add:
+
+  - `test_persona_editor_keeps_shared_identity_and_persona_visual_as_separate_sections`
+  - `test_local_persona_shows_path_free_metadata_lazy_preview_and_manual_labels`
+  - `test_unbound_local_persona_offers_create_replace_clear_save_cancel`
+  - `test_server_persona_disables_shared_identity_with_save_local_copy_first`
+  - `test_normal_and_80x24_compact_layout_paints_labelled_focusable_actions`
+
+  Reuse the existing widget/messages. Add an actor mode only for truthful copy and action availability; do not clone DOM IDs or introduce Persona Visual state keys.
+
+- [ ] **Step 2: Run widget REDs**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_persona_visual_identity_pack.py Tests/UI/test_personas_visual_identity_pack.py
+  ```
+
+  Expected: Persona editor has no Shared Visual Identity section.
+
+- [ ] **Step 3: Mount the distinct Workbench section**
+
+  Add a separate Shared Visual Identity holder below the profile fields and before/after the existing Persona Visual section with explicit titles (`Shared Visual Identity reactions` versus `Persona Visual operational states`). Keep selected-only preview decode and plain/path-free labels. No implicit terminal-convention bindings.
+
+- [ ] **Step 4: Write screen authority/cancellation REDs**
+
+  Add barrier tests:
+
+  - `test_persona_metadata_stale_after_profile_read_does_not_mount`
+  - `test_persona_preview_stale_after_resolve_or_decode_does_not_paint`
+  - `test_persona_replace_clear_and_save_revalidate_source_session_actor_binding_version_and_profile_revision_after_every_await`
+  - `test_declined_dirty_navigation_preserves_draft_and_staging`
+  - `test_accepted_navigation_and_cancel_signal_and_drain_before_discard`
+  - `test_failed_or_cancelled_save_preserves_active_version_and_draft_truthfully`
+  - `test_successful_save_invalidates_only_exact_actor_old_and_new_identity`
+
+- [ ] **Step 5: Run screen REDs**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_persona_visual_identity_pack.py Tests/UI/test_personas_workbench.py -k 'persona and (visual_identity or shared_visual or dirty_navigation)'
+  ```
+
+- [ ] **Step 6: Implement one Persona editor-owned candidate lifetime**
+
+  Capture weak editor/browser references, exact local service/DB identity, source, Persona ID/revision, screen/editor-session generations, and binding/pack/version identities. After each `get_persona_profile`, graph read, resolve/decode, picker result, staging operation, publication, cleanup, and invalidation await, compare the complete snapshot. Use the incumbent `_drain_to_thread`/`_drain_async` behavior; register work before awaiting, signal cancellation, shield/drain uncancellable work, and release serialization only after drain. Accepted navigation or Cancel discards only the unpublished candidate; failed publication keeps the authoritative active version.
+
+- [ ] **Step 7: Run GREEN, Pilot, and mutations**
+
+  Run Steps 2 and 5 at 80x24 and a normal/wide Pilot size. Remove one await fence, skip drain, allow server source, and invalidate all actor caches one at a time; each named test must fail before restoration.
+
+- [ ] **Step 8: Commit Task 3**
+
+  ```bash
+  git add tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_persona_visual_identity_pack.py Tests/UI/test_personas_visual_identity_pack.py Tests/UI/test_personas_workbench.py
+  git commit -m "feat: author Persona expression packs"
+  ```
+
+## Task 4: Render Persona expressions in Console without Buddy coupling
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/character.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify only if required by RED: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Create: `Tests/UI/test_console_persona_visual_identity.py`
+- Modify: `Tests/UI/test_console_character_avatar.py`
+- Modify: `Tests/UI/test_console_reaction_picker.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+
+- [ ] **Step 1: Write local Persona session/scope REDs**
+
+  Add:
+
+  - `test_local_persona_start_chat_creates_exact_persona_session_authority`
+  - `test_server_persona_start_chat_never_claims_local_visual_identity`
+  - `test_current_visual_identity_scope_returns_local_persona_id_without_integer_coercion`
+  - `test_persona_replacement_clears_only_prior_session_manual_reaction`
+
+  Preserve the existing Character handoff/session path byte-for-behavior. If native Persona Start Chat is not required to make an existing Persona session reachable, keep session creation out of scope and construct the existing `assistant_kind="persona"` path in tests instead; decide from the born-RED product path, not by assumption.
+
+- [ ] **Step 2: Write Console render/cache REDs**
+
+  Add:
+
+  - `test_console_persona_expression_resolves_and_paints_active_asset`
+  - `test_console_persona_manual_reaction_is_session_and_actor_scoped`
+  - `test_persona_publication_invalidates_only_matching_actor_cache`
+  - `test_persona_source_revision_binding_or_asset_change_drops_stale_decode`
+  - `test_persona_expression_never_changes_persona_buddy_state_or_lease_maps`
+  - `test_character_console_avatar_and_four_operational_states_remain_unchanged`
+
+- [ ] **Step 3: Run Console REDs**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_persona_visual_identity.py Tests/UI/test_console_character_avatar.py Tests/UI/test_console_reaction_picker.py Tests/UI/test_console_native_chat_flow.py -k 'visual_identity or reaction or avatar or persona_start_chat'
+  ```
+
+- [ ] **Step 4: Extend the actor-scoped controller minimally**
+
+  Make `_current_visual_identity_actor_scope()` return `(session_id, actor_kind, actor_id)` for exact eligible local Character or Persona sessions. Remove `int(actor_scope[2])` assumptions from `ConsoleCharacterController`; display specs carry generic `actor_kind`/`actor_id`. Resolve Persona through the new Persona entry point off-loop. Retain complete `resolution.cache_identity`, perform the existing second resolution after decode, and fence current session/source/actor/manual/state before DOM mutation. Targeted invalidation continues matching `actor_kind` and `actor_id` tokens only.
+
+- [ ] **Step 5: Prove runtime separation**
+
+  Add an architecture/static test that `Character_Chat.visual_identity`, the new Persona authority adapter, and Console reaction paths do not import `Persona_Buddy`, `Persona_Visual`, Actor Pack, or server write modules. Add behavioral proof that selecting/manual-changing a Shared Visual Identity expression leaves Buddy controller state/leases/generation unchanged.
+
+- [ ] **Step 6: Run GREEN and mutations**
+
+  Run Step 3. Mutate away actor kind in cache invalidation, coerce Persona IDs to integers, accept server Persona scope, and route a reaction to the Buddy sink; each dedicated test must fail before restoration.
+
+- [ ] **Step 7: Commit Task 4**
+
+  ```bash
+  git add tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Console_Modules/character.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_persona_visual_identity.py Tests/UI/test_console_character_avatar.py Tests/UI/test_console_reaction_picker.py Tests/UI/test_console_native_chat_flow.py
+  git commit -m "feat: render Persona expressions in Console"
+  ```
+
+## Task 5: Lifecycle, navigation, and Character non-regression
+
+**Files:**
+
+- Modify: `Tests/Character_Chat/test_persona_visual_identity_resolution.py`
+- Modify: `Tests/Character_Chat/test_persona_visual_identity_publication.py`
+- Modify: `Tests/UI/test_personas_persona_visual_identity_pack.py`
+- Modify: `Tests/UI/test_console_persona_visual_identity.py`
+- Modify: `Tests/Character_Chat/test_visual_identity_lifecycle.py`
+- Create: `Tests/Architecture/test_persona_shared_visual_identity_boundary.py`
+
+- [ ] **Step 1: Add lifecycle/race REDs**
+
+  Cover disabled/delete/restore/missing, profile revision ABA, local Persona replacement, source local→server→local ABA, binding replacement, concurrent publication, old editor completion after navigation, duplicate submit, repeated outer cancellation, and app/screen teardown before cleanup. Assert stable path-free categories and no mutation/repaint on stale authority.
+
+- [ ] **Step 2: Run lifecycle REDs**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Character_Chat/test_persona_visual_identity_resolution.py Tests/Character_Chat/test_persona_visual_identity_publication.py Tests/UI/test_personas_persona_visual_identity_pack.py Tests/UI/test_console_persona_visual_identity.py Tests/Character_Chat/test_visual_identity_lifecycle.py
+  ```
+
+- [ ] **Step 3: Apply only proven lifecycle fixes**
+
+  Use monotonic screen/editor operation generations and exact immutable actor/binding/version/cache tuples. Never add polling, a generic coordinator framework, or cross-runtime invalidation. Restore keeps the prior binding dormant and re-resolves; explicit binding replacement advances exact identity; late views remove/update only themselves.
+
+- [ ] **Step 4: Add architecture/privacy and Character equivalence gates**
+
+  The architecture test pins no Persona Visual/Buddy/Actor Pack/server imports or state-key mapping. Character tests compare resolver/publication/cache/four-state outputs against pre-task fixtures. Added diagnostics contain fixed categories/IDs only; scan added lines for Persona content, prompts, local paths, raw bytes, and cleanup tokens.
+
+- [ ] **Step 5: Run mutations**
+
+  Individually weaken source, Persona revision, editor generation, binding version, post-decode identity, and affected-only invalidation guards. Each corresponding test must fail before restoration.
+
+- [ ] **Step 6: Commit Task 5**
+
+  ```bash
+  git add Tests/Character_Chat/test_persona_visual_identity_resolution.py Tests/Character_Chat/test_persona_visual_identity_publication.py Tests/UI/test_personas_persona_visual_identity_pack.py Tests/UI/test_console_persona_visual_identity.py Tests/Character_Chat/test_visual_identity_lifecycle.py Tests/Architecture/test_persona_shared_visual_identity_boundary.py
+  git commit -m "test: prove Persona expression lifecycle safety"
+  ```
+
+## Task 6: Final isolated verification and task closeout
+
+**Files:**
+
+- Modify: `backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md`
+- Modify only when this task produced a genuinely reusable incident: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-live-verification.md`
+
+- [ ] **Step 1: Record assigned-worktree provenance before imports**
+
+  ```bash
+  SCRATCH_ROOT="$(mktemp -d /private/tmp/tldw-task19056.XXXXXX)"
+  env HOME="$SCRATCH_ROOT/home" XDG_CONFIG_HOME="$SCRATCH_ROOT/config" XDG_DATA_HOME="$SCRATCH_ROOT/data" XDG_CACHE_HOME="$SCRATCH_ROOT/cache" TLDW_CONFIG_PATH="$SCRATCH_ROOT/config/tldw_cli/config.toml" TLDW_TEST_MODE=1 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/test_probe_import_provenance.py Tests/Architecture/test_persona_shared_visual_identity_boundary.py
+  ```
+
+  Expected: imports resolve beneath `.worktrees/task-19056-persona-svi`; architecture passes.
+
+- [ ] **Step 2: Run the complete affected component gate in the same isolated environment**
+
+  ```bash
+  env HOME="$SCRATCH_ROOT/home" XDG_CONFIG_HOME="$SCRATCH_ROOT/config" XDG_DATA_HOME="$SCRATCH_ROOT/data" XDG_CACHE_HOME="$SCRATCH_ROOT/cache" TLDW_CONFIG_PATH="$SCRATCH_ROOT/config/tldw_cli/config.toml" TLDW_TEST_MODE=1 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/ChaChaNotesDB/test_visual_identity_repository.py Tests/Character_Chat/test_visual_identity_resolution.py Tests/Character_Chat/test_visual_identity_publication.py Tests/Character_Chat/test_visual_identity_lifecycle.py Tests/Character_Chat/test_persona_visual_identity_resolution.py Tests/Character_Chat/test_persona_visual_identity_publication.py Tests/UI/test_personas_visual_identity_pack.py Tests/UI/test_personas_persona_visual_identity_pack.py Tests/UI/test_personas_workbench.py Tests/UI/test_console_persona_visual_identity.py Tests/UI/test_console_character_avatar.py Tests/UI/test_console_reaction_picker.py Tests/UI/test_console_native_chat_flow.py Tests/Architecture/test_persona_shared_visual_identity_boundary.py
+  ```
+
+  Expected: all affected tests pass. Do not claim or run full-repository pytest.
+
+- [ ] **Step 3: Run static, generated-inventory, and governance gates**
+
+  Build a reviewed list of every changed Python path, then run Ruff check, Ruff format check, and `py_compile`/`compileall` on every changed production/test module. Also run:
+
+  ```bash
+  git diff --check origin/dev...HEAD
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Architecture/test_persona_shared_visual_identity_boundary.py Tests/Architecture/test_persistent_diagnostic_inventory.py
+  rg -n "Persona_Buddy|Persona_Visual|actor-pack|server.*write" tldw_chatbook/Character_Chat/persona_visual_identity.py tldw_chatbook/Character_Chat/visual_identity.py
+  ```
+
+  Review diagnostic-inventory changes semantically; regenerate only if this branch truly changes the inventory. Verify no CSS bundle changes unless visible widget CSS changed; if it did, use the canonical builder and review all generated outputs.
+
+- [ ] **Step 4: Run live/Pilot evidence only under isolation**
+
+  Use production CSS and real SQLite in Pilot at 80x24 and normal/wide sizes. Prove metadata, selected preview, Replace/Clear/Save/Cancel focus and paint, source feedback, Console Persona expression paint, Character non-regression, and navigation cancellation. If an ad hoc interpreter or real TUI probe is needed, set the Step 1 environment before the first Chatbook import and fingerprint the real profile before/after.
+
+- [ ] **Step 5: Self-review scope and evidence**
+
+  Confirm no Persona Visual/Buddy state mapping, Actor Pack archive, server write, schema migration, new provider, unrelated formatting, or default behavior entered the diff. Confirm all eight task ACs have direct evidence. If any scoped gate fails, leave TASK-19056 In Progress and record the exact baseline/branch attribution; do not check ACs or mark Done.
+
+- [ ] **Step 6: Close the Backlog task only after all gates pass**
+
+  Use Backlog CLI first to add concise Implementation Notes/status, then verify the rendered task. Check all eight ACs, retain this plan link, record ADR-067/ADR-074, affected files, RED→GREEN/mutation evidence, exact scoped commands/results, and any truthful deviations. Then:
+
+  ```bash
+  backlog task edit 19056 -s Done
+  backlog task 19056 --plain
+  git diff --check
+  git add 'backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md'
+  git commit -m "docs: close Persona Shared Visual Identity task"
+  ```

--- a/Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
+++ b/Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
@@ -125,6 +125,7 @@
 **Files:**
 
 - Modify: `tldw_chatbook/Character_Chat/visual_identity.py`
+- Modify: `tldw_chatbook/Character_Chat/persona_visual_identity.py`
 - Modify only if RED requires: `tldw_chatbook/DB/VisualIdentity_DB.py`
 - Create: `Tests/Character_Chat/test_persona_visual_identity_publication.py`
 - Modify: `Tests/Character_Chat/test_visual_identity_publication.py`
@@ -185,7 +186,7 @@
 - [ ] **Step 8: Commit Task 2**
 
   ```bash
-  git add tldw_chatbook/Character_Chat/visual_identity.py tldw_chatbook/DB/VisualIdentity_DB.py Tests/Character_Chat/test_persona_visual_identity_publication.py Tests/Character_Chat/test_visual_identity_publication.py Tests/ChaChaNotesDB/test_visual_identity_repository.py
+  git add tldw_chatbook/Character_Chat/visual_identity.py tldw_chatbook/Character_Chat/persona_visual_identity.py tldw_chatbook/DB/VisualIdentity_DB.py Tests/Character_Chat/test_persona_visual_identity_publication.py Tests/Character_Chat/test_visual_identity_publication.py Tests/ChaChaNotesDB/test_visual_identity_repository.py Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
   git commit -m "feat: publish Persona expression packs"
   ```
 

--- a/Tests/Architecture/test_persona_shared_visual_identity_boundary.py
+++ b/Tests/Architecture/test_persona_shared_visual_identity_boundary.py
@@ -1,0 +1,91 @@
+"""Architecture guardrails for Persona Shared Visual Identity reactions."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PERSONA_ADAPTER = (
+    REPO_ROOT / "tldw_chatbook" / "Character_Chat" / "persona_visual_identity.py"
+)
+SHARED_RUNTIME = REPO_ROOT / "tldw_chatbook" / "Character_Chat" / "visual_identity.py"
+CONSOLE_SESSION = REPO_ROOT / "tldw_chatbook" / "UI" / "Console_Modules" / "session.py"
+CONSOLE_CHARACTER = (
+    REPO_ROOT / "tldw_chatbook" / "UI" / "Console_Modules" / "character.py"
+)
+PRODUCTION_MODULES = (
+    PERSONA_ADAPTER,
+    SHARED_RUNTIME,
+    CONSOLE_SESSION,
+    CONSOLE_CHARACTER,
+)
+FORBIDDEN_IMPORT_PARTS = frozenset(
+    {
+        "Actor_Pack",
+        "Persona_Buddy",
+        "Persona_Visual",
+        "tldw_api",
+        "tldw_server",
+    }
+)
+CONSOLE_REACTION_FUNCTIONS = frozenset(
+    {
+        "_resolve_visual_identity_for_db",
+        "_visual_identity_options_for_db",
+        "_set_manual_reaction",
+        "_select_console_reaction",
+        "_preview_console_reaction",
+    }
+)
+
+
+def _tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _imports(path: Path) -> set[str]:
+    imported: set[str] = set()
+    for node in ast.walk(_tree(path)):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(("." * node.level) + (node.module or ""))
+    return imported
+
+
+def test_persona_shared_identity_modules_do_not_cross_other_runtime_boundaries() -> (
+    None
+):
+    for path in PRODUCTION_MODULES:
+        for imported in _imports(path):
+            assert not FORBIDDEN_IMPORT_PARTS.intersection(imported.split(".")), (
+                f"{path.relative_to(REPO_ROOT)} imports forbidden boundary {imported}"
+            )
+
+
+def test_persona_adapter_reuses_shared_operational_state_mapping() -> None:
+    assigned_names = {
+        target.id
+        for node in ast.walk(_tree(PERSONA_ADAPTER))
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        for target in (node.targets if isinstance(node, ast.Assign) else (node.target,))
+        if isinstance(target, ast.Name)
+    }
+
+    assert "_OPERATIONAL_EXPRESSION_KEYS" not in assigned_names
+
+
+def test_console_reaction_functions_do_not_reference_buddy_or_persona_visual() -> None:
+    functions = {
+        node.name: ast.unparse(node).lower()
+        for node in ast.walk(_tree(CONSOLE_SESSION))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in CONSOLE_REACTION_FUNCTIONS
+    }
+
+    assert functions.keys() == CONSOLE_REACTION_FUNCTIONS
+    for name, source in functions.items():
+        assert "persona_buddy" not in source, name
+        assert "server" not in source, name

--- a/Tests/Character_Chat/test_persona_visual_identity_publication.py
+++ b/Tests/Character_Chat/test_persona_visual_identity_publication.py
@@ -1,0 +1,378 @@
+"""Persona Shared Visual Identity candidate and publication contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from Tests.Character_Chat.test_persona_visual_identity_resolution import (
+    _LocalPersonaService,
+    _activate,
+)
+from tldw_chatbook.Character_Chat.persona_visual_identity import (
+    capture_local_persona_visual_identity,
+    local_persona_visual_identity_is_current,
+)
+from tldw_chatbook.Character_Chat.visual_identity import (
+    CANONICAL_EXPRESSION_SLOTS,
+    VisualIdentityPublicationError,
+    create_visual_identity_candidate,
+    publish_visual_identity_candidate,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.VisualIdentity_DB import VisualIdentityRepository
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(
+        tmp_path / "persona-svi-publication.db", "persona-svi-publication"
+    )
+    yield database
+    database.close_connection()
+
+
+@pytest.fixture
+def service(db: CharactersRAGDB) -> _LocalPersonaService:
+    local = _LocalPersonaService()
+    portrait = _png((4, 5, 6))
+    character_id = db.add_character_card(
+        {"name": "Persona portrait", "image": portrait}
+    )
+    assert character_id is not None
+    local.personas["p-1"]["character_card_id"] = int(character_id)
+    local.characters = {
+        int(character_id): {
+            "id": int(character_id),
+            "version": 3,
+            "deleted": False,
+            "image": portrait,
+        }
+    }
+    return local
+
+
+def _candidate(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+):
+    authority = capture_local_persona_visual_identity(service, "p-1")
+    assert authority is not None
+    return create_visual_identity_candidate(
+        db,
+        actor_kind="persona",
+        actor_id="p-1",
+        actor_authority=authority.cache_identity,
+        actor_guard=lambda: local_persona_visual_identity_is_current(
+            service, authority
+        ),
+    )
+
+
+def _png(color: tuple[int, int, int]) -> bytes:
+    output = BytesIO()
+    Image.new("RGB", (8, 8), color).save(output, format="PNG")
+    return output.getvalue()
+
+
+def test_unbound_local_persona_can_create_empty_canonical_candidate(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+) -> None:
+    candidate = _candidate(db, service)
+
+    assert candidate.actor_kind == "persona"
+    assert candidate.actor_id == "p-1"
+    assert candidate.old_pack_id is None
+    assert candidate.old_version_id is None
+    assert candidate.old_binding_id is None
+    assert candidate.actor_authority
+    assert (
+        tuple(asset["expression_key"] for asset in candidate.assets)
+        == CANONICAL_EXPRESSION_SLOTS
+    )
+    assert all(asset["bytes"] == 0 for asset in candidate.assets)
+    assert VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1") is None
+
+
+def test_bound_persona_candidate_snapshots_exact_binding_and_actor_authority(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    graph = _activate(db, tmp_path, ("neutral", "thinking"))
+
+    candidate = _candidate(db, service)
+
+    assert candidate.old_pack_id == graph["pack"]["id"]
+    assert candidate.old_pack_version == graph["pack"]["version"]
+    assert candidate.old_version_id == graph["version"]["id"]
+    assert candidate.old_binding_id == graph["binding"]["id"]
+    assert candidate.old_binding_version == graph["binding"]["version"]
+    assert (
+        candidate.actor_authority
+        == capture_local_persona_visual_identity(service, "p-1").cache_identity
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        {"backend": "server"},
+        {"deleted": True},
+        {"is_active": False},
+    ),
+)
+def test_persona_candidate_rejects_server_deleted_disabled_missing_and_stale_actor(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    mutation: dict[str, object],
+) -> None:
+    authority = capture_local_persona_visual_identity(service, "p-1")
+    assert authority is not None
+    service.personas["p-1"].update(mutation)
+
+    with pytest.raises(ValueError, match="^visual_identity_actor_changed$"):
+        create_visual_identity_candidate(
+            db,
+            actor_kind="persona",
+            actor_id="p-1",
+            actor_authority=authority.cache_identity,
+            actor_guard=lambda: local_persona_visual_identity_is_current(
+                service, authority
+            ),
+        )
+
+
+def test_candidate_replace_clear_and_cancel_leave_active_version_unchanged(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    graph = _activate(db, tmp_path, ("neutral", "thinking"))
+    candidate = _candidate(db, service)
+
+    candidate.stage_replacement("neutral", b"replacement")
+    candidate.stage_clear("thinking")
+    candidate.cancel()
+
+    current = VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1")
+    assert current is not None
+    assert current["version"]["id"] == graph["version"]["id"]
+    assert current["binding"]["version"] == graph["binding"]["version"]
+    with pytest.raises(
+        VisualIdentityPublicationError, match="^visual_identity_candidate_cancelled$"
+    ):
+        candidate.stage_replacement("neutral", b"later")
+
+
+def test_unbound_persona_publish_creates_one_pack_version_assets_and_binding(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    candidate = _candidate(db, service)
+    candidate.stage_replacement("neutral", _png((10, 20, 30)))
+
+    result = publish_visual_identity_candidate(db, candidate, user_data_dir=tmp_path)
+
+    graph = VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1")
+    assert graph is not None
+    assert result.old_pack_id is None
+    assert result.old_version_id is None
+    assert result.new_pack_id == graph["pack"]["id"]
+    assert result.new_version_id == graph["version"]["id"]
+    assert graph["version"]["version_number"] == 1
+    assert [asset["expression_key"] for asset in graph["assets"]] == ["neutral"]
+    assert result.version_directory.is_dir()
+
+
+def test_bound_persona_publish_appends_immutable_version_and_preserves_old_rows(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    first = _candidate(db, service)
+    first.stage_replacement("neutral", _png((10, 20, 30)))
+    first_result = publish_visual_identity_candidate(db, first, user_data_dir=tmp_path)
+    old_graph = VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1")
+    assert old_graph is not None
+
+    second = _candidate(db, service)
+    second.stage_replacement("neutral", _png((30, 20, 10)))
+    second_result = publish_visual_identity_candidate(
+        db, second, user_data_dir=tmp_path
+    )
+
+    new_graph = VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1")
+    assert new_graph is not None
+    assert second_result.old_version_id == first_result.new_version_id
+    assert second_result.new_version_id != first_result.new_version_id
+    assert new_graph["version"]["version_number"] == 2
+    old_row = db.execute_query(
+        "SELECT id FROM visual_identity_pack_versions WHERE id = ?",
+        (first_result.new_version_id,),
+    ).fetchone()
+    assert old_row is not None
+    assert first_result.version_directory.is_dir()
+    assert second_result.version_directory.is_dir()
+
+
+@pytest.mark.parametrize("change", ("revision", "source", "portrait"))
+def test_persona_revision_source_binding_version_and_portrait_change_fail_closed(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+    change: str,
+) -> None:
+    candidate = _candidate(db, service)
+    candidate.stage_replacement("neutral", _png((1, 2, 3)))
+    if change == "revision":
+        service.personas["p-1"]["version"] = 5
+    elif change == "source":
+        service.personas["p-1"]["backend"] = "server"
+    else:
+        character_id = service.personas["p-1"]["character_card_id"]
+        service.characters[character_id]["version"] = 4
+
+    with pytest.raises(
+        VisualIdentityPublicationError, match="^visual_identity_actor_changed$"
+    ):
+        publish_visual_identity_candidate(db, candidate, user_data_dir=tmp_path)
+
+    assert VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1") is None
+
+
+def test_persona_binding_version_change_fails_closed(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    first = _candidate(db, service)
+    first.stage_replacement("neutral", _png((5, 6, 7)))
+    publish_visual_identity_candidate(db, first, user_data_dir=tmp_path)
+    candidate = _candidate(db, service)
+    candidate.stage_replacement("neutral", _png((7, 6, 5)))
+    old_version_id = candidate.old_version_id
+    with db.transaction():
+        db.execute_query(
+            "UPDATE visual_identity_bindings SET version = version + 1 WHERE id = ?",
+            (candidate.old_binding_id,),
+        )
+
+    with pytest.raises(
+        VisualIdentityPublicationError, match="^visual_identity_binding_changed$"
+    ):
+        publish_visual_identity_candidate(db, candidate, user_data_dir=tmp_path)
+
+    current = VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1")
+    assert current is not None
+    assert current["version"]["id"] == old_version_id
+
+
+def test_persona_authority_is_rechecked_inside_reserved_sqlite_transaction(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    authority = capture_local_persona_visual_identity(service, "p-1")
+    assert authority is not None
+    observations: list[bool] = []
+
+    def guard() -> bool:
+        in_transaction = db.get_connection().in_transaction
+        observations.append(in_transaction)
+        return not in_transaction and local_persona_visual_identity_is_current(
+            service, authority
+        )
+
+    candidate = create_visual_identity_candidate(
+        db,
+        actor_kind="persona",
+        actor_id="p-1",
+        actor_authority=authority.cache_identity,
+        actor_guard=guard,
+    )
+    candidate.stage_replacement("neutral", _png((1, 2, 3)))
+
+    with pytest.raises(
+        VisualIdentityPublicationError, match="^visual_identity_actor_changed$"
+    ):
+        publish_visual_identity_candidate(db, candidate, user_data_dir=tmp_path)
+
+    assert observations == [False, False, True]
+    assert VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1") is None
+
+
+def test_failed_cancelled_or_stale_publish_keeps_prior_binding_and_cleans_owned_staging(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    cancelled = _candidate(db, service)
+    cancelled.stage_replacement("neutral", _png((1, 2, 3)))
+    cancelled.cancel()
+    with pytest.raises(
+        VisualIdentityPublicationError, match="^visual_identity_candidate_cancelled$"
+    ):
+        publish_visual_identity_candidate(db, cancelled, user_data_dir=tmp_path)
+
+    stale = _candidate(db, service)
+    stale.stage_replacement("neutral", _png((3, 2, 1)))
+    service.personas["p-1"]["version"] = 5
+    with pytest.raises(
+        VisualIdentityPublicationError, match="^visual_identity_actor_changed$"
+    ):
+        publish_visual_identity_candidate(db, stale, user_data_dir=tmp_path)
+
+    assert VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1") is None
+    publication_root = tmp_path / "visual_identities"
+    assert not publication_root.exists() or not any(
+        publication_root.rglob(".staging-*")
+    )
+
+
+def test_unbound_persona_publish_rejects_concurrent_binding_creation(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = _candidate(db, service)
+    candidate.stage_replacement("neutral", _png((8, 9, 10)))
+    original_activate = VisualIdentityRepository.activate_pack
+    competitor: dict[str, object] = {}
+
+    def race(self, **kwargs):
+        if not competitor:
+            competitor.update(
+                original_activate(
+                    self,
+                    pack={
+                        "title": "Concurrent Persona reactions",
+                        "description": "",
+                        "default_expression_key": "neutral",
+                        "source_kind": "manual",
+                        "source_context": {"source_id": "concurrent.fixture"},
+                    },
+                    manifest=kwargs["manifest"],
+                    assets=kwargs["assets"],
+                    actor_kind="persona",
+                    actor_id="p-1",
+                )
+            )
+        return original_activate(self, **kwargs)
+
+    monkeypatch.setattr(VisualIdentityRepository, "activate_pack", race)
+
+    with pytest.raises(
+        VisualIdentityPublicationError, match="^visual_identity_binding_changed$"
+    ):
+        publish_visual_identity_candidate(db, candidate, user_data_dir=tmp_path)
+
+    current = VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1")
+    assert current is not None
+    assert current["pack"]["id"] == competitor["pack"]["id"]

--- a/Tests/Character_Chat/test_persona_visual_identity_resolution.py
+++ b/Tests/Character_Chat/test_persona_visual_identity_resolution.py
@@ -355,6 +355,41 @@ def test_persona_unavailable_or_changed_authority_returns_actor_unavailable(
     assert stale.image_bytes is None
 
 
+def test_persona_delete_source_change_and_restore_reuse_exact_binding(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    graph = _activate(db, tmp_path, ("neutral",))
+    binding_id = graph["binding"]["id"]
+
+    service.personas["p-1"]["deleted"] = True
+    deleted = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+    service.personas["p-1"].update(
+        {"deleted": False, "backend": "server", "version": 5}
+    )
+    server = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+
+    dormant = VisualIdentityRepository(db).get_active_actor_pack("persona", "p-1")
+    assert deleted.fallback_reason == "actor_unavailable"
+    assert server.fallback_reason == "actor_unavailable"
+    assert dormant is not None
+    assert dormant["binding"]["id"] == binding_id
+
+    service.personas["p-1"].update({"backend": "local", "version": 6})
+    restored = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+
+    assert restored.resolved_expression_key == "neutral"
+    assert f"binding_id={binding_id}" in restored.cache_identity
+    assert "persona_revision=6" in restored.cache_identity
+
+
 def test_persona_authority_change_during_portrait_decode_fails_closed(
     db: CharactersRAGDB,
     service: _LocalPersonaService,

--- a/Tests/Character_Chat/test_persona_visual_identity_resolution.py
+++ b/Tests/Character_Chat/test_persona_visual_identity_resolution.py
@@ -297,6 +297,35 @@ def test_persona_bound_pack_resolves_manual_requested_default_and_neutral_order(
     assert result.image_bytes
 
 
+def test_persona_pack_query_runs_inside_managed_transaction(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _activate(db, tmp_path, ("neutral",))
+    original_query = db.execute_query
+    transaction_states: list[bool] = []
+
+    def observe_query(query: str, params=None):
+        if "visual_identity_resolver" in query:
+            transaction_states.append(db.get_connection().in_transaction)
+        return original_query(query, params)
+
+    monkeypatch.setattr(db, "execute_query", observe_query)
+
+    result = resolve_persona_visual_identity(
+        db,
+        service,
+        persona_id="p-1",
+        requested_state="idle",
+        user_data_dir=tmp_path,
+    )
+
+    assert result.resolution_source == "pack_operational"
+    assert transaction_states == [True]
+
+
 def test_persona_missing_pack_asset_falls_back_to_linked_portrait(
     db: CharactersRAGDB,
     service: _LocalPersonaService,

--- a/Tests/Character_Chat/test_persona_visual_identity_resolution.py
+++ b/Tests/Character_Chat/test_persona_visual_identity_resolution.py
@@ -1,0 +1,435 @@
+"""Local Persona authority and Shared Visual Identity resolution contracts."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from copy import deepcopy
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from tldw_chatbook.Character_Chat import persona_visual_identity as persona_svi
+from tldw_chatbook.Character_Chat.persona_visual_identity import (
+    LocalPersonaVisualIdentityAuthority,
+    capture_local_persona_visual_identity,
+    local_persona_visual_identity_is_current,
+    resolve_persona_visual_identity,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.VisualIdentity_DB import VisualIdentityRepository
+
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"persona-portrait"
+
+
+class _LocalPersonaService:
+    def __init__(self) -> None:
+        self.personas = {
+            "p-1": {
+                "backend": "local",
+                "id": "p-1",
+                "version": 4,
+                "deleted": False,
+                "is_active": True,
+                "character_card_id": 7,
+            }
+        }
+        self.characters = {
+            7: {
+                "id": 7,
+                "version": 3,
+                "deleted": False,
+                "image": _PNG,
+            }
+        }
+
+    def get_persona_profile(self, persona_id: str):
+        record = self.personas.get(persona_id)
+        if record is None:
+            raise ValueError("local_persona_profile_not_found")
+        return deepcopy(record)
+
+    def get_character(self, character_id: int):
+        record = self.characters.get(character_id)
+        if record is None:
+            raise ValueError("character_not_found")
+        return deepcopy(record)
+
+
+def test_capture_requires_exact_local_persona_id_revision_and_active_state() -> None:
+    service = _LocalPersonaService()
+
+    authority = capture_local_persona_visual_identity(service, "p-1")
+
+    assert type(authority) is LocalPersonaVisualIdentityAuthority
+    assert authority.source == "local"
+    assert authority.persona_id == "p-1"
+    assert authority.persona_revision == 4
+    assert authority.portrait is not None
+    assert authority.portrait.portrait_id == "local-character:7"
+    assert authority.portrait.revision == 3
+    assert authority.portrait.content_type == "image/png"
+    assert authority.portrait.sha256 == hashlib.sha256(_PNG).hexdigest()
+    assert authority.portrait.data == _PNG
+    assert dataclasses.is_dataclass(authority)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        authority.persona_revision = 5  # type: ignore[misc]
+    assert not hasattr(authority, "__dict__")
+    assert "persona-portrait" not in repr(authority)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "persona_id"),
+    (
+        ({"backend": "server"}, "p-1"),
+        ({"id": "p-2"}, "p-1"),
+        ({"version": True}, "p-1"),
+        ({"version": 0}, "p-1"),
+        ({"deleted": True}, "p-1"),
+        ({"is_active": False}, "p-1"),
+        ({}, "missing"),
+    ),
+)
+def test_capture_rejects_deleted_disabled_missing_and_server_records(
+    mutation: dict[str, object], persona_id: str
+) -> None:
+    service = _LocalPersonaService()
+    if persona_id in service.personas:
+        service.personas[persona_id].update(mutation)
+
+    assert capture_local_persona_visual_identity(service, persona_id) is None
+
+
+@pytest.mark.parametrize(
+    "character_mutation",
+    (
+        {"id": 8},
+        {"version": True},
+        {"version": -1},
+        {"deleted": True},
+        {"image": b"not-an-image"},
+        {"image": b"\x89PNG\r\n\x1a\n" + b"x" * (25 * 1024 * 1024)},
+    ),
+)
+def test_linked_character_portrait_is_bounded_and_path_free(
+    character_mutation: dict[str, object],
+) -> None:
+    service = _LocalPersonaService()
+    service.characters[7].update(character_mutation)
+
+    authority = capture_local_persona_visual_identity(service, "p-1")
+
+    assert authority is not None
+    assert authority.portrait is None
+    assert "/Users/" not in repr(authority)
+
+
+def test_authority_revalidation_detects_revision_aba_and_linked_portrait_change() -> (
+    None
+):
+    service = _LocalPersonaService()
+    authority = capture_local_persona_visual_identity(service, "p-1")
+    assert authority is not None
+    assert local_persona_visual_identity_is_current(service, authority) is True
+
+    service.personas["p-1"]["version"] = 5
+    assert local_persona_visual_identity_is_current(service, authority) is False
+
+    service.personas["p-1"]["version"] = 4
+    service.characters[7]["image"] = b"\x89PNG\r\n\x1a\nchanged"
+    assert local_persona_visual_identity_is_current(service, authority) is False
+
+    service.characters[7]["image"] = _PNG
+    service.characters[7]["version"] = 4
+    assert local_persona_visual_identity_is_current(service, authority) is False
+
+
+def test_capture_rejects_stateful_mapping_subclasses() -> None:
+    service = _LocalPersonaService()
+    record = service.personas["p-1"]
+
+    class _StatefulRecord(dict):
+        pass
+
+    service.get_persona_profile = lambda _persona_id: _StatefulRecord(record)  # type: ignore[method-assign]
+
+    assert capture_local_persona_visual_identity(service, "p-1") is None
+
+
+def _image_bytes(image_format: str, color: tuple[int, int, int]) -> bytes:
+    output = BytesIO()
+    Image.new("RGB", (8, 8), color).save(output, format=image_format)
+    return output.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(tmp_path / "persona-svi.db", "persona-svi-test")
+    yield database
+    database.close_connection()
+
+
+@pytest.fixture
+def service(db: CharactersRAGDB) -> _LocalPersonaService:
+    local = _LocalPersonaService()
+    portrait = _image_bytes("PNG", (2, 4, 8))
+    character_id = db.add_character_card(
+        {"name": "Persona portrait", "image": portrait}
+    )
+    assert character_id is not None
+    local.personas["p-1"]["character_card_id"] = int(character_id)
+    local.characters = {
+        int(character_id): {
+            "id": int(character_id),
+            "version": 3,
+            "deleted": False,
+            "image": portrait,
+        }
+    }
+    return local
+
+
+def _asset(
+    profile_root: Path,
+    expression_key: str,
+    color: tuple[int, int, int],
+) -> dict[str, Any]:
+    data = _image_bytes("WEBP", color)
+    filename = expression_key.replace("custom:", "") + ".webp"
+    relative_path = f"personas/p-1/{filename}"
+    path = profile_root / "visual_identities" / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return {
+        "expression_key": expression_key,
+        "original_expression_key": expression_key,
+        "display_label": expression_key.title(),
+        "source_filename": filename,
+        "storage_relpath": relative_path,
+        "content_type": "image/webp",
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "width": 8,
+        "height": 8,
+        "source_context": {"fixture": True},
+        "is_animated": False,
+        "frame_count": 1,
+    }
+
+
+def _activate(
+    db: CharactersRAGDB,
+    profile_root: Path,
+    keys: tuple[str, ...],
+    *,
+    default: str = "neutral",
+) -> dict[str, Any]:
+    return VisualIdentityRepository(db).activate_pack(
+        pack={
+            "title": "Persona reactions",
+            "default_expression_key": default,
+            "source_kind": "manual",
+            "source_context": {"source_id": "persona.fixture"},
+        },
+        manifest={"schema_id": "resolver/v1", "fixture": "persona"},
+        assets=[
+            _asset(profile_root, key, (index * 40, 70, 120))
+            for index, key in enumerate(keys, 1)
+        ],
+        actor_kind="persona",
+        actor_id="p-1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("manual", "state", "keys", "default", "expected", "source"),
+    (
+        (
+            "admiration",
+            "thinking",
+            ("custom:admiration", "thinking", "neutral"),
+            "neutral",
+            "custom:admiration",
+            "pack_manual",
+        ),
+        (
+            None,
+            "thinking",
+            ("thinking", "neutral"),
+            "neutral",
+            "thinking",
+            "pack_operational",
+        ),
+        (None, "error", ("happy", "neutral"), "happy", "happy", "pack_default"),
+        (None, "error", ("neutral",), "missing", "neutral", "pack_neutral"),
+    ),
+)
+def test_persona_bound_pack_resolves_manual_requested_default_and_neutral_order(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+    manual: str | None,
+    state: str,
+    keys: tuple[str, ...],
+    default: str,
+    expected: str,
+    source: str,
+) -> None:
+    _activate(db, tmp_path, keys, default=default)
+
+    result = resolve_persona_visual_identity(
+        db,
+        service,
+        persona_id="p-1",
+        requested_state=state,
+        manual_expression_key=manual,
+        user_data_dir=tmp_path,
+    )
+
+    assert result.actor_kind == "persona"
+    assert result.actor_id == "p-1"
+    assert result.resolved_expression_key == expected
+    assert result.resolution_source == source
+    assert result.image_bytes
+
+
+def test_persona_missing_pack_asset_falls_back_to_linked_portrait(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    graph = _activate(db, tmp_path, ("thinking", "neutral"))
+    for asset in graph["assets"]:
+        (tmp_path / "visual_identities" / asset["storage_relpath"]).unlink()
+
+    result = resolve_persona_visual_identity(
+        db,
+        service,
+        persona_id="p-1",
+        requested_state="thinking",
+        user_data_dir=tmp_path,
+    )
+
+    portrait = next(iter(service.characters.values()))["image"]
+    assert result.resolution_source == "persona_portrait"
+    assert result.fallback_reason == "pack_assets_unavailable"
+    assert result.image_bytes == portrait
+    assert result.storage_relpath is None
+
+
+def test_persona_unavailable_or_changed_authority_returns_actor_unavailable(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _activate(db, tmp_path, ("neutral",))
+    service.personas["p-1"]["deleted"] = True
+    unavailable = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+    assert unavailable.fallback_reason == "actor_unavailable"
+
+    service.personas["p-1"]["deleted"] = False
+    original_query = db.execute_query
+    changed = False
+
+    def mutate_after_query(query: str, params=None):
+        nonlocal changed
+        cursor = original_query(query, params)
+        if "visual_identity_resolver" in query and not changed:
+            service.personas["p-1"]["version"] = 5
+            changed = True
+        return cursor
+
+    monkeypatch.setattr(db, "execute_query", mutate_after_query)
+    stale = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+    assert stale.resolution_source == "placeholder"
+    assert stale.fallback_reason == "actor_unavailable"
+    assert stale.image_bytes is None
+
+
+def test_persona_authority_change_during_portrait_decode_fails_closed(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_validate = persona_svi._shared._validate_fallback_image
+
+    def mutate_during_decode(value):
+        result = original_validate(value)
+        service.personas["p-1"]["version"] = 5
+        return result
+
+    monkeypatch.setattr(
+        persona_svi._shared, "_validate_fallback_image", mutate_during_decode
+    )
+
+    result = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+
+    assert result.resolution_source == "placeholder"
+    assert result.fallback_reason == "actor_unavailable"
+    assert result.image_bytes is None
+
+
+def test_persona_cache_identity_contains_full_actor_binding_version_asset_and_portrait_identity(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+) -> None:
+    graph = _activate(db, tmp_path, ("neutral",))
+    result = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+    cache = set(result.cache_identity)
+    portrait = next(iter(service.characters.values()))
+    assert {
+        "actor_kind=persona",
+        "actor_id=p-1",
+        "actor_source=local",
+        "persona_revision=4",
+        f"portrait_id=local-character:{portrait['id']}",
+        "portrait_revision=3",
+        f"binding_id={graph['binding']['id']}",
+        f"binding_version={graph['binding']['version']}",
+        f"pack_id={graph['pack']['id']}",
+        f"pack_revision={graph['pack']['version']}",
+        f"pack_version_id={graph['version']['id']}",
+        f"pack_version_number={graph['version']['version_number']}",
+        f"asset_id={graph['assets'][0]['id']}",
+        f"sha256={graph['assets'][0]['sha256']}",
+    } <= cache
+    assert any(token.startswith("manifest_sha256=") for token in cache)
+    assert any(token.startswith("portrait_sha256=") for token in cache)
+
+
+def test_persona_resolution_does_not_read_character_legacy_expression_rows(
+    db: CharactersRAGDB,
+    service: _LocalPersonaService,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _activate(db, tmp_path, ("neutral",))
+    queries: list[str] = []
+    original_query = db.execute_query
+
+    def record_query(query: str, params=None):
+        queries.append(query)
+        return original_query(query, params)
+
+    monkeypatch.setattr(db, "execute_query", record_query)
+    result = resolve_persona_visual_identity(
+        db, service, persona_id="p-1", requested_state="idle", user_data_dir=tmp_path
+    )
+
+    assert result.image_bytes
+    assert not any("character_expression_images" in query for query in queries)

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -1553,6 +1553,9 @@ def test_expanding_the_character_section_reallows_a_rail_width_avatar():
         def apply_section_open(self, section_id, section_open):
             applied.append((section_id, section_open))
 
+        def request_allocation_reconcile(self):
+            pass
+
     def _fake_query_one(selector, expect_type=None):
         # Final review finding 5: a wildcard fake here would still pass even
         # if `_toggle_console_rail_section` queried the wrong id or type --

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -8493,12 +8493,14 @@ async def test_console_workspace_conversation_search_blank_query_clears_error_ca
             "Workspace conversation search is unavailable.",
         )
 
-        console.query_one("#console-workspace-conversation-search", Input)
-        await _set_console_conversation_browser_search(console, pilot, "")
+        search = console.query_one("#console-workspace-conversation-search", Input)
+        search.value = ""
+        console.on_console_workspace_conversation_search_changed(_InputChangedEvent(""))
 
         assert console._console_workspace_conversation_search_rows == ()
         assert console._console_workspace_conversation_search_total is None
         assert console._console_workspace_conversation_search_error == ""
+        await pilot.pause(0.3)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -8084,21 +8084,20 @@ async def test_console_new_chat_tab_appears_in_workspace_conversation_rail():
         first.persisted_conversation_id = "persisted-chat-1"
         await console._sync_native_console_chat_ui()
 
-        assert any(
-            "Chat 1" in text for text in _console_workspace_conversation_texts(console)
-        )
+        await _wait_for_workspace_conversation_text(console, pilot, "Chat 1")
 
         await pilot.click("#console-new-chat-tab")
         second = store.active_session_id
         assert second != first.id
         await _wait_for_selector(console, pilot, f"#console-session-tab-{second}")
 
-        row_texts = _console_workspace_conversation_texts(console)
-        assert any("Chat 1" in text for text in row_texts)
-        assert any("Chat 2" in text for text in row_texts)
-        assert any(
-            "Chat 2" in text for text in _selected_workspace_conversation_texts(console)
+        row_texts = await _wait_for_workspace_conversation_text(
+            console,
+            pilot,
+            "Chat 2",
+            selected=True,
         )
+        assert any("Chat 1" in text for text in row_texts)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_persona_visual_identity.py
+++ b/Tests/UI/test_console_persona_visual_identity.py
@@ -1,0 +1,342 @@
+"""Console contracts for local Persona Shared Visual Identity reactions."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
+from tldw_chatbook.Character_Chat.visual_identity import VisualIdentityResolution
+from tldw_chatbook.UI.Console_Modules import session as session_module
+from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+from tldw_chatbook.Widgets.Console.console_reaction_picker_modal import ReactionOption
+
+
+def _persona_record(*, revision: int = 2, active: bool = True) -> dict:
+    return {
+        "backend": "local",
+        "id": "persona-alpha",
+        "version": revision,
+        "is_active": active,
+        "deleted": False,
+    }
+
+
+def _session(*, backend: str = "local") -> ConsoleChatSession:
+    return ConsoleChatSession(
+        id="session-a",
+        runtime_backend=backend,
+        assistant_kind="persona",
+        assistant_id="persona-alpha",
+    )
+
+
+def _session_controller(session: ConsoleChatSession) -> ConsoleSessionController:
+    controller = ConsoleSessionController.__new__(ConsoleSessionController)
+    controller._active_native_console_session = lambda: session
+    controller._manual_reaction_overrides = {}
+    local = Mock()
+    local.get_persona_profile.return_value = _persona_record()
+    controller.app_instance = SimpleNamespace(
+        character_persona_scope_service=SimpleNamespace(local_service=local),
+    )
+    return controller
+
+
+def _resolution() -> VisualIdentityResolution:
+    return VisualIdentityResolution(
+        actor_kind="persona",
+        actor_id="persona-alpha",
+        requested_expression_key="neutral",
+        manual_expression_key=None,
+        resolved_expression_key="neutral",
+        pack_id=7,
+        pack_version_id=8,
+        asset_id=9,
+        expression_id=None,
+        storage_source="manual",
+        storage_relpath=None,
+        content_type="image/png",
+        is_animated=False,
+        resolution_source="pack_default",
+        fallback_reason="none",
+        cache_identity=(
+            "visual-identity-v1",
+            "actor_kind=persona",
+            "actor_id=persona-alpha",
+            "persona_revision=2",
+            "binding_version=3",
+            "pack_version_id=8",
+            "asset_id=9",
+            "sha256=abc",
+        ),
+        image_bytes=b"image",
+    )
+
+
+def test_current_visual_identity_scope_returns_local_persona_id_without_integer_coercion() -> (
+    None
+):
+    controller = _session_controller(_session())
+
+    assert controller._current_visual_identity_actor_scope() == (
+        "session-a",
+        "persona",
+        "persona-alpha",
+    )
+
+
+def test_server_persona_never_claims_local_visual_identity() -> None:
+    controller = _session_controller(_session(backend="server"))
+
+    assert controller._current_visual_identity_actor_scope() is None
+
+
+def test_persona_resolution_uses_exact_local_service_and_opaque_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = object()
+    service = object()
+    expected = _resolution()
+    resolver = Mock(return_value=expected)
+    monkeypatch.setattr(session_module, "resolve_persona_visual_identity", resolver)
+
+    actual = session_module._resolve_visual_identity_for_db(
+        db,
+        ("session-a", "persona", "persona-alpha"),
+        "thinking",
+        "custom:relief",
+        service,
+    )
+
+    assert actual is expected
+    resolver.assert_called_once_with(
+        db,
+        service,
+        persona_id="persona-alpha",
+        requested_state="thinking",
+        manual_expression_key="custom:relief",
+    )
+
+
+def test_inactive_persona_has_no_reaction_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    local = Mock()
+    local.get_persona_profile.return_value = _persona_record(active=False)
+    repository = Mock(side_effect=AssertionError("graph read must not start"))
+    monkeypatch.setattr(session_module, "VisualIdentityRepository", repository)
+
+    assert (
+        session_module._visual_identity_options_for_db(
+            object(),
+            ("session-a", "persona", "persona-alpha"),
+            local,
+        )
+        == ()
+    )
+    repository.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_persona_picker_discards_inventory_after_local_service_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _session_controller(_session())
+    controller._screen = SimpleNamespace(app=SimpleNamespace(push_screen=Mock()))
+    store = SimpleNamespace(active_session_id="session-a")
+    controller._current_chat_store_accessor = lambda: store
+    controller._visual_identity_db_accessor = lambda: db
+    controller.app_instance.app_config = {
+        "console": {"react_character_expressions": True}
+    }
+    db = object()
+    first_service = controller._local_persona_visual_identity_service()
+    started = threading.Event()
+    release = threading.Event()
+    option = ReactionOption("custom:relief", "Relief", "image/png", False)
+
+    def blocked_options(_db, _scope, service):
+        assert service is first_service
+        started.set()
+        assert release.wait(timeout=5)
+        return (option,)
+
+    monkeypatch.setattr(
+        session_module, "_visual_identity_options_for_db", blocked_options
+    )
+    pending = asyncio.create_task(controller._open_console_reaction_picker())
+    assert await asyncio.to_thread(started.wait, 5)
+    controller.app_instance.character_persona_scope_service.local_service = object()
+    release.set()
+    await pending
+
+    controller._screen.app.push_screen.assert_not_called()
+
+
+def test_persona_replacement_clears_only_prior_session_manual_reaction() -> None:
+    controller = _session_controller(_session())
+    controller._manual_reaction_overrides = {
+        ("session-a", "persona", "persona-old"): "custom:alarm",
+        ("session-a", "persona", "persona-alpha"): "custom:relief",
+        ("session-b", "persona", "persona-old"): "custom:love",
+    }
+
+    controller._clear_replaced_actor_reactions(
+        "session-a", actor_kind="persona", actor_id="persona-alpha"
+    )
+
+    assert controller._manual_reaction_overrides == {
+        ("session-a", "persona", "persona-alpha"): "custom:relief",
+        ("session-b", "persona", "persona-old"): "custom:love",
+    }
+
+
+def test_console_persona_manual_reaction_is_session_and_actor_scoped() -> None:
+    controller = _session_controller(_session())
+    first = ("session-a", "persona", "persona-alpha")
+    second_session = ("session-b", "persona", "persona-alpha")
+    second_actor = ("session-a", "persona", "persona-beta")
+
+    controller._set_manual_reaction(first, "custom:relief")
+    controller._set_manual_reaction(second_session, "custom:alarm")
+    controller._set_manual_reaction(second_actor, "custom:love")
+    controller._clear_manual_reaction(first)
+
+    assert controller._manual_reaction_overrides == {
+        second_session: "custom:alarm",
+        second_actor: "custom:love",
+    }
+
+
+@pytest.mark.asyncio
+async def test_console_persona_expression_resolves_and_paints_active_asset() -> None:
+    scope = ("session-a", "persona", "persona-alpha")
+    render = AsyncMock()
+    cache = SimpleNamespace(
+        prepare=lambda _key, _data: True,
+        get_pil=lambda _key: "decoded-persona-frame",
+    )
+    store = SimpleNamespace(active_session_id="session-a")
+    controller = ConsoleCharacterController(
+        app_config_accessor=lambda: {
+            "console": {"show_character_avatar": True},
+            "chat": {"images": {"show_character_avatar": True}},
+        },
+        chat_store_accessor=lambda: store,
+        active_native_session_accessor=lambda: _session(),
+        current_conversation_id_accessor=lambda: None,
+        character_db_accessor=lambda: None,
+        ensure_chat_store=lambda: None,
+        provider_readiness_config_accessor=lambda: {},
+        default_session_settings=lambda: None,
+        swap_session_character=lambda *_args, **_kwargs: False,
+        sync_temporary_chip=lambda: None,
+        sync_native_chat_ui=AsyncMock(),
+        notify=lambda *_args, **_kwargs: None,
+        actor_scope_accessor=lambda: scope,
+        manual_reaction_key=lambda _scope: None,
+        resolve_visual_identity=lambda *_args: _resolution(),
+        ensure_console_image_view=lambda: (None, cache),
+        console_image_default_mode=lambda: "pixels",
+        is_mounted=lambda: True,
+        render_character_avatar=render,
+    )
+
+    await controller._refresh_active_character_avatar_if_scope_changed(force=True)
+
+    spec = controller._active_character_avatar
+    assert spec["actor_kind"] == "persona"
+    assert spec["actor_id"] == "persona-alpha"
+    assert spec["pil"] == "decoded-persona-frame"
+    assert "character_id" not in spec
+    render.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persona_source_revision_binding_or_asset_change_drops_stale_decode() -> (
+    None
+):
+    scope = ("session-a", "persona", "persona-alpha")
+    store = SimpleNamespace(active_session_id="session-a")
+    first = _resolution()
+    changed = replace(
+        first,
+        cache_identity=(*first.cache_identity[:-1], "sha256=changed"),
+    )
+    resolutions = iter((first, changed))
+    render = AsyncMock()
+    controller = ConsoleCharacterController(
+        app_config_accessor=lambda: {
+            "console": {"show_character_avatar": True},
+            "chat": {"images": {"show_character_avatar": True}},
+        },
+        chat_store_accessor=lambda: store,
+        active_native_session_accessor=lambda: _session(),
+        current_conversation_id_accessor=lambda: None,
+        character_db_accessor=lambda: None,
+        ensure_chat_store=lambda: None,
+        provider_readiness_config_accessor=lambda: {},
+        default_session_settings=lambda: None,
+        swap_session_character=lambda *_args, **_kwargs: False,
+        sync_temporary_chip=lambda: None,
+        sync_native_chat_ui=AsyncMock(),
+        notify=lambda *_args, **_kwargs: None,
+        actor_scope_accessor=lambda: scope,
+        manual_reaction_key=lambda _scope: None,
+        resolve_visual_identity=lambda *_args: next(resolutions),
+        ensure_console_image_view=lambda: (
+            None,
+            SimpleNamespace(
+                prepare=lambda _key, _data: True,
+                get_pil=lambda _key: "stale-frame",
+            ),
+        ),
+        console_image_default_mode=lambda: "pixels",
+        is_mounted=lambda: True,
+        render_character_avatar=render,
+    )
+
+    await controller._refresh_active_character_avatar_if_scope_changed(force=True)
+
+    assert controller._active_character_avatar is None
+    render.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persona_publication_invalidates_only_matching_actor_cache() -> None:
+    controller = ConsoleCharacterController.__new__(ConsoleCharacterController)
+    persona = _resolution().cache_identity
+    character = tuple(
+        "actor_kind=character" if item == "actor_kind=persona" else item
+        for item in persona
+    )
+    controller._console_expression_spec_cache = {
+        persona: {"actor_kind": "persona"},
+        character: {"actor_kind": "character"},
+    }
+    controller._active_character_avatar = None
+    controller._last_console_avatar_scope = None
+
+    controller._invalidate_actor("persona", "persona-alpha")
+
+    assert persona not in controller._console_expression_spec_cache
+    assert character in controller._console_expression_spec_cache
+
+
+def test_persona_expression_does_not_touch_buddy_state() -> None:
+    controller = _session_controller(_session())
+    buddy = SimpleNamespace(generation=11, leases={"voice": "listening"})
+    controller.app_instance.persona_buddy_controller = buddy
+    scope = controller._current_visual_identity_actor_scope()
+
+    controller._set_manual_reaction(scope, "custom:relief")
+
+    assert buddy.generation == 11
+    assert buddy.leases == {"voice": "listening"}

--- a/Tests/UI/test_personas_persona_visual_identity_pack.py
+++ b/Tests/UI/test_personas_persona_visual_identity_pack.py
@@ -1,0 +1,586 @@
+"""Persona editor Shared Visual Identity surface contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.widgets import Button, Static
+
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+import tldw_chatbook.UI.Screens.personas_screen as personas_screen_module
+from Tests.UI.test_personas_workbench import (
+    CHARACTERS,
+    PROFILE,
+    PersonasTestApp,
+    _mounted,
+)
+from tldw_chatbook.Character_Chat.visual_identity import (
+    CANONICAL_EXPRESSION_SLOTS,
+    VisualIdentityPublicationError,
+    VisualIdentityPublicationResult,
+    VisualIdentityResolution,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
+    PersonaProfileEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    EditPersonaProfileRequested,
+    VisualIdentityAssetMetadata,
+    VisualIdentityPackMetadata,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_persona_visual_pack_widget import (
+    PersonasPersonaVisualPackWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_visual_identity_pack_widget import (
+    PersonasVisualIdentityPackWidget,
+)
+
+
+def _pack(*, bound: bool = True) -> VisualIdentityPackMetadata:
+    return VisualIdentityPackMetadata(
+        binding_id=5 if bound else 0,
+        pack_id=10 if bound else 0,
+        pack_version_id=20 if bound else 0,
+        title="Shared Visual Identity reactions",
+        source_kind="manual" if bound else "unbound",
+        default_expression_key="neutral",
+        assets=tuple(
+            VisualIdentityAssetMetadata(
+                asset_id=index if bound else -index,
+                expression_key=key,
+                original_label=key,
+                display_label=key.replace("custom:", "").replace("-", " ").title(),
+                content_type="image/png" if bound else "",
+                is_animated=False,
+            )
+            for index, key in enumerate(CANONICAL_EXPRESSION_SLOTS, start=1)
+        ),
+    )
+
+
+class _EditorApp(App):
+    def compose(self) -> ComposeResult:
+        yield PersonaProfileEditorWidget()
+
+
+@pytest.fixture
+def stub_characters(monkeypatch):
+    from Tests.UI.test_personas_dictionaries import patch_character_paging
+
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_all_characters",
+        lambda: [dict(character) for character in CHARACTERS],
+    )
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_character_by_id",
+        lambda character_id: next(
+            dict(character)
+            for character in CHARACTERS
+            if str(character["id"]) == str(character_id)
+        ),
+    )
+    patch_character_paging(monkeypatch)
+
+
+@pytest.fixture
+def local_scope(mock_app_instance):
+    record = {
+        **PROFILE,
+        "backend": "local",
+        "version": 2,
+        "is_active": True,
+        "deleted": False,
+    }
+    local = Mock()
+    local.get_persona_profile.return_value = dict(record)
+    scope = Mock()
+    scope.local_service = local
+    scope.list_persona_profiles = AsyncMock(
+        return_value={"items": [dict(record)], "total": 1}
+    )
+    scope.get_persona_profile = AsyncMock(return_value=dict(record))
+    mock_app_instance.character_persona_scope_service = scope
+    mock_app_instance.chachanotes_db = object()
+    return scope
+
+
+class _PersonaVisualRepository:
+    def __init__(self, _db):
+        pass
+
+    def get_active_persona_pack(self, _persona_id):
+        return None
+
+
+class _SharedRepository:
+    def __init__(self, _db):
+        pass
+
+    def get_active_actor_pack(self, actor_kind, actor_id):
+        assert (actor_kind, actor_id) == ("persona", "p-1")
+        return None
+
+
+class _BoundSharedRepository(_SharedRepository):
+    def get_active_actor_pack(self, actor_kind, actor_id):
+        assert (actor_kind, actor_id) == ("persona", "p-1")
+        return {
+            "binding": {"id": 5},
+            "pack": {"id": 10, "title": "Persona reactions", "source_kind": "manual"},
+            "version": {"id": 20, "default_expression_key": "neutral"},
+            "assets": [
+                {
+                    "id": 30,
+                    "expression_key": "neutral",
+                    "original_expression_key": "neutral",
+                    "display_label": "Neutral",
+                    "content_type": "image/png",
+                    "is_animated": False,
+                }
+            ],
+        }
+
+
+def _resolution() -> VisualIdentityResolution:
+    return VisualIdentityResolution(
+        actor_kind="persona",
+        actor_id="p-1",
+        requested_expression_key="neutral",
+        manual_expression_key="neutral",
+        resolved_expression_key="neutral",
+        pack_id=10,
+        pack_version_id=20,
+        asset_id=30,
+        expression_id=None,
+        storage_source="manual",
+        storage_relpath=None,
+        content_type="image/png",
+        is_animated=False,
+        resolution_source="manual",
+        fallback_reason="",
+        cache_identity=("persona", "p-1", "20", "30"),
+        image_bytes=b"image",
+    )
+
+
+class _Candidate:
+    old_binding_id = None
+    old_pack_id = None
+    old_version_id = None
+
+    def __init__(self):
+        self.replacements = []
+        self.clears = []
+        self.cancelled = False
+
+    def stage_replacement(self, expression_key, data, *, source):
+        self.replacements.append((expression_key, bytes(data), source))
+
+    def stage_clear(self, expression_key):
+        self.clears.append(expression_key)
+
+    def cancel(self):
+        self.cancelled = True
+
+
+async def _open_persona_editor(pilot):
+    screen = await _mounted(pilot)
+    await pilot.click("#personas-mode-personas")
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.click("#personas-library-row-persona-p-1")
+    await pilot.pause()
+    screen.post_message(EditPersonaProfileRequested("p-1"))
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return screen
+
+
+@pytest.mark.asyncio
+async def test_persona_editor_keeps_shared_identity_and_persona_visual_as_separate_sections() -> (
+    None
+):
+    app = _EditorApp()
+    async with app.run_test(size=(100, 40)):
+        editor = app.query_one(PersonaProfileEditorWidget)
+        await editor.show_shared_visual_identity_pack(_pack())
+
+        shared = editor.query_one(PersonasVisualIdentityPackWidget)
+        operational = editor.query_one(PersonasPersonaVisualPackWidget)
+        assert shared is not operational
+        assert "Shared Visual Identity reactions" in str(
+            shared.query_one("#personas-visual-identity-title", Static).renderable
+        )
+        assert "Persona Visual operational states" in str(
+            editor.query_one("#personas-editor-persona-visual-title", Static).renderable
+        )
+
+
+@pytest.mark.asyncio
+async def test_local_persona_shows_path_free_metadata_lazy_preview_and_manual_labels() -> (
+    None
+):
+    app = _EditorApp()
+    async with app.run_test(size=(100, 40)):
+        editor = app.query_one(PersonaProfileEditorWidget)
+        browser = await editor.show_shared_visual_identity_pack(_pack())
+        assert browser is not None
+        assert browser.selected_asset is not None
+        assert browser.selected_asset.expression_key == "neutral"
+        assert "/Users/" not in repr(browser.pack)
+        preview = browser.query_one(
+            "#personas-visual-identity-preview-image", Container
+        )
+        assert "Loading" in str(preview.children[0].renderable)
+
+
+@pytest.mark.asyncio
+async def test_unbound_local_persona_offers_create_replace_clear_save_cancel() -> None:
+    app = _EditorApp()
+    async with app.run_test(size=(100, 40)):
+        editor = app.query_one(PersonaProfileEditorWidget)
+        browser = await editor.show_shared_visual_identity_pack(_pack(bound=False))
+        assert browser is not None
+        assert (
+            tuple(asset.expression_key for asset in browser.pack.assets)
+            == CANONICAL_EXPRESSION_SLOTS
+        )
+        assert (
+            browser.query_one("#personas-visual-identity-replace", Button).disabled
+            is False
+        )
+        assert (
+            browser.query_one("#personas-visual-identity-clear", Button).disabled
+            is False
+        )
+        browser.set_staged_change("neutral", "replace")
+        assert (
+            browser.query_one("#personas-visual-identity-save", Button).disabled
+            is False
+        )
+        assert (
+            browser.query_one("#personas-visual-identity-cancel", Button).display
+            is True
+        )
+
+
+@pytest.mark.asyncio
+async def test_server_persona_disables_shared_identity_with_save_local_copy_first() -> (
+    None
+):
+    app = _EditorApp()
+    async with app.run_test(size=(100, 40)):
+        editor = app.query_one(PersonaProfileEditorWidget)
+        editor.load_persona({"id": "server-p"}, runtime_source="server")
+
+        host = editor.query_one(
+            "#personas-editor-shared-visual-identity-host", Container
+        )
+        assert "Save a local copy first" in str(host.children[0].renderable)
+        assert not host.query(PersonasVisualIdentityPackWidget)
+
+
+@pytest.mark.asyncio
+async def test_workbench_loads_canonical_unbound_shared_identity_for_local_persona(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _SharedRepository
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        await _open_persona_editor(pilot)
+        browser = pilot.app.screen.query_one(PersonasVisualIdentityPackWidget)
+
+        assert browser.pack is not None
+        assert browser.pack.source_kind == "unbound"
+        assert (
+            tuple(asset.expression_key for asset in browser.pack.assets)
+            == CANONICAL_EXPRESSION_SLOTS
+        )
+
+
+@pytest.mark.asyncio
+async def test_workbench_discards_shared_identity_when_persona_revision_changes(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _SharedRepository
+    )
+    calls = 0
+    original = personas_screen_module.capture_local_persona_visual_identity
+
+    def changing_capture(service, persona_id):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            service.get_persona_profile.return_value = {
+                **PROFILE,
+                "backend": "local",
+                "version": 3,
+                "is_active": True,
+                "deleted": False,
+            }
+        return original(service, persona_id)
+
+    monkeypatch.setattr(
+        personas_screen_module,
+        "capture_local_persona_visual_identity",
+        changing_capture,
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        await _open_persona_editor(pilot)
+        host = pilot.app.screen.query_one(
+            "#personas-editor-shared-visual-identity-host", Container
+        )
+
+        assert not host.query(PersonasVisualIdentityPackWidget)
+        assert "unavailable" in str(host.children[0].renderable).lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_preview_stale_after_resolve_does_not_paint(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _BoundSharedRepository
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_persona_editor(pilot)
+        browser = screen.query_one(PersonasVisualIdentityPackWidget)
+        snapshot = screen._persona_shared_visual_identity_author_snapshot()
+        assert snapshot is not None
+        asset = browser.pack.assets[0]
+
+        def stale_resolve(*_args, **_kwargs):
+            local_scope.local_service.get_persona_profile.return_value = {
+                **PROFILE,
+                "backend": "local",
+                "version": 3,
+                "is_active": True,
+                "deleted": False,
+            }
+            return _resolution()
+
+        monkeypatch.setattr(
+            personas_screen_module, "resolve_persona_visual_identity", stale_resolve
+        )
+        screen._avatar_render_cache = SimpleNamespace(
+            prepare=lambda *_args: True,
+            get_pil=lambda *_args: None,
+        )
+        unavailable = Mock(wraps=browser.set_preview_unavailable)
+        monkeypatch.setattr(browser, "set_preview_unavailable", unavailable)
+
+        await screen._render_persona_shared_visual_identity_preview(snapshot, asset)
+
+        unavailable.assert_called_with(asset_id=asset.asset_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", ((100, 40), (80, 24)))
+async def test_normal_and_80x24_compact_layout_paints_labelled_focusable_actions(
+    size: tuple[int, int],
+) -> None:
+    app = _EditorApp()
+    async with app.run_test(size=size):
+        editor = app.query_one(PersonaProfileEditorWidget)
+        browser = await editor.show_shared_visual_identity_pack(_pack(bound=False))
+        assert browser is not None
+        labels = {
+            str(button.label)
+            for button in browser.query("#personas-visual-identity-actions Button")
+        }
+        assert {
+            "Replace…",
+            "Generate",
+            "Generate All",
+            "Clear",
+            "Save",
+            "Cancel",
+        } <= labels
+        assert all(button.can_focus for button in browser.query(Button))
+
+
+@pytest.mark.asyncio
+async def test_persona_replace_clear_save_and_cancel_own_one_unpublished_candidate(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _SharedRepository
+    )
+    candidate = _Candidate()
+    monkeypatch.setattr(
+        personas_screen_module,
+        "create_visual_identity_candidate",
+        lambda *_args, **_kwargs: candidate,
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_persona_editor(pilot)
+        browser = screen.query_one(PersonasVisualIdentityPackWidget)
+        asset = browser.pack.assets[0]
+
+        assert await screen._stage_persona_shared_visual_identity_replacement(
+            asset, b"image"
+        )
+        assert await screen._stage_persona_shared_visual_identity_clear(asset)
+        assert candidate.replacements == [("neutral", b"image", "upload")]
+        assert candidate.clears == ["neutral"]
+        assert screen._persona_shared_visual_identity_has_unsaved_authoring()
+
+        screen._request_persona_shared_visual_identity_cancel()
+        assert candidate.cancelled is True
+        assert screen._persona_shared_visual_identity_authoring is None
+
+
+@pytest.mark.asyncio
+async def test_failed_persona_publication_preserves_draft_and_active_pack(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _SharedRepository
+    )
+    candidate = _Candidate()
+    monkeypatch.setattr(
+        personas_screen_module,
+        "create_visual_identity_candidate",
+        lambda *_args, **_kwargs: candidate,
+    )
+
+    async def failed_publish(*_args, **_kwargs):
+        return personas_screen_module._DrainedTaskResult(
+            error=VisualIdentityPublicationError("visual_identity_actor_changed")
+        )
+
+    monkeypatch.setattr(personas_screen_module, "_drain_to_thread", failed_publish)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_persona_editor(pilot)
+        browser = screen.query_one(PersonasVisualIdentityPackWidget)
+        authoritative_pack = browser.pack
+        assert await screen._stage_persona_shared_visual_identity_replacement(
+            browser.pack.assets[0], b"image"
+        )
+
+        assert await screen._save_persona_shared_visual_identity_pack() is False
+        assert screen._persona_shared_visual_identity_authoring is not None
+        assert browser.pack == authoritative_pack
+
+
+@pytest.mark.asyncio
+async def test_successful_persona_save_invalidates_only_exact_actor_result(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _SharedRepository
+    )
+    candidate = _Candidate()
+    monkeypatch.setattr(
+        personas_screen_module,
+        "create_visual_identity_candidate",
+        lambda *_args, **_kwargs: candidate,
+    )
+    result = VisualIdentityPublicationResult(
+        actor_kind="persona",
+        actor_id="p-1",
+        old_pack_id=None,
+        old_version_id=None,
+        new_pack_id=10,
+        new_version_id=20,
+        version_directory=Path("unused"),
+    )
+
+    async def successful_publish(*_args, **_kwargs):
+        return personas_screen_module._DrainedTaskResult(completed=True, value=result)
+
+    monkeypatch.setattr(personas_screen_module, "_drain_to_thread", successful_publish)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_persona_editor(pilot)
+        browser = screen.query_one(PersonasVisualIdentityPackWidget)
+        assert await screen._stage_persona_shared_visual_identity_replacement(
+            browser.pack.assets[0], b"image"
+        )
+        invalidate = AsyncMock()
+        refresh = AsyncMock()
+        screen._invalidate_visual_identity_publication = invalidate
+        screen._configure_persona_shared_visual_identity = refresh
+
+        assert await screen._save_persona_shared_visual_identity_pack() is True
+        invalidate.assert_awaited_once_with(result)
+        refresh.assert_awaited_once()
+        assert screen._persona_shared_visual_identity_authoring is None
+
+
+@pytest.mark.asyncio
+async def test_dirty_navigation_decline_preserves_persona_reaction_draft_and_accept_drains(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _SharedRepository
+    )
+    candidate = _Candidate()
+    monkeypatch.setattr(
+        personas_screen_module,
+        "create_visual_identity_candidate",
+        lambda *_args, **_kwargs: candidate,
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_persona_editor(pilot)
+        browser = screen.query_one(PersonasVisualIdentityPackWidget)
+        assert await screen._stage_persona_shared_visual_identity_replacement(
+            browser.pack.assets[0], b"image"
+        )
+        continuation = AsyncMock()
+
+        screen._confirm_discard_unsaved = AsyncMock(return_value=False)
+        await screen._confirm_then_run(continuation)
+        continuation.assert_not_awaited()
+        assert screen._persona_shared_visual_identity_authoring is not None
+        assert candidate.cancelled is False
+
+        screen._confirm_discard_unsaved = AsyncMock(return_value=True)
+        await screen._confirm_then_run(continuation)
+        continuation.assert_awaited_once()
+        assert candidate.cancelled is True
+        assert screen._persona_shared_visual_identity_authoring is None

--- a/Tests/UI/test_personas_persona_visual_identity_pack.py
+++ b/Tests/UI/test_personas_persona_visual_identity_pack.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -400,6 +401,33 @@ async def test_persona_preview_stale_after_resolve_does_not_paint(
 
 
 @pytest.mark.asyncio
+async def test_old_persona_editor_generation_cannot_mutate_replacement_session(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _BoundSharedRepository
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_persona_editor(pilot)
+        snapshot = screen._persona_shared_visual_identity_author_snapshot()
+        assert snapshot is not None
+        assert screen._persona_shared_visual_identity_author_snapshot_is_current(
+            snapshot
+        )
+
+        screen._persona_visual_generation += 1
+
+        assert not screen._persona_shared_visual_identity_author_snapshot_is_current(
+            snapshot
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("size", ((100, 40), (80, 24)))
 async def test_normal_and_80x24_compact_layout_paints_labelled_focusable_actions(
     size: tuple[int, int],
@@ -548,6 +576,58 @@ async def test_successful_persona_save_invalidates_only_exact_actor_result(
 
 
 @pytest.mark.asyncio
+async def test_duplicate_persona_save_is_rejected_until_first_publish_drains(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+) -> None:
+    monkeypatch.setattr(
+        personas_screen_module, "PersonaVisualRepository", _PersonaVisualRepository
+    )
+    monkeypatch.setattr(
+        personas_screen_module, "VisualIdentityRepository", _SharedRepository
+    )
+    candidate = _Candidate()
+    monkeypatch.setattr(
+        personas_screen_module,
+        "create_visual_identity_candidate",
+        lambda *_args, **_kwargs: candidate,
+    )
+    result = VisualIdentityPublicationResult(
+        actor_kind="persona",
+        actor_id="p-1",
+        old_pack_id=None,
+        old_version_id=None,
+        new_pack_id=10,
+        new_version_id=20,
+        version_directory=Path("unused"),
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_publish(*_args, **_kwargs):
+        started.set()
+        await release.wait()
+        return personas_screen_module._DrainedTaskResult(completed=True, value=result)
+
+    monkeypatch.setattr(personas_screen_module, "_drain_to_thread", blocked_publish)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_persona_editor(pilot)
+        browser = screen.query_one(PersonasVisualIdentityPackWidget)
+        assert await screen._stage_persona_shared_visual_identity_replacement(
+            browser.pack.assets[0], b"image"
+        )
+        screen._invalidate_visual_identity_publication = AsyncMock()
+        screen._configure_persona_shared_visual_identity = AsyncMock()
+
+        first = asyncio.create_task(screen._save_persona_shared_visual_identity_pack())
+        await started.wait()
+        assert await screen._save_persona_shared_visual_identity_pack() is False
+        release.set()
+        assert await first is True
+
+
+@pytest.mark.asyncio
 async def test_dirty_navigation_decline_preserves_persona_reaction_draft_and_accept_drains(
     monkeypatch, mock_app_instance, stub_characters, local_scope
 ) -> None:
@@ -584,3 +664,33 @@ async def test_dirty_navigation_decline_preserves_persona_reaction_draft_and_acc
         continuation.assert_awaited_once()
         assert candidate.cancelled is True
         assert screen._persona_shared_visual_identity_authoring is None
+
+
+@pytest.mark.asyncio
+async def test_repeated_outer_cancellation_drains_persona_reaction_work() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def critical_work() -> str:
+        started.set()
+        await release.wait()
+        return "committed"
+
+    operation = asyncio.create_task(
+        personas_screen_module._drain_async(
+            critical_work(), task_name="persona-reaction-repeated-cancel"
+        )
+    )
+    await started.wait()
+    operation.cancel()
+    await asyncio.sleep(0)
+    operation.cancel()
+    await asyncio.sleep(0)
+    assert not operation.done()
+
+    release.set()
+    outcome = await operation
+
+    assert outcome.completed is True
+    assert outcome.value == "committed"
+    assert isinstance(outcome.cancellation, asyncio.CancelledError)

--- a/Tests/test_config_delete_settings.py
+++ b/Tests/test_config_delete_settings.py
@@ -540,8 +540,8 @@ def test_shared_lock_prevents_lost_concurrent_set_and_delete_updates(
                 self._owner = None
             self._lock.release()
 
-    instrumented_lock = InstrumentedLock(config_module._CONFIG_FILE_LOCK)
-    monkeypatch.setattr(config_module, "_CONFIG_FILE_LOCK", instrumented_lock)
+    instrumented_lock = InstrumentedLock(config_module._SETTINGS_REBUILD_LOCK)
+    monkeypatch.setattr(config_module, "_SETTINGS_REBUILD_LOCK", instrumented_lock)
     monkeypatch.setattr(
         config_module,
         "load_settings",

--- a/Tests/test_config_delete_settings.py
+++ b/Tests/test_config_delete_settings.py
@@ -540,7 +540,7 @@ def test_shared_lock_prevents_lost_concurrent_set_and_delete_updates(
                 self._owner = None
             self._lock.release()
 
-    instrumented_lock = InstrumentedLock(config_module._SETTINGS_REBUILD_LOCK)
+    instrumented_lock = InstrumentedLock(config_module._settings_rebuild_lock())
     monkeypatch.setattr(config_module, "_SETTINGS_REBUILD_LOCK", instrumented_lock)
     monkeypatch.setattr(
         config_module,

--- a/Tests/test_config_settings_cache_concurrency.py
+++ b/Tests/test_config_settings_cache_concurrency.py
@@ -155,3 +155,39 @@ def test_config_write_waits_for_settings_rebuild_before_file_lock(tmp_path):
     assert not thread.is_alive()
     assert entered_while_rebuilding is False
     assert file_lock_was_free is True
+
+
+def test_runtime_snapshot_takes_rebuild_lock_before_file_lock(monkeypatch):
+    """Runtime snapshots must follow the global rebuild -> file lock order."""
+    events: list[str] = []
+
+    class TrackingLock:
+        def __init__(self, name: str) -> None:
+            self._name = name
+            self._lock = threading.RLock()
+
+        def __enter__(self):
+            events.append(self._name)
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback) -> None:
+            del exc_type, exc_value, traceback
+            self._lock.release()
+
+    rebuild_lock = TrackingLock("rebuild")
+    file_lock = TrackingLock("file")
+    monkeypatch.setattr(config_module, "_SETTINGS_REBUILD_LOCK", rebuild_lock)
+    monkeypatch.setattr(config_module, "_CONFIG_FILE_LOCK", file_lock)
+
+    def load_settings(*, force_reload: bool = False) -> dict:
+        del force_reload
+        with config_module._settings_rebuild_lock():
+            return {"source": "test"}
+
+    monkeypatch.setattr(config_module, "load_settings", load_settings)
+
+    snapshot = config_module.get_runtime_config_snapshot(force_reload=True)
+
+    assert snapshot.values == {"source": "test"}
+    assert events[:2] == ["rebuild", "file"]

--- a/Tests/test_config_settings_cache_concurrency.py
+++ b/Tests/test_config_settings_cache_concurrency.py
@@ -129,3 +129,29 @@ def test_cache_hit_path_does_no_rebuild(counting_bootstrap):
     for _ in range(5):
         assert isinstance(config_module.load_settings(), dict)
     assert counting_bootstrap == [], "a cache hit must not rebuild"
+
+
+def test_config_write_waits_for_settings_rebuild_before_file_lock(tmp_path):
+    """A writer must not invert the settings-rebuild/config-file lock order."""
+    config_module.load_settings()
+    entered_write = threading.Event()
+    release_write = threading.Event()
+
+    def writer() -> None:
+        with config_module._config_write_lock(tmp_path / "config.toml"):
+            entered_write.set()
+            release_write.wait(timeout=5)
+
+    with config_module._SETTINGS_REBUILD_LOCK:
+        thread = threading.Thread(target=writer)
+        thread.start()
+        entered_while_rebuilding = entered_write.wait(timeout=0.25)
+        file_lock_was_free = config_module._CONFIG_FILE_LOCK.acquire(blocking=False)
+        if file_lock_was_free:
+            config_module._CONFIG_FILE_LOCK.release()
+        release_write.set()
+
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert entered_while_rebuilding is False
+    assert file_lock_was_free is True

--- a/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
+++ b/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-19056
 title: Enable Shared Visual Identity for Persona actors
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-20 18:01'
-updated_date: '2026-08-22 17:11'
+updated_date: '2026-08-22 18:33'
 labels: []
 dependencies:
   - TASK-16319
@@ -61,4 +61,6 @@ Implemented Persona actors on the existing Shared Visual Identity boundary: exac
 Verification: assigned-worktree provenance and architecture gate 4 passed; complete affected-component gate 984 passed with 1 Windows-only skip and 3 dependency warnings; diagnostic, privacy, architecture, and governance gate 68 passed; focused Console gate 99 passed with 314 deselected; lifecycle and mutation matrix 88 passed. Born-RED to GREEN and mutation evidence covered source, Persona revision, editor generation, binding version, post-decode identity, cancellation drain, and affected-only invalidation guards. All changed Python files pass Ruff, format, py_compile, and diff checks; the forbidden-boundary scan found no Persona Buddy, Persona Visual, Actor Pack archive, or server-write coupling. No full repository suite was run.
 
 ADR: no new ADR was required; the implementation follows ADR-067 and ADR-074. The executable plan at Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md was completed without architectural deviation. No reusable lesson entry was warranted.
+
+Rebase follow-up: rebased onto current dev and repaired three inherited/overlap failures before PR publication. A born-RED config lock-order test exposed a settings-rebuild/config-file inversion; the shared write boundary now acquires those locks in one order, with 78 focused config tests green. The Console avatar fake was aligned with dev's new allocation callback, blank conversation search now clears synchronously, and the workspace-rail test uses its existing bounded recompose waiter (five independent green runs). The complete affected gate passed 984 tests with one Windows-only skip and four warnings before the final no-conflict rebase; post-rebase overlap verification passed 116 rail/shell tests, 68 architecture/governance tests, and the repaired rail-row test in five isolated processes. The diagnostic inventory update was reviewed statement-by-statement: it pins dev's existing Inspector structural-fingerprint warning (no row values/action labels, secrets, paths, or tracebacks) and removes one stale expectation for a deleted Library warning. Ruff, py_compile, and diff checks pass; inherited formatter baselines are unchanged. No full repository suite was run.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
+++ b/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-19056
 title: Enable Shared Visual Identity for Persona actors
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-20 18:01'
-updated_date: '2026-08-22 06:38'
+updated_date: '2026-08-22 16:31'
 labels: []
 dependencies:
   - TASK-16319
@@ -25,14 +25,14 @@ Complete the already-declared Persona actor path in Shared Visual Identity so lo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Eligible local Personas, identified by exact local source/id plus current profile/editor revision, can create, replace, clear, publish, and resolve Shared Visual Identity bindings using the existing immutable pack/version model; inactive, disabled, deleted, or missing Personas cannot author, publish, or render. Restore, replacement, or concurrent update re-resolves authority, and stale authority cannot mutate active state.
-- [ ] #2 Personas Workbench exposes path-free Shared Visual Identity metadata, lazy selected preview, staged edits, visible manual labels where applicable, Save, and Cancel with full session/actor/binding fences; declining dirty navigation preserves the draft and staging, while accepted navigation or Cancel signals and drains in-flight work, discards only the unpublished candidate/draft, and preserves the active version.
-- [ ] #3 Persona resolution uses exact full actor and cache identities, deterministic fallback, targeted actor invalidation, and source-only change detection.
-- [ ] #4 Console/persona-chat consumers render the active Persona expression without giving Persona Buddy operational states any reaction semantics.
-- [ ] #5 Server-backed Personas require Save Local Copy first; source, session, actor, binding, version, and profile-revision authority is revalidated after every await, and any stale change fails closed without publication or repaint.
-- [ ] #6 Existing Character creation, authoring, Console rendering, publication, cache, and four-state operational behavior remain unchanged.
-- [ ] #7 No schema/runtime merge with Persona Visual, Actor Pack archive workflow, or server write path is introduced.
-- [ ] #8 Labelled actions are keyboard-operable and compact and normal layouts paint usable controls; user-facing errors, logs, and diagnostics remain path-free. Focused real SQLite repository/resolver/Workbench/Console/race/invalidation/lifecycle tests pass in an isolated profile with born-RED → GREEN evidence and mutation proof for authority, cancellation, and invalidation guards. Evidence records assigned-worktree provenance and establishes isolated `HOME`, XDG, config, and data roots before imports; scoped Ruff, format, compile, diff, diagnostic, privacy, architecture, and governance checks, including ADR-067 gates, pass.
+- [x] #1 Eligible local Personas, identified by exact local source/id plus current profile/editor revision, can create, replace, clear, publish, and resolve Shared Visual Identity bindings using the existing immutable pack/version model; inactive, disabled, deleted, or missing Personas cannot author, publish, or render. Restore, replacement, or concurrent update re-resolves authority, and stale authority cannot mutate active state.
+- [x] #2 Personas Workbench exposes path-free Shared Visual Identity metadata, lazy selected preview, staged edits, visible manual labels where applicable, Save, and Cancel with full session/actor/binding fences; declining dirty navigation preserves the draft and staging, while accepted navigation or Cancel signals and drains in-flight work, discards only the unpublished candidate/draft, and preserves the active version.
+- [x] #3 Persona resolution uses exact full actor and cache identities, deterministic fallback, targeted actor invalidation, and source-only change detection.
+- [x] #4 Console/persona-chat consumers render the active Persona expression without giving Persona Buddy operational states any reaction semantics.
+- [x] #5 Server-backed Personas require Save Local Copy first; source, session, actor, binding, version, and profile-revision authority is revalidated after every await, and any stale change fails closed without publication or repaint.
+- [x] #6 Existing Character creation, authoring, Console rendering, publication, cache, and four-state operational behavior remain unchanged.
+- [x] #7 No schema/runtime merge with Persona Visual, Actor Pack archive workflow, or server write path is introduced.
+- [x] #8 Labelled actions are keyboard-operable and compact and normal layouts paint usable controls; user-facing errors, logs, and diagnostics remain path-free. Focused real SQLite repository/resolver/Workbench/Console/race/invalidation/lifecycle tests pass in an isolated profile with born-RED → GREEN evidence and mutation proof for authority, cancellation, and invalidation guards. Evidence records assigned-worktree provenance and establishes isolated `HOME`, XDG, config, and data roots before imports; scoped Ruff, format, compile, diff, diagnostic, privacy, architecture, and governance checks, including ADR-067 gates, pass.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -51,3 +51,13 @@ Executable plan: Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-vis
 5. Prove lifecycle, race, targeted invalidation, privacy, architecture, and Character-equivalence contracts.
 6. Run isolated touched-component/static/governance evidence and close the task only if every scoped gate is green.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Persona actors on the existing Shared Visual Identity boundary: exact local authority and immutable resolution/publication, Workbench staging with Save/Cancel and lifecycle fences, Console expression rendering, and affected-only invalidation while retaining Character and Persona Buddy separation.
+
+Verification: assigned-worktree provenance and architecture gate 4 passed; complete affected-component gate 984 passed with 1 Windows-only skip and 3 dependency warnings; diagnostic, privacy, architecture, and governance gate 68 passed; focused Console gate 99 passed with 314 deselected; lifecycle and mutation matrix 88 passed. Born-RED to GREEN and mutation evidence covered source, Persona revision, editor generation, binding version, post-decode identity, cancellation drain, and affected-only invalidation guards. All changed Python files pass Ruff, format, py_compile, and diff checks; the forbidden-boundary scan found no Persona Buddy, Persona Visual, Actor Pack archive, or server-write coupling. No full repository suite was run.
+
+ADR: no new ADR was required; the implementation follows ADR-067 and ADR-074. The executable plan at Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md was completed without architectural deviation. No reusable lesson entry was warranted.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
+++ b/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-19056
 title: Enable Shared Visual Identity for Persona actors
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-20 18:01'
-updated_date: '2026-08-20 18:02'
+updated_date: '2026-08-22 06:38'
 labels: []
 dependencies:
   - TASK-16319
@@ -34,3 +34,20 @@ Complete the already-declared Persona actor path in Shared Visual Identity so lo
 - [ ] #7 No schema/runtime merge with Persona Visual, Actor Pack archive workflow, or server write path is introduced.
 - [ ] #8 Labelled actions are keyboard-operable and compact and normal layouts paint usable controls; user-facing errors, logs, and diagnostics remain path-free. Focused real SQLite repository/resolver/Workbench/Console/race/invalidation/lifecycle tests pass in an isolated profile with born-RED → GREEN evidence and mutation proof for authority, cancellation, and invalidation guards. Evidence records assigned-worktree provenance and establishes isolated `HOME`, XDG, config, and data roots before imports; scoped Ruff, format, compile, diff, diagnostic, privacy, architecture, and governance checks, including ADR-067 gates, pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/067-bundled-samira-visual-identity-pack.md and backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
+Reason: Existing ADRs already define Persona actor bindings and require Shared Visual Identity expressions to remain separate from Persona Visual/Buddy operational states.
+
+Executable plan: Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-visual-identity.md
+
+1. Freeze exact local Persona authority and generalize deterministic Shared Visual Identity resolution with Character non-regression.
+2. Support unbound Persona candidates and authority-fenced immutable publication through the existing repository/filesystem boundary.
+3. Add the distinct Personas Workbench Shared Visual Identity editor with lazy preview, staging, Save/Cancel, dirty-navigation, and cancellation drain.
+4. Extend the existing Console actor-scoped reaction/cache path to eligible local Personas without Buddy coupling.
+5. Prove lifecycle, race, targeted invalidation, privacy, architecture, and Character-equivalence contracts.
+6. Run isolated touched-component/static/governance evidence and close the task only if every scoped gate is green.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
+++ b/backlog/tasks/task-19056 - Enable-Shared-Visual-Identity-for-Persona-actors.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-19056
 title: Enable Shared Visual Identity for Persona actors
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-08-20 18:01'
-updated_date: '2026-08-22 16:31'
+updated_date: '2026-08-22 17:11'
 labels: []
 dependencies:
   - TASK-16319
@@ -50,6 +50,7 @@ Executable plan: Docs/superpowers/plans/2026-08-22-task-19056-persona-shared-vis
 4. Extend the existing Console actor-scoped reaction/cache path to eligible local Personas without Buddy coupling.
 5. Prove lifecycle, race, targeted invalidation, privacy, architecture, and Character-equivalence contracts.
 6. Run isolated touched-component/static/governance evidence and close the task only if every scoped gate is green.
+7. After rebasing onto current `dev`, reproduce the Console config-lock regression, add one lock-order test, apply the minimal shared-lock ordering fix, and rerun affected evidence before re-closing.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/tldw_chatbook/Character_Chat/persona_visual_identity.py
+++ b/tldw_chatbook/Character_Chat/persona_visual_identity.py
@@ -36,7 +36,11 @@ class LocalPersonaVisualIdentityAuthority:
 
     @property
     def cache_identity(self) -> tuple[str, ...]:
-        """Return the complete path-free authority identity."""
+        """Return the complete path-free authority identity.
+
+        Returns:
+            Stable source, Persona revision, and portrait identity fields.
+        """
 
         portrait = self.portrait
         return (
@@ -53,7 +57,15 @@ def capture_local_persona_visual_identity(
     local_service: object,
     persona_id: str,
 ) -> LocalPersonaVisualIdentityAuthority | None:
-    """Capture one eligible local Persona and its optional linked portrait."""
+    """Capture one eligible local Persona and its optional linked portrait.
+
+    Args:
+        local_service: Local Persona profile service.
+        persona_id: Exact profile-local Persona identifier.
+
+    Returns:
+        Immutable current authority, or ``None`` when the Persona is ineligible.
+    """
 
     if type(persona_id) is not str or not persona_id or len(persona_id) > 200:
         return None
@@ -89,7 +101,15 @@ def local_persona_visual_identity_is_current(
     local_service: object,
     authority: LocalPersonaVisualIdentityAuthority,
 ) -> bool:
-    """Return whether the complete local Persona authority is unchanged."""
+    """Return whether the complete local Persona authority is unchanged.
+
+    Args:
+        local_service: Local Persona profile service.
+        authority: Previously captured authority to revalidate.
+
+    Returns:
+        ``True`` only when every authority field is still current.
+    """
 
     if type(authority) is not LocalPersonaVisualIdentityAuthority:
         return False
@@ -108,7 +128,19 @@ def resolve_persona_visual_identity(
     manual_expression_key: str | None = None,
     user_data_dir: str | Path | None = None,
 ) -> _shared.VisualIdentityResolution:
-    """Resolve one eligible local Persona reaction and linked portrait fallback."""
+    """Resolve one eligible local Persona reaction and linked portrait fallback.
+
+    Args:
+        db: Initialized profile-local character database.
+        local_service: Local Persona profile service.
+        persona_id: Exact profile-local Persona identifier.
+        requested_state: Current Console operational state.
+        manual_expression_key: Optional session-local reaction override.
+        user_data_dir: Injectable profile root for profile-owned pack assets.
+
+    Returns:
+        Frozen reaction resolution with selected image bytes or stable fallback.
+    """
 
     requested_state_key = (
         requested_state.strip().lower() if type(requested_state) is str else ""
@@ -125,8 +157,9 @@ def resolve_persona_visual_identity(
             "persona", str(persona_id), requested_key, manual_key, "actor_unavailable"
         )
 
-    rows = db.execute_query(
-        """
+    with db.transaction():
+        rows = db.execute_query(
+            """
         /* visual_identity_resolver */
         WITH active_graph AS MATERIALIZED (
             SELECT b.id AS binding_id,
@@ -221,8 +254,8 @@ def resolve_persona_visual_identity(
                   a.id
          LIMIT 4
         """,
-        (authority.persona_id, manual_key, requested_key),
-    ).fetchall()
+            (authority.persona_id, manual_key, requested_key),
+        ).fetchall()
     candidates = [dict(row) for row in rows]
     for candidate in candidates:
         if candidate["asset_id"] is None:

--- a/tldw_chatbook/Character_Chat/persona_visual_identity.py
+++ b/tldw_chatbook/Character_Chat/persona_visual_identity.py
@@ -34,6 +34,20 @@ class LocalPersonaVisualIdentityAuthority:
     persona_revision: int
     portrait: LocalPersonaVisualIdentityPortrait | None
 
+    @property
+    def cache_identity(self) -> tuple[str, ...]:
+        """Return the complete path-free authority identity."""
+
+        portrait = self.portrait
+        return (
+            f"source={self.source}",
+            f"persona_id={self.persona_id}",
+            f"persona_revision={self.persona_revision}",
+            f"portrait_id={portrait.portrait_id if portrait is not None else ''}",
+            f"portrait_revision={portrait.revision if portrait is not None else ''}",
+            f"portrait_sha256={portrait.sha256 if portrait is not None else ''}",
+        )
+
 
 def capture_local_persona_visual_identity(
     local_service: object,

--- a/tldw_chatbook/Character_Chat/persona_visual_identity.py
+++ b/tldw_chatbook/Character_Chat/persona_visual_identity.py
@@ -1,0 +1,428 @@
+"""Exact local-Persona authority for Shared Visual Identity reactions."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from . import visual_identity as _shared
+
+
+_MAX_PORTRAIT_BYTES = 25 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class LocalPersonaVisualIdentityPortrait:
+    """One bounded linked Character portrait with no filesystem identity."""
+
+    portrait_id: str
+    revision: int
+    content_type: str
+    sha256: str
+    data: bytes = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalPersonaVisualIdentityAuthority:
+    """Exact local Persona and linked-portrait authority for one operation."""
+
+    source: str
+    persona_id: str
+    persona_revision: int
+    portrait: LocalPersonaVisualIdentityPortrait | None
+
+
+def capture_local_persona_visual_identity(
+    local_service: object,
+    persona_id: str,
+) -> LocalPersonaVisualIdentityAuthority | None:
+    """Capture one eligible local Persona and its optional linked portrait."""
+
+    if type(persona_id) is not str or not persona_id or len(persona_id) > 200:
+        return None
+    getter = getattr(local_service, "get_persona_profile", None)
+    if not callable(getter):
+        return None
+    try:
+        record = getter(persona_id)
+    except Exception:
+        return None
+    if type(record) is not dict:
+        return None
+    revision = record.get("version")
+    if (
+        record.get("backend") != "local"
+        or type(record.get("id")) is not str
+        or record.get("id") != persona_id
+        or type(revision) is not int
+        or revision < 1
+        or record.get("deleted", False) is not False
+        or record.get("is_active", True) is not True
+    ):
+        return None
+    return LocalPersonaVisualIdentityAuthority(
+        source="local",
+        persona_id=persona_id,
+        persona_revision=revision,
+        portrait=_linked_portrait(local_service, record),
+    )
+
+
+def local_persona_visual_identity_is_current(
+    local_service: object,
+    authority: LocalPersonaVisualIdentityAuthority,
+) -> bool:
+    """Return whether the complete local Persona authority is unchanged."""
+
+    if type(authority) is not LocalPersonaVisualIdentityAuthority:
+        return False
+    return (
+        capture_local_persona_visual_identity(local_service, authority.persona_id)
+        == authority
+    )
+
+
+def resolve_persona_visual_identity(
+    db: Any,
+    local_service: object,
+    *,
+    persona_id: str,
+    requested_state: str,
+    manual_expression_key: str | None = None,
+    user_data_dir: str | Path | None = None,
+) -> _shared.VisualIdentityResolution:
+    """Resolve one eligible local Persona reaction and linked portrait fallback."""
+
+    requested_state_key = (
+        requested_state.strip().lower() if type(requested_state) is str else ""
+    )
+    requested_key = _shared._OPERATIONAL_EXPRESSION_KEYS.get(requested_state_key)
+    manual_key = (
+        _shared.normalize_expression_key(manual_expression_key)
+        if manual_expression_key is not None
+        else None
+    )
+    authority = capture_local_persona_visual_identity(local_service, persona_id)
+    if authority is None:
+        return _shared._placeholder_resolution(
+            "persona", str(persona_id), requested_key, manual_key, "actor_unavailable"
+        )
+
+    rows = db.execute_query(
+        """
+        /* visual_identity_resolver */
+        WITH active_graph AS MATERIALIZED (
+            SELECT b.id AS binding_id,
+                   b.version AS binding_version,
+                   p.id AS pack_id,
+                   p.version AS pack_revision,
+                   p.source_kind AS pack_source_kind,
+                   v.id AS pack_version_id,
+                   v.version_number AS pack_version_number,
+                   v.manifest_json AS manifest_json,
+                   v.default_expression_key AS version_default_expression_key
+              FROM visual_identity_bindings b
+              JOIN visual_identity_packs p
+                ON p.id = b.pack_id
+               AND p.owner_user_id = 0
+               AND p.status = 'active'
+               AND p.active_version_id = b.active_version_id
+              JOIN visual_identity_pack_versions v
+                ON v.id = b.active_version_id
+               AND v.pack_id = p.id
+               AND v.owner_user_id = 0
+             WHERE b.owner_user_id = 0
+               AND b.actor_kind = 'persona'
+               AND b.actor_id = ?
+               AND b.status = 'active'
+        ),
+        candidate_slots(expression_key, priority) AS MATERIALIZED (
+            SELECT column1, column2
+              FROM (VALUES (?, 0), (?, 1))
+             WHERE column1 IS NOT NULL
+            UNION ALL
+            SELECT version_default_expression_key, 2
+              FROM active_graph
+             WHERE pack_version_id IS NOT NULL
+               AND version_default_expression_key IS NOT NULL
+            UNION ALL
+            SELECT 'neutral', 3
+              FROM active_graph
+             WHERE pack_version_id IS NOT NULL
+        ),
+        deduplicated_slots AS MATERIALIZED (
+            SELECT expression_key, MIN(priority) AS priority
+              FROM candidate_slots
+             GROUP BY expression_key
+        ),
+        selected_slots AS MATERIALIZED (
+            SELECT slots.expression_key,
+                   slots.priority,
+                   (
+                       SELECT a2.id
+                         FROM visual_identity_assets a2
+                        WHERE a2.pack_id = graph.pack_id
+                          AND a2.pack_version_id = graph.pack_version_id
+                          AND a2.owner_user_id = 0
+                          AND a2.deleted = 0
+                          AND a2.expression_key = slots.expression_key
+                        ORDER BY a2.id
+                        LIMIT 1
+                   ) AS asset_id
+              FROM deduplicated_slots slots
+              CROSS JOIN active_graph graph
+        )
+        SELECT graph.binding_id,
+               graph.binding_version,
+               graph.pack_id,
+               graph.pack_revision,
+               graph.pack_source_kind,
+               graph.pack_version_id,
+               graph.pack_version_number,
+               graph.manifest_json,
+               graph.version_default_expression_key,
+               a.id AS asset_id,
+               a.expression_key AS asset_expression_key,
+               a.original_expression_key AS asset_original_expression_key,
+               a.display_label AS asset_display_label,
+               a.storage_relpath AS asset_storage_relpath,
+               a.content_type AS asset_content_type,
+               a.bytes AS asset_bytes,
+               a.sha256 AS asset_sha256,
+               a.width AS asset_width,
+               a.height AS asset_height,
+               a.is_animated AS asset_is_animated,
+               a.frame_count AS asset_frame_count,
+               a.duration_ms AS asset_duration_ms
+          FROM active_graph graph
+          LEFT JOIN selected_slots selected ON 1 = 1
+          LEFT JOIN visual_identity_assets a ON a.id = selected.asset_id
+         ORDER BY CASE
+                    WHEN selected.priority IS NOT NULL THEN selected.priority
+                    ELSE 4
+                  END,
+                  a.id
+         LIMIT 4
+        """,
+        (authority.persona_id, manual_key, requested_key),
+    ).fetchall()
+    candidates = [dict(row) for row in rows]
+    for candidate in candidates:
+        if candidate["asset_id"] is None:
+            continue
+        try:
+            asset = _shared._resolution_manifest_asset(candidate)
+            loaded = _shared.load_visual_identity_asset(
+                asset,
+                source_kind=str(candidate["pack_source_kind"]),
+                user_data_dir=user_data_dir,
+            )
+            _shared._validate_image_bytes(loaded, decoded_pixels_before=0)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if not local_persona_visual_identity_is_current(local_service, authority):
+            return _shared._placeholder_resolution(
+                "persona",
+                authority.persona_id,
+                requested_key,
+                manual_key,
+                "actor_unavailable",
+            )
+        source, reason = _shared._pack_resolution_category(
+            str(candidate["asset_expression_key"]),
+            manual_key=manual_key,
+            requested_key=requested_key,
+            default_key=str(candidate["version_default_expression_key"]),
+        )
+        manifest_sha256 = hashlib.sha256(
+            str(candidate["manifest_json"]).encode("utf-8")
+        ).hexdigest()
+        return _shared.VisualIdentityResolution(
+            actor_kind="persona",
+            actor_id=authority.persona_id,
+            requested_expression_key=requested_key,
+            manual_expression_key=manual_key,
+            resolved_expression_key=str(candidate["asset_expression_key"]),
+            pack_id=int(candidate["pack_id"]),
+            pack_version_id=int(candidate["pack_version_id"]),
+            asset_id=int(candidate["asset_id"]),
+            expression_id=None,
+            storage_source=str(candidate["pack_source_kind"]),
+            storage_relpath=str(candidate["asset_storage_relpath"]),
+            content_type=str(candidate["asset_content_type"]),
+            is_animated=bool(candidate["asset_is_animated"]),
+            resolution_source=source,
+            fallback_reason=reason,
+            cache_identity=_persona_cache_identity(
+                authority,
+                requested_key=requested_key,
+                manual_key=manual_key,
+                resolution_source=source,
+                binding_id=int(candidate["binding_id"]),
+                binding_version=int(candidate["binding_version"]),
+                pack_id=int(candidate["pack_id"]),
+                pack_revision=int(candidate["pack_revision"]),
+                pack_version_id=int(candidate["pack_version_id"]),
+                pack_version_number=int(candidate["pack_version_number"]),
+                manifest_sha256=manifest_sha256,
+                asset_id=int(candidate["asset_id"]),
+                asset_sha256=str(candidate["asset_sha256"]),
+            ),
+            image_bytes=loaded.data,
+        )
+
+    if not local_persona_visual_identity_is_current(local_service, authority):
+        return _shared._placeholder_resolution(
+            "persona",
+            authority.persona_id,
+            requested_key,
+            manual_key,
+            "actor_unavailable",
+        )
+    validated_portrait = _shared._validate_fallback_image(
+        authority.portrait.data if authority.portrait is not None else None
+    )
+    if not local_persona_visual_identity_is_current(local_service, authority):
+        return _shared._placeholder_resolution(
+            "persona",
+            authority.persona_id,
+            requested_key,
+            manual_key,
+            "actor_unavailable",
+        )
+    if validated_portrait is None:
+        return _shared._placeholder_resolution(
+            "persona",
+            authority.persona_id,
+            requested_key,
+            manual_key,
+            "portrait_unavailable",
+        )
+    data, content_type, is_animated = validated_portrait
+    return _shared.VisualIdentityResolution(
+        actor_kind="persona",
+        actor_id=authority.persona_id,
+        requested_expression_key=requested_key,
+        manual_expression_key=manual_key,
+        resolved_expression_key=requested_key,
+        pack_id=None,
+        pack_version_id=None,
+        asset_id=None,
+        expression_id=None,
+        storage_source="database",
+        storage_relpath=None,
+        content_type=content_type,
+        is_animated=is_animated,
+        resolution_source="persona_portrait",
+        fallback_reason="pack_assets_unavailable" if candidates else "pack_unavailable",
+        cache_identity=_persona_cache_identity(
+            authority,
+            requested_key=requested_key,
+            manual_key=manual_key,
+            resolution_source="persona_portrait",
+        ),
+        image_bytes=data,
+    )
+
+
+def _persona_cache_identity(
+    authority: LocalPersonaVisualIdentityAuthority,
+    *,
+    requested_key: str | None,
+    manual_key: str | None,
+    resolution_source: str,
+    binding_id: int | None = None,
+    binding_version: int | None = None,
+    pack_id: int | None = None,
+    pack_revision: int | None = None,
+    pack_version_id: int | None = None,
+    pack_version_number: int | None = None,
+    manifest_sha256: str | None = None,
+    asset_id: int | None = None,
+    asset_sha256: str | None = None,
+) -> tuple[str, ...]:
+    portrait = authority.portrait
+    return _shared._resolution_cache_identity(
+        "persona",
+        authority.persona_id,
+        requested_key,
+        manual_key,
+        resolution_source,
+        "actor_source=local",
+        f"persona_revision={authority.persona_revision}",
+        f"portrait_id={portrait.portrait_id if portrait is not None else ''}",
+        f"portrait_revision={portrait.revision if portrait is not None else ''}",
+        f"portrait_sha256={portrait.sha256 if portrait is not None else ''}",
+        f"binding_id={binding_id if binding_id is not None else ''}",
+        f"binding_version={binding_version if binding_version is not None else ''}",
+        f"pack_id={pack_id if pack_id is not None else ''}",
+        f"pack_revision={pack_revision if pack_revision is not None else ''}",
+        f"pack_version_id={pack_version_id if pack_version_id is not None else ''}",
+        f"pack_version_number={pack_version_number if pack_version_number is not None else ''}",
+        f"manifest_sha256={manifest_sha256 or ''}",
+        f"asset_id={asset_id if asset_id is not None else ''}",
+        f"sha256={asset_sha256 or ''}",
+    )
+
+
+def _linked_portrait(
+    local_service: object,
+    persona_record: Mapping[str, Any],
+) -> LocalPersonaVisualIdentityPortrait | None:
+    character_id = persona_record.get("character_card_id")
+    getter = getattr(local_service, "get_character", None)
+    if type(character_id) is not int or character_id < 1 or not callable(getter):
+        return None
+    try:
+        character = getter(character_id)
+    except Exception:
+        return None
+    if type(character) is not dict:
+        return None
+    revision = character.get("version")
+    data = character.get("image")
+    if (
+        type(character.get("id")) is not int
+        or character.get("id") != character_id
+        or type(revision) is not int
+        or revision < 0
+        or character.get("deleted", False) is not False
+        or type(data) is not bytes
+        or not data
+        or len(data) > _MAX_PORTRAIT_BYTES
+    ):
+        return None
+    content_type = _portrait_content_type(data)
+    if content_type is None:
+        return None
+    return LocalPersonaVisualIdentityPortrait(
+        portrait_id=f"local-character:{character_id}",
+        revision=revision,
+        content_type=content_type,
+        sha256=hashlib.sha256(data).hexdigest(),
+        data=data,
+    )
+
+
+def _portrait_content_type(data: bytes) -> str | None:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+__all__ = [
+    "LocalPersonaVisualIdentityAuthority",
+    "LocalPersonaVisualIdentityPortrait",
+    "capture_local_persona_visual_identity",
+    "local_persona_visual_identity_is_current",
+    "resolve_persona_visual_identity",
+]

--- a/tldw_chatbook/Character_Chat/visual_identity.py
+++ b/tldw_chatbook/Character_Chat/visual_identity.py
@@ -323,11 +323,11 @@ class VisualIdentityCandidate:
 
     actor_kind: str
     actor_id: str
-    old_pack_id: int
-    old_version_id: int
-    old_binding_id: int
-    old_binding_version: int
-    old_pack_version: int
+    old_pack_id: int | None
+    old_version_id: int | None
+    old_binding_id: int | None
+    old_binding_version: int | None
+    old_pack_version: int | None
     source_kind: str
     title: str
     description: str
@@ -335,6 +335,8 @@ class VisualIdentityCandidate:
     original_default_expression_key: str
     source_context: dict[str, Any]
     assets: tuple[dict[str, Any], ...] = field(repr=False)
+    actor_authority: tuple[str, ...] = ()
+    _actor_guard: Callable[[], bool] | None = field(default=None, repr=False)
     _replacements: dict[str, tuple[bytes, str]] = field(
         default_factory=dict, init=False, repr=False
     )
@@ -463,8 +465,8 @@ class VisualIdentityPublicationResult:
 
     actor_kind: str
     actor_id: str
-    old_pack_id: int
-    old_version_id: int
+    old_pack_id: int | None
+    old_version_id: int | None
     new_pack_id: int
     new_version_id: int
     version_directory: Path
@@ -1775,15 +1777,53 @@ def _image_duration_ms(image: Image.Image, frame_count: int) -> int:
 
 
 def create_visual_identity_candidate(
-    db: Any, *, actor_kind: str, actor_id: int | str
+    db: Any,
+    *,
+    actor_kind: str,
+    actor_id: int | str,
+    actor_authority: tuple[str, ...] = (),
+    actor_guard: Callable[[], bool] | None = None,
 ) -> VisualIdentityCandidate:
     """Snapshot one active immutable graph for in-memory copy-on-write edits."""
 
     from tldw_chatbook.DB.VisualIdentity_DB import VisualIdentityRepository
 
-    if actor_kind != "character":
+    if actor_kind not in {"character", "persona"}:
         raise ValueError("visual_identity_actor_kind_invalid")
+    if actor_kind == "persona":
+        if (
+            type(actor_authority) is not tuple
+            or not actor_authority
+            or any(type(item) is not str or not item for item in actor_authority)
+            or not callable(actor_guard)
+        ):
+            raise ValueError("visual_identity_actor_changed")
+        try:
+            actor_current = actor_guard()
+        except Exception:
+            actor_current = False
+        if actor_current is not True:
+            raise ValueError("visual_identity_actor_changed")
     graph = VisualIdentityRepository(db).get_active_actor_pack(actor_kind, actor_id)
+    if graph is None and actor_kind == "persona":
+        return VisualIdentityCandidate(
+            actor_kind="persona",
+            actor_id=str(actor_id),
+            old_pack_id=None,
+            old_version_id=None,
+            old_binding_id=None,
+            old_binding_version=None,
+            old_pack_version=None,
+            source_kind="manual",
+            title="Persona reactions",
+            description="",
+            default_expression_key="neutral",
+            original_default_expression_key="neutral",
+            source_context={"source_id": "persona.local"},
+            assets=_empty_persona_candidate_assets(),
+            actor_authority=actor_authority,
+            _actor_guard=actor_guard,
+        )
     if graph is None or not graph["assets"]:
         raise ValueError("visual_identity_active_pack_not_found")
     pack = graph["pack"]
@@ -1812,6 +1852,33 @@ def create_visual_identity_candidate(
         original_default_expression_key=str(graph["version"]["default_expression_key"]),
         source_context=dict(source_context),
         assets=tuple(dict(asset) for asset in graph["assets"]),
+        actor_authority=actor_authority,
+        _actor_guard=actor_guard,
+    )
+
+
+def _empty_persona_candidate_assets() -> tuple[dict[str, Any], ...]:
+    """Return canonical metadata slots for an unpublished Persona pack."""
+
+    return tuple(
+        {
+            "id": None,
+            "expression_key": key,
+            "original_expression_key": key,
+            "display_label": display_label_for_expression_key(key),
+            "source_filename": "",
+            "storage_relpath": "",
+            "content_type": "",
+            "bytes": 0,
+            "sha256": "",
+            "width": 0,
+            "height": 0,
+            "source_context_json": "{}",
+            "is_animated": False,
+            "frame_count": 1,
+            "duration_ms": None,
+        }
+        for key in CANONICAL_EXPRESSION_SLOTS
     )
 
 
@@ -1844,15 +1911,25 @@ def publish_visual_identity_candidate(
             raise VisualIdentityPublicationError("visual_identity_candidate_clean")
         if not callable(atomic_replace):
             raise VisualIdentityPublicationError("visual_identity_candidate_invalid")
+        if candidate._actor_guard is not None:
+            try:
+                actor_current = candidate._actor_guard()
+            except Exception:
+                actor_current = False
+            if actor_current is not True:
+                raise VisualIdentityPublicationError("visual_identity_actor_changed")
         candidate._publishing = True
 
     repository = VisualIdentityRepository(db)
+    unbound = candidate.old_pack_id is None
     try:
         live = repository.get_active_actor_pack(
             candidate.actor_kind, candidate.actor_id
         )
-        active_binding_count = repository.count_active_pack_bindings(
-            candidate.old_pack_id
+        active_binding_count = (
+            0
+            if unbound
+            else repository.count_active_pack_bindings(candidate.old_pack_id)
         )
     except (
         CharactersRAGDBError,
@@ -1866,25 +1943,30 @@ def publish_visual_identity_candidate(
         raise VisualIdentityPublicationError(
             "visual_identity_database_failed"
         ) from None
-    if live is None or (
-        int(live["binding"]["id"]),
-        int(live["pack"]["id"]),
-        int(live["version"]["id"]),
-        int(live["binding"]["version"]),
-        int(live["pack"]["version"]),
-    ) != (
-        candidate.old_binding_id,
-        candidate.old_pack_id,
-        candidate.old_version_id,
-        candidate.old_binding_version,
-        candidate.old_pack_version,
-    ):
+    binding_changed = live is not None if unbound else live is None
+    if not unbound and live is not None:
+        binding_changed = (
+            int(live["binding"]["id"]),
+            int(live["pack"]["id"]),
+            int(live["version"]["id"]),
+            int(live["binding"]["version"]),
+            int(live["pack"]["version"]),
+        ) != (
+            candidate.old_binding_id,
+            candidate.old_pack_id,
+            candidate.old_version_id,
+            candidate.old_binding_version,
+            candidate.old_pack_version,
+        )
+    if binding_changed:
         _reset_candidate_publication(candidate)
         raise VisualIdentityPublicationError("visual_identity_binding_changed")
 
     try:
         profile_root, assets_root = _visual_identity_publication_roots(user_data_dir)
-        fork_pack = candidate.source_kind == "builtin" or active_binding_count > 1
+        fork_pack = (
+            unbound or candidate.source_kind == "builtin" or active_binding_count > 1
+        )
         profile_pack_token = _publication_pack_token(candidate, force_new=fork_pack)
     except VisualIdentityPublicationError:
         _reset_candidate_publication(candidate)
@@ -2029,42 +2111,74 @@ def publish_visual_identity_candidate(
             _verify_materialized_candidate(published_read, assets)
             _sync_publication_directory(versions_fd if posix_guards else versions_root)
 
+            actor_denied = False
+
             def publication_guard() -> bool:
+                nonlocal actor_denied
                 if posix_guards:
-                    return _publication_chain_matches(
+                    filesystem_current = _publication_chain_matches(
                         chain, secured_identities
                     ) and _entry_matches_fd(versions_fd, final_name, staging_fd)
-                return (
-                    _path_chain_matches(secured_identities, profile_root=profile_root)
-                    and staging_identity is not None
-                    and _path_matches_identity(final_dir, staging_identity)
-                )
+                else:
+                    filesystem_current = (
+                        _path_chain_matches(
+                            secured_identities, profile_root=profile_root
+                        )
+                        and staging_identity is not None
+                        and _path_matches_identity(final_dir, staging_identity)
+                    )
+                if not filesystem_current:
+                    return False
+                if candidate._actor_guard is None:
+                    return True
+                try:
+                    actor_current = candidate._actor_guard()
+                except Exception:
+                    actor_current = False
+                if actor_current is not True:
+                    actor_denied = True
+                    return False
+                return True
 
             try:
                 if fork_pack:
+                    source_context = (
+                        {
+                            "profile_pack_id": profile_pack_token,
+                            "source_id": "persona.local",
+                        }
+                        if unbound
+                        else {
+                            "profile_pack_id": profile_pack_token,
+                            "forked_from_pack_id": candidate.old_pack_id,
+                            "forked_from_version_id": candidate.old_version_id,
+                        }
+                    )
                     graph = repository.activate_pack(
                         pack={
-                            "title": f"{candidate.title} (Profile Copy)",
+                            "title": (
+                                candidate.title
+                                if unbound
+                                else f"{candidate.title} (Profile Copy)"
+                            ),
                             "description": candidate.description,
                             "default_expression_key": candidate.default_expression_key,
                             "source_kind": "manual",
-                            "source_context": {
-                                "profile_pack_id": profile_pack_token,
-                                "forked_from_pack_id": candidate.old_pack_id,
-                                "forked_from_version_id": candidate.old_version_id,
-                            },
+                            "source_context": source_context,
                         },
                         manifest=manifest,
                         assets=assets,
                         actor_kind=candidate.actor_kind,
                         actor_id=candidate.actor_id,
                         expected_active_identity=(
-                            candidate.old_pack_id,
-                            candidate.old_version_id,
+                            None
+                            if unbound
+                            else (candidate.old_pack_id, candidate.old_version_id)
                         ),
                         expected_binding_id=candidate.old_binding_id,
                         expected_binding_version=candidate.old_binding_version,
                         expected_source_pack_version=candidate.old_pack_version,
+                        require_unbound_actor=unbound,
                         publication_guard=publication_guard,
                     )
                 else:
@@ -2086,7 +2200,11 @@ def publish_visual_identity_candidate(
                 if str(error) == "visual_identity_binding_changed":
                     category = "visual_identity_binding_changed"
                 elif str(error) == "visual_identity_publication_changed":
-                    category = "visual_identity_publication_denied"
+                    category = (
+                        "visual_identity_actor_changed"
+                        if actor_denied
+                        else "visual_identity_publication_denied"
+                    )
                 else:
                     category = "visual_identity_database_failed"
                 raise VisualIdentityPublicationError(category) from None
@@ -2345,6 +2463,8 @@ def _materialize_visual_identity_candidate(
         if expression_key in candidate._cleared:
             continue
         replacement = candidate._replacements.get(expression_key)
+        if replacement is None and stored.get("id") is None:
+            continue
         if replacement is None:
             source_asset = _manifest_asset_from_row(stored)
             loaded = load_visual_identity_asset(

--- a/tldw_chatbook/Character_Chat/visual_identity.py
+++ b/tldw_chatbook/Character_Chat/visual_identity.py
@@ -2038,19 +2038,20 @@ def publish_visual_identity_candidate(
                 os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
                 dir_fd=versions_fd,
             )
-            write_file = lambda name, data: _write_private_publication_file(
-                staging_fd, name, data
-            )
-            read_file = lambda name, limit: _read_private_publication_file(
-                staging_fd, name, max_bytes=limit
-            )
+
+            def write_file(name, data):
+                return _write_private_publication_file(staging_fd, name, data)
+
+            def read_file(name, limit):
+                return _read_private_publication_file(staging_fd, name, max_bytes=limit)
+
         else:
-            write_file = lambda name, data: _write_private_publication_path(
-                staging_dir, name, data
-            )
-            read_file = lambda name, limit: _read_private_publication_path(
-                staging_dir, name, limit
-            )
+
+            def write_file(name, data):
+                return _write_private_publication_path(staging_dir, name, data)
+
+            def read_file(name, limit):
+                return _read_private_publication_path(staging_dir, name, limit)
 
         assets, manifest = _materialize_visual_identity_candidate(
             candidate,

--- a/tldw_chatbook/DB/VisualIdentity_DB.py
+++ b/tldw_chatbook/DB/VisualIdentity_DB.py
@@ -189,6 +189,7 @@ class VisualIdentityRepository:
         expected_binding_id: int | None = None,
         expected_binding_version: int | None = None,
         expected_source_pack_version: int | None = None,
+        require_unbound_actor: bool = False,
         publication_guard: Callable[[], bool] | None = None,
     ) -> dict[str, Any]:
         """Atomically create and activate one complete pack graph.
@@ -205,6 +206,8 @@ class VisualIdentityRepository:
                 must still own the actor before activation.
             expected_binding_version: Optional optimistic binding revision.
             expected_source_pack_version: Optional optimistic source-pack revision.
+            require_unbound_actor: Require the actor to remain without an active
+                binding while the write reservation is held.
             publication_guard: Optional final filesystem identity check invoked
                 while the transaction holds its write reservation.
 
@@ -220,6 +223,12 @@ class VisualIdentityRepository:
             raise ValueError("visual_identity_pack_active_version_mismatch")
 
         with self.db.transaction():
+            if (
+                require_unbound_actor
+                and self._validate_existing_actor_binding(actor_kind, str(actor_id))
+                is not None
+            ):
+                raise ValueError("visual_identity_binding_changed")
             if expected_active_identity is not None:
                 existing = self._validate_existing_actor_binding(
                     actor_kind, str(actor_id)

--- a/tldw_chatbook/UI/Console_Modules/character.py
+++ b/tldw_chatbook/UI/Console_Modules/character.py
@@ -369,7 +369,7 @@ class ConsoleCharacterController:
         if actor_scope is None:
             await self._paint(request, None, name=name, manual_label=manual_label)
             return
-        character_id = int(actor_scope[2])
+        _session_id, actor_kind, actor_id = actor_scope
         resolution = await asyncio.to_thread(
             self._resolve_visual_identity,
             actor_scope,
@@ -391,7 +391,8 @@ class ConsoleCharacterController:
         mode = self._console_image_default_mode() or "pixels"
         key = "visual-identity:" + "|".join(identity)
         spec = {
-            "character_id": character_id,
+            "actor_kind": actor_kind,
+            "actor_id": actor_id,
             "state": state,
             "name": name,
             "mode": mode,
@@ -400,6 +401,8 @@ class ConsoleCharacterController:
             "manual_expression_key": manual_key,
             "resolution_cache_identity": identity,
         }
+        if actor_kind == "character":
+            spec["character_id"] = int(actor_id)
         try:
             if resolution.image_bytes:
                 ok = await asyncio.to_thread(cache.prepare, key, resolution.image_bytes)

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -178,6 +178,10 @@ from ...Character_Chat.visual_identity import (
     VisualIdentityResolution,
     resolve_visual_identity,
 )
+from ...Character_Chat.persona_visual_identity import (
+    capture_local_persona_visual_identity,
+    resolve_persona_visual_identity,
+)
 from ...DB.VisualIdentity_DB import VisualIdentityRepository
 from ...config import coerce_bool_setting
 from ...Widgets.Console import (
@@ -425,11 +429,22 @@ def _resolve_visual_identity_for_db(
     scope: tuple[str, str, str],
     requested_state: str,
     manual_expression_key: str | None,
+    local_persona_service: object | None = None,
 ) -> VisualIdentityResolution | None:
     """Resolve one immutable preview request without retaining its screen."""
 
     _session_id, actor_kind, actor_id = scope
     try:
+        if actor_kind == "persona":
+            if local_persona_service is None:
+                return None
+            return resolve_persona_visual_identity(
+                db,
+                local_persona_service,
+                persona_id=actor_id,
+                requested_state=requested_state,
+                manual_expression_key=manual_expression_key,
+            )
         return resolve_visual_identity(
             db,
             actor_kind=actor_kind,
@@ -449,13 +464,30 @@ def _resolve_visual_identity_for_db(
 
 
 def _visual_identity_options_for_db(
-    db: Any, scope: tuple[str, str, str]
+    db: Any,
+    scope: tuple[str, str, str],
+    local_persona_service: object | None = None,
 ) -> tuple[ReactionOption, ...]:
     """Read metadata-only preview options without retaining its screen."""
 
     _session_id, actor_kind, actor_id = scope
     try:
+        persona_authority = None
+        if actor_kind == "persona":
+            if local_persona_service is None:
+                return ()
+            persona_authority = capture_local_persona_visual_identity(
+                local_persona_service, actor_id
+            )
+            if persona_authority is None:
+                return ()
         graph = VisualIdentityRepository(db).get_active_actor_pack(actor_kind, actor_id)
+        if (
+            actor_kind == "persona"
+            and capture_local_persona_visual_identity(local_persona_service, actor_id)
+            != persona_authority
+        ):
+            return ()
     except (SQLiteError, TypeError, ValueError, OverflowError) as exc:
         logger.debug(  # noqa: PLE1205 - Loguru uses brace-style arguments.
             "Console reaction inventory failed for actor_kind={} actor_id={} "
@@ -897,15 +929,26 @@ class ConsoleSessionController:
                 self._manual_reaction_overrides.pop(scope, None)
 
     def _current_visual_identity_actor_scope(self) -> tuple[str, str, str] | None:
-        """Return the active local character's session-and-actor scope."""
+        """Return the active local Character or Persona actor scope."""
 
         session = self._active_native_console_session()
         if session is None or session.runtime_backend != "local":
             return None
+        if session.assistant_kind == "persona":
+            actor_id = session.assistant_id
+            if type(actor_id) is not str or not actor_id or len(actor_id) > 200:
+                return None
+            return (session.id, "persona", actor_id)
         actor_id = session.local_character_id()
-        if actor_id is None:
-            return None
-        return (session.id, "character", str(actor_id))
+        return (
+            (session.id, "character", str(actor_id)) if actor_id is not None else None
+        )
+
+    def _local_persona_visual_identity_service(self) -> object | None:
+        """Return the current local Persona service without retaining it."""
+
+        scope = getattr(self.app_instance, "character_persona_scope_service", None)
+        return getattr(scope, "local_service", None)
 
     def _manual_reaction_label_for_current_actor(self) -> str | None:
         """Return a compact display label for the active manual reaction."""
@@ -952,7 +995,15 @@ class ConsoleSessionController:
         if db is None:
             return None
         return _resolve_visual_identity_for_db(
-            db, scope, requested_state, manual_expression_key
+            db,
+            scope,
+            requested_state,
+            manual_expression_key,
+            (
+                self._local_persona_visual_identity_service()
+                if scope[1] == "persona"
+                else None
+            ),
         )
 
     def _visual_identity_options(
@@ -963,7 +1014,15 @@ class ConsoleSessionController:
         db = self._visual_identity_db_accessor()
         if db is None:
             return ()
-        return _visual_identity_options_for_db(db, scope)
+        return _visual_identity_options_for_db(
+            db,
+            scope,
+            (
+                self._local_persona_visual_identity_service()
+                if scope[1] == "persona"
+                else None
+            ),
+        )
 
     async def _open_console_reaction_picker(self) -> None:
         """Query reaction metadata off-thread and open the owned picker."""
@@ -972,25 +1031,35 @@ class ConsoleSessionController:
         scope = context[0]
         if scope is None:
             self.app_instance.notify(
-                "Choose a local character before selecting a reaction.",
+                "Choose a local Character or Persona before selecting a reaction.",
                 severity="warning",
             )
             return
         db = self._visual_identity_db_accessor()
+        persona_service = (
+            self._local_persona_visual_identity_service()
+            if scope[1] == "persona"
+            else None
+        )
         if db is None:
             options = ()
         else:
-            options = await asyncio.to_thread(
-                _visual_identity_options_for_db, db, scope
+            args = (
+                (db, scope, persona_service) if scope[1] == "persona" else (db, scope)
             )
+            options = await asyncio.to_thread(_visual_identity_options_for_db, *args)
         if (
             self._visual_identity_db_accessor() is not db
             or self._visual_identity_request_context() != context
+            or (
+                scope[1] == "persona"
+                and self._local_persona_visual_identity_service() is not persona_service
+            )
         ):
             return
         if not options:
             self.app_instance.notify(
-                "This character has no reaction pack.", severity="information"
+                "This actor has no reaction pack.", severity="information"
             )
             return
         self.push_screen(
@@ -1066,10 +1135,20 @@ class ConsoleSessionController:
         db = self._visual_identity_db_accessor()
         if db is None:
             return False
-        options = await asyncio.to_thread(_visual_identity_options_for_db, db, scope)
+        persona_service = (
+            self._local_persona_visual_identity_service()
+            if scope[1] == "persona"
+            else None
+        )
+        args = (db, scope, persona_service) if scope[1] == "persona" else (db, scope)
+        options = await asyncio.to_thread(_visual_identity_options_for_db, *args)
         if (
             self._visual_identity_db_accessor() is not db
             or self._visual_identity_request_context() != context
+            or (
+                scope[1] == "persona"
+                and self._local_persona_visual_identity_service() is not persona_service
+            )
         ):
             return False
         if option.expression_key not in {
@@ -1108,12 +1187,18 @@ class ConsoleSessionController:
         db: object,
         expression_key: str,
         picker_ref: weakref.ReferenceType[ConsoleReactionPickerModal],
+        persona_service: object | None = None,
     ) -> bool:
         picker = picker_ref()
         return (
             generation == getattr(self, "_reaction_preview_generation", 0)
             and self._visual_identity_db_accessor() is db
             and self._visual_identity_request_context() == context
+            and (
+                context[0] is None
+                or context[0][1] != "persona"
+                or self._local_persona_visual_identity_service() is persona_service
+            )
             and picker is not None
             and picker.is_preview_current(expression_key)
         )
@@ -1139,6 +1224,11 @@ class ConsoleSessionController:
         context = self._visual_identity_request_context()
         scope, state, _manual = context
         db = self._visual_identity_db_accessor()
+        persona_service = (
+            self._local_persona_visual_identity_service()
+            if scope is not None and scope[1] == "persona"
+            else None
+        )
         if (
             scope is None
             or db is None
@@ -1148,12 +1238,16 @@ class ConsoleSessionController:
                 db=db,
                 expression_key=option.expression_key,
                 picker_ref=picker_ref,
+                persona_service=persona_service,
             )
         ):
             return
 
+        options_args = (
+            (db, scope, persona_service) if scope[1] == "persona" else (db, scope)
+        )
         options = await self._run_serialized_preview_sync(
-            _visual_identity_options_for_db, db, scope
+            _visual_identity_options_for_db, *options_args
         )
         if not self._preview_request_is_current(
             generation=generation,
@@ -1161,6 +1255,7 @@ class ConsoleSessionController:
             db=db,
             expression_key=option.expression_key,
             picker_ref=picker_ref,
+            persona_service=persona_service,
         ):
             return
         if option.expression_key not in {
@@ -1171,12 +1266,13 @@ class ConsoleSessionController:
             )
             return
 
+        resolution_args = (
+            (db, scope, state, option.expression_key, persona_service)
+            if scope[1] == "persona"
+            else (db, scope, state, option.expression_key)
+        )
         resolution = await self._run_serialized_preview_sync(
-            _resolve_visual_identity_for_db,
-            db,
-            scope,
-            state,
-            option.expression_key,
+            _resolve_visual_identity_for_db, *resolution_args
         )
         if not self._preview_request_is_current(
             generation=generation,
@@ -1184,6 +1280,7 @@ class ConsoleSessionController:
             db=db,
             expression_key=option.expression_key,
             picker_ref=picker_ref,
+            persona_service=persona_service,
         ):
             return
         if (
@@ -1208,6 +1305,7 @@ class ConsoleSessionController:
             db=db,
             expression_key=option.expression_key,
             picker_ref=picker_ref,
+            persona_service=persona_service,
         ):
             return
         if not prepared:
@@ -1225,14 +1323,11 @@ class ConsoleSessionController:
             db=db,
             expression_key=option.expression_key,
             picker_ref=picker_ref,
+            persona_service=persona_service,
         ):
             return
         current = await self._run_serialized_preview_sync(
-            _resolve_visual_identity_for_db,
-            db,
-            scope,
-            state,
-            option.expression_key,
+            _resolve_visual_identity_for_db, *resolution_args
         )
         if (
             not self._preview_request_is_current(
@@ -1241,6 +1336,7 @@ class ConsoleSessionController:
                 db=db,
                 expression_key=option.expression_key,
                 picker_ref=picker_ref,
+                persona_service=persona_service,
             )
             or current is None
             or current.cache_identity != identity

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -566,6 +566,9 @@ class ConsoleWorkspaceController:
         """Apply one input change and schedule its canonical browser refresh."""
         if disabled or query == self._console_conversation_browser_query:
             return
+        if not query.strip():
+            self.clear_console_conversation_browser_search()
+            return
         self._console_conversation_browser_query = query
         self._console_conversation_browser_search_token += 1
         token = self._console_conversation_browser_search_token

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -51,13 +51,21 @@ from ...Character_Chat.expression_generation import (
 )
 from ...Character_Chat.local_chat_dictionary_service import statistics_from_record
 from ...Character_Chat.persona_list_paging import page_persona_profiles
+from ...Character_Chat.persona_visual_identity import (
+    LocalPersonaVisualIdentityAuthority,
+    capture_local_persona_visual_identity,
+    local_persona_visual_identity_is_current,
+    resolve_persona_visual_identity,
+)
 from ...Character_Chat.visual_identity import (
+    CANONICAL_EXPRESSION_SLOTS,
     VisualIdentityCandidate,
     VisualIdentityPublicationError,
     VisualIdentityPublicationResult,
     VisualIdentityResolution,
     cleanup_visual_identity_publication_candidate,
     create_visual_identity_candidate,
+    display_label_for_expression_key,
     publish_visual_identity_candidate,
     resolve_visual_identity,
 )
@@ -602,6 +610,47 @@ class _PersonaVisualAuthorSnapshot:
     editor_session_token: int
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class _PersonaSharedVisualIdentityLoadSnapshot:
+    """Exact local Persona editor authority for Shared Identity metadata."""
+
+    editor_ref: weakref.ReferenceType[PersonaProfileEditorWidget]
+    db: object
+    local_service: object
+    persona_id: str
+    persona_revision: int
+    screen_generation: int
+    editor_session_token: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _PersonaSharedVisualIdentityAuthorSnapshot:
+    """Exact Persona/editor/pack authority for one unpublished reaction draft."""
+
+    editor_ref: weakref.ReferenceType[PersonaProfileEditorWidget]
+    browser_ref: weakref.ReferenceType[PersonasVisualIdentityPackWidget]
+    db: object
+    local_service: object
+    persona_id: str
+    persona_revision: int
+    persona_authority: LocalPersonaVisualIdentityAuthority
+    screen_generation: int
+    editor_session_token: int
+    binding_id: int
+    pack_id: int
+    pack_version_id: int
+
+
+@dataclasses.dataclass(slots=True)
+class _PersonaSharedVisualIdentityAuthoringState:
+    """One Persona reaction candidate plus its cancellation authority."""
+
+    snapshot: _PersonaSharedVisualIdentityAuthorSnapshot
+    candidate: VisualIdentityCandidate
+    cancel_event: threading.Event
+    authoritative_pack: VisualIdentityPackMetadata
+
+
 @dataclasses.dataclass(slots=True)
 class _PersonaVisualAuthoringState:
     """One unpublished Persona Visual draft plus its private source lease."""
@@ -964,6 +1013,19 @@ class PersonasScreen(BaseAppScreen):
         self._visual_identity_operation_task: asyncio.Task[Any] | None = None
         self._visual_identity_operation_event: threading.Event | None = None
         self._visual_identity_publication_inflight: bool = False
+        self._persona_shared_visual_identity_authority: (
+            LocalPersonaVisualIdentityAuthority | None
+        ) = None
+        self._persona_shared_visual_identity_authoring: (
+            _PersonaSharedVisualIdentityAuthoringState | None
+        ) = None
+        self._persona_shared_visual_identity_operation_task: (
+            asyncio.Task[Any] | None
+        ) = None
+        self._persona_shared_visual_identity_operation_event: threading.Event | None = (
+            None
+        )
+        self._persona_shared_visual_identity_publication_inflight = False
         self._persona_visual_authoring: _PersonaVisualAuthoringState | None = None
         self._persona_visual_generation = 0
         self._persona_visual_operation_task: asyncio.Task[Any] | None = None
@@ -6193,6 +6255,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _begin_create_profile(self) -> None:
         self._advance_persona_buddy_session()
+        await self._drain_persona_shared_visual_identity_authoring()
+        self._persona_shared_visual_identity_authority = None
         await self._discard_persona_visual_authoring_async()
         self._persona_visual_generation += 1
         self._edit_mode = "create"
@@ -6545,6 +6609,8 @@ class PersonasScreen(BaseAppScreen):
         self._profile_save_operation_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
+        await self._drain_persona_shared_visual_identity_authoring()
+        self._persona_shared_visual_identity_authority = None
         await self._discard_persona_visual_authoring_async()
         self._persona_visual_generation += 1
         editor = self.query_one(PersonaProfileEditorWidget)
@@ -6552,6 +6618,17 @@ class PersonasScreen(BaseAppScreen):
             record,
             runtime_source=self.persona_handler.current_mode(),
         )
+        self._persona_shared_visual_identity_authority = None
+        shared_identity_snapshot = self._persona_shared_visual_identity_snapshot(editor)
+        if shared_identity_snapshot is not None:
+            self.run_worker(
+                self._configure_persona_shared_visual_identity(
+                    shared_identity_snapshot
+                ),
+                group="personas-shared-visual-identity-load",
+                exit_on_error=False,
+                exclusive=True,
+            )
         visual_snapshot = self._persona_visual_snapshot(editor)
         if visual_snapshot is not None:
             self.run_worker(
@@ -6566,6 +6643,623 @@ class PersonasScreen(BaseAppScreen):
         inspector.show_validation_editing()
         self._sync_title_and_console_actions()
         self.call_after_refresh(self._focus_editor_name)
+
+    def _persona_shared_visual_identity_snapshot(
+        self, editor: PersonaProfileEditorWidget | None = None
+    ) -> _PersonaSharedVisualIdentityLoadSnapshot | None:
+        """Capture one saved local Persona editor before metadata I/O."""
+
+        if self._edit_mode != "edit" or self.persona_handler.current_mode() != "local":
+            return None
+        try:
+            editor = editor or self.query_one(PersonaProfileEditorWidget)
+            data = editor.collect()
+        except (QueryError, ValueError):
+            return None
+        persona_id = data.get("id")
+        persona_revision = data.get("version")
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        scope = getattr(self.app_instance, "character_persona_scope_service", None)
+        local_service = getattr(scope, "local_service", None)
+        if (
+            type(persona_id) is not str
+            or not persona_id
+            or type(persona_revision) is not int
+            or persona_revision < 1
+            or db is None
+            or local_service is None
+        ):
+            return None
+        return _PersonaSharedVisualIdentityLoadSnapshot(
+            editor_ref=weakref.ref(editor),
+            db=db,
+            local_service=local_service,
+            persona_id=persona_id,
+            persona_revision=persona_revision,
+            screen_generation=self._persona_visual_generation,
+            editor_session_token=editor.persona_visual_session_token,
+        )
+
+    def _persona_shared_visual_identity_snapshot_is_current(
+        self,
+        snapshot: _PersonaSharedVisualIdentityLoadSnapshot,
+    ) -> bool:
+        """Fence local source, editor, revision, profile, and service identity."""
+
+        editor = snapshot.editor_ref()
+        scope = getattr(self.app_instance, "character_persona_scope_service", None)
+        if (
+            editor is None
+            or not self.is_mounted
+            or self._edit_mode != "edit"
+            or self.state.active_mode != "personas"
+            or self.persona_handler.current_mode() != "local"
+            or self._persona_visual_generation != snapshot.screen_generation
+            or getattr(self.app_instance, "chachanotes_db", None) is not snapshot.db
+            or getattr(scope, "local_service", None) is not snapshot.local_service
+            or editor.persona_visual_session_token != snapshot.editor_session_token
+        ):
+            return False
+        try:
+            current_editor = self.query_one(PersonaProfileEditorWidget)
+            data = current_editor.collect()
+        except (QueryError, ValueError):
+            return False
+        if (
+            current_editor is not editor
+            or not editor.display
+            or data.get("id") != snapshot.persona_id
+            or data.get("version") != snapshot.persona_revision
+        ):
+            return False
+        return True
+
+    @staticmethod
+    def _unbound_persona_shared_visual_identity_metadata() -> (
+        VisualIdentityPackMetadata
+    ):
+        """Return canonical path-free slots for creating a Persona binding."""
+
+        return VisualIdentityPackMetadata(
+            binding_id=0,
+            pack_id=0,
+            pack_version_id=0,
+            title="Shared Visual Identity reactions",
+            source_kind="unbound",
+            default_expression_key="neutral",
+            assets=tuple(
+                VisualIdentityAssetMetadata(
+                    asset_id=-index,
+                    expression_key=key,
+                    original_label=key,
+                    display_label=display_label_for_expression_key(key),
+                    content_type="",
+                    is_animated=False,
+                )
+                for index, key in enumerate(CANONICAL_EXPRESSION_SLOTS, start=1)
+            ),
+        )
+
+    async def _configure_persona_shared_visual_identity(
+        self, snapshot: _PersonaSharedVisualIdentityLoadSnapshot
+    ) -> None:
+        """Mount one bound or canonical-unbound local Persona pack browser."""
+
+        if not self._persona_shared_visual_identity_snapshot_is_current(snapshot):
+            return
+        try:
+            authority = await asyncio.to_thread(
+                capture_local_persona_visual_identity,
+                snapshot.local_service,
+                snapshot.persona_id,
+            )
+            graph = await asyncio.to_thread(
+                VisualIdentityRepository(snapshot.db).get_active_actor_pack,
+                "persona",
+                snapshot.persona_id,
+            )
+            checked_authority = await asyncio.to_thread(
+                capture_local_persona_visual_identity,
+                snapshot.local_service,
+                snapshot.persona_id,
+            )
+            metadata = (
+                self._visual_identity_pack_metadata(graph)
+                if graph is not None
+                else self._unbound_persona_shared_visual_identity_metadata()
+            )
+        except (sqlite3.Error, TypeError, ValueError, OverflowError):
+            authority = None
+            metadata = None
+        editor = snapshot.editor_ref()
+        if (
+            authority is None
+            or authority.persona_revision != snapshot.persona_revision
+            or checked_authority != authority
+            or metadata is None
+            or editor is None
+            or not self._persona_shared_visual_identity_snapshot_is_current(snapshot)
+        ):
+            if (
+                editor is not None
+                and self._persona_shared_visual_identity_snapshot_is_current(snapshot)
+            ):
+                await editor.show_shared_visual_identity_unavailable()
+            return
+        mounted = await editor.show_shared_visual_identity_pack(metadata)
+        if not self._persona_shared_visual_identity_snapshot_is_current(snapshot):
+            await editor.discard_shared_visual_identity_pack(mounted)
+            return
+        try:
+            mounted_authority = await asyncio.to_thread(
+                capture_local_persona_visual_identity,
+                snapshot.local_service,
+                snapshot.persona_id,
+            )
+            final_graph = await asyncio.to_thread(
+                VisualIdentityRepository(snapshot.db).get_active_actor_pack,
+                "persona",
+                snapshot.persona_id,
+            )
+            final_authority = await asyncio.to_thread(
+                capture_local_persona_visual_identity,
+                snapshot.local_service,
+                snapshot.persona_id,
+            )
+            final_metadata = (
+                self._visual_identity_pack_metadata(final_graph)
+                if final_graph is not None
+                else self._unbound_persona_shared_visual_identity_metadata()
+            )
+        except (sqlite3.Error, TypeError, ValueError, OverflowError):
+            final_metadata = None
+        if (
+            final_metadata != metadata
+            or mounted_authority != authority
+            or final_authority != authority
+            or not self._persona_shared_visual_identity_snapshot_is_current(snapshot)
+        ):
+            await editor.discard_shared_visual_identity_pack(mounted)
+            if self._persona_shared_visual_identity_snapshot_is_current(snapshot):
+                await editor.show_shared_visual_identity_unavailable()
+            return
+        self._persona_shared_visual_identity_authority = authority
+
+    def _persona_shared_visual_identity_author_snapshot(
+        self,
+    ) -> _PersonaSharedVisualIdentityAuthorSnapshot | None:
+        """Capture the active local Persona reaction editor without service I/O."""
+
+        authority = self._persona_shared_visual_identity_authority
+        if authority is None:
+            return None
+        try:
+            editor = self.query_one(PersonaProfileEditorWidget)
+            browser = editor.query_one(PersonasVisualIdentityPackWidget)
+            data = editor.collect()
+        except (QueryError, ValueError):
+            return None
+        pack = browser.pack
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        scope = getattr(self.app_instance, "character_persona_scope_service", None)
+        local_service = getattr(scope, "local_service", None)
+        if (
+            pack is None
+            or db is None
+            or local_service is None
+            or not self.is_mounted
+            or self.state.active_mode != "personas"
+            or self._edit_mode != "edit"
+            or self.persona_handler.current_mode() != "local"
+            or not editor.display
+            or data.get("id") != authority.persona_id
+            or data.get("version") != authority.persona_revision
+        ):
+            return None
+        return _PersonaSharedVisualIdentityAuthorSnapshot(
+            editor_ref=weakref.ref(editor),
+            browser_ref=weakref.ref(browser),
+            db=db,
+            local_service=local_service,
+            persona_id=authority.persona_id,
+            persona_revision=authority.persona_revision,
+            persona_authority=authority,
+            screen_generation=self._persona_visual_generation,
+            editor_session_token=editor.persona_visual_session_token,
+            binding_id=pack.binding_id,
+            pack_id=pack.pack_id,
+            pack_version_id=pack.pack_version_id,
+        )
+
+    def _persona_shared_visual_identity_author_snapshot_is_current(
+        self, snapshot: _PersonaSharedVisualIdentityAuthorSnapshot
+    ) -> bool:
+        """Fence the mounted Persona reaction editor without blocking I/O."""
+
+        editor = snapshot.editor_ref()
+        browser = snapshot.browser_ref()
+        scope = getattr(self.app_instance, "character_persona_scope_service", None)
+        if (
+            editor is None
+            or browser is None
+            or not self.is_mounted
+            or self.state.active_mode != "personas"
+            or self._edit_mode != "edit"
+            or self.persona_handler.current_mode() != "local"
+            or self._persona_visual_generation != snapshot.screen_generation
+            or getattr(self.app_instance, "chachanotes_db", None) is not snapshot.db
+            or getattr(scope, "local_service", None) is not snapshot.local_service
+            or editor.persona_visual_session_token != snapshot.editor_session_token
+            or self._persona_shared_visual_identity_authority
+            != snapshot.persona_authority
+            or not editor.display
+            or not browser.is_mounted
+        ):
+            return False
+        try:
+            data = editor.collect()
+            current_browser = editor.query_one(PersonasVisualIdentityPackWidget)
+        except (QueryError, ValueError):
+            return False
+        pack = browser.pack
+        return bool(
+            current_browser is browser
+            and data.get("id") == snapshot.persona_id
+            and data.get("version") == snapshot.persona_revision
+            and pack is not None
+            and (pack.binding_id, pack.pack_id, pack.pack_version_id)
+            == (snapshot.binding_id, snapshot.pack_id, snapshot.pack_version_id)
+        )
+
+    async def _persona_shared_visual_identity_authority_is_current(
+        self, snapshot: _PersonaSharedVisualIdentityAuthorSnapshot
+    ) -> bool:
+        """Re-read exact local Persona authority off-loop after an await."""
+
+        if not self._persona_shared_visual_identity_author_snapshot_is_current(
+            snapshot
+        ):
+            return False
+        current = await asyncio.to_thread(
+            capture_local_persona_visual_identity,
+            snapshot.local_service,
+            snapshot.persona_id,
+        )
+        return current == snapshot.persona_authority and (
+            self._persona_shared_visual_identity_author_snapshot_is_current(snapshot)
+        )
+
+    def _begin_persona_shared_visual_identity_operation(
+        self, snapshot: _PersonaSharedVisualIdentityAuthorSnapshot
+    ) -> tuple[asyncio.Task[Any], threading.Event] | None:
+        """Admit one Persona reaction operation without overlapping work."""
+
+        task = asyncio.current_task()
+        active = self._persona_shared_visual_identity_operation_task
+        state = self._persona_shared_visual_identity_authoring
+        if (
+            task is None
+            or self._profile_save_operation_inflight
+            or (active is not None and not active.done())
+            or (state is not None and state.snapshot != snapshot)
+        ):
+            return None
+        event = state.cancel_event if state is not None else threading.Event()
+        self._persona_shared_visual_identity_operation_task = task
+        self._persona_shared_visual_identity_operation_event = event
+        browser = snapshot.browser_ref()
+        if browser is not None and browser.parent is not None:
+            browser.set_preparing(True)
+        return task, event
+
+    def _finish_persona_shared_visual_identity_operation(
+        self,
+        task: asyncio.Task[Any],
+        browser: PersonasVisualIdentityPackWidget | None,
+    ) -> None:
+        """Release serialization only after the admitted operation drains."""
+
+        if self._persona_shared_visual_identity_operation_task is not task:
+            return
+        self._persona_shared_visual_identity_operation_task = None
+        if self._persona_shared_visual_identity_authoring is None:
+            self._persona_shared_visual_identity_operation_event = None
+        if (
+            browser is not None
+            and browser.parent is not None
+            and self._persona_shared_visual_identity_author_snapshot() is not None
+        ):
+            browser.set_preparing(False)
+
+    def _persona_shared_visual_identity_has_unsaved_authoring(self) -> bool:
+        task = self._persona_shared_visual_identity_operation_task
+        return self._persona_shared_visual_identity_authoring is not None or (
+            task is not None and not task.done()
+        )
+
+    async def _drain_persona_shared_visual_identity_authoring(self) -> None:
+        """Signal and drain Persona reaction work before discarding its draft."""
+
+        event = self._persona_shared_visual_identity_operation_event
+        state = self._persona_shared_visual_identity_authoring
+        if event is None and state is not None:
+            event = state.cancel_event
+        if event is not None:
+            event.set()
+        task = self._persona_shared_visual_identity_operation_task
+        cancellation: asyncio.CancelledError | None = None
+        if task is not None and task is not asyncio.current_task() and not task.done():
+            drained = await _drain_async(
+                _join_task(task),
+                task_name="personas-persona-reaction-pack-drain",
+            )
+            cancellation = drained.cancellation
+        self._discard_persona_shared_visual_identity_authoring()
+        if cancellation is not None:
+            raise cancellation
+
+    def _discard_persona_shared_visual_identity_authoring(self) -> None:
+        """Discard only the unpublished Persona reaction candidate."""
+
+        state = self._persona_shared_visual_identity_authoring
+        self._persona_shared_visual_identity_authoring = None
+        if state is None:
+            return
+        state.cancel_event.set()
+        try:
+            state.candidate.cancel()
+        except VisualIdentityPublicationError:
+            pass
+        browser = state.snapshot.browser_ref()
+        if (
+            browser is not None
+            and browser.parent is not None
+            and self._persona_shared_visual_identity_author_snapshot_is_current(
+                state.snapshot
+            )
+        ):
+            browser.pack = state.authoritative_pack
+            browser.apply_filter(
+                browser.query_one("#personas-visual-identity-filter", Input).value
+            )
+            browser.reset_staged()
+
+    async def _persona_shared_visual_identity_candidate(
+        self,
+        snapshot: _PersonaSharedVisualIdentityAuthorSnapshot,
+        event: threading.Event,
+    ) -> _PersonaSharedVisualIdentityAuthoringState | None:
+        """Create one authority-fenced Persona reaction candidate off-loop."""
+
+        current = self._persona_shared_visual_identity_authoring
+        if current is not None and current.snapshot == snapshot:
+            return current
+        self._discard_persona_shared_visual_identity_authoring()
+        try:
+            candidate = await asyncio.to_thread(
+                create_visual_identity_candidate,
+                snapshot.db,
+                actor_kind="persona",
+                actor_id=snapshot.persona_id,
+                actor_authority=snapshot.persona_authority.cache_identity,
+                actor_guard=lambda: local_persona_visual_identity_is_current(
+                    snapshot.local_service, snapshot.persona_authority
+                ),
+            )
+        except (ValueError, sqlite3.Error, RuntimeError):
+            return None
+        expected = (
+            snapshot.binding_id or None,
+            snapshot.pack_id or None,
+            snapshot.pack_version_id or None,
+        )
+        actual = (
+            candidate.old_binding_id,
+            candidate.old_pack_id,
+            candidate.old_version_id,
+        )
+        if (
+            actual != expected
+            or event.is_set()
+            or not await self._persona_shared_visual_identity_authority_is_current(
+                snapshot
+            )
+        ):
+            event.set()
+            candidate.cancel()
+            return None
+        browser = snapshot.browser_ref()
+        authoritative_pack = browser.pack if browser is not None else None
+        if authoritative_pack is None:
+            candidate.cancel()
+            return None
+        state = _PersonaSharedVisualIdentityAuthoringState(
+            snapshot=snapshot,
+            candidate=candidate,
+            cancel_event=event,
+            authoritative_pack=authoritative_pack,
+        )
+        self._persona_shared_visual_identity_authoring = state
+        return state
+
+    async def _stage_persona_shared_visual_identity_replacement(
+        self, asset: VisualIdentityAssetMetadata, data: bytes
+    ) -> bool:
+        snapshot = self._persona_shared_visual_identity_author_snapshot()
+        browser = snapshot.browser_ref() if snapshot is not None else None
+        if snapshot is None or browser is None or asset not in browser.pack.assets:
+            return False
+        admission = self._begin_persona_shared_visual_identity_operation(snapshot)
+        if admission is None:
+            return False
+        task, event = admission
+        try:
+            state = await self._persona_shared_visual_identity_candidate(
+                snapshot, event
+            )
+            if state is None:
+                return False
+            await asyncio.to_thread(
+                state.candidate.stage_replacement,
+                asset.expression_key,
+                data,
+                source="upload",
+            )
+            if (
+                event.is_set()
+                or not await self._persona_shared_visual_identity_authority_is_current(
+                    snapshot
+                )
+            ):
+                self._discard_persona_shared_visual_identity_authoring()
+                return False
+            browser.set_staged_change(asset.expression_key, "replace")
+            return True
+        except (ValueError, VisualIdentityPublicationError):
+            return False
+        finally:
+            self._finish_persona_shared_visual_identity_operation(task, browser)
+
+    async def _stage_persona_shared_visual_identity_clear(
+        self, asset: VisualIdentityAssetMetadata
+    ) -> bool:
+        snapshot = self._persona_shared_visual_identity_author_snapshot()
+        browser = snapshot.browser_ref() if snapshot is not None else None
+        if snapshot is None or browser is None or asset not in browser.pack.assets:
+            return False
+        admission = self._begin_persona_shared_visual_identity_operation(snapshot)
+        if admission is None:
+            return False
+        task, event = admission
+        try:
+            state = await self._persona_shared_visual_identity_candidate(
+                snapshot, event
+            )
+            if state is None:
+                return False
+            await asyncio.to_thread(state.candidate.stage_clear, asset.expression_key)
+            if (
+                event.is_set()
+                or not await self._persona_shared_visual_identity_authority_is_current(
+                    snapshot
+                )
+            ):
+                self._discard_persona_shared_visual_identity_authoring()
+                return False
+            browser.set_staged_change(asset.expression_key, "clear")
+            return True
+        except (ValueError, VisualIdentityPublicationError):
+            return False
+        finally:
+            self._finish_persona_shared_visual_identity_operation(task, browser)
+
+    async def _save_persona_shared_visual_identity_pack(self) -> bool:
+        """Publish one Persona reaction candidate and reconcile exact consumers."""
+
+        state = self._persona_shared_visual_identity_authoring
+        if (
+            state is None
+            or not await self._persona_shared_visual_identity_authority_is_current(
+                state.snapshot
+            )
+        ):
+            return False
+        admission = self._begin_persona_shared_visual_identity_operation(state.snapshot)
+        if admission is None:
+            return False
+        task, _event = admission
+        browser = state.snapshot.browser_ref()
+        published = False
+        cancellation: asyncio.CancelledError | None = None
+        try:
+            if browser is not None:
+                browser.set_saving(True)
+            self._persona_shared_visual_identity_publication_inflight = True
+            outcome = await _drain_to_thread(
+                publish_visual_identity_candidate,
+                state.snapshot.db,
+                state.candidate,
+                user_data_dir=get_user_data_dir(),
+                task_name="personas-persona-reaction-pack-publish",
+            )
+            cancellation = outcome.cancellation
+            error = outcome.error
+            if isinstance(error, VisualIdentityPublicationError):
+                token = error.cleanup_candidate_relpath
+                if token is not None:
+                    cleanup = await _drain_to_thread(
+                        cleanup_visual_identity_publication_candidate,
+                        state.snapshot.db,
+                        token,
+                        user_data_dir=get_user_data_dir(),
+                        task_name="personas-persona-reaction-pack-cleanup",
+                    )
+                    if cancellation is None:
+                        cancellation = cleanup.cancellation
+            if outcome.error is not None or not isinstance(
+                outcome.value, VisualIdentityPublicationResult
+            ):
+                if await self._persona_shared_visual_identity_authority_is_current(
+                    state.snapshot
+                ):
+                    self._notify("Reaction pack was not saved.", "error")
+                return False
+            result = outcome.value
+            published = True
+            self._persona_shared_visual_identity_authoring = None
+
+            async def reconcile() -> None:
+                await self._invalidate_visual_identity_publication(result)
+                if not await self._persona_shared_visual_identity_authority_is_current(
+                    state.snapshot
+                ):
+                    return
+                editor = state.snapshot.editor_ref()
+                if editor is None:
+                    return
+                await self._configure_persona_shared_visual_identity(
+                    _PersonaSharedVisualIdentityLoadSnapshot(
+                        editor_ref=weakref.ref(editor),
+                        db=state.snapshot.db,
+                        local_service=state.snapshot.local_service,
+                        persona_id=state.snapshot.persona_id,
+                        persona_revision=state.snapshot.persona_revision,
+                        screen_generation=state.snapshot.screen_generation,
+                        editor_session_token=state.snapshot.editor_session_token,
+                    )
+                )
+
+            reconciled = await _drain_async(
+                reconcile(), task_name="personas-persona-reaction-pack-reconcile"
+            )
+            if cancellation is None:
+                cancellation = reconciled.cancellation
+            return True
+        finally:
+            self._persona_shared_visual_identity_publication_inflight = False
+            if browser is not None and browser.parent is not None:
+                if published:
+                    browser.reset_staged()
+                elif self._persona_shared_visual_identity_author_snapshot_is_current(
+                    state.snapshot
+                ):
+                    browser.set_saving(False)
+            self._finish_persona_shared_visual_identity_operation(task, browser)
+            if cancellation is not None:
+                raise cancellation
+
+    def _request_persona_shared_visual_identity_cancel(self) -> None:
+        """Signal in-flight draft work or discard an idle unpublished draft."""
+
+        if self._persona_shared_visual_identity_publication_inflight:
+            return
+        event = self._persona_shared_visual_identity_operation_event
+        task = self._persona_shared_visual_identity_operation_task
+        if event is not None and task is not None and not task.done():
+            event.set()
+            return
+        self._discard_persona_shared_visual_identity_authoring()
+        self._persona_shared_visual_identity_operation_event = None
 
     def _persona_visual_snapshot(
         self, editor: PersonaProfileEditorWidget | None = None
@@ -8420,6 +9114,23 @@ class PersonasScreen(BaseAppScreen):
         """Decode only the selected pack asset in a fenced screen worker."""
 
         message.stop()
+        if self.state.active_mode == "personas":
+            snapshot = self._persona_shared_visual_identity_author_snapshot()
+            browser = snapshot.browser_ref() if snapshot is not None else None
+            if (
+                snapshot is not None
+                and browser is not None
+                and browser.selected_asset == message.asset
+            ):
+                self.run_worker(
+                    self._render_persona_shared_visual_identity_preview(
+                        snapshot, message.asset
+                    ),
+                    group="personas-shared-visual-identity-preview",
+                    exit_on_error=False,
+                    exclusive=True,
+                )
+            return
         editor = self._editor_or_none()
         if editor is None:
             return
@@ -8455,6 +9166,89 @@ class PersonasScreen(BaseAppScreen):
             exit_on_error=False,
             exclusive=True,
         )
+
+    async def _render_persona_shared_visual_identity_preview(
+        self,
+        snapshot: _PersonaSharedVisualIdentityAuthorSnapshot,
+        asset: VisualIdentityAssetMetadata,
+    ) -> None:
+        """Resolve and paint one Persona reaction under complete authority."""
+
+        browser = snapshot.browser_ref()
+        if browser is None or snapshot.pack_version_id == 0:
+            if browser is not None:
+                browser.set_preview_unavailable(asset_id=asset.asset_id)
+            return
+        try:
+            resolution = await asyncio.to_thread(
+                resolve_persona_visual_identity,
+                snapshot.db,
+                snapshot.local_service,
+                persona_id=snapshot.persona_id,
+                requested_state="idle",
+                manual_expression_key=asset.expression_key,
+            )
+        except (TypeError, ValueError, OverflowError, sqlite3.Error):
+            browser.set_preview_unavailable(asset_id=asset.asset_id)
+            return
+        if (
+            browser.selected_asset != asset
+            or resolution.pack_id != snapshot.pack_id
+            or resolution.pack_version_id != snapshot.pack_version_id
+            or resolution.asset_id != asset.asset_id
+            or not resolution.image_bytes
+            or not await self._persona_shared_visual_identity_authority_is_current(
+                snapshot
+            )
+        ):
+            browser.set_preview_unavailable(asset_id=asset.asset_id)
+            return
+        from ...Chat.console_image_view import ConsoleImageRenderCache
+
+        if getattr(self, "_avatar_render_cache", None) is None:
+            self._avatar_render_cache = ConsoleImageRenderCache()
+        cache = self._avatar_render_cache
+        cache_key = (
+            "personas-persona-shared-visual-preview-"
+            f"{snapshot.screen_generation}-{hash(resolution.cache_identity)}"
+        )
+        try:
+            decoded = await asyncio.to_thread(
+                cache.prepare, cache_key, bytes(resolution.image_bytes)
+            )
+        except Exception:
+            decoded = False
+        if (
+            not decoded
+            or not await self._persona_shared_visual_identity_authority_is_current(
+                snapshot
+            )
+        ):
+            browser.set_preview_unavailable(asset_id=asset.asset_id)
+            return
+        latest = await asyncio.to_thread(
+            resolve_persona_visual_identity,
+            snapshot.db,
+            snapshot.local_service,
+            persona_id=snapshot.persona_id,
+            requested_state="idle",
+            manual_expression_key=asset.expression_key,
+        )
+        if (
+            latest.cache_identity != resolution.cache_identity
+            or latest.image_bytes != resolution.image_bytes
+            or browser.selected_asset != asset
+            or not await self._persona_shared_visual_identity_authority_is_current(
+                snapshot
+            )
+        ):
+            browser.set_preview_unavailable(asset_id=asset.asset_id)
+            return
+        renderable = self._build_avatar_pixels(cache, cache_key)
+        if renderable is None:
+            browser.set_preview_unavailable(asset_id=asset.asset_id)
+            return
+        browser.set_preview(renderable, asset_id=asset.asset_id)
 
     def _visual_identity_snapshot_is_current(
         self,
@@ -9438,8 +10232,13 @@ class PersonasScreen(BaseAppScreen):
         self, message: VisualIdentityPackClearRequested
     ) -> None:
         message.stop()
+        operation = (
+            self._stage_persona_shared_visual_identity_clear(message.asset)
+            if self.state.active_mode == "personas"
+            else self._stage_visual_identity_clear(message.asset)
+        )
         self.run_worker(
-            self._stage_visual_identity_clear(message.asset),
+            operation,
             group="personas-visual-identity-authoring",
             exit_on_error=False,
         )
@@ -9449,6 +10248,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: VisualIdentityPackGenerateRequested
     ) -> None:
         message.stop()
+        if self.state.active_mode == "personas":
+            return
         self.run_worker(
             self._generate_visual_identity_assets((message.asset,)),
             group="personas-visual-identity-authoring",
@@ -9460,6 +10261,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: VisualIdentityPackGenerateAllRequested
     ) -> None:
         message.stop()
+        if self.state.active_mode == "personas":
+            return
         self.run_worker(
             self._generate_visual_identity_pack_all(),
             group="personas-visual-identity-authoring",
@@ -9471,6 +10274,9 @@ class PersonasScreen(BaseAppScreen):
         self, message: VisualIdentityPackCancelRequested
     ) -> None:
         message.stop()
+        if self.state.active_mode == "personas":
+            self._request_persona_shared_visual_identity_cancel()
+            return
         self._request_visual_identity_generation_cancel()
 
     @on(VisualIdentityPackSaveRequested)
@@ -9478,6 +10284,13 @@ class PersonasScreen(BaseAppScreen):
         self, message: VisualIdentityPackSaveRequested
     ) -> None:
         message.stop()
+        if self.state.active_mode == "personas":
+            self.run_worker(
+                self._save_persona_shared_visual_identity_pack(),
+                group="personas-persona-shared-visual-identity-save",
+                exit_on_error=False,
+            )
+            return
         snapshot = self._visual_identity_author_snapshot()
         browser = snapshot.browser_ref() if snapshot is not None else None
         self.run_worker(
@@ -9495,13 +10308,15 @@ class PersonasScreen(BaseAppScreen):
             return
         self._io_dialog_active = True
         self.run_worker(
-            self._visual_identity_replace_dialog(message.asset),
+            self._visual_identity_replace_dialog(
+                message.asset, persona_mode=self.state.active_mode == "personas"
+            ),
             group="personas-io",
             exit_on_error=False,
         )
 
     async def _visual_identity_replace_dialog(
-        self, asset: VisualIdentityAssetMetadata
+        self, asset: VisualIdentityAssetMetadata, *, persona_mode: bool = False
     ) -> None:
         from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
 
@@ -9523,7 +10338,14 @@ class PersonasScreen(BaseAppScreen):
             if not path:
                 return
             data = await asyncio.to_thread(self._read_avatar_image_bytes, str(path))
-            await self._stage_visual_identity_replacement(asset, data, source="upload")
+            if persona_mode:
+                await self._stage_persona_shared_visual_identity_replacement(
+                    asset, data
+                )
+            else:
+                await self._stage_visual_identity_replacement(
+                    asset, data, source="upload"
+                )
         except (OSError, ValueError) as exc:
             logger.warning(
                 "Reaction replacement failed (category=image_read_failed, error_type={}).",
@@ -12744,8 +13566,18 @@ class PersonasScreen(BaseAppScreen):
         # cache and must go back to the DB).
         editor = self.query_one(PersonaProfileEditorWidget)
         editor.mark_saved(saved)
+        await self._drain_persona_shared_visual_identity_authoring()
+        self._persona_shared_visual_identity_authority = None
         await self._discard_persona_visual_authoring_async()
         self._persona_visual_generation += 1
+        shared_snapshot = self._persona_shared_visual_identity_snapshot(editor)
+        if shared_snapshot is not None:
+            self.run_worker(
+                self._configure_persona_shared_visual_identity(shared_snapshot),
+                group="personas-shared-visual-identity-load",
+                exit_on_error=False,
+                exclusive=True,
+            )
         visual_snapshot = self._persona_visual_snapshot(editor)
         if visual_snapshot is not None:
             self.run_worker(
@@ -12771,6 +13603,8 @@ class PersonasScreen(BaseAppScreen):
 
     def _finish_cancel_edit(self) -> None:
         self._discard_visual_identity_authoring()
+        self._discard_persona_shared_visual_identity_authoring()
+        self._persona_shared_visual_identity_authority = None
         self._character_editor_generation += 1
         # A picked image-gen style is scoped to the editor session that
         # picked it (fix round 1) - the session just ended.
@@ -12933,6 +13767,7 @@ class PersonasScreen(BaseAppScreen):
         if not (
             self.state.has_unsaved_changes
             or self._visual_identity_has_unsaved_authoring()
+            or self._persona_shared_visual_identity_has_unsaved_authoring()
             or self._persona_visual_has_unsaved_authoring()
         ):
             await continuation()
@@ -12956,6 +13791,7 @@ class PersonasScreen(BaseAppScreen):
             # (the continuation may move the selection without a row rebuild).
             self._set_active_row_unsaved(False)
             await self._drain_visual_identity_authoring()
+            await self._drain_persona_shared_visual_identity_authoring()
             await self._drain_persona_visual_authoring()
             await continuation()
             self._sync_title_and_console_actions()
@@ -12972,6 +13808,7 @@ class PersonasScreen(BaseAppScreen):
         if not (
             self.state.has_unsaved_changes
             or self._visual_identity_has_unsaved_authoring()
+            or self._persona_shared_visual_identity_has_unsaved_authoring()
             or self._persona_visual_has_unsaved_authoring()
         ):
             return True

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -8,6 +8,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.timer import Timer
+from textual.widget import Widget
 from textual.widgets import Button, Input, Label, Select, Static, Switch, TextArea
 
 from ...tldw_api.character_persona_schemas import PersonaMode
@@ -15,8 +16,10 @@ from .personas_pane_messages import (
     EditorContentChanged,
     PersonaProfileEditCancelled,
     PersonaProfileSaveRequested,
+    VisualIdentityPackMetadata,
 )
 from .personas_persona_visual_pack_widget import PersonasPersonaVisualPackWidget
+from .personas_visual_identity_pack_widget import PersonasVisualIdentityPackWidget
 
 #: The `PersonaMode` literal's values, for the editor's mode `Select` options.
 PERSONA_MODES: tuple[str, ...] = get_args(PersonaMode)
@@ -127,6 +130,15 @@ class PersonaProfileEditorWidget(Container):
             with Horizontal(classes="ds-field-row"):
                 yield Label("Enabled")
                 yield Switch(id="personas-editor-enabled", value=True)
+            yield Container(
+                Static("Loading Shared Visual Identity reactions…", markup=False),
+                id="personas-editor-shared-visual-identity-host",
+            )
+            yield Static(
+                "Persona Visual operational states",
+                id="personas-editor-persona-visual-title",
+                classes="destination-section",
+            )
             yield PersonasPersonaVisualPackWidget()
         # Validation stays outside the scroll body so it is always visible
         # next to Save (anchored-footer principle, same as the character editor).
@@ -208,12 +220,24 @@ class PersonaProfileEditorWidget(Container):
                 data.get("is_active", True)
             )
             visual = self.query_one(PersonasPersonaVisualPackWidget)
+            shared_host = self.query_one(
+                "#personas-editor-shared-visual-identity-host", Container
+            )
             if self._runtime_source == "server":
                 visual.set_availability("server")
+                self._set_shared_visual_identity_status(
+                    shared_host, "Save a local copy first"
+                )
             elif self._persona_id is None:
                 visual.set_availability("unsaved")
+                self._set_shared_visual_identity_status(
+                    shared_host, "Save the Persona first"
+                )
             else:
                 visual.set_availability("loading")
+                self._set_shared_visual_identity_status(
+                    shared_host, "Loading Shared Visual Identity reactions…"
+                )
             self.query_one("#personas-editor-validation", Static).update("")
             # Clear any stale per-field invalid marks left by a prior session:
             # if the reopened record's values are byte-identical to what's
@@ -231,6 +255,46 @@ class PersonaProfileEditorWidget(Container):
     def new_persona(self, *, runtime_source: str | None = None) -> None:
         """Clear the form for a new (unsaved) persona."""
         self.load_persona({}, runtime_source=runtime_source)
+
+    @staticmethod
+    def _set_shared_visual_identity_status(host: Container, copy: str) -> None:
+        """Replace or update the host's single path-free status line."""
+
+        children = tuple(host.children)
+        if len(children) == 1 and isinstance(children[0], Static):
+            children[0].update(copy)
+            return
+        host.remove_children()
+        host.mount(Static(copy, markup=False))
+
+    async def show_shared_visual_identity_pack(
+        self, pack: VisualIdentityPackMetadata
+    ) -> PersonasVisualIdentityPackWidget:
+        """Mount one local Persona Shared Visual Identity metadata browser."""
+
+        host = self.query_one("#personas-editor-shared-visual-identity-host", Container)
+        await host.remove_children()
+        browser = PersonasVisualIdentityPackWidget(pack, actor_kind="persona")
+        await host.mount(browser)
+        return browser
+
+    async def show_shared_visual_identity_unavailable(self) -> Static:
+        """Show one path-free non-authoring Shared Visual Identity state."""
+
+        host = self.query_one("#personas-editor-shared-visual-identity-host", Container)
+        await host.remove_children()
+        status = Static("Unavailable", markup=False)
+        await host.mount(status)
+        return status
+
+    async def discard_shared_visual_identity_pack(self, content: Widget | None) -> None:
+        """Remove only one stale Shared Visual Identity mount."""
+
+        if content is None:
+            return
+        host = self.query_one("#personas-editor-shared-visual-identity-host", Container)
+        if content.parent is host:
+            await content.remove()
 
     def mark_saved(self, record: Dict[str, Any]) -> None:
         """Re-baseline dirty state to a just-persisted persona (save-in-place).

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_visual_identity_pack_widget.py
@@ -113,11 +113,16 @@ class PersonasVisualIdentityPackWidget(Vertical):
     }"""
 
     def __init__(
-        self, pack: VisualIdentityPackMetadata | None = None, **kwargs: Any
+        self,
+        pack: VisualIdentityPackMetadata | None = None,
+        *,
+        actor_kind: Literal["character", "persona"] = "character",
+        **kwargs: Any,
     ) -> None:
         kwargs.setdefault("id", "personas-visual-identity-pack")
         super().__init__(**kwargs)
         self.pack = pack
+        self.actor_kind = actor_kind
         self._filtered: tuple[VisualIdentityAssetMetadata, ...] = ()
         self._selected: VisualIdentityAssetMetadata | None = None
         self._staged: dict[str, str] = {}
@@ -246,9 +251,12 @@ class PersonasVisualIdentityPackWidget(Vertical):
         )
         disabled = selected is None
         for action in ("replace", "generate", "clear"):
-            self.query_one(
-                f"#personas-visual-identity-{action}", Button
-            ).disabled = disabled
+            self.query_one(f"#personas-visual-identity-{action}", Button).disabled = (
+                disabled or (self.actor_kind == "persona" and action == "generate")
+            )
+        self.query_one("#personas-visual-identity-generate-all", Button).disabled = (
+            self.actor_kind == "persona" or self.pack is None
+        )
 
     def _replace_preview(self, renderable: object) -> None:
         """Replace the preview holder with one renderable or status."""
@@ -322,10 +330,12 @@ class PersonasVisualIdentityPackWidget(Vertical):
         selected_missing = self._selected is None
         for action in ("replace", "generate", "clear"):
             self.query_one(f"#personas-visual-identity-{action}", Button).disabled = (
-                busy is not None or selected_missing
+                busy is not None
+                or selected_missing
+                or (self.actor_kind == "persona" and action == "generate")
             )
         self.query_one("#personas-visual-identity-generate-all", Button).disabled = (
-            busy is not None or self.pack is None
+            busy is not None or self.pack is None or self.actor_kind == "persona"
         )
         self.query_one("#personas-visual-identity-save", Button).disabled = (
             busy is not None or not self._staged

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -955,6 +955,17 @@ _SETTINGS_CACHE_LOCK = None  # Will be initialized when needed
 _SETTINGS_REBUILD_LOCK = None  # Will be initialized when needed
 
 
+def _settings_rebuild_lock():
+    """Return the process-wide reentrant settings rebuild lock."""
+
+    global _SETTINGS_REBUILD_LOCK
+    if _SETTINGS_REBUILD_LOCK is None:
+        import threading
+
+        _SETTINGS_REBUILD_LOCK = threading.RLock()
+    return _SETTINGS_REBUILD_LOCK
+
+
 def resolve_tldw_api_config(app_config) -> Dict:
     """Return the [tldw_api] section from either config shape.
 
@@ -1352,15 +1363,12 @@ def load_settings(force_reload: bool = False) -> Dict:
     Returns:
         The merged settings mapping.
     """
-    global _SETTINGS_CACHE_LOCK, _SETTINGS_REBUILD_LOCK
+    global _SETTINGS_CACHE_LOCK
 
-    if _SETTINGS_CACHE_LOCK is None or _SETTINGS_REBUILD_LOCK is None:
+    if _SETTINGS_CACHE_LOCK is None:
         import threading
 
-        if _SETTINGS_CACHE_LOCK is None:
-            _SETTINGS_CACHE_LOCK = threading.Lock()
-        if _SETTINGS_REBUILD_LOCK is None:
-            _SETTINGS_REBUILD_LOCK = threading.RLock()
+        _SETTINGS_CACHE_LOCK = threading.Lock()
 
     active_config_path = _get_effective_config_path()
 
@@ -1381,7 +1389,7 @@ def load_settings(force_reload: bool = False) -> Dict:
     # Miss: serialize the rebuild. Whoever loses the race re-checks the cache
     # and returns the winner's freshly built settings rather than repeating
     # the entire rebuild.
-    with _SETTINGS_REBUILD_LOCK:
+    with _settings_rebuild_lock():
         if not force_reload:
             cached = _cache_hit()
             if cached is not None:
@@ -5054,7 +5062,11 @@ def _config_interprocess_lock(config_path: Path) -> Iterator[None]:
 def _config_write_lock(config_path: Path) -> Iterator[None]:
     """Serialize one config write transaction within and across processes."""
 
-    with _config_file_lock(), _config_interprocess_lock(config_path):
+    with (
+        _settings_rebuild_lock(),
+        _config_file_lock(),
+        _config_interprocess_lock(config_path),
+    ):
         yield
 
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -5246,7 +5246,7 @@ def get_runtime_config_snapshot(
 ) -> RuntimeConfigSnapshot:
     """Return a defensive current runtime config view."""
 
-    with _config_file_lock():
+    with _settings_rebuild_lock(), _config_file_lock():
         values = load_settings(force_reload=force_reload)
         return RuntimeConfigSnapshot(
             generation=_CONFIG_GENERATION,


### PR DESCRIPTION
## Summary

- enable eligible local Persona actors to resolve and publish immutable Shared Visual Identity expression packs with exact source, actor, revision, binding, and cache authority
- add Personas Workbench authoring, preview, Save/Cancel, dirty-navigation, cancellation-drain, and targeted invalidation behavior
- render Persona expressions in Console while keeping Persona Buddy operational states and Character behavior separate and unchanged
- harden the rebased branch with consistent config cache/write lock ordering, synchronous blank-search clearing, and deterministic Console test fixtures/waits
- close TASK-19056 with all acceptance criteria complete; reuse ADR-067 and ADR-074 without introducing a new architecture decision

## Verification

- complete affected-component gate before the final conflict-free rebase: `984 passed, 1 skipped`
- final-base Persona SVI resolver/publication/Workbench/Console core: `68 passed`
- final-base config cache/write concurrency and deletion coverage: `41 passed`
- final-base Console rail/shell overlap coverage: `116 passed`
- final-base architecture and persistent-diagnostic governance: `68 passed`
- repaired workspace-rail recompose test: five independent processes passed
- changed-file Ruff and `py_compile`: passed
- `git diff --check origin/dev...HEAD`: passed
- Ruff formatter: 17 changed Python files pass; the two reported files reproduce the same inherited `origin/dev` formatter baseline

No repository-wide test suite was run. The Windows-only skip and dependency/deprecation warnings are recorded in TASK-19056's implementation notes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Shared Visual Identity (SVI) for eligible local Persona actors and renders Persona expressions in Console. Previously SVI was Character-only; now Personas can capture a linked portrait, author and publish immutable packs, and resolve deterministically without affecting Persona Buddy behavior. Completes TASK-19056.

- Adds a Persona-local SVI authority (exact source/persona id/revision + optional portrait) with capture/resolve helpers; `VisualIdentityCandidate` now supports optional old_* fields and carries `actor_authority` with a guard; repository `activate_pack` adds `require_unbound_actor` and a final `publication_guard`.
- Console resolves Persona SVI via a provided local persona service and keys avatar updates by `actor_kind`/`actor_id`; `_resolve_visual_identity_for_db` accepts a `local_persona_service`; blank search clears immediately; tests use deterministic waits/fixtures; architecture tests guard Persona/Console import boundaries.
- Personas Workbench adds SVI authoring (preview, staged edits, Save/Cancel, dirty-navigation, cancellation-drain, targeted invalidation) with Persona Buddy state kept separate; config writes now wait on a process-wide settings rebuild lock to preserve lock ordering.

Migration
- If constructing `VisualIdentityCandidate` directly, handle optional old_* fields and pass `actor_authority` plus a guard when enforcing actor ownership.
- If calling `activate_pack` directly, set `require_unbound_actor` only when the actor must remain unbound during activation.
- When resolving Persona SVI in Console, supply a `local_persona_service` for persona-scoped requests.
- Update any avatar paint/spec calls to include `actor_kind` and `actor_id` keys.

<sup>Written for commit 26a023f21b0b5009c2eb81432213e6e9097370ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

