### PR TITLE
fix(privacy): stop logging the raw URL when the egress policy check itself fails

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1077,7 +1077,7 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "42439470f236b1611763",
+      "diagnostic_digest": "d7e85acdb99de3005f73",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/ingest_preflight.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/Library/test_ingest_preflight_egress.py
+++ b/Tests/Library/test_ingest_preflight_egress.py
@@ -41,6 +41,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import BaseHandler
 
 import pytest
+from loguru import logger
 
 from Tests import network_guard
 from tldw_chatbook.Library import ingest_preflight
@@ -513,3 +514,66 @@ def test_the_probe_reports_a_redirect_as_an_answered_status_not_an_error(
     assert [w.get("label") for w in result.warnings] == ["Could not check the link"]
     assert "302" in result.warnings[0]["hint"]
     assert _FakeRedirectingHTTPHandler.opened == [PUBLIC_REDIRECTOR]
+
+
+# ---------------------------------------------------------------------------
+# 7. Privacy: the raw URL (credentials, query-string secrets) must never
+#    reach a log line -- including when policy EVALUATION itself blows up,
+#    not just when it declines.
+# ---------------------------------------------------------------------------
+
+#: A URL carrying both an embedded credential and a query-string secret --
+#: exactly what `validate_url` exists to keep out of `analyze_path`'s
+#: network path, but `_probe_url` is reachable directly (and defends in
+#: depth regardless of caller).
+_CREDENTIAL_URL = (
+    "http://sneaky_user:hunter2@10.255.255.1/report?api_key=SECRET_TOKEN_VALUE"
+)
+
+
+def test_policy_check_failure_does_not_log_the_credential_or_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `except Exception` fallback around the policy check must not log
+    more than the `EgressBlockedError` branch immediately above it does.
+
+    That sibling branch is careful on purpose: `EgressBlockedError.__str__`
+    renders `Utils/egress.py`'s `_log_origin(url)` -- a credential- and
+    query-free `scheme://host[:port]` label -- never the raw URL. This
+    exercises the *other* except clause: `check_url_or_raise` raising
+    something other than `EgressBlockedError` (a bug in policy evaluation
+    itself, not a decline), with a URL carrying an embedded credential and
+    a query-string secret.
+
+    Channel: this module's `logger` is `loguru`'s global singleton
+    (`from loguru import logger`, no reassignment) -- confirmed by reading
+    `ingest_preflight.py` directly, not assumed. A `logger.add(...)` sink
+    captures the RENDERED message text, the same channel a real deployment
+    writes to, so a leak here is a leak there.
+    """
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("config lookup exploded")
+
+    monkeypatch.setattr(ingest_preflight, "check_url_or_raise", _boom)
+
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]), level="DEBUG"
+    )
+    try:
+        result = ingest_preflight._probe_url(_CREDENTIAL_URL)
+    finally:
+        logger.remove(sink_id)
+
+    assert result.note == ingest_preflight._UNVERIFIABLE_NOTE
+
+    rendered = "\n".join(messages)
+    assert rendered, "expected the policy-check-failed line to be logged at all"
+    for secret in ("sneaky_user", "hunter2", "SECRET_TOKEN_VALUE", "api_key"):
+        assert secret not in rendered, f"credential/secret leaked into log: {rendered!r}"
+    assert "/report" not in rendered, f"URL path leaked into log: {rendered!r}"
+    assert _CREDENTIAL_URL not in rendered, f"raw URL leaked into log: {rendered!r}"
+    # Still diagnostic: the exception type distinguishes "policy evaluation
+    # itself failed" from an ordinary EgressBlockedError decline.
+    assert "RuntimeError" in rendered

--- a/tldw_chatbook/Library/ingest_preflight.py
+++ b/tldw_chatbook/Library/ingest_preflight.py
@@ -24,7 +24,7 @@ from tldw_chatbook.Library.ingest_capabilities import (
 )
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Local_Ingestion.local_file_ingestion import is_http_url
-from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise
+from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise, log_origin
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.path_validation import validate_path_simple
 
@@ -306,7 +306,15 @@ def _probe_url(url: str) -> UrlProbe:
         logger.debug(f"URL probe declined by egress policy: {exc}")
         return UrlProbe(note=_UNVERIFIABLE_NOTE)
     except Exception as exc:  # policy evaluation itself failed
-        logger.debug(f"URL probe policy check failed for {url}: {exc!r}")
+        # Same discipline as the branch above: name the origin, not the raw
+        # URL (which may carry an embedded credential or a query-string
+        # secret). This is a rarer condition than a policy decline -- the
+        # check itself blew up rather than returning a decision -- so the
+        # message still carries the exception TYPE to tell the two apart.
+        logger.debug(
+            f"URL probe policy check failed for {log_origin(url)}: "
+            f"{type(exc).__name__}: {exc}"
+        )
         return UrlProbe(note=_UNVERIFIABLE_NOTE)
 
     try:
@@ -336,10 +344,10 @@ def _probe_url(url: str) -> UrlProbe:
         # No HTTP response at all: DNS failure, refused connection, bad TLS.
         # (task-3305, MI-13) The user-facing line names the failure's KIND;
         # the raw exception detail is debug-log material, never UI copy.
-        logger.debug(f"URL probe failure for {url}: {exc!r}")
+        logger.debug(f"URL probe failure for {log_origin(url)}: {exc!r}")
         return UrlProbe(error=_plain_unreachable_reason(exc))
     except Exception as exc:
-        logger.debug(f"URL probe unexpected failure for {url}: {exc!r}")
+        logger.debug(f"URL probe unexpected failure for {log_origin(url)}: {exc!r}")
         return UrlProbe(
             error="URL probe failed — the address could not be checked."
         )

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -209,6 +209,21 @@ def _log_origin(url: str) -> str:
     return f"{parsed.scheme}://{rendered_host}{rendered_port}"
 
 
+def log_origin(url: str) -> str:
+    """Public wrapper for :func:`_log_origin` (same ``_host_of``/``host_of``
+    pattern used below): a credential- and query-free ``scheme://host[:port]``
+    label, safe to interpolate into a log line outside this module.
+
+    Any caller that would otherwise log a raw URL -- which may carry an
+    embedded ``user:pass@`` credential or a query string with a token/API
+    key -- should call this instead. It is the same redaction the
+    ``EgressBlockedError``/``EgressFetchError`` messages already apply to
+    themselves; this just makes it reusable so there is one spelling of
+    "how we name a URL in a log", not a second copy of the logic.
+    """
+    return _log_origin(url)
+
+
 def _blocked(url: str, reason: str, host: str, detail: str = "") -> EgressDecision:
     logger.warning(f"Egress blocked ({reason}): {_log_origin(url)} {detail}".rstrip())
     log_counter("egress_blocked", labels={"reason": reason})


### PR DESCRIPTION
## Summary

Fixes a privacy leak in code shipped earlier today by TASK-19556.

`tldw_chatbook/Library/ingest_preflight.py`'s `_probe_url` has two `except`
branches around the egress policy check:

- `except EgressBlockedError` logs `exc` -- deliberately careful.
  `EgressBlockedError.__str__` (`Utils/egress.py`) renders `_log_origin(url)`,
  a credential- and query-free `scheme://host[:port]` label; `exc.reason` is
  not even read.
- `except Exception` (policy *evaluation itself* failing, a rarer condition
  than an ordinary decline) undid that discipline in one line: it logged the
  **raw pasted URL** -- full path, query string, and any embedded
  `user:pass@` credential -- via `f"...for {url}: {exc!r}"`.

Before:
```python
except Exception as exc:  # policy evaluation itself failed
    logger.debug(f"URL probe policy check failed for {url}: {exc!r}")
    return UrlProbe(note=_UNVERIFIABLE_NOTE)
```

After:
```python
except Exception as exc:  # policy evaluation itself failed
    logger.debug(
        f"URL probe policy check failed for {log_origin(url)}: "
        f"{type(exc).__name__}: {exc}"
    )
    return UrlProbe(note=_UNVERIFIABLE_NOTE)
```

**Shared-helper resolution**: `Utils/egress.py`'s `_log_origin` was private,
used only via `EgressBlockedError`/`EgressFetchError`'s own `__str__`
(neither is callable elsewhere for its return value). Rather than copy the
redaction logic into `ingest_preflight.py`, I exported it as a public
`log_origin(url)` wrapper -- the exact `_host_of`/`host_of` pattern already
present in that same file -- so there is one spelling of "how we name a URL
in a log."

**The `!r`**: reconsidered per the task brief. Switched to explicit
`type(exc).__name__: {exc}` (matching the sibling branch's plain `{exc}`,
not `repr`), so the message still lets a reader distinguish "policy
evaluation blew up" from "policy declined" by exception type, without
leaning on `!r`'s formatting of an arbitrary exception.

**Module sweep**: two more `logger.debug` calls in the same function's
second `try` (the actual HEAD request, reached only after egress already
passed) interpolated the same raw `url` -- same one-line class, same fix
(`log_origin(url)`, `!r` left alone since those are unaffected by this
finding). No other `url`-into-log line exists in the module (confirmed via
`grep -n "logger\." tldw_chatbook/Library/ingest_preflight.py`).

## TASK-19864?

Not a duplicate. TASK-19864 is about local **file paths and workspace
roots** reaching the terminal/Logs pane/clipboard (`redact_user_paths`,
census over `Utils/file_handlers.py`, `DB/ChaChaNotes_DB.py`,
`UI/Screens/change_review_screen.py`, etc.) -- a disjoint file set and a
different redaction mechanism. This is a **URL** (embedded
credential/query-string) leak into a debug log line, fixed with
`Utils/egress.py`'s own origin-label helper. Genuinely separate; noting
here rather than folding it in.

## Evidence

**Born-red** (`Tests/Library/test_ingest_preflight_egress.py::test_policy_check_failure_does_not_log_the_credential_or_query`):
drives `_probe_url` directly with
`http://sneaky_user:hunter2@10.255.255.1/report?api_key=SECRET_TOKEN_VALUE`,
monkeypatches `check_url_or_raise` to raise a generic `RuntimeError` (forcing
the *policy-evaluation-itself-failed* branch, not a decline), and asserts
against a `loguru.logger.add(...)` sink capturing `message.record["message"]`
-- the RENDERED text. Channel confirmed by reading `ingest_preflight.py`'s
import (`from loguru import logger`, no reassignment) rather than assumed.

At `origin/dev` this fails:
```
AssertionError: credential/secret leaked into log: "URL probe policy check
failed for http://sneaky_user:hunter2@10.255.255.1/report?api_key=SECRET_TOKEN_VALUE:
RuntimeError('config lookup exploded')"
```

**Mutation check**: reverted the fix to the original f-string, reran the new
test alone -- red, same leak reproduced via the sink. Edit-restored the fix;
`git diff` on the production file matched the intended patch exactly
(verified before committing).

## Test evidence

- `Tests/Library/test_ingest_preflight.py` + `test_ingest_preflight_egress.py`: 67 passed
- `Tests/Utils/test_egress.py` + `test_egress_adoption_census.py` + `test_egress_cross_origin_header_allowlist.py` + the two ingest_preflight files together: 208 passed
- `Tests/Library/` (full): 2345 passed, 3 failed -- all three in `test_library_rag_scope.py` (`test_console_scope_resolution_*`), an unrelated `AttributeError` deep in `Actor_Packs/persona_coordinator.py` during `TldwCli()` construction. Confirmed pre-existing at `origin/dev` HEAD (`35d4bf3a1`): fails identically in isolation with zero files from this branch touched.
- Repo-wide `--collect-only -q`: 56522 tests collected, 5 collection errors -- exactly the known dev reds (`Tests/UI/test_library_file_notes_workspace.py` + four `Tests/UI/test_settings_*` suites, TASK-20970/TASK-20972). No new collection errors.
- `Tests/DB/test_sql_validation.py::...::test_no_missing_tables` (TASK-20971) not touched by this change; not re-run individually since it's an unrelated pre-known red.

## Diagnostic inventory

`scripts/check_persistent_diagnostic_inventory.py` went red after the fix
(expected -- 3 `logger.debug` statement bodies changed). Reviewed with
`--statements tldw_chatbook/Library/ingest_preflight.py --since 35d4bf3a1`
first: confirmed the only diff is the 3 intended removed/added statements
(old `{url}` lines out, new `{log_origin(url)}` lines in), nothing else
drifted. Then ran `--write`; `Docs/security/production-diagnostic-inventory.json`
now shows a clean 1-line digest change for that file, and the checker
re-verifies green (528 owners, 1222/7241 calls, 8 sink files).

## Scope

Focused fix only -- no changes to the probe's control flow, the debounce, or
the `[library] ingest_url_preflight_probe` config gate. No backlog task
exists for this (per the instructions I did not create one); this PR body
carries the review record instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts raw URLs from debug logs when egress policy evaluation fails. Previously the fallback path logged the full URL (including credentials and query params); now it logs only scheme://host[:port] and the exception type.

- Exposes `log_origin(url)` from `tldw_chatbook/Utils/egress.py` and uses it in `tldw_chatbook/Library/ingest_preflight.py::_probe_url` for the policy-check failure path and two other debug lines in the HTTP probe.
- Adds a log-capturing test to ensure credentials/query strings never appear; reverting the change reproduces the leak.
- Updates `Docs/security/production-diagnostic-inventory.json` to reflect the modified debug statements.
- No changes to probe control flow or config gates; this is a log redaction only.

<sup>Written for commit 01495dd3c3748c3bbfcc5afbdf4fa39c6e448eb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

