### PR TITLE
fix(startup): stop Actor Pack recovery from killing app construction when the ChaChaNotes DB cannot be opened

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -3666,8 +3666,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 328,
-      "diagnostic_digest": "5a92956a5766f8b313e0",
+      "call_count": 329,
+      "diagnostic_digest": "09c4ee210584f33664ef",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3906,6 +3906,6 @@
     "owner_files": 528,
     "persistent_sink_files": 8,
     "task_492_calls": 1222,
-    "task_494_calls": 7241
+    "task_494_calls": 7242
   }
 }

--- a/Tests/Actor_Packs/test_actor_pack_creation.py
+++ b/Tests/Actor_Packs/test_actor_pack_creation.py
@@ -314,3 +314,71 @@ def test_app_owns_creation_only_after_recovery_and_before_surfaces() -> None:
     creation = wiring.index("ActorPackCreationService(")
     scope = wiring.index("CharacterPersonaScopeService(")
     assert recovery < creation < scope
+
+
+def test_app_wires_live_actor_pack_services_when_the_database_opens(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """TASK-20970 review: the *open-database* half of the new wiring branch.
+
+    The sibling above asserts source-text ordering, which a behaviour-only
+    regression walks straight past: nulling all three services at the end of
+    the ``else`` branch leaves that assertion (and every other test in
+    `Tests/Actor_Packs`, `Tests/App`, `Tests/UI/test_actor_pack_creation_
+    workflow.py`) green, because `TASK-20970`'s own coverage only pins the
+    *degraded* side and the shared app factory patches
+    `get_chachanotes_db_lazy` to `None` for every app-building test in the
+    repo. Nothing behavioural asserted that a working database still yields
+    working Actor Pack services. This does.
+    """
+
+    from unittest.mock import Mock
+
+    from tldw_chatbook import app as app_module
+
+    database = CharactersRAGDB(tmp_path / "wiring.db", client_id="wiring")
+    try:
+        monkeypatch.setattr(
+            app_module.ServerCharacterPersonaService,
+            "from_server_context_provider",
+            Mock(return_value=Mock()),
+        )
+        monkeypatch.setattr(
+            app_module.ServerChatDictionaryService,
+            "from_server_context_provider",
+            Mock(return_value=Mock()),
+        )
+
+        fake_app = Mock()
+        fake_app.chachanotes_db = database
+        fake_app.service_policy_enforcer = object()
+        fake_app.server_context_provider = object()
+
+        app_module.TldwCli._wire_character_persona_services(fake_app)
+
+        assert isinstance(fake_app.actor_pack_repository, ActorPackRepository)
+        assert fake_app.actor_pack_repository.db is database
+        assert isinstance(
+            fake_app.persona_actor_pack_coordinator, PersonaActorPackCoordinator
+        )
+        assert (
+            fake_app.persona_actor_pack_coordinator.repository
+            is fake_app.actor_pack_repository
+        )
+        assert isinstance(
+            fake_app.actor_pack_creation_service, ActorPackCreationService
+        )
+        assert fake_app.actor_pack_creation_service.database is database
+        assert (
+            fake_app.actor_pack_creation_service.repository
+            is fake_app.actor_pack_repository
+        )
+        assert (
+            fake_app.actor_pack_creation_service.persona_coordinator
+            is fake_app.persona_actor_pack_coordinator
+        )
+        # Recovery ran and found nothing to reconcile: no fixed category is
+        # recorded, so the degraded/blocked/failed states stay distinguishable.
+        assert fake_app.actor_pack_recovery_error is None
+    finally:
+        database.close_connection()

--- a/Tests/Actor_Packs/test_actor_pack_repository.py
+++ b/Tests/Actor_Packs/test_actor_pack_repository.py
@@ -359,3 +359,19 @@ def test_sqlite_failures_do_not_expose_database_details(
     assert str(write_error.value) == "actor_pack_repository_write_failed"
     assert "private" not in repr(read_error.value)
     assert "private" not in repr(write_error.value)
+
+
+def test_missing_database_is_rejected_in_the_repositorys_own_error_category() -> None:
+    """TASK-20970: a `None` database fails typed, at the boundary.
+
+    The app hands its callers `None` whenever the ChaChaNotes database could
+    not be opened. Every query method here guards `sqlite3.Error` /
+    `CharactersRAGDBError`, which a `None` database sails past as a raw
+    `AttributeError` -- and callers that guard on this class's own error type
+    (or on `PersonaActorPackCoordinatorError`, which is also a `ValueError`
+    subclass) never see it coming. Rejecting it once, here, is what makes
+    those guards true.
+    """
+    with pytest.raises(ActorPackRepositoryError) as unavailable:
+        ActorPackRepository(None)
+    assert str(unavailable.value) == "actor_pack_repository_unavailable"

--- a/Tests/App/test_app_degraded_without_chachanotes_db.py
+++ b/Tests/App/test_app_degraded_without_chachanotes_db.py
@@ -1,0 +1,120 @@
+"""TASK-20970: the app still constructs when the ChaChaNotes DB cannot open.
+
+`TldwCli.__init__` has always tolerated an absent ChaChaNotes database -- it
+logs `ChaChaNotesDB (CharactersRAGDB) instance not found/assigned in
+app.__init__` and sets `self.chachanotes_db = None`, and every other wiring
+degrades around that (`_wire_chat_conversation_services` guards the same value
+explicitly). TASK-19057's Actor Pack wiring did not: it built an
+`ActorPackRepository(None)` and called `recover()` on it, so the repository
+dereferenced `None` and raised `AttributeError` -- which walked straight
+through the `except PersonaActorPackCoordinatorError` written to contain it,
+because that error subclasses `ValueError`. Constructing the app object failed
+outright, taking 294 tests and 4 whole test modules with it.
+
+Two tests, deliberately not one:
+
+* the first uses the shared factory, which patches `get_chachanotes_db_lazy`
+  to `None` -- the cheap shape, and the one the 294 reds were measured on;
+* the second is the same degraded start driven **end to end against a real
+  unopenable file on disk**, with nothing patched out. That is the shape a
+  user actually hits (a corrupt database, a permission error, or TASK-19860's
+  migration `.sql` files missing from the wheel), and a test that only ever
+  sees a mocked-away service cannot prove the real loader still returns
+  `None` into the branch this fix guards.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# The single fixed category the wiring records when the database is missing.
+# Distinct from `actor_pack_recovery_failed`: recovery did not fail, it was
+# never attempted, and an operator reading the log needs to see the
+# difference.
+_UNAVAILABLE = "actor_pack_recovery_unavailable"
+
+
+def _assert_actor_pack_wiring_degraded(app) -> None:
+    """Assert the explicit no-database decision the sibling wiring makes."""
+    assert app.chachanotes_db is None
+    # Explicit decision, not a half-built object holding a `None` database:
+    # `_wire_chat_conversation_services` treats the same value the same way.
+    assert app.actor_pack_repository is None
+    assert app.persona_actor_pack_coordinator is None
+    # `PersonasScreen` already guards this one -- it notifies "Actor Pack
+    # creation is unavailable." on `None` -- so the degraded app has a real
+    # user-facing story rather than a latent crash.
+    assert app.actor_pack_creation_service is None
+    assert app.actor_pack_recovery_error == _UNAVAILABLE
+
+
+def _capture_errors():
+    """Return (sink_id, messages) capturing ERROR-level loguru output."""
+    from loguru import logger as loguru_logger
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(
+        lambda message: messages.append(message.record["message"]), level="ERROR"
+    )
+    return sink_id, messages
+
+
+def test_app_constructs_with_no_chachanotes_database():
+    """Building the app with no ChaChaNotes DB must not raise."""
+    from loguru import logger as loguru_logger
+
+    from Tests.UI.app_factory import _build_test_app
+
+    sink_id, errors = _capture_errors()
+    try:
+        # Fails at origin/dev: this line raises AttributeError out of
+        # ActorPackRepository.list_persona_intents.
+        app = _build_test_app()
+    finally:
+        loguru_logger.remove(sink_id)
+
+    _assert_actor_pack_wiring_degraded(app)
+
+    # Operator-legible: names the subsystem, the cause, and the consequence --
+    # not a traceback, and not silence.
+    diagnostic = next((line for line in errors if _UNAVAILABLE in line), None)
+    assert diagnostic is not None, errors
+    assert "ChaChaNotes database" in diagnostic
+    assert "Actor Pack" in diagnostic
+
+
+def test_app_constructs_against_a_real_unopenable_chachanotes_file():
+    """Degraded start, end to end, against a genuinely unopenable file.
+
+    Nothing is patched: the file on disk is not a SQLite database, so the
+    real `get_chachanotes_db_lazy()` fails to open it and returns `None`
+    exactly as it does for a corrupt file, a permission error, or a
+    migration that cannot complete.
+    """
+    from loguru import logger as loguru_logger
+
+    from tldw_chatbook.config import get_chachanotes_db_lazy, get_chachanotes_db_path
+
+    # The autouse `isolate_test_environment` fixture has already re-pointed
+    # HOME/XDG at this test's own sandbox and cleared config.py's lazy
+    # database singletons, so this path is never the user's real database.
+    db_path = get_chachanotes_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_bytes(b"not a sqlite database\n" * 64)
+
+    # Measured, not assumed: the loader really does return None here.
+    assert get_chachanotes_db_lazy() is None
+
+    from tldw_chatbook.app import TldwCli
+
+    sink_id, errors = _capture_errors()
+    try:
+        # Fails at origin/dev with the same AttributeError.
+        app = TldwCli()
+    finally:
+        loguru_logger.remove(sink_id)
+
+    _assert_actor_pack_wiring_degraded(app)
+    assert any(_UNAVAILABLE in line for line in errors), errors

--- a/Tests/Character_Chat/test_character_persona_scope_service.py
+++ b/Tests/Character_Chat/test_character_persona_scope_service.py
@@ -2984,8 +2984,30 @@ def test_app_wires_character_persona_services(monkeypatch):
         app_module, "CharacterPersonaScopeService", scope_service_factory
     )
 
+    class EmptyIntentDatabase:
+        """Answer the one query this wiring now runs at construction time.
+
+        TASK-20970: `chachanotes_db` here used to be a bare ``object()``,
+        which was harmless right up until TASK-19057 made this function
+        actually *use* the database -- `PersonaActorPackCoordinator.recover()`
+        lists Persona intents before any Persona surface mounts. From then on
+        the sentinel raised `AttributeError: 'object' object has no attribute
+        'execute_query'` straight out of the function under test, in the same
+        frame chain as the 294 app-construction reds. A double that reports
+        no intents keeps this test about the scope-service wiring it is
+        named for.
+        """
+
+        class _Cursor:
+            @staticmethod
+            def fetchall():
+                return []
+
+        def execute_query(self, *_args, **_kwargs):
+            return self._Cursor()
+
     fake_app = Mock()
-    fake_app.chachanotes_db = object()
+    fake_app.chachanotes_db = EmptyIntentDatabase()
     fake_app.service_policy_enforcer = object()
     fake_app.server_context_provider = object()
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6808,3 +6808,50 @@ per-key work was ~7 widget refreshes — the static read had been right all alon
 
 Full disclosure section: `Docs/Design/2026-08-22-holistic-perf-review.md`
 ("Measurement-artifact disclosure").
+
+## A test double that is a bare `object()` is a lie with a delayed fuse (TASK-20970)
+
+`Tests/Character_Chat/test_character_persona_scope_service.py::test_app_wires_
+character_persona_services` set `fake_app.chachanotes_db = object()` — a
+sentinel, chosen because the wiring under test only ever *passed the value
+along*. It stayed green for as long as that was true. TASK-19057 then made the
+same function actually **use** the database (`PersonaActorPackCoordinator.
+recover()` lists Persona intents at construction time), and the sentinel
+started raising `AttributeError: 'object' object has no attribute
+'execute_query'` from inside the function under test — a red that says nothing
+about the scope-service wiring the test is named for. The sentinel had been
+asserting "this collaborator is never used", implicitly and invisibly, for as
+long as it sat there.
+
+The same task showed the *other* half of that trap: the shared app factory
+patches `get_chachanotes_db_lazy` to `None`, so **every** app-building test in
+the repo silently became a no-database test. When the wiring stopped tolerating
+`None`, 294 tests across four suites and 4 whole `Tests/UI/test_settings_*`
+modules went red at once with one identical frame chain. Rule: when a double
+stands in for a real collaborator, give it the collaborator's shape (even a
+two-line class answering one query), so that a change which starts using the
+collaborator fails in the code that changed, not in an unrelated test's
+sentinel.
+
+## An `except` clause is only as true as the layer beneath it (TASK-20970)
+
+The Actor Pack wiring wrapped its startup recovery in `except
+PersonaActorPackCoordinatorError` — a guard that reads as complete. It was not:
+that error subclasses `ValueError`, and the repository under it dereferenced a
+`None` database, so a raw `AttributeError` walked straight through the clause
+written to contain it and killed `TldwCli.__init__`. Grepping for "is this call
+guarded?" answers yes; the honest question is "does the guard's type actually
+cover everything the callee can raise?", which requires reading the callee's own
+error boundary. The repository's boundary caught `sqlite3.Error` /
+`CharactersRAGDBError` at every query site — and a `None` database sails past
+all of them, at all of them.
+
+The durable repair was not to widen the caller to `except Exception` (which
+would also swallow the programming errors the wiring should surface) but to
+make the store reject the impossible state **in its own typed category, once,
+at construction**. Ten query sites each remembering to catch `AttributeError`
+is not a boundary; one constructor check is. Mutation-proved both halves
+independently: removing only the constructor check reds the repository's unit
+test and leaves the app tests green; disabling only the caller's guard reds the
+app tests with the typed error; removing both reproduces the original
+`AttributeError` verbatim.

--- a/backlog/tasks/task-20970 - Actor Pack recovery aborts app construction when the ChaChaNotes DB is unavailable.md
+++ b/backlog/tasks/task-20970 - Actor Pack recovery aborts app construction when the ChaChaNotes DB is unavailable.md
@@ -3,9 +3,10 @@ id: TASK-20970
 title: >-
   Actor Pack recovery aborts app construction when the ChaChaNotes DB is
   unavailable
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-22'
+updated_date: '2026-08-22'
 labels:
   - bug
   - app-startup
@@ -70,23 +71,23 @@ terminates in the identical frame chain `app.py:6010` →
 
 ## Acceptance Criteria
 
-- [ ] Constructing `TldwCli` with no ChaChaNotes database succeeds, and the app
+- [x] Constructing `TldwCli` with no ChaChaNotes database succeeds, and the app
       reaches the same degraded-but-running state it reached before TASK-19057
-- [ ] The Actor Pack wiring makes an explicit decision about a missing
+- [x] The Actor Pack wiring makes an explicit decision about a missing
       database rather than dereferencing it, consistent with how the sibling
       wiring in the same constructor treats the same value
-- [ ] A missing database produces an operator-legible diagnostic, not an
+- [x] A missing database produces an operator-legible diagnostic, not an
       unhandled `AttributeError`
-- [ ] The recovery call's failure handling covers the errors the repository can
+- [x] The recovery call's failure handling covers the errors the repository can
       actually raise, so a repository failure cannot escape the guard that is
       written to contain it
-- [ ] A test builds the app with no ChaChaNotes database and fails if
+- [x] A test builds the app with no ChaChaNotes database and fails if
       construction raises — so this specific regression cannot return silently
-- [ ] The 294 failures across `Tests/App`, `Tests/Scheduling`,
+- [x] The 294 failures across `Tests/App`, `Tests/Scheduling`,
       `Tests/Subscriptions` and `Tests/Watchlists` are green
-- [ ] The 4 `Tests/UI/test_settings_*` collection errors are gone and a
+- [x] The 4 `Tests/UI/test_settings_*` collection errors are gone and a
       repo-wide `pytest --collect-only` no longer reports them
-- [ ] A degraded start is verified end to end at least once against a real
+- [x] A degraded start is verified end to end at least once against a real
       unopenable database file, not only against a patched-out service
 
 ## Notes
@@ -103,3 +104,98 @@ is entirely red from this cause, including the test TASK-20978 is about, so
 that flake cannot be re-measured until this is fixed. Second, the reason the
 None branch exists at all is that it was reachable; nothing about TASK-19057
 made it less so.
+
+## Implementation Plan
+
+1. Reproduce at `origin/dev` in a fresh worktree: run the four named suites and
+   the four `Tests/UI/test_settings_*` modules, and confirm every failure ends
+   in the one frame chain the filing names.
+2. Write the born-red regression coverage first, in two shapes: the cheap one
+   through the shared app factory (which patches `get_chachanotes_db_lazy` to
+   `None`), and an end-to-end one against a genuinely unopenable database file
+   on disk with nothing patched out.
+3. Fix the layer that is actually wrong. Two separate defects, kept separate:
+   the wiring dereferences a value it should decide about, and the repository
+   lets a `None` database escape its own error boundary.
+4. Mutation-check both halves of the guard independently, then Edit-restore and
+   confirm the diff is byte-identical.
+5. Re-measure the four suites, the settings modules, and a repo-wide
+   `--collect-only`, each against a pinned `origin/dev` baseline.
+6. Regenerate the production-diagnostic inventory, reading the changed
+   statements with `--statements` before writing.
+
+## Implementation Notes
+
+Two independent repairs, deliberately not collapsed into one.
+
+**The wiring now decides.** `_wire_character_persona_services` reads
+`chachanotes_db` once and branches on it, exactly as the sibling
+`_wire_chat_conversation_services` does with the same value: when it is `None`,
+`actor_pack_repository`, `persona_actor_pack_coordinator` and
+`actor_pack_creation_service` are all set to `None`, `actor_pack_recovery_error`
+records the new fixed category `actor_pack_recovery_unavailable`, and one
+operator-legible ERROR is logged. Nothing else in the method is skipped — the
+branch is an `if/else`, not an early `return`, so the chat-dictionary and
+scope-service wiring below it still runs. `PersonasScreen` already guards
+`actor_pack_creation_service is None` and notifies "Actor Pack creation is
+unavailable.", so the degraded app has a real user-facing story rather than a
+latent crash. The diagnostic:
+
+    Actor Pack services disabled: the ChaChaNotes database could not be
+    opened, so portable-identity recovery was skipped and Actor Pack creation
+    is unavailable for this session (actor_pack_recovery_unavailable)
+
+**The repository now raises its own typed error.** `ActorPackRepository.
+__init__` rejects a `None` database with
+`ActorPackRepositoryError("actor_pack_repository_unavailable")`. This is the
+durable half and it was chosen over the two alternatives on purpose. Widening
+the call site to `except Exception` would have contained *this* symptom while
+also swallowing genuine programming errors in a startup path. Adding
+`AttributeError` to each query method's `except` tuple would mean ten sites
+each remembering, and would swallow real attribute bugs inside the repository
+itself. A single construction-time check converts every method on the class
+into the repository's own typed category, and it is a true statement about the
+class's contract rather than a patch on one caller. The call site's `except`
+was widened to `(PersonaActorPackCoordinatorError, ActorPackRepositoryError)`
+as well: `recover()` does convert the repository's failures today, but it sits
+above a store with its own error type and only that store knows what it can
+raise — naming both is what makes "a repository failure cannot escape this
+guard" true rather than incidental.
+
+**Evidence.** Born-red at `origin/dev` `80248f3e4`: both new tests fail with
+`AttributeError: 'NoneType' object has no attribute 'execute_query'` through
+`app.py:6010` → `app.py:6612` → `persona_coordinator.py:174` →
+`repository.py:276`. Four suites `294 failed, 1795 passed, 1 skipped` →
+`2091 passed, 1 skipped` (the +2 are the new tests). The four
+`Tests/UI/test_settings_*` modules: 4 collection errors → `22 passed`.
+Repo-wide `--collect-only`: `56524 collected, 5 errors` → `56549 collected,
+1 error`, the survivor being TASK-20972's unrelated parametrize-signature
+error; the +25 is 22 settings tests + 2 app tests + 1 repository test.
+Mutation: removing only the repository check reds the repository unit test and
+leaves the app tests green; disabling only the wiring guard reds both app tests
+with the typed `ActorPackRepositoryError`; removing both reproduces the original
+`AttributeError` verbatim. Edit-restore returned a byte-identical diff
+(sha256 `7bd13d55…`).
+
+**A fifth shadow, baselined and fixed.**
+`Tests/Character_Chat/test_character_persona_scope_service.py::
+test_app_wires_character_persona_services` was already red at `origin/dev` with
+`AttributeError: 'object' object has no attribute 'execute_query'` — it passed
+a bare `object()` as `chachanotes_db`, which was fine while the wiring only
+forwarded the value and stopped being fine when TASK-19057 made it query.
+Replaced with a two-line double that reports no intents, so the test is about
+the scope-service wiring it is named for. Not fixed here and not caused here:
+`Tests/UI/test_console_runtime_ownership.py::
+test_app_fences_console_then_drains_buddy_before_profile_teardown`, red before
+and after with `'TldwCli' object has no attribute 'notes_sync_runtime_owner'`
+(the other four reds in that module were this defect and are now green).
+
+**Files:** `tldw_chatbook/app.py`,
+`tldw_chatbook/Actor_Packs/repository.py`,
+`Tests/App/test_app_degraded_without_chachanotes_db.py` (new),
+`Tests/Actor_Packs/test_actor_pack_repository.py`,
+`Tests/Character_Chat/test_character_persona_scope_service.py`,
+`Docs/security/production-diagnostic-inventory.json` (regenerated: +1 call —
+the new diagnostic, plus the pre-existing `actor_pack_recovery_failed` call
+re-wrapped and one warning re-indented; all constant strings, no interpolation),
+`backlog/docs/lessons-testing-evidence.md`.

--- a/tldw_chatbook/Actor_Packs/repository.py
+++ b/tldw_chatbook/Actor_Packs/repository.py
@@ -70,6 +70,29 @@ class ActorPackRepository:
         *,
         uuid_factory: Callable[[], uuid.UUID] = uuid.uuid4,
     ) -> None:
+        """Bind the repository to one open ChaChaNotes database.
+
+        Args:
+            db: The open ChaChaNotes database every query runs against.
+            uuid_factory: Portable-UUID source, overridable for tests.
+
+        Raises:
+            ActorPackRepositoryError: If ``db`` is absent. TASK-20970: the
+                app tolerates an unopenable ChaChaNotes database and hands
+                its callers ``None`` (`app.py`'s
+                ``ChaChaNotesDB ... not found/assigned`` branch), and every
+                query method here has a ``sqlite3.Error``/
+                ``CharactersRAGDBError`` boundary that a ``None`` database
+                sails straight past as an ``AttributeError`` -- which then
+                escapes callers guarding on this class's own error type.
+                Rejecting the missing database once, here, makes every
+                method on the class fail in the repository's own typed
+                category instead of asking ten query sites each to remember
+                to catch ``AttributeError`` (which would also swallow real
+                attribute bugs).
+        """
+        if db is None:
+            raise ActorPackRepositoryError("actor_pack_repository_unavailable")
         self.db = db
         self._uuid_factory = uuid_factory
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -389,7 +389,7 @@ from .Actor_Packs.persona_coordinator import (
     PersonaActorPackCoordinatorError,
 )
 from .Actor_Packs.creation import ActorPackCreationService
-from .Actor_Packs.repository import ActorPackRepository
+from .Actor_Packs.repository import ActorPackRepository, ActorPackRepositoryError
 from .Persona_Buddy import (
     PersonaBuddyController,
     load_local_persona_portrait,
@@ -6602,29 +6602,59 @@ class TldwCli(
             self.chachanotes_db,
             persona_store_path=get_user_data_dir() / "tldw_chatbook_personas.json",
         )
-        self.actor_pack_repository = ActorPackRepository(self.chachanotes_db)
-        self.persona_actor_pack_coordinator = PersonaActorPackCoordinator(
-            self.actor_pack_repository,
-            self.local_character_persona_service,
-        )
+        # TASK-20970: `self.chachanotes_db` is `None` whenever the database
+        # could not be opened -- a corrupt file, a permission error, or a
+        # migration that cannot complete all land in the branch a few hundred
+        # lines above that logs `ChaChaNotesDB (CharactersRAGDB) instance not
+        # found/assigned` and assigns `None`. Decide about it explicitly, the
+        # way `_wire_chat_conversation_services` decides about the same value,
+        # rather than handing `None` to the repository and discovering it as
+        # an `AttributeError` from inside `recover()`.
+        actor_pack_db = getattr(self, "chachanotes_db", None)
         self.actor_pack_recovery_error: str | None = None
-        try:
-            recovery = self.persona_actor_pack_coordinator.recover()
-        except PersonaActorPackCoordinatorError:
-            self.actor_pack_recovery_error = "actor_pack_recovery_failed"
-            self.loguru_logger.error("Actor Pack recovery failed: actor_pack_recovery_failed")
+        if actor_pack_db is None:
+            self.actor_pack_repository = None
+            self.persona_actor_pack_coordinator = None
+            self.actor_pack_creation_service = None
+            self.actor_pack_recovery_error = "actor_pack_recovery_unavailable"
+            self.loguru_logger.error(
+                "Actor Pack services disabled: the ChaChaNotes database could "
+                "not be opened, so portable-identity recovery was skipped and "
+                "Actor Pack creation is unavailable for this session "
+                "(actor_pack_recovery_unavailable)"
+            )
         else:
-            if recovery.blocked_intent_ids:
-                self.actor_pack_recovery_error = "actor_pack_recovery_blocked"
-                self.loguru_logger.warning(
-                    "Actor Pack recovery retained quarantined intents: "
-                    "actor_pack_recovery_blocked"
+            self.actor_pack_repository = ActorPackRepository(actor_pack_db)
+            self.persona_actor_pack_coordinator = PersonaActorPackCoordinator(
+                self.actor_pack_repository,
+                self.local_character_persona_service,
+            )
+            try:
+                recovery = self.persona_actor_pack_coordinator.recover()
+            # `recover()` converts the repository's failures into its own
+            # category, but it sits one layer above a store that has its own
+            # typed error, and only that store knows what it can raise. Naming
+            # both here means a repository failure cannot escape the guard
+            # written to contain it -- without widening to a bare
+            # `except Exception`, which would also swallow the programming
+            # errors this wiring should still surface.
+            except (PersonaActorPackCoordinatorError, ActorPackRepositoryError):
+                self.actor_pack_recovery_error = "actor_pack_recovery_failed"
+                self.loguru_logger.error(
+                    "Actor Pack recovery failed: actor_pack_recovery_failed"
                 )
-        self.actor_pack_creation_service = ActorPackCreationService(
-            self.chachanotes_db,
-            self.actor_pack_repository,
-            self.persona_actor_pack_coordinator,
-        )
+            else:
+                if recovery.blocked_intent_ids:
+                    self.actor_pack_recovery_error = "actor_pack_recovery_blocked"
+                    self.loguru_logger.warning(
+                        "Actor Pack recovery retained quarantined intents: "
+                        "actor_pack_recovery_blocked"
+                    )
+            self.actor_pack_creation_service = ActorPackCreationService(
+                actor_pack_db,
+                self.actor_pack_repository,
+                self.persona_actor_pack_coordinator,
+            )
         self.character_persona_scope_service = CharacterPersonaScopeService(
             local_service=self.local_character_persona_service,
             server_service=self.server_character_persona_service,


### PR DESCRIPTION
Closes TASK-20970. **This is a live breakage on `dev`**, not a latent finding.

## The defect

`TldwCli.__init__` → `_wire_character_persona_services` calls `persona_actor_pack_coordinator.recover()` inside `except PersonaActorPackCoordinatorError`. With no ChaChaNotes database the repository raises `AttributeError: 'NoneType' object has no attribute 'execute_query'` — and **`PersonaActorPackCoordinatorError` subclasses `ValueError`, so the `AttributeError` walks straight through the `except` written to contain it.** App construction dies.

Measured at `origin/dev`: **294 of 294** failures across `Tests/App`, `Tests/Scheduling`, `Tests/Subscriptions` and `Tests/Watchlists` end in that identical frame chain, with no second error type present, plus **4 uncollectable `Tests/UI/test_settings_*` suites**. Introduced by TASK-19057.

**Not test-only.** The constructor has always tolerated a missing ChaChaNotes DB — it logs and sets `None`, and the sibling wiring guards that same value. And **TASK-19860 is a shipped cause**: migration `.sql` files are missing from the built wheel, so a PyPI install cannot initialize that database at all. The two findings compound — the user gets a database that will not build and an app that will not start.

## Two repairs, deliberately separate

Collapsing them would leave one layer still lying.

**1. The wiring decides.** `_wire_character_persona_services` reads the database once and branches, matching `_wire_chat_conversation_services` exactly: on `None` it nulls the Actor Pack trio, records `actor_pack_recovery_error`, and logs. It is an `if/else`, **not** an early `return` — the first draft used `return` and would have silently skipped the chat-dictionary and scope-service wiring below it, trading one degraded-mode bug for a quieter one. Review diffed both branches and confirmed they are symmetric, with everything below the `if/else` running in both.

**2. The repository raises its own typed error at construction.** `ActorPackRepository(None)` now raises `ActorPackRepositoryError`. The alternatives were weighed and rejected: `except Exception` at the call site swallows genuine programming errors in a startup path, and adding `AttributeError` to ~10 methods' except-tuples means every method must remember while also swallowing real attribute bugs *inside* the repository. One construction-time check is a true statement about the class's contract rather than a patch on one caller. The call site's `except` is widened to `(PersonaActorPackCoordinatorError, ActorPackRepositoryError)`.

Review confirmed no bypass exists: one production construction site, no classmethods, no alternate constructors, no `__new__`/`__reduce__`/`__copy__`, `self.db` written in exactly one place, and no reassignment anywhere. It cannot fire on a healthy start — proven live, with zero ERROR records during a normal `__init__`.

## The degraded app runs, not merely constructs

Verified live rather than reasoned: isolated HOME/XDG, a real `tldw_chatbook_ChaChaNotes.db` of non-SQLite bytes, **nothing patched** — constructed, mounted, navigated to the Personas screen, drove the real Characters-mode flow, and captured the notification `{"msg": "Actor Pack creation is unavailable.", "severity": "error"}`. Nothing blew up a frame later. Review swept for other consumers of the three attributes and found exactly one outside `app.py`, already guarded.

Born-red for both the no-database and the real-unopenable-file cases; the real-file test asserts the unpatched loader genuinely returns `None` before construction is attempted.

**Three-way mutation, each half independently load-bearing**: repository check removed only → the repository test reds while both app tests stay green; wiring guard disabled only → both app tests red with the *typed* error; both removed → the original `AttributeError` verbatim.

## Review added the missing half of the pin

The fix made this wiring conditional for the first time and pinned only the **degraded** side. Measured gap: nulling all three services at the end of the healthy `else:` branch left 389 tests passing. The only existing guard there is an `inspect.getsource()` ordering assertion — and because the shared app factory patches the database loader to `None`, **no test in the repo constructed `TldwCli` against a working ChaChaNotes database at all.** A new test drives the wiring against a real `CharactersRAGDB` and asserts the trio is live and correctly cross-wired; with it, that mutation reds.

## Also fixed: a fifth shadow, pre-existing

`Tests/Character_Chat/test_character_persona_scope_service.py::test_app_wires_character_persona_services` was already red at `origin/dev` — it passed a bare `object()` as the database, harmless while the wiring only *forwarded* that value, fatal once TASK-19057 made it *query*. Replaced with a two-line double. Review's independent call: every assertion is unchanged and the identity assertion would have gone vacuous under a `None` stand-in, so this is the stronger of the two available repairs.

## Verification

| Gate | `origin/dev` | this branch |
|---|---|---|
| `Tests/App` + `Scheduling` + `Subscriptions` + `Watchlists` | **294 failed**, 1795 passed | **2091 passed**, 1 skipped |
| 4 × `Tests/UI/test_settings_*` | 4 collection errors, 0 collected | **22 passed** |
| repo-wide `--collect-only` | 56,524 collected, **5 errors** | 56,550 collected, **1 error** |

Post-rebase, including `Tests/Actor_Packs`: **2187 passed, 1 skipped**. The surviving collection error is TASK-20972's parametrize mismatch. The diagnostic inventory was regenerated after reading the changed rows with `--statements`: one moved, one re-wrapped, one genuinely new — an all-constant string with no interpolation.

## Honest caveats, both recorded rather than papered over

The operator diagnostic appears verbatim at ERROR, but `PersistentDiagnosticFilter` allowlists the persistent log to structured `diagnostics.*` events, and the in-app Logs handler attaches at mount — so nothing replays `__init__`-era records. In a real TUI run the operator sees this only via `textual console`; their real signal is the point-of-use toast. This branch regresses nothing (it matches the sibling exactly), but "operator-legible" is weaker in practice than it reads.

And "makes *every* method fail in the repository's own typed category" is true for a **missing** database; a non-`None` but wrong-shaped one still raises a raw `AttributeError`.

**Filed separately**: `Tests/UI/test_console_runtime_ownership.py::test_app_fences_console_then_drains_buddy_before_profile_teardown` fails identically before and after (`'TldwCli' object has no attribute 'notes_sync_runtime_owner'`) — a hand-built `object.__new__(TldwCli)` double that never gained an attribute a later drain step started requiring. The other four reds in that module were this defect and are now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents startup failure when the ChaChaNotes DB cannot open by degrading Actor Pack wiring instead of dereferencing a missing DB. Previously startup built `ActorPackRepository(None)` and `recover()` raised `AttributeError`; now the app starts and Personas features degrade safely.

- `_wire_character_persona_services` branches on `chachanotes_db`. When `None`, it sets the repository/coordinator/creation service to `None`, records `actor_pack_recovery_unavailable`, and logs one ERROR. The rest of app wiring still runs.
- With a working DB, wires repository/coordinator and runs recovery. Catches `(PersonaActorPackCoordinatorError, ActorPackRepositoryError)` and records `actor_pack_recovery_failed` if recovery fails; warns on quarantined intents as before.
- `ActorPackRepository.__init__` now raises `ActorPackRepositoryError("actor_pack_repository_unavailable")` if constructed with `None`, preventing raw `AttributeError` escapes.
- Added tests for degraded startup (factory and real unopenable file) and a repository test; fixed a scope-service test by using a minimal DB double. Regenerated diagnostics inventory and updated docs.
- No migrations or config changes. User-visible effect: when the DB is unavailable or corrupt, Actor Pack creation is unavailable; the UI already guards and logs one operator-legible message.

Addresses TASK-20970.

<sup>Written for commit 99729c736445ea4eb021229ab39ae8d6b455aac6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

