### PR TITLE
fix(startup): move actor-pack recovery out of TldwCli.__init__ — re-arms the CSS cliff guard (TASK-21106)

### DIFF
--- a/Tests/Actor_Packs/test_actor_pack_creation.py
+++ b/Tests/Actor_Packs/test_actor_pack_creation.py
@@ -306,11 +306,30 @@ def test_foundation_writes_no_archives_visuals_or_chats(
         assert row is not None and int(row[0]) == 0
 
 
-def test_app_owns_creation_only_after_recovery_and_before_surfaces() -> None:
+def test_app_defers_recovery_and_the_mutation_path_self_gates() -> None:
+    """task-21106 rewired the old ``recover-before-creation-service`` pin.
+
+    Construction must no longer run recovery at all — the synchronous SQLite
+    call in ``__init__`` cost every boot and crashed the test app factory
+    (disarming the CSS cliff guard). The ordering guarantee the old pin
+    protected now lives inside the coordinator: ``create_persona`` calls the
+    idempotent ``ensure_recovered()`` before consulting the quarantine block,
+    so a mutation can never be admitted against unreconciled intents no
+    matter who mounts first (behavioral proof:
+    ``test_create_persona_runs_recovery_before_admitting_the_mutation`` in
+    test_persona_actor_pack_coordinator.py).
+    """
     from tldw_chatbook.app import TldwCli
 
     wiring = inspect.getsource(TldwCli._wire_character_persona_services)
-    recovery = wiring.index(".recover()")
+    assert ".recover()" not in wiring, (
+        "recovery is back on the construction path (task-21106 regression)"
+    )
     creation = wiring.index("ActorPackCreationService(")
     scope = wiring.index("CharacterPersonaScopeService(")
-    assert recovery < creation < scope
+    assert creation < scope
+
+    create = inspect.getsource(PersonaActorPackCoordinator.create_persona)
+    assert create.index("self.ensure_recovered()") < create.index(
+        "self._blocked_intent_ids"
+    )

--- a/Tests/Actor_Packs/test_persona_actor_pack_coordinator.py
+++ b/Tests/Actor_Packs/test_persona_actor_pack_coordinator.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 import uuid
 from pathlib import Path
 
@@ -12,7 +14,10 @@ from tldw_chatbook.Actor_Packs.persona_coordinator import (
     PersonaActorPackCoordinator,
     PersonaActorPackCoordinatorError,
 )
-from tldw_chatbook.Actor_Packs.repository import ActorPackRepository
+from tldw_chatbook.Actor_Packs.repository import (
+    ActorPackRepository,
+    ActorPackRepositoryError,
+)
 from tldw_chatbook.Character_Chat.local_character_persona_service import (
     LocalCharacterPersonaService,
 )
@@ -319,6 +324,112 @@ def test_unknown_store_digest_is_quarantined_without_guessing(components) -> Non
     result = coordinator.recover()
     assert result.quarantined == 1
     assert store.read_text(encoding="utf-8") == '{"profiles":[],"external":true}'
+
+
+# --- task-21106: once-per-app-session recovery gate ------------------------
+# Startup recovery moved out of TldwCli.__init__; `ensure_recovered` is the
+# idempotent, thread-safe seam every affected surface now goes through.
+
+
+def test_ensure_recovered_runs_recovery_once_per_session(components) -> None:
+    coordinator, repository, _service, _store = components
+    calls = {"count": 0}
+    original = repository.list_persona_intents
+
+    def counting():
+        calls["count"] += 1
+        return original()
+
+    repository.list_persona_intents = counting
+
+    first = coordinator.ensure_recovered()
+    second = coordinator.ensure_recovered()
+
+    assert calls["count"] == 1
+    assert first is second and first is not None
+    assert coordinator.recovery_attempted is True
+    assert coordinator.recovery_error is None
+
+
+def test_ensure_recovered_records_failure_and_consumes_the_attempt(
+    components,
+) -> None:
+    coordinator, repository, _service, _store = components
+    calls = {"count": 0}
+
+    def failing():
+        calls["count"] += 1
+        raise ActorPackRepositoryError("actor_pack_repository_read_failed")
+
+    repository.list_persona_intents = failing
+
+    assert coordinator.ensure_recovered() is None
+    assert coordinator.recovery_error == "actor_pack_recovery_failed"
+    # A broken store must not retry-loop: the single attempt is consumed.
+    assert coordinator.ensure_recovered() is None
+    assert calls["count"] == 1
+
+
+def test_ensure_recovered_is_single_flight_across_threads(components) -> None:
+    coordinator, repository, _service, _store = components
+    calls = {"count": 0}
+    count_lock = threading.Lock()
+    original = repository.list_persona_intents
+
+    def slow():
+        with count_lock:
+            calls["count"] += 1
+        time.sleep(0.05)
+        return original()
+
+    repository.list_persona_intents = slow
+
+    workers = [
+        threading.Thread(target=coordinator.ensure_recovered) for _ in range(6)
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert calls["count"] == 1
+    assert coordinator.recovery_attempted is True
+
+
+def test_create_persona_runs_recovery_before_admitting_the_mutation(
+    components,
+) -> None:
+    """A create must reconcile stale intents itself — no caller ordering needed.
+
+    Seeds the third-authority crash shape (prepared intent, identity already
+    at the new UUID, store still old): recovery quarantines it, so the very
+    first `create_persona` of the session must surface
+    ``actor_pack_creation_blocked`` without anyone having called `recover()`.
+    Before task-21106 this depended on `TldwCli.__init__` having run recovery;
+    with an unrecovered coordinator the create sailed straight past the
+    quarantine check.
+    """
+    coordinator, repository, service, _store = components
+    plan = service._actor_pack_plan_persona_profile(_profile(), operation="create")
+    intent = repository.prepare_persona_intent(
+        persona_id="guide",
+        operation="create",
+        old_profile=None,
+        new_profile=_profile(),
+        old_store_sha256=plan.old_store_sha256,
+        new_store_sha256=plan.new_store_sha256,
+        old_registry_uuid=None,
+        new_registry_uuid=UUID_A,
+        intent_id="f" * 32,
+    )
+    repository.assign_identity("persona", "guide")
+
+    with pytest.raises(PersonaActorPackCoordinatorError) as excinfo:
+        coordinator.create_persona(_profile(), portable_uuid=UUID_A)
+
+    assert excinfo.value.category == "actor_pack_creation_blocked"
+    assert coordinator.blocked_intent_ids == (intent.intent_id,)
+    assert coordinator.recovery_attempted is True
 
 
 def test_store_plan_preserves_unrelated_sections(tmp_path: Path) -> None:

--- a/Tests/UI/test_actor_pack_recovery_seam.py
+++ b/Tests/UI/test_actor_pack_recovery_seam.py
@@ -1,0 +1,180 @@
+# Tests/UI/test_actor_pack_recovery_seam.py
+"""task-21106: Actor Pack recovery moved out of ``TldwCli.__init__``.
+
+Startup recovery used to run synchronous SQLite during app construction —
+which also crashed ``_build_test_app`` (its ChaChaNotes DB is None) and
+silently disarmed the CSS parse-cache cliff guard. These pins cover the new
+seam end to end:
+
+- construction performs NO recovery (and no longer needs a live DB);
+- ``ensure_actor_pack_recovery`` skips cleanly without a profile DB, and maps
+  the coordinator outcome onto ``actor_pack_recovery_error`` exactly the way
+  ``__init__`` used to;
+- the deferred-startup worker actually kicks recovery on a real mounted app;
+- the Personas surface gates recovery ahead of its first library read.
+
+Imported pytest fixtures are intentionally rebound as test parameters.
+"""
+
+# ruff: noqa: F811
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_personas_workbench import (
+    PersonasTestApp,
+    stub_characters as _stub_characters,  # noqa: F401 - registers fixture
+    stub_scope_service as _stub_scope_service,  # noqa: F401 - registers fixture
+)
+from tldw_chatbook.UI.CCP_Modules.ccp_character_handler import CCPCharacterHandler
+
+
+def test_app_construction_defers_actor_pack_recovery():
+    """__init__ wires the coordinator but never runs recovery itself.
+
+    Red on the pre-fix tree in the strongest possible way: `_build_test_app`
+    itself crashed with ``AttributeError: 'NoneType' object has no attribute
+    'execute_query'`` (repository.py:276) before this test body could assert
+    anything.
+    """
+    app = _build_test_app()
+    coordinator = app.persona_actor_pack_coordinator
+    assert coordinator is not None
+    assert coordinator.recovery_attempted is False
+    assert app.actor_pack_recovery_error is None
+
+
+def test_ensure_recovery_skips_without_a_profile_database():
+    """No ChaChaNotes DB (the factory harness) means recovery is a no-op."""
+    app = _build_test_app()
+    assert app.chachanotes_db is None
+
+    app.ensure_actor_pack_recovery()
+
+    assert app.persona_actor_pack_coordinator.recovery_attempted is False
+    assert app.actor_pack_recovery_error is None
+
+
+@pytest.mark.parametrize(
+    ("recovery_error", "blocked_ids", "expected"),
+    [
+        (None, (), None),
+        (None, ("i" * 32,), "actor_pack_recovery_blocked"),
+        ("actor_pack_recovery_failed", (), "actor_pack_recovery_failed"),
+    ],
+    ids=["clean", "blocked", "failed"],
+)
+def test_ensure_recovery_maps_coordinator_outcomes(
+    recovery_error, blocked_ids, expected
+):
+    """The __init__-era outcome mapping survives the move verbatim."""
+    app = _build_test_app()
+    app.chachanotes_db = object()  # the harness builds without one
+    result = (
+        None
+        if recovery_error is not None
+        else SimpleNamespace(blocked_intent_ids=blocked_ids)
+    )
+    app.persona_actor_pack_coordinator = SimpleNamespace(
+        recovery_attempted=False,
+        recovery_error=recovery_error,
+        ensure_recovered=lambda: result,
+    )
+
+    app.ensure_actor_pack_recovery()
+
+    assert app.actor_pack_recovery_error == expected
+
+
+def test_ensure_recovery_runs_real_recovery_through_the_app_method(tmp_path):
+    """The app seam drives genuine SQLite recovery, once, when a DB exists.
+
+    The factory harness has no ChaChaNotes DB, so the mounted pins above can
+    only prove the wiring; this closes the loop against a real store — the
+    exact combination production boots with.
+    """
+    from tldw_chatbook.Actor_Packs.persona_coordinator import (
+        PersonaActorPackCoordinator,
+    )
+    from tldw_chatbook.Actor_Packs.repository import ActorPackRepository
+    from tldw_chatbook.Character_Chat.local_character_persona_service import (
+        LocalCharacterPersonaService,
+    )
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+    app = _build_test_app()
+    database = CharactersRAGDB(tmp_path / "actors.db", client_id="seam-test")
+    try:
+        repository = ActorPackRepository(database)
+        service = LocalCharacterPersonaService(
+            database, persona_store_path=tmp_path / "personas.json"
+        )
+        app.chachanotes_db = database
+        app.persona_actor_pack_coordinator = PersonaActorPackCoordinator(
+            repository, service
+        )
+
+        app.ensure_actor_pack_recovery()
+        app.ensure_actor_pack_recovery()  # idempotent second call
+
+        assert app.persona_actor_pack_coordinator.recovery_attempted is True
+        assert app.persona_actor_pack_coordinator.recovery_error is None
+        assert app.actor_pack_recovery_error is None
+    finally:
+        database.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_deferred_startup_kicks_the_recovery_worker():
+    """A real mounted app runs recovery via the deferred-startup thread worker.
+
+    This is the only automatic runner left after the move, so it must be
+    proven on the genuine app, not a harness double: swap the app-level
+    ensure for a recorder and mount for real.
+    """
+    app = _build_test_app()
+    ran = threading.Event()
+    app.ensure_actor_pack_recovery = ran.set  # instance attr shadows the method
+    async with app.run_test() as pilot:
+        for _ in range(80):
+            if ran.is_set():
+                break
+            await pilot.pause(0.05)
+    assert ran.is_set(), (
+        "deferred startup never invoked ensure_actor_pack_recovery — the "
+        "task-21106 background kick is unwired"
+    )
+
+
+@pytest.mark.asyncio
+async def test_personas_mount_gates_recovery_before_the_library_read(
+    mock_app_instance, _stub_characters, _stub_scope_service, monkeypatch
+):
+    """The Personas surface awaits recovery before its first library read."""
+    order: list[str] = []
+    mock_app_instance.ensure_actor_pack_recovery = lambda: order.append("recovery")
+
+    async def recording_refresh(self):
+        order.append("library_read")
+
+    monkeypatch.setattr(
+        CCPCharacterHandler, "refresh_character_list", recording_refresh
+    )
+
+    app = PersonasTestApp(mock_app_instance)
+    async with app.run_test() as pilot:
+        for _ in range(80):
+            if "library_read" in order:
+                break
+            await pilot.pause(0.05)
+
+    assert "library_read" in order, "the mount-time library read never ran"
+    assert order[0] == "recovery", (
+        f"recovery must land before the first library read; observed {order!r}"
+    )
+    assert order.count("recovery") == 1

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -487,17 +487,50 @@ def test_persona_buddy_is_app_owned_and_shutdown_after_console_producers():
 
 @pytest.mark.unit
 def test_actor_pack_recovery_precedes_character_persona_surfaces():
-    """Cross-store recovery runs before scope services and Buddy construction."""
+    """Cross-store recovery is gated ahead of every affected surface.
+
+    task-21106 rewrote what this pin means. Recovery no longer runs inside
+    ``_wire_character_persona_services`` — synchronous SQLite during
+    ``__init__`` cost every boot and crashed the test app factory — so the
+    old ``local_service < coordinator < recover() < scope`` source ordering
+    is gone by design. The guarantee it protected now has three seams, and
+    this test pins all of them:
+
+    - the deferred-startup worker kicks ``ensure_actor_pack_recovery`` on a
+      thread right after first paint (ahead of any user-driven Console/Buddy
+      persona read);
+    - the Personas surface awaits the same idempotent gate before its first
+      library read (behavioral proof in test_actor_pack_recovery_seam.py);
+    - the coordinator itself runs ``ensure_recovered`` before admitting a
+      ``create_persona`` mutation, so no caller ordering can bypass it.
+    """
     import inspect
 
+    from tldw_chatbook.Actor_Packs.persona_coordinator import (
+        PersonaActorPackCoordinator,
+    )
     from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 
     wiring = inspect.getsource(TldwCli._wire_character_persona_services)
     local_service = wiring.index("LocalCharacterPersonaService(")
     coordinator = wiring.index("PersonaActorPackCoordinator(")
-    recovery = wiring.index(".recover()")
     scope = wiring.index("CharacterPersonaScopeService(")
-    assert local_service < coordinator < recovery < scope, wiring
+    assert local_service < coordinator < scope, wiring
+    assert ".recover()" not in wiring, (
+        "recovery is back on the construction path (task-21106 regression)"
+    )
+
+    deferred = inspect.getsource(TldwCli._schedule_deferred_startup_work)
+    assert "ensure_actor_pack_recovery" in deferred, deferred
+
+    personas_load = inspect.getsource(PersonasScreen._load_after_mount)
+    assert "ensure_actor_pack_recovery" in personas_load, personas_load
+
+    create = inspect.getsource(PersonaActorPackCoordinator.create_persona)
+    assert create.index("self.ensure_recovered()") < create.index(
+        "self._blocked_intent_ids"
+    ), create
 
     initializer = inspect.getsource(TldwCli.__init__)
     wiring_call = initializer.index("self._wire_character_persona_services()")

--- a/Tests/Utils/test_tldw_api_schema_deferral.py
+++ b/Tests/Utils/test_tldw_api_schema_deferral.py
@@ -100,6 +100,14 @@ def test_app_import_schema_submodule_set_is_within_allowlist(tmp_path):
         f"tldw_api submodules loaded by `import tldw_chatbook.app` beyond the "
         f"phase-2 allowlist: {sorted(extra)}"
     )
+    # task-21106: `Actor_Packs/creation.py` (on app.py's own import chain)
+    # regressed to a module-scope import of this 79-model schema module,
+    # defeating the lazy facade. Pin the exact module by name so the next
+    # regression reads as itself, not just an allowlist diff.
+    assert "tldw_chatbook.tldw_api.character_persona_schemas" not in loaded, (
+        "`import tldw_chatbook.app` loaded character_persona_schemas eagerly "
+        "(task-21106 regression — check Actor_Packs/creation.py first)"
+    )
 
 
 def test_server_chat_grammars_service_defers_schema_import_then_fails_gracefully():

--- a/backlog/tasks/task-21106 - Move Actor_Packs recovery out of app __init__ - it also crashes the test app factory and disarms the CSS cliff guard.md
+++ b/backlog/tasks/task-21106 - Move Actor_Packs recovery out of app __init__ - it also crashes the test app factory and disarms the CSS cliff guard.md
@@ -2,8 +2,9 @@
 id: TASK-21106
 title: >-
   Move Actor_Packs recovery out of app __init__ - it also crashes the test app factory and disarms the CSS cliff guard
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-22'
 labels:
   - performance
@@ -30,6 +31,154 @@ docstring only requires running before affected surfaces mount - Personas mount 
 
 ## Acceptance Criteria
 
-- [ ] Actor-pack recovery runs at Personas-surface mount (or an equivalent pre-surface seam), not inside TldwCli.__init__; recovery semantics preserved
-- [ ] The character_persona_schemas import is TYPE_CHECKING/function-local; a sys.modules assertion pins it off the app import path
-- [ ] `test_full_destination_tour_stays_under_the_parse_cache_cliff` runs green on dev again (guard re-armed), with its measured source count recorded in the task
+- [x] Actor-pack recovery runs at Personas-surface mount (or an equivalent pre-surface seam), not inside TldwCli.__init__; recovery semantics preserved
+- [x] The character_persona_schemas import is TYPE_CHECKING/function-local; a sys.modules assertion pins it off the app import path
+- [x] `test_full_destination_tour_stays_under_the_parse_cache_cliff` runs green on dev again (guard re-armed), with its measured source count recorded in the task
+
+## Implementation Plan
+
+Consumer census (who reads recovery-affected state):
+
+- Recovery reconciles `actor_pack_persona_intents` + `actor_portable_identities`
+  (read ONLY by `PersonaActorPackCoordinator` / `ActorPackCreationService`; the
+  only external holder is `personas_screen.py:6593` via
+  `app.actor_pack_creation_service`) and can compensate half-applied writes in
+  the Persona JSON profile store (read via `LocalCharacterPersonaService` by the
+  Personas screen / CCP handlers, the Persona Buddy controller, and Console
+  persona-session paths through `character_persona_scope_service`).
+  `VisualIdentityRepository.get_active_actor_pack` (Console avatar path) reads
+  `visual_identity_*` tables, which recovery never touches.
+
+Steps:
+
+1. Coordinator: add an idempotent, thread-safe `ensure_recovered()`
+   (threading.Lock + attempted flag; caches the result, records the failure
+   category like `__init__` did, guarantees at-most-once even on unexpected
+   exceptions). `create_persona()` calls it first so a mutation can never
+   run against unreconciled intents regardless of scheduling (it already runs
+   on a `_drain_to_thread` worker thread).
+2. app.py: `_wire_character_persona_services` stops calling `recover()`
+   (construction becomes DB-free); add `ensure_actor_pack_recovery()` — safe
+   from any thread, early-returns when `chachanotes_db` is None (the test
+   harness), delegates to the coordinator and maps the outcome onto
+   `actor_pack_recovery_error` with the same log lines as before.
+3. Kick recovery on a background thread from `_schedule_deferred_startup_work`
+   (the sanctioned post-first-paint seam) so on every real boot it completes
+   ahead of any user-driven persona interaction (Console attach, Buddy).
+4. Hard gate the primary surface: Personas screen `_load_after_mount` awaits
+   `asyncio.to_thread(app.ensure_actor_pack_recovery)` before any
+   library/persona read. Once-per-app-session holds because the guard lives on
+   the coordinator (screens are never cached; re-mounts re-call the idempotent
+   ensure).
+5. creation.py: make the `character_persona_schemas` import function-local in
+   the two `model_validate` sites (same pattern as
+   `local_character_persona_service.py`); the existing fresh-subprocess
+   allowlist test `Tests/Utils/test_tldw_api_schema_deferral.py::
+   test_app_import_schema_submodule_set_is_within_allowlist` is the sys.modules
+   pin (currently RED with exactly this module leaking) — strengthen it with an
+   explicit `character_persona_schemas not in loaded` assertion.
+6. Tests: new unit coverage for `ensure_recovered` once-semantics +
+   create-persona gating + app-level ensure wiring; re-run
+   `Tests/UI/test_widget_css_consolidation.py` (record the cliff test's
+   measured source count), `Tests/Performance/test_ui_latency_guardrails.py`,
+   `Tests/Actor_Packs`, `Tests/Utils/test_tldw_api_schema_deferral.py`,
+   `Tests/UI/test_screen_navigation.py` (99 baseline reds from the same
+   factory crash), plus a full `--collect-only` sweep.
+
+Baseline on `0f9638cef` (logs in `test-logs/`):
+
+- `Tests/UI/test_widget_css_consolidation.py`: **1 failed** (the cliff test;
+  `AttributeError: 'NoneType' object has no attribute 'execute_query'` at
+  `repository.py:276` via `app.py:6612 recover()`), 30 passed.
+- `Tests/UI/test_screen_navigation.py`: **99 failed, 31 passed** — same crash.
+- `Tests/Utils/test_tldw_api_schema_deferral.py`: **1 failed** (allowlist test,
+  leaking exactly `tldw_chatbook.tldw_api.character_persona_schemas`), 3 passed.
+- `Tests/Performance/test_ui_latency_guardrails.py`: 2 passed.
+- `Tests/Actor_Packs`: 94 passed.
+
+## Implementation Notes
+
+Recovery moved off the construction path onto a once-per-app-session gate; the
+schema import went function-local; the CSS cliff guard is re-armed.
+
+**Approach.**
+
+- `PersonaActorPackCoordinator.ensure_recovered()` (persona_coordinator.py):
+  idempotent, thread-safe (threading.Lock + attempted flag), caches the result,
+  records `actor_pack_recovery_failed` instead of raising (matching how
+  `__init__` always absorbed it), and consumes its single attempt even on an
+  unexpected exception so a broken store cannot retry-loop. `create_persona()`
+  now calls it first, so a mutation can never be admitted against unreconciled
+  intents regardless of caller ordering (it already runs on a worker thread via
+  `_drain_to_thread`).
+- app.py: `_wire_character_persona_services` no longer calls `recover()`
+  (construction is DB-free — this is what un-crashes `_build_test_app`, whose
+  ChaChaNotes DB is None). New `ensure_actor_pack_recovery()` maps the
+  coordinator outcome onto `actor_pack_recovery_error` with the exact
+  `__init__`-era log lines, and skips when there is no ChaChaNotes DB.
+  `_schedule_deferred_startup_work` kicks it on a thread worker right after
+  first paint, ahead of any user-driven persona interaction.
+- Personas surface (`personas_screen.py::_load_after_mount`): awaits
+  `asyncio.to_thread(app.ensure_actor_pack_recovery)` before the first
+  library/persona read. Screens are never cached, so the once-guard living on
+  the coordinator (not the screen) is what keeps this once-per-session.
+- Consumer census (who reads recovery-affected state): the intents/identities
+  tables are read only by the coordinator/creation service (sole external
+  holder: personas_screen.py:6593); the persona JSON store is read by the
+  Personas screen/CCP handlers, Persona Buddy, and Console persona paths via
+  `character_persona_scope_service`. Console's avatar path reads
+  `visual_identity_*` tables, which recovery never touches. Personas gets the
+  hard await-gate; mutations get the coordinator self-gate; Console reads and
+  Buddy (both user-driven, post-first-paint) are covered by the deferred kick.
+- `Actor_Packs/creation.py`: the `character_persona_schemas` import (79
+  pydantic models, ~34 ms) moved function-local to its two `model_validate`
+  sites (the `local_character_persona_service.py` pattern). The existing
+  fresh-subprocess allowlist test is the sys.modules pin and was RED with
+  exactly this module; strengthened with an explicit
+  `character_persona_schemas not in loaded` assertion.
+
+**Tests** (base `0f9638cef` → after; logs in `test-logs/`):
+
+- `Tests/UI/test_widget_css_consolidation.py`: 1 failed/30 passed →
+  **31 passed**. The cliff test measured **47 live stylesheet sources** after
+  the full 13-destination tour (cap: 64-cache with the guard asserting < 56).
+- `Tests/UI/test_screen_navigation.py`: 99 failed/31 passed → **130 passed**
+  (all 99 were the same `recover()` AttributeError through `_build_test_app`).
+- `Tests/Utils/test_tldw_api_schema_deferral.py`: 1 failed/3 passed →
+  **4 passed**.
+- `Tests/Actor_Packs`: 94 → **98 passed** (4 new coordinator tests; the
+  create-persona gate test was A/B-verified red without the `ensure_recovered`
+  call in `create_persona`).
+- New `Tests/UI/test_actor_pack_recovery_seam.py`: **8 passed** — construction
+  runs no recovery; ensure skips without a DB; outcome mapping; real-SQLite
+  recovery through the app method; mounted real app proves the deferred worker
+  fires; mounted Personas harness proves recovery lands before the first
+  library read (A/B-verified red with the gate disabled).
+- `Tests/Performance/test_ui_latency_guardrails.py`: 2 passed (unchanged).
+- Personas UI suites (`test_personas_workbench.py` +
+  `test_actor_pack_creation_workflow.py`): 357 passed;
+  `test_character_persona_scope_service.py`: 54 passed;
+  `Tests/Architecture/test_actor_pack_boundary.py`: 5 passed.
+- Full `pytest Tests --collect-only`: 55041 collected, 29 errors — all
+  pre-existing (missing optional deps: numpy/audio/TTS stacks, plus the dev
+  red below); none in files this task touched.
+- Live verification: real app booted from an isolated sandbox profile,
+  navigated to Roleplay via the palette; screen mounted, library loaded, and
+  the app log contained zero "Actor Pack recovery" failure lines.
+
+**Updated dev pins that asserted the retired ordering** (both were
+source-inspection tests requiring `.recover()` inside the wiring):
+`Tests/Actor_Packs/test_actor_pack_creation.py` (now
+`test_app_defers_recovery_and_the_mutation_path_self_gates`) and
+`Tests/UI/test_console_runtime_ownership.py::test_actor_pack_recovery_precedes_character_persona_surfaces`
+(now pins all three new seams).
+
+**Discovered, deliberately not fixed** (pre-existing dev red, out of AC
+scope):
+`Tests/UI/test_console_runtime_ownership.py::test_app_fences_console_then_drains_buddy_before_profile_teardown`
+builds a skeletal `object.__new__(TldwCli)` that never sets
+`notes_sync_runtime_owner`, but `_shutdown_app_owned_lifecycles`
+(app.py:12178 on this branch) now awaits `_shutdown_notes_sync_runtime()`
+first — AttributeError before the console fence, so the 2 s wait times out.
+Proven pre-existing: the shutdown chain and that test's fixture set are
+byte-identical to HEAD, and none of this task's hunks touch shutdown.

--- a/tldw_chatbook/Actor_Packs/creation.py
+++ b/tldw_chatbook/Actor_Packs/creation.py
@@ -14,11 +14,14 @@ from typing import Any
 from pydantic import ValidationError
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
-from tldw_chatbook.tldw_api.character_persona_schemas import (
-    CharacterCreateRequest,
-    LocalPersonaProfileCreate,
-)
 
+# task-21106: `tldw_api.character_persona_schemas` (79 pydantic models, ~34 ms)
+# must NOT be imported at module scope — this module sits on the
+# `import tldw_chatbook.app` path and a module-scope import here defeats
+# tldw_api's PEP 562 lazy facade (task-285 phase 2; regression net:
+# Tests/Utils/test_tldw_api_schema_deferral.py). The two schema classes are
+# imported function-locally at their `model_validate` call sites, the same
+# pattern `Character_Chat/local_character_persona_service.py` uses.
 from .contracts import ActorPackValidationError, validate_actor_portrait
 from .persona_coordinator import (
     PersonaActorPackCoordinator,
@@ -85,6 +88,10 @@ class ActorPackCreationService:
         Raises:
             ActorPackCreationError: If validation, authority, or persistence fails.
         """
+
+        from tldw_chatbook.tldw_api.character_persona_schemas import (  # noqa: PLC0415
+            CharacterCreateRequest,
+        )
 
         self._begin_operation()
         try:
@@ -158,6 +165,10 @@ class ActorPackCreationService:
         Raises:
             ActorPackCreationError: If validation, authority, or persistence fails.
         """
+
+        from tldw_chatbook.tldw_api.character_persona_schemas import (  # noqa: PLC0415
+            LocalPersonaProfileCreate,
+        )
 
         self._begin_operation()
         try:

--- a/tldw_chatbook/Actor_Packs/persona_coordinator.py
+++ b/tldw_chatbook/Actor_Packs/persona_coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -56,12 +57,28 @@ class PersonaActorPackCoordinator:
         self.repository = repository
         self.local_service = local_service
         self._blocked_intent_ids: tuple[str, ...] = ()
+        self._recovery_lock = threading.Lock()
+        self._recovery_attempted = False
+        self._recovery_error: str | None = None
+        self._recovery_result: PersonaActorPackRecoveryResult | None = None
 
     @property
     def blocked_intent_ids(self) -> tuple[str, ...]:
         """Return opaque quarantined intent identifiers."""
 
         return self._blocked_intent_ids
+
+    @property
+    def recovery_attempted(self) -> bool:
+        """Return whether `ensure_recovered` has already run recovery."""
+
+        return self._recovery_attempted
+
+    @property
+    def recovery_error(self) -> str | None:
+        """Return the recovery failure category recorded by `ensure_recovered`."""
+
+        return self._recovery_error
 
     def create_persona(
         self,
@@ -76,6 +93,10 @@ class PersonaActorPackCoordinator:
     ) -> PersonaActorPackCreationResult:
         """Create/update one pack-ready Persona with compensating rollback."""
 
+        # task-21106: recovery no longer runs during TldwCli.__init__, so a
+        # mutation must never race ahead of the once-per-session reconcile.
+        # Idempotent and cached, so the steady-state cost is one lock hop.
+        self.ensure_recovered()
         if self._blocked_intent_ids:
             raise PersonaActorPackCoordinatorError("actor_pack_creation_blocked")
         try:
@@ -164,6 +185,37 @@ class PersonaActorPackCoordinator:
         except (ActorPackRepositoryError, ValueError):
             return PersonaActorPackCreationResult(identity, cleanup_pending=True)
         return PersonaActorPackCreationResult(identity, cleanup_pending=False)
+
+    def ensure_recovered(self) -> PersonaActorPackRecoveryResult | None:
+        """Run `recover` at most once per coordinator lifetime, from any thread.
+
+        task-21106 moved startup recovery out of `TldwCli.__init__`; this is
+        the idempotent gate every affected surface goes through instead.
+        Screens are never cached in this app (Personas re-mounts on every
+        visit), so the once-flag lives here — per app session — not per mount.
+        A concurrent caller blocks on the lock until the first run finishes,
+        which is exactly the "reconcile before the surface reads" contract.
+
+        Returns:
+            The cached recovery summary, or None when recovery failed. A
+            coordination failure (`actor_pack_recovery_failed`) is recorded on
+            `recovery_error` rather than raised, matching how app startup has
+            always absorbed it; unexpected exceptions propagate but still
+            consume the single attempt so a broken store cannot retry-loop.
+        """
+
+        with self._recovery_lock:
+            if self._recovery_attempted:
+                return self._recovery_result
+            self._recovery_attempted = True
+            try:
+                self._recovery_result = self.recover()
+            except PersonaActorPackCoordinatorError as exc:
+                self._recovery_error = exc.category
+            except BaseException:
+                self._recovery_error = "actor_pack_recovery_failed"
+                raise
+            return self._recovery_result
 
     def recover(self) -> PersonaActorPackRecoveryResult:
         """Reconcile all intents before affected application surfaces mount."""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1569,6 +1569,16 @@ class PersonasScreen(BaseAppScreen):
     async def _load_after_mount(self) -> None:
         """Load the character library once the screen is already on screen."""
         try:
+            # task-21106: Actor Pack crash recovery must land before this
+            # surface reads persona/library state (the coordinator docstring's
+            # "before affected surfaces mount"). Once-per-app-session — the
+            # guard lives on the coordinator, so re-mounts are a cached no-op —
+            # and off-thread, because a non-trivial recovery does real SQLite.
+            ensure_recovery = getattr(
+                self.app_instance, "ensure_actor_pack_recovery", None
+            )
+            if callable(ensure_recovery):
+                await asyncio.to_thread(ensure_recovery)
             # Must precede everything below: `_apply_pending_restore` and the
             # selection sync assume the full center-view DOM (task-2725).
             await self._mount_deferred_center_views()

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -384,10 +384,7 @@ from .Character_Chat.server_chat_dictionary_service import ServerChatDictionaryS
 from .Character_Chat.server_character_persona_service import (
     ServerCharacterPersonaService,
 )
-from .Actor_Packs.persona_coordinator import (
-    PersonaActorPackCoordinator,
-    PersonaActorPackCoordinatorError,
-)
+from .Actor_Packs.persona_coordinator import PersonaActorPackCoordinator
 from .Actor_Packs.creation import ActorPackCreationService
 from .Actor_Packs.repository import ActorPackRepository
 from .Persona_Buddy import (
@@ -6607,19 +6604,15 @@ class TldwCli(
             self.actor_pack_repository,
             self.local_character_persona_service,
         )
+        # task-21106: crash recovery no longer runs here — synchronous SQLite
+        # during __init__ cost every boot and crashed the test app factory
+        # (which builds the app with chachanotes_db=None), silently disarming
+        # the CSS parse-cache cliff guard. `ensure_actor_pack_recovery` now
+        # runs it once per app session: kicked on a background thread from
+        # `_schedule_deferred_startup_work`, and hard-gated ahead of the
+        # Personas screen's first library read and (inside the coordinator)
+        # every `create_persona` mutation.
         self.actor_pack_recovery_error: str | None = None
-        try:
-            recovery = self.persona_actor_pack_coordinator.recover()
-        except PersonaActorPackCoordinatorError:
-            self.actor_pack_recovery_error = "actor_pack_recovery_failed"
-            self.loguru_logger.error("Actor Pack recovery failed: actor_pack_recovery_failed")
-        else:
-            if recovery.blocked_intent_ids:
-                self.actor_pack_recovery_error = "actor_pack_recovery_blocked"
-                self.loguru_logger.warning(
-                    "Actor Pack recovery retained quarantined intents: "
-                    "actor_pack_recovery_blocked"
-                )
         self.actor_pack_creation_service = ActorPackCreationService(
             self.chachanotes_db,
             self.actor_pack_repository,
@@ -6646,6 +6639,41 @@ class TldwCli(
             server_service=self.server_chat_dictionary_service,
             policy_enforcer=self.service_policy_enforcer,
         )
+
+    def ensure_actor_pack_recovery(self) -> None:
+        """Run Actor Pack crash recovery once per app session (task-21106).
+
+        Safe to call from any thread and idempotent: the once-guard lives on
+        the coordinator (screens are never cached, so a per-mount flag would
+        re-run recovery on every Personas visit). Callers that may touch
+        recovery-affected state before the deferred startup kick has finished
+        call this first — from a worker thread, because a non-trivial recovery
+        does real SQLite work.
+
+        Preserves the exact `__init__`-era outcome mapping: a coordination
+        failure records ``actor_pack_recovery_failed``; retained quarantined
+        intents record ``actor_pack_recovery_blocked``. With no ChaChaNotes DB
+        (the test app factory builds the app without one) recovery is skipped
+        entirely, matching a boot where the profile store never opened.
+        """
+        coordinator = getattr(self, "persona_actor_pack_coordinator", None)
+        if coordinator is None or getattr(self, "chachanotes_db", None) is None:
+            return
+        first_run = not coordinator.recovery_attempted
+        recovery = coordinator.ensure_recovered()
+        if coordinator.recovery_error is not None:
+            self.actor_pack_recovery_error = "actor_pack_recovery_failed"
+            if first_run:
+                self.loguru_logger.error(
+                    "Actor Pack recovery failed: actor_pack_recovery_failed"
+                )
+        elif recovery is not None and recovery.blocked_intent_ids:
+            self.actor_pack_recovery_error = "actor_pack_recovery_blocked"
+            if first_run:
+                self.loguru_logger.warning(
+                    "Actor Pack recovery retained quarantined intents: "
+                    "actor_pack_recovery_blocked"
+                )
 
     def _wire_chat_conversation_services(self) -> None:
         trace_db = getattr(self, "chachanotes_db", None)
@@ -11493,6 +11521,19 @@ class TldwCli(
     def _schedule_deferred_startup_work(self) -> None:
         """Start nonessential services after the first interactive UI frame."""
 
+        # task-21106: Actor Pack crash recovery moved here from __init__ —
+        # synchronous SQLite has no place on the construction path. A thread
+        # worker (not a coroutine) because recovery does blocking DB I/O; the
+        # coordinator's own once-guard makes every later surface-side call
+        # (Personas mount, create_persona) a cached no-op.
+        self.run_worker(
+            self.ensure_actor_pack_recovery,
+            name="deferred_actor_pack_recovery",
+            group="actor_pack_recovery",
+            thread=True,
+            exclusive=True,
+            exit_on_error=False,
+        )
         self.set_timer(
             DEFERRED_DB_SIZE_UPDATE_DELAY_SECONDS,
             self._schedule_footer_status_updates,


### PR DESCRIPTION
## Summary

`_wire_character_persona_services` ran `persona_actor_pack_coordinator.recover()` — synchronous SQLite — during app construction. Cost every boot, and crashed `Tests/UI/app_factory._build_test_app()` (DB unassigned), which had silently disarmed the CSS parse-cache cliff guard and reddened ~100 navigation tests plus ~286 Scheduling/Watchlists tests on dev. Found by the 2026-08-22 holistic perf review (finding 21106).

## Changes

- New idempotent, thread-safe `PersonaActorPackCoordinator.ensure_recovered()` (lock held across the recovery work; at-most-once even on exception; errors absorbed exactly as the `__init__`-era mapping did).
- Recovery now runs: deferred post-first-paint thread worker + an awaited gate in Personas `_load_after_mount` before its first library read + a self-gate in `create_persona()` ahead of the quarantine check — so no caller ordering can admit a mutation against unreconciled intents.
- `Actor_Packs/creation.py`'s `character_persona_schemas` import (79 pydantic models, ~34 ms) moved function-local, restoring tldw_api's lazy facade.
- Tests: 8-test recovery-seam suite, 4 coordinator tests, strengthened schema-deferral assertion; two source-inspection pins rewritten to the new seams.

## Evidence

- `test_full_destination_tour_stays_under_the_parse_cache_cliff`: FAILED on base → **PASSES, 47 measured stylesheet sources** (guard asserts <56) — the cliff guard is re-armed.
- `Tests/UI/test_screen_navigation.py`: 99 failed → **130 passed**. Actor_Packs 98 passed; schema-deferral 4/4.
- Adversarial review: MERGE-READY. Mutation-entry census found no ungated write path (`create_character` provably disjoint by actor_kind); skip-when-DB-None sets no attempted flag (pinned by test); single-flight verified across threads; three mutations (drop self-gate / drop mount await / unwire worker) all redden their pins; error-handling parity byte-equivalent; two cosmetic Minors recorded in the task file.
- Pre-existing red documented, not touched: `test_app_fences_console_then_drains_buddy_before_profile_teardown` (skeletal-app shutdown fixture, notes-sync territory — ledgered for filing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Actor Pack recovery out of `TldwCli.__init__` into a once-per-session gate executed after first paint. Previously recovery ran synchronously during construction; now it runs via `ensure_actor_pack_recovery`, avoiding DB-on-boot crashes and re-arming the CSS parse-cache cliff guard (TASK-21106).

- Adds `PersonaActorPackCoordinator.ensure_recovered()` (idempotent, thread-safe); `create_persona()` calls it to block mutations until recovery completes; preserves prior error mapping.
- Adds `app.ensure_actor_pack_recovery()`; skips when `chachanotes_db` is `None`; scheduled on a background thread in `_schedule_deferred_startup_work`; `PersonasScreen._load_after_mount` awaits it before the first library read.
- Moves `tldw_chatbook.tldw_api.character_persona_schemas` import to function-local sites in `Actor_Packs/creation.py`, restoring lazy import.
- Tests cover the new seams; CSS cliff guard passes again (47 stylesheet sources); UI navigation and schema deferral tests are green.

<sup>Written for commit f13bd04987007c416e78ce488664e98ba77c3c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

