### PR TITLE
chore(security): re-pin the production diagnostic inventory after nine reviewed rows

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -607,8 +607,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 344,
-      "diagnostic_digest": "22e3d8d857ae4a241db1",
+      "call_count": 353,
+      "diagnostic_digest": "60f0a72ab44899222c90",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1076,8 +1076,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 2,
-      "diagnostic_digest": "6df67f334af25efefb64",
+      "call_count": 4,
+      "diagnostic_digest": "42439470f236b1611763",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/ingest_preflight.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1118,10 +1118,17 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 11,
-      "diagnostic_digest": "7938af9458d11adfbc56",
+      "call_count": 12,
+      "diagnostic_digest": "966692f9721f5fab93a3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_rechunk_service.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
+      "diagnostic_digest": "9153fdc8d8d86c93cc23",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Library/local_media_chunk_tool_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -1223,8 +1230,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 79,
-      "diagnostic_digest": "1b9df414299edc45a159",
+      "call_count": 80,
+      "diagnostic_digest": "7efd617a1a8a01cd589a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/video_processing.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1678,8 +1685,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 7,
-      "diagnostic_digest": "52679127ce38295e85e9",
+      "call_count": 8,
+      "diagnostic_digest": "4c61620a3eda8a204868",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/handlers/briefing_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1878,6 +1885,13 @@
       "diagnostic_digest": "3b2bcd0d82a09b3bab05",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/site_config_manager.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 3,
+      "diagnostic_digest": "ee14f3053a1a3fa9d266",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Subscriptions/startup_reconcile.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -2903,6 +2917,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 7,
+      "diagnostic_digest": "7c686df399f7fd7e5e24",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Utils/app_shutdown.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 6,
       "diagnostic_digest": "19bb63f9e8210cae9406",
       "owner": "TASK-494",
@@ -3645,8 +3666,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 329,
-      "diagnostic_digest": "8572788d96bc0d81c4fa",
+      "call_count": 328,
+      "diagnostic_digest": "5a92956a5766f8b313e0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3882,9 +3903,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 525,
+    "owner_files": 528,
     "persistent_sink_files": 8,
     "task_492_calls": 1222,
-    "task_494_calls": 7216
+    "task_494_calls": 7241
   }
 }


### PR DESCRIPTION
## Why

`scripts/check_persistent_diagnostic_inventory.py` is red on current `origin/dev` (`c9bf06dac`). That makes `scripts/preflight.sh` fail for **every** PR, and the new `derived-artifacts` CI job would be red on day one. The drift is ours — today's merges (`9025050c5`, `ede216214`, `8986abe39`, `5622f6987`, `2c7d94236`, `8d53d626f` and neighbours) added diagnostics without regenerating the pin.

This PR changes **one file**: `Docs/security/production-diagnostic-inventory.json`.

## The report acted on

```
summary:  owner_files: 525 -> 528   task_494_calls: 7216 -> 7241
  + only in rebuild: tldw_chatbook/Library/local_media_chunk_tool_service.py  count=2
  + only in rebuild: tldw_chatbook/Subscriptions/startup_reconcile.py         count=3
  + only in rebuild: tldw_chatbook/Utils/app_shutdown.py                      count=7
  ~ changed: DB/ChaChaNotes_DB.py                              344 -> 353  (+9)
  ~ changed: Library/ingest_preflight.py                         2 -> 4   (+2)
  ~ changed: Library/library_rechunk_service.py                 11 -> 12  (+1)
  ~ changed: Local_Ingestion/video_processing.py                79 -> 80  (+1)
  ~ changed: Scheduling/scheduler/handlers/briefing_handler.py   7 -> 8   (+1)
  ~ changed: app.py                                           329 -> 328  (-1)
```

No sink-topology row, and `task_492_calls` is unchanged at 1222 — the delta is entirely TASK-494 owners.

## How the review was done

Not with `git diff`. Every row was recovered with the checker's own AST scanner and per-call digest:

```
base=$(git log -1 --format=%H -- Docs/security/production-diagnostic-inventory.json)   # c4667b1fc
python scripts/check_persistent_diagnostic_inventory.py --statements <every path above> --since $base
```

Every count delta reconciles exactly inside that range (added − removed == the row's delta on all nine rows), so the base is the true lower bound here and did not need widening.

### Scope of the exposure, stated precisely

`PersistentDiagnosticFilter.filter` admits a Chatbook record only when it carries the `log_persistent_metadata`/`persist_event` marker; everything else returns `False` (`tldw_chatbook/Utils/persistent_diagnostics.py:260-266`). **All 25 added statements below are plain `logger.*` calls with no marker**, so none of them reaches the on-disk sink. What follows is classified as **terminal + in-app Logs** exposure, which is what these records actually reach — not "persistent diagnostic leak".

## Per-row classification

| Row | Δ | Statements read | Verdict |
|---|---|---|---|
| `Library/local_media_chunk_tool_service.py` | new, +2 | `logger.error("chunk-spec save failed: %s", exc)` (`ChunkingTemplateError`); `logger.debug(f"shared RAG service unavailable for re-chunk: {exc}")` (import/availability failure) | **Benign** — store/import error text only. |
| `Subscriptions/startup_reconcile.py` | new, +3 | boundary-read warning interpolating `{table}` (from the static `_BOUNDED_TABLES` tuple) + `type(exc).__name__`; `f"failed {count} interrupted watchlist run(s)"`; sweep-failure warning with `{name}` + `type(exc).__name__` | **Benign** — the file already uses the `type(exc).__name__` metadata-only idiom throughout. |
| `Utils/app_shutdown.py` | new, +7 | `logger.error(message)` where `message` is built at `:324` from a grace-period reason plus `_live_thread_names()` (thread names + daemon flag); signal-number/grace-seconds infos; handler-install warnings; one `logger.opt(exception=True).error(...)` with fully static text | **Benign** — internal thread/signal identifiers, no user content. |
| `DB/ChaChaNotes_DB.py` | +9 | V45→V46 migration start/success/failure; three `sync_log` prune/delete paths with row counts and `{e}`. Four interpolate `self.db_path_str` | **Benign, but see note below.** No message content, no user content, no secret. Row counts and `change_id_threshold` are integers. |
| `Library/ingest_preflight.py` | +2 | `:306` `logger.debug(f"URL probe declined by egress policy: {exc}")` — `EgressBlockedError.__str__` renders `_log_origin(url)`, a deliberately credential- and query-free `scheme://host[:port]` label (`Utils/egress.py:197-209`). `:309` `logger.debug(f"URL probe policy check failed for {url}: {exc!r}")` | `:306` **benign**; **`:309` is a REAL new exposure — see below.** |
| `Library/library_rechunk_service.py` | +1 net | One removal + two additions. The removed `:644` statement is textually identical to the added `:719` one — the multi-line call was reflowed onto one line, which moves the digest. The genuinely new one is `:793` `logger.error(f"Re-chunk failed for media {media_id}: {exc}")` | **Benign** — reflow plus a sibling of the already-pinned per-item pattern; `media_id` is an integer id. |
| `Local_Ingestion/video_processing.py` | +1 | `:502` `logger.error(f"Metadata extraction refused: {exc}")`. `exc` is the `VideoDownloadError` raised at `:91`, whose message wraps `EgressBlockedError` → `_log_origin(url)` | **Benign** — the origin label is the module's documented redaction boundary; the full URL never reaches the string. This is the same text the download seam already surfaces. |
| `Scheduling/.../briefing_handler.py` | +1 | `f"{len(unsettled)} scheduled briefing generation(s) did not settle within {timeout}s of cancellation."` | **Benign** — counts and a timeout only. |
| `app.py` | −1 (1 moved, 9 removed, 8 added) | The 9 removals are the old inline shutdown logging, relocated into `Utils/app_shutdown.py`. Added: startup-reconcile warnings using `type(exc).__name__` and a counts dict; worker-cancellation logs interpolating `phase`, `WORKER_CANCELLATION_GRACE_SECONDS`, and `stragglers` (a list of Textual **worker names**, `:12036`); briefing-cancellation counts | **Benign** — internal worker/phase identifiers and counts. The single "moved" entry the checker paired off needed no review by construction. |

### Note on `ChaChaNotes_DB.py` and `db_path_str`

Four of the nine new statements interpolate `self.db_path_str`. That is not a new class: the same file already did so in **86** places at the pin's base (now 91), including every prior `Migrating schema from V<n> to V<n+1> ... in DB: {self.db_path_str}` line. The new V45→V46 rows follow that established pattern exactly. Flagging it for awareness — the app's own DB path embeds the user's home directory — not as a finding introduced here.

## REAL FINDING — not absorbed, please file

**`tldw_chatbook/Library/ingest_preflight.py:309`**

```python
except Exception as exc:  # policy evaluation itself failed
    logger.debug(f"URL probe policy check failed for {url}: {exc!r}")
```

`url` is the **raw URL the user pasted into the ingest form**, complete with path, query string, and any embedded `user:password@` credentials. It is logged verbatim to the terminal and the in-app Logs pane.

This is the TASK-19864 class, and what makes it stand out is that it sits three lines below its own counter-example: the sibling handler at `:306` deliberately logs only `EgressBlockedError`'s credential-free origin label, and its comment explains that even `exc.reason` is withheld because "private vs dns_failure vs metadata is precisely the difference an internal scan wants". The `except Exception` fallback path added alongside it discards that discipline and logs strictly more than the branch it backstops.

Suggested fix (not applied here — this PR is the gate repair only): render `_log_origin(url)` instead of `url`, and drop `!r` on an exception of unknown provenance.

The row is still pinned, as the procedure requires, so the gate goes green — the finding is reported rather than silently absorbed.

## Verification

`scripts/preflight.sh` at this branch tip — **all four checkers pass**:

```
=== generated stylesheets ===       CSS bundle + 4 generated tcss all reproduce
=== profile-owned path census ===   48 executable occurrence(s) / 18 file(s) / 46 approved exceptions
=== production diagnostic inventory === 528 owners, 1222 TASK-492 calls, 7241 TASK-494 calls, 8 sink files
=== backlog task ids ===            no duplicates across 2439 task files
preflight: all derived-artifact checks passed.
```

Guard suites — **121 passed, 0 failed** (160.89s):
`Tests/Architecture/test_persistent_diagnostic_inventory.py`, `Tests/Architecture/test_derived_artifact_checkers.py`, `Tests/CI/test_derived_artifacts_workflow.py`, `Tests/Architecture/test_profile_owned_path_inventory.py`, `Tests/UI/test_css_bundle_sync_guard.py`.

Repo-wide `--collect-only -q`: **56521 tests collected, 5 collection errors — none of them this branch's**. The branch's entire diff is one JSON file that no module imports at collection time, so all five are identically present on `origin/dev`:

- `Tests/UI/test_library_file_notes_workspace.py` — known, TASK-20972.
- **`Tests/UI/test_settings_category_sweep.py` — NEW dev red, not previously filed.** Module-level `SettingsScreen(_build_test_app())` now dies in `TldwCli.__init__` → `_wire_character_persona_services` (`app.py:6612`) → `persona_actor_pack_coordinator.recover()` → `Actor_Packs/repository.py:276` `AttributeError: 'NoneType' object has no attribute 'execute_query'`. Introduced by today's `8d53d626f` "feat: coordinate Persona Actor Pack creation" — same Actor Pack family as TASK-20971. It cascades into three more collection errors (`test_settings_footer_hints.py`, `test_settings_model_catalog_layout.py`, `test_settings_save_commit_models.py`) that import helpers from it. **Four Settings suites are currently uncollectable on `dev`; needs a task.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pins the production diagnostic inventory to match current dev so `scripts/preflight.sh` and the `derived-artifacts` CI job pass again. Previously the checker failed on dev due to unpinned diagnostic changes; now it passes with the updated pin.

- Adds three owner files and updates six existing rows in `Docs/security/production-diagnostic-inventory.json` (owner_files 525→528; `TASK-494` calls 7216→7241; no new persistent sinks; `app.py` net −1).
- All nine drifted rows were reviewed; the 25 added statements are non-persistent logger calls only.
- One real finding remains and is intentionally pinned to unblock CI: `tldw_chatbook/Library/ingest_preflight.py:309` logs the raw user-pasted URL. Follow-up: log `_log_origin(url)` instead of `url` and remove `!r` on the exception.

<sup>Written for commit d53694c1fbfa17bdb67a7ba80d6bd1778ccad8aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

