### PR TITLE
fix(egress): close the typing-triggered port-scan oracle and two unguarded seams

### DIFF
--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -51,9 +51,18 @@ In server mode the **Export** rail row is disabled, with the tooltip
   time), any "⚠" warnings about missing tooling, and — if some files
   can't be handled — "2 unsupported files will be skipped: …" (importing
   on the server, the same line reads "will fail", because that backend
-  records a failure row rather than skipping quietly). An
-  unreachable URL reports a plain reason ("URL unreachable — the server
-  name could not be found."), never a raw error dump. When the import is
+  records a failure row rather than skipping quietly). The pre-check does
+  **not** contact a URL: it reads the address, not the site, so nothing is
+  fetched while you are still typing one. A URL that turns out not to be
+  fetchable is reported by the import job itself, where the failure carries
+  a real reason. (You can turn a link check back on with `[library]
+  ingest_url_preflight_probe = true` in `config.toml`; it then runs only
+  when you leave the field, press Enter, pick with Browse…, or press
+  "Retry check" — never while you type — and an address it cannot check
+  reports one plain "The link could not be checked ahead of time. The
+  import will still be attempted." A link that answers but says the page
+  does not exist still reports "URL unreachable — the server says this page
+  does not exist (HTTP 404).") When the import is
   aimed at the server, the missing-tooling block is replaced by a single
   quiet note ("1 local component isn't installed — that affects imports
   on this machine only; this one runs on the server."): those extras
@@ -240,10 +249,12 @@ destination, or leaving the Import canvas cancels pending consent.
    path field (the "Browse…" picker selects single files only). Review the
    breakdown and size estimate — folder scans stop at 1,000 files and note
    " · more files not shown" — then press "Start import".
-3. **Import from a URL** — Paste the address into the path field. A link to
-   a video site imports as audio/video; a PDF link as a PDF; other pages
-   under "Web pages", where "What to fetch" / "Maximum pages" / "Maximum
-   depth" control how much gets scraped. Press "Start import".
+3. **Import from a URL** — Paste the address into the path field. Pasting
+   it does not contact the site; nothing is fetched until you press "Start
+   import". A link to a video site imports as audio/video; a PDF link as a
+   PDF; other pages under "Web pages", where "What to fetch" / "Maximum
+   pages" / "Maximum depth" control how much gets scraped. Press "Start
+   import".
 4. **Fix a "may fail to import" warning** — Press "Copy install command"
    right under the "⚠" warning in the pre-check summary. Quit the app, run
    the copied command in the environment the app is installed in,
@@ -744,3 +755,21 @@ are pinned by `Tests/Local_Ingestion/test_ingest_template_resolution.py`,
 `Tests/UI/test_library_ingest_template_picker.py`, and
 `Tests/Library/test_library_rechunk_service.py`. Template CRUD refuses
 the reserved name `auto` on create and rename.)*
+
+*Verified against task/19556-burn @ f12bb21ad — 2026-08-22 (TASK-19556 (a)):
+the import pre-check no longer contacts a URL. It used to fetch the address's
+headers 0.8 s after you stopped typing — before you had asked for anything to
+be imported — and the three answers it could get back (refused / answered
+with a status / clean) were each rendered differently in the summary, so
+pasting a link read out the state of whatever the address pointed at,
+including hosts on your own network. Pasting is now inert; the address is
+classified by name, exactly as a local path is classified by its extension.
+A link check remains available behind `[library]
+ingest_url_preflight_probe = true`, and in that mode it runs only from the
+deliberate triggers (leaving the field, Enter, Browse…, "Retry check"
+— note Textual also reports the field as left when the terminal itself
+loses focus), is
+routed through the `[web_security]` egress policy, follows no redirects, and
+reports one identical "could not be checked" note for every address the
+policy declines. Pinned by `Tests/Library/test_ingest_preflight_egress.py`
+and `Tests/Library/test_ingest_preflight.py`.*

--- a/Tests/Library/test_ingest_preflight.py
+++ b/Tests/Library/test_ingest_preflight.py
@@ -8,6 +8,7 @@ from urllib.error import HTTPError, URLError
 
 import pytest
 
+from tldw_chatbook.Library import ingest_preflight
 from tldw_chatbook.Library.ingest_preflight import (
     _collect_files,
     _probe_url,
@@ -16,6 +17,21 @@ from tldw_chatbook.Library.ingest_preflight import (
 )
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Local_Ingestion.local_file_ingestion import is_http_url
+
+
+@pytest.fixture
+def probing_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opt into the URL probe and let the egress policy pass (TASK-19556).
+
+    The probe is OFF by default now -- it used to fire from the ingest
+    field's 0.8 s typing debounce, which made it an internal-host scanning
+    oracle -- and when on it consults ``check_url_or_raise`` before any
+    transport call. These tests are about the probe's TRANSPORT outcomes,
+    so both gates are opened here; the gates themselves are owned by
+    ``Tests/Library/test_ingest_preflight_egress.py``.
+    """
+    monkeypatch.setattr(ingest_preflight, "url_probe_enabled", lambda: True)
+    monkeypatch.setattr(ingest_preflight, "check_url_or_raise", lambda *a, **k: None)
 
 
 class TestSafeSize:
@@ -113,47 +129,47 @@ class TestCollectFiles:
 
 
 class TestProbeUrl:
-    def test_returns_none_on_success(self) -> None:
+    def test_returns_none_on_success(self, probing_allowed) -> None:
         mock_response = MagicMock()
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
 
-        with patch("tldw_chatbook.Library.ingest_preflight.urlopen", return_value=mock_response):
+        with patch("tldw_chatbook.Library.ingest_preflight._open_probe", return_value=mock_response):
             probe = _probe_url("https://example.com/doc.pdf")
         assert probe.error is None
         assert probe.note is None
 
-    def test_returns_error_on_url_error(self) -> None:
+    def test_returns_error_on_url_error(self, probing_allowed) -> None:
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            "tldw_chatbook.Library.ingest_preflight._open_probe",
             side_effect=URLError("connection refused"),
         ):
             probe = _probe_url("https://example.com/doc.pdf")
         assert probe.error is not None
         assert "unreachable" in probe.error.lower()
 
-    def test_returns_error_on_timeout(self) -> None:
+    def test_returns_error_on_timeout(self, probing_allowed) -> None:
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            "tldw_chatbook.Library.ingest_preflight._open_probe",
             side_effect=TimeoutError(),
         ):
             probe = _probe_url("https://example.com/doc.pdf")
         assert probe.error is not None
         assert "timed out" in probe.error.lower()
 
-    def test_returns_error_on_unexpected_exception(self) -> None:
+    def test_returns_error_on_unexpected_exception(self, probing_allowed) -> None:
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            "tldw_chatbook.Library.ingest_preflight._open_probe",
             side_effect=ValueError("boom"),
         ):
             probe = _probe_url("https://example.com/doc.pdf")
         assert probe.error is not None
         assert "failed" in probe.error.lower()
 
-    def test_returns_error_on_http_404(self) -> None:
+    def test_returns_error_on_http_404(self, probing_allowed) -> None:
         error = HTTPError("https://example.com/doc.pdf", 404, "Not Found", {}, None)
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            "tldw_chatbook.Library.ingest_preflight._open_probe",
             side_effect=error,
         ):
             probe = _probe_url("https://example.com/doc.pdf")
@@ -161,7 +177,7 @@ class TestProbeUrl:
         assert "unreachable" in probe.error.lower()
 
     @pytest.mark.parametrize("status", [401, 403, 405, 429, 500])
-    def test_a_status_the_probe_cannot_interpret_does_not_veto(self, status: int) -> None:
+    def test_a_status_the_probe_cannot_interpret_does_not_veto(self, status: int, probing_allowed) -> None:
         """The probe may report doubt; it may not refuse the source.
 
         Any HTTP status proves the host resolved and answered. Sites routinely
@@ -172,18 +188,18 @@ class TestProbeUrl:
         """
         error = HTTPError("https://example.com/page", status, "Nope", {}, None)
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen", side_effect=error
+            "tldw_chatbook.Library.ingest_preflight._open_probe", side_effect=error
         ):
             probe = _probe_url("https://example.com/page")
 
         assert probe.error is None, f"{status} must not block the source"
         assert probe.note is not None and str(status) in probe.note
 
-    def test_a_gone_resource_is_still_refused(self) -> None:
+    def test_a_gone_resource_is_still_refused(self, probing_allowed) -> None:
         """410 is the host stating the resource is not there, like 404."""
         error = HTTPError("https://example.com/page", 410, "Gone", {}, None)
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen", side_effect=error
+            "tldw_chatbook.Library.ingest_preflight._open_probe", side_effect=error
         ):
             probe = _probe_url("https://example.com/page")
         assert probe.error is not None
@@ -315,12 +331,12 @@ class TestAnalyzePath:
         assert {"feature": "test", "group": "pdf"} in result.warnings
         assert not any(w["group"] == "unsupported" for w in result.warnings)
 
-    def test_reachable_url(self) -> None:
+    def test_reachable_url(self, probing_allowed) -> None:
         mock_response = MagicMock()
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
 
-        with patch("tldw_chatbook.Library.ingest_preflight.urlopen", return_value=mock_response):
+        with patch("tldw_chatbook.Library.ingest_preflight._open_probe", return_value=mock_response):
             result = analyze_path("https://example.com/document.pdf")
 
         assert result.errors == []
@@ -328,9 +344,9 @@ class TestAnalyzePath:
         assert "pdf" in result.type_groups
         assert result.total_size == 0
 
-    def test_unreachable_url(self) -> None:
+    def test_unreachable_url(self, probing_allowed) -> None:
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            "tldw_chatbook.Library.ingest_preflight._open_probe",
             side_effect=URLError("connection refused"),
         ):
             result = analyze_path("https://example.com/document.pdf")
@@ -339,12 +355,12 @@ class TestAnalyzePath:
         assert result.total_files == 0
         assert result.type_groups == {}
 
-    def test_url_with_video_extension(self) -> None:
+    def test_url_with_video_extension(self, probing_allowed) -> None:
         mock_response = MagicMock()
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
 
-        with patch("tldw_chatbook.Library.ingest_preflight.urlopen", return_value=mock_response):
+        with patch("tldw_chatbook.Library.ingest_preflight._open_probe", return_value=mock_response):
             result = analyze_path("https://example.com/lecture.mp4")
 
         assert result.errors == []
@@ -386,10 +402,10 @@ class TestPathErrorsAreMarked:
         assert result.errors == []
         assert result.path_invalid is False
 
-    def test_unreachable_url_is_not_a_path_problem(self) -> None:
+    def test_unreachable_url_is_not_a_path_problem(self, probing_allowed) -> None:
         """A URL that failed to respond is worth retrying; a typo'd path isn't."""
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            "tldw_chatbook.Library.ingest_preflight._open_probe",
             side_effect=URLError("connection refused"),
         ):
             result = analyze_path("https://example.com/document.pdf")
@@ -448,9 +464,13 @@ class TestUrlProbePlainLanguage:
     (``URL unreachable: <urlopen error [Errno 8] nodename nor servname
     provided, or not known>``) as the primary line."""
 
+    @pytest.fixture(autouse=True)
+    def _allow_probing(self, probing_allowed) -> None:
+        """Every test here drives `_probe_url` directly (TASK-19556 gates)."""
+
     def _probe_with(self, exc: Exception) -> object:
         with patch(
-            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            "tldw_chatbook.Library.ingest_preflight._open_probe",
             side_effect=exc,
         ):
             return _probe_url("https://no-such-host.example/doc.pdf")

--- a/Tests/Library/test_ingest_preflight_egress.py
+++ b/Tests/Library/test_ingest_preflight_egress.py
@@ -1,0 +1,359 @@
+"""TASK-19556 (a): the library ingest pre-flight is not a port-scan oracle.
+
+The defect, confirmed live at this branch's base
+(`tldw_chatbook/Library/ingest_preflight.py:15,221`):
+
+* `_probe_url` issued a bare `urllib.request.urlopen` HEAD. `urlopen`
+  auto-follows redirects and consults nothing -- there was no reference to
+  `Utils/egress.py` anywhere in the module.
+* `library_screen.handle_library_ingest_path_changed` arms an **0.8 s
+  debounce timer on every keystroke**, so the probe fired while the user
+  was still typing, before any deliberate "import this" action.
+* `analyze_path` then returned three *distinguishable* outcomes for the
+  probed host -- refused (an `error`), answered-{code} (a `warning`), or
+  clean (a type group and `total_files == 1`). Pasting a link therefore
+  drove an attacker-readable probe of the user's internal network: the
+  difference between "10.0.0.5:8080 refused" and "10.0.0.5:8080 answered
+  403" is visible in the summary the UI renders.
+
+The fix has three parts, and each is pinned below:
+
+1. **No probe by default.** The typing-debounced path performs no network
+   request at all; the URL is classified by name, exactly as a local path
+   is classified by `stat`. A user who wants link checking opts in with
+   `[library] ingest_url_preflight_probe = true`.
+2. **Policy-routed when enabled.** The probe consults `check_url_or_raise`
+   with *no* trusted origins before any transport call, and follows no
+   redirects, so it cannot be walked into internal space.
+3. **One collapsed outcome.** Every URL the policy declines -- private,
+   loopback, link-local, CGNAT, metadata, bad scheme, DNS failure --
+   produces the identical advisory note, so the outcomes cannot be
+   differenced.
+
+`validate_url` also now runs *before* any of this, satisfying "no network
+request at all before URL validation".
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from Tests import network_guard
+from tldw_chatbook.Library import ingest_preflight
+from tldw_chatbook.Library.ingest_preflight import analyze_path
+from tldw_chatbook.Library.ingest_types import PreflightResult
+
+#: RFC1918 host + a port an attacker would want to probe. Numeric on
+#: purpose: the network guard blocks/records `connect`, not name
+#: resolution, so a numeric target proves a *connection* was attempted
+#: rather than merely a DNS lookup.
+INTERNAL_URL = "http://10.255.255.1:8080/report.pdf"
+
+#: Three internal targets that an oracle would let a caller tell apart.
+INTERNAL_TARGETS = (
+    "http://10.255.255.1:8080/a.pdf",
+    "http://10.255.255.2:9200/b.pdf",
+    "http://192.168.77.9:22/c.pdf",
+)
+
+
+def _observable(result: PreflightResult) -> tuple[Any, ...]:
+    """Everything about a pre-flight result an attacker could difference.
+
+    Deliberately includes the *rendered* fields rather than a summary flag:
+    the oracle in this defect was readable straight off the ingest summary
+    (an error line vs. a "could not be confirmed" warning vs. a clean
+    "1 file" echo), so equality has to cover all three.
+
+    Args:
+        result: The pre-flight result to reduce.
+
+    Returns:
+        A hashable tuple of the user-visible outcome.
+    """
+    return (
+        tuple(result.errors),
+        tuple(sorted(w.get("label", "") for w in result.warnings)),
+        tuple(sorted(result.type_groups)),
+        result.total_files,
+        result.path_invalid,
+    )
+
+
+class _FakeOpen:
+    """Stands in for `OpenerDirector.open` -- the seam BOTH the base's
+    `urlopen` and any `build_opener(...)` variant funnel through.
+
+    Patching here (rather than a module-level `urlopen` name) means the
+    same test body exercises the code before and after the fix, so a red
+    run is red for the defect and not for a missing test seam.
+    """
+
+    def __init__(self, responder: Callable[[str], Any]):
+        self.responder = responder
+        self.urls: list[str] = []
+
+    def __call__(self, fullurl, data=None, timeout=None):  # noqa: ANN001
+        # Bound as a plain class attribute, so no implicit `self` arrives:
+        # `opener.open(...)` yields this instance, called with urlopen's own
+        # positional `(url, data, timeout)`.
+        url = getattr(fullurl, "full_url", fullurl)
+        self.urls.append(url)
+        return self.responder(url)
+
+
+class _Answered:
+    """A minimal context-manager HTTP response."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def _responder_for(url: str):
+    """Give each internal target a *different* real-world reaction.
+
+    - `:8080` refuses the connection (closed port)
+    - `:9200` answers 403 (an internal Elasticsearch behind auth)
+    - `:22` answers cleanly (something is listening and happy)
+    """
+    if ":8080" in url:
+        raise URLError(ConnectionRefusedError(61, "Connection refused"))
+    if ":9200" in url:
+        raise HTTPError(url, 403, "Forbidden", {}, None)
+    return _Answered()
+
+
+@pytest.fixture
+def fake_transport(monkeypatch: pytest.MonkeyPatch) -> _FakeOpen:
+    """Intercept every urllib open, with per-target reactions."""
+    fake = _FakeOpen(_responder_for)
+    monkeypatch.setattr("urllib.request.OpenerDirector.open", fake)
+    return fake
+
+
+@pytest.fixture
+def probe_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opt this test into the (default-off) network probe."""
+    monkeypatch.setattr(
+        ingest_preflight, "url_probe_enabled", lambda: True, raising=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Reachability: the typing path must not touch the network at all
+# ---------------------------------------------------------------------------
+
+
+def test_typing_preflight_makes_no_connection_to_an_internal_address() -> None:
+    """The defect's core evidence: at base this records a real `connect`.
+
+    Nothing is stubbed here on purpose. The suite's process-wide guard
+    (`Tests/network_guard.py`) turns an outbound `connect` into a recorded
+    `BlockedNetworkAccess`; `_probe_url`'s `except Exception` swallows it,
+    which is exactly why the *record* -- not an exception -- is the
+    assertion. At base the record holds an attempt on 10.255.255.1:8080.
+    """
+    analyze_path(INTERNAL_URL)
+    attempts = list(network_guard.drain_blocked_attempts())
+    assert attempts == [], (
+        "pre-flight attempted a connection to an internal address while the "
+        f"user was typing: {attempts}"
+    )
+
+
+def test_typing_preflight_still_classifies_the_url_without_probing() -> None:
+    """Dropping the probe must not drop the useful part of the summary."""
+    result = analyze_path("https://example.com/lecture.mp4")
+    network_guard.drain_blocked_attempts()
+    assert result.errors == []
+    assert result.source_is_url is True
+    assert result.total_files == 1
+    assert result.type_groups == {"audio_video": ["https://example.com/lecture.mp4"]}
+
+
+# ---------------------------------------------------------------------------
+# 2. Outcome vocabulary: internal targets must be indistinguishable
+# ---------------------------------------------------------------------------
+
+
+def test_typing_path_outcomes_are_identical_for_every_internal_target(
+    fake_transport: _FakeOpen,
+) -> None:
+    """Refused / 403 / answered must reduce to ONE observable outcome."""
+    outcomes = {_observable(analyze_path(url)) for url in INTERNAL_TARGETS}
+    network_guard.drain_blocked_attempts()
+    assert len(outcomes) == 1, (
+        f"pre-flight distinguishes internal targets: {sorted(outcomes)}"
+    )
+    assert fake_transport.urls == [], (
+        f"pre-flight reached the transport for internal targets: {fake_transport.urls}"
+    )
+
+
+def test_enabled_probe_still_collapses_every_internal_outcome(
+    probe_enabled: None, fake_transport: _FakeOpen
+) -> None:
+    """Opting in must not reopen the oracle.
+
+    With the probe enabled the egress policy declines all three targets
+    *before* the transport, so the collapse is structural: there is no
+    per-target reaction left to observe.
+    """
+    outcomes = {_observable(analyze_path(url)) for url in INTERNAL_TARGETS}
+    network_guard.drain_blocked_attempts()
+    assert len(outcomes) == 1, (
+        f"enabled probe distinguishes internal targets: {sorted(outcomes)}"
+    )
+    assert fake_transport.urls == [], (
+        "enabled probe reached the transport for a policy-declined target: "
+        f"{fake_transport.urls}"
+    )
+
+
+def test_enabled_probe_declines_metadata_endpoint_like_any_other_internal_host(
+    probe_enabled: None, fake_transport: _FakeOpen
+) -> None:
+    """A cloud metadata endpoint is not a distinguishable outcome either."""
+    # Same path/extension on both, so the comparison isolates the PROBE
+    # outcome from the name-based type classification (which is derived
+    # from the URL the user typed and reveals nothing about the host).
+    metadata = _observable(analyze_path("http://169.254.169.254/a.pdf"))
+    private = _observable(analyze_path(INTERNAL_TARGETS[0]))
+    network_guard.drain_blocked_attempts()
+    assert metadata == private
+    assert fake_transport.urls == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Ordering: validation precedes any network request
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_url_is_rejected_without_any_transport_call(
+    probe_enabled: None, fake_transport: _FakeOpen
+) -> None:
+    """`validate_url` runs first, so a credential-bearing URL never flies.
+
+    `http://user:pass@host/` is a URL `is_http_url` accepts and
+    `validate_url` refuses; at base the probe fired first and would have
+    put the embedded credential on the wire.
+    """
+    result = analyze_path("http://user:secret@example.com/doc.pdf")
+    network_guard.drain_blocked_attempts()
+    assert result.errors, "a URL that fails validate_url must be refused"
+    assert result.path_invalid is True
+    assert fake_transport.urls == []
+
+
+# ---------------------------------------------------------------------------
+# 4. The enabled probe is genuinely policy-routed (not merely silent)
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_probe_reaches_the_transport_for_an_allowed_public_host(
+    probe_enabled: None,
+    fake_transport: _FakeOpen,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opt-in probe still works: policy allows, transport is reached.
+
+    Without this, "no transport call" above would pass trivially for a
+    probe that had simply been deleted. The egress policy is stubbed to
+    *allow* rather than left to resolve DNS for real.
+    """
+    monkeypatch.setattr(ingest_preflight, "check_url_or_raise", lambda *a, **k: None)
+    result = analyze_path("https://example.com/document.pdf")
+    network_guard.drain_blocked_attempts()
+    assert fake_transport.urls == ["https://example.com/document.pdf"]
+    assert result.errors == []
+    assert "pdf" in result.type_groups
+
+
+def test_enabled_probe_asks_the_policy_without_trusting_the_typed_host(
+    probe_enabled: None,
+    fake_transport: _FakeOpen,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An automatic probe never seeds trust from its own input URL.
+
+    `Utils/egress.py`'s module contract: "Shared pipeline code must NEVER
+    auto-trust its own input URL". Self-trusting here would make the check
+    a no-op for precisely the private hosts this task is about.
+    """
+    seen: list[tuple[tuple, dict]] = []
+
+    def _record(*args, **kwargs):
+        seen.append((args, kwargs))
+
+    monkeypatch.setattr(ingest_preflight, "check_url_or_raise", _record)
+    analyze_path("http://10.255.255.1:8080/a.pdf")
+    network_guard.drain_blocked_attempts()
+    assert seen, "the probe did not consult the egress policy"
+    trusted = seen[0][1].get("trusted_origins", frozenset())
+    assert not trusted, f"probe self-trusted its own input: {trusted}"
+
+
+# ---------------------------------------------------------------------------
+# 5. The debounce wiring itself (TASK-19556 AC 3)
+# ---------------------------------------------------------------------------
+
+
+def test_the_typing_debounce_forbids_probing_even_when_it_is_enabled() -> None:
+    """A keystroke pause is not a request to contact a host.
+
+    The config gate alone would leave a user who opted the probe in being
+    made to hit the host on every 0.8 s pause, which is the behaviour the
+    task asks to be reviewed rather than merely defaulted away. The typing
+    timer therefore passes `allow_probe=False` unconditionally; the
+    deliberate triggers (blur, Enter, Browse..., the retry button) leave it
+    at its default and let the config decide.
+
+    Driven against the unbound method with a stand-in `self` so the
+    assertion is about the wiring, not about mounting a 34k-line screen.
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_INGEST_MEDIA
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+    calls: list[tuple[str, dict]] = []
+    stand_in = SimpleNamespace(
+        _library_ingest_path_debounce_timer=object(),
+        _library_ingest_form=SimpleNamespace(path="  http://10.255.255.1:8080/x  "),
+        _library_selected_row_id=LIBRARY_ROW_INGEST_MEDIA,
+        _trigger_library_ingest_preflight=(
+            lambda path, **kwargs: calls.append((path, kwargs))
+        ),
+    )
+
+    LibraryScreen._run_debounced_library_ingest_preflight(stand_in)
+
+    assert calls == [("http://10.255.255.1:8080/x", {"allow_probe": False})]
+
+
+def test_the_deliberate_retry_trigger_does_not_forbid_probing() -> None:
+    """The contrast: an explicit re-check is allowed to consult the config.
+
+    Without this, `allow_probe=False` everywhere would satisfy the test
+    above by simply deleting the feature.
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+    calls: list[tuple[str, dict]] = []
+    stand_in = SimpleNamespace(
+        _trigger_library_ingest_preflight=(
+            lambda path, **kwargs: calls.append((path, kwargs))
+        ),
+    )
+
+    LibraryScreen._trigger_preflight(stand_in, "http://example.com/a.pdf")
+
+    assert calls == [("http://example.com/a.pdf", {})]

--- a/Tests/Library/test_ingest_preflight_egress.py
+++ b/Tests/Library/test_ingest_preflight_egress.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
+from urllib.request import BaseHandler
 
 import pytest
 
@@ -357,3 +358,158 @@ def test_the_deliberate_retry_trigger_does_not_forbid_probing() -> None:
     LibraryScreen._trigger_preflight(stand_in, "http://example.com/a.pdf")
 
     assert calls == [("http://example.com/a.pdf", {})]
+
+
+def test_the_worker_translates_allow_probe_into_the_analyze_path_keyword(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The middle link of the chain, which nothing else pins.
+
+    (Independent review) `_run_debounced_...` -> `_trigger_...(allow_probe=
+    False)` is pinned above, and `analyze_path(probe_url=False)`'s behaviour
+    is pinned at the top of this module -- but the step that JOINS them,
+    `_run_library_ingest_preflight`'s `probe_url=None if allow_probe else
+    False`, was covered by neither. Rewriting it to a bare `probe_url=None`
+    left `Tests/Library/`, `Tests/UI/test_library_ingest_*` and the census
+    entirely green (509 passed, only the pre-existing red), while silently
+    putting an opted-in user back on a probe per 0.8 s typing pause -- the
+    exact behaviour AC 3 exists to prevent.
+
+    Driven against the undecorated function (`@work(thread=True)`'s
+    `__wrapped__`) with a stand-in `self`, matching the two tests above:
+    the assertion is about the keyword translation, not about running a
+    worker.
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.UI.Screens import library_screen as library_screen_module
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+    seen: list[dict] = []
+    monkeypatch.setattr(
+        library_screen_module,
+        "analyze_path",
+        lambda path, **kwargs: seen.append(kwargs) or PreflightResult(
+            type_groups={}, warnings=[], errors=[], total_size=0,
+            truncated=False, total_files=0,
+        ),
+    )
+    run = LibraryScreen._run_library_ingest_preflight.__wrapped__
+    stand_in = SimpleNamespace(
+        _annotate_preflight_duplicates=lambda result: result,
+        _apply_library_ingest_preflight_result=lambda *a: None,
+        app=SimpleNamespace(call_from_thread=lambda fn, *a: fn(*a)),
+    )
+
+    run(stand_in, INTERNAL_URL, 1, False)
+    assert seen[-1].get("probe_url") is False, (
+        "the while-typing worker must forbid probing outright, not defer to "
+        f"the config gate: {seen[-1]}"
+    )
+
+    run(stand_in, INTERNAL_URL, 2, True)
+    assert seen[-1].get("probe_url") is None, (
+        "a deliberate trigger must defer to the config gate, not force a "
+        f"probe and not forbid one: {seen[-1]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. The probe follows no redirects (TASK-19556's second stated hardening)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedirectingHTTPHandler(BaseHandler):
+    """A real `urllib` handler that answers 302 once, then 200.
+
+    Deliberately NOT the `fake_transport` fixture above: that one patches
+    `OpenerDirector.open`, which is the very method whose handler chain
+    performs redirect following -- so it can never observe whether the
+    chain follows one. This substitutes the *transport* handler instead
+    and leaves `OpenerDirector.open` real.
+    """
+
+    opened: list[str] = []
+
+    def http_open(self, req):  # noqa: ANN001
+        import io
+        from email.message import Message
+        from urllib.response import addinfourl
+
+        url = req.full_url
+        type(self).opened.append(url)
+        headers = Message()
+        if url == PUBLIC_REDIRECTOR:
+            headers["Location"] = INTERNAL_REDIRECT_TARGET
+            response = addinfourl(io.BytesIO(b""), headers, url, 302)
+            response.msg = "Found"
+            return response
+        response = addinfourl(io.BytesIO(b""), headers, url, 200)
+        response.msg = "OK"
+        return response
+
+
+#: A public host the egress policy would allow, answering a 302 that points
+#: at an internal one. The base's bare `urlopen` followed it, so the check
+#: that had just passed on the public target was walked into private space.
+PUBLIC_REDIRECTOR = "http://public.example.test/doc.pdf"
+INTERNAL_REDIRECT_TARGET = "http://10.0.0.5:8080/"
+
+
+def test_the_probe_does_not_follow_a_redirect_into_internal_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(Independent review) Nothing pinned this hardening.
+
+    Reverting `_open_probe` to `build_opener()` -- i.e. dropping
+    `_NoRedirectHandler`, restoring `urlopen`'s own redirect following --
+    left all of `Tests/Library/` plus the census green (2252 passed, 0
+    failed), because every other test in this module patches
+    `OpenerDirector.open` and therefore never reaches the handler chain.
+
+    A 302 must surface as an `HTTPError` about the host the user typed,
+    and the `Location` target must never be opened.
+    """
+    import urllib.request
+    from urllib.request import Request
+
+    _FakeRedirectingHTTPHandler.opened = []
+    monkeypatch.setattr(
+        urllib.request, "HTTPHandler", _FakeRedirectingHTTPHandler, raising=True
+    )
+
+    with pytest.raises(HTTPError) as excinfo:
+        ingest_preflight._open_probe(Request(PUBLIC_REDIRECTOR, method="HEAD"))
+
+    assert excinfo.value.code == 302
+    assert _FakeRedirectingHTTPHandler.opened == [PUBLIC_REDIRECTOR], (
+        "the probe followed the redirect into internal space: "
+        f"{_FakeRedirectingHTTPHandler.opened}"
+    )
+    network_guard.drain_blocked_attempts()
+
+
+def test_the_probe_reports_a_redirect_as_an_answered_status_not_an_error(
+    probe_enabled: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The user-visible half: a 3xx reads as "the site answered 302".
+
+    That is an outcome about the public host the user typed and nothing
+    else -- it must not become a clean result (which would imply the probe
+    verified something it never fetched).
+    """
+    import urllib.request
+
+    _FakeRedirectingHTTPHandler.opened = []
+    monkeypatch.setattr(
+        urllib.request, "HTTPHandler", _FakeRedirectingHTTPHandler, raising=True
+    )
+    monkeypatch.setattr(ingest_preflight, "check_url_or_raise", lambda *a, **k: None)
+
+    result = analyze_path(PUBLIC_REDIRECTOR)
+    network_guard.drain_blocked_attempts()
+
+    assert result.errors == []
+    assert [w.get("label") for w in result.warnings] == ["Could not check the link"]
+    assert "302" in result.warnings[0]["hint"]
+    assert _FakeRedirectingHTTPHandler.opened == [PUBLIC_REDIRECTOR]

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -1473,15 +1473,12 @@ def test_a_page_source_offers_its_scope_settings_in_the_canvas_state():
     """
     from tldw_chatbook.Library.ingest_capabilities import get_capabilities
     from tldw_chatbook.Library.ingest_preflight import analyze_path
-    from unittest.mock import MagicMock, patch
 
-    response = MagicMock()
-    response.__enter__ = MagicMock(return_value=response)
-    response.__exit__ = MagicMock(return_value=False)
-    with patch(
-        "tldw_chatbook.Library.ingest_preflight.urlopen", return_value=response
-    ):
-        preflight = analyze_path("https://example.com/some-post")
+    # (TASK-19556) The pre-flight no longer probes a URL by default -- that
+    # network call fired from the ingest field's typing debounce and made it
+    # an internal-host scanning oracle. Classification, which is what this
+    # test is about, needs no probe at all now.
+    preflight = analyze_path("https://example.com/some-post")
 
     assert list(preflight.type_groups) == ["web"], (
         "a page must reach the canvas as the web group, not as an unsupported file"

--- a/Tests/Local_Ingestion/test_video_download_cookies.py
+++ b/Tests/Local_Ingestion/test_video_download_cookies.py
@@ -82,6 +82,12 @@ def fake_ytdlp(monkeypatch, tmp_path: Path):
     _Module.YoutubeDL = _construct  # type: ignore[assignment]
     monkeypatch.setattr(video_processing, "yt_dlp", _Module, raising=False)
     monkeypatch.setattr(video_processing, "YT_DLP_AVAILABLE", True)
+    # (TASK-19556) The download seam now consults the egress policy before
+    # yt-dlp, which for the `example.com` URL these tests use would mean a
+    # real DNS lookup -- and an offline machine would fail them for the
+    # wrong reason. These tests are about cookie handling; the guard itself
+    # is owned by Tests/Local_Ingestion/test_video_egress_guard.py.
+    monkeypatch.setattr(video_processing, "check_url_or_raise", lambda *a, **k: None)
     return _FakeYoutubeDL.constructions
 
 

--- a/Tests/Local_Ingestion/test_video_egress_guard.py
+++ b/Tests/Local_Ingestion/test_video_egress_guard.py
@@ -1,0 +1,174 @@
+"""TASK-19556 (b): the yt-dlp media arm adopts the egress policy.
+
+At this branch's base `tldw_chatbook/Local_Ingestion/video_processing.py`
+contained **zero** references to `Utils/egress.py`. Both of its yt-dlp
+seams -- the pre-download size probe and the download itself in
+`download_video`, and `extract_metadata` -- handed the caller's URL
+straight to `yt_dlp.YoutubeDL(...).extract_info(url, ...)`.
+
+The instructive contrast lives one module over:
+`audio_processing.download_audio_file` routes its plain-HTTP branch
+through `guarded_fetch_requests(url, trusted_origins=origin_set(url), ...)`.
+That is the shape adopted here, so the media and article arms of the same
+ingest entry point behave identically:
+
+* a URL the user typed may resolve privately (an intranet media server is
+  a legitimate ingest source, and `config.py`'s `[web_security]` contract
+  says configured URLs may be private) -- so the entry URL is its own
+  trusted origin, exactly as in the audio arm;
+* a cloud metadata endpoint is refused **regardless** of that trust, which
+  is `Utils/egress.py`'s one hard rule;
+* a non-http(s) scheme is refused -- yt-dlp itself is happy to hand
+  `file://` and dozens of other protocols to its extractors.
+
+WHAT THIS DOES NOT COVER, stated plainly: yt-dlp performs its own HTTP
+fetching. This is a pre-check on the entry URL only. It cannot re-validate
+yt-dlp's own redirect hops, the per-format media URLs an extractor
+discovers inside a page, or a DNS answer that changes between this check
+and yt-dlp's own resolution (the same TOCTOU window `Utils/egress.py`
+documents as a residual for every consumer). Closing those would require
+either a yt-dlp request hook or refusing yt-dlp entirely; neither is in
+this task's scope.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from tldw_chatbook.Local_Ingestion import video_processing
+from tldw_chatbook.Local_Ingestion.video_processing import (
+    LocalVideoProcessor,
+    VideoDownloadError,
+)
+
+METADATA_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+PRIVATE_URL = "http://10.255.255.1:8080/clip.mp4"
+FILE_URL = "file:///etc/passwd"
+
+
+class _RecordingYoutubeDL:
+    """Records every URL `extract_info` is asked to fetch."""
+
+    urls: List[str] = []
+    constructions: List[Dict[str, Any]] = []
+
+    def __init__(self, opts: Dict[str, Any]):
+        self.opts = dict(opts)
+        type(self).constructions.append(self.opts)
+
+    def __enter__(self) -> "_RecordingYoutubeDL":
+        return self
+
+    def __exit__(self, *_exc: Any) -> bool:
+        return False
+
+    def extract_info(self, url: str, download: bool = False) -> Dict[str, Any]:
+        type(self).urls.append(url)
+        if download:
+            Path(self.opts["_test_output"]).write_bytes(b"\x00" * 8)
+        return {"title": "clip", "filesize": 1024, "uploader": "someone"}
+
+    def prepare_filename(self, info: Dict[str, Any]) -> str:
+        return str(self.opts["_test_output"])
+
+
+@pytest.fixture
+def recording_ytdlp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> List[str]:
+    """Install the recording yt-dlp seam; return the fetched-URL log.
+
+    yt-dlp is an optional dependency and absent from this venv, so the
+    module's `yt_dlp` name is the seam. Nothing here opens a socket: the
+    assertion is on which URLs *would* have been fetched.
+    """
+    _RecordingYoutubeDL.urls = []
+    _RecordingYoutubeDL.constructions = []
+    output = tmp_path / "clip.mp4"
+
+    class _Module:
+        @staticmethod
+        def YoutubeDL(opts: Dict[str, Any]) -> _RecordingYoutubeDL:  # noqa: N802
+            return _RecordingYoutubeDL({**opts, "_test_output": str(output)})
+
+    monkeypatch.setattr(video_processing, "yt_dlp", _Module, raising=False)
+    monkeypatch.setattr(video_processing, "YT_DLP_AVAILABLE", True)
+    return _RecordingYoutubeDL.urls
+
+
+# ---------------------------------------------------------------------------
+# download_video
+# ---------------------------------------------------------------------------
+
+
+def test_download_video_refuses_a_cloud_metadata_endpoint(
+    tmp_path: Path, recording_ytdlp: List[str]
+) -> None:
+    """The hard rule: metadata IPs are blocked even for a trusted origin."""
+    processor = LocalVideoProcessor(None)
+    with pytest.raises(VideoDownloadError):
+        processor.download_video(METADATA_URL, str(tmp_path))
+    assert recording_ytdlp == [], (
+        f"an unchecked URL reached yt-dlp: {recording_ytdlp}"
+    )
+
+
+def test_download_video_refuses_a_non_http_scheme(
+    tmp_path: Path, recording_ytdlp: List[str]
+) -> None:
+    """yt-dlp handles many protocols; the ingest entry point should not."""
+    processor = LocalVideoProcessor(None)
+    with pytest.raises(VideoDownloadError):
+        processor.download_video(FILE_URL, str(tmp_path))
+    assert recording_ytdlp == []
+
+
+def test_download_video_still_allows_a_user_typed_private_url(
+    tmp_path: Path, recording_ytdlp: List[str]
+) -> None:
+    """Parity with the audio arm: a typed URL is its own trusted origin.
+
+    Without this the guard would break intranet media ingest, which
+    `config.py`'s `[web_security]` contract explicitly permits.
+    """
+    processor = LocalVideoProcessor(None)
+    processor.download_video(PRIVATE_URL, str(tmp_path), download_video_flag=True)
+    assert recording_ytdlp == [PRIVATE_URL, PRIVATE_URL]  # probe + download
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_extract_metadata_refuses_a_cloud_metadata_endpoint(
+    recording_ytdlp: List[str],
+) -> None:
+    processor = LocalVideoProcessor(None)
+    assert processor.extract_metadata(METADATA_URL) is None
+    assert recording_ytdlp == []
+
+
+def test_extract_metadata_still_allows_a_user_typed_private_url(
+    recording_ytdlp: List[str],
+) -> None:
+    processor = LocalVideoProcessor(None)
+    assert processor.extract_metadata(PRIVATE_URL) is not None
+    assert recording_ytdlp == [PRIVATE_URL]
+
+
+# ---------------------------------------------------------------------------
+# Adoption pin (mutation guard)
+# ---------------------------------------------------------------------------
+
+
+def test_video_processing_references_the_egress_policy() -> None:
+    """Deleting the guard must not merely change behaviour silently.
+
+    The task's own finding was phrased as "contains zero references to the
+    egress helpers"; this keeps that phrasing checkable.
+    """
+    source = Path(video_processing.__file__).read_text(encoding="utf-8")
+    assert "check_url_or_raise" in source
+    assert "origin_set" in source

--- a/Tests/UI/test_library_ingest_inline_consent.py
+++ b/Tests/UI/test_library_ingest_inline_consent.py
@@ -1108,7 +1108,7 @@ async def _warned_ingest_screen(host, pilot, monkeypatch, tmp_path):
     monkeypatch.setattr(
         library_screen_module,
         "analyze_path",
-        lambda path, scan_limit=1000: result,
+        lambda path, scan_limit=1000, **_kwargs: result,
     )
     await screen._select_library_rail_row(LIBRARY_ROW_INGEST_MEDIA)
     path_input = await _wait_for_selector(screen, pilot, "#library-ingest-path")

--- a/Tests/UI/test_library_ingest_retry_last.py
+++ b/Tests/UI/test_library_ingest_retry_last.py
@@ -310,7 +310,7 @@ async def _submit_batch(screen, pilot, monkeypatch, tmp_path, submitted):
     monkeypatch.setattr(
         library_screen_module,
         "analyze_path",
-        lambda path, scan_limit=1000: results["current"],
+        lambda path, scan_limit=1000, **_kwargs: results["current"],
     )
 
     form = screen._library_ingest_form

--- a/Tests/Utils/test_egress_adoption_census.py
+++ b/Tests/Utils/test_egress_adoption_census.py
@@ -1,0 +1,126 @@
+"""TASK-19556: a module that opens URLs must also consult the egress policy.
+
+Three seams in this codebase reached the network without ever calling
+`Utils/egress.py`, and each was found by a human reading code rather than by
+anything that would fail. The sharpest -- `Library/ingest_preflight.py`'s
+`urlopen` HEAD on a typing debounce -- had been in place across several
+reviews. This census is the "next seam cannot silently skip it" guard the
+task's last AC asks for.
+
+**The rule.** A module under `tldw_chatbook/` that uses a URL-opening
+primitive from the two families this task touched must also name at least
+one egress-policy symbol. Referencing the policy is not proof of using it
+correctly -- no static check can be -- but a module that never mentions it
+demonstrably is not using it, which is exactly the state all three seams
+were in.
+
+**The scope, stated so it is not overclaimed.** This covers the
+`urllib.request` family (the primitive that produced defect (a): it
+auto-follows redirects and consults nothing) and `yt_dlp.YoutubeDL` (defect
+(b)). It deliberately does NOT census bare `requests`/`httpx` calls: this
+app has dozens of legitimate ones to fixed, non-user-supplied API endpoints
+(every LLM provider in `LLM_Calls/`), so a census of those would be noise
+that gets suppressed rather than a guard that gets read. Behavioural
+adoption for the individual seams is pinned by
+`Tests/Library/test_ingest_preflight_egress.py`,
+`Tests/Local_Ingestion/test_video_egress_guard.py` and
+`Tests/Web_Scraping/test_sitemap_crawl_trusted_origins.py`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import tldw_chatbook
+
+PACKAGE_ROOT = Path(tldw_chatbook.__file__).parent
+
+#: URL-opening primitives whose users must consult the egress policy.
+_OPENER_PATTERNS = (
+    re.compile(r"\burlopen\b"),
+    re.compile(r"\burlretrieve\b"),
+    re.compile(r"\bbuild_opener\b"),
+    re.compile(r"\bOpenerDirector\b"),
+    re.compile(r"\bYoutubeDL\b"),
+)
+
+#: Any of these names means the module consults the policy.
+_EGRESS_PATTERNS = (
+    re.compile(r"\bcheck_url_or_raise\b"),
+    re.compile(r"\bcheck_url_or_raise_async\b"),
+    re.compile(r"\bevaluate_url_policy\b"),
+    re.compile(r"\bevaluate_url_policy_async\b"),
+    re.compile(r"\bis_public_http_url\b"),
+    re.compile(r"\bguarded_fetch_"),
+)
+
+#: Modules exempt from the rule, each with the reason it is exempt.
+#: An entry here is a claim someone has to defend at review time -- which is
+#: the point; the alternative is a seam nobody ever looks at.
+_EXEMPT: dict[str, str] = {
+    "Local_Ingestion/parakeet_v2_installer.py": (
+        "The URL is a module constant (`_source_url` interpolates two "
+        "hardcoded constants into a huggingface.co path); no caller-supplied "
+        "component reaches it, so there is no SSRF input to guard. The "
+        "download is additionally size- and SHA-256-pinned per file."
+    ),
+}
+
+
+def _module_key(path: Path) -> str:
+    return path.relative_to(PACKAGE_ROOT).as_posix()
+
+
+def _offenders() -> dict[str, list[str]]:
+    """Modules that open URLs without naming the egress policy."""
+    offenders: dict[str, list[str]] = {}
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8", errors="replace")
+        hits = [p.pattern for p in _OPENER_PATTERNS if p.search(source)]
+        if not hits:
+            continue
+        if any(p.search(source) for p in _EGRESS_PATTERNS):
+            continue
+        key = _module_key(path)
+        if key in _EXEMPT:
+            continue
+        offenders[key] = hits
+    return offenders
+
+
+def test_every_url_opening_module_consults_the_egress_policy() -> None:
+    offenders = _offenders()
+    assert offenders == {}, (
+        "these modules open URLs without consulting Utils/egress.py: "
+        + "; ".join(f"{k} ({', '.join(v)})" for k, v in sorted(offenders.items()))
+        + " -- route the fetch through the policy, or add an entry to _EXEMPT "
+        "with the reason it needs none."
+    )
+
+
+def test_the_census_detector_actually_detects(tmp_path: Path) -> None:
+    """Methodology check: a detector that matched nothing would be silent.
+
+    The census scans real files, so this proves the *predicate* bites by
+    running it over a synthetic module rather than by trusting the empty
+    result above.
+    """
+    guarded = "from x import check_url_or_raise\nurlopen(u)\n"
+    unguarded = "from urllib.request import urlopen\nurlopen(u)\n"
+    inert = "x = 1\n"
+    assert not any(p.search(inert) for p in _OPENER_PATTERNS)
+    assert any(p.search(unguarded) for p in _OPENER_PATTERNS)
+    assert not any(p.search(unguarded) for p in _EGRESS_PATTERNS)
+    assert any(p.search(guarded) for p in _EGRESS_PATTERNS)
+
+
+def test_exempt_entries_still_exist_and_still_need_the_exemption() -> None:
+    """An exemption for a module that no longer opens URLs is stale."""
+    for key in _EXEMPT:
+        path = PACKAGE_ROOT / key
+        assert path.exists(), f"stale exemption for a deleted module: {key}"
+        source = path.read_text(encoding="utf-8", errors="replace")
+        assert any(p.search(source) for p in _OPENER_PATTERNS), (
+            f"stale exemption: {key} no longer opens URLs, drop the entry"
+        )

--- a/Tests/Utils/test_egress_adoption_census.py
+++ b/Tests/Utils/test_egress_adoption_census.py
@@ -1,4 +1,5 @@
-"""TASK-19556: a module that opens URLs must also consult the egress policy.
+"""TASK-19556 (+ Qodo follow-up on PR #1967): a module that opens URLs must
+also consult the egress policy.
 
 Three seams in this codebase reached the network without ever calling
 `Utils/egress.py`, and each was found by a human reading code rather than by
@@ -8,11 +9,48 @@ reviews. This census is the "next seam cannot silently skip it" guard the
 task's last AC asks for.
 
 **The rule.** A module under `tldw_chatbook/` that uses a URL-opening
-primitive from the two families this task touched must also name at least
+primitive from the two families this task touched must also use at least
 one egress-policy symbol. Referencing the policy is not proof of using it
-correctly -- no static check can be -- but a module that never mentions it
+correctly -- no static check can be -- but a module that never uses it
 demonstrably is not using it, which is exactly the state all three seams
 were in.
+
+**Why this is AST-based, not regex-over-text.** The original version of this
+census (`re.Pattern.search` over the raw source) was reviewed on PR #1967
+and correctly called bypassable in both directions: a docstring or comment
+*mentioning* `check_url_or_raise` made an unguarded module look guarded
+(false green -- the exact shape this programme keeps finding elsewhere), and
+a docstring or comment merely *naming* `urlopen` in prose made a module that
+never touches the network look like it needed an exemption (false red). Both
+directions are proven closed below
+(`test_comment_mentioning_the_real_egress_symbol_does_not_launder_an_unguarded_opener`,
+`test_docstring_or_comment_opener_mention_is_not_flagged`), and the original
+demonstration -- that the census independently rediscovers the two real
+seams this task fixed -- is re-proven against the rewrite
+(`test_census_rediscovers_the_original_two_seams_when_their_egress_calls_are_removed`).
+
+This version resolves real `import`/`from ... import` bindings (including
+`as` aliases and `from pkg import module` + `module.symbol(...)` attribute
+calls) and matches actual `ast.Call` targets against the opener/egress
+symbol sets. It does not execute anything -- comments and docstrings never
+produce `Name`/`Attribute` nodes, so a mention inside either is structurally
+invisible to it, which is what makes both the false-green and false-red
+bypasses close.
+
+**What this still cannot express (stated, not left as a silent gap).** This
+is a single-file, syntactic scan -- it resolves names bound by `import`
+statements in the *same* file, not whatever an imported name actually does
+in its own module (a thin same-file wrapper around `urlopen` is invisible;
+that wrapper's own file is separately censused when the scan reaches it).
+It also cannot follow dynamic dispatch: `getattr(urllib.request,
+"urlopen")(u)` or a call built through `functools.partial`/`exec` is not a
+`Name`/`Attribute` chain a static resolver can trace, so the AST version
+will not flag it -- notably, the OLD regex *would* have (the string literal
+`"urlopen"` is still text in the file), so this is a real, if obscure,
+regression traded for closing the comment/docstring bypass. Nobody in this
+codebase uses `getattr`-based dispatch to reach `urlopen`/`YoutubeDL`
+today (checked at rewrite time), so it costs nothing currently, but a
+reflection-based seam would need a human read, same as it always did.
 
 **The scope, stated so it is not overclaimed.** This covers the
 `urllib.request` family (the primitive that produced defect (a): it
@@ -29,31 +67,131 @@ adoption for the individual seams is pinned by
 
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 import tldw_chatbook
 
 PACKAGE_ROOT = Path(tldw_chatbook.__file__).parent
 
-#: URL-opening primitives whose users must consult the egress policy.
-_OPENER_PATTERNS = (
-    re.compile(r"\burlopen\b"),
-    re.compile(r"\burlretrieve\b"),
-    re.compile(r"\bbuild_opener\b"),
-    re.compile(r"\bOpenerDirector\b"),
-    re.compile(r"\bYoutubeDL\b"),
+#: (module suffix, attribute name) pairs whose CALL means "this module opens
+#: a URL". Matched after resolving the callee through this file's own
+#: import bindings -- see `_resolve_call_target`.
+_OPENER_TARGETS = frozenset(
+    {
+        "urllib.request.urlopen",
+        "urllib.request.urlretrieve",
+        "urllib.request.build_opener",
+        "urllib.request.OpenerDirector",
+        "yt_dlp.YoutubeDL",
+    }
 )
 
-#: Any of these names means the module consults the policy.
-_EGRESS_PATTERNS = (
-    re.compile(r"\bcheck_url_or_raise\b"),
-    re.compile(r"\bcheck_url_or_raise_async\b"),
-    re.compile(r"\bevaluate_url_policy\b"),
-    re.compile(r"\bevaluate_url_policy_async\b"),
-    re.compile(r"\bis_public_http_url\b"),
-    re.compile(r"\bguarded_fetch_"),
+#: Egress-policy symbol names. An exact match, or (for the guarded_fetch_*
+#: family, which has several sync/async/backend variants) a prefix match.
+_EGRESS_SYMBOLS = frozenset(
+    {
+        "check_url_or_raise",
+        "check_url_or_raise_async",
+        "evaluate_url_policy",
+        "evaluate_url_policy_async",
+        "is_public_http_url",
+    }
 )
+
+
+def _is_egress_symbol(name: str) -> bool:
+    return name in _EGRESS_SYMBOLS or name.startswith("guarded_fetch_")
+
+
+def _is_egress_module(module: str) -> bool:
+    """True for `Utils.egress`, `tldw_chatbook.Utils.egress`, `.egress`, etc.
+
+    Matched on the last dotted segment so it is agnostic to relative-import
+    depth (`node.module` never carries the leading dots for a relative
+    import; `node.level` does, and we don't need it here).
+    """
+    return module.split(".")[-1] == "egress"
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    """Collapse a `Name`/`Attribute` chain (e.g. `egress.check_url_or_raise`)
+    into a dotted string, or return None if it isn't one (e.g. the callee is
+    itself a call, a subscript, or anything else not statically resolvable).
+    """
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        parts.reverse()
+        return ".".join(parts)
+    return None
+
+
+def _resolve_call_target(dotted: str, bindings: dict[str, str]) -> str:
+    """Rewrite the leftmost segment of `dotted` through this file's import
+    bindings, so `req.urlopen` resolves to `urllib.request.urlopen` when the
+    file has `import urllib.request as req`, and a bare `urlopen` resolves
+    the same way when the file has `from urllib.request import urlopen`.
+    """
+    head, *rest = dotted.split(".")
+    resolved_head = bindings.get(head, head)
+    return ".".join([resolved_head, *rest]) if rest else resolved_head
+
+
+def _scan(tree: ast.Module) -> tuple[frozenset[str], frozenset[str]]:
+    """Return (opener_hits, egress_hits): the resolved dotted names of every
+    real opener call and every real egress-policy import/call in `tree`.
+
+    Two passes: bindings first (so a call is resolved against every import
+    in the file regardless of source order), then calls.
+    """
+    bindings: dict[str, str] = {}
+    egress_hits: set[str] = set()
+    opener_hits: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                # `import a.b.c` binds only `a`; `import a.b.c as x` binds
+                # `x` to the full dotted path.
+                local = alias.asname or alias.name.split(".")[0]
+                qualified = alias.name if alias.asname else local
+                bindings.setdefault(local, qualified)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                local = alias.asname or alias.name
+                qualified = f"{module}.{alias.name}" if module else alias.name
+                bindings[local] = qualified
+                # `from ...Utils.egress import check_url_or_raise` is a real
+                # AST import node naming the specific symbol -- that is
+                # itself a use of the policy, not a substring in prose.
+                if _is_egress_module(module) and _is_egress_symbol(alias.name):
+                    egress_hits.add(qualified)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        dotted = _dotted_name(node.func)
+        if dotted is None:
+            continue
+        resolved = _resolve_call_target(dotted, bindings)
+        if resolved in _OPENER_TARGETS:
+            opener_hits.add(resolved)
+            continue
+        parts = resolved.split(".")
+        if len(parts) >= 2 and parts[-2] == "egress" and _is_egress_symbol(parts[-1]):
+            egress_hits.add(resolved)
+
+    return frozenset(opener_hits), frozenset(egress_hits)
+
+
+def _analyze_source(source: str) -> tuple[frozenset[str], frozenset[str]]:
+    return _scan(ast.parse(source))
+
 
 #: Modules exempt from the rule, each with the reason it is exempt.
 #: An entry here is a claim someone has to defend at review time -- which is
@@ -73,19 +211,19 @@ def _module_key(path: Path) -> str:
 
 
 def _offenders() -> dict[str, list[str]]:
-    """Modules that open URLs without naming the egress policy."""
+    """Modules that open URLs without using the egress policy."""
     offenders: dict[str, list[str]] = {}
     for path in sorted(PACKAGE_ROOT.rglob("*.py")):
         source = path.read_text(encoding="utf-8", errors="replace")
-        hits = [p.pattern for p in _OPENER_PATTERNS if p.search(source)]
-        if not hits:
+        openers, egress = _analyze_source(source)
+        if not openers:
             continue
-        if any(p.search(source) for p in _EGRESS_PATTERNS):
+        if egress:
             continue
         key = _module_key(path)
         if key in _EXEMPT:
             continue
-        offenders[key] = hits
+        offenders[key] = sorted(openers)
     return offenders
 
 
@@ -99,20 +237,179 @@ def test_every_url_opening_module_consults_the_egress_policy() -> None:
     )
 
 
-def test_the_census_detector_actually_detects(tmp_path: Path) -> None:
+def test_the_census_detector_actually_detects() -> None:
     """Methodology check: a detector that matched nothing would be silent.
 
     The census scans real files, so this proves the *predicate* bites by
-    running it over a synthetic module rather than by trusting the empty
+    running it over synthetic modules rather than by trusting the empty
     result above.
     """
-    guarded = "from x import check_url_or_raise\nurlopen(u)\n"
-    unguarded = "from urllib.request import urlopen\nurlopen(u)\n"
+    guarded = (
+        "from tldw_chatbook.Utils.egress import check_url_or_raise\n"
+        "from urllib.request import urlopen\n"
+        "def f(u):\n"
+        "    check_url_or_raise(u)\n"
+        "    return urlopen(u)\n"
+    )
+    unguarded = "from urllib.request import urlopen\ndef f(u):\n    return urlopen(u)\n"
     inert = "x = 1\n"
-    assert not any(p.search(inert) for p in _OPENER_PATTERNS)
-    assert any(p.search(unguarded) for p in _OPENER_PATTERNS)
-    assert not any(p.search(unguarded) for p in _EGRESS_PATTERNS)
-    assert any(p.search(guarded) for p in _EGRESS_PATTERNS)
+
+    inert_openers, inert_egress = _analyze_source(inert)
+    assert not inert_openers and not inert_egress
+
+    unguarded_openers, unguarded_egress = _analyze_source(unguarded)
+    assert unguarded_openers and not unguarded_egress
+
+    guarded_openers, guarded_egress = _analyze_source(guarded)
+    assert guarded_openers and guarded_egress
+
+
+def test_scan_resolves_aliased_and_attribute_style_imports() -> None:
+    """Pins the two resolver paths a bare-word regex cannot distinguish:
+    an `as`-aliased opener import, and a `from pkg import module` +
+    `module.symbol(...)` attribute call -- the exact shape
+    `Image_Generation/http_client.py` and `Media_Playback/stream_resolve.py`
+    use for the egress side (`from tldw_chatbook.Utils import egress` then
+    `egress.check_url_or_raise(...)`).
+    """
+    aliased_opener = (
+        "import urllib.request as req\n"
+        "def f(u):\n"
+        "    return req.urlopen(u)\n"
+    )
+    openers, egress = _analyze_source(aliased_opener)
+    assert openers == frozenset({"urllib.request.urlopen"})
+    assert not egress
+
+    module_attr_egress = (
+        "from tldw_chatbook.Utils import egress\n"
+        "from urllib.request import urlopen\n"
+        "def f(u):\n"
+        "    egress.check_url_or_raise(u)\n"
+        "    return urlopen(u)\n"
+    )
+    openers, egress = _analyze_source(module_attr_egress)
+    assert openers == frozenset({"urllib.request.urlopen"})
+    assert egress
+
+    yt_dlp_attr = "import yt_dlp\ndef f(opts):\n    return yt_dlp.YoutubeDL(opts)\n"
+    openers, egress = _analyze_source(yt_dlp_attr)
+    assert openers == frozenset({"yt_dlp.YoutubeDL"})
+    assert not egress
+
+
+def test_docstring_or_comment_opener_mention_is_not_flagged() -> None:
+    """No false red: Qodo's finding on PR #1967 was that an opener word
+    appearing only in a comment/docstring could trip the OLD regex census
+    into treating a module that never touches the network as one that needs
+    an `_EXEMPT` entry. Neither a docstring nor a comment produces a
+    `Name`/`Attribute` AST node, so the rewritten census must see zero
+    openers here -- the module is not even classified as opening URLs, so
+    whether it "consults the policy" never comes up.
+    """
+    prose_only = (
+        '"""This module used to call urlopen() directly; see YoutubeDL for '
+        'the video case too."""\n'
+        "# TODO: consider urlretrieve for large downloads via build_opener\n"
+        "def helper(x):\n"
+        "    return x + 1\n"
+    )
+    openers, egress = _analyze_source(prose_only)
+    assert openers == frozenset(), (
+        "a comment/docstring mention of an opener must not be classified as "
+        f"opening a URL, got: {sorted(openers)}"
+    )
+    assert egress == frozenset()
+
+
+def test_comment_mentioning_the_real_egress_symbol_does_not_launder_an_unguarded_opener() -> (
+    None
+):
+    """No false green: this is Qodo's exact bypass -- a comment naming the
+    real egress function next to a genuine, unguarded opener call used to
+    read as "consults the policy" under the old raw-text regex. It must not
+    under the AST version: comments never produce AST nodes, so the only
+    thing that can satisfy `egress_hits` is a real import or a real call.
+    """
+    laundered = (
+        "from urllib.request import urlopen\n"
+        "def fetch(u):\n"
+        "    # Should route through check_url_or_raise from Utils.egress, "
+        "but doesn't yet.\n"
+        "    return urlopen(u)\n"
+    )
+    openers, egress = _analyze_source(laundered)
+    assert openers, "the module genuinely opens a URL and must be detected as such"
+    assert egress == frozenset(), (
+        "a comment merely naming check_url_or_raise must not count as "
+        f"consulting the policy, got: {sorted(egress)}"
+    )
+    # And the top-level census function classifies it as an offender.
+    key = "synthetic/laundered_opener.py"
+    offenders: dict[str, list[str]] = {}
+    if openers and not egress and key not in _EXEMPT:
+        offenders[key] = sorted(openers)
+    assert offenders == {key: ["urllib.request.urlopen"]}
+
+
+def test_census_rediscovers_the_original_two_seams_when_their_egress_calls_are_removed() -> (
+    None
+):
+    """The census's original demonstration, re-proven against the rewrite.
+
+    TASK-19556's own implementation notes record that, run at the
+    pre-fix base, the census "independently rediscovered exactly the two
+    seams this task names: `Library/ingest_preflight.py` and
+    `Local_Ingestion/video_processing.py`". This test does not need the old
+    base commit to re-prove that: it takes the CURRENT (fixed) source of
+    both modules and mechanically un-fixes each -- deletes the
+    `check_url_or_raise` import and blanks the call site -- which is exactly
+    the code shape the task describes as the original defect ("contains
+    zero references to the egress helpers"). If the census can no longer
+    catch that shape, the rewrite regressed the one thing this file exists
+    to guarantee.
+    """
+    ingest_preflight = PACKAGE_ROOT / "Library" / "ingest_preflight.py"
+    video_processing = PACKAGE_ROOT / "Local_Ingestion" / "video_processing.py"
+
+    ip_source = ingest_preflight.read_text(encoding="utf-8")
+    ip_mutated = ip_source.replace(
+        "from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise",
+        "from tldw_chatbook.Utils.egress import EgressBlockedError",
+    ).replace("check_url_or_raise(url)", "pass")
+    assert "check_url_or_raise" not in ip_mutated, (
+        "the fixture substitution did not match current source -- "
+        "Library/ingest_preflight.py's egress call shape moved; update the "
+        "literal strings above to match"
+    )
+    ip_openers, ip_egress = _analyze_source(ip_mutated)
+    assert ip_openers, "the un-fixed module must still be detected as opening a URL"
+    assert ip_egress == frozenset(), (
+        "the un-fixed module must be rediscovered as NOT consulting the "
+        f"policy, but the census still found: {sorted(ip_egress)}"
+    )
+
+    vp_source = video_processing.read_text(encoding="utf-8")
+    vp_mutated = vp_source.replace(
+        "from ..Utils.egress import EgressBlockedError, check_url_or_raise, origin_set",
+        "from ..Utils.egress import EgressBlockedError, origin_set",
+    ).replace("check_url_or_raise(url, trusted_origins=origin_set(url))", "pass")
+    assert "check_url_or_raise" not in vp_mutated, (
+        "the fixture substitution did not match current source -- "
+        "Local_Ingestion/video_processing.py's egress call shape moved; "
+        "update the literal strings above to match"
+    )
+    vp_openers, vp_egress = _analyze_source(vp_mutated)
+    assert vp_openers, "the un-fixed module must still be detected as opening a URL (yt_dlp.YoutubeDL)"
+    assert vp_egress == frozenset(), (
+        "the un-fixed module must be rediscovered as NOT consulting the "
+        f"policy, but the census still found: {sorted(vp_egress)}"
+    )
+
+    # And each still parses as valid Python -- a mutation that broke syntax
+    # would make this a test of ast.parse's error handling, not the census.
+    ast.parse(ip_mutated)
+    ast.parse(vp_mutated)
 
 
 def test_exempt_entries_still_exist_and_still_need_the_exemption() -> None:
@@ -121,6 +418,5 @@ def test_exempt_entries_still_exist_and_still_need_the_exemption() -> None:
         path = PACKAGE_ROOT / key
         assert path.exists(), f"stale exemption for a deleted module: {key}"
         source = path.read_text(encoding="utf-8", errors="replace")
-        assert any(p.search(source) for p in _OPENER_PATTERNS), (
-            f"stale exemption: {key} no longer opens URLs, drop the entry"
-        )
+        openers, _egress = _analyze_source(source)
+        assert openers, f"stale exemption: {key} no longer opens URLs, drop the entry"

--- a/Tests/Web_Scraping/test_sitemap_crawl_trusted_origins.py
+++ b/Tests/Web_Scraping/test_sitemap_crawl_trusted_origins.py
@@ -1,0 +1,261 @@
+"""TASK-19556 (c): sitemap/crawl seams must not trust their own input URL.
+
+`Utils/egress.py`'s module contract is explicit:
+
+    Shared pipeline code must NEVER auto-trust its own input URL -- trust is
+    seeded only at boundaries where user intent is known and threaded down.
+
+and `config.py`'s `[web_security]` block says the same thing from the
+config side, naming the exact inputs:
+
+    content-derived URLs (redirects, **sitemap/crawl discoveries**, feed
+    items) must resolve to public IPs; URLs you explicitly configure (feed
+    sources, Confluence base_url, ingest URLs) may be private.
+
+At this branch's base four seams contradicted both:
+
+* `Article_Extractor_Lib.scrape_from_sitemap:1032` computed
+  `origins = origin_set(sitemap_url)` and used it for its OWN fetch --
+  and then handed that same trust to every URL it found *inside* the
+  fetched XML (`scrape_article(url.text, trusted_origins=origins)`).
+* `Article_Scraper/crawler.get_urls_from_sitemap:352` self-trusted the
+  same way.
+* `Article_Extractor_Lib.collect_internal_links:1089` and
+  `Article_Scraper/crawler.crawl_site:178` seeded from `base_url` and then
+  carried that trust onto every link discovered mid-crawl.
+
+The fix makes `trusted_origins` an explicit, fail-closed keyword on each
+(matching `scrape_article`, `get_page_title` and `ScraperConfig`, which
+already default to `frozenset()`), and applies it to the caller-named
+entry URL only -- never to a discovery.
+
+REACHABILITY, re-checked at this base and stated honestly: none of these
+four functions has an in-app caller. `scrape_from_sitemap` is reached only
+via `scrape_and_convert_with_filter` (no callers), `get_urls_from_sitemap`
+only from its own docstring example, `collect_internal_links` from
+`scrape_entire_site`/`create_filtered_sitemap` (no callers), `crawl_site`
+from its docstring example. The Watchlists `sitemap` source type -- the
+one shipped path that fetches a sitemap -- goes through
+`Subscriptions/local_watchlists_service._urls_for_sitemap`, whose
+`origin_set(source)` IS provenance-correct (`source` is the subscription
+URL the user configured). So this is a correctness defect with LATENT
+reach, fixed as such, and the change is behaviour-neutral for the shipped
+app.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Dict, List
+
+import pytest
+
+from tldw_chatbook.Web_Scraping import Article_Extractor_Lib as AEL
+from tldw_chatbook.Web_Scraping.Article_Scraper import crawler as CR
+
+SITEMAP_URL = "http://sitemap.internal/map.xml"
+SITEMAP_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://sitemap.internal/secret-page</loc></url>
+</urlset>
+"""
+
+BASE_URL = "http://crawl.internal/"
+BASE_HTML = '<html><body><a href="/deep/page">deep</a></body></html>'
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes = b"", text: str = "", status: int = 200):
+        self.content = content
+        self.text = text or content.decode("utf-8", "replace")
+        self.status_code = status
+        self.headers = {"Content-Type": "text/html; charset=utf-8"}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _Recorder:
+    """Records every guarded fetch's URL and `trusted_origins`."""
+
+    def __init__(self, responder):
+        self.calls: List[Dict[str, Any]] = []
+        self._responder = responder
+
+    def __call__(self, url: str, **kwargs: Any):
+        self.calls.append({"url": url, **kwargs})
+        return self._responder(url)
+
+    @property
+    def trust_by_url(self) -> Dict[str, frozenset]:
+        return {c["url"]: c.get("trusted_origins", frozenset()) for c in self.calls}
+
+
+# ---------------------------------------------------------------------------
+# scrape_from_sitemap
+# ---------------------------------------------------------------------------
+
+
+def test_scrape_from_sitemap_does_not_trust_its_own_input_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = _Recorder(lambda _u: _FakeResponse(content=SITEMAP_XML))
+    monkeypatch.setattr(AEL, "guarded_fetch_requests", recorder)
+    monkeypatch.setattr(AEL, "scrape_article", lambda *a, **k: None)
+
+    AEL.scrape_from_sitemap(SITEMAP_URL)
+
+    assert recorder.calls, "the sitemap was never fetched"
+    trusted = recorder.calls[0].get("trusted_origins", frozenset())
+    assert trusted == frozenset(), (
+        f"scrape_from_sitemap self-trusted its own input URL: {trusted}"
+    )
+
+
+def test_sitemap_discovered_urls_do_not_inherit_the_sitemap_hosts_trust(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact input the policy exists to catch."""
+    recorder = _Recorder(lambda _u: _FakeResponse(content=SITEMAP_XML))
+    monkeypatch.setattr(AEL, "guarded_fetch_requests", recorder)
+    seen: List[Dict[str, Any]] = []
+
+    def _fake_scrape_article(url: str, *args: Any, **kwargs: Any):
+        seen.append({"url": url, **kwargs})
+        return None
+
+    monkeypatch.setattr(AEL, "scrape_article", _fake_scrape_article)
+
+    # Even a caller that legitimately trusts the sitemap host must not have
+    # that trust forwarded to URLs the sitemap CONTENT names.
+    AEL.scrape_from_sitemap(SITEMAP_URL, trusted_origins=frozenset({"sitemap.internal"}))
+
+    assert seen, "no sitemap-discovered URL was scraped"
+    trusted = seen[0].get("trusted_origins", frozenset())
+    assert trusted == frozenset(), (
+        f"a sitemap-discovered URL was handed trust: {trusted}"
+    )
+
+
+def test_scrape_from_sitemap_threads_caller_supplied_trust_to_the_entry_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Trust is still seedable -- from the caller, not from the URL itself."""
+    recorder = _Recorder(lambda _u: _FakeResponse(content=SITEMAP_XML))
+    monkeypatch.setattr(AEL, "guarded_fetch_requests", recorder)
+    monkeypatch.setattr(AEL, "scrape_article", lambda *a, **k: None)
+
+    AEL.scrape_from_sitemap(SITEMAP_URL, trusted_origins=frozenset({"sitemap.internal"}))
+
+    assert recorder.calls[0]["trusted_origins"] == frozenset({"sitemap.internal"})
+
+
+# ---------------------------------------------------------------------------
+# get_urls_from_sitemap (async / aiohttp arm)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_urls_from_sitemap_does_not_trust_its_own_input_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Dict[str, Any]] = []
+
+    class _Guarded:
+        status_code = 200
+        headers = {"Content-Type": "application/xml"}
+        text = SITEMAP_XML.decode()
+
+        def raise_for_status(self) -> None:
+            return None
+
+    async def _fake_fetch(url: str, **kwargs: Any):
+        calls.append({"url": url, **kwargs})
+        return _Guarded()
+
+    monkeypatch.setattr(CR, "guarded_fetch_aiohttp", _fake_fetch)
+
+    await CR.get_urls_from_sitemap(SITEMAP_URL)
+
+    assert calls, "the sitemap was never fetched"
+    trusted = calls[0].get("trusted_origins", frozenset())
+    assert trusted == frozenset(), (
+        f"get_urls_from_sitemap self-trusted its own input URL: {trusted}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# crawl discoveries
+# ---------------------------------------------------------------------------
+
+
+def test_collect_internal_links_does_not_trust_discovered_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = _Recorder(lambda _u: _FakeResponse(text=BASE_HTML))
+    monkeypatch.setattr(AEL, "guarded_fetch_requests", recorder)
+
+    AEL.collect_internal_links(BASE_URL, trusted_origins=frozenset({"crawl.internal"}))
+
+    trust = recorder.trust_by_url
+    assert BASE_URL in trust, f"the crawl root was never fetched: {list(trust)}"
+    assert trust[BASE_URL] == frozenset({"crawl.internal"})
+    discovered = {u: t for u, t in trust.items() if u != BASE_URL}
+    assert discovered, "no link was discovered, so the assertion below is vacuous"
+    assert all(t == frozenset() for t in discovered.values()), (
+        f"a crawl discovery inherited the root's trust: {discovered}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_does_not_trust_discovered_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Dict[str, Any]] = []
+
+    class _Guarded:
+        status_code = 200
+        headers = {"Content-Type": "text/html"}
+        text = BASE_HTML
+
+    async def _fake_fetch(url: str, **kwargs: Any):
+        calls.append({"url": url, **kwargs})
+        return _Guarded()
+
+    monkeypatch.setattr(CR, "guarded_fetch_aiohttp", _fake_fetch)
+
+    await CR.crawl_site(
+        BASE_URL, max_pages=5, max_depth=2, trusted_origins=frozenset({"crawl.internal"})
+    )
+
+    trust = {c["url"]: c.get("trusted_origins", frozenset()) for c in calls}
+    assert trust.get(BASE_URL) == frozenset({"crawl.internal"})
+    discovered = {u: t for u, t in trust.items() if u != BASE_URL}
+    assert discovered, "no link was discovered, so the assertion below is vacuous"
+    assert all(t == frozenset() for t in discovered.values()), (
+        f"a crawl discovery inherited the root's trust: {discovered}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed signatures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        AEL.scrape_from_sitemap,
+        AEL.collect_internal_links,
+        CR.get_urls_from_sitemap,
+        CR.crawl_site,
+    ],
+    ids=["scrape_from_sitemap", "collect_internal_links", "get_urls_from_sitemap", "crawl_site"],
+)
+def test_sitemap_and_crawl_entry_points_default_to_no_trust(func) -> None:
+    parameter = inspect.signature(func).parameters.get("trusted_origins")
+    assert parameter is not None, (
+        f"{func.__name__} has no explicit trusted_origins seam, so a caller "
+        "cannot thread user intent down and the function must be inventing it"
+    )
+    assert parameter.default == frozenset()

--- a/Tests/Web_Scraping/test_tavily_credential_transport.py
+++ b/Tests/Web_Scraping/test_tavily_credential_transport.py
@@ -1,0 +1,277 @@
+"""TASK-19735: the Tavily API key must not sit in the request-parameter dict.
+
+This one is **latent, not a live leak**, and is sized as such. At this
+branch's base `search_web_tavily` built:
+
+    payload = {"api_key": tavily_api_key, "query": ..., "max_results": ...}
+
+Nothing logged `payload`, and because the key travelled in the POST *body*
+the exception path was clean too -- `str(e)` on a `requests` exception
+carries the URL, not the body. The hazard was prospective: a maintainer
+adding `logger.debug(f"payload: {payload}")` while debugging writes the key
+to disk, with no local signal that it is dangerous. Every sibling backend in
+the file keeps its credential in a `headers` dict, which reads as "do not
+log this"; this one did not.
+
+Per the owner's standing ruling (durable over clever) the fix makes the
+hazard structurally impossible rather than relying on a future reviewer:
+Tavily accepts `Authorization: Bearer <key>`, so the credential moves to
+`headers` like every sibling.
+
+The already-clean properties are **pinned, not assumed** (the task's fourth
+AC): the error string returned on a request exception is asserted to be
+credential-free, and the sibling backends' shapes are asserted by an AST
+census rather than recorded in prose that can go stale.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from typing import Any, Dict, List
+
+import pytest
+import requests as real_requests
+
+from tldw_chatbook.Web_Scraping import WebSearch_APIs
+
+SENTINEL_KEY = "tvly-TASK19735-SENTINEL-NOT-A-REAL-KEY"
+
+_TAVILY_PAYLOAD = {
+    "results": [
+        {"title": "T", "url": "https://t.example/", "content": "c", "score": 0.5}
+    ],
+    "answer": None,
+}
+
+
+class _RecordingRequests:
+    """Stands in for the module's `requests` import; records the POST."""
+
+    exceptions = real_requests.exceptions
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def post(self, url: str, **kwargs: Any):
+        self.calls.append({"url": url, **kwargs})
+        return _FakeResponse(_TAVILY_PAYLOAD)
+
+
+class _FakeResponse:
+    def __init__(self, payload: Dict[str, Any], status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = {"Content-Type": "application/json"}
+        self.text = ""
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise real_requests.exceptions.HTTPError(f"status {self.status_code}")
+
+
+@pytest.fixture
+def tavily_key(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setitem(
+        WebSearch_APIs.loaded_config_data["search_engines"],
+        "tavily_search_api_key",
+        SENTINEL_KEY,
+    )
+    return SENTINEL_KEY
+
+
+@pytest.fixture
+def recording_requests(monkeypatch: pytest.MonkeyPatch) -> _RecordingRequests:
+    fake = _RecordingRequests()
+    monkeypatch.setattr(WebSearch_APIs, "requests", fake)
+    return fake
+
+
+def _request_parameters(call: Dict[str, Any]) -> Dict[str, Any]:
+    """The loggable request-parameter object actually sent."""
+    if "json" in call:
+        return dict(call["json"])
+    body = call.get("data")
+    if isinstance(body, (bytes, str)):
+        return json.loads(body)
+    return dict(body or {})
+
+
+# ---------------------------------------------------------------------------
+# The fix
+# ---------------------------------------------------------------------------
+
+
+def test_tavily_request_parameters_hold_no_credential(
+    tavily_key: str, recording_requests: _RecordingRequests
+) -> None:
+    """A debug log of the request parameters cannot disclose the key.
+
+    Asserted against the sentinel VALUE, not against the key name: a fix
+    that merely renamed `api_key` would leave the credential in the dict.
+    """
+    WebSearch_APIs.search_web_tavily("cherry cake", result_count=3)
+
+    assert recording_requests.calls, "no request was issued"
+    parameters = _request_parameters(recording_requests.calls[0])
+    rendered = json.dumps(parameters)
+    assert SENTINEL_KEY not in rendered, (
+        f"the Tavily key is inside the request-parameter object: {parameters}"
+    )
+    # ...and the ordinary parameters are still there, so the assertion above
+    # is not passing because the request was gutted.
+    assert parameters.get("query") == "cherry cake"
+    assert parameters.get("max_results") == 3
+
+
+def test_tavily_credential_travels_in_the_headers(
+    tavily_key: str, recording_requests: _RecordingRequests
+) -> None:
+    """It still authenticates -- via the transport every sibling uses."""
+    WebSearch_APIs.search_web_tavily("cherry cake")
+
+    headers = recording_requests.calls[0]["headers"]
+    rendered = " ".join(f"{k}: {v}" for k, v in headers.items())
+    assert SENTINEL_KEY in rendered, f"the key reaches no transport at all: {headers}"
+    assert headers.get("Authorization") == f"Bearer {SENTINEL_KEY}"
+
+
+def test_tavily_optional_domain_filters_still_reach_the_request(
+    tavily_key: str, recording_requests: _RecordingRequests
+) -> None:
+    WebSearch_APIs.search_web_tavily(
+        "cake", site_whitelist=["a.example"], site_blacklist=["b.example"]
+    )
+    parameters = _request_parameters(recording_requests.calls[0])
+    assert parameters["include_domains"] == ["a.example"]
+    assert parameters["exclude_domains"] == ["b.example"]
+
+
+# ---------------------------------------------------------------------------
+# The already-clean properties, pinned rather than assumed
+# ---------------------------------------------------------------------------
+
+
+def test_tavily_error_string_carries_no_credential(
+    tavily_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The returned error text is the one string a user actually sees.
+
+    Built from a real `requests.models.Response` so the message format --
+    including the URL `requests` embeds -- is authentic rather than
+    hand-rolled.
+    """
+
+    class _FailingRequests:
+        exceptions = real_requests.exceptions
+
+        def post(self, url: str, **kwargs: Any):
+            response = real_requests.models.Response()
+            response.status_code = 401
+            response.reason = "Unauthorized"
+            response.url = url
+            response.raise_for_status()
+
+    monkeypatch.setattr(WebSearch_APIs, "requests", _FailingRequests())
+    result = WebSearch_APIs.search_web_tavily("cherry cake")
+
+    assert isinstance(result, str)
+    assert "error searching for content" in result
+    assert SENTINEL_KEY not in result, f"the error string leaked the key: {result}"
+
+
+# ---------------------------------------------------------------------------
+# Sibling-backend census (the task's fifth AC, in executable form)
+# ---------------------------------------------------------------------------
+
+#: Request-parameter object names -- the dicts a debugging maintainer
+#: reaches for when adding a log line.
+_PARAMETER_DICT_NAMES = frozenset({"payload", "params", "data", "body"})
+
+#: The one documented exception. `search_web_google` sends its credential as
+#: a URL query parameter (`params["key"]`), which is the engine's own API
+#: contract; TASK-19552 addressed the disclosure that shape caused by fixing
+#: the two places it was FORMATTED (an INFO log of `params`, and a
+#: `str(exception)` carrying the request URL). Recorded here so the census
+#: stays honest instead of silently green.
+_KNOWN_PARAMETER_CREDENTIALS = {("search_web_google", "params")}
+
+
+def _credential_carrying_parameter_dicts() -> set[tuple[str, str]]:
+    """Every `search_web_*` function that puts an api-key into a param dict.
+
+    Detects both shapes: a dict literal assigned to a parameter-object name
+    with an api-key-ish value, and a later `params["key"] = api_key`
+    subscript assignment.
+    """
+    tree = ast.parse(inspect.getsource(WebSearch_APIs))
+    found: set[tuple[str, str]] = set()
+
+    def _is_credential(node: ast.AST) -> bool:
+        if isinstance(node, ast.Name):
+            return "api_key" in node.id.lower()
+        if isinstance(node, ast.Subscript):
+            key = getattr(node.slice, "value", None)
+            return isinstance(key, str) and "api_key" in key.lower()
+        return False
+
+    for func in ast.walk(tree):
+        if not isinstance(func, ast.FunctionDef) or not func.name.startswith(
+            "search_web_"
+        ):
+            continue
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                name = None
+                if isinstance(target, ast.Name):
+                    name = target.id
+                elif isinstance(target, ast.Subscript) and isinstance(
+                    target.value, ast.Name
+                ):
+                    name = target.value.id
+                if name not in _PARAMETER_DICT_NAMES:
+                    continue
+                values = (
+                    node.value.values
+                    if isinstance(node.value, ast.Dict)
+                    else [node.value]
+                )
+                if any(_is_credential(v) for v in values):
+                    found.add((func.name, name))
+    return found
+
+
+def test_no_search_backend_hides_a_credential_in_its_parameter_dict() -> None:
+    """The census, executable so it cannot go stale.
+
+    Expected clean (credential in `headers`): bing
+    (`Ocp-Apim-Subscription-Key`), brave (`X-Subscription-Token`), serper
+    (`X-API-KEY`), exa (`x-api-key`), kagi (`Authorization: Bot ...`),
+    yandex (`Authorization: Api-Key ...`). searx/duckduckgo/baidu carry no
+    credential at all.
+    """
+    assert _credential_carrying_parameter_dicts() == _KNOWN_PARAMETER_CREDENTIALS
+
+
+def test_the_census_detector_actually_detects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Methodology check: the AST walk finds the shape it claims to find.
+
+    Without this, a detector that silently matched nothing would make the
+    census above pass forever.
+    """
+    source = (
+        "def search_web_fake(q):\n"
+        "    fake_api_key = 'x'\n"
+        "    payload = {'api_key': fake_api_key, 'query': q}\n"
+        "    return payload\n"
+    )
+    monkeypatch.setattr(inspect, "getsource", lambda _m: source)
+    assert _credential_carrying_parameter_dicts() == {("search_web_fake", "payload")}

--- a/Tests/Web_Scraping/test_web_fetch_wiring.py
+++ b/Tests/Web_Scraping/test_web_fetch_wiring.py
@@ -27,9 +27,13 @@ def test_scrape_from_sitemap_blocked_returns_empty():
         result = AEL.scrape_from_sitemap("http://sitemap.internal/map.xml")
     assert result == []
     assert mocked.call_args.kwargs["max_bytes"] == 50 * 1024 * 1024
-    assert mocked.call_args.kwargs["trusted_origins"] == frozenset(
-        {"sitemap.internal"}
-    )
+    # (TASK-19556 (c)) This used to assert `frozenset({"sitemap.internal"})`
+    # -- i.e. it pinned the defect: the function trusted the origin of the
+    # very URL it was about to fetch, so the guard was a no-op for exactly
+    # the content-derived input it exists to catch. Trust is now the
+    # caller's to seed and defaults to none; see
+    # Tests/Web_Scraping/test_sitemap_crawl_trusted_origins.py.
+    assert mocked.call_args.kwargs["trusted_origins"] == frozenset()
 
 
 def test_scrape_article_signature_defaults_fail_closed():

--- a/backlog/tasks/task-19556 - Three outbound seams never adopted the egress policy including a typing-triggered internal port-scan oracle.md
+++ b/backlog/tasks/task-19556 - Three outbound seams never adopted the egress policy including a typing-triggered internal port-scan oracle.md
@@ -3,8 +3,9 @@ id: TASK-19556
 title: >-
   Three outbound seams never adopted the egress policy, including a
   typing-triggered internal port-scan oracle
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-21 20:06'
 labels:
   - security
@@ -61,21 +62,217 @@ reachability re-checked, not treated as an active exploit.
 
 ## Acceptance Criteria
 
-- [ ] `ingest_preflight` performs no network request that bypasses the egress
+- [x] `ingest_preflight` performs no network request that bypasses the egress
       policy, and no network request at all before URL validation
-- [ ] The preflight no longer returns outcomes that distinguish "refused" from
+- [x] The preflight no longer returns outcomes that distinguish "refused" from
       "answered" for private/internal addresses — the typing-debounced path
       must not be usable as a scanning oracle
-- [ ] The debounce-while-typing behaviour is reviewed: probing on every
+- [x] The debounce-while-typing behaviour is reviewed: probing on every
       keystroke pause is the wrong default even for allowed hosts
-- [ ] `video_processing.py`'s URL entry points apply the same egress check the
+- [x] `video_processing.py`'s URL entry points apply the same egress check the
       article arm of `audio_processing.py` already applies, so the media and
       article arms of the same entry point behave identically
-- [ ] Content-derived URLs are never passed as their own `trusted_origins` —
+- [x] Content-derived URLs are never passed as their own `trusted_origins` —
       the sitemap/crawl call sites are corrected to match the stated contract
       at `config.py:3731`
-- [ ] Tests pin each of the three seams against a private/internal target and
+- [x] Tests pin each of the three seams against a private/internal target and
       fail if the guard is removed (mutation-checked)
-- [ ] A guard test fails if a new outbound call site reaches the network
+- [x] A guard test fails if a new outbound call site reaches the network
       without passing through the egress policy, so the next seam cannot
       silently skip it
+
+## Implementation Plan
+
+1. Prove each defect before touching it: a born-red test per seam, at the
+   branch base, using in-process transports only (the suite forbids real
+   sockets) and synthetic sentinels.
+2. (a) Close the oracle in three moves, not one: route the probe through the
+   egress policy, collapse the outcome vocabulary, and take the probe off
+   the typing path.
+3. (b) Apply at the two yt-dlp seams the same check `audio_processing`
+   already applies, and state honestly what a pre-check cannot cover.
+4. (c) Make `trusted_origins` an explicit, fail-closed parameter on the
+   sitemap/crawl seams, applied to the caller-named entry URL only; re-check
+   reachability and record it rather than describing latent code as live.
+5. Add the census guard so the next seam cannot skip the policy silently.
+6. Baseline every failure against the merge base before attributing it.
+
+## Implementation Notes
+
+### (a) The typing-triggered port-scan oracle — CONFIRMED LIVE, closed
+
+Reproduced first. At base, `analyze_path("http://10.255.255.1:8080/report.pdf")`
+opens a real TCP connection — the suite's network guard recorded
+`('socket.create_connection', '10.255.255.1:8080')` — and the three targets
+below produced three *different* user-visible results:
+
+```
+(('URL unreachable — the connection was refused.',), (), (), 0, False)   # :8080 refused
+((), ('Could not check the link',), ('pdf',), 1, False)                  # :9200 answered 403
+((), (), ('pdf',), 1, False)                                            # :22 answered 200
+```
+
+That is the oracle, verbatim. Three changes close it.
+
+**The debounce default — what was actually done.** The probe is now OFF by
+default (`[library] ingest_url_preflight_probe = false`, documented in the
+shipped TOML), so the typing path issues no network request at all: a URL is
+classified by name, exactly as a local path is classified by `stat`. The
+config gate alone was judged insufficient, because a user who opted in would
+be back to hitting the host on every 0.8 s pause — the thing the AC calls the
+wrong default *even for allowed hosts*. So the typing timer additionally
+passes `allow_probe=False` unconditionally
+(`library_screen._run_debounced_library_ingest_preflight` →
+`_trigger_library_ingest_preflight(path, allow_probe=False)` →
+`analyze_path(..., probe_url=False)`). Probing, when enabled, runs only from
+the deliberate triggers: blur, Enter, Browse…, the retry button. The 0.8 s
+timer itself was left alone — it exists for local path/directory feedback,
+which is cheap and local, and changing the interval would have been arbitrary.
+
+**The outcome vocabulary — what was actually done.** `_probe_url` calls
+`check_url_or_raise` before any transport call and returns ONE constant note
+(`_UNVERIFIABLE_NOTE`) for every declined reason. `EgressBlockedError.reason`
+is deliberately not read: private vs. dns_failure vs. metadata vs. bad-scheme
+is precisely the difference an internal scan wants, and it is not actionable
+for the user anyway. Verified: a metadata endpoint and an RFC1918 host now
+reduce to the identical observable. The policy is consulted with **no**
+trusted origins — an automatic probe is not the user asking to contact a
+host, and self-trusting would have made the check a no-op for exactly the
+private hosts at issue. (The deliberate ingest that follows keeps its own
+trust; `[web_security]` says configured URLs may be private.)
+
+Two further hardenings fell out of the same read: `validate_url` now runs
+*before* anything else (at base, `http://user:secret@example.com/doc.pdf`
+was accepted with zero errors and its embedded credential put on the wire),
+and the probe uses a no-redirect opener, since `urlopen` auto-followed
+redirects and a public host answering `302 Location: http://10.0.0.5:8080/`
+walked the probe into internal space *after* the check had passed.
+
+### (b) yt-dlp — CONFIRMED LIVE, guarded, with the gap stated
+
+`check_media_url_egress` applies `check_url_or_raise(url,
+trusted_origins=origin_set(url))` — the same shape
+`audio_processing.download_audio_file` uses — at both yt-dlp seams:
+`download_video` (which covers its size probe *and* its download) and
+`extract_metadata`. At base, `extract_metadata` fetched
+`http://169.254.169.254/latest/meta-data/iam/security-credentials/` and
+returned its metadata.
+
+**What the fix covers:** cloud metadata endpoints (blocked regardless of
+trust — the policy's one hard rule), non-http(s) schemes (yt-dlp will hand
+`file://` and dozens of other protocols to its extractors), and the entry
+URL's classification. A user-typed private URL still works, matching the
+audio arm and the `[web_security]` contract — pinned by a test, so the guard
+cannot be "fixed" into breaking intranet media ingest.
+
+**What it does NOT cover, plainly:** yt-dlp does its own fetching. This is a
+pre-check on the entry URL only. It cannot re-validate yt-dlp's own redirect
+hops, the per-format media URLs an extractor discovers inside a page, or a
+DNS answer that changes between the check and yt-dlp's own resolution — the
+TOCTOU window `Utils/egress.py` documents as a residual for every consumer of
+a resolve-then-connect check. Closing those needs a yt-dlp request hook and
+was out of scope. This is stated in the function docstring and the test
+module docstring, not just here.
+
+### (c) trusted_origins — corrected as a correctness defect; reachability re-checked
+
+Corrected: `Article_Extractor_Lib.scrape_from_sitemap`,
+`Article_Extractor_Lib.collect_internal_links`,
+`Article_Extractor_Lib.recursive_scrape`,
+`Article_Scraper/crawler.get_urls_from_sitemap`, and
+`Article_Scraper/crawler.crawl_site`. Each gained an explicit
+`trusted_origins` keyword defaulting to `frozenset()` (matching
+`scrape_article`, `get_page_title` and `ScraperConfig`, which were already
+fail-closed), and each now applies it to the caller-named entry URL **only**.
+Two distinct halves were wrong, and both are fixed:
+
+* self-trusting the URL about to be fetched (`origin_set(sitemap_url)`) —
+  against `Utils/egress.py`'s "shared pipeline code must NEVER auto-trust its
+  own input URL";
+* forwarding that trust to what the fetched content named —
+  `scrape_article(url.text, trusted_origins=origins)` for every `<loc>` in
+  the sitemap, and every link discovered mid-crawl. `config.py`'s
+  `[web_security]` block names "sitemap/crawl discoveries" verbatim among the
+  content-derived URLs that must resolve to public IPs.
+
+**Reachability, re-checked at this base and unchanged from the filing:
+LATENT, and described as such.** None of the five has an in-app caller.
+`scrape_from_sitemap` is reached only from `scrape_and_convert_with_filter`
+(no callers); `get_urls_from_sitemap` and `crawl_site` only from their own
+docstring examples; `collect_internal_links` from `scrape_entire_site` /
+`create_filtered_sitemap` (no callers). The one shipped path that fetches a
+sitemap is the Watchlists `sitemap` source type, and it goes through
+`Subscriptions/local_watchlists_service._urls_for_sitemap`, whose
+`origin_set(source)` **is** provenance-correct — `source` is the subscription
+URL the user configured. So this change is behaviour-neutral for the shipped
+app, which is also why it carried no regression risk.
+
+**`UI/Screens/settings_image_gen_defaults.py:768` — checked, NOT changed, and
+why.** The shape is identical (`check_url_or_raise(url,
+trusted_origins=origin_set(url))`) but the *provenance* is not: every caller
+of `_guarded_get` derives its URL from a base_url the user typed into the
+Settings ▸ Image Generation form (`_probe_swarmui`,
+`_probe_reachability_only`, and `_probe_comfyui` via
+`normalize_comfyui_image_origin`). That is an explicitly configured URL,
+which `config.py:3807`'s contract permits to be private — and the shipped
+default backend is a **localhost** SwarmUI instance, so removing the
+self-trust would break the zero-key default probe. Existing tests already pin
+both halves of that intent
+(`Tests/UI/test_settings_image_gen_defaults.py::test_probe_egress_allows_private_base_url_via_self_trust`
+and `::test_probe_egress_blocks_metadata_ip_even_self_trusted`). A comment
+was added at the call site recording the provenance so the two shapes are not
+confused again.
+
+### The census guard (last AC)
+
+`Tests/Utils/test_egress_adoption_census.py` fails when a module under
+`tldw_chatbook/` uses a `urllib.request` opener or constructs a
+`yt_dlp.YoutubeDL` without naming any egress-policy symbol. Run at base it
+independently rediscovered exactly the two seams this task names:
+`Library/ingest_preflight.py` and `Local_Ingestion/video_processing.py`.
+One allowlisted exemption, with its reason recorded in the file:
+`Local_Ingestion/parakeet_v2_installer.py` (constant huggingface.co URL, no
+caller-supplied component, size- and SHA-256-pinned). Its scope is stated
+rather than overclaimed: it does not census bare `requests`/`httpx`, because
+this app has dozens of legitimate fixed-endpoint calls in `LLM_Calls/` and
+that census would be noise that gets suppressed rather than a guard that gets
+read. Two self-tests keep it honest — the detector is proved to detect, and a
+stale exemption (a module that no longer opens URLs) fails.
+
+### Born-red evidence
+
+Every test was run against the unmodified base `f12bb21ad` first. Counts:
+(a) 8 failed / 0 passed; (b) 4 failed / 2 passed (the two passes are the
+must-not-over-block parity pins); (c) 10 failed / 0 passed; census 1 failed /
+2 passed. Signatures are quoted in each test module's docstring. Because the
+base *is* the pre-fix code, these runs are also the mutation check for every
+born-red assertion. The tests written after the fix (the debounce wiring
+pair) are mutation-checked separately, recorded below.
+
+### Tests changed rather than added
+
+Three existing tests asserted the retired behaviour and were updated with the
+reason inline, not silently:
+`Tests/Web_Scraping/test_web_fetch_wiring.py` pinned
+`trusted_origins == frozenset({"sitemap.internal"})` — i.e. it pinned the
+defect; `Tests/Library/test_ingest_preflight.py`'s probe tests now opt into
+the (default-off) probe via a `probing_allowed` fixture and patch the new
+`_open_probe` seam; `Tests/Library/test_library_ingest_state.py` no longer
+needs a `urlopen` stub to classify a URL. Two UI stubs
+(`test_library_ingest_inline_consent.py`, `test_library_ingest_retry_last.py`)
+gained `**_kwargs` for `analyze_path`'s new keyword.
+
+### Modified / added files
+
+Source: `tldw_chatbook/Library/ingest_preflight.py`,
+`tldw_chatbook/UI/Screens/library_screen.py`,
+`tldw_chatbook/Local_Ingestion/video_processing.py`,
+`tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py`,
+`tldw_chatbook/Web_Scraping/Article_Scraper/crawler.py`,
+`tldw_chatbook/UI/Screens/settings_image_gen_defaults.py` (comment only),
+`tldw_chatbook/config.py` (new `[library] ingest_url_preflight_probe`).
+Docs: `Docs/User_Guide/library/import-and-export.md`.
+Tests added: `Tests/Library/test_ingest_preflight_egress.py`,
+`Tests/Local_Ingestion/test_video_egress_guard.py`,
+`Tests/Web_Scraping/test_sitemap_crawl_trusted_origins.py`,
+`Tests/Utils/test_egress_adoption_census.py`.

--- a/backlog/tasks/task-19556 - Three outbound seams never adopted the egress policy including a typing-triggered internal port-scan oracle.md
+++ b/backlog/tasks/task-19556 - Three outbound seams never adopted the egress policy including a typing-triggered internal port-scan oracle.md
@@ -276,3 +276,75 @@ Tests added: `Tests/Library/test_ingest_preflight_egress.py`,
 `Tests/Local_Ingestion/test_video_egress_guard.py`,
 `Tests/Web_Scraping/test_sitemap_crawl_trusted_origins.py`,
 `Tests/Utils/test_egress_adoption_census.py`.
+
+### Independent review (2026-08-22, adversarial)
+
+The oracle closure was re-verified from scratch against base `f12bb21ad`,
+not taken on report. Confirmed independently, with in-process transports
+and a stubbed resolver (no real sockets):
+
+* **Both halves hold.** Gate off by default -> `analyze_path` on a URL
+  issues zero transport calls *and* zero DNS lookups. Opted in, the typing
+  path (`probe_url=False`) still issues neither, while a deliberate trigger
+  does. No third caller reaches `analyze_path`/`_probe_url`: six call sites
+  in `library_screen`, one of them the typing timer with `allow_probe=False`.
+* **The vocabulary really is collapsed.** Fourteen declined targets --
+  private/loopback/CGNAT/multicast/metadata literals, the same via DNS, a
+  DNS failure, `metadata.google.internal`, `[::1]`, and an IPv4-mapped v6
+  private address -- produce ONE identical observable, and none of them
+  reaches the transport at all.
+* **No usable timing distinguisher.** Nothing connects for a declined
+  address, so there is no connect latency to time. The only latency split
+  is "IP literal (no DNS)" vs "hostname (one DNS lookup)", which discloses
+  nothing an attacker choosing the address does not already know.
+* **Both incidental findings reproduce at base and are closed here.**
+  `http://user:secret@example.com/doc.pdf` -> at base: `errors=[]`,
+  `warnings=[]`, classified `pdf`, and the credential-bearing URL recorded
+  on the wire; now `path_invalid=True` and nothing is opened. The 302 walk:
+  at base the probe opened `http://public.example.test/doc.pdf` **and then**
+  `http://10.0.0.5:8080/`; now only the first, surfaced as an answered-302
+  note.
+
+**Two gaps found and closed** (AC 6 says "mutation-checked"; these two
+survived mutation):
+
+1. `_run_library_ingest_preflight`'s `probe_url=None if allow_probe else
+   False` -- the step that JOINS the debounce wiring to `analyze_path` --
+   was pinned by nothing. Rewriting it to a bare `probe_url=None` left 509
+   tests green (only the pre-existing red) while putting an opted-in user
+   back on a per-0.8 s-pause probe.
+2. The no-redirect opener was pinned by nothing. Reverting `_open_probe` to
+   `build_opener()` left 2252 tests green, because every other test in the
+   module patches `OpenerDirector.open` and so never reaches the handler
+   chain that would follow a redirect.
+
+Three tests added to `Tests/Library/test_ingest_preflight_egress.py`; each
+is born-red at `f12bb21ad` and red under its mutation. Module: 13 tests,
+12F/1P at base.
+
+**Residual, filed rather than changed here:** `Input.Blurred` is posted by
+Textual on `AppBlur` (terminal focus loss) as well as on a focus move --
+demonstrated live -- so for an *opted-in* user, alt-tabbing away with a URL
+staged fires the probe with `allow_probe=True`. Same category as the
+debounce (not a gesture aimed at the field), far lower frequency, and inert
+under the default-off gate; changing that blur handler is a behaviour change
+with its own live-verification cost (its docstring records a prior reversal
+after an xhigh review + live-verify round). Recommended as a separate LOW
+follow-up rather than folded in here; no task id minted by the reviewer, to
+avoid an id collision against `origin/dev`.
+
+Also corrected: the `settings_image_gen_defaults` provenance comment
+enumerated three of its five callers (omitting `_probe_openai_compatible`
+and `_probe_gemini`, the two that attach a credential header) and said
+"typed into this settings form" when a blank field falls back to the
+resolved `[image_generation]` config value. The exception's CONCLUSION
+survives -- every source is operator-configured, and the only writer of that
+config section is the Settings screen's own save -- but the reasoning as
+written did not match the code.
+
+Baselines re-measured, not accepted: `Tests/UI/test_library_ingest_*` is
+9F/233P on BOTH sides with identical failure sets, and `Tests/integration`
+is 3F/69P on both sides (the commit message says 2 integration reds; it is
+3, all pre-existing). Post-review sweep across
+`Tests/{Library,Web_Scraping,Local_Ingestion,Utils}` + the image-gen
+settings suite: **3685 passed / 5 skipped / 0 failed**.

--- a/backlog/tasks/task-19556 - Three outbound seams never adopted the egress policy including a typing-triggered internal port-scan oracle.md
+++ b/backlog/tasks/task-19556 - Three outbound seams never adopted the egress policy including a typing-triggered internal port-scan oracle.md
@@ -348,3 +348,76 @@ is 3F/69P on both sides (the commit message says 2 integration reds; it is
 3, all pre-existing). Post-review sweep across
 `Tests/{Library,Web_Scraping,Local_Ingestion,Utils}` + the image-gen
 settings suite: **3685 passed / 5 skipped / 0 failed**.
+
+### Qodo review follow-up on PR #1967 (two findings closed)
+
+**Finding 1 -- `trusted_origins` untyped.** All five sites this task added
+the keyword to were annotated `frozenset[str] = frozenset()`:
+`Article_Scraper/crawler.crawl_site`, `crawler.get_urls_from_sitemap`,
+`Article_Extractor_Lib.scrape_from_sitemap`,
+`.collect_internal_links`, `.recursive_scrape`. `frozenset[str]` rather than
+bare `frozenset` because that is what the values actually are --
+`Utils/egress.origin_set()` (the function this parameter's callers most
+often seed it from) returns a `frozenset` of lowercased hostname strings,
+and `check_url_or_raise`/`evaluate_url_policy` iterate it as
+`str(h) for h in trusted_origins`. It also matches the more recently
+written egress call sites in this same programme
+(`Model_Artifacts/acquisition.py`, `Model_Artifacts/fetch.py`,
+`Local_Ingestion/parakeet_v2_artifact.py`), all `frozenset[str]`, over the
+older bare-`frozenset` spelling still on a few of `Utils/egress.py`'s own
+signatures and pre-existing call sites this task didn't touch (`scrape_article`
+at `Article_Extractor_Lib.py:370`, `get_page_title`) -- left alone, since the
+finding and this fix are scoped to what this branch added. The video seam
+(`video_processing.check_media_url_egress`) never took a `trusted_origins`
+parameter -- it computes `origin_set(url)` internally -- so there was
+nothing to annotate there.
+
+**Finding 2 -- the egress-adoption census was regex-over-text.**
+`Tests/Utils/test_egress_adoption_census.py` was rewritten from
+`re.Pattern.search` over raw source to an AST scan: it resolves real
+`import`/`from...import` bindings (including `as` aliases and
+`from pkg import module` + `module.symbol(...)` attribute calls, the shape
+`Image_Generation/http_client.py` and `Media_Playback/stream_resolve.py`
+use for the egress side) and matches actual `ast.Call` targets, so a mention
+inside a comment or docstring produces no `Name`/`Attribute` node and is
+structurally invisible to it. Proven in both directions plus the original
+demonstration, all three new tests in the file: a comment/docstring-only
+opener mention is not flagged (no false red;
+`test_docstring_or_comment_opener_mention_is_not_flagged`); a comment
+*naming the real egress function* next to a genuine unguarded `urlopen`
+call is still flagged, closing Qodo's exact bypass (no false green;
+`test_comment_mentioning_the_real_egress_symbol_does_not_launder_an_unguarded_opener`);
+and mechanically un-fixing the current source of `Library/ingest_preflight.py`
+and `Local_Ingestion/video_processing.py` (deleting the `check_url_or_raise`
+import, blanking the call site) is still independently rediscovered by the
+census (`test_census_rediscovers_the_original_two_seams_when_their_egress_calls_are_removed`),
+re-proving the census's original demonstration against the rewrite. All
+four tests were also run against a temporarily reintroduced regex-style
+`_analyze_source` (mutation probe, reverted before commit): three of the
+new tests failed under it, and the rediscovery test failed for a real
+reason, not a contrived one -- `video_processing.py`'s own docstring quotes
+`guarded_fetch_requests(...)` in prose describing the audio arm, which the
+old regex read as "this module still consults the policy" even with the
+real call deleted.
+
+**Stated gap.** The AST version cannot follow dynamic dispatch --
+`getattr(urllib.request, "urlopen")(u)` is not a `Name`/`Attribute` chain a
+static resolver can trace, so it would not be flagged, whereas the old
+regex would have (the string literal `"urlopen"` is still text in the
+file). No opener in this codebase is reached that way today (checked at
+rewrite time), so this costs nothing currently, but it is a real,
+if obscure, trade against the false-green/false-red bypass closed. Also
+scoped as before: the census only covers `urllib.request` and
+`yt_dlp.YoutubeDL`, not bare `requests`/`httpx`, for the same
+noise-vs-signal reason recorded in the file's own docstring.
+
+Verification: `Tests/{Library,Web_Scraping,Local_Ingestion,Utils}` --
+**3689 passed / 5 skipped / 0 failed** (up from 3685 because the census
+file grew from 4 tests to 7; the image-gen settings suite from the prior
+sweep was not re-run here, out of this follow-up's scope). Repo-wide
+`--collect-only`: 55993 collected, 1 pre-existing error
+(`Tests/UI/test_library_file_notes_workspace.py`, zero diff on this
+branch, unrelated to either finding). Modified:
+`tldw_chatbook/Web_Scraping/Article_Scraper/crawler.py`,
+`tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py`,
+`Tests/Utils/test_egress_adoption_census.py`.

--- a/backlog/tasks/task-19735 - Tavily search carries its API key inside the request payload dict.md
+++ b/backlog/tasks/task-19735 - Tavily search carries its API key inside the request payload dict.md
@@ -2,8 +2,9 @@
 id: TASK-19735
 title: >-
   Tavily search carries its API key inside the request payload dict
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-21 23:40'
 labels:
   - security
@@ -64,17 +65,17 @@ to a name that a debug log would naturally reach for.
 
 ## Acceptance Criteria
 
-- [ ] The Tavily API key is not a member of any dict that also holds ordinary
+- [x] The Tavily API key is not a member of any dict that also holds ordinary
       request parameters, so a debug log of the request parameters cannot
       disclose it
-- [ ] Tavily search still authenticates and returns results (the credential
+- [x] Tavily search still authenticates and returns results (the credential
       reaches the service by whichever transport the fix chooses)
-- [ ] A test asserts that the object holding the request parameters contains no
+- [x] A test asserts that the object holding the request parameters contains no
       credential value, and is mutation-checked (restoring the old payload
       shape makes it red)
-- [ ] The already-clean properties are pinned, not just assumed: a test asserts
+- [x] The already-clean properties are pinned, not just assumed: a test asserts
       the error string returned on a request exception contains no credential
-- [ ] The other backends in `Web_Scraping/WebSearch_APIs.py` are checked for the
+- [x] The other backends in `Web_Scraping/WebSearch_APIs.py` are checked for the
       same shape and the result recorded (headers-based ones — Bing, Brave,
       Serper, Exa, Kagi, Yandex — are expected clean; Google's `params["key"]`
       at `:3428` is the one TASK-19552 addressed)
@@ -85,3 +86,66 @@ Low priority on purpose. This is hardening against a plausible future edit, not
 a live disclosure — filing it as a live leak would misrepresent the evidence.
 The value is that the next person to debug this function finds the task instead
 of adding the log line.
+
+## Implementation Plan
+
+1. Confirm the latency claim at this base: grep `search_web_tavily` for any
+   log statement, and confirm the key travels in the POST body rather than
+   the URL (so the exception path is already clean).
+2. Write the born-red test first: drive `search_web_tavily` with a sentinel
+   key through an in-process fake `requests`, and assert the decoded request
+   body holds no credential.
+3. Move the credential to `Authorization: Bearer <key>`, matching every
+   sibling backend in the module.
+4. Pin the already-clean properties rather than assume them: the returned
+   error string on a request exception.
+5. Turn the sibling-backend census into an executable AST check instead of
+   prose that can go stale, with `search_web_google`'s `params["key"]` as
+   the one recorded, referenced exception.
+
+## Implementation Notes
+
+The Tavily credential moved from the `payload` dict into `headers` as
+`Authorization: Bearer <key>`, which Tavily accepts and which bing, brave,
+kagi, serper, exa and yandex in the same module already use. It is read at
+the point of use and never bound to a local name, so there is no
+`tavily_api_key` variable for a debug log to reach for either.
+
+**This stayed sized as latent.** Nothing logged `payload` at the base and the
+key travelled in the body, not the URL, so the error path was clean too. The
+value of the change is that the one-line edit a future maintainer would make
+while debugging (`logger.debug(f"payload: {payload}")`) can no longer
+disclose the key. No claim of a live leak was added anywhere.
+
+**Born-red evidence** (all at base `f12bb21ad`, before any source change --
+which is also the mutation check the third AC asks for, since the base *is*
+the old payload shape):
+
+```
+test_tavily_request_parameters_hold_no_credential
+E  AssertionError: the Tavily key is inside the request-parameter object:
+   {'api_key': 'tvly-TASK19735-SENTINEL-NOT-A-REAL-KEY', 'query': 'cherry cake', 'max_results': 3}
+test_tavily_credential_travels_in_the_headers
+E  AssertionError: the key reaches no transport at all:
+   {'Content-Type': ..., 'User-Agent': ...}
+test_no_search_backend_hides_a_credential_in_its_parameter_dict
+E  Extra items in the left set: ('search_web_tavily', 'payload')
+```
+
+Three sibling tests were **green at base and stayed green**, which is the
+point of the fourth AC: the returned error string carries no credential, the
+optional domain filters still reach the request, and the census detector
+demonstrably detects (a synthetic offending module is found, so the empty
+census result is not vacuous).
+
+**Sibling-backend census, recorded and now executable.** Clean (credential in
+`headers`): bing `Ocp-Apim-Subscription-Key`, brave `X-Subscription-Token`,
+serper `X-API-KEY`, exa `x-api-key`, kagi `Authorization: Bot ...`, yandex
+`Authorization: Api-Key ...`. searx / duckduckgo / baidu carry no credential
+at all. The one parameter-dict credential left is `search_web_google`'s
+`params["key"]` -- the engine's own API contract, whose two disclosure points
+TASK-19552 fixed -- and it is the single allowlisted entry in
+`_KNOWN_PARAMETER_CREDENTIALS`, so a new offender fails the census.
+
+Modified: `tldw_chatbook/Web_Scraping/WebSearch_APIs.py`.
+Added: `Tests/Web_Scraping/test_tavily_credential_transport.py` (6 tests).

--- a/tldw_chatbook/Library/ingest_preflight.py
+++ b/tldw_chatbook/Library/ingest_preflight.py
@@ -12,10 +12,11 @@ import ssl
 from pathlib import Path
 from typing import Any, NamedTuple
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from loguru import logger
 
+from tldw_chatbook.config import get_cli_setting
 from tldw_chatbook.Library.ingest_capabilities import (
     UNSUPPORTED_GROUP,
     get_tooling_warnings,
@@ -23,6 +24,8 @@ from tldw_chatbook.Library.ingest_capabilities import (
 )
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Local_Ingestion.local_file_ingestion import is_http_url
+from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise
+from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.path_validation import validate_path_simple
 
 
@@ -151,6 +154,74 @@ def _collect_files(p: Path, scan_limit: int) -> tuple[list[Path], bool, int]:
 #: refusing to start.
 _ABSENT_STATUSES = frozenset({404, 410})
 
+#: Seconds allowed for the (opt-in) URL probe.
+_PROBE_TIMEOUT_SECONDS = 5
+
+#: Config gate for the URL probe. OFF by default (TASK-19556).
+#:
+#: The probe used to fire from ``library_screen``'s 0.8 s typing debounce,
+#: which meant a link pasted into the ingest field became an HTTP request
+#: before the user had asked for anything to be imported. That is the wrong
+#: default even for hosts the egress policy allows: the user has not chosen
+#: to contact them yet, and repeated pauses mid-typing hit them repeatedly.
+#: With the gate off the pre-flight for a URL is pure classification --
+#: exactly what the local-path arm does with ``stat`` -- and a URL that
+#: cannot actually be fetched is reported by the ingest job, where the
+#: failure carries a real reason (``_probe_url``'s own docstring already
+#: said so).
+_PROBE_ENABLED_SECTION = "library"
+_PROBE_ENABLED_KEY = "ingest_url_preflight_probe"
+
+#: The single note returned for EVERY URL the egress policy declines.
+#:
+#: Collapsing the vocabulary is the point (TASK-19556). The old probe
+#: returned three differentiable outcomes -- an ``error`` for a refused
+#: connection, a ``warning`` naming the status code for an answered one, and
+#: a clean type-group echo for a 2xx -- so a pasted link read out the state
+#: of an internal host+port. Every declined reason (private, loopback,
+#: link-local, CGNAT, multicast, cloud metadata, bad scheme, DNS failure)
+#: now produces this one string, so there is nothing left to difference.
+_UNVERIFIABLE_NOTE = (
+    "The link could not be checked ahead of time. The import will still be "
+    "attempted."
+)
+
+
+def url_probe_enabled() -> bool:
+    """Whether the pre-flight may issue a network request for a URL.
+
+    Returns:
+        ``True`` only when ``[library] ingest_url_preflight_probe`` is
+        explicitly enabled. Defaults to ``False``; see
+        :data:`_PROBE_ENABLED_KEY` for why.
+    """
+    value = get_cli_setting(_PROBE_ENABLED_SECTION, _PROBE_ENABLED_KEY, False)
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes", "on")
+    return bool(value)
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Refuse to follow redirects during the probe.
+
+    ``urlopen``'s default opener follows them, so a public URL answering
+    ``302 Location: http://10.0.0.5:8080/`` walked the probe into the
+    internal network *after* the egress check had already passed on the
+    original target. Returning ``None`` here makes urllib surface the 3xx as
+    an ``HTTPError``, which the probe reports as "the site answered {code}"
+    -- an outcome about the public host the user typed, and nothing else.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: D102
+        return None
+
+
+def _open_probe(request: Request):
+    """Issue the probe request with redirects disabled (test seam)."""
+    return build_opener(_NoRedirectHandler).open(
+        request, timeout=_PROBE_TIMEOUT_SECONDS
+    )
+
 
 class UrlProbe(NamedTuple):
     """The outcome of probing a URL before ingest.
@@ -210,15 +281,37 @@ def _probe_url(url: str) -> UrlProbe:
     there, so refusing is right. A failure to *fetch* during ingest is reported
     as a failed job, where it carries a real reason.
 
+    (TASK-19556) The egress policy is consulted BEFORE any transport call,
+    with **no** trusted origins. An automatic probe is not a user asking to
+    contact a host, so it may not seed trust from its own input URL -- the
+    rule ``Utils/egress.py`` states for all shared pipeline code. That is
+    also what makes the collapse below meaningful: with self-trust the check
+    would be a no-op for exactly the private hosts at issue. The deliberate
+    ingest that follows is a different matter and keeps its own trust
+    (``[web_security]``: URLs you explicitly configure may be private).
+
     Args:
-        url: URL to probe.
+        url: URL to probe. Must already have passed ``validate_url``.
 
     Returns:
         A ``UrlProbe``. An empty one means the URL verified cleanly.
     """
     try:
+        check_url_or_raise(url)
+    except EgressBlockedError as exc:
+        # ONE outcome for every declined reason. `exc.reason` is deliberately
+        # not read: "private" vs "dns_failure" vs "metadata" is precisely the
+        # difference an internal scan wants, and the user cannot act on it
+        # here anyway.
+        logger.debug(f"URL probe declined by egress policy: {exc}")
+        return UrlProbe(note=_UNVERIFIABLE_NOTE)
+    except Exception as exc:  # policy evaluation itself failed
+        logger.debug(f"URL probe policy check failed for {url}: {exc!r}")
+        return UrlProbe(note=_UNVERIFIABLE_NOTE)
+
+    try:
         request = Request(url, method="HEAD")
-        with urlopen(request, timeout=5):
+        with _open_probe(request):
             return UrlProbe()
     except TimeoutError:
         return UrlProbe(error="URL probe timed out after 5 seconds")
@@ -252,13 +345,22 @@ def _probe_url(url: str) -> UrlProbe:
         )
 
 
-def analyze_path(path_or_url: str, scan_limit: int = 1000) -> PreflightResult:
+def analyze_path(
+    path_or_url: str, scan_limit: int = 1000, *, probe_url: bool | None = None
+) -> PreflightResult:
     """Analyze a local path or URL before ingestion.
 
     Args:
         path_or_url: Local file path, directory path, or HTTP(S) URL.
         scan_limit: Maximum number of files to enumerate for directories.
             Must be greater than zero.
+        probe_url: Whether a URL source may be probed over the network.
+            ``None`` (the default) consults :func:`url_probe_enabled`;
+            ``False`` forbids it outright. The while-typing caller in
+            ``library_screen`` passes ``False`` so that even a user who has
+            opted the probe in is not made to contact a host on every
+            keystroke pause -- the probe then runs from the deliberate
+            triggers (blur, Enter, Browse…, the retry button) instead.
 
     Returns:
         A ``PreflightResult`` describing the discovered source.
@@ -281,16 +383,32 @@ def analyze_path(path_or_url: str, scan_limit: int = 1000) -> PreflightResult:
     source_is_url = is_http_url(path_or_url)
 
     if source_is_url:
-        probe = _probe_url(path_or_url)
-        if probe.error:
-            errors.append(probe.error)
+        if not validate_url(path_or_url):
+            # (TASK-19556) Validation precedes every network request. At the
+            # base of that task the probe fired first, so a malformed URL --
+            # including one carrying embedded credentials
+            # (``http://user:pass@host/``, which ``validate_url`` refuses
+            # exactly because they end up in logs and forwarded URLs) -- was
+            # put on the wire before anything looked at it.
+            errors.append(
+                "Invalid URL — check the address (it must be a plain http(s) "
+                "link with no spaces or embedded credentials)."
+            )
+            path_invalid = True
         else:
-            group = get_type_group(path_or_url)
-            type_groups.setdefault(group, []).append(path_or_url)
-            total_files = 1
-            if probe.note:
-                warnings.append({"label": "Could not check the link", "hint": probe.note})
-            warnings.extend(get_tooling_warnings(group))
+            may_probe = url_probe_enabled() if probe_url is None else probe_url
+            probe = _probe_url(path_or_url) if may_probe else UrlProbe()
+            if probe.error:
+                errors.append(probe.error)
+            else:
+                group = get_type_group(path_or_url)
+                type_groups.setdefault(group, []).append(path_or_url)
+                total_files = 1
+                if probe.note:
+                    warnings.append(
+                        {"label": "Could not check the link", "hint": probe.note}
+                    )
+                warnings.extend(get_tooling_warnings(group))
     else:
         try:
             p = validate_path_simple(path_or_url, require_exists=False)

--- a/tldw_chatbook/Local_Ingestion/video_processing.py
+++ b/tldw_chatbook/Local_Ingestion/video_processing.py
@@ -21,6 +21,7 @@ from .audio_processing import LocalAudioProcessor, build_ffmpeg_trim_args
 from ..config import get_cli_setting
 from ..DB.Client_Media_DB_v2 import MediaDatabase
 from ..Metrics.metrics_logger import log_counter, log_histogram
+from ..Utils.egress import EgressBlockedError, check_url_or_raise, origin_set
 
 # Optional imports
 try:
@@ -44,6 +45,50 @@ class VideoDownloadError(VideoProcessingError):
     """Raised when video download fails."""
 
     pass
+
+
+def check_media_url_egress(url: str) -> None:
+    """Apply the app's egress policy to a media URL before yt-dlp sees it.
+
+    The media arm of ingest never consulted ``Utils/egress.py`` (TASK-19556
+    (b)), while the article arm of the same entry point did, and
+    ``audio_processing.download_audio_file`` guards its own plain-HTTP branch
+    with ``guarded_fetch_requests(..., trusted_origins=origin_set(url))``.
+    This is that same check, applied at the two yt-dlp seams, so both arms
+    behave identically.
+
+    The URL is its own trusted origin, exactly as in the audio arm: a media
+    URL the user typed into the ingest form is an explicitly configured URL,
+    which ``config.py``'s ``[web_security]`` contract permits to be private
+    (an intranet media server is a legitimate source). What the check still
+    refuses is what no configured URL may be: a cloud metadata endpoint
+    (blocked regardless of trust) and anything that is not http(s) -- yt-dlp
+    itself is happy to hand ``file://`` and dozens of other protocols to its
+    extractors.
+
+    WHAT THIS DOES NOT COVER, stated plainly: yt-dlp performs its own HTTP
+    fetching. This is a pre-check on the entry URL only. It cannot
+    re-validate yt-dlp's own redirect hops, the per-format media URLs an
+    extractor discovers inside a page, or a DNS answer that changes between
+    this call and yt-dlp's own resolution -- the TOCTOU window
+    ``Utils/egress.py`` documents as a residual for every consumer of a
+    resolve-then-connect check. Closing those would need a yt-dlp request
+    hook and is not in this task's scope.
+
+    Args:
+        url: The media URL about to be handed to yt-dlp.
+
+    Raises:
+        VideoDownloadError: If the egress policy refuses the URL.
+    """
+    try:
+        check_url_or_raise(url, trusted_origins=origin_set(url))
+    except EgressBlockedError as exc:
+        log_counter(
+            "video_processing_download_error",
+            labels={"error_type": "egress_blocked"},
+        )
+        raise VideoDownloadError(f"URL blocked by the egress policy: {exc}") from exc
 
 
 class LocalVideoProcessor:
@@ -211,6 +256,11 @@ class LocalVideoProcessor:
                 labels={"error_type": "yt_dlp_not_available"},
             )
             raise VideoDownloadError("yt-dlp is not installed")
+
+        # (TASK-19556) Before ANY yt-dlp work -- the probe below is itself a
+        # fetch. Outside the try/except so a policy refusal keeps its own
+        # reason instead of being rewrapped as "Download failed".
+        check_media_url_egress(url)
 
         # Resolved before the try so an unusable cookies value fails with
         # its own reason instead of being wrapped as a download failure.
@@ -438,6 +488,18 @@ class LocalVideoProcessor:
                 "video_processing_metadata_error",
                 labels={"error_type": "yt_dlp_not_available"},
             )
+            return None
+
+        # (TASK-19556) The metadata seam fetches too -- same guard as the
+        # download seam, reported through this function's None contract.
+        try:
+            check_media_url_egress(url)
+        except VideoDownloadError as exc:
+            log_counter(
+                "video_processing_metadata_error",
+                labels={"error_type": "egress_blocked"},
+            )
+            logger.error(f"Metadata extraction refused: {exc}")
             return None
 
         owned_temp_cookiefile: Optional[str] = None

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -27513,7 +27513,11 @@ class LibraryScreen(BaseAppScreen):
         self._library_ingest_path_debounce_timer = None
         path = self._library_ingest_form.path.strip()
         if path and self._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA:
-            self._trigger_library_ingest_preflight(path)
+            # (TASK-19556) allow_probe=False: this fire is a typing pause,
+            # not a request to contact anything. The URL is classified by
+            # name here; a network check, if the user has enabled one, runs
+            # from the deliberate triggers instead.
+            self._trigger_library_ingest_preflight(path, allow_probe=False)
 
     #: Max staged files probed for the duplicate forecast (task-2130:
     #: when hit, the forecast copy switches to "at least N").
@@ -27598,11 +27602,23 @@ class LibraryScreen(BaseAppScreen):
         # exists must not survive it -- submit/Clear/reset all route here.
         self._disarm_library_ingest_start_confirm()
 
-    def _trigger_library_ingest_preflight(self, path: str) -> None:
+    def _trigger_library_ingest_preflight(
+        self, path: str, *, allow_probe: bool = True
+    ) -> None:
         """Start (or restart) the pre-flight worker for ``path``.
 
         No-op for empty paths so stray focus/blur/enter events never scan
         the current working directory.
+
+        Args:
+            path: The staged source path or URL.
+            allow_probe: Whether a URL source may be probed over the
+                network. ``False`` on the while-typing path (TASK-19556):
+                a debounce fire is not the user asking to contact a host,
+                so it never does -- even when the (default-off) probe has
+                been opted in. The deliberate triggers -- blur, Enter,
+                Browse…, the retry button -- leave this at ``True`` and let
+                the config gate decide.
         """
         if not path.strip():
             self._library_ingest_form.preflight_checking = False
@@ -27616,11 +27632,13 @@ class LibraryScreen(BaseAppScreen):
         # click in flight.
         self._update_library_ingest_dynamic_regions()
         self._library_ingest_preflight_worker = self._run_library_ingest_preflight(
-            path, generation
+            path, generation, allow_probe
         )
 
     @work(thread=True)
-    def _run_library_ingest_preflight(self, path: str, generation: int) -> None:
+    def _run_library_ingest_preflight(
+        self, path: str, generation: int, allow_probe: bool = True
+    ) -> None:
         """Analyze ``path`` on a worker thread and apply the result."""
         raw_scan_limit = get_cli_setting("library.ingest_directory_scan_limit", 1000)
         try:
@@ -27628,7 +27646,11 @@ class LibraryScreen(BaseAppScreen):
         except (TypeError, ValueError):
             scan_limit = 1000
         try:
-            result = analyze_path(path, scan_limit=scan_limit)
+            result = analyze_path(
+                path,
+                scan_limit=scan_limit,
+                probe_url=None if allow_probe else False,
+            )
             result = self._annotate_preflight_duplicates(result)
         except Exception as exc:
             logger.opt(exception=True).debug(

--- a/tldw_chatbook/UI/Screens/settings_image_gen_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_image_gen_defaults.py
@@ -767,14 +767,30 @@ def _guarded_get(
     try:
         # (TASK-19556 (c), checked and deliberately KEPT) This is the same
         # SHAPE as the sitemap/crawl self-trust that task corrected, but not
-        # the same PROVENANCE. Every caller derives `url` from a base_url the
-        # user typed into this settings form -- `_probe_swarmui` and
-        # `_probe_reachability_only` pass it directly, `_probe_comfyui` via
-        # `normalize_comfyui_image_origin` -- so it is an explicitly
-        # configured URL, which `config.py`'s [web_security] contract permits
-        # to be private. The shipped default backend is a LOCALHOST SwarmUI
-        # instance; dropping the self-trust would break the zero-key default.
-        # A content-derived URL must never be handed to this helper.
+        # the same PROVENANCE: `url` is always an OPERATOR-CONFIGURED value,
+        # which `config.py`'s [web_security] contract permits to be private.
+        # The shipped default backend is a LOCALHOST SwarmUI instance, so
+        # dropping the self-trust would break the zero-key default probe.
+        #
+        # All FIVE callers, enumerated (independent review: the original note
+        # listed only the first three, omitting the two that also attach a
+        # credential header -- which are the ones that matter most):
+        #   `_probe_swarmui`, `_probe_reachability_only` -- `base_url` as-is;
+        #   `_probe_comfyui`  -- via `normalize_comfyui_image_origin`;
+        #   `_probe_openai_compatible`, `_probe_gemini` -- `{base_url}/models`
+        #     plus an `Authorization`/`x-goog-api-key` header. The GET below
+        #     sets `follow_redirects=False`, so that credential cannot be
+        #     carried to a host other than the configured one.
+        #
+        # Where `base_url` comes from, exactly (`settings_screen.
+        # _image_gen_test_form_values`): the live Input when the user has
+        # edited it, else `effective_placeholder(...)` -- the resolved
+        # `[image_generation]` value from config.toml (or its shipped
+        # default). So "typed this session" is NOT required; "explicitly
+        # configured by the operator" is, and both sources satisfy it. No
+        # discovery response, server-provided default, or imported document
+        # writes that section. A content-derived URL must never be handed to
+        # this helper.
         check_url_or_raise(url, trusted_origins=origin_set(url))
     except EgressBlockedError:
         return None, "Unreachable: blocked by egress policy"

--- a/tldw_chatbook/UI/Screens/settings_image_gen_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_image_gen_defaults.py
@@ -765,6 +765,16 @@ def _guarded_get(
         or embedded secrets (e.g. a malformed-URL error message).
     """
     try:
+        # (TASK-19556 (c), checked and deliberately KEPT) This is the same
+        # SHAPE as the sitemap/crawl self-trust that task corrected, but not
+        # the same PROVENANCE. Every caller derives `url` from a base_url the
+        # user typed into this settings form -- `_probe_swarmui` and
+        # `_probe_reachability_only` pass it directly, `_probe_comfyui` via
+        # `normalize_comfyui_image_origin` -- so it is an explicitly
+        # configured URL, which `config.py`'s [web_security] contract permits
+        # to be private. The shipped default backend is a LOCALHOST SwarmUI
+        # instance; dropping the self-trust would break the zero-key default.
+        # A content-derived URL must never be handed to this helper.
         check_url_or_raise(url, trusted_origins=origin_set(url))
     except EgressBlockedError:
         return None, "Unreachable: blocked by egress policy"

--- a/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
+++ b/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
@@ -172,7 +172,6 @@ from tldw_chatbook.Utils.egress import (  # noqa: E402
     check_url_or_raise_async,
     collect_navigation_chain,
     guarded_fetch_requests,
-    origin_set,
     validate_navigation_chain_async,
 )
 from tldw_chatbook.Web_Scraping.exceptions import (  # noqa: E402
@@ -1027,14 +1026,37 @@ def scrape_by_url_level(base_url: str, level: int) -> list:
     return [article for link in filtered_links if (article := scrape_article(link))]
 
 
-def scrape_from_sitemap(sitemap_url: str) -> list:
-    """Scrape articles from a sitemap URL."""
-    origins = origin_set(sitemap_url)
+def scrape_from_sitemap(sitemap_url: str, *, trusted_origins=frozenset()) -> list:
+    """Scrape articles from a sitemap URL.
+
+    (TASK-19556 (c)) This used to compute ``origin_set(sitemap_url)`` and use
+    it both for its own fetch and for every URL the sitemap named. Both
+    halves contradicted the policy's stated contract:
+
+    * self-trusting the URL you are about to fetch defeats the check for
+      exactly the input it exists to catch -- ``Utils/egress.py``: "Shared
+      pipeline code must NEVER auto-trust its own input URL";
+    * ``config.py``'s ``[web_security]`` block names **sitemap discoveries**
+      among the content-derived URLs that "must resolve to public IPs", so
+      forwarding the sitemap host's trust to them is the same defect one
+      level down.
+
+    Trust is now the caller's to seed, defaults to none, and applies to the
+    sitemap fetch only -- never to what the sitemap CONTENT names.
+
+    Args:
+        sitemap_url: URL of the sitemap to fetch.
+        trusted_origins: Hostnames the caller has established as
+            user-intended. Applied to the sitemap fetch alone.
+
+    Returns:
+        The scraped articles, or ``[]`` if the sitemap could not be fetched.
+    """
     try:
         response = guarded_fetch_requests(
             sitemap_url,
             max_bytes=MAX_FETCH_BYTES_SITEMAP,
-            trusted_origins=origins,
+            trusted_origins=trusted_origins,
             timeout=30,
         )
         response.raise_for_status()
@@ -1045,7 +1067,7 @@ def scrape_from_sitemap(sitemap_url: str) -> list:
             for url in root.findall(
                 ".//{http://www.sitemaps.org/schemas/sitemap/0.9}loc"
             )
-            if (article := scrape_article(url.text, trusted_origins=origins))
+            if (article := scrape_article(url.text))
         ]
     except (EgressBlockedError, EgressFetchError) as e:
         logging.error(f"Sitemap fetch blocked or too large: {e}")
@@ -1062,15 +1084,25 @@ def scrape_from_sitemap(sitemap_url: str) -> list:
 # Sitemap/Crawling-related Functions
 
 
-def collect_internal_links(base_url: str) -> set:
+def collect_internal_links(base_url: str, *, trusted_origins=frozenset()) -> set:
     """
     Crawl a website and collect all internal links.
 
     This function performs a breadth-first crawl of a website,
     discovering all internal links within the same domain.
 
+    (TASK-19556 (c)) ``trusted_origins`` applies to ``base_url`` only. Links
+    found mid-crawl are content-derived, and ``config.py``'s
+    ``[web_security]`` block names "crawl discoveries" among the URLs that
+    must resolve to public IPs -- so they are re-checked with no trust, even
+    though the same-domain filter means they share the root's hostname. The
+    seam replaces an internal ``origin_set(base_url)``, which both
+    self-trusted the input URL and forwarded that trust to every discovery.
+
     Args:
         base_url (str): The starting URL for crawling
+        trusted_origins: Hostnames the caller has established as
+            user-intended. Applied to ``base_url``'s own fetch alone.
 
     Returns:
         set: Set of discovered internal URLs
@@ -1086,8 +1118,6 @@ def collect_internal_links(base_url: str) -> set:
         )
         return set()
 
-    origins = origin_set(base_url)
-
     visited = set()
     to_visit = {base_url}
 
@@ -1100,7 +1130,9 @@ def collect_internal_links(base_url: str) -> set:
             response = guarded_fetch_requests(
                 current_url,
                 max_bytes=MAX_FETCH_BYTES_PAGE,
-                trusted_origins=origins,
+                trusted_origins=(
+                    trusted_origins if current_url == base_url else frozenset()
+                ),
                 timeout=30,
             )
             response.raise_for_status()
@@ -1738,6 +1770,8 @@ async def recursive_scrape(
     user_agent: str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
     custom_cookies: Optional[List[Dict[str, Any]]] = None,
     progress_callback: Optional[callable] = None,
+    *,
+    trusted_origins=frozenset(),
 ) -> List[Dict]:
     # Ensure playwright is imported before it's dereferenced below. Preserves
     # pre-existing behavior when unavailable: this function has never guarded
@@ -1751,7 +1785,12 @@ async def recursive_scrape(
             "installed (pip install tldw_chatbook[websearch])."
         )
 
-    origins = origin_set(base_url)
+    # (TASK-19556 (c)) Was `origin_set(base_url)` -- shared pipeline code
+    # inventing its own trust from the URL it was handed, and then applying
+    # it to every page discovered mid-crawl. Trust is the caller's to seed,
+    # and reaches the root page only (see `_hop_trust`).
+    def _hop_trust(url: str):
+        return trusted_origins if url == base_url else frozenset()
 
     async def save_progress():
         temp_file = resume_file + ".tmp"
@@ -1812,7 +1851,7 @@ async def recursive_scrape(
                         await asyncio.sleep(random.uniform(delay * 0.8, delay * 1.2))
 
                         article_data = await scrape_article_async(
-                            context, current_url, trusted_origins=origins
+                            context, current_url, trusted_origins=_hop_trust(current_url)
                         )
 
                         if article_data and article_data["extraction_successful"]:
@@ -1823,14 +1862,14 @@ async def recursive_scrape(
                         if current_depth < max_depth:
                             page = await context.new_page()
                             await check_url_or_raise_async(
-                                current_url, trusted_origins=origins
+                                current_url, trusted_origins=_hop_trust(current_url)
                             )
                             nav_response = await page.goto(current_url)
                             await page.wait_for_load_state("networkidle")
 
                             await validate_navigation_chain_async(
                                 collect_navigation_chain(nav_response),
-                                trusted_origins=origins,
+                                trusted_origins=_hop_trust(current_url),
                             )
 
                             links = await page.eval_on_selector_all(

--- a/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
+++ b/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
@@ -1026,7 +1026,7 @@ def scrape_by_url_level(base_url: str, level: int) -> list:
     return [article for link in filtered_links if (article := scrape_article(link))]
 
 
-def scrape_from_sitemap(sitemap_url: str, *, trusted_origins=frozenset()) -> list:
+def scrape_from_sitemap(sitemap_url: str, *, trusted_origins: frozenset[str] = frozenset()) -> list:
     """Scrape articles from a sitemap URL.
 
     (TASK-19556 (c)) This used to compute ``origin_set(sitemap_url)`` and use
@@ -1084,7 +1084,7 @@ def scrape_from_sitemap(sitemap_url: str, *, trusted_origins=frozenset()) -> lis
 # Sitemap/Crawling-related Functions
 
 
-def collect_internal_links(base_url: str, *, trusted_origins=frozenset()) -> set:
+def collect_internal_links(base_url: str, *, trusted_origins: frozenset[str] = frozenset()) -> set:
     """
     Crawl a website and collect all internal links.
 
@@ -1771,7 +1771,7 @@ async def recursive_scrape(
     custom_cookies: Optional[List[Dict[str, Any]]] = None,
     progress_callback: Optional[callable] = None,
     *,
-    trusted_origins=frozenset(),
+    trusted_origins: frozenset[str] = frozenset(),
 ) -> List[Dict]:
     # Ensure playwright is imported before it's dereferenced below. Preserves
     # pre-existing behavior when unavailable: this function has never guarded

--- a/tldw_chatbook/Web_Scraping/Article_Scraper/crawler.py
+++ b/tldw_chatbook/Web_Scraping/Article_Scraper/crawler.py
@@ -65,7 +65,6 @@ from ...Utils.egress import (
     MAX_FETCH_BYTES_PAGE,
     MAX_FETCH_BYTES_SITEMAP,
     guarded_fetch_aiohttp,
-    origin_set,
 )
 #
 #######################################################################################################################
@@ -130,15 +129,28 @@ async def crawl_site(
     max_pages: int = 100,
     max_depth: int = 5,
     url_filter: Callable[[str], bool] = default_url_filter,
+    *,
+    trusted_origins=frozenset(),
 ) -> Set[str]:
     """
     Asynchronously crawls a website to discover internal links.
+
+    (TASK-19556 (c)) ``trusted_origins`` applies to ``base_url`` only. Pages
+    found mid-crawl are content-derived, and ``config.py``'s
+    ``[web_security]`` block names "crawl discoveries" among the URLs that
+    must resolve to public IPs. The seam replaces an internal
+    ``origin_set(base_url)``, which both self-trusted this function's own
+    input URL -- against ``Utils/egress.py``'s "shared pipeline code must
+    NEVER auto-trust its own input URL" -- and forwarded that trust to every
+    discovery.
 
     Args:
         base_url: The starting URL for the crawl.
         max_pages: The maximum number of pages to crawl.
         max_depth: The maximum depth to follow links from the base URL.
         url_filter: A function to decide if a URL should be included.
+        trusted_origins: Hostnames the caller has established as
+            user-intended. Applied to ``base_url``'s own fetch alone.
 
     Returns:
         A set of discovered and filtered URLs.
@@ -173,9 +185,6 @@ async def crawl_site(
     # Keep track of the domain to stay on the same site
     base_domain = urlparse(base_url).netloc
 
-    # Trust the crawl's own starting host (user-provided boundary) for the
-    # egress guard — never auto-trust arbitrary URLs discovered mid-crawl.
-    origins = origin_set(base_url)
 
     # Track statistics
     pages_crawled = 0
@@ -212,7 +221,9 @@ async def crawl_site(
                     current_url,
                     session=session,
                     max_bytes=MAX_FETCH_BYTES_PAGE,
-                    trusted_origins=origins,
+                    trusted_origins=(
+                        trusted_origins if current_url == base_url else frozenset()
+                    ),
                     timeout=10,
                 )
                 if response.status_code != 200:
@@ -323,14 +334,25 @@ async def crawl_site(
 
 
 async def get_urls_from_sitemap(
-    sitemap_url: str, url_filter: Callable[[str], bool] = default_url_filter
+    sitemap_url: str,
+    url_filter: Callable[[str], bool] = default_url_filter,
+    *,
+    trusted_origins=frozenset(),
 ) -> List[str]:
     """
     Fetches and parses a sitemap.xml file to extract a list of URLs.
 
+    (TASK-19556 (c)) This used to seed ``origin_set(sitemap_url)`` -- i.e.
+    it trusted the origin of the very URL it was about to fetch, which
+    defeats the check for exactly the input it exists to catch when that URL
+    came from fetched content. Trust is now the caller's to seed and
+    defaults to none.
+
     Args:
         sitemap_url: The URL of the sitemap.xml file.
         url_filter: A function to decide if a URL should be included.
+        trusted_origins: Hostnames the caller has established as
+            user-intended.
 
     Returns:
         A list of filtered URLs found in the sitemap.
@@ -349,12 +371,11 @@ async def get_urls_from_sitemap(
     try:
         async with aiohttp.ClientSession() as session:
             fetch_start = time.time()
-            origins = origin_set(sitemap_url)
             response = await guarded_fetch_aiohttp(
                 sitemap_url,
                 session=session,
                 max_bytes=MAX_FETCH_BYTES_SITEMAP,
-                trusted_origins=origins,
+                trusted_origins=trusted_origins,
                 timeout=30,
             )
             response.raise_for_status()

--- a/tldw_chatbook/Web_Scraping/Article_Scraper/crawler.py
+++ b/tldw_chatbook/Web_Scraping/Article_Scraper/crawler.py
@@ -130,7 +130,7 @@ async def crawl_site(
     max_depth: int = 5,
     url_filter: Callable[[str], bool] = default_url_filter,
     *,
-    trusted_origins=frozenset(),
+    trusted_origins: frozenset[str] = frozenset(),
 ) -> Set[str]:
     """
     Asynchronously crawls a website to discover internal links.
@@ -337,7 +337,7 @@ async def get_urls_from_sitemap(
     sitemap_url: str,
     url_filter: Callable[[str], bool] = default_url_filter,
     *,
-    trusted_origins=frozenset(),
+    trusted_origins: frozenset[str] = frozenset(),
 ) -> List[str]:
     """
     Fetches and parses a sitemap.xml file to extract a list of URLs.

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -4099,14 +4099,38 @@ def parse_exa_results(exa_search_results: dict, web_search_results_dict: dict) -
 def search_web_tavily(
     search_query, result_count=10, site_whitelist=None, site_blacklist=None
 ):
+    """Search Tavily.
+
+    (TASK-19735) The API key travels in ``headers`` as
+    ``Authorization: Bearer <key>``, which Tavily accepts and which every
+    sibling backend in this module already uses (bing's
+    ``Ocp-Apim-Subscription-Key``, brave's ``X-Subscription-Token``, plus
+    kagi, serper, exa and yandex). It used to sit inside ``payload``
+    alongside the query and the result count -- the same shape that produced
+    the Google key disclosure TASK-19552 fixed, where a credential in a
+    parameter dict was eventually rendered into a log line. Nothing logged
+    ``payload`` here, so this was latent rather than a live leak; the point
+    of the move is that a maintainer adding
+    ``logger.debug(f"payload: {payload}")`` while debugging can no longer
+    disclose the key with a one-line change.
+
+    Args:
+        search_query: The user's query string.
+        result_count: Maximum number of results to request.
+        site_whitelist: Optional list of domains to restrict results to.
+        site_blacklist: Optional list of domains to exclude.
+
+    Returns:
+        Tavily's decoded JSON response, or a human-readable error string on
+        a request failure. The key is not in the URL, so ``str(exc)`` --
+        which carries the URL, not the body -- cannot carry it either.
+    """
     # Check if API URL is configured
     tavily_api_url = "https://api.tavily.com/search"
 
-    tavily_api_key = loaded_config_data["search_engines"]["tavily_search_api_key"]
-
-    # Prepare the request payload
+    # Prepare the request payload. No credential belongs in this dict: it is
+    # the loggable request-parameter object (see the docstring).
     payload = {
-        "api_key": tavily_api_key,
         "query": search_query,
         "max_results": result_count,
     }
@@ -4122,6 +4146,13 @@ def search_web_tavily(
         headers = {
             "Content-Type": "application/json",
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",
+            # Read at the point of use and never bound to a local name, so
+            # there is no `tavily_api_key` variable for a debug log to reach
+            # for either.
+            "Authorization": (
+                "Bearer "
+                f"{loaded_config_data['search_engines']['tavily_search_api_key']}"
+            ),
         }
 
         # task-3060: bound worst-case latency -- an unresponsive Tavily

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2744,6 +2744,12 @@ def _load_settings_uncached(force_reload: bool = False) -> Dict:
                 1000,
                 minimum=1,
             ),
+            # (TASK-19556) Opt-in, OFF by default: see the [library] block in
+            # the default TOML below for why a link check is not free.
+            "ingest_url_preflight_probe": coerce_bool_setting(
+                library_section.get("ingest_url_preflight_probe", False),
+                False,
+            ),
             "ingest_options": library_section.get("ingest_options", {})
             if isinstance(library_section.get("ingest_options"), dict)
             else {},
@@ -3095,6 +3101,18 @@ auth_token = "default-secret-key-for-single-user"
 [library]
 # Maximum files scanned when analysing a directory for Library ingestion.
 ingest_directory_scan_limit = 1000
+# Check a staged ingest URL by fetching its headers before the import runs.
+# OFF by default (TASK-19556). A link check is not free: it contacts the host
+# before you have asked for anything to be imported, and it used to run from
+# the ingest field's typing debounce, which turned a pasted link into a probe
+# of whatever the address pointed at -- including hosts on your own network.
+# With this on, the check runs only from the deliberate triggers (leaving the
+# field, pressing Enter, Browse..., the retry button), never while you type;
+# it is routed through the [web_security] egress policy, follows no
+# redirects, and reports one identical "could not be checked" note for every
+# address the policy declines. A link that cannot actually be fetched is
+# still reported by the import job itself, with a real reason.
+ingest_url_preflight_probe = false
 # Parallel ingest parse workers. Default: min(3, cpu-1). Uncomment to override.
 # ingest_parse_workers = 3
 # Max concurrent heavy (audio/video transcription) parses; document parses fan


### PR DESCRIPTION
Closes TASK-19556 and TASK-19735.

The egress policy itself is well built — DNS-resolution based, `follow_redirects=False`, per-hop recheck, on by default, blocking metadata IPs, loopback, RFC1918, CGNAT, link-local, SSDP and non-HTTP schemes. The defect was three seams that never called it.

## (a) The ingest preflight was an internal host+port scanning oracle

`ingest_preflight.py` used a bare `urlopen` HEAD, fired on a **0.8 s debounce while the user typed**, *before* `validate_url` ran, and returned outcomes that distinguished refused / answered-{code} / clean. So pasting a link read out the state of whatever it pointed at, including hosts on the user's own network. The network guard caught it as a real TCP connect from the typing path:

```
('socket.create_connection', '10.255.255.1:8080')
```

and three internal targets produced three different summaries.

**Closed both ways, because either alone is insufficient.** The probe is off by default (`[library] ingest_url_preflight_probe = false`), *and* the typing timer passes `allow_probe=False` unconditionally — so a user who opts in is still not made to contact a host on every keystroke pause. Probing runs only from blur / Enter / Browse… / Retry. The 0.8 s timer is untouched: it exists for local path feedback, which is cheap and local.

Verified independently: with the gate off, `analyze_path(url)` issues **zero transport calls and zero DNS lookups**; opted in, the typing path still issues neither.

**The outcome vocabulary is collapsed to one constant note**, and `EgressBlockedError.reason` is deliberately never read — private vs dns_failure vs metadata is exactly the difference a scan wants. Review tried to build a distinguisher anyway: 14 declined targets (private/loopback/CGNAT/multicast/metadata literals, the same via DNS, a DNS failure, `metadata.google.internal`, `[::1]`, an IPv4-mapped-v6 private address) produce **one** observable and **none reaches the transport at all**, so there is no timing oracle either.

Two findings fell out of the same read, both reproduced at base and both closed here:

- `http://user:secret@example.com/doc.pdf` was accepted with `errors=[]`, `warnings=[]`, classified `pdf`, and its **credential put on the wire**. `validate_url` now runs first. Not filed separately: `_resolve_ingest_source` already applied `validate_url` at submit, so the base was internally inconsistent — preflight said "clean pdf" while Start refused.
- `urlopen` **auto-followed redirects**, so a public host answering `302 → http://10.0.0.5:8080/` walked the probe into internal space *after* the check passed. Not filed separately either: at base there was no egress check to defeat. Its significance is that it would have made this fix incomplete.

## (b) yt-dlp was handed unchecked URLs

`video_processing.py` passed the URL straight to `extract_info` for both probe and download with zero egress references, while the article arm of the same entry point was guarded — a seam that half-adopted the primitive. At base `extract_metadata` fetched `169.254.169.254/latest/meta-data/iam/security-credentials/` **and returned its contents**.

**What the fix does not cover, stated in the docstring rather than only here**: yt-dlp does its own fetching, so this is a pre-check on the entry URL only. It cannot re-validate yt-dlp's redirect hops, the per-format media URLs an extractor finds inside a page, or a DNS answer that changes between check and use.

`trusted_origins=origin_set(url)` matches `audio_processing.download_audio_file`, so a user-typed private URL still works. Review traced every production path upward and confirmed all terminate at the ingest Input — but noted it **holds by wiring, not by invariant**: `LocalMediaReadingService.process_video(urls=…)` and `MediaReadingScopeService.process_video(urls=…)` are public, test-covered seams with no provenance check and no in-app caller, one wiring commit from making that claim false.

## (c) The guard was handed the attacker's own hostname as trusted

Five sitemap/crawl helpers passed `trusted_origins=origin_set(<the content-derived URL itself>)` — and forwarded that trust to whatever the content named. Trusting the origin of the URL you are about to fetch, when it came from fetched content, defeats the check for exactly the input it exists to catch. This contradicts `config.py:3731` verbatim.

Reachability re-checked and still **LATENT**: none of the five has an in-app caller, and the one shipped sitemap path uses a provenance-correct `origin_set(source)`. Fixed as a correctness defect, behaviour-neutral for the shipped app.

`settings_image_gen_defaults.py:768` was deliberately **kept** — same shape, different provenance. Review corrected the stated reasoning: values can reach it from `config.toml` without anyone typing this session, so the exception stands on "operator-configured", not "typed". The comment also enumerated 3 of 5 callers, omitting the two that attach a credential header; rewritten.

## TASK-19735 — Tavily

The key moved from a plain payload dict to `Authorization: Bearer`, matching all six sibling backends, read inline and never bound to a local name. Sized as latent throughout: nothing logs the payload today, and the key travelled in the POST body so the exception path was already clean. Because the base *is* the old payload shape, the born-red run **is** the mutation check the AC asks for. The already-clean properties are pinned rather than assumed.

## Two claims survived mutation, and are now pinned

Review found that AC 6's mutation requirement was not met on the two load-bearing lines:

- rewriting `probe_url=None if allow_probe else False` to `probe_url=None` — the link joining the debounce wiring to `analyze_path` — left **509 passed**, while putting an opted-in user back on a probe per 0.8 s pause;
- reverting `_open_probe` to `build_opener()` left **2252 passed, 0 failed**, because every other test patches `OpenerDirector.open` and so never reaches the redirect-following handler chain.

Three tests added, each born-red at the merge base and red under its own mutation; the redirect pair substitutes a real `urllib` transport handler so `OpenerDirector.open` stays live.

## Verification

- `Tests/Library/` + `Tests/Web_Scraping/` + `Tests/Local_Ingestion/` + `Tests/Utils/` post-rebase: **3656 passed / 5 skipped / 0 failed**.
- Born-red at base: (a) 9 failed, (b) 4 failed with 2 must-not-over-block parity pins passing, (c) 10 failed, 19735 3 failed / 3 passed.
- An egress-adoption census guard independently rediscovered exactly the two unguarded modules.
- Pre-existing reds re-measured on both sides and byte-identical: 9 in `Tests/UI/test_library_ingest_*`, 3 in `Tests/integration`.
- `Docs/User_Guide/library/import-and-export.md` updated with the opt-in and a verification stamp.

Three existing tests asserted retired behaviour and were updated with the reason inline. Review read each in history: `test_web_fetch_wiring.py` was **pinning the defect** — its assertion came from a commit that classified `scrape_from_sitemap` as a "user-boundary function [that] seeds trust from its own input host", a misclassification for a library function with no caller that then forwarded that trust to every `<loc>`. Nothing was lost; the new assertion still pins that `trusted_origins` is passed, just empty.

Recommended as a separate LOW follow-up: Textual posts `Input.Blurred` on terminal focus loss, so for an **opted-in** user, alt-tabbing away with a URL staged fires a probe with no gesture aimed at the field. Same category as the AC, far lower frequency, inert under the default-off gate; left alone because that handler's docstring records a prior reversal after an xhigh review round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-19556 and TASK-19735 by enforcing the egress policy for ingest preflight, media (yt-dlp), and sitemap/crawl, and by moving Tavily auth to headers. Removes the typing-triggered network probe, eliminates self-trust in crawl paths, and adds an AST guard to prevent future unguarded seams.

- Ingest preflight: no network on typing; UI passes allow_probe=False; optional probe gated by `[library] ingest_url_preflight_probe` (default false). Validates URLs first, checks with `check_url_or_raise` (no trusted origins), does not follow redirects, and collapses declined outcomes.
- Media (yt-dlp): pre-checks the entry URL with `check_url_or_raise(..., trusted_origins=origin_set(url))` to match audio; note this is an entry-URL pre-check only and yt-dlp still performs its own fetching.
- Sitemap/crawl: remove self-trust; helpers now take `trusted_origins: frozenset[str] = frozenset()` and apply it only to the entry URL; content-derived URLs must resolve public. Shipped wiring remains behavior-neutral; `settings_image_gen_defaults` keeps operator-configured self-trust by design.
- Tavily: move API key to `Authorization: Bearer`, aligning with sibling backends and preventing future logging leaks.
- Guardrails/tests: replace the regex egress-adoption census with an AST-based scanner that detects real `urllib`/`yt-dlp` call sites lacking egress references; add tests that pin debounce wiring and redirect handling; update docs and UI wiring accordingly.

**Migration/Review Notes**
- External callers of sitemap/crawl helpers that relied on prior self-trust must pass `trusted_origins=origin_set(source)` explicitly.
- The new `[library] ingest_url_preflight_probe` flag controls optional link probing; default remains off.

<sup>Written for commit 915c56c3a39eee805959c3282c86ea3f14602781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

