### PR TITLE
fix(notes): NotesDeviceStateStore — WAL+NORMAL held-connection template, schema census once per connection (TASK-21101)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1398,6 +1398,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "520bedd9fcb7c2faceed",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Notes/notes_device_state_store.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 2,
       "diagnostic_digest": "fd52ab3f664b86181725",
       "owner": "TASK-494",
@@ -3903,9 +3910,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 528,
+    "owner_files": 529,
     "persistent_sink_files": 8,
     "task_492_calls": 1222,
-    "task_494_calls": 7241
+    "task_494_calls": 7242
   }
 }

--- a/Tests/Notes/test_note_import_receipts.py
+++ b/Tests/Notes/test_note_import_receipts.py
@@ -227,12 +227,13 @@ def test_effect_transition_loads_only_the_affected_dependency_subgraph(
 
     monkeypatch.setattr(repository, "_load_dependency_snapshot", capture)
 
-    def traced_connect():
-        connection = original_connect()
+    def traced_connect(**kwargs):
+        connection = original_connect(**kwargs)
         connection.set_trace_callback(statements.append)
         return connection
 
     monkeypatch.setattr(repository._store, "_connect", traced_connect)
+    repository._store.close()  # force the reconnect through the traced seam
     repository.transition_effects(
         _APPROVAL_ID,
         (
@@ -269,12 +270,13 @@ def test_effect_transition_loads_only_the_affected_dependency_subgraph(
     small_statements: list[str] = []
     small_connect = small._store._connect
 
-    def traced_small_connect():
-        connection = small_connect()
+    def traced_small_connect(**kwargs):
+        connection = small_connect(**kwargs)
         connection.set_trace_callback(small_statements.append)
         return connection
 
     monkeypatch.setattr(small._store, "_connect", traced_small_connect)
+    small._store.close()  # force the reconnect through the traced seam
     small.transition_effects(
         small_id,
         (
@@ -706,8 +708,8 @@ def test_prior_observation_lookup_uses_bounded_large_input_query_count(
     statements: list[str] = []
     original_connect = repository._store._connect
 
-    def traced_connect():
-        connection = original_connect()
+    def traced_connect(**kwargs):
+        connection = original_connect(**kwargs)
         connection.set_trace_callback(statements.append)
         return connection
 
@@ -765,8 +767,8 @@ def test_prior_observation_lookup_respects_a_lowered_sqlite_variable_limit(
     statements: list[str] = []
     original_connect = repository._store._connect
 
-    def limited_connect():
-        connection = original_connect()
+    def limited_connect(**kwargs):
+        connection = original_connect(**kwargs)
         connection.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 10)
         connection.set_trace_callback(statements.append)
         return connection

--- a/Tests/Notes/test_notes_device_state_store.py
+++ b/Tests/Notes/test_notes_device_state_store.py
@@ -534,6 +534,18 @@ def test_root_and_child_lifecycle_propagation_rolls_back_together(
     with pytest.raises(sqlite3.DatabaseError):
         store.transition_root("root-1", NotesSyncRootState.PAUSED)
 
+    # Prove through an independent connection -- before close() below could
+    # implicitly roll back -- that the denied transaction neither committed
+    # its first UPDATE (bindings stay active) nor still holds the write slot
+    # open un-rolled-back (BEGIN IMMEDIATE at zero busy timeout must win).
+    with closing(sqlite3.connect(database)) as independent:
+        independent.execute("PRAGMA busy_timeout = 0")
+        assert independent.execute(
+            "SELECT state FROM notes_sync_bindings WHERE binding_id = 'binding-1'"
+        ).fetchone() == ("active",)
+        independent.execute("BEGIN IMMEDIATE")
+        independent.rollback()
+
     monkeypatch.setattr(store, "_connect", original_connect)
     store.close()
     assert store.get_root("root-1").state is NotesSyncRootState.ACTIVE
@@ -1159,6 +1171,18 @@ def test_close_releases_held_connections_of_every_thread_and_the_store_reopens(
         worker_connections[0].execute("SELECT 1")
     assert store.get_root("root-1").state is NotesSyncRootState.PENDING
     store.close()
+
+
+def test_transaction_error_is_not_masked_by_rollback_on_a_closed_connection(
+    tmp_path: Path,
+) -> None:
+    store = NotesDeviceStateStore(tmp_path / "notes-sync.sqlite3")
+    store.initialize()
+
+    with pytest.raises(ValueError, match="original private failure"):
+        with store.transaction():
+            store.close()  # a racing shutdown closed the held connection
+            raise ValueError("original private failure")
 
 
 def test_refused_foreign_database_is_never_switched_to_wal(tmp_path: Path) -> None:

--- a/Tests/Notes/test_notes_device_state_store.py
+++ b/Tests/Notes/test_notes_device_state_store.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+import threading
+from contextlib import closing
 from dataclasses import asdict
 from pathlib import Path
 
@@ -509,8 +511,8 @@ def test_root_and_child_lifecycle_propagation_rolls_back_together(
     store.create_binding(_binding())
     original_connect = store._connect
 
-    def rejecting_connect(*, read_only: bool = False, must_exist: bool = False):
-        connection = original_connect(read_only=read_only, must_exist=must_exist)
+    def rejecting_connect(**kwargs):
+        connection = original_connect(**kwargs)
 
         def authorize(
             action: int,
@@ -527,11 +529,13 @@ def test_root_and_child_lifecycle_propagation_rolls_back_together(
         return connection
 
     monkeypatch.setattr(store, "_connect", rejecting_connect)
+    store.close()  # force the next operation to reconnect through the seam
 
     with pytest.raises(sqlite3.DatabaseError):
         store.transition_root("root-1", NotesSyncRootState.PAUSED)
 
     monkeypatch.setattr(store, "_connect", original_connect)
+    store.close()
     assert store.get_root("root-1").state is NotesSyncRootState.ACTIVE
     assert store.get_binding("binding-1").state is NotesSyncBindingState.ACTIVE
 
@@ -1041,6 +1045,134 @@ def test_store_settings_accept_canonical_values_and_fail_closed_on_corrupt_rows(
 
     with pytest.raises(ValueError, match="setting"):
         store.get_setting("recovery_capacity")
+
+
+def test_held_connection_reads_back_wal_normal_and_true_autocommit(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "notes-sync.sqlite3"
+    store = NotesDeviceStateStore(database)
+    store.initialize()
+
+    with store.transaction() as connection:
+        held = connection
+    with store.transaction() as connection:
+        assert connection is held
+
+    assert held.isolation_level is None
+    assert held.execute("PRAGMA journal_mode").fetchone() == ("wal",)
+    assert held.execute("PRAGMA synchronous").fetchone() == (1,)
+    assert held.execute("PRAGMA foreign_keys").fetchone() == (1,)
+    with closing(sqlite3.connect(database)) as independent:
+        assert independent.execute("PRAGMA journal_mode").fetchone() == ("wal",)
+
+
+def test_schema_census_runs_once_per_connection_lifetime_not_per_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    census_calls = 0
+    real_initialize = notes_device_state_schema.initialize_notes_device_schema
+
+    def counting_initialize(connection: sqlite3.Connection) -> None:
+        nonlocal census_calls
+        census_calls += 1
+        real_initialize(connection)
+
+    monkeypatch.setattr(
+        notes_device_state_schema,
+        "initialize_notes_device_schema",
+        counting_initialize,
+    )
+    store = NotesDeviceStateStore(tmp_path / "notes-sync.sqlite3")
+    store.initialize()
+    assert census_calls == 1
+
+    store.create_root(_root())
+    store.get_root("root-1")
+    store.list_root_summaries()
+    with store.transaction() as connection:
+        held = connection
+    assert census_calls == 1
+
+    statements: list[str] = []
+    held.set_trace_callback(statements.append)
+    try:
+        store.get_root("root-1")
+    finally:
+        held.set_trace_callback(None)
+    assert 1 <= len(statements) <= 5
+    joined = "\n".join(statements).upper()
+    assert "SQLITE_SCHEMA" not in joined
+    assert "CREATE INDEX" not in joined
+
+
+def test_each_thread_holds_its_own_connection_and_work_is_visible_across_threads(
+    tmp_path: Path,
+) -> None:
+    store = NotesDeviceStateStore(tmp_path / "notes-sync.sqlite3")
+    store.initialize()
+    with store.transaction() as connection:
+        main_thread_connection = connection
+
+    worker_connections: list[sqlite3.Connection] = []
+
+    def create_in_worker() -> None:
+        store.create_root(_root())
+        with store.transaction() as connection:
+            worker_connections.append(connection)
+        with store.transaction() as connection:
+            worker_connections.append(connection)
+
+    worker = threading.Thread(target=create_in_worker)
+    worker.start()
+    worker.join()
+
+    assert len(worker_connections) == 2
+    assert worker_connections[0] is worker_connections[1]
+    assert worker_connections[0] is not main_thread_connection
+    assert store.get_root("root-1").state is NotesSyncRootState.PENDING
+
+
+def test_close_releases_held_connections_of_every_thread_and_the_store_reopens(
+    tmp_path: Path,
+) -> None:
+    store = NotesDeviceStateStore(tmp_path / "notes-sync.sqlite3")
+    store.create_root(_root())
+    with store.transaction() as connection:
+        main_thread_connection = connection
+    worker_connections: list[sqlite3.Connection] = []
+
+    def observe_in_worker() -> None:
+        with store.transaction() as connection:
+            worker_connections.append(connection)
+
+    worker = threading.Thread(target=observe_in_worker)
+    worker.start()
+    worker.join()
+
+    store.close()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        main_thread_connection.execute("SELECT 1")
+    with pytest.raises(sqlite3.ProgrammingError):
+        worker_connections[0].execute("SELECT 1")
+    assert store.get_root("root-1").state is NotesSyncRootState.PENDING
+    store.close()
+
+
+def test_refused_foreign_database_is_never_switched_to_wal(tmp_path: Path) -> None:
+    database = tmp_path / "notes-sync.sqlite3"
+    with closing(sqlite3.connect(database)) as connection:
+        connection.execute("CREATE TABLE unrelated_private_owner (value TEXT)")
+        connection.commit()
+    database.chmod(0o600)
+
+    with pytest.raises(NotesDeviceStateError, match="incompatible"):
+        NotesDeviceStateStore(database).initialize()
+
+    with closing(sqlite3.connect(database)) as connection:
+        assert connection.execute("PRAGMA journal_mode").fetchone() == ("delete",)
 
 
 def test_read_only_connect_requires_existing_database_and_cannot_write(

--- a/Tests/Notes/test_notes_sync_runtime.py
+++ b/Tests/Notes/test_notes_sync_runtime.py
@@ -7,6 +7,7 @@ import hashlib
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -2332,6 +2333,91 @@ async def test_pause_closes_root_admission_and_releases_its_lease(
         "lease-released",
     ]
     await owner.shutdown()
+
+
+class _GatedTransactionStore(NotesDeviceStateStore):
+    """Hold one armed transaction open with its connection checked out.
+
+    task-21101 review round: models a pool thread parked inside
+    ``transaction()`` while shutdown runs, so the store's held connection is
+    exactly mid-transaction when ``close()`` could fire.
+    """
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
+        self.mid_transaction = threading.Event()
+        self.release = threading.Event()
+        self._armed = False
+
+    def arm(self) -> None:
+        self._armed = True
+
+    @contextmanager
+    def transaction(self, *, immediate: bool = False):
+        with super().transaction(immediate=immediate) as connection:
+            if self._armed:
+                self._armed = False
+                self.mid_transaction.set()
+                assert self.release.wait(timeout=5)
+            yield connection
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["pause_root", "resume_root"])
+async def test_shutdown_settles_in_flight_pause_and_resume_before_store_close(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    """Reviewer probe for task-21101: pause/resume mid-transaction at shutdown.
+
+    pause_root/resume_root touch the held-connection store but were invisible
+    to settle(), so _shutdown_once could close the store while their pool
+    thread held a checked-out connection (ProgrammingError on a closed
+    database). Shutdown must now wait for them.
+    """
+
+    store = _GatedTransactionStore(tmp_path / "sync.sqlite3")
+    store.initialize()
+    store.create_root(
+        NotesSyncRootRecord(
+            root_id="root-1",
+            note_scope_id="local_note",
+            logical_folder_id="folder-1",
+            canonical_path=str(tmp_path / "root"),
+            direction=NotesSyncDirection.BIDIRECTIONAL,
+            state=NotesSyncRootState.ACTIVE,
+        )
+    )
+    store.set_setting(NotesSyncStoreSetting("cutover_marker", "notes-sync-cutover-v1"))
+    (tmp_path / "root").mkdir()
+    adapter = _Adapter(
+        [
+            _input(file_digest=_A, note_digest=_A),
+            _input(file_digest=_A, note_digest=_A),
+        ]
+    )
+    owner, _, _ = _owner(store=store, admitted=True, adapter=adapter)
+    await owner.start()
+    if operation == "resume_root":
+        await owner.pause_root("root-1")
+        expected_state = NotesSyncRootState.ACTIVE
+    else:
+        expected_state = NotesSyncRootState.PAUSED
+
+    store.arm()
+    in_flight = asyncio.create_task(getattr(owner, operation)("root-1"))
+    assert await asyncio.to_thread(store.mid_transaction.wait, 5)
+
+    shutdown = asyncio.create_task(owner.shutdown())
+    await asyncio.sleep(0.05)
+    assert not shutdown.done()
+
+    store.release.set()
+    result = await in_flight
+    await shutdown
+
+    assert result.accepted is True
+    assert store.get_root("root-1").state is expected_state
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-21101 - NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction.md
+++ b/backlog/tasks/task-21101 - NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction.md
@@ -141,3 +141,40 @@ Evidence (logs in `test-logs/task-21101-*.log`):
 
 Deliberately NOT touched (task-21129): `notes_sync_executor.py` loop-side call
 patterns and missing indexes.
+
+### Review fix round (adversarial review, pre-merge)
+
+The reviewer confirmed one introduced defect and one rig weakness; both fixed:
+
+- **MAJOR-1 (shutdown close() race)**: `pause_root`, `resume_root`, and
+  `review_setup` touch the store but were invisible to `settle()` (only four
+  entrypoints registered via `_admit_task`), so `_shutdown_once` could close the
+  store while their pool thread held a checked-out connection
+  (`ProgrammingError: Cannot operate on a closed database`, with the
+  `transaction()` rollback re-raising the same error and masking the original).
+  Fixed both halves: (a) split `_admit_task` into gate + `_register_task`
+  (registration must not gate on `_closed_roots` — resume runs on a closed
+  root, pause closes its own) and registered all three entrypoints
+  (`resume_root` now delegates to `_resume_root` exactly like
+  `activate_root`/`_activate_root`); (b) `transaction()`'s except-path rollback
+  no longer masks — a failing rollback is suppressed with a type-name-only
+  debug log and the ORIGINAL exception re-raises. Regression tests:
+  `test_shutdown_settles_in_flight_pause_and_resume_before_store_close`
+  (parametrized pause/resume; a `_GatedTransactionStore` parks the pool thread
+  mid-transaction, reproducing the reviewer's probe — red-first it failed with
+  shutdown completing under the gated op and the exact masked-ProgrammingError
+  signature) and
+  `test_transaction_error_is_not_masked_by_rollback_on_a_closed_connection`.
+- **MINOR-1 (rig hardening)**: the adapted rollback-atomicity rig now proves,
+  through an INDEPENDENT connection before `store.close()` can implicitly roll
+  back, that the denied transaction neither committed its first UPDATE
+  (bindings still `active`) nor still holds the write slot
+  (`BEGIN IMMEDIATE` at zero busy timeout must succeed). Mutation-verified:
+  a skip-rollback mutant reds the rig via `database is locked`; a
+  commit-instead-of-rollback mutant reds it via `('paused',) != ('active',)`.
+
+Review-round evidence: red-first 3 failed (both runtime params + store
+masking test) with the reviewer's exact signatures; after the fix 411 passed /
+0 failed across store + runtime + executor + receipts + cutover + legacy
+migration; census/pragma/WAL-refusal tests re-confirmed green; ProductionApp
+lifecycle unchanged (same 6 pre-existing Actor_Packs reds); ruff clean.

--- a/backlog/tasks/task-21101 - NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction.md
+++ b/backlog/tasks/task-21101 - NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction.md
@@ -2,8 +2,9 @@
 id: TASK-21101
 title: >-
   NotesDeviceStateStore - adopt the WAL+NORMAL held-connection template and stop re-running the schema census per transaction
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-22'
 labels:
   - performance
@@ -28,6 +29,115 @@ sweep because it lives outside `DB/`.
 
 ## Acceptance Criteria
 
-- [ ] The store uses the sanctioned template: held thread-local connection, WAL journal_mode, synchronous=NORMAL, isolation_level=None (exemplar `Library_Ingest_Jobs_DB.py`), with pragmas verified by read-back in a test
-- [ ] `initialize_notes_device_schema` runs once per connection lifetime (the `initialize()` seam), not per transaction; a statement-count probe demonstrates the reduction
-- [ ] Write transactions keep their current BEGIN IMMEDIATE semantics; existing notes-sync and import tests stay green
+- [x] The store uses the sanctioned template: held thread-local connection, WAL journal_mode, synchronous=NORMAL, isolation_level=None (exemplar `Library_Ingest_Jobs_DB.py`), with pragmas verified by read-back in a test
+- [x] `initialize_notes_device_schema` runs once per connection lifetime (the `initialize()` seam), not per transaction; a statement-count probe demonstrates the reduction
+- [x] Write transactions keep their current BEGIN IMMEDIATE semantics; existing notes-sync and import tests stay green
+
+## Implementation Plan
+
+1. Baseline: run the existing notes-device-store / notes-sync / receipts / private-sqlite
+   interop test files on the base commit and record counts (tee to `test-logs/`).
+2. Red-first tests in `Tests/Notes/test_notes_device_state_store.py`:
+   pragma read-back on the LIVE held connection (journal_mode=wal, synchronous=1,
+   foreign_keys=1, isolation_level None, persistent wal in the file); a census-call-count
+   probe (monkeypatch-count `initialize_notes_device_schema`: exactly 1 for
+   initialize+N operations on one thread) plus a `set_trace_callback` statement-count
+   probe on a pure read (BEGIN/SELECT/COMMIT, no sqlite_schema census, no CREATE INDEX);
+   per-thread connection affinity (same thread reuses one connection, another thread gets
+   its own, cross-thread visibility); `close()` closes held connections and the store
+   re-arms on next use.
+3. Implement in `Notes/notes_device_state_store.py`:
+   - `_get_connection()`: thread-local held connection created via the `_connect` seam
+     with `check_same_thread=False, isolation_level=None`; on open: `foreign_keys=ON`,
+     then the schema pass inside its own `BEGIN IMMEDIATE` transaction, and only after
+     it succeeds `journal_mode=WAL` + `synchronous=NORMAL` (never adopt WAL on a
+     database the census refuses — preserves the bytes-unchanged refusal tests).
+   - `transaction()`: reuse the held connection; keep explicit `BEGIN`/`BEGIN IMMEDIATE`,
+     commit on success, rollback on BaseException (no per-transaction schema pass).
+   - `initialize()`: first call rides the connection-open schema pass; a repeated call
+     re-validates explicitly in one immediate transaction (tamper-detection contract of
+     the existing reject-unexpected-objects tests). Error mapping unchanged.
+   - `close()`: best-effort close of every held connection across threads; store re-arms.
+   - `_connect` stays the raw one-shot factory (read-only planning path + interop test).
+   - Wire `store.close()` into `NotesSyncRuntimeOwner._shutdown_once` (existing seam).
+4. Adapt `test_root_and_child_lifecycle_propagation_rolls_back_together` to the held
+   connection (monkeypatched `_connect` + `store.close()` to force the reconnect through
+   the seam) while preserving its rollback-atomicity semantics.
+5. Run: new tests, every test file touching notes_device_state_store / notes_sync /
+   note_import_receipts / private_sqlite interop+inventory, then a full
+   `--collect-only` sweep. Timed before/after probe from an isolated tmp path.
+
+## Implementation Notes
+
+The store now holds ONE long-lived connection per thread (`threading.local`;
+`check_same_thread=False`, `isolation_level=None` — the exemplar's known omission
+included) instead of opening a fresh connection per operation, and the schema
+census runs once per connection lifetime, at open, not inside every transaction.
+
+Key decisions:
+
+- **WAL is adopted only AFTER the census succeeds.** `journal_mode=WAL` is
+  persisted in the database file; this store's contract is that a refused
+  foreign/tampered database stays byte-identical (several existing tests assert
+  `read_bytes()` equality after a refused `initialize()`). `_open_schema_ready_connection`
+  therefore runs `foreign_keys=ON` → `BEGIN IMMEDIATE` + census + commit →
+  only then `journal_mode=WAL` + `synchronous=NORMAL`. A new test pins this
+  (`test_refused_foreign_database_is_never_switched_to_wal`).
+- **`initialize()` keeps its tamper-detection contract.** A fresh store's first
+  `initialize()` rides the connection-open census (exactly one pass); a repeated
+  `initialize()` re-runs the census on the held connection so the existing
+  reject-unexpected-objects tests still detect external tampering. Error
+  mapping (Unsupported / incompatible / generic) unchanged.
+- **`transaction()` semantics preserved**: explicit `BEGIN` / `BEGIN IMMEDIATE`,
+  commit on success; rollback widened from `except Exception` to
+  `except BaseException` because a held connection (unlike the old
+  close-per-op form) must never carry a poisoned open transaction forward.
+- **`close()`** closes every held connection (tracked in a lock-guarded list so
+  cross-thread close works) and re-arms: the next use transparently reopens.
+  Wired into `NotesSyncRuntimeOwner._shutdown_once` via the same getattr-guarded
+  pattern the adapter close already uses (tests supply fake stores).
+- **`_connect` stays the raw one-shot seam** (read-only planning path in
+  `note_import_receipts.py` and the private-sqlite interop test pin its
+  signature/owner-id); it now forwards extra kwargs so the held path opens
+  through the same audited seam (`sqlite-private-owner-inventory.md` symbol
+  stays accurate).
+
+Test-rig adaptations (semantics preserved): the store rollback-atomicity test and
+three receipts query-shape probes monkeypatched `_connect` per operation; they now
+pass `**kwargs` through and call `store.close()` after patching so the next
+operation reconnects through the traced/authorized seam.
+
+Files: `tldw_chatbook/Notes/notes_device_state_store.py` (template + docstring),
+`tldw_chatbook/Notes/notes_sync_runtime.py` (+9 lines: store close at shutdown),
+`Tests/Notes/test_notes_device_state_store.py` (5 new tests + 1 rig adaptation),
+`Tests/Notes/test_note_import_receipts.py` (3 rig adaptations).
+
+Evidence (logs in `test-logs/task-21101-*.log`):
+
+- Baseline (base `0f9638cef`, 9 touching files): 450 passed / 6 failed — all 6
+  the pre-existing Actor_Packs `execute_query` AttributeError dev red
+  (ProductionApp lifecycle; perf-review finding 21106).
+- New tests red-first on base: 4 failed / 1 passed (the WAL-refusal guard is a
+  guard on the new ordering and passes trivially on base).
+- After: same 9 files → 452 passed / 6 failed (identical pre-existing set;
+  diff of FAILED lines shows zero additions). Wide set (all `Tests/Notes` +
+  private-sqlite + Library lasting-sync + lifecycle): 3166 passed / 6 failed
+  (same set). UI sync files: 22 failures A/B-proven identical on base
+  (Actor_Packs family + one unrelated SimpleNamespace harness gap);
+  `test_library_shell` spot A/B also failed identically on base.
+- Pragma read-back (live held connection): journal_mode=wal, synchronous=1,
+  foreign_keys=1, isolation_level None; persistent wal confirmed via an
+  independent connection.
+- Census elimination: `initialize_notes_device_schema` called exactly once for
+  initialize + 4 subsequent operations (was once per transaction); a pure
+  `get_root` now executes 3 statements (BEGIN/SELECT/COMMIT) with no
+  sqlite_schema census and no CREATE INDEX re-execution (was ~60).
+- Timed probe (isolated tmp path): 500 `update_root_status` calls =
+  1,000 transactions: 1.467s before → 0.016s after (~92x); the receipt-shaped
+  workload a 500-note import pays.
+- Full collect sweep: 55,013 tests collected; 33 collection errors, all
+  pre-existing optional-dep/app-construction families (numpy, mlx, Confluence,
+  settings sweep), none in Notes. `ruff check` clean on all four files.
+
+Deliberately NOT touched (task-21129): `notes_sync_executor.py` loop-side call
+patterns and missing indexes.

--- a/tldw_chatbook/Notes/notes_device_state_store.py
+++ b/tldw_chatbook/Notes/notes_device_state_store.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from types import MappingProxyType
 from weakref import WeakValueDictionary
 
+from loguru import logger
+
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
 from tldw_chatbook.Notes import notes_device_state_schema
 from tldw_chatbook.Notes.notes_sync_models import (
@@ -528,7 +530,17 @@ class NotesDeviceStateStore:
             yield connection
             connection.commit()
         except BaseException:
-            connection.rollback()
+            try:
+                connection.rollback()
+            except Exception as rollback_error:
+                # A rollback can itself fail (e.g. shutdown close()d the
+                # held connection under us); that secondary error must not
+                # mask the original one. Type name only: no private values.
+                logger.debug(
+                    "Notes device store rollback failed after a transaction "
+                    "error: {}",
+                    type(rollback_error).__name__,
+                )
             raise
 
     def close(self) -> None:

--- a/tldw_chatbook/Notes/notes_device_state_store.py
+++ b/tldw_chatbook/Notes/notes_device_state_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+import threading
 import time
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
@@ -419,13 +420,35 @@ class NotesDeviceStateError(RuntimeError):
 
 
 class NotesDeviceStateStore:
-    """Own the sole private connection and transaction seam for notes.sync_state."""
+    """Own the sole private connection and transaction seam for notes.sync_state.
+
+    Connection model (task-21101): each thread that uses the store holds ONE
+    long-lived connection created on first use (``threading.local``), rather
+    than opening a fresh connection per operation. The held connection runs
+    ``journal_mode=WAL`` + ``synchronous=NORMAL`` with ``isolation_level=None``
+    (true autocommit; transactions are the explicit ``BEGIN``/``BEGIN
+    IMMEDIATE`` issued by :meth:`transaction`), and the schema census
+    (``initialize_notes_device_schema``) runs once per connection lifetime --
+    at open -- not per transaction. WAL is only adopted after the census has
+    proven the database is this owner's: a refused foreign database is never
+    modified.
+
+    Thread affinity: the store is reached from the UI thread and from
+    ``asyncio.to_thread`` worker pools. ``check_same_thread=False`` is safe
+    here because thread-local storage guarantees each connection is used only
+    by its creating thread; the one cross-thread touch is :meth:`close`, which
+    sqlite3 permits. Call :meth:`close` only after in-flight operations have
+    quiesced; a closed store transparently re-opens on next use.
+    """
 
     def __init__(self, database_path: str | Path) -> None:
         self._database_path = Path(database_path)
         self._operation_locks: WeakValueDictionary[str, asyncio.Lock] = (
             WeakValueDictionary()
         )
+        self._thread_local = threading.local()
+        self._connections_guard = threading.Lock()
+        self._connections: list[sqlite3.Connection] = []
 
     def __repr__(self) -> str:
         return "NotesDeviceStateStore(<private>)"
@@ -445,38 +468,100 @@ class NotesDeviceStateStore:
         *,
         read_only: bool = False,
         must_exist: bool = False,
+        **connection_options: object,
     ) -> sqlite3.Connection:
         connection = connect_private_sqlite(
             "notes.sync_state",
             self._database_path,
             read_only=read_only,
             must_exist=must_exist,
+            **connection_options,
         )
         connection.execute("PRAGMA foreign_keys = ON")
         return connection
 
+    def _open_schema_ready_connection(self) -> sqlite3.Connection:
+        """Open, census-validate, and WAL-configure one held connection."""
+
+        connection = self._connect(
+            check_same_thread=False,
+            isolation_level=None,
+        )
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                notes_device_state_schema.initialize_notes_device_schema(connection)
+            except BaseException:
+                connection.rollback()
+                raise
+            connection.commit()
+            # journal_mode is persisted in the database file, so WAL is
+            # adopted only AFTER the census proved the database is this
+            # owner's; a refused foreign database must stay byte-identical.
+            # synchronous is per-connection and must be reapplied per open;
+            # NORMAL is app-crash-safe under WAL and drops the per-commit
+            # fsync that made receipt-heavy imports pay FULL's price.
+            connection.execute("PRAGMA journal_mode = WAL")
+            connection.execute("PRAGMA synchronous = NORMAL")
+        except BaseException:
+            connection.close()
+            raise
+        return connection
+
+    def _get_connection(self) -> sqlite3.Connection:
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            return connection
+        connection = self._open_schema_ready_connection()
+        self._thread_local.connection = connection
+        with self._connections_guard:
+            self._connections.append(connection)
+        return connection
+
     @contextmanager
     def transaction(self, *, immediate: bool = False) -> Iterator[sqlite3.Connection]:
-        """Yield one writable connection inside a schema-ready transaction."""
+        """Yield this thread's schema-ready held connection in one transaction."""
 
-        connection = self._connect()
+        connection = self._get_connection()
         try:
             connection.execute("BEGIN IMMEDIATE" if immediate else "BEGIN")
-            notes_device_state_schema.initialize_notes_device_schema(connection)
             yield connection
             connection.commit()
-        except Exception:
+        except BaseException:
             connection.rollback()
             raise
-        finally:
-            connection.close()
+
+    def close(self) -> None:
+        """Close every held connection; the store re-arms on next use.
+
+        Best-effort and callable from any thread; callers must let in-flight
+        operations quiesce first.
+        """
+
+        with self._connections_guard:
+            connections = tuple(self._connections)
+            self._connections.clear()
+            self._thread_local = threading.local()
+        for connection in connections:
+            try:
+                connection.close()
+            except Exception:
+                continue
 
     def initialize(self) -> None:
         """Atomically initialize or migrate this isolated private owner."""
 
         try:
-            with self.transaction(immediate=True):
-                pass
+            if getattr(self._thread_local, "connection", None) is None:
+                # A fresh connection runs the schema census as it opens.
+                self._get_connection()
+            else:
+                # A repeated initialize() keeps its tamper-detection
+                # contract: re-run the census on the held connection.
+                with self.transaction(immediate=True) as connection:
+                    notes_device_state_schema.initialize_notes_device_schema(
+                        connection
+                    )
         except notes_device_state_schema.NotesDeviceSchemaError as error:
             message = str(error)
             if message.startswith("Unsupported"):

--- a/tldw_chatbook/Notes/notes_sync_runtime.py
+++ b/tldw_chatbook/Notes/notes_sync_runtime.py
@@ -1808,6 +1808,15 @@ class NotesSyncRuntimeOwner:
                     continue
                 self._leases.pop(root_id, None)
                 self._admissions.pop(root_id, None)
+        # Release the store's held per-thread connections (task-21101); the
+        # store transparently re-opens if a later start() needs it again.
+        # getattr-guarded like close_adapter above: tests supply fake stores.
+        close_store = getattr(self._store, "close", None)
+        if callable(close_store):
+            try:
+                await asyncio.to_thread(close_store)
+            except Exception:
+                pass
         if close_failed:
             self._status = "failed"
             self._next_action = "review_settings"

--- a/tldw_chatbook/Notes/notes_sync_runtime.py
+++ b/tldw_chatbook/Notes/notes_sync_runtime.py
@@ -975,25 +975,29 @@ class NotesSyncRuntimeOwner:
             if root_id != matching_root_id:
                 await self.abandon_setup(root_id)
         root_id = matching_root_id or str(uuid4())
-        root = NotesSyncRootRecord(
-            root_id=root_id,
-            note_scope_id=setup.note_scope_id,
-            logical_folder_id=None,
-            canonical_path=setup.canonical_path,
-            direction=setup.direction,
-            state=NotesSyncRootState.PENDING,
-        )
-        self._root_paths[root_id] = setup.canonical_path
-        if matching_root_id is None and not await self._ensure_lease(root):
-            self._root_paths.pop(root_id, None)
-            raise RuntimeError("root_lease_unavailable")
+        task = self._register_task(root_id)
         try:
-            plan = await self._review_candidate(root)
-        except Exception:
-            await self._release_setup_authority(root_id)
-            raise
-        self._setup_reviews[root_id] = _SetupReview(setup, plan)
-        return plan
+            root = NotesSyncRootRecord(
+                root_id=root_id,
+                note_scope_id=setup.note_scope_id,
+                logical_folder_id=None,
+                canonical_path=setup.canonical_path,
+                direction=setup.direction,
+                state=NotesSyncRootState.PENDING,
+            )
+            self._root_paths[root_id] = setup.canonical_path
+            if matching_root_id is None and not await self._ensure_lease(root):
+                self._root_paths.pop(root_id, None)
+                raise RuntimeError("root_lease_unavailable")
+            try:
+                plan = await self._review_candidate(root)
+            except Exception:
+                await self._release_setup_authority(root_id)
+                raise
+            self._setup_reviews[root_id] = _SetupReview(setup, plan)
+            return plan
+        finally:
+            self._finish_task(root_id, task)
 
     async def abandon_setup(self, root_id: str) -> None:
         """Release one unpersisted setup review and its provisional lease."""
@@ -1392,20 +1396,24 @@ class NotesSyncRuntimeOwner:
 
     async def pause_root(self, root_id: str) -> NotesSyncControlResult:
         self._require_cutover(root_id)
-        self._closed_roots.add(root_id)
-        self._blocked_roots.add(root_id)
-        await self._settle_root(root_id)
-        await asyncio.to_thread(
-            self._store.transition_root, root_id, NotesSyncRootState.PAUSED
-        )
-        lease = self._leases.pop(root_id, None)
-        self._admissions.pop(root_id, None)
-        if lease is not None and self._coordinator is not None:
+        task = self._register_task(root_id)
+        try:
+            self._closed_roots.add(root_id)
+            self._blocked_roots.add(root_id)
+            await self._settle_root(root_id)
             await asyncio.to_thread(
-                self._coordinator.close_admission, lease, lambda: None
+                self._store.transition_root, root_id, NotesSyncRootState.PAUSED
             )
-        await self._publish(root_id, "paused", "resume_sync")
-        return NotesSyncControlResult(True, "paused", "resume_sync")
+            lease = self._leases.pop(root_id, None)
+            self._admissions.pop(root_id, None)
+            if lease is not None and self._coordinator is not None:
+                await asyncio.to_thread(
+                    self._coordinator.close_admission, lease, lambda: None
+                )
+            await self._publish(root_id, "paused", "resume_sync")
+            return NotesSyncControlResult(True, "paused", "resume_sync")
+        finally:
+            self._finish_task(root_id, task)
 
     async def resolve_cleanup(self, root_id: str, operation_id: str) -> object:
         """Resolve one explicit durable cleanup action under root authority."""
@@ -1444,6 +1452,13 @@ class NotesSyncRuntimeOwner:
 
     async def resume_root(self, root_id: str) -> NotesSyncControlResult:
         self._require_cutover(root_id)
+        task = self._register_task(root_id)
+        try:
+            return await self._resume_root(root_id)
+        finally:
+            self._finish_task(root_id, task)
+
+    async def _resume_root(self, root_id: str) -> NotesSyncControlResult:
         root = await asyncio.to_thread(self._store.get_root, root_id)
         if root.state is not NotesSyncRootState.PAUSED:
             return NotesSyncControlResult(False, "needs_attention", "review_settings")
@@ -1709,6 +1724,19 @@ class NotesSyncRuntimeOwner:
         self._require_cutover(root_id)
         if root_id in self._closed_roots:
             raise RuntimeError("root_admission_closed")
+        return self._register_task(root_id)
+
+    def _register_task(self, root_id: str) -> asyncio.Task[object]:
+        """Make this coroutine's store work visible to settle()/shutdown.
+
+        task-21101 review round: pause_root, resume_root, and review_setup
+        touch the held-connection store but were invisible to settle(), so
+        _shutdown_once could close the store while their pool thread held a
+        checked-out connection. Unlike _admit_task, registration does not
+        gate on _closed_roots -- resume_root must run on a closed root, and
+        pause_root closes its own root as it starts.
+        """
+
         task = asyncio.current_task()
         if task is None:
             raise RuntimeError("runtime_task_required")


### PR DESCRIPTION
## Summary

`NotesDeviceStateStore` was the app's only remaining DELETE-journal + synchronous=FULL store (live pragma read-back: delete/2), opening a fresh connection per operation and re-running a ~60-statement schema census inside EVERY transaction — including pure reads. It sits behind the always-on notes-sync runtime and the note import executor (2–4 receipt transactions per imported note). Found by the 2026-08-22 holistic perf review (finding 21101, P0).

## Changes

- Held thread-local connections (`check_same_thread=False`, `isolation_level=None`) through the audited `_connect` seam; **WAL+NORMAL applied only after the schema census accepts the file** — a refused foreign DB stays byte-identical (pinned: zero sidecar files, journal stays delete).
- Schema census runs once per connection lifetime; `transaction()` keeps its explicit BEGIN/BEGIN IMMEDIATE semantics; new `close()` releases all threads' connections and re-arms transparently; runtime `_shutdown_once` closes the store.
- **Review fix round**: closed an introduced shutdown race — `pause_root`/`resume_root`/`review_setup` now register with the runtime's task tracking (via an `_admit_task`/`_register_task` split, since resume must run on closed roots) so `settle()` parks shutdown until in-flight store ops finish; `transaction()`'s rollback no longer masks the original exception; rollback rig hardened with independent-connection visibility + write-slot asserts (both mutants now redden the rig itself).
- Reviewed one-row diagnostic-inventory re-pin for the new type-name-only rollback breadcrumb.

## Evidence

- 1,000 receipt-shaped transactions: **1.467 s → 0.016 s (~92×)**; pure `get_root`: ~60 statements → 3.
- Pragma read-back test (wal / NORMAL / FK / isolation None); census-once count test; per-thread affinity, cross-thread close + re-arm tests.
- Adversarial review + scoped re-review: MERGE-READY after the fix round; gate-split verified leak-free (`_require_cutover` still refuses post-shutdown admission, check-then-register atomic per loop step); red-first A/B on all fix-round tests; **456 passed / 0 failed** across store/runtime/executor/receipts/cutover/legacy + inventory suites; Architecture inventory gate 65 passed.
- Pre-existing reds A/B'd and named (Actor_Packs `__init__` crash — fixed separately in #1988).

Residual (accepted, ledgered): `review_setup`'s stale-review branch has awaits between gate and registration — an extreme-scheduling window in the same no-data-loss exception class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches NotesDeviceStateStore from per-operation DELETE+FULL connections to a per-thread held connection with WAL+NORMAL and a single schema census per connection, and makes runtime shutdown wait for pause/resume/review_setup before closing the store. This removes ~60-statement overhead per transaction and prevents masked errors during shutdown.

- Held connection per thread: true autocommit (isolation_level=None), foreign_keys=ON; WAL+NORMAL applied only after the schema census accepts the file so a refused foreign DB remains unchanged.
- Schema census once per connection: first initialize rides connection open; repeated initialize re-validates to preserve tamper-detection.
- Transaction semantics preserved: explicit BEGIN/BEGIN IMMEDIATE; rollback widened to BaseException and no longer masks the original error (adds a type-name debug breadcrumb).
- New close(): closes all held connections across threads; store transparently reopens; runtime `_shutdown_once` now invokes it.
- Runtime task tracking: split admission gate from `_register_task`; `pause_root`, `resume_root` (now delegates to `_resume_root`), and `review_setup` register so `settle()`/shutdown park until they finish.
- Tests updated to trace the `_connect` seam and force reconnect via `close()`; new probes verify pragma read-back, census-once, per-thread affinity, cross-thread close/re-arm, and WAL is not adopted for incompatible databases.

<sup>Written for commit 1f7b40621e1119d41a1dea1b2b5c057fe9363dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

