### PR TITLE
test(chat): make provider loopback tests sandbox-safe

### DIFF
--- a/Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md
+++ b/Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md
@@ -1,0 +1,249 @@
+# TASK-19642.2 Loopback Capability Skip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the two real-socket provider-gateway loop-ownership tests explicitly skip when the host cannot construct a numeric-loopback listener, while preserving their real HTTP/1.1 coverage and blocking external network access.
+
+**Architecture:** Keep the existing shared stdlib HTTP server fixture and both concurrency scenarios. Catch only `PermissionError` at listener construction, use the repository's numeric-loopback-only marker, and pin both the positive skip classification and the negative non-permission error path with fixture-contract tests.
+
+**Tech Stack:** Python 3.11+, pytest fixtures/markers, stdlib `http.server` and `threading`, repository `Tests.network_guard` policy.
+
+---
+
+## File Structure
+
+- Modify `Tests/Chat/test_console_provider_gateway.py`: add two fixture-contract tests, classify only listener-construction `PermissionError` as a capability skip, and narrow the two assigned tests to `loopback_network`.
+- Modify `backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md`: record this implementation plan and, after verification/review, completion evidence.
+- Modify `Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md`: check off executed steps if implementation follows this plan.
+- No production, network-guard, marker-registration, dependency, or ADR files change.
+
+### Task 1: Pin listener-construction error classification
+
+**Files:**
+- Modify: `Tests/Chat/test_console_provider_gateway.py:2870-2884`
+- Test: `Tests/Chat/test_console_provider_gateway.py`
+
+- [ ] **Step 1: Add the two fixture-contract tests below the fixture**
+
+```python
+def test_local_http_server_permission_denied_skips_with_capability_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def deny_listener(*_args, **_kwargs):
+        raise PermissionError("sandbox denied loopback bind")
+
+    monkeypatch.setitem(globals(), "_DeepBacklogHTTPServer", deny_listener)
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        next(local_http_server.__wrapped__())
+
+    assert str(exc_info.value) == "loopback listener unavailable: permission denied"
+
+
+def test_local_http_server_non_permission_oserror_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_listener(*_args, **_kwargs):
+        raise OSError("address resources exhausted")
+
+    def fail_if_skipped(reason: str) -> None:
+        pytest.fail(f"unexpected capability skip: {reason}")
+
+    monkeypatch.setitem(globals(), "_DeepBacklogHTTPServer", fail_listener)
+    monkeypatch.setattr(pytest, "skip", fail_if_skipped)
+
+    with pytest.raises(OSError, match="address resources exhausted"):
+        next(local_http_server.__wrapped__())
+```
+
+The constructor replacements open no sockets, so neither regression gets a
+network marker. The negative case is required: replacing `pytest.skip` with an
+explicit failure ensures that broadening the implementation to `except OSError`
+fails this gate instead of being counted as a successful pytest skip.
+
+- [ ] **Step 2: Run the fixture-contract tests and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_provider_gateway.py::test_local_http_server_permission_denied_skips_with_capability_reason \
+  Tests/Chat/test_console_provider_gateway.py::test_local_http_server_non_permission_oserror_propagates \
+  --tb=short
+```
+
+Expected: one failure and one pass. The permission-denied case fails because the fixture still propagates `PermissionError`; the non-permission case already passes.
+
+- [ ] **Step 3: Save the RED evidence in the task working notes, but do not weaken either assertion**
+
+Use `backlog task edit 19642.2 --notes` only if the task's existing notes need the exact RED result preserved before the implementation commit.
+
+### Task 2: Implement the minimal capability skip and narrow markers
+
+**Files:**
+- Modify: `Tests/Chat/test_console_provider_gateway.py:2870-3155`
+
+- [ ] **Step 1: Catch only `PermissionError` at listener construction**
+
+Change the fixture setup to:
+
+```python
+@pytest.fixture
+def local_http_server():
+    try:
+        server = _DeepBacklogHTTPServer(("127.0.0.1", 0), _JSONOKHandler)
+    except PermissionError:
+        pytest.skip("loopback listener unavailable: permission denied")
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+```
+
+Do not catch `OSError`, do not add a preflight socket, and do not replace the server with `httpx.MockTransport`.
+
+- [ ] **Step 2: Narrow only the two assigned test markers**
+
+Replace `@pytest.mark.allow_network` with `@pytest.mark.loopback_network` on:
+
+- `test_owned_http_client_survives_agent_bridge_style_loop_swap`
+- `test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_loop`
+
+Update the nearby comment so it says the tests permit only the numeric loopback listener they own and may explicitly skip when the host denies listener construction.
+
+- [ ] **Step 3: Run the fixture-contract tests and verify GREEN**
+
+Run the exact Task 1 command.
+
+Expected: `2 passed`. Mutation check: temporarily broadening `except PermissionError` to `except OSError` must make `test_local_http_server_non_permission_oserror_propagates` fail; restore the narrow catch immediately afterward.
+
+- [ ] **Step 4: Run the assigned nodes in the restricted host**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_provider_gateway.py::test_owned_http_client_survives_agent_bridge_style_loop_swap \
+  Tests/Chat/test_console_provider_gateway.py::test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_loop \
+  -rs --tb=short
+```
+
+Expected on this restricted host: `2 skipped`, each with exactly `loopback listener unavailable: permission denied`, and no setup error.
+
+- [ ] **Step 5: Verify marker narrowing at collection**
+
+Run both exact assigned nodes with `--collect-only -m loopback_network`, then with `--collect-only -m allow_network`.
+
+Expected: the loopback selection collects both nodes; the unrestricted-network selection deselects both.
+
+- [ ] **Step 6: Commit the tested behavior**
+
+```bash
+git add Tests/Chat/test_console_provider_gateway.py
+git commit -m "test(chat): skip unavailable loopback listener"
+```
+
+### Task 3: Prove capable-host non-vacuity and network confinement
+
+**Files:**
+- Verify: `Tests/Chat/test_console_provider_gateway.py`
+- Verify: `Tests/test_network_guard.py`
+
+- [ ] **Step 1: Run the two assigned nodes with numeric-loopback capability**
+
+Run the exact two-node command from Task 2 outside the restricted filesystem/network sandbox, without changing pytest markers or enabling external destinations.
+
+Expected: `2 passed`, proving both existing real HTTP/1.1 concurrency scenarios execute rather than skip when the OS permits the owned listener.
+
+- [ ] **Step 2: Run the loopback network-policy owner checks on the capable host**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/test_network_guard.py::test_loopback_destination_classification_is_numeric_and_family_specific \
+  Tests/test_network_guard.py::test_network_mode_rejects_conflicting_loopback_and_allow_all_markers \
+  Tests/test_network_guard.py::test_loopback_only_test_connects_owned_listener_and_blocks_remote_ip \
+  Tests/test_network_guard.py::test_loopback_only_mode_covers_connect_connect_ex_and_sendto \
+  --tb=short
+```
+
+Expected: `4 passed`. The owner tests prove numeric loopback is allowed while remote destinations remain blocked.
+
+- [ ] **Step 3: Run the complete modified-module gate**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_provider_gateway.py \
+  --tb=short
+```
+
+Expected: all module tests pass on the capable host. If a failure is unrelated, stop and diagnose it; do not broaden this task or run the full repository suite.
+
+- [ ] **Step 4: Run static checks for the sole modified Python module**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Tests/Chat/test_console_provider_gateway.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check Tests/Chat/test_console_provider_gateway.py
+git diff --check origin/dev...HEAD
+git status --short
+```
+
+Expected: Ruff and diff checks pass and the worktree contains only the planned task/plan bookkeeping before closeout.
+
+### Task 4: Review and close TASK-19642.2
+
+**Files:**
+- Modify: `backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md`
+- Modify: `Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md`
+- Review: `Tests/Chat/test_console_provider_gateway.py`
+
+- [ ] **Step 1: Dispatch an independent requirements review**
+
+Have a reviewer confirm the diff implements every acceptance criterion and no
+unapproved production or network-policy changes. The review must verify the two
+existing scenarios still contain their real-socket assertions and are not
+vacuous on the capable-host run.
+
+- [ ] **Step 2: Dispatch an independent correctness/security review**
+
+Have a separate reviewer check especially that only `PermissionError` skips,
+the reason is exact, all other setup/runtime errors fail, markers are
+loopback-only, server cleanup is unchanged after successful construction, and
+no external network path was enabled.
+
+- [ ] **Step 3: Update task evidence and documentation**
+
+Use the Backlog CLI to check all three acceptance criteria, add concise Implementation Notes with RED/GREEN, restricted-host, capable-host, network-policy, module, and static evidence, and document:
+
+```text
+ADR required: no
+ADR path: N/A
+Reason: test-fixture correction using the existing TASK-15111 loopback policy.
+```
+
+No lessons entry is expected unless implementation uncovers a new repeatable trap beyond the committed design.
+
+- [ ] **Step 4: Mark the task Done only after every gate and review is green**
+
+```bash
+backlog task edit 19642.2 -s Done
+```
+
+- [ ] **Step 5: Commit closeout bookkeeping**
+
+```bash
+git add \
+  Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md \
+  "backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md"
+git commit -m "docs(backlog): close TASK-19642.2"
+```
+
+- [ ] **Step 6: Run final clean-tree verification before claiming completion**
+
+Re-run the two fixture-contract nodes, the two assigned nodes in both restricted and capable modes, the four network-policy owner nodes, Ruff, `git diff --check origin/dev...HEAD`, and `git status --short`. Record exact counts and the final commit SHA.

--- a/Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md
+++ b/Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md
@@ -260,6 +260,20 @@ git commit -m "docs(backlog): close TASK-19642.2"
 
 Re-run the two fixture-contract nodes, the two assigned nodes in both restricted and capable modes, the four network-policy owner nodes, Ruff, `git diff --check origin/dev...HEAD`, and `git status --short`. Record exact counts and the final commit SHA.
 
+### PR Review Remediation
+
+- [x] Reopen TASK-19642.2 while addressing Qodo's two maintainability findings.
+- [x] Define the canonical listener-permission skip reason once and reuse the named constant in the fixture and assertion.
+- [x] Add concise Google-style intent docstrings, including fixture argument documentation, to both new contract tests.
+- [x] Re-run the restricted contract/consumer gate: 2 passed and 2 exact-reason skips.
+- [x] Re-run the capable-host consumer/policy gate: 6 passed.
+- [x] Re-run Ruff and whitespace checks on the review diff.
+
+The named constant is a documented deviation from Task 2's original
+no-constant constraint. Qodo's active repository compliance rule requires
+centralizing the repeated semantic literal; no helper abstraction or production
+change was introduced.
+
 Deliberately not completed as written: the user prohibited code-test reruns
 during closeout. The accepted fresh independent functional, policy, and Ruff
 evidence is recorded in the task. The bookkeeping-only portion was completed

--- a/Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md
+++ b/Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md
@@ -23,7 +23,7 @@
 - Modify: `Tests/Chat/test_console_provider_gateway.py:2870-2884`
 - Test: `Tests/Chat/test_console_provider_gateway.py`
 
-- [ ] **Step 1: Add the two fixture-contract tests below the fixture**
+- [x] **Step 1: Add the two fixture-contract tests below the fixture**
 
 ```python
 def test_local_http_server_permission_denied_skips_with_capability_reason(
@@ -61,7 +61,7 @@ network marker. The negative case is required: replacing `pytest.skip` with an
 explicit failure ensures that broadening the implementation to `except OSError`
 fails this gate instead of being counted as a successful pytest skip.
 
-- [ ] **Step 2: Run the fixture-contract tests and verify RED**
+- [x] **Step 2: Run the fixture-contract tests and verify RED**
 
 Run:
 
@@ -74,16 +74,19 @@ Run:
 
 Expected: one failure and one pass. The permission-denied case fails because the fixture still propagates `PermissionError`; the non-permission case already passes.
 
-- [ ] **Step 3: Save the RED evidence in the task working notes, but do not weaken either assertion**
+- [x] **Step 3: Save the RED evidence in the task working notes, but do not weaken either assertion**
 
 Use `backlog task edit 19642.2 --notes` only if the task's existing notes need the exact RED result preserved before the implementation commit.
+
+The task had no pre-existing notes requiring a pre-commit amendment. The exact
+RED result is preserved in the final Implementation Notes.
 
 ### Task 2: Implement the minimal capability skip and narrow markers
 
 **Files:**
 - Modify: `Tests/Chat/test_console_provider_gateway.py:2870-3155`
 
-- [ ] **Step 1: Catch only `PermissionError` at listener construction**
+- [x] **Step 1: Catch only `PermissionError` at listener construction**
 
 Change the fixture setup to:
 
@@ -105,7 +108,7 @@ def local_http_server():
 
 Do not catch `OSError`, do not add a preflight socket, and do not replace the server with `httpx.MockTransport`.
 
-- [ ] **Step 2: Narrow only the two assigned test markers**
+- [x] **Step 2: Narrow only the two assigned test markers**
 
 Replace `@pytest.mark.allow_network` with `@pytest.mark.loopback_network` on:
 
@@ -114,13 +117,13 @@ Replace `@pytest.mark.allow_network` with `@pytest.mark.loopback_network` on:
 
 Update the nearby comment so it says the tests permit only the numeric loopback listener they own and may explicitly skip when the host denies listener construction.
 
-- [ ] **Step 3: Run the fixture-contract tests and verify GREEN**
+- [x] **Step 3: Run the fixture-contract tests and verify GREEN**
 
 Run the exact Task 1 command.
 
 Expected: `2 passed`. Mutation check: temporarily broadening `except PermissionError` to `except OSError` must make `test_local_http_server_non_permission_oserror_propagates` fail; restore the narrow catch immediately afterward.
 
-- [ ] **Step 4: Run the assigned nodes in the restricted host**
+- [x] **Step 4: Run the assigned nodes in the restricted host**
 
 Run:
 
@@ -133,13 +136,13 @@ Run:
 
 Expected on this restricted host: `2 skipped`, each with exactly `loopback listener unavailable: permission denied`, and no setup error.
 
-- [ ] **Step 5: Verify marker narrowing at collection**
+- [x] **Step 5: Verify marker narrowing at collection**
 
 Run both exact assigned nodes with `--collect-only -m loopback_network`, then with `--collect-only -m allow_network`.
 
 Expected: the loopback selection collects both nodes; the unrestricted-network selection deselects both.
 
-- [ ] **Step 6: Commit the tested behavior**
+- [x] **Step 6: Commit the tested behavior**
 
 ```bash
 git add Tests/Chat/test_console_provider_gateway.py
@@ -152,13 +155,13 @@ git commit -m "test(chat): skip unavailable loopback listener"
 - Verify: `Tests/Chat/test_console_provider_gateway.py`
 - Verify: `Tests/test_network_guard.py`
 
-- [ ] **Step 1: Run the two assigned nodes with numeric-loopback capability**
+- [x] **Step 1: Run the two assigned nodes with numeric-loopback capability**
 
 Run the exact two-node command from Task 2 outside the restricted filesystem/network sandbox, without changing pytest markers or enabling external destinations.
 
 Expected: `2 passed`, proving both existing real HTTP/1.1 concurrency scenarios execute rather than skip when the OS permits the owned listener.
 
-- [ ] **Step 2: Run the loopback network-policy owner checks on the capable host**
+- [x] **Step 2: Run the loopback network-policy owner checks on the capable host**
 
 Run:
 
@@ -185,7 +188,12 @@ Run:
 
 Expected: all module tests pass on the capable host. If a failure is unrelated, stop and diagnose it; do not broaden this task or run the full repository suite.
 
-- [ ] **Step 4: Run static checks for the sole modified Python module**
+Deliberately omitted per explicit user scope. The complete module was not run;
+the replacement verification comprised the exact two fixture-contract nodes,
+two assigned consumer nodes in restricted and capable modes, and four
+network-policy owner nodes.
+
+- [x] **Step 4: Run static checks for the sole modified Python module**
 
 ```bash
 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Tests/Chat/test_console_provider_gateway.py
@@ -196,6 +204,10 @@ git status --short
 
 Expected: Ruff and diff checks pass and the worktree contains only the planned task/plan bookkeeping before closeout.
 
+Ruff check and `git diff --check` passed. Ruff format check exited 1, but the
+normalized formatter diff exactly matched pinned pre-change base `96bee228f`;
+no new formatting debt was introduced and no bulk format was applied.
+
 ### Task 4: Review and close TASK-19642.2
 
 **Files:**
@@ -203,21 +215,21 @@ Expected: Ruff and diff checks pass and the worktree contains only the planned t
 - Modify: `Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md`
 - Review: `Tests/Chat/test_console_provider_gateway.py`
 
-- [ ] **Step 1: Dispatch an independent requirements review**
+- [x] **Step 1: Dispatch an independent requirements review**
 
 Have a reviewer confirm the diff implements every acceptance criterion and no
 unapproved production or network-policy changes. The review must verify the two
 existing scenarios still contain their real-socket assertions and are not
 vacuous on the capable-host run.
 
-- [ ] **Step 2: Dispatch an independent correctness/security review**
+- [x] **Step 2: Dispatch an independent correctness/security review**
 
 Have a separate reviewer check especially that only `PermissionError` skips,
 the reason is exact, all other setup/runtime errors fail, markers are
 loopback-only, server cleanup is unchanged after successful construction, and
 no external network path was enabled.
 
-- [ ] **Step 3: Update task evidence and documentation**
+- [x] **Step 3: Update task evidence and documentation**
 
 Use the Backlog CLI to check all three acceptance criteria, add concise Implementation Notes with RED/GREEN, restricted-host, capable-host, network-policy, module, and static evidence, and document:
 
@@ -229,13 +241,13 @@ Reason: test-fixture correction using the existing TASK-15111 loopback policy.
 
 No lessons entry is expected unless implementation uncovers a new repeatable trap beyond the committed design.
 
-- [ ] **Step 4: Mark the task Done only after every gate and review is green**
+- [x] **Step 4: Mark the task Done only after every gate and review is green**
 
 ```bash
 backlog task edit 19642.2 -s Done
 ```
 
-- [ ] **Step 5: Commit closeout bookkeeping**
+- [x] **Step 5: Commit closeout bookkeeping**
 
 ```bash
 git add \
@@ -247,3 +259,10 @@ git commit -m "docs(backlog): close TASK-19642.2"
 - [ ] **Step 6: Run final clean-tree verification before claiming completion**
 
 Re-run the two fixture-contract nodes, the two assigned nodes in both restricted and capable modes, the four network-policy owner nodes, Ruff, `git diff --check origin/dev...HEAD`, and `git status --short`. Record exact counts and the final commit SHA.
+
+Deliberately not completed as written: the user prohibited code-test reruns
+during closeout. The accepted fresh independent functional, policy, and Ruff
+evidence is recorded in the task. The bookkeeping-only portion was completed
+after the closeout commit: the committed range passed `git diff --check`, the
+worktree was clean, and the rendered task was Done with all AC checked and
+Implementation Notes present.

--- a/Docs/superpowers/specs/2026-08-22-task-19642-2-loopback-capability-design.md
+++ b/Docs/superpowers/specs/2026-08-22-task-19642-2-loopback-capability-design.md
@@ -1,0 +1,81 @@
+# TASK-19642.2 Provider-Gateway Loopback Capability Design
+
+**Status:** Approved by user on 2026-08-22; independent review issues resolved.
+
+## Problem
+
+Two provider-gateway regressions intentionally use a real HTTP/1.1 server on
+`127.0.0.1:0` because `httpx.MockTransport` does not create httpcore's
+loop-bound connection-pool primitives. On restricted hosts, the shared server
+fixture fails during `socket.bind` with `PermissionError` before either
+event-loop ownership contract runs.
+
+The tests currently opt into unrestricted sockets with `allow_network`, even
+though every request is to a listener owned by the test. That permission is
+wider than the scenario requires and does not express what should happen when
+the host cannot bind loopback.
+
+## Decision
+
+Keep the real HTTP server and both existing concurrency scenarios. Narrow the
+two tests from unrestricted networking to the repository's existing
+`loopback_network` policy. At construction of their shared numeric-loopback
+listener, translate only `PermissionError` into an explicit pytest capability
+skip. Listener construction is the capability boundary because the stdlib
+server constructor owns socket creation, bind, and listen as one operation.
+The canonical skip reason is exactly:
+
+`loopback listener unavailable: permission denied`
+
+Do not catch other `OSError` subclasses. Address exhaustion, malformed server
+configuration, handler failures, timeouts, and gateway regressions remain test
+failures rather than being mislabeled as unsupported-host behavior.
+
+## Test Contract
+
+Add focused fixture-contract regressions that replace only the server
+constructor. One injects `PermissionError` and proves fixture setup skips with
+the exact canonical reason. The other injects a non-permission `OSError` and
+proves it propagates instead of being reclassified as an unsupported-host
+capability. These regressions do not need a network marker because they open no
+socket.
+
+Verification has two modes:
+
+1. Under the restricted test host, the two assigned nodes skip with
+   `loopback listener unavailable: permission denied` rather than erroring at
+   setup.
+2. On a host granted numeric loopback bind capability, both assigned nodes run
+   their existing real-socket assertions: agent-bridge-style loop swapping and
+   concurrent client swapping remain non-vacuous.
+
+The network-policy owner tests must continue to prove that `loopback_network`
+permits numeric loopback only and blocks remote destinations.
+
+## Scope
+
+Expected implementation scope is one test module:
+`Tests/Chat/test_console_provider_gateway.py`. Production gateway code,
+process-wide network-guard behavior, marker registration, and external network
+permissions do not change.
+
+## Alternatives Rejected
+
+- **Replace the server with `httpx.MockTransport`:** vacuous for these
+  regressions because it bypasses the real httpcore connection pool and its
+  event-loop binding.
+- **Run a separate bind preflight:** adds a second socket and a time-of-check /
+  time-of-use race without improving the fixture's direct error boundary.
+- **Catch every `OSError`:** hides genuine server and resource failures as
+  capability skips.
+- **Keep `allow_network`:** grants external networking that neither test needs.
+
+## ADR Check
+
+ADR required: no.
+
+ADR path: N/A.
+
+Reason: this is a test-fixture correction that reuses the established
+TASK-15111 `loopback_network` contract. It changes no production boundary,
+storage, security policy, service interface, or long-lived architecture.

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2869,12 +2869,17 @@ class _DeepBacklogHTTPServer(http.server.ThreadingHTTPServer):
     request_queue_size = 32
 
 
+_LOOPBACK_LISTENER_PERMISSION_SKIP_REASON = (
+    "loopback listener unavailable: permission denied"
+)
+
+
 @pytest.fixture
 def local_http_server():
     try:
         server = _DeepBacklogHTTPServer(("127.0.0.1", 0), _JSONOKHandler)
     except PermissionError:
-        pytest.skip("loopback listener unavailable: permission denied")
+        pytest.skip(_LOOPBACK_LISTENER_PERMISSION_SKIP_REASON)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -2887,6 +2892,12 @@ def local_http_server():
 def test_local_http_server_permission_denied_skips_with_capability_reason(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Classify listener permission denial as an explicit capability skip.
+
+    Args:
+        monkeypatch: Pytest fixture used to replace listener construction.
+    """
+
     def deny_listener(*_args, **_kwargs):
         raise PermissionError("sandbox denied loopback bind")
 
@@ -2895,12 +2906,18 @@ def test_local_http_server_permission_denied_skips_with_capability_reason(
     with pytest.raises(pytest.skip.Exception) as exc_info:
         next(local_http_server.__wrapped__())
 
-    assert str(exc_info.value) == "loopback listener unavailable: permission denied"
+    assert str(exc_info.value) == _LOOPBACK_LISTENER_PERMISSION_SKIP_REASON
 
 
 def test_local_http_server_non_permission_oserror_propagates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Keep non-permission listener failures actionable instead of skipping.
+
+    Args:
+        monkeypatch: Pytest fixture used to replace listener construction.
+    """
+
     def fail_listener(*_args, **_kwargs):
         raise OSError("address resources exhausted")
 

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2871,7 +2871,10 @@ class _DeepBacklogHTTPServer(http.server.ThreadingHTTPServer):
 
 @pytest.fixture
 def local_http_server():
-    server = _DeepBacklogHTTPServer(("127.0.0.1", 0), _JSONOKHandler)
+    try:
+        server = _DeepBacklogHTTPServer(("127.0.0.1", 0), _JSONOKHandler)
+    except PermissionError:
+        pytest.skip("loopback listener unavailable: permission denied")
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -2881,12 +2884,42 @@ def local_http_server():
         thread.join(timeout=2)
 
 
+def test_local_http_server_permission_denied_skips_with_capability_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def deny_listener(*_args, **_kwargs):
+        raise PermissionError("sandbox denied loopback bind")
+
+    monkeypatch.setitem(globals(), "_DeepBacklogHTTPServer", deny_listener)
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        next(local_http_server.__wrapped__())
+
+    assert str(exc_info.value) == "loopback listener unavailable: permission denied"
+
+
+def test_local_http_server_non_permission_oserror_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_listener(*_args, **_kwargs):
+        raise OSError("address resources exhausted")
+
+    def fail_if_skipped(reason: str) -> None:
+        pytest.fail(f"unexpected capability skip: {reason}")
+
+    monkeypatch.setitem(globals(), "_DeepBacklogHTTPServer", fail_listener)
+    monkeypatch.setattr(pytest, "skip", fail_if_skipped)
+
+    with pytest.raises(OSError, match="address resources exhausted"):
+        next(local_http_server.__wrapped__())
+
+
 # Real owned client AND a real socket: the whole point is httpx's per-loop
-# connection-pool binding against a server this test starts itself
-# (`local_http_server`, ephemeral loopback port). Opts out of both autouse
-# guards (Tests/conftest.py, task-15111).
+# connection-pool binding against a server this test starts itself on numeric
+# loopback only. The fixture skips explicitly when the host denies listener
+# construction (Tests/conftest.py, task-15111).
 @pytest.mark.owned_http_client
-@pytest.mark.allow_network
+@pytest.mark.loopback_network
 def test_owned_http_client_survives_agent_bridge_style_loop_swap(local_http_server):
     """Regression (Task 8 live gate): every agent turn crashed against a real
     llama.cpp server with ``RuntimeError: <asyncio.locks.Event ...> is bound
@@ -3147,7 +3180,7 @@ def test_aclose_closes_current_loop_client_and_schedules_others(monkeypatch):
 
 # Same as above: real owned client + this test's own `local_http_server`.
 @pytest.mark.owned_http_client
-@pytest.mark.allow_network
+@pytest.mark.loopback_network
 def test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_loop(
     local_http_server,
     monkeypatch,

--- a/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
+++ b/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-21 23:25'
-updated_date: '2026-08-22 22:51'
+updated_date: '2026-08-22 22:57'
 labels:
   - testing
   - chat
@@ -30,3 +30,16 @@ Resolve the two console provider-gateway setup errors where local HTTP fixtures 
 - [ ] #2 The tests still exercise concurrent client swapping and agent-bridge loop ownership when loopback listeners are available.
 - [ ] #3 No test silently opens external network access.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add fixture-contract RED tests for exact PermissionError skip classification and non-PermissionError OSError propagation.
+2. Catch only listener-construction PermissionError, narrow the two assigned nodes to loopback_network, and verify focused GREEN behavior.
+3. Prove restricted-host skips, capable-host real-socket execution, numeric-loopback confinement, the modified-module gate, and static checks.
+4. Complete independent requirements and correctness/security reviews, record evidence, and close the task only when all gates pass.
+
+ADR required: no
+ADR path: N/A
+Reason: test-fixture correction using the existing TASK-15111 loopback policy.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
+++ b/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-19642.2
 title: Make provider-gateway loopback tests sandbox-safe
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-21 23:25'
+updated_date: '2026-08-22 22:51'
 labels:
   - testing
   - chat
@@ -11,6 +13,7 @@ labels:
 dependencies: []
 references:
   - backlog/docs/task-19520-verification-failure-inventory.md
+  - Docs/superpowers/specs/2026-08-22-task-19642-2-loopback-capability-design.md
 parent_task_id: TASK-19642
 priority: high
 ---

--- a/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
+++ b/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-21 23:25'
-updated_date: '2026-08-22 23:24'
+updated_date: '2026-08-22 23:39'
 labels:
   - testing
   - chat
@@ -58,4 +58,7 @@ Reason: test-fixture correction using the existing TASK-15111 loopback policy.
 - Files: Implementation commit f4d42e694 changes only Tests/Chat/test_console_provider_gateway.py. Closeout changes only this task file and Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md.
 - ADR required: no. ADR path: N/A. Reason: test-fixture correction using the existing TASK-15111 loopback policy.
 - Lessons: No new generalized trap beyond the design and review record was uncovered, so no lessons entry was added.
+
+- PR review remediation: Qodo reported repeated canonical skip copy and missing Google-style test docstrings. The skip reason now has one private named constant reused by the fixture and contract assertion; both new tests document intent and the monkeypatch fixture. This intentionally supersedes the plan's no-constant implementation detail to satisfy repository compliance without adding a helper or changing behavior.
+- Post-review verification: restricted gate 2 passed and 2 exact-reason skipped; capable-host gate 6 passed; Ruff check and git diff --check passed. TASK-19642.2 was reopened during remediation and returned to Done after verification.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
+++ b/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-19642.2
 title: Make provider-gateway loopback tests sandbox-safe
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-21 23:25'
-updated_date: '2026-08-22 22:57'
+updated_date: '2026-08-22 23:24'
 labels:
   - testing
   - chat
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - backlog/docs/task-19520-verification-failure-inventory.md
   - Docs/superpowers/specs/2026-08-22-task-19642-2-loopback-capability-design.md
+  - Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md
 parent_task_id: TASK-19642
 priority: high
 ---
@@ -26,9 +27,9 @@ Resolve the two console provider-gateway setup errors where local HTTP fixtures 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Both provider-gateway nodes listed in the TASK-19520 verification inventory pass or skip for an explicit, documented capability check.
-- [ ] #2 The tests still exercise concurrent client swapping and agent-bridge loop ownership when loopback listeners are available.
-- [ ] #3 No test silently opens external network access.
+- [x] #1 Both provider-gateway nodes listed in the TASK-19520 verification inventory pass or skip for an explicit, documented capability check.
+- [x] #2 The tests still exercise concurrent client swapping and agent-bridge loop ownership when loopback listeners are available.
+- [x] #3 No test silently opens external network access.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,3 +44,18 @@ ADR required: no
 ADR path: N/A
 Reason: test-fixture correction using the existing TASK-15111 loopback policy.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: Added exact fixture-contract coverage, caught only listener-construction PermissionError with the documented skip reason, and narrowed only the two assigned scenarios to numeric-loopback policy. No production or global network-policy code changed.
+- TDD evidence: RED was 1 failed and 1 passed because PermissionError propagated; GREEN was 2 passed. A temporary broad except OSError mutation made the negative contract hard-fail with unexpected capability skip; restoring the narrow catch returned 2 passed.
+- Dual-mode evidence: restricted fixture contracts were 2 passed in 0.20s; restricted assigned consumers were 2 skipped in 0.21s with exactly loopback listener unavailable: permission denied and no setup errors. On a capable host, the same two consumers were 2 passed in 1.36s through real stdlib HTTP/1.1, httpx/httpcore, and loop-concurrency paths.
+- Security evidence: four loopback-policy owner tests passed in 0.47s and asserted BlockedNetworkAccess for remote 192.0.2.1 create_connection, connect, connect_ex, and sendto paths. Marker collection selected both assigned nodes for loopback_network and none for allow_network; no unrestricted marker was enabled.
+- Static evidence: Ruff check passed. Ruff format --check exited 1, but its normalized diff exactly matched pinned pre-change base 96bee228f, so no formatting debt was added. git diff --check passed. The only warning was the existing RequestsDependencyWarning; no unexpected network, setup, or teardown errors occurred.
+- Verification scope: Per explicit user scope, the complete modified-module gate was deliberately not run. It was replaced by the exact two fixture-contract, two assigned-consumer, and four policy-owner gates above; code tests are not rerun during closeout.
+- Reviews: Independent requirements review approved with no issues. Independent correctness, code-quality, and security review reported no findings and Ready to proceed.
+- Files: Implementation commit f4d42e694 changes only Tests/Chat/test_console_provider_gateway.py. Closeout changes only this task file and Docs/superpowers/plans/2026-08-22-task-19642-2-loopback-capability.md.
+- ADR required: no. ADR path: N/A. Reason: test-fixture correction using the existing TASK-15111 loopback policy.
+- Lessons: No new generalized trap beyond the design and review record was uncovered, so no lessons entry was added.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- classify only numeric-loopback listener `PermissionError` as an explicit capability skip
- narrow the two real-socket provider-gateway tests from unrestricted networking to `loopback_network`
- add positive and inverse fixture-contract regressions while preserving real HTTP/1.1 loop-ownership coverage

## Verification
- restricted: 2 fixture contracts passed; 2 consumers skipped with exact documented reason
- capable host: 2 real-socket consumers and 4 loopback-policy owners passed
- broad `except OSError` mutation hard-failed the inverse regression
- Ruff check and `git diff --check origin/dev...HEAD` passed
- Ruff format baseline is unchanged from the pinned pre-change revision

## Scope
Per user direction, verification was limited to the modified fixture, its two consumers, and the four loopback-policy owners; no broad repository or full provider-gateway module suite was run.

Closes TASK-19642.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes provider-gateway loopback tests sandbox-safe by skipping only when a numeric-loopback bind is denied, while preserving real HTTP/1.1 coverage on capable hosts and blocking external networking.

- Catch only PermissionError at listener construction; all other OSErrors propagate. Skip reason is exactly "loopback listener unavailable: permission denied" and is centralized in a private constant reused by the fixture and assertions.
- Narrow two real-socket tests from allow_network to loopback_network to confine them to numeric loopback only.
- Add two fixture-contract tests: one pins the PermissionError skip and reason; the other ensures non-PermissionError failures are not reclassified.
- Add concise design/plan docs and mark TASK-19642.2 complete; no production code, network guard, or marker registration changes.

<sup>Written for commit 0acde45ea6bbe2b4ba9b5c87c8a5c96666a22fe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

