### PR TITLE
fix(subscriptions): guard the extras-only bs4 boot import — base install can import the app again (TASK-21104)

### DIFF
--- a/Tests/Packaging/test_extras_import_closure.py
+++ b/Tests/Packaging/test_extras_import_closure.py
@@ -1,0 +1,239 @@
+"""Import-closure guards for extras-gated packages (TASK-21104).
+
+`Subscriptions/monitoring_engine.py` used to do a module-level
+`from bs4 import BeautifulSoup` while `beautifulsoup4` exists only under
+`[project.optional-dependencies]` in pyproject.toml. The module is imported
+eagerly at boot (app.py -> Scheduling/scheduler/handlers ->
+watchlist_check_handler -> monitoring_engine), so an install without the
+extra could not `import tldw_chatbook.app` at all, and every configured
+install paid the bs4+soupsieve import at boot. (In practice the crash was
+masked on healthy installs because the CORE dependency `markdownify` pins
+`beautifulsoup4<5,>=4.9` transitively -- but nothing in the project's own
+dependency declarations guarantees bs4, so boot must not rely on it.)
+
+Two guards, so the NEXT unguarded optional import is caught at PR time:
+
+* `test_app_imports_with_bs4_absent` simulates a bs4-less install with a
+  meta-path blocker in a fresh subprocess and asserts the app still imports.
+* `test_app_import_closure_excludes_extras_only_packages` asserts that a
+  plain `import tldw_chatbook.app` loads NONE of an explicit list of
+  extras-only packages.
+
+Subprocesses are used because `sys.modules` is process-global: an earlier
+test in the session may already have imported bs4, which would false-pass
+an in-process closure check (same rationale as
+`Tests/Performance/test_app_import_weight.py`, whose isolation pattern this
+file follows).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Extras-only packages that must NEVER be resident after a plain
+# `import tldw_chatbook.app`. Every entry is (pyproject/pip name, importable
+# module name) and was verified extras-only against pyproject.toml's
+# [project.optional-dependencies] at the time of writing (none appear in the
+# core `dependencies` list). soupsieve is bs4's own hard dependency, listed
+# so a sneaky `import soupsieve` cannot ride in either.
+#
+# Deliberately EXCLUDED, with reasons:
+# * defusedxml, pillow (PIL), rich-pixels, textual-image -- CORE deps in
+#   pyproject `dependencies`; they are legitimately resident at boot even
+#   though optional_deps.py also tracks their availability.
+# * torch, transformers, nltk, scipy, sklearn, pandas-as-heavy-dep --
+#   already guarded by Tests/Performance/test_app_import_weight.py
+#   (task 163); pandas stays here too because it is ALSO extras-only.
+EXTRAS_ONLY_MODULES: tuple[tuple[str, str], ...] = (
+    ("beautifulsoup4", "bs4"),
+    ("soupsieve (beautifulsoup4 dep)", "soupsieve"),
+    ("lxml", "lxml"),
+    ("pandas", "pandas"),
+    ("playwright", "playwright"),
+    ("trafilatura", "trafilatura"),
+    ("aiohttp", "aiohttp"),
+    ("chromadb", "chromadb"),
+    ("pymupdf", "fitz"),
+    ("pymupdf4llm", "pymupdf4llm"),
+    ("ebooklib", "ebooklib"),
+    ("html2text", "html2text"),
+    ("markdown", "markdown"),
+    ("schedule", "schedule"),
+    ("feedparser", "feedparser"),
+    ("textual-serve", "textual_serve"),
+    ("mcp-unified", "mcp"),
+)
+
+
+def _run_isolated_python(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in a fresh interpreter with isolated config/data dirs.
+
+    Args:
+        tmp_path: Per-test scratch directory for the subprocess's HOME/XDG so
+            the app import can never read or write the live user config.
+        code: The Python source to execute with ``python -c``.
+
+    Returns:
+        The completed process (never raises on nonzero exit).
+    """
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+
+_BS4_ABSENT_SNIPPET = """
+import importlib.abc
+import sys
+
+
+class _Blocker(importlib.abc.MetaPathFinder):
+    BLOCKED = ("bs4", "soupsieve")
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".")[0] in self.BLOCKED:
+            raise ImportError(f"blocked by test: {fullname}")
+        return None
+
+
+sys.meta_path.insert(0, _Blocker())
+
+import tldw_chatbook.app
+
+leaked = sorted(
+    m for m in sys.modules
+    if m.split(".")[0] in _Blocker.BLOCKED and sys.modules[m] is not None
+)
+assert not leaked, f"blocked modules leaked into sys.modules: {leaked}"
+print("BS4_ABSENT_IMPORT_OK")
+"""
+
+
+def test_app_imports_with_bs4_absent(tmp_path: Path) -> None:
+    """A base (no-extras) install must be able to import tldw_chatbook.app.
+
+    Regression guard for the TASK-21104 defect: before the fix this failed
+    with `ImportError: blocked by test: bs4` raised from
+    `Subscriptions/monitoring_engine.py`'s module-level bs4 import, reached
+    via app.py's eager scheduler-handler imports.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _BS4_ABSENT_SNIPPET)
+    assert result.returncode == 0, (
+        "import tldw_chatbook.app must survive beautifulsoup4 being absent, "
+        f"but the bs4-blocked subprocess failed:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "BS4_ABSENT_IMPORT_OK" in result.stdout
+
+
+_CLOSURE_SNIPPET = (
+    "import json, sys\n"
+    "import tldw_chatbook.app\n"
+    f"candidates = {sorted(module for _pip_name, module in EXTRAS_ONLY_MODULES)!r}\n"
+    "resident = sorted(m for m in candidates if sys.modules.get(m) is not None)\n"
+    "print('CLOSURE:' + json.dumps(resident))\n"
+)
+
+
+def test_app_import_closure_excludes_extras_only_packages(tmp_path: Path) -> None:
+    """No extras-only package may be resident after `import tldw_chatbook.app`.
+
+    Catches the NEXT unguarded optional import at PR time: any module-scope
+    `import <extras-only package>` reachable from the app's import closure
+    turns up in this list. For packages not installed in the running
+    environment the check is trivially true (they could not have imported),
+    which is the honest scope: the guard bites exactly on the dev/CI
+    environments that have extras installed, where an unguarded import would
+    otherwise go unnoticed until a base install crashed.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _CLOSURE_SNIPPET)
+    assert result.returncode == 0, (
+        f"import tldw_chatbook.app failed in isolated subprocess:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    closure_lines = [
+        line for line in result.stdout.splitlines() if line.startswith("CLOSURE:")
+    ]
+    assert closure_lines, f"closure marker missing from stdout: {result.stdout!r}"
+    resident = json.loads(closure_lines[-1][len("CLOSURE:") :])
+    assert resident == [], (
+        "import tldw_chatbook.app eagerly imported extras-only packages "
+        f"{resident}; either guard the import (see "
+        "Subscriptions/monitoring_engine.py's _require_beautifulsoup for the "
+        "pattern) or promote the package to core dependencies AND remove it "
+        "from EXTRAS_ONLY_MODULES with a comment."
+    )
+
+
+def test_extract_text_from_html_degrades_actionably_without_bs4(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With bs4 missing, HTML extraction raises an actionable install hint.
+
+    The monitors' per-check exception handling records the error against the
+    subscription, so this message is what the user sees -- it must name the
+    package and the exact install command, not be a bare ImportError or a
+    silent no-op.
+
+    Args:
+        monkeypatch: pytest fixture; poisons sys.modules['bs4'] (None makes
+            any `import bs4` raise) and restores it afterwards.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import ContentExtractor
+
+    monkeypatch.setitem(sys.modules, "bs4", None)
+
+    with pytest.raises(ImportError) as excinfo:
+        ContentExtractor.extract_text_from_html("<p>hello</p>")
+
+    message = str(excinfo.value)
+    assert "beautifulsoup4" in message
+    assert "pip install tldw_chatbook[subscriptions]" in message
+
+
+def test_extract_text_from_html_works_with_bs4_present() -> None:
+    """The lazy resolution must still parse HTML once bs4 is importable."""
+    pytest.importorskip("bs4")
+    from tldw_chatbook.Subscriptions.monitoring_engine import ContentExtractor
+
+    text = ContentExtractor.extract_text_from_html(
+        "<p>hello <b>world</b></p><script>ignored()</script>"
+    )
+    assert text == "hello world"
+    assert "ignored" not in text

--- a/backlog/tasks/task-21104 - bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app.md
+++ b/backlog/tasks/task-21104 - bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app.md
@@ -2,8 +2,9 @@
 id: TASK-21104
 title: >-
   bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-22'
 labels:
   - bug
@@ -27,6 +28,104 @@ import at boot.
 
 ## Acceptance Criteria
 
-- [ ] Decision made and implemented: either beautifulsoup4 moves to core dependencies, or the import is guarded with graceful degradation of the affected monitors (consistent with `optional_deps.py`)
-- [ ] A test covers the import-closure of extras-gated packages so the next unguarded optional import is caught at PR time
-- [ ] A base (no-extras) install can import tldw_chatbook.app
+- [x] Decision made and implemented: either beautifulsoup4 moves to core dependencies, or the import is guarded with graceful degradation of the affected monitors (consistent with `optional_deps.py`)
+- [x] A test covers the import-closure of extras-gated packages so the next unguarded optional import is caught at PR time
+- [x] A base (no-extras) install can import tldw_chatbook.app
+
+## Implementation Plan
+
+1. Census every `from bs4`/`import bs4` site in `tldw_chatbook/` and classify:
+   guarded (try/except), lazy (function-local), or unguarded-top-level; identify
+   which are reachable from `import tldw_chatbook.app`.
+2. Baseline with teed evidence (`test-logs/`): (a) subprocess with bs4 blocked
+   via a meta-path finder -> `import tldw_chatbook.app` fails today; (b) plain
+   import -> bs4/soupsieve ARE in the boot closure today; (c) census which
+   optional-registry modules are already unavoidably in the closure, to scope
+   the guard list honestly.
+3. Decision: guard-and-degrade (owner prefers durable; promoting bs4 to core
+   would not fix the boot-cost half anyway). At the defect site
+   (`Subscriptions/monitoring_engine.py:37`) move the import into
+   `ContentExtractor.extract_text_from_html` (its only use) behind a
+   try/except that raises an actionable ImportError naming the
+   `[subscriptions]` extra — the per-check error handling in FeedMonitor/
+   URLMonitor already records exceptions per subscription, so HTML monitors
+   degrade at use time instead of crashing boot. Also make the module-level
+   `_SELECTOR_PARSE_ERRORS = selector_parse_errors()` call lazy (it imports
+   soupsieve at boot; the function is already lru_cached and its other caller
+   already calls it at the except site).
+4. Guard the three remaining unguarded top-level sites found by the census
+   (`baseline_manager.py`, `scrapers/generic_scraper.py`,
+   `scrapers/custom_scraper.py`) with the same lazy/actionable-error pattern so
+   a base install can import any Subscriptions module.
+5. Red-first tests in `Tests/Packaging/test_extras_import_closure.py`
+   (subprocess-isolated, following `Tests/Performance/test_app_import_weight.py`):
+   (a) app imports with bs4 blocked; (b) explicit-list import-closure guard for
+   extras-gated packages (scoped by the step-2 census, exclusions documented);
+   plus a use-time degrade test asserting the actionable error message.
+6. Run: new tests, existing Subscriptions/monitoring tests, full
+   `pytest Tests --collect-only -q` sweep. Tick ACs, notes, Done, commit.
+
+## Implementation Notes
+
+Took the guard-and-degrade branch (owner prefers durable over clever, and
+promotion-to-core would not have fixed the boot-cost half — the lazy import
+was needed either way).
+
+**Census of `from bs4`/`import bs4` in `tldw_chatbook/` (21 sites).** Exactly
+four were unguarded module-level imports, all in `Subscriptions/`:
+`monitoring_engine.py:37` (the defect — the only one on the boot path, via
+app.py -> Scheduling/scheduler/handlers -> watchlist_check_handler),
+`baseline_manager.py:52` (NOT-WIRED module, zero importers),
+`scrapers/generic_scraper.py:15` and `scrapers/custom_scraper.py:20` (the
+scrapers package has no external importers). Every other site was already
+guarded (try/except with a `BS4_AVAILABLE` flag, the Web_Scraping house
+pattern) or function-local lazy.
+
+**Fix.** `monitoring_engine` now resolves BeautifulSoup lazily inside
+`ContentExtractor.extract_text_from_html` (its only use) via
+`_require_beautifulsoup()`, which raises an ImportError naming the package
+and `pip install tldw_chatbook[subscriptions]`; the monitors' existing
+per-check exception handling records that against the subscription, so HTML
+monitors degrade at use time with an actionable message instead of crashing
+boot. The module-level `_SELECTOR_PARSE_ERRORS = selector_parse_errors()`
+constant was also retired in favour of calling the (lru_cached) function at
+the except site — it probed soupsieve at import, which would have kept
+soupsieve on the boot path. The other three files got the same guarded
+pattern (module-level try/except keeps the `BeautifulSoup` name defined for
+annotations; every runtime constructor call goes through the raising helper;
+`custom_scraper.validate_rules` reports missing bs4 as itself rather than as
+"invalid CSS selector"). Deliberately did NOT use
+`optional_deps.require_dependency("bs4", "subscriptions")`: its
+`check_dependency` side effect writes `DEPENDENCIES_AVAILABLE["subscriptions"]`
+from bs4 alone, which would collide with `check_subscriptions_deps()`'s
+five-package computation.
+
+**Evidence** (teed to `test-logs/task-21104-*`). Baseline: subprocess with
+bs4 blocked failed `import tldw_chatbook.app` with ImportError at
+monitoring_engine.py:37; closure census showed bs4+soupsieve resident
+(1852 modules). Post-fix: bs4-blocked import succeeds; bs4/soupsieve out of
+the closure (1831 modules); the only extras-tracked residents left
+(defusedxml, PIL, rich_pixels, textual_image) are all CORE deps in
+pyproject. New tests: `Tests/Packaging/test_extras_import_closure.py`
+(4 passed) — bs4-absent app-import guard, explicit-list extras closure guard
+(detector mutation-tested against a known-resident module), use-time
+actionable-error test, bs4-present happy path. Existing:
+Tests/Subscriptions 808 passed / 1 failed pre-existing (the finding-21106
+`_build_test_app()` Actor_Packs crash — A/B'd against base `0f9638cef`,
+fails identically there); Tests/Scheduling+Tests/Watchlists 765 passed /
+285 failed, ALL with that same pre-existing 21106 signature (285/285 grep
+match, two of them A/B'd on base). Collect sweep: 55,012 collected,
+33 errors — identical count on base (missing-optional-dep envs: playwright,
+numpy, audio stacks).
+
+**Worth knowing.** The finding's "a base install cannot import the app" is
+in practice masked on healthy installs: the CORE dep `markdownify` pins
+`beautifulsoup4<5,>=4.9` transitively, so bs4 is usually present even
+without extras. Nothing in the project's own declarations guarantees it
+(and `--no-deps`/partial envs break), so the guard is still the right fix —
+but absence tests must BLOCK the module rather than trust pip state, which
+is what the new subprocess guard does.
+
+**Files.** `tldw_chatbook/Subscriptions/monitoring_engine.py`,
+`baseline_manager.py`, `scrapers/generic_scraper.py`,
+`scrapers/custom_scraper.py`, new `Tests/Packaging/test_extras_import_closure.py`.

--- a/backlog/tasks/task-21104 - bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app.md
+++ b/backlog/tasks/task-21104 - bs4 is imported unguarded at boot but beautifulsoup4 is extras-only - base install cannot import the app.md
@@ -85,15 +85,21 @@ pattern) or function-local lazy.
 `ContentExtractor.extract_text_from_html` (its only use) via
 `_require_beautifulsoup()`, which raises an ImportError naming the package
 and `pip install tldw_chatbook[subscriptions]`; the monitors' existing
-per-check exception handling records that against the subscription, so HTML
-monitors degrade at use time with an actionable message instead of crashing
+per-check exception handling records that against the subscription for single-`url`
+sources (review-verified: the hint survives verbatim into the run's error_msg via
+`record_run_failure`); `url_list`/`sitemap` sources route through
+`_check_url_isolated`, whose task-1394 privacy suppression reduces the ImportError
+to a type-only DEBUG line + DISPOSITION_ERROR with no reason -- degradation is
+still graceful (run completes WITH ERRORS) but the install hint is not
+user-visible on those arms; surfacing permanent ImportErrors there is a filed
+follow-up candidate. HTML monitors degrade at use time instead of crashing
 boot. The module-level `_SELECTOR_PARSE_ERRORS = selector_parse_errors()`
 constant was also retired in favour of calling the (lru_cached) function at
 the except site — it probed soupsieve at import, which would have kept
 soupsieve on the boot path. The other three files got the same guarded
 pattern (module-level try/except keeps the `BeautifulSoup` name defined for
 annotations; every runtime constructor call goes through the raising helper;
-`custom_scraper.validate_rules` reports missing bs4 as itself rather than as
+`custom_scraper.validate_config` reports missing bs4 as itself rather than as
 "invalid CSS selector"). Deliberately did NOT use
 `optional_deps.require_dependency("bs4", "subscriptions")`: its
 `check_dependency` side effect writes `DEPENDENCIES_AVAILABLE["subscriptions"]`

--- a/tldw_chatbook/Subscriptions/baseline_manager.py
+++ b/tldw_chatbook/Subscriptions/baseline_manager.py
@@ -49,8 +49,27 @@ from difflib import SequenceMatcher
 
 #
 # Third-Party Imports
-from bs4 import BeautifulSoup
 from loguru import logger
+
+# bs4 is extras-only (`[subscriptions]` among others): guarded so a base
+# install can import this module; parsing degrades at use time (TASK-21104).
+try:
+    from bs4 import BeautifulSoup
+except ImportError:  # pragma: no cover - exercised via the base-install probe
+    BeautifulSoup = None  # type: ignore[assignment]
+
+_BS4_INSTALL_HINT = (
+    "beautifulsoup4 is required to analyze HTML content for baselines, "
+    "but it is not installed. "
+    "Install it with: pip install tldw_chatbook[subscriptions]"
+)
+
+
+def _require_beautifulsoup() -> type:
+    """Return the BeautifulSoup class or raise an actionable ImportError."""
+    if BeautifulSoup is None:
+        raise ImportError(_BS4_INSTALL_HINT)
+    return BeautifulSoup
 
 #
 # Local Imports
@@ -155,7 +174,7 @@ class ContentAnalyzer:
     def extract_text(self, html_content: str) -> str:
         """Extract clean text from HTML."""
         try:
-            soup = BeautifulSoup(html_content, "html.parser")
+            soup = _require_beautifulsoup()(html_content, "html.parser")
 
             # Remove script and style elements
             for script in soup(["script", "style"]):
@@ -178,7 +197,7 @@ class ContentAnalyzer:
     def calculate_structural_hash(self, html_content: str) -> str:
         """Calculate hash of HTML structure (tags only, no content)."""
         try:
-            soup = BeautifulSoup(html_content, "html.parser")
+            soup = _require_beautifulsoup()(html_content, "html.parser")
 
             # Build structure string
             structure_parts = []
@@ -201,7 +220,7 @@ class ContentAnalyzer:
     def extract_key_elements(self, html_content: str) -> Dict[str, Any]:
         """Extract key elements like headers, links, images."""
         try:
-            soup = BeautifulSoup(html_content, "html.parser")
+            soup = _require_beautifulsoup()(html_content, "html.parser")
 
             elements = {
                 "title": soup.find("title").get_text() if soup.find("title") else None,
@@ -367,7 +386,7 @@ class ChangeDetector:
     def _apply_ignore_selectors(self, content: str, ignore_selectors: List[str]) -> str:
         """Remove elements matching ignore selectors."""
         try:
-            soup = BeautifulSoup(content, "html.parser")
+            soup = _require_beautifulsoup()(content, "html.parser")
 
             for selector in ignore_selectors:
                 for element in soup.select(selector):

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -34,7 +34,6 @@ except ImportError:
     logger.warning(
         "defusedxml not available, using standard xml.etree. Install defusedxml for better security."
     )
-from bs4 import BeautifulSoup
 from loguru import logger
 
 #
@@ -76,11 +75,37 @@ from .security import SecurityValidator
 #
 ########################################################################################################################
 
-# Resolved once at import: this module hard-imports bs4, so soupsieve is
-# certainly present here. Kept in `noise_defaults` rather than inline so the
-# extraction guard and the two UI save-path validators share one definition of
-# "the selector is malformed" -- see `selector_parse_errors`.
-_SELECTOR_PARSE_ERRORS = selector_parse_errors()
+# bs4 is extras-only (`[subscriptions]` among others) while this module is
+# imported eagerly at boot via the scheduler handlers (app.py ->
+# Scheduling/scheduler/handlers -> here), so a module-level
+# `from bs4 import BeautifulSoup` made an install without the extra unable to
+# import the app at all, and made every install pay the bs4+soupsieve import
+# at boot (TASK-21104). BeautifulSoup is therefore resolved lazily at first
+# HTML extraction; a missing install degrades to a per-check ImportError that
+# the monitors' existing exception handling records against the subscription.
+_BS4_INSTALL_HINT = (
+    "beautifulsoup4 is required to extract text from HTML for "
+    "watchlist/subscription monitoring, but it is not installed. "
+    "Install it with: pip install tldw_chatbook[subscriptions]"
+)
+
+
+def _require_beautifulsoup() -> type:
+    """Resolve the ``BeautifulSoup`` class lazily (TASK-21104).
+
+    Returns:
+        The ``bs4.BeautifulSoup`` class.
+
+    Raises:
+        ImportError: When beautifulsoup4 is not installed; the message names
+            the feature and the exact install command so the per-check error
+            surfaced on the subscription is actionable.
+    """
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:
+        raise ImportError(_BS4_INSTALL_HINT) from exc
+    return BeautifulSoup
 
 
 class FetchBlockedError(SubscriptionError):
@@ -209,7 +234,7 @@ class ContentExtractor:
         Returns:
             Extracted text
         """
-        soup = BeautifulSoup(html, "html.parser")
+        soup = _require_beautifulsoup()(html, "html.parser")
 
         # Remove script and style elements
         for script in soup(["script", "style"]):
@@ -227,7 +252,12 @@ class ContentExtractor:
             for selector in ignore_selectors:
                 try:
                     matches = soup.select(selector)
-                except _SELECTOR_PARSE_ERRORS as exc:
+                # `selector_parse_errors()` is lru_cached and shared with the
+                # two UI save-path validators (`noise_defaults`) so the
+                # definition of "the selector is malformed" cannot drift.
+                # Called here rather than resolved at module import because it
+                # probes soupsieve, which is extras-only like bs4 (TASK-21104).
+                except selector_parse_errors() as exc:
                     # One line per bad selector per extraction: named, so the
                     # log says which rule to fix, not merely that one is broken.
                     logger.warning(

--- a/tldw_chatbook/Subscriptions/scrapers/custom_scraper.py
+++ b/tldw_chatbook/Subscriptions/scrapers/custom_scraper.py
@@ -17,8 +17,28 @@ from urllib.parse import urljoin
 #
 # Third-Party Imports
 import httpx
-from bs4 import BeautifulSoup
 from loguru import logger
+
+# bs4 is extras-only (`[subscriptions]` among others): guarded so a base
+# install can import this module; parsing degrades at use time (TASK-21104).
+try:
+    from bs4 import BeautifulSoup
+except ImportError:  # pragma: no cover - exercised via the base-install probe
+    BeautifulSoup = None  # type: ignore[assignment]
+
+_BS4_INSTALL_HINT = (
+    "beautifulsoup4 is required to parse web pages for scraping pipelines, "
+    "but it is not installed. "
+    "Install it with: pip install tldw_chatbook[subscriptions]"
+)
+
+
+def _require_beautifulsoup() -> type:
+    """Return the BeautifulSoup class or raise an actionable ImportError."""
+    if BeautifulSoup is None:
+        raise ImportError(_BS4_INSTALL_HINT)
+    return BeautifulSoup
+
 
 #
 # Local Imports
@@ -88,7 +108,13 @@ class CustomScrapingPipeline(BaseScrapingPipeline):
                     # Basic CSS selector validation
                     try:
                         # Test parse with BeautifulSoup
-                        BeautifulSoup("<div></div>", "html.parser").select(selector)
+                        _require_beautifulsoup()("<div></div>", "html.parser").select(
+                            selector
+                        )
+                    except ImportError as exc:
+                        # Missing bs4 is an install problem, not a bad
+                        # selector -- report it as itself (TASK-21104).
+                        return False, str(exc)
                     except Exception:
                         return False, f"Invalid CSS selector in {rule_name}: {selector}"
 
@@ -149,7 +175,7 @@ class CustomScrapingPipeline(BaseScrapingPipeline):
         items = []
 
         try:
-            soup = BeautifulSoup(raw_content, "html.parser")
+            soup = _require_beautifulsoup()(raw_content, "html.parser")
 
             # Extract JSON-LD data if available
             json_ld_data = {}

--- a/tldw_chatbook/Subscriptions/scrapers/generic_scraper.py
+++ b/tldw_chatbook/Subscriptions/scrapers/generic_scraper.py
@@ -12,8 +12,28 @@ from urllib.parse import urljoin, urlparse
 #
 # Third-Party Imports
 import httpx
-from bs4 import BeautifulSoup
 from loguru import logger
+
+# bs4 is extras-only (`[subscriptions]` among others): guarded so a base
+# install can import this module; parsing degrades at use time (TASK-21104).
+try:
+    from bs4 import BeautifulSoup
+except ImportError:  # pragma: no cover - exercised via the base-install probe
+    BeautifulSoup = None  # type: ignore[assignment]
+
+_BS4_INSTALL_HINT = (
+    "beautifulsoup4 is required to parse web pages for scraping pipelines, "
+    "but it is not installed. "
+    "Install it with: pip install tldw_chatbook[subscriptions]"
+)
+
+
+def _require_beautifulsoup() -> type:
+    """Return the BeautifulSoup class or raise an actionable ImportError."""
+    if BeautifulSoup is None:
+        raise ImportError(_BS4_INSTALL_HINT)
+    return BeautifulSoup
+
 
 #
 # Local Imports
@@ -184,7 +204,7 @@ class GenericWebScrapingPipeline(BaseScrapingPipeline):
         items = []
 
         try:
-            soup = BeautifulSoup(raw_content, "html.parser")
+            soup = _require_beautifulsoup()(raw_content, "html.parser")
 
             # Check if this is a listing page or single article
             if self._is_listing_page(soup):


### PR DESCRIPTION
## Summary

`Subscriptions/monitoring_engine.py:37` imported `bs4` unguarded at module level, and the module is on the boot path (scheduler handlers ← app.py). `beautifulsoup4` exists only in optional extras, so a base `pip install .` could not `import tldw_chatbook.app` at all — and every install paid the bs4+soupsieve import at boot. Found by the 2026-08-22 holistic perf review (evidence: `Docs/Design/2026-08-22-holistic-perf-review.md`, finding 21104).

## Changes

- Guard-and-degrade at all 4 unguarded module-level sites (census of 21 bs4 sites package-wide; the other 17 were already guarded/function-local): import moved to first use behind `_require_beautifulsoup()` with an actionable `pip install tldw_chatbook[subscriptions]` message; watchlist checks record the failure per-subscription instead of crashing boot.
- Retired the module-level `_SELECTOR_PARSE_ERRORS` constant that probed soupsieve at import (evaluated lazily at the except site; base semantics verified identical).
- New `Tests/Packaging/test_extras_import_closure.py`: bs4-blocked subprocess app-import guard + an extras-only import-closure ratchet over 17 packages (mutation-verified to bite), + use-time error and happy-path tests.

## Evidence

- bs4-blocked `import tldw_chatbook.app`: ImportError on base → succeeds after; module closure 1852 → 1831 (bs4+soupsieve out).
- New tests 4/4; focused monitoring 102 passed; Tests/Subscriptions 808 passed / 1 failed — named and A/B'd on base as the pre-existing Actor_Packs `__init__` crash (TASK-21106's target, which also reddens 285 Scheduling/Watchlists tests on dev).
- Adversarial review verdict: MERGE-READY. NameError-at-use probed clean with bs4+soupsieve blocked across all four modules; guards mutation-tested; `_SELECTOR_PARSE_ERRORS` retirement verified sole-consumer. Review polish applied (notes scoped: the install hint reaches single-`url` runs verbatim; `url_list`/`sitemap` arms suppress it under the task-1394 privacy rule — follow-up candidate recorded).
- Honesty note: core dep `markdownify` transitively pins bs4 today, masking the crash on healthy installs; nothing in our own declarations guarantees it, so the guard stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop importing `bs4` at boot and resolve `BeautifulSoup` lazily so base installs can import the app. Before: `Subscriptions/monitoring_engine.py` imported `bs4` at module import, base installs could not `import tldw_chatbook.app`, and all installs loaded `bs4`/`soupsieve` at boot. Now: first use resolves `BeautifulSoup`; if missing, an actionable error points to `pip install tldw_chatbook[subscriptions]`; monitors record the error per subscription.

- Changes
  - Guard all four unguarded module-level `bs4` sites: `Subscriptions/monitoring_engine.py`, `Subscriptions/baseline_manager.py`, `Subscriptions/scrapers/generic_scraper.py`, `Subscriptions/scrapers/custom_scraper.py`. HTML parsing now degrades with an actionable ImportError.
  - Retire `_SELECTOR_PARSE_ERRORS`; call `selector_parse_errors()` lazily where needed to avoid importing `soupsieve` at boot.
  - Add `Tests/Packaging/test_extras_import_closure.py`: subprocess guard that `import tldw_chatbook.app` works with `bs4` blocked; explicit import-closure ratchet against extras-only packages; degrade and happy-path tests.
  - Side effects: boot import closure drops `bs4`/`soupsieve`. `url_list`/`sitemap` arms still degrade gracefully but suppress the install-hint message due to the privacy rule.

- Notes
  - No migrations. Base installs can import the app; users who need HTML extraction or scrapers must install `tldw_chatbook[subscriptions]`.
  - Addresses Linear TASK-21104 acceptance criteria: guard vs promote decided (guard), base import succeeds, and an import-closure test prevents regressions.

<sup>Written for commit b91d68826ef57fd0d5cbf38a3de8a4959a509fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

