### PR TITLE
Complete Remote model adoption handoff

### DIFF
--- a/Tests/UI/test_llm_gguf_source_modes.py
+++ b/Tests/UI/test_llm_gguf_source_modes.py
@@ -426,6 +426,74 @@ async def test_managed_selector_uses_exact_refs_and_path_free_labels(
 
 
 @pytest.mark.asyncio
+async def test_configure_managed_gguf_opens_runtime_and_preselects_exact_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote adoption configures source state without starting or activating."""
+    choices = (
+        ManagedGGUFChoice(REF_A, "Model A · Q4_K_M · 4 MiB · Managed"),
+        ManagedGGUFChoice(REF_B, "Model B · Q8_0 · 8 MiB · Managed"),
+    )
+    app, pilot, context, _screen, window, _service = await _mount_models(
+        monkeypatch,
+        choices=choices,
+    )
+    try:
+        accepted = window.configure_managed_gguf("llamafile", REF_B)
+        await pilot.pause()
+
+        selection = window.gguf_source_snapshot("llamafile")
+        assert accepted is True
+        assert window.active_view == "llamafile"
+        assert selection.mode is GGUFSourceMode.MANAGED
+        assert selection.managed_ref == REF_B
+        assert window.query_one("#llamafile-gguf-source-mode", Select).value == "managed"
+        assert window.query_one("#llamafile-gguf-managed-select", Select).value == REF_B
+        assert current_server_claim(app, "llamafile") is None
+    finally:
+        await _close_context(context)
+
+
+@pytest.mark.asyncio
+async def test_configure_managed_gguf_waits_for_fresh_exact_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A just-downloaded ref is selected only after inventory proves it exists."""
+    choice_a = ManagedGGUFChoice(REF_A, "Model A · Q4_K_M · 4 MiB · Managed")
+    choice_b = ManagedGGUFChoice(REF_B, "Model B · Q8_0 · 8 MiB · Managed")
+    _app, pilot, context, _screen, window, _service = await _mount_models(
+        monkeypatch,
+        choices=(choice_a,),
+    )
+    try:
+        monkeypatch.setattr(
+            window_module,
+            "managed_gguf_choices",
+            lambda _installed: (choice_a, choice_b),
+        )
+        generation = window._managed_gguf_inventory_generation
+
+        assert window.configure_managed_gguf("llamacpp", REF_B) is True
+        await _settle_pilot_until(
+            pilot,
+            lambda: (
+                window._managed_gguf_inventory_generation > generation
+                and window.query_one(
+                    "#llamacpp-gguf-managed-select", Select
+                ).value
+                == REF_B
+            ),
+            message="fresh exact managed GGUF was not selected",
+        )
+
+        selection = window.gguf_source_snapshot("llamacpp")
+        assert selection.mode is GGUFSourceMode.MANAGED
+        assert selection.managed_ref == REF_B
+    finally:
+        await _close_context(context)
+
+
+@pytest.mark.asyncio
 async def test_inventory_runs_off_loop_and_stale_results_are_ignored(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/Tests/UI/test_llm_gguf_source_modes.py
+++ b/Tests/UI/test_llm_gguf_source_modes.py
@@ -494,6 +494,28 @@ async def test_configure_managed_gguf_waits_for_fresh_exact_inventory(
 
 
 @pytest.mark.asyncio
+async def test_configure_managed_gguf_rejects_if_server_starts_before_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refresh guard race cannot strand an accepted runtime handoff."""
+    choice_a = ManagedGGUFChoice(REF_A, "Model A · Q4_K_M · 4 MiB · Managed")
+    _app, _pilot, context, _screen, window, _service = await _mount_models(
+        monkeypatch,
+        choices=(choice_a,),
+    )
+    try:
+        states = iter((False, False, True))
+        monkeypatch.setattr(window, "_server_active", lambda _provider: next(states))
+        generation = window._managed_gguf_inventory_generation
+
+        assert window.configure_managed_gguf("llamacpp", REF_B) is False
+        assert window._pending_managed_gguf_handoff is None
+        assert window._managed_gguf_inventory_generation == generation
+    finally:
+        await _close_context(context)
+
+
+@pytest.mark.asyncio
 async def test_inventory_runs_off_loop_and_stale_results_are_ignored(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -3968,6 +3968,27 @@ def test_configure_runtime_request_opens_choice_and_preserves_exact_reference(
     )
 
 
+def test_runtime_refresh_rejection_clears_screen_owned_handoff():
+    """A synchronous lifecycle refusal cannot survive as pending intent."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    reference = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    screen = LLMScreen.__new__(LLMScreen)
+    screen.llm_window = MagicMock()
+    screen.llm_window.configure_managed_gguf.return_value = False
+    screen._remote_runtime_handoff = None
+    screen.notify = MagicMock()
+
+    screen._remote_runtime_selected(reference, "llamacpp")
+
+    assert screen._remote_runtime_handoff is None
+    screen.notify.assert_called_once_with(
+        "Stop the active Llama.cpp or Llamafile server, then configure this "
+        "managed model again.",
+        severity="warning",
+    )
+
+
 @pytest.mark.asyncio
 async def test_pending_runtime_handoff_replays_into_recomposed_models_window(
     monkeypatch,

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -655,6 +655,78 @@ async def test_remote_two_pane_install_action_stays_inside_real_models_body_at_8
 
 
 @pytest.mark.asyncio
+async def test_remote_completion_and_runtime_choice_fit_real_models_at_80_columns():
+    """The complete adoption path must remain painted and keyboard-operable."""
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+    from tldw_chatbook.Widgets.ModelArtifacts import ManagedGGUFRuntimeChoiceModal
+
+    app = _app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        screen = await _models_screen(app)
+        assert await _wait_for(lambda: bool(screen.query("#remote-models-view")), pilot)
+
+        remote_row = next(
+            row for row in _rail_rows(screen) if row.lab_view_key == "remote"
+        )
+        remote_row.press()
+        await pilot.pause()
+
+        window = screen.query_one(LLMManagementWindow)
+        remote = window.query_one("#remote-models-view", RemoteView)
+        resolved = _resolved_remote_model()
+        remote.query_one("#remote-model-query", Input).value = resolved.repository
+        remote._resolve_generation = 1
+        remote._apply_resolve_result(
+            1,
+            resolved.repository,
+            resolved.repository,
+            resolved,
+            None,
+        )
+        await pilot.pause()
+        remote.query_one(".remote-candidate", Button).press()
+        await pilot.pause()
+
+        reference = _remote_catalog().artifact.reference
+        remote.finish_install(
+            "Model downloaded and managed.",
+            completed_reference=reference,
+        )
+        await pilot.pause()
+
+        parent = window.query_one("#llm-view-remote")
+        open_installed = remote.query_one("#remote-model-open-installed", Button)
+        configure = remote.query_one("#remote-model-configure-runtime", Button)
+        _assert_painted_inside(app, open_installed, parent)
+        _assert_painted_inside(app, configure, parent)
+        assert (
+            open_installed.region.bottom <= configure.region.y
+            or open_installed.region.right <= configure.region.x
+        )
+
+        open_installed.focus()
+        await pilot.press("tab")
+        assert app.focused is configure
+        await pilot.press("enter")
+        await pilot.pause()
+
+        modal = app.screen
+        assert isinstance(modal, ManagedGGUFRuntimeChoiceModal)
+        dialog = modal.query_one(".managed-gguf-runtime-modal")
+        llama_cpp = modal.query_one("#managed-gguf-runtime-llamacpp", Button)
+        llamafile = modal.query_one("#managed-gguf-runtime-llamafile", Button)
+        cancel = modal.query_one("#managed-gguf-runtime-cancel", Button)
+        _assert_painted_inside(app, dialog, modal)
+        for action in (llama_cpp, llamafile, cancel):
+            _assert_painted_inside(app, action, dialog)
+        assert app.focused is llama_cpp
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen is screen
+
+
+@pytest.mark.asyncio
 async def test_the_window_no_longer_carries_nav_buttons():
     app = _app()
     async with app.run_test(size=(120, 40)) as pilot:
@@ -3588,7 +3660,7 @@ def test_apply_remote_provision_result_notifies_mirrors_and_resets_state(
     screen._model_install_reference = reference
     screen._model_install_service = MagicMock()
     screen._model_install_catalog = catalog
-    screen._model_install_candidate = None
+    screen._model_install_candidate = _resolved_remote_model().candidates[0]
     screen._model_install_credential_resolver = MagicMock()
     screen._model_install_pending_report = object()
     screen._model_install_kind = "remote"
@@ -3612,7 +3684,13 @@ def test_apply_remote_provision_result_notifies_mirrors_and_resets_state(
     assert delivered.active is False
     assert delivered.succeeded == (error is None)
 
-    view.finish_install.assert_called_once_with(expected_message)
+    if error is None:
+        view.finish_install.assert_called_once_with(
+            expected_message,
+            completed_reference=reference,
+        )
+    else:
+        view.finish_install.assert_called_once_with(expected_message)
 
 
 @pytest.mark.parametrize(
@@ -3678,7 +3756,317 @@ def test_remote_terminal_outcome_crosses_the_recompose_gap(
     module.LLMScreen._hydrate_model_install_progress(screen)
 
     fresh_view.restore_install_context.assert_called_once_with(catalog, candidate)
-    getattr(fresh_view, expected_method).assert_called_once_with(expected_message)
+    outcome = getattr(fresh_view, expected_method)
+    if terminal_path == "provision" and error is None:
+        outcome.assert_called_once_with(
+            expected_message,
+            completed_reference=catalog.artifact.reference,
+        )
+    else:
+        outcome.assert_called_once_with(expected_message)
+
+
+def test_successful_remote_completion_survives_later_recomposes(monkeypatch):
+    """A consumed success remains durable until Remote starts new discovery."""
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+    catalog = _remote_catalog()
+    candidate = _resolved_remote_model().candidates[0]
+    reference = catalog.artifact.reference
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._deliver_curated = MagicMock()
+    screen._remote_view = MagicMock(return_value=None)
+    screen._installed_view = MagicMock(return_value=None)
+    screen._model_install_worker = MagicMock()
+    screen._model_install_reference = reference
+    screen._model_install_service = MagicMock()
+    screen._model_install_catalog = catalog
+    screen._model_install_candidate = candidate
+    screen._model_install_credential_resolver = MagicMock()
+    screen._model_install_pending_report = object()
+    screen._model_install_kind = "remote"
+    screen._model_install_active = False
+    screen._model_install_last_progress = None
+    screen._remote_install_terminal_catalog = None
+    screen._remote_install_terminal_candidate = None
+    screen._remote_install_terminal_action = None
+    screen._remote_install_terminal_message = None
+    screen._remote_install_completed_catalog = None
+    screen._remote_install_completed_candidate = None
+    screen._remote_install_completed_reference = None
+    screen._remote_install_completed_message = None
+
+    module.LLMScreen._apply_remote_provision_result(screen, None)
+
+    first_view = MagicMock(is_mounted=True)
+    first_view.restore_install_context.return_value = True
+    screen._remote_view.return_value = first_view
+    module.LLMScreen._hydrate_model_install_progress(screen)
+
+    second_view = MagicMock(is_mounted=True)
+    second_view.restore_install_context.return_value = True
+    screen._remote_view.return_value = second_view
+    module.LLMScreen._hydrate_model_install_progress(screen)
+
+    for view in (first_view, second_view):
+        view.restore_install_context.assert_called_once_with(catalog, candidate)
+        view.finish_install.assert_called_once_with(
+            "Model downloaded and managed. Runtime compatibility has not been verified.",
+            completed_reference=reference,
+        )
+
+
+def test_new_remote_discovery_clears_durable_completion_identity():
+    """A new query supersedes the prior completed model at screen scope."""
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._remote_install_completed_catalog = object()
+    screen._remote_install_completed_candidate = object()
+    screen._remote_install_completed_reference = object()
+    screen._remote_install_completed_message = "done"
+
+    screen._remote_discovery_started(RemoteView.DiscoveryStarted("new model"))
+
+    assert screen._remote_install_completed_catalog is None
+    assert screen._remote_install_completed_candidate is None
+    assert screen._remote_install_completed_reference is None
+    assert screen._remote_install_completed_message is None
+
+
+def test_open_installed_switches_and_reveals_exact_reference_without_activation():
+    """The Remote completion action is navigation, never implicit activation."""
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    reference = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.llm_window = MagicMock()
+    installed = MagicMock()
+    screen._installed_view = MagicMock(return_value=installed)
+    screen.call_after_refresh = MagicMock(
+        side_effect=lambda callback, *args: callback(*args)
+    )
+    event = RemoteView.OpenInstalledRequested(reference)
+
+    screen._remote_open_installed_requested(event)
+
+    assert screen.llm_window.active_view == "installed"
+    screen.call_after_refresh.assert_called_once_with(
+        installed.reveal_reference,
+        reference,
+    )
+    installed.reveal_reference.assert_called_once_with(reference)
+    assert not any(
+        call[0] == "activate"
+        for call in installed.method_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_installed_exact_row_focus_wins_real_window_switch(
+    tmp_path,
+):
+    """The handoff focus must run after Installed's standard focus restore."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_browser_state import InventoryRow
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    reference = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    row = InventoryRow(
+        path=tmp_path / reference.artifact_id,
+        reference=reference,
+        model_label=reference.artifact_id,
+        revision=reference.revision,
+        precision=reference.variant,
+        dependencies=(),
+        ready=True,
+        active=False,
+        activation_allowed=True,
+        is_broken=False,
+        is_unmanaged=False,
+        provenance="Integrity verified",
+        action_hint="Ready",
+        error=None,
+        size_bytes=1024,
+        installed_store_bytes=1024,
+        staging_store_bytes=0,
+        free_bytes=4096,
+    )
+
+    app = _app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        screen = await _models_screen(app)
+        assert await _wait_for(
+            lambda: bool(screen.query("#installed-models-view")),
+            pilot,
+        )
+        window = screen.query_one(LLMManagementWindow)
+        installed = window.query_one("#installed-models-view", InstalledView)
+        installed._loaded = True
+        installed._rows = (row,)
+        installed.refresh(recompose=True)
+        assert await _wait_for(
+            lambda: bool(installed.query(".installed-model-row")),
+            pilot,
+        )
+        window._model_library_focus_ids["installed"] = "installed-models-refresh"
+
+        screen._remote_open_installed_requested(
+            RemoteView.OpenInstalledRequested(reference)
+        )
+        for _ in range(4):
+            await pilot.pause()
+
+        focused = app.focused
+        assert window.active_view == "installed"
+        assert focused is not None
+        assert focused.has_class("model-activate")
+        assert any(
+            getattr(ancestor, "reference", None) == reference
+            for ancestor in focused.ancestors_with_self
+        )
+
+
+def test_configure_runtime_request_opens_choice_and_preserves_exact_reference(
+    monkeypatch,
+):
+    """The host owns provider choice while Remote contributes only identity."""
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+    from tldw_chatbook.Widgets.ModelArtifacts import ManagedGGUFRuntimeChoiceModal
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+    reference = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.llm_window = MagicMock()
+    screen.llm_window.configure_managed_gguf.return_value = True
+    event = RemoteView.ConfigureRuntimeRequested(reference)
+
+    screen._remote_configure_runtime_requested(event)
+
+    modal, callback = fake_app.push_screen.call_args.args
+    assert isinstance(modal, ManagedGGUFRuntimeChoiceModal)
+    callback("llamacpp")
+    screen.llm_window.configure_managed_gguf.assert_called_once_with(
+        "llamacpp",
+        reference,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_runtime_handoff_replays_into_recomposed_models_window(
+    monkeypatch,
+):
+    """A fresh Models body must retain a still-resolving exact handoff."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    reference = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    accepted: list[tuple[LLMManagementWindow, str, ArtifactRef]] = []
+
+    def configure(
+        window: LLMManagementWindow,
+        provider: str,
+        received: ArtifactRef,
+    ) -> bool:
+        accepted.append((window, provider, received))
+        return True
+
+    monkeypatch.setattr(LLMManagementWindow, "configure_managed_gguf", configure)
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        assert await _wait_for(lambda: bool(screen.query("#remote-models-view")), pilot)
+        first_window = screen.query_one(LLMManagementWindow)
+
+        screen._remote_runtime_selected(reference, "llamacpp")
+        assert accepted == [(first_window, "llamacpp", reference)]
+
+        screen.refresh(recompose=True)
+        assert await _wait_for(
+            lambda: screen.llm_window is not first_window
+            and screen.llm_window is not None
+            and screen.llm_window.is_attached,
+            pilot,
+        )
+        replacement = screen.llm_window
+        assert replacement is not None
+        assert await _wait_for(lambda: len(accepted) == 2, pilot)
+
+        assert accepted == [
+            (first_window, "llamacpp", reference),
+            (replacement, "llamacpp", reference),
+        ]
+
+
+def test_runtime_handoff_clears_only_after_matching_window_resolution():
+    """Detached-window results cannot clear a replacement window's intent."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    reference = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    stale = ArtifactRef("other-gguf", "b" * 40, "q8_0")
+    screen = LLMScreen.__new__(LLMScreen)
+    screen._remote_runtime_handoff = ("llamacpp", reference)
+    screen.notify = MagicMock()
+
+    screen._managed_gguf_handoff_resolved(
+        LLMManagementWindow.ManagedGGUFHandoffResolved(
+            "llamacpp",
+            stale,
+            succeeded=True,
+        )
+    )
+    assert screen._remote_runtime_handoff == ("llamacpp", reference)
+
+    screen._managed_gguf_handoff_resolved(
+        LLMManagementWindow.ManagedGGUFHandoffResolved(
+            "llamacpp",
+            reference,
+            succeeded=True,
+        )
+    )
+    assert screen._remote_runtime_handoff is None
+    screen.notify.assert_not_called()
+
+
+def test_runtime_handoff_failure_surfaces_inventory_specific_recovery():
+    """A resolved inventory failure clears intent with actionable copy."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    reference = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    screen = LLMScreen.__new__(LLMScreen)
+    screen._remote_runtime_handoff = ("llamafile", reference)
+    screen.notify = MagicMock()
+
+    screen._managed_gguf_handoff_resolved(
+        LLMManagementWindow.ManagedGGUFHandoffResolved(
+            "llamafile",
+            reference,
+            succeeded=False,
+            reason="inventory-error",
+        )
+    )
+
+    assert screen._remote_runtime_handoff is None
+    screen.notify.assert_called_once_with(
+        "Managed models could not be loaded. Refresh Installed models, then try again.",
+        severity="warning",
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_model_artifact_widgets.py
+++ b/Tests/UI/test_model_artifact_widgets.py
@@ -249,6 +249,45 @@ async def test_confirm_and_cancel_return_decisions(tmp_path: Path) -> None:
         assert decisions == [True, False]
 
 
+@pytest.mark.asyncio
+async def test_runtime_choice_modal_explains_and_returns_explicit_provider() -> None:
+    """Runtime handoff is an informed choice and cannot start a server itself."""
+    from tldw_chatbook.Widgets.ModelArtifacts import ManagedGGUFRuntimeChoiceModal
+
+    app = _ModalApp()
+    decisions: list[str | None] = []
+    async with app.run_test() as pilot:
+        await app.push_screen(ManagedGGUFRuntimeChoiceModal(), decisions.append)
+        await pilot.pause()
+
+        painted = "\n".join(
+            str(item.renderable) for item in app.screen.query(Static)
+        )
+        assert "Llama.cpp" in str(
+            app.screen.query_one("#managed-gguf-runtime-llamacpp", Button).label
+        )
+        assert "Llamafile" in str(
+            app.screen.query_one("#managed-gguf-runtime-llamafile", Button).label
+        )
+        assert "does not activate it or start a server" in painted
+        assert app.focused is app.screen.query_one(
+            "#managed-gguf-runtime-llamacpp", Button
+        )
+
+        await pilot.click("#managed-gguf-runtime-llamacpp")
+        await pilot.pause()
+
+        await app.push_screen(ManagedGGUFRuntimeChoiceModal(), decisions.append)
+        await pilot.click("#managed-gguf-runtime-llamafile")
+        await pilot.pause()
+
+        await app.push_screen(ManagedGGUFRuntimeChoiceModal(), decisions.append)
+        await pilot.press("escape")
+        await pilot.pause()
+
+    assert decisions == ["llamacpp", "llamafile", None]
+
+
 @pytest.mark.parametrize("source", ["visible", "escape", "backdrop"])
 @pytest.mark.asyncio
 async def test_model_install_library_modal_contract_exact_negative_once(

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -161,6 +161,31 @@ def _unmanaged_inventory(source: Path):
     )
 
 
+def _managed_inventory_row(tmp_path: Path, reference: ArtifactRef):
+    from tldw_chatbook.UI.Screens.model_browser_state import InventoryRow
+
+    return InventoryRow(
+        path=tmp_path / reference.artifact_id,
+        reference=reference,
+        model_label=reference.artifact_id,
+        revision=reference.revision,
+        precision=reference.variant,
+        dependencies=(),
+        ready=True,
+        active=False,
+        activation_allowed=True,
+        is_broken=False,
+        is_unmanaged=False,
+        provenance="Integrity verified",
+        action_hint="Ready",
+        error=None,
+        size_bytes=1024,
+        installed_store_bytes=2048,
+        staging_store_bytes=0,
+        free_bytes=4096,
+    )
+
+
 async def _wait_until(pilot, predicate, *, timeout_seconds: float = 10.0) -> None:
     """Pump Textual until a cross-thread observation becomes true.
 
@@ -243,6 +268,153 @@ async def test_installed_view_performs_no_io_at_compose_time(tmp_path: Path) -> 
         await pilot.pause()
 
     service_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reveal_reference_focuses_the_exact_installed_row_without_activation(
+    tmp_path: Path,
+) -> None:
+    """Open Installed locates one exact managed identity and remains read-only."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    target = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    other = ArtifactRef("other-gguf", "b" * 40, "q8_0")
+
+    service_factory = MagicMock()
+    view = InstalledView(service_factory=service_factory, legacy_dir=tmp_path)
+    view._loaded = True
+    view._rows = (
+        _managed_inventory_row(tmp_path, other),
+        _managed_inventory_row(tmp_path, target),
+    )
+    app = _InstalledApp(view)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        view.reveal_reference(target)
+        await _wait_until(
+            pilot,
+            lambda: any(
+                widget.has_class("-revealed")
+                for widget in view.query(".installed-model-row")
+            ),
+        )
+        await _wait_until(
+            pilot,
+            lambda: app.focused is not None
+            and any(
+                getattr(ancestor, "reference", None) == target
+                for ancestor in app.focused.ancestors_with_self
+            ),
+        )
+
+        target_row = next(
+            widget
+            for widget in view.query(".installed-model-row")
+            if getattr(widget, "reference", None) == target
+        )
+        focused = app.focused
+
+        assert target_row.has_class("-revealed")
+        assert focused is not None
+        assert target_row in focused.ancestors_with_self
+        assert focused.has_class("model-activate")
+        assert target_row in app.screen._compositor.visible_widgets
+
+    service_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reveal_reference_focuses_after_a_fresh_inventory_load(
+    tmp_path: Path,
+) -> None:
+    """A just-downloaded model is located even when Installed was initially stale."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    target = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    app = _InstalledApp(view)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        view.ensure_loaded = MagicMock()
+        view.reveal_reference(target)
+        view._apply_inventory(
+            (_managed_inventory_row(tmp_path, target),),
+            ArtifactDiskUsage(1024, 0, 4096),
+            None,
+        )
+        await _wait_until(
+            pilot,
+            lambda: app.focused is not None
+            and any(
+                getattr(ancestor, "reference", None) == target
+                for ancestor in app.focused.ancestors_with_self
+            ),
+        )
+
+        assert view.ensure_loaded.call_args.kwargs == {"force": True}
+        assert app.focused is not None
+        assert app.focused.has_class("model-activate")
+
+
+@pytest.mark.asyncio
+async def test_reveal_reference_missing_after_successful_refresh_surfaces_recovery(
+    tmp_path: Path,
+) -> None:
+    """A vanished exact ref clears pending focus and explains recovery inline."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    target = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    app = _InstalledApp(view)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        view.ensure_loaded = MagicMock()
+        view.reveal_reference(target)
+        view._apply_inventory(
+            (),
+            ArtifactDiskUsage(0, 0, 4096),
+            None,
+        )
+        await _wait_until(
+            pilot,
+            lambda: bool(view.query("#installed-reveal-status")),
+        )
+
+        recovery = view.query_one("#installed-reveal-status", Static)
+        assert view._revealed_reference is None
+        assert str(recovery.renderable) == (
+            "That managed model is no longer available. Refresh Installed models "
+            "and try again."
+        )
+        assert str(tmp_path) not in str(recovery.renderable)
+
+
+@pytest.mark.asyncio
+async def test_reveal_reference_inventory_error_keeps_retryable_identity(
+    tmp_path: Path,
+) -> None:
+    """A load failure stays distinct from proof that the exact ref vanished."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    target = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    app = _InstalledApp(view)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        view.ensure_loaded = MagicMock()
+        view.reveal_reference(target)
+        view._apply_inventory(
+            (),
+            None,
+            "The local model inventory could not be loaded.",
+        )
+        await pilot.pause()
+
+        assert view._revealed_reference == target
+        assert not view.query("#installed-reveal-status")
+        assert "The local model inventory could not be loaded." in _rendered_static_text(
+            view
+        )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -324,6 +324,42 @@ async def test_reveal_reference_focuses_the_exact_installed_row_without_activati
 
 
 @pytest.mark.asyncio
+async def test_reveal_reference_never_auto_focuses_delete_when_activation_unavailable(
+    tmp_path: Path,
+) -> None:
+    """A revealed non-activatable row keeps focus on a safe header action."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    target = ArtifactRef("remote-gguf", "a" * 40, "q4_k_m")
+    row = replace(
+        _managed_inventory_row(tmp_path, target),
+        activation_allowed=False,
+    )
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    view._loaded = True
+    view._rows = (row,)
+    app = _InstalledApp(view)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _wait_until(pilot, lambda: bool(view.query(".model-delete")))
+        refresh = view.query_one("#installed-models-refresh", Button)
+        refresh.focus()
+        view.reveal_reference(target)
+        await _wait_until(
+            pilot,
+            lambda: any(
+                widget.has_class("-revealed")
+                for widget in view.query(".installed-model-row")
+            ),
+        )
+        await pilot.pause()
+
+        delete = view.query_one(".model-delete", Button)
+        assert app.focused is refresh
+        assert app.focused is not delete
+
+
+@pytest.mark.asyncio
 async def test_reveal_reference_focuses_after_a_fresh_inventory_load(
     tmp_path: Path,
 ) -> None:

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -619,6 +619,46 @@ async def test_two_pane_layout_and_install_action_paint_at_eighty_columns() -> N
 
 
 @pytest.mark.asyncio
+async def test_completion_actions_paint_and_tab_at_eighty_columns() -> None:
+    """Both post-download handoffs remain visible and keyboard reachable."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    resolved = _resolved()
+    reference = ArtifactRef("owner-repository", "a" * 40, "q4_k_m")
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        view.query_one("#remote-model-query", Input).value = resolved.repository
+        view._resolve_generation = 1
+        view._apply_resolve_result(
+            1,
+            resolved.repository,
+            resolved.repository,
+            resolved,
+            None,
+        )
+        await pilot.pause()
+        view.query_one(".remote-candidate", Button).press()
+        view.finish_install("done", completed_reference=reference)
+        await pilot.pause()
+
+        open_installed = view.query_one("#remote-model-open-installed", Button)
+        configure = view.query_one("#remote-model-configure-runtime", Button)
+        for button in (open_installed, configure):
+            button.scroll_visible(animate=False, immediate=True, force=True)
+            await pilot.pause()
+            widget, _offset = app.get_widget_at(*button.region.center)
+            assert button in app.screen._compositor.visible_widgets
+            assert button.region.bottom <= view.region.bottom
+            assert widget is button
+
+        app.screen.set_focus(open_installed)
+        await pilot.press("tab")
+        assert app.focused is configure
+
+
+@pytest.mark.asyncio
 async def test_stale_search_and_resolve_completions_cannot_replace_newer_results() -> (
     None
 ):
@@ -1379,6 +1419,222 @@ async def test_finish_install_clears_the_indicator_progress_and_shows_the_given_
         status = str(view.query_one("#remote-model-status", Static).renderable)
 
     assert status == "Model downloaded and managed."
+
+
+@pytest.mark.asyncio
+async def test_successful_install_exposes_provider_attributed_adoption_actions() -> None:
+    """A verified Remote download ends in explicit next actions, not another install."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    resolved = _resolved()
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+    reference = ArtifactRef("owner-repository", "a" * 40, "q4_k_m")
+
+    async with app.run_test() as pilot:
+        query = view.query_one("#remote-model-query", Input)
+        query.value = resolved.repository
+        view._resolve_generation = 1
+        view._apply_resolve_result(
+            1,
+            resolved.repository,
+            resolved.repository,
+            resolved,
+            None,
+        )
+        await pilot.pause()
+        view.query_one(".remote-candidate", Button).press()
+        await pilot.pause()
+
+        view.finish_install(
+            "Model downloaded and managed.",
+            completed_reference=reference,
+        )
+        await pilot.pause()
+
+        rendered = _text(view)
+        open_installed = view.query_one("#remote-model-open-installed", Button)
+        configure = view.query_one("#remote-model-configure-runtime", Button)
+
+        assert "Source: Hugging Face" in rendered
+        assert "Downloaded · Verified · Managed · Not active" in rendered
+        assert open_installed.disabled is False
+        assert configure.disabled is False
+        assert list(view.query("#remote-model-install")) == []
+
+
+@pytest.mark.asyncio
+async def test_open_installed_posts_the_exact_completed_reference() -> None:
+    """The completion action carries managed identity without filename recovery."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    resolved = _resolved()
+    reference = ArtifactRef("owner-repository", "a" * 40, "q4_k_m")
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+
+    class _AdoptionApp(ConsolidatedCSSApp):
+        def __init__(self) -> None:
+            self.opened: list[ArtifactRef] = []
+            super().__init__()
+
+        def compose(self) -> ComposeResult:
+            yield view
+
+        @on(RemoteView.OpenInstalledRequested)
+        def _opened(self, event: RemoteView.OpenInstalledRequested) -> None:
+            self.opened.append(event.reference)
+
+    app = _AdoptionApp()
+    async with app.run_test() as pilot:
+        query = view.query_one("#remote-model-query", Input)
+        query.value = resolved.repository
+        view._resolve_generation = 1
+        view._apply_resolve_result(
+            1,
+            resolved.repository,
+            resolved.repository,
+            resolved,
+            None,
+        )
+        await pilot.pause()
+        view.query_one(".remote-candidate", Button).press()
+        await pilot.pause()
+        view.finish_install(
+            "Model downloaded and managed.",
+            completed_reference=reference,
+        )
+        await pilot.pause()
+
+        view.query_one("#remote-model-open-installed", Button).press()
+        await pilot.pause()
+
+    assert app.opened == [reference]
+
+
+@pytest.mark.asyncio
+async def test_configure_runtime_posts_the_exact_completed_reference() -> None:
+    """Remote delegates runtime choice while preserving exact managed identity."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    resolved = _resolved()
+    reference = ArtifactRef("owner-repository", "a" * 40, "q4_k_m")
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+
+    class _AdoptionApp(ConsolidatedCSSApp):
+        def __init__(self) -> None:
+            self.configured: list[ArtifactRef] = []
+            super().__init__()
+
+        def compose(self) -> ComposeResult:
+            yield view
+
+        @on(RemoteView.ConfigureRuntimeRequested)
+        def _configured(self, event: RemoteView.ConfigureRuntimeRequested) -> None:
+            self.configured.append(event.reference)
+
+    app = _AdoptionApp()
+    async with app.run_test() as pilot:
+        query = view.query_one("#remote-model-query", Input)
+        query.value = resolved.repository
+        view._resolve_generation = 1
+        view._apply_resolve_result(
+            1,
+            resolved.repository,
+            resolved.repository,
+            resolved,
+            None,
+        )
+        await pilot.pause()
+        view.query_one(".remote-candidate", Button).press()
+        await pilot.pause()
+        view.finish_install(
+            "Model downloaded and managed.",
+            completed_reference=reference,
+        )
+        await pilot.pause()
+
+        view.query_one("#remote-model-configure-runtime", Button).press()
+        await pilot.pause()
+
+    assert app.configured == [reference]
+
+
+@pytest.mark.asyncio
+async def test_new_search_clears_the_prior_completion_actions() -> None:
+    """A new discovery cannot retain adoption actions for a stale managed root."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    resolved = _resolved()
+    adapter = _Adapter(search_result=(_summary("new/repository"),), resolved=resolved)
+    reference = ArtifactRef("owner-repository", "a" * 40, "q4_k_m")
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver([]),
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        query = view.query_one("#remote-model-query", Input)
+        query.value = resolved.repository
+        view._resolve_generation = 1
+        view._apply_resolve_result(
+            1,
+            resolved.repository,
+            resolved.repository,
+            resolved,
+            None,
+        )
+        await pilot.pause()
+        view.query_one(".remote-candidate", Button).press()
+        await pilot.pause()
+        view.finish_install(
+            "Model downloaded and managed.",
+            completed_reference=reference,
+        )
+        await pilot.pause()
+
+        await _submit(app, pilot, "new model")
+
+        assert view._query_value == "new model"
+        assert adapter.search_calls == [("new model", "configured-token")]
+        assert [result.repository for result in view._results] == ["new/repository"]
+        assert list(view.query("#remote-model-open-installed")) == []
+        assert list(view.query("#remote-model-configure-runtime")) == []
+        assert view.query_one("#remote-model-install", Button).disabled is True
+        assert "new/repository" in _text(view)
+
+
+@pytest.mark.asyncio
+async def test_new_discovery_notifies_the_host_to_clear_durable_completion() -> None:
+    """Starting a search invalidates the screen owner's prior adoption target."""
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    adapter = _Adapter(search_result=(_summary("new/repository"),))
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver([]),
+    )
+
+    class _DiscoveryApp(ConsolidatedCSSApp):
+        def __init__(self) -> None:
+            self.view = view
+            self.started: list[str] = []
+            super().__init__()
+
+        def compose(self) -> ComposeResult:
+            yield view
+
+        @on(RemoteView.DiscoveryStarted)
+        def _started(self, event: RemoteView.DiscoveryStarted) -> None:
+            self.started.append(event.query)
+
+    app = _DiscoveryApp()
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "new model")
+
+    assert app.started == ["new model"]
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-20936 - Complete-Remote-model-adoption-handoff.md
+++ b/backlog/tasks/task-20936 - Complete-Remote-model-adoption-handoff.md
@@ -1,0 +1,50 @@
+---
+id: TASK-20936
+title: Complete Remote model adoption handoff
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-22 17:44'
+updated_date: '2026-08-22 18:40'
+labels:
+  - models
+  - ui
+dependencies:
+  - TASK-19906
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete the Remote model journey after a verified managed download so users can find the exact installed model or configure it for a compatible local runtime without silent activation or startup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A successful Remote install presents a durable `Downloaded · Verified · Managed · Not active` state attributed to the current `Hugging Face` source, and this outcome survives Models screen recomposition until the user starts another Remote discovery or install.
+- [x] #2 `Open Installed` switches to Installed and locates the exact managed model reference that completed, without activating it.
+- [x] #3 `Configure and use…` presents only compatible managed-GGUF runtime choices, preselects the exact completed model for the chosen runtime, and opens that runtime without activating the managed artifact or starting a server.
+- [x] #4 Failed or cancelled installs retain their existing recovery behavior and never expose successful-adoption actions.
+- [x] #5 The provider-neutral `Remote` destination identifies `Hugging Face` as the current source without introducing a redundant one-option provider selector.
+- [x] #6 The completion and handoff controls remain painted, contained, text-labeled, and keyboard reachable at 80 columns under the production stylesheet.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already governs provider-neutral managed GGUF identity, explicit activation, and llama.cpp/llamafile managed-source authority. This task adds a UI handoff over those existing boundaries without changing storage, runtime ownership, or provider contracts.
+
+1. Add failing RemoteView tests for the provider-attributed completion state, success-only actions, reset behavior, and 80-column rendering.
+2. Add failing host/window tests for exact-reference Installed navigation and explicit llama.cpp/llamafile managed-source configuration without activation or process startup.
+3. Implement the minimal completion message/state boundary across RemoteView, LLMScreen, InstalledView, and LLMManagementWindow while preserving the existing install worker and managed-store ownership.
+4. Regenerate consolidated CSS if required, run the focused Remote/Models suites, and visually verify idle, success, Installed handoff, and runtime handoff states under the production stylesheet.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a durable provider-attributed Remote completion state with exact Open Installed and explicit Llama.cpp/Llamafile configuration handoffs. The Models screen now owns pending runtime intent across recomposition; the management window validates and reports exact managed inventory outcomes without activation or server startup. Installed navigation highlights and focuses the exact reference, with distinct inline recovery when a successful refresh proves it missing versus when inventory loading fails. Added production-stylesheet compositor and keyboard coverage at 80 columns plus lifecycle, focus-order, failure, and recompose regressions. ADR required: no; existing ADR-025 continues to govern managed artifact identity and runtime authority. Verification: 73 Remote/widget tests passed; 115 Installed/GGUF tests passed; 9 focused real-host adoption tests passed; CSS bundle guard 4 passed; Ruff and git diff checks passed. A broader host selection reached 178 passed with one unrelated modal child-mount race; that existing test passed immediately in isolation. Full repository sweep was not run under the targeted-test policy.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-20936 - Complete-Remote-model-adoption-handoff.md
+++ b/backlog/tasks/task-20936 - Complete-Remote-model-adoption-handoff.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-22 17:44'
-updated_date: '2026-08-22 18:40'
+updated_date: '2026-08-22 19:03'
 labels:
   - models
   - ui
@@ -46,5 +46,5 @@ Reason: ADR-025 already governs provider-neutral managed GGUF identity, explicit
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented a durable provider-attributed Remote completion state with exact Open Installed and explicit Llama.cpp/Llamafile configuration handoffs. The Models screen now owns pending runtime intent across recomposition; the management window validates and reports exact managed inventory outcomes without activation or server startup. Installed navigation highlights and focuses the exact reference, with distinct inline recovery when a successful refresh proves it missing versus when inventory loading fails. Added production-stylesheet compositor and keyboard coverage at 80 columns plus lifecycle, focus-order, failure, and recompose regressions. ADR required: no; existing ADR-025 continues to govern managed artifact identity and runtime authority. Verification: 73 Remote/widget tests passed; 115 Installed/GGUF tests passed; 9 focused real-host adoption tests passed; CSS bundle guard 4 passed; Ruff and git diff checks passed. A broader host selection reached 178 passed with one unrelated modal child-mount race; that existing test passed immediately in isolation. Full repository sweep was not run under the targeted-test policy.
+Implemented a durable provider-attributed Remote completion state with exact Open Installed and explicit Llama.cpp/Llamafile configuration handoffs. The Models screen owns pending runtime intent across recomposition; the management window validates exact managed inventory without activation or server startup. Installed navigation highlights and safely focuses the exact reference, retaining non-destructive focus when activation is unavailable. A refresh blocked by changing server lifecycle now synchronously rejects and clears both window and screen handoff intent. Added path-free missing-versus-load-failure recovery and Google-style constructor documentation. Qodo findings addressed: Delete is never auto-focused, refresh refusal cannot strand a handoff, and message arguments are documented. ADR required: no; ADR-025 remains authoritative. Verification after review fixes: 204 focused tests passed; Ruff, CSS bundle synchronization, and git diff checks passed. Full repository sweep was not run under the targeted-test policy.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -60,6 +60,7 @@ from ..Event_Handlers.LLM_Management_Events.server_lifecycle import (
     server_lifecycle_snapshot,
     server_is_active,
 )
+from ..Model_Artifacts.service import ArtifactRef
 from ..Model_Artifacts.store import managed_service
 from ..Utils.log_widget_manager import LogWidgetManager
 from ..Widgets.ModelArtifacts import InstallProgressed, InstallStatusChanged
@@ -281,6 +282,31 @@ class LLMManagementWindow(Container):
         `call_after_refresh`, which raced (and lost to) the deferred mount —
         get a second, correctly-ordered chance.
         """
+
+    class ManagedGGUFHandoffResolved(Message):
+        """Report exact managed-GGUF validation to the owning Models screen."""
+
+        def __init__(
+            self,
+            provider: str,
+            reference: ArtifactRef,
+            *,
+            succeeded: bool,
+            reason: str | None = None,
+        ) -> None:
+            """Create a path-free handoff result.
+
+            Args:
+                provider: Internal GGUF runtime key.
+                reference: Exact managed identity that was validated.
+                succeeded: Whether the identity was committed to the runtime.
+                reason: Allowlisted failure category, never a filesystem path.
+            """
+            super().__init__()
+            self.provider = provider
+            self.reference = reference
+            self.succeeded = succeeded
+            self.reason = reason
 
     BUNDLED_CSS = """
     LLMManagementWindow {
@@ -544,6 +570,7 @@ class LLMManagementWindow(Container):
         self._managed_gguf_inventory_generation = 0
         self._managed_gguf_inventory_started = False
         self._managed_gguf_inventory_error = False
+        self._pending_managed_gguf_handoff: tuple[str, ArtifactRef] | None = None
         self._server_active_states = {
             provider: False for provider in self.SERVER_CONTROLS
         }
@@ -1521,6 +1548,67 @@ class LLMManagementWindow(Container):
             self._gguf_sources[provider] = selection
         return selection.validate_for(provider)
 
+    def configure_managed_gguf(
+        self,
+        provider: str,
+        reference: ArtifactRef,
+    ) -> bool:
+        """Open a GGUF runtime and preselect one exact managed model.
+
+        The method changes configuration state only. It never activates a
+        managed root, claims a server, or starts a process.
+
+        Args:
+            provider: Internal GGUF provider key (``llamacpp`` or ``llamafile``).
+            reference: Exact verified managed root to select.
+
+        Returns:
+            ``True`` when the handoff was accepted, including while a fresh
+            inventory read is resolving the exact reference.
+        """
+        if (
+            provider not in self.GGUF_PROVIDERS
+            or type(reference) is not ArtifactRef
+            or any(self._server_active(item) for item in self.GGUF_PROVIDERS)
+        ):
+            return False
+        self.active_view = "llama-cpp" if provider == "llamacpp" else "llamafile"
+        self._pending_managed_gguf_handoff = (provider, reference)
+        if reference in {choice.reference for choice in self._managed_gguf_choices}:
+            self._commit_managed_gguf_handoff(provider, reference)
+            return True
+        self._refresh_managed_gguf_inventory()
+        return True
+
+    def _commit_managed_gguf_handoff(
+        self,
+        provider: str,
+        reference: ArtifactRef,
+    ) -> None:
+        """Commit a provider/ref pair already proven present in inventory."""
+        selection = self._gguf_sources[provider]
+        self._gguf_sources[provider] = GGUFSourceSelection(
+            mode=GGUFSourceMode.MANAGED,
+            managed_ref=reference,
+            external_path=selection.external_path,
+        )
+        mode = self.query_one(f"#{provider}-gguf-source-mode", Select)
+        managed = self.query_one(f"#{provider}-gguf-managed-select", Select)
+        with mode.prevent(Select.Changed):
+            mode.value = GGUFSourceMode.MANAGED.value
+        with managed.prevent(Select.Changed):
+            managed.value = reference
+        self._pending_managed_gguf_handoff = None
+        self._render_gguf_source(provider)
+        self._sync_process_controls(provider)
+        self.post_message(
+            self.ManagedGGUFHandoffResolved(
+                provider,
+                reference,
+                succeeded=True,
+            )
+        )
+
     def _render_gguf_source(self, provider: str) -> None:
         """Patch one source region and its path-free status in place."""
 
@@ -1708,6 +1796,18 @@ class LLMManagementWindow(Container):
             return
         if any(self._server_active(p) for p in self.GGUF_PROVIDERS):
             self._managed_gguf_inventory_started = False
+            pending = self._pending_managed_gguf_handoff
+            if pending is not None:
+                self._pending_managed_gguf_handoff = None
+                provider, reference = pending
+                self.post_message(
+                    self.ManagedGGUFHandoffResolved(
+                        provider,
+                        reference,
+                        succeeded=False,
+                        reason="server-active",
+                    )
+                )
             return
         self._managed_gguf_choices = choices
         self._managed_gguf_inventory_error = bool(error)
@@ -1741,6 +1841,21 @@ class LLMManagementWindow(Container):
                     else Select.NULL
                 )
             self._sync_process_controls(provider)
+        pending = self._pending_managed_gguf_handoff
+        if pending is not None:
+            provider, reference = pending
+            if not error and reference in references:
+                self._commit_managed_gguf_handoff(provider, reference)
+            else:
+                self._pending_managed_gguf_handoff = None
+                self.post_message(
+                    self.ManagedGGUFHandoffResolved(
+                        provider,
+                        reference,
+                        succeeded=False,
+                        reason="inventory-error" if error else "missing",
+                    )
+                )
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         """Route allowlisted actions inside this destination."""

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -1577,7 +1577,9 @@ class LLMManagementWindow(Container):
         if reference in {choice.reference for choice in self._managed_gguf_choices}:
             self._commit_managed_gguf_handoff(provider, reference)
             return True
-        self._refresh_managed_gguf_inventory()
+        if not self._refresh_managed_gguf_inventory():
+            self._pending_managed_gguf_handoff = None
+            return False
         return True
 
     def _commit_managed_gguf_handoff(
@@ -1745,13 +1747,18 @@ class LLMManagementWindow(Container):
         if not self._managed_gguf_inventory_started:
             self._refresh_managed_gguf_inventory()
 
-    def _refresh_managed_gguf_inventory(self) -> None:
-        """Start a path-free, generation-fenced inventory thread worker."""
+    def _refresh_managed_gguf_inventory(self) -> bool:
+        """Start a path-free, generation-fenced inventory thread worker.
+
+        Returns:
+            ``True`` when a worker was scheduled, or ``False`` when current
+            lifecycle authority prevents a refresh.
+        """
 
         if self.app_instance is None:
-            return
+            return False
         if any(self._server_active(p) for p in self.GGUF_PROVIDERS):
-            return
+            return False
         self._managed_gguf_inventory_started = True
         self._managed_gguf_inventory_generation += 1
         generation = self._managed_gguf_inventory_generation
@@ -1762,6 +1769,7 @@ class LLMManagementWindow(Container):
             description="Loading managed GGUF models",
             exclusive=True,
         )
+        return True
 
     def _load_managed_gguf_inventory(self, generation: int) -> None:
         """Read store inventory off-loop and deliver only path-free choices."""

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from pathlib import Path
 import threading
 from typing import TYPE_CHECKING, Any, cast
@@ -38,6 +39,7 @@ from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.ModelArtifacts import (
     InstallProgressed,
     InstallStatusChanged,
+    ManagedGGUFRuntimeChoiceModal,
     ModelInstallModal,
 )
 from ..Navigation.audio_cpp_model_handoff import (
@@ -306,6 +308,18 @@ class LLMScreen(LabScreen):
         self._remote_install_terminal_candidate: "RemoteGGUFCandidate | None" = None
         self._remote_install_terminal_action: str | None = None
         self._remote_install_terminal_message: str | None = None
+        #: Last verified Remote root and its frozen discovery context. Unlike
+        #: the narrow terminal-presentation bridge above, this remains after
+        #: delivery so a later screen recompose preserves the adoption CTA.
+        self._remote_install_completed_catalog: "ResolvedRemoteCatalog | None" = None
+        self._remote_install_completed_candidate: "RemoteGGUFCandidate | None" = None
+        self._remote_install_completed_reference: ArtifactRef | None = None
+        self._remote_install_completed_message: str | None = None
+        #: Exact runtime adoption intent retained by the screen while the
+        #: current LLMManagementWindow validates a freshly-downloaded root.
+        #: LabScreen recomposition replaces that window, so window-local
+        #: ownership alone would strand the handoff with the detached worker.
+        self._remote_runtime_handoff: tuple[str, ArtifactRef] | None = None
         self._audio_cpp_model_request_claim: (
             HandoffClaim[AudioCppModelLibraryRequest] | None
         ) = None
@@ -2340,6 +2354,92 @@ class LLMScreen(LabScreen):
     # steps below are duplicated, exactly as the curated block duplicates
     # LibraryScreen's own Parakeet v2 shape.
 
+    @on(RemoteView.OpenInstalledRequested)
+    def _remote_open_installed_requested(
+        self, event: RemoteView.OpenInstalledRequested
+    ) -> None:
+        """Open the exact verified row without activating or starting it."""
+        event.stop()
+        if self.llm_window is None or type(event.reference) is not ArtifactRef:
+            return
+        installed = self._installed_view()
+        self.llm_window.active_view = "installed"
+        if installed is not None:
+            self.call_after_refresh(installed.reveal_reference, event.reference)
+
+    @on(RemoteView.ConfigureRuntimeRequested)
+    def _remote_configure_runtime_requested(
+        self, event: RemoteView.ConfigureRuntimeRequested
+    ) -> None:
+        """Present compatible runtime destinations for one verified root."""
+        event.stop()
+        if type(event.reference) is not ArtifactRef:
+            return
+        self.app.push_screen(
+            ManagedGGUFRuntimeChoiceModal(),
+            partial(self._remote_runtime_selected, event.reference),
+        )
+
+    def _remote_runtime_selected(
+        self,
+        reference: ArtifactRef,
+        provider: str | None,
+    ) -> None:
+        """Apply one explicit runtime choice without activating or starting it."""
+        if provider not in {"llamacpp", "llamafile"} or self.llm_window is None:
+            return
+        self._remote_runtime_handoff = (provider, reference)
+        if not self.llm_window.configure_managed_gguf(provider, reference):
+            self._remote_runtime_handoff = None
+            self.notify(
+                "Stop the active Llama.cpp or Llamafile server, then configure "
+                "this managed model again.",
+                severity="warning",
+            )
+
+    def _replay_remote_runtime_handoff(self) -> None:
+        """Resume an exact runtime handoff in the current management window."""
+        if self.llm_window is None or self._remote_runtime_handoff is None:
+            return
+        provider, reference = self._remote_runtime_handoff
+        if not self.llm_window.configure_managed_gguf(provider, reference):
+            self._remote_runtime_handoff = None
+            self.notify(
+                "Stop the active Llama.cpp or Llamafile server, then configure "
+                "this managed model again.",
+                severity="warning",
+            )
+
+    @on(LLMManagementWindow.ManagedGGUFHandoffResolved)
+    def _managed_gguf_handoff_resolved(
+        self,
+        event: LLMManagementWindow.ManagedGGUFHandoffResolved,
+    ) -> None:
+        """Clear only the exact screen-owned handoff a window resolved."""
+        event.stop()
+        pending = getattr(self, "_remote_runtime_handoff", None)
+        if pending != (event.provider, event.reference):
+            return
+        self._remote_runtime_handoff = None
+        if event.succeeded:
+            return
+        if event.reason == "inventory-error":
+            message = (
+                "Managed models could not be loaded. Refresh Installed models, "
+                "then try again."
+            )
+        elif event.reason == "server-active":
+            message = (
+                "Stop the active Llama.cpp or Llamafile server, then configure "
+                "this managed model again."
+            )
+        else:
+            message = (
+                "That managed model is no longer available. Refresh Installed "
+                "models, then try again."
+            )
+        self.notify(message, severity="warning")
+
     @on(RemoteView.InstallRequested)
     def _remote_install_requested(self, event: RemoteView.InstallRequested) -> None:
         """Resolve an install plan for a reviewed remote candidate, off the Textual event loop.
@@ -2384,6 +2484,7 @@ class LLMScreen(LabScreen):
             self._clear_remote_install_state()
             return
         self._clear_remote_terminal_presentation()
+        self._clear_remote_completed_presentation()
         self._model_install_kind = "remote"
         self._model_install_reference = event.catalog.artifact.reference
         self._model_install_service = event.service
@@ -2611,6 +2712,15 @@ class LLMScreen(LabScreen):
                 "not been verified."
             )
             self.notify(message, severity="information")
+            if (
+                isinstance(reference, ArtifactRef)
+                and isinstance(self._model_install_catalog, ResolvedRemoteCatalog)
+                and isinstance(self._model_install_candidate, RemoteGGUFCandidate)
+            ):
+                self._remote_install_completed_catalog = self._model_install_catalog
+                self._remote_install_completed_candidate = self._model_install_candidate
+                self._remote_install_completed_reference = reference
+                self._remote_install_completed_message = message
         if reference is not None:
             self._deliver_curated(
                 InstallStatusChanged(reference, active=False, succeeded=error is None)
@@ -2659,6 +2769,19 @@ class LLMScreen(LabScreen):
         self._remote_install_terminal_action = None
         self._remote_install_terminal_message = None
 
+    def _clear_remote_completed_presentation(self) -> None:
+        """Discard the last success when a new Remote journey supersedes it."""
+        self._remote_install_completed_catalog = None
+        self._remote_install_completed_candidate = None
+        self._remote_install_completed_reference = None
+        self._remote_install_completed_message = None
+
+    @on(RemoteView.DiscoveryStarted)
+    def _remote_discovery_started(self, event: RemoteView.DiscoveryStarted) -> None:
+        """Make a submitted discovery the new Remote lifecycle authority."""
+        event.stop()
+        self._clear_remote_completed_presentation()
+
     def _deliver_or_retain_remote_terminal_presentation(
         self,
         action: str,
@@ -2680,7 +2803,13 @@ class LLMScreen(LabScreen):
             ):
                 view.restore_install_context(catalog, candidate)
             if action == _REMOTE_INSTALL_TERMINAL_FINISH:
-                view.finish_install(message)
+                completed = getattr(
+                    self, "_remote_install_completed_reference", None
+                )
+                if isinstance(completed, ArtifactRef):
+                    view.finish_install(message, completed_reference=completed)
+                else:
+                    view.finish_install(message)
             else:
                 view.cancel_pending_install(message)
             self._clear_remote_terminal_presentation()
@@ -2711,10 +2840,36 @@ class LLMScreen(LabScreen):
             return False
         message = getattr(self, "_remote_install_terminal_message", None)
         if action == _REMOTE_INSTALL_TERMINAL_FINISH:
-            view.finish_install(message)
+            completed = getattr(self, "_remote_install_completed_reference", None)
+            if isinstance(completed, ArtifactRef):
+                view.finish_install(message, completed_reference=completed)
+            else:
+                view.finish_install(message)
         else:
             view.cancel_pending_install(message)
         self._clear_remote_terminal_presentation()
+        return True
+
+    def _hydrate_remote_completed_presentation(self) -> bool:
+        """Restore the durable verified completion into a fresh Remote view."""
+        catalog = getattr(self, "_remote_install_completed_catalog", None)
+        candidate = getattr(self, "_remote_install_completed_candidate", None)
+        reference = getattr(self, "_remote_install_completed_reference", None)
+        if (
+            not isinstance(catalog, ResolvedRemoteCatalog)
+            or not isinstance(candidate, RemoteGGUFCandidate)
+            or not isinstance(reference, ArtifactRef)
+        ):
+            return False
+        view = self._remote_view()
+        if view is None or not view.is_mounted:
+            return False
+        if not view.restore_install_context(catalog, candidate):
+            return False
+        view.finish_install(
+            getattr(self, "_remote_install_completed_message", None),
+            completed_reference=reference,
+        )
         return True
 
     def _model_install_presentation_pending(self) -> bool:
@@ -2727,6 +2882,7 @@ class LLMScreen(LabScreen):
                 and self._model_install_candidate is not None
             )
             or getattr(self, "_remote_install_terminal_action", None) is not None
+            or getattr(self, "_remote_install_completed_reference", None) is not None
         )
 
     def _remote_install_context_status(self) -> str:
@@ -2869,6 +3025,7 @@ class LLMScreen(LabScreen):
         if self._model_install_presentation_pending():
             self._hydrate_model_install_progress()
         self._hydrate_external_status()
+        self._replay_remote_runtime_handoff()
 
     def _hydrate_model_install_progress(self) -> None:
         """Re-apply selected-model context and progress after a recompose.
@@ -2909,7 +3066,8 @@ class LLMScreen(LabScreen):
         every (re)mount, rather than by trying to identify and replay
         whichever specific message the gap happened to swallow.
         """
-        self._hydrate_remote_terminal_presentation()
+        if not self._hydrate_remote_terminal_presentation():
+            self._hydrate_remote_completed_presentation()
         view = self._active_install_view()
         if (
             isinstance(view, RemoteView)

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -818,7 +818,7 @@ class InstalledView(Widget):
             self.set_timer(0.01, self._focus_revealed_after_recompose)
 
     def _focus_revealed_reference(self) -> bool:
-        """Scroll the revealed row into view and focus its first safe action."""
+        """Scroll the revealed row into view and focus activation when available."""
         reference = self._revealed_reference
         if reference is None:
             return False
@@ -836,17 +836,14 @@ class InstalledView(Widget):
         action = next(
             (
                 button
-                for button in row.query(".model-activate, .model-delete").results(
-                    Button
-                )
+                for button in row.query(".model-activate").results(Button)
                 if not button.disabled
             ),
             None,
         )
         if action is not None:
             action.focus()
-            return True
-        return False
+        return True
 
     def refresh_observations(self) -> None:
         """Refresh current exact refs without re-reading managed inventory."""

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -200,6 +200,11 @@ class InstalledView(Widget):
         border: solid $surface-lighten-1;
     }
 
+    InstalledView .installed-model-row.-revealed {
+        border: solid $accent;
+        background: $accent 8%;
+    }
+
     InstalledView .installed-model-title {
         text-style: bold;
     }
@@ -281,6 +286,9 @@ class InstalledView(Widget):
         self._import_status: str | None = None
         self._import_retry_available = False
         self._restore_header_focus_id: str | None = None
+        self._revealed_reference: ArtifactRef | None = None
+        self._reveal_status: str | None = None
+        self._reveal_focus_attempts = 0
         self._observation_generation = 0
         self._observation_focus_locator: ModelLibraryFocusLocator | None = None
         # TASK-19563: monotonic inventory-read counter; see `_apply_inventory`.
@@ -356,6 +364,13 @@ class InstalledView(Widget):
             yield Static(
                 self._lifecycle_status,
                 id="installed-lifecycle-status",
+                classes="installed-recovery-status",
+                markup=False,
+            )
+        if self._reveal_status is not None:
+            yield Static(
+                self._reveal_status,
+                id="installed-reveal-status",
                 classes="installed-recovery-status",
                 markup=False,
             )
@@ -518,6 +533,8 @@ class InstalledView(Widget):
             if audio_cpp is not None
             else "installed-model-row"
         )
+        if row.reference == self._revealed_reference:
+            classes += " -revealed"
         widget = Vertical(*children, classes=classes)
         widget.reference = row.reference
         return widget
@@ -736,6 +753,16 @@ class InstalledView(Widget):
             self._audio_cpp_projections = audio_cpp
         reload_after_load = self._reload_after_load
         self._reload_after_load = False
+        revealed = self._revealed_reference
+        if error is None and revealed is not None and not reload_after_load:
+            if any(row.reference == revealed for row in rows):
+                self._reveal_status = None
+            else:
+                self._revealed_reference = None
+                self._reveal_status = (
+                    "That managed model is no longer available. Refresh Installed "
+                    "models and try again."
+                )
         if reload_after_load:
             self.ensure_loaded(force=True)
         elif self.is_attached:
@@ -748,6 +775,78 @@ class InstalledView(Widget):
                 focus_id = self._restore_header_focus_id
                 self._restore_header_focus_id = None
                 self.call_after_refresh(self.restore_focus, focus_id)
+            elif self._revealed_reference is not None:
+                self._schedule_revealed_focus()
+
+    def reveal_reference(self, reference: ArtifactRef) -> None:
+        """Reveal and focus one exact managed row without activating it.
+
+        Args:
+            reference: Verified managed identity selected by another Models view.
+        """
+        if type(reference) is not ArtifactRef:
+            return
+        had_recovery = self._reveal_status is not None
+        self._reveal_status = None
+        self._revealed_reference = reference
+        if any(row.reference == reference for row in self._rows):
+            if had_recovery and self.is_attached:
+                self.refresh(recompose=True)
+                self._schedule_revealed_focus()
+                return
+            for row in self.query(".installed-model-row"):
+                row.set_class(
+                    getattr(row, "reference", None) == reference,
+                    "-revealed",
+                )
+            self._focus_revealed_reference()
+            return
+        self.ensure_loaded(force=True)
+
+    def _schedule_revealed_focus(self) -> None:
+        """Focus after recompose, retrying across Textual's child-mount gap."""
+        self._reveal_focus_attempts = 3
+        self.call_after_refresh(self._focus_revealed_after_recompose)
+
+    def _focus_revealed_after_recompose(self) -> None:
+        """Resolve one bounded post-recompose focus attempt."""
+        if self._focus_revealed_reference():
+            self._reveal_focus_attempts = 0
+            return
+        self._reveal_focus_attempts -= 1
+        if self._reveal_focus_attempts > 0:
+            self.set_timer(0.01, self._focus_revealed_after_recompose)
+
+    def _focus_revealed_reference(self) -> bool:
+        """Scroll the revealed row into view and focus its first safe action."""
+        reference = self._revealed_reference
+        if reference is None:
+            return False
+        row = next(
+            (
+                widget
+                for widget in self.query(".installed-model-row")
+                if getattr(widget, "reference", None) == reference
+            ),
+            None,
+        )
+        if row is None:
+            return False
+        row.scroll_visible(animate=False, immediate=True, force=True)
+        action = next(
+            (
+                button
+                for button in row.query(".model-activate, .model-delete").results(
+                    Button
+                )
+                if not button.disabled
+            ),
+            None,
+        )
+        if action is not None:
+            action.focus()
+            return True
+        return False
 
     def refresh_observations(self) -> None:
         """Refresh current exact refs without re-reading managed inventory."""

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -141,6 +141,30 @@ class RemoteView(Widget):
             self.service = service
             self.credential_resolver = credential_resolver
 
+    class OpenInstalledRequested(Message):
+        """Request navigation to the exact completed managed model."""
+
+        def __init__(self, reference: ArtifactRef) -> None:
+            """Carry the verified managed root without deriving identity from UI copy."""
+            super().__init__()
+            self.reference = reference
+
+    class ConfigureRuntimeRequested(Message):
+        """Request runtime selection for the exact completed managed model."""
+
+        def __init__(self, reference: ArtifactRef) -> None:
+            """Carry the verified managed root into the host-owned chooser."""
+            super().__init__()
+            self.reference = reference
+
+    class DiscoveryStarted(Message):
+        """Notify the host that prior durable completion is no longer current."""
+
+        def __init__(self, query: str) -> None:
+            """Carry the submitted provider query for lifecycle attribution."""
+            super().__init__()
+            self.query = query
+
     BUNDLED_CSS = """
     RemoteView {
         height: 100%;
@@ -148,9 +172,19 @@ class RemoteView(Widget):
     }
 
     RemoteView .remote-header {
-        height: 3;
+        height: 5;
         padding: 0 1;
         background: $panel;
+    }
+
+    RemoteView .remote-source {
+        height: 2;
+        padding: 0;
+        color: $text-muted;
+    }
+
+    RemoteView .remote-search-row {
+        height: 3;
     }
 
     RemoteView #remote-model-query {
@@ -274,6 +308,16 @@ class RemoteView(Widget):
         min-width: 22;
     }
 
+    RemoteView .remote-completion-actions {
+        width: auto;
+        height: 3;
+    }
+
+    RemoteView .remote-completion-actions Button {
+        width: auto;
+        margin-left: 1;
+    }
+
     RemoteView.-narrow .remote-results-pane {
         width: 2fr;
         min-width: 0;
@@ -298,8 +342,14 @@ class RemoteView(Widget):
     }
 
     RemoteView.-narrow #remote-model-selection,
-    RemoteView.-narrow #remote-model-install {
+    RemoteView.-narrow #remote-model-install,
+    RemoteView.-narrow .remote-completion-actions {
         width: 100%;
+        min-width: 0;
+    }
+
+    RemoteView.-narrow .remote-completion-actions Button {
+        width: 1fr;
         min-width: 0;
     }
 
@@ -315,6 +365,7 @@ class RemoteView(Widget):
         credential_resolver_factory: Callable[[], "CredentialResolver"] = (
             _default_credential_resolver
         ),
+        source_label: str = "Hugging Face",
         id: str | None = None,
     ) -> None:
         """Create an idle Remote view without instantiating I/O dependencies.
@@ -323,11 +374,15 @@ class RemoteView(Widget):
             adapter_factory: Lazy bounded metadata-adapter factory.
             service_factory: Lazy managed-store service factory.
             credential_resolver_factory: Lazy credential resolver factory.
+            source_label: Current provider authority shown without implying
+                that Remote is permanently tied to one provider.
             id: Optional Textual widget id.
         """
         self._adapter_factory = adapter_factory
         self._service_factory = service_factory
         self._credential_resolver_factory = credential_resolver_factory
+        self._source_label = source_label
+        self._query_value = ""
         self._search_generation = 0
         self._resolve_generation = 0
         self._results: tuple[RemoteModelSummary, ...] = ()
@@ -335,24 +390,32 @@ class RemoteView(Widget):
         self._selected_repository: str | None = None
         self._selected_candidate: RemoteGGUFCandidate | None = None
         self._operation_reference: ArtifactRef | None = None
+        self._completed_reference: ArtifactRef | None = None
         self._progress: "AcquisitionProgress | None" = None
         super().__init__(id=id)
 
     def compose(self) -> ComposeResult:
         """Compose retained display state without metadata or store access."""
         disabled = self._operation_reference is not None
-        with Horizontal(classes="remote-header"):
-            yield Input(
-                placeholder="Search or enter owner/repository",
-                id="remote-model-query",
-                disabled=disabled,
+        with Vertical(classes="remote-header"):
+            yield Static(
+                f"Source: {self._source_label}",
+                classes="remote-source",
+                markup=False,
             )
-            yield Button(
-                "Search",
-                id="remote-model-search",
-                variant="primary",
-                disabled=disabled,
-            )
+            with Horizontal(classes="remote-search-row"):
+                yield Input(
+                    value=self._query_value,
+                    placeholder="Search or enter owner/repository",
+                    id="remote-model-query",
+                    disabled=disabled,
+                )
+                yield Button(
+                    "Search",
+                    id="remote-model-search",
+                    variant="primary",
+                    disabled=disabled,
+                )
         with Horizontal(classes="remote-workspace"):
             with Vertical(classes="remote-results-pane"):
                 yield Static("Repositories", classes="remote-pane-title")
@@ -382,12 +445,25 @@ class RemoteView(Widget):
                         id="remote-model-selection",
                         markup=False,
                     )
-                    yield Button(
-                        "Review and install…",
-                        id="remote-model-install",
-                        variant="primary",
-                        disabled=disabled or self._selected_candidate is None,
-                    )
+                    if self._completed_reference is None:
+                        yield Button(
+                            "Review and install…",
+                            id="remote-model-install",
+                            variant="primary",
+                            disabled=disabled or self._selected_candidate is None,
+                        )
+                    else:
+                        with Horizontal(classes="remote-completion-actions"):
+                            yield Button(
+                                "Open Installed",
+                                id="remote-model-open-installed",
+                                variant="default",
+                            )
+                            yield Button(
+                                "Configure and use…",
+                                id="remote-model-configure-runtime",
+                                variant="primary",
+                            )
 
     def on_mount(self) -> None:
         """Apply the measured compact layout without creating dependencies."""
@@ -402,6 +478,8 @@ class RemoteView(Widget):
         self.set_class(width < _NARROW_WIDTH, "-narrow")
 
     def _default_status(self) -> str:
+        if self._completed_reference is not None:
+            return "Downloaded · Verified · Managed · Not active"
         if self._selected_candidate is not None:
             return (
                 "GGUF variant selected. Review the managed install before downloading."
@@ -417,6 +495,8 @@ class RemoteView(Widget):
 
     def _selection_summary(self) -> str:
         """Describe the selected GGUF candidate beside the install action."""
+        if self._completed_reference is not None:
+            return "Choose where to configure the verified managed model."
         if self._selected_candidate is None:
             return "Select one GGUF file or complete shard set."
         return (
@@ -559,9 +639,12 @@ class RemoteView(Widget):
         self.query_one("#remote-model-selection", Static).update(
             self._selection_summary()
         )
-        self.query_one("#remote-model-install", Button).disabled = (
-            disabled or self._selected_candidate is None
-        )
+        try:
+            install = self.query_one("#remote-model-install", Button)
+        except NoMatches:
+            self.refresh(recompose=True)
+            return
+        install.disabled = disabled or self._selected_candidate is None
 
     def _set_selected_result_variant(self) -> None:
         """Paint repository selection without replacing the focused result row."""
@@ -591,20 +674,52 @@ class RemoteView(Widget):
         if self._operation_reference is not None:
             return
         query = self.query_one("#remote-model-query", Input).value.strip()
+        self._query_value = query
+        self.post_message(self.DiscoveryStarted(query))
+        was_completed = self._completed_reference is not None
         self._search_generation += 1
         self._resolve_generation += 1
         self._results = ()
         self._resolved = None
         self._selected_repository = None
         self._selected_candidate = None
+        self._completed_reference = None
+        if was_completed:
+            self.refresh(recompose=True)
+            self.call_after_refresh(
+                self._begin_discovery,
+                query,
+                self._search_generation,
+                self._resolve_generation,
+            )
+            return
+        self._begin_discovery(
+            query,
+            self._search_generation,
+            self._resolve_generation,
+        )
+
+    def _begin_discovery(
+        self,
+        query: str,
+        search_generation: int,
+        resolve_generation: int,
+    ) -> None:
+        """Start a current discovery after any completion-state recompose."""
+        if (
+            search_generation != self._search_generation
+            or resolve_generation != self._resolve_generation
+            or query != self._query_value
+        ):
+            return
         self._set_metadata_controls_disabled(True)
         if is_exact_repository(query):
             self._selected_repository = query
             self._refresh_with_status("Inspecting repository…")
-            self._resolve_remote(query, self._resolve_generation, query)
+            self._resolve_remote(query, resolve_generation, query)
             return
         self._refresh_with_status("Searching remote models…")
-        self._search_remote(query, self._search_generation)
+        self._search_remote(query, search_generation)
 
     @on(Button.Pressed, ".remote-result")
     def _result_pressed(self, event: Button.Pressed) -> None:
@@ -695,6 +810,22 @@ class RemoteView(Widget):
                 credential_resolver=credential_resolver,
             )
         )
+
+    @on(Button.Pressed, "#remote-model-open-installed")
+    def _open_installed_pressed(self, event: Button.Pressed) -> None:
+        """Request the exact completed model in the persistent inventory."""
+        event.stop()
+        reference = self._completed_reference
+        if type(reference) is ArtifactRef:
+            self.post_message(self.OpenInstalledRequested(reference))
+
+    @on(Button.Pressed, "#remote-model-configure-runtime")
+    def _configure_runtime_pressed(self, event: Button.Pressed) -> None:
+        """Request host-owned runtime choice for the completed model."""
+        event.stop()
+        reference = self._completed_reference
+        if type(reference) is ArtifactRef:
+            self.post_message(self.ConfigureRuntimeRequested(reference))
 
     @work(thread=True, group="remote_model_search", exit_on_error=False)
     def _search_remote(self, query: str, generation: int) -> None:
@@ -968,7 +1099,12 @@ class RemoteView(Widget):
             return
         self._set_status(message)
 
-    def finish_install(self, message: str | None = None) -> None:
+    def finish_install(
+        self,
+        message: str | None = None,
+        *,
+        completed_reference: ArtifactRef | None = None,
+    ) -> None:
         """Clear the in-flight indicator and hide progress after a completed install.
 
         Called by the host screen (``LLMScreen``) once provisioning
@@ -977,8 +1113,16 @@ class RemoteView(Widget):
         Args:
             message: The outcome copy to show (success or sanitized
                 failure); ``None`` restores the default status.
+            completed_reference: Exact verified managed root on success.
+                ``None`` retains the failure presentation without adoption
+                actions.
         """
         self._operation_reference = None
+        self._completed_reference = (
+            completed_reference
+            if type(completed_reference) is ArtifactRef
+            else None
+        )
         self._progress = None
         try:
             progress = self.query_one(
@@ -990,6 +1134,9 @@ class RemoteView(Widget):
         if progress is not None:
             progress.display = False
         self._set_metadata_controls_disabled(False)
+        if self._completed_reference is not None:
+            self.refresh(recompose=True)
+            return
         self._set_status(message or self._default_status())
 
 

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -145,7 +145,11 @@ class RemoteView(Widget):
         """Request navigation to the exact completed managed model."""
 
         def __init__(self, reference: ArtifactRef) -> None:
-            """Carry the verified managed root without deriving identity from UI copy."""
+            """Carry the verified managed root without deriving identity from UI copy.
+
+            Args:
+                reference: Exact verified managed root to reveal.
+            """
             super().__init__()
             self.reference = reference
 
@@ -153,7 +157,11 @@ class RemoteView(Widget):
         """Request runtime selection for the exact completed managed model."""
 
         def __init__(self, reference: ArtifactRef) -> None:
-            """Carry the verified managed root into the host-owned chooser."""
+            """Carry the verified managed root into the host-owned chooser.
+
+            Args:
+                reference: Exact verified managed root to configure.
+            """
             super().__init__()
             self.reference = reference
 
@@ -161,7 +169,11 @@ class RemoteView(Widget):
         """Notify the host that prior durable completion is no longer current."""
 
         def __init__(self, query: str) -> None:
-            """Carry the submitted provider query for lifecycle attribution."""
+            """Carry the submitted provider query for lifecycle attribution.
+
+            Args:
+                query: Provider search text that supersedes prior completion.
+            """
             super().__init__()
             self.query = query
 

--- a/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
@@ -19,6 +19,10 @@ from .local_gguf_import import (
     LocalGGUFImportRequested,
 )
 from .plan_panel import ModelPlanPanel
+from .runtime_choice_modal import (
+    ManagedGGUFRuntimeChoice,
+    ManagedGGUFRuntimeChoiceModal,
+)
 
 __all__ = [
     "ActivationRequested",
@@ -32,6 +36,8 @@ __all__ = [
     "ModelInstallModal",
     "ModelInstallProgress",
     "ModelPlanPanel",
+    "ManagedGGUFRuntimeChoice",
+    "ManagedGGUFRuntimeChoiceModal",
     "RepairRequested",
     "make_progress_callback",
 ]

--- a/tldw_chatbook/Widgets/ModelArtifacts/runtime_choice_modal.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/runtime_choice_modal.py
@@ -1,0 +1,112 @@
+"""Explicit runtime choice for a verified managed GGUF model."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+from ..modal_dismissal import SafeModalDismissMixin
+
+
+ManagedGGUFRuntimeChoice = Literal["llamacpp", "llamafile"]
+
+
+class ManagedGGUFRuntimeChoiceModal(
+    SafeModalDismissMixin,
+    ModalScreen[ManagedGGUFRuntimeChoice | None],
+):
+    """Choose a compatible runtime without activating or starting it."""
+
+    BUNDLED_CSS = """
+    ManagedGGUFRuntimeChoiceModal {
+        align: center middle;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-modal {
+        width: 64;
+        height: auto;
+        border: tall $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-copy {
+        height: auto;
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-actions {
+        height: 3;
+        align-horizontal: right;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-actions Button {
+        width: auto;
+        margin-left: 1;
+    }
+    """
+
+    BINDINGS = [("escape", "request_safe_cancel", "Cancel")]
+    SAFE_MODAL_CONTENT = ".managed-gguf-runtime-modal"
+
+    def compose(self) -> ComposeResult:
+        """Compose one compact, keyboard-operable provider decision."""
+        with Vertical(classes="managed-gguf-runtime-modal"):
+            yield Static(
+                "Configure managed GGUF",
+                classes="managed-gguf-runtime-title",
+                markup=False,
+            )
+            yield Static(
+                "Choose a compatible local runtime. This preselects the exact "
+                "managed model; it does not activate it or start a server.",
+                classes="managed-gguf-runtime-copy",
+                markup=False,
+            )
+            with Horizontal(classes="managed-gguf-runtime-actions"):
+                yield Button(
+                    "Cancel",
+                    id="managed-gguf-runtime-cancel",
+                    variant="default",
+                )
+                yield Button(
+                    "Llamafile",
+                    id="managed-gguf-runtime-llamafile",
+                    variant="default",
+                )
+                yield Button(
+                    "Llama.cpp",
+                    id="managed-gguf-runtime-llamacpp",
+                    variant="primary",
+                )
+
+    def on_mount(self) -> None:
+        """Place keyboard users on the primary compatible runtime."""
+        self.query_one("#managed-gguf-runtime-llamacpp", Button).focus()
+
+    @on(Button.Pressed)
+    async def _button_pressed(self, event: Button.Pressed) -> None:
+        """Dismiss with only an explicit compatible provider identifier."""
+        event.stop()
+        if event.button.id == "managed-gguf-runtime-llamacpp":
+            self.dismiss("llamacpp")
+        elif event.button.id == "managed-gguf-runtime-llamafile":
+            self.dismiss("llamafile")
+        elif event.button.id == "managed-gguf-runtime-cancel":
+            await self.request_safe_cancel(source="visible")
+
+    async def _perform_safe_cancel(self, *, source: str) -> None:
+        """Dismiss once without selecting a runtime."""
+        del source
+        self.dismiss_safe_once(None)

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -1012,6 +1012,11 @@
         border: solid $surface-lighten-1;
     }
 
+    InstalledView .installed-model-row.-revealed {
+        border: solid $accent;
+        background: $accent 8%;
+    }
+
     InstalledView .installed-model-title {
         text-style: bold;
     }
@@ -1038,9 +1043,19 @@
     }
 
     RemoteView .remote-header {
-        height: 3;
+        height: 5;
         padding: 0 1;
         background: $panel;
+    }
+
+    RemoteView .remote-source {
+        height: 2;
+        padding: 0;
+        color: $text-muted;
+    }
+
+    RemoteView .remote-search-row {
+        height: 3;
     }
 
     RemoteView #remote-model-query {
@@ -1164,6 +1179,16 @@
         min-width: 22;
     }
 
+    RemoteView .remote-completion-actions {
+        width: auto;
+        height: 3;
+    }
+
+    RemoteView .remote-completion-actions Button {
+        width: auto;
+        margin-left: 1;
+    }
+
     RemoteView.-narrow .remote-results-pane {
         width: 2fr;
         min-width: 0;
@@ -1188,8 +1213,14 @@
     }
 
     RemoteView.-narrow #remote-model-selection,
-    RemoteView.-narrow #remote-model-install {
+    RemoteView.-narrow #remote-model-install,
+    RemoteView.-narrow .remote-completion-actions {
         width: 100%;
+        min-width: 0;
+    }
+
+    RemoteView.-narrow .remote-completion-actions Button {
+        width: 1fr;
         min-width: 0;
     }
 
@@ -1370,6 +1401,42 @@
 
     ModelInstallProgress ProgressBar {
         margin-top: 1;
+    }
+
+
+/* ===== WIDGET: ManagedGGUFRuntimeChoiceModal (Widgets/ModelArtifacts/runtime_choice_modal.py) ===== */
+
+    ManagedGGUFRuntimeChoiceModal {
+        align: center middle;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-modal {
+        width: 64;
+        height: auto;
+        border: tall $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-copy {
+        height: auto;
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-actions {
+        height: 3;
+        align-horizontal: right;
+    }
+
+    ManagedGGUFRuntimeChoiceModal .managed-gguf-runtime-actions Button {
+        width: auto;
+        margin-left: 1;
     }
 
 


### PR DESCRIPTION
## Summary

- add a durable, provider-attributed Remote completion state after verified managed downloads
- let users open the exact Installed model or explicitly configure it for Llama.cpp or Llamafile without activation or server startup
- preserve pending runtime handoffs across Models recomposition and surface distinct missing-model, inventory-load, and active-server recovery
- keep completion actions and the runtime chooser contained and keyboard reachable at 80 columns under production CSS

## Verification

- 201 focused UI and lifecycle tests passed after rebasing onto current dev
- Ruff passed for all changed Python files
- CSS bundle and derived-artifact synchronization passed
- git diff --check passed
- full repository sweep not run under the repository targeted-test policy

## Backlog

- TASK-20936 marked Done
- ADR required: no; existing ADR-025 governs the managed artifact and runtime boundaries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the Remote model adoption handoff. After a verified managed download, Remote shows a provider-attributed success state and offers two actions—open the exact Installed model or configure it for `llamacpp` or `llamafile`—without activation or starting a server. Previously, Remote returned to an install-oriented state and lost context on recompose.

- Durable completion: persists across Models recomposes and clears when a new Remote discovery or install starts. Remote header shows “Source: Hugging Face” and “Downloaded · Verified · Managed · Not active.”
- Open Installed: switches to Installed, reveals and focuses the exact managed row, and never activates. A successful refresh that can’t find the ref shows recovery; inventory-load errors retain a retryable identity.
- Explicit runtime choice: a modal collects a provider; the window preselects the exact managed ref; no server starts. Handoff resolution reports “inventory-error”, “server-active”, or “missing”; pending handoffs replay across recomposes and clear only after the matching window resolves.
- UI constraints: completion actions and the runtime chooser fit and tab correctly at 80 columns; Installed highlights the revealed row; Remote adds a source line.
- Tests/policy: focused UI and lifecycle suites cover durability, handoffs, refresh races, and 80-column rendering. No migrations. Satisfies TASK-20936 under ADR-025.

<sup>Written for commit 4c292b171cbf5b0e8a79872d947ca44766715fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

