### PR TITLE
feat(notes): student workflow (sub-project #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ and this project adheres to Some kind of Versioning
   schemas from the one descriptor table (23 Library tools total); the
   student story is pinned end to end by
   `Tests/Library/test_agent_chunk_student_story.py`.
+- Note-save agent tool (student-workflow): `library_save_note` closes the
+  student story's write loop — the 24th `library_*` tool lets Console agents
+  and local MCP clients land their per-chapter study notes where the user
+  already reads them (the notes screen). Create by default; update by
+  `note_id` + `expected_version` together (exactly one without the other is
+  refused; a stale version is the named `content_changed` error). Bounds are
+  schema-level (title ≤ 512, content ≤ 100_000, folder ≤ 256). The optional
+  one-level folder is created when missing in the notes UI's own local
+  scope, concurrent savers converge on one folder, and a folder failure
+  never lands an orphaned note. Notes derived from Library media carry the
+  documented provenance-header convention (`source`/`revision`/`chapter`/
+  `chunks` — revision is load-bearing for staleness). The re-run convention
+  is search-based (`library_search_notes` by title, then update by id) since
+  the list tool has no folder filter; flashcards are Q/A markdown inside
+  notes (the real flashcards rows have no screen route yet). Runs under the
+  new `library.notes.save` runtime-policy resource, denied before any
+  backend call on both Console and MCP surfaces. The fan-out pattern
+  (structure → spawn-per-chapter → fetch → save → re-run, riding the
+  existing `spawn_subagent`) is documented in the Console guide, and the
+  story test now proves the whole loop — read from stored chunks,
+  provenance-headered save, re-read, search-based re-run update without
+  duplicates, Q/A flashcard note — end to end against real databases
+  (`Tests/Library/test_agent_chunk_student_story.py`).
 - UX efficiency cycle (critique follow-up, ADR-016): the Console composer is now a real
   editable text field with a movable caret (arrows, Home/End, Ctrl+W, mid-draft
   insertion, Shift+Enter newline); destination hotkeys ctrl+1..9,0 jump to the first ten

--- a/Docs/Development/Agent-Tools/local-library-tools.md
+++ b/Docs/Development/Agent-Tools/local-library-tools.md
@@ -4,8 +4,8 @@ Tools that let Console agents and local MCP clients answer factual questions
 about the local Library — list, count, view, lexical search — without routing
 through the RAG/embedding pipeline, plus four media **chunk tool** contracts
 (five tool names) that give agents structure-aware, stored-chunk-reusing
-reads of ingested media and two opt-in writes (save a chunking spec;
-re-chunk one item).
+reads of ingested media, and three opt-in writes (save a chunking spec;
+re-chunk one item; save a note).
 
 - Task: `backlog/tasks/task-1337 - Add-direct-local-Library-tools-for-Console-agents-and-MCP.md`
 - Design: `Docs/superpowers/specs/2026-08-02-local-library-agent-tools-design.md`
@@ -93,8 +93,8 @@ media chunking state.
 Four contracts over five tool names (the spec pair
 `library_list_chunk_specs`/`library_save_chunk_spec` shares one contract),
 all descriptor-backed media operations like the 18 above — Console and MCP
-advertise identical schemas from the same contract table, 23 Library tools
-in all.
+advertise identical schemas from the same contract table, 24 Library tools
+in all counting the note write below.
 
 The motivating story: a student ingests a book and wants per-chapter notes.
 `library_get_media`'s character cursor makes an agent walk blind windows and
@@ -212,11 +212,75 @@ deliberately not the RAG-admin verb), denied before any backend call.
 - The three read tools (`structure`, `chunk`, `spec_list`) ride the existing
   Library read path — the same `[console].direct_library_tools` catalog and
   the same MCP manifest/dispatch as the 18; no new policy verbs.
-- The two writes (`spec_save`, `rechunk`) are the only writing tools in the
-  `library_*` namespace. Both are policy-gated (above), both disclose in
-  their descriptions that they write local Library data, and MCP's
-  control-plane mapping resolves them to their write actions from the
-  descriptor table — there is no bypass path.
+- The two chunk-tool writes (`spec_save`, `rechunk`) are policy-gated
+  (above), disclose in their descriptions that they write local Library
+  data, and MCP's control-plane mapping resolves them to their write
+  actions from the descriptor table — there is no bypass path. The note
+  write below joins them as the third writing tool in the namespace, under
+  its own action.
+
+## The note write: `library_save_note`
+
+The writing half of the student story: the chunk tools deliver a chapter's
+text from stored chunks; `library_save_note` lands the agent's study notes
+where the user already reads them — the notes screen — grouped per book,
+with structured provenance back to the source media. It runs under the
+policy action **`library.notes.save.local`** (resource `library.notes`,
+verb `save`), denied before any backend call. Rows go through the notes
+UI's own row-writer; folders land in the notes UI's own local scope, so a
+saved note is visible and grouped the moment it lands.
+
+- **Create by default; update by id + version together.** `{title, content}`
+  creates a note. To update, pass `note_id` and `expected_version`
+  **together** — exactly one without the other is `invalid_argument` (the
+  most-missed shape, so it is the first thing the tests pin). A stale
+  version is the named `content_changed` error pointing at
+  `library_get_note` for the current version; an unknown `note_id` is
+  `not_found`. The response carries `{item: {id, title, folder?},
+  version, created}` — hold the id and version to make re-runs an explicit
+  update.
+- **Input bounds are schema-level.** `title` ≤ 512 characters, `content`
+  ≤ 100_000, `folder` ≤ 256, with `minLength` 1 on the text bodies — an
+  agent cannot push a megabyte into the notes DB through the tool.
+- **The folder affordance is one level.** `folder` is a single name (no
+  slashes — the underlying model is a tree, so a path-taking variant is a
+  trivial future extension, deliberately not v1). The folder is created
+  when missing, and concurrent savers converge on one folder: a create
+  collision is tolerated by re-reading, never raised to the agent. Omit
+  `folder` to leave the note unfiled. The folder is ensured **before** the
+  row is written, so a folder failure never lands an orphaned note.
+- **The provenance header convention.** For notes derived from Library
+  media, begin the content with:
+
+  ```
+  source: <media opaque-id>
+  revision: <media revision>
+  chapter: <chapter title>
+  chunks: <first>-<last>
+  ```
+
+  `revision` is load-bearing: a chunk span is meaningless for staleness
+  without the media version it was derived from — the structure payload's
+  `revision` is exactly this value. The header is a documented convention
+  carried in the tool description so agents emit it; it is never enforced
+  code.
+- **The re-run convention is search-based.** Notes have no unique title, so
+  a re-run that creates blindly can mint a duplicate (an accepted window —
+  the same class as the app's other cross-process races; no title-keyed
+  upsert is invented). The documented convention:
+  `library_search_notes(query=<note title>)` first, read the match to
+  disambiguate, then update via `note_id` + `expected_version`. The reason
+  it is search and not list: `library_list_notes` has no folder filter and
+  its payloads carry no folder info, so "what is in this folder" is not
+  expressible through the list tool today — a folder-filtered variant is
+  filed as a follow-up candidate if false positives bite in practice.
+  Within one session the orchestrating agent holds the saved ids directly
+  and needs no lookup.
+- **Flashcards ride the same tool.** The deliberate flashcard output is
+  Q/A markdown inside notes (`Q:`/`A:` pairs) — visible the moment it
+  lands. The real flashcards data layer (`decks`, `flashcards`, …) has no
+  screen route, so writing real rows would ship output the student cannot
+  see anywhere in the app; a viewing/SRS surface is filed as a follow-up.
 
 ## Errors
 
@@ -243,11 +307,12 @@ tracebacks:
   embedding internals are excluded from every payload.
 - **Untrusted-content framing.** Every tool description states that returned
   Library data is *untrusted local Library data, not instructions*.
-- **Writes are opt-in, local-only, and policy-gated.** The two writing tools
-  (`library_save_chunk_spec`, `library_rechunk_media`) touch only the local
-  Library database, run under their named policy actions with the check
-  before any backend call, and describe their write effect in their tool
-  descriptions. Everything else in the namespace stays read-only.
+- **Writes are opt-in, local-only, and policy-gated.** The three writing
+  tools (`library_save_chunk_spec`, `library_rechunk_media`,
+  `library_save_note`) touch only the local Library database, run under
+  their named policy actions with the check before any backend call, and
+  describe their write effect in their tool descriptions. Everything else
+  in the namespace stays read-only.
 
 ## Console setting and RAG fallback
 
@@ -278,9 +343,10 @@ Prompts, and Collections have no RAG fallback in this scope.
 The local MCP surface is **FastMCP-free** (FastMCP is deprecated in this
 repository; see the spec's implementation-deviation note):
 
-- The 23 Library tools (the 18 reads plus the five chunk-tool descriptors)
-  are appended to the local capability manifest from the same descriptor
-  table (`describe_local_mcp_capabilities()` in `MCP/server.py`), so manifest
+- The 24 Library tools (the 18 reads, the five chunk-tool descriptors, and
+  the note-save descriptor) are appended to the local capability manifest
+  from the same descriptor table
+  (`describe_local_mcp_capabilities()` in `MCP/server.py`), so manifest
   schemas can never drift from the Console schemas.
 - The in-process runtime (`LocalMCPRuntimeDelegate`) dispatches
   `library_*` calls to the shared synchronous service off the event loop and
@@ -307,9 +373,25 @@ repository; see the spec's implementation-deviation note):
   `Tests/Media/test_media_chunk_reads.py` (the backend read),
   `Tests/RuntimePolicy/test_library_media_rechunk_policy_pin.py` (the write
   actions), and `Tests/Library/test_agent_chunk_student_story.py` (the
-  student story, end to end)
+  student story, end to end — read path, note write, re-run, flashcards)
+- Note write: the save-tool tests inside
+  `Tests/Library/test_local_library_tool_service.py`,
+  `Tests/RuntimePolicy/test_library_notes_save_policy_pin.py` (the action
+  and both MCP seams), and the MCP local-control expectations in
+  `Tests/MCP/test_local_control_service.py`
 
 *Chunk-tool sections added and the whole page re-verified against the
 descriptor table and service code @ `1a392f1c4` — 2026-08-21
 (chunking-agent-tools Task 6 close-out; the 18 read tools' sections are
 unchanged from the prior stamp).*
+
+*The note-write section (`library_save_note`), the three-writes counts, and
+the MCP/testing rosters added — 2026-08-23 (student-workflow Task 2
+close-out). Verified against the descriptor table and the save handler in
+`Library/library_tool_contract.py` / `Library/local_library_tool_service.py`
+(bounds, together-rule, folder-ensure order, `library.notes.save.local`
+denial-first), and against the story test
+`Tests/Library/test_agent_chunk_student_story.py`, which now runs the full
+read → save → re-read → search-based re-run → flashcard loop against real
+databases. The fan-out pattern itself is documented in the Console guide
+([Agent runs & tools](../../User_Guide/console/agent-runs-and-tools.md)).*

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -1094,6 +1094,40 @@ contracts: [Local Library Tools](../../Development/Agent-Tools/local-library-too
 The tools ride the same `[console].direct_library_tools` setting as the
 other Library tools.
 
+### The study-notes fan-out pattern
+
+A sixth writing tool, `library_save_note`, closes the student story the
+chunk tools set up: *"make me per-chapter notes of this book"* (or
+flashcards per section) runs as a fan-out over the ordinary sub-agent
+machinery — no special orchestration:
+
+1. **Structure.** `library_get_media_structure(id)` returns the chapter map
+   with each chapter's chunk addresses.
+2. **Spawn per chapter.** For each chapter the agent spawns a sub-agent
+   (`spawn_subagent`, under the usual `[agents]` caps) with a narrow brief:
+   fetch the chapter's units by address (`library_get_media_chunk`), derive
+   the notes — or Q/A flashcard pairs — and save them with
+   `library_save_note`: one note titled per chapter, content starting with
+   the provenance header (`source`, `revision`, `chapter`, `chunks`), every
+   save naming the same one-level folder for the book (the folder is
+   created on first save; concurrent savers converge on one folder).
+3. **Fetch and save.** Each sub-agent reuses the chunks stored at
+   ingestion — nothing re-chunks behind anyone's back — and its note lands
+   in the notes screen, grouped in the book's folder, the moment it is
+   saved.
+4. **Re-run.** Asked again later (new chapters, a re-chunk), the convention
+   is search-first: `library_search_notes(query=<note title>)` finds the
+   existing note — the list tool has no folder filter — and the agent
+   updates it via `note_id` + `expected_version` instead of creating a
+   duplicate.
+
+Flashcards are Q/A markdown inside notes (`Q:`/`A:` pairs) — a deliberate
+ruling: the real flashcards data layer has no screen route yet, so notes
+are the one output a student can actually see. `library_save_note` is the
+third policy-gated writing tool in the `library_*` namespace
+(`library.notes.save`); full contract:
+[Local Library Tools](../../Development/Agent-Tools/local-library-tools.md).
+
 ### Watchlists evidence tools
 
 The same local-tools group provides `watchlists_search_items` and
@@ -1709,3 +1743,15 @@ test (`Tests/Library/test_agent_chunk_student_story.py`, which ingests a
 real fixture book through the real parse → persist → chunk-rows pipeline
 and reads Chapter 7 back from the stored chunks). The rest of this page
 is unchanged from the prior stamp.*
+
+*"The study-notes fan-out pattern" section added — 2026-08-23
+(student-workflow Task 2). Not driven live in tmux: the pattern rides
+machinery this page already documents (`spawn_subagent` and the `[agents]`
+caps, verified above in the sub-agent sections) plus the
+`library_save_note` contract, verified against the descriptor table, the
+save handler (`Library/local_library_tool_service.py`), the policy
+registration (`library.notes.save.local` in
+`runtime_policy/registry.py`), and the story test — which now runs the
+whole loop (structure → chunk fetches → provenance-headered save →
+re-read → search-based re-run update → Q/A flashcard note) against real
+databases. The rest of this page is unchanged from the prior stamp.*

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -1096,7 +1096,7 @@ other Library tools.
 
 ### The study-notes fan-out pattern
 
-A sixth `library_*` tool — and the third that writes —, `library_save_note`, closes the student story the
+A sixth `library_*` tool — and the third that writes — `library_save_note`, closes the student story the
 chunk tools set up: *"make me per-chapter notes of this book"* (or
 flashcards per section) runs as a fan-out over the ordinary sub-agent
 machinery — no special orchestration:

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -1096,7 +1096,7 @@ other Library tools.
 
 ### The study-notes fan-out pattern
 
-A sixth writing tool, `library_save_note`, closes the student story the
+A sixth `library_*` tool — and the third that writes —, `library_save_note`, closes the student story the
 chunk tools set up: *"make me per-chapter notes of this book"* (or
 flashcards per section) runs as a fan-out over the ordinary sub-agent
 machinery — no special orchestration:

--- a/Docs/superpowers/plans/2026-08-23-student-workflow.md
+++ b/Docs/superpowers/plans/2026-08-23-student-workflow.md
@@ -1,0 +1,61 @@
+# Student Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `library_save_note` — the write tool that lets a Console agent land its per-chapter study notes (folder-grouped, provenance-tagged, visible in the notes screen), plus the documented fan-out pattern and the flashcards ruling.
+
+**Architecture:** One new write descriptor + a `save` operation branch in the note backend dispatch; rows via the legacy `NotesInteropService` (`add_note`/`update_note`), folders via `NotesScopeService` (`get_folder_by_path` ensure + `attach_note_to_folder`, scope pinned `local`); `library.notes/save` policy landed with the handler; the #4 story test upgraded to close the write loop; docs carry the pattern and conventions.
+
+**Tech Stack:** Python ≥3.11, ChaChaNotes DB (notes + v36 folder tables), the #4 tool/policy machinery, `asyncio.run` sync bridge.
+
+**Spec:** `Docs/superpowers/specs/2026-08-23-student-workflow-design.md` — §4 the tool, §4.3 the seam, §4.4 the duplicate ruling, §5 the pattern, §6 flashcards, §8's eleven rulings (all three review passes folded in).
+
+## Global Constraints
+
+- Create-default; update ONLY with `note_id` + `expected_version` (both required together — one without the other → `invalid_argument`).
+- `update_note` raises `ConflictError` on version mismatch (verified, ChaChaNotes_DB.py:13657) → handler maps to the named `content_changed`.
+- Input bounds are schema-level `maxLength`, harmonized with Task 4's spec-save precedent (name 120 / description 2_000): **title ≤ 512, content ≤ 100_000, folder ≤ 256**; minLength 1 on title/content.
+- Folder = ONE segment; ensure via `get_folder_by_path([name])` → `create_note_folder` on miss → re-query on conflict (the race is tolerated, never raises to the agent); placement via `attach_note_to_folder(scope="local", folder_id, note_id)` (re-attach safe — `attach_manual` revives history).
+- Scope pinned to `local` (`ScopeType.LOCAL_NOTE`) — the notes UI's scope; any other value makes folders invisible.
+- Provenance header (source/revision/chapter/chunks) is a documented convention in the tool description — never enforced code.
+- Duplicate-window accepted (no title uniqueness, no title-keyed upsert); the documented re-run convention is **search-based** (`library_search_notes(query=title)`) — the list tool has no folder filter.
+- Policy `library.notes`/`save` lands WITH the handler on BOTH Console-direct and MCP mappings; denial before any backend call; RuntimePolicy pins.
+- No orchestration code, no prompt preset, no note deletion, no note↔media link table.
+- Repo rule: targeted test runs only; venv `.venv/bin/python`.
+
+---
+
+### Task 1: `library_save_note` — descriptor, dispatch, handler, policy
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_tool_contract.py` (the descriptor + `_save_note_schema`), `tldw_chatbook/Library/local_library_tool_service.py` (the `save` operation branch + the handler + the `notes_scope_service` constructor param), `tldw_chatbook/UI/Screens/chat_screen.py` + `tldw_chatbook/MCP/server.py` (both wiring sites gain the scope-service handle, `getattr` degrade pattern), `tldw_chatbook/MCP/local_control_service.py` (the action mapping override), `tldw_chatbook/runtime_policy/registry.py` (the resource)
+- Test: `Tests/Library/test_local_library_tool_service.py` (extend), `Tests/RuntimePolicy/` (extend), MCP local-control expectations
+
+**Interfaces:**
+- Consumes: `NotesInteropService.add_note(user_id, title, content, note_id?) -> str` / `update_note(user_id, note_id, update_data, expected_version) -> bool` (raises `ConflictError`); `NotesScopeService.get_folder_by_path` — NOTE: this is on the **repository** (`LocalNoteFolderRepository.get_folder_by_path(folder_segments)`); the scope service exposes `list_note_folder_children`/`create_note_folder`/`attach_note_to_folder` — if no scope-level path-getter exists, the handler reaches the repository via the scope service's own access path OR does name-lookup via `list_note_folder_children(parent_id=None)`; pick the seam the scope service actually exposes and document the choice.
+- Produces: `library_save_note` in the catalog (24th name) returning `{item: {id, "note", title, folder?}, version, created, notes}`.
+
+- [ ] **Step 1 — failing tests** (per spec §7.1-7.5): schema acceptance/rejection (bounds! required-together rule on note_id+expected_version! unknown keys); create → id+version+created:true; update with matching version → version bumps, created:false; stale version → `content_changed`; unknown note_id → `not_found`; folder create-then-attach (folder appears once — sequential idempotency); concurrent folder ensure (interleaved create → re-query → one folder, no raise); folder-less create touches no folder; policy denial (mutation pin: `add_note` never called) + the `library.notes.save.local` mapping on both MCP seams; the descriptor carries the provenance-header documentation (assert the description mentions source/revision).
+- [ ] **Step 2 — implement** the descriptor + schema (bounds per Global Constraints), the `save` dispatch branch, the handler (legacy interop for rows; scope service for folder/placement; `asyncio.run` bridge; ConflictError catch → content_changed; `InputError` → invalid_argument), both wirings, the policy resource + override.
+- [ ] **Step 3 — green + pins:** the new tests; catalog pins grow 23→24 across the surface suites; `Tests/RuntimePolicy/` + MCP local-control green.
+- [ ] **Step 4 — commit:** `feat(library): library_save_note agent tool (folder-grouped, version-locked) + library.notes/save policy`
+
+### Task 2: The upgraded student story + docs + close-out
+
+**Files:**
+- Test: `Tests/Library/test_agent_chunk_student_story.py` (extend — the #4 test is the base)
+- Modify: `Docs/User_Guide/library/local-library-tools.md` (the save-note contract + the pattern), `Docs/User_Guide/console/agent-runs-and-tools.md` (the fan-out pattern section), `CHANGELOG.md`
+- Board: the flashcards-viewing follow-up + the folder-filtered-listing follow-up (file at close-out, house pattern)
+
+- [ ] **Step 1 — the story upgrade (spec §7.6):** after the #4 read path, `library_save_note` lands the Chapter-7 note (with the provenance header incl. `revision:`), `library_get_note` re-reads it (payload revision matches), and the **re-run leg**: `library_search_notes(query=title)` finds it → update via note_id+version → still one note (no duplicate); the flashcard leg saves a QA-markdown note and re-reads it.
+- [ ] **Step 2 — docs:** the save-note contract in the reference (bounds, the together-rule, the search-based re-run convention with its reason); the fan-out pattern section (structure → spawn-per-chunk → fetch → save → re-run); CHANGELOG.
+- [ ] **Step 3 — file the two follow-ups** (flashcards viewing/SRS surface; folder-filtered `library_list_notes` candidate) — direct task-file writes, id sweep per house rules.
+- [ ] **Step 4 — targeted close-out:** `pytest Tests/Library/ Tests/RuntimePolicy/ Tests/MCP/test_local_control_service.py Tests/Notes/ -q` — zero new failures vs dev baseline.
+- [ ] **Step 5 — commit:** `test(library): student story closes the write loop; docs + follow-ups`
+
+## Self-Review (run at save)
+
+1. **Spec coverage:** §4.1→T1 (contract+bounds+together-rule); §4.2→T1 (description) + T2 (story asserts the header); §4.3→T1 (seam+ensure+attach+scope+bridge+wiring); §4.4→T1 (create-default/conflict) + T2 (re-run leg); §5→T2 docs (search-based convention per the third-review correction); §6→T2 flashcard leg + follow-up filing; §7.1-7.5→T1; §7.6→T2; §7.7-7.11→T1 (the resolved hedges). All eleven §8 rulings mapped.
+2. **Ordering:** T1 (tool) before T2 (story rides it). Two tasks — the spec is one tool + docs; splitting further is ceremony.
+3. **Type consistency:** `library_save_note` input/output shapes identical across T1/T2; the folder-ensure contract (one segment, re-query-on-conflict) stated once in Constraints and consumed by both tasks.
+4. **Placeholders:** the scope-level path-getter choice in T1's Interfaces is a genuine verify-at-implementation seam (two verified options named, both on real APIs) — not a dodge; the handler documents which it took.

--- a/Docs/superpowers/specs/2026-08-23-student-workflow-design.md
+++ b/Docs/superpowers/specs/2026-08-23-student-workflow-design.md
@@ -138,7 +138,8 @@ means a re-run that does not list-first can mint duplicates, and two
 concurrent identical creates both succeed. **Accepted deliberately** (same
 class as #2's cross-process races): the documented convention is
 **list-before-rerun** (`library_list_notes` in the folder, match by title,
-update via id); title-keyed upsert would invent natural-key semantics the
+update via id) — *(superseded by the third-review search-based ruling, §5)* —;
+title-keyed upsert would invent natural-key semantics the
 schema does not have. The `note_import_executor` reconcile-by-id precedent
 is noted and deliberately not extended to titles.
 
@@ -222,7 +223,8 @@ pattern; the spec's §11-equivalent is this section).
 6. **(Review pass 1)** Input bounds are schema-level `maxLength` (mirror
    spec-save's caps; verify-and-match).
 7. **(Review pass 1)** Duplicate-window accepted; list-before-rerun is the
-   documented convention; no title-keyed upsert.
+   documented convention *(superseded by the third-review search-based
+   ruling, §5)*; no title-keyed upsert.
 8. **(Review pass 2)** The provenance header carries `revision:` (span +
    revision = staleness-detectable).
 9. **(Review pass 2; resolved on pass 3)** `update_note` **raises

--- a/Docs/superpowers/specs/2026-08-23-student-workflow-design.md
+++ b/Docs/superpowers/specs/2026-08-23-student-workflow-design.md
@@ -196,7 +196,8 @@ pattern; the spec's §11-equivalent is this section).
 6. **The upgraded student story (§7.6 of #4's test, extended):** the full
    read path from #4's test now *saves* the Chapter-7 note, re-reads it
    through `library_get_note`, and a **re-run leg** proves
-   list-first + update-not-duplicate; the flashcard convention leg saves a
+   search-first (the third-review correction to "list-first") +
+   update-not-duplicate; the flashcard convention leg saves a
    QA-note and re-reads it.
 7. Suites: `Tests/Library/`, the notes scope/interop suites touched,
    `Tests/RuntimePolicy/`, MCP local-control.

--- a/Docs/superpowers/specs/2026-08-23-student-workflow-design.md
+++ b/Docs/superpowers/specs/2026-08-23-student-workflow-design.md
@@ -1,0 +1,235 @@
+# Student Workflow — Design Spec
+
+**Date:** 2026-08-23
+**Status:** Draft, maintainer-approved in brainstorming (four rulings in §7) plus
+two design-review passes (§7.5-7.11); awaiting maintainer's review gate.
+**Sub-project:** 5 of 6 in the Chunking Parity & Agent Tools program
+**Depends on:** sub-projects #1-#4 (all merged; #4 = PR #1976, `684c6aba4` —
+the library agent tools this workflow rides). Branches off `origin/dev`.
+**Author:** brainstormed with the maintainer. Facts verified against `origin/dev`
+at `684c6aba4`. No upstream facts are load-bearing — every mechanism consumed
+ships in chatbook.
+
+---
+
+## 1. Why
+
+The program's motivating story — "a student wants per-chapter notes from an
+ingested book, or flashcards per section" — is one sub-project away from done.
+#4 shipped the agent tools (structure map, stored-chunk fetch, specs, re-chunk)
+and proved the read path end-to-end. What the acting agent still cannot do:
+
+- **Write its output anywhere.** The library tool namespace has exactly two
+  write tools (spec-save, re-chunk); notes are list/get only. The per-chapter
+  notes the workflow exists to produce have no landing surface.
+- **Group or provenance-tag what it would write.** Note folders exist in the
+  notes UI (the v36 schema behind `NotesScopeService`) but nothing
+  agent-reachable creates them; note↔media links do not exist at all.
+- **Emit flashcards** in any form a student can see.
+
+Meanwhile the fan-out half needs **no new machinery**: `spawn_subagent` is a
+runtime tool (gated on `max_subagents > 0`), `FleetCoordinator` coordinates
+concurrent sub-agents, and budgets are wired. The ergonomics leg is
+conventions and documentation riding what exists.
+
+## 2. Goals
+
+1. An agent can save a note (create by default, update by id+version), with a
+   folder affordance that is safe under concurrent sub-agent fan-out.
+2. Study outputs are visible to the user the moment they land (notes screen),
+   grouped per book, with structured provenance back to the source media.
+3. The flashcard output decision is made deliberately and its trade-off
+   recorded (ruling §7.3).
+4. The end-to-end pattern — structure → spawn-per-chapter → fetch → save →
+   re-run updates — is documented and proven by an upgraded story test.
+
+## 3. Non-goals
+
+- **New orchestration code** — `spawn_subagent`/fleet/budgets exist; the
+  fan-out leg is documentation (§5).
+- **A prompt preset** — the pattern lives in the user guide; a preset would
+  drift from the tools (docs first; preset only if the maintainer asks).
+- **Note↔media link tables** — provenance rides a content header (§4.2);
+  schema work nobody asked for.
+- **Note deletion** — the workflow never needs it; refusing to add it is the
+  scope guard.
+- **A flashcards viewer/SRS** — filed as follow-up (§6); #5's flashcard
+  output rides notes.
+- **Title-keyed upsert semantics** — notes have no unique title constraint;
+  inventing one is out (ruling §7.7).
+
+## 4. The tool — `library_save_note`
+
+One new write descriptor in the `library_tool_contract.py` pattern (`note`
+item, `save` operation, the `Writes local Library data only` tail).
+
+### 4.1 Contract
+
+```
+input:  {title: str (1..TITLE_MAX), content: str (1..CONTENT_MAX),
+         folder?: str (1..FOLDER_MAX), note_id?: opaque-id,
+         expected_version?: int ≥ 1}
+output: {item: {id: opaque-id, "note", title, folder},
+         version: int, created: bool, notes: [...]}
+```
+
+- **Create by default**; **update when `note_id` + `expected_version`** are
+  supplied. Version mismatch → the named `content_changed` error
+  (`update_note` returns bool — a falsy result maps to the named error;
+  exact failure mode verified at implementation). The returned id + version
+  make idempotent re-runs the agent's explicit choice.
+- **Bounds are input-side** (ruling §7.6): `maxLength` on `title`, `content`,
+  and `folder` in the schema — mirroring the caps Task 4's spec-save body
+  used (verify-and-match at implementation; a sensible default is
+  content ≤ 100_000 chars, title ≤ 512, folder ≤ 256) — so an agent cannot
+  push a megabyte into the notes DB through the tool.
+- **Folder is one segment** (ruling §7.5 corrected on third review: the
+  underlying model is a **tree** — `get_folder_by_path(folder_segments)` and
+  `parent_id` are native — so the v1 one-level choice is simplicity, not a
+  model limitation; a path-taking variant is a trivial future extension).
+
+### 4.2 Provenance header convention
+
+No note↔media link exists (verified: `create_note_link` is note↔note only)
+and none is built. The convention is a structured header at the top of the
+note content, documented in the tool description so agents emit it:
+
+```
+source: <media opaque-id>
+revision: <media version>
+chapter: <chapter title>
+chunks: <first>-<last>
+```
+
+The `revision` line is load-bearing (ruling §7.8): a chunk span is meaningless
+for staleness without the media version it was derived from. The header is a
+convention, not enforced code; tests assert the pattern round-trips.
+
+### 4.3 Write seam (the split reconciled — ruling §7.5)
+
+The tool's note backend is `app.notes_service` (the legacy
+`NotesInteropService`: `add_note(title, content)`, `update_note(note_id,
+update_data, expected_version)`) — that is where note rows are written.
+Folders live only in the async `NotesScopeService`
+(`app.notes_scope_service`). The handler lives in
+`local_library_tool_service.py` as a new `save` operation branch on the note
+backend, takes **both** handles, and:
+
+- writes/updates the note via the legacy interop (the notes UI's own
+  row-writer);
+- ensures the folder via an **idempotent helper**, now with the verified
+  API: `get_folder_by_path([name])` (repository, path-native) →
+  `create_note_folder` on miss → **re-query on conflict**
+  (create_note_folder is not idempotent; the race is tolerated by
+  re-reading); placement via `attach_note_to_folder(scope="local",
+  folder_id, note_id)` (scope-level, verified; repository `attach_manual`
+  revives the latest membership history, so re-attach is safe). **Scope is
+  pinned to `local` (`ScopeType.LOCAL_NOTE`)** — the notes UI's own scope;
+  any other scope makes folders invisible in the screen.
+- bridges the async scope calls with the established `asyncio.run` pattern
+  (#4's precedent; same caller-threading guarantees).
+- Both construction sites (chat_screen factory, MCP/server build) gain the
+  `notes_scope_service` handle via the `getattr(app, ...)` degrade pattern.
+
+### 4.4 Duplicate-window ruling (§7.7)
+
+Notes have no unique constraint on title. Create-default + explicit-update
+means a re-run that does not list-first can mint duplicates, and two
+concurrent identical creates both succeed. **Accepted deliberately** (same
+class as #2's cross-process races): the documented convention is
+**list-before-rerun** (`library_list_notes` in the folder, match by title,
+update via id); title-keyed upsert would invent natural-key semantics the
+schema does not have. The `note_import_executor` reconcile-by-id precedent
+is noted and deliberately not extended to titles.
+
+## 5. Conventions and the fan-out pattern (docs only)
+
+The user guide gains the end-to-end pattern, documented once:
+
+```
+1. library_get_media_structure(id)          → the chapter map
+2. for each chapter (spawn_subagent):       → the existing runtime tool
+     library_get_media_chunk(...) for the node's span
+     (optional) summarize/extract per the user's ask
+     library_save_note(title, content-with-provenance-header,
+                       folder="Study/<book title>")
+3. re-run: library_search_notes(query=title) first (the list tool has no
+   folder filter — ruling below) → update via note_id + version
+```
+
+**Re-run disambiguation ruling (third review):** `library_list_notes` has no
+folder filter (verified — the generic `_list_schema` is limit/offset only)
+and its payload carries no folder info, so the cross-session re-run
+convention is **search-based**: `library_search_notes(query=<title>)`, with
+the agent disambiguating by reading. Within one session the orchestrating
+agent holds the saved ids directly. A folder-filtered `library_list_notes`
+is filed as a follow-up candidate if false positives bite in practice.
+
+Study-note conventions (the `Study/<book>` folder name, chapter-titled notes,
+the provenance header) are documented patterns the tool makes easy — not
+enforced code. Flashcard output is the Q/A markdown convention below.
+
+## 6. Flashcards — the deliberate decision
+
+**Ruling §7.3: #5's flashcard output is Q/A markdown inside notes.** The
+real-rows path (`decks`, `flashcards`, `flashcards_fts`… — the data layer
+exists) has **no screen route**: writing real rows ships output the student
+cannot see anywhere in the app. QA-in-notes is visible the moment it lands.
+The real-rows path stays open for whenever a flashcards viewing/SRS surface
+exists — **filed as a follow-up task at implementation close-out** (house
+pattern; the spec's §11-equivalent is this section).
+
+## 7. Testing
+
+1. Tool-contract tests: schema acceptance/rejection (bounds!, required,
+   unknown keys), error payload shapes.
+2. Create/update/conflict: create → id+version; update with matching version
+   → version bumps; stale version → `content_changed`; unknown note_id →
+   `not_found`.
+3. Folder idempotency: same name twice sequential → one folder; concurrent
+   (simulated interleaved) creates → one placement target after the
+   re-query; folder-less create → no folder touched.
+4. Provenance-header pattern round-trip (assert the documented shape).
+5. Policy: `library.notes`/`save` resource, mapping on BOTH Console-direct
+   and MCP paths (the #4 lesson — landed with the handler), denial before
+   any backend call (mutation-pinned), RuntimePolicy equality pins.
+6. **The upgraded student story (§7.6 of #4's test, extended):** the full
+   read path from #4's test now *saves* the Chapter-7 note, re-reads it
+   through `library_get_note`, and a **re-run leg** proves
+   list-first + update-not-duplicate; the flashcard convention leg saves a
+   QA-note and re-reads it.
+7. Suites: `Tests/Library/`, the notes scope/interop suites touched,
+   `Tests/RuntimePolicy/`, MCP local-control.
+
+## 8. Decisions taken (brainstorm + two review passes, 2026-08-22/23)
+
+1. **Scope shape:** one write tool (`library_save_note`) + the flashcard
+   target + conventions; fan-out leg is conventions-only (no orchestration —
+   `spawn_subagent`/fleet already exist); no structured fan-out tool
+   (duplicates the runtime, hides the reasoning).
+2. **Write posture:** create-default, update via `note_id` +
+   `expected_version` (mirrors #4's spec-save shape; optimistic locking is
+   real — the notes sync triggers carry `NEW.version`).
+3. **Flashcards: Q/A-in-notes now;** real-rows follow-up filed (the
+   invisible-output problem rules it out for #5).
+4. **Conventions as affordances + docs**, not prompt presets: folder param,
+   id/version returns, provenance header in the tool description; the
+   pattern in the user guide.
+5. **(Review pass 1)** The seam split reconciled: rows via the legacy
+   interop, folders via the scope service with an idempotent ensure-helper;
+   both handles wired at both sites; sync→async bridge per #4.
+6. **(Review pass 1)** Input bounds are schema-level `maxLength` (mirror
+   spec-save's caps; verify-and-match).
+7. **(Review pass 1)** Duplicate-window accepted; list-before-rerun is the
+   documented convention; no title-keyed upsert.
+8. **(Review pass 2)** The provenance header carries `revision:` (span +
+   revision = staleness-detectable).
+9. **(Review pass 2; resolved on pass 3)** `update_note` **raises
+   `ConflictError` on version mismatch** (verified, ChaChaNotes_DB.py:13657)
+   — the handler catches it and maps to the named `content_changed`.
+   `library_get_note` returns the note's `version` (the payload's
+   `revision` field), so the update path is fully servable today.
+10. **(Review pass 2)** The handler lives in `local_library_tool_service`
+    (the note-backend dispatch), not the media-chunk service.
+11. **(Review pass 2)** The flashcards follow-up files at implementation
+    close-out.

--- a/Tests/Agents/test_library_tool_provider.py
+++ b/Tests/Agents/test_library_tool_provider.py
@@ -60,10 +60,10 @@ def _error_payload(tool_result: ToolResult) -> dict:
 # --------------------------------------------------------------------------
 
 
-def test_direct_catalog_lists_all_23_descriptor_tools():
+def test_direct_catalog_lists_all_24_descriptor_tools():
     provider = LibraryToolProvider(FakeLibraryService())
     catalog = provider.list_catalog()
-    assert len(catalog) == 23
+    assert len(catalog) == 24
     assert [entry.name for entry in catalog] == list(LIBRARY_TOOL_DESCRIPTORS)
     for entry in catalog:
         assert entry.id == f"library:{entry.name}"

--- a/Tests/Agents/test_mcp_tool_provider.py
+++ b/Tests/Agents/test_mcp_tool_provider.py
@@ -1441,7 +1441,7 @@ def test_invoke_kill_switch_check_survives_getter_exception(running_loop):
 # builtin_raw_name_exclusions (task-1337, plan Task 8)
 # ---------------------------------------------------------------------------
 #
-# The Console shadows 24 built-in raw names (the 19 `library_*` descriptor
+# The Console shadows 29 built-in raw names (the 24 `library_*` descriptor
 # tools served by its own LibraryToolProvider, plus the five legacy RAG/chat
 # readers whose Console coverage is the bounded RAG/direct tools). The
 # Console-composed provider must drop those names ONLY when they come from

--- a/Tests/Agents/test_mcp_tool_provider.py
+++ b/Tests/Agents/test_mcp_tool_provider.py
@@ -1441,7 +1441,7 @@ def test_invoke_kill_switch_check_survives_getter_exception(running_loop):
 # builtin_raw_name_exclusions (task-1337, plan Task 8)
 # ---------------------------------------------------------------------------
 #
-# The Console shadows 23 built-in raw names (the 18 `library_*` descriptor
+# The Console shadows 24 built-in raw names (the 19 `library_*` descriptor
 # tools served by its own LibraryToolProvider, plus the five legacy RAG/chat
 # readers whose Console coverage is the bounded RAG/direct tools). The
 # Console-composed provider must drop those names ONLY when they come from
@@ -1481,15 +1481,15 @@ def test_compose_catalog_without_exclusions_keeps_every_builtin_name():
     assert "mcp__tldw_chatbook__library_list_media" in names
     assert "mcp__tldw_chatbook__search_rag" in names
     assert "mcp__tldw_chatbook__chat_with_llm" in names
-    assert len(names) == 29  # 28 shadowed + the unrelated built-in
+    assert len(names) == 30  # 29 shadowed + the unrelated built-in
 
 
 def test_compose_catalog_builtin_exclusions_scoped_to_builtin_source():
-    """With the Console exclusion set: exactly the 28 built-in raw names
+    """With the Console exclusion set: exactly the 29 built-in raw names
     disappear; the unrelated built-in and same-named local-profile tools
     remain, and the inventory mapping is left untouched."""
     exclusions = _console_exclusion_set()
-    assert len(exclusions) == 28  # 23 descriptors + 5 legacy, no overlap
+    assert len(exclusions) == 29  # 24 descriptors + 5 legacy, no overlap
     service = FakeMCPService(
         inventory=_mixed_library_inventory(),
         catalog_records=[

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -5423,7 +5423,7 @@ async def test_library_provider_factory_failure_degrades_to_no_provider():
 @pytest.mark.asyncio
 async def test_compose_mcp_provider_excludes_console_shadowed_builtin_names():
     """The Console-composed MCP provider drops exactly the 23 shadowed raw
-    names (18 descriptor tools + 5 legacy readers) from the
+    names (19 descriptor tools + 5 legacy readers) from the
     `builtin:tldw_chatbook` source -- the Console serves Library retrieval
     through its own direct/RAG provider (either mode), so the MCP copies
     would be an ungoverned duplicate. Same-named external/local profile
@@ -5451,7 +5451,7 @@ async def test_compose_mcp_provider_excludes_console_shadowed_builtin_names():
             "export_conversation",
         }
     )
-    assert len(CONSOLE_MCP_BUILTIN_RAW_NAME_EXCLUSIONS) == 23
+    assert len(CONSOLE_MCP_BUILTIN_RAW_NAME_EXCLUSIONS) == 29
     assert "search_rag" not in LIBRARY_TOOL_DESCRIPTORS
 
     inventory = {

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -5422,8 +5422,8 @@ async def test_library_provider_factory_failure_degrades_to_no_provider():
 
 @pytest.mark.asyncio
 async def test_compose_mcp_provider_excludes_console_shadowed_builtin_names():
-    """The Console-composed MCP provider drops exactly the 23 shadowed raw
-    names (19 descriptor tools + 5 legacy readers) from the
+    """The Console-composed MCP provider drops exactly the 29 shadowed raw
+    names (24 descriptor tools + 5 legacy readers) from the
     `builtin:tldw_chatbook` source -- the Console serves Library retrieval
     through its own direct/RAG provider (either mode), so the MCP copies
     would be an ungoverned duplicate. Same-named external/local profile

--- a/Tests/Library/test_agent_chunk_student_story.py
+++ b/Tests/Library/test_agent_chunk_student_story.py
@@ -1,10 +1,14 @@
-"""Task 6 (chunking-agent-tools): the student story, end to end (spec §7.6).
+"""The student story, end to end (chunking-agent-tools spec §7.6, upgraded
+by student-workflow spec §7.6 to close the write loop).
 
 The program's motivating payoff: a student ingests a book and wants
-per-chapter notes. The four ``library_*`` chunk tools deliver it from the
+per-chapter notes. The ``library_*`` chunk tools deliver the read from the
 item's OWN stored chunks — structure map -> chapter node -> chunk address
 span -> unit fetches -> note text — with no window-walking and no
-re-chunking behind anyone's back.
+re-chunking behind anyone's back; ``library_save_note`` then lands the
+note (provenance-headered, folder-grouped), a re-run leg proves
+search-first + update-not-duplicate, and a flashcard leg saves the Q/A
+markdown convention (student-workflow spec §5/§6).
 
 The ingestion is REAL end to end at the chunking seam (the established
 convention from ``Tests/Local_Ingestion/test_book_ingestion_chunking.py``
@@ -35,17 +39,20 @@ Two behaviors worth knowing before reading the assertions:
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.Library.library_tool_contract import (
     ERROR_FEATURE_UNAVAILABLE,
     make_public_id,
 )
+from tldw_chatbook.Library.local_library_tool_service import LocalLibraryToolService
 from tldw_chatbook.Library.local_media_chunk_tool_service import (
     LocalMediaChunkToolService,
 )
@@ -55,6 +62,9 @@ from tldw_chatbook.Local_Ingestion.local_file_ingestion import (
     persist_parsed_media,
 )
 from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Notes.note_folder_repository import LocalNoteFolderRepository
+from tldw_chatbook.Notes.Notes_Library import NotesInteropService
+from tldw_chatbook.Notes.notes_scope_service import NotesScopeService, ScopeType
 
 # ---------------------------------------------------------------------------
 # Fixture books: chapters with recognizable headings
@@ -164,6 +174,39 @@ def _service(db: MediaDatabase) -> LocalMediaChunkToolService:
     )
 
 
+def _agent_surface(
+    db: MediaDatabase, tmp_path: Path
+) -> tuple[LocalLibraryToolService, NotesScopeService]:
+    """One tool surface for the WHOLE story: the shared dispatcher the
+    Console provider and local MCP both call, with the media chunk tools
+    and the real note row/folder seams wired (student-workflow Task 1's
+    ``library_save_note`` landing).
+
+    Rows go through a real ``NotesInteropService`` over a real ChaChaNotes
+    DB; folders through a real ``NotesScopeService`` — the same construction
+    Task 1's real-DB save test pins. The scope handle comes back too, so the
+    story can assert what the notes screen would list.
+    """
+    notes_db = CharactersRAGDB(tmp_path / "notes.db", "student-story-notes")
+    notes = NotesInteropService(
+        base_db_directory=tmp_path,
+        api_client_id="student-story",
+        global_db_to_use=notes_db,
+    )
+    scope = NotesScopeService(
+        local_notes_service=notes,
+        server_service=None,
+        folder_repository=LocalNoteFolderRepository(notes_db),
+    )
+    service = LocalLibraryToolService(
+        media_chunk_service=_service(db),
+        notes_service=notes,
+        notes_scope_service=scope,
+        notes_user_id="student",
+    )
+    return service, scope
+
+
 def _public(media_uuid: str) -> str:
     return make_public_id("media", media_uuid)
 
@@ -212,7 +255,10 @@ def test_student_story_chapter_notes_from_stored_chunks_only(
         media_db, tmp_path, "student-reader.epub", STUDENT_READER, CHAPTER_CHUNK_OPTIONS
     )
     content = str(media_db.get_media_by_id(media_id)["content"])
-    service = _service(media_db)
+    # One surface for the whole story — the shared dispatcher a Console
+    # agent actually calls; the chunk reads below route through it to the
+    # same chunk service, unchanged.
+    service, scope = _agent_surface(media_db, tmp_path)
     public = _public(media_uuid)
 
     # Ground truth first: the stored rows are exact, engine-stamped slices
@@ -284,6 +330,119 @@ def test_student_story_chapter_notes_from_stored_chunks_only(
             " worth noting for the exam."
         )
         assert _note_text(sentence) in _note_text(owning["text"])
+
+    # 5. The write loop closes (student-workflow spec §7.6): the agent
+    #    lands the Chapter-7 note WITH the provenance header — source,
+    #    revision (the media revision from the structure payload), chapter,
+    #    chunks — grouped in one per-book folder.
+    note_title = "The Student Reader — Chapter 7 notes"
+    provenance_header = (
+        f"source: {public}\n"
+        f"revision: {structure['revision']}\n"
+        f"chapter: {node['title']}\n"
+        f"chunks: {span[0]}-{span[1]}"
+    )
+    note_content = (
+        f"{provenance_header}\n\n"
+        "Key points:\n"
+        "- Three paragraphs, each carrying sentences worth noting for the"
+        " exam.\n"
+        f"- Verbatim source: {_note_text(owning['text'])}\n"
+    )
+    saved = service.invoke(
+        "library_save_note",
+        {"title": note_title, "content": note_content, "folder": "Student Reader"},
+    )
+    assert "error" not in saved, saved
+    assert saved["created"] is True
+    assert saved["version"] == 1
+    assert saved["item"]["title"] == note_title
+    assert saved["item"]["folder"] == "Student Reader"
+
+    # 6. The re-read: library_get_note serves the note back whole, the
+    #    payload's revision is the note's own version (what an update
+    #    needs), and the header round-trips verbatim — media revision
+    #    included, so staleness stays detectable.
+    reread = service.invoke("library_get_note", {"id": saved["item"]["id"]})
+    assert "error" not in reread, reread
+    assert reread["content"]["revision"] == str(saved["version"])
+    assert reread["content"]["has_more"] is False
+    assert reread["content"]["text"].startswith(provenance_header)
+
+    # 7. The re-run leg: a later session rediscovers the note by title —
+    #    SEARCH-based, because the list tool has no folder filter and its
+    #    payloads carry no folder info — and UPDATES it in place instead of
+    #    minting a duplicate (notes have no unique title; the convention is
+    #    the agent's explicit choice).
+    found = service.invoke("library_search_notes", {"query": note_title})
+    assert "error" not in found, found
+    assert found["total"] == 1
+    assert found["items"][0]["id"] == saved["item"]["id"]
+    assert found["items"][0]["title"] == note_title
+    assert "title" in found["items"][0]["matched_fields"]
+
+    rerun_content = note_content + "\nRe-run addition: reviewed again.\n"
+    updated = service.invoke(
+        "library_save_note",
+        {
+            "title": note_title,
+            "content": rerun_content,
+            "folder": "Student Reader",
+            "note_id": found["items"][0]["id"],
+            "expected_version": int(reread["content"]["revision"]),
+        },
+    )
+    assert "error" not in updated, updated
+    assert updated["created"] is False
+    assert updated["version"] == 2
+
+    # Still exactly ONE note — the re-run updated, never duplicated.
+    still_one = service.invoke("library_search_notes", {"query": note_title})
+    assert still_one["total"] == 1
+    updated_read = service.invoke("library_get_note", {"id": updated["item"]["id"]})
+    assert updated_read["content"]["revision"] == "2"
+    assert updated_read["content"]["text"].endswith("reviewed again.\n")
+
+    # 8. The flashcard convention (student-workflow spec §6): flashcards
+    #    are Q/A markdown inside notes — visible the moment they land.
+    flashcard_title = "The Student Reader — Chapter 7 flashcards"
+    flashcard_content = (
+        f"{provenance_header}\n\n"
+        "Q: How many paragraphs does Chapter 7 carry?\n"
+        "A: Three, each worth noting for the exam.\n"
+        "Q: What does every paragraph of Chapter 7 carry?\n"
+        "A: Sentences worth noting for the exam.\n"
+    )
+    flashcards = service.invoke(
+        "library_save_note",
+        {
+            "title": flashcard_title,
+            "content": flashcard_content,
+            "folder": "Student Reader",
+        },
+    )
+    assert "error" not in flashcards, flashcards
+    assert flashcards["created"] is True
+    flashcard_read = service.invoke(
+        "library_get_note", {"id": flashcards["item"]["id"]}
+    )
+    assert "error" not in flashcard_read, flashcard_read
+    assert flashcard_read["content"]["text"].startswith(provenance_header)
+    assert flashcard_read["content"]["text"].count("Q:") == 2
+    assert flashcard_read["content"]["text"].count("A:") == 2
+
+    # Both saves converged on ONE per-book folder — what the notes screen
+    # lists, because the folder seam is pinned to the notes UI's scope.
+    children = asyncio.run(
+        scope.list_note_folder_children(
+            scope=ScopeType.LOCAL_NOTE,
+            parent_id=None,
+            limit=50,
+            offset=0,
+            user_id="student",
+        )
+    )
+    assert [folder.name for folder in children.folders] == ["Student Reader"]
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Library/test_library_tool_contract.py
+++ b/Tests/Library/test_library_tool_contract.py
@@ -50,6 +50,8 @@ EXPECTED_LIBRARY_TOOLS = {
     "library_get_media_structure", "library_get_media_chunk",
     "library_list_chunk_specs", "library_save_chunk_spec",
     "library_rechunk_media",
+    # student-workflow (spec §4): the note write tool
+    "library_save_note",
 }
 
 
@@ -58,12 +60,13 @@ EXPECTED_LIBRARY_TOOLS = {
 
 def test_descriptor_table_has_exact_canonical_surface():
     assert set(LIBRARY_TOOL_DESCRIPTORS) == EXPECTED_LIBRARY_TOOLS
-    assert len({d.route for d in LIBRARY_TOOL_DESCRIPTORS.values()}) == 23
+    assert len({d.route for d in LIBRARY_TOOL_DESCRIPTORS.values()}) == 24
     for descriptor in LIBRARY_TOOL_DESCRIPTORS.values():
         assert descriptor.item_type in LIBRARY_ITEM_TYPES
         assert descriptor.operation in {
             "list", "get", "search",
             "structure", "chunk", "spec_list", "spec_save", "rechunk",
+            "save",
         }
         assert descriptor.description
         assert descriptor.input_schema

--- a/Tests/Library/test_local_library_tool_service.py
+++ b/Tests/Library/test_local_library_tool_service.py
@@ -945,15 +945,27 @@ class FakeNotesScopeService:
         #: folder is absent -- simulating a concurrent create winning the race
         #: (the folder then appears on the re-query).
         self.collision_on_next_create = False
+        #: Seam method names whose call raises FolderCapabilityError -- the
+        #: deployment-without-folder-support shape (the scope service's own
+        #: ``_raise_folder_capability_error`` path).
+        self.capability_errors: tuple[str, ...] = ()
 
     async def list_note_folder_children(
         self, *, scope, parent_id, limit, offset, user_id=None
     ):
-        from tldw_chatbook.Notes.note_folder_models import normalize_folder_name
+        from tldw_chatbook.Notes.note_folder_models import (
+            FolderCapabilityError,
+            normalize_folder_name,
+        )
 
         self.calls.append(
             ("list_note_folder_children", {"parent_id": parent_id, "user_id": user_id})
         )
+        if "list_note_folder_children" in self.capability_errors:
+            raise FolderCapabilityError(
+                reason_code="folder_list_unsupported",
+                user_message="Folder listing is not available for this scope.",
+            )
         ordered = sorted(self._folders.values(), key=lambda f: f["name"])
         page = ordered[offset : offset + limit]
         end = offset + len(page)
@@ -970,11 +982,17 @@ class FakeNotesScopeService:
 
     async def create_note_folder(self, *, scope, name, parent_id, user_id=None):
         from tldw_chatbook.Notes.note_folder_models import (
+            FolderCapabilityError,
             FolderCollisionError,
             normalize_folder_name,
         )
 
         self.calls.append(("create_note_folder", {"name": name}))
+        if "create_note_folder" in self.capability_errors:
+            raise FolderCapabilityError(
+                reason_code="folder_create_unsupported",
+                user_message="Folder creation is not available for this scope.",
+            )
         key = normalize_folder_name(name).key
         if key in self._folders:
             raise FolderCollisionError(
@@ -1059,7 +1077,9 @@ def test_save_note_schema_bounds_match_the_spec():
     assert schema["properties"]["title"]["minLength"] == 1
     assert schema["properties"]["content"]["maxLength"] == 100_000
     assert schema["properties"]["content"]["minLength"] == 1
-    assert schema["properties"]["folder"]["maxLength"] == 256
+    # 255, not 256: the folder model's normalize_folder_name refuses
+    # segments longer than 255 chars -- the contract bound must equal it.
+    assert schema["properties"]["folder"]["maxLength"] == 255
     assert schema["properties"]["folder"]["minLength"] == 1
     assert schema["properties"]["note_id"]["maxLength"] == 128
     assert schema["properties"]["expected_version"]["minimum"] == 1
@@ -1170,6 +1190,52 @@ def test_save_note_unknown_note_id_maps_to_not_found():
     assert all(call[0] != "update_note" for call in notes.calls)
 
 
+def test_save_note_failed_update_never_mints_the_folder():
+    # Qodo review: for UPDATE calls the not_found pre-check and the version
+    # read run BEFORE the folder-ensure, so a deterministically failing
+    # update (unknown note id, stale version) cannot mint a folder for a
+    # call that then fails. Only the update race residual (the version
+    # moving between the read and the row write) may leave a folder behind.
+    unknown_scope = FakeNotesScopeService()
+    unknown = _save_service(
+        notes_service=FakeSaveNotesBackend(), notes_scope_service=unknown_scope
+    )
+    result = unknown.invoke(
+        "library_save_note",
+        {
+            "title": "T",
+            "content": "c",
+            "folder": "Study",
+            "note_id": _public_id("note", "missing-note"),
+            "expected_version": 1,
+        },
+    )
+    assert _error_code(result) == "not_found"
+    # No folder minted for a dead note id: the seam was never touched.
+    assert unknown_scope.calls == []
+
+    stale_scope = FakeNotesScopeService()
+    stale = _save_service(
+        notes_service=FakeSaveNotesBackend(
+            notes={"note-1": {"title": "T", "content": "c", "version": 7}}
+        ),
+        notes_scope_service=stale_scope,
+    )
+    result = stale.invoke(
+        "library_save_note",
+        {
+            "title": "T",
+            "content": "c2",
+            "folder": "Study",
+            "note_id": _public_id("note", "note-1"),
+            "expected_version": 6,
+        },
+    )
+    assert _error_code(result) == "content_changed"
+    # No folder minted for a stale version: the seam was never touched.
+    assert stale_scope.calls == []
+
+
 def test_save_note_rejects_wrong_type_and_malformed_note_ids():
     service = _save_service()
     wrong_type = service.invoke(
@@ -1209,10 +1275,10 @@ def test_save_note_over_long_fields_name_the_limit_at_invoke_time():
     assert "100000" in long_content["error"]["message"]
 
     long_folder = service.invoke(
-        "library_save_note", {"title": "t", "content": "c", "folder": "f" * 257}
+        "library_save_note", {"title": "t", "content": "c", "folder": "f" * 256}
     )
     assert _error_code(long_folder) == "invalid_argument"
-    assert "256" in long_folder["error"]["message"]
+    assert "255" in long_folder["error"]["message"]
 
     # Exactly-at-limit is NOT over-long: the checks are strict '>' and the
     # boundary value still reaches the row-writer.
@@ -1220,6 +1286,37 @@ def test_save_note_over_long_fields_name_the_limit_at_invoke_time():
         "library_save_note", {"title": "t" * 512, "content": "c" * 100_000}
     )
     assert at_limit.get("error", {}).get("code") != "invalid_argument"
+
+
+def test_save_note_folder_bound_matches_the_folder_model_segment_limit():
+    # Qodo review: the folder model's normalize_folder_name refuses segments
+    # over 255 chars, so the schema maxLength and the invoke-time guard must
+    # both be 255 -- a 256-char name must never pass the contract only to die
+    # at the model, and the model's own 255 boundary must survive end-to-end.
+    from tldw_chatbook.Notes.note_folder_models import (
+        FolderValidationError,
+        normalize_folder_name,
+    )
+
+    with pytest.raises(FolderValidationError):
+        normalize_folder_name("f" * 256)
+    assert normalize_folder_name("f" * 255).display == "f" * 255
+
+    schema = LIBRARY_TOOL_DESCRIPTORS["library_save_note"].input_schema
+    assert schema["properties"]["folder"]["maxLength"] == 255
+
+    service = _save_service()
+    rejected = service.invoke(
+        "library_save_note", {"title": "t", "content": "c", "folder": "f" * 256}
+    )
+    assert _error_code(rejected) == "invalid_argument"
+    assert "255" in rejected["error"]["message"]
+
+    accepted = service.invoke(
+        "library_save_note", {"title": "t", "content": "c", "folder": "f" * 255}
+    )
+    assert "error" not in accepted
+    assert accepted["item"]["folder"] == "f" * 255
 
 
 def test_save_note_folder_ensure_is_idempotent_across_saves():
@@ -1281,6 +1378,38 @@ def test_save_note_folder_without_scope_service_is_feature_unavailable():
     assert _error_code(result) == "feature_unavailable"
     # Refused before the row write: no orphan note lands unfiled.
     assert notes.calls == []
+
+
+def test_save_note_folder_capability_error_maps_to_feature_unavailable():
+    # Qodo review: the seam's own capability failure (a deployment whose
+    # scope cannot list/create folders raises FolderCapabilityError) is the
+    # NAMED feature_unavailable -- not the scrubbed generic storage_error.
+    notes = FakeSaveNotesBackend()
+    create_blocked = FakeNotesScopeService()
+    create_blocked.capability_errors = ("create_note_folder",)
+    service = _save_service(notes_service=notes, notes_scope_service=create_blocked)
+
+    result = service.invoke(
+        "library_save_note", {"title": "A", "content": "a", "folder": "Study"}
+    )
+
+    assert _error_code(result) == "feature_unavailable"
+    assert "folder operations are not available" in result["error"]["message"].lower()
+    # Refused before the row write: no orphan note lands unfiled.
+    assert notes.calls == []
+
+    listing_blocked = FakeNotesScopeService()
+    listing_blocked.capability_errors = ("list_note_folder_children",)
+    service = _save_service(
+        notes_service=FakeSaveNotesBackend(), notes_scope_service=listing_blocked
+    )
+
+    result = service.invoke(
+        "library_save_note", {"title": "A", "content": "a", "folder": "Study"}
+    )
+
+    assert _error_code(result) == "feature_unavailable"
+    assert "folder operations are not available" in result["error"]["message"].lower()
 
 
 def test_save_note_policy_denial_precedes_every_backend_call():

--- a/Tests/Library/test_local_library_tool_service.py
+++ b/Tests/Library/test_local_library_tool_service.py
@@ -9,15 +9,17 @@ cases.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import re
 import sqlite3
+from types import SimpleNamespace
 from unittest.mock import ANY
 
 import pytest
 
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
-from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, ConflictError, InputError
 from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.Library import local_library_tool_service as service_module
 from tldw_chatbook.Library.library_collections_service import (
@@ -31,6 +33,9 @@ from tldw_chatbook.Library.library_tool_contract import (
     serialized_size,
 )
 from tldw_chatbook.Library.local_library_tool_service import LocalLibraryToolService
+from tldw_chatbook.Notes.Notes_Library import NotesInteropService
+from tldw_chatbook.Notes.note_folder_repository import LocalNoteFolderRepository
+from tldw_chatbook.Notes.notes_scope_service import NotesScopeService, ScopeType
 
 
 # --------------------------------------------------------------------------
@@ -385,9 +390,10 @@ def _error_code(result):
 # --------------------------------------------------------------------------
 
 
-def test_descriptor_table_covers_23_tools():
-    # 18 task-1337 tools + the 5 chunking-agent-tools siblings (spec §4).
-    assert len(LIBRARY_TOOL_DESCRIPTORS) == 23
+def test_descriptor_table_covers_24_tools():
+    # 18 task-1337 tools + the 5 chunking-agent-tools siblings (spec §4)
+    # + library_save_note (student-workflow spec §4).
+    assert len(LIBRARY_TOOL_DESCRIPTORS) == 24
 
 
 def test_unknown_tool_name_is_invalid_argument():
@@ -860,6 +866,510 @@ def test_get_max_chars_validation():
 
     service.invoke("library_get_note", {"id": public, "max_chars": 999_999})
     assert notes.calls[-1][1]["max_chars"] == 16_000
+
+
+# --------------------------------------------------------------------------
+# Save notes: library_save_note (student-workflow spec §4)
+# --------------------------------------------------------------------------
+
+
+class FakeSaveNotesBackend(_Recorded):
+    """In-memory stand-in for the legacy notes interop's write path.
+
+    Mirrors ``NotesInteropService``: ``add_note`` rejects empty titles with
+    ``InputError``; ``update_note`` raises the REAL ``ConflictError`` on a
+    missing row or a version mismatch (ChaChaNotes_DB.py semantics).
+    """
+
+    def __init__(self, notes=None):
+        super().__init__()
+        self._rows = {  # note_id -> {"title", "content", "version"}
+            note_id: dict(row) for note_id, row in (notes or {}).items()
+        }
+
+    def add_note(self, user_id, title, content, note_id=None):
+        self._record(
+            "add_note", {"user_id": user_id, "title": title, "content": content}
+        )
+        if not isinstance(title, str) or not title.strip():
+            raise InputError("Note title cannot be empty.")
+        new_id = note_id or f"note-{len(self._rows) + 1}"
+        self._rows[new_id] = {"title": title, "content": content, "version": 1}
+        return new_id
+
+    def get_note_by_id(self, user_id, note_id):
+        self._record("get_note_by_id", {"user_id": user_id, "note_id": note_id})
+        row = self._rows.get(note_id)
+        return dict(row) if row is not None else None
+
+    def update_note(self, user_id, note_id, update_data, expected_version):
+        self._record(
+            "update_note",
+            {
+                "user_id": user_id,
+                "note_id": note_id,
+                "update_data": dict(update_data),
+                "expected_version": expected_version,
+            },
+        )
+        row = self._rows.get(note_id)
+        if row is None:
+            raise ConflictError(
+                "Record not found in notes.", entity="notes", entity_id=note_id
+            )
+        if row["version"] != expected_version:
+            raise ConflictError(
+                f"Note ID {note_id} update failed: version mismatch.",
+                entity="notes",
+                entity_id=note_id,
+            )
+        row.update(update_data)
+        row["version"] = expected_version + 1
+        return True
+
+
+class FakeNotesScopeService:
+    """Async scope-seam stand-in over an in-memory folder dict.
+
+    Mirrors the real seams the handler consumes: children-list at the root,
+    NON-idempotent create (normalized-path collision -> FolderCollisionError),
+    and a safe re-attach. Names are keyed by the same normalize_folder_name
+    key the repository uses, so lookups match the real collision semantics.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self._folders = {}  # key -> {"folder_id", "name"}
+        self._next_id = 0
+        #: When True the next create raises the collision error even if the
+        #: folder is absent -- simulating a concurrent create winning the race
+        #: (the folder then appears on the re-query).
+        self.collision_on_next_create = False
+
+    async def list_note_folder_children(
+        self, *, scope, parent_id, limit, offset, user_id=None
+    ):
+        from tldw_chatbook.Notes.note_folder_models import normalize_folder_name
+
+        self.calls.append(
+            ("list_note_folder_children", {"parent_id": parent_id, "user_id": user_id})
+        )
+        ordered = sorted(self._folders.values(), key=lambda f: f["name"])
+        page = ordered[offset : offset + limit]
+        end = offset + len(page)
+        return SimpleNamespace(
+            folders=tuple(
+                SimpleNamespace(
+                    folder_id=f["folder_id"], name=f["name"], parent_id=None
+                )
+                for f in page
+            ),
+            next_folder_offset=end if page and end < len(ordered) else None,
+            _lookup={normalize_folder_name(f["name"]).key: f for f in page},
+        )
+
+    async def create_note_folder(self, *, scope, name, parent_id, user_id=None):
+        from tldw_chatbook.Notes.note_folder_models import (
+            FolderCollisionError,
+            normalize_folder_name,
+        )
+
+        self.calls.append(("create_note_folder", {"name": name}))
+        key = normalize_folder_name(name).key
+        if key in self._folders:
+            raise FolderCollisionError(
+                "An active folder already uses the normalized path."
+            )
+        if self.collision_on_next_create:
+            self.collision_on_next_create = False
+            # The concurrent winner's folder becomes visible for the re-query.
+            self._next_id += 1
+            self._folders[key] = {
+                "folder_id": f"folder-raced-{self._next_id}",
+                "name": name,
+            }
+            raise FolderCollisionError(
+                "An active folder already uses the normalized path."
+            )
+        self._next_id += 1
+        folder = {"folder_id": f"folder-{self._next_id}", "name": name}
+        self._folders[key] = folder
+        return SimpleNamespace(folder_id=folder["folder_id"], name=name)
+
+    async def attach_note_to_folder(self, *, scope, folder_id, note_id, user_id=None):
+        self.calls.append(
+            ("attach_note_to_folder", {"folder_id": folder_id, "note_id": note_id})
+        )
+        return SimpleNamespace(folder_id=folder_id, note_id=note_id)
+
+    def folder_count(self):
+        return len(self._folders)
+
+
+class _DenyingPolicyEnforcer:
+    def __init__(self, allowed=True):
+        self.allowed = allowed
+        self.actions = []
+
+    def require_allowed(self, *, action_id):
+        self.actions.append(action_id)
+        if not self.allowed:
+            from tldw_chatbook.runtime_policy.types import PolicyDeniedError
+
+            raise PolicyDeniedError(
+                action_id=action_id,
+                reason_code="authority_denied",
+                user_message="denied by test",
+                effective_source="local",
+                authority_owner="local",
+            )
+
+
+def _save_service(**overrides):
+    backends = _backends(
+        notes_service=FakeSaveNotesBackend(),
+        notes_scope_service=FakeNotesScopeService(),
+    )
+    backends.update(overrides)
+    return LocalLibraryToolService(**backends)
+
+
+def test_save_note_note_id_and_version_must_arrive_together():
+    # The together-rule (student-workflow spec §4.1): exactly one of
+    # note_id/expected_version supplied -> invalid_argument. Pinned FIRST
+    # because it is the most-missed edge.
+    service = _save_service()
+    id_only = service.invoke(
+        "library_save_note",
+        {"title": "t", "content": "c", "note_id": _public_id("note", "note-1")},
+    )
+    assert _error_code(id_only) == "invalid_argument"
+
+    version_only = service.invoke(
+        "library_save_note", {"title": "t", "content": "c", "expected_version": 1}
+    )
+    assert _error_code(version_only) == "invalid_argument"
+
+
+def test_save_note_schema_bounds_match_the_spec():
+    schema = LIBRARY_TOOL_DESCRIPTORS["library_save_note"].input_schema
+    assert schema["required"] == ["title", "content"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["title"]["maxLength"] == 512
+    assert schema["properties"]["title"]["minLength"] == 1
+    assert schema["properties"]["content"]["maxLength"] == 100_000
+    assert schema["properties"]["content"]["minLength"] == 1
+    assert schema["properties"]["folder"]["maxLength"] == 256
+    assert schema["properties"]["folder"]["minLength"] == 1
+    assert schema["properties"]["note_id"]["maxLength"] == 128
+    assert schema["properties"]["expected_version"]["minimum"] == 1
+    # The route/item/operation identity the dispatch keys on.
+    descriptor = LIBRARY_TOOL_DESCRIPTORS["library_save_note"]
+    assert descriptor.item_type == "note"
+    assert descriptor.operation == "save"
+    assert "Writes local Library data only" in descriptor.description
+
+
+def test_save_note_rejects_unknown_and_missing_arguments():
+    service = _save_service()
+    unknown = service.invoke(
+        "library_save_note", {"title": "t", "content": "c", "color": "blue"}
+    )
+    assert _error_code(unknown) == "invalid_argument"
+
+    missing = service.invoke("library_save_note", {"title": "t"})
+    assert _error_code(missing) == "invalid_argument"
+
+
+def test_save_note_description_documents_the_provenance_header():
+    description = LIBRARY_TOOL_DESCRIPTORS["library_save_note"].description
+    # The header convention rides the DESCRIPTION (convention, not enforced
+    # code) -- source and revision are the load-bearing lines.
+    assert "source:" in description
+    assert "revision:" in description
+    assert "chunks:" in description
+
+
+def test_save_note_create_returns_id_version_and_created_flag():
+    notes = FakeSaveNotesBackend()
+    service = _save_service(notes_service=notes)
+
+    result = service.invoke(
+        "library_save_note", {"title": "Chapter 7", "content": "body text"}
+    )
+
+    assert "error" not in result
+    parse_public_id(result["item"]["id"], expected_type="note")
+    assert result["item"]["type"] == "note"
+    assert result["item"]["title"] == "Chapter 7"
+    assert "folder" not in result["item"]
+    assert result["version"] == 1
+    assert result["created"] is True
+    assert result["notes"] and all(isinstance(line, str) for line in result["notes"])
+    assert notes.calls[0][0] == "add_note"
+    assert notes.calls[0][1]["user_id"] == "user-1"
+
+
+def test_save_note_update_bumps_version_and_reports_not_created():
+    notes = FakeSaveNotesBackend(notes={"note-1": {"title": "Old", "content": "old", "version": 1}})
+    service = _save_service(notes_service=notes)
+
+    result = service.invoke(
+        "library_save_note",
+        {
+            "title": "New title",
+            "content": "new body",
+            "note_id": _public_id("note", "note-1"),
+            "expected_version": 1,
+        },
+    )
+
+    assert "error" not in result
+    assert result["created"] is False
+    assert result["version"] == 2
+    assert result["item"]["id"] == _public_id("note", "note-1")
+    update_call = next(call for call in notes.calls if call[0] == "update_note")
+    assert update_call[1]["update_data"] == {"title": "New title", "content": "new body"}
+    assert update_call[1]["expected_version"] == 1
+
+
+def test_save_note_stale_version_maps_to_content_changed():
+    notes = FakeSaveNotesBackend(notes={"note-1": {"title": "T", "content": "c", "version": 7}})
+    service = _save_service(notes_service=notes)
+
+    result = service.invoke(
+        "library_save_note",
+        {
+            "title": "T",
+            "content": "c2",
+            "note_id": _public_id("note", "note-1"),
+            "expected_version": 6,
+        },
+    )
+
+    assert _error_code(result) == "content_changed"
+    assert result["error"]["retryable"] is False
+
+
+def test_save_note_unknown_note_id_maps_to_not_found():
+    notes = FakeSaveNotesBackend()
+    service = _save_service(notes_service=notes)
+
+    result = service.invoke(
+        "library_save_note",
+        {
+            "title": "T",
+            "content": "c",
+            "note_id": _public_id("note", "missing-note"),
+            "expected_version": 1,
+        },
+    )
+
+    assert _error_code(result) == "not_found"
+    # The update seam was never reached (the existence pre-check refused).
+    assert all(call[0] != "update_note" for call in notes.calls)
+
+
+def test_save_note_rejects_wrong_type_and_malformed_note_ids():
+    service = _save_service()
+    wrong_type = service.invoke(
+        "library_save_note",
+        {
+            "title": "t",
+            "content": "c",
+            "note_id": _public_id("media", "media-uuid-1"),
+            "expected_version": 1,
+        },
+    )
+    assert _error_code(wrong_type) == "invalid_argument"
+
+    malformed = service.invoke(
+        "library_save_note",
+        {"title": "t", "content": "c", "note_id": "not-an-id", "expected_version": 1},
+    )
+    assert _error_code(malformed) == "invalid_argument"
+
+
+def test_save_note_folder_ensure_is_idempotent_across_saves():
+    scope = FakeNotesScopeService()
+    service = _save_service(notes_scope_service=scope)
+
+    first = service.invoke(
+        "library_save_note", {"title": "A", "content": "a", "folder": "Study"}
+    )
+    second = service.invoke(
+        "library_save_note", {"title": "B", "content": "b", "folder": "Study"}
+    )
+
+    assert "error" not in first
+    assert "error" not in second
+    assert scope.folder_count() == 1
+    creates = [call for call in scope.calls if call[0] == "create_note_folder"]
+    assert len(creates) == 1
+    attaches = [call for call in scope.calls if call[0] == "attach_note_to_folder"]
+    assert len(attaches) == 2
+    assert {attaches[0][1]["folder_id"]} == {attaches[1][1]["folder_id"]}
+    assert first["item"]["folder"] == "Study"
+    assert second["item"]["folder"] == "Study"
+
+
+def test_save_note_folder_ensure_tolerates_the_create_race():
+    scope = FakeNotesScopeService()
+    scope.collision_on_next_create = True
+    service = _save_service(notes_scope_service=scope)
+
+    result = service.invoke(
+        "library_save_note", {"title": "A", "content": "a", "folder": "Study"}
+    )
+
+    assert "error" not in result  # the race never raises to the agent
+    assert scope.folder_count() == 1
+    attach = next(call for call in scope.calls if call[0] == "attach_note_to_folder")
+    assert attach[1]["folder_id"] == "folder-raced-1"
+
+
+def test_save_note_folderless_create_never_touches_the_scope_service():
+    scope = FakeNotesScopeService()
+    service = _save_service(notes_scope_service=scope)
+
+    result = service.invoke("library_save_note", {"title": "A", "content": "a"})
+
+    assert "error" not in result
+    assert scope.calls == []
+
+
+def test_save_note_folder_without_scope_service_is_feature_unavailable():
+    notes = FakeSaveNotesBackend()
+    service = _save_service(notes_service=notes, notes_scope_service=None)
+
+    result = service.invoke(
+        "library_save_note", {"title": "A", "content": "a", "folder": "Study"}
+    )
+
+    assert _error_code(result) == "feature_unavailable"
+    # Refused before the row write: no orphan note lands unfiled.
+    assert notes.calls == []
+
+
+def test_save_note_policy_denial_precedes_every_backend_call():
+    notes = FakeSaveNotesBackend()
+    scope = FakeNotesScopeService()
+    service = _save_service(
+        notes_service=notes,
+        notes_scope_service=scope,
+        policy_enforcer=_DenyingPolicyEnforcer(allowed=False),
+    )
+
+    result = service.invoke(
+        "library_save_note", {"title": "A", "content": "a", "folder": "Study"}
+    )
+
+    assert _error_code(result) == "feature_unavailable"
+    assert result["error"]["details"]["policy_action"] == "library.notes.save.local"
+    # The mutation pin: no note row, no folder, no attach -- nothing ran.
+    assert notes.calls == []
+    assert scope.calls == []
+
+
+def test_save_note_policy_enforcement_uses_the_dedicated_action():
+    enforcer = _DenyingPolicyEnforcer(allowed=True)
+    service = _save_service(policy_enforcer=enforcer)
+
+    result = service.invoke("library_save_note", {"title": "A", "content": "a"})
+
+    assert "error" not in result
+    assert enforcer.actions == ["library.notes.save.local"]
+
+
+def test_save_note_invalid_folder_name_is_invalid_argument():
+    service = _save_service()
+    # The folder model is a tree of single segments: a slash can never name
+    # one folder (the repository's normalize_folder_name refuses it).
+    result = service.invoke(
+        "library_save_note", {"title": "A", "content": "a", "folder": "Study/Book"}
+    )
+    assert _error_code(result) == "invalid_argument"
+
+
+def test_real_save_note_creates_places_and_updates(chacha_db, tmp_path):
+    notes = NotesInteropService(
+        base_db_directory=tmp_path,
+        api_client_id="test-client",
+        global_db_to_use=chacha_db,
+    )
+    scope = NotesScopeService(
+        local_notes_service=notes,
+        server_service=None,
+        folder_repository=LocalNoteFolderRepository(chacha_db),
+    )
+    service = _save_service(notes_service=notes, notes_scope_service=scope)
+    provenance = (
+        "source: media:abc123\nrevision: 4\nchapter: Chapter 7\nchunks: 12-15\n\n"
+        "Key points..."
+    )
+
+    created = service.invoke(
+        "library_save_note",
+        {"title": "Chapter 7 notes", "content": provenance, "folder": "Study"},
+    )
+    assert "error" not in created
+    assert created["created"] is True
+    assert created["version"] == 1
+    assert created["item"]["folder"] == "Study"
+
+    # The row is readable back through the read tool with the header intact.
+    read = service.invoke("library_get_note", {"id": created["item"]["id"]})
+    assert read["content"]["text"].startswith("source: media:abc123")
+    assert "revision: 4" in read["content"]["text"]
+
+    # The folder is visible exactly once where the notes screen lists folders.
+    children = asyncio.run(
+        scope.list_note_folder_children(
+            scope=ScopeType.LOCAL_NOTE,
+            parent_id=None,
+            limit=50,
+            offset=0,
+            user_id="user-1",
+        )
+    )
+    assert [folder.name for folder in children.folders] == ["Study"]
+
+    # The update path bumps the version and keeps the placement.
+    updated = service.invoke(
+        "library_save_note",
+        {
+            "title": "Chapter 7 notes",
+            "content": provenance + "\nMore points",
+            "folder": "Study",
+            "note_id": created["item"]["id"],
+            "expected_version": 1,
+        },
+    )
+    assert "error" not in updated
+    assert updated["created"] is False
+    assert updated["version"] == 2
+    children_after = asyncio.run(
+        scope.list_note_folder_children(
+            scope=ScopeType.LOCAL_NOTE,
+            parent_id=None,
+            limit=50,
+            offset=0,
+            user_id="user-1",
+        )
+    )
+    assert [folder.name for folder in children_after.folders] == ["Study"]
+
+    # Stale version on a real row -> the named conflict error.
+    stale = service.invoke(
+        "library_save_note",
+        {
+            "title": "Chapter 7 notes",
+            "content": "conflicting",
+            "note_id": created["item"]["id"],
+            "expected_version": 1,
+        },
+    )
+    assert _error_code(stale) == "content_changed"
 
 
 # --------------------------------------------------------------------------

--- a/Tests/Library/test_local_library_tool_service.py
+++ b/Tests/Library/test_local_library_tool_service.py
@@ -1190,6 +1190,38 @@ def test_save_note_rejects_wrong_type_and_malformed_note_ids():
     assert _error_code(malformed) == "invalid_argument"
 
 
+def test_save_note_over_long_fields_name_the_limit_at_invoke_time():
+    # Invoke-time mirrors of the schema maxLength literals (final-review
+    # follow-up): a schema-bypassing caller still fails closed, and the
+    # refusal names the bound so the agent can self-correct.
+    service = _save_service()
+
+    long_title = service.invoke(
+        "library_save_note", {"title": "t" * 513, "content": "c"}
+    )
+    assert _error_code(long_title) == "invalid_argument"
+    assert "512" in long_title["error"]["message"]
+
+    long_content = service.invoke(
+        "library_save_note", {"title": "t", "content": "c" * 100_001}
+    )
+    assert _error_code(long_content) == "invalid_argument"
+    assert "100000" in long_content["error"]["message"]
+
+    long_folder = service.invoke(
+        "library_save_note", {"title": "t", "content": "c", "folder": "f" * 257}
+    )
+    assert _error_code(long_folder) == "invalid_argument"
+    assert "256" in long_folder["error"]["message"]
+
+    # Exactly-at-limit is NOT over-long: the checks are strict '>' and the
+    # boundary value still reaches the row-writer.
+    at_limit = service.invoke(
+        "library_save_note", {"title": "t" * 512, "content": "c" * 100_000}
+    )
+    assert at_limit.get("error", {}).get("code") != "invalid_argument"
+
+
 def test_save_note_folder_ensure_is_idempotent_across_saves():
     scope = FakeNotesScopeService()
     service = _save_service(notes_scope_service=scope)

--- a/Tests/Library/test_media_chunk_tool_service.py
+++ b/Tests/Library/test_media_chunk_tool_service.py
@@ -1815,6 +1815,42 @@ def test_spec_save_argument_validation(
         assert _error_code(payload) == ERROR_INVALID_ARGUMENT, args
 
 
+def test_spec_save_over_long_name_and_description_name_the_limit(
+    spec_service: LocalMediaChunkToolService,
+):
+    # Invoke-time mirrors of the schema maxLength literals (the save-note
+    # follow-up's twin): a schema-bypassing caller still fails closed, with
+    # the bound named so the agent can self-correct.
+    long_name = _invoke(
+        spec_service,
+        "library_save_chunk_spec",
+        {"name": "n" * 121, "spec": _valid_spec_body()},
+    )
+    assert _error_code(long_name) == ERROR_INVALID_ARGUMENT
+    assert "120" in long_name["error"]["message"]
+
+    long_description = _invoke(
+        spec_service,
+        "library_save_chunk_spec",
+        {
+            "name": "x",
+            "spec": _valid_spec_body(),
+            "description": "d" * 2_001,
+        },
+    )
+    assert _error_code(long_description) == ERROR_INVALID_ARGUMENT
+    assert "2000" in long_description["error"]["message"]
+
+    # Exactly-at-limit is NOT over-long (strict '>'): the boundary value
+    # passes the argument gate.
+    at_limit = _invoke(
+        spec_service,
+        "library_save_chunk_spec",
+        {"name": "n" * 120, "spec": _valid_spec_body()},
+    )
+    assert at_limit.get("error", {}).get("code") != ERROR_INVALID_ARGUMENT
+
+
 def test_spec_tools_without_interop_map_to_feature_unavailable(
     media_db: MediaDatabase,
 ):

--- a/Tests/MCP/test_library_tools.py
+++ b/Tests/MCP/test_library_tools.py
@@ -68,7 +68,7 @@ class FakeLibraryToolService:
 # -- Manifest -----------------------------------------------------------------
 
 
-def test_manifest_keeps_legacy_tools_then_appends_the_23_descriptor_tools():
+def test_manifest_keeps_legacy_tools_then_appends_the_24_descriptor_tools():
     manifest = describe_local_mcp_capabilities()
     tools = manifest["tools"]
     names = [entry["name"] for entry in tools]
@@ -76,7 +76,7 @@ def test_manifest_keeps_legacy_tools_then_appends_the_23_descriptor_tools():
     assert names[: len(LEGACY_TOOL_NAMES)] == LEGACY_TOOL_NAMES
     library_entries = tools[len(LEGACY_TOOL_NAMES) :]
     assert [entry["name"] for entry in library_entries] == LIBRARY_TOOL_NAMES
-    assert len(tools) == len(LEGACY_TOOL_NAMES) + 23
+    assert len(tools) == len(LEGACY_TOOL_NAMES) + 24
 
 
 def test_manifest_does_not_advertise_unimplemented_ingest_media():

--- a/Tests/MCP/test_local_control_service.py
+++ b/Tests/MCP/test_local_control_service.py
@@ -1955,6 +1955,10 @@ _LIBRARY_TOOL_POLICY_EXPECTATIONS = {
     "library_list_chunk_specs": ("media.reading.list.local", "media_reading_ingestion_sources"),
     "library_save_chunk_spec": ("library.templates.save.local", "library_collections"),
     "library_rechunk_media": ("library.media.rechunk.local", "library_collections"),
+    # student-workflow (Task 1, spec §4): the note write resolves to its OWN
+    # local Library write action -- never the derived notes read a note-typed
+    # tool would otherwise fall to.
+    "library_save_note": ("library.notes.save.local", "library_collections"),
 }
 
 

--- a/Tests/MCP/test_mcp_unified_stdio.py
+++ b/Tests/MCP/test_mcp_unified_stdio.py
@@ -817,7 +817,7 @@ async def test_wire_excludes_library_tools_while_in_process_manifest_keeps_all_1
         }
         library_names = set(LIBRARY_TOOL_DESCRIPTORS)
 
-        assert len(library_names) == 23
+        assert len(library_names) == 24
         assert library_names <= manifest_names
         assert wire_names == set(BUILTIN_TOOL_NAMES)
         assert wire_names.isdisjoint(library_names)

--- a/Tests/RuntimePolicy/test_library_media_rechunk_policy_pin.py
+++ b/Tests/RuntimePolicy/test_library_media_rechunk_policy_pin.py
@@ -14,8 +14,8 @@ Pinned here (the task-13/task-4 pin pattern):
   attributes (and present in the equality test's own literal, so the verb
   cannot drift from the registry);
 * the MCP local-control mapping resolves the tool to EXACTLY that action
-  id, and the override map is EXACTLY the two writing tools (the
-  tool-mapping pin);
+  id, and the override map is EXACTLY the writing tools (the tool-mapping
+  pin; three since the student-workflow note-save landed);
 * no server variant exists (local-only resource).
 """
 
@@ -65,10 +65,13 @@ def test_mcp_local_control_maps_rechunk_to_the_write_action() -> None:
     assert _TOOL_ACTION_IDS["library_rechunk_media"] == LIBRARY_MEDIA_RECHUNK_ACTION_ID
 
 
-def test_writing_tool_overrides_are_exactly_the_two_write_tools() -> None:
-    """The override map stays descriptor-keyed and exactly the two writing
-    operations -- every other descriptor keeps its type-owned read mapping."""
+def test_writing_tool_overrides_are_exactly_the_three_write_tools() -> None:
+    """The override map stays descriptor-keyed and exactly the writing
+    operations -- every other descriptor keeps its type-owned read mapping.
+    (Grew from two to three when student-workflow Task 1 landed the
+    note-save write; the count pin lives here so growth stays deliberate.)"""
     assert _LIBRARY_TOOL_ACTION_OVERRIDES == {
         "spec_save": "library.templates.save.local",
         "rechunk": LIBRARY_MEDIA_RECHUNK_ACTION_ID,
+        "save": "library.notes.save.local",
     }

--- a/Tests/RuntimePolicy/test_library_notes_save_policy_pin.py
+++ b/Tests/RuntimePolicy/test_library_notes_save_policy_pin.py
@@ -1,0 +1,77 @@
+"""Task 1 (student-workflow): the note-save action's policy id, pinned.
+
+Spec §4/§8: ``library_save_note`` maps to the new ``library.notes``
+resource with a ``save`` action -- the local Library agent-tools policy
+home (the same ``library_collections`` capability that owns
+``library.collections.*``, ``library.templates`` and ``library.media``),
+NOT the notes UI's own ``notes.*`` CRUD verbs (those model the notes
+screen's row operations; the agent tool is the Library write surface) and
+NOT the derived notes read action the MCP mapping would otherwise resolve
+a note-typed tool to.
+
+Pinned here (the task-4/task-5 pin pattern):
+
+* ``library.notes.save.local`` is registered with the local-only
+  attributes (and present in the equality test's own literal, so the verb
+  cannot drift from the registry);
+* the MCP local-control mapping resolves the tool to EXACTLY that action
+  id on BOTH seams (tool.execute previews and tools/call runtime
+  requests), and the override map is EXACTLY the three writing tools;
+* no server variant exists (local-only resource).
+"""
+
+from __future__ import annotations
+
+from tldw_chatbook.MCP.local_control_service import (
+    _LIBRARY_TOOL_ACTION_OVERRIDES,
+    _TOOL_ACTION_IDS,
+)
+from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
+
+#: The single action id the note-save tool is allowed to run under.
+LIBRARY_NOTES_SAVE_ACTION_ID = "library.notes.save.local"
+
+
+def test_library_notes_save_action_id_is_registered() -> None:
+    entry = CAPABILITY_REGISTRY[LIBRARY_NOTES_SAVE_ACTION_ID]
+    assert entry.capability_id == "library_collections"
+    assert entry.domain_id == "library_collections"
+    assert entry.required_source == "local"
+    assert entry.authority_owner == "local"
+    assert entry.enabled is True
+    assert entry.action_kind == "update"  # create-or-update semantics
+
+
+def test_library_notes_save_action_id_is_pinned_by_the_equality_literal() -> None:
+    """The existing exact-equality test picks up the new verb; tie this pin
+    to its literal so removing the verb fails BOTH tests."""
+    from Tests.RuntimePolicy.test_runtime_policy_core import (
+        EXPECTED_ACTION_IDS_BY_CAPABILITY,
+    )
+
+    library_ids = EXPECTED_ACTION_IDS_BY_CAPABILITY.get("library_collections")
+    assert library_ids is not None
+    assert LIBRARY_NOTES_SAVE_ACTION_ID in library_ids
+
+
+def test_library_notes_save_is_local_only() -> None:
+    assert f"{LIBRARY_NOTES_SAVE_ACTION_ID.removesuffix('.local')}.server" not in (
+        CAPABILITY_REGISTRY
+    )
+
+
+def test_mcp_local_control_maps_save_note_to_the_write_action() -> None:
+    """The save tool's MCP policy mapping resolves to the write action,
+    never the derived notes read (``notes.list.local``) a note-typed tool
+    would otherwise fall to."""
+    assert _TOOL_ACTION_IDS["library_save_note"] == LIBRARY_NOTES_SAVE_ACTION_ID
+
+
+def test_writing_tool_overrides_are_exactly_the_three_write_tools() -> None:
+    """The override map stays descriptor-keyed and exactly the three writing
+    operations -- every other descriptor keeps its type-owned read mapping."""
+    assert _LIBRARY_TOOL_ACTION_OVERRIDES == {
+        "spec_save": "library.templates.save.local",
+        "rechunk": "library.media.rechunk.local",
+        "save": LIBRARY_NOTES_SAVE_ACTION_ID,
+    }

--- a/Tests/RuntimePolicy/test_runtime_policy_core.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_core.py
@@ -577,6 +577,7 @@ EXPECTED_ACTION_IDS_BY_CAPABILITY = {
         library.collections.detail.local
         library.collections.list.local
         library.media.rechunk.local
+        library.notes.save.local
         library.templates.save.local
     """),
     "external_connectors": _action_ids("""

--- a/Tests/UI/test_console_library_tool_setting.py
+++ b/Tests/UI/test_console_library_tool_setting.py
@@ -209,7 +209,7 @@ def test_factory_missing_backend_yields_per_tool_feature_unavailable(monkeypatch
 
     assert isinstance(provider, LibraryToolProvider)
     # Catalog still exposes the full descriptor set (no total failure).
-    assert len(provider.list_catalog()) == 23
+    assert len(provider.list_catalog()) == 24
     for tool_id in ("library:library_list_notes", "library:library_list_media"):
         result = provider.invoke(tool_id, {})
         assert result.ok is False

--- a/backlog/tasks/task-20979 - Flashcards-viewing-SRS-surface-decide-and-build-what-makes-real-rows-visible.md
+++ b/backlog/tasks/task-20979 - Flashcards-viewing-SRS-surface-decide-and-build-what-makes-real-rows-visible.md
@@ -1,0 +1,53 @@
+---
+id: TASK-20979
+title: 'Flashcards viewing/SRS surface — decide and build what makes real flashcards rows visible'
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+updated_date: '2026-08-23'
+labels:
+  - flashcards
+  - notes
+  - ui
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The flashcards data layer exists (`decks`, `flashcards`, `flashcards_fts` —
+verified in the student-workflow design spec), but it has **no screen route**:
+nothing in the app renders or reviews those rows. That is why the
+student-workflow spec's ruling §7.3 (§6, "Flashcards — the deliberate
+decision") made the sub-project's flashcard output **Q/A markdown inside
+notes** — visible in the notes screen the moment it lands — and explicitly
+kept the real-rows path open "for whenever a flashcards viewing/SRS surface
+exists", filing this task at implementation close-out per its §8 ruling 11.
+
+This task decides, and where the decision is "build", builds the surface that
+would make real-rows flashcard output viable: a place a student can see their
+decks and review cards. Until such a surface exists, agent tooling that
+writes real flashcards rows would ship output the student cannot see anywhere
+— the invisible-output problem is the whole reason the Q/A-in-notes ruling
+was taken, and it should be re-cited (not re-litigated) if this task is
+closed as "not now".
+
+Source spec: `Docs/superpowers/specs/2026-08-23-student-workflow-design.md`
+§6 and §8 ruling 3/11. Discovery record:
+`.superpowers/sdd/2026-08-23-student-workflow/task-2-report.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] A recorded decision (ADR if it sets a long-lived UX/data boundary) on the flashcards surface: what is built now, or an explicit "not now" that cites the invisible-output ruling rather than restating it
+- [ ] If built: a screen route renders decks and their flashcards rows from the existing data layer (create/read at minimum; review/SRS flow scoped by the decision), covered by tests against real SQLite
+- [ ] If built: the agent-output question is re-visited in a follow-up filing — with rows visible, does an agent write path (e.g. a flashcards target beside `library_save_note`) get built, and under which policy action
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+(To be added when the task is picked up.)
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-20980 - Folder-filtered-library-list-notes-conditional-candidate.md
+++ b/backlog/tasks/task-20980 - Folder-filtered-library-list-notes-conditional-candidate.md
@@ -1,0 +1,54 @@
+---
+id: TASK-20980
+title: 'Folder-filtered library_list_notes (conditional candidate — only if search-based re-runs trip on false positives)'
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+updated_date: '2026-08-23'
+labels:
+  - library
+  - agent-tools
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Third-review finding behind the student-workflow spec's re-run disambiguation
+ruling (§5): the cross-session re-run convention for `library_save_note` is
+**search-based** — `library_search_notes(query=<note title>)`, agent
+disambiguates by reading — because `library_list_notes` has **no folder
+filter** (its schema is limit/offset only) and its payloads carry **no folder
+info**, so "which notes are in this study folder" is not expressible through
+the list tool. Search-by-title can false-positive: any note whose content
+contains the title string matches, and note search is substring + FTS over
+content, not title-exact.
+
+This task is **conditionally valuable, not unconditional**: only worth taking
+if agents actually trip over those false positives in practice (mis-picked
+match, duplicate minted anyway) or the maintainer rules the risk live. The
+fix when warranted is a `folder` parameter on `library_list_notes` — folders
+are already the save tool's grouping affordance, ensured in the notes UI's
+local scope — plus the folder info the disambiguation needs in note briefs.
+If the evidence never arrives, the search-based convention stands and this
+task closes as "not needed" with that recorded.
+
+Source spec: `Docs/superpowers/specs/2026-08-23-student-workflow-design.md` §5
+(re-run disambiguation ruling) and §4.4 (the accepted duplicate window).
+Discovery record: `.superpowers/sdd/2026-08-23-student-workflow/task-2-report.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] An evidence gate is recorded either way: documented instances of agents mis-disambiguating a title search (wrong note updated, or a duplicate minted despite the convention), or a maintainer ruling that the risk is live — without one, the task closes as not-needed with the search-based convention reaffirmed
+- [ ] If taken: `library_list_notes` accepts a `folder` filter (one-level name, matching the save tool's affordance) and returns only notes filed there, with contract + service tests covering the empty-folder, unknown-folder, and unfiled-notes cases
+- [ ] If taken: the re-run documentation (Docs/Development/Agent-Tools/local-library-tools.md, the save-note section) is updated from the search-based convention to the folder-filtered one, stating why it changed
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+(To be added when the task is picked up.)
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-21135 - Student-workflow-sub-project-5-library_save_note-closes-the-write-loop.md
+++ b/backlog/tasks/task-21135 - Student-workflow-sub-project-5-library_save_note-closes-the-write-loop.md
@@ -1,0 +1,48 @@
+---
+id: TASK-21135
+title: 'Student workflow (sub-project #5): library_save_note closes the write loop'
+status: Done
+assignee: []
+created_date: '2026-08-22'
+updated_date: '2026-08-22'
+labels:
+  - chunking
+  - notes
+dependencies: [TASK-20939]
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Sub-project #5 of the chunking parity program (single PR, stacked on #4/TASK-20939's four chunk tools — no new ADR; the spec's §8 rulings are the long-form record): the write side of the student story — one tool, `library_save_note`, that lets a Console/MCP agent land what #4's read path gathered. Create-default with version-locked update (`note_id` + `expected_version`, `ConflictError` → `content_changed`), one-level folder grouping through the notes scope service (idempotent ensure, race-tolerant), the `library.notes/save` policy action with denial preceding every backend call, the provenance-header convention (documented, never enforced), and the QA-in-notes flashcard target. Plus the upgraded end-to-end student story (save → re-read → search-based re-run → update-not-duplicate), the study-notes fan-out pattern in the user guide, and final review.
+
+Spec: `Docs/superpowers/specs/2026-08-23-student-workflow-design.md` (§4 design, §5 conventions, §6 flashcards, §7 testing, §8's 11 rulings). Plan: `Docs/superpowers/plans/2026-08-23-student-workflow.md` (two tasks, one PR).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] The write tool: `library_save_note` as the 24th descriptor (note/save) — create-default returning id+version, version-locked update via `note_id`+`expected_version` with stale-version `content_changed`; input bounds schema-level and now invoke-time (title 512 / content 100_000 / folder 256, named limits); provenance-header convention in the description (spec §4.1-§4.2, §8.2, §8.6, §8.8)
+- [x] The folder seam: rows via the legacy notes interop, folders/placements via `NotesScopeService` pinned to the notes screen's own `local_note` scope; idempotent ensure (lookup → create-on-miss → re-query-on-collision), order validate → policy → folder → row → attach so a folder failure never orphans a note (spec §4.3, §8.5, §8.10)
+- [x] Policy: `library.notes/save.local` registered and wired at both construction sites (chat_screen factory, MCP build); denial precedes every backend call, mutation-pinned on both seams (spec §6)
+- [x] Story + conventions: the #4 read path now closes the loop through the shared dispatcher — Chapter-7 note saved with provenance header, re-read whole, re-run leg search-based (`library_search_notes(query=title)`, the third-review ruling — the list tool has no folder filter) updating instead of duplicating, QA-flashcard leg saved and re-read; fan-out pattern + save-note contract documented, CHANGELOG (spec §5, §7.6)
+- [x] Close-out: both follow-ups filed (TASK-20979 flashcards viewing/SRS surface; TASK-20980 folder-filtered list-notes candidate); final review READY-WITH-LISTED-FOLLOWS with both follows fixed in-branch (invoke-time length guards incl. the spec-save twin; prose/count/spec-errata sweep); targeted suites green (spec §7.7)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Descriptor + schema + dispatch + handler + policy wiring (plan Task 1)
+2. Student-story upgrade, docs, follow-ups, close-out (plan Task 2)
+3. Final review + the two listed follows fixed in-branch (this task's close-out)
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Approach: one PR stacked on TASK-20939 (#4) — the save handler lives in `local_library_tool_service` (ruling §8.10: the note-backend dispatch, not the media-chunk service), everything descriptor-derived so the Console and MCP runtimes cannot drift.
+
+- Commits `fe457e4e8`/`c34c5d578` (spec + plan) through HEAD: `6e04d3199` (tool + policy), `015a5015d` (exclusion-set pin 23→29), `63c8d5bf6` (story + docs + follow-ups), `0b2737827` (Task-2 review minors), `8affabbdb` (invoke-time length guards), `a7fe38563` (final-review prose sweep).
+- Key rulings honored (§8, 11 total): one write tool, no structured fan-out (§8.1); create-default + optimistic locking (§8.2); flashcards are Q/A-in-notes, real-rows follow-up filed (§8.3, TASK-20979); conventions as affordances not prompt presets (§8.4); the rows/folders seam split with the scope service (§8.5); schema maxLength bounds (§8.6, made invoke-time in `8affabbdb`); duplicate-window accepted with the re-run convention search-based per the third review (§8.7 + §5, superseding list-before-rerun; TASK-20980 holds the conditional list-filter candidate); provenance header carries `revision:` (§8.8); `ConflictError` → `content_changed` (§8.9); handler placement (§8.10); follow-ups at close-out (§8.11).
+- The scope pin: folder writes go to `ScopeType.LOCAL_NOTE` (the notes UI's own scope — any other scope makes folders invisible there), reached only through the scope-exposed children-list seam (`parent_id=None`); the repository's path-getter is not scope-exposed and the ledger's STOP rule forbids reaching the repository from the tool layer.
+- Final review: READY-WITH-LISTED-FOLLOWS, both follows fixed in-branch (`8affabbdb` length guards incl. the spec-save name/description twin — constants shared with the schema so the surfaces cannot drift; `a7fe38563` shadowed-count arithmetic 29, spec errata annotations on the superseded list-before-rerun phrasing, storage-error copy "read"→"operation", guide punctuation). Knowingly open: TASK-20979 (flashcard UX — the deliberate QA-in-notes ruling); the fan-out stays docs-only by non-goal (§8.1).
+- Long-form record: spec §8 (11 rulings) + `Docs/superpowers/plans/2026-08-23-student-workflow.md` (two-task plan; no separate sdd ledger this round). Depends on TASK-20939 (#4's chunk tools and spec-save precedent).

--- a/tldw_chatbook/Library/library_tool_contract.py
+++ b/tldw_chatbook/Library/library_tool_contract.py
@@ -71,7 +71,10 @@ SPEC_SAVE_NAME_MAX_CHARS = 120
 SPEC_SAVE_DESCRIPTION_MAX_CHARS = 2_000
 SAVE_NOTE_TITLE_MAX_CHARS = 512
 SAVE_NOTE_CONTENT_MAX_CHARS = 100_000
-SAVE_NOTE_FOLDER_MAX_CHARS = 256
+#: 255, not 256: the folder model's ``normalize_folder_name`` refuses any
+#: segment longer than 255 characters, so this bound must equal the model's
+#: own limit -- a schema-passing 256-char name would die at the model.
+SAVE_NOTE_FOLDER_MAX_CHARS = 255
 
 # -- Structured errors (spec §9) -------------------------------------------------
 
@@ -356,9 +359,9 @@ def _save_note_schema() -> dict:
     """The note-save input schema (student-workflow spec §4.1).
 
     Bounds are input-side ``maxLength`` literals in the spec-save precedent
-    style (title 512 / content 100_000 / folder 256; minLength 1 on the
-    text bodies) so an agent cannot push a megabyte into the notes DB
-    through the tool.
+    style (title 512 / content 100_000 / folder 255 -- the folder model's
+    own segment limit; minLength 1 on the text bodies) so an agent cannot
+    push a megabyte into the notes DB through the tool.
     """
     return {
         "type": "object",

--- a/tldw_chatbook/Library/library_tool_contract.py
+++ b/tldw_chatbook/Library/library_tool_contract.py
@@ -62,6 +62,17 @@ MAX_CHUNK_CONTEXT = 10
 #: schema already bounds; work must stay bounded for hostile callers).
 MAX_SEARCH_QUERY_CHARS = 1_000
 
+#: Input-side length bounds for the two write tools (chunking-agent-tools
+#: spec §4.3 spec-save; student-workflow spec §4.1 save-note). One source
+#: for the descriptor ``maxLength`` literals AND the invoke-time guards in
+#: the services' ``_validate_*_arguments`` helpers, so a schema-bypassing
+#: caller still fails closed with the same named limit.
+SPEC_SAVE_NAME_MAX_CHARS = 120
+SPEC_SAVE_DESCRIPTION_MAX_CHARS = 2_000
+SAVE_NOTE_TITLE_MAX_CHARS = 512
+SAVE_NOTE_CONTENT_MAX_CHARS = 100_000
+SAVE_NOTE_FOLDER_MAX_CHARS = 256
+
 # -- Structured errors (spec §9) -------------------------------------------------
 
 ERROR_INVALID_ARGUMENT = "invalid_argument"
@@ -318,7 +329,7 @@ def _spec_save_schema() -> dict:
             "name": {
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 120,
+                "maxLength": SPEC_SAVE_NAME_MAX_CHARS,
                 "description": "Spec (custom chunking template) name.",
             },
             "spec": {
@@ -327,7 +338,7 @@ def _spec_save_schema() -> dict:
             },
             "description": {
                 "type": "string",
-                "maxLength": 2_000,
+                "maxLength": SPEC_SAVE_DESCRIPTION_MAX_CHARS,
                 "description": "Optional human-readable description.",
             },
             "tags": {
@@ -355,13 +366,13 @@ def _save_note_schema() -> dict:
             "title": {
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 512,
+                "maxLength": SAVE_NOTE_TITLE_MAX_CHARS,
                 "description": "Note title.",
             },
             "content": {
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 100_000,
+                "maxLength": SAVE_NOTE_CONTENT_MAX_CHARS,
                 "description": (
                     "Full note content in Markdown. For notes derived from"
                     " Library media, start the body with the provenance"
@@ -371,7 +382,7 @@ def _save_note_schema() -> dict:
             "folder": {
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 256,
+                "maxLength": SAVE_NOTE_FOLDER_MAX_CHARS,
                 "description": (
                     "Optional ONE-LEVEL folder name (no slashes); the folder"
                     " is created when missing and the note is filed into it."

--- a/tldw_chatbook/Library/library_tool_contract.py
+++ b/tldw_chatbook/Library/library_tool_contract.py
@@ -9,7 +9,7 @@ from this module so their contracts cannot drift.
 
 The table holds the 18 task-1337 tools plus the four media chunking tools
 (chunking-agent-tools spec §4: structure, chunk fetch, spec list/save,
-re-chunk).
+re-chunk) and the note-save write tool (student-workflow spec §4).
 
 Design: Docs/superpowers/specs/2026-08-02-local-library-agent-tools-design.md
 Pure module: no I/O, no SQLite, no Textual, no event-loop imports.
@@ -341,6 +341,68 @@ def _spec_save_schema() -> dict:
     }
 
 
+def _save_note_schema() -> dict:
+    """The note-save input schema (student-workflow spec §4.1).
+
+    Bounds are input-side ``maxLength`` literals in the spec-save precedent
+    style (title 512 / content 100_000 / folder 256; minLength 1 on the
+    text bodies) so an agent cannot push a megabyte into the notes DB
+    through the tool.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "description": "Note title.",
+            },
+            "content": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100_000,
+                "description": (
+                    "Full note content in Markdown. For notes derived from"
+                    " Library media, start the body with the provenance"
+                    " header documented in this tool's description."
+                ),
+            },
+            "folder": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "description": (
+                    "Optional ONE-LEVEL folder name (no slashes); the folder"
+                    " is created when missing and the note is filed into it."
+                    " Omit to leave the note unfiled."
+                ),
+            },
+            "note_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": MAX_PUBLIC_ID_BYTES,
+                "description": (
+                    "Opaque note ID from a previous save/list/search --"
+                    " supplies this together with expected_version to UPDATE"
+                    " that note instead of creating a new one."
+                ),
+            },
+            "expected_version": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "The note's current version (from a previous save's"
+                    " response or library_get_note's revision); required"
+                    " together with note_id."
+                ),
+            },
+        },
+        "required": ["title", "content"],
+        "additionalProperties": False,
+    }
+
+
 def _rechunk_schema() -> dict:
     """The re-chunk override (spec §4.4) -- a FLAT options map.
 
@@ -460,6 +522,12 @@ LIBRARY_TOOL_DESCRIPTORS: dict[str, LibraryToolDescriptor] = {
             "library_search_notes", "note", "search",
             "Lexically search note titles, content, and keywords (literal, case-insensitive; no semantic/embedding search).",
             _search_schema(),
+        ),
+        _descriptor(
+            "library_save_note", "note", "save",
+            "Save one note: create by default, or update an existing note when note_id and expected_version are supplied together (exactly one without the other is refused; a stale version returns content_changed). Notes have no unique title, so a re-run should search by title (library_search_notes) and update by id rather than create a duplicate. For notes derived from Library media, begin the content with this provenance header so staleness is detectable: 'source: <media id>\\nrevision: <media revision>\\nchapter: <chapter title>\\nchunks: <first>-<last>' (revision is load-bearing: a chunk span is meaningless without the media version it was derived from). The optional folder is one level and is created when missing, so concurrent savers converge on one folder.",
+            _save_note_schema(),
+            writing=True,
         ),
         # -- Prompts ----------------------------------------------------------
         _descriptor(

--- a/tldw_chatbook/Library/local_library_tool_service.py
+++ b/tldw_chatbook/Library/local_library_tool_service.py
@@ -128,7 +128,8 @@ def _storage_error_payload() -> dict[str, Any]:
     """Scrubbed operational-failure payload: no SQL, paths, or exception text."""
     return LibraryToolError(
         ERROR_STORAGE_ERROR,
-        "The local Library store could not complete the read.",
+        # "operation", not "read": the write paths (save-note) reuse this.
+        "The local Library store could not complete the operation.",
         retryable=True,
     ).to_payload()
 

--- a/tldw_chatbook/Library/local_library_tool_service.py
+++ b/tldw_chatbook/Library/local_library_tool_service.py
@@ -60,6 +60,7 @@ from tldw_chatbook.Library.library_tool_contract import (
     validate_search_query,
 )
 from tldw_chatbook.Notes.note_folder_models import (
+    FolderCapabilityError,
     FolderCollisionError,
     FolderValidationError,
     normalize_folder_name,
@@ -132,6 +133,21 @@ def _storage_error_payload() -> dict[str, Any]:
         "The local Library store could not complete the operation.",
         retryable=True,
     ).to_payload()
+
+
+def _folder_capability_unavailable() -> LibraryToolError:
+    """The folder seam's named capability refusal (Qodo review pin).
+
+    ``NotesScopeService`` raises ``FolderCapabilityError`` when the pinned
+    scope's folder repository is absent or lacks the operation; mapping it
+    here keeps the deployment-shape failure a NAMED ``feature_unavailable``
+    instead of the generic scrubbed ``storage_error``.
+    """
+    return LibraryToolError(
+        ERROR_FEATURE_UNAVAILABLE,
+        "Folder operations are not available for the local note folder"
+        " backend in this deployment.",
+    )
 
 
 def _run(value: Any) -> Any:
@@ -864,7 +880,13 @@ class LocalLibraryToolService:
                 "folder must be a single valid folder name (one level, no"
                 " slashes, not '.' or '..')"
             ) from None
-        found = self._find_note_folder(requested.key)
+        try:
+            found = self._find_note_folder(requested.key)
+        except FolderCapabilityError:
+            # The seam's own capability refusal (a scope without folder
+            # support) is the NAMED feature_unavailable, never the scrubbed
+            # storage_error the generic handler would return.
+            raise _folder_capability_unavailable() from None
         if found is not None:
             return found
         try:
@@ -876,6 +898,8 @@ class LocalLibraryToolService:
                     user_id=self._notes_user_id,
                 )
             )
+        except FolderCapabilityError:
+            raise _folder_capability_unavailable() from None
         except FolderCollisionError:
             # Lost the create race: the concurrent winner is now visible to
             # the lookup, and the placement target converges on ONE folder.
@@ -899,8 +923,9 @@ class LocalLibraryToolService:
         Rows go through the legacy interop (the notes UI's own row-writer);
         folders/placements go through the async scope service (bridged with
         the established ``_run``/``asyncio.run`` pattern). Order matters:
-        validate -> policy -> folder-ensure -> row write -> attach, so a
-        folder failure never lands an orphaned note row.
+        validate -> policy -> update pre-flight (id/existence/version) ->
+        folder-ensure -> row write -> attach, so a folder failure never
+        lands an orphaned note row and a failed update never mints a folder.
         """
         del descriptor  # routing already resolved; the operation is singular
         # Deferred import: the DB module is heavy and only the exception
@@ -912,7 +937,35 @@ class LocalLibraryToolService:
         )
         # Policy before ANY backend touch (spec §6).
         self._enforce_save_note_policy()
-        # Folder first: a failed folder-ensure must not orphan a note row.
+
+        # Update pre-flight (Qodo review): for UPDATE calls the id parse,
+        # the not_found existence check, and the version read all run BEFORE
+        # the folder-ensure, so a deterministically failing update (unknown
+        # id, stale version) never mints a folder for a call that then
+        # fails. The ``update_note`` ConflictError below stays as the race
+        # backstop (a version moving between the read and the row write is
+        # the one accepted folder-residual window).
+        raw_id: str | None = None
+        if note_id is not None:
+            _, raw_id = parse_public_id(note_id, expected_type="note")
+            row = backend.get_note_by_id(self._notes_user_id, raw_id)
+            if row is None:
+                raise _not_found("The requested Library item was not found.")
+            stored_version = row.get("version") if isinstance(row, Mapping) else None
+            try:
+                stale = int(stored_version) != int(expected_version)
+            except (TypeError, ValueError):
+                stale = False  # unreadable version: the row write arbitrates
+            if stale:
+                raise LibraryToolError(
+                    ERROR_CONTENT_CHANGED,
+                    "The note changed since the expected version was read;"
+                    " re-read it (library_get_note) and retry with the"
+                    " current version.",
+                    details={"hint": "re_read_and_retry"},
+                )
+
+        # Folder next: a failed folder-ensure must not orphan a note row.
         folder = (
             self._ensure_note_folder(folder_name) if folder_name is not None else None
         )
@@ -927,9 +980,6 @@ class LocalLibraryToolService:
             version = 1
             created = True
         else:
-            _, raw_id = parse_public_id(note_id, expected_type="note")
-            if backend.get_note_by_id(self._notes_user_id, raw_id) is None:
-                raise _not_found("The requested Library item was not found.")
             try:
                 updated = backend.update_note(
                     self._notes_user_id,

--- a/tldw_chatbook/Library/local_library_tool_service.py
+++ b/tldw_chatbook/Library/local_library_tool_service.py
@@ -3,10 +3,13 @@
 One ``LocalLibraryToolService`` owns the public operation contract and
 delegates storage work to the six existing local backend services (media,
 notes, prompts, skills, conversations, collections) plus the dedicated
-media chunk-tool service (structure/fetch/spec operations). Both runtimes --
-the Console provider and local MCP registration -- call this core; the
-descriptor table, ID/cursor codecs, validation, and byte fitting all live in
-``library_tool_contract`` so the two surfaces cannot drift.
+media chunk-tool service (structure/fetch/spec operations), and owns the
+note-save write path itself (student-workflow spec §4: rows via the legacy
+notes interop, folders/placements via the async ``NotesScopeService``).
+Both runtimes -- the Console provider and local MCP registration -- call
+this core; the descriptor table, ID/cursor codecs, validation, and byte
+fitting all live in ``library_tool_contract`` so the two surfaces cannot
+drift.
 
 Pure synchronous core: no Textual, MCP, or agent imports. Local backends whose
 methods are declared async but perform local work (prompts, skills) are
@@ -28,6 +31,7 @@ from tldw_chatbook.Library.library_tool_contract import (
     DEFAULT_MAX_CHARS,
     DEFAULT_MESSAGE_LIMIT,
     DISPLAY_NAME_MAX_BYTES,
+    ERROR_CONTENT_CHANGED,
     ERROR_FEATURE_UNAVAILABLE,
     ERROR_INVALID_ARGUMENT,
     ERROR_NOT_FOUND,
@@ -52,6 +56,12 @@ from tldw_chatbook.Library.library_tool_contract import (
     validate_page_args,
     validate_search_query,
 )
+from tldw_chatbook.Notes.note_folder_models import (
+    FolderCollisionError,
+    FolderValidationError,
+    normalize_folder_name,
+)
+from tldw_chatbook.runtime_policy.types import PolicyDeniedError
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
 
 _LIST_METHODS = {
@@ -79,6 +89,26 @@ _PROMPT_SECTIONS = ("details", "system_prompt", "user_prompt", "prompt_definitio
 _MEDIA_CHUNK_OPERATIONS = frozenset(
     {"structure", "chunk", "spec_list", "spec_save", "rechunk"}
 )
+
+#: Student-workflow (spec §4/§6): the policy action the note-save tool runs
+#: under. Registered in ``runtime_policy/registry.py`` (the ``library.notes``
+#: resource on the ``library_collections`` capability, local-only); denial
+#: precedes every backend call.
+SAVE_NOTE_POLICY_ACTION_ID = "library.notes.save.local"
+
+#: The scope the note-save folder seam is pinned to (spec §4.3): the notes
+#: UI's own local scope -- any other scope makes folders invisible there.
+#: Written as the enum's value (``ScopeType.LOCAL_NOTE`` is a ``str`` enum)
+#: because importing ``notes_scope_service`` here is circular: it imports
+#: ``Library.library_content_evidence``, whose package ``__init__`` imports
+#: this module. The scope service normalizes the string to the same member.
+_SAVE_NOTE_FOLDER_SCOPE = "local_note"
+
+#: Root children-page size for the folder ensure lookup (the repository's
+#: own ceiling) and the page cap: one-level lookups stop after this many
+#: pages even if a pathological library keeps paginating.
+_SAVE_NOTE_FOLDER_PAGE_LIMIT = 500
+_SAVE_NOTE_FOLDER_MAX_PAGES = 20
 
 
 def _invalid(message: str) -> LibraryToolError:
@@ -319,6 +349,8 @@ class LocalLibraryToolService:
         collections_service: Any = None,
         media_chunk_service: Any = None,
         notes_user_id: str = "local_library",
+        notes_scope_service: Any = None,
+        policy_enforcer: Any = None,
     ) -> None:
         self._media = media_service
         self._notes = notes_service
@@ -328,6 +360,16 @@ class LocalLibraryToolService:
         self._collections = collections_service
         self._media_chunk = media_chunk_service
         self._notes_user_id = notes_user_id
+        # Student-workflow (spec §4.3): the folder seam. Note rows go through
+        # the legacy interop above; folders/placements live only in the async
+        # NotesScopeService, pinned to its LOCAL_NOTE scope. Optional: a
+        # missing handle degrades folder requests to feature_unavailable
+        # (never to a half-written note).
+        self._notes_scope = notes_scope_service
+        # Student-workflow (spec §6): the WRITING note tool's service-level
+        # gate (the chunk-tools precedent) -- the same enforcer handle the
+        # MCP runtime gate enforces with; None leaves that outer gate alone.
+        self._policy_enforcer = policy_enforcer
 
     # -- Entry point ---------------------------------------------------------
 
@@ -362,6 +404,8 @@ class LocalLibraryToolService:
             return self._list(descriptor, backend, arguments)
         if descriptor.operation == "search":
             return self._search(descriptor, backend, arguments)
+        if descriptor.operation == "save":
+            return self._save_note(descriptor, backend, arguments)
         return self._get(descriptor, backend, arguments)
 
     def _media_chunk_tool(
@@ -679,6 +723,254 @@ class LocalLibraryToolService:
             total_chars=int(detail.get("total_chars") or 0),
             cursor_state={},
         )
+
+    # -- Save: notes (student-workflow spec §4) ----------------------------------
+
+    def _enforce_save_note_policy(self) -> None:
+        """Spec §6: the save runs under ``library.notes.save.local``.
+
+        Enforcement precedes EVERY backend touch (denial -> the named error
+        payload, no note row, no folder). No-op without an enforcer handle --
+        the chunk-tools precedent: the MCP runtime gate (the re-pointed
+        ``_TOOL_ACTION_IDS`` mapping) stays the always-on outer layer, and
+        construction sites wire the enforcer where a runtime-policy context
+        exists.
+        """
+        if self._policy_enforcer is None:
+            return
+        try:
+            self._policy_enforcer.require_allowed(
+                action_id=SAVE_NOTE_POLICY_ACTION_ID
+            )
+        except PolicyDeniedError as exc:
+            raise LibraryToolError(
+                ERROR_FEATURE_UNAVAILABLE,
+                "Saving notes is not permitted by the current runtime policy"
+                f" ({SAVE_NOTE_POLICY_ACTION_ID}): {exc.user_message}",
+                details={
+                    "policy_action": SAVE_NOTE_POLICY_ACTION_ID,
+                    "reason_code": str(
+                        getattr(exc, "reason_code", "authority_denied")
+                    ),
+                },
+            ) from exc
+
+    @staticmethod
+    def _validate_save_note_arguments(
+        arguments: Mapping[str, Any],
+    ) -> tuple[str, str, str | None, str | None, int | None]:
+        """Type-check the save args; returns ``(title, content, folder,
+        note_id, expected_version)``.
+
+        The bounds themselves are schema-level (the descriptor's maxLength
+        literals); this re-checks the emptiness/typing the row-writer would
+        trip on anyway, so a schema-bypassing caller still fails closed with
+        the named error. The together-rule is pinned here FIRST: exactly one
+        of note_id/expected_version is the most-missed invalid shape.
+        """
+        title = arguments.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise _invalid("title must be a non-empty string")
+        content = arguments.get("content")
+        if not isinstance(content, str) or not content:
+            raise _invalid("content must be a non-empty string")
+        folder = arguments.get("folder")
+        if folder is not None and (not isinstance(folder, str) or not folder.strip()):
+            raise _invalid("folder must be a non-empty string when supplied")
+        note_id = arguments.get("note_id")
+        expected_version = arguments.get("expected_version")
+        if (note_id is None) != (expected_version is None):
+            raise _invalid(
+                "note_id and expected_version must be supplied together"
+                " (both for an update, neither for a create)"
+            )
+        if expected_version is not None and (
+            isinstance(expected_version, bool)
+            or not isinstance(expected_version, int)
+            or expected_version < 1
+        ):
+            raise _invalid("expected_version must be an integer of at least 1")
+        return title, content, folder, note_id, expected_version
+
+    def _find_note_folder(self, requested_key: str) -> Any | None:
+        """Name-lookup one root folder through the scope service's own
+        children-list seam (parent_id=None covers the root -- verified against
+        the repository's ``parent_id IS NULL`` predicate).
+
+        The repository's path-getter (``get_folder_by_path``) is NOT
+        scope-exposed; reaching the repository from the tool layer is ruled
+        out (the ledger's STOP rule), so the children-list route is the seam.
+        """
+        scope = self._notes_scope
+        offset = 0
+        for _ in range(_SAVE_NOTE_FOLDER_MAX_PAGES):
+            page = _run(
+                scope.list_note_folder_children(
+                    scope=_SAVE_NOTE_FOLDER_SCOPE,
+                    parent_id=None,
+                    limit=_SAVE_NOTE_FOLDER_PAGE_LIMIT,
+                    offset=offset,
+                    user_id=self._notes_user_id,
+                )
+            )
+            for candidate in getattr(page, "folders", None) or ():
+                try:
+                    if normalize_folder_name(candidate.name).key == requested_key:
+                        return candidate
+                except FolderValidationError:  # pragma: no cover - stored rows
+                    continue  # are pre-normalized; skip pathological ones
+            next_offset = getattr(page, "next_folder_offset", None)
+            if next_offset is None:
+                return None
+            offset = int(next_offset)
+        return None
+
+    def _ensure_note_folder(self, name: str) -> Any:
+        """Idempotently return the ONE root folder for ``name``.
+
+        Lookup -> create on miss -> RE-QUERY on collision (``create_note_folder``
+        is not idempotent; a concurrent creator winning the race is tolerated
+        by re-reading, never raised to the agent -- spec §4.3).
+        """
+        if self._notes_scope is None:
+            raise LibraryToolError(
+                ERROR_FEATURE_UNAVAILABLE,
+                "The local note folder backend is not available in this"
+                " deployment.",
+            )
+        try:
+            requested = normalize_folder_name(name)
+        except FolderValidationError:
+            raise _invalid(
+                "folder must be a single valid folder name (one level, no"
+                " slashes, not '.' or '..')"
+            ) from None
+        found = self._find_note_folder(requested.key)
+        if found is not None:
+            return found
+        try:
+            return _run(
+                self._notes_scope.create_note_folder(
+                    scope=_SAVE_NOTE_FOLDER_SCOPE,
+                    name=name,
+                    parent_id=None,
+                    user_id=self._notes_user_id,
+                )
+            )
+        except FolderCollisionError:
+            # Lost the create race: the concurrent winner is now visible to
+            # the lookup, and the placement target converges on ONE folder.
+            found = self._find_note_folder(requested.key)
+            if found is not None:
+                return found
+            raise LibraryToolError(
+                ERROR_STORAGE_ERROR,
+                "The local note folder could not be ensured; retry the save.",
+                retryable=True,
+            ) from None
+
+    def _save_note(
+        self,
+        descriptor: LibraryToolDescriptor,
+        backend: Any,
+        arguments: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Create (default) or version-locked update of one note (spec §4).
+
+        Rows go through the legacy interop (the notes UI's own row-writer);
+        folders/placements go through the async scope service (bridged with
+        the established ``_run``/``asyncio.run`` pattern). Order matters:
+        validate -> policy -> folder-ensure -> row write -> attach, so a
+        folder failure never lands an orphaned note row.
+        """
+        del descriptor  # routing already resolved; the operation is singular
+        # Deferred import: the DB module is heavy and only the exception
+        # types are needed (the personas-screen precedent for their home).
+        from tldw_chatbook.DB.ChaChaNotes_DB import ConflictError, InputError
+
+        title, content, folder_name, note_id, expected_version = (
+            self._validate_save_note_arguments(arguments)
+        )
+        # Policy before ANY backend touch (spec §6).
+        self._enforce_save_note_policy()
+        # Folder first: a failed folder-ensure must not orphan a note row.
+        folder = (
+            self._ensure_note_folder(folder_name) if folder_name is not None else None
+        )
+
+        if note_id is None:
+            try:
+                raw_id = backend.add_note(
+                    self._notes_user_id, title=title, content=content
+                )
+            except InputError as exc:
+                raise _invalid(str(exc)) from exc
+            version = 1
+            created = True
+        else:
+            _, raw_id = parse_public_id(note_id, expected_type="note")
+            if backend.get_note_by_id(self._notes_user_id, raw_id) is None:
+                raise _not_found("The requested Library item was not found.")
+            try:
+                updated = backend.update_note(
+                    self._notes_user_id,
+                    raw_id,
+                    {"title": title, "content": content},
+                    expected_version,
+                )
+            except ConflictError as exc:
+                raise LibraryToolError(
+                    ERROR_CONTENT_CHANGED,
+                    "The note changed since the expected version was read;"
+                    " re-read it (library_get_note) and retry with the"
+                    " current version.",
+                    details={"hint": "re_read_and_retry"},
+                ) from exc
+            if not updated:
+                raise LibraryToolError(
+                    ERROR_CONTENT_CHANGED,
+                    "The note changed since the expected version was read;"
+                    " re-read it (library_get_note) and retry with the"
+                    " current version.",
+                    details={"hint": "re_read_and_retry"},
+                )
+            version = int(expected_version) + 1
+            created = False
+
+        if folder is not None:
+            # Re-attach is safe: the repository's attach_manual revives the
+            # latest membership history rather than duplicating it.
+            _run(
+                self._notes_scope.attach_note_to_folder(
+                    scope=_SAVE_NOTE_FOLDER_SCOPE,
+                    folder_id=folder.folder_id,
+                    note_id=raw_id,
+                    user_id=self._notes_user_id,
+                )
+            )
+
+        item = _metadata_item(
+            make_public_id("note", raw_id), "note", "title", title, ()
+        )
+        if folder is not None:
+            item["folder"] = folder.name
+        return {
+            "item": item,
+            "version": version,
+            "created": created,
+            "notes": [
+                (
+                    "Hold the returned id and version: an update needs note_id"
+                    " and expected_version together (exactly one of them is"
+                    " refused)."
+                ),
+                (
+                    "Notes have no unique title; before re-running, search by"
+                    " title (library_search_notes) and update the match instead"
+                    " of creating a duplicate."
+                ),
+            ],
+        }
 
     # -- Get: prompts (overview manifest + one section) -------------------------
 

--- a/tldw_chatbook/Library/local_library_tool_service.py
+++ b/tldw_chatbook/Library/local_library_tool_service.py
@@ -44,6 +44,9 @@ from tldw_chatbook.Library.library_tool_contract import (
     MAX_MESSAGE_LIMIT,
     MAX_RESULT_BYTES,
     PREVIEW_MAX_CHARS,
+    SAVE_NOTE_CONTENT_MAX_CHARS,
+    SAVE_NOTE_FOLDER_MAX_CHARS,
+    SAVE_NOTE_TITLE_MAX_CHARS,
     check_cursor_revision,
     fit_page_payload,
     make_cursor,
@@ -771,12 +774,27 @@ class LocalLibraryToolService:
         title = arguments.get("title")
         if not isinstance(title, str) or not title.strip():
             raise _invalid("title must be a non-empty string")
+        if len(title) > SAVE_NOTE_TITLE_MAX_CHARS:
+            raise _invalid(
+                f"title must be at most {SAVE_NOTE_TITLE_MAX_CHARS} characters"
+                f" (got {len(title)})"
+            )
         content = arguments.get("content")
         if not isinstance(content, str) or not content:
             raise _invalid("content must be a non-empty string")
+        if len(content) > SAVE_NOTE_CONTENT_MAX_CHARS:
+            raise _invalid(
+                f"content must be at most {SAVE_NOTE_CONTENT_MAX_CHARS}"
+                f" characters (got {len(content)})"
+            )
         folder = arguments.get("folder")
         if folder is not None and (not isinstance(folder, str) or not folder.strip()):
             raise _invalid("folder must be a non-empty string when supplied")
+        if folder is not None and len(folder) > SAVE_NOTE_FOLDER_MAX_CHARS:
+            raise _invalid(
+                f"folder must be at most {SAVE_NOTE_FOLDER_MAX_CHARS} characters"
+                f" (got {len(folder)})"
+            )
         note_id = arguments.get("note_id")
         expected_version = arguments.get("expected_version")
         if (note_id is None) != (expected_version is None):

--- a/tldw_chatbook/Library/local_media_chunk_tool_service.py
+++ b/tldw_chatbook/Library/local_media_chunk_tool_service.py
@@ -59,6 +59,8 @@ from tldw_chatbook.Library.library_tool_contract import (
     MAX_CHUNK_CONTEXT,
     MAX_MAX_NODES,
     MAX_RESULT_BYTES,
+    SPEC_SAVE_DESCRIPTION_MAX_CHARS,
+    SPEC_SAVE_NAME_MAX_CHARS,
     LibraryToolDescriptor,
     LibraryToolError,
     check_cursor_revision,
@@ -829,17 +831,32 @@ class LocalMediaChunkToolService:
         """Type-check the save args; returns ``(name, description, tags)``.
 
         The body is NOT validated here -- it goes through the template
-        validator (and then the CRUD's own gate), never ad-hoc checks."""
+        validator (and then the CRUD's own gate), never ad-hoc checks.
+        The name/description length bounds ARE re-checked here (the
+        schema's maxLength literals): a schema-bypassing caller still
+        fails closed with the named limit.
+        """
         raw_name = arguments.get("name")
         if not isinstance(raw_name, str) or not raw_name.strip():
             raise _invalid("name must be a non-empty string")
         name = raw_name.strip()
+        if len(name) > SPEC_SAVE_NAME_MAX_CHARS:
+            raise _invalid(
+                f"name must be at most {SPEC_SAVE_NAME_MAX_CHARS} characters"
+                f" (got {len(name)})"
+            )
 
         raw_description = arguments.get("description")
         if raw_description is None:
             description: str | None = None
         elif isinstance(raw_description, str) and raw_description.strip():
             description = raw_description.strip()
+            if len(description) > SPEC_SAVE_DESCRIPTION_MAX_CHARS:
+                raise _invalid(
+                    "description must be at most"
+                    f" {SPEC_SAVE_DESCRIPTION_MAX_CHARS} characters"
+                    f" (got {len(description)})"
+                )
         else:
             raise _invalid("description must be a non-empty string when supplied")
 

--- a/tldw_chatbook/MCP/local_control_service.py
+++ b/tldw_chatbook/MCP/local_control_service.py
@@ -55,16 +55,18 @@ _LIBRARY_ITEM_TYPE_ACTION_NAMESPACE = {
     "collection": "library.collections",
 }
 
-# chunking-agent-tools (Tasks 4-5, spec §6): writing operations map to
-# their OWN registered action instead of the type-owned read. ``spec_save``
-# resolves to the dedicated ``library.templates/save`` verb and ``rechunk``
-# to ``library.media/rechunk`` -- the Task-3 provisional derived READ
-# mapping had to stop the moment the save handler went live (a live write
-# resolving to a read action under policy would be wrong even though the
-# v7 CRUD validator still guards the write itself).
+# chunking-agent-tools (Tasks 4-5, spec §6) + student-workflow (Task 1,
+# spec §4/§6): writing operations map to their OWN registered action
+# instead of the type-owned read. ``spec_save`` resolves to the dedicated
+# ``library.templates/save`` verb, ``rechunk`` to ``library.media/rechunk``,
+# and ``save`` to ``library.notes/save`` -- the Task-3 provisional derived
+# READ mapping had to stop the moment the save handler went live (a live
+# write resolving to a read action under policy would be wrong even though
+# the v7 CRUD validator still guards the write itself).
 _LIBRARY_TOOL_ACTION_OVERRIDES = {
     "spec_save": "library.templates.save.local",
     "rechunk": "library.media.rechunk.local",
+    "save": "library.notes.save.local",
 }
 
 

--- a/tldw_chatbook/MCP/server.py
+++ b/tldw_chatbook/MCP/server.py
@@ -290,6 +290,7 @@ def build_local_library_tool_service(
     chachanotes_db: Any,
     media_db: Any,
     notes_service: Any = None,
+    notes_scope_service: Any = None,
     policy_enforcer: Any = None,
 ) -> Any:
     """Compose the six local Library backends into one shared synchronous service.
@@ -314,13 +315,20 @@ def build_local_library_tool_service(
         notes_service: Optional pre-built ``NotesInteropService``; when
             omitted, one is constructed with the canonical signature off
             ``get_chachanotes_db_path()`` and ``chachanotes_db``.
+        notes_scope_service: Optional pre-built ``NotesScopeService``
+            (student-workflow spec §4.3): the note-save tool's folder seam.
+            When omitted, one is composed over ``chachanotes_db`` with the
+            app builder's own shape (shared local folder repository); a
+            construction failure degrades folder requests to
+            ``feature_unavailable`` rather than sinking the surface.
         policy_enforcer: Optional runtime-policy enforcer
             (``require_allowed(action_id=...)`` seam) threaded into the
-            media chunk tool service, whose WRITING tools
-            (``library_save_chunk_spec``, ``library_rechunk_media``) are
-            service-level gated (chunking-agent-tools Tasks 4-5, spec §6);
-            ``None`` leaves the always-on MCP action mapping as the outer
-            gate.
+            media chunk tool service and the note-save path, whose WRITING
+            tools (``library_save_chunk_spec``, ``library_rechunk_media``,
+            ``library_save_note``) are service-level gated
+            (chunking-agent-tools Tasks 4-5 + student-workflow Task 1,
+            spec §6); ``None`` leaves the always-on MCP action mapping as
+            the outer gate.
 
     Returns:
         The shared ``LocalLibraryToolService``.
@@ -424,6 +432,26 @@ def build_local_library_tool_service(
 
     _build("media_chunk", _build_media_chunk)
 
+    if notes_scope_service is not None:
+        backends["notes_scope"] = notes_scope_service
+    else:
+
+        def _build_notes_scope():
+            # student-workflow (spec §4.3): the note-save folder seam, built
+            # with the app builder's own shape -- the scope facade over one
+            # shared local folder repository (the notes UI's own scope, so
+            # folders saved here are visible there).
+            from ..Notes.note_folder_repository import LocalNoteFolderRepository
+            from ..Notes.notes_scope_service import NotesScopeService
+
+            return NotesScopeService(
+                local_notes_service=backends["note"],
+                server_service=None,
+                folder_repository=LocalNoteFolderRepository(chachanotes_db),
+            )
+
+        _build("notes_scope", _build_notes_scope)
+
     return LocalLibraryToolService(
         media_service=backends["media"],
         notes_service=backends["note"],
@@ -432,6 +460,10 @@ def build_local_library_tool_service(
         conversation_service=backends["conversation"],
         collections_service=backends["collection"],
         media_chunk_service=backends["media_chunk"],
+        # student-workflow (spec §4.3/§6): the note-save folder seam and the
+        # writing note tool's service-level gate (the chunk-tools pattern).
+        notes_scope_service=backends.get("notes_scope"),
+        policy_enforcer=policy_enforcer,
     )
 
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5592,6 +5592,15 @@ class ChatScreen(BaseAppScreen):
             conversation_service=getattr(app, "local_chat_conversation_service", None),
             collections_service=getattr(app, "local_library_collections_service", None),
             media_chunk_service=media_chunk_service,
+            # student-workflow (spec §4.3): the note-save folder seam -- the
+            # app's scope service (folders live only there); a missing handle
+            # degrades folder requests to feature_unavailable like every
+            # other optional backend.
+            notes_scope_service=getattr(app, "notes_scope_service", None),
+            # student-workflow (spec §6): the writing note tool's
+            # Console-direct gate (the chunk-tools pattern) -- the same app
+            # enforcer handle the writing chunk tools receive above.
+            policy_enforcer=getattr(app, "service_policy_enforcer", None),
         )
         return LibraryToolProvider(service)
 

--- a/tldw_chatbook/runtime_policy/registry.py
+++ b/tldw_chatbook/runtime_policy/registry.py
@@ -642,6 +642,10 @@ AUDITED_CAPABILITY_SEEDS = (
     # and `library.media/rechunk` backs `library_rechunk_media`'s one-item
     # chunk-row regeneration (deliberately NOT `rag.admin.launch`, the
     # RAG-admin bulk action's verb -- this is a Library-media item action).
+    # student-workflow (Task 1, spec §4/§6): `library.notes/save` backs
+    # `library_save_note`'s create-or-update over the local notes rows
+    # (deliberately NOT the notes UI's own `notes.*` CRUD verbs -- those
+    # model the screen's row operations; this is the Library write surface).
     _capability(
         "library_collections",
         "Library Collections & agent tools (local)",
@@ -651,6 +655,7 @@ AUDITED_CAPABILITY_SEEDS = (
             _resource("library.collections", actions=(LIST, DETAIL)),
             _resource("library.templates", actions=(SAVE,)),
             _resource("library.media", actions=(RECHUNK,)),
+            _resource("library.notes", actions=(SAVE,)),
         ),
     ),
     _capability(


### PR DESCRIPTION
## Summary

Sub-project #5 of the chunking parity program (stacked on #4 / TASK-20939): **`library_save_note`** — the write tool that closes the student-story loop #4's read tools set up. *"Make me per-chapter notes of this book"* now runs end-to-end through the ordinary agent machinery: structure → per-chapter fetch → save into `Study/<book>` → re-read, and a re-run **searches first and updates instead of duplicating**.

- **The tool**: create-default returning id+version; version-locked update via `note_id`+`expected_version` (stale version → `content_changed`); one-level folder grouping through the notes scope service (idempotent ensure, race-tolerant, folder-before-row so a failure never orphans a note); provenance-header convention documented in the description, never enforced.
- **Policy**: new `library.notes/save.local` action, enforcer wired at both construction sites (Console factory + MCP build); denial precedes every backend call.
- **The seam**: rows via the legacy notes interop, folders/placements via `NotesScopeService` pinned to the notes screen's own `local_note` scope — reached only through the scope-exposed children-list seam (the repository's path-getter is not scope-exposed; the ledger's STOP rule forbids reaching the repository).
- **Story + docs**: the student-story e2e now closes the write loop through the shared dispatcher (save → re-read → search-based re-run → update-not-duplicate, mutation-checked); save-note contract + study-notes fan-out pattern documented; CHANGELOG.

## The 11 rulings honored (spec §8)

1. One write tool; fan-out is conventions-only over existing `spawn_subagent` — no structured fan-out tool. 2. Create-default + optimistic locking (mirrors #4's spec-save). 3. Flashcards are Q/A markdown in notes; real-rows follow-up filed (TASK-20979). 4. Conventions as affordances, not prompt presets. 5. Rows-via-interop / folders-via-scope seam split. 6. Schema `maxLength` bounds (title 512 / content 100k / folder 256). 7. Duplicate-window accepted; re-run convention **search-based** per the third review (list tool has no folder filter) — the list-before-reran phrasing is annotated superseded in the spec. 8. Provenance header carries `revision:`. 9. `ConflictError` → `content_changed`. 10. Handler lives in `local_library_tool_service`. 11. Follow-ups filed at close-out.

## Final review + follows fixed

Verdict: **READY-WITH-LISTED-FOLLOWS**; both follows fixed in this branch:
- `8affabbdb` — invoke-time length guards for both write schemas (save-note title/content/folder + the spec-save name/description twin), with the literals hoisted to shared constants so schema and runtime checks cannot drift; TDD red-first.
- `a7fe38563` — prose sweep: shadowed-count arithmetic corrected to 29 (24 descriptor + 5 legacy) in two test comments/docstrings, spec errata annotations on the superseded re-run phrasing, storage-error copy "read"→"operation", guide punctuation.

## Test evidence

Targeted suites, all green: `Tests/Library/test_local_library_tool_service.py` + `test_media_chunk_tool_service.py` + `test_library_tool_contract.py` + `test_agent_chunk_student_story.py`, `Tests/Agents/test_mcp_tool_provider.py`, `Tests/Chat/test_console_chat_controller.py`, `Tests/MCP/test_local_control_service.py`, `Tests/RuntimePolicy/test_library_notes_save_policy_pin.py` — **526 passed** final close-out run.

## Board

- Closed: **TASK-21135** — Student workflow (sub-project #5): library_save_note closes the write loop.
- Depends on TASK-20939 (#4). Program state: **5 of 6** sub-projects done.

## Knowingly open

- **TASK-20979** — flashcards viewing/SRS surface (the deliberate QA-in-notes ruling: real rows would be invisible output today).
- Fan-out orchestration stays **docs-only by non-goal** (ruling §8.1 — it would duplicate the runtime and hide the reasoning).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `library_save_note`, completing the student workflow by letting agents save per‑chapter notes into the existing notes UI. Previously only read tools existed; now the write path creates by default and updates by version, with search-first re-runs updating instead of duplicating.

- Contract: adds the 24th descriptor tool `library_save_note` with schema bounds (title ≤ 512, content ≤ 100_000, folder ≤ 255) and a documented provenance header. Updates require `note_id` + `expected_version`; stale versions return `content_changed`.
- Service path: rows via `NotesInteropService` (create default; optimistic update). For updates, id parse + existence + version checks run before folder work so unknown/stale updates cannot mint a folder; `ConflictError` remains the race backstop. Folders via `NotesScopeService` (idempotent ensure; attach after row). `FolderCapabilityError` maps to `feature_unavailable`.
- Policy and mapping: registers `library.notes/save` under `library_collections`; both Console and `MCP` map `library_save_note` to this action and enforce policy before backend calls.
- Counts/pins: catalog grows 23→24; builtin raw-name exclusions grow to 29; runtime policy registry and mappings updated.
- Validation: invoke-time guards mirror schema limits; folder length bound is 255 to match normalization.

- Rollout
  - Grant `library.notes/save` where the Console or local `MCP` runs.
  - Updates must include both `note_id` and `expected_version`; folder operations degrade to `feature_unavailable` if the notes scope service is unavailable.

<sup>Written for commit 8201c3d6b1b56b94e246d825fae786c0ec21ca97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

