### PR TITLE
docs(lessons): a Pilot-driven latency probe can measure the harness, not the app

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6783,3 +6783,28 @@ usually writes the *same* value the outer statement did and its emitter's
 statement supplies a different timestamp — which means probing the natural path
 alone would have concluded, wrongly, that there was no same-version content
 row. Construct the hostile input; the friendly one hid the bug.
+
+---
+
+## A Pilot-driven latency probe can measure the harness, not the app
+
+**What happened (2026-08-22, holistic perf review of dev `35d4bf3a1`).** A live message
+census attributed **~940 posted `Callback` messages per keypress** in the configured Console —
+looking exactly like an app-side message storm, and superficially contradicting the static
+lane's verdict that the keystroke path was clean. Attribution by callback qualname (patching
+`MessagePump.call_later`/`call_next`) showed 18,640 of 18,648 were
+`Pilot._wait_for_screen.<locals>.decrement_counter`: Textual's `pilot.pause()` posts **one
+callback per mounted widget per pause**, so every `press()+pause()` latency median in the
+probe (82–226 ms) was harness-inflated, and the "storm" was the probe itself. The app-side
+per-key work was ~7 widget refreshes — the static read had been right all along.
+
+**Rules.**
+- Never quote an absolute latency measured through `pilot.press()+pause()`; use that shape
+  only for A/B comparisons where the pause overhead is identical on both arms.
+- Before believing any message/callback storm, attribute the POSTERS by qualname — counting
+  message types alone cannot distinguish app traffic from harness traffic.
+- When a live probe contradicts a careful static read, suspect the probe's harness before the
+  static read; resolve by attribution, not by majority.
+
+Full disclosure section: `Docs/Design/2026-08-22-holistic-perf-review.md`
+("Measurement-artifact disclosure").


### PR DESCRIPTION
Appends the 2026-08-22 perf-review measurement-artifact incident to lessons-testing-evidence.md: pilot.pause() posts one callback per mounted widget per pause, so press+pause latencies are harness-inflated and callback 'storms' must be attributed by poster qualname before being believed. Evidence section lives in Docs/Design/2026-08-22-holistic-perf-review.md (merged in #1981).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a measurement artifact in `Textual` pilot-driven latency probes: `pilot.pause()` posts one callback per mounted widget per pause, inflating `press()+pause()` latencies and creating callback “storms” from the harness, not the app. This prevents misattributing latency and message volume in perf reviews.

- Adds a lessons entry to `backlog/docs/lessons-testing-evidence.md` and points to the full disclosure in `Docs/Design/2026-08-22-holistic-perf-review.md`.
- Required: do not quote absolute latencies from `pilot.press()+pause()`; use that shape only for A/B comparisons with identical pause overhead.
- Required: attribute callback/message posters by qualname (e.g., instrument `MessagePump.call_later`/`call_next`) before acting on any “storm.”
- If existing docs/dashboards cite `press()+pause()` absolute numbers, replace them with A/B results or app-sourced timings.

<sup>Written for commit c8b1e9cf013618df98ecef20647b53d14f34836a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

