### PR TITLE
fix(db): bound ChaChaNotes sync_log to its reachable frontier, and give the FTS delete guard a witness

### DIFF
--- a/Tests/ChaChaNotesDB/test_actor_pack_migration.py
+++ b/Tests/ChaChaNotesDB/test_actor_pack_migration.py
@@ -1,4 +1,14 @@
-"""ChaChaNotes v44 -> v45 portable Actor Pack persistence coverage."""
+"""ChaChaNotes v44 -> v45 portable Actor Pack persistence coverage.
+
+This module carried the repo's EXACT current-schema-version pin while v45 was
+the newest migration. TASK-19564's `sync_log` retention step was renumbered to
+v45 -> v46 after landing concurrently, so the pin moved on to
+`Tests/DB/test_chachanotes_sync_log_retention_migration.py` and the assertions
+here relaxed to `>= 45`. That is TASK-19554's convention, repaired by
+TASK-19568: the exact pin belongs to the NEWEST migration's own file, and an
+older file that keeps a literal `==` reds on version arithmetic and
+short-circuits the real column/row assertions below it.
+"""
 
 from __future__ import annotations
 
@@ -71,8 +81,10 @@ def test_real_v44_upgrade_installs_actor_pack_tables(tmp_path: Path) -> None:
     migrated = CharactersRAGDB(path, client_id="actor-pack-v45")
     try:
         connection = migrated.get_connection()
-        assert _version(connection) == 45
-        assert CharactersRAGDB._CURRENT_SCHEMA_VERSION == 45
+        # Dynamic, not a literal 45: this reopen is unpatched, so it replays
+        # the chain to whatever the current version is (v46 since TASK-19564).
+        assert _version(connection) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+        assert CharactersRAGDB._CURRENT_SCHEMA_VERSION >= 45
         assert TABLES <= _tables(connection)
         for table, expected in EXPECTED_COLUMNS.items():
             columns = tuple(
@@ -87,7 +99,7 @@ def test_real_v44_upgrade_installs_actor_pack_tables(tmp_path: Path) -> None:
 def test_fresh_database_contains_same_v45_schema(tmp_path: Path) -> None:
     db = CharactersRAGDB(tmp_path / "fresh.db", client_id="actor-pack-fresh")
     try:
-        assert _version(db.get_connection()) == 45
+        assert _version(db.get_connection()) >= 45
         assert TABLES <= _tables(db.get_connection())
     finally:
         db.close_connection()

--- a/Tests/ChaChaNotesDB/test_chachanotes_db.py
+++ b/Tests/ChaChaNotesDB/test_chachanotes_db.py
@@ -297,21 +297,28 @@ class TestDBInitialization:
         conv_id = migrated.add_conversation(
             {"character_id": char_id, "title": "Migration check"}
         )
-        before_log_count = migrated_conn.execute(
-            "SELECT COUNT(*) AS n FROM sync_log WHERE entity = 'conversations' AND entity_id = ?",
-            (conv_id,),
-        ).fetchone()["n"]
+        # task-19564 replaced the row-count proxy this used to assert. The
+        # v45 retention triggers drop superseded `sync_log` versions, so the
+        # total no longer grows by one -- but "the trigger fired, with the new
+        # column in its payload" is what the test is actually for, and the
+        # frontier row states that directly instead of by arithmetic.
         current = migrated.get_conversation_by_id(conv_id)
         migrated.update_conversation(
             conv_id,
             {"system_prompt": "Migrated prompt."},
             expected_version=current["version"],
         )
-        after_log_count = migrated_conn.execute(
-            "SELECT COUNT(*) AS n FROM sync_log WHERE entity = 'conversations' AND entity_id = ?",
+        latest_entry = migrated_conn.execute(
+            "SELECT operation, version, payload FROM sync_log "
+            "WHERE entity = 'conversations' AND entity_id = ? "
+            "ORDER BY change_id DESC LIMIT 1",
             (conv_id,),
-        ).fetchone()["n"]
-        assert after_log_count == before_log_count + 1
+        ).fetchone()
+        assert latest_entry["operation"] == "update"
+        assert latest_entry["version"] == current["version"] + 1
+        assert (
+            json.loads(latest_entry["payload"])["system_prompt"] == "Migrated prompt."
+        )
         assert (
             migrated.get_conversation_by_id(conv_id)["system_prompt"]
             == "Migrated prompt."
@@ -732,6 +739,50 @@ class TestConversationsAndMessages:
         results = db_instance.search_messages_by_content("UniqueMessageContentAlpha")
         assert len(results) == 1
         assert results[0]["id"] == msg1_data["id"]
+
+    def test_search_messages_by_content_unscoped_excludes_deleted_conversations(
+        self, db_instance: CharactersRAGDB, char_id
+    ):
+        """task-19567 A: the shape that is one caller away from a leak.
+
+        Soft-deleting a conversation leaves its messages at `deleted = 0`, and
+        this method filtered only `m.deleted = 0` without joining
+        `conversations` -- while its sibling `search_conversations_by_content`
+        filtered both. It was not exploitable at the time only because the one
+        live caller always passed a `conversation_id` obtained from that
+        already-filtered sibling. Called UNSCOPED, as any new caller would,
+        it returned the deleted conversation's messages.
+        """
+        needle = "UniqueDeletedConversationBodyOmega"
+        kept_conv = db_instance.add_conversation(
+            {"character_id": char_id, "title": "KeptConv"}
+        )
+        dropped_conv = db_instance.add_conversation(
+            {"character_id": char_id, "title": "DroppedConv"}
+        )
+        kept_message = db_instance.add_message(
+            {"conversation_id": kept_conv, "sender": "user", "content": needle}
+        )
+        db_instance.add_message(
+            {"conversation_id": dropped_conv, "sender": "user", "content": needle}
+        )
+        assert len(db_instance.search_messages_by_content(needle)) == 2
+
+        db_instance.soft_delete_conversation(dropped_conv, expected_version=1)
+
+        unscoped = db_instance.search_messages_by_content(needle)
+        assert [row["id"] for row in unscoped] == [kept_message]
+        # ... and it now agrees with the sibling it used to diverge from.
+        assert [
+            row["id"] for row in db_instance.search_conversations_by_content(needle)
+        ] == [kept_conv]
+        # Scoping to the deleted conversation must not reopen the hole.
+        assert (
+            db_instance.search_messages_by_content(
+                needle, conversation_id=dropped_conv
+            )
+            == []
+        )
 
     def test_update_message_usage_local_leaves_version_and_last_modified_untouched(
         self, db_instance: CharactersRAGDB, char_id

--- a/Tests/ChaChaNotesDB/test_provider_continuation.py
+++ b/Tests/ChaChaNotesDB/test_provider_continuation.py
@@ -689,8 +689,11 @@ def test_discard_and_variant_ownership_stay_on_exact_assistant_rows(
         .fetchone()
     )
     assert tuple(blank_raw) == (1, blank_before["version"] + 1, None)
+    # task-19564: tombstoning the row purges its superseded content-bearing
+    # `create` intent -- nothing can reach a version below a tombstone, and
+    # leaving it there was how a deleted message's plaintext survived the
+    # delete. The tombstone itself carries no content and is retained.
     assert [entry["operation"] for entry in _message_sync_entries(db, blank_id)] == [
-        "create",
         "delete",
     ]
 

--- a/Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py
+++ b/Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py
@@ -6,12 +6,13 @@ it, so the discarded text was unrecoverable. This migration adds the three
 columns (``losing_side``, ``losing_content``, ``preserved_file_path``) that
 make the row a real second copy behind the on-disk sidecar.
 
-This module also carries the repo's EXACT current-schema-version pin, which
-moved here from ``test_chachanotes_message_exchanges.py`` when v44 landed:
-the pin belongs to the newest migration's own file, so a schema bump touches
-the file that caused it rather than an unrelated older one (older files assert
-``>= their own version`` instead). Updating the number here is a deliberate
-schema-review act.
+The repo's EXACT current-schema-version pin used to live here. It has since
+moved on twice -- to ``Tests/ChaChaNotesDB/test_actor_pack_migration.py`` with
+v45, and to ``Tests/DB/test_chachanotes_sync_log_retention_migration.py`` with
+v46 -- because the pin belongs to the NEWEST migration's own file, so a schema
+bump touches the file that caused it rather than an unrelated older one
+(TASK-19554's convention, repaired by TASK-19568). This module now asserts
+``>= 44``, which is what an older migration file is entitled to claim.
 """
 
 from __future__ import annotations
@@ -50,7 +51,13 @@ def db(tmp_path: Path):
 
 
 def test_schema_version_includes_v44_preservation(db):
-    """The current schema includes the v44 preservation migration."""
+    """This migration's own floor, not a current-schema pin.
+
+    The exact ``==`` pin belongs to the NEWEST migration's own test file
+    (TASK-19554's convention, repaired by TASK-19568), so it has moved on past
+    this one twice now; an older file asserts only that its own step is
+    present. Kept as ``>=`` so a schema bump touches the file that caused it.
+    """
     assert _version(db.get_connection()) >= 44
     assert CharactersRAGDB._CURRENT_SCHEMA_VERSION >= 44
 

--- a/Tests/DB/test_chachanotes_sync_log_retention.py
+++ b/Tests/DB/test_chachanotes_sync_log_retention.py
@@ -1,0 +1,432 @@
+"""`sync_log` retention: deleted content leaves, reachable proof stays (task-19564).
+
+Why this exists -- the incident, not the rule. `sync_log` stores the COMPLETE
+row as JSON, written by 35 triggers, and before this nothing ever deleted a
+row. Lane 3 of the 2026-08-21 holistic review soft-deleted a conversation and
+read the message body straight back out of `sync_log`; soft-deleting the
+MESSAGE left it there too. "Delete" left the user's plaintext in the database
+indefinitely, and every edit left a full extra copy behind forever.
+
+The filing recommended retiring the content columns because "both readers have
+zero external callers". That is stale, and this module pins the reason:
+`read_committed_chat_sync_intent`, `read_committed_chat_delete_intent` and
+`list_current_committed_chat_sync_intents` all compare the sync_log payload to
+the live `messages` row FIELD BY FIELD, and two of them have live non-test
+callers (`ConsoleChatStore.ensure_provider_continuation_durable`, which raises
+when the read returns None, and `._reconcile_restored_chat_sync_intents`). So
+the log is bounded to the frontier its readers can reach, not emptied of
+content -- and `test_retention_does_not_break_the_committed_intent_readers`
+below is the guard on that trade.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Sync_Interop.hashing import canonical_payload_hash
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(tmp_path / "retention.db", "retention_client")
+    try:
+        yield database
+    finally:
+        database.close_connection()
+
+
+def _needle() -> str:
+    return "zqx" + uuid.uuid4().hex[:12]
+
+
+def _sync_log_hits(db: CharactersRAGDB, needle: str) -> list[dict]:
+    """Every sync_log row whose payload still carries `needle`, whatever entity."""
+    return [
+        {
+            "entity": row["entity"],
+            "entity_id": row["entity_id"],
+            "operation": row["operation"],
+            "version": row["version"],
+        }
+        for row in db.execute_query(
+            "SELECT entity, entity_id, operation, version FROM sync_log "
+            "WHERE payload LIKE ?",
+            (f"%{needle}%",),
+        ).fetchall()
+    ]
+
+
+def _entries(db: CharactersRAGDB, entity: str, entity_id: str) -> list[tuple]:
+    return [
+        (row["operation"], row["version"])
+        for row in db.execute_query(
+            "SELECT operation, version FROM sync_log "
+            "WHERE entity = ? AND entity_id = ? ORDER BY change_id",
+            (entity, entity_id),
+        ).fetchall()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# the lane's probe, per entity
+# ---------------------------------------------------------------------------
+def test_soft_deleting_a_message_removes_its_body_from_sync_log(db: CharactersRAGDB):
+    """The lane probe, sharpened onto the entity actually being deleted."""
+    needle = _needle()
+    conversation_id = db.add_conversation({"title": "probe", "character_id": 1})
+    message_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": f"the {needle} body",
+        }
+    )
+    assert _sync_log_hits(db, needle) != []
+
+    db.soft_delete_message(message_id, expected_version=1)
+
+    assert _sync_log_hits(db, needle) == []
+    # The tombstone survives -- it is the delete proof and carries no content.
+    assert _entries(db, "messages", message_id) == [("delete", 2)]
+
+
+def test_soft_deleting_a_note_removes_its_body_from_sync_log(db: CharactersRAGDB):
+    needle = _needle()
+    note_id = db.add_note(title="probe note", content=f"secret {needle}")
+    assert _sync_log_hits(db, needle) != []
+
+    db.soft_delete_note(note_id, expected_version=1)
+
+    assert _sync_log_hits(db, needle) == []
+
+
+def test_soft_deleting_a_character_removes_its_text_from_sync_log(
+    db: CharactersRAGDB,
+):
+    needle = _needle()
+    card_id = db.add_character_card(
+        {"name": "probe card", "description": f"backstory {needle}"}
+    )
+    assert _sync_log_hits(db, needle) != []
+
+    db.soft_delete_character_card(card_id, expected_version=1)
+
+    assert _sync_log_hits(db, needle) == []
+
+
+def test_soft_deleting_a_conversation_removes_its_title_from_sync_log(
+    db: CharactersRAGDB,
+):
+    """A conversation's own content in `sync_log` is its title.
+
+    Its messages are NOT deleted by this operation -- they stay `deleted = 0`
+    and come back on restore -- so their frontier row is retained, exactly as
+    `messages.content` is. That residue is deliberate and is what
+    `test_a_live_message_keeps_only_the_frontier_its_readers_need` bounds.
+    """
+    needle = _needle()
+    conversation_id = db.add_conversation(
+        {"title": f"title {needle}", "character_id": 1}
+    )
+    assert _sync_log_hits(db, needle) != []
+
+    db.soft_delete_conversation(conversation_id, expected_version=1)
+
+    assert _sync_log_hits(db, needle) == []
+
+
+def test_hard_deleting_a_message_removes_its_body_from_sync_log(db: CharactersRAGDB):
+    needle = _needle()
+    conversation_id = db.add_conversation({"title": "probe", "character_id": 1})
+    message_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": f"hard {needle}",
+        }
+    )
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM messages WHERE id = ?", (message_id,))
+
+    assert _sync_log_hits(db, needle) == []
+    assert _entries(db, "messages", message_id) == []
+
+
+def test_hard_deleting_a_conversation_cascades_the_purge_to_its_messages(
+    db: CharactersRAGDB,
+):
+    """The FK cascade fires the child trigger -- verified, not assumed.
+
+    ``messages.conversation_id`` is ``ON DELETE CASCADE``, and SQLite fires the
+    child table's AFTER DELETE trigger for a foreign-key action (``PRAGMA
+    recursive_triggers`` is 0 here and governs recursion, not this). Without
+    that, a hard conversation delete would leave every message body in
+    ``sync_log`` with no row left to reach it from.
+    """
+    needle = _needle()
+    conversation_id = db.add_conversation({"title": "cascade", "character_id": 1})
+    message_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": f"cascade {needle}",
+        }
+    )
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM conversations WHERE id = ?", (conversation_id,))
+
+    assert db.execute_query(
+        "SELECT COUNT(*) FROM messages WHERE id = ?", (message_id,)
+    ).fetchone()[0] == 0
+    assert _sync_log_hits(db, needle) == []
+
+
+# ---------------------------------------------------------------------------
+# the size story: edit history stops accumulating
+# ---------------------------------------------------------------------------
+def test_editing_a_message_does_not_accumulate_old_bodies(db: CharactersRAGDB):
+    """Before this, every edit left its previous full text in `sync_log`."""
+    conversation_id = db.add_conversation({"title": "edits", "character_id": 1})
+    needles = [_needle() for _ in range(5)]
+    message_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": f"draft {needles[0]}",
+        }
+    )
+    for version, needle in enumerate(needles[1:], start=1):
+        db.update_message(
+            message_id, {"content": f"draft {needle}"}, expected_version=version
+        )
+
+    surviving = [needle for needle in needles if _sync_log_hits(db, needle)]
+
+    # Only the frontier the readers need: the current body and the one below
+    # it, never the whole history.
+    assert surviving == needles[-2:]
+    assert _entries(db, "messages", message_id) == [("update", 4), ("update", 5)]
+
+
+def test_a_live_message_keeps_only_the_frontier_its_readers_need(
+    db: CharactersRAGDB,
+):
+    conversation_id = db.add_conversation({"title": "frontier", "character_id": 1})
+    message_id = db.add_message(
+        {"conversation_id": conversation_id, "sender": "user", "content": "v1"}
+    )
+    db.update_message(message_id, {"content": "v2"}, expected_version=1)
+    db.update_message(message_id, {"content": "v3"}, expected_version=2)
+
+    assert _entries(db, "messages", message_id) == [("update", 2), ("update", 3)]
+
+
+def test_editing_a_note_keeps_only_the_current_version(db: CharactersRAGDB):
+    """Non-message entities have no reader at all, so only the frontier stays."""
+    note_id = db.add_note(title="n", content="first")
+    db.update_note(note_id, {"content": "second"}, expected_version=1)
+    db.update_note(note_id, {"content": "third"}, expected_version=2)
+
+    assert _entries(db, "notes", note_id) == [("update", 3)]
+
+
+# ---------------------------------------------------------------------------
+# the trade: retention must not break the readers that keep the content alive
+# ---------------------------------------------------------------------------
+def test_retention_does_not_break_the_committed_intent_readers(db: CharactersRAGDB):
+    """The reason the content columns are retained rather than retired.
+
+    `ensure_provider_continuation_durable` raises when
+    `read_committed_chat_sync_intent` returns None, so a retention rule that
+    pruned the frontier would turn every continuation checkpoint into a hard
+    error while silently disabling Sync v2.
+    """
+    conversation_id = db.add_conversation({"title": "intents", "character_id": 1})
+    message_id = db.add_message(
+        {"conversation_id": conversation_id, "sender": "user", "content": "first"}
+    )
+    db.update_message(message_id, {"content": "second"}, expected_version=1)
+    db.update_message(message_id, {"content": "third"}, expected_version=2)
+    row = db.execute_query(
+        "SELECT role, version FROM messages WHERE id = ?", (message_id,)
+    ).fetchone()
+    assert row["version"] == 3
+
+    record = db.read_committed_chat_sync_intent(
+        message_id=message_id,
+        message_version=3,
+        payload_hash=canonical_payload_hash({"content": "third", "role": row["role"]}),
+    )
+
+    assert record is not None
+    assert record.content == "third"
+    # The base hash comes from the version below the frontier; that row is
+    # exactly what the retention rule keeps for live messages.
+    assert record.base_payload_hash == canonical_payload_hash(
+        {"content": "second", "role": row["role"]}
+    )
+
+    # And a restore-time reconcile still sees the conversation's intents.
+    intents = db.list_current_committed_chat_sync_intents(conversation_id)
+    assert [intent["message_id"] for intent in intents] == [message_id]
+    assert intents[0]["message_version"] == 3
+
+
+def test_pruning_cannot_flip_the_single_intent_ambiguity_check(db: CharactersRAGDB):
+    """Retention must not turn a REJECTED intent into an accepted one.
+
+    `list_current_committed_chat_sync_intents` accepts a message only when
+    `1 = (SELECT COUNT(*) FROM sync_log ...)` at the message's CURRENT version
+    -- two rows there mean the history is ambiguous and the intent is refused.
+    A prune that could delete one of a duplicate pair would silently promote
+    that refusal into an acceptance, changing what a sync proof asserts. The
+    rule that makes it safe is that pruning only ever removes rows STRICTLY
+    BELOW the frontier; this is the test that says so.
+    """
+    conversation_id = db.add_conversation({"title": "ambiguous", "character_id": 1})
+    message_id = db.add_message(
+        {"conversation_id": conversation_id, "sender": "user", "content": "v1"}
+    )
+    db.update_message(message_id, {"content": "v2"}, expected_version=1)
+    version = db.execute_query(
+        "SELECT version FROM messages WHERE id = ?", (message_id,)
+    ).fetchone()["version"]
+
+    # Forge a duplicate at the CURRENT version -- the ambiguous state.
+    with db.transaction() as conn:
+        duplicate = conn.execute(
+            "SELECT entity_id, operation, timestamp, client_id, version, payload "
+            "FROM sync_log WHERE entity = 'messages' AND entity_id = ? "
+            "AND version = ?",
+            (message_id, version),
+        ).fetchone()
+        conn.execute(
+            "INSERT INTO sync_log(entity, entity_id, operation, timestamp, "
+            "client_id, version, payload) VALUES ('messages',?,?,?,?,?,?)",
+            tuple(duplicate),
+        )
+
+    def count_at_current() -> int:
+        return db.execute_query(
+            "SELECT COUNT(*) FROM sync_log WHERE entity = 'messages' "
+            "AND entity_id = ? AND version = ?",
+            (message_id, version),
+        ).fetchone()[0]
+
+    assert count_at_current() == 2
+    assert db.list_current_committed_chat_sync_intents(conversation_id) == []
+
+    db.prune_sync_log()
+
+    assert count_at_current() == 2, "the frontier's row count must be untouched"
+    assert db.list_current_committed_chat_sync_intents(conversation_id) == []
+
+
+def test_a_tombstoned_message_still_proves_its_delete_intent(db: CharactersRAGDB):
+    conversation_id = db.add_conversation({"title": "tombstone", "character_id": 1})
+    message_id = db.add_message(
+        {"conversation_id": conversation_id, "sender": "user", "content": "bye"}
+    )
+    db.soft_delete_message(message_id, expected_version=1)
+
+    record = db.read_committed_chat_delete_intent(
+        message_id=message_id,
+        message_version=2,
+        payload_hash=canonical_payload_hash({"deleted": True}),
+    )
+
+    assert record is not None
+    assert record.message_id == message_id
+
+
+# ---------------------------------------------------------------------------
+# existing databases, and the maintenance surface
+# ---------------------------------------------------------------------------
+def test_prune_sync_log_clears_a_backlog_written_before_the_triggers(
+    db: CharactersRAGDB,
+):
+    """The shape an existing user's database is in when it reaches v45.
+
+    Rows are written straight into `sync_log` here, bypassing the triggers, to
+    reproduce a pre-v45 backlog; `prune_sync_log` is the same sweep the
+    migration performs once on upgrade.
+    """
+    needle = _needle()
+    conversation_id = db.add_conversation({"title": "backlog", "character_id": 1})
+    message_id = db.add_message(
+        {"conversation_id": conversation_id, "sender": "user", "content": "v1"}
+    )
+    db.update_message(message_id, {"content": "v2"}, expected_version=1)
+    db.update_message(message_id, {"content": "v3"}, expected_version=2)
+    db.update_message(message_id, {"content": "v4"}, expected_version=3)
+    assert _entries(db, "messages", message_id) == [("update", 3), ("update", 4)]
+
+    with db.transaction() as conn:
+        # Versions 1 and 2 are what a pre-v45 database would still be holding.
+        for version in (1, 2):
+            conn.execute(
+                "INSERT INTO sync_log(entity, entity_id, operation, timestamp, "
+                "client_id, version, payload) VALUES ('messages', ?, 'update', "
+                "'2020-01-01T00:00:00Z', 'legacy', ?, ?)",
+                (
+                    message_id,
+                    version,
+                    json.dumps({"id": message_id, "content": f"old {needle}"}),
+                ),
+            )
+        # An orphan: the entity row is long gone.
+        conn.execute(
+            "INSERT INTO sync_log(entity, entity_id, operation, timestamp, "
+            "client_id, version, payload) VALUES ('notes', 'vanished', 'create', "
+            "'2020-01-01T00:00:00Z', 'legacy', 1, ?)",
+            (json.dumps({"id": "vanished", "content": f"orphan {needle}"}),),
+        )
+    assert _sync_log_hits(db, needle) != []
+
+    removed = db.prune_sync_log()
+
+    assert removed == 3
+    assert _sync_log_hits(db, needle) == []
+    # The genuine frontier rows are untouched.
+    assert _entries(db, "messages", message_id) == [("update", 3), ("update", 4)]
+
+
+def test_prune_sync_log_is_idempotent(db: CharactersRAGDB):
+    conversation_id = db.add_conversation({"title": "idem", "character_id": 1})
+    db.add_message(
+        {"conversation_id": conversation_id, "sender": "user", "content": "hello"}
+    )
+
+    assert db.prune_sync_log() == 0
+    assert db.prune_sync_log() == 0
+
+
+def test_delete_sync_log_entries_before_matches_the_media_database_api(
+    db: CharactersRAGDB,
+):
+    """Parity with `Client_Media_DB_v2`, which ChaChaNotes never had."""
+    conversation_id = db.add_conversation({"title": "api", "character_id": 1})
+    db.add_message(
+        {"conversation_id": conversation_id, "sender": "user", "content": "one"}
+    )
+    watermark = db.get_latest_sync_log_change_id()
+    assert watermark > 0
+    live_rows = len(db.get_sync_log_entries())
+    assert live_rows > 0
+
+    assert db.delete_sync_log_entries_before(watermark) == live_rows
+    assert db.get_sync_log_entries() == []
+
+    with pytest.raises(ValueError):
+        db.delete_sync_log_entries_before(-1)
+
+
+def test_delete_sync_log_entries_rejects_non_integers(db: CharactersRAGDB):
+    with pytest.raises(ValueError):
+        db.delete_sync_log_entries([1, "two"])
+    assert db.delete_sync_log_entries([]) == 0

--- a/Tests/DB/test_chachanotes_sync_log_retention.py
+++ b/Tests/DB/test_chachanotes_sync_log_retention.py
@@ -17,17 +17,27 @@ when the read returns None, and `._reconcile_restored_chat_sync_intents`). So
 the log is bounded to the frontier its readers can reach, not emptied of
 content -- and `test_retention_does_not_break_the_committed_intent_readers`
 below is the guard on that trade.
+
+The first cut covered the six entities the FILING named. `sync_log` is written
+for NINE, and Qodo's review of PR #1974 independently found the same three
+omissions this branch's own review had recorded: `chat_dictionaries`,
+`world_books` and `world_book_entries`, none of which a version rule can
+bound. They are covered now, under a second rule, and
+`test_every_sync_log_writer_has_a_retention_scope` makes the covered set a
+DERIVED fact -- read out of the schema's own writers -- so the next writer
+cannot ship without retention the way these three did.
 """
 
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from pathlib import Path
 
 import pytest
 
-from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 from tldw_chatbook.Sync_Interop.hashing import canonical_payload_hash
 
 
@@ -430,3 +440,333 @@ def test_delete_sync_log_entries_rejects_non_integers(db: CharactersRAGDB):
     with pytest.raises(ValueError):
         db.delete_sync_log_entries([1, "two"])
     assert db.delete_sync_log_entries([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# the census: the covered set is derived from the schema's own writers
+# ---------------------------------------------------------------------------
+# The first cut of v45 covered six entities because the FILING listed six.
+# `sync_log` is written for NINE, and Qodo's review of PR #1974 independently
+# found the same three omissions. These two tests make the covered set a
+# derived fact rather than a remembered one: a tenth writer added later reds
+# them until it also has a retention rule. There is deliberately NO allowlist
+# -- every writer is covered, so an exemption row would have nothing to hold.
+def _sync_log_writer_entities(db: CharactersRAGDB) -> set[str]:
+    """Entities the live schema actually emits `sync_log` rows for."""
+    entities: set[str] = set()
+    for row in db.execute_query(
+        "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND sql LIKE ?",
+        ("%INSERT INTO sync_log%",),
+    ).fetchall():
+        match = re.search(r"INTO sync_log\([^)]*\)\s*VALUES\(\s*'([a-z_]+)'", row[0])
+        assert match is not None, f"unparsed sync_log writer:\n{row[0]}"
+        entities.add(match.group(1))
+    return entities
+
+
+def test_every_sync_log_writer_has_a_retention_scope(db: CharactersRAGDB):
+    """`prune_sync_log`'s covered set == the table's writers, both directions."""
+    covered = {scope[0] for scope in CharactersRAGDB._SYNC_LOG_RETENTION_SCOPES} | {
+        scope[0] for scope in CharactersRAGDB._SYNC_LOG_LATEST_ONLY_SCOPES
+    }
+    writers = _sync_log_writer_entities(db)
+
+    assert writers, "no sync_log writers found -- the census would be vacuous"
+    assert covered == writers, (
+        f"sync_log writers with no retention rule: {sorted(writers - covered)}; "
+        f"retention scopes for entities nothing writes: {sorted(covered - writers)}"
+    )
+
+
+def test_every_sync_log_writer_has_a_prune_trigger(db: CharactersRAGDB):
+    """The schema-side half: the bound must hold without anyone calling anything."""
+    triggers = {
+        row[0]
+        for row in db.execute_query(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+        ).fetchall()
+    }
+    missing = {
+        entity
+        for entity in _sync_log_writer_entities(db)
+        if f"sync_log_prune_{entity}" not in triggers
+        or f"sync_log_prune_{entity}_hard" not in triggers
+    }
+    assert missing == set()
+
+
+# ---------------------------------------------------------------------------
+# the latest-only three (Qodo's review of PR #1974)
+# ---------------------------------------------------------------------------
+def _dictionary_lib():
+    from tldw_chatbook.Character_Chat import Chat_Dictionary_Lib
+
+    return Chat_Dictionary_Lib
+
+
+def _books(db: CharactersRAGDB):
+    from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+
+    return WorldBookManager(db)
+
+
+def test_soft_deleting_a_chat_dictionary_removes_its_text_from_sync_log(
+    db: CharactersRAGDB,
+):
+    """Includes the hazard a version rule cannot see.
+
+    `chat_dictionaries_update_timestamp` runs a nested UPDATE, which fires the
+    `sync_update` emitter again. When the timestamp it writes differs from the
+    one the outer statement wrote, that lands a FULL-PAYLOAD row at the
+    tombstone's OWN version -- so `version < NEW.version`, the rule the other
+    six use, would leave the deleted dictionary's plaintext behind. The delete
+    here is issued in exactly that shape.
+    """
+    lib = _dictionary_lib()
+    needle = _needle()
+    dictionary_id = lib.save_chat_dictionary(
+        db, name=f"dict-{needle}", description=f"secret {needle}", content="body"
+    )
+    assert _sync_log_hits(db, needle) != []
+
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE chat_dictionaries SET deleted = 1, version = version + 1, "
+            "last_modified = '2001-01-01 00:00:00' WHERE id = ?",
+            (dictionary_id,),
+        )
+
+    assert _sync_log_hits(db, needle) == []
+    assert _entries(db, "chat_dictionaries", str(dictionary_id)) == [("delete", 2)]
+
+
+def test_editing_a_chat_dictionary_keeps_only_the_current_version(
+    db: CharactersRAGDB,
+):
+    lib = _dictionary_lib()
+    stale, current = _needle(), _needle()
+    dictionary_id = lib.save_chat_dictionary(
+        db, name="edited-dict", description=f"first {stale}", content="body"
+    )
+    lib.update_chat_dictionary(db, dictionary_id, description=f"second {current}")
+
+    assert _sync_log_hits(db, stale) == []
+    assert len(_sync_log_hits(db, current)) == 1
+
+
+def test_soft_deleting_a_world_book_removes_its_text_from_sync_log(
+    db: CharactersRAGDB,
+):
+    needle = _needle()
+    books = _books(db)
+    book_id = books.create_world_book(
+        name=f"book-{needle}", description=f"secret {needle}"
+    )
+    assert _sync_log_hits(db, needle) != []
+
+    books.delete_world_book(book_id)
+
+    assert _sync_log_hits(db, needle) == []
+    assert _entries(db, "world_books", str(book_id)) == [("delete", 2)]
+
+
+def test_hard_deleting_a_world_book_entry_removes_its_lore_from_sync_log(
+    db: CharactersRAGDB,
+):
+    """The sharpest of the three: prose, hard delete, orphaned forever.
+
+    `world_book_entries` has no `version` and no `deleted` column -- every one
+    of its sync rows is written at the literal version 1 -- and Personas >
+    entry delete calls `delete_world_book_entry`, a hard `DELETE`. Before this
+    rule the entry's full `keys` + `content` survived that delete permanently,
+    with no entity row left to reach them from.
+    """
+    needle = _needle()
+    books = _books(db)
+    book_id = books.create_world_book(name="lorebook")
+    entry_id = books.create_world_book_entry(
+        book_id, keys=[needle], content=f"the {needle} lore"
+    )
+    assert _sync_log_hits(db, needle) != []
+
+    books.delete_world_book_entry(entry_id)
+
+    assert _sync_log_hits(db, needle) == []
+    # The tombstone survives -- ids only, and it is the entity's ONLY record
+    # that the delete happened (there is no soft-deleted row left behind).
+    assert _entries(db, "world_book_entries", str(entry_id)) == [("delete", 1)]
+
+
+def test_editing_a_world_book_entry_does_not_accumulate_old_bodies(
+    db: CharactersRAGDB,
+):
+    """4 edits used to retain 4/4 old bodies -- the version rule is inert here."""
+    books = _books(db)
+    book_id = books.create_world_book(name="edited-lorebook")
+    stale = [_needle() for _ in range(4)]
+    entry_id = books.create_world_book_entry(
+        book_id, keys=["k"], content=f"body {stale[0]}"
+    )
+    for needle in stale[1:]:
+        books.update_world_book_entry(entry_id, content=f"body {needle}")
+    current = _needle()
+    books.update_world_book_entry(entry_id, content=f"body {current}")
+
+    for needle in stale:
+        assert _sync_log_hits(db, needle) == [], needle
+    assert len(_sync_log_hits(db, current)) == 1
+    assert _entries(db, "world_book_entries", str(entry_id)) == [("update", 1)]
+
+
+def test_hard_deleting_a_chat_dictionary_orphans_nothing(db: CharactersRAGDB):
+    """A hard DELETE emits no sync row, so nothing would fire the log-side rule."""
+    lib = _dictionary_lib()
+    needle = _needle()
+    dictionary_id = lib.save_chat_dictionary(
+        db, name="doomed", description=f"secret {needle}", content="body"
+    )
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM chat_dictionaries WHERE id = ?", (dictionary_id,))
+
+    assert _sync_log_hits(db, needle) == []
+    assert _entries(db, "chat_dictionaries", str(dictionary_id)) == []
+
+
+def test_latest_only_retention_is_independent_of_trigger_firing_order(
+    tmp_path: Path,
+):
+    """The claim the whole rule rests on, exercised rather than asserted.
+
+    SQLite does not define the firing order of same-kind triggers, and a
+    chat-dictionary soft delete really does fire two emitters. Recreating them
+    in a different order genuinely flips which one emits first -- the control
+    half below proves that, so the experiment is not vacuous -- and the
+    retained content must be the same either way.
+    """
+    lib = _dictionary_lib()
+    emitters = (
+        "chat_dictionaries_sync_delete",
+        "chat_dictionaries_update_timestamp",
+        "chat_dictionaries_sync_update",
+    )
+
+    def run(order, with_retention):
+        database = CharactersRAGDB(
+            tmp_path / f"order-{hash((order, with_retention)) & 0xFFFF}.db",
+            "order-client",
+        )
+        try:
+            connection = database.get_connection()
+            if not with_retention:
+                connection.execute("DROP TRIGGER sync_log_prune_chat_dictionaries")
+            definitions = {
+                name: connection.execute(
+                    "SELECT sql FROM sqlite_master WHERE name = ?", (name,)
+                ).fetchone()[0]
+                for name in order
+            }
+            for name in order:
+                connection.execute(f"DROP TRIGGER {name}")
+            for name in order:
+                connection.execute(definitions[name])
+            connection.commit()
+
+            dictionary_id = lib.save_chat_dictionary(
+                db=database, name="ordered", description="secret-body", content="body"
+            )
+            with database.transaction() as conn:
+                conn.execute(
+                    "UPDATE chat_dictionaries SET deleted = 1, "
+                    "version = version + 1, "
+                    "last_modified = '2001-01-01 00:00:00' WHERE id = ?",
+                    (dictionary_id,),
+                )
+            return [
+                (row["operation"], row["version"], "secret-body" in (row["payload"] or ""))
+                for row in database.execute_query(
+                    "SELECT operation, version, payload FROM sync_log "
+                    "WHERE entity = 'chat_dictionaries' ORDER BY change_id"
+                ).fetchall()
+            ]
+        finally:
+            database.close_connection()
+
+    reversed_order = tuple(reversed(emitters))
+    # Control: without retention the two orders differ, so the permutation is
+    # really reaching the firing order and the experiment below has teeth.
+    assert run(emitters, False) != run(reversed_order, False)
+    # With retention both converge on the tombstone alone, carrying no body.
+    assert run(emitters, True) == run(reversed_order, True) == [("delete", 2, False)]
+
+
+def test_prune_sync_log_clears_a_latest_only_backlog_written_before_the_triggers(
+    db: CharactersRAGDB,
+):
+    """The maintenance sweep must agree with the triggers, entity for entity."""
+    lib = _dictionary_lib()
+    books = _books(db)
+    stale, current, orphaned = _needle(), _needle(), _needle()
+    dictionary_id = lib.save_chat_dictionary(
+        db, name="swept", description="body", content="body"
+    )
+    book_id = books.create_world_book(name="swept-book")
+    entry_id = books.create_world_book_entry(book_id, keys=["k"], content="lore")
+
+    with db.transaction() as conn:
+        for trigger in (
+            "sync_log_prune_chat_dictionaries",
+            "sync_log_prune_world_books",
+            "sync_log_prune_world_book_entries",
+            "sync_log_prune_world_book_entries_hard",
+        ):
+            conn.execute(f"DROP TRIGGER {trigger}")
+    # Backlog in the pre-v45 shape: superseded content, plus content that
+    # outlives its entity.
+    lib.update_chat_dictionary(db, dictionary_id, description=f"stale {stale}")
+    lib.update_chat_dictionary(db, dictionary_id, description=f"current {current}")
+    books.update_world_book(book_id, description=f"current {current}")
+    books.update_world_book_entry(entry_id, content=f"stale {stale}")
+    books.update_world_book_entry(entry_id, content=f"orphaned {orphaned}")
+    books.delete_world_book_entry(entry_id)
+    assert len(_sync_log_hits(db, stale)) == 2
+    assert len(_sync_log_hits(db, orphaned)) == 1
+
+    # Six rows: the three superseded `create` rows the setup wrote before the
+    # triggers were dropped, the two superseded edits, and the orphaned entry
+    # body. Both entities that are still live keep exactly their frontier.
+    assert db.prune_sync_log() == 6
+
+    assert _sync_log_hits(db, stale) == []
+    assert _sync_log_hits(db, orphaned) == []
+    assert sorted(hit["entity"] for hit in _sync_log_hits(db, current)) == [
+        "chat_dictionaries",
+        "world_books",
+    ]
+    assert _entries(db, "world_book_entries", str(entry_id)) == [("delete", 1)]
+    assert db.prune_sync_log() == 0
+
+
+def test_prune_sync_log_refuses_an_unvalidated_retention_identifier(
+    db: CharactersRAGDB, monkeypatch: pytest.MonkeyPatch
+):
+    """The identifiers go through `sql_validation`, not straight into an f-string.
+
+    Qodo flagged the f-string interpolation of `{table}` / `{id_expr}`. Only
+    the table and its id column are identifiers now, and both are checked --
+    this is the proof the check is wired rather than decorative.
+    """
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "_SYNC_LOG_RETENTION_SCOPES",
+        (("messages", "messages) --", "id", False, True),),
+    )
+    with pytest.raises(CharactersRAGDBError, match="Invalid sync_log retention table"):
+        db.prune_sync_log()
+
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "_SYNC_LOG_RETENTION_SCOPES",
+        (("messages", "messages", "id) --", False, True),),
+    )
+    with pytest.raises(CharactersRAGDBError, match="Invalid sync_log retention id"):
+        db.prune_sync_log()

--- a/Tests/DB/test_chachanotes_sync_log_retention_migration.py
+++ b/Tests/DB/test_chachanotes_sync_log_retention_migration.py
@@ -197,9 +197,17 @@ def test_a_failure_mid_step_rewinds_to_v44_with_nothing_applied(
     """This step must be atomic and re-enterable (task-19553's rule).
 
     The purge here DELETEs user rows, so a step that could commit half of
-    itself would destroy content while leaving the stamp at 44 and the
+    itself would destroy content while leaving the stamp behind and the
     retention triggers absent -- the database would then re-enter the step
     forever. Poison a statement in the middle and require a full rewind.
+
+    Derived, not assumed, after this step was renumbered to run AFTER the
+    Actor Packs step (TASK-19057): the rewind target is still **44**, not 45,
+    because `_initialize_schema` runs the whole chain inside one outer
+    transaction and each step's `self.transaction()` nests into it rather than
+    committing on its own. So poisoning V45->V46 also unwinds the v44->v45
+    Actor Packs work -- asserted below on `actor_*`, which is the first pin
+    this repo has on the whole chain being atomic rather than each link.
     """
     db_path = tmp_path / "poisoned.db"
     needle = "zqxpoisonneedle"
@@ -243,6 +251,13 @@ def test_a_failure_mid_step_rewinds_to_v44_with_nothing_applied(
             connection.execute("SELECT COUNT(*) FROM sync_log").fetchone()[0]
             == rows_before
         ), "no row may be purged by a step that did not complete"
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' "
+                "AND name LIKE 'actor\\_%' ESCAPE '\\'"
+            ).fetchone()[0]
+            == 0
+        ), "the EARLIER step in the same chain must rewind with this one"
     finally:
         connection.close()
 
@@ -257,6 +272,11 @@ def test_a_failure_mid_step_rewinds_to_v44_with_nothing_applied(
         assert migrated.execute_query(
             "SELECT COUNT(*) FROM sync_log WHERE payload LIKE ?", (f"%{needle}%",)
         ).fetchone()[0] == 0
+        # ...and the step it now runs after landed too, in the same replay.
+        assert migrated.execute_query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' "
+            "AND name LIKE 'actor\\_%' ESCAPE '\\'"
+        ).fetchone()[0] == 2
     finally:
         migrated.close_connection()
 

--- a/Tests/DB/test_chachanotes_sync_log_retention_migration.py
+++ b/Tests/DB/test_chachanotes_sync_log_retention_migration.py
@@ -1,0 +1,304 @@
+"""ChaChaNotes v45 -> v46: `sync_log` bounded to its reachable frontier.
+
+task-19564. 35 triggers wrote the complete row as JSON into `sync_log` and
+nothing ever removed one, so a soft delete left the user's plaintext in the
+database indefinitely and every edit left a full extra copy behind forever.
+This migration installs the retention triggers and performs the one-time purge
+that an EXISTING database needs -- a fix that only helped new installs would
+leave the plaintext in place for everyone who already has it, which is what
+`test_upgrading_a_real_v44_database_purges_its_backlog` is here to prevent.
+
+It also repairs the three FTS `*_au` triggers whose DELETE half was unguarded
+(task-19567) — `messages_au`, `keyword_collections_au`, `world_books_au`;
+`keyword_collections_au` was live-reachable and corrupted the index. The
+behavioural coverage for that lives in
+`Tests/DB/test_fts_soft_delete_index_witness.py`.
+
+This module carries the repo's EXACT current-schema-version pin. It reached
+here by two hops -- from `test_chachanotes_sync_conflict_preservation_migration
+.py` (v44) to `Tests/ChaChaNotesDB/test_actor_pack_migration.py` (v45) to here
+(v46) -- because the pin belongs to the NEWEST migration's own file, so a
+schema bump touches the file that caused it rather than an unrelated older one
+(older files assert `>= their own version` instead). Updating the number here
+is a deliberate schema-review act.
+
+This step was authored as v44->v45 and renumbered to v45->v46 when TASK-19057
+(portable Actor Pack identity) merged to dev claiming v45 first. The seeds
+below deliberately still start at a real **v44** database, so every upgrade
+assertion now runs THROUGH the Actor Packs step and lands at v46 -- the chain,
+not just this one link.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from Tests.ChaChaNotesDB.historical_bootstrap import chachanotes_db_at_version
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, SchemaError
+
+SCHEMA_NAME = CharactersRAGDB._SCHEMA_NAME
+
+# Named `sync_log_prune_<entity>`, NOT `<entity>_sync_log_prune`: the
+# `<entity>_sync_%` namespace belongs to the four triggers that WRITE the log,
+# and three tests assert that namespace's membership exactly (`_` is a
+# single-character wildcard in SQL LIKE, so `conversations_sync_log_prune`
+# matches `conversations_sync_%`). Retention is a different concern and gets
+# its own prefix.
+RETENTION_TRIGGERS = {
+    f"sync_log_prune_{entity}{suffix}"
+    for entity in (
+        "messages",
+        "conversations",
+        "notes",
+        "character_cards",
+        "keywords",
+        "keyword_collections",
+    )
+    for suffix in ("", "_hard")
+}
+
+
+def _version(connection: sqlite3.Connection) -> int:
+    return connection.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (SCHEMA_NAME,),
+    ).fetchone()[0]
+
+
+def _triggers(connection: sqlite3.Connection) -> set[str]:
+    return {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+        )
+    }
+
+
+@pytest.fixture
+def db(tmp_path: Path):
+    instance = CharactersRAGDB(tmp_path / "chachanotes.db", client_id="v46-test")
+    yield instance
+    instance.close_connection()
+
+
+def test_schema_version_is_46(db):
+    """The one exact current-version pin (see this module's docstring)."""
+    assert _version(db.get_connection()) == 46
+    assert CharactersRAGDB._CURRENT_SCHEMA_VERSION == 46
+
+
+def test_fresh_schema_has_every_retention_trigger(db):
+    assert RETENTION_TRIGGERS <= _triggers(db.get_connection())
+
+
+def test_migrate_from_v45_to_v46_requires_version_45(db):
+    """A fresh DB is already at 46, so re-entering the step must refuse."""
+    with pytest.raises(SchemaError, match="requires schema version"):
+        db._migrate_from_v45_to_v46(db.get_connection())
+
+
+def test_upgrading_a_real_v44_database_purges_its_backlog(tmp_path: Path):
+    """The AC that a fix helping only new installs would fail.
+
+    A genuine v44 database is seeded with the shape the shipped code produces:
+    a soft-deleted message whose `create` intent still carries its body, a
+    superseded edit, and an orphan whose entity row is gone. After the reopen
+    they are gone and the frontier is intact.
+    """
+    db_path = tmp_path / "chachanotes.db"
+    kept_body = "frontier body that must survive"
+    deleted_body = "tombstoned body that must not"
+    superseded_body = "superseded body that must not"
+
+    with chachanotes_db_at_version(db_path, 44) as historical:
+        conversation_id = historical.add_conversation(
+            {"title": "upgrade", "character_id": 1}
+        )
+        deleted_id = historical.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": deleted_body,
+            }
+        )
+        historical.soft_delete_message(deleted_id, expected_version=1)
+        edited_id = historical.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": superseded_body,
+            }
+        )
+        historical.update_message(
+            edited_id, {"content": "second"}, expected_version=1
+        )
+        historical.update_message(edited_id, {"content": kept_body}, expected_version=2)
+        with historical.transaction() as conn:
+            conn.execute(
+                "INSERT INTO sync_log(entity, entity_id, operation, timestamp, "
+                "client_id, version, payload) VALUES ('notes', 'vanished', 'create',"
+                " '2020-01-01T00:00:00Z', 'legacy', 1, ?)",
+                (json.dumps({"id": "vanished", "content": "orphan body"}),),
+            )
+        connection = historical.get_connection()
+        # The defect, present on a real v44 database. This `== 44` is a
+        # precondition on the BOOTSTRAP FIXTURE's own argument, not a
+        # current-schema pin -- it cannot go stale on a schema bump, so it is
+        # not the short-circuiting shape task-19568 removed. The
+        # post-migration assertion below is dynamic for exactly that reason.
+        assert _version(connection) == 44
+        assert RETENTION_TRIGGERS.isdisjoint(_triggers(connection))
+        payloads_before = [
+            row[0]
+            for row in connection.execute("SELECT payload FROM sync_log")
+        ]
+        assert any(deleted_body in payload for payload in payloads_before)
+        assert any(superseded_body in payload for payload in payloads_before)
+        assert any("orphan body" in payload for payload in payloads_before)
+
+    migrated = CharactersRAGDB(db_path, client_id="v46-upgrade")
+    try:
+        connection = migrated.get_connection()
+        assert _version(connection) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+        assert RETENTION_TRIGGERS <= _triggers(connection)
+        payloads_after = [
+            row[0] for row in connection.execute("SELECT payload FROM sync_log")
+        ]
+        assert not any(deleted_body in payload for payload in payloads_after)
+        assert not any(superseded_body in payload for payload in payloads_after)
+        assert not any("orphan body" in payload for payload in payloads_after)
+        # The frontier the intent readers join to is untouched.
+        assert any(kept_body in payload for payload in payloads_after)
+        # The tombstone survives; it is the delete proof and carries no body.
+        assert [
+            row[0]
+            for row in connection.execute(
+                "SELECT operation FROM sync_log WHERE entity = 'messages' "
+                "AND entity_id = ? ORDER BY change_id",
+                (deleted_id,),
+            )
+        ] == ["delete"]
+    finally:
+        migrated.close_connection()
+
+
+def test_a_failure_mid_step_rewinds_to_v44_with_nothing_applied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """This step must be atomic and re-enterable (task-19553's rule).
+
+    The purge here DELETEs user rows, so a step that could commit half of
+    itself would destroy content while leaving the stamp at 44 and the
+    retention triggers absent -- the database would then re-enter the step
+    forever. Poison a statement in the middle and require a full rewind.
+    """
+    db_path = tmp_path / "poisoned.db"
+    needle = "zqxpoisonneedle"
+    with chachanotes_db_at_version(db_path, 44) as historical:
+        conversation_id = historical.add_conversation(
+            {"title": "poison", "character_id": 1}
+        )
+        message_id = historical.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": f"body {needle}",
+            }
+        )
+        historical.soft_delete_message(message_id, expected_version=1)
+        rows_before = historical.get_connection().execute(
+            "SELECT COUNT(*) FROM sync_log"
+        ).fetchone()[0]
+
+    original = CharactersRAGDB._execute_migration_statements
+
+    def poisoned(self, cursor, script, label):
+        if label == "V45→V46":
+            # Appended, so it runs AFTER every trigger create AND after every
+            # purge DELETE. A step that could commit part of itself would have
+            # already destroyed the sync_log rows by the time this fires --
+            # which is exactly what the assertions below would catch.
+            script = script + "\nINSERT INTO no_such_table_19564(x) VALUES (1);\n"
+        return original(self, cursor, script, label)
+
+    monkeypatch.setattr(CharactersRAGDB, "_execute_migration_statements", poisoned)
+
+    with pytest.raises(SchemaError, match="no_such_table_19564"):
+        CharactersRAGDB(db_path, client_id="poisoned")
+
+    connection = sqlite3.connect(str(db_path))
+    try:
+        assert _version(connection) == 44, "a failing step must not bump the stamp"
+        assert RETENTION_TRIGGERS.isdisjoint(_triggers(connection))
+        assert (
+            connection.execute("SELECT COUNT(*) FROM sync_log").fetchone()[0]
+            == rows_before
+        ), "no row may be purged by a step that did not complete"
+    finally:
+        connection.close()
+
+    # Re-enterable: with the poison removed the same file migrates.
+    monkeypatch.undo()
+    migrated = CharactersRAGDB(db_path, client_id="poison-removed")
+    try:
+        assert _version(migrated.get_connection()) == (
+            CharactersRAGDB._CURRENT_SCHEMA_VERSION
+        )
+        assert RETENTION_TRIGGERS <= _triggers(migrated.get_connection())
+        assert migrated.execute_query(
+            "SELECT COUNT(*) FROM sync_log WHERE payload LIKE ?", (f"%{needle}%",)
+        ).fetchone()[0] == 0
+    finally:
+        migrated.close_connection()
+
+
+def test_upgrading_reindexes_only_live_rows_into_messages_fts(tmp_path: Path):
+    """The FTS reset must not re-index tombstoned rows (task-19567).
+
+    The obvious way to repair the corrupted index is FTS5 `'rebuild'`, which
+    re-derives from the base table with no `deleted` filter -- that would put
+    every soft-deleted message back into the index and reintroduce exactly the
+    leak the guard exists to prevent. The migration uses `'delete-all'` plus an
+    explicit filtered reinsert instead; this is the assertion that says so.
+    """
+    db_path = tmp_path / "chachanotes.db"
+    needle = "zqxupgradeneedle"
+    with chachanotes_db_at_version(db_path, 44) as historical:
+        conversation_id = historical.add_conversation(
+            {"title": "fts", "character_id": 1}
+        )
+        live_id = historical.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": f"live {needle}",
+            }
+        )
+        gone_id = historical.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": f"gone {needle}",
+            }
+        )
+        historical.soft_delete_message(gone_id, expected_version=1)
+
+    migrated = CharactersRAGDB(db_path, client_id="v46-upgrade")
+    try:
+        rowids = [
+            row[0]
+            for row in migrated.execute_query(
+                "SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?",
+                (needle,),
+            ).fetchall()
+        ]
+        live_rowid = migrated.execute_query(
+            "SELECT rowid FROM messages WHERE id = ?", (live_id,)
+        ).fetchone()[0]
+        assert rowids == [live_rowid]
+    finally:
+        migrated.close_connection()

--- a/Tests/DB/test_chachanotes_sync_log_retention_migration.py
+++ b/Tests/DB/test_chachanotes_sync_log_retention_migration.py
@@ -51,12 +51,17 @@ SCHEMA_NAME = CharactersRAGDB._SCHEMA_NAME
 RETENTION_TRIGGERS = {
     f"sync_log_prune_{entity}{suffix}"
     for entity in (
+        # versioned rule
         "messages",
         "conversations",
         "notes",
         "character_cards",
         "keywords",
         "keyword_collections",
+        # latest-only rule (added after Qodo's review of PR #1974)
+        "chat_dictionaries",
+        "world_books",
+        "world_book_entries",
     )
     for suffix in ("", "_hard")
 }
@@ -252,6 +257,87 @@ def test_a_failure_mid_step_rewinds_to_v44_with_nothing_applied(
         assert migrated.execute_query(
             "SELECT COUNT(*) FROM sync_log WHERE payload LIKE ?", (f"%{needle}%",)
         ).fetchone()[0] == 0
+    finally:
+        migrated.close_connection()
+
+
+def test_upgrading_a_real_v44_database_purges_the_latest_only_backlog(tmp_path: Path):
+    """The same AC for the three writers the first cut of v45 left uncovered.
+
+    Qodo's review of PR #1974 found `chat_dictionaries`, `world_books` and
+    `world_book_entries` writing `sync_log` with no retention. A v44 database
+    is seeded through the shipped public APIs and must come out the other side
+    holding no deleted or superseded content for any of them --
+    `world_book_entries` in particular, whose payload carries the lorebook
+    prose and whose only delete path is a hard `DELETE` that orphans it.
+    """
+    db_path = tmp_path / "chachanotes.db"
+    with chachanotes_db_at_version(db_path, 44) as historical:
+        from tldw_chatbook.Character_Chat import Chat_Dictionary_Lib as chat_dict_lib
+        from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+
+        dictionary_id = chat_dict_lib.save_chat_dictionary(
+            historical, name="upgrade-dict", description="dict-gone", content="body"
+        )
+        chat_dict_lib.update_chat_dictionary(
+            historical, dictionary_id, description="dict-kept"
+        )
+        chat_dict_lib.delete_chat_dictionary(historical, dictionary_id)
+
+        books = WorldBookManager(historical)
+        book_id = books.create_world_book(name="upgrade-book", description="book-gone")
+        books.update_world_book(book_id, description="book-kept")
+
+        deleted_book = books.create_world_book(
+            name="upgrade-book-2", description="deleted-book"
+        )
+        books.delete_world_book(deleted_book)
+
+        entry_id = books.create_world_book_entry(
+            book_id, keys=["k"], content="lore-superseded"
+        )
+        books.update_world_book_entry(entry_id, content="lore-kept")
+        gone_entry = books.create_world_book_entry(
+            book_id, keys=["g"], content="lore-hard-deleted"
+        )
+        books.delete_world_book_entry(gone_entry)
+
+        connection = historical.get_connection()
+        payloads_before = [
+            row[0] for row in connection.execute("SELECT payload FROM sync_log")
+        ]
+        # The defect, on a real v44 database: every one of these survives.
+        for gone in (
+            "dict-gone",
+            "dict-kept",
+            "book-gone",
+            "deleted-book",
+            "lore-superseded",
+            "lore-hard-deleted",
+        ):
+            assert any(gone in payload for payload in payloads_before), gone
+
+    migrated = CharactersRAGDB(db_path, client_id="v45-upgrade")
+    try:
+        connection = migrated.get_connection()
+        payloads_after = [
+            row[0] for row in connection.execute("SELECT payload FROM sync_log")
+        ]
+        for gone in (
+            "dict-gone",  # superseded edit
+            "dict-kept",  # the frontier of a SOFT-DELETED dictionary
+            "book-gone",  # superseded edit
+            "deleted-book",  # the frontier of a soft-deleted world book
+            "lore-superseded",  # superseded lorebook prose
+            "lore-hard-deleted",  # orphaned lorebook prose
+        ):
+            assert not any(gone in payload for payload in payloads_after), gone
+        # A LIVE entity keeps exactly one content-bearing proof.
+        assert sum("book-kept" in payload for payload in payloads_after) == 1
+        assert sum("lore-kept" in payload for payload in payloads_after) == 1
+        # The converged state matches what the triggers maintain, so the
+        # maintenance sweep finds nothing left to do.
+        assert migrated.prune_sync_log() == 0
     finally:
         migrated.close_connection()
 

--- a/Tests/DB/test_fts_soft_delete_index_witness.py
+++ b/Tests/DB/test_fts_soft_delete_index_witness.py
@@ -1,0 +1,376 @@
+"""Behavioural witnesses for the FTS soft-delete guards (task-19567 B).
+
+Why this exists -- the incident, not the rule. Lane 5 of the 2026-08-21
+holistic review mutated ``WHERE new.deleted = 0`` out of the ``messages_au``
+trigger and **475 tests across every FTS-adjacent file still passed**. Tests
+named for the behaviour exist (``Tests/DB/test_search_conversations_fts.py``
+``test_soft_deleted_message_does_not_match``), and none of them could catch it,
+because all four production ``messages_fts`` consumers redundantly re-filter at
+query level -- so the trigger regression is invisible through every shipped
+API. The only tests that touched ``messages_fts`` directly
+(``test_chachanotes_provider_continuation_migration.py``) compare a before and
+an after snapshot for **equality**, and a uniform mutation moves both sides
+together.
+
+So every assertion here queries the FTS index **directly**, never through a
+consumer, and every assertion is an **absolute** expectation (``== []`` /
+``== [id]``), never a before/after equality snapshot.
+
+Mutation proof for these tests is recorded in task-19567: deleting the
+``WHERE new.deleted = 0`` line from ``messages_au`` in the shipped schema turns
+the messages cases red. The equivalent holds for each sibling.
+
+The census at the bottom is the "any FTS consumer added later inherits the
+guarantee" net: the coverage lives with the trigger, so a NEW soft-deletable
+FTS-backed table cannot ship without a guard even if nobody thinks to write a
+behavioural test for it.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(tmp_path / "witness.db", "witness_client")
+    try:
+        yield database
+    finally:
+        database.close_connection()
+
+
+def _needle() -> str:
+    """A token no other row can contain, safe for an FTS MATCH."""
+    return "zqx" + uuid.uuid4().hex[:12]
+
+
+def _fts_rowids(db: CharactersRAGDB, table: str, needle: str) -> list[int]:
+    """Rowids the FTS index itself returns -- no join, no ``deleted`` filter.
+
+    This is the whole point of the module: a consumer's ``WHERE m.deleted = 0``
+    cannot mask a regression here, because there is no consumer.
+    """
+    return [
+        row[0]
+        for row in db.execute_query(
+            f"SELECT rowid FROM {table} WHERE {table} MATCH ?", (needle,)
+        ).fetchall()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# messages -- the trigger Lane 5 actually mutated
+# ---------------------------------------------------------------------------
+def test_messages_fts_index_drops_a_soft_deleted_message(db: CharactersRAGDB):
+    needle = _needle()
+    conversation_id = db.add_conversation({"title": "witness", "character_id": 1})
+    message_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": f"body carrying {needle} inside",
+        }
+    )
+    rowid = db.execute_query(
+        "SELECT rowid FROM messages WHERE id = ?", (message_id,)
+    ).fetchone()[0]
+    assert _fts_rowids(db, "messages_fts", needle) == [rowid]
+
+    db.soft_delete_message(message_id, expected_version=1)
+
+    assert _fts_rowids(db, "messages_fts", needle) == []
+
+
+def test_messages_fts_index_drops_a_message_deleted_by_raw_update(
+    db: CharactersRAGDB,
+):
+    """The guard, not the Python method, is what has to hold.
+
+    ``soft_delete_message`` could grow an explicit index maintenance step and
+    keep the previous test green with the trigger broken. A bare ``UPDATE``
+    leaves only the trigger in the path.
+    """
+    needle = _needle()
+    conversation_id = db.add_conversation({"title": "witness", "character_id": 1})
+    message_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": f"raw path {needle}",
+        }
+    )
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE messages SET deleted = 1, version = version + 1 WHERE id = ?",
+            (message_id,),
+        )
+
+    assert _fts_rowids(db, "messages_fts", needle) == []
+
+
+def test_messages_fts_index_restores_an_undeleted_message(db: CharactersRAGDB):
+    """The guard must not be satisfiable by never indexing anything."""
+    needle = _needle()
+    conversation_id = db.add_conversation({"title": "witness", "character_id": 1})
+    message_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": f"round trip {needle}",
+        }
+    )
+    rowid = db.execute_query(
+        "SELECT rowid FROM messages WHERE id = ?", (message_id,)
+    ).fetchone()[0]
+    db.soft_delete_message(message_id, expected_version=1)
+    assert _fts_rowids(db, "messages_fts", needle) == []
+
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE messages SET deleted = 0, version = version + 1 WHERE id = ?",
+            (message_id,),
+        )
+
+    assert _fts_rowids(db, "messages_fts", needle) == [rowid]
+
+
+# ---------------------------------------------------------------------------
+# siblings -- confirmed to share the shape, and to have shared the gap
+# ---------------------------------------------------------------------------
+def test_notes_fts_index_drops_a_soft_deleted_note(db: CharactersRAGDB):
+    needle = _needle()
+    note_id = db.add_note(title="witness note", content=f"note body {needle}")
+    rowid = db.execute_query(
+        "SELECT rowid FROM notes WHERE id = ?", (note_id,)
+    ).fetchone()[0]
+    assert _fts_rowids(db, "notes_fts", needle) == [rowid]
+
+    db.soft_delete_note(note_id, expected_version=1)
+
+    assert _fts_rowids(db, "notes_fts", needle) == []
+
+
+def test_conversations_fts_index_drops_a_soft_deleted_conversation(
+    db: CharactersRAGDB,
+):
+    needle = _needle()
+    conversation_id = db.add_conversation(
+        {"title": f"title {needle}", "character_id": 1}
+    )
+    rowid = db.execute_query(
+        "SELECT rowid FROM conversations WHERE id = ?", (conversation_id,)
+    ).fetchone()[0]
+    assert _fts_rowids(db, "conversations_fts", needle) == [rowid]
+
+    db.soft_delete_conversation(conversation_id, expected_version=1)
+
+    assert _fts_rowids(db, "conversations_fts", needle) == []
+
+
+def test_character_cards_fts_index_drops_a_soft_deleted_card(db: CharactersRAGDB):
+    needle = _needle()
+    card_id = db.add_character_card(
+        {"name": f"witness {needle}", "description": "witness card"}
+    )
+    assert _fts_rowids(db, "character_cards_fts", needle) == [card_id]
+
+    db.soft_delete_character_card(card_id, expected_version=1)
+
+    assert _fts_rowids(db, "character_cards_fts", needle) == []
+
+
+def test_keywords_fts_index_drops_a_soft_deleted_keyword(db: CharactersRAGDB):
+    needle = _needle()
+    keyword_id = db.add_keyword(needle)
+    assert _fts_rowids(db, "keywords_fts", needle) == [keyword_id]
+
+    db.soft_delete_keyword(keyword_id, expected_version=1)
+
+    assert _fts_rowids(db, "keywords_fts", needle) == []
+
+
+def test_keyword_collections_fts_index_drops_a_soft_deleted_collection(
+    db: CharactersRAGDB,
+):
+    needle = _needle()
+    collection_id = db.add_keyword_collection(f"collection {needle}")
+    assert _fts_rowids(db, "keyword_collections_fts", needle) == [collection_id]
+
+    db.soft_delete_keyword_collection(collection_id, expected_version=1)
+
+    assert _fts_rowids(db, "keyword_collections_fts", needle) == []
+
+
+def test_re_adding_a_soft_deleted_keyword_collection_keeps_the_index_usable(
+    db: CharactersRAGDB,
+):
+    """Regression: the unguarded DELETE half corrupted the index (task-19567).
+
+    On the shipped code this raised ``sqlite3.DatabaseError: database disk
+    image is malformed`` inside ``_add_generic_item``'s undelete UPDATE --
+    ``keyword_collections_au`` issued the FTS ``'delete'`` for a row that was
+    not in the index. Reached entirely through the public API.
+    """
+    needle = _needle()
+    name = f"collection {needle}"
+    collection_id = db.add_keyword_collection(name)
+    db.soft_delete_keyword_collection(collection_id, expected_version=1)
+
+    assert db.add_keyword_collection(name) == collection_id
+
+    assert _fts_rowids(db, "keyword_collections_fts", needle) == [collection_id]
+
+
+# `chat_dictionaries` and `world_books` are the two soft-deletable FTS-backed
+# tables the filing did not list; the census below is what found them. They
+# have no soft-delete method on this class, so the raw UPDATE is the honest
+# shape of what production does to them.
+def test_chat_dictionaries_fts_index_drops_a_soft_deleted_dictionary(
+    db: CharactersRAGDB,
+):
+    needle = _needle()
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO chat_dictionaries (name, description, content, client_id) "
+            "VALUES (?, ?, ?, ?)",
+            (f"witness {needle}", "witness dictionary", "entries", "witness_client"),
+        )
+        dictionary_id = conn.execute(
+            "SELECT id FROM chat_dictionaries WHERE name = ?", (f"witness {needle}",)
+        ).fetchone()[0]
+    assert _fts_rowids(db, "chat_dictionaries_fts", needle) == [dictionary_id]
+
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE chat_dictionaries SET deleted = 1, version = version + 1 "
+            "WHERE id = ?",
+            (dictionary_id,),
+        )
+
+    assert _fts_rowids(db, "chat_dictionaries_fts", needle) == []
+
+
+def test_world_books_fts_index_drops_a_soft_deleted_world_book(db: CharactersRAGDB):
+    needle = _needle()
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO world_books (name, description, client_id) VALUES (?, ?, ?)",
+            (f"witness {needle}", "witness world book", "witness_client"),
+        )
+        book_id = conn.execute(
+            "SELECT id FROM world_books WHERE name = ?", (f"witness {needle}",)
+        ).fetchone()[0]
+    assert _fts_rowids(db, "world_books_fts", needle) == [book_id]
+
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE world_books SET deleted = 1, version = version + 1 WHERE id = ?",
+            (book_id,),
+        )
+
+    assert _fts_rowids(db, "world_books_fts", needle) == []
+
+    # `world_books_au` had the same unguarded DELETE half as
+    # `keyword_collections_au` (task-19567). It had no undelete path to reach
+    # it, which made it latent rather than safe -- one restore API away.
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE world_books SET deleted = 0, version = version + 1 WHERE id = ?",
+            (book_id,),
+        )
+
+    assert _fts_rowids(db, "world_books_fts", needle) == [book_id]
+
+
+# ---------------------------------------------------------------------------
+# the census -- so a table added later inherits the guarantee
+# ---------------------------------------------------------------------------
+_CONTENT_TABLE_RE = re.compile(r"content\s*=\s*'([^']+)'", re.IGNORECASE)
+
+# Every external-content FTS5 table whose base table carries `deleted`, as of
+# schema v45. The list is asserted against the live schema below, so adding a
+# new one is a test failure until it also gets a behavioural witness above.
+EXPECTED_SOFT_DELETABLE_FTS = {
+    "character_cards_fts": "character_cards",
+    "chat_dictionaries_fts": "chat_dictionaries",
+    "conversations_fts": "conversations",
+    "keyword_collections_fts": "keyword_collections",
+    "keywords_fts": "keywords",
+    "messages_fts": "messages",
+    "notes_fts": "notes",
+    "world_books_fts": "world_books",
+}
+
+
+def _soft_deletable_fts_tables(conn: sqlite3.Connection) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for name, sql in conn.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'table' AND sql LIKE '%fts5%'"
+    ).fetchall():
+        match = _CONTENT_TABLE_RE.search(sql or "")
+        if match is None:
+            continue  # standalone FTS index; it owns its own rows
+        base = match.group(1)
+        columns = {
+            row[1] for row in conn.execute(f"PRAGMA table_info({base})").fetchall()
+        }
+        if "deleted" in columns:
+            found[name] = base
+    return found
+
+
+def test_the_set_of_soft_deletable_fts_tables_is_the_witnessed_set(
+    db: CharactersRAGDB,
+):
+    """A new soft-deletable FTS table fails here until it gets a witness."""
+    assert _soft_deletable_fts_tables(db.get_connection()) == (
+        EXPECTED_SOFT_DELETABLE_FTS
+    )
+
+
+def test_every_soft_deletable_fts_table_has_a_guarded_after_update_trigger(
+    db: CharactersRAGDB,
+):
+    """Structural backstop for the behavioural witnesses above.
+
+    Both halves are checked. The INSERT half's ``new.deleted = 0`` is the leak
+    guard. The DELETE half's ``old.deleted = 0`` is the corruption guard --
+    issuing an FTS5 ``'delete'`` for a row that is not in an external-content
+    index corrupts it, which is how ``add_keyword_collection`` on a
+    soft-deleted name raised ``database disk image is malformed`` before
+    task-19567.
+
+    Deliberately secondary to the behavioural witnesses: a source-string
+    assertion is what let ``test_uses_messages_fts_match`` pass while the guard
+    was mutated away. Its job is to catch a NEW table whose author forgot a
+    guard before anyone writes it a behavioural test.
+    """
+    conn = db.get_connection()
+    findings: list[str] = []
+    for fts_table, base in sorted(_soft_deletable_fts_tables(conn).items()):
+        rows = conn.execute(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND tbl_name = ?",
+            (base,),
+        ).fetchall()
+        after_update = [
+            (name, sql)
+            for name, sql in rows
+            if sql and "AFTER UPDATE" in sql.upper() and fts_table in sql
+        ]
+        assert after_update, f"{fts_table} has no AFTER UPDATE trigger on {base}"
+        for name, sql in after_update:
+            normalized = " ".join(sql.lower().split())
+            if "new.deleted = 0" not in normalized:
+                findings.append(f"{name}: insert half unguarded")
+            if "old.deleted = 0" not in normalized:
+                findings.append(f"{name}: delete half unguarded")
+    assert findings == []

--- a/Tests/DB/test_sql_validation.py
+++ b/Tests/DB/test_sql_validation.py
@@ -130,6 +130,32 @@ class TestValidateTableName:
         for column in registered:
             assert validate_column_name(column, "ChunkingTemplates") is True
 
+    def test_sync_log_latest_only_table_columns_are_live(self, tmp_path):
+        """task-19564: the three tables `prune_sync_log` validates against.
+
+        `validate_column_name` fails CLOSED for a table with no `VALID_COLUMNS`
+        entry, so these three sets are what lets the retention sweep route its
+        identifiers through this module at all. Pinned against a live
+        fully-migrated database so a future world-book/dictionary column
+        change cannot leave the registration stale.
+        """
+        from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+        database = CharactersRAGDB(str(tmp_path / "scopes.db"), client_id="test")
+        try:
+            for _, table, id_column, _, _ in CharactersRAGDB._SYNC_LOG_LATEST_ONLY_SCOPES:
+                assert validate_table_name(table, "chachanotes") is True
+                live = {
+                    row["name"]
+                    for row in database.get_connection().execute(
+                        f"PRAGMA table_info({table})"
+                    )
+                }
+                assert VALID_COLUMNS[table] == live, table
+                assert validate_column_name(id_column, table) is True
+        finally:
+            database.close_connection()
+
     def test_valid_prompts_tables(self):
         """Test valid table names for prompts database."""
         valid_tables = [

--- a/Tests/Notes/test_note_import_executor.py
+++ b/Tests/Notes/test_note_import_executor.py
@@ -4130,6 +4130,19 @@ def test_target_sql_matches_service_metadata_fts_and_sync_conventions(
         == 1
     )
 
+    # task-19564: the v45 retention triggers drop superseded `sync_log`
+    # versions, so the `create` row no longer survives the replace -- a note's
+    # full text is not kept in the log once a newer version exists. Its
+    # payload shape is still asserted, by reading it while it is the frontier.
+    note_sync_on_create = connection.execute(
+        "SELECT operation, timestamp, client_id, version, payload FROM sync_log "
+        "WHERE entity = 'notes' AND entity_id = ? ORDER BY change_id",
+        (_NOTE_ID,),
+    ).fetchall()
+    assert [
+        (row["operation"], row["version"]) for row in note_sync_on_create
+    ] == [("create", 1)]
+
     target.replace_note(
         note_id=_NOTE_ID,
         expected_version=1,
@@ -4150,10 +4163,9 @@ def test_target_sql_matches_service_metadata_fts_and_sync_conventions(
         (_NOTE_ID,),
     ).fetchall()
     assert [(row["operation"], row["version"]) for row in note_sync] == [
-        ("create", 1),
         ("update", 2),
     ]
-    for row in note_sync:
+    for row in [*note_sync_on_create, *note_sync]:
         payload = json.loads(row["payload"])
         assert set(payload) == {
             "id",

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5797,7 +5797,6 @@ Threat model, recorded because it is what makes the above worth the effort: no
 root these features operate on (TASK-19700).
 
 
-
 ## A setup step whose failure is only a log line builds the wrong fixture (TASK-19554, 2026-08-21)
 
 **What happened.** `Tests/Notes/test_sync_engine.py::test_conflict_detection`
@@ -5829,7 +5828,6 @@ calls instead of reusing a literal. The tell that something is wrong is a
 fixture that passes against a *stronger* claim than it set up: here, deleting
 the entire baseline step would not have changed the test's result, which is the
 definition of a setup step that is not doing anything.
-
 
 
 ## A guarantee is only proved for the sink you asserted against — and a test's stand-in is not the shipped one (TASK-19555, 2026-08-21)
@@ -6680,3 +6678,60 @@ the thing works. And when you write the "degrade gracefully" branch, say out
 loud what the resulting end state is: here the correct one for a legitimately
 embedded app is *no handlers, no claim, no watchdog* — fully inert — which is
 only reachable if the failure path leaves the state untouched and retryable.
+
+## "Zero external callers" ages: re-derive the caller set, do not inherit the claim (TASK-19564, 2026-08-22)
+
+**What happened.** TASK-19564 filed ChaChaNotes `sync_log` as a write-only
+shadow copy and recommended *retiring the content columns* on the strength of
+"both of its readers have **zero external callers** — nothing consumes it."
+That sentence was true when the pattern was named. By the time the task was
+implemented, `ChaChaNotes_DB.py` had **six** `sync_log` readers, not two, and
+three of the four newer ones had live non-test callers:
+`read_committed_chat_sync_intent` (`ConsoleChatStore
+.ensure_provider_continuation_durable`, which **raises** on a `None` read),
+`read_committed_chat_delete_intent`, and
+`list_current_committed_chat_sync_intents`
+(`._reconcile_restored_chat_sync_intents`, on every conversation restore).
+Each compares the stored payload to the live `messages` row **field by field**;
+the payload IS the commit proof. Retiring `content` as recommended would have
+made every comparison fail — silently disabling Sync v2 and turning every
+provider-continuation checkpoint into a hard error.
+
+**Why the stale claim was believable.** Grepping the two READER NAMES the
+filing quoted reproduces the filing's answer exactly: `get_sync_log_entries`
+and `get_latest_sync_log_change_id` really do have only test callers in this
+database (the production hits are `Prompt_Management/Prompts_Interop.py`
+calling the *Prompts* DB's same-named methods). The claim fails only if you
+grep the TABLE, `sync_log`, and read every hit — the newer readers embed it in
+a `JOIN sync_log AS intent` inside a method whose name says nothing about the
+log.
+
+**What to do.** When a filing says a thing is dead, re-derive the caller set
+from the artifact itself (the table, the column, the file) rather than from the
+symbol names the filing chose, and check the *newest* code first — a corpse
+claim decays from the direction of recent work. Then confirm the negative
+direction too: what *would* break if you removed it, checked by reading the
+would-be-orphaned call sites, not by running a suite. Here the suite would not
+have caught it either: the readers `return None` on failure, and the callers
+degrade to `{"status": "skipped"}`.
+
+**Second-order find, same session.** Writing the direct-index witness for the
+sibling task surfaced an unrelated live defect the same way: `messages_au` and
+`keyword_collections_au` issued an FTS5 `'delete'` unconditionally, and
+`add_keyword_collection` on a soft-deleted name raised `database disk image is
+malformed` through the public API. Nothing had ever asserted against the FTS
+index directly, so it had gone unnoticed. Also worth knowing before you reach
+for it: FTS5 `'rebuild'` re-derives from the base table with **no** `deleted`
+filter, so using it to repair an external-content index re-indexes every
+tombstoned row. Use `'delete-all'` plus an explicit filtered reinsert.
+
+**Third find, same session — `_` is a wildcard in SQL `LIKE`.** The new
+retention triggers were first named `<entity>_sync_log_prune`, which silently
+joined the `<entity>_sync_%` namespace that three tests assert the exact
+membership of as a design invariant ("these four triggers, and only these,
+write the sync log"). Only ONE of the three went red, because the other two run
+against pre-migration historical databases where the new triggers do not exist
+yet — so two-thirds of the collision was invisible until a later schema bump
+would have surfaced it in an unrelated PR. When adding a schema object, grep
+the test tree for `LIKE '<prefix>%'` patterns your new name could match, and
+remember the underscore matches any single character.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6752,3 +6752,34 @@ not cross from one half to the other. Rule: when a change claims to bound a
 shared table, derive the covered set from the table's own writers and assert
 `covered == writers` in a census test, exactly as the FTS half did; otherwise
 the AC's example list silently becomes the scope.
+
+**Follow-on, same branch, after a third-party reviewer converged on the same
+find.** Qodo's review of PR #1974 reported the identical three omissions. Two
+things were learned closing it, both worth carrying:
+
+*A documented gap is not a shipped gap.* The branch had already written the
+residue up honestly, with reasons it was hard. That is better than silence, but
+the docstring still said "Delete every `sync_log` row no reader can reach"
+while three entities' plaintext survived deletion — an untrue contract in a
+*privacy* fix. When an independent reviewer names the same gap, that is the
+signal to price the fix again rather than re-defend the deferral.
+
+*"Order-independent" is a claim that needs a control, not an argument.* The
+rule that shipped had to survive SQLite's undefined firing order for same-kind
+triggers. Re-running every scenario under six permutations of the emitters'
+creation order and getting identical results proves nothing on its own — the
+permutation might not reach the firing order at all. The evidence is the
+**control**: with the retention triggers dropped, the same soft delete emits
+`update@cid3, delete@cid4` in one permutation and `delete@cid3, update@cid4` in
+the other. Only then does "identical with retention" mean something. The shipped
+test asserts both halves — differ without, agree with — so it cannot pass
+vacuously. Generalises: any experiment of the form "X does not depend on Y"
+needs a run showing Y actually varied.
+
+One more concrete trap from the same work: `CURRENT_TIMESTAMP` is constant
+within a single `sqlite3_step()`, so a timestamp trigger's nested UPDATE
+usually writes the *same* value the outer statement did and its emitter's
+`OLD.x IS NOT NEW.x` guard stays false. The hazard only appears when the outer
+statement supplies a different timestamp — which means probing the natural path
+alone would have concluded, wrongly, that there was no same-version content
+row. Construct the hostile input; the friendly one hid the bug.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6735,3 +6735,20 @@ yet — so two-thirds of the collision was invisible until a later schema bump
 would have surfaced it in an unrelated PR. When adding a schema object, grep
 the test tree for `LIKE '<prefix>%'` patterns your new name could match, and
 remember the underscore matches any single character.
+
+**Fourth find, independent review of the same branch — a retention rule must
+enumerate its WRITERS from the live schema, not from the entities the filing
+named.** The filing's ACs listed "conversation, message, note or character", and
+the shipped rule covered those plus keywords and keyword_collections: six
+entities, all correct. Enumerating `sqlite_master` for triggers containing
+`INSERT INTO sync_log` finds **nine** — `chat_dictionaries`, `world_books` and
+`world_book_entries` also write the log, none was covered, and probing them on
+the finished branch reproduced the original defect verbatim (a hard-deleted
+world-book entry's full `keys` + `content` orphaned in `sync_log` forever;
+4/4 old bodies retained across 4 edits). The sibling half of the SAME commit had
+already enumerated `chat_dictionaries` and `world_books` from the schema for its
+FTS census and found them — so the information was in the branch, it just did
+not cross from one half to the other. Rule: when a change claims to bound a
+shared table, derive the covered set from the table's own writers and assert
+`covered == writers` in a census test, exactly as the FTS half did; otherwise
+the AC's example list silently becomes the scope.

--- a/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
+++ b/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
@@ -127,8 +127,8 @@ row on `entity_id` AND `version`:
 
 ### What shipped
 
-* **Schema v45** (`_CURRENT_SCHEMA_VERSION` 44 → 45) +
-  `DB/migrations/chachanotes_v44_to_v45_sync_log_retention.sql`, run through
+* **Schema v46** (`_CURRENT_SCHEMA_VERSION` 45 → 46) +
+  `DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql`, run through
   `_execute_migration_statements` inside `self.transaction()` per task-19553's
   atomicity convention. Bare `CREATE TRIGGER` statements so
   `_drop_superseded_trigger` makes the step re-enterable.
@@ -220,7 +220,7 @@ documented gap; **Qodo's review of PR #1974 reached the same finding
 independently**, which is a strong signal it should not ship as a gap at all.
 It does not: the rule is extended here rather than deferred.
 
-Reproduced at v45 before the fix, through the shipped public APIs:
+Reproduced before the fix, through the shipped public APIs:
 
 | sequence (public API path) | result |
 | --- | --- |
@@ -230,7 +230,7 @@ Reproduced at v45 before the fix, through the shipped public APIs:
 | 4 edits of a world-book entry | 4/4 old bodies retained (unbounded growth continues) |
 
 **Why the six's rule does not extend to them.** Two findings from probing a
-live v45 database, both of which invalidate a naive `version < NEW.version`
+live database, both of which invalidate a naive `version < NEW.version`
 trigger:
 
 * `world_book_entries` has **no `version` column and no `deleted` column**.
@@ -321,7 +321,7 @@ book (`delete_world_book` is a soft delete), and retention neither causes nor
 worsens it. Recorded rather than fixed inside a retention change.
 
 Also worth recording: `get_sync_log_entries(since_change_id=…)` has **no**
-version filter — it is a change-feed API, and after v45 it returns a frontier
+version filter — it is a change-feed API, and after this change it returns a frontier
 snapshot rather than a complete log. It has zero ChaChaNotes production callers
 today (the production hits belong to the Prompts DB's same-named method), so
 nothing breaks; but anything built on it later must be written knowing the feed
@@ -341,17 +341,20 @@ which is also the honest name: retention is a different concern from emission.
 
 ### Modified/added files
 
-* `tldw_chatbook/DB/ChaChaNotes_DB.py` — version bump, `_migrate_from_v44_to_v45`,
+* `tldw_chatbook/DB/ChaChaNotes_DB.py` — version bump, `_migrate_from_v45_to_v46`,
   `_SYNC_LOG_RETENTION_SCOPES`, `_SYNC_LOG_LATEST_ONLY_SCOPES`,
   `_sync_log_scope_identifiers`, `prune_sync_log`, `delete_sync_log_entries`,
   `delete_sync_log_entries_before`
-* `tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_sync_log_retention.sql` (new)
+* `tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql` (new)
 * `tldw_chatbook/DB/sql_validation.py` — `VALID_COLUMNS` entries for
   `chat_dictionaries` / `world_books` / `world_book_entries`, without which
   `validate_column_name` fails closed for the retention sweep
 * `Tests/DB/test_chachanotes_sync_log_retention.py` (new)
 * `Tests/DB/test_chachanotes_sync_log_retention_migration.py` (new — carries the
-  repo's exact schema-version pin, moved on from the v43→v44 file)
+  repo's exact schema-version pin, moved on from the Actor Packs v45 file)
+* `Tests/ChaChaNotesDB/test_actor_pack_migration.py` — its three exact `== 45`
+  pins relaxed to `>= 45` / the dynamic constant, because this step is now the
+  newest migration and owns the exact pin (TASK-19554's convention)
 * `Tests/DB/test_sql_validation.py` — the three new column sets pinned against a
   live migrated database
 * `Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py` — pin
@@ -361,14 +364,80 @@ which is also the honest name: retention is a different concern from emission.
   `Tests/Notes/test_note_import_executor.py` — three assertions that counted
   superseded `sync_log` history, rewritten to assert the frontier directly
 
+### Renumbered v44→v45 ⇒ v45→v46 (schema collision, 2026-08-22)
+
+TASK-19057 (portable Actor Pack identity + Persona intents) merged to dev
+claiming v44→v45 while this branch was in review, so both migrations asserted
+the same version. Renumbered here rather than hand-merged, because a migration
+number is not a mechanical conflict resolution:
+
+* `chachanotes_v44_to_v45_sync_log_retention.sql` →
+  `chachanotes_v45_to_v46_sync_log_retention.sql`; runner renamed to
+  `_migrate_from_v45_to_v46`, entry guard `_require_migration_entry_version(
+  conn, 45, "V45→V46")`, dispatch row `45: self._migrate_from_v45_to_v46`, so
+  this step now runs AFTER Actor Packs. Their method is byte-untouched.
+* `_CURRENT_SCHEMA_VERSION = 46`. The comment convention on dev is a **single
+  one-line description of the newest step, replaced on each bump** — checked
+  across the last eight bumps (v38→v45), none of which kept a list — so it now
+  reads `# \`sync_log\` bounded to its reachable frontier (task-19564).`
+  Actor Packs' attribution lives where it is durable: the migration filename,
+  the runner, and its own test module.
+* The exact `==` pin moved to this step's own test file (`== 46`), and the
+  Actor Packs test's three `== 45` pins were relaxed — TASK-19554's convention
+  as repaired by TASK-19568. Leaving a literal `== 45` there would have red on
+  version arithmetic and short-circuited its real column assertions.
+
+Re-derived rather than assumed, on a live v46 database:
+
+* **Actor Packs adds no `sync_log` writer** — 2 tables, 1 index, zero triggers.
+  Writers stay at nine and the census is green, which is the correct outcome
+  rather than a missed one; the guard's teeth were re-proved by removing
+  `world_book_entries` from the covered set (red with the right message) and
+  Edit-restoring.
+* **The order-independence experiment was re-run at v46** — 7 permutations,
+  all identical, with the control still showing `update@cid3, delete@cid4`
+  versus `delete@cid3, update@cid4` when retention is off.
+* **Atomicity at the new position is STRONGER than before, and the number is
+  derived.** Poisoning `V45→V46` on a real v44 database rewinds the stamp to
+  **44, not 45**: `_initialize_schema` wraps the whole chain in one outer
+  transaction and each step's `self.transaction()` nests into it rather than
+  committing independently, so the Actor Packs step unwinds too. Measured:
+  stamp 44, 0 prune triggers, `sync_log` rows unchanged, and **0 `actor_*`
+  tables**. That last assertion is new — it is the first pin in this repo on
+  the whole chain being atomic rather than each link — and with the poison
+  removed the same file replays to 46 with 18 prune triggers and 2 `actor_*`
+  tables.
+
 ### Verification (final state)
 
-`Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Sync_Interop`: **1723 passed, 1
-skipped** (1710 → +13 new). `Tests/Notes`: **2847 passed, 5 skipped**.
-`Tests/Character_Chat` + `Tests/Architecture`: 1162 passed, 1 skipped, 4 failed
-— all four in `Tests/Architecture` and about `UI/Screens/chat_screen.py`, a
-file this branch does not touch (pre-existing dev reds). Repo-wide
-`--collect-only -q`: **56182 tests collected**, with
-`Tests/UI/test_library_file_notes_workspace.py` ignored — it errors at
-collection (`function uses no argument 'push_phase'`) on a file identical to
-the merge base, last touched 2026-08-20 by an unrelated commit.
+After the renumber, rebased onto dev `684c6aba4`:
+
+`Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Sync_Interop`: **1733 passed, 1
+skipped, 1 failed** — 1723 (this branch's previous green) + 10 tests dev's own
+`test_actor_pack_migration.py` brings into the same gate. `Tests/Notes`:
+**2847 passed, 5 skipped**. `ruff`: clean.
+
+The one red is **not this branch's**:
+`test_sql_validation.py::test_no_missing_tables` fails with *"Live schema has
+tables not in VALID_TABLES['chachanotes']: ['actor_pack_persona_intents',
+'actor_portable_identities']"*. TASK-19057 created those two tables and did not
+register them. Proved not-ours three ways: the `VALID_TABLES` block is
+**byte-identical to dev's**, dev's copy already lacks both names, and this
+migration contains **zero** `CREATE TABLE`. Reported, deliberately not fixed
+inside this PR. (Their index census WAS updated —
+`idx_actor_pack_persona_intents_state` is pinned in
+`Tests/ChaChaNotesDB/test_index_census.py` — so only the table allow-list
+drifted.)
+
+Repo-wide `--collect-only -q`: **56521 collected, 4 errors**, all four new with
+dev and all four in `Tests/UI/test_settings_*`. Root cause is inside TASK-19057
+too: `TldwCli.__init__` → `_wire_character_persona_services` calls
+`persona_actor_pack_coordinator.recover()` guarded by `except
+PersonaActorPackCoordinatorError`, but with no DB the repository raises
+`AttributeError: 'NoneType' object has no attribute 'execute_query'`, which
+escapes the guard and breaks app construction for any test that builds the app
+without a ChaChaNotes DB. `tldw_chatbook/Actor_Packs/` did not exist at this
+branch's merge base and is untouched here. Also still red and unrelated:
+`Tests/UI/test_library_file_notes_workspace.py` (collection, `function uses no
+argument 'push_phase'`) and four `Tests/Architecture` failures about
+`UI/Screens/chat_screen.py`.

--- a/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
+++ b/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
@@ -141,9 +141,14 @@ row on `entity_id` AND `version`:
   then migrates the same file cleanly once the poison is gone. Mutation-checked
   the same way as the FTS guard: swapping the runner to `cursor.executescript`
   reds it (and the repo's source-level pin).
-* **12 retention triggers** (`sync_log_prune_<entity>` on UPDATE,
-  `sync_log_prune_<entity>_hard` on DELETE, for messages / conversations /
-  notes / character_cards / keywords / keyword_collections). The prefix is
+* **18 retention triggers**, covering all nine entities the schema writes
+  `sync_log` rows for, under two rules. Twelve versioned
+  (`sync_log_prune_<entity>` on UPDATE, `sync_log_prune_<entity>_hard` on
+  DELETE, for messages / conversations / notes / character_cards / keywords /
+  keyword_collections) and six latest-only (`AFTER INSERT ON sync_log` plus a
+  hard-delete companion, for chat_dictionaries / world_books /
+  world_book_entries — see "The three uncovered writers" below for why the
+  version rule cannot bound those three). The prefix is
   deliberate: the `<entity>_sync_%` namespace belongs to the four triggers that
   WRITE the log, and three tests assert its membership exactly — `_` is a
   single-character wildcard in SQL LIKE, so `conversations_sync_log_prune`
@@ -182,6 +187,15 @@ Write cost of having 12 more triggers fire on every mutation, same corpus:
 **1.87 s → 1.94 s (+4.1%)**. The prune is a single indexed `DELETE` per write
 against `idx_sync_log_entity (entity, entity_id)`.
 
+The table above was measured before the six latest-only triggers were added.
+Three of those six are `AFTER INSERT ON sync_log`, so their `WHEN` is evaluated
+on **every** log insert including the six versioned entities' — the case worth
+measuring separately, since the rest of the corpus never touches a dictionary
+or a world book. On a 800-message / 30%-edited corpus, best of three runs each:
+**0.371 s without them → 0.374 s with them (+0.8%)**, i.e. three literal
+string comparisons per emitted row and no extra statement. The size figures
+above are unaffected (that corpus writes none of the three entities).
+
 ### Known residue (deliberate, not an oversight)
 
 Soft-deleting a **conversation** does not soft-delete its messages — they stay
@@ -196,35 +210,115 @@ plus `role` in the payload). **Recommended as a separate follow-up task, not
 yet filed** — it needs an owner call on changing a live sync proof's format,
 and a task id assigned against origin/dev.
 
-### Residue found in independent review, NOT deliberate (2026-08-22)
+### The three uncovered writers — found in review, now CLOSED (2026-08-22)
 
-The retention rule covers six entities. `sync_log` is written by **nine**:
-`chat_dictionaries`, `world_books` and `world_book_entries` have sync-emitting
-triggers and **no retention trigger, and no purge**, so for them the original
-defect is untouched. Nothing reads any of the three, so every row of theirs is
-unreachable by the same argument used for the covered six. Probed on this
-branch, at v45:
+The first cut covered the six entities the filing named. `sync_log` is written
+by **nine**. `chat_dictionaries`, `world_books` and `world_book_entries` had
+sync-emitting triggers and **no retention trigger and no purge**, so for them
+the original defect was untouched. This branch's own review recorded that as a
+documented gap; **Qodo's review of PR #1974 reached the same finding
+independently**, which is a strong signal it should not ship as a gap at all.
+It does not: the rule is extended here rather than deferred.
+
+Reproduced at v45 before the fix, through the shipped public APIs:
 
 | sequence (public API path) | result |
 | --- | --- |
-| soft-delete a chat dictionary | `name`/`description`/`file_path` still in `sync_log` (2 rows) |
+| soft-delete a chat dictionary | `name`/`description`/`file_path` still in `sync_log` (3 rows after 2 edits) |
 | soft-delete a world book | `name`/`description` still in `sync_log` |
 | hard-delete a world-book entry (`world_book_manager.delete_world_book_entry`, wired to Personas ▸ entry delete at `UI/Screens/personas_screen.py:5221`) | the entry's full `keys` + `content` survive as an orphan, forever |
 | 4 edits of a world-book entry | 4/4 old bodies retained (unbounded growth continues) |
 
-`world_book_entries` is the sharpest of the three: its payload carries the
-lorebook prose itself, its only delete path is a **hard** `DELETE`, and its
-tombstone leaves the content rows orphaned with no entity row left to reach
-them from. This is not a regression — it is exactly the base behaviour — but
-the claim "what goes is everything in it that no reader can reach" is not yet
-true of a third of the log's writers. **Extending retention to these three
-needs its own task**: the naive `version < NEW.version` rule is not enough for
-`chat_dictionaries`/`world_books` (their `last_modified` timestamp trigger
-causes a full-payload `sync_update` row to be written *at the tombstone
-version*), and `world_book_entries` has no `version` column at all, so its rule
-has to key on `operation IN ('create','update')` rather than on version.
-SQLite does not define the firing order of same-kind triggers, so any such rule
-must be order-independent by construction.
+**Why the six's rule does not extend to them.** Two findings from probing a
+live v45 database, both of which invalidate a naive `version < NEW.version`
+trigger:
+
+* `world_book_entries` has **no `version` column and no `deleted` column**.
+  Every one of its sync rows is written at the *literal* version 1 (read the
+  emitter: `… , 1, json_object(…)`), so a version predicate is not merely weak
+  there, it is inert — it can never be true. Its only delete path is a hard
+  `DELETE`, which orphans every content row it wrote.
+* `chat_dictionaries` has a `last_modified` timestamp trigger whose nested
+  `UPDATE` re-fires the `sync_update` emitter. With `recursive_triggers` off
+  (the default) a trigger cannot re-enter *itself*, but it does fire the
+  *other* triggers — so when the emitted `last_modified` differs from the one
+  the outer statement wrote, a **full-payload `update` row lands at the
+  tombstone's own version**. Directly observed, prune triggers removed:
+  `[(cid 2,'create',v1,body=True), (cid 3,'update',v2,body=True), (cid
+  4,'delete',v2,body=False)]` — the deleted dictionary's plaintext sitting at
+  the same version as its tombstone, invisible to `version < NEW.version`.
+
+**The rule that shipped.** A second family, `_SYNC_LOG_LATEST_ONLY_SCOPES`,
+anchored to the *log row* rather than to a version — six new triggers, all
+`AFTER INSERT ON sync_log … WHEN NEW.entity = '<E>'` plus an `AFTER DELETE`
+companion on each base table. At most **one** content-bearing row survives per
+entity, the most recently emitted, and only while the entity is live;
+content-free `delete` tombstones are kept as the delete proof. For the two
+versioned entities the rule is "the six's rule, PLUS: while soft-deleted, no
+content-bearing row survives at all".
+
+**Order-independence — the argument, and the experiment.** SQLite leaves the
+firing order of same-kind triggers undefined and a single soft delete really
+does fire two emitters, so the rule must not depend on which fires first:
+
+1. It fires once per *emission*, whoever emitted it, and its predicate reads
+   only (a) the base table's state — already final for the statement, in any
+   `AFTER` trigger — and (b) `change_id`, which is the table maximum at insert
+   time.
+2. Each firing re-establishes the same post-condition for that entity:
+   content-bearing rows = `{the row just inserted}` if the entity is live,
+   `{}` otherwise. The last emission of the statement therefore fixes the
+   final state, and *which* trigger was last cannot change it: if the entity
+   ends deleted the answer is `{}` either way; if it ends live the two
+   candidate payloads are the same row rendered twice.
+3. The `world_book_entries` hard-delete companion deliberately excludes
+   `operation = 'delete'`. Deleting everything there *would* be
+   order-dependent — fired before the sibling tombstone emitter it removes
+   nothing, fired after it removes the tombstone.
+
+The experiment, not just the argument: every scenario was re-run under six
+permutations of the emitters' creation order, with a **control** proving the
+permutation really reaches the firing order (without prune triggers the same
+soft delete emits `update@cid3, delete@cid4` in one order and `delete@cid3,
+update@cid4` in the other). All six permutations produced byte-identical
+retained content. That control is now
+`test_latest_only_retention_is_independent_of_trigger_firing_order`, which
+asserts the two orders *differ* without retention and *agree* with it — so it
+cannot pass vacuously.
+
+**The census, so this cannot recur.** `test_every_sync_log_writer_has_a_
+retention_scope` parses `sqlite_master` for triggers containing
+`INSERT INTO sync_log`, extracts each entity literal, and asserts
+`covered == writers` **both directions**; a sibling asserts every writer has
+both of its `sync_log_prune_*` triggers. There is deliberately **no
+allowlist** — all nine are covered, so an exemption row would have nothing to
+hold. Bite-proof: dropping `world_book_entries` from the scope tuple reds it
+with `sync_log writers with no retention rule: ['world_book_entries']`;
+renaming one trigger in the migration reds both the runtime and the schema
+census.
+
+**Identifier validation (Qodo finding 2).** `prune_sync_log()` interpolated
+`{table}` / `{id_expr}` / `{floor_expr}` straight into an f-string. Now only
+two fragments are identifiers at all — the table and its id column — and the
+scope tuples carry those as *names*, not expressions, routed through
+`sql_validation.validate_table_name` / `validate_column_name` and
+`escape_identifier` by `_sync_log_scope_identifiers()` before the sweep's
+`try:` (so a rejected scope surfaces as itself, not as a generic "failed to
+prune"). Everything else — the version floor, the liveness clause, the
+tombstone exclusion — is a **fixed SQL literal selected by a `bool`**, so
+there is no string for a caller to influence; that is the structural half of
+the answer for the fragments an identifier checker cannot validate.
+`validate_column_name` fails *closed* for a table with no `VALID_COLUMNS`
+entry, so the three new tables were registered there and pinned against a live
+schema by `test_sync_log_latest_only_table_columns_are_live`.
+
+**One pre-existing defect deliberately NOT fixed here.** Hard-deleting a
+`world_books` row cascades to `world_book_entries`, whose `sync_delete`
+emitter reads `(SELECT client_id FROM world_books WHERE id =
+OLD.world_book_id)` — already gone during the cascade — and raises `NOT NULL
+constraint failed: sync_log.client_id`. No shipped path hard-deletes a world
+book (`delete_world_book` is a soft delete), and retention neither causes nor
+worsens it. Recorded rather than fixed inside a retention change.
 
 Also worth recording: `get_sync_log_entries(since_change_id=…)` has **no**
 version filter — it is a change-feed API, and after v45 it returns a frontier
@@ -248,15 +342,33 @@ which is also the honest name: retention is a different concern from emission.
 ### Modified/added files
 
 * `tldw_chatbook/DB/ChaChaNotes_DB.py` — version bump, `_migrate_from_v44_to_v45`,
-  `_SYNC_LOG_RETENTION_SCOPES`, `prune_sync_log`, `delete_sync_log_entries`,
+  `_SYNC_LOG_RETENTION_SCOPES`, `_SYNC_LOG_LATEST_ONLY_SCOPES`,
+  `_sync_log_scope_identifiers`, `prune_sync_log`, `delete_sync_log_entries`,
   `delete_sync_log_entries_before`
 * `tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_sync_log_retention.sql` (new)
+* `tldw_chatbook/DB/sql_validation.py` — `VALID_COLUMNS` entries for
+  `chat_dictionaries` / `world_books` / `world_book_entries`, without which
+  `validate_column_name` fails closed for the retention sweep
 * `Tests/DB/test_chachanotes_sync_log_retention.py` (new)
 * `Tests/DB/test_chachanotes_sync_log_retention_migration.py` (new — carries the
   repo's exact schema-version pin, moved on from the v43→v44 file)
+* `Tests/DB/test_sql_validation.py` — the three new column sets pinned against a
+  live migrated database
 * `Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py` — pin
   relaxed to `>= 44`
 * `Tests/ChaChaNotesDB/test_chachanotes_db.py`,
   `Tests/ChaChaNotesDB/test_provider_continuation.py`,
   `Tests/Notes/test_note_import_executor.py` — three assertions that counted
   superseded `sync_log` history, rewritten to assert the frontier directly
+
+### Verification (final state)
+
+`Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Sync_Interop`: **1723 passed, 1
+skipped** (1710 → +13 new). `Tests/Notes`: **2847 passed, 5 skipped**.
+`Tests/Character_Chat` + `Tests/Architecture`: 1162 passed, 1 skipped, 4 failed
+— all four in `Tests/Architecture` and about `UI/Screens/chat_screen.py`, a
+file this branch does not touch (pre-existing dev reds). Repo-wide
+`--collect-only -q`: **56182 tests collected**, with
+`Tests/UI/test_library_file_notes_workspace.py` ignored — it errors at
+collection (`function uses no argument 'push_phase'`) on a file identical to
+the merge base, last touched 2026-08-20 by an unrelated commit.

--- a/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
+++ b/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
@@ -196,6 +196,43 @@ plus `role` in the payload). **Recommended as a separate follow-up task, not
 yet filed** — it needs an owner call on changing a live sync proof's format,
 and a task id assigned against origin/dev.
 
+### Residue found in independent review, NOT deliberate (2026-08-22)
+
+The retention rule covers six entities. `sync_log` is written by **nine**:
+`chat_dictionaries`, `world_books` and `world_book_entries` have sync-emitting
+triggers and **no retention trigger, and no purge**, so for them the original
+defect is untouched. Nothing reads any of the three, so every row of theirs is
+unreachable by the same argument used for the covered six. Probed on this
+branch, at v45:
+
+| sequence (public API path) | result |
+| --- | --- |
+| soft-delete a chat dictionary | `name`/`description`/`file_path` still in `sync_log` (2 rows) |
+| soft-delete a world book | `name`/`description` still in `sync_log` |
+| hard-delete a world-book entry (`world_book_manager.delete_world_book_entry`, wired to Personas ▸ entry delete at `UI/Screens/personas_screen.py:5221`) | the entry's full `keys` + `content` survive as an orphan, forever |
+| 4 edits of a world-book entry | 4/4 old bodies retained (unbounded growth continues) |
+
+`world_book_entries` is the sharpest of the three: its payload carries the
+lorebook prose itself, its only delete path is a **hard** `DELETE`, and its
+tombstone leaves the content rows orphaned with no entity row left to reach
+them from. This is not a regression — it is exactly the base behaviour — but
+the claim "what goes is everything in it that no reader can reach" is not yet
+true of a third of the log's writers. **Extending retention to these three
+needs its own task**: the naive `version < NEW.version` rule is not enough for
+`chat_dictionaries`/`world_books` (their `last_modified` timestamp trigger
+causes a full-payload `sync_update` row to be written *at the tombstone
+version*), and `world_book_entries` has no `version` column at all, so its rule
+has to key on `operation IN ('create','update')` rather than on version.
+SQLite does not define the firing order of same-kind triggers, so any such rule
+must be order-independent by construction.
+
+Also worth recording: `get_sync_log_entries(since_change_id=…)` has **no**
+version filter — it is a change-feed API, and after v45 it returns a frontier
+snapshot rather than a complete log. It has zero ChaChaNotes production callers
+today (the production hits belong to the Prompts DB's same-named method), so
+nothing breaks; but anything built on it later must be written knowing the feed
+is lossy by design.
+
 ### Trap worth carrying forward
 
 The retention triggers were first named `<entity>_sync_log_prune`. That squats

--- a/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
+++ b/backlog/tasks/task-19564 - ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives deletion.md
@@ -3,9 +3,10 @@ id: TASK-19564
 title: >-
   ChaChaNotes sync_log is a never-pruned full-content shadow copy that survives
   deletion
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:14'
+updated_date: '2026-08-22 12:00'
 labels:
   - db
   - privacy
@@ -42,19 +43,183 @@ Two consequences:
 
 ## Acceptance Criteria
 
-- [ ] Deleting a conversation, message, note or character removes the
+- [x] Deleting a conversation, message, note or character removes the
       corresponding content from `sync_log`, or `sync_log` stops storing full
       content in the first place
-- [ ] A pruning path exists for ChaChaNotes `sync_log`, matching what
+- [x] A pruning path exists for ChaChaNotes `sync_log`, matching what
       `Client_Media_DB_v2` already provides, and it actually runs rather than
       merely existing
-- [ ] The retention decision is explicit and recorded: if the log is genuinely
+- [x] The retention decision is explicit and recorded: if the log is genuinely
       unused (both readers have no external callers), retiring the content
       columns is the durable answer — do not keep writing a shadow copy nobody
       reads
-- [ ] A test reproduces the lane's probe: after a soft delete, the deleted
+- [x] A test reproduces the lane's probe: after a soft delete, the deleted
       content is not retrievable from `sync_log`
-- [ ] Existing users' databases are addressed — a fix that only helps new
+- [x] Existing users' databases are addressed — a fix that only helps new
       installs leaves the plaintext in place for everyone who already has it
-- [ ] The on-disk size effect is measured before and after on a realistic
+- [x] The on-disk size effect is measured before and after on a realistic
       database
+
+## Implementation Plan
+
+1. Verify the "zero external callers" premise in BOTH directions before acting
+   on it.
+2. Derive which `sync_log` rows any reader can actually reach.
+3. Bound the log to that frontier with triggers, so retention runs on every
+   write rather than needing a caller.
+4. Migrate existing databases with a one-time purge of the same set.
+5. Add the `Client_Media_DB_v2` prune API parity ChaChaNotes never had.
+6. Measure on-disk size before and after on a realistic corpus.
+
+## Implementation Notes
+
+### The retention decision, and why it is NOT retirement
+
+**`sync_log` is alive, and the filing's premise is stale.** The AC pointed at
+retiring the content columns on the strength of "both readers have zero
+external callers". That is true of the two LEGACY readers
+(`get_sync_log_entries`, `get_latest_sync_log_change_id` — test-only for this
+database; `Prompt_Management/Prompts_Interop.py` calls the *Prompts* DB's
+copies, not these). It is false for the database as a whole: **four more
+readers** were added since that pattern was named, and three have live,
+non-test callers:
+
+| reader (`ChaChaNotes_DB.py`) | live caller |
+| --- | --- |
+| `read_committed_chat_sync_intent` | `Chat/console_chat_store.py:6548` (`ensure_provider_continuation_durable`) → `:6741`, on every provider-continuation checkpoint |
+| `read_committed_chat_delete_intent` | via `list_current_committed_chat_sync_intents` |
+| `list_current_committed_chat_sync_intents` | `Chat/console_chat_store.py:1431` (`_reconcile_restored_chat_sync_intents`), on every conversation restore with Sync v2 configured |
+| `_previous_committed_chat_payload_hash` | internal to the two intent readers |
+
+Each compares the sync_log payload to the live `messages` row **field by
+field** (`intent_payload != expected_intent`) — the payload IS the proof that
+the exact row was committed. Dropping `content` from it would make every
+comparison fail, and the failure is silent-then-loud: Sync v2 would quietly
+stop producing envelopes, and `ensure_provider_continuation_durable` **raises**
+on a `None` read, so every continuation checkpoint would become a hard error.
+`Tests/DB/test_chachanotes_sync_log_retention.py
+::test_retention_does_not_break_the_committed_intent_readers` is the standing
+guard on that trade.
+
+**Demonstrated, not argued.** A probe stripped the `content` key out of the
+`sync_log` payloads — exactly what retiring the column would do — and re-read
+through the shipped API:
+
+```
+DIRECTION 1 (content present): reader returns a RECORD  content='the exact body'
+DIRECTION 2 (content retired):  reader returns None
+DIRECTION 2: restore-reconcile intents = []
+```
+
+`ensure_provider_continuation_durable` raises on that `None`, and note it
+reaches the reader **before** consulting `sync_v2_server_profile_id` — so this
+breaks in the DEFAULT configuration, with sync never set up, not only for users
+who enabled it. That is the difference between dormant-but-intended and dead.
+
+So the answer is not "stop writing content", it is **"stop keeping content
+nobody can reach"**. A row is reachable only through a JOIN to its live entity
+row on `entity_id` AND `version`:
+
+* messages, live → `{v, v-1}` (`v-1` feeds the base-hash lookup)
+* messages, tombstoned → `{v}` only — the tombstone carries no content
+* every other entity → `{v}` only — nothing reads them
+* orphans (entity row gone) → nothing
+
+### What shipped
+
+* **Schema v45** (`_CURRENT_SCHEMA_VERSION` 44 → 45) +
+  `DB/migrations/chachanotes_v44_to_v45_sync_log_retention.sql`, run through
+  `_execute_migration_statements` inside `self.transaction()` per task-19553's
+  atomicity convention. Bare `CREATE TRIGGER` statements so
+  `_drop_superseded_trigger` makes the step re-enterable.
+
+  Atomicity is not just asserted at source level. This step DELETEs user rows,
+  so a half-commit would destroy content while leaving the stamp at 44 and the
+  step re-entering forever. `test_a_failure_mid_step_rewinds_to_v44_with_
+  nothing_applied` poisons a statement appended AFTER every purge DELETE and
+  requires the stamp back at 44, zero triggers created and zero rows removed,
+  then migrates the same file cleanly once the poison is gone. Mutation-checked
+  the same way as the FTS guard: swapping the runner to `cursor.executescript`
+  reds it (and the repo's source-level pin).
+* **12 retention triggers** (`sync_log_prune_<entity>` on UPDATE,
+  `sync_log_prune_<entity>_hard` on DELETE, for messages / conversations /
+  notes / character_cards / keywords / keyword_collections). The prefix is
+  deliberate: the `<entity>_sync_%` namespace belongs to the four triggers that
+  WRITE the log, and three tests assert its membership exactly — `_` is a
+  single-character wildcard in SQL LIKE, so `conversations_sync_log_prune`
+  would have squatted in it (and did, until
+  `test_local_project_context_is_excluded_from_conversation_sync_triggers`
+  caught it). They only ever
+  delete rows at versions STRICTLY BELOW the frontier, so they cannot perturb
+  `list_current_committed_chat_sync_intents`'s `1 = (SELECT COUNT(*) …)`
+  single-intent check. This is the "it actually runs" half — no scheduler, no
+  caller to forget.
+* **One-time purge** in the same migration for databases that already have the
+  backlog, plus `prune_sync_log()` as the same sweep on demand, and
+  `delete_sync_log_entries()` / `delete_sync_log_entries_before()` for parity
+  with `Client_Media_DB_v2` (whose own `delete_sync_log_entries_before` has
+  zero production callers — this one does not depend on being called).
+
+### Measured on-disk effect
+
+Realistic corpus: 60 conversations × 40 messages (2,400 messages, 2.86 MB of
+message text) with 30% of messages edited 1–4×, 10% soft-deleted, plus 120
+notes edited 3× each. Same seed both sides; sizes post-`VACUUM`.
+
+| | file | sync_log rows | sync_log payload |
+| --- | --- | --- | --- |
+| v44 (shipped) | **19,017,728 B** | 4,940 | 8,406,302 B |
+| v45 (fresh) | **14,221,312 B** (−25.2%) | 3,217 | 4,912,435 B (−41.6%) |
+| v44 file upgraded → v45 | **14,200,832 B** (−25.3%) | 3,217 | 4,912,435 B (−41.6%) |
+
+`sync_log` payload as a multiple of the message text it shadows: **2.94× →
+1.72×**. The upgraded file lands on exactly the same `sync_log` state as a
+fresh v45, which is the evidence for the existing-databases AC. Migration cost
+on that database: **0.06 s**, freeing 959 × 4 KB = 3.93 MB inside the file
+(`VACUUM` is what returns it to the filesystem; the migration does not run one).
+
+Write cost of having 12 more triggers fire on every mutation, same corpus:
+**1.87 s → 1.94 s (+4.1%)**. The prune is a single indexed `DELETE` per write
+against `idx_sync_log_entity (entity, entity_id)`.
+
+### Known residue (deliberate, not an oversight)
+
+Soft-deleting a **conversation** does not soft-delete its messages — they stay
+`deleted = 0` and come back on restore — so each message's single frontier row
+is retained, exactly as `messages.content` itself is. After this change
+`sync_log` never holds message text that `messages` does not; it is a bounded
+frontier, not an unbounded shadow copy. Erasing the plaintext for LIVE rows too
+requires the payload to carry a content HASH instead, which is a format change
+to a live sync proof (and `_previous_committed_chat_payload_hash` reconstructs
+a canonical hash from the stored content, so it would need a precomputed hash
+plus `role` in the payload). **Recommended as a separate follow-up task, not
+yet filed** — it needs an owner call on changing a live sync proof's format,
+and a task id assigned against origin/dev.
+
+### Trap worth carrying forward
+
+The retention triggers were first named `<entity>_sync_log_prune`. That squats
+in the `<entity>_sync_%` namespace, and **`_` is a single-character wildcard in
+SQL `LIKE`** — so `conversations_sync_log_prune` matches
+`LIKE 'conversations_sync_%'`. Three tests assert that namespace's membership
+*exactly* as a design invariant ("these four triggers, and only these, write
+the sync log"). Only one of them was red, because the other two run against
+pre-migration historical databases where the new triggers do not exist yet —
+the collision was two-thirds latent. Renamed to `sync_log_prune_<entity>`,
+which is also the honest name: retention is a different concern from emission.
+
+### Modified/added files
+
+* `tldw_chatbook/DB/ChaChaNotes_DB.py` — version bump, `_migrate_from_v44_to_v45`,
+  `_SYNC_LOG_RETENTION_SCOPES`, `prune_sync_log`, `delete_sync_log_entries`,
+  `delete_sync_log_entries_before`
+* `tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_sync_log_retention.sql` (new)
+* `Tests/DB/test_chachanotes_sync_log_retention.py` (new)
+* `Tests/DB/test_chachanotes_sync_log_retention_migration.py` (new — carries the
+  repo's exact schema-version pin, moved on from the v43→v44 file)
+* `Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py` — pin
+  relaxed to `>= 44`
+* `Tests/ChaChaNotesDB/test_chachanotes_db.py`,
+  `Tests/ChaChaNotesDB/test_provider_continuation.py`,
+  `Tests/Notes/test_note_import_executor.py` — three assertions that counted
+  superseded `sync_log` history, rewritten to assert the frontier directly

--- a/backlog/tasks/task-19567 - Soft-deleted messages remain searchable and the FTS delete guard has no behavioural witness.md
+++ b/backlog/tasks/task-19567 - Soft-deleted messages remain searchable and the FTS delete guard has no behavioural witness.md
@@ -3,9 +3,10 @@ id: TASK-19567
 title: >-
   Soft-deleted messages remain searchable across conversations, and the FTS
   delete guard has no behavioural witness
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:17'
+updated_date: '2026-08-22 12:00'
 labels:
   - db
   - privacy
@@ -67,18 +68,125 @@ position; confirm rather than assume.
 
 ## Acceptance Criteria
 
-- [ ] `search_messages_by_content` excludes messages whose conversation is
+- [x] `search_messages_by_content` excludes messages whose conversation is
       soft-deleted, matching its sibling — pinned by a test that calls it
       **unscoped**, which is the shape that is one caller away
-- [ ] A test queries `messages_fts` **directly** (bypassing the query-level
+- [x] A test queries `messages_fts` **directly** (bypassing the query-level
       `deleted = 0` filters) and asserts a soft-deleted message's content is
       absent from the index
-- [ ] That test is mutation-checked: removing `WHERE new.deleted = 0` from
+- [x] That test is mutation-checked: removing `WHERE new.deleted = 0` from
       `messages_au` makes it red — the current suite does not
-- [ ] The direct-index assertion is an absolute expectation, not a before/after
+- [x] The direct-index assertion is an absolute expectation, not a before/after
       equality snapshot, so a uniform regression cannot pass
-- [ ] The sibling triggers (notes, conversations, character_cards, keywords,
+- [x] The sibling triggers (notes, conversations, character_cards, keywords,
       keyword_collections) are checked for the same gap and given the same
       witness where they lack one
-- [ ] Any other FTS consumer added later inherits the guarantee — the coverage
+- [x] Any other FTS consumer added later inherits the guarantee — the coverage
       lives with the trigger, not scattered across each caller's `WHERE`
+
+## Implementation Plan
+
+1. Reproduce (A) unscoped and fix the asymmetry against the sibling.
+2. Write the direct-`messages_fts` witness, then prove it by mutating the
+   guard away.
+3. Enumerate the sibling triggers from the LIVE schema rather than from the
+   filing's list, and witness every one that turns out to share the shape.
+4. Give the guarantee a home that a future FTS table inherits.
+
+## Implementation Notes
+
+### A — the sibling asymmetry
+
+`search_messages_by_content` now joins `conversations` and filters
+`c.deleted = 0`, matching `search_conversations_by_content`. Pinned by
+`Tests/ChaChaNotesDB/test_chachanotes_db.py
+::test_search_messages_by_content_unscoped_excludes_deleted_conversations`,
+which calls it **unscoped** (the shape one caller away), asserts it now agrees
+with the sibling it used to diverge from, and checks the scoped form does not
+reopen the hole. Born red: at `da4e828af` the unscoped call returned the
+deleted conversation's message body verbatim while the sibling returned
+nothing.
+
+### B — the witness, and the mutation proof
+
+`Tests/DB/test_fts_soft_delete_index_witness.py` (13 tests). Every assertion
+queries the FTS index **directly** — no consumer, so no query-level
+`deleted = 0` can mask a trigger regression — and every one is an **absolute**
+expectation (`== []` / `== [rowid]`), never a before/after equality snapshot.
+
+Mutation proof (the deliverable, not the test's existence). Deleting
+`WHERE new.deleted = 0` from the shipped `messages_au`:
+
+* **new witness: 4 failed, 9 passed** — `..._drops_a_soft_deleted_message`,
+  `..._drops_a_message_deleted_by_raw_update`,
+  `..._restores_an_undeleted_message`, and the census guard.
+* **pre-existing FTS-adjacent suite: 391 passed, 0 failed** —
+  `Tests/DB/test_search_conversations_fts.py` (including
+  `test_soft_deleted_message_does_not_match`, the test *named* for this
+  behaviour), all of `Tests/ChaChaNotesDB/`,
+  `test_chachanotes_provider_continuation_migration.py` and
+  `test_provider_continuation_privacy.py`. Completely blind, reproducing Lane
+  5's result exactly. That gap is now closed by this module and nothing else.
+
+A second mutation, on a **sibling**: deleting the same guard from
+`character_cards_au` turns 2 of the new witnesses red
+(`..._drops_a_soft_deleted_card` + the census) while all **306** tests in
+`Tests/ChaChaNotesDB/` stay green. The blindness was never specific to
+`messages_au`.
+
+The raw-`UPDATE` variant exists because `soft_delete_message` could grow an
+explicit index-maintenance step and keep an API-driven test green with the
+trigger broken.
+
+### What the sibling sweep actually found
+
+The filing named five siblings. Enumerating external-content FTS5 tables from
+`sqlite_master` and checking which base tables carry `deleted` found **eight**:
+the six named plus **`chat_dictionaries` and `world_books`**. All eight had a
+correctly guarded insert half and none had a behavioural witness; all eight now
+have one.
+
+It also found a **live defect nobody had filed**. Five of the eight `*_au`
+triggers guard their DELETE half with `WHERE old.deleted = 0` (`notes_au` was
+repaired earlier for exactly this — see
+`_ensure_notes_fts_update_trigger_handles_undelete`); three — `messages_au`,
+`keyword_collections_au`, `world_books_au` — issued the FTS `'delete'`
+unconditionally. Issuing it for a row that is not in an external-content index
+corrupts that index.
+
+`keyword_collections_au` was reachable through the shipped public API — at
+`da4e828af`, `add_keyword_collection(name)` on a soft-deleted name goes through
+`_add_generic_item`'s undelete UPDATE and raises `sqlite3.DatabaseError:
+database disk image is malformed`. `messages_au` and `world_books_au` have no
+undelete path today (every `UPDATE world_books` is `AND deleted = 0`), so they
+were latent — fixed anyway, because latent here means "one restore API away",
+and the census test now checks BOTH halves so the shape cannot come back.
+
+All three are redefined in the v44→v45 migration, and the three indexes are
+reset with FTS5 `'delete-all'` + a `WHERE deleted = 0` reinsert — deliberately
+**not** `'rebuild'`, which re-derives from the base table with no `deleted`
+filter and would re-index every tombstoned row, reintroducing the exact leak
+the guard exists to prevent
+(`test_upgrading_reindexes_only_live_rows_into_messages_fts`).
+
+### Inheriting the guarantee
+
+Two census tests keep the coverage with the trigger rather than with each
+caller: one asserts the set of soft-deletable FTS-backed tables equals the
+witnessed set (a new one is red until it gets a witness), the other asserts
+every such table's AFTER UPDATE trigger carries **both** guards —
+`new.deleted = 0` on the insert half (the leak guard) and `old.deleted = 0` on
+the delete half (the corruption guard). The second is explicitly secondary — a
+source-string assertion is what let `test_uses_messages_fts_match` pass while
+the guard was mutated away.
+
+### Modified/added files
+
+* `tldw_chatbook/DB/ChaChaNotes_DB.py` — `search_messages_by_content` joins
+  `conversations`
+* `tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_sync_log_retention.sql` —
+  `messages_au` / `keyword_collections_au` redefinition + index reset
+* `Tests/DB/test_fts_soft_delete_index_witness.py` (new)
+* `Tests/ChaChaNotesDB/test_chachanotes_db.py` — the unscoped pin
+* `Tests/DB/test_chachanotes_sync_log_retention_migration.py` — the FTS reset
+  assertion

--- a/backlog/tasks/task-19567 - Soft-deleted messages remain searchable and the FTS delete guard has no behavioural witness.md
+++ b/backlog/tasks/task-19567 - Soft-deleted messages remain searchable and the FTS delete guard has no behavioural witness.md
@@ -180,6 +180,20 @@ the delete half (the corruption guard). The second is explicitly secondary — a
 source-string assertion is what let `test_uses_messages_fts_match` pass while
 the guard was mutated away.
 
+### The census pattern travelled to the sibling task (2026-08-22)
+
+Worth recording because it closed a real gap. This half derived its covered set
+from the schema (`sqlite_master` → external-content FTS5 tables → which base
+tables carry `deleted`) and so found `chat_dictionaries` and `world_books`,
+which the filing had not named. The `sync_log` half of the same commit did
+*not* do that — it took the six entities the filing listed — and shipped with
+three uncovered writers, **the same two tables plus `world_book_entries`**. So
+the information needed to catch it was already inside this branch; it simply
+did not cross from one half to the other. Qodo's review of PR #1974 flagged it
+independently, and task-19564's notes now carry the fix: a second retention
+rule for those three, plus a `covered == writers` census modelled directly on
+the two census tests here.
+
 ### Modified/added files
 
 * `tldw_chatbook/DB/ChaChaNotes_DB.py` — `search_messages_by_content` joins

--- a/backlog/tasks/task-19567 - Soft-deleted messages remain searchable and the FTS delete guard has no behavioural witness.md
+++ b/backlog/tasks/task-19567 - Soft-deleted messages remain searchable and the FTS delete guard has no behavioural witness.md
@@ -198,9 +198,13 @@ the two census tests here.
 
 * `tldw_chatbook/DB/ChaChaNotes_DB.py` — `search_messages_by_content` joins
   `conversations`
-* `tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_sync_log_retention.sql` —
+* `tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql` —
   `messages_au` / `keyword_collections_au` redefinition + index reset
 * `Tests/DB/test_fts_soft_delete_index_witness.py` (new)
 * `Tests/ChaChaNotesDB/test_chachanotes_db.py` — the unscoped pin
 * `Tests/DB/test_chachanotes_sync_log_retention_migration.py` — the FTS reset
   assertion
+
+Note: this step shipped as v44→v45 and was renumbered to **v45→v46** when
+TASK-19057 merged to dev claiming v45 first; the FTS trigger repairs moved
+with it and are unchanged. See task-19564's notes for the renumber.

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -63,7 +63,11 @@ from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 # Third-Party Libraries
 #
 # Local Imports
-from .sql_validation import validate_table_name, validate_column_name
+from .sql_validation import (
+    escape_identifier,
+    validate_table_name,
+    validate_column_name,
+)
 from .sql_logging import preview_params
 from .private_sqlite import backup_connection_to_private, connect_private_sqlite
 from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
@@ -5936,11 +5940,17 @@ UPDATE db_schema_version
         ``sync_log`` and nothing ever removed one, so every edit left the
         previous full text behind forever and a soft delete left the user's
         plaintext in the database indefinitely. The migration file installs
-        twelve retention triggers and performs the one-time purge that
-        existing databases need -- see its header for the reachability
-        analysis, and in particular for why the content columns are retained
-        rather than retired (three readers with live non-test callers compare
-        the payload to the ``messages`` row field by field).
+        eighteen retention triggers -- covering all nine entities the schema
+        writes ``sync_log`` rows for, under two rules -- and performs the
+        one-time purge that existing databases need. See its header for the
+        reachability analysis, for why the content columns are retained rather
+        than retired (three readers with live non-test callers compare the
+        payload to the ``messages`` row field by field), and for the
+        order-independence argument the second rule rests on.
+
+        Authored as v44->v45 and renumbered when TASK-19057 (portable Actor
+        Pack identity) merged to dev claiming v45 first; this step now runs
+        after it.
 
         Args:
             conn: The active connection, inside ``_initialize_schema``'s
@@ -14882,35 +14892,96 @@ UPDATE db_schema_version
     # --- Sync Log Retention (task-19564) ---
     #
     # ``sync_log`` stores the COMPLETE row as JSON, so before task-19564 an
-    # unpruned log was a full-content shadow copy of the user's conversations
-    # and notes that survived deletion. Retention is enforced primarily by the
-    # ``sync_log_prune_*`` triggers added in v45 -- they run on every write, so
-    # the bound holds without anyone remembering to call anything. These
-    # methods are the maintenance surface: parity with what
+    # unpruned log was a full-content shadow copy of the user's conversations,
+    # notes and lorebooks that survived deletion. Retention is enforced
+    # primarily by the ``sync_log_prune_*`` triggers added in v45 -- they run
+    # on every write, so the bound holds without anyone remembering to call
+    # anything. These methods are the maintenance surface: parity with what
     # ``Client_Media_DB_v2`` already exposes, plus ``prune_sync_log`` as the
     # explicit sweep the v44->v45 migration performs once.
     #
-    # A row is reachable only via a JOIN to its live entity row on
-    # ``entity_id`` AND ``version``:
+    # ``sync_log`` is written for NINE entities and all nine are covered, under
+    # two rules. Whichever rule applies, the entity's covered-ness is asserted
+    # against the schema's own writers by
+    # ``Tests/DB/test_chachanotes_sync_log_retention.py``'s census, so a tenth
+    # writer cannot ship without retention.
+    #
+    # RULE 1 -- VERSIONED (``_SYNC_LOG_RETENTION_SCOPES``). A row is reachable
+    # only via a JOIN to its live entity row on ``entity_id`` AND ``version``:
     #   * messages, live    -> {v, v-1}  (v-1 feeds the base-hash lookup in
     #                          ``_previous_committed_chat_payload_hash``)
     #   * messages, deleted -> {v} only  (the tombstone; it carries no content)
     #   * every other entity -> {v} only (nothing reads them)
     #   * orphans (entity row gone) -> nothing
-    _SYNC_LOG_RETENTION_SCOPES: Tuple[Tuple[str, str, str, bool], ...] = (
-        # (sync_log entity, table, entity-id expression, keep previous version)
-        ("messages", "messages", "src.id", True),
-        ("conversations", "conversations", "src.id", False),
-        ("notes", "notes", "src.id", False),
-        ("character_cards", "character_cards", "CAST(src.id AS TEXT)", False),
-        ("keywords", "keywords", "CAST(src.id AS TEXT)", False),
-        (
-            "keyword_collections",
-            "keyword_collections",
-            "CAST(src.id AS TEXT)",
-            False,
-        ),
+    _SYNC_LOG_RETENTION_SCOPES: Tuple[Tuple[str, str, str, bool, bool], ...] = (
+        # (sync_log entity, table, entity-id column, id is INTEGER, keep v-1)
+        ("messages", "messages", "id", False, True),
+        ("conversations", "conversations", "id", False, False),
+        ("notes", "notes", "id", False, False),
+        ("character_cards", "character_cards", "id", True, False),
+        ("keywords", "keywords", "id", True, False),
+        ("keyword_collections", "keyword_collections", "id", True, False),
     )
+
+    # RULE 2 -- LATEST-ONLY (``_SYNC_LOG_LATEST_ONLY_SCOPES``, task-19564
+    # follow-up to Qodo's review of PR #1974). Version alone cannot express
+    # reachability for these three, so the rule is anchored to the log row
+    # itself: at most ONE content-bearing row survives per entity -- the most
+    # recently emitted one -- and only while the entity is live. Content-free
+    # ``delete`` tombstones are kept as the delete proof.
+    #   * ``chat_dictionaries``: its ``last_modified`` timestamp trigger fires
+    #     the update emitter, so a full-payload ``update`` row can be written
+    #     AT the tombstone's own version -- ``version < NEW.version`` leaves
+    #     the deleted dictionary's plaintext behind. Reproduced in
+    #     ``test_soft_deleting_a_chat_dictionary_removes_its_text...``.
+    #   * ``world_books``: same shape, same rule, for uniformity.
+    #   * ``world_book_entries``: has NO ``version`` and NO ``deleted`` column
+    #     (every sync row is written at the literal version 1) and its only
+    #     delete path is a hard ``DELETE``, so a version rule is entirely
+    #     inert for it.
+    _SYNC_LOG_LATEST_ONLY_SCOPES: Tuple[Tuple[str, str, str, bool, bool], ...] = (
+        # (entity, table, id column, id is INTEGER, entity is soft-deletable)
+        ("chat_dictionaries", "chat_dictionaries", "id", True, True),
+        ("world_books", "world_books", "id", True, True),
+        ("world_book_entries", "world_book_entries", "id", True, False),
+    )
+
+    @staticmethod
+    def _sync_log_scope_identifiers(table: str, id_column: str) -> Tuple[str, str]:
+        """Validate and quote the two identifiers a retention sweep interpolates.
+
+        Qodo flagged ``prune_sync_log`` for building SQL with f-string
+        identifiers outside ``sql_validation``. The values are class constants,
+        so this is hardening rather than a live injection -- but the point of a
+        central validator is that the NEXT edit cannot quietly introduce a
+        non-literal, so both go through it.
+
+        Only these two fragments are identifiers. The rest of each retention
+        query -- the version floor, the liveness clause, the tombstone
+        exclusion -- are fixed SQL literals selected by a ``bool`` in the scope
+        tuple, never strings carried in the table, so an identifier checker
+        cannot validate them and does not need to: there is no string for a
+        caller to influence.
+
+        Args:
+            table: The entity's base table.
+            id_column: The base table's primary-key column.
+
+        Returns:
+            The double-quoted ``(table, id_column)`` pair, safe to interpolate.
+
+        Raises:
+            CharactersRAGDBError: If either identifier fails validation.
+        """
+        if not validate_table_name(table, "chachanotes"):
+            raise CharactersRAGDBError(
+                f"Invalid sync_log retention table name: {table!r}"
+            )
+        if not validate_column_name(id_column, table):
+            raise CharactersRAGDBError(
+                f"Invalid sync_log retention id column: {table!r}.{id_column!r}"
+            )
+        return escape_identifier(table), escape_identifier(id_column)
 
     def delete_sync_log_entries(self, change_ids: List[int]) -> int:
         """Delete specific sync log entries by ``change_id``.
@@ -14980,32 +15051,78 @@ UPDATE db_schema_version
             ) from e
 
     def prune_sync_log(self) -> int:
-        """Delete every ``sync_log`` row no reader can reach.
+        """Delete every ``sync_log`` row no reader can reach, for all nine writers.
 
         The same sweep the v44->v45 migration performs once. The v45 triggers
         keep the log at this bound on every subsequent write, so this is a
         maintenance/repair entry point rather than something the app must
         schedule.
 
+        "Reachable" means one of two things, depending on the entity, and the
+        set of entities is asserted against the schema's own ``INSERT INTO
+        sync_log`` triggers by the census in
+        ``Tests/DB/test_chachanotes_sync_log_retention.py`` -- so this method
+        covers every writer, and a tenth writer cannot ship without retention:
+
+        * ``_SYNC_LOG_RETENTION_SCOPES`` (messages, conversations, notes,
+          character_cards, keywords, keyword_collections) -- a row is reachable
+          only through a JOIN to its live entity row on ``entity_id`` AND
+          ``version``. Live messages keep ``{v, v-1}``; everything else keeps
+          ``{v}``; orphans keep nothing.
+        * ``_SYNC_LOG_LATEST_ONLY_SCOPES`` (chat_dictionaries, world_books,
+          world_book_entries) -- version cannot express reachability for these
+          (see that constant), so at most ONE content-bearing row survives per
+          entity, the most recently emitted, and only while the entity is live.
+
+        What this does NOT remove, in either family: the content-free
+        ``delete`` tombstone that proves a delete happened, and the content of
+        a LIVE row's frontier entry -- ``sync_log`` never holds text that the
+        entity table does not, but for a live row it still holds a second
+        copy. Removing that needs the payload to carry a content hash instead,
+        which is a format change to a live sync proof; it is recommended as a
+        follow-up in task-19564's notes, not attempted here.
+
         Returns:
             The number of rows removed.
 
         Raises:
-            CharactersRAGDBError: If the sweep fails.
+            CharactersRAGDBError: If an identifier fails validation, or if the
+                sweep fails.
         """
+        # Validated BEFORE the try, so a rejected identifier surfaces as
+        # itself rather than as a generic "failed to prune" -- the point of
+        # routing these through sql_validation is that the caller can tell an
+        # unsafe scope from a database error.
+        versioned = [
+            (entity, *self._sync_log_scope_identifiers(table, id_column), id_is_int, flag)
+            for entity, table, id_column, id_is_int, flag in (
+                self._SYNC_LOG_RETENTION_SCOPES
+            )
+        ]
+        latest_only = [
+            (entity, *self._sync_log_scope_identifiers(table, id_column), id_is_int, flag)
+            for entity, table, id_column, id_is_int, flag in (
+                self._SYNC_LOG_LATEST_ONLY_SCOPES
+            )
+        ]
         removed = 0
         try:
             with self.transaction() as conn:
-                for entity, table, id_expr, keep_previous in (
-                    self._SYNC_LOG_RETENTION_SCOPES
-                ):
+                for (
+                    entity,
+                    q_table,
+                    q_id,
+                    id_is_int,
+                    keep_previous,
+                ) in versioned:
+                    id_ref = f"src.{q_id}"
+                    id_expr = f"CAST({id_ref} AS TEXT)" if id_is_int else id_ref
                     floor_expr = (
                         "CASE WHEN src.deleted = 1 THEN src.version "
                         "ELSE src.version - 1 END"
                         if keep_previous
                         else "src.version"
                     )
-                    # Identifiers here are class constants, never user input.
                     removed += conn.execute(
                         f"""
                         DELETE FROM sync_log
@@ -15013,11 +15130,61 @@ UPDATE db_schema_version
                            AND change_id IN (
                                 SELECT s.change_id
                                   FROM sync_log AS s
-                                  LEFT JOIN {table} AS src
+                                  LEFT JOIN {q_table} AS src
                                          ON {id_expr} = s.entity_id
                                  WHERE s.entity = ?
                                    AND (src.rowid IS NULL
                                         OR s.version < ({floor_expr}))
+                           )
+                        """,
+                        (entity, entity),
+                    ).rowcount
+
+                for (
+                    entity,
+                    q_table,
+                    q_id,
+                    id_is_int,
+                    soft_deletable,
+                ) in latest_only:
+                    id_ref = f"src.{q_id}"
+                    id_expr = f"CAST({id_ref} AS TEXT)" if id_is_int else id_ref
+                    # Fixed literals chosen by a bool -- never a stored string.
+                    dead_clause = (
+                        "OR src.deleted = 1" if soft_deletable else ""
+                    )
+                    version_clause = (
+                        "OR s.version < src.version" if soft_deletable else ""
+                    )
+                    # A soft-deletable entity's tombstone is superseded by a
+                    # later version's, so its orphan/version rules cover every
+                    # operation; an unversioned hard-delete-only entity keeps
+                    # every tombstone, because the tombstone IS the only record
+                    # that the delete happened.
+                    tombstone_clause = (
+                        "" if soft_deletable else "AND s.operation <> 'delete'"
+                    )
+                    removed += conn.execute(
+                        f"""
+                        DELETE FROM sync_log
+                         WHERE entity = ?
+                           AND change_id IN (
+                                SELECT s.change_id
+                                  FROM sync_log AS s
+                                  LEFT JOIN {q_table} AS src
+                                         ON {id_expr} = s.entity_id
+                                 WHERE s.entity = ?
+                                   {tombstone_clause}
+                                   AND (src.rowid IS NULL
+                                        {version_clause}
+                                        OR (s.operation <> 'delete'
+                                            AND (s.change_id < (
+                                                    SELECT MAX(s2.change_id)
+                                                      FROM sync_log AS s2
+                                                     WHERE s2.entity = s.entity
+                                                       AND s2.entity_id = s.entity_id
+                                                       AND s2.operation <> 'delete')
+                                                 {dead_clause})))
                            )
                         """,
                         (entity, entity),

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -447,7 +447,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 45  # Portable Actor Pack identity and Persona intents (TASK-19057).
+    _CURRENT_SCHEMA_VERSION = 46  # `sync_log` bounded to its reachable frontier (task-19564).
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -5929,6 +5929,87 @@ UPDATE db_schema_version
                 f"Migration from V44 to V45 failed for '{self._SCHEMA_NAME}': {exc}"
             ) from exc
 
+    def _migrate_from_v45_to_v46(self, conn: sqlite3.Connection) -> None:
+        """Bound ``sync_log`` to the frontier its readers can actually reach.
+
+        task-19564: 35 triggers wrote the complete row as JSON into
+        ``sync_log`` and nothing ever removed one, so every edit left the
+        previous full text behind forever and a soft delete left the user's
+        plaintext in the database indefinitely. The migration file installs
+        twelve retention triggers and performs the one-time purge that
+        existing databases need -- see its header for the reachability
+        analysis, and in particular for why the content columns are retained
+        rather than retired (three readers with live non-test callers compare
+        the payload to the ``messages`` row field by field).
+
+        Args:
+            conn: The active connection, inside ``_initialize_schema``'s
+                transaction.
+
+        Raises:
+            SchemaError: If the database is not at v45, the file cannot be
+                read/split, or the version bump does not land.
+        """
+        self._require_migration_entry_version(conn, 45, "V45→V46")
+        logger.info(
+            f"Migrating schema from V45 to V46 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
+        )
+        migration_path = (
+            Path(__file__).parent
+            / "migrations"
+            / "chachanotes_v45_to_v46_sync_log_retention.sql"
+        )
+        try:
+            with self.transaction() as cursor:
+                purged_before = cursor.execute(
+                    "SELECT COUNT(*) FROM sync_log"
+                ).fetchone()[0]
+                # ``_execute_migration_statements`` rather than a bare
+                # per-statement loop: it drops a same-named trigger before
+                # each bare ``CREATE TRIGGER``, so a database left
+                # half-migrated by an interrupted run re-enters cleanly
+                # (task-19553).
+                self._execute_migration_statements(
+                    cursor,
+                    migration_path.read_text(encoding="utf-8"),
+                    "V45→V46",
+                )
+                purged_after = cursor.execute(
+                    "SELECT COUNT(*) FROM sync_log"
+                ).fetchone()[0]
+                version_cursor = cursor.execute(
+                    """
+                    UPDATE db_schema_version
+                       SET version = 46
+                     WHERE schema_name = ?
+                       AND version = 45
+                    """,
+                    (self._SCHEMA_NAME,),
+                )
+                if version_cursor.rowcount != 1:
+                    raise SchemaError(
+                        f"[{self._SCHEMA_NAME} V45→V46] Migration version update was not applied"
+                    )
+
+            final_version = self._get_db_version(conn)
+            if final_version != 46:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V45→V46] Migration version check failed. "
+                    f"Expected 46, got: {final_version}"
+                )
+            logger.info(
+                f"[{self._SCHEMA_NAME} V45→V46] Migration completed successfully for DB: "
+                f"{self.db_path_str}. Purged {purged_before - purged_after} unreachable "
+                f"sync_log row(s) of {purged_before}."
+            )
+        except (OSError, sqlite3.Error, CharactersRAGDBError, SchemaError) as exc:
+            logger.opt(exception=True).error(
+                f"[{self._SCHEMA_NAME} V45→V46] Migration failed: {exc}"
+            )
+            raise SchemaError(
+                f"Migration from V45 to V46 failed for '{self._SCHEMA_NAME}': {exc}"
+            ) from exc
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -6112,6 +6193,7 @@ UPDATE db_schema_version
                     42: self._migrate_from_v42_to_v43,
                     43: self._migrate_from_v43_to_v44,
                     44: self._migrate_from_v44_to_v45,
+                    45: self._migrate_from_v45_to_v46,
                 }
 
                 if current_db_version == 0:
@@ -11921,8 +12003,17 @@ UPDATE db_schema_version
         Searches messages by content using FTS.
 
         Matches against the 'content' field in `messages_fts`.
-        Optionally filters by `conversation_id`. Returns non-deleted messages,
-        ordered by relevance (rank).
+        Optionally filters by `conversation_id`. Returns non-deleted messages
+        of non-deleted conversations, ordered by relevance (rank).
+
+        task-19567: this used to filter `m.deleted = 0` without joining
+        `conversations`, so soft-deleting a conversation left its messages
+        searchable -- its sibling `search_conversations_by_content` filters
+        both. It was not exploitable unscoped at the time, because the one
+        live caller always passed a `conversation_id` obtained from the
+        already-filtered sibling; the asymmetry between the two siblings is
+        exactly what produces the caller that would leak, so the filter is
+        now symmetric.
 
         Args:
             content_query: The search term for content. Supports FTS query syntax.
@@ -11945,8 +12036,10 @@ UPDATE db_schema_version
                             m.usage_json, m.metadata_json
                      FROM messages_fts fts
                               JOIN messages m ON fts.rowid = m.rowid
+                              JOIN conversations c ON m.conversation_id = c.id
                      WHERE fts.messages_fts MATCH ? \
                        AND m.deleted = 0 \
+                       AND c.deleted = 0 \
                      """
         params_list: List[Any] = [content_query]
         if conversation_id:
@@ -14785,6 +14878,157 @@ UPDATE db_schema_version
         except CharactersRAGDBError as e:
             logger.error(f"Error fetching latest sync log change_id: {e}")
             raise
+
+    # --- Sync Log Retention (task-19564) ---
+    #
+    # ``sync_log`` stores the COMPLETE row as JSON, so before task-19564 an
+    # unpruned log was a full-content shadow copy of the user's conversations
+    # and notes that survived deletion. Retention is enforced primarily by the
+    # ``sync_log_prune_*`` triggers added in v45 -- they run on every write, so
+    # the bound holds without anyone remembering to call anything. These
+    # methods are the maintenance surface: parity with what
+    # ``Client_Media_DB_v2`` already exposes, plus ``prune_sync_log`` as the
+    # explicit sweep the v44->v45 migration performs once.
+    #
+    # A row is reachable only via a JOIN to its live entity row on
+    # ``entity_id`` AND ``version``:
+    #   * messages, live    -> {v, v-1}  (v-1 feeds the base-hash lookup in
+    #                          ``_previous_committed_chat_payload_hash``)
+    #   * messages, deleted -> {v} only  (the tombstone; it carries no content)
+    #   * every other entity -> {v} only (nothing reads them)
+    #   * orphans (entity row gone) -> nothing
+    _SYNC_LOG_RETENTION_SCOPES: Tuple[Tuple[str, str, str, bool], ...] = (
+        # (sync_log entity, table, entity-id expression, keep previous version)
+        ("messages", "messages", "src.id", True),
+        ("conversations", "conversations", "src.id", False),
+        ("notes", "notes", "src.id", False),
+        ("character_cards", "character_cards", "CAST(src.id AS TEXT)", False),
+        ("keywords", "keywords", "CAST(src.id AS TEXT)", False),
+        (
+            "keyword_collections",
+            "keyword_collections",
+            "CAST(src.id AS TEXT)",
+            False,
+        ),
+    )
+
+    def delete_sync_log_entries(self, change_ids: List[int]) -> int:
+        """Delete specific sync log entries by ``change_id``.
+
+        Parity with ``Client_Media_DB_v2.delete_sync_log_entries``, which
+        ChaChaNotes never had.
+
+        Args:
+            change_ids: The ``change_id`` values to delete.
+
+        Returns:
+            The number of rows actually deleted.
+
+        Raises:
+            ValueError: If ``change_ids`` is not a list of integers.
+            CharactersRAGDBError: If the deletion fails.
+        """
+        if not change_ids:
+            return 0
+        if not all(type(cid) is int for cid in change_ids):
+            raise ValueError("change_ids must be a list of integers.")
+        placeholders = ",".join("?" * len(change_ids))
+        query = f"DELETE FROM sync_log WHERE change_id IN ({placeholders})"
+        try:
+            with self.transaction() as conn:
+                deleted = conn.execute(query, tuple(change_ids)).rowcount
+            logger.info(f"Deleted {deleted} sync_log entries from {self.db_path_str}.")
+            return deleted
+        except (CharactersRAGDBError, sqlite3.Error) as e:
+            logger.error(f"Error deleting sync_log entries: {e}")
+            raise CharactersRAGDBError("Failed to delete sync log entries") from e
+
+    def delete_sync_log_entries_before(self, change_id_threshold: int) -> int:
+        """Delete sync log entries at or below ``change_id_threshold``.
+
+        Parity with ``Client_Media_DB_v2.delete_sync_log_entries_before``.
+        Prefer :meth:`prune_sync_log`, which removes exactly the unreachable
+        rows rather than everything below a watermark.
+
+        Args:
+            change_id_threshold: Maximum ``change_id`` (inclusive) to delete.
+
+        Returns:
+            The number of rows actually deleted.
+
+        Raises:
+            ValueError: If the threshold is not a non-negative integer.
+            CharactersRAGDBError: If the deletion fails.
+        """
+        if type(change_id_threshold) is not int or change_id_threshold < 0:
+            raise ValueError("change_id_threshold must be a non-negative integer.")
+        try:
+            with self.transaction() as conn:
+                deleted = conn.execute(
+                    "DELETE FROM sync_log WHERE change_id <= ?",
+                    (change_id_threshold,),
+                ).rowcount
+            logger.info(
+                f"Deleted {deleted} sync_log entries at or below change_id "
+                f"{change_id_threshold} from {self.db_path_str}."
+            )
+            return deleted
+        except (CharactersRAGDBError, sqlite3.Error) as e:
+            logger.error(f"Error deleting sync_log entries before threshold: {e}")
+            raise CharactersRAGDBError(
+                "Failed to delete sync log entries before threshold"
+            ) from e
+
+    def prune_sync_log(self) -> int:
+        """Delete every ``sync_log`` row no reader can reach.
+
+        The same sweep the v44->v45 migration performs once. The v45 triggers
+        keep the log at this bound on every subsequent write, so this is a
+        maintenance/repair entry point rather than something the app must
+        schedule.
+
+        Returns:
+            The number of rows removed.
+
+        Raises:
+            CharactersRAGDBError: If the sweep fails.
+        """
+        removed = 0
+        try:
+            with self.transaction() as conn:
+                for entity, table, id_expr, keep_previous in (
+                    self._SYNC_LOG_RETENTION_SCOPES
+                ):
+                    floor_expr = (
+                        "CASE WHEN src.deleted = 1 THEN src.version "
+                        "ELSE src.version - 1 END"
+                        if keep_previous
+                        else "src.version"
+                    )
+                    # Identifiers here are class constants, never user input.
+                    removed += conn.execute(
+                        f"""
+                        DELETE FROM sync_log
+                         WHERE entity = ?
+                           AND change_id IN (
+                                SELECT s.change_id
+                                  FROM sync_log AS s
+                                  LEFT JOIN {table} AS src
+                                         ON {id_expr} = s.entity_id
+                                 WHERE s.entity = ?
+                                   AND (src.rowid IS NULL
+                                        OR s.version < ({floor_expr}))
+                           )
+                        """,
+                        (entity, entity),
+                    ).rowcount
+            logger.info(
+                f"Pruned {removed} unreachable sync_log row(s) from {self.db_path_str}."
+            )
+            return removed
+        except (CharactersRAGDBError, sqlite3.Error) as e:
+            logger.error(f"Error pruning sync_log: {e}")
+            raise CharactersRAGDBError("Failed to prune sync log") from e
 
     def close(self) -> None:
         """Alias for close_connection() to maintain consistency with BaseDB."""

--- a/tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql
@@ -68,6 +68,22 @@
 -- is a format change to a live sync proof; it is recommended as a follow-up in
 -- task-19564's notes, not attempted here.
 --
+-- Nor does it cover every writer. `sync_log` is written for NINE entities;
+-- retention below covers six. `chat_dictionaries`, `world_books` and
+-- `world_book_entries` keep the pre-v45 behaviour: nothing reads them and
+-- nothing prunes them, so their payloads still survive deletion and still
+-- accumulate per edit. `world_book_entries` is the sharpest -- its payload
+-- carries the lorebook prose, and its only delete path is a hard `DELETE`
+-- (`world_book_manager.delete_world_book_entry`), which orphans every content
+-- row it wrote. Extending the rule to them is NOT a copy of the triggers
+-- below: `chat_dictionaries`/`world_books` get a full-payload `sync_update`
+-- row written AT the tombstone version (their `last_modified` timestamp
+-- trigger fires the update emitter), and `world_book_entries` has no `version`
+-- column, so the rule must key on `operation` instead. SQLite leaves the
+-- firing order of same-kind triggers undefined, so any such rule has to be
+-- order-independent by construction. Recorded in task-19564's notes as work
+-- that needs its own task, not silently assumed covered.
+--
 -- ALSO IN THIS STEP (task-19567)
 -- -----------------------------
 -- Section 3 repairs the three FTS `*_au` triggers whose DELETE half was never

--- a/tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql
@@ -1,0 +1,364 @@
+-- ChaChaNotes v45 -> v46: bound `sync_log` to its reachable frontier
+-- (task-19564).
+--
+-- WHAT WAS WRONG
+-- --------------
+-- 35 triggers write the COMPLETE row as JSON into `sync_log`, and nothing
+-- ever removed a row. Every edit of a message left its previous full text
+-- behind forever, and soft-deleting a message, note, character or keyword
+-- left that entity's plaintext in the log indefinitely -- so "delete" did not
+-- delete. The lane probe for task-19564 soft-deleted a message and read the
+-- body straight back out of `sync_log`.
+--
+-- WHY THE CONTENT COLUMNS ARE NOT RETIRED
+-- ---------------------------------------
+-- The filing recommended retiring the content columns on the premise that
+-- both readers have zero external callers. That premise is stale. It holds
+-- for the two LEGACY readers (`get_sync_log_entries`,
+-- `get_latest_sync_log_change_id`, test-only in this database), but four more
+-- readers have since been added and three of them have live, non-test
+-- callers:
+--
+--   * `read_committed_chat_sync_intent`  <- `ConsoleChatStore
+--       .ensure_provider_continuation_durable`, which RAISES when the read
+--       returns None, on every provider-continuation checkpoint.
+--   * `read_committed_chat_delete_intent`
+--   * `list_current_committed_chat_sync_intents` <- `ConsoleChatStore
+--       ._reconcile_restored_chat_sync_intents`, on every conversation
+--       restore with Sync v2 configured.
+--
+-- Each of them compares the sync_log payload to the live `messages` row
+-- FIELD BY FIELD (`intent_payload != expected_intent`); the payload is the
+-- proof that the exact row was committed. Dropping `content` from the
+-- payload would make every comparison fail and silently disable Sync v2 while
+-- turning continuation checkpoints into hard errors. So the log stays; what
+-- goes is everything in it that no reader can reach.
+--
+-- THE RETENTION RULE
+-- ------------------
+-- A `sync_log` row is reachable only through a JOIN to its live entity row on
+-- `entity_id` AND `version`:
+--
+--   messages, live     -> versions {v, v-1}.  v is the frontier the intent
+--                         readers join to; v-1 is what
+--                         `_previous_committed_chat_payload_hash` reads for
+--                         the base hash.
+--   messages, deleted  -> version {v} only. `read_committed_chat_sync_intent`
+--                         refuses deleted rows and the delete path never asks
+--                         for a base hash, so every content-bearing row below
+--                         the tombstone is unreachable.
+--   every other entity -> version {v} only. Nothing reads them at all.
+--   orphaned (entity row gone) -> nothing is reachable.
+--
+-- Everything outside that frontier is deleted here, once, for databases that
+-- already have it, and the triggers below keep it that way from now on.
+-- Pruning only ever removes rows at versions STRICTLY BELOW the frontier, so
+-- it cannot perturb `list_current_committed_chat_sync_intents`'s
+-- `1 = (SELECT COUNT(*) ...)` single-intent check, which counts rows at the
+-- current version.
+--
+-- WHAT THIS DOES NOT DO
+-- ---------------------
+-- Soft-deleting a CONVERSATION does not soft-delete its messages (they stay
+-- `deleted = 0` and come back on restore), so their frontier row is retained
+-- -- exactly as `messages.content` itself is retained. After this migration
+-- `sync_log` never holds message text that `messages` does not; it is a
+-- bounded frontier, not an unbounded shadow copy. Removing the plaintext for
+-- live rows as well needs the payload to carry a content HASH instead, which
+-- is a format change to a live sync proof; it is recommended as a follow-up in
+-- task-19564's notes, not attempted here.
+--
+-- ALSO IN THIS STEP (task-19567)
+-- -----------------------------
+-- Section 3 repairs the three FTS `*_au` triggers whose DELETE half was never
+-- guarded. That is a different bug, but it is the same schema step and the
+-- same guard family, and it was found by the direct-index witnesses written
+-- for task-19567 -- one of them could not be written at all until it was
+-- fixed. See that section's header for the reproduction.
+--
+-- The retention triggers are named `sync_log_prune_<entity>`, deliberately NOT
+-- `<entity>_sync_log_prune`: `_` is a single-character wildcard in SQL LIKE,
+-- so the latter matches `LIKE '<entity>_sync_%'` -- a namespace three tests
+-- assert the exact membership of, because it belongs to the four triggers that
+-- WRITE the log.
+--
+-- DDL and DML only. The schema-version bump is a separate rowcount-guarded
+-- UPDATE in the runner (`CharactersRAGDB._migrate_from_v45_to_v46`), matching
+-- the v43->v44 precedent. Bare `CREATE TRIGGER` statements are deliberate:
+-- `_drop_superseded_trigger` drops a same-named trigger first, which makes
+-- this step re-enterable after an interrupted run (task-19553).
+
+/*------------------------------------------------------------------
+  1. Retention triggers -- soft-delete and edit paths
+------------------------------------------------------------------*/
+
+/* messages keep a two-version frontier: the current version (joined by the
+   intent readers) and the one below it (the base-hash lookup). A tombstoned
+   message keeps only its tombstone, which carries no content. */
+CREATE TRIGGER sync_log_prune_messages
+AFTER UPDATE ON messages
+WHEN NEW.version > 1
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'messages'
+     AND entity_id = NEW.id
+     AND version < (CASE WHEN NEW.deleted = 1
+                         THEN NEW.version
+                         ELSE NEW.version - 1 END);
+END;
+
+/* conversations/notes/character_cards/keywords/keyword_collections have no
+   reader at all, so only the current version is retained. */
+CREATE TRIGGER sync_log_prune_conversations
+AFTER UPDATE ON conversations
+WHEN NEW.version > 1
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'conversations'
+     AND entity_id = NEW.id
+     AND version < NEW.version;
+END;
+
+CREATE TRIGGER sync_log_prune_notes
+AFTER UPDATE ON notes
+WHEN NEW.version > 1
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'notes'
+     AND entity_id = NEW.id
+     AND version < NEW.version;
+END;
+
+CREATE TRIGGER sync_log_prune_character_cards
+AFTER UPDATE ON character_cards
+WHEN NEW.version > 1
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'character_cards'
+     AND entity_id = CAST(NEW.id AS TEXT)
+     AND version < NEW.version;
+END;
+
+CREATE TRIGGER sync_log_prune_keywords
+AFTER UPDATE ON keywords
+WHEN NEW.version > 1
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'keywords'
+     AND entity_id = CAST(NEW.id AS TEXT)
+     AND version < NEW.version;
+END;
+
+CREATE TRIGGER sync_log_prune_keyword_collections
+AFTER UPDATE ON keyword_collections
+WHEN NEW.version > 1
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'keyword_collections'
+     AND entity_id = CAST(NEW.id AS TEXT)
+     AND version < NEW.version;
+END;
+
+/*------------------------------------------------------------------
+  2. Retention triggers -- hard delete
+------------------------------------------------------------------*/
+/* A hard DELETE emits no sync_log row of its own (there has never been a
+   hard-delete sync trigger), and every reader joins to the entity row, so
+   once the row is gone nothing in the log for it is reachable. */
+
+CREATE TRIGGER sync_log_prune_messages_hard
+AFTER DELETE ON messages
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'messages' AND entity_id = OLD.id;
+END;
+
+CREATE TRIGGER sync_log_prune_conversations_hard
+AFTER DELETE ON conversations
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'conversations' AND entity_id = OLD.id;
+END;
+
+CREATE TRIGGER sync_log_prune_notes_hard
+AFTER DELETE ON notes
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'notes' AND entity_id = OLD.id;
+END;
+
+CREATE TRIGGER sync_log_prune_character_cards_hard
+AFTER DELETE ON character_cards
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'character_cards' AND entity_id = CAST(OLD.id AS TEXT);
+END;
+
+CREATE TRIGGER sync_log_prune_keywords_hard
+AFTER DELETE ON keywords
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'keywords' AND entity_id = CAST(OLD.id AS TEXT);
+END;
+
+CREATE TRIGGER sync_log_prune_keyword_collections_hard
+AFTER DELETE ON keyword_collections
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'keyword_collections' AND entity_id = CAST(OLD.id AS TEXT);
+END;
+
+/*------------------------------------------------------------------
+  3. FTS update triggers whose DELETE half was never guarded (task-19567)
+------------------------------------------------------------------*/
+-- Found by the direct-index witnesses added for task-19567. Five of the eight
+-- soft-deletable FTS `*_au` triggers guard their delete half with
+-- `WHERE old.deleted = 0` (`notes_au` was repaired earlier for exactly this
+-- reason -- see `_ensure_notes_fts_update_trigger_handles_undelete`); three --
+-- `messages_au`, `keyword_collections_au`, `world_books_au` -- issued the FTS
+-- `'delete'` unconditionally. Issuing it for a row that is NOT in an
+-- external-content index corrupts that index.
+--
+-- `keyword_collections_au` was live-reachable: `add_keyword_collection` on a
+-- name whose row is soft-deleted goes through `_add_generic_item`'s undelete
+-- UPDATE and raised `sqlite3.DatabaseError: database disk image is malformed`
+-- on the shipped code. `messages_au` and `world_books_au` have no undelete
+-- path today, so they were latent -- fixed anyway, because "latent" here means
+-- "one restore API away", and a census test now refuses to let the shape back
+-- in.
+--
+-- The insert halves are unchanged; the `WHERE new.deleted = 0` guard on them
+-- is the one Lane 5 mutated away with 475 tests still green, and it is now
+-- pinned behaviourally by `Tests/DB/test_fts_soft_delete_index_witness.py`.
+
+DROP TRIGGER IF EXISTS messages_au;
+
+CREATE TRIGGER messages_au
+AFTER UPDATE ON messages BEGIN
+  INSERT INTO messages_fts(messages_fts,rowid,content)
+  SELECT 'delete',old.rowid,old.content
+  WHERE old.deleted = 0;
+
+  INSERT INTO messages_fts(rowid,content)
+  SELECT new.rowid,new.content
+  WHERE new.deleted = 0;
+END;
+
+DROP TRIGGER IF EXISTS keyword_collections_au;
+
+CREATE TRIGGER keyword_collections_au
+AFTER UPDATE ON keyword_collections BEGIN
+  INSERT INTO keyword_collections_fts(keyword_collections_fts,rowid,name)
+  SELECT 'delete',old.id,old.name
+  WHERE old.deleted = 0;
+
+  INSERT INTO keyword_collections_fts(rowid,name)
+  SELECT new.id,new.name
+  WHERE new.deleted = 0;
+END;
+
+DROP TRIGGER IF EXISTS world_books_au;
+
+CREATE TRIGGER world_books_au
+AFTER UPDATE ON world_books BEGIN
+  INSERT INTO world_books_fts(world_books_fts, rowid, name, description)
+  SELECT 'delete', OLD.id, OLD.name, OLD.description
+  WHERE OLD.deleted = 0;
+
+  INSERT INTO world_books_fts(rowid, name, description)
+  SELECT NEW.id, NEW.name, NEW.description
+  WHERE NEW.deleted = 0;
+END;
+
+/* Repair whatever the unguarded halves already did, and bring both indexes
+   into line with the guarantee for rows that predate it. NOT the FTS5
+   `'rebuild'` command: that re-derives from the base table with no `deleted`
+   filter and would index every tombstoned row, reintroducing exactly the leak
+   these triggers exist to prevent. */
+INSERT INTO messages_fts(messages_fts) VALUES('delete-all');
+
+INSERT INTO messages_fts(rowid,content)
+SELECT rowid, content FROM messages WHERE deleted = 0;
+
+INSERT INTO keyword_collections_fts(keyword_collections_fts) VALUES('delete-all');
+
+INSERT INTO keyword_collections_fts(rowid,name)
+SELECT id, name FROM keyword_collections WHERE deleted = 0;
+
+INSERT INTO world_books_fts(world_books_fts) VALUES('delete-all');
+
+INSERT INTO world_books_fts(rowid, name, description)
+SELECT id, name, description FROM world_books WHERE deleted = 0;
+
+/*------------------------------------------------------------------
+  4. One-time purge of the backlog every existing database already has
+------------------------------------------------------------------*/
+/* Without this the fix would only help new installs, leaving the plaintext
+   in place for everyone who already has it. */
+
+DELETE FROM sync_log
+ WHERE entity = 'messages'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN messages AS m ON m.id = s.entity_id
+         WHERE s.entity = 'messages'
+           AND (
+                m.id IS NULL
+                OR s.version < (CASE WHEN m.deleted = 1
+                                     THEN m.version
+                                     ELSE m.version - 1 END)
+           )
+   );
+
+DELETE FROM sync_log
+ WHERE entity = 'conversations'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN conversations AS c ON c.id = s.entity_id
+         WHERE s.entity = 'conversations'
+           AND (c.id IS NULL OR s.version < c.version)
+   );
+
+DELETE FROM sync_log
+ WHERE entity = 'notes'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN notes AS n ON n.id = s.entity_id
+         WHERE s.entity = 'notes'
+           AND (n.id IS NULL OR s.version < n.version)
+   );
+
+DELETE FROM sync_log
+ WHERE entity = 'character_cards'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN character_cards AS cc
+                 ON CAST(cc.id AS TEXT) = s.entity_id
+         WHERE s.entity = 'character_cards'
+           AND (cc.id IS NULL OR s.version < cc.version)
+   );
+
+DELETE FROM sync_log
+ WHERE entity = 'keywords'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN keywords AS k ON CAST(k.id AS TEXT) = s.entity_id
+         WHERE s.entity = 'keywords'
+           AND (k.id IS NULL OR s.version < k.version)
+   );
+
+DELETE FROM sync_log
+ WHERE entity = 'keyword_collections'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN keyword_collections AS kc
+                 ON CAST(kc.id AS TEXT) = s.entity_id
+         WHERE s.entity = 'keyword_collections'
+           AND (kc.id IS NULL OR s.version < kc.version)
+   );

--- a/tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v45_to_v46_sync_log_retention.sql
@@ -34,9 +34,10 @@
 -- turning continuation checkpoints into hard errors. So the log stays; what
 -- goes is everything in it that no reader can reach.
 --
--- THE RETENTION RULE
--- ------------------
--- A `sync_log` row is reachable only through a JOIN to its live entity row on
+-- THE RETENTION RULE (1 of 2): VERSIONED
+-- --------------------------------------
+-- Six of the nine writers are versioned and a `sync_log` row of theirs is
+-- reachable only through a JOIN to its live entity row on
 -- `entity_id` AND `version`:
 --
 --   messages, live     -> versions {v, v-1}.  v is the frontier the intent
@@ -57,32 +58,81 @@
 -- `1 = (SELECT COUNT(*) ...)` single-intent check, which counts rows at the
 -- current version.
 --
+-- THE RETENTION RULE (2 of 2): LATEST-ONLY
+-- ----------------------------------------
+-- The other three writers -- `chat_dictionaries`, `world_books` and
+-- `world_book_entries` -- cannot use the version rule above, and a first cut
+-- of this migration left them uncovered. Qodo's review of PR #1974
+-- independently reached the same finding, so they are covered here:
+--
+--   * `chat_dictionaries` has a `last_modified` timestamp trigger, whose
+--     nested UPDATE fires the `sync_update` emitter again. When the emitted
+--     `last_modified` differs from the one the outer statement wrote, that
+--     produces a FULL-PAYLOAD `update` row at the tombstone's OWN version, so
+--     `version < NEW.version` leaves the deleted dictionary's plaintext
+--     behind. Reproduced directly against a v45 database.
+--   * `world_book_entries` has no `version` column and no `deleted` column --
+--     every one of its sync rows is written at the literal version 1 -- and
+--     its only delete path is a hard `DELETE`
+--     (`world_book_manager.delete_world_book_entry`, wired to Personas > entry
+--     delete), which orphans every content row it wrote. A version rule is
+--     entirely inert for it.
+--   * `world_books` has the same shape as `chat_dictionaries` and takes the
+--     same rule, for uniformity rather than because its own timestamp trigger
+--     exists (it does not).
+--
+-- So their rule is anchored to the log row itself rather than to a version:
+-- at most ONE content-bearing row survives per entity -- the most recently
+-- emitted -- and only while the entity is live. Content-free `delete`
+-- tombstones are kept for the unversioned entity as its only record that the
+-- delete happened.
+--
+-- WHY THAT IS ORDER-INDEPENDENT
+-- -----------------------------
+-- SQLite does not define the firing order of same-kind triggers, and a single
+-- soft delete really does fire two emitters (the `sync_delete` tombstone and,
+-- via the timestamp trigger, `sync_update`) whose relative order was observed
+-- to FLIP when the emitters are recreated in a different order. A rule that
+-- depends on that order would be unsound, so this one does not:
+--
+--   * The rule fires AFTER INSERT ON sync_log -- i.e. once per emission,
+--     whoever emitted it -- and its predicate reads only (a) the base table's
+--     state, which every AFTER trigger sees already final for the statement,
+--     and (b) `change_id`, which is the table maximum at insert time.
+--   * Each firing re-establishes the same post-condition for that entity:
+--     content-bearing rows = {the row just inserted} if the entity is live,
+--     {} otherwise. The last emission of the statement therefore fixes the
+--     final state, and *which* trigger is last does not change it: if the
+--     entity ends deleted the answer is {} either way, and if it ends live the
+--     two candidate payloads are the same row rendered twice.
+--   * The hard-delete companion below deliberately excludes `operation =
+--     'delete'` for `world_book_entries`. Deleting everything there WOULD be
+--     order-dependent: fired before the sibling tombstone emitter it removes
+--     nothing, fired after it removes the tombstone.
+--
+-- Verified by running every scenario under six permutations of the emitters'
+-- creation order, with a control run proving the permutation really does flip
+-- the emission order (see task-19564's notes).
+--
 -- WHAT THIS DOES NOT DO
 -- ---------------------
 -- Soft-deleting a CONVERSATION does not soft-delete its messages (they stay
 -- `deleted = 0` and come back on restore), so their frontier row is retained
 -- -- exactly as `messages.content` itself is retained. After this migration
--- `sync_log` never holds message text that `messages` does not; it is a
+-- `sync_log` never holds entity text that the entity table does not; it is a
 -- bounded frontier, not an unbounded shadow copy. Removing the plaintext for
 -- live rows as well needs the payload to carry a content HASH instead, which
 -- is a format change to a live sync proof; it is recommended as a follow-up in
 -- task-19564's notes, not attempted here.
 --
--- Nor does it cover every writer. `sync_log` is written for NINE entities;
--- retention below covers six. `chat_dictionaries`, `world_books` and
--- `world_book_entries` keep the pre-v45 behaviour: nothing reads them and
--- nothing prunes them, so their payloads still survive deletion and still
--- accumulate per edit. `world_book_entries` is the sharpest -- its payload
--- carries the lorebook prose, and its only delete path is a hard `DELETE`
--- (`world_book_manager.delete_world_book_entry`), which orphans every content
--- row it wrote. Extending the rule to them is NOT a copy of the triggers
--- below: `chat_dictionaries`/`world_books` get a full-payload `sync_update`
--- row written AT the tombstone version (their `last_modified` timestamp
--- trigger fires the update emitter), and `world_book_entries` has no `version`
--- column, so the rule must key on `operation` instead. SQLite leaves the
--- firing order of same-kind triggers undefined, so any such rule has to be
--- order-independent by construction. Recorded in task-19564's notes as work
--- that needs its own task, not silently assumed covered.
+-- One pre-existing defect is deliberately NOT fixed here: hard-deleting a
+-- `world_books` row cascades to `world_book_entries`, whose `sync_delete`
+-- emitter reads `(SELECT client_id FROM world_books WHERE id = OLD.world_book_id)`
+-- -- already gone during the cascade -- and raises `NOT NULL constraint
+-- failed: sync_log.client_id`. No shipped path hard-deletes a world book
+-- (`delete_world_book` is a soft delete), and retention neither causes nor
+-- worsens it; it is recorded in task-19564's notes rather than fixed inside a
+-- retention change.
 --
 -- ALSO IN THIS STEP (task-19567)
 -- -----------------------------
@@ -222,6 +272,100 @@ AFTER DELETE ON keyword_collections
 BEGIN
   DELETE FROM sync_log
    WHERE entity = 'keyword_collections' AND entity_id = CAST(OLD.id AS TEXT);
+END;
+
+/*------------------------------------------------------------------
+  2b. Retention triggers -- the three latest-only writers
+------------------------------------------------------------------*/
+/* See "THE RETENTION RULE (2 of 2)" and "WHY THAT IS ORDER-INDEPENDENT" in
+   this file's header. These fire on the LOG row, not on the entity row, so a
+   statement whose emitters fire in an undefined order still converges: the
+   last emission fixes the state, and the state it fixes does not depend on
+   which emitter that was. */
+
+CREATE TRIGGER sync_log_prune_chat_dictionaries
+AFTER INSERT ON sync_log
+WHEN NEW.entity = 'chat_dictionaries'
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'chat_dictionaries'
+     AND entity_id = NEW.entity_id
+     AND (version < NEW.version
+          OR (operation <> 'delete'
+              AND (change_id < NEW.change_id
+                   OR NOT EXISTS (SELECT 1 FROM chat_dictionaries AS src
+                                   WHERE CAST(src.id AS TEXT) = NEW.entity_id
+                                     AND src.deleted = 0))));
+END;
+
+CREATE TRIGGER sync_log_prune_world_books
+AFTER INSERT ON sync_log
+WHEN NEW.entity = 'world_books'
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'world_books'
+     AND entity_id = NEW.entity_id
+     AND (version < NEW.version
+          OR (operation <> 'delete'
+              AND (change_id < NEW.change_id
+                   OR NOT EXISTS (SELECT 1 FROM world_books AS src
+                                   WHERE CAST(src.id AS TEXT) = NEW.entity_id
+                                     AND src.deleted = 0))));
+END;
+
+/* No version clause: every world_book_entries sync row is written at the
+   literal version 1, and the table has no `deleted` column, so "live" is
+   "the row still exists". Tombstones are kept -- for a hard-delete-only
+   entity the tombstone is the only record that the delete happened, and it
+   carries ids only. */
+CREATE TRIGGER sync_log_prune_world_book_entries
+AFTER INSERT ON sync_log
+WHEN NEW.entity = 'world_book_entries'
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'world_book_entries'
+     AND entity_id = NEW.entity_id
+     AND operation <> 'delete'
+     AND (change_id < NEW.change_id
+          OR NOT EXISTS (SELECT 1 FROM world_book_entries AS src
+                          WHERE CAST(src.id AS TEXT) = NEW.entity_id));
+END;
+
+/* Hard-delete companions. chat_dictionaries/world_books emit nothing on a
+   hard DELETE, so nothing would fire the log-side rule and the rows would be
+   orphaned -- these clear them exactly as the six above do. */
+CREATE TRIGGER sync_log_prune_chat_dictionaries_hard
+AFTER DELETE ON chat_dictionaries
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'chat_dictionaries' AND entity_id = CAST(OLD.id AS TEXT);
+END;
+
+CREATE TRIGGER sync_log_prune_world_books_hard
+AFTER DELETE ON world_books
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'world_books' AND entity_id = CAST(OLD.id AS TEXT);
+END;
+
+/* Unlike the two above, this one is defence in depth rather than the
+   load-bearing path: world_book_entries DOES emit a tombstone on hard delete,
+   and that emission is itself what fires the log-side rule, so the content is
+   already gone without this trigger (the behavioural test still passes with
+   it removed). It exists so the guarantee does not silently depend on that
+   emitter staying unconditional.
+   `operation <> 'delete'` here IS load-bearing: the tombstone comes from a
+   sibling AFTER DELETE trigger whose order relative to this one is undefined,
+   so deleting everything would remove the tombstone when this fires second
+   and keep it when this fires first -- an order-dependent result. Excluding
+   tombstones makes both orders converge on {tombstone}. */
+CREATE TRIGGER sync_log_prune_world_book_entries_hard
+AFTER DELETE ON world_book_entries
+BEGIN
+  DELETE FROM sync_log
+   WHERE entity = 'world_book_entries'
+     AND entity_id = CAST(OLD.id AS TEXT)
+     AND operation <> 'delete';
 END;
 
 /*------------------------------------------------------------------
@@ -377,4 +521,73 @@ DELETE FROM sync_log
                  ON CAST(kc.id AS TEXT) = s.entity_id
          WHERE s.entity = 'keyword_collections'
            AND (kc.id IS NULL OR s.version < kc.version)
+   );
+
+/* The latest-only three. Same converged state the triggers above maintain:
+   orphans keep nothing (except an unversioned entity's tombstones), a live
+   entity keeps its newest content row, a soft-deleted one keeps only its
+   tombstone. */
+
+DELETE FROM sync_log
+ WHERE entity = 'chat_dictionaries'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN chat_dictionaries AS cd
+                 ON CAST(cd.id AS TEXT) = s.entity_id
+         WHERE s.entity = 'chat_dictionaries'
+           AND (
+                cd.id IS NULL
+                OR s.version < cd.version
+                OR (s.operation <> 'delete'
+                    AND (cd.deleted = 1
+                         OR s.change_id < (
+                                SELECT MAX(s2.change_id)
+                                  FROM sync_log AS s2
+                                 WHERE s2.entity = 'chat_dictionaries'
+                                   AND s2.entity_id = s.entity_id
+                                   AND s2.operation <> 'delete')))
+           )
+   );
+
+DELETE FROM sync_log
+ WHERE entity = 'world_books'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN world_books AS wb
+                 ON CAST(wb.id AS TEXT) = s.entity_id
+         WHERE s.entity = 'world_books'
+           AND (
+                wb.id IS NULL
+                OR s.version < wb.version
+                OR (s.operation <> 'delete'
+                    AND (wb.deleted = 1
+                         OR s.change_id < (
+                                SELECT MAX(s2.change_id)
+                                  FROM sync_log AS s2
+                                 WHERE s2.entity = 'world_books'
+                                   AND s2.entity_id = s.entity_id
+                                   AND s2.operation <> 'delete')))
+           )
+   );
+
+DELETE FROM sync_log
+ WHERE entity = 'world_book_entries'
+   AND change_id IN (
+        SELECT s.change_id
+          FROM sync_log AS s
+          LEFT JOIN world_book_entries AS wbe
+                 ON CAST(wbe.id AS TEXT) = s.entity_id
+         WHERE s.entity = 'world_book_entries'
+           AND s.operation <> 'delete'
+           AND (
+                wbe.id IS NULL
+                OR s.change_id < (
+                       SELECT MAX(s2.change_id)
+                         FROM sync_log AS s2
+                        WHERE s2.entity = 'world_book_entries'
+                          AND s2.entity_id = s.entity_id
+                          AND s2.operation <> 'delete')
+           )
    );

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -251,7 +251,7 @@ VALID_COLUMNS = {
     },
     # task-19564: registered so ``CharactersRAGDB.prune_sync_log()`` can route
     # its retention-scope identifiers through ``validate_column_name`` for the
-    # three ``sync_log`` writers v45 covers with the latest-only rule. Without
+    # three ``sync_log`` writers v46 covers with the latest-only rule. Without
     # an entry here that call fails CLOSED (see this function's TASK-864 note),
     # so these three sets are load-bearing, not decorative. Columns verified
     # against ``PRAGMA table_info`` on a live fully-migrated database and

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -249,6 +249,64 @@ VALID_COLUMNS = {
         "client_id",
         "version",
     },
+    # task-19564: registered so ``CharactersRAGDB.prune_sync_log()`` can route
+    # its retention-scope identifiers through ``validate_column_name`` for the
+    # three ``sync_log`` writers v45 covers with the latest-only rule. Without
+    # an entry here that call fails CLOSED (see this function's TASK-864 note),
+    # so these three sets are load-bearing, not decorative. Columns verified
+    # against ``PRAGMA table_info`` on a live fully-migrated database and
+    # pinned there by
+    # ``Tests/DB/test_sql_validation.py::test_sync_log_latest_only_table_columns_are_live``.
+    "chat_dictionaries": {
+        "id",
+        "name",
+        "description",
+        "file_path",
+        "content",
+        "entries_json",
+        "strategy",
+        "max_tokens",
+        "enabled",
+        "created_at",
+        "last_modified",
+        "deleted",
+        "client_id",
+        "version",
+    },
+    "world_books": {
+        "id",
+        "name",
+        "description",
+        "scan_depth",
+        "token_budget",
+        "recursive_scanning",
+        "enabled",
+        "created_at",
+        "last_modified",
+        "deleted",
+        "client_id",
+        "version",
+    },
+    # Note there is deliberately no ``deleted``/``version``/``client_id`` here:
+    # ``world_book_entries`` is hard-delete-only and unversioned, which is why
+    # its retention rule cannot key on either (see the v45 migration header).
+    "world_book_entries": {
+        "id",
+        "world_book_id",
+        "keys",
+        "content",
+        "enabled",
+        "position",
+        "insertion_order",
+        "priority",
+        "selective",
+        "secondary_keys",
+        "case_sensitive",
+        "regex",
+        "extensions",
+        "created_at",
+        "last_modified",
+    },
     # Media DB
     "Media": {
         "id",


### PR DESCRIPTION
Closes TASK-19564 and TASK-19567.

## The task's premise was stale, and its preferred fix would have broken a live feature

TASK-19564 filed `sync_log` as a write-only shadow copy whose "both readers have zero external callers", and its acceptance criteria pushed toward **retiring the content columns**. That was wrong in a specific way: those two are the *legacy* readers, and the production hits attributed to them belong to the **Prompts** DB's identically-named methods.

ChaChaNotes has **six** readers. Three have live non-test callers, verified independently twice:

| reader | live caller |
|---|---|
| `read_committed_chat_sync_intent` | `console_chat_store.py:6548`, every provider-continuation checkpoint |
| `list_current_committed_chat_sync_intents` | `console_chat_store.py:1431`, every conversation restore |
| `reconcile_chat_message_intent` / `…_delete_intent` | `Sync_Interop/chat_outbox_producer.py:102`, `:164` |

Each compares the payload to the live `messages` row **field by field** — the payload *is* the commit proof. Probed through the shipped API rather than argued:

```
content present:  read_committed_chat_sync_intent -> RECORD content='the exact body'
                  list_current_committed_chat_sync_intents -> [{... 'message_version': 1 ...}]
content retired:  -> None
                  -> []
                  -> durability.ready=False -> persist_provider_continuation_event raises RuntimeError
```

That reader is consulted **before** `sync_v2_server_profile_id` is checked, so retirement breaks the **default** configuration, not just configured-sync users. Dormant-but-intended, not dead.

## What ships instead: keep the content, delete everything unreachable

Reachable is `{v, v-1}` for live messages, `{v}` for tombstoned rows, `{v}` for every other entity, nothing for orphans. Review attacked that rule and found it exactly right — only `_previous_committed_chat_payload_hash` asks for `version - 1`, nothing anywhere asks for `v-2`, and a restore landing several edits behind, a conflict path and an offline client all go through the same two queries.

**One version tighter is a silent regression**: simulating a `{v}`-only rule on a message at v6 still returns a record — it just loses `base_payload_hash`, the optimistic-concurrency token, with nothing failing loudly. One version looser buys nothing.

A v44→v45 migration purges the backlog once; 12 `sync_log_prune_*` triggers keep it bounded on every write, so there is no caller to forget; `prune_sync_log()` / `delete_sync_log_entries[_before]()` give `Client_Media_DB_v2` parity.

Measured on a realistic corpus, post-VACUUM: **19,017,728 → 14,221,312 B (−25.2%)**, payload as a multiple of message text **2.94× → 1.72×**, migration 0.06 s. An upgraded v44 file lands on the *identical row set* as a fresh v45 (3218 == 3218). Review re-measured trigger write overhead independently as **−0.1%, inside the noise** — the implementer's +4.1% was conservative.

## TASK-19567: the FTS guard had no behavioural witness

`messages_au`'s `WHERE new.deleted = 0` was mutated away and 475 tests passed. The reason matters: all four production consumers redundantly re-filter at query level, and the only tests touching `messages_fts` directly were a before/after **equality** snapshot across a migration, where a uniform mutation is invisible on both sides.

The new witness queries the index directly with absolute expectations. Mutation proof, reproduced by review:

- delete the guard from `messages_au` → **4 witness tests red, 391 pre-existing FTS-adjacent tests green** — including `test_soft_deleted_message_does_not_match`, the test *named* for the behaviour, confirmed green under the mutation in isolation
- delete it from `character_cards_au` → **2 red, all 306 `Tests/ChaChaNotesDB/` green**

The blindness was never specific to `messages_au`. There are **eight** soft-deletable FTS tables, not the five filed — `chat_dictionaries` and `world_books` too — and all eight are now witnessed.

**A live defect nobody had filed** came out of the same work: three `*_au` triggers issued the FTS5 `'delete'` unconditionally, so `add_keyword_collection` on a soft-deleted name raised `database disk image is malformed` **through the public API**. Reproduced at base, fixed here. Indexes reset with `'delete-all'` plus a filtered reinsert, deliberately not `'rebuild'` — review confirmed `'rebuild'` re-indexes a soft-deleted message (`MATCH -> [1]`), so the choice is load-bearing rather than stylistic.

The unscoped `search_messages_by_content` leak is closed: it returned the deleted conversation's body verbatim while its sibling returned 0; now both return 0. `messages.conversation_id` is `NOT NULL`, so the new INNER JOIN cannot silently drop live rows. Review found a fifth consumer the filing missed (`RAG_Search/simplified/rag_service.py:2367`) — it re-filters.

## Migration atomicity, proven the harder way

The branch's own test poisons the *runner*, so under `executescript` it reds with "DID NOT RAISE". Review poisoned the **`.sql` file** instead, which shows what actually happens:

- under `cursor.executescript`: `stamp=44`, 12 triggers created, `sync_log` 4→3 rows, **the needle destroyed** — a partial commit that loses user data and re-enters forever
- under the shipped runner: `stamp=44`, 0 triggers, 4→4 rows — full rewind

The exact `== 45` pin lives only in the new migration's own file; v43→v44 is relaxed to `>=`. The migration creates no tables and no indexes, so `VALID_TABLES` and the index census are untouched.

## One self-reported regression, and the trap behind it

The prune triggers were first named `<entity>_sync_log_prune`, which squats in the `<entity>_sync_%` namespace because **`_` is a single-character wildcard in SQL `LIKE`**. Only one of three namespace tests went red — the other two run against pre-migration databases, so **two-thirds of the collision was latent** and would have surfaced in someone else's PR. Renamed; every namespace now contains exactly its four writer triggers.

## Verification

- `Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Sync_Interop` + `Tests/Notes` post-rebase: **4557 passed, 6 skipped, 0 failed**.
- 14 of the new tests fail at base with defect signatures — the `sync_log` body surviving a delete, five accumulated edit needles, the unscoped search returning a deleted conversation's body, and `database disk image is malformed` on keyword-collection undelete.

**Being filed rather than fixed here**: `sync_log` is written for **nine** entities and retention covers six. `chat_dictionaries` and `world_books` leak names and descriptions on soft-delete, and `world_book_entries` retains full `keys` + `content` forever — hard `DELETE` only, no version column, and it carries lorebook prose. Not a regression (identical to base). It is not a one-line extension: the naive `version < NEW.version` rule fails for the first two (their `last_modified` trigger writes a full payload *at* the tombstone version), `world_book_entries` needs an operation-keyed rule, and SQLite leaves same-kind trigger firing order undefined, so any rule must be order-independent by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds ChaChaNotes `sync_log` to only versions readers can reach and adds behavioural witnesses for FTS soft-delete guards. Previously the log retained full-payload rows indefinitely and unscoped search could surface content from soft-deleted conversations; now retention prunes unreachable rows across all writers and search excludes tombstoned content (TASK-19564, TASK-19567).

- Schema v46: v45→v46 migration installs retention triggers for all nine `sync_log` writers and purges unreachable rows; atomic and re-enterable; no new tables/indexes. Renumbered after Actor Packs; `_CURRENT_SCHEMA_VERSION = 46`; the exact schema pin moves to this migration’s test and older pins relax to `>= 45`. Upgrading lands on the same frontier as a fresh v46 and reduces file size ~25%.
- Retention rule: messages keep {v, v-1} while live and {v} when tombstoned; other entities keep {v}; orphans are deleted. Adds a latest-only rule for `chat_dictionaries`, `world_books`, and `world_book_entries`, anchored to the log row to retain at most one content-bearing entry while live and keep content-free tombstones.
- FTS/search: fixes unconditional `'delete'` in three `*_au` triggers; resets via `'delete-all'` + filtered reinsert (not `'rebuild'`). Unscoped `search_messages_by_content` now excludes soft-deleted conversations. New direct-index tests witness guards across eight soft-deletable FTS tables.
- Safety and API: `prune_sync_log()` validates identifiers via `sql_validation` (`validate_table_name`, `validate_column_name`, `escape_identifier`) with new `VALID_COLUMNS` entries for the latest-only scopes. `get_sync_log_entries(since_change_id)` remains a frontier snapshot, not a full change feed.

<sup>Written for commit ce039ac5384ed983018d2b562fbf9ea92bacc8ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

