### PR TITLE
docs(perf): holistic performance review of dev 35d4bf3a1 — 35 tasks filed (21100-21134)

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -1,0 +1,415 @@
+# Holistic performance review — dev `35d4bf3a1` (2026-08-22)
+
+**Symptom:** users report the app has recently slowed down — general sluggishness, input/click
+lag, and slow startup/screen switches; historically 3–5× worse on constrained hardware, more
+when fsync-bound.
+**Method:** seven parallel read-only review lanes (regression re-check of every 2026-08-11
+audit fix · startup & first interaction · input paths · cross-cutting hooks & timers · DB & I/O
+· new-subsystem cost-when-idle · rendering & CSS) against a pinned worktree of dev `35d4bf3a1`,
+plus live headless-Pilot probes run in an isolated second worktree (scratch
+HOME/XDG/`TLDW_CONFIG_PATH`, fresh profile, no live-config writes). Top claims re-verified
+first-hand; lane contradictions resolved by measurement (two below). Baseline for
+"regression?" is the 2026-08-11 input-latency audit pin `82b595049`
+(`Docs/Design/2026-08-11-input-latency-audit.md`); dev absorbed ~3,800 commits / +231k package
+LOC (+24%) in those 11 days.
+
+**Verdict in one paragraph.** None of the 13 audited 2026-08-11 fix families is broken —
+regression re-check found them all structurally intact. The recent slowdown is instead
+(1) a **first-boot-after-upgrade wall**: schema v34→v46 replays 12 migrations inside
+`TldwCli.__init__`, and the brand-new v46 migration rewrites the entire `messages_fts` index
+in one transaction; (2) **boot-cost accretion** from new subsystems — ~15k LOC of Chunking
+imported to read one string constant, Persona_Buddy dragging 93% of Persona_Visual (and PIL)
+eagerly, 155 pydantic models through two lazy-facade leaks, seven feature DBs schema'd in
+`__init__` for features the user may never touch; (3) **new per-input-event work** in the
+rewritten Console surfaces (drag-selection re-wraps the message body per mouse-move; the
+right-rail forces a layout refresh per scroll frame; every keystroke does a synchronous
+Workspace-DB read — measured live, ~1.25 reads/key); and (4) **fsync-shaped stores that dodged
+the audit's WAL+NORMAL sweep** because they live outside `DB/`, above all the notes
+device-state store (DELETE+FULL, fresh connection AND a ~60-statement schema census per
+transaction). The CSS parse-cache cliff is NOT re-crossed on the plain tab tour (47 sources
+measured vs the 64 cliff), but 34 new `DEFAULT_CSS` classes since the consolidation put a
+feature-rich session (~10 distinct modal opens) over it — and the guard test that would say so
+is red for an unrelated reason (below) while CI hasn't completed since June.
+
+The filed backlog for this review is **task-21100 – task-21134**. This document is the durable
+evidence record those tasks cite (the backlog CLI drops custom sections, so measurements live
+here).
+
+---
+
+## Live measurements (fast M-series, headless Pilot, isolated profile)
+
+### Boot and import
+
+| probe | result |
+|---|---|
+| `import tldw_chatbook.app`, cold (first import: .pyc compile + first dylib loads — what a user pays on first launch after an upgrade) | **3.10 s** |
+| same, warm | **0.825 s** |
+| largest cold chain | `Chat.console_runtime` → `Persona_Buddy.console_adapter` → `Persona_Buddy.controller` → `Persona_Visual.assets` → `PIL.Image` → **`PIL._imaging` 1.276 s (41% of cold import)** |
+| largest warm chains | `Library.ingest_capabilities` 83 ms · `Chat.chat_conversation_scope_service` 65 ms (pulls Library → Sync_Interop) · `TTS` 58 ms · scheduler handlers → Subscriptions → bs4 ~80 ms · `Notes.file_notes_git_service` 39.5 ms self |
+| `TldwCli()` construction (UI thread, pre-paint) | **0.528 s** |
+| `run_test()` boot-to-ready | **2.212 s** |
+| total to interactive | ≈ **3.5 s** fast HW → 10–17 s constrained (matches known ~10–12 s tmux cold starts) |
+
+### 13-destination tab tour
+
+Stylesheet sources: 27 at boot → **47 after the full tour** (cliff = 64, guard soft limit 56;
+Aug-11 pre-fix: 93, post-fix: 49). Warm `stylesheet.parse()` after the tour: **0.8 / 0.2 /
+0.1 ms** — the parse cache is healthy on the plain tour. Per-switch wall (first visit):
+Chat **1.398 s**, Personas **1.381 s**, LLM 0.842 s, Library 0.576 s, Settings 0.577 s,
+Schedules 0.544 s, the rest 0.21–0.45 s. Warm re-visits (screens are never cached): 0.33–0.62 s
+⇒ construct+compose+teardown floor of ~0.3–0.6 s fast HW → 1–3 s constrained on every switch.
+
+### CSS guard tests on the pin
+
+`Tests/UI/test_widget_css_consolidation.py::test_full_destination_tour_stays_under_the_parse_cache_cliff`
+**FAILS — but not on the count**: `_build_test_app()` crashes inside `TldwCli.__init__` →
+`_wire_character_persona_services` (app.py:6010→6612) → Actor_Packs
+`persona_coordinator.recover()` → `ActorPackRepository.list_persona_intents()` → DB query with
+the ChaChaNotes DB unassigned in the harness. **The cliff guard is disarmed on dev**, invisibly
+(CI has not completed since 2026-06-26). The Performance-suite twin
+(`test_destination_tour_css_sources_stay_below_parse_cache`) passes via its own app factory.
+Net: 1 failed, 32 passed.
+
+### Pre-importer A/B (suspect eliminated)
+
+20 keystrokes immediately after boot, then idle to 30 s — `TLDW_SCREEN_PREIMPORT` default vs
+`=0`: keystroke median 82.1 vs 99.0 ms, p90 120.8 vs 160.7 ms, 30 s CPU 2.51 vs 2.75 s —
+**no measurable pre-importer penalty on multi-core hardware** (differences within noise).
+Residual concern is 1–2-core boxes only (GIL competition is structural: the import loop has no
+sleep/yield between the ~21 modules / ~117k lines it executes); filed as design-hardening, not
+as a measured harm.
+
+### Idle burn
+
+| state | 30 s / 15 s CPU | attribution (timer census) |
+|---|---|---|
+| Console, **setup state** (no provider configured) | **9.9% of a core** | `ConsoleSetupBackdrop._tick` at **5 Hz** — the setup modal's decorative snow field; every tick refreshes the full-screen widget → `Screen._on_timer_update` → layout+render (75 Layout messages/15 s) |
+| Console, **configured state** | **1.8% of a core** | nav overflow 2 Hz (no-op-gated) + composer caret blink ~1.9 Hz (28 Static refreshes/15 s) + 1 Hz heartbeat |
+
+The configured-state idle floor is acceptable (×3–5 ⇒ ~5–9% constrained). The setup state —
+every new user's first experience, on whatever hardware they have — burns 5.5× more for a
+decoration. A `reduced_motion` flag exists but is not the default.
+
+### Per-keystroke Workspace-DB reads (lane contradiction, resolved by measurement)
+
+Lane L1 (static) cleared the keystroke builders as DB-free; lane L3 (static) traced a
+synchronous SQLite read one level deeper. Live counter: 20 printable keys in the configured
+composer → **25 × `ensure_default_workspace` + 25 × `get_active_workspace`** (~1.25 each per
+key), 3.10 ms cumulative for all 50 calls (≈62 µs/call, warm page cache, fast SSD). L3 is
+right; the cost profile is benign on fast hardware and disk-sensitive (cold cache, slow disk,
+and the repair branch's DELETE write are the risk cases).
+
+### Measurement-artifact disclosure
+
+An intermediate census attributed ~940 posted `Callback` messages per keypress; attribution by
+qualname showed 18,640/18,648 were `Pilot._wait_for_screen.<locals>.decrement_counter` —
+**Textual Pilot's own `pause()` machinery (one callback per widget per pause), not app
+behavior**. All absolute keystroke latencies measured through `pilot.press()+pause()` in this
+review are inflated by that overhead and are quoted only as A/B comparisons, never as app
+latency. App-attributable per-key work in the configured Console measured ~7 widget refreshes.
+
+### Pragma read-back (new stores)
+
+`NotesDeviceStateStore`: **journal_mode=delete, synchronous=2 (FULL)** — live confirmation.
+(TTS profile repository read back statically by the DB lane: WAL+NORMAL, dedicated executor —
+conforms; its v3→v4 migration memory spike is a separate finding.)
+
+---
+
+## Findings → tasks
+
+Severity is stated for constrained hardware (×3–5). "REGRESSION" = absent at `82b595049`.
+
+### P0 — the upgrade wall and the store that dodged the sweep
+
+- **21100** · First boot after upgrade replays v34→v46 (12 migrations) inside
+  `TldwCli.__init__`, and `chachanotes_v45_to_v46_sync_log_retention.sql` (merged 2026-08-22,
+  PR #1974) unconditionally rebuilds the whole `messages_fts` index (`delete-all` + reinsert of
+  every non-deleted message) plus nine full-`sync_log` purge scans, all in ONE transaction —
+  tens of seconds to minutes of silent pre-paint hang on real profiles on slow disks, WAL
+  ballooning to index size. REGRESSION. Fix: chunked resumable FTS backfill outside the
+  version-bump transaction (in-repo exemplar: `Subscriptions/fts_backfill.py`) + an "upgrading
+  database…" splash state. Runner: `ChaChaNotes_DB.py:5936-6021`; boot placement `app.py:5808`
+  → `_init_notes_service`. (ChaChaNotes runs WAL+NORMAL — the wall is I/O volume, not fsync.)
+- **21101** · `Notes/notes_device_state_store.py:443-472` — the app's only remaining
+  DELETE+FULL store (live-confirmed above), fresh connection per op, and
+  `initialize_notes_device_schema` re-runs a full `sqlite_schema` census + re-executes 16
+  `CREATE INDEX IF NOT EXISTS` (~60 statements) inside **every** transaction, including pure
+  reads. Behind the notes-sync runtime (boots unconditionally) and the notes import executor
+  (2–4 receipt transactions per imported note ⇒ a 500-note import ≈ 1,000+ open/census/fsync
+  cycles). REGRESSION. Fix: the sanctioned template (held thread-local conn, WAL+NORMAL,
+  `isolation_level=None`) + schema init once at `initialize()`.
+
+### P1 — startup cost accretion
+
+- **21102** · ~15k LOC of `Chunking/` (incl. 28/38 vendored engine modules, a real
+  `import langdetect`, an nltk `find_spec` path scan, and the Internal_Prompts package) is
+  imported eagerly through SIX entry points, the first being
+  `Local_Ingestion/local_file_ingestion.py:172` importing `ENGINE_VERSION` — a string literal
+  (`Chunk_Lib.py:150`). All six must break (ingest_preflight.py:26, web_clip_request.py:27,
+  RAG_Search/__init__.py:21, RAG_Admin/local_rag_admin_service.py:17-18, app.py:1997-2007);
+  fixing app.py alone buys zero. Durable guard: a test asserting `"Chunking" not in
+  sys.modules` after `import tldw_chatbook.app`. REGRESSION.
+- **21103** · `Persona_Buddy` (eager at app.py:393) drags **93% of Persona_Visual (6,633 LOC)**
+  via `controller.py:18,23` + `rendering.py:11-13` (the latter imports the tree for one `int`
+  constant) — this is the chain that puts `PIL._imaging` (1.28 s cold) on the boot path. Both
+  consumers already tolerate absence (`app.py:8582`, `console_runtime.py:468,519`). Fix: lazy
+  controller property (house pattern: `_build_rag_admin_services`, app.py:6054-6124), split the
+  stdlib-only `console_adapter` out of the package-init surface, constant moved. REGRESSION.
+- **21104** · `Subscriptions/monitoring_engine.py:37` imports `bs4` unguarded (eager via
+  scheduler handlers ← app.py:429) while `beautifulsoup4` exists only in
+  `[project.optional-dependencies]` (four extras; verified none in core) — a base
+  `pip install .` cannot `import tldw_chatbook.app` at all, and everyone else pays the import.
+  PRE-EXISTING. Fix: promote to core deps or guard-and-degrade; add an import-closure test for
+  extras-gated packages.
+- **21105** · Seven feature databases are created + schema'd synchronously inside
+  `TldwCli.__init__` for features a never-user doesn't touch: research (5 tables+migrations),
+  notifications, event_state (10 DDL) + sync_state (16 DDL) server-parity stores, writing (16
+  DDL), kanban (24 DDL — zero UI consumers found at all), notes_sync_state. The lazy seam
+  already exists (`BaseDB.__init__(initialize_schema=False)`, base_db.py:43). Fix: open-on-
+  first-use uniformly + per-store test asserting no DB file exists after boot without feature
+  use. Mostly PRE-EXISTING; notes-sync leg REGRESSION.
+- **21106** · Actor_Packs: `recover()` runs synchronous SQLite inside `__init__`
+  (app.py:6612) — this is ALSO what crashes `_build_test_app()` and disarms the CSS cliff
+  guard; and `creation.py:17` imports `tldw_api.character_persona_schemas` (79 pydantic
+  models, ~34 ms) eagerly. Fix: move recovery to Personas-surface mount (its own docstring
+  only requires "before affected surfaces mount"); TYPE_CHECKING the schema import; re-arm and
+  re-run the cliff guard. REGRESSION.
+- **21107** · `Kanban_Interop/server_kanban_service.py:10` module-level `from ..tldw_api
+  import` (31 names) forces `kanban_schemas` (76 pydantic models, ~44 ms), defeating tldw_api's
+  PEP-562 lazy facade — one of exactly two leaks (the other fixed by 21106). Fix +
+  `sys.modules` guard test for `tldw_chatbook.tldw_api.kanban_schemas` after app import.
+- **21108** · app.py import diet (top-level imports 194→220): `speech_tts_settings_panel`
+  (5,618-line widget module imported for one payload dataclass — move
+  `SpeechTTSPanelDraftSnapshot` to a types module), `TTS/voice_bundle_service` (1,857),
+  `Notes/notes_sync_runtime` chain, Notifications package init. None needed before first
+  paint. Also tighten `Tests/Performance/test_app_import_weight.py` (currently 8.0 s / 4,000
+  modules — far above drift). REGRESSION.
+- **21109** · `_build_generated_video_store()` runs `VideoStore.enforce_retention()` in
+  `__init__` behind an EXCLUSIVE interprocess portalocker lease with a **5.0 s poll-timeout**
+  (video_store.py:56,191-233) — a held lease from a concurrent instance blocks boot up to 5 s;
+  scan+delete runs pre-paint. Fix: construction stays path-only; retention moves to
+  `_schedule_deferred_startup_work`. REGRESSION.
+- **21110** · Splash serializes with, instead of hiding, the initial chat_screen import: splash
+  runs 1.5 s doing nothing, THEN ~20k lines import+compose on the loop
+  (app.py:8343-8386 → 12611-12642 → 11166-11222); the pre-importer only starts post-mount.
+  Fix: kick the resolved initial route's module import on a thread at splash-mount.
+  PRE-EXISTING.
+- **21111** · Startup-init hygiene bundle: (a) the `__init__` parallel-task timing log measures
+  durations AFTER `future.result()` returns (app.py:5823-5825) so every task logs ~0 s — the
+  existing STARTUP TIMING SUMMARY cannot attribute the parallel phase (fix first, it makes all
+  other startup work measurable); (b) 2–3 `keyring.get_keyring()` backend discoveries during
+  `__init__` (server credentials ~13 ms + Security.framework ctypes; skills trust ×2) → lazy
+  properties; (c) `_restore_ingest_jobs` does open+read+reconcile-writes on the UI thread in
+  `on_mount` (app.py:2211-2239) → `to_thread`; (d) `ensure_builtin_samira` full-scans
+  `character_cards` parsing every `extensions` JSON per boot
+  (`Character_Chat/visual_identity.py:3044-3060`) → targeted `json_extract` + LIMIT 1 or cached
+  id. Mixed provenance.
+- **21112** · Notes-sync runtime hardening: starts unconditionally at `app.py:10297-10303`
+  (`cutover_admitted=True` hardcoded) — zero-profile boots still create the state DB, run ≥3
+  censused transactions, and first boot runs two unbounded SELECTs over chachanotes.db
+  (notes_sync_legacy.py:603-628); with ≥1 active root the watcher does a **full recursive
+  stat walk of every root every 1 s forever** (notes_sync_watcher.py; bounds 10k entries —
+  over-bounds roots pay the full scan every tick before bailing). Fix: gate `start()` on
+  non-empty `list_root_summaries()` (+ legacy config key for migration; Library already falls
+  back to `InertLastingSyncRuntime`), back the watcher off on unchanged signatures (1 s →
+  5–15 s) or use FS events, bound the legacy scan. REGRESSION.
+- **21113** · Screen pre-importer niceness (design hardening; A/B above showed no fast-HW
+  harm): `_preimport_screens` (app.py:11762-11886) is a tight no-yield loop over ~117k lines
+  on a GIL-holding daemon thread starting 0.2 s after first paint. Fix: sleep between routes,
+  order by configured default_tab first, skip while `_screen_navigation_lock` is held,
+  consider disabling below 4 cores. Keep `TLDW_SCREEN_PREIMPORT` overrides. REGRESSION
+  (mechanism itself shipped by task-15472's arc).
+
+### P1 — Console input paths and rendering
+
+- **21114** · Transcript drag-selection does, per MouseMove at 50–100 Hz:
+  uncached `get_display_text()` rebuild of the full message body (plain rows), a full
+  `Content(text).wrap(width)` over the body, an ungated `set_selection_range` →
+  `body.update()` full re-render even when the range didn't move, and a sweep over every
+  mounted row calling `clear_selection()` (console_transcript.py:5036-5064, 4896-4928,
+  2278-2311, 1740-1787). Tens of ms per event on multi-KB rows ⇒ seconds of cumulative lag per
+  drag on slow HW. REGRESSION (whole feature post-baseline). Fix: cache display text
+  (invalidate in `sync_message`), memoize the wrap table per (text,width) per drag, early-out
+  on unchanged range, remember the single selected row.
+- **21115** · CSS parse-cache headroom nearly consumed: **34 new `DEFAULT_CSS` declarations /
+  29 files since the consolidation** (Console modals/inspector rail/turn-file card, Library
+  dialogs, trajectory, speech). Arithmetic on the pin: plain tour ≈47 measured (empty
+  transcript, no modals); + conversation-row classes + ~10 distinct modal opens **crosses the
+  64 cliff today**; accretion rate ~+8 classes/3 days with the tour guard red (21106) and CI
+  not running. Every one is a plain string block that can ride the sanctioned
+  `BUNDLED_CSS`/`BUNDLED_SCREEN_CSS` + `build_css.py` mechanism; also convert the last
+  class-level `CSS` (`UI/SiteConfigSettings.py:41`). Durable guard: a STATIC allowlist ratchet
+  (the AST walk already exists in test_widget_css_consolidation.py) failing on any new
+  `DEFAULT_CSS`/`CSS` outside the list — so the invariant stops depending on the slow
+  integration tour. REGRESSION by accretion.
+- **21116** · library_screen.py still performs whole-screen `refresh(recompose=True)` on
+  per-click paths — ~105 statement-level sites (99 `self.`) on a screen that grew 26k→34.8k
+  lines; confirmed hot: `_open_library_item_by_id` (rail row / RAG result / media open),
+  `_apply_library_row_toggle`, media-viewer back, skills/prompts import open/cancel, export
+  open. Continue the 15457 canvas-scoped conversion (`library_canvas_sync` seam, 82 call
+  sites) + a ratchet test on the count. PRE-EXISTING pattern, cost-per-event regressed with
+  screen growth (9 sites added post-fix are low-frequency admin flows).
+- **21117** · Right-rail (Inspector) scroll pipeline: `watch_scroll_y` → geometry reconcile
+  runs `self.refresh(layout=True)` on the whole rail per scroll frame plus two DOM queries and
+  a second `call_after_refresh` hop, even when nothing changed (right_rail.py:116-145,
+  298-375; file grew 249→1,092). Fix: split the pure-scroll path (hint update only) from the
+  layout+refold reconcile (resize/section-demand only). REGRESSION.
+- **21118** · Per-keystroke synchronous Workspace-DB reads (measured: ~1.25 ×
+  `ensure_default_workspace` + `get_active_workspace` per key): memoize the workspace context
+  on the screen, invalidate on workspace-change events, make the keystroke path read-only
+  (repair side-effects move to session-start/workspace-switch); also cache staged-launch
+  `EvidenceBundle.from_payload` (re-parsed ≥2× per keystroke during staged launches).
+  PRE-EXISTING, partially mitigated by 15452/15465.
+- **21119** · Chat-screen click dismissal walks the whole screen DOM twice
+  (`query(ConsoleTranscript)` + `query(ConsoleSelectionMenu)`) on BOTH MouseDown and Click of
+  every physical press (chat_screen.py:18939-18990). Fix: mounted-menu flag / cached
+  transcript ref, early-return when nothing is mounted. REGRESSION.
+- **21120** · Composer per-key residue: `_sync_send_disabled_reason` does an unconditional
+  `strip.update(Content(...))` per key (the `reason_changed` gate covers only the ARIA
+  announcement — the audit's half-gate pattern, console_composer_bar.py:1582-1607); hidden
+  compatibility `Input.value` mirror re-set with the full draft per key (fires a second
+  Changed handler); ghost-text reverse scan of prompt history per render AND per 0.5 s blink
+  tick. Mixed provenance.
+- **21121** · The 0.2 s run tick gained `_console_changed_files_scope()` — a full
+  shallow-snapshot pass over every session message per tick when no change-review marker
+  exists (the common case), making ≥2 full passes per tick with the cost path
+  (chat_screen.py:11467-11497 → console_chat_store.py:2858-2865). Fix: memoize newest run-id
+  on the store, bump on marker append (pattern: the estimate cache). REGRESSION.
+
+### P1/P2 — cross-cutting hooks, timers, DB & I/O
+
+- **21122** · Persona Buddy runtime costs (feature-enabled case): the widget repaints
+  unconditionally at 10 Hz (`set_interval(0.10, refresh_from_controller)` with no change gate
+  — verified; three `Static.update` per tick while a separate frame timer already animates);
+  the resolution loop can retry a failed visual at 10 Hz with four `to_thread` hops + DB reads
+  per iteration; geometry keys spawn one non-exclusive config-write worker per keypress.
+  Fixes: gate the poll on (snapshot generation, preferences generation, visual identity) or
+  replace with controller-posted messages; capped backoff on unconfirmed-unavailable;
+  coalesce geometry persists. REGRESSION (feature is new).
+- **21123** · Persona Buddy hook placement: `BaseAppScreen` awaits
+  `reconcile_persona_buddy_view()` at the end of EVERY screen recompose, and every
+  mount/resume schedules a reconcile worker — even with the feature disabled (default), and
+  the widget module imports before the enabled check (base_app_screen.py:357-524). Disabled-
+  case per-event cost is µs-scale (verified) — the payload is multiplied lifecycle work,
+  per-screen duplicated state, and teardown-race defense. Fix: relocate to a single app-level
+  overlay owner reacting to screen-change events + controller generation bumps; short-term,
+  early-return before `run_worker`/import when disabled. REGRESSION.
+- **21124** · `get_cli_setting` (398 call sites, many on the event loop) takes the global
+  config file lock BEFORE the cache check (config.py:5107), so any concurrent config write —
+  which holds the lock through 2 fsyncs + 3 full TOML parses + a settings rebuild — stalls
+  every loop-side read. Amplified by per-click writers (Logs filter chip = 2 rewrites/4 fsyncs
+  per click, theme switch, lab rail) and a per-keystroke writer
+  (Dictation_Window_Improved.py:602). Fix: double-checked fast path on the existing
+  `_CONFIG_GENERATION` before taking the lock; coalesce the write path to one parse; debounce
+  the hot writers. PRE-EXISTING amplifier.
+- **21125** · Writing screen: ~45 per-op `connect_private_sqlite` sites run directly on the
+  event loop (load, tree clicks, autosave — no `to_thread` anywhere under UI/Writing_Modules
+  or Writing_Interop) and every connection is GC-leaked (`with conn:` is a transaction, not a
+  closer). Each open pays the private-seam's ~4 artifact verifications. Fix: held thread-local
+  conn + route through `to_thread` + explicit close. PRE-EXISTING.
+- **21126** · Library → Search/RAG panel runs `SELECT chunk_engine_version, COUNT(DISTINCT
+  media_id) ... GROUP BY` over `UnvectorizedMediaChunks` (no index; rows-per-chunk table) ON
+  THE EVENT LOOP per panel mount — and the panel remounts per destination switch
+  (RAG_Admin/local_rag_admin_service.py:592-596; the `_maybe_await` seam evaluates the sync
+  call before any await). Fix: `to_thread` + cache per session + index or maintained count.
+  REGRESSION.
+- **21127** · Research runs: per-op GC-leaked connects; engine launched as a loop coroutine
+  (not thread) with a 30 s lease WRITE and a 2 s `get_run` read poll on the loop while a run
+  is active (local_research_service.py:99-123; Research_Window.py:594,816-831). Fix: held
+  conn, `to_thread` service calls, batch keepalive with progress writes. PRE-EXISTING (likely).
+- **21128** · `messages_au` FTS trigger fires on ANY `messages` UPDATE (no `OF content`
+  column list, re-confirmed in the v46 SQL), so usage-only and metadata-only flushes — now
+  3–4 UPDATEs per chat turn — each re-tokenize and rewrite the full assistant reply into
+  `messages_fts`. Fix: `AFTER UPDATE OF content`, preserving the v46 deleted-guards.
+  PRE-EXISTING shape, flush-count growth post-baseline.
+- **21129** · Notes-sync executor: six `list_bindings` read-all sites (no LIMIT, no
+  `root_id` index), five invoked WITHOUT `to_thread` from async methods — ~3·K full owner-set
+  reads per sync batch, each also paying 21101's per-op connect+census until that lands
+  (notes_sync_executor.py:1144,1256,1761,1978,2260,2682). Fix: indexed predicates +
+  `to_thread`. REGRESSION.
+- **21130** · TTS profile v3→v4 migration snapshots the entire reference-BLOB table
+  (`wav_bytes`) into memory TWICE, first snapshot still held — up to ~1 GB peak at open under
+  the 512 MiB store bound (TTS/profile_schema.py:1300-1316, 1439, 1468). Fix: project without
+  `wav_bytes` (sibling `profile_migration_candidate.py:320` already does) + hash compare.
+  REGRESSION.
+- **21131** · Notifications event-state repository: per-op GC-leaked connects, 3+ per feed
+  build on a 3 s-TTL Home cache in server mode (event_state_repository.py:85-106). Fix: clone
+  the sibling `client_notifications_db.py:69-108` held-conn template. PRE-EXISTING.
+- **21132** · Note-folder managed-membership recursive CTE anchors on the WHOLE closure and
+  filters at the end; runs twice per Notes-tree refresh (note_folder_repository.py:1831-1861;
+  off-loop, latency only). Fix: seed the anchor from the requested ids. REGRESSION.
+- **21133** · Dead 10 s token-count producer: its entire consumer surface was retired by
+  task-17653 (`#chat-log` no longer exists; footers compose `show_token_count=False`), yet the
+  app-global timer still resolves footers and runs four failing queries every 10 s
+  (app.py:11746; chat_token_events.py:103-181). Fix: delete the interval + periodic path;
+  keep the estimator for on-demand callers. Producer PRE-EXISTING, dead state REGRESSION.
+- **21134** · Small-residue batch (each verified on the pin): setup-modal snow ticks a
+  full-screen refresh at 5 Hz for every not-yet-configured user (measured 9.9% of a core —
+  honor reduced-motion by default on low-core machines or drop the tick rate);
+  `unicode_casefold` Python-UDF in WHERE+ORDER BY on watchlists agent-tool queries
+  (Subscriptions_DB.py:2908-2985); MCP execution log does two full-file JSON parses +
+  fsync-on-close per tool invocation (MCP/execution_log.py:156); re-chunk per-chunk INSERT
+  loop → executemany (library_rechunk_service.py:265-271); GC-leaked `with conn:` closes in
+  sync_state/event_state/writing/research/tamagotchi; `EnhancedStatusWidget` recompose-per-
+  status-message during ingest (status_widget.py:82-140); media-viewer match-nav restyles the
+  whole document per click (library_media_content.py:16-53 — cache match list, restyle two
+  lines); trajectory brush-drag rebuilds the ledger DataTable per mouse-move
+  (trajectory_screen.py:861-867 → sync `_render_ledger`); `CAPABILITY_REGISTRY` builds 1,323
+  frozen dataclasses (62% server-only) + runs `validate_registry_completeness()` in
+  production at every import (registry.py:1358,1414 — move validation to tests, lazy-build
+  the server partition); dormant sqlite owners to verify-then-retire
+  (`Sync_Interop/notes_mirror.py`, `Widgets/Tamagotchi/tamagotchi_storage.py` never imported,
+  Kanban boot connect with no UI, `Third_Party/aider/repomap.py` diskcache with no prod
+  caller).
+
+---
+
+## Verified clean — do not re-fix
+
+- **All 13 audited 2026-08-11 fix families are structurally intact** (checked one by one):
+  CSS consolidation mechanism · cost-chip TokenEstimateCache + fingerprint gating · 15452
+  derivation memo + push equality gate · transcript reconciler `already_in_position` guard ·
+  rail-search debounce-before-query · windowing/prune invariants under the 2.5× transcript
+  rewrite (incl. 16851's under-lock re-check) · fence-delta Pygments buffering · Library
+  canvas seam (whole-screen sites 147→105, none hot re-added except the 9 admin flows in
+  21116) · Watchlists recompose removals (zero live screen-level recompose reactives) ·
+  SubscriptionsDB held conn + off-loop scheduler · all five blocking-I/O fix families
+  (media hub `to_thread` leaves, notes import thread worker, dictionaries scan replaced,
+  config-write sites 149→~133 net DOWN, star-toggle off-loop) · nav-overflow signature gate +
+  scheduled Ollama probe · streaming invariants (O(1) chunk append, ~2 creates + 2–3
+  auxiliary UPDATEs per turn — see 21128 for the FTS amplification, no per-chunk/per-tick DB
+  writes, trajectory sidecar batched once per turn).
+- **DB/ pragma census: every `DB/` module on the WAL+NORMAL held-conn template** (full census
+  table in the review record; `Workspace_DB`/`client_notifications_db` carry the reference
+  liveness-ping shape).
+- **`config.py` read caching intact** (`_SETTINGS_CACHE`/`_CONFIG_CACHE` source-keyed; the
+  lock-ordering defect is 21124, not a cache defect).
+- **The new subsystems are boot-cost, not idle-cost**: none of Persona_Buddy, Actor_Packs,
+  Persona_Visual, runtime_policy, Chunking, Research_Interop, Notifications, notes-sync (zero
+  profiles), Skills/Sync/Writing/Kanban_Interop, tldw_api, Video_Generation runs a thread,
+  timer, poll loop, or subscription at idle for a never-user. The feared Research `while
+  True` loop is a per-run 30 s keep-alive; the Notifications event_observer is
+  subscribe-model, never boot-started.
+- **runtime_policy hot path**: ~5 µs per capability check, zero checks on
+  keystroke/chat-send/screen-switch paths.
+- **UI-responsiveness heartbeat** (1 s): trivial arithmetic, edge-triggered stall records
+  drained by a daemon thread — no I/O on the measured loop.
+- **Console run-tick family** (0.2 s sync / 10 s cost TTL / 0.1 s realtime): all gated and
+  self-stopping. **Nav overflow tick**: signature-gated no-op. **Video preview / prompt-queue
+  / background-effect timers**: scoped, gated, or default-off.
+- **tldw_api lazy facade holds** except the two leaks (21106/21107); Video_Generation
+  module-lazy except the `__init__` retention slice (21109).
+- **Textual Pilot latency numbers are harness-inflated** — see the artifact disclosure above
+  before quoting any absolute keystroke figure from this or future reviews.
+
+## Environment notes for reproduction
+
+Probe recipe: second worktree at the pin, own venv (`VIRTUAL_ENV=<wt>/.venv uv pip install -e
+".[dev]"`), assert `tldw_chatbook.__file__` resolves into that worktree; scratch
+HOME/XDG/`TLDW_CONFIG_PATH` with `[first_run] setup_completed=true`, `[splash_screen]
+enabled=false`; configured-state probes need a valid-shaped `api_settings.openai.api_key`
+(otherwise the Console mounts the setup modal and you measure the snow, not the app). App boot
+writes to the scratch config and regenerates the worktree CSS bundle — keep probes out of the
+review worktree. `pilot.pause()` costs O(mounted widgets) — use it for A/B only.

--- a/backlog/tasks/task-21100 - First-boot migration wall - move the v46 messages_fts rebuild out of the version-bump transaction.md
+++ b/backlog/tasks/task-21100 - First-boot migration wall - move the v46 messages_fts rebuild out of the version-bump transaction.md
@@ -1,0 +1,36 @@
+---
+id: TASK-21100
+title: >-
+  First-boot migration wall - move the v46 messages_fts rebuild out of the version-bump transaction
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - database
+  - migrations
+  - startup
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1` (2026-08-22). Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21100).
+
+First boot after an upgrade replays schema v34->v46 (12 migrations) inside `TldwCli.__init__`
+(app.py:5808 thread-pool join -> `_init_notes_service`), before anything paints.
+`chachanotes_v45_to_v46_sync_log_retention.sql` (merged 2026-08-22, PR #1974) unconditionally
+rebuilds the entire `messages_fts` index (`delete-all` + reinsert of every non-deleted message)
+plus nine full-`sync_log` purge scans, all in ONE transaction (runner
+`ChaChaNotes_DB.py:5936-6021`). On a large profile on a slow disk this is tens of seconds to
+minutes of silent pre-paint hang, with the WAL ballooning to roughly index size. This is very
+plausibly the literal "it got slow after updating" complaint. The migration's privacy goal must
+be preserved; the delivery mechanism is the problem.
+
+## Acceptance Criteria
+
+- [ ] The v45->v46 FTS rebuild runs as a resumable, chunked backfill outside the schema-version-bump transaction (in-repo exemplar: `Subscriptions/fts_backfill.py`), so an interrupted upgrade neither bricks the DB nor loses the version bump
+- [ ] A visible "upgrading database..." state (splash or equivalent) is shown while any pending migration chain runs, instead of a silent hang
+- [ ] A timed probe on a seeded scratch DB (stamped v45, >=10k messages) demonstrates the first-paint path no longer blocks on the full FTS rewrite, with before/after numbers recorded in the task
+- [ ] Existing migration tests stay green; the v46 privacy semantics (sync_log retention, deleted-guards) are unchanged

--- a/backlog/tasks/task-21101 - NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction.md
+++ b/backlog/tasks/task-21101 - NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction.md
@@ -1,0 +1,33 @@
+---
+id: TASK-21101
+title: >-
+  NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - database
+  - notes-sync
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21101).
+
+`Notes/notes_device_state_store.py:443-472` is the app's only remaining DELETE-journal +
+synchronous=FULL store (live pragma read-back confirmed: journal_mode=delete, synchronous=2).
+It opens a fresh connection per operation, and `initialize_notes_device_schema` re-runs a full
+`sqlite_schema` census plus 16 `CREATE INDEX IF NOT EXISTS` re-executions (~60 statements)
+inside EVERY transaction, including pure reads. It sits behind the notes-sync runtime (boots
+unconditionally) and the notes import executor (2-4 receipt transactions per imported note: a
+500-note import pays 1,000+ open/census/fsync cycles). This store dodged the task-15465/15466
+sweep because it lives outside `DB/`.
+
+## Acceptance Criteria
+
+- [ ] The store uses the sanctioned template: held thread-local connection, WAL journal_mode, synchronous=NORMAL, isolation_level=None (exemplar `Library_Ingest_Jobs_DB.py`), with pragmas verified by read-back in a test
+- [ ] `initialize_notes_device_schema` runs once per connection lifetime (the `initialize()` seam), not per transaction; a statement-count probe demonstrates the reduction
+- [ ] Write transactions keep their current BEGIN IMMEDIATE semantics; existing notes-sync and import tests stay green

--- a/backlog/tasks/task-21102 - Break the six eager Chunking import chains - ~15k LOC imported at boot to read one string constant.md
+++ b/backlog/tasks/task-21102 - Break the six eager Chunking import chains - ~15k LOC imported at boot to read one string constant.md
@@ -1,0 +1,33 @@
+---
+id: TASK-21102
+title: >-
+  Break the six eager Chunking import chains - ~15k LOC imported at boot to read one string constant
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - imports
+  - chunking
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21102).
+
+~15k LOC of `Chunking/` (incl. 28/38 vendored engine modules, a real `import langdetect`, an
+nltk `find_spec` path scan, and the Internal_Prompts package) is imported eagerly through SIX
+entry points. The first is `Local_Ingestion/local_file_ingestion.py:172` importing
+`ENGINE_VERSION` - a string literal (`Chunk_Lib.py:150`). The others:
+`Library/ingest_preflight.py:26`, `Library/web_clip_request.py:27`, `RAG_Search/__init__.py:21`,
+`RAG_Admin/local_rag_admin_service.py:17-18`, `app.py:1997-2007`. Fixing only app.py buys
+nothing - all six must break.
+
+## Acceptance Criteria
+
+- [ ] `import tldw_chatbook.app` no longer executes the Chunking package (nor langdetect) - pinned by a test asserting `"tldw_chatbook.Chunking" not in sys.modules` after importing the app module
+- [ ] All six entry points are converted (constant inlined or lazily accessed; PEP-562 re-exports where a facade is needed); chunking behavior at first real use is unchanged
+- [ ] Warm `python -X importtime` before/after numbers recorded in the task

--- a/backlog/tasks/task-21103 - Defer Persona_Buddy so it stops dragging Persona_Visual and PIL onto the boot path.md
+++ b/backlog/tasks/task-21103 - Defer Persona_Buddy so it stops dragging Persona_Visual and PIL onto the boot path.md
@@ -1,0 +1,32 @@
+---
+id: TASK-21103
+title: >-
+  Defer Persona_Buddy so it stops dragging Persona_Visual and PIL onto the boot path
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - imports
+  - persona-buddy
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21103).
+
+`Persona_Buddy` (eager at app.py:393) drags 93% of Persona_Visual (6,633 LOC) via
+`controller.py:18,23` and `rendering.py:11-13` - the latter imports the tree for a single int
+constant. This chain puts `PIL.Image`/`PIL._imaging` on the boot path: measured 1.276 s of the
+3.10 s cold app import (41%). Both consumers already tolerate absence (`app.py:8582`,
+`console_runtime.py:468,519`); the lazy-service house pattern is `_build_rag_admin_services`
+(app.py:6054-6124).
+
+## Acceptance Criteria
+
+- [ ] `import tldw_chatbook.app` no longer imports Persona_Visual or PIL - pinned by a sys.modules assertion test
+- [ ] The buddy controller is constructed lazily at first feature use; enabling/using Persona Buddy still works end to end
+- [ ] Cold and warm importtime before/after numbers recorded in the task

--- a/backlog/tasks/task-21104 - bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app.md
+++ b/backlog/tasks/task-21104 - bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app.md
@@ -1,0 +1,32 @@
+---
+id: TASK-21104
+title: >-
+  bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - bug
+  - packaging
+  - startup
+  - subscriptions
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21104).
+
+`Subscriptions/monitoring_engine.py:37` does `from bs4 import BeautifulSoup` with no guard
+(directly after a carefully guarded defusedxml import), and the module is eager at boot via
+scheduler handlers <- app.py:429. `beautifulsoup4` exists only in
+`[project.optional-dependencies]` (verified: four extras, none core). A base `pip install .`
+therefore cannot `import tldw_chatbook.app` at all, and every configured install pays the
+import at boot.
+
+## Acceptance Criteria
+
+- [ ] Decision made and implemented: either beautifulsoup4 moves to core dependencies, or the import is guarded with graceful degradation of the affected monitors (consistent with `optional_deps.py`)
+- [ ] A test covers the import-closure of extras-gated packages so the next unguarded optional import is caught at PR time
+- [ ] A base (no-extras) install can import tldw_chatbook.app

--- a/backlog/tasks/task-21105 - Open feature databases on first use instead of schema-ing seven of them inside TldwCli.__init__.md
+++ b/backlog/tasks/task-21105 - Open feature databases on first use instead of schema-ing seven of them inside TldwCli.__init__.md
@@ -1,0 +1,32 @@
+---
+id: TASK-21105
+title: >-
+  Open feature databases on first use instead of schema-ing seven of them inside TldwCli.__init__
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - database
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21105).
+
+Seven feature databases are created and schema'd synchronously inside `TldwCli.__init__` for
+features a user may never touch: research (5 tables + migrations, app.py:6948), notifications
+(app.py:7068), event_state (10 DDL) + sync_state (16 DDL) server-parity stores (app.py:7081),
+writing (16 DDL, app.py:6723), kanban (24 DDL, app.py:7277 - zero UI consumers found at all),
+notes_sync_state (start path). Each is file create + WAL setup + executescript + fsync traffic,
+serial, pre-paint. The lazy seam already exists: `BaseDB.__init__(initialize_schema=False)`
+(DB/base_db.py:43).
+
+## Acceptance Criteria
+
+- [ ] Each of the listed stores opens (and creates its schema) on first feature use, not during app construction; feature behavior on first use is unchanged
+- [ ] Per-store regression tests assert no DB file exists after a boot that never touches the feature
+- [ ] Boot construction time before/after recorded in the task (isolated-profile probe)

--- a/backlog/tasks/task-21106 - Move Actor_Packs recovery out of app __init__ - it also crashes the test app factory and disarms the CSS cliff guard.md
+++ b/backlog/tasks/task-21106 - Move Actor_Packs recovery out of app __init__ - it also crashes the test app factory and disarms the CSS cliff guard.md
@@ -1,0 +1,35 @@
+---
+id: TASK-21106
+title: >-
+  Move Actor_Packs recovery out of app __init__ - it also crashes the test app factory and disarms the CSS cliff guard
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - test-integrity
+  - actor-packs
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21106).
+
+`_wire_character_persona_services` (app.py:6010 -> 6612) calls
+`persona_actor_pack_coordinator.recover()` during `TldwCli.__init__`, running synchronous
+SQLite on the app thread every boot. Consequence found live: `Tests/UI/app_factory.py`'s
+`_build_test_app()` crashes (ChaChaNotes DB unassigned in that harness), which makes
+`test_full_destination_tour_stays_under_the_parse_cache_cliff` FAIL on dev - the CSS cliff
+guard is disarmed, invisibly, since CI has not completed since June. Additionally
+`Actor_Packs/creation.py:17` imports `tldw_api.character_persona_schemas` (79 pydantic models,
+~34 ms) eagerly, contradicting the task-285 deferral comment at app.py:7518. The recover()
+docstring only requires running before affected surfaces mount - Personas mount satisfies it.
+
+## Acceptance Criteria
+
+- [ ] Actor-pack recovery runs at Personas-surface mount (or an equivalent pre-surface seam), not inside TldwCli.__init__; recovery semantics preserved
+- [ ] The character_persona_schemas import is TYPE_CHECKING/function-local; a sys.modules assertion pins it off the app import path
+- [ ] `test_full_destination_tour_stays_under_the_parse_cache_cliff` runs green on dev again (guard re-armed), with its measured source count recorded in the task

--- a/backlog/tasks/task-21107 - Kanban_Interop defeats tldw_api's lazy facade - 76 pydantic models forced at every boot.md
+++ b/backlog/tasks/task-21107 - Kanban_Interop defeats tldw_api's lazy facade - 76 pydantic models forced at every boot.md
@@ -1,0 +1,27 @@
+---
+id: TASK-21107
+title: >-
+  Kanban_Interop defeats tldw_api's lazy facade - 76 pydantic models forced at every boot
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - imports
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21107).
+
+`Kanban_Interop/server_kanban_service.py:10` does a module-level 31-name `from ..tldw_api
+import`, forcing `tldw_api/kanban_schemas.py` (76 pydantic models, ~44 ms self) through the
+otherwise-lazy PEP-562 facade - one of exactly two leaks (the other is fixed by TASK-21106).
+
+## Acceptance Criteria
+
+- [ ] The import is TYPE_CHECKING/function-local; kanban behavior (such as it is - zero UI consumers found) unchanged
+- [ ] A test asserts `tldw_chatbook.tldw_api.kanban_schemas` is not in sys.modules after importing the app module

--- a/backlog/tasks/task-21108 - app.py import diet - 5.6k-line settings panel imported for one dataclass, and the import-weight guard is too loose to notice.md
+++ b/backlog/tasks/task-21108 - app.py import diet - 5.6k-line settings panel imported for one dataclass, and the import-weight guard is too loose to notice.md
@@ -1,0 +1,32 @@
+---
+id: TASK-21108
+title: >-
+  app.py import diet - 5.6k-line settings panel imported for one dataclass, and the import-weight guard is too loose to notice
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - imports
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21108).
+
+app.py's top-level imports grew 194 -> 220 since the 2026-08-11 audit pin. Concrete deferrable
+whales verified: `Widgets/Settings_Widgets/speech_tts_settings_panel` (5,618-line widget module
+imported for the single `SpeechTTSPanelDraftSnapshot` payload class used in isinstance checks,
+app.py:329-331); `TTS/voice_bundle_service` (1,857); the `Notes/notes_sync_runtime` chain;
+Notifications package init. None is needed before first paint. Meanwhile
+`Tests/Performance/test_app_import_weight.py:85-86` allows 8.0 s / 4,000 modules - far above
+any real drift signal.
+
+## Acceptance Criteria
+
+- [ ] `SpeechTTSPanelDraftSnapshot` lives in a small types module; the 5,618-line panel module is no longer on the app import path (sys.modules assertion)
+- [ ] voice_bundle_service and the notes_sync_runtime import chain are deferred to first use
+- [ ] The import-weight guardrail budgets are tightened to sit just above the measured post-diet reality, so the next regression of this class fails a test

--- a/backlog/tasks/task-21109 - Generated-video store retention runs in __init__ behind a 5s interprocess lease - move it to deferred startup.md
+++ b/backlog/tasks/task-21109 - Generated-video store retention runs in __init__ behind a 5s interprocess lease - move it to deferred startup.md
@@ -1,0 +1,30 @@
+---
+id: TASK-21109
+title: >-
+  Generated-video store retention runs in __init__ behind a 5s interprocess lease - move it to deferred startup
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - video-generation
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21109).
+
+`_build_generated_video_store()` (app.py:5676 -> 5322-5333) runs `VideoStore.enforce_retention()`
+during `TldwCli.__init__`: mkdir, lock-file create, an EXCLUSIVE interprocess portalocker lease
+with a 5.0 s poll-timeout (video_store.py:56, 191-233), then a scan+delete pass - all pre-paint.
+A held lease from a concurrent instance (a deliberate, supported usage pattern) blocks boot for
+up to 5 s.
+
+## Acceptance Criteria
+
+- [ ] App construction only resolves paths; `enforce_retention()` runs from `_schedule_deferred_startup_work` after first paint
+- [ ] A probe holding the lease from a second process shows boot is no longer blocked
+- [ ] Retention semantics (including the session default) unchanged; existing video-store tests green

--- a/backlog/tasks/task-21110 - Overlap the splash with the initial screen import instead of serializing them.md
+++ b/backlog/tasks/task-21110 - Overlap the splash with the initial screen import instead of serializing them.md
@@ -1,0 +1,29 @@
+---
+id: TASK-21110
+title: >-
+  Overlap the splash with the initial screen import instead of serializing them
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21110).
+
+With the splash enabled (default, 1.5 s), boot is strictly serial: `__init__` -> splash runs
+1.5 s doing nothing else -> splash closes -> THEN chat_screen (~20k lines + closure) imports
+and composes on the loop (app.py:8343-8386 -> 12611-12642 -> 11166-11222). The screen
+pre-importer only starts after `_post_mount_setup`, so it cannot help the first screen. The
+1.5 s window is pure wasted overlap on exactly the machines that hurt.
+
+## Acceptance Criteria
+
+- [ ] The resolved initial route's screen module import is kicked off (on a thread) when the splash mounts, so splash time overlaps the import
+- [ ] Time-to-interactive with splash on, measured on the isolated-profile probe, improves by roughly the warm import cost of the initial screen; numbers recorded in the task
+- [ ] Boot with splash disabled is unchanged; no import races introduced (the existing per-module import lock semantics are relied on, not fought)

--- a/backlog/tasks/task-21111 - Startup-init hygiene - broken phase timing log, eager keyring probes, UI-thread ingest-job restore, Samira full-table scan.md
+++ b/backlog/tasks/task-21111 - Startup-init hygiene - broken phase timing log, eager keyring probes, UI-thread ingest-job restore, Samira full-table scan.md
@@ -1,0 +1,35 @@
+---
+id: TASK-21111
+title: >-
+  Startup-init hygiene - broken phase timing log, eager keyring probes, UI-thread ingest-job restore, Samira full-table scan
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+  - diagnostics
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21111).
+
+Four small, verified startup defects: (a) the `__init__` parallel-task timing log measures
+durations AFTER `future.result()` returns (app.py:5823-5825), so every task logs ~0 s and the
+STARTUP TIMING SUMMARY cannot attribute the parallel phase - fix first, it makes all other
+startup work measurable; (b) 2-3 `keyring.get_keyring()` backend discoveries run during
+`__init__` (server credentials ~13 ms + Security.framework ctypes load; skills trust x2) for
+features not in use; (c) `_restore_ingest_jobs` (app.py:2211-2239) does DB open + read +
+reconcile writes synchronously on the UI thread in on_mount; (d) `ensure_builtin_samira` full-
+scans `character_cards` parsing every `extensions` JSON per boot
+(`Character_Chat/visual_identity.py:3044-3060`).
+
+## Acceptance Criteria
+
+- [ ] The startup timing summary reports real per-task durations (measured around result(), not after it)
+- [ ] Keyring backend discovery happens on first server-mode/skills-trust use, not at boot
+- [ ] Ingest-job restore runs off the UI thread; behavior unchanged
+- [ ] The Samira preflight uses a targeted query (json_extract + LIMIT 1) or a cached id instead of a full scan with per-row JSON parsing

--- a/backlog/tasks/task-21112 - Notes-sync runtime - gate the unconditional start, bound the legacy scan, and back off the 1Hz full-tree watcher.md
+++ b/backlog/tasks/task-21112 - Notes-sync runtime - gate the unconditional start, bound the legacy scan, and back off the 1Hz full-tree watcher.md
@@ -1,0 +1,34 @@
+---
+id: TASK-21112
+title: >-
+  Notes-sync runtime - gate the unconditional start, bound the legacy scan, and back off the 1Hz full-tree watcher
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - notes-sync
+  - startup
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21112).
+
+The lasting notes-sync runtime starts unconditionally at app.py:10297-10303
+(`cutover_admitted=True` hardcoded at app.py:5986). Zero-profile boots still create the state
+DB, run >=3 schema-censused transactions, and the first boot runs two unbounded SELECTs over
+chachanotes.db (notes_sync_legacy.py:603-628). With >=1 active root, the watcher performs a
+full recursive stat walk of every root every 1 second forever
+(notes_sync_watcher.py:18,74-77; discovery bounds 10k entries - an over-bounds root pays the
+full scan every tick before bailing). Library already falls back to `InertLastingSyncRuntime`
+(library_screen.py:3212-3214).
+
+## Acceptance Criteria
+
+- [ ] `start()` is gated on actual configuration (non-empty root summaries, plus the legacy `notes.sync_directory` key for one-time migration); a zero-profile boot creates no notes-sync state DB and runs no legacy scans
+- [ ] The watcher backs off when consecutive polls see no change (1 s -> 5-15 s with jitter, or native FS events with polling fallback); the interval is configurable
+- [ ] The legacy first-boot SELECTs are bounded/paginated
+- [ ] Existing notes-sync tests stay green; a probe with an active 5k-file root shows the reduced steady-state stat traffic

--- a/backlog/tasks/task-21113 - Screen pre-importer niceness - yield between modules, priority order, low-core guard.md
+++ b/backlog/tasks/task-21113 - Screen pre-importer niceness - yield between modules, priority order, low-core guard.md
@@ -1,0 +1,31 @@
+---
+id: TASK-21113
+title: >-
+  Screen pre-importer niceness - yield between modules, priority order, low-core guard
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - startup
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21113).
+
+`_preimport_screens` (app.py:11762-11886) is a tight no-yield loop importing ~21 screen modules
+(~117k lines + closures) on a GIL-holding daemon thread starting 0.2 s after first paint. A
+live A/B on multi-core hardware measured NO first-interaction penalty (keystroke median 82 vs
+99 ms, 30 s CPU 2.51 vs 2.75 s - within noise), so this is design hardening for 1-2-core
+machines, not a measured regression: on such boxes the entire post-boot window has a CPU
+competitor for every keystroke. Keep the `TLDW_SCREEN_PREIMPORT` overrides.
+
+## Acceptance Criteria
+
+- [ ] A short sleep between route imports bounds GIL contention to one module at a time
+- [ ] Import order starts with the configured default tab, then the heavy trio
+- [ ] The pre-import pass parks while a screen navigation is resolving, and is disabled (or heavily throttled) below 4 CPU cores
+- [ ] The existing A/B env override still works both ways

--- a/backlog/tasks/task-21114 - Transcript drag-selection re-wraps and re-renders the message body on every mouse-move.md
+++ b/backlog/tasks/task-21114 - Transcript drag-selection re-wraps and re-renders the message body on every mouse-move.md
@@ -1,0 +1,33 @@
+---
+id: TASK-21114
+title: >-
+  Transcript drag-selection re-wraps and re-renders the message body on every mouse-move
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - console
+  - transcript
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21114).
+
+During an active drag (MouseMove at 50-100 Hz), `console_transcript.py` per event: rebuilds the
+full message render text for plain rows (uncached `get_display_text()`, :1727-1729), runs
+`Content(text).wrap(width)` over the entire body (:2278-2311), calls `set_selection_range` ->
+full `body.update()` re-render even when the range did not move (:1740-1787), and sweeps every
+mounted row calling `clear_selection()` (:5055-5063; watermarks default 20k/12k lines so
+hundreds of rows can be mounted). Tens of ms per event on multi-KB rows - seconds of cumulative
+lag per drag on slow hardware. The whole feature is post-baseline.
+
+## Acceptance Criteria
+
+- [ ] Plain-row display text is cached and invalidated in sync_message; the wrap table is memoized per (text, width) for the drag's lifetime
+- [ ] set_selection_range early-returns on an unchanged range; the drag remembers the single row holding a selection instead of sweeping all mounted rows
+- [ ] A counter/timing probe over a drag across a ~20 KB row shows the per-event cost drop; numbers in the task
+- [ ] Selection behavior (visuals, copy, menus) unchanged - existing selection tests green

--- a/backlog/tasks/task-21115 - CSS parse-cache headroom - bundle-ride the 34 new DEFAULT_CSS classes and add a static allowlist ratchet.md
+++ b/backlog/tasks/task-21115 - CSS parse-cache headroom - bundle-ride the 34 new DEFAULT_CSS classes and add a static allowlist ratchet.md
@@ -1,0 +1,36 @@
+---
+id: TASK-21115
+title: >-
+  CSS parse-cache headroom - bundle-ride the 34 new DEFAULT_CSS classes and add a static allowlist ratchet
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - css
+  - console
+  - library
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21115).
+
+34 new `DEFAULT_CSS` declarations across 29 files landed since the task-15450 consolidation
+(Console modals/inspector rail/turn-file card, Library dialogs, trajectory, speech; full list in
+the evidence doc). Live tour on the pin measured 47 sources (empty transcript, no modals)
+against the LRUCache(64) cliff and the 56 soft guard limit; adding conversation-row classes and
+~10 distinct modal opens crosses 64 today, at which point every later first-mount of any unseen
+widget class re-pays a full cold parse (~150-450 ms fast HW, x3-5 constrained) for the rest of
+the session. Accretion is ~+8 classes/3 days while the tour guard is red (TASK-21106) and CI
+does not run. All 34 are plain string blocks that can ride the sanctioned
+BUNDLED_CSS/BUNDLED_SCREEN_CSS + build_css.py mechanism; `UI/SiteConfigSettings.py:41` is also
+the last class-level `CSS` remaining.
+
+## Acceptance Criteria
+
+- [ ] The 34 new DEFAULT_CSS blocks (and SiteConfigSettings' class CSS) ride the bundle; harness parse-standalone requirements still hold
+- [ ] A STATIC allowlist ratchet test (AST walk, no app boot) fails on any DEFAULT_CSS/CSS declaration outside the allowlist, so the invariant no longer depends on the slow integration tour running
+- [ ] A post-change tour + 12-modal probe stays comfortably under the 56 soft limit; measured count recorded in the task

--- a/backlog/tasks/task-21116 - Library screen still whole-screen-recomposes on per-click paths - continue the canvas-scoped conversion with a ratchet.md
+++ b/backlog/tasks/task-21116 - Library screen still whole-screen-recomposes on per-click paths - continue the canvas-scoped conversion with a ratchet.md
@@ -1,0 +1,31 @@
+---
+id: TASK-21116
+title: >-
+  Library screen still whole-screen-recomposes on per-click paths - continue the canvas-scoped conversion with a ratchet
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - library
+  - recompose
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21116).
+
+library_screen.py holds ~105 statement-level `refresh(recompose=True)` sites (99 on self =
+whole-screen) on a screen that grew 26k -> 34.8k lines since the audit pin. Confirmed per-click
+sites: `_open_library_item_by_id` (rail row / RAG result / media open), `_apply_library_row_toggle`,
+media-viewer back (Escape), skills/prompts import open/cancel, export open. The 15457
+canvas-scoped seam (`library_canvas_sync`, 82 call sites) is the sanctioned conversion target;
+9 whole-screen sites were re-added post-fix on low-frequency admin flows.
+
+## Acceptance Criteria
+
+- [ ] The confirmed per-click sites above no longer rebuild the whole screen (converted to the canvas-scoped seam or narrower)
+- [ ] A ratchet test pins the statement-level whole-screen recompose count at (or below) the post-conversion number
+- [ ] Click-to-settle timing on a rail-row open, before/after, recorded in the task

--- a/backlog/tasks/task-21117 - Inspector right-rail scroll forces refresh(layout=True) per scroll frame - split the pure-scroll path.md
+++ b/backlog/tasks/task-21117 - Inspector right-rail scroll forces refresh(layout=True) per scroll frame - split the pure-scroll path.md
@@ -1,0 +1,30 @@
+---
+id: TASK-21117
+title: >-
+  Inspector right-rail scroll forces refresh(layout=True) per scroll frame - split the pure-scroll path
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21117).
+
+`UI/Console_Modules/right_rail.py` (249 -> 1,092 lines since the pin): `_InspectorOuterBody.
+watch_scroll_y` (:116-120) routes every scroll frame into the outer geometry reconcile, which
+unconditionally runs two DOM queries plus `self.refresh(layout=True)` on the whole rail (:313)
+and a second call_after_refresh hop with focus-recovery + fold measurement - even for a pure
+scroll where no geometry changed. Coalescing trims a wheel gesture to ~2-3 full layout passes,
+on the app's hottest screen.
+
+## Acceptance Criteria
+
+- [ ] A pure scroll updates only what scroll can change (hint text / clamp) without refresh(layout=True) or the refold chain
+- [ ] The full reconcile still runs for resize / section-demand / virtual-size changes (the `_size_updated` override already distinguishes them)
+- [ ] A counter probe while wheel-scrolling the rail shows zero whole-rail layout refreshes on pure scrolls; rail behavior (fold, focus recovery) unchanged

--- a/backlog/tasks/task-21118 - Console keystroke path does synchronous Workspace-DB reads - measured ~1.25 per key - memoize the workspace context.md
+++ b/backlog/tasks/task-21118 - Console keystroke path does synchronous Workspace-DB reads - measured ~1.25 per key - memoize the workspace context.md
@@ -1,0 +1,32 @@
+---
+id: TASK-21118
+title: >-
+  Console keystroke path does synchronous Workspace-DB reads - measured ~1.25 per key - memoize the workspace context
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - console
+  - database
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21118).
+
+Live counter: 20 printable keys in the configured composer -> 25 x `ensure_default_workspace` +
+25 x `get_active_workspace` (LocalWorkspaceRegistryService), i.e. ~1.25 synchronous SQLite
+round-trips per keystroke on the UI thread (chain: DraftChanged ->
+`_build_console_control_state` -> `_current_console_workspace_context`). 62 us/call measured on
+a warm fast SSD - the risk cases are cold page cache, slow disks, and the repair branch's
+DELETE write. During staged live-work launches, `EvidenceBundle.from_payload` is additionally
+re-parsed >=2x per keystroke.
+
+## Acceptance Criteria
+
+- [ ] The workspace context is memoized on the screen and invalidated by workspace-change events (activation, registry mutation); the keystroke path performs zero DB round-trips (counter-probe verified)
+- [ ] ensure_default_workspace's repair side-effects move to session-start/workspace-switch; the keystroke path is read-only
+- [ ] The staged-launch evidence bundle is parsed once per launch and cached on the launch object

--- a/backlog/tasks/task-21119 - Every Chat-screen press walks the whole screen DOM twice for selection-menu dismissal.md
+++ b/backlog/tasks/task-21119 - Every Chat-screen press walks the whole screen DOM twice for selection-menu dismissal.md
@@ -1,0 +1,28 @@
+---
+id: TASK-21119
+title: >-
+  Every Chat-screen press walks the whole screen DOM twice for selection-menu dismissal
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21119).
+
+`chat_screen.py:18939-18990`: `_dismiss_console_selection_menus_outside_transcript` runs
+`self.query(ConsoleTranscript)` and `self.query(ConsoleSelectionMenu)` - two full-screen DOM
+traversals - and is invoked on BOTH on_mouse_down and on_click of the same physical press
+(~4 traversals per click) on the largest-DOM screen in the app. A direct contributor to the
+click-lag symptom on every click.
+
+## Acceptance Criteria
+
+- [ ] Dismissal early-returns via a mounted-menu flag/registry (at most one menu is ever mounted) and a cached transcript reference - no full-screen queries when nothing is mounted
+- [ ] Selection-menu dismissal behavior is unchanged (covered by existing selection tests)

--- a/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
+++ b/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
@@ -1,0 +1,30 @@
+---
+id: TASK-21120
+title: >-
+  Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - console
+  - composer
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21120).
+
+Per printable key in `console_composer_bar.py`: `_sync_send_disabled_reason` calls
+`strip.update(Content(reason))` unconditionally (:1588/:1596) - the computed `reason_changed`
+gate covers only the ARIA announcement (the audit's known half-gate pattern); the hidden
+compatibility `Input.value` is re-set with the full canonical draft (O(draft), firing a second
+Changed handler, :1532-1539); ghost text runs a reverse linear scan of prompt history per draft
+render AND per 0.5 s blink tick (:4214-4240).
+
+## Acceptance Criteria
+
+- [ ] The reason strip updates only when reason_changed; the hidden-input mirror skips unchanged text; the ghost-text history scan is capped or cached
+- [ ] Composer behavior (send gating, ARIA announcements, ghost suggestions) unchanged - existing composer tests green

--- a/backlog/tasks/task-21121 - The 0.2s run tick gained a full per-tick message-snapshot pass for changed-files scope.md
+++ b/backlog/tasks/task-21121 - The 0.2s run tick gained a full per-tick message-snapshot pass for changed-files scope.md
@@ -1,0 +1,28 @@
+---
+id: TASK-21121
+title: >-
+  The 0.2s run tick gained a full per-tick message-snapshot pass for changed-files scope
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21121).
+
+`_console_changed_files_scope()` (chat_screen.py:11467-11497) runs on every 0.2 s run tick and
+calls `messages_for_session` - a full shallow-snapshot of every session message
+(console_chat_store.py:2858-2865) - then reverse-scans; its own docstring concedes worst-case
+O(messages) per tick when the session has no change-review marker, which is the common case.
+Combined with the cost path this makes >=2 full snapshot passes per tick during a run.
+
+## Acceptance Criteria
+
+- [ ] The newest run-id (or marker presence) is memoized on the store and bumped on marker append (pattern: the token-estimate cache), so the no-marker common case is O(1) per tick
+- [ ] A counter probe during a streamed reply in a large session shows the snapshot-pass reduction; run-tick behavior unchanged

--- a/backlog/tasks/task-21122 - Persona Buddy enabled-state runtime costs - ungated 10Hz repaint, 10Hz resolution retries, per-keypress config-write workers.md
+++ b/backlog/tasks/task-21122 - Persona Buddy enabled-state runtime costs - ungated 10Hz repaint, 10Hz resolution retries, per-keypress config-write workers.md
@@ -1,0 +1,32 @@
+---
+id: TASK-21122
+title: >-
+  Persona Buddy enabled-state runtime costs - ungated 10Hz repaint, 10Hz resolution retries, per-keypress config-write workers
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - persona-buddy
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21122).
+
+Verified on the pin (`persona_buddy_widget.py`): (a) `set_interval(0.10, refresh_from_controller)`
+(:227) repaints unconditionally at 10 Hz - no change gate; each tick takes the controller lock
+twice, rebuilds an ~11-field visual identity, and issues three `Static.update` calls while a
+separate frame timer already animates; (b) the resolution loop (:257-313) can retry a failed
+visual at 10 Hz, each iteration four `to_thread` hops + DB reads, until the confirm fence
+lands; (c) every h/j/k/l geometry keypress spawns a non-exclusive config-write worker
+(:671-690, :779-799) - held-down key repeat queues an unbounded backlog of file writes.
+
+## Acceptance Criteria
+
+- [ ] The 10 Hz poll repaints only when (snapshot generation, preferences generation, visual identity) changes - or is replaced by controller-posted messages; the frame timer remains the sole animation clock
+- [ ] The unconfirmed-unavailable resolution path uses capped exponential backoff (0.1 -> 2 s)
+- [ ] Geometry persists are coalesced (exclusive worker or ~250 ms debounce)
+- [ ] A Static.update counter with a static visual shows ~0 updates/s at steady state (was ~30/s)

--- a/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
+++ b/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
@@ -1,0 +1,33 @@
+---
+id: TASK-21123
+title: >-
+  Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - architecture
+  - persona-buddy
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21123).
+
+`UI/Navigation/base_app_screen.py` awaits `reconcile_persona_buddy_view()` at the tail of EVERY
+screen recompose (~421 recompose=True sites repo-wide), and every mount AND screen-resume
+schedules a reconcile worker - with the widget module imported before the enabled check - even
+when the feature is disabled (the default). The disabled-case per-event cost is us-scale
+(verified), but the design multiplies lifecycle work across every screen, duplicates five
+methods + three fields of state per screen, and spends ~80 lines defending teardown races the
+placement itself creates. The app already owns the authoritative entry point (app.py:8610), the
+controller is app-owned, and the widget floats via overlay: screen.
+
+## Acceptance Criteria
+
+- [ ] A single app-level overlay owner reacts to screen-change events and controller generation bumps; the per-screen recompose/mount/resume hooks and per-screen buddy state are removed
+- [ ] Short-term (or as part of the move): no worker is spawned and no widget module imported when the feature is disabled
+- [ ] Buddy behavior when enabled (placement, persistence, unavailable-fence) is unchanged - existing buddy tests green

--- a/backlog/tasks/task-21124 - get_cli_setting takes the global config file lock before the cache check - one write stalls all 398 read sites.md
+++ b/backlog/tasks/task-21124 - get_cli_setting takes the global config file lock before the cache check - one write stalls all 398 read sites.md
@@ -1,0 +1,32 @@
+---
+id: TASK-21124
+title: >-
+  get_cli_setting takes the global config file lock before the cache check - one write stalls all 398 read sites
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - config
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21124).
+
+Reads: `config.py:6057 -> :4976 -> :5107` acquires `_config_file_lock()` BEFORE the cache
+short-circuit (which sits inside `_load_cli_config_bootstrap_unlocked:4872-4877`). Writes hold
+that lock through 2 fsyncs (temp fd + parent dir, `Utils/private_paths.py:660,691`), 3 full
+TOML parses, and a settings rebuild. With 398 `get_cli_setting` call sites - many on the event
+loop - any concurrent config write (even correctly off-loop ones) stalls loop-side reads for
+the whole write. Amplifiers verified: Logs filter chip = 2 rewrites/4 fsyncs per click
+(UI/Logs_Window.py:273-276), theme switch (app.py:872), lab rail toggle, and a per-keystroke
+writer (UI/Dictation_Window_Improved.py:602 -> dictation_service_lazy.py:1383).
+
+## Acceptance Criteria
+
+- [ ] Cache-hit reads never take the file lock (double-checked fast path on the existing _CONFIG_GENERATION; writers already bump it)
+- [ ] The write path is coalesced to one parse (verify re-parse dropped or debug-gated); the Logs-chip and dictation writers are debounced
+- [ ] A two-thread probe (writer loop vs timed reader) shows reader p95 unaffected by concurrent writes; before/after numbers in the task

--- a/backlog/tasks/task-21125 - Writing screen runs all SQLite on the event loop with per-op leaked connections.md
+++ b/backlog/tasks/task-21125 - Writing screen runs all SQLite on the event loop with per-op leaked connections.md
@@ -1,0 +1,30 @@
+---
+id: TASK-21125
+title: >-
+  Writing screen runs all SQLite on the event loop with per-op leaked connections
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - database
+  - writing
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21125).
+
+`Writing_Interop/local_writing_service.py:56-78`: ~45 `with self._connect()` sites open a fresh
+connection per operation (sqlite3's `with conn:` is a transaction manager, not a closer -
+GC-only leak), and the entire call chain from `UI/Writing_Window.py` / writing_controller has
+zero thread offload - tree clicks and autosave run open + query + commit on the Textual event
+loop, each open paying the private-seam's ~4 artifact verifications.
+
+## Acceptance Criteria
+
+- [ ] The service holds a thread-local connection (WAL+NORMAL already set) and closes it explicitly on shutdown
+- [ ] Controller calls route through asyncio.to_thread; a thread-assert (or log probe) confirms no SQLite on the loop from this screen
+- [ ] Writing screen behavior unchanged - existing tests green

--- a/backlog/tasks/task-21126 - Library Search-RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount.md
+++ b/backlog/tasks/task-21126 - Library Search-RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount.md
@@ -1,0 +1,33 @@
+---
+id: TASK-21126
+title: >-
+  Library Search/RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - library
+  - rag
+  - database
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21126).
+
+`RAG_Admin/local_rag_admin_service.py:592-596` runs `SELECT chunk_engine_version,
+COUNT(DISTINCT media_id) ... GROUP BY chunk_engine_version` over `UnvectorizedMediaChunks`
+(rows-per-chunk; no index on chunk_engine_version; temp B-tree for the DISTINCT). The
+`_maybe_await` seam (rag_admin_scope_service.py:81-84) evaluates this sync call ON the loop,
+and the panel remounts per destination switch (its own docstring,
+library_search_rag_panel.py:95-98). Full scan + sort per Library navigation click at realistic
+chunk counts (1e5-1e6 rows).
+
+## Acceptance Criteria
+
+- [ ] The census query runs off the loop and its result is cached per session (invalidated on ingest/re-chunk)
+- [ ] An index or maintained count removes the full-scan; EXPLAIN QUERY PLAN before/after recorded in the task
+- [ ] Panel content unchanged

--- a/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
+++ b/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
@@ -1,0 +1,30 @@
+---
+id: TASK-21127
+title: >-
+  Research runs - per-op leaked connects and loop-side periodic reads/writes while a run is active
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - research
+  - database
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21127).
+
+`Research_Interop/local_research_service.py:99-123` opens per-op and GC-leaks connections
+(~with conn: sites); the engine is launched as a loop coroutine (Research_Window.py:594,
+chat_screen.py:16200 - run_worker without thread), with a 30 s lease WRITE
+(local_research_engine.py:387-393) and a 2 s `get_run` read poll (Research_Window.py:816-831)
+on the loop while a run is active.
+
+## Acceptance Criteria
+
+- [ ] The service holds a thread-local connection; engine service calls route through to_thread
+- [ ] The 30 s keepalive is batched with progress writes; the 2 s auto-refresh reads off-loop
+- [ ] Research behavior unchanged - existing tests green

--- a/backlog/tasks/task-21128 - messages_au FTS trigger fires on ANY messages UPDATE - usage and metadata flushes rewrite the full reply into FTS.md
+++ b/backlog/tasks/task-21128 - messages_au FTS trigger fires on ANY messages UPDATE - usage and metadata flushes rewrite the full reply into FTS.md
@@ -1,0 +1,30 @@
+---
+id: TASK-21128
+title: >-
+  messages_au FTS trigger fires on ANY messages UPDATE - usage and metadata flushes rewrite the full reply into FTS
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - database
+  - fts
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21128).
+
+The `messages_au` trigger (recreated, still unconditional, in the v46 migration SQL ~lines
+396-405) has no `UPDATE OF content` column list, so usage-only and metadata-only flushes - now
+3-4 UPDATEs per chat turn (content finalize, usage flush ChaChaNotes_DB.py:11030-11082,
+metadata flush :11098+) - each re-tokenize and rewrite the full assistant reply into
+`messages_fts`. WAL+NORMAL, so write amplification rather than fsync storm.
+
+## Acceptance Criteria
+
+- [ ] The trigger fires only on content changes (`AFTER UPDATE OF content ON messages`), preserving the v46 deleted-guards
+- [ ] A migration (with version bump per repo policy) ships the trigger change; FTS search results for edited/streamed messages remain correct under existing tests
+- [ ] A write-count probe over one streamed turn shows the FTS rewrite count drop from 3-4 to 1

--- a/backlog/tasks/task-21129 - Notes-sync executor - six read-all list_bindings sites, five on the event loop.md
+++ b/backlog/tasks/task-21129 - Notes-sync executor - six read-all list_bindings sites, five on the event loop.md
@@ -1,0 +1,31 @@
+---
+id: TASK-21129
+title: >-
+  Notes-sync executor - six read-all list_bindings sites, five on the event loop
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - notes-sync
+  - database
+priority: medium
+dependencies:
+  - TASK-21101
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21129).
+
+`Notes/notes_sync_executor.py:1144,1256,1761,1978,2260,2682` each read EVERY binding for the
+root (notes_device_state_store.py:889-897 - no LIMIT; no index on root_id found), and five of
+the six are invoked without to_thread from async methods (unlike notes_sync_runtime.py:1363
+which wraps correctly) - ~3K full owner-set reads per sync batch, each also paying TASK-21101's
+per-op connect + census until that lands.
+
+## Acceptance Criteria
+
+- [ ] The read-all sites use indexed predicates (starting with `_require_new_candidate_owner`); an index on the binding root/owner columns exists
+- [ ] The five loop-side call sites route through to_thread
+- [ ] Sync outcomes unchanged - existing executor tests green

--- a/backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md
+++ b/backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md
@@ -1,0 +1,29 @@
+---
+id: TASK-21130
+title: >-
+  TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - tts
+  - migrations
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21130).
+
+`TTS/profile_schema.py:1300-1316` (`_migration_reference_snapshot`) pulls `wav_bytes` for every
+row, and is called at :1439 and :1468 with the first snapshot still held - up to ~1 GB peak at
+profile-store open under the 512 MiB store bound (profile_reference_types.py:21), against the
+module's own 256 KiB streaming norm. Swap-thrash on constrained hardware at exactly the moment
+TTS opens.
+
+## Acceptance Criteria
+
+- [ ] The migration compares projections without wav_bytes (sibling profile_migration_candidate.py:320 already does) using hashes; peak memory during v3->v4 is bounded and asserted by a test with synthetic large references
+- [ ] Migration outcomes byte-identical for the existing fixtures

--- a/backlog/tasks/task-21131 - Notifications event-state repository - per-op leaked connects on a 3s-TTL feed - clone the sibling held-conn fix.md
+++ b/backlog/tasks/task-21131 - Notifications event-state repository - per-op leaked connects on a 3s-TTL feed - clone the sibling held-conn fix.md
@@ -1,0 +1,28 @@
+---
+id: TASK-21131
+title: >-
+  Notifications event-state repository - per-op leaked connects on a 3s-TTL feed - clone the sibling held-conn fix
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - notifications
+  - database
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21131).
+
+`Notifications/event_state_repository.py:85-106` opens per-op (GC-leaked `with conn:`; no FK on
+the file branch), 3+ opens per `build_server_notification_feed` call on the Home screen's 3 s
+TTL cache in server mode. The sibling `client_notifications_db.py:69-108` is already the held
+thread-local template with a liveness ping - clone it.
+
+## Acceptance Criteria
+
+- [ ] The repository holds a thread-local connection (template shape) with explicit close; FK enabled consistently
+- [ ] Server-mode feed behavior unchanged

--- a/backlog/tasks/task-21132 - Note-folder managed-membership CTE anchors on the whole closure instead of the requested subtrees.md
+++ b/backlog/tasks/task-21132 - Note-folder managed-membership CTE anchors on the whole closure instead of the requested subtrees.md
@@ -1,0 +1,28 @@
+---
+id: TASK-21132
+title: >-
+  Note-folder managed-membership CTE anchors on the whole closure instead of the requested subtrees
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - notes
+  - database
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21132).
+
+`Notes/note_folder_repository.py:1831-1861`: the recursive CTE's anchor ignores the requested
+folder_ids and filters only at the end, so every Notes-tree interaction walks the entire
+managed-membership closure - twice per tree refresh (library_screen.py:11805,11943; off-loop,
+so latency not freeze).
+
+## Acceptance Criteria
+
+- [ ] The CTE anchor is seeded from the requested ids' subtrees; results identical on existing fixtures
+- [ ] A timing probe on a deep synthetic tree shows the reduction

--- a/backlog/tasks/task-21133 - Retire the dead 10s token-count timer - its entire consumer surface was removed.md
+++ b/backlog/tasks/task-21133 - Retire the dead 10s token-count timer - its entire consumer surface was removed.md
@@ -1,0 +1,28 @@
+---
+id: TASK-21133
+title: >-
+  Retire the dead 10s token-count timer - its entire consumer surface was removed
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - cleanup
+  - performance
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21133).
+
+The app-global 10 s interval (app.py:11746) resolves the active footer and, on the chat tab,
+attempts four widget queries that ALL fail - `#chat-log` no longer exists anywhere, footers
+compose `show_token_count=False` since task-17653, and the estimator result is only
+debug-logged (chat_token_events.py:103-181; the file's own comments say the counter is
+retired). The producer ticks forever for nothing.
+
+## Acceptance Criteria
+
+- [ ] The interval, update_token_count_display, and the periodic path are deleted; the estimator remains for on-demand callers (input-changed / model-changed)
+- [ ] No footer or token-display regression - existing tests green

--- a/backlog/tasks/task-21134 - Perf small-residue batch - setup-modal snow idle burn, casefold UDF, MCP log parses, executemany, connection closes, misc.md
+++ b/backlog/tasks/task-21134 - Perf small-residue batch - setup-modal snow idle burn, casefold UDF, MCP log parses, executemany, connection closes, misc.md
@@ -1,0 +1,45 @@
+---
+id: TASK-21134
+title: >-
+  Perf small-residue batch - setup-modal snow idle burn, casefold UDF, MCP log parses, executemany, connection closes, misc
+status: To Do
+assignee: []
+created_date: '2026-08-22'
+labels:
+  - performance
+  - cleanup
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `35d4bf3a1`. Evidence, measurements, and file:line cites: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21134). Each item
+verified on the pin; none warrants a task alone, together they are a real tax.
+
+1. Setup-modal snow animation ticks a full-screen refresh at 5 Hz - measured 9.9% of a core
+   idle (vs 1.8% configured) for every not-yet-configured user: honor reduced-motion by default
+   on low-core machines or lower the tick rate (console_setup_modal.py:88+).
+2. `unicode_casefold` Python-UDF in WHERE + ORDER BY on watchlists agent-tool queries
+   (Subscriptions_DB.py:2908-2985).
+3. MCP execution log: two full-file JSON parses + fsync-on-close per tool invocation
+   (MCP/execution_log.py:156).
+4. Re-chunk per-chunk INSERT loop -> executemany (library_rechunk_service.py:265-271).
+5. GC-leaked `with conn:` (no close) in sync_state / event_state / writing / research /
+   tamagotchi stores.
+6. `EnhancedStatusWidget` recompose-per-status-message during ingest (status_widget.py:82-140).
+7. Media-viewer match-nav restyles the whole document per click (library_media_content.py:16-53
+   - cache the match list, restyle two lines).
+8. Trajectory brush-drag rebuilds the ledger DataTable per mouse-move
+   (trajectory_screen.py:861-867 - throttle to once per frame or use the existing worker path).
+9. `CAPABILITY_REGISTRY` builds 1,323 frozen dataclasses (62% server-only) and runs
+   `validate_registry_completeness()` in production at every import (registry.py:1358,1414 -
+   move validation to tests; lazy-build the server partition).
+10. Dormant sqlite owners to verify-then-retire: Sync_Interop/notes_mirror.py (no prod caller),
+    Widgets/Tamagotchi/tamagotchi_storage.py (never imported), Kanban boot connect with no UI,
+    Third_Party/aider/repomap.py diskcache (no prod caller).
+
+## Acceptance Criteria
+
+- [ ] Each numbered item is either fixed as described or explicitly declined with a reason in the task notes
+- [ ] No behavior change beyond the stated performance mechanics; touched areas keep their existing tests green


### PR DESCRIPTION
## Summary

Holistic performance review commissioned against the latest dev (`35d4bf3a1`), targeting the reported recent slowdown (general sluggishness, input/click lag, slow startup/screen switches). Seven parallel read-only review lanes + live headless-Pilot probes in an isolated worktree; top claims re-verified first-hand; two lane contradictions resolved by measurement.

**Files 35 backlog tasks (TASK-21100 – TASK-21134)** plus the durable evidence record `Docs/Design/2026-08-22-holistic-perf-review.md` (measurements live there; the backlog CLI drops custom sections).

## Headlines

- **P0 21100**: first boot after upgrade replays v34→v46, and the v46 migration (merged 2026-08-22) rebuilds the entire `messages_fts` index in ONE transaction inside `TldwCli.__init__` — the likely literal "it got slow after updating" complaint.
- **P0 21101**: `NotesDeviceStateStore` is the app's only DELETE+FULL store (live pragma read-back), fresh connection AND a ~60-statement schema census per transaction, behind the always-on notes-sync runtime and note imports.
- **Boot accretion (21102-21113)**: ~15k LOC of Chunking imported to read one string constant (6 entry points); Persona_Buddy drags 93% of Persona_Visual + PIL (1.28 s of the 3.10 s cold import); unguarded extras-only `bs4` import (base install cannot import the app); 7 feature DBs schema'd in `__init__`; Actor_Packs `recover()` in `__init__` **crashes the test app factory and has been silently disarming the CSS cliff guard**.
- **Input paths (21114-21121)**: drag-selection re-wraps the full message body per mouse-move; right-rail `refresh(layout=True)` per scroll frame; per-keystroke synchronous Workspace-DB reads (measured live: ~1.25/key); double whole-DOM walks per click.
- **21124**: `get_cli_setting` takes the global config file lock before the cache check — one config write (2 fsyncs, 3 TOML parses) stalls all 398 read sites.
- **Verified intact**: all 13 fix families from the 2026-08-11 input-latency audit — the slowdown is accretion, not reversion. CSS cliff NOT re-crossed on the plain tour (47/64 measured) but ~10 modal opens crosses it today (21115).

## Verification

- Task ids swept case-insensitively across all refs + worktrees at filing time (max elsewhere = 21000; block 21100-21134 clean; distinctive offset chosen because two sessions leapfrogging the same observed max collided twice before).
- Every task cites the evidence doc; every headline claim is either measured live or file:line-verified on the pin.
- `backlog task 21100 --plain` parses the generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files a holistic performance review for dev 35d4bf3a1 and adds 35 backlog tasks with evidence. This organizes the recent slowdown reports into actionable work, with P0/P1 items and measured file/line cites; no runtime behavior changes.

- Review `Docs/Design/2026-08-22-holistic-perf-review.md` first; the diff shows task stubs, the evidence and measurements live in the doc.
- Verify TASK-21100–TASK-21134 parse and cross-reference the doc; confirm the distinctive ID block is free and matches the current dev pin.
- Prioritize validation for planning: 21100 (first-boot v46 `messages_fts` rebuild inside `__init__`) and 21101 (`NotesDeviceStateStore` DELETE+FULL with per-transaction schema census), then startup import weight (21102–21108) and input-path costs (21114–21121).
- No migrations or code paths are touched in this PR; merging only publishes documentation and task files.

<sup>Written for commit 94bab5a9563ddb9880f6758a003dec5d660e3e34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

