### PR TITLE
fix(db): close the VALID_TABLES drift loop with an authoring-time guard

### DIFF
--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -12,9 +12,10 @@ name: Derived Artifacts
 #
 # Every check below is stdlib-only and needs no dependency install. Measured on
 # an M-series laptop: bundle-sync 0.86 s, profile-owned-path 10.98 s, diagnostic
-# inventory 20.17 s, backlog ids <0.5 s -- ~33 s of work, ~90 s with checkout
-# and setup-python. That budget is the whole point: it is small enough to run on
-# every PR, which is what makes it usable as a REQUIRED status check.
+# inventory 20.17 s, backlog ids <0.5 s, chachanotes table allowlist 0.10 s --
+# ~33 s of work, ~90 s with checkout and setup-python. That budget is the whole
+# point: it is small enough to run on every PR, which is what makes it usable as
+# a REQUIRED status check.
 
 on:
   pull_request:
@@ -101,3 +102,14 @@ jobs:
           # by the one required status check rather than by a path-filtered
           # workflow nobody is gated on.
           python scripts/check_backlog_task_ids.py
+
+      - name: ChaChaNotes table allowlist covers every migrated table
+        if: ${{ !cancelled() }}
+        run: |
+          # TASK-20971. Statically scans the CREATE TABLE statements in
+          # DB/migrations/chachanotes_*.sql and in ChaChaNotes_DB.py's SQL
+          # string literals, and fails when VALID_TABLES['chachanotes'] does
+          # not list one of them (or lists one nothing creates). Prints the
+          # exact lines to paste. No database is built; runtime is milliseconds,
+          # so this does not move the ~90 s budget this job depends on.
+          python scripts/check_schema_table_allowlist.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,13 @@ Key sections:
 
 ## Project-Specific Gotchas
 
-1. **Schema migrations** - Always increment version, add to migrations/
+1. **Schema migrations** - Always increment version, add to migrations/. Read
+   `tldw_chatbook/DB/migrations/README.md` first: a `CREATE TABLE` also
+   requires a `VALID_TABLES['chachanotes']` entry in `DB/sql_validation.py`
+   and a `CREATE INDEX` also requires an `EXPECTED_CHACHANOTES_INDEXES` entry,
+   both in the same commit. `./scripts/preflight.sh` checks the first and
+   prints the lines to paste (TASK-20971: that allowlist went stale, was
+   repaired, and went stale again 14.5 hours later).
 2. **Optional deps** - Check with `optional_deps.py` before importing
 3. **Thread safety** - Use transaction() context manager
 4. **Tab constants** - Must match IDs in compose()

--- a/Tests/CI/test_derived_artifacts_workflow.py
+++ b/Tests/CI/test_derived_artifacts_workflow.py
@@ -26,6 +26,9 @@ CHECKERS = (
     "scripts/check_profile_owned_path_inventory.py",
     "scripts/check_persistent_diagnostic_inventory.py",
     "scripts/check_backlog_task_ids.py",
+    # TASK-20971. VALID_TABLES['chachanotes'] went stale, was repaired, and
+    # went stale again 14.5 hours later; this is its authoring-time half.
+    "scripts/check_schema_table_allowlist.py",
 )
 
 
@@ -69,7 +72,7 @@ def test_every_checker_runs():
 
 
 def test_checker_steps_survive_an_earlier_failure():
-    """One red checker must not hide the other three.
+    """One red checker must not hide the others.
 
     With the default `success()` condition the first failure skips the rest, so
     a burn-down needs one push per checker. `!cancelled()` reports all of the

--- a/Tests/DB/test_schema_table_allowlist_guard.py
+++ b/Tests/DB/test_schema_table_allowlist_guard.py
@@ -1,0 +1,228 @@
+"""The authoring-time half of the ``VALID_TABLES`` guard bites (TASK-20971).
+
+``scripts/check_schema_table_allowlist.py`` exists because the runtime pin in
+``test_sql_validation.py`` reports only after a merge: it was repaired by
+TASK-19568 at 2026-08-22 00:16 -0700 and broken again by TASK-19057 at 14:51
+the same day. A guard whose own failure mode is "silently stops failing" is
+worse than none, so this module pins the properties that make it a guard:
+
+1. it fails when a migration creates a table the allowlist does not name;
+2. it fails when the allowlist names a table nothing creates;
+3. it refuses to pass vacuously when it can find no ``CREATE TABLE`` at all
+   (the shape a moved-sources change would otherwise take); and
+4. **its expectation is not derived from the allowlist it guards.** TASK-19045
+   established the rule for the index census: a census that re-derives its
+   expectation from the artifact it checks is the identity function on exactly
+   the defect class it exists to catch. The test below proves independence
+   directly -- it holds the schema SQL fixed and mutates only the allowlist,
+   and the verdict changes. An identity check could not do that.
+
+The shipped-tree assertion at the end is the belt to that braces: the static
+scan must agree, name for name, with a real fully-migrated
+``CharactersRAGDB(":memory:")``. Two independent oracles that agree are
+evidence; one oracle asserted against itself is not.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts" / "check_schema_table_allowlist.py"
+
+
+def _load_checker():
+    """Import the checker by path (``scripts/`` is not a package)."""
+    spec = importlib.util.spec_from_file_location("_check_schema_table_allowlist", CHECKER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_tree(tmp_path: Path, *, migration_sql: str, allowlisted: list[str]) -> object:
+    """Build a miniature repo the checker can run against, and rebind it there.
+
+    The checker resolves its paths from ``REPO_ROOT`` at import time, so a
+    freshly loaded copy is repointed at ``tmp_path``. This keeps the mutation
+    tests off the real tree entirely -- no Edit-and-restore dance, and no way
+    for a failed test to leave the repo dirty.
+    """
+    migrations = tmp_path / "tldw_chatbook" / "DB" / "migrations"
+    migrations.mkdir(parents=True)
+    (migrations / "chachanotes_v1_to_v2_fixture.sql").write_text(migration_sql, encoding="utf-8")
+
+    db_module = tmp_path / "tldw_chatbook" / "DB" / "ChaChaNotes_DB.py"
+    # A Python source whose *comment* claims a table, to pin the AST-vs-text
+    # distinction: a raw-text scan of the real ChaChaNotes_DB.py reports three
+    # phantom tables from prose exactly like this line.
+    db_module.write_text(
+        textwrap.dedent(
+            '''\
+            # Prose that mentions CREATE TABLE phantom_from_a_comment on purpose.
+            _SCHEMA = """
+            CREATE TABLE IF NOT EXISTS from_python_literal(id INTEGER PRIMARY KEY);
+            """
+            '''
+        ),
+        encoding="utf-8",
+    )
+
+    body = "".join(f'        "{name}",\n' for name in allowlisted)
+    (tmp_path / "tldw_chatbook" / "DB" / "sql_validation.py").write_text(
+        f'VALID_TABLES = {{\n    "chachanotes": {{\n{body}    }},\n}}\n',
+        encoding="utf-8",
+    )
+
+    module = _load_checker()
+    module.REPO_ROOT = tmp_path
+    module.MIGRATIONS_DIR = migrations
+    module.SQL_VALIDATION = tmp_path / "tldw_chatbook" / "DB" / "sql_validation.py"
+    module.SCHEMAS = (
+        module.SchemaSources(
+            key="chachanotes",
+            sql_globs=("chachanotes_*.sql",),
+            python_files=(db_module,),
+        ),
+    )
+    return module
+
+
+_FIXTURE_SQL = textwrap.dedent(
+    """\
+    CREATE TABLE IF NOT EXISTS from_sql_migration(id INTEGER PRIMARY KEY);
+    CREATE VIRTUAL TABLE from_sql_migration_fts USING fts5(body);
+    """
+)
+_FIXTURE_TABLES = ["from_python_literal", "from_sql_migration"]
+
+
+def test_passes_when_every_created_table_is_allowlisted(tmp_path, capsys):
+    module = _fake_tree(tmp_path, migration_sql=_FIXTURE_SQL, allowlisted=_FIXTURE_TABLES)
+    assert module.main([]) == 0
+    out = capsys.readouterr().out
+    assert "2 declared tables" in out
+    # The FTS5 virtual table is not an allowlist target and must not be
+    # counted; the filter has to match the runtime pin's exactly.
+    assert "from_sql_migration_fts" not in out
+
+
+def test_bites_when_a_migration_adds_an_unlisted_table(tmp_path, capsys):
+    """AC: adding a CREATE TABLE without touching the allowlist fails."""
+    sql = _FIXTURE_SQL + "CREATE TABLE brand_new_table(id INTEGER PRIMARY KEY);\n"
+    module = _fake_tree(tmp_path, migration_sql=sql, allowlisted=_FIXTURE_TABLES)
+    assert module.main([]) == 1
+    out = capsys.readouterr().out
+    assert "brand_new_table" in out
+    assert "chachanotes_v1_to_v2_fixture.sql" in out
+    # It must tell the author what to paste, not merely that they are wrong.
+    assert '        "brand_new_table",' in out
+
+
+def test_bites_when_the_allowlist_names_a_table_nothing_creates(tmp_path, capsys):
+    module = _fake_tree(
+        tmp_path,
+        migration_sql=_FIXTURE_SQL,
+        allowlisted=_FIXTURE_TABLES + ["retired_table"],
+    )
+    assert module.main([]) == 1
+    assert "retired_table" in capsys.readouterr().out
+
+
+def test_verdict_is_not_derived_from_the_allowlist_it_guards(tmp_path, capsys):
+    """The expectation comes from the SQL, so the allowlist cannot self-satisfy.
+
+    Same schema sources in both halves; only ``VALID_TABLES`` moves. A checker
+    that re-derived its expectation from ``VALID_TABLES`` would return the same
+    verdict for both, which is the TASK-19045 identity-function failure.
+    """
+    sql = _FIXTURE_SQL + "CREATE TABLE brand_new_table(id INTEGER PRIMARY KEY);\n"
+
+    incomplete = _fake_tree(tmp_path / "a", migration_sql=sql, allowlisted=_FIXTURE_TABLES)
+    assert incomplete.main([]) == 1
+    capsys.readouterr()
+
+    complete = _fake_tree(
+        tmp_path / "b",
+        migration_sql=sql,
+        allowlisted=_FIXTURE_TABLES + ["brand_new_table"],
+    )
+    assert complete.main([]) == 0
+
+
+def test_comment_prose_is_never_read_as_a_table_declaration(tmp_path, capsys):
+    """The .py side is scanned via ast, so ``# ... CREATE TABLE x`` is inert.
+
+    Without this, a raw-text scan of the real ChaChaNotes_DB.py /
+    Client_Media_DB_v2.py reports the phantom tables ``IF``, ``column`` and
+    ``as`` -- and a guard that reports phantoms gets muted.
+    """
+    module = _fake_tree(tmp_path, migration_sql=_FIXTURE_SQL, allowlisted=_FIXTURE_TABLES)
+    assert module.main([]) == 0
+    assert "phantom_from_a_comment" not in capsys.readouterr().out
+
+
+def test_empty_scan_fails_instead_of_passing_vacuously(tmp_path, capsys):
+    """Moving the schema sources must break the guard loudly, not silently."""
+    module = _fake_tree(tmp_path, migration_sql="-- nothing here\n", allowlisted=[])
+    module.SCHEMAS[0].python_files[0].write_text("# no SQL at all\n", encoding="utf-8")
+    assert module.main([]) == 1
+    assert "no CREATE TABLE statements found" in capsys.readouterr().out
+
+
+def test_shipped_static_scan_matches_the_live_chachanotes_schema():
+    """Both oracles, on the real tree, must name the same tables.
+
+    This is what licenses the fast static checker to stand in for the runtime
+    pin at authoring time. If a future migration creates a table somewhere the
+    scanner does not look, this fails here rather than silently narrowing the
+    guard.
+    """
+    from Tests.DB.test_sql_validation import _live_chachanotes_table_names
+
+    module = _load_checker()
+    (schema,) = module.SCHEMAS
+    declared = set(module.declared_tables(schema))
+    live = _live_chachanotes_table_names()
+    assert declared == live, (
+        "static CREATE TABLE scan and the live schema disagree: "
+        f"only-in-scan={sorted(declared - live)}, only-in-live={sorted(live - declared)}"
+    )
+
+
+def test_checker_is_stdlib_only_and_never_imports_the_package():
+    """The contract every preflight check keeps, asserted two ways.
+
+    Statically: no import reaches ``tldw_chatbook``. Importing it would load
+    config, touch the filesystem, emit log lines, and -- fatally for a
+    derived-artifact checker -- make the guard depend on the package being
+    installed. It also matters for independence: the allowlist is read by
+    parsing ``sql_validation.py``, never by importing it.
+
+    Dynamically: the script still exits 0 under ``-I -S``, which suppresses
+    site-packages entirely, so nothing outside the stdlib is in play.
+    """
+    import ast
+
+    tree = ast.parse(CHECKER.read_text(encoding="utf-8"), filename=str(CHECKER))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imported.add(node.module.split(".")[0])
+    assert "tldw_chatbook" not in imported, imported
+    assert imported <= set(sys.stdlib_module_names), imported - set(sys.stdlib_module_names)
+
+    completed = subprocess.run(
+        [sys.executable, "-I", "-S", str(CHECKER)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "all present in VALID_TABLES['chachanotes']" in completed.stdout

--- a/Tests/DB/test_schema_table_allowlist_guard.py
+++ b/Tests/DB/test_schema_table_allowlist_guard.py
@@ -21,6 +21,21 @@ The shipped-tree assertion at the end is the belt to that braces: the static
 scan must agree, name for name, with a real fully-migrated
 ``CharactersRAGDB(":memory:")``. Two independent oracles that agree are
 evidence; one oracle asserted against itself is not.
+
+PR #1983's Qodo round found three more traps in the checker itself, each
+pinned below: raw ``.sql`` text was scanned without stripping SQL comments,
+so a migration comment containing ``CREATE TABLE`` failed CI spuriously
+(``test_sql_line_comment_does_not_produce_a_phantom_table``,
+``test_sql_block_comment_does_not_produce_a_phantom_table``, plus a direct
+unit test of the stripper proving it does not mangle a string literal that
+happens to contain ``--`` or ``/*``); the same bare ``CREATE_TABLE_RE``
+backtracked into reading the word ``IF`` as a phantom table name for
+interpolated DDL (``test_if_not_exists_backtracking_does_not_produce_a_phantom_if_table``);
+and ``allowlisted_tables()`` recognised only ``ast.Assign``, so annotating
+``VALID_TABLES: dict[str, set[str]] = {...}`` -- a semantics-preserving
+refactor -- broke the guard (``test_allowlisted_tables_reads_annotated_assignment``,
+plus a companion pinning that a genuinely-missing assignment still fails
+loudly rather than passing vacuously).
 """
 
 from __future__ import annotations
@@ -30,6 +45,8 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKER = REPO_ROOT / "scripts" / "check_schema_table_allowlist.py"
@@ -164,6 +181,135 @@ def test_comment_prose_is_never_read_as_a_table_declaration(tmp_path, capsys):
     module = _fake_tree(tmp_path, migration_sql=_FIXTURE_SQL, allowlisted=_FIXTURE_TABLES)
     assert module.main([]) == 0
     assert "phantom_from_a_comment" not in capsys.readouterr().out
+
+
+def test_sql_line_comment_does_not_produce_a_phantom_table(tmp_path):
+    """AC: a ``-- CREATE TABLE ghost(...)`` comment is not a declaration.
+
+    Unlike the ``.py`` side (immune via ``ast``, see the test above), the
+    ``.sql`` side reads raw file text, so before Qodo's round-2 review this
+    regex-scanned comment prose exactly like a real ``CREATE TABLE`` and
+    failed CI/preflight spuriously.
+    """
+    sql = (
+        "-- CREATE TABLE ghost_table(id INTEGER PRIMARY KEY);\n"
+        "CREATE TABLE real_table(id INTEGER PRIMARY KEY);\n"
+    )
+    module = _fake_tree(
+        tmp_path, migration_sql=sql, allowlisted=["real_table", "from_python_literal"]
+    )
+    declared = module.declared_tables(module.SCHEMAS[0])
+    assert "ghost_table" not in declared
+    assert "real_table" in declared
+
+
+def test_sql_block_comment_does_not_produce_a_phantom_table(tmp_path):
+    """AC: a ``/* ... */`` comment -- including a multi-line one -- is inert too."""
+    sql = (
+        "/* legacy note:\n"
+        "CREATE TABLE ghost_table(id INTEGER PRIMARY KEY);\n"
+        "kept for history */\n"
+        "CREATE TABLE real_table(id INTEGER PRIMARY KEY);\n"
+    )
+    module = _fake_tree(
+        tmp_path, migration_sql=sql, allowlisted=["real_table", "from_python_literal"]
+    )
+    declared = module.declared_tables(module.SCHEMAS[0])
+    assert "ghost_table" not in declared
+    assert "real_table" in declared
+
+
+def test_strip_sql_comments_preserves_string_literals():
+    """The stripper must not treat ``--``/``/*`` inside a string as a comment opener.
+
+    A comment-stripper that mangles real SQL (e.g. eating a DEFAULT value
+    that happens to contain ``--``) would be worse than the phantom-table bug
+    it fixes.
+    """
+    module = _load_checker()
+    text = (
+        "CREATE TABLE t (\n"
+        "    note TEXT DEFAULT 'a -- not a comment',\n"
+        "    tag TEXT DEFAULT '/* also not a comment */'\n"
+        ");\n"
+        "-- real comment CREATE TABLE ghost(id INTEGER);\n"
+    )
+    stripped = module._strip_sql_comments(text)
+    assert "a -- not a comment" in stripped
+    assert "/* also not a comment */" in stripped
+    assert "ghost" not in stripped
+
+
+def test_strip_sql_comments_handles_escaped_quotes_in_strings():
+    """SQL escapes a quote by doubling it; that doubled quote must not end the string early."""
+    module = _load_checker()
+    text = "INSERT INTO t VALUES ('it''s -- not a comment');\n-- actual comment\n"
+    stripped = module._strip_sql_comments(text)
+    assert "it''s -- not a comment" in stripped
+    assert "actual comment" not in stripped
+
+
+def test_if_not_exists_backtracking_does_not_produce_a_phantom_if_table(tmp_path):
+    """Interpolated DDL must not surface a phantom table literally named ``IF``.
+
+    ``sql = "CREATE TABLE IF NOT EXISTS " + table_name + " (...)"`` is one of
+    the documented WHAT THIS CANNOT SEE shapes: the real table name is hidden
+    behind string concatenation, so the checker is allowed to simply miss it
+    (fail safe, like the rest of that list). Before Qodo's round-2 review, the
+    bare optional ``(?:IF\\s+NOT\\s+EXISTS\\s+)?`` group backtracked out of a
+    dead-end match and read the leftover word ``IF`` as the table name
+    instead -- an active false positive, not a miss.
+    """
+    module = _fake_tree(tmp_path, migration_sql=_FIXTURE_SQL, allowlisted=_FIXTURE_TABLES)
+    db_module = module.SCHEMAS[0].python_files[0]
+    db_module.write_text(
+        'sql = "CREATE TABLE IF NOT EXISTS " + table_name + " (id INTEGER PRIMARY KEY)"\n',
+        encoding="utf-8",
+    )
+    declared = module.declared_tables(module.SCHEMAS[0])
+    assert "IF" not in declared
+
+
+def test_allowlisted_tables_reads_annotated_assignment(tmp_path):
+    """A semantics-preserving refactor to an annotated assignment must not break the guard.
+
+    ``allowlisted_tables()`` used to filter on ``ast.Assign`` only; if
+    ``sql_validation.py`` were ever refactored to
+    ``VALID_TABLES: dict[str, set[str]] = {...}`` (``ast.AnnAssign``), the
+    checker could no longer find the literal at all.
+    """
+    module = _load_checker()
+    module.SQL_VALIDATION = tmp_path / "sql_validation.py"
+    module.SQL_VALIDATION.write_text(
+        'VALID_TABLES: dict[str, set[str]] = {\n    "chachanotes": {"a", "b"},\n}\n',
+        encoding="utf-8",
+    )
+    assert module.allowlisted_tables("chachanotes") == {"a", "b"}
+
+
+def test_allowlisted_tables_still_reads_the_plain_assignment(tmp_path):
+    """The original, un-annotated form (``ast.Assign``) keeps working."""
+    module = _load_checker()
+    module.SQL_VALIDATION = tmp_path / "sql_validation.py"
+    module.SQL_VALIDATION.write_text(
+        'VALID_TABLES = {\n    "chachanotes": {"a", "b"},\n}\n',
+        encoding="utf-8",
+    )
+    assert module.allowlisted_tables("chachanotes") == {"a", "b"}
+
+
+def test_allowlisted_tables_still_fails_loudly_when_the_assignment_is_gone(tmp_path):
+    """Accepting AnnAssign must not weaken the loud-failure case for a real 'it's gone'.
+
+    A silent empty set here would turn the guard off, so a file with no
+    ``VALID_TABLES`` assignment at all -- annotated or not -- must still
+    raise ``SystemExit``, exactly as it did before this fix.
+    """
+    module = _load_checker()
+    module.SQL_VALIDATION = tmp_path / "sql_validation.py"
+    module.SQL_VALIDATION.write_text("SOMETHING_ELSE = 1\n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        module.allowlisted_tables("chachanotes")
 
 
 def test_empty_scan_fails_instead_of_passing_vacuously(tmp_path, capsys):

--- a/Tests/DB/test_sql_validation.py
+++ b/Tests/DB/test_sql_validation.py
@@ -430,24 +430,55 @@ class TestChachanotesValidTablesMatchesLiveSchema:
     table without updating it -- exactly how ``keyword_collections`` was
     missed. This test is the guard: it fails the moment the two diverge,
     instead of waiting for a user to hit an unconditional ``ValueError``.
+
+    TASK-20971: this class is the *runtime* half of a two-part guard. It has
+    now caught the same drift twice in one day (TASK-19568's repair merged at
+    00:16, TASK-19057 re-broke it at 14:51) -- both times *after* the merge,
+    because a hours-long suite with no CI verdict since 2026-06-26 only
+    reports to whoever runs it. The authoring-time half is
+    ``scripts/check_schema_table_allowlist.py`` (in ``scripts/preflight.sh``
+    and the required ``derived-artifacts`` job): it reaches the same verdict
+    by statically scanning the migration SQL, in milliseconds, with no
+    database. The two are deliberately independent oracles -- this one asks a
+    live ``sqlite_master``, that one asks the ``CREATE TABLE`` text -- and at
+    the commit that added it they agreed exactly: 69 substantive tables,
+    symmetric difference empty. The failure messages below name the checker
+    so an author who reaches this test late still learns where the early
+    signal lives.
     """
+
+    #: Appended to both failure messages. A message that names the drift but
+    #: not the fix leaves the author to go find the literal; that is friction
+    #: on the exact path this guard exists to make frictionless.
+    _WHERE_TO_FIX = (
+        "\n\nThe allowlist is VALID_TABLES['chachanotes'] in "
+        "tldw_chatbook/DB/sql_validation.py.\n"
+        "To get this verdict BEFORE you commit (no database, ~milliseconds):\n"
+        "    python3 scripts/check_schema_table_allowlist.py\n"
+        "which also runs inside ./scripts/preflight.sh."
+    )
 
     def test_no_missing_tables(self):
         """Every real, substantive table in the live schema must be allowlisted."""
         live_tables = _live_chachanotes_table_names()
         missing = live_tables - VALID_TABLES["chachanotes"]
+        paste = "\n".join(f'        "{name}",' for name in sorted(missing))
         assert not missing, (
             f"Live schema has tables not in VALID_TABLES['chachanotes']: "
-            f"{sorted(missing)}. Add them (or document a deliberate "
-            f"exclusion) in tldw_chatbook/DB/sql_validation.py."
+            f"{sorted(missing)}.\n"
+            f"Paste these lines into the set (or document a deliberate "
+            f"exclusion):\n{paste}"
+            f"{self._WHERE_TO_FIX}"
         )
 
     def test_no_stale_tables(self):
         """Every allowlisted name must correspond to a real, live table."""
         live_tables = _live_chachanotes_table_names()
         stale = VALID_TABLES["chachanotes"] - live_tables
+        remove = "\n".join(f'        "{name}",' for name in sorted(stale))
         assert not stale, (
             f"VALID_TABLES['chachanotes'] allowlists tables that no longer "
-            f"exist in the live schema: {sorted(stale)}. Remove them from "
-            f"tldw_chatbook/DB/sql_validation.py."
+            f"exist in the live schema: {sorted(stale)}.\n"
+            f"Delete these lines from the set:\n{remove}"
+            f"{self._WHERE_TO_FIX}"
         )

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6808,3 +6808,60 @@ per-key work was ~7 widget refreshes — the static read had been right all alon
 
 Full disclosure section: `Docs/Design/2026-08-22-holistic-perf-review.md`
 ("Measurement-artifact disclosure").
+
+## Which hand-maintained literal an author updates is decided by DISCOVERY PATH, not by importance (TASK-20971, 2026-08-22)
+
+**What happened.** `VALID_TABLES['chachanotes']` in `DB/sql_validation.py` is a
+hand-maintained allowlist; `validate_table_name()` rejects anything not in it,
+so a forgotten table makes every generic CRUD helper raise for that table.
+TASK-864 filed it when 9 of ~47 tables were listed. TASK-19568 repaired it
+after it went stale again — merged `aaec11812`, 2026-08-22 **00:16** -0700.
+TASK-19057 added two Actor Pack tables in a v44→v45 migration and broke it
+again — merged `2fe6ca20f`, **14:51** the same day. **Fourteen and a half
+hours** between "repaired" and "red again."
+
+**The instructive part is what that same author *did* update.** They correctly
+added `idx_actor_pack_persona_intents_state` to
+`Tests/ChaChaNotesDB/test_index_census.py` — an equally hand-maintained
+literal, guarding the same migration, with the same "nothing connects the
+migration to the literal" weakness. And they correctly bumped three
+schema-version pins under `Tests/DB/`. Measured on that branch
+(`git diff b593f853d 09b768239`), both were reachable by something the author
+actually did:
+
+* the index census sits in `Tests/ChaChaNotesDB/`, the directory where they had
+  just written `test_actor_pack_migration.py` — running that directory turned
+  it red; and
+* the version pins contain the schema version number, which a grep for the
+  constant finds.
+
+`VALID_TABLES` is reachable by neither. It names no schema version, and nothing
+else in `Tests/DB/test_sql_validation.py` mentions the feature. **Its guard had
+been surviving by geography, and stopped the first time a migration landed from
+a directory that did not happen to sit next to it.** Nothing about the
+allowlist's importance, its comment block, or the correctness of its pin
+mattered — the pin was right and it did report; it reported after the merge.
+
+**What to do.** When you add a hand-maintained literal as a guard, ask what
+*discovery path* connects the change to the literal, and assume the author will
+have only two: (a) they run the directory their new test lives in, and (b) they
+grep for a token their change forces them to touch. If the literal is in
+neither, the guard depends on memory and will decay on a schedule set by how
+often work lands from elsewhere. Give it a path: put the check where the author
+already runs (here, `scripts/preflight.sh`, which is stdlib-only and ~0.1 s for
+this check), and make its failure message print the exact lines to paste rather
+than only the names of what drifted.
+
+**Do not "fix" it by generating the literal.** TASK-19045's rule stands: a
+census that re-derives its expectation from the artifact it guards is the
+identity function on the defect class it exists to catch. The way out is a
+*different* artifact. Here the schema's own `CREATE TABLE` text —
+`DB/migrations/chachanotes_*.sql` plus the SQL string literals in
+`ChaChaNotes_DB.py` — is independent of `VALID_TABLES` and was already
+authoritative. Two details made that scan trustworthy: parse the `.py` sources
+through `ast` and read only string constants (a raw-text scan reports three
+phantom tables — `IF`, `column`, `as` — from prose in `#` comments that says
+"CREATE TABLE", and a guard that reports phantoms gets muted), and prove the
+new oracle against the old one rather than asserting it alone: the static scan
+and a live fully-migrated `CharactersRAGDB(":memory:")` agree exactly, 69
+substantive tables, symmetric difference empty.

--- a/backlog/tasks/task-20971 - The chachanotes VALID_TABLES guard went red again within a day of being repaired.md
+++ b/backlog/tasks/task-20971 - The chachanotes VALID_TABLES guard went red again within a day of being repaired.md
@@ -168,9 +168,20 @@ the one-row-each extension point.
 `migrations/chachanotes_v45_to_v46_sync_log_retention.sql` at runtime, and that
 filename is absent from `MANIFEST.in`, `[tool.setuptools.package-data]`, and
 `Packaging/check_manifest.py` — all three of which list migrations by name with
-no wildcard (`include-package-data = false`). As shipped, an installed
-distribution cannot migrate past v45. This is TASK-19564 residue; flagged for
-filing.
+no wildcard (`include-package-data = false`). This is TASK-19564 residue;
+flagged for filing.
+
+*Reviewer correction to that finding:* there is a **fourth** hand-enumerated
+list, `Tests/Packaging/test_installed_distribution.py`, which also stops at
+v44→v45, so nothing tests for the omission either. And the consequence is worse
+than "cannot migrate past v45": of the 15 migration files read at runtime,
+`chachanotes_v40_to_v41_persona_visual.sql` is missing from all four lists too,
+so an installed distribution walls at **v40**. That first wall is TASK-19860's
+already-filed case; the v45→v46 file is the same defect, newly added *after*
+19860 was filed, which is itself the evidence that enumeration keeps trailing.
+19860's acceptance criteria are artifact-content based ("a wheel … contains
+every `.sql` file present under `tldw_chatbook/DB/migrations/`"), so its fix
+covers this file automatically — it does not need naming.
 
 **Files:** added `scripts/check_schema_table_allowlist.py`,
 `Tests/DB/test_schema_table_allowlist_guard.py`,
@@ -183,7 +194,48 @@ filing.
 skipped**. Repo-wide `--collect-only -q`: **56,532 collected**, 5 collection
 errors, all pre-existing dev reds not touched here (4 × `Tests/UI/
 test_settings_*` = TASK-20970, `Tests/UI/test_library_file_notes_workspace.py`
-= TASK-20972). `./scripts/preflight.sh` green on all five checks. Note the
-`preflight.sh` default `python3` may be below the repo's 3.11 floor (it is 3.9
-here, which breaks three of the other four checks); run it with
-`PYTHON=.venv/bin/python`.
+= TASK-20972). `./scripts/preflight.sh` green on all five checks.
+
+## Independent review (2026-08-22)
+
+Re-ran every claim. The mechanism holds: the checker never imports
+`tldw_chatbook` (verified by inspecting `sys.modules` after a `runpy` execution,
+not only by the AST assertion), runs in 0.14 s, and the identity-function
+property was proven on the **real** tree in both directions — holding the
+migration SQL fixed and moving only `VALID_TABLES` flips the verdict 0→1
+(phantom) and 1→0 (unlisted). The three phantom tables (`IF`, `column`, `as`)
+were reproduced exactly. The empty-scan guard bites, including the fully
+vacuous case (no sources *and* an empty allowlist). Gates re-run:
+`Tests/DB/` + `Tests/ChaChaNotesDB/` **1479 passed, 1 skipped**; guard suite 8
+passed; repo-wide collect **56,532 / 5 known errors**. Two fixes were added by
+the reviewer:
+
+1. **`Tests/CI/test_derived_artifacts_workflow.py` was left red by this
+   branch.** Its `CHECKERS` tuple enumerates the required job's steps, and
+   `test_checker_steps_survive_an_earlier_failure` asserts the step count
+   matches it — adding the fifth step made it `5 == 4`. Green at the merge-base
+   `80248f3e4`, red at `5f2e89c71`. Fixed by adding the new checker to the
+   tuple. This is the task's own thesis recurring inside the task: the author
+   ran `Tests/DB/` and `Tests/ChaChaNotesDB/` (their geography) while the guard
+   for the file they edited lives in `Tests/CI/`.
+2. **`scripts/preflight.sh` defaulted to `python3`**, which on macOS is the
+   system 3.9 — below the repo's `requires-python = ">=3.11"` floor — under
+   which three of the other four checks die on unrelated tracebacks
+   (`list[str] | None` at runtime, `enum.StrEnum`, `ast.parse` of `except*`).
+   Since this branch's entire remedy is "put the guard where the author already
+   runs", a seam that reports three false FAILEDs to anyone invoking it the
+   obvious way is the same defect class the task is about. `preflight.sh` now
+   selects an interpreter that meets the floor (repo `.venv` first, then
+   `python3.14`…`python3.11`, then `python3`), verifies an explicitly-set
+   `$PYTHON` and fails in one line rather than three tracebacks, and prints
+   which interpreter it used.
+
+Documented limitations added to the checker's docstring, each demonstrated
+against a fixture tree: it cannot see DDL whose table name is interpolated
+(`.format`/f-string/`+`, which additionally yields a phantom `IF`), a `.sql`
+file not matching a `SCHEMAS` glob, a table created from a `.py` module not in
+`SCHEMAS` or from DDL read at runtime, or `DROP TABLE` / `ALTER TABLE … RENAME
+TO`. None exists in the `chachanotes` sources today. The removal case is the
+sharp one: retiring a table would make this checker and the runtime pin demand
+opposite things, with no `VALID_TABLES` contents satisfying both — worth a
+follow-up before the first table is ever dropped.

--- a/backlog/tasks/task-20971 - The chachanotes VALID_TABLES guard went red again within a day of being repaired.md
+++ b/backlog/tasks/task-20971 - The chachanotes VALID_TABLES guard went red again within a day of being repaired.md
@@ -3,9 +3,11 @@ id: TASK-20971
 title: >-
   The chachanotes VALID_TABLES guard went red again within a day of being
   repaired
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-22'
+updated_date: '2026-08-22'
 labels:
   - bug
   - database
@@ -58,18 +60,18 @@ about the entry that *does* have a guard and went red anyway.
 
 ## Acceptance Criteria
 
-- [ ] `Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema`
+- [x] `Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema`
       is green on `dev`
-- [ ] `VALID_TABLES['chachanotes']` matches the tables a freshly initialized
+- [x] `VALID_TABLES['chachanotes']` matches the tables a freshly initialized
       ChaChaNotes database actually contains
-- [ ] A mechanism exists that makes the *next* table-adding migration fail
+- [x] A mechanism exists that makes the *next* table-adding migration fail
       loudly at authoring time rather than after merge — the outcome required is
       that the literal cannot silently fall behind the schema again, not that it
       is correct today
-- [ ] The chosen mechanism is proven to bite: adding a table without updating
+- [x] The chosen mechanism is proven to bite: adding a table without updating
       the allowlist is shown to fail, and the proof does not depend on the same
       hand-maintained list it guards
-- [ ] The recurrence is recorded where a future migration author will encounter
+- [x] The recurrence is recorded where a future migration author will encounter
       it, so the cost of this class of drift is not re-learned a third time
 
 ## Notes
@@ -81,3 +83,107 @@ whatever stops recurrence rather than for another correct-on-the-day list.
 This is residue of the TASK-19057 merge, not of the retention work that found
 it: `VALID_TABLES` is byte-identical to `dev`'s on TASK-19564's branch, and that
 branch's migration contains zero `CREATE TABLE` statements.
+
+## Implementation Plan
+
+1. Reproduce the red pin and re-derive the drift.
+2. Answer why the index census survived the same migration and this did not —
+   the asymmetry is the design input, not a curiosity.
+3. Build an authoring-time guard whose expectation comes from an artifact
+   *other* than `VALID_TABLES`, and wire it into `scripts/preflight.sh` and the
+   required `derived-artifacts` job.
+4. Repair the literal; make the runtime pin's failure message paste-ready.
+5. Mutation-prove the new guard on the real tree; Edit-restore.
+6. Record the recurrence where a migration author will meet it.
+7. Re-derive the `media`/`prompts` state rather than inheriting TASK-19867's.
+
+## Implementation Notes
+
+Two halves: the literal is repaired, and the reason it kept needing repairing
+is closed.
+
+**Why the index census survived and this did not.** Both are hand-maintained
+literals guarding the same migration; neither is generated. The difference is
+purely discovery path. Measured on the TASK-19057 branch
+(`git diff b593f853d 09b768239`), the author updated
+`Tests/ChaChaNotesDB/test_index_census.py` — the directory where they had just
+written `test_actor_pack_migration.py`, so a directory run turned it red — and
+bumped three schema-version pins under `Tests/DB/`, which a grep for the
+version constant finds. `VALID_TABLES` is reachable by neither: it carries no
+schema version, and nothing else in `Tests/DB/test_sql_validation.py` mentions
+the feature. Its guard had been surviving by geography. That rules out "update
+the literal" and also rules out "add another test".
+
+**Mechanism: `scripts/check_schema_table_allowlist.py`**, run by
+`scripts/preflight.sh` and as a step of the required `derived-artifacts` CI
+job. Stdlib-only, no database, no install, 0.10 s.
+
+*Independent source of truth: the schema-defining SQL text.* The expected set
+is every `CREATE TABLE <name>` in `DB/migrations/chachanotes_*.sql` plus the
+SQL string literals of `ChaChaNotes_DB.py`. `VALID_TABLES` is only ever read
+(by `ast.literal_eval`, not import) and never contributes to the expectation —
+TASK-19045's rule, which is also why auto-generating the literal was rejected.
+The `.py` side is scanned through `ast` string constants: a raw-text scan
+reports three phantom tables (`IF`, `column`, `as`) from prose inside `#`
+comments, and a guard that reports phantoms gets muted.
+
+*Proven to bite, three ways.* (1) Against the un-repaired tree the checker
+named `actor_pack_persona_intents` and `actor_portable_identities` and their
+migration file, from a static scan alone. (2) Adding
+`CREATE TABLE mutation_probe_task_20971` to
+`chachanotes_v45_to_v46_sync_log_retention.sql` with `VALID_TABLES` untouched
+turned preflight red on exactly one of its five checks, and turned the runtime
+pin red on the same name; Edit-restored, `git diff` on that file empty.
+(3) `Tests/DB/test_schema_table_allowlist_guard.py` pins the properties
+permanently — both drift directions, the vacuous-empty-scan case, the
+comment-prose case, the stdlib-only contract, and a direct independence test
+that holds the SQL fixed and moves only the allowlist (an identity check could
+not change verdict). It also asserts the static scan equals a live
+fully-migrated `CharactersRAGDB(":memory:")`: 69 substantive tables, symmetric
+difference empty.
+
+The runtime pin stays — two independent oracles — and its failure messages now
+print the exact lines to paste and name the fast checker.
+
+**Recurrence recorded** in `tldw_chatbook/DB/migrations/README.md` (new; the
+directory a migration author is already in, with the three-date timeline and
+the discovery-path explanation), in the `VALID_TABLES` comment block, in
+`backlog/docs/lessons-testing-evidence.md`, and as one clause on CLAUDE.md
+gotcha #1.
+
+**`media` / `prompts`, re-derived, not inherited** (live `MediaDatabase` /
+`PromptsDatabase`, FTS shadows + `sqlite_sequence` excluded): media has 5 live
+tables unlisted and 6 listed names that do not exist; prompts has 5 and 4.
+TASK-19867's write-up still holds except that `ChunkingTemplates` has since
+been allowlisted (6 → 5 on the media side). Both `_get_next_version` methods
+still have zero callers in `tldw_chatbook/` and `Tests/`, so the hygiene rating
+stands. Left to TASK-19867 deliberately: enabling them here would make
+preflight red for everyone on day one, and their sources
+(`Client_Media_DB_v2.py`'s `ChunkingTemplates_v7` rebuild-and-rename step)
+need a decision this task has no mandate for. The checker's `SCHEMAS` table is
+the one-row-each extension point.
+
+**Adjacent finding, not fixed here (different owner).**
+`_migrate_from_v45_to_v46` reads
+`migrations/chachanotes_v45_to_v46_sync_log_retention.sql` at runtime, and that
+filename is absent from `MANIFEST.in`, `[tool.setuptools.package-data]`, and
+`Packaging/check_manifest.py` — all three of which list migrations by name with
+no wildcard (`include-package-data = false`). As shipped, an installed
+distribution cannot migrate past v45. This is TASK-19564 residue; flagged for
+filing.
+
+**Files:** added `scripts/check_schema_table_allowlist.py`,
+`Tests/DB/test_schema_table_allowlist_guard.py`,
+`tldw_chatbook/DB/migrations/README.md`; modified
+`tldw_chatbook/DB/sql_validation.py`, `Tests/DB/test_sql_validation.py`,
+`scripts/preflight.sh`, `.github/workflows/derived-artifacts.yml`,
+`backlog/docs/lessons-testing-evidence.md`, `CLAUDE.md`.
+
+**Verification.** `Tests/DB/` + `Tests/ChaChaNotesDB/`: **1479 passed, 1
+skipped**. Repo-wide `--collect-only -q`: **56,532 collected**, 5 collection
+errors, all pre-existing dev reds not touched here (4 × `Tests/UI/
+test_settings_*` = TASK-20970, `Tests/UI/test_library_file_notes_workspace.py`
+= TASK-20972). `./scripts/preflight.sh` green on all five checks. Note the
+`preflight.sh` default `python3` may be below the repo's 3.11 floor (it is 3.9
+here, which breaks three of the other four checks); run it with
+`PYTHON=.venv/bin/python`.

--- a/scripts/check_schema_table_allowlist.py
+++ b/scripts/check_schema_table_allowlist.py
@@ -49,6 +49,39 @@ difference empty -- and the static scan reproduces the drift the runtime pin
 reported (``actor_pack_persona_intents``, ``actor_portable_identities``)
 without opening a database.
 
+WHAT THIS CANNOT SEE (measured, not assumed -- each case was run against a
+fixture tree using this exact script). None of these shapes exists in the
+``chachanotes`` sources today, which is why the static scan and a live
+``sqlite_master`` agree exactly; they are the ways that could stop being true,
+and they matter because an authoring-time guard is trusted whether or not it
+covers a creation style:
+
+* **DDL whose table name is not a literal.** ``"CREATE TABLE {} ...".format(n)``,
+  ``f"CREATE TABLE {n} ..."`` and ``"CREATE TABLE " + n`` all hide the name from
+  the regex -- and, worse, the optional ``IF NOT EXISTS`` group then captures
+  the phantom table ``IF``. Keep schema DDL a literal string.
+* **A ``.sql`` file whose name does not match a glob in ``SCHEMAS``.**
+  ``migrations/add_sync_fields_to_notes.sql`` is exactly that shape today (it
+  is unreferenced, and its two tables happen to be declared inline in
+  ``ChaChaNotes_DB.py`` as well, so nothing is currently missed).
+* **A table created from a ``.py`` module not listed in ``SCHEMAS``**, or from
+  DDL loaded from a file at runtime and ``executescript``-ed.
+* **``DROP TABLE`` and ``ALTER TABLE ... RENAME TO``.** The scan is
+  append-only: it reads every historical ``CREATE TABLE`` and has no notion of
+  a table being removed or renamed later. Retiring a table would put this
+  checker (which would demand the name stay allowlisted) in direct conflict
+  with the runtime pin (which would demand it be removed) -- one of the two
+  must be taught about the removal in the same commit, and until then there is
+  no combination of ``VALID_TABLES`` contents that satisfies both.
+
+The first three fail *safe* in the sense that the missed table simply is not
+reported -- the runtime pin still catches it, i.e. the guard degrades to the
+status quo rather than lying. The backstop for all of them is
+``Tests/DB/test_schema_table_allowlist_guard.py::
+test_shipped_static_scan_matches_the_live_chachanotes_schema``, which asserts
+this scan equals a live fully-migrated database name for name; if a future
+migration uses one of these shapes, that test is what says so.
+
 Scope: ``chachanotes`` only, deliberately. The ``media`` and ``prompts``
 entries of the same allowlist have drifted in both directions and are owned by
 TASK-19867; wiring them in here before that task lands would make preflight

--- a/scripts/check_schema_table_allowlist.py
+++ b/scripts/check_schema_table_allowlist.py
@@ -58,8 +58,13 @@ covers a creation style:
 
 * **DDL whose table name is not a literal.** ``"CREATE TABLE {} ...".format(n)``,
   ``f"CREATE TABLE {n} ..."`` and ``"CREATE TABLE " + n`` all hide the name from
-  the regex -- and, worse, the optional ``IF NOT EXISTS`` group then captures
-  the phantom table ``IF``. Keep schema DDL a literal string.
+  the regex. A dead-end fragment like the literal half of the last example
+  (``"CREATE TABLE IF NOT EXISTS "``, with the name arriving later via ``+``)
+  used to make the regex backtrack out of its optional ``IF NOT EXISTS``
+  group and report a phantom table named ``IF``; ``CREATE_TABLE_RE`` now
+  matches that clause as an all-or-nothing unit (TASK-20971 Qodo round), so
+  this shape simply is not reported, like the rest of this bullet. Keep
+  schema DDL a literal string.
 * **A ``.sql`` file whose name does not match a glob in ``SCHEMAS``.**
   ``migrations/add_sync_fields_to_notes.sql`` is exactly that shape today (it
   is unreferenced, and its two tables happen to be declared inline in
@@ -111,9 +116,21 @@ MIGRATIONS_DIR = REPO_ROOT / "tldw_chatbook" / "DB" / "migrations"
 #: ``CREATE [VIRTUAL|TEMP|TEMPORARY] TABLE [IF NOT EXISTS] [schema.]name``.
 #: The modifier is captured rather than skipped so virtual/temp declarations can
 #: be classified instead of silently swallowed by an over-broad pattern.
+#:
+#: The ``IF NOT EXISTS`` clause is matched as an all-or-nothing unit --
+#: ``(?:IF\s+NOT\s+EXISTS\s+|(?!IF\s+NOT\s+EXISTS\b))`` -- rather than a bare
+#: ``(?:...)?``. A plain optional group backtracks: when the clause is present
+#: but the text ends right after it (the interpolated-DDL shape in the module
+#: docstring's WHAT THIS CANNOT SEE section, e.g. the literal half of
+#: ``"CREATE TABLE IF NOT EXISTS " + table_name``), the engine falls back to
+#: matching zero-width and then reads the leftover word ``IF`` as the table
+#: name. The alternation's second branch is a negative lookahead for the same
+#: clause, so it only succeeds when the clause genuinely is not there --
+#: closing the backtrack path without needing atomic groups (unavailable in
+#: Python's ``re`` before 3.11; this script also runs under 3.9).
 CREATE_TABLE_RE = re.compile(
     r"\bCREATE\s+(?:(?P<modifier>VIRTUAL|TEMP|TEMPORARY)\s+)?TABLE\s+"
-    r"(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"(?:IF\s+NOT\s+EXISTS\s+|(?!IF\s+NOT\s+EXISTS\b))"
     r"(?:[A-Za-z_][A-Za-z_0-9]*\s*\.\s*)?"
     r"[\"'`\[]?(?P<name>[A-Za-z_][A-Za-z_0-9]*)",
     re.IGNORECASE,
@@ -180,6 +197,71 @@ def _sql_fragments(path: Path) -> Iterable[tuple[str, str]]:
             yield node.value, f"{label}:{node.lineno}"
 
 
+def _strip_sql_comments(text: str) -> str:
+    """Remove ``--`` line comments and ``/* ... */`` block comments from SQL.
+
+    Without this, a migration comment like ``-- CREATE TABLE ghost(...)`` or
+    a historical note inside a ``/* ... */`` block reads as a real
+    declaration to ``CREATE_TABLE_RE`` and fails preflight/CI spuriously --
+    the same phantom-table failure mode the ``.py`` side already avoids by
+    scanning through ``ast`` instead of raw text (see ``_sql_fragments``).
+
+    A comment opener inside a string literal is not a comment: SQL escapes a
+    quote by doubling it (``'it''s'``), so this walks the text tracking
+    whether it is inside a ``'``/``"``/`` ` `` -delimited literal and only
+    treats ``--``/``/*`` as comment openers outside of one -- a stripper that
+    mangles a real string literal (e.g. a ``DEFAULT`` value containing
+    ``--``) would be worse than the bug it fixes.
+
+    Args:
+        text: Raw SQL text -- a whole ``.sql`` file, or one SQL string
+            literal pulled out of a ``.py`` source by ``_sql_fragments``.
+
+    Returns:
+        ``text`` with every comment removed and every string literal intact.
+        A line comment is replaced by a bare newline (so a line's contents
+        after ``--`` are gone but the newline, and therefore any ``lineno``
+        computed from later text, is unaffected); a block comment -- even one
+        spanning multiple lines -- is removed entirely.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in ("'", '"', "`"):
+            out.append(ch)
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == ch:
+                    if i + 1 < n and text[i + 1] == ch:
+                        # Doubled quote: an escaped quote character, still
+                        # inside the string literal.
+                        out.append(text[i + 1])
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            continue
+        if text[i : i + 2] == "--":
+            j = text.find("\n", i)
+            if j == -1:
+                i = n
+            else:
+                out.append("\n")
+                i = j + 1
+            continue
+        if text[i : i + 2] == "/*":
+            j = text.find("*/", i + 2)
+            i = n if j == -1 else j + 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _is_substantive(name: str) -> bool:
     """Whether a declared table is one ``VALID_TABLES`` is meant to allowlist.
 
@@ -214,7 +296,7 @@ def declared_tables(schema: SchemaSources) -> dict[str, list[str]]:
     found: dict[str, set[str]] = {}
     for path in files:
         for text, origin in _sql_fragments(path):
-            for match in CREATE_TABLE_RE.finditer(text):
+            for match in CREATE_TABLE_RE.finditer(_strip_sql_comments(text)):
                 if match.group("modifier"):
                     # VIRTUAL (the FTS tables) and TEMP tables are not
                     # allowlist targets; _is_substantive drops the FTS names
@@ -250,15 +332,28 @@ def allowlisted_tables(key: str) -> set[str]:
     """
     tree = ast.parse(SQL_VALIDATION.read_text(encoding="utf-8"), filename=str(SQL_VALIDATION))
     for node in tree.body:
-        if not isinstance(node, ast.Assign):
+        # ``VALID_TABLES = {...}`` (ast.Assign, possibly multiple/chained
+        # targets) and ``VALID_TABLES: dict[str, set[str]] = {...}``
+        # (ast.AnnAssign, exactly one target) are both semantics-preserving
+        # ways to write this literal; a refactor from the first to the second
+        # must not make this guard unable to find it.
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if value is None:  # bare "VALID_TABLES: dict[...]" with no RHS yet
             continue
         if not any(
             isinstance(target, ast.Name) and target.id == "VALID_TABLES"
-            for target in node.targets
+            for target in targets
         ):
             continue
         try:
-            table_map = ast.literal_eval(node.value)
+            table_map = ast.literal_eval(value)
         except (ValueError, SyntaxError) as exc:  # pragma: no cover - defensive
             raise SystemExit(
                 f"::error::VALID_TABLES in {SQL_VALIDATION} is no longer a "
@@ -324,6 +419,20 @@ def _report(schema: SchemaSources, declared: dict[str, list[str]], allowed: set[
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the allowlist check for every schema in ``SCHEMAS`` (or a subset).
+
+    Args:
+        argv: Command-line arguments, excluding the program name (e.g.
+            ``["--schema", "chachanotes"]``). ``None`` (the default) makes
+            ``argparse`` read from ``sys.argv`` itself.
+
+    Returns:
+        ``0`` if every selected schema's declared tables match its
+        ``VALID_TABLES`` entry exactly (see ``_report``); ``1`` if any
+        schema has an unlisted table, a phantom allowlist entry, or an empty
+        scan (a moved/renamed schema source, which would otherwise pass this
+        guard vacuously).
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--schema",

--- a/scripts/check_schema_table_allowlist.py
+++ b/scripts/check_schema_table_allowlist.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Guard: every table a ChaChaNotes migration CREATEs must be allowlisted.
+
+TASK-20971. ``DB/sql_validation.py``'s ``VALID_TABLES['chachanotes']`` is a
+hand-maintained allowlist; a table name that is missing from it is rejected by
+``validate_table_name`` and every generic CRUD helper that routes through it
+raises unconditionally. TASK-864 found nine of ~47 tables listed. TASK-19568
+repaired the entry after it went stale again. TASK-19057 broke it **fourteen
+and a half hours later** by adding two tables in a v44->v45 migration.
+
+Why a second guard, when ``Tests/DB/test_sql_validation.py::
+TestChachanotesValidTablesMatchesLiveSchema`` already pins this: that test is
+correct and it did go red -- it just went red *after* the merge. The full suite
+takes hours and has produced no CI verdict since 2026-06-26 (see
+``.github/workflows/derived-artifacts.yml``), so in practice a migration author
+sees only the tests they run, and which tests those are is decided by
+geography. Measured on the TASK-19057 branch: the author updated
+``Tests/ChaChaNotesDB/test_index_census.py`` -- an equally hand-maintained
+literal -- because it lives beside the migration test they wrote and a
+directory run turned it red; and they updated three schema-version pins under
+``Tests/DB/`` that a grep for the version constant finds. ``VALID_TABLES`` is
+reachable by neither route: it names no schema version, and nothing else in
+``Tests/DB/test_sql_validation.py`` mentions the feature. Nothing connected
+"I added a table" to "update the allowlist" except a human remembering.
+
+This checker makes that connection mechanical, at authoring time, in
+``scripts/preflight.sh`` (~ms, stdlib-only, no dependency install, no database
+built).
+
+**The expectation is NOT derived from the thing it guards.** TASK-19045
+established the rule for the index census: a census that re-derives its
+expectation from the artifact it checks is the identity function on exactly
+the defect class it exists to catch, which is why ``VALID_TABLES`` is
+deliberately not generated from the schema. The independent source of truth
+used here is the **schema-defining SQL text itself**:
+
+* ``tldw_chatbook/DB/migrations/chachanotes_*.sql`` -- read as raw text, and
+* the SQL string literals inside ``tldw_chatbook/DB/ChaChaNotes_DB.py``
+  (``_FULL_SCHEMA_SQL_V4`` and the inline ``_migrate_from_vX_to_vY`` scripts),
+  extracted through ``ast`` so that prose in a ``#`` comment saying "the base
+  CREATE TABLE as well" can never be mistaken for a table declaration.
+
+Every ``CREATE TABLE <name>`` found there is a name the schema declares.
+``VALID_TABLES`` is only ever *read* here, never used to decide what the
+expected set is. Measured at the commit that fixed TASK-20971, against a real
+fully-migrated ``CharactersRAGDB(":memory:")``: the static scan and the live
+``sqlite_master`` set are **identical** -- 69 substantive tables, symmetric
+difference empty -- and the static scan reproduces the drift the runtime pin
+reported (``actor_pack_persona_intents``, ``actor_portable_identities``)
+without opening a database.
+
+Scope: ``chachanotes`` only, deliberately. The ``media`` and ``prompts``
+entries of the same allowlist have drifted in both directions and are owned by
+TASK-19867; wiring them in here before that task lands would make preflight
+red for everyone on day one. Extending this checker is a matter of adding rows
+to ``SCHEMAS`` below once those literals describe reality -- but the source
+files for those two schemas are ``Client_Media_DB_v2.py`` /``Prompts_DB.py``,
+whose rebuild-and-rename steps (``ChunkingTemplates_v7``) need an explicit
+decision first, so do it under TASK-19867, not as a drive-by.
+
+Usage:  ./scripts/check_schema_table_allowlist.py
+Exit 0 when the allowlist matches the declared schema, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SQL_VALIDATION = REPO_ROOT / "tldw_chatbook" / "DB" / "sql_validation.py"
+MIGRATIONS_DIR = REPO_ROOT / "tldw_chatbook" / "DB" / "migrations"
+
+#: ``CREATE [VIRTUAL|TEMP|TEMPORARY] TABLE [IF NOT EXISTS] [schema.]name``.
+#: The modifier is captured rather than skipped so virtual/temp declarations can
+#: be classified instead of silently swallowed by an over-broad pattern.
+CREATE_TABLE_RE = re.compile(
+    r"\bCREATE\s+(?:(?P<modifier>VIRTUAL|TEMP|TEMPORARY)\s+)?TABLE\s+"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"(?:[A-Za-z_][A-Za-z_0-9]*\s*\.\s*)?"
+    r"[\"'`\[]?(?P<name>[A-Za-z_][A-Za-z_0-9]*)",
+    re.IGNORECASE,
+)
+
+
+class SchemaSources(NamedTuple):
+    """Where one database's schema is declared, and how to read it."""
+
+    #: Key into ``VALID_TABLES``.
+    key: str
+    #: ``.sql`` files read as raw text.
+    sql_globs: tuple[str, ...]
+    #: ``.py`` files whose *string literals* are read (comments excluded).
+    python_files: tuple[Path, ...]
+
+
+SCHEMAS: tuple[SchemaSources, ...] = (
+    SchemaSources(
+        key="chachanotes",
+        sql_globs=("chachanotes_*.sql",),
+        python_files=(REPO_ROOT / "tldw_chatbook" / "DB" / "ChaChaNotes_DB.py",),
+    ),
+    # TASK-19867 owns adding "media" and "prompts" here; see the module
+    # docstring for why they are not enabled yet.
+)
+
+
+class Declaration(NamedTuple):
+    """One ``CREATE TABLE`` occurrence, with where it was found."""
+
+    name: str
+    origin: str
+
+
+def _sql_fragments(path: Path) -> Iterable[tuple[str, str]]:
+    """Yield ``(sql_text, origin_label)`` pairs for one schema source file.
+
+    ``.sql`` files are schema top-to-bottom, so the whole file is one fragment.
+    ``.py`` files are read through ``ast``: only string constants are returned,
+    which is what makes the scan immune to prose. ``ChaChaNotes_DB.py`` and
+    ``Client_Media_DB_v2.py`` both contain ``#`` comments that say
+    "CREATE TABLE" in a sentence; a raw-text scan of those two files reports
+    three phantom tables (``IF``, ``column``, ``as``). An AST scan reports zero.
+
+    Args:
+        path: A ``.sql`` or ``.py`` schema source file.
+
+    Yields:
+        ``(text, origin)`` where ``origin`` is a human-readable ``path:line``.
+
+    Raises:
+        OSError: If the file cannot be read.
+        SyntaxError: If a ``.py`` source cannot be parsed.
+    """
+    text = path.read_text(encoding="utf-8")
+    label = path.relative_to(REPO_ROOT).as_posix()
+    if path.suffix != ".py":
+        yield text, label
+        return
+    tree = ast.parse(text, filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.value, f"{label}:{node.lineno}"
+
+
+def _is_substantive(name: str) -> bool:
+    """Whether a declared table is one ``VALID_TABLES`` is meant to allowlist.
+
+    Mirrors the filter in ``Tests/DB/test_sql_validation.py``
+    (``_live_chachanotes_table_names``) exactly, so the two guards cannot
+    disagree about what counts:
+
+    * ``sqlite_sequence`` -- SQLite's own AUTOINCREMENT bookkeeping.
+    * anything containing ``_fts`` -- the FTS5 virtual tables and their
+      ``_data``/``_idx``/``_docsize``/``_config`` shadows, written to only by
+      triggers, never through a helper that calls ``validate_table_name``.
+    """
+    return name != "sqlite_sequence" and "_fts" not in name
+
+
+def declared_tables(schema: SchemaSources) -> dict[str, list[str]]:
+    """Every substantive table name the schema sources declare.
+
+    Args:
+        schema: The source registration to scan.
+
+    Returns:
+        Mapping of table name -> the origins that declare it, sorted.
+    """
+    files = [
+        path
+        for pattern in schema.sql_globs
+        for path in sorted(MIGRATIONS_DIR.glob(pattern))
+    ]
+    files.extend(schema.python_files)
+
+    found: dict[str, set[str]] = {}
+    for path in files:
+        for text, origin in _sql_fragments(path):
+            for match in CREATE_TABLE_RE.finditer(text):
+                if match.group("modifier"):
+                    # VIRTUAL (the FTS tables) and TEMP tables are not
+                    # allowlist targets; _is_substantive drops the FTS names
+                    # anyway, and a TEMP table has no persistent identity.
+                    continue
+                name = match.group("name")
+                if _is_substantive(name):
+                    found.setdefault(name, set()).add(origin)
+    return {name: sorted(origins) for name, origins in found.items()}
+
+
+def allowlisted_tables(key: str) -> set[str]:
+    """Read one ``VALID_TABLES`` entry without importing the package.
+
+    ``sql_validation.py`` is parsed, not imported. Importing it pulls in
+    ``tldw_chatbook``, which loads config, touches the filesystem, and emits
+    log lines -- none of which a derived-artifact checker should do, and all of
+    which would break the stdlib-only, no-install contract the other four
+    preflight checks keep.
+
+    This is a *read* of the artifact under test. It is not the source of the
+    expectation: the expected set comes from ``declared_tables``.
+
+    Args:
+        key: A ``VALID_TABLES`` key, e.g. ``"chachanotes"``.
+
+    Returns:
+        The allowlisted table names.
+
+    Raises:
+        SystemExit: If the literal cannot be located or evaluated -- a silent
+            empty set here would turn the guard off.
+    """
+    tree = ast.parse(SQL_VALIDATION.read_text(encoding="utf-8"), filename=str(SQL_VALIDATION))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "VALID_TABLES"
+            for target in node.targets
+        ):
+            continue
+        try:
+            table_map = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError) as exc:  # pragma: no cover - defensive
+            raise SystemExit(
+                f"::error::VALID_TABLES in {SQL_VALIDATION} is no longer a "
+                f"plain literal and cannot be read statically ({exc}). This "
+                f"guard reads it with ast.literal_eval on purpose (no import, "
+                f"no database); either keep it a literal or update this script."
+            ) from exc
+        if key not in table_map:
+            raise SystemExit(
+                f"::error::VALID_TABLES has no {key!r} entry in {SQL_VALIDATION}."
+            )
+        return set(table_map[key])
+    raise SystemExit(f"::error::no module-level VALID_TABLES assignment in {SQL_VALIDATION}.")
+
+
+def _report(schema: SchemaSources, declared: dict[str, list[str]], allowed: set[str]) -> bool:
+    """Print the verdict for one schema. Returns True when it passes."""
+    unlisted = sorted(set(declared) - allowed)
+    phantom = sorted(allowed - set(declared))
+
+    if not unlisted and not phantom:
+        print(
+            f"{schema.key}: {len(declared)} declared tables, all present in "
+            f"VALID_TABLES['{schema.key}']."
+        )
+        return True
+
+    if unlisted:
+        print(
+            f"::error::{len(unlisted)} table(s) created by the {schema.key} "
+            f"schema are missing from VALID_TABLES['{schema.key}'] in "
+            f"tldw_chatbook/DB/sql_validation.py:"
+        )
+        for name in unlisted:
+            print(f"  - {name}   (declared in {', '.join(declared[name])})")
+        print()
+        print(
+            "Paste these lines into the VALID_TABLES["
+            f'"{schema.key}"] set (it is sorted; keep it sorted):'
+        )
+        for name in unlisted:
+            print(f'        "{name}",')
+        print()
+        print(
+            "A table that is not allowlisted is rejected by "
+            "validate_table_name(), so every generic CRUD helper that routes "
+            "through it raises unconditionally for that table."
+        )
+
+    if phantom:
+        print(
+            f"::error::{len(phantom)} name(s) in VALID_TABLES['{schema.key}'] "
+            "are not created by any migration or schema script:"
+        )
+        for name in phantom:
+            print(f"  - {name}")
+        print(
+            "Remove them, or -- if the table is created somewhere this checker "
+            "does not scan -- add that file to SCHEMAS in this script so the "
+            "guard keeps covering it."
+        )
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--schema",
+        action="append",
+        dest="schemas",
+        choices=[schema.key for schema in SCHEMAS],
+        help="limit the check to one VALID_TABLES key; repeatable",
+    )
+    args = parser.parse_args(argv)
+
+    selected = [
+        schema
+        for schema in SCHEMAS
+        if args.schemas is None or schema.key in args.schemas
+    ]
+    if not selected:  # pragma: no cover - argparse choices make this unreachable
+        print("::error::no schema selected", file=sys.stderr)
+        return 1
+
+    ok = True
+    for schema in selected:
+        declared = declared_tables(schema)
+        if not declared:
+            print(
+                f"::error::no CREATE TABLE statements found for {schema.key}. "
+                "The schema sources moved; update SCHEMAS in "
+                "scripts/check_schema_table_allowlist.py. (An empty scan would "
+                "otherwise pass this guard vacuously.)"
+            )
+            ok = False
+            continue
+        ok = _report(schema, declared, allowlisted_tables(schema.key)) and ok
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -20,7 +20,7 @@
 # ../../scripts/preflight.sh .git/hooks/pre-commit`), but the gate that counts
 # is the CI job.
 #
-# Usage:  ./scripts/preflight.sh          # uses `python3` (stdlib only)
+# Usage:  ./scripts/preflight.sh          # picks an interpreter at the repo floor
 #         PYTHON=.venv/bin/python ./scripts/preflight.sh
 #
 # Exits 0 when every check passes, 1 otherwise. Every check runs even after one
@@ -31,7 +31,57 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
 
-PYTHON="${PYTHON:-python3}"
+# "stdlib-only" means the PROJECT's stdlib floor (pyproject: requires-python
+# >=3.11), not whatever `python3` happens to be. On macOS `python3` is the
+# system 3.9, and under it three of the five checks below die on unrelated
+# tracebacks: `list[str] | None` evaluated at runtime (check_bundle_sync.py),
+# `from enum import StrEnum` (check_profile_owned_path_inventory.py), and
+# `ast.parse` of a source using `except*` (check_persistent_diagnostic_
+# inventory.py). Defaulting to a below-floor interpreter therefore made the
+# obvious invocation report three FAILED checks that have nothing to do with
+# the author's change -- and a guard that cries wolf is a guard that gets
+# muted, which is the exact failure this file exists to prevent. So pick an
+# interpreter that meets the floor, and say so plainly when none is reachable.
+PYTHON_FLOOR_MAJOR=3
+PYTHON_FLOOR_MINOR=11
+
+meets_python_floor() {
+  command -v "$1" >/dev/null 2>&1 || [ -x "$1" ] || return 1
+  "$1" -c "import sys; raise SystemExit(0 if sys.version_info[:2] >= (${PYTHON_FLOOR_MAJOR}, ${PYTHON_FLOOR_MINOR}) else 1)" \
+    >/dev/null 2>&1
+}
+
+if [ -n "${PYTHON:-}" ]; then
+  # An explicit choice is honoured, but verified: failing here with one line
+  # beats failing later with three tracebacks.
+  if ! meets_python_floor "$PYTHON"; then
+    echo "preflight: PYTHON=$PYTHON is missing or below this repo's Python" \
+      "${PYTHON_FLOOR_MAJOR}.${PYTHON_FLOOR_MINOR} floor; three of the five checks cannot run under it." >&2
+    exit 1
+  fi
+else
+  # Order matters: the repo's own venv, then whatever the developer has
+  # activated, and only then a versioned interpreter off PATH. Preferring the
+  # newest available would silently run the checks under an interpreter the
+  # project does not otherwise use.
+  for candidate in \
+    "$REPO_ROOT/.venv/bin/python" \
+    python3 python3.14 python3.13 python3.12 python3.11 python
+  do
+    if meets_python_floor "$candidate"; then
+      PYTHON="$candidate"
+      break
+    fi
+  done
+  if [ -z "${PYTHON:-}" ]; then
+    echo "preflight: no Python >= ${PYTHON_FLOOR_MAJOR}.${PYTHON_FLOOR_MINOR} found" \
+      "(tried $REPO_ROOT/.venv/bin/python, python3.14 .. python3.11, python3, python)." >&2
+    echo "preflight: re-run as  PYTHON=/path/to/python3.11-or-newer ./scripts/preflight.sh" >&2
+    exit 1
+  fi
+fi
+
+echo "preflight: using $PYTHON ($("$PYTHON" -c 'import sys; print(sys.version.split()[0])'))"
 
 failed=()
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # Run every derived-artifact guard the CI job runs, locally, in one command.
 #
-# TASK-19572. These four checks are the only ones that have reliably caught
-# real drift, and until now the burn-down workflow was "remember four separate
+# TASK-19572. These checks are the only ones that have reliably caught real
+# drift, and until now the burn-down workflow was "remember several separate
 # commands" -- which is why the same diagnostic-inventory drift was
 # rediscovered by hand in four separate tasks. This is the same list, in the
 # same order, as .github/workflows/derived-artifacts.yml.
+#
+# TASK-20971 added the fifth: VALID_TABLES['chachanotes'] went stale, was
+# repaired, and went stale again fourteen and a half hours later when the next
+# migration added two tables. Its runtime pin (Tests/DB/test_sql_validation.py)
+# was correct both times and reported both times -- after the merge. This is
+# the same class of problem TASK-19572 built this file for: a guard that only
+# lives in a suite nobody runs locally is not an authoring-time guard.
 #
 # Deliberately NOT a git hook: at ~33 s a pre-commit hook is punitive at this
 # repo's commit rate, is bypassable with `git commit -n`, and does not survive
@@ -48,6 +55,8 @@ run_check "production diagnostic inventory" \
   "$PYTHON" scripts/check_persistent_diagnostic_inventory.py
 run_check "backlog task ids" \
   "$PYTHON" scripts/check_backlog_task_ids.py
+run_check "chachanotes table allowlist" \
+  "$PYTHON" scripts/check_schema_table_allowlist.py
 
 echo
 if [ ${#failed[@]} -eq 0 ]; then

--- a/tldw_chatbook/DB/migrations/README.md
+++ b/tldw_chatbook/DB/migrations/README.md
@@ -10,11 +10,22 @@ methods in the matching `DB/*.py` module. Filenames are
 2. Add `<db>_v<n>_to_v<n+1>_<what>.sql` here **and** the
    `_migrate_from_v<n>_to_v<n+1>` step that runs it.
 3. If the step reads the `.sql` at runtime (`migration_path.read_text(...)`),
-   list the file **by name in all three** of `MANIFEST.in`,
-   `[tool.setuptools.package-data]` in `pyproject.toml`, and
-   `Packaging/check_manifest.py`. There is no wildcard; `include-package-data`
-   is `false`. A migration missing from the built distribution raises `OSError`
-   at upgrade time and pins installed users below that version.
+   list the file **by name in all four** of `MANIFEST.in`,
+   `[tool.setuptools.package-data]` in `pyproject.toml`,
+   `Packaging/check_manifest.py`, and `Tests/Packaging/
+   test_installed_distribution.py`. There is no wildcard;
+   `include-package-data` is `false`. A migration missing from the built
+   distribution raises `OSError` at upgrade time and pins installed users below
+   that version.
+
+   This step is a known trap rather than a good design — hand enumeration
+   trails reality, and it already has: measured 2026-08-22, of the 15 migration
+   files read at runtime, `chachanotes_v40_to_v41_persona_visual.sql` and
+   `chachanotes_v45_to_v46_sync_log_retention.sql` are in none of the four
+   lists, so an installed distribution walls at v40. **TASK-19860 owns
+   replacing all four enumerations with a glob plus a test that asserts against
+   the built artifact.** When it lands, this step becomes "nothing to do";
+   delete it then rather than adding a sixth list.
 4. **If the migration contains `CREATE TABLE`, add every new table name to
    `VALID_TABLES['chachanotes']` in `DB/sql_validation.py`, in the same
    commit.** See below — this is the step that keeps getting missed.

--- a/tldw_chatbook/DB/migrations/README.md
+++ b/tldw_chatbook/DB/migrations/README.md
@@ -1,0 +1,79 @@
+# DB migrations
+
+`.sql` steps for the SQLite schemas, applied by the `_migrate_from_vX_to_vY`
+methods in the matching `DB/*.py` module. Filenames are
+`<db>_v<from>_to_v<to>_<what>.sql`.
+
+## Adding a migration
+
+1. Bump `_CURRENT_SCHEMA_VERSION` in the owning DB module.
+2. Add `<db>_v<n>_to_v<n+1>_<what>.sql` here **and** the
+   `_migrate_from_v<n>_to_v<n+1>` step that runs it.
+3. If the step reads the `.sql` at runtime (`migration_path.read_text(...)`),
+   list the file **by name in all three** of `MANIFEST.in`,
+   `[tool.setuptools.package-data]` in `pyproject.toml`, and
+   `Packaging/check_manifest.py`. There is no wildcard; `include-package-data`
+   is `false`. A migration missing from the built distribution raises `OSError`
+   at upgrade time and pins installed users below that version.
+4. **If the migration contains `CREATE TABLE`, add every new table name to
+   `VALID_TABLES['chachanotes']` in `DB/sql_validation.py`, in the same
+   commit.** See below — this is the step that keeps getting missed.
+5. **If it contains `CREATE INDEX`, add the index to
+   `EXPECTED_CHACHANOTES_INDEXES` in `Tests/ChaChaNotesDB/test_index_census.py`.**
+6. Run `./scripts/preflight.sh`. It checks 4 and reports exactly what to paste.
+
+## The table-allowlist trap (TASK-20971)
+
+`VALID_TABLES` is a hand-maintained allowlist keyed by database. It is not
+decoration: `validate_table_name()` rejects any name that is not in it, so
+every generic CRUD helper routed through it raises unconditionally for a table
+you forgot to list. TASK-864 was filed because `keyword_collections` was one of
+38 tables missing from it, which made `update_keyword_collection()` raise for
+everyone.
+
+It has now gone stale three times, and the third time is the reason this
+section exists:
+
+| When | What |
+| --- | --- |
+| TASK-864 | 9 of ~47 tables listed. Added `Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema` as a pin. |
+| TASK-19568, merged `aaec11812` 2026-08-22 00:16 -0700 | Pin had gone red; entry repaired. |
+| TASK-19057, merged `2fe6ca20f` 2026-08-22 14:51 -0700 | v44→v45 added `actor_portable_identities` and `actor_pack_persona_intents`. Pin red again. **Fourteen and a half hours.** |
+
+The instructive part is *why* TASK-19057 updated one hand-maintained literal
+and not the other. It correctly added `idx_actor_pack_persona_intents_state` to
+the index census, and it correctly bumped three schema-version pins under
+`Tests/DB/`. Measured on that branch, those two literals were reachable by the
+two things the author actually did:
+
+* the index census lives in `Tests/ChaChaNotesDB/`, beside the migration test
+  they wrote — running that directory turned it red; and
+* the version pins contain the schema version number, which a grep for it
+  finds.
+
+`VALID_TABLES` is reachable by neither. It names no schema version, and
+nothing else in `Tests/DB/test_sql_validation.py` mentions the feature. Its
+guard survived by geography for years and stopped surviving the moment a
+migration landed from a directory that did not happen to sit next to it.
+
+So the pin is not the fix on its own — a guard that only reports to whoever
+runs it reports after the merge. The authoring-time guard is:
+
+```
+python3 scripts/check_schema_table_allowlist.py     # also in ./scripts/preflight.sh
+```
+
+It statically scans the `CREATE TABLE` statements in
+`migrations/chachanotes_*.sql` and in the SQL string literals of
+`ChaChaNotes_DB.py`, requires each name to be in `VALID_TABLES['chachanotes']`
+in both directions, and prints the lines to paste. Stdlib-only, no database
+built, ~0.1 s, and it is a step in the required `derived-artifacts` CI job.
+
+Its expectation comes from the migration SQL, never from `VALID_TABLES` — the
+rule TASK-19045 established for the index census: a census that re-derives its
+expectation from the artifact it checks is the identity function on exactly the
+defect class it exists to catch. That is also why neither literal is
+auto-generated, and why "just generate it from the schema" is the wrong repair.
+
+`VALID_TABLES['media']` and `VALID_TABLES['prompts']` are drifted in both
+directions and are **not** covered by this checker yet; TASK-19867 owns them.

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -34,8 +34,29 @@ from loguru import logger
 # removes a table fails the test immediately instead of surfacing as a user
 # hitting an unconditional ``ValueError`` the next time they touch the new
 # table through a generic CRUD helper.
+#
+# IF YOU ARE ADDING A TABLE IN A MIGRATION, ADD IT HERE IN THE SAME COMMIT.
+# NOTE (TASK-20971): that runtime test is correct and it *has* been repaired
+# twice. It is not enough on its own, because it only reports after someone
+# runs it, and the full suite has produced no CI verdict since 2026-06-26.
+# Timeline: TASK-864 found 9 of ~47 tables listed. TASK-19568 repaired the
+# entry at 2026-08-22 00:16 -0700. TASK-19057 added two Actor Pack tables and
+# broke it again at 14:51 the same day -- fourteen and a half hours. The
+# authoring-time guard is therefore
+# ``scripts/check_schema_table_allowlist.py``, run by ``scripts/preflight.sh``
+# and by the required ``derived-artifacts`` CI job: it statically scans the
+# ``CREATE TABLE`` statements in ``DB/migrations/chachanotes_*.sql`` and in the
+# SQL string literals of ``ChaChaNotes_DB.py``, and prints the exact lines to
+# paste below. It needs no database, no install, and ~milliseconds. Its
+# expectation comes from the migration SQL, never from this set (TASK-19045's
+# rule: a census that re-derives its expectation from what it guards is the
+# identity function on the defect it exists to catch).
 VALID_TABLES = {
     "chachanotes": {
+        # TASK-19057 (v44->v45): the two Actor Pack tables. Their absence here
+        # is what TASK-20971 was filed for.
+        "actor_pack_persona_intents",
+        "actor_portable_identities",
         "character_cards",
         "character_expression_images",
         "chat_dictionaries",


### PR DESCRIPTION
Closes TASK-20971.

## Why this is not "update the literal"

`VALID_TABLES['chachanotes']` went red on `dev` because TASK-19057 added two Actor Pack tables without updating it. TASK-19568 had repaired that same pin **14 hours 34 minutes earlier**. Twice-stale-in-a-day is evidence that the repair shape is wrong, so the task's acceptance criteria ask for a mechanism that fails at **authoring time**, with the explicit constraint that its proof must not depend on the hand-maintained list it guards.

## Why the index census survived the same migration and this did not

Not a structural difference — both are hand-maintained literals guarding the same schema, neither generated. It is **discovery path**, measured from TASK-19057's own diff (`b593f853d..09b768239`):

- `test_index_census.py` lives in `Tests/ChaChaNotesDB/`, the directory where that author had just written `test_actor_pack_migration.py`. Running the directory you just added a test to turned it red, and they fixed it in the same commit.
- They also touched three `Tests/DB/test_chachanotes_*` version-pin modules — reachable by grepping the schema-version constant.
- `sql_validation.py` is absent from that diff entirely. It names no schema version, and nothing else in its test file mentions the feature.

**It survived by geography.** That rules out both "update the literal" and "add another test" as remedies.

## The mechanism

`scripts/check_schema_table_allowlist.py` — stdlib-only, 0.14 s, no database, no install. Wired into `scripts/preflight.sh` and the `derived-artifacts` workflow.

**Independent source of truth: the schema-defining SQL text itself** — every `CREATE TABLE` in `migrations/chachanotes_*.sql` plus the SQL string literals inside `ChaChaNotes_DB.py`. `VALID_TABLES` is only *read*, via `ast.literal_eval` on the parsed module; it is never imported (verified: after a `runpy` execution, `tldw_chatbook` modules in `sys.modules` is `[]`, `sqlite3 imported: False`). Auto-generating the literal was rejected outright — TASK-19045 established that a census re-deriving from its own subject is the identity function.

**The identity-function test, run both directions on the real tree:**

| SQL | Allowlist | Verdict |
|---|---|---|
| mutated (`+CREATE TABLE reviewer_probe`) | untouched | exit 1 — names the table, its migration file, and the paste-ready line |
| mutated | `+reviewer_probe` | exit 0 |
| shipped (restored) | still `+reviewer_probe` | exit 1 — phantom direction |

The verdict flips on an allowlist-only delta, in both directions. A checker deriving from `VALID_TABLES` could not do that. The static scan also equals a live fully-migrated `CharactersRAGDB(":memory:")` — 69 tables, symmetric difference empty.

It uses AST rather than raw text because a raw scan of the DB modules reports three **phantom** tables (`IF`, `column`, `as`) from prose in `#` comments — and a guard that reports phantoms gets muted. And it fails, rather than passing vacuously, on a zero-`CREATE TABLE` scan: that is the shape a moved-sources refactor would take.

## What it cannot see — measured, and in the checker's own docstring

Each demonstrated against a fixture tree rather than asserted: DDL built by `.format()`, f-string or concatenation; a `.sql` outside the `chachanotes_*` glob; a `.py` module not in `SCHEMAS`; DDL read from a file at runtime. None exists in the chachanotes sources today (verified zero of each), which is why the 69==69 equality holds.

One deserves a follow-up before it bites: the scan is **append-only**, so `DROP TABLE` / `RENAME TO` would make this checker demand a name stay allowlisted while `test_no_stale_tables` demands it be removed — **no allowlist contents satisfies both**, and there is no ignore hatch. The chachanotes sources contain zero of either today.

## Two fixes from review

**A red the branch introduced.** `Tests/CI/test_derived_artifacts_workflow.py` asserts the workflow's checker-step count equals its `CHECKERS` tuple; adding the fifth step made it `assert 5 == 4`. Green at the merge base, red on the branch, and the test file is untouched by it — the author ran `Tests/DB/` and `Tests/ChaChaNotesDB/`, but the guard for the file they edited lives in `Tests/CI/`. **The task's own thesis, recurring inside the task.**

**The seam this remedy leans on was unusable by the obvious invocation.** `/usr/bin/python3` is 3.9.6, and a fresh login shell resolves `python3` to it. Under that interpreter, **3 of the 4 pre-existing preflight checks crash** — `list[str] | None` at runtime, `from enum import StrEnum`, and `ast.parse` of `except*` — so preflight reported three false FAILEDs to anyone running it the obvious way. That is the same cry-wolf class this task exists to fix, on the file the remedy depends on. `preflight.sh` now selects an interpreter meeting `requires-python = ">=3.11"` (repo `.venv` → active `python3` → versioned fallbacks), refuses an explicit below-floor `$PYTHON` in one line instead of three tracebacks, and prints which interpreter it used. Verified across four PATH configurations.

## Recorded where the next author will hit it

A new `tldw_chatbook/DB/migrations/README.md` (the directory they are already in), the `VALID_TABLES` comment block, and a lessons entry. **CLAUDE.md's schema-migration gotcha gained one clause** pointing at that README and naming both literals a migration must update — flagged for the owner as a project-instruction change.

## Verification

- `Tests/DB/` + `Tests/ChaChaNotesDB/` + `Tests/CI/` post-rebase: **1776 passed / 1 skipped**.
- `preflight.sh`: **5/5 green**, reporting `69 declared tables, all present`.
- Repo-wide `--collect-only`: 56,532 with exactly the known dev reds (TASK-20970, in flight; TASK-20972).
- `media` and `prompts` re-derived live (5 unlisted / 6 phantom and 5 / 4). Both `_get_next_version` methods still have **zero callers**, so TASK-19867's hygiene rating stands. Extending the checker there belongs to that task — `Client_Media_DB_v2.py` declares a `ChunkingTemplates_v7` that is renamed away and not live, which the append-only model cannot currently resolve.

**Filed separately**: an installed distribution walls at **v40**, not v45 — `chachanotes_v40_to_v41_persona_visual.sql` and `chachanotes_v45_to_v46_sync_log_retention.sql` are both read at runtime and absent from **four** hand-enumerated lists (`MANIFEST.in`, `pyproject.toml`, `Packaging/check_manifest.py`, and `Tests/Packaging/test_installed_distribution.py`, which stops at v44→v45 so nothing tests for the omission). TASK-19860's artifact-content ACs and glob remedy cover it without naming; the new information is that the list **grew after 19860 was filed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the `VALID_TABLES['chachanotes']` drift loop by adding an authoring-time guard that fails preflight/CI when a migration creates an unlisted table or the allowlist names a non-existent table. Previously drift surfaced only after merge in long-running tests; now it fails fast and prints paste-ready fixes. Connects to TASK-20971.

- Adds `scripts/check_schema_table_allowlist.py` and wires it into `scripts/preflight.sh` and the `derived-artifacts` workflow. It statically scans `migrations/chachanotes_*.sql` and SQL literals in `ChaChaNotes_DB.py` (AST-based), is stdlib-only, needs no DB, runs in ~0.1 s, and is independent of the allowlist it guards; it matches the live schema (69 substantive tables).
- Updates `VALID_TABLES['chachanotes']` with `actor_pack_persona_intents` and `actor_portable_identities`; improves runtime test messages to print paste-ready lines and point to the checker.
- Adds `Tests/DB/test_schema_table_allowlist_guard.py`; broadens coverage to: both drift directions, empty-scan fails, stdlib-only contract, equality with a live DB, SQL comment stripping, “IF NOT EXISTS” phantom avoidance, and support for annotated `VALID_TABLES` assignments.
- CI/workflow and preflight: adds the checker step to `.github/workflows/derived-artifacts.yml`, updates `Tests/CI/test_derived_artifacts_workflow.py`, and makes `scripts/preflight.sh` select a Python >=3.11 interpreter (prints choice; rejects below-floor) to avoid false failures.
- Robustness: strips SQL comments to avoid phantom tables, treats “IF NOT EXISTS” as an all-or-nothing unit to prevent a phantom `IF` table, and fails loudly when no `CREATE TABLE` statements are found; documents limits and workflow in `tldw_chatbook/DB/migrations/README.md`, with notes in `CLAUDE.md` and `backlog/docs/lessons-testing-evidence.md`.

Required actions for future migrations
- When you add a table, add its name to `VALID_TABLES['chachanotes']` in `tldw_chatbook/DB/sql_validation.py` in the same commit, then run `./scripts/preflight.sh` (or `python scripts/check_schema_table_allowlist.py`) to get paste-ready lines.
- When you add an index, add it to `EXPECTED_CHACHANOTES_INDEXES` in `Tests/ChaChaNotesDB/test_index_census.py`.

<sup>Written for commit a7528c598279ac7455f95d7a35b0057274411cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

