### PR TITLE
feat(scheduling): single-owner execution — local loop never dispatches server-scoped rows (task-18940 slice 1)

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -153,6 +153,14 @@ A reminder that is both queued and run manually dispatches exactly once —
 the pending scheduled occurrence is claimed by the manual run rather than
 firing twice.
 
+**Server-scheduled reminders cannot be run from here.** When the Schedules
+owner is a connected server, reminders synced to it carry a server scope:
+the **server** executes them on schedule and delivers the notification
+through the server feed, and the local scheduler never fires them (no
+double execution — one owner, one executor). Pressing **r** on one refuses
+with a toast saying so. This is the single-owner execution rule the
+server-offload design is built on; local-owner reminders are unaffected.
+
 ## Execution timeouts
 
 A scheduled task's handler is bounded: if it is still running after its

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1748,15 +1748,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 8,
-      "diagnostic_digest": "cfcd741a717ab954770a",
+      "call_count": 9,
+      "diagnostic_digest": "34b48f40fbfd6b33451d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/loop.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 8,
-      "diagnostic_digest": "7e5174010d9423ebe609",
+      "call_count": 9,
+      "diagnostic_digest": "0351e6f0955020f0d9b8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/scheduling_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11054,6 +11054,6 @@
     "path_privacy_candidate_calls": 713,
     "persistent_sink_files": 8,
     "task_492_calls": 1277,
-    "task_494_calls": 7337
+    "task_494_calls": 7339
   }
 }

--- a/Tests/Scheduling/test_owner_filter.py
+++ b/Tests/Scheduling/test_owner_filter.py
@@ -1,0 +1,165 @@
+"""Single-owner execution tests (ADR-077 decision 1, TASK-18940 slice 1).
+
+Server-scoped reminder rows ("server:<user_id>") are the server's to
+execute: the local queue never arms them, ticks never dispatch them, and
+Run-now refuses at every seam. All through the real DB/queue/loop/service
+paths.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
+from tldw_chatbook.Scheduling.scheduler.queue import (
+    PriorityQueue,
+    is_server_scoped_owner,
+)
+from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+
+NOW = datetime(2026, 8, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = ScheduledTasksDB(tmp_path / "owner_filter.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _make_reminder(db, *, owner_id, next_run_at=NOW, enabled=True, title="row"):
+    return db.create_reminder_task(
+        owner_id=owner_id,
+        title=title,
+        schedule_kind="recurring",
+        cron="0 * * * *",
+        timezone="UTC",
+        next_run_at=next_run_at.isoformat(),
+        enabled=enabled,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The owner predicate
+# ---------------------------------------------------------------------------
+
+
+def test_is_server_scoped_owner():
+    """Only 'server:'-prefixed owners mark server execution."""
+    assert is_server_scoped_owner("server:42") is True
+    assert is_server_scoped_owner("server:") is True
+    assert is_server_scoped_owner("local") is False
+    assert is_server_scoped_owner(None) is False
+    assert is_server_scoped_owner(123) is False
+
+
+# ---------------------------------------------------------------------------
+# The queue seam: server-scoped rows are never armed (both load paths)
+# ---------------------------------------------------------------------------
+
+
+def test_queue_load_excludes_server_scoped_rows(db):
+    """The default load path drops server-scoped rows, keeps local ones."""
+    local_id = _make_reminder(db, owner_id="local", title="local-row")
+    server_id = _make_reminder(db, owner_id="server:42", title="server-row")
+
+    queue = PriorityQueue(db)
+    queue.load()
+
+    ids = {item["id"] for item in queue._items}
+    assert local_id in ids
+    assert server_id not in ids
+
+
+def test_queue_due_before_path_excludes_server_scoped_rows(db):
+    """The back-compat due-before load path filters identically."""
+    local_id = _make_reminder(db, owner_id="local", title="local-row")
+    server_id = _make_reminder(db, owner_id="server:7", title="server-row")
+
+    queue = PriorityQueue(db)
+    queue.load(now=NOW + timedelta(minutes=5))
+
+    ids = {item["id"] for item in queue._items}
+    assert local_id in ids
+    assert server_id not in ids
+
+
+def test_tick_never_dispatches_server_scoped_rows(db):
+    """End to end through the real loop: a due server row never fires."""
+    _make_reminder(db, owner_id="local", title="local-row")
+    _make_reminder(db, owner_id="server:42", title="server-row")
+
+    handler = AsyncMock()
+    loop = SchedulerLoop(
+        db,
+        handlers={"reminder": handler},
+        clock=lambda: NOW + timedelta(minutes=5),
+        missed_fire_grace_seconds=60.0,
+    )
+    loop.queue.load()
+    asyncio.run(loop.tick())
+
+    # Only the local row dispatched; the server row was never armed.
+    titles = [call.args[0]["title"] for call in handler.await_args_list]
+    assert titles == ["local-row"]
+    # And its state was untouched by this side -- no last_run, no status.
+    server_row = [
+        row
+        for row in db.list_reminder_tasks(enabled=True)
+        if row["title"] == "server-row"
+    ][0]
+    assert server_row["last_run_at"] is None
+    assert server_row["last_status"] is None
+
+
+# ---------------------------------------------------------------------------
+# Run-now refusals at every seam
+# ---------------------------------------------------------------------------
+
+
+def test_loop_run_now_refuses_server_scoped(db):
+    """The loop's manual entry refuses without dispatching."""
+    task_id = _make_reminder(db, owner_id="server:42")
+    handler = AsyncMock()
+    loop = SchedulerLoop(db, handlers={"reminder": handler}, clock=lambda: NOW)
+    loop.queue.load()
+
+    succeeded = asyncio.run(loop.run_reminder_now(task_id))
+
+    assert succeeded is False
+    handler.assert_not_awaited()
+    row = db.get_reminder_task(task_id)
+    assert row["last_run_at"] is None  # untouched, not consumed
+
+
+def test_service_run_now_refuses_server_scoped(db):
+    """The service seam returns None (refusal) without touching the row."""
+    task_id = _make_reminder(db, owner_id="server:42")
+    handler = AsyncMock()
+    loop = SchedulerLoop(db, handlers={"reminder": handler}, clock=lambda: NOW)
+    service = SchedulingService(db=db, server_client=None, runtime_source="local")
+    loop.queue.load()
+
+    result = asyncio.run(service.run_reminder_now(task_id, loop=loop))
+
+    assert result is None
+    handler.assert_not_awaited()
+
+
+def test_local_rows_still_dispatch_after_the_filter(db):
+    """The guard changes nothing for local-owner rows (AC#5 of 18940)."""
+    task_id = _make_reminder(db, owner_id="local")
+    handler = AsyncMock()
+    loop = SchedulerLoop(db, handlers={"reminder": handler}, clock=lambda: NOW)
+    loop.queue.load()
+
+    succeeded = asyncio.run(loop.run_reminder_now(task_id))
+
+    assert succeeded is True
+    handler.assert_awaited_once()
+    assert db.get_reminder_task(task_id)["last_status"] == "completed"

--- a/backlog/tasks/task-18940 - Server-offloaded-scheduled-agent-tasks-execution-seam.md
+++ b/backlog/tasks/task-18940 - Server-offloaded-scheduled-agent-tasks-execution-seam.md
@@ -60,3 +60,7 @@ Reason: cross-system service contract (client↔server execution ownership, resu
 5. Reconciliation with 18937–18939 semantics; per-task model payload
 6. Live verification against a real server; docs (schedules.md is a stub — this task should also give it its real content)
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+**Client slice 1 (2026-08-23, `feat/18940-owner-filter`): single-owner execution.** ADR-077 decision 1 landed client-side: `PriorityQueue.load` drops server-scoped rows (`owner_id` starting `server:`) at the queue seam — both load paths — so no tick, reload, or variant can ever dispatch one locally (notifications arrive via the server feed instead; no local missed-fire state, per decision 6). Run-now refuses at all three seams (workbench toast with precise copy, service returns None, loop returns False without consuming the row). Local-owner rows unchanged (pinned). Tests: `Tests/Scheduling/test_owner_filter.py` (7 — predicate, both queue paths, tick-never-dispatches with row untouched, loop/service refusals, local-row no-regression). Scheduling suite 335 passed (2 pre-existing dev failures reproduced with changes stashed: briefing wiring getter tests); scheduling UI suites 56 passed (5 unrelated settings-module collection errors also pre-exist on clean dev in this worktree — persona coordinator DB handle at import). Docs: schedules.md gains the server-scheduled callout the ADR's Consequences section requires.

--- a/tldw_chatbook/Scheduling/scheduler/loop.py
+++ b/tldw_chatbook/Scheduling/scheduler/loop.py
@@ -16,7 +16,10 @@ from tldw_chatbook.Scheduling.constants import (
     SCHEDULER_POLL_INTERVAL_SECONDS,
     coerce_positive_float,
 )
-from tldw_chatbook.Scheduling.scheduler.queue import PriorityQueue
+from tldw_chatbook.Scheduling.scheduler.queue import (
+    PriorityQueue,
+    is_server_scoped_owner,
+)
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
 
@@ -473,6 +476,18 @@ class SchedulerLoop:
         self.queue.remove(task_id)
         row = await asyncio.to_thread(self.db.get_reminder_task, task_id)
         if row is None:
+            return False
+
+        # ADR-077 decision 1: server-scoped rows are the server's to
+        # execute. A local manual run would either double-execute against
+        # the server's own firing or consume a row this side never owns --
+        # refuse honestly rather than dispatch on the wrong side.
+        if is_server_scoped_owner(row.get("owner_id")):
+            logger.warning(
+                "Manual reminder run refused for task {task_id}: "
+                "server-scoped rows are executed by the server (ADR-077)",
+                task_id=task_id,
+            )
             return False
 
         succeeded = await self.dispatch_reminder(

--- a/tldw_chatbook/Scheduling/scheduler/queue.py
+++ b/tldw_chatbook/Scheduling/scheduler/queue.py
@@ -15,6 +15,16 @@ from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProj
 
 _FUTURE_SORT_KEY = "9999-12-31T23:59:59+00:00"
 _DEFAULT_OWNER_ID = "local"
+#: Server-scoped owners ("server:<user_id>") mark rows the SERVER executes
+#: (ADR-077 decision 1, single-owner execution): the local loop must never
+#: arm or dispatch them, or an app running while the server also fires the
+#: row would double-execute by construction.
+_SERVER_OWNER_PREFIX = "server:"
+
+
+def is_server_scoped_owner(owner_id: Any) -> bool:
+    """Return True when a row's owner marks it server-executed (ADR-077)."""
+    return isinstance(owner_id, str) and owner_id.startswith(_SERVER_OWNER_PREFIX)
 
 
 class PriorityQueue:
@@ -54,6 +64,16 @@ class PriorityQueue:
             self._items = [item for item in self._items if item.get("next_run_at")]
         else:
             self._items = self.db.reminders_due_before(now)
+
+        # ADR-077 decision 1 (single-owner execution): server-scoped rows
+        # are the server's to execute. They are dropped at the queue seam
+        # so no tick, reload, or load-path variant can ever dispatch one
+        # locally -- their notifications arrive through the server feed.
+        self._items = [
+            item
+            for item in self._items
+            if not is_server_scoped_owner(item.get("owner_id"))
+        ]
 
         self._append_projected(self.watchlist_projection)
         self._append_projected(self.briefing_projection)

--- a/tldw_chatbook/Scheduling/scheduler/queue.py
+++ b/tldw_chatbook/Scheduling/scheduler/queue.py
@@ -23,7 +23,16 @@ _SERVER_OWNER_PREFIX = "server:"
 
 
 def is_server_scoped_owner(owner_id: Any) -> bool:
-    """Return True when a row's owner marks it server-executed (ADR-077)."""
+    """Return True when a row's owner marks it server-executed (ADR-077).
+
+    Args:
+        owner_id: A reminder row's ``owner_id`` value (any type tolerated;
+            non-strings simply are not server-scoped).
+
+    Returns:
+        True when ``owner_id`` is a string prefixed with the server-owner
+        prefix, marking the row as executed by the server.
+    """
     return isinstance(owner_id, str) and owner_id.startswith(_SERVER_OWNER_PREFIX)
 
 

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -361,6 +361,19 @@ class SchedulingService:
         if row is None:
             return None
 
+        # ADR-077 decision 1: server-scoped rows are executed by the
+        # server. The workbench surfaces a precise refusal message; the
+        # loop carries the same guard for direct callers.
+        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+        if is_server_scoped_owner(row.get("owner_id")):
+            logger.warning(
+                "Manual reminder run refused for task {task_id}: "
+                "server-scoped (executed by the server per ADR-077)",
+                task_id=task_id,
+            )
+            return None
+
         succeeded = await loop.run_reminder_now(task_id)
         self._notify_queue_changed()
 

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -749,7 +749,13 @@ class SchedulesWorkbench(BaseAppScreen):
         # ADR-077 decision 1: server-scoped reminders are executed by the
         # server; a local Run-now would be a dispatch on the wrong side.
         # The refusal is precise rather than the generic did-not-run copy.
-        if str(getattr(task, "owner_id", "local") or "local").startswith("server:"):
+        # The predicate is the shared source of truth (queue.py) so the
+        # UI can never drift from the scheduler/service refusal behavior.
+        from tldw_chatbook.Scheduling.scheduler.queue import (
+            is_server_scoped_owner,
+        )
+
+        if is_server_scoped_owner(getattr(task, "owner_id", None)):
             self.app_instance.notify(
                 f"'{task.title}' is server-scheduled: the server runs it and "
                 "delivers the notification -- it cannot be run from here.",

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -746,6 +746,17 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             return
 
+        # ADR-077 decision 1: server-scoped reminders are executed by the
+        # server; a local Run-now would be a dispatch on the wrong side.
+        # The refusal is precise rather than the generic did-not-run copy.
+        if str(getattr(task, "owner_id", "local") or "local").startswith("server:"):
+            self.app_instance.notify(
+                f"'{task.title}' is server-scheduled: the server runs it and "
+                "delivers the notification -- it cannot be run from here.",
+                severity="warning",
+            )
+            return
+
         was_disabled = not bool(getattr(task, "enabled", True))
 
         async def _run_and_refresh() -> None:


### PR DESCRIPTION
## Summary

First client-side slice of **TASK-18940**, landing ADR-077 decision 1 (accepted 2026-08-21): **single-owner execution**.

- **The queue seam**: `PriorityQueue.load` drops server-scoped rows (`owner_id` starting `server:`) on both load paths — no tick, periodic reload, or load variant can ever arm or dispatch one locally. This is the accepted behavior change: server-synced reminders stop firing locally; their notifications arrive through the server feed. No local missed-fire state is recorded for them (ADR-077 decision 6 — server run rows are authoritative for server-scoped tasks).
- **Run-now refuses at every seam**: the workbench shows a precise toast ("server-scheduled: the server runs it and delivers the notification — it cannot be run from here"), the service returns `None`, and the loop returns `False` without consuming the row.
- **Local-owner rows unchanged** — pinned by test.
- `schedules.md` gains the user-facing callout the ADR's Consequences section requires.

Server-side counterparts already merged (tldw_server #2798/#2801/#2803/#2804): definitions arm → enqueue → execute generation-only → notify, with run-now and honest capabilities.

## Verification

- 7 new tests in `Tests/Scheduling/test_owner_filter.py`: the predicate, both queue load paths, tick-never-dispatches (server row's state untouched — no last_run, no status), loop + service Run-now refusals, local-row no-regression
- Scheduling suite **335 passed** — the 2 failures (`test_briefing_handler` / `test_scheduling_service` wiring-getter tests) reproduce identically with my changes stashed: pre-existing on dev
- Scheduling UI suites **56 passed** (5 unrelated settings-module collection errors also reproduce on clean dev in this worktree — a persona-coordinator DB handle at import time)

Part of TASK-18940 (AC#5 in particular: local-first path not regressed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces single-owner execution for scheduled reminders. Local scheduling no longer arms or runs server-scoped rows (`owner_id` starting `server:`); the server executes and delivers notifications, and local missed-fire/last_run are not recorded.

- Queue seam: `PriorityQueue.load` filters server-scoped rows on both default and due-before paths so no tick/reload can dispatch them locally.
- Run-now refusals: workbench shows a precise toast, the service returns None, and the loop returns False without consuming the row.
- Shared predicate: adds `is_server_scoped_owner` as the single source of truth across UI, service, and loop.
- Local-owner behavior unchanged; tests pin the predicate, both queue paths, tick-never-dispatches with row state untouched, refusals, and a local-row no-regression.
- Docs: `schedules.md` adds the server-scheduled callout.
- Rollout: no migrations. Clients on this branch stop firing server-scheduled reminders; the server runs them. Production diagnostic inventory is pinned for the new refusal logs. Part of TASK-18940.

<sup>Written for commit c8b8a7369d0b0883de648ccef384aac675242d68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

