### PR TITLE
docs(backlog): close TASK-20970 as superseded by task-21106

### DIFF
--- a/backlog/tasks/task-20970 - Actor Pack recovery aborts app construction when the ChaChaNotes DB is unavailable.md
+++ b/backlog/tasks/task-20970 - Actor Pack recovery aborts app construction when the ChaChaNotes DB is unavailable.md
@@ -3,7 +3,7 @@ id: TASK-20970
 title: >-
   Actor Pack recovery aborts app construction when the ChaChaNotes DB is
   unavailable
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-22'
 labels:
@@ -70,23 +70,23 @@ terminates in the identical frame chain `app.py:6010` →
 
 ## Acceptance Criteria
 
-- [ ] Constructing `TldwCli` with no ChaChaNotes database succeeds, and the app
+- [x] Constructing `TldwCli` with no ChaChaNotes database succeeds, and the app
       reaches the same degraded-but-running state it reached before TASK-19057
-- [ ] The Actor Pack wiring makes an explicit decision about a missing
+- [x] The Actor Pack wiring makes an explicit decision about a missing
       database rather than dereferencing it, consistent with how the sibling
       wiring in the same constructor treats the same value
-- [ ] A missing database produces an operator-legible diagnostic, not an
+- [x] A missing database produces an operator-legible diagnostic, not an
       unhandled `AttributeError`
-- [ ] The recovery call's failure handling covers the errors the repository can
+- [x] The recovery call's failure handling covers the errors the repository can
       actually raise, so a repository failure cannot escape the guard that is
       written to contain it
-- [ ] A test builds the app with no ChaChaNotes database and fails if
+- [x] A test builds the app with no ChaChaNotes database and fails if
       construction raises — so this specific regression cannot return silently
-- [ ] The 294 failures across `Tests/App`, `Tests/Scheduling`,
+- [x] The 294 failures across `Tests/App`, `Tests/Scheduling`,
       `Tests/Subscriptions` and `Tests/Watchlists` are green
-- [ ] The 4 `Tests/UI/test_settings_*` collection errors are gone and a
+- [x] The 4 `Tests/UI/test_settings_*` collection errors are gone and a
       repo-wide `pytest --collect-only` no longer reports them
-- [ ] A degraded start is verified end to end at least once against a real
+- [x] A degraded start is verified end to end at least once against a real
       unopenable database file, not only against a patched-out service
 
 ## Notes
@@ -103,3 +103,47 @@ is entirely red from this cause, including the test TASK-20978 is about, so
 that flake cannot be re-measured until this is fixed. Second, the reason the
 None branch exists at all is that it was reachable; nothing about TASK-19057
 made it less so.
+
+## Implementation Notes
+
+Fixed on `dev` by **task-21106**, not by this task's own branch, which was
+closed unmerged (PR #1987) as superseded.
+
+**What 21106 did, and why it is the better shape.** Rather than teaching the
+wiring and the repository to tolerate a missing database, it moved Actor Pack
+crash recovery out of `TldwCli.__init__` altogether: `ensure_actor_pack_recovery`
+now runs once per app session, kicked from a background thread in
+`_schedule_deferred_startup_work` and hard-gated ahead of the Personas screen's
+first library read and every `create_persona` mutation. Nothing queries during
+construction at all, which also removes synchronous SQLite from every boot — a
+cost this task never set out to address. 21106's own comment records a further
+consequence of the original defect that this task had not found: the crash
+silently disarmed the CSS parse-cache cliff guard in the test app factory.
+
+**Verified on `dev` after the merge**: `Tests/App` + `Tests/Scheduling` = 504
+passed; `Tests/Subscriptions` + `Tests/Watchlists` + the four previously
+uncollectable `Tests/UI/test_settings_*` suites = 1596 passed / 1 skipped. The
+294-failure cluster and all four collection errors are gone.
+
+**Why the two fixes could not be combined.** They are semantically opposed. This
+task's branch made `ActorPackRepository(None)` raise a typed error at
+construction; 21106 deliberately constructs the repository with `None` and defers
+the query. Rebasing one onto the other would have re-broken it.
+
+**Residue carried forward rather than lost** — recorded here and in PR #1987's
+close comment, because it survives whichever fix won:
+
+* **No test constructs `TldwCli` against a working ChaChaNotes database.** The
+  shared app factory patches `get_chachanotes_db_lazy` to `None`, so the healthy
+  wiring path is unexercised. Measured on this task's branch by nulling all three
+  Actor Pack services in the healthy branch: **389 tests still passed.** 21106's
+  deferral arguably widens the gap, since even less now runs at construction time.
+* The AC asking for a test that builds the app with no ChaChaNotes database and
+  fails if construction raises is **satisfied in behaviour but not in kind** —
+  the shared factory exercises that path on nearly every UI test, but no test
+  asserts it as a property, so a future regression would surface as hundreds of
+  unrelated failures again rather than one named one.
+* `Tests/UI/test_console_runtime_ownership.py::test_app_fences_console_then_drains_buddy_before_profile_teardown`
+  remains red on `dev` for an unrelated reason: a hand-built
+  `object.__new__(TldwCli)` double that never gained `notes_sync_runtime_owner`,
+  which a later drain step started requiring.


### PR DESCRIPTION
Bookkeeping only — no code changes.

TASK-20970 (app construction dies when the ChaChaNotes database cannot be opened) was fixed on `dev` by **task-21106**, which landed while this task's own branch was in review. That branch (PR #1987) was closed unmerged.

**Why they could not be combined.** The two fixes are semantically opposed: 20970's branch made `ActorPackRepository(None)` raise a typed error at construction, while 21106 deliberately constructs the repository with `None` and defers the query onto a background thread gated ahead of the Personas screen's first read. Rebasing either onto the other would have re-broken it. 21106's is the better shape — nothing queries during `__init__` at all, which also removes synchronous SQLite from every boot, a cost 20970 never set out to address.

**Verified on `dev` after the merge**: `Tests/App` + `Tests/Scheduling` = 504 passed; `Tests/Subscriptions` + `Tests/Watchlists` + the four previously uncollectable `Tests/UI/test_settings_*` suites = 1596 passed / 1 skipped. The 294-failure cluster and all four collection errors are gone.

**Residue recorded rather than lost**, since it survives whichever fix won:

- **No test constructs `TldwCli` against a working ChaChaNotes database** — the shared app factory patches the loader to `None`. Measured on 20970's branch by nulling all three Actor Pack services in the *healthy* branch: **389 tests still passed.** 21106's deferral arguably widens this, since even less now runs at construction.
- The AC asking for a test that builds the app with no database is satisfied in behaviour but not in kind: the factory exercises that path constantly, but nothing asserts it as a property, so a regression would again surface as hundreds of unrelated failures rather than one named one.
- `test_app_fences_console_then_drains_buddy_before_profile_teardown` stays red on `dev` for an unrelated fixture-omission reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes backlog task TASK-20970 as superseded by TASK-21106; documents that the defect is fixed on dev via deferred Actor Pack recovery. No code changes.

- Old vs new behavior: 20970 raised on `ActorPackRepository(None)` during construction; 21106 constructs with `None` and defers Actor Pack recovery off `__init__`, gated before the first Personas read and `create_persona`. Side effect: removes synchronous SQLite at boot.
- Not combinable: the approaches are semantically opposed; rebasing either would re-break the fix.
- Verification on dev: App+Scheduling 504 passed; Subscriptions+Watchlists+settings suites 1596 passed / 1 skipped; prior 294 failures and 4 collection errors eliminated.

<sup>Written for commit f58cd4ef479e23bf51b3480a71c4dfccbf1c07d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

