### PR TITLE
docs: file 9 findings from the holistic-review batch-4 burn-down

### DIFF
--- a/backlog/tasks/task-20970 - Actor Pack recovery aborts app construction when the ChaChaNotes DB is unavailable.md
+++ b/backlog/tasks/task-20970 - Actor Pack recovery aborts app construction when the ChaChaNotes DB is unavailable.md
@@ -1,0 +1,105 @@
+---
+id: TASK-20970
+title: >-
+  Actor Pack recovery aborts app construction when the ChaChaNotes DB is
+  unavailable
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - bug
+  - app-startup
+  - database
+  - resilience
+  - test-integrity
+priority: high
+dependencies:
+  - TASK-19057
+---
+
+## Description
+
+Source: surfaced while baselining **TASK-19561** against a clean `origin/dev`
+worktree, and independently while renumbering **TASK-19564**'s migration after
+the schema-version collision with TASK-19057. Re-verified at `684c6aba4`.
+
+`TldwCli.__init__` has always tolerated an absent ChaChaNotes database. When
+the DB cannot be opened it logs `ChaChaNotesDB (CharactersRAGDB) instance not
+found/assigned in app.__init__` (`app.py:5956`), sets `self.chachanotes_db =
+None`, and every downstream wiring degrades around it — the sibling
+`_wire_chat_conversation_services` guards the same value explicitly
+(`app.py:6664`, `:6678`, `:6705`).
+
+TASK-19057's Actor Packs wiring does not. `_wire_character_persona_services`
+constructs `ActorPackRepository(self.chachanotes_db)` unconditionally
+(`app.py:6605`) and then calls `recover()` (`app.py:6612`). With no database
+the repository dereferences `None` (`Actor_Packs/repository.py:276`) and raises
+`AttributeError`. The call is wrapped in `except
+PersonaActorPackCoordinatorError`, which is a `ValueError` subclass
+(`Actor_Packs/persona_coordinator.py:22`) — so the error escapes the guard that
+exists, and construction of the application object fails outright.
+
+**This is not confined to the test harness.** `get_chachanotes_db_lazy()`
+returns `None` on *any* failure to open the database (`config.py:7011-7016`) —
+a corrupt file, a permission error, or a migration that cannot complete. That
+was measured directly, without patching anything: pointing an isolated
+`HOME`/`XDG` at a ChaChaNotes file containing non-SQLite bytes gives
+`CharactersRAGDBError: file is not a database`, the loader returns `None`, and
+the app is then in exactly the state its own error branch anticipates. A
+degraded-but-running app is now an app that cannot be constructed at all, and
+the failure is an unhandled `AttributeError` rather than the operator-legible
+message the existing branch was written to produce. TASK-19860 (migration `.sql`
+files missing from the wheel) is a shipped example of a real cause.
+
+Measured symptoms at `684c6aba4`, all one root cause — every failure below
+terminates in the identical frame chain `app.py:6010` →
+`_wire_character_persona_services` `app.py:6612` → `repository.py:276`:
+
+- **294 test failures** across `Tests/App`, `Tests/Scheduling`,
+  `Tests/Subscriptions` and `Tests/Watchlists` (`294 failed, 1795 passed`), of
+  which **294 of 294** report `AttributeError: 'NoneType' object has no
+  attribute 'execute_query'` and nothing else. `Tests/Watchlists/
+  test_watchlists_artifacts_pane.py` alone contributes 122.
+- **4 collection errors** in `Tests/UI`.
+  `test_settings_category_sweep.py:27-29` builds an app at module scope, so it
+  errors during collection, and `test_settings_footer_hints.py`,
+  `test_settings_model_catalog_layout.py` and
+  `test_settings_save_commit_models.py` cascade into `ImportError` because they
+  import from it.
+- A clean repo-wide `pytest --collect-only` therefore exits non-zero.
+
+## Acceptance Criteria
+
+- [ ] Constructing `TldwCli` with no ChaChaNotes database succeeds, and the app
+      reaches the same degraded-but-running state it reached before TASK-19057
+- [ ] The Actor Pack wiring makes an explicit decision about a missing
+      database rather than dereferencing it, consistent with how the sibling
+      wiring in the same constructor treats the same value
+- [ ] A missing database produces an operator-legible diagnostic, not an
+      unhandled `AttributeError`
+- [ ] The recovery call's failure handling covers the errors the repository can
+      actually raise, so a repository failure cannot escape the guard that is
+      written to contain it
+- [ ] A test builds the app with no ChaChaNotes database and fails if
+      construction raises — so this specific regression cannot return silently
+- [ ] The 294 failures across `Tests/App`, `Tests/Scheduling`,
+      `Tests/Subscriptions` and `Tests/Watchlists` are green
+- [ ] The 4 `Tests/UI/test_settings_*` collection errors are gone and a
+      repo-wide `pytest --collect-only` no longer reports them
+- [ ] A degraded start is verified end to end at least once against a real
+      unopenable database file, not only against a patched-out service
+
+## Notes
+
+Filed as one task on measured evidence rather than as three. The
+`test_app_watchlists_db_wiring` failure, the 8 `Tests/App` + 2
+`Tests/Scheduling` reds, and the 4 `Tests/UI/test_settings_*` collection errors
+were each reported separately; running them showed 294 of 294 failures ending
+in the same three frames, so they are one defect with several shadows.
+
+Two consequences worth keeping in view while this is open. First, this is
+currently **masking** other test signal — `test_watchlists_artifacts_pane.py`
+is entirely red from this cause, including the test TASK-20978 is about, so
+that flake cannot be re-measured until this is fixed. Second, the reason the
+None branch exists at all is that it was reachable; nothing about TASK-19057
+made it less so.

--- a/backlog/tasks/task-20971 - The chachanotes VALID_TABLES guard went red again within a day of being repaired.md
+++ b/backlog/tasks/task-20971 - The chachanotes VALID_TABLES guard went red again within a day of being repaired.md
@@ -1,0 +1,83 @@
+---
+id: TASK-20971
+title: >-
+  The chachanotes VALID_TABLES guard went red again within a day of being
+  repaired
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - bug
+  - database
+  - testing
+  - test-integrity
+  - process
+priority: high
+dependencies:
+  - TASK-19568
+  - TASK-19057
+---
+
+## Description
+
+Source: found on a clean `origin/dev` worktree at `684c6aba4` while renumbering
+TASK-19564's migration after the schema-version collision with TASK-19057.
+
+`Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema::
+test_no_missing_tables` is red on `dev`:
+
+> `AssertionError: Live schema has tables not in VALID_TABLES['chachanotes']:
+> ['actor_pack_persona_intents', 'actor_portable_identities']. Add them (or
+> document a deliberate exclusion) in tldw_chatbook/DB/sql_validation.py.`
+
+TASK-19057's v44→v45 migration created two tables and did not add them to the
+hand-maintained literal in `DB/sql_validation.py`.
+
+**The drift itself is minor. The recurrence interval is the finding.** This is
+the same pin TASK-19568 repaired — that task existed *because* the entry had
+gone stale and a red gate stops gating. Its repair merged at `aaec11812`,
+2026-08-22 00:16 -0700. TASK-19057 merged at `2fe6ca20f`, 2026-08-22 14:51
+-0700 and broke it again. **Fourteen and a half hours.** A one-shot literal
+update demonstrably does not hold, and this programme has already paid for a
+masked gate once: TASK-19191's per-row inventory review cleared 13 red gate
+tests and surfaced three privacy findings that had been sitting behind them,
+and TASK-19044's stale version pin had been masking a shipped can't-migrate-past-v39
+packaging bug.
+
+Scope note, measured: the **index** census is unaffected —
+`idx_actor_pack_persona_intents_state` is already pinned
+(`Tests/ChaChaNotesDB/test_index_census.py:93`), and
+`Tests/ChaChaNotesDB/test_actor_pack_migration.py` covers the new tables'
+migration. It is specifically the `VALID_TABLES` tables literal that drifted,
+because nothing connects adding a table to updating it except a human
+remembering.
+
+The related TASK-19867 covers the `media` and `prompts` entries of the same
+allowlist, which have drifted further and have no guard at all. This task is
+about the entry that *does* have a guard and went red anyway.
+
+## Acceptance Criteria
+
+- [ ] `Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema`
+      is green on `dev`
+- [ ] `VALID_TABLES['chachanotes']` matches the tables a freshly initialized
+      ChaChaNotes database actually contains
+- [ ] A mechanism exists that makes the *next* table-adding migration fail
+      loudly at authoring time rather than after merge — the outcome required is
+      that the literal cannot silently fall behind the schema again, not that it
+      is correct today
+- [ ] The chosen mechanism is proven to bite: adding a table without updating
+      the allowlist is shown to fail, and the proof does not depend on the same
+      hand-maintained list it guards
+- [ ] The recurrence is recorded where a future migration author will encounter
+      it, so the cost of this class of drift is not re-learned a third time
+
+## Notes
+
+Not filed as "update the literal". Twice-repaired-in-a-day is evidence that the
+repair shape is wrong, and the acceptance criteria are written to ask for
+whatever stops recurrence rather than for another correct-on-the-day list.
+
+This is residue of the TASK-19057 merge, not of the retention work that found
+it: `VALID_TABLES` is byte-identical to `dev`'s on TASK-19564's branch, and that
+branch's migration contains zero `CREATE TABLE` statements.

--- a/backlog/tasks/task-20972 - A parametrize-signature mismatch breaks repo-wide test collection.md
+++ b/backlog/tasks/task-20972 - A parametrize-signature mismatch breaks repo-wide test collection.md
@@ -1,0 +1,64 @@
+---
+id: TASK-20972
+title: >-
+  A parametrize-signature mismatch breaks repo-wide test collection
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - bug
+  - testing
+  - test-integrity
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: found while baselining **TASK-19561** against a clean `origin/dev`
+worktree. Re-verified at `684c6aba4`.
+
+`Tests/UI/test_library_file_notes_workspace.py` errors during **collection**:
+
+> `In test_wide_files_task_return_restores_database_browse_receipt: function
+> uses no argument 'push_phase'`
+
+`test_wide_files_task_return_restores_database_browse_receipt`
+(`Tests/UI/test_library_file_notes_workspace.py:1263-1272`) carries two
+`@pytest.mark.parametrize` decorators — one on `("save_state", "save_copy")`
+and one on `("push_phase", "push_copy", "git_count")` — while its signature
+takes no arguments at all. pytest reports the second one and stops.
+
+The cost is out of proportion to the mistake. A collection error aborts the run
+for the whole invocation, so `pytest --collect-only` over the repository exits
+non-zero and cannot be used as a clean gate. That sweep is the cheapest check
+this programme has: it is how a rebase is confirmed not to have broken an
+import, and it is run before nearly every merge. While it is red by default,
+every user of it has to hold a list of failures that are "expected", which is
+the state in which a genuinely new breakage goes unnoticed.
+
+Two further facts about the test itself should be settled rather than assumed.
+Neither parametrize set is consumed, so the six cases the decorators describe
+have never run in any form; and because the arguments are unused, whatever
+`push_phase` / `save_state` were meant to vary is not being varied. The
+question is whether the intended coverage was lost or was never written.
+
+## Acceptance Criteria
+
+- [ ] `pytest --collect-only` over the repository completes without a
+      collection error from this module
+- [ ] `test_wide_files_task_return_restores_database_browse_receipt` either
+      consumes the parameters it is parametrized on, or is no longer
+      parametrized on parameters it does not use
+- [ ] It is established and recorded whether the parametrized cases represent
+      coverage that was intended and lost, or decorators that were never wired
+      up — and if coverage was intended, it exists and passes
+- [ ] The test passes in every configuration it declares
+
+## Notes
+
+Filed medium rather than low because of what it costs the gate, not because of
+what it costs this one module. The same run also surfaced four further
+collection errors in `Tests/UI/test_settings_*`; those have a different root
+cause and are TASK-20970. Both must be fixed before a repo-wide
+`--collect-only` is green.

--- a/backlog/tasks/task-20973 - Two public media seams let a caller supply the URL that vouches for itself.md
+++ b/backlog/tasks/task-20973 - Two public media seams let a caller supply the URL that vouches for itself.md
@@ -1,0 +1,79 @@
+---
+id: TASK-20973
+title: >-
+  Two public media seams let a caller supply the URL that vouches for itself
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - security
+  - egress
+  - media
+  - architecture
+priority: medium
+dependencies:
+  - TASK-19556
+---
+
+## Description
+
+Source: raised by **TASK-19556**'s reviewer while verifying the yt-dlp egress
+guard. Re-verified at `684c6aba4`.
+
+TASK-19556 put the app's egress policy in front of the two yt-dlp seams, as
+`check_url_or_raise(url, trusted_origins=origin_set(url))`
+(`Local_Ingestion/video_processing.py:85`). The URL is its own trusted origin.
+That is a deliberate and correct choice *for a URL the user typed into the
+ingest form*: `config.py`'s `[web_security]` contract permits an explicitly
+configured URL to be private, because an intranet media server is a legitimate
+source. The function's own docstring states this reasoning
+(`video_processing.py:56-62`).
+
+The reasoning holds only as long as every URL arriving at that check is
+user-entered. Today it is — but by **wiring, not by invariant**. Two public,
+test-covered methods accept caller-supplied URLs and forward them with no
+provenance check of any kind:
+
+- `LocalMediaReadingService.process_video(urls=…)`
+  (`Media/local_media_reading_service.py:1217`)
+- `MediaReadingScopeService.process_video(urls=…)`
+  (`Media/media_reading_scope_service.py:2112`)
+
+Neither has an in-app caller today — the only production reference to a
+similarly named method is the unrelated private
+`BackendIntegration._process_video` — so nothing is exposed right now. But
+`trusted_origins=origin_set(url)` means a URL that reaches that seam from
+anywhere else instructs the policy to trust its own host, which is precisely
+what the policy exists to refuse for untrusted input. Wiring either seam to any
+source that is not the ingest Input — a config file, an API payload, a feed, an
+agent tool — silently converts a correct guard into no guard, with no test
+failing and no reviewer prompted to look.
+
+This is the "safe because of who happens to call it" shape rather than "safe by
+construction". The fix wanted is a provenance decision at the boundary, not a
+larger denylist.
+
+## Acceptance Criteria
+
+- [ ] A URL reaching the yt-dlp egress check is trusted as its own origin only
+      when its provenance actually establishes that trust; a caller-supplied URL
+      of unknown provenance is not self-trusting
+- [ ] The two `process_video(urls=…)` seams either establish provenance
+      explicitly or cannot reach the self-trusting path
+- [ ] The trust decision is expressed where it is made rather than inferred from
+      the current caller set, so adding a caller cannot silently change it
+- [ ] A test proves that wiring a new, non-user-entered source into these seams
+      does not grant self-trust — i.e. the guarantee survives a hypothetical
+      future caller, which is the property that does not hold today
+- [ ] Existing user-entered ingest of a private or intranet media URL still
+      works, and a test pins it, so the fix does not close a legitimate case
+- [ ] The residual limits TASK-19556 documented (yt-dlp's own redirect hops,
+      extractor-discovered per-format URLs, resolve-then-connect TOCTOU) remain
+      accurately stated and are not implied to be closed by this work
+
+## Notes
+
+Filed medium with no live exposure, deliberately. The severity is not what an
+attacker can do today — nothing reaches these seams — it is that the security
+property is held by a fact nobody is watching, one wiring commit from being
+false, and that the commit which makes it false will look entirely ordinary.

--- a/backlog/tasks/task-20974 - Subscriptions DB shutdown methods have no production caller and their rationale is now stale.md
+++ b/backlog/tasks/task-20974 - Subscriptions DB shutdown methods have no production caller and their rationale is now stale.md
@@ -1,0 +1,83 @@
+---
+id: TASK-20974
+title: >-
+  Subscriptions DB shutdown methods have no production caller and their
+  rationale is now stale
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - bug
+  - database
+  - shutdown
+  - durability
+priority: medium
+dependencies:
+  - TASK-19562
+  - TASK-19561
+---
+
+## Description
+
+Source: noted but deliberately not fixed by **TASK-19562**, which added the two
+methods. Re-verified at `684c6aba4`, after TASK-19561 merged (`5622f6987`).
+
+`SubscriptionsDB.checkpoint_wal()` (`DB/Subscriptions_DB.py:1608`) and
+`SubscriptionsDB.close_all_connections()` (`:1659`) exist and are tested, but
+nothing in the running application calls them. Their only caller is
+`_checkpoint_open_databases_at_exit` (`:212`), registered via `atexit`
+(`:1605`) — and that hook's own docstring says plainly that it is *not* what
+saves the `-wal` on an ordinary exit, because CPython finalizes the connection
+objects and SQLite checkpoints when the last connection closes. That was tested
+when it was written: a child process that wrote a 4.1 MB `-wal` and exited
+normally left only `subs.db`, identically with the hook enabled and suppressed.
+
+So the two methods are, in practice, machinery with no moment at which they
+run for the reason they were written.
+
+**TASK-19562 said wiring them in belonged with TASK-19561's signal path.
+TASK-19561 has now merged, and it built exactly that seam** — `Utils/
+app_shutdown.py`, with one process-level `SIGTERM`/`SIGINT` handler that
+answers the first signal with an ordinary `App.exit()` and bounds the exit with
+a watchdog. `os._exit(0)` no longer appears anywhere in `app.py`.
+
+That makes the docstring at `DB/Subscriptions_DB.py:193-196` **false as
+written**. It still says:
+
+> "The path where the `-wal` genuinely does survive is `app.py`'s SIGINT/SIGTERM
+> handler, which calls `os._exit(0)` — that skips `atexit` too, so no hook here
+> can reach it."
+
+The premise is gone. A hook *can* now reach that path, because that path is now
+an ordinary shutdown. A comment that describes a mechanism the code no longer
+has is worse than no comment: the next reader takes it as a reason not to look.
+This is the same "asserts something it did not produce" theme the holistic
+review found throughout.
+
+## Acceptance Criteria
+
+- [ ] `checkpoint_wal()` and `close_all_connections()` are reachable from the
+      application's real shutdown path, or are removed
+- [ ] If wired in, the seam they attach to is named explicitly, and the
+      behaviour is verified against a real termination rather than by unit test
+      alone
+- [ ] If wired in, shutdown remains bounded — settling the database cannot make
+      a slow exit into a hung one
+- [ ] `DB/Subscriptions_DB.py`'s docstrings no longer describe an `os._exit(0)`
+      signal path that no longer exists, and state accurately what the `atexit`
+      hook does and does not achieve
+- [ ] The already-tested facts are preserved and not re-litigated: a clean exit
+      does not leave a `-wal` behind, and SQLite refuses a cross-thread close, so
+      other threads' connections are reported rather than closed
+- [ ] A test fails if these methods lose their production caller again
+
+## Notes
+
+The honest framing is "wire them in — the seam now exists", not "these are dead
+code". They were written for a real hazard (a standing `-wal`, and connections
+abandoned by a hard exit); what was missing was a defined moment to run them,
+and TASK-19561 has now created one.
+
+Removing them instead is an acceptable outcome of this task, but only with the
+hazard explicitly re-checked against the post-TASK-19561 shutdown — not by
+inheriting the stale docstring's conclusion.

--- a/backlog/tasks/task-20975 - Hard-deleting a world book raises on its own entries sync emitter.md
+++ b/backlog/tasks/task-20975 - Hard-deleting a world book raises on its own entries sync emitter.md
@@ -1,0 +1,80 @@
+---
+id: TASK-20975
+title: >-
+  Hard-deleting a world book raises on its own entries sync emitter
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - bug
+  - database
+  - sync
+  - latent
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: found while surveying `sync_log` retention for **TASK-19564**.
+Re-verified independently at `684c6aba4` against a real schema-v45 database.
+
+`world_book_entries` has no `client_id` column of its own, so its `sync_delete`
+trigger reads one from its parent:
+
+```
+CREATE TRIGGER world_book_entries_sync_delete
+AFTER DELETE ON world_book_entries BEGIN
+  INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
+  VALUES('world_book_entries', CAST(OLD.id AS TEXT), 'delete', datetime('now'),
+         (SELECT client_id FROM world_books WHERE id = OLD.world_book_id), 1, ...);
+END;
+```
+
+(`DB/ChaChaNotes_DB.py:1712-1718`.) The child rows are wired to the parent with
+`ON DELETE CASCADE` (`:1520`). So when a `world_books` row is hard-deleted the
+cascade fires the child trigger *after* the parent row is already gone, the
+subselect yields `NULL`, and the insert violates `sync_log`'s `NOT NULL` on
+`client_id`. The whole delete is rolled back.
+
+Measured on a fresh v45 database with one world book and one entry:
+
+| operation | result |
+| --- | --- |
+| `UPDATE world_books SET deleted=1` (the shipped path) | ok |
+| `DELETE FROM world_books WHERE id=?` | `IntegrityError: NOT NULL constraint failed: sync_log.client_id` |
+
+**This is latent, not live.** No shipped path hard-deletes a world book: the
+deletion the UI performs is a soft delete, and a repository-wide search finds no
+`DELETE FROM world_books` outside the FTS maintenance triggers. The defect is
+reachable only by a future caller, a migration, or a maintenance script that
+does the obvious thing.
+
+It is worth fixing anyway because of how it will present. The trigger works
+correctly for a *direct* entry delete and fails only under cascade, so the bug
+is invisible to any test that deletes entries; and it surfaces as a constraint
+violation on an unrelated table, which is a poor signpost to a parent-child
+trigger ordering problem.
+
+Recorded for accuracy: this is neither caused nor worsened by the `sync_log`
+retention work. It reproduces on `dev` with TASK-19564 unmerged.
+
+## Acceptance Criteria
+
+- [ ] Hard-deleting a `world_books` row succeeds and removes its entries
+- [ ] The `sync_log` row emitted for each cascaded entry carries a valid
+      `client_id`, or the design decides deliberately that no row is emitted for
+      a cascaded delete and records why
+- [ ] A test covers the cascade path specifically, distinct from a direct
+      `world_book_entries` delete, since the direct path already works
+- [ ] The same parent-lookup pattern is checked across the other sync emitters
+      and either found absent or fixed with this one
+- [ ] The chosen fix does not depend on trigger firing order, which SQLite
+      leaves undefined for same-kind triggers
+
+## Notes
+
+Filed low because it is unreachable from the shipped UI today. The reason to
+fix it rather than note it is that the first caller to hard-delete a world book
+will get a `NOT NULL constraint failed: sync_log.client_id` and no obvious
+route from that message to a cascade-ordering cause.

--- a/backlog/tasks/task-20976 - The egress adoption census cannot see a dynamically dispatched opener.md
+++ b/backlog/tasks/task-20976 - The egress adoption census cannot see a dynamically dispatched opener.md
@@ -1,0 +1,74 @@
+---
+id: TASK-20976
+title: >-
+  The egress adoption census cannot see a dynamically dispatched opener
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - testing
+  - test-integrity
+  - egress
+  - security
+  - hygiene
+priority: low
+dependencies:
+  - TASK-19556
+---
+
+## Description
+
+Source: disclosed by **TASK-19556**'s implementer when Qodo required the
+adoption census be rewritten on the AST. Re-verified at `684c6aba4`.
+
+`Tests/Utils/test_egress_adoption_census.py` is the guard that stops the *next*
+network seam from silently skipping the egress policy. It decides, per module,
+"does this open URLs" and "does it consult the policy". Round one of TASK-19556
+made that decision by regex over raw source text, which was shown to be
+bypassable in both directions — most sharply, `Local_Ingestion/
+video_processing.py`'s own docstring quotes `guarded_fetch_requests(...)` in
+prose, and the regex read that as "still consults the policy" **even with the
+actual call deleted**, so the guard would not have caught its own subject
+regressing. It is now an AST scan (`_analyze_source` → `_scan(ast.parse(source))`,
+`Tests/Utils/test_egress_adoption_census.py:192-193`), with three
+non-hollowness proofs.
+
+The AST version is strictly better and has one honest, known limit that should
+be recorded rather than discovered later. A statically-resolvable call like
+`urllib.request.urlopen(u)` is a `Name`/`Attribute` chain the scanner can trace.
+A dynamically dispatched one — `getattr(urllib.request, "urlopen")(u)`, or the
+same shape through a dict lookup or a module alias — is not, so an unguarded
+opener written that way would not be flagged. The old regex would have matched
+the string literal.
+
+No opener in the codebase uses that pattern today; a search for
+`getattr(<module>, "<opener>")` across `tldw_chatbook/` returns nothing. So this
+is a documented boundary of a guard, not a defect in it, and it should not be
+re-reported later as an unguarded seam.
+
+The value in doing something about it is that the limit is currently known only
+to the people who were in that review. A test that states the boundary makes it
+survive them, and makes it visible to whoever next widens the census.
+
+## Acceptance Criteria
+
+- [ ] The census's inability to resolve a dynamically dispatched opener is
+      recorded in the guard itself, not only in a task or a review thread
+- [ ] A test documents the limit by example — a dynamically dispatched opener is
+      shown to be invisible to the scanner — so the boundary is executable rather
+      than prose that can go stale
+- [ ] The three existing non-hollowness proofs still pass, including Qodo's
+      bypass case (a comment naming the real egress function beside a genuine
+      unguarded opener)
+- [ ] It is re-confirmed at implementation time that no module in
+      `tldw_chatbook/` currently opens URLs through a dynamically resolved
+      reference, and the check used is recorded so it can be re-run
+- [ ] If the limit is closed rather than documented, the closure is shown not to
+      reintroduce the regex-era false greens the AST rewrite removed
+
+## Notes
+
+Filed explicitly as a known limit rather than a defect, and filed low. Over-rating
+it would invite a fix that trades the AST's precision back for text matching,
+which is the shape this programme has repeatedly found hollow — the regex version
+of this very guard failed to notice its own subject regressing.

--- a/backlog/tasks/task-20977 - Losing terminal focus fires the ingest URL probe with no gesture at the field.md
+++ b/backlog/tasks/task-20977 - Losing terminal focus fires the ingest URL probe with no gesture at the field.md
@@ -1,0 +1,76 @@
+---
+id: TASK-20977
+title: >-
+  Losing terminal focus fires the ingest URL probe with no gesture at the field
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - bug
+  - egress
+  - privacy
+  - library-ingest
+  - ui
+priority: low
+dependencies:
+  - TASK-19556
+---
+
+## Description
+
+Source: found live by **TASK-19556**'s reviewer while verifying that the
+typing-triggered probe oracle was closed. Re-verified at `684c6aba4`.
+
+TASK-19556 closed the case where a staged URL was probed on a timer as the user
+typed. The remaining triggers are deliberate gestures: blur, Enter, Browse…, and
+an explicit retry. Blur is a reasonable proxy for "the user has finished
+entering this URL and moved on".
+
+It is not only that. Textual posts `Input.Blurred` on `events.AppBlur` —
+terminal focus loss — so switching away from the terminal entirely counts as
+leaving the field. `handle_library_ingest_path_blurred`
+(`UI/Screens/library_screen.py:26586-26612`) calls
+`_trigger_library_ingest_preflight(path)` with no `allow_probe=False`, unlike
+the typing path which passes it unconditionally (`:27520`). So for a user who
+has opted in, alt-tabbing away with a URL staged in the ingest field causes the
+application to contact that host, with no gesture aimed at the field and
+nothing on screen to prompt it. Demonstrated live.
+
+This is the same category as the oracle TASK-19556 closed — network activity
+the user did not ask for at that moment — at far lower frequency, and it is
+inert under the shipped default: `[library] ingest_url_preflight_probe` defaults
+to `false` (`config.py:2749-2750`), so nobody is affected without opting in.
+
+**Read the handler's history before changing it.** Its docstring
+(`library_screen.py:26588-26608`) records a prior reversal of TASK-3314 AC#4
+after an xhigh review and live-verify round: blur deliberately does *not* disarm
+a pending Start consent, because the Start click that the confirmation copy asks
+for itself blurs the path field on its way in, so the original rule made the
+prescribed route unable to ever submit. That is a different concern from
+probing, but it is the same handler and the same event, and it is exactly the
+kind of correction that gets silently undone by someone treating blur as simple.
+
+## Acceptance Criteria
+
+- [ ] Losing terminal focus with a URL staged does not by itself cause a network
+      probe, for an opted-in user
+- [ ] A genuine within-app blur — moving to another field or control — still
+      probes, so the useful trigger is not lost along with the unwanted one
+- [ ] Enter, Browse… and explicit retry continue to probe
+- [ ] The consent behaviour the handler's docstring documents is unchanged: a
+      blur still does not disarm a pending Start consent, and the Start-click
+      route still submits
+- [ ] A test distinguishes an application-level focus loss from a within-app
+      blur, so the two cannot be conflated again
+- [ ] The default-off gate is unchanged and still verified to issue no transport
+      calls and no DNS lookups when off
+
+## Notes
+
+Low, and only reachable behind an opt-in — but it is a real instance of the
+class TASK-19556 exists to eliminate, and leaving it unrecorded would mean the
+next audit of that gate re-derives it from scratch.
+
+Whoever takes this should read the docstring history first. The handler has
+already been changed once on a plausible-sounding rule that turned out to break
+the flow the UI copy instructs the user to follow.

--- a/backlog/tasks/task-20978 - A watchlists export test fails under load inside the directory picker.md
+++ b/backlog/tasks/task-20978 - A watchlists export test fails under load inside the directory picker.md
@@ -1,0 +1,80 @@
+---
+id: TASK-20978
+title: >-
+  A watchlists export test fails under load inside the directory picker
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - testing
+  - test-integrity
+  - flake
+  - watchlists
+priority: low
+dependencies:
+  - TASK-20970
+---
+
+## Description
+
+Source: observed during **TASK-19561**'s post-rebase verification run, and run
+down rather than assumed.
+
+`Tests/Watchlists/test_watchlists_artifacts_pane.py::
+test_export_feed_press_survives_an_os_error_from_the_service`
+(`:5382`) failed once inside a 1570-test run with:
+
+> `KeyError("No 'directory-navigation--hidden' key in COMPONENT_CLASSES")`
+
+raised from inside the third-party `SelectDirectory` picker, not from
+application code.
+
+Evidence gathered at the time, all pointing the same way:
+
+- Green on an identical re-run of the same selection (1566 passed).
+- Green with the five tests added by that branch deselected (1561 passed).
+- Green 8/8 consecutively when run alone.
+- Green in an isolated run of the module (131 passed).
+- Unreachable from the change under test — the failing test's harness is a
+  `DestinationHarness`, never `TldwCli`, so none of that branch's
+  `on_unmount` / watchdog / signal code runs in it.
+- `pytest-randomly` is not installed in this environment, so collection order is
+  fixed. The variation therefore is **not** ordering; it is load or accumulated
+  process state.
+- A baseline of the same four-directory selection on clean `origin/dev` produced
+  one failure that was a *different* test, and no artifacts-pane failure —
+  consistent with a flake rather than a defect in either branch.
+
+A `COMPONENT_CLASSES` lookup failing intermittently inside a widget suggests the
+picker is being queried at a point in its lifecycle where its component classes
+are not yet resolved, which under load is a timing question. Whether the right
+answer is a fix in how the test drives the picker, or an upstream constraint, is
+open.
+
+**This cannot currently be re-measured on `dev`.** All 122 tests in that module
+are red at `684c6aba4` from the unrelated Actor Pack construction failure
+(TASK-20970) — including this one — so any observation taken now would be of
+that error, not this one. The dependency is recorded for that reason.
+
+## Acceptance Criteria
+
+- [ ] The cause of the intermittent `KeyError` in the directory picker is
+      identified, not merely made to stop appearing
+- [ ] `test_export_feed_press_survives_an_os_error_from_the_service` passes
+      reliably under a loaded full-suite run, not only in isolation
+- [ ] The fix is shown to address timing or lifecycle rather than suppressing the
+      symptom — a retry, a broad `except`, or a skip does not satisfy this
+- [ ] If the cause is shared by sibling tests that drive the same picker, they
+      are covered too
+- [ ] If the conclusion is that the flake originates upstream and cannot be
+      fixed here, that is recorded with the evidence, and the test is made
+      deterministic in a way that still exercises the behaviour it names
+- [ ] Verification is performed after TASK-20970 is fixed, so the module is
+      otherwise green and the measurement is of this defect
+
+## Notes
+
+Filed with its negative evidence intact deliberately. "Flaky, re-run it" is how
+a real load-dependent defect gets absorbed; the run-down above is what
+distinguishes this from that, and it should not have to be repeated by whoever
+picks this up.


### PR DESCRIPTION
Nine tasks, ids **20970-20978**. Global MAX task id was **20940** (swept case-insensitively across all 118 `refs/remotes/*`, all local branches, and every `git worktree list` filesystem, matching on the exact `task-<id> - ` delimiter and on `id:` frontmatter); leapfrogged +30.

Every finding was re-verified against `origin/dev` at `684c6aba4` before filing. Nothing here is copied forward on trust.

## Filed

| id | title | priority |
| --- | --- | --- |
| 20970 | Actor Pack recovery aborts app construction when the ChaChaNotes DB is unavailable | high |
| 20971 | The chachanotes VALID_TABLES guard went red again within a day of being repaired | high |
| 20972 | A parametrize-signature mismatch breaks repo-wide test collection | medium |
| 20973 | Two public media seams let a caller supply the URL that vouches for itself | medium |
| 20974 | Subscriptions DB shutdown methods have no production caller and their rationale is now stale | medium |
| 20975 | Hard-deleting a world book raises on its own entries sync emitter | low |
| 20976 | The egress adoption census cannot see a dynamically dispatched opener | low |
| 20977 | Losing terminal focus fires the ingest URL probe with no gesture at the field | low |
| 20978 | A watchlists export test fails under load inside the directory picker | low |

## Three reports merged into TASK-20970

The `test_app_watchlists_db_wiring` failure, the 8 `Tests/App` + 2 `Tests/Scheduling` reds, and the 4 `Tests/UI/test_settings_*` collection errors were reported as three findings. Running them showed **294 of 294** failures across `Tests/App`, `Tests/Scheduling`, `Tests/Subscriptions` and `Tests/Watchlists` (`294 failed, 1795 passed`) ending in the identical frame chain `app.py:6010` -> `_wire_character_persona_services` `app.py:6612` -> `repository.py:276`, with no second error type present. One defect, several shadows.

Severity was established rather than assumed. The constructor has always tolerated a missing ChaChaNotes DB — it logs an error and sets `None` at `app.py:5956`, and the sibling wiring guards that value explicitly at `app.py:6664`. A probe with an isolated `HOME`/`XDG` and a ChaChaNotes file containing non-SQLite bytes confirmed `get_chachanotes_db_lazy()` returns `None` on any open failure, unpatched. So this is **not** test-only, and the escape is specific: `PersonaActorPackCoordinatorError` subclasses `ValueError`, so the `AttributeError` walks straight through the `except` written to contain it.

## Dropped

**Finding 10 (git_status `path` is not a scope) was not filed — it already exists as TASK-19874**, which names the exact model-facing schema at `Agents/local_tool_provider.py:1258-1261` and carries acceptance criteria for both options. Re-filing would have duplicated it.

## Verification notes

- `scripts/preflight.sh` duplicate-id guard: green, no duplicates across **2439** task files.
- The preflight's production-diagnostic-inventory check fails, and it is **not from this branch**: `HEAD` is byte-identical to `origin/dev` and the branch adds only `backlog/tasks/` files. Attributed below; deliberately **not** regenerated, per the TASK-19572 precedent.
- TASK-20975 was proven on a real schema-v45 database: the shipped soft delete succeeds, the hard delete raises `IntegrityError: NOT NULL constraint failed: sync_log.client_id`.

## Pre-existing dev red found while filing (not filed — flagging for routing)

`Docs/security/production-diagnostic-inventory.json` is stale on `dev`, so preflight fails for every PR. The pin was last committed at `c4667b1fc` (2026-08-22 14:48), and `5622f6987` (PR #1972) then changed `tldw_chatbook/app.py` without regenerating it — the report reads `-1 diagnostic call(s)`. Same masked-gate class as TASK-20971; happy to file it if wanted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files nine backlog tasks (TASK-20970–TASK-20978) from the holistic-review batch-4 burn-down to capture defects with acceptance criteria and verification notes. No runtime or test behavior changes; this is documentation only to de-duplicate reports and unblock follow-up work.

- Doc-only: adds nine markdown files under backlog/tasks; no `tldw_chatbook/` or tests changed.
- Consolidation: three symptom reports merged into TASK-20970 after confirming the same failure chain; an existing finding was not re-filed (see TASK-19874).
- Preflight notes: duplicate-id guard is green; the production-diagnostic-inventory gate is red on `dev` and unrelated to this branch; not regenerated by design.
- Dependencies: TASK-20978’s re-measurement depends on fixing TASK-20970 (the module is currently red on `dev` for that root cause).

<sup>Written for commit 39bca8f358393306e0831e3479369cbfddaf4df7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

