### PR TITLE
test(rag): gate real embedding benchmark

### DIFF
--- a/Docs/superpowers/plans/2026-08-22-rag-real-embedding-capability-gate.md
+++ b/Docs/superpowers/plans/2026-08-22-rag-real-embedding-capability-gate.md
@@ -1,0 +1,215 @@
+# RAG Real-Embedding Capability Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the thirteen TASK-19642.3 inventory nodes complete offline without errors by skipping the real-model benchmark before transformer initialization unless its existing capability flag is enabled.
+
+**Architecture:** Add one combined pytest skip marker at the existing `Tests/RAG_Search/conftest.py` marker seam. Apply it and the descriptive integration marker to the one real-model performance test; leave production embeddings, the real-model fixture, and the repository network guard unchanged.
+
+**Tech Stack:** Python 3.12 test environment, pytest markers/fixtures, Ruff, Backlog.md
+
+---
+
+## File Map
+
+- Modify `Tests/RAG_Search/conftest.py`: expose the existing real-embedding environment decision to a combined dependency/capability skip marker.
+- Modify `Tests/RAG_Search/test_embeddings_performance.py`: apply that marker and classify the real benchmark as integration coverage.
+- Modify `backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md`: track plan, evidence, acceptance criteria, and closeout notes.
+- Reference `backlog/docs/lessons-testing-evidence.md`: its existing “exact live-test gate must be the first gate” lesson already covers the general trap; update only if implementation reveals distinct new evidence.
+
+## Scope Boundaries
+
+- Do not modify production embedding code.
+- Do not add `allow_network` or weaken `Tests/conftest.py::_no_network_io`.
+- Do not mock the real-model benchmark.
+- Do not change `real_transformers_session` or the opt-in real-integration suite.
+- Do not run broad RAG or repository suites; the user limited verification to modified functionality.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a test-only correction applying the existing capability and network-guard policy. It introduces no production, security, storage, dependency, or cross-module contract.
+
+### Task 1: Gate the real-model benchmark before fixture setup
+
+**Files:**
+
+- Modify: `Tests/RAG_Search/conftest.py:20-32,641-660`
+- Modify: `Tests/RAG_Search/test_embeddings_performance.py:20,152-164`
+- Test: `Tests/RAG_Search/test_embeddings_performance.py::TestEmbeddingPerformance::test_real_model_performance`
+
+- [ ] **Step 1: Establish the isolated control**
+
+Run from the task worktree:
+
+```bash
+env -u TLDW_RUN_REAL_EMBEDDINGS -u TLDW_TEST_ALLOW_HF_DOWNLOADS \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/RAG_Search/test_embeddings_performance.py::TestEmbeddingPerformance::test_real_model_performance \
+  --tb=short -rs
+```
+
+Expected: one ordinary model-unavailable skip, zero errors, and no guard-reported
+attempts. This control proves the defect depends on earlier RAG imports freezing
+Hugging Face state; the isolated node is not the RED reproducer.
+
+- [ ] **Step 2: Reproduce the order-dependent RED with the exact inventory**
+
+```bash
+nodes=()
+while IFS= read -r line; do
+  nodes+=("$(jq -r . <<< "$line")")
+done < <(sed -n '568,580p' backlog/docs/task-19520-verification-failure-inventory.md)
+env -u TLDW_RUN_REAL_EMBEDDINGS -u TLDW_TEST_ALLOW_HF_DOWNLOADS \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  "${nodes[@]}" --tb=short -rs
+```
+
+Expected: `12 passed, 1 skipped, 1 error`; `_no_network_io` reports blocked
+`huggingface.co:443` attempts from the tiny-BERT warm-up and MiniLM
+initialization. The captured baseline reports eight, but any nonzero count is
+the required RED; the retry count is not the contract.
+
+- [ ] **Step 3: Reuse the parsed capability decision in the RAG_Search conftest**
+
+Change the existing environment block to name the real-embedding decision once:
+
+```python
+_TRUTHY = {"1", "true", "yes", "on"}
+_RUN_REAL_EMBEDDINGS = (
+    os.environ.get("TLDW_RUN_REAL_EMBEDDINGS", "").strip().lower() in _TRUTHY
+)
+_ALLOW_HF_DOWNLOADS = (
+    _RUN_REAL_EMBEDDINGS
+    or os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS", "").strip().lower()
+    in _TRUTHY
+)
+```
+
+Do not change the subsequent offline environment assignments.
+
+- [ ] **Step 4: Add one combined dependency/capability marker**
+
+Add beside `requires_embeddings`:
+
+```python
+requires_real_embeddings = pytest.mark.skipif(
+    not DEPENDENCIES_AVAILABLE.get("embeddings_rag", False)
+    or not _RUN_REAL_EMBEDDINGS,
+    reason=(
+        "Embeddings dependencies not available"
+        if not DEPENDENCIES_AVAILABLE.get("embeddings_rag", False)
+        else "TLDW_RUN_REAL_EMBEDDINGS is not enabled"
+    ),
+)
+```
+
+This single marker preserves the existing dependency reason and otherwise identifies the explicit capability that is absent.
+
+- [ ] **Step 5: Apply the marker before the benchmark body can request fixtures**
+
+Replace the conftest import and decorator in `test_embeddings_performance.py`:
+
+```python
+from .conftest import requires_chromadb, requires_real_embeddings
+```
+
+```python
+    @pytest.mark.integration
+    @requires_real_embeddings
+    def test_real_model_performance(self, request):
+```
+
+Do not modify the benchmark body. `integration` is descriptive; `requires_real_embeddings` is the setup-time behavioral gate.
+
+- [ ] **Step 6: Run the exact inventory as GREEN**
+
+Run the Step 2 command unchanged.
+
+Expected: `12 passed, 1 skipped`, zero errors, capability skip reason
+`TLDW_RUN_REAL_EMBEDDINGS is not enabled`, no transformer session-start output,
+and no `huggingface.co` guard attempts.
+
+- [ ] **Step 7: Run file-level static checks**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  Tests/RAG_Search/conftest.py Tests/RAG_Search/test_embeddings_performance.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  Tests/RAG_Search/conftest.py Tests/RAG_Search/test_embeddings_performance.py
+```
+
+Expected: both commands exit 0. The latest-dev baseline already reports both files formatted.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add Tests/RAG_Search/conftest.py Tests/RAG_Search/test_embeddings_performance.py
+git commit -m "test(rag): gate real embedding benchmark"
+```
+
+### Task 2: Verify the exact inventory and close the backlog task
+
+**Files:**
+
+- Modify: `backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md`
+- Optional modify only for distinct new evidence: `backlog/docs/lessons-testing-evidence.md`
+- Test inventory: `backlog/docs/task-19520-verification-failure-inventory.md:568-580`
+
+- [ ] **Step 1: Run all thirteen exact inventory nodes under the blocked guard**
+
+Use the JSON-quoted node IDs in the canonical inventory so the long parametrized chunking node remains exact:
+
+```bash
+nodes=()
+while IFS= read -r line; do
+  nodes+=("$(jq -r . <<< "$line")")
+done < <(sed -n '568,580p' backlog/docs/task-19520-verification-failure-inventory.md)
+env -u TLDW_RUN_REAL_EMBEDDINGS -u TLDW_TEST_ALLOW_HF_DOWNLOADS \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  "${nodes[@]}" --tb=short -rs
+```
+
+Expected: `12 passed, 1 skipped`, zero failures/errors, capability skip reason `TLDW_RUN_REAL_EMBEDDINGS is not enabled`, and no guard-reported `huggingface.co` attempts.
+
+- [ ] **Step 2: Re-run static and revision hygiene gates**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  Tests/RAG_Search/conftest.py Tests/RAG_Search/test_embeddings_performance.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  Tests/RAG_Search/conftest.py Tests/RAG_Search/test_embeddings_performance.py
+git diff --check origin/dev...HEAD
+git status --short
+```
+
+Expected: Ruff and diff-check exit 0. Status may contain only the planned task/plan closeout edits before their commit.
+
+- [ ] **Step 3: Self-review against the inverse failure and scope boundaries**
+
+Confirm from the diff and RED/GREEN evidence that:
+
+- removing the capability marker restores the nonzero-attempt teardown error;
+- the integration marker does not authorize network;
+- the dependency-missing reason remains unchanged;
+- no production, global network guard, fixture body, or unrelated test changed.
+
+- [ ] **Step 4: Complete task hygiene**
+
+Use Backlog.md to check all three acceptance criteria, add concise Implementation Notes containing the RED/GREEN counts and modified files, and mark TASK-19642.3 Done only after every scoped gate is green. Link the existing live-gate lesson in the notes; do not add a duplicate lesson unless implementation produces materially different evidence.
+
+- [ ] **Step 5: Commit closeout documentation**
+
+```bash
+git add 'backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md'
+git commit -m "docs(rag): close TASK-19642.3"
+```
+
+- [ ] **Step 6: Final clean-tree verification**
+
+Re-run the exact thirteen-node command from Step 1, both Ruff commands from Step 2, `git diff --check origin/dev...HEAD`, and `git status --short`.
+
+Expected: `12 passed, 1 skipped`, both Ruff commands and diff-check exit 0, and the worktree is clean.

--- a/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
+++ b/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
@@ -1,0 +1,71 @@
+# RAG Real-Embedding Capability Gate Design
+
+## Goal
+
+Keep the TASK-19642.3 RAG verification nodes offline by default without turning
+the real-model performance benchmark into a mocked or vacuous test.
+
+## Root Cause
+
+Twelve of the thirteen inventory nodes already complete under the repository's
+blocked-network guard. The remaining node,
+`TestEmbeddingPerformance.test_real_model_performance`, requests the
+session-scoped `real_transformers_session` fixture before it discovers that the
+real MiniLM model is unavailable. That fixture tries to initialize
+`hf-internal-testing/tiny-bert`, and the benchmark then tries to initialize
+`sentence-transformers/all-MiniLM-L6-v2`. Hugging Face catches and retries the
+guard's `OSError`, so the test body skips while teardown correctly reports the
+swallowed egress attempts.
+
+## Design
+
+Use the existing `TLDW_RUN_REAL_EMBEDDINGS` capability switch to gate the real
+performance benchmark before its body requests `real_transformers_session`.
+The gate belongs in `Tests/RAG_Search/conftest.py` beside the existing embedding
+dependency markers and is consumed by
+`Tests/RAG_Search/test_embeddings_performance.py`.
+
+The default run therefore performs no transformer warm-up and no real model
+construction. It reports the benchmark as an explicit capability skip. When
+the capability is enabled, the benchmark remains unchanged and continues to
+exercise the real embedding implementation rather than a test double.
+
+This change does not weaken or bypass the repository-wide network guard. It
+does not add `allow_network`, modify production embedding code, or alter the
+other twelve inventory nodes.
+
+## Error and Capability Behavior
+
+- Missing embedding dependencies continue to skip with the existing dependency
+  reason.
+- Available dependencies without `TLDW_RUN_REAL_EMBEDDINGS=1` skip before any
+  real-model fixture or background initialization begins.
+- An explicitly enabled benchmark retains its existing model-unavailable skip
+  behavior after attempting the real initialization path.
+
+## Verification
+
+Use the current failing node as the TDD regression:
+
+1. Confirm it reaches teardown with recorded `huggingface.co` attempts before
+   the capability gate.
+2. Add the minimal gate and confirm the node becomes an explicit capability
+   skip with no guard error.
+3. Run all thirteen exact TASK-19520 inventory nodes together under the default
+   blocked-network guard. Expected outcome: twelve passed, one explicit
+   capability skip, and no guard-reported network attempts.
+4. Run Ruff and whitespace checks only for the modified test files and revision
+   range.
+
+No broad RAG or repository test suite is required because the user limited
+verification to modified functionality.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a test-only correction applying an existing capability switch
+and network-guard policy. It introduces no production, security, storage,
+dependency, or cross-module contract decision.

--- a/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
+++ b/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
@@ -7,15 +7,21 @@ the real-model performance benchmark into a mocked or vacuous test.
 
 ## Root Cause
 
-Twelve of the thirteen inventory nodes already complete under the repository's
-blocked-network guard. The remaining node,
+The benchmark passes as an isolated control because `Tests/RAG_Search/conftest.py`
+establishes offline environment defaults before Hugging Face evaluates its
+module-level constants. The thirteen-node inventory run exposes the defect:
+earlier RAG collection/imports evaluate those constants first, so the later
+environment defaults cannot change the already-frozen client state.
+
+Twelve inventory nodes then complete normally. The remaining node,
 `TestEmbeddingPerformance.test_real_model_performance`, requests the
 session-scoped `real_transformers_session` fixture before it discovers that the
 real MiniLM model is unavailable. That fixture tries to initialize
 `hf-internal-testing/tiny-bert`, and the benchmark then tries to initialize
 `sentence-transformers/all-MiniLM-L6-v2`. Hugging Face catches and retries the
 guard's `OSError`, so the test body skips while teardown correctly reports the
-swallowed egress attempts.
+swallowed egress attempts. The capability gate fixes this order-dependent path
+without relying on mutable Hugging Face import state.
 
 ## Design
 
@@ -62,16 +68,16 @@ other twelve inventory nodes.
 Use the current failing node as the TDD regression:
 
 1. With `TLDW_RUN_REAL_EMBEDDINGS` and `TLDW_TEST_ALLOW_HF_DOWNLOADS`
-   explicitly absent from the command environment, confirm the benchmark
-   reaches teardown with recorded `huggingface.co` attempts before the
-   capability gate.
-2. Add the minimal gate and confirm the node becomes an explicit capability
-   skip with no guard error.
-3. Run all thirteen exact TASK-19520 inventory nodes together under the default
-   blocked-network guard, again explicitly removing both capability/download
-   environment variables from the command environment. Expected outcome: all
-   thirteen complete without errors—twelve passed, one explicit capability
-   skip—and no guard-reported network attempts.
+   explicitly absent from the command environment, run the benchmark alone as
+   the order-dependence control. Expected: one ordinary model-unavailable skip
+   and no guard error.
+2. Run all thirteen exact TASK-19520 inventory nodes together under the same
+   environment. Expected RED: twelve passed, the benchmark body skipped, and
+   teardown errored with recorded `huggingface.co` attempts (eight in the
+   captured baseline; any nonzero count proves the defect).
+3. Add the minimal gate and rerun the exact thirteen-node command. Expected
+   GREEN: all thirteen complete without errors—twelve passed, one explicit
+   capability skip—and no guard-reported network attempts.
 4. Run Ruff and whitespace checks only for the modified test files and revision
    range.
 

--- a/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
+++ b/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
@@ -21,9 +21,9 @@ swallowed egress attempts.
 
 Use the existing `TLDW_RUN_REAL_EMBEDDINGS` capability switch to gate the real
 performance benchmark before its body requests `real_transformers_session`.
-The gate belongs in `Tests/RAG_Search/conftest.py` beside the existing embedding
-dependency markers and is consumed by
-`Tests/RAG_Search/test_embeddings_performance.py`.
+The gate is a collection/setup-time `pytest.mark.skipif` marker in
+`Tests/RAG_Search/conftest.py` beside the existing embedding dependency markers
+and is consumed by `Tests/RAG_Search/test_embeddings_performance.py`.
 
 The default run therefore performs no transformer warm-up and no real model
 construction. It reports the benchmark as an explicit capability skip. When
@@ -40,8 +40,12 @@ other twelve inventory nodes.
   reason.
 - Available dependencies without `TLDW_RUN_REAL_EMBEDDINGS=1` skip before any
   real-model fixture or background initialization begins.
-- An explicitly enabled benchmark retains its existing model-unavailable skip
-  behavior after attempting the real initialization path.
+- An explicitly enabled benchmark can run from an already-populated local model
+  cache. On a cold cache, the unchanged repository network guard still blocks
+  Hugging Face egress and reports the attempt at teardown even if the benchmark
+  catches the model-load exception and skips. Download authorization and a
+  capable integration environment are separate from this offline-default task;
+  this change deliberately does not add `allow_network` or weaken that guard.
 
 ## Verification
 
@@ -52,8 +56,9 @@ Use the current failing node as the TDD regression:
 2. Add the minimal gate and confirm the node becomes an explicit capability
    skip with no guard error.
 3. Run all thirteen exact TASK-19520 inventory nodes together under the default
-   blocked-network guard. Expected outcome: twelve passed, one explicit
-   capability skip, and no guard-reported network attempts.
+   blocked-network guard. Expected outcome: all thirteen complete without
+   errors—twelve passed, one explicit capability skip—and no guard-reported
+   network attempts.
 4. Run Ruff and whitespace checks only for the modified test files and revision
    range.
 

--- a/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
+++ b/Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md
@@ -21,9 +21,19 @@ swallowed egress attempts.
 
 Use the existing `TLDW_RUN_REAL_EMBEDDINGS` capability switch to gate the real
 performance benchmark before its body requests `real_transformers_session`.
-The gate is a collection/setup-time `pytest.mark.skipif` marker in
-`Tests/RAG_Search/conftest.py` beside the existing embedding dependency markers
-and is consumed by `Tests/RAG_Search/test_embeddings_performance.py`.
+The gate is a combined collection/setup-time `requires_real_embeddings`
+`pytest.mark.skipif` marker in `Tests/RAG_Search/conftest.py`. Its condition
+covers both the existing embedding dependency check and the explicit capability
+switch; its reason remains `Embeddings dependencies not available` when the
+dependency is missing and otherwise identifies the disabled
+`TLDW_RUN_REAL_EMBEDDINGS` capability. The benchmark replaces its existing
+`requires_embeddings` marker with this combined marker, avoiding stacked and
+potentially ambiguous skip reasons.
+
+The benchmark also receives `pytest.mark.integration`, matching the existing
+real-embedding integration suite and satisfying the task's explicit
+integration-classification requirement. The integration marker labels the
+test; `requires_real_embeddings` is the behavior that prevents initialization.
 
 The default run therefore performs no transformer warm-up and no real model
 construction. It reports the benchmark as an explicit capability skip. When
@@ -36,8 +46,8 @@ other twelve inventory nodes.
 
 ## Error and Capability Behavior
 
-- Missing embedding dependencies continue to skip with the existing dependency
-  reason.
+- Missing embedding dependencies continue to skip with the existing
+  `Embeddings dependencies not available` reason.
 - Available dependencies without `TLDW_RUN_REAL_EMBEDDINGS=1` skip before any
   real-model fixture or background initialization begins.
 - An explicitly enabled benchmark can run from an already-populated local model
@@ -51,14 +61,17 @@ other twelve inventory nodes.
 
 Use the current failing node as the TDD regression:
 
-1. Confirm it reaches teardown with recorded `huggingface.co` attempts before
-   the capability gate.
+1. With `TLDW_RUN_REAL_EMBEDDINGS` and `TLDW_TEST_ALLOW_HF_DOWNLOADS`
+   explicitly absent from the command environment, confirm the benchmark
+   reaches teardown with recorded `huggingface.co` attempts before the
+   capability gate.
 2. Add the minimal gate and confirm the node becomes an explicit capability
    skip with no guard error.
 3. Run all thirteen exact TASK-19520 inventory nodes together under the default
-   blocked-network guard. Expected outcome: all thirteen complete without
-   errors—twelve passed, one explicit capability skip—and no guard-reported
-   network attempts.
+   blocked-network guard, again explicitly removing both capability/download
+   environment variables from the command environment. Expected outcome: all
+   thirteen complete without errors—twelve passed, one explicit capability
+   skip—and no guard-reported network attempts.
 4. Run Ruff and whitespace checks only for the modified test files and revision
    range.
 

--- a/Tests/RAG_Search/conftest.py
+++ b/Tests/RAG_Search/conftest.py
@@ -22,8 +22,11 @@ os.environ.pop("PYTEST_CURRENT_TEST", None)  # Remove pytest env var temporarily
 # TLDW_TEST_ALLOW_HF_DOWNLOADS is the general escape hatch). setdefault so an
 # externally-set value always wins.
 _TRUTHY = {"1", "true", "yes", "on"}
-_ALLOW_HF_DOWNLOADS = (
+_RUN_REAL_EMBEDDINGS = (
     os.environ.get("TLDW_RUN_REAL_EMBEDDINGS", "").strip().lower() in _TRUTHY
+)
+_ALLOW_HF_DOWNLOADS = (
+    _RUN_REAL_EMBEDDINGS
     or os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS", "").strip().lower() in _TRUTHY
 )
 if _ALLOW_HF_DOWNLOADS:
@@ -641,6 +644,15 @@ def performance_monitor():
 requires_embeddings = pytest.mark.skipif(
     not DEPENDENCIES_AVAILABLE.get("embeddings_rag", False),
     reason="Embeddings dependencies not available",
+)
+
+requires_real_embeddings = pytest.mark.skipif(
+    not DEPENDENCIES_AVAILABLE.get("embeddings_rag", False) or not _RUN_REAL_EMBEDDINGS,
+    reason=(
+        "Embeddings dependencies not available"
+        if not DEPENDENCIES_AVAILABLE.get("embeddings_rag", False)
+        else "TLDW_RUN_REAL_EMBEDDINGS is not enabled"
+    ),
 )
 
 requires_chromadb = pytest.mark.skipif(

--- a/Tests/RAG_Search/test_embeddings_performance.py
+++ b/Tests/RAG_Search/test_embeddings_performance.py
@@ -17,7 +17,7 @@ from tldw_chatbook.RAG_Search.simplified import (
 )
 
 # Import test utilities from conftest
-from .conftest import requires_embeddings, requires_chromadb
+from .conftest import requires_real_embeddings, requires_chromadb
 
 
 @pytest.mark.performance
@@ -149,7 +149,8 @@ class TestEmbeddingPerformance:
 
             service.close()
 
-    @requires_embeddings
+    @pytest.mark.integration
+    @requires_real_embeddings
     def test_real_model_performance(self, request):
         """Benchmark performance with real embedding model.
 

--- a/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
+++ b/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-19642.3
 title: Keep RAG tests offline during embedding initialization
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-21 23:25'
-updated_date: '2026-08-23 01:39'
+updated_date: '2026-08-23 01:57'
 labels:
   - testing
   - rag
@@ -24,9 +24,9 @@ Stop the 13 RAG and embedding-performance teardown errors caused by background H
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All 13 RAG embedding-egress error nodes in the TASK-19520 verification inventory complete without errors in a network-blocked focused run: 12 pass and the real-model benchmark reports one explicit capability skip.
-- [ ] #2 Embedding initialization is fully stubbed, cached locally, or explicitly integration-marked before background work starts.
-- [ ] #3 The no-network guard reports no swallowed huggingface.co connection attempts.
+- [x] #1 All 13 RAG embedding-egress error nodes in the TASK-19520 verification inventory complete without errors in a network-blocked focused run: 12 pass and the real-model benchmark reports one explicit capability skip.
+- [x] #2 Embedding initialization is fully stubbed, cached locally, or explicitly integration-marked before background work starts.
+- [x] #3 The no-network guard reports no swallowed huggingface.co connection attempts.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,3 +42,15 @@ ADR required: no
 ADR path: N/A
 Reason: test-only use of existing capability and network-guard policy; no production or architectural boundary changes.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: added a setup-time `requires_real_embeddings` capability gate in `Tests/RAG_Search/conftest.py` and applied it with the descriptive integration marker to `Tests/RAG_Search/test_embeddings_performance.py`, so the benchmark skips before fixture resolution unless real embeddings are explicitly enabled.
+- Decisions/tradeoffs: kept the change test-only and limited to the exact real-model benchmark; preserved the missing-dependency skip reason and existing offline policy. No production code, global guard, or fixture body changed.
+- Evidence: isolated control completed with 1 skipped and 0 errors. Exact RED inventory produced 12 passed, 1 skipped, 1 teardown error, and nonzero blocked `huggingface.co` attempts. Exact GREEN inventory produced 12 passed, 1 explicit capability skip (`TLDW_RUN_REAL_EMBEDDINGS is not enabled`), 0 errors, no `huggingface.co` attempts, and no transformer session-start output; the pre-closeout rerun reproduced 12 passed and 1 skipped in 1.38s.
+- Static verification: Ruff check passed; Ruff format reported both files already formatted; `git diff --check origin/dev...HEAD` passed. Spec compliance and code-quality review both approved the implementation with no findings.
+- ADR required: no. ADR path: N/A. This is a test-only application of existing capability/network policy and introduces no architectural boundary.
+- Lessons: the existing `backlog/docs/lessons-testing-evidence.md` section “An exact live-test gate must be the first gate that can skip the test” already captures the generalized lesson; no new lesson was needed.
+- Modified files: `Tests/RAG_Search/conftest.py`; `Tests/RAG_Search/test_embeddings_performance.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
+++ b/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-19642.3
 title: Keep RAG tests offline during embedding initialization
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-21 23:25'
+updated_date: '2026-08-23 01:39'
 labels:
   - testing
   - rag
@@ -27,3 +28,17 @@ Stop the 13 RAG and embedding-performance teardown errors caused by background H
 - [ ] #2 Embedding initialization is fully stubbed, cached locally, or explicitly integration-marked before background work starts.
 - [ ] #3 The no-network guard reports no swallowed huggingface.co connection attempts.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Establish the isolated benchmark as a passing control, then reproduce the order-dependent teardown error in the exact 13-node inventory run with both Hugging Face capability variables absent.
+2. Add one combined requires_real_embeddings marker in Tests/RAG_Search/conftest.py that preserves the dependency skip reason, gates on TLDW_RUN_REAL_EMBEDDINGS, and apply it plus the integration marker to the benchmark before fixture resolution.
+3. Run the benchmark and all 13 exact inventory nodes under the blocked-network guard; require 12 passed, 1 explicit capability skip, zero errors, and no huggingface.co attempts.
+4. Run Ruff check/format and revision whitespace checks only for the modified functionality.
+5. Self-review, reference the existing live-gate testing lesson, complete the acceptance criteria, add implementation notes, and mark the task Done only after all scoped evidence is green.
+
+ADR required: no
+ADR path: N/A
+Reason: test-only use of existing capability and network-guard policy; no production or architectural boundary changes.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
+++ b/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
@@ -23,7 +23,7 @@ Stop the 13 RAG and embedding-performance teardown errors caused by background H
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All 13 RAG embedding-egress error nodes in the TASK-19520 verification inventory pass in a network-blocked focused run.
+- [ ] #1 All 13 RAG embedding-egress error nodes in the TASK-19520 verification inventory complete without errors in a network-blocked focused run: 12 pass and the real-model benchmark reports one explicit capability skip.
 - [ ] #2 Embedding initialization is fully stubbed, cached locally, or explicitly integration-marked before background work starts.
 - [ ] #3 The no-network guard reports no swallowed huggingface.co connection attempts.
 <!-- AC:END -->

--- a/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
+++ b/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
@@ -52,5 +52,5 @@ Reason: test-only use of existing capability and network-guard policy; no produc
 - Static verification: Ruff check passed; Ruff format reported both files already formatted; `git diff --check origin/dev...HEAD` passed. Spec compliance and code-quality review both approved the implementation with no findings.
 - ADR required: no. ADR path: N/A. This is a test-only application of existing capability/network policy and introduces no architectural boundary.
 - Lessons: the existing `backlog/docs/lessons-testing-evidence.md` section “An exact live-test gate must be the first gate that can skip the test” already captures the generalized lesson; no new lesson was needed.
-- Modified files: `Tests/RAG_Search/conftest.py`; `Tests/RAG_Search/test_embeddings_performance.py`.
+- Modified files: `Tests/RAG_Search/conftest.py`; `Tests/RAG_Search/test_embeddings_performance.py`; `Docs/superpowers/specs/2026-08-22-rag-real-embedding-capability-gate-design.md`; `Docs/superpowers/plans/2026-08-22-rag-real-embedding-capability-gate.md`; `backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md`.
 <!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- gate the real embedding performance benchmark behind `TLDW_RUN_REAL_EMBEDDINGS` before transformer fixture setup
- preserve dependency-specific skip behavior and classify the benchmark as integration coverage
- close TASK-19642.3 with design, plan, and exact offline verification evidence

## Test Plan
- [x] exact 13 TASK-19520 RAG inventory nodes: 12 passed, 1 explicit capability skip, 0 errors
- [x] no `huggingface.co` attempts or transformer session warm-up in the blocked-network run
- [x] Ruff check and format check on the two modified Python files
- [x] `git diff --check origin/dev...HEAD`

Broad suites were intentionally not run per the user-requested modified-functionality test scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the real embedding performance benchmark behind `TLDW_RUN_REAL_EMBEDDINGS` so offline RAG runs no longer trigger Hugging Face initialization or teardown errors. Previously the benchmark requested the real transformers fixture and warmed models; now it skips at collection time unless explicitly enabled and is marked as integration.

- Adds `_RUN_REAL_EMBEDDINGS` and a combined `requires_real_embeddings` skip marker in `Tests/RAG_Search/conftest.py`, preserving the existing dependency skip reason.
- Applies `@pytest.mark.integration` and `@requires_real_embeddings` to `TestEmbeddingPerformance.test_real_model_performance`; removes the prior `requires_embeddings` gate for this test.
- No production code or network guard changes. To run the benchmark, set `TLDW_RUN_REAL_EMBEDDINGS=1`; download authorization remains separate and unchanged.
- Updates design/plan docs and closes TASK-19642.3.

<sup>Written for commit 6b09b412f156da891d7914430f3ac980eb94aa03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

