### PR TITLE
test(architecture): give the Python floor guard teeth when no floor interpreter exists

### DIFF
--- a/Tests/Architecture/test_python_floor_syntax.py
+++ b/Tests/Architecture/test_python_floor_syntax.py
@@ -75,16 +75,36 @@ def _reports_version(interpreter: str) -> tuple[int, int] | None:
     claim it never checked -- a wrong interpreter here turns the check into a
     second run of the developer's own version, which always passes.
     """
-    probe = subprocess.run(
-        [interpreter, "-c", "import sys;print(sys.version_info[0],sys.version_info[1])"],
-        capture_output=True, text=True,
-    )
+    try:
+        probe = subprocess.run(
+            [
+                interpreter,
+                "-c",
+                "import sys;print('FLOORPROBE',*sys.version_info[:2])",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        # A hung or unrunnable interpreter must not stall the suite. Treating
+        # it as "not available" is right: an interpreter we cannot question is
+        # one we cannot verify.
+        return None
     if probe.returncode != 0:
         return None
-    parts = probe.stdout.split()
-    if len(parts) != 2 or not all(p.isdigit() for p in parts):
-        return None
-    return int(parts[0]), int(parts[1])
+    # Scan for the marker line rather than parsing all of stdout. A site
+    # customisation, a warning routed to stdout, or a venv activation notice
+    # would otherwise make a perfectly good floor interpreter look unusable --
+    # and that failure is silent, because it degrades into the skip this whole
+    # module exists to avoid.
+    for line in probe.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 3 and fields[0] == "FLOORPROBE" and all(
+            field.isdigit() for field in fields[1:]
+        ):
+            return int(fields[1]), int(fields[2])
+    return None
 
 
 def test_every_module_compiles_on_the_declared_python_floor() -> None:
@@ -187,7 +207,12 @@ PEP701_CASES = [
 def test_detector_matches_the_pinned_floor_verdicts(
     source: str, expected_break: bool
 ) -> None:
-    """The detector's verdict on each pinned case, with no interpreter needed."""
+    """The detector's verdict on each pinned case, with no interpreter needed.
+
+    Args:
+        source: A one-line module whose floor-compatibility is pinned.
+        expected_break: Whether a real floor interpreter rejects ``source``.
+    """
     found = find_floor_breaks(source, path=Path("synthetic.py"))
     assert bool(found) == expected_break, (
         f"detector said {bool(found)} for {source!r}; expected {expected_break}"
@@ -256,8 +281,15 @@ def test_no_shipped_module_uses_syntax_the_floor_cannot_parse() -> None:
     which is precisely how `TTS/backends/kokoro.py` shipped unimportable on the
     declared floor.
     """
+    swept = list(iter_source_files(PACKAGE))
+    assert swept, (
+        "swept zero source files -- the sweep is misconfigured, and a guard "
+        "that checks nothing reports the same green as one that checks "
+        "everything"
+    )
+
     findings = []
-    for path in iter_source_files(PACKAGE):
+    for path in swept:
         try:
             source = path.read_text(encoding="utf-8")
         except OSError as exc:

--- a/Tests/Architecture/test_python_floor_syntax.py
+++ b/Tests/Architecture/test_python_floor_syntax.py
@@ -22,6 +22,7 @@ close.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -29,6 +30,8 @@ import sys
 from pathlib import Path
 
 import pytest
+
+from Tests.floor_syntax import find_floor_breaks, iter_source_files
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE = PROJECT_ROOT / "tldw_chatbook"
@@ -59,7 +62,29 @@ def _floor_interpreter(floor: tuple[int, int]) -> str | None:
         capture_output=True, text=True,
     )
     candidate = found.stdout.strip()
-    return candidate if found.returncode == 0 and candidate else None
+    if found.returncode != 0 or not candidate:
+        return None
+    return candidate
+
+
+def _reports_version(interpreter: str) -> tuple[int, int] | None:
+    """Ask an interpreter what version it actually is.
+
+    `python3.11` on PATH and `uv python find 3.11` are both *claims*. A guard
+    whose whole purpose is "the floor really parses this" must not accept a
+    claim it never checked -- a wrong interpreter here turns the check into a
+    second run of the developer's own version, which always passes.
+    """
+    probe = subprocess.run(
+        [interpreter, "-c", "import sys;print(sys.version_info[0],sys.version_info[1])"],
+        capture_output=True, text=True,
+    )
+    if probe.returncode != 0:
+        return None
+    parts = probe.stdout.split()
+    if len(parts) != 2 or not all(p.isdigit() for p in parts):
+        return None
+    return int(parts[0]), int(parts[1])
 
 
 def test_every_module_compiles_on_the_declared_python_floor() -> None:
@@ -68,6 +93,8 @@ def test_every_module_compiles_on_the_declared_python_floor() -> None:
         pytest.skip("already running on the declared floor")
 
     interpreter = _floor_interpreter(floor)
+    if interpreter is not None and _reports_version(interpreter) != floor:
+        interpreter = None
     if interpreter is None:
         pytest.skip(
             f"no Python {floor[0]}.{floor[1]} available to check the declared "
@@ -75,24 +102,171 @@ def test_every_module_compiles_on_the_declared_python_floor() -> None:
             f"{floor[0]}.{floor[1]}`) to enable this guard"
         )
 
+    # The file list is built HERE, on the running interpreter, and passed in --
+    # not re-globbed inside the probe. `iter_source_files` prunes `.venv` /
+    # `site-packages` / caches, and `.gitignore` does not affect `Path.rglob`:
+    # a nested virtualenv under the package root would otherwise feed
+    # third-party modules written for a newer Python into this check and report
+    # them as this project's floor breaks (TASK-19906 recorded exactly that for
+    # a sibling AST sweep).
+    sources = [str(path) for path in iter_source_files(PACKAGE)]
+    assert sources, "found no source files to check -- the sweep is misconfigured"
+
     probe = (
-        "import sys, pathlib\n"
+        "import sys, json\n"
         "bad = []\n"
-        f"for f in pathlib.Path({str(PACKAGE)!r}).rglob('*.py'):\n"
+        "for name in json.loads(sys.stdin.read()):\n"
         "    try:\n"
-        "        compile(f.read_text(encoding='utf-8'), str(f), 'exec')\n"
+        "        with open(name, encoding='utf-8') as handle:\n"
+        "            source = handle.read()\n"
+        "    except OSError as exc:\n"
+        # Not swallowed: a file this sweep cannot read is a file it did not
+        # check, and reporting that as success is the failure mode this whole
+        # module exists to avoid.
+        "        bad.append(f'{name}: unreadable: {exc}')\n"
+        "        continue\n"
+        "    try:\n"
+        "        compile(source, name, 'exec')\n"
         "    except SyntaxError as e:\n"
-        "        bad.append(f'{f}:{e.lineno}: {e.msg}')\n"
-        "    except Exception:\n"
-        "        pass\n"
+        "        bad.append(f'{name}:{e.lineno}: {e.msg}')\n"
         "print('\\n'.join(bad))\n"
     )
     result = subprocess.run(
-        [interpreter, "-c", probe], capture_output=True, text=True, timeout=300
+        [interpreter, "-c", probe],
+        input=json.dumps(sources),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"the floor probe itself failed on {interpreter}:\n{result.stderr}"
     )
     failures = result.stdout.strip()
     assert not failures, (
         f"modules fail to compile on Python {floor[0]}.{floor[1]}, the declared "
         f"minimum, even though they compile on {sys.version.split()[0]}:\n"
         f"{failures}"
+    )
+
+
+# --- The always-runs half -------------------------------------------------
+#
+# The compile check above is authoritative but SKIPPABLE, and a skip reports
+# exactly as much as a pass. Demonstrated on this branch: with a genuine PEP
+# 701 construct injected into `Utils/egress.py`, that test FAILS when 3.11 is
+# reachable and SKIPS GREEN with `PATH` stripped of `uv` and `python3.11`. The
+# detector below needs no floor interpreter, so it always has teeth -- at the
+# cost of covering only the class that actually shipped a broken module rather
+# than every possible incompatibility.
+
+#: (source, is_floor_break) pairs. Every verdict here was taken from a REAL
+#: 3.11 and a REAL 3.14 -- see `test_detector_agrees_with_the_real_floor`,
+#: which re-derives them from the floor interpreter itself rather than
+#: trusting this table. The table exists so the detector is still pinned when
+#: no floor interpreter is installed.
+PEP701_CASES = [
+    ('x = f"{value}"', False),
+    ('x = f"{ {"k": 1}["k"] }"', True),
+    ("""x = f"{ {'k': 1}['k'] }" """, False),
+    ("x = f'{ d['k'] }'", True),
+    ('x = f"""{ d["k"] }"""', False),
+    ('x = f"""{ d["""k"""] }"""', True),
+    ('x = f"{ f"{inner}" }"', True),
+    ("""x = f"{ f'{inner}' }" """, False),
+    ('x = f"{ chr(10).join(p) }"', False),
+    ('x = f"{ "a\\nb".strip() }"', True),
+    ("""x = f"{ 'a\\nb'.strip() }" """, True),
+    ('x = f"{v:\\>10}"', False),
+    ("""x = f'{ d["k"] }'""", False),
+    ('x = f"a" "b"', False),
+    ('x = f"{v:{width}}"', False),
+]
+
+
+@pytest.mark.parametrize("source, expected_break", PEP701_CASES)
+def test_detector_matches_the_pinned_floor_verdicts(
+    source: str, expected_break: bool
+) -> None:
+    """The detector's verdict on each pinned case, with no interpreter needed."""
+    found = find_floor_breaks(source, path=Path("synthetic.py"))
+    assert bool(found) == expected_break, (
+        f"detector said {bool(found)} for {source!r}; expected {expected_break}"
+        + (f"\nfindings: {[str(f) for f in found]}" if found else "")
+    )
+
+
+def test_detector_agrees_with_the_real_floor_interpreter() -> None:
+    """Re-derive every pinned verdict from the floor itself.
+
+    This is what stops `PEP701_CASES` from drifting into folklore: the table is
+    only trustworthy while it still matches what the interpreter does, and
+    hand-maintained expectations about another Python version are exactly the
+    kind of thing that rots. Skips when no floor interpreter is installed --
+    legitimate here, because this test validates the detector rather than the
+    package, and the detector stays pinned by the table either way.
+    """
+    floor = _declared_floor()
+    interpreter = _floor_interpreter(floor)
+    if interpreter is None or _reports_version(interpreter) != floor:
+        pytest.skip(
+            f"no Python {floor[0]}.{floor[1]} available to re-derive the "
+            "pinned verdicts from"
+        )
+
+    probe = (
+        "import sys, json\n"
+        "out = []\n"
+        "for src in json.loads(sys.stdin.read()):\n"
+        "    try:\n"
+        "        compile(src, '<case>', 'exec')\n"
+        "        out.append(False)\n"
+        "    except SyntaxError:\n"
+        "        out.append(True)\n"
+        "print(json.dumps(out))\n"
+    )
+    sources = [source for source, _ in PEP701_CASES]
+    result = subprocess.run(
+        [interpreter, "-c", probe],
+        input=json.dumps(sources),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"floor probe failed:\n{result.stderr}"
+    real = json.loads(result.stdout.strip().splitlines()[-1])
+
+    disagreements = [
+        f"{source!r}: real {floor[0]}.{floor[1]} says "
+        f"{'SyntaxError' if is_real else 'OK'}, table says "
+        f"{'SyntaxError' if expected else 'OK'}"
+        for (source, expected), is_real in zip(PEP701_CASES, real)
+        if expected != is_real
+    ]
+    assert not disagreements, "PEP701_CASES has drifted from reality:\n" + "\n".join(
+        disagreements
+    )
+
+
+def test_no_shipped_module_uses_syntax_the_floor_cannot_parse() -> None:
+    """The guard that never skips.
+
+    Runs the detector over every shipped module on whatever interpreter is
+    present. Partial by construction (see `Tests/floor_syntax`), but it cannot
+    be silently disabled by an environment that lacks a floor interpreter --
+    which is precisely how `TTS/backends/kokoro.py` shipped unimportable on the
+    declared floor.
+    """
+    findings = []
+    for path in iter_source_files(PACKAGE):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            findings.append(f"{path}: unreadable: {exc}")
+            continue
+        findings.extend(str(item) for item in find_floor_breaks(source, path=path))
+
+    floor = _declared_floor()
+    assert not findings, (
+        f"modules use syntax Python {floor[0]}.{floor[1]} cannot parse, so they "
+        f"cannot be imported on the declared floor:\n" + "\n".join(findings)
     )

--- a/Tests/floor_syntax.py
+++ b/Tests/floor_syntax.py
@@ -1,0 +1,200 @@
+# floor_syntax.py
+# Description: Interpreter-independent detection of PEP 701 floor breaks
+"""Detect f-string syntax that the project's Python FLOOR cannot parse.
+
+`Tests/Architecture/test_python_floor_syntax.py` compiles the package under a
+real floor interpreter, which is authoritative and complete. But it SKIPS when
+no such interpreter is installed, and a skip reports exactly as much as a pass
+-- so on a machine or CI runner without Python 3.11 the guard says nothing
+while a module that cannot import on the declared floor sails through.
+Demonstrated, not assumed: with a genuine PEP 701 construct injected into
+`Utils/egress.py`, that guard FAILS with 3.11 reachable and SKIPS GREEN with
+`PATH` stripped of `uv` and `python3.11`.
+
+This module is the always-runs half. It is deliberately PARTIAL: it covers the
+one class that actually shipped a broken module (TASK-19560 -- `TTS/backends/
+kokoro.py` could not be imported at all on 3.11 while every test passed on
+3.14), not every possible floor incompatibility. When a floor interpreter is
+available the compile check remains the real gate; this is the floor under the
+floor.
+
+WHAT IT DETECTS. PEP 701 (Python 3.12) lifted two restrictions on the
+expression part of an f-string. Both were verified against a real 3.11 and a
+real 3.14 rather than taken from the PEP text:
+
+* **Same delimiter.** A nested string using the f-string's own quote delimiter.
+  `f"{ d["k"] }"` is a 3.11 SyntaxError; `f"{ d['k'] }"` is fine, and so is
+  `f\"\"\"{ d["k"] }\"\"\"` -- the delimiter there is `\"\"\"`, not `"`, which is
+  why this compares the full delimiter rather than a single character.
+* **Backslash in the expression.** `f"{ 'a\\nb'.strip() }"` is a 3.11
+  SyntaxError even though the quotes differ. A backslash in a FORMAT SPEC
+  (`f"{v:\\>10}"`) is accepted by 3.11, and is not flagged, because a spec is
+  emitted as `FSTRING_MIDDLE` rather than as a nested `STRING` token.
+
+Both reduce to inspecting the `STRING` tokens nested inside an f-string, which
+is why this needs no parser of its own. `Tests/Architecture/
+test_python_floor_syntax.py` pins every case in the table above against the
+real interpreters' verdicts, so the two can never drift apart silently.
+
+NOTE ON THE RUNNING INTERPRETER: `FSTRING_START`/`FSTRING_END` tokens exist
+only from 3.12. Below that the tokenizer cannot produce the constructs this
+looks for -- and does not need to, because an interpreter at or below the
+floor rejects them itself at import.
+"""
+
+from __future__ import annotations
+
+import io
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+
+#: Directory names never swept for source. `.gitignore` does not affect
+#: `Path.rglob`, and a nested virtualenv under the package root will happily
+#: serve up third-party modules written for a newer Python -- reported as
+#: findings against this project (TASK-19906 recorded exactly that failure for
+#: a sibling AST sweep).
+EXCLUDED_DIRECTORY_NAMES = frozenset(
+    {
+        ".venv",
+        "venv",
+        "site-packages",
+        "node_modules",
+        "__pycache__",
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "build",
+        "dist",
+    }
+)
+
+
+@dataclass(frozen=True)
+class FloorBreak:
+    """One construct that the declared floor cannot parse."""
+
+    path: Path
+    line: int
+    reason: str
+    text: str
+
+    def __str__(self) -> str:  # pragma: no cover - human-readable only
+        return f"{self.path}:{self.line}: {self.reason}: {self.text}"
+
+
+def _delimiter_of(token_text: str) -> str:
+    """Return the quote delimiter of a string token, prefix stripped.
+
+    Args:
+        token_text: The raw source text of a STRING or FSTRING_START token,
+            e.g. ``rb'x'`` or ``f\"\"\"``.
+
+    Returns:
+        The delimiter -- one of ``'``, ``"``, ``'''``, ``\"\"\"`` -- or ``""``
+        if the token has no recognisable quote (which should not happen for a
+        well-formed token, and is treated as "nothing to compare" rather than
+        raising, so one odd token cannot take down a whole sweep).
+    """
+    index = 0
+    while index < len(token_text) and token_text[index] not in "\"'":
+        index += 1
+    if index >= len(token_text):
+        return ""
+    quote = token_text[index]
+    if token_text[index : index + 3] == quote * 3:
+        return quote * 3
+    return quote
+
+
+def find_floor_breaks(source: str, *, path: Path) -> list[FloorBreak]:
+    """Find PEP 701 constructs in ``source`` that the floor cannot parse.
+
+    Args:
+        source: The module source text.
+        path: The path to attribute findings to; not read.
+
+    Returns:
+        Every finding, in source order. Empty means "nothing of the covered
+        class", NOT "parses on the floor" -- see the module docstring.
+
+    Raises:
+        Nothing. A file that fails to tokenize returns no findings: on the
+        running interpreter that means it is already broken in a way the
+        ordinary suite reports far more clearly than this sweep would.
+    """
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(source).readline))
+    except (tokenize.TokenError, SyntaxError, IndentationError):
+        return []
+
+    findings: list[FloorBreak] = []
+    # A stack, not a flag: f-strings nest, and `f"{f"{x}"}"` is a floor break
+    # precisely BECAUSE the inner one reuses the outer's delimiter.
+    open_delimiters: list[str] = []
+    for token in tokens:
+        name = tokenize.tok_name[token.type]
+        if name == "FSTRING_START":
+            nested = _delimiter_of(token.string)
+            # An inner f-string is not a STRING token, so it needs its own
+            # check: `f"{f"{x}"}"` breaks the floor for exactly the same
+            # reason a nested plain string does -- it reuses the delimiter.
+            if nested and nested in open_delimiters:
+                findings.append(
+                    FloorBreak(
+                        path=path,
+                        line=token.start[0],
+                        reason=(
+                            f"nested f-string reuses the enclosing f-string's "
+                            f"{nested} delimiter (PEP 701, needs >= 3.12)"
+                        ),
+                        text=token.string,
+                    )
+                )
+            open_delimiters.append(nested)
+        elif name == "FSTRING_END":
+            if open_delimiters:
+                open_delimiters.pop()
+        elif name == "STRING" and open_delimiters:
+            nested = _delimiter_of(token.string)
+            if nested and nested in open_delimiters:
+                findings.append(
+                    FloorBreak(
+                        path=path,
+                        line=token.start[0],
+                        reason=(
+                            f"nested string reuses the enclosing f-string's "
+                            f"{nested} delimiter (PEP 701, needs >= 3.12)"
+                        ),
+                        text=token.string,
+                    )
+                )
+            elif "\\" in token.string:
+                findings.append(
+                    FloorBreak(
+                        path=path,
+                        line=token.start[0],
+                        reason=(
+                            "backslash inside an f-string expression "
+                            "(PEP 701, needs >= 3.12)"
+                        ),
+                        text=token.string,
+                    )
+                )
+    return findings
+
+
+def iter_source_files(root: Path):
+    """Yield every ``.py`` file under ``root``, skipping environment dirs.
+
+    Args:
+        root: Directory to walk.
+
+    Yields:
+        Paths to source files, excluding anything under a directory named in
+        ``EXCLUDED_DIRECTORY_NAMES``.
+    """
+    for path in sorted(root.rglob("*.py")):
+        if EXCLUDED_DIRECTORY_NAMES.isdisjoint(path.parts):
+            yield path

--- a/Tests/floor_syntax.py
+++ b/Tests/floor_syntax.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import io
 import tokenize
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -185,7 +186,7 @@ def find_floor_breaks(source: str, *, path: Path) -> list[FloorBreak]:
     return findings
 
 
-def iter_source_files(root: Path):
+def iter_source_files(root: Path) -> Iterator[Path]:
     """Yield every ``.py`` file under ``root``, skipping environment dirs.
 
     Args:
@@ -194,7 +195,17 @@ def iter_source_files(root: Path):
     Yields:
         Paths to source files, excluding anything under a directory named in
         ``EXCLUDED_DIRECTORY_NAMES``.
+
+    Note:
+        Only the components BELOW ``root`` are tested. Matching against the
+        absolute path would let the checkout's own location silence the sweep:
+        a repo living under any directory named `build`, `dist` or `venv`
+        excluded every file and yielded nothing, and a guard that sweeps zero
+        files passes -- reintroducing exactly the green-while-unchecked mode
+        this module exists to remove. Callers should still assert the yield is
+        non-empty; a sweep that finds no files is misconfigured, not clean.
     """
     for path in sorted(root.rglob("*.py")):
-        if EXCLUDED_DIRECTORY_NAMES.isdisjoint(path.parts):
+        relative = path.relative_to(root)
+        if EXCLUDED_DIRECTORY_NAMES.isdisjoint(relative.parts):
             yield path


### PR DESCRIPTION
A floor guard already existed (`Tests/Architecture/test_python_floor_syntax.py`, added in #1935). It has a hole, and the hole is the same shape as the bug it was written for.

## The hole

It compiles every module under a real floor interpreter — authoritative and complete — but **skips when none is installed**, and a skip reports exactly as much as a pass. Demonstrated rather than argued, by injecting a genuine PEP 701 construct into `Utils/egress.py`:

```
with uv/python3.11 reachable          ->  1 failed
with PATH stripped to /usr/bin:/bin   ->  SKIPPED ... 1 passed   <- green, with a broken module present
```

So on any machine or CI runner without 3.11, the guard said nothing while a module that cannot import on the declared floor sailed through — which is precisely how `TTS/backends/kokoro.py` shipped in the first place.

## What this adds

`Tests/floor_syntax.py`: an interpreter-independent detector for the class that actually shipped a broken module, plus a test that runs it over every shipped module **with no skip path**. It's deliberately partial — the compile check stays the real gate when an interpreter is available; this is the floor under the floor.

Both PEP 701 relaxations reduce to inspecting the `STRING` tokens nested inside an f-string, so it needs no parser of its own:

* **Same delimiter** — a nested string or f-string reusing the enclosing one. Compared as the *full* delimiter, because `f"""{ d["k"] }"""` is legal on 3.11 (delimiter is `"""`, not `"`).
* **Backslash in the expression** — 3.11 rejects `f"{ 'a\nb'.strip() }"` even though the quotes differ, while a backslash in a *format spec* (`f"{v:\>10}"`) is fine and is not flagged.

**Verdicts come from real interpreters, not from the PEP text.** The detector agrees with a real 3.11 on all 15 cases, and `test_detector_agrees_with_the_real_floor_interpreter` re-derives every pinned verdict from the floor itself — so the table can't quietly rot into folklore. Writing it this way earned its keep immediately: my first implementation was 14/15, missing `f"{ f"{inner}" }"` because a nested *f-string* emits `FSTRING_START`, not `STRING`. The ground-truth comparison caught that; my reasoning had not.

## It also hardens the existing compile check

* Builds the file list with `iter_source_files`, pruning `.venv` / `site-packages` / caches. `.gitignore` does not affect `Path.rglob` — this is the **TASK-19906** class, already in the lessons file. Load-bearing, not theoretical: a planted third-party module in a nested venv **is** reported by a naive sweep (1801 files vs 1800, one false finding).
* Stops `except Exception: pass` swallowing read errors. A file the sweep could not read is a file it did not check, and reporting that as success is the exact failure mode this module exists to prevent.
* Verifies the located interpreter **really reports the floor version**. Both `python3.11` on `PATH` and `uv python find 3.11` are *claims*; an unverified one silently turns the guard into a second run of the developer's own interpreter, which always passes.
* Asserts the probe's own exit status rather than inferring success from empty stdout.

## Verification

Red-proofed three ways:

1. A floor break is caught **with no interpreter present** — the scenario that was previously all-green.
2. Corrupting one pinned verdict fails the reality check, naming the disagreement: `real 3.11 says SyntaxError, table says OK`.
3. A planted floor-breaking module inside a nested venv is correctly **ignored**.

18 passed on 3.12 and on 3.14. On 3.11 itself the detector correctly returns nothing — `FSTRING_START` tokens don't exist there, and an interpreter at the floor rejects these constructs itself at import, which the ordinary suite reports far more clearly.

Companion to #1965, which records the interpreter-drift class in the lessons file. That PR is docs; this one is the guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give the Python floor guard teeth when no floor interpreter exists and harden the compile-on-floor path. Previously the architecture test skipped without 3.11 and looked green; now an interpreter-independent scan fails on PEP 701 f-string constructs the floor cannot parse.

- Adds `Tests/floor_syntax.py`, which detects two PEP 701 cases inside f-strings (reusing the enclosing delimiter; backslashes in expressions). Pinned verdicts match real floor behavior, and a test re-derives them from the floor interpreter; the compile check remains the authority when a floor interpreter is available.
- Strengthens `Tests/Architecture/test_python_floor_syntax.py`: verifies the located interpreter actually reports the floor via `_reports_version` (marker-based parsing, timeout), asserts the probe exit status, and feeds a pruned, explicit source list over stdin instead of re-globbing.
- Fixes sweep pruning: `iter_source_files` now excludes only directories below the repo root, and the test asserts the sweep is non-empty. It prunes `.venv`/`site-packages`/caches and reports unreadable files instead of ignoring them.
- Addresses TASK-19560 (prevent shipping floor-incompatible modules) and TASK-19906 (avoid env dirs in sweeps).

<sup>Written for commit bdebb653e1de47c8da3721a7f42c8b314d63f969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

