### PR TITLE
fix(packaging): ship every migration script, and prove it from the built artifact

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include requirements.txt
 # Include explicit runtime and source-distribution data
 recursive-include tldw_chatbook/Config_Files *.json *.md rag_pipelines.toml
 recursive-include tldw_chatbook/Evals/config *.yaml
+recursive-include tldw_chatbook/Evals/eval_datasets *.json
 recursive-include tldw_chatbook/Image_Generation/workflows *.json
 recursive-include tldw_chatbook/Video_Generation/workflows *.json
 recursive-include tldw_chatbook/css *.tcss *.css
@@ -21,6 +22,10 @@ include tldw_chatbook/TTS/audio_cpp_artifact_manifest.json
 recursive-include tldw_chatbook/DB/migrations *.sql
 include tldw_chatbook/Third_Party/aider/LICENSE.txt
 include tldw_chatbook/Third_Party/textual_fspicker/LICENSE
+# Apache-2.0 re-licensed subtrees: their modules ship, so their licence text
+# must ship with them (task-19860 review).
+include tldw_chatbook/LLM_Calls/LICENSE
+include tldw_chatbook/tldw_api/LICENSE
 
 # Exclude tests and development artifacts
 recursive-exclude Tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,17 +14,11 @@ recursive-include tldw_chatbook/Image_Generation/workflows *.json
 recursive-include tldw_chatbook/Video_Generation/workflows *.json
 recursive-include tldw_chatbook/css *.tcss *.css
 include tldw_chatbook/TTS/audio_cpp_artifact_manifest.json
-include tldw_chatbook/DB/migrations/chachanotes_v26_to_v27_citation_provenance.sql
-include tldw_chatbook/DB/migrations/chachanotes_v27_to_v28_character_authority.sql
-include tldw_chatbook/DB/migrations/chachanotes_v32_to_v33_console_context_memory.sql
-include tldw_chatbook/DB/migrations/chachanotes_v33_to_v34_visual_compaction_policy.sql
-include tldw_chatbook/DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql
-include tldw_chatbook/DB/migrations/chachanotes_v35_to_v36_note_folders.sql
-include tldw_chatbook/DB/migrations/chachanotes_v36_to_v37_provider_continuation.sql
-include tldw_chatbook/DB/migrations/chachanotes_v39_to_v40_transcript_annotations.sql
-include tldw_chatbook/DB/migrations/chachanotes_v42_to_v43_message_exchanges.sql
-include tldw_chatbook/DB/migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql
-include tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_actor_packs.sql
+# Every migration script, matched -- never enumerated (task-19860). The
+# hand-written list this replaced named 11 of 32; the sdist is the input to
+# every rebuild, so a migration missing here is a migration that can never
+# reach a wheel built from it.
+recursive-include tldw_chatbook/DB/migrations *.sql
 include tldw_chatbook/Third_Party/aider/LICENSE.txt
 include tldw_chatbook/Third_Party/textual_fspicker/LICENSE
 

--- a/Packaging/PACKAGING_CHECKLIST.md
+++ b/Packaging/PACKAGING_CHECKLIST.md
@@ -10,6 +10,12 @@ must start from a fresh output directory; do not treat an existing checkout
 - [x] `tldw-cli` and `tldw-serve` are declared in `[project.scripts]`.
 - [x] `[tool.setuptools.package-data]` explicitly owns wheel runtime data.
 - [x] `include-package-data = false` keeps sdist-only files out of wheels.
+- [x] Asset directories that grow are matched by pattern, never enumerated.
+  Only three lists name files on purpose, each for a reason recorded beside
+  it in `pyproject.toml`: `Config_Files/rag_pipelines.toml` (a `*.toml` glob
+  would ship the forbidden example TOML), `TTS/audio_cpp_artifact_manifest.json`
+  (one pinned manifest), and the vendored `LICENSE` notices. Adding a new
+  runtime asset to one of those three means adding its name too.
 - [x] The project license uses the `AGPL-3.0-or-later` SPDX expression and
   declares `LICENSE`.
 
@@ -19,9 +25,8 @@ must start from a fresh output directory; do not treat an existing checkout
 - [x] The sdist contains release metadata, runtime data, TCSS modules, the
   source-only `stats_screen.css` input, and project/vendored licenses.
 - [x] The wheel contains the compiled CSS bundle, RAG pipeline configuration,
-  thirteen chunking JSON templates, eval configuration, configuration
-  resources, the ChaChaNotes citation-provenance and character-authority
-  runtime migrations, and both vendored license notices.
+  eval configuration, configuration resources, **every** `.sql` file under
+  `tldw_chatbook/DB/migrations/`, and both vendored license notices.
 - [x] The wheel excludes source-only CSS, example TOML, development Markdown,
   the namespace-discovered chunking example, tests, caches, and OS metadata.
 - [x] Wheel and sdist metadata use Core Metadata 2.4 and declare the project
@@ -37,8 +42,11 @@ python Packaging/check_manifest.py fresh-dist
 ```
 
 `check_manifest.py` requires exactly one sdist and one wheel. It checks
-required and forbidden archive paths, exact chunking templates, entry points,
-SPDX metadata, the project license, and vendored notices.
+required and forbidden archive paths, entry points, SPDX metadata, the project
+license, and vendored notices. Its migration requirement is derived twice and
+fails closed: from the `.sql` files in the checkout beside it, and from the
+`.sql` names the artifact's own `ChaChaNotes_DB.py` opens. It names every
+missing script, not just the first.
 
 Run the isolated installed-wheel regression:
 

--- a/Packaging/PACKAGING_CHECKLIST.md
+++ b/Packaging/PACKAGING_CHECKLIST.md
@@ -14,8 +14,15 @@ must start from a fresh output directory; do not treat an existing checkout
   Only three lists name files on purpose, each for a reason recorded beside
   it in `pyproject.toml`: `Config_Files/rag_pipelines.toml` (a `*.toml` glob
   would ship the forbidden example TOML), `TTS/audio_cpp_artifact_manifest.json`
-  (one pinned manifest), and the vendored `LICENSE` notices. Adding a new
+  (one pinned manifest), and the licence notices. Adding a new
   runtime asset to one of those three means adding its name too.
+- [x] The licence list is complete, not merely explicit. The reason it stays
+  enumerated — one fixed obligation per subtree — is also what makes an
+  omission a licence breach, and it had two: `LLM_Calls/LICENSE` and
+  `tldw_api/LICENSE` (Apache-2.0 subtrees whose modules ship) were in no
+  artifact. Re-derive it by listing every `LICEN*`/`NOTICE`/`COPYING` file
+  under `tldw_chatbook/` and diffing against the built archives, not by
+  reading `pyproject.toml`.
 - [x] The project license uses the `AGPL-3.0-or-later` SPDX expression and
   declares `LICENSE`.
 
@@ -26,7 +33,9 @@ must start from a fresh output directory; do not treat an existing checkout
   source-only `stats_screen.css` input, and project/vendored licenses.
 - [x] The wheel contains the compiled CSS bundle, RAG pipeline configuration,
   eval configuration, configuration resources, **every** `.sql` file under
-  `tldw_chatbook/DB/migrations/`, and both vendored license notices.
+  `tldw_chatbook/DB/migrations/`, **every** `.json` under
+  `tldw_chatbook/Evals/eval_datasets/` (read at runtime by the bundled
+  research template), and every license notice.
 - [x] The wheel excludes source-only CSS, example TOML, development Markdown,
   the namespace-discovered chunking example, tests, caches, and OS metadata.
 - [x] Wheel and sdist metadata use Core Metadata 2.4 and declare the project

--- a/Packaging/check_manifest.py
+++ b/Packaging/check_manifest.py
@@ -93,6 +93,9 @@ REQUIRED_SDIST_PATHS = {
     "tldw_chatbook/Evals/config/eval_config.yaml",
     "tldw_chatbook/Third_Party/aider/LICENSE.txt",
     "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
+    # Apache-2.0 re-licensed subtrees whose modules ship (task-19860 review).
+    "tldw_chatbook/LLM_Calls/LICENSE",
+    "tldw_chatbook/tldw_api/LICENSE",
 } | SAMIRA_RESOURCE_PATHS
 
 REQUIRED_WHEEL_PATHS = {
@@ -103,6 +106,9 @@ REQUIRED_WHEEL_PATHS = {
     "tldw_chatbook/Evals/config/eval_config.yaml",
     "tldw_chatbook/Third_Party/aider/LICENSE.txt",
     "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
+    # Apache-2.0 re-licensed subtrees whose modules ship (task-19860 review).
+    "tldw_chatbook/LLM_Calls/LICENSE",
+    "tldw_chatbook/tldw_api/LICENSE",
 } | SAMIRA_RESOURCE_PATHS
 
 REQUIRED_SDIST_GLOBS = {
@@ -114,6 +120,8 @@ REQUIRED_SDIST_GLOBS = {
     "tldw_chatbook/Config_Files/*.json",
     "tldw_chatbook/Config_Files/*.md",
     "tldw_chatbook/Evals/config/*.yaml",
+    # Runtime eval datasets: matched, never enumerated (task-19860 review).
+    "tldw_chatbook/Evals/eval_datasets/*.json",
 }
 
 REQUIRED_WHEEL_GLOBS = {
@@ -125,6 +133,8 @@ REQUIRED_WHEEL_GLOBS = {
     "tldw_chatbook/Config_Files/*.json",
     "tldw_chatbook/Config_Files/*.md",
     "tldw_chatbook/Evals/config/*.yaml",
+    # Runtime eval datasets: matched, never enumerated (task-19860 review).
+    "tldw_chatbook/Evals/eval_datasets/*.json",
 }
 
 FORBIDDEN_WHEEL_PATHS = {

--- a/Packaging/check_manifest.py
+++ b/Packaging/check_manifest.py
@@ -8,6 +8,7 @@ import configparser
 from email.parser import Parser
 import fnmatch
 from pathlib import Path, PurePosixPath
+import re
 import tarfile
 import zipfile
 
@@ -15,6 +16,19 @@ import zipfile
 # The file template store (tldw_chatbook/Chunking/templates/) is deleted
 # (spec §8.1.2): no path under it may appear in either artifact.
 CHUNKING_TEMPLATES_PREFIX = "tldw_chatbook/Chunking/templates/"
+
+# Migration scripts are DERIVED, never listed (task-19860). Two independent
+# derivations, because either one alone can be defeated:
+#   * the source tree next to this file -- the full set the artifact owes;
+#   * the ``.sql`` names the ARTIFACT'S OWN ``ChaChaNotes_DB.py`` opens --
+#     which still holds when the checker is run somewhere the source tree is
+#     not, and which is what actually decides whether the app starts.
+MIGRATIONS_PREFIX = "tldw_chatbook/DB/migrations/"
+CHACHANOTES_DB_MODULE_PATH = "tldw_chatbook/DB/ChaChaNotes_DB.py"
+# Matches the ``Path(__file__).parent / "migrations" / "<name>.sql"`` form
+# every file-backed migration step uses to locate its script.
+RUNTIME_MIGRATION_READ = re.compile(r'"migrations"\s*/\s*"([^"\n]+\.sql)"')
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 SAMIRA_RESOURCE_ROOT = "tldw_chatbook/assets/characters/samira"
 SAMIRA_REACTION_LABELS = (
@@ -76,19 +90,6 @@ REQUIRED_SDIST_PATHS = {
     "tldw_chatbook/css/tldw_cli_modular.tcss",
     "tldw_chatbook/css/components/stats_screen.css",
     "tldw_chatbook/Config_Files/rag_pipelines.toml",
-    "tldw_chatbook/DB/migrations/chachanotes_v26_to_v27_citation_provenance.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v27_to_v28_character_authority.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v32_to_v33_console_context_memory.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v33_to_v34_visual_compaction_policy.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v35_to_v36_note_folders.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v36_to_v37_provider_continuation.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v38_to_v39_visual_identity.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v39_to_v40_transcript_annotations.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v42_to_v43_message_exchanges.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_actor_packs.sql",
     "tldw_chatbook/Evals/config/eval_config.yaml",
     "tldw_chatbook/Third_Party/aider/LICENSE.txt",
     "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
@@ -99,19 +100,6 @@ REQUIRED_WHEEL_PATHS = {
     "tldw_chatbook/app.py",
     "tldw_chatbook/css/tldw_cli_modular.tcss",
     "tldw_chatbook/Config_Files/rag_pipelines.toml",
-    "tldw_chatbook/DB/migrations/chachanotes_v26_to_v27_citation_provenance.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v27_to_v28_character_authority.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v32_to_v33_console_context_memory.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v33_to_v34_visual_compaction_policy.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v35_to_v36_note_folders.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v36_to_v37_provider_continuation.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v38_to_v39_visual_identity.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v39_to_v40_transcript_annotations.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v42_to_v43_message_exchanges.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql",
-    "tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_actor_packs.sql",
     "tldw_chatbook/Evals/config/eval_config.yaml",
     "tldw_chatbook/Third_Party/aider/LICENSE.txt",
     "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
@@ -152,6 +140,55 @@ EXPECTED_CONSOLE_SCRIPTS = {
 }
 
 
+def source_migration_paths(repo_root: Path = REPO_ROOT) -> set[str]:
+    """Return every migration script the source tree owes the artifacts.
+
+    Args:
+        repo_root: Checkout root that contains ``tldw_chatbook/``.
+
+    Returns:
+        Archive-relative paths of every ``.sql`` under ``DB/migrations/``.
+
+    Raises:
+        FileNotFoundError: If the migrations directory is absent or empty --
+            the check fails closed rather than requiring nothing.
+    """
+    directory = repo_root / "tldw_chatbook" / "DB" / "migrations"
+    scripts = sorted(directory.glob("*.sql")) if directory.is_dir() else []
+    if not scripts:
+        raise FileNotFoundError(
+            f"no migration scripts found under {directory}; "
+            "run the checker from a checkout that contains tldw_chatbook/"
+        )
+    return {f"{MIGRATIONS_PREFIX}{path.name}" for path in scripts}
+
+
+def runtime_migration_paths(module_source: str) -> set[str]:
+    """Return the migrations the shipped schema runner opens at runtime.
+
+    Parsed from the artifact's own ``ChaChaNotes_DB.py`` so the requirement
+    holds even where no source checkout is present.
+
+    Args:
+        module_source: Text of the packaged ``ChaChaNotes_DB.py``.
+
+    Returns:
+        Archive-relative paths of the ``.sql`` files it reads.
+
+    Raises:
+        ValueError: If no read site is detected at all -- that means the
+            detector has drifted from the code, not that the app stopped
+            needing migrations.
+    """
+    names = set(RUNTIME_MIGRATION_READ.findall(module_source))
+    if not names:
+        raise ValueError(
+            "no migration reads detected in the packaged ChaChaNotes_DB.py; "
+            "RUNTIME_MIGRATION_READ no longer matches the schema runner"
+        )
+    return {f"{MIGRATIONS_PREFIX}{name}" for name in names}
+
+
 def _sdist_members(path: Path) -> tuple[set[str], list[str]]:
     errors: list[str] = []
     with tarfile.open(path, "r:gz") as archive:
@@ -169,6 +206,46 @@ def _sdist_members(path: Path) -> tuple[set[str], list[str]]:
 def _wheel_members(path: Path) -> set[str]:
     with zipfile.ZipFile(path) as archive:
         return {name for name in archive.namelist() if not name.endswith("/")}
+
+
+def _sdist_member_text(path: Path, member: str) -> str | None:
+    with tarfile.open(path, "r:gz") as archive:
+        for item in archive.getmembers():
+            if item.isfile() and item.name.split("/", 1)[-1] == member:
+                stream = archive.extractfile(item)
+                if stream is None:
+                    return None
+                return stream.read().decode("utf-8")
+    return None
+
+
+def _wheel_member_text(path: Path, member: str) -> str | None:
+    with zipfile.ZipFile(path) as archive:
+        if member not in archive.namelist():
+            return None
+        return archive.read(member).decode("utf-8")
+
+
+def _archive_migration_requirements(
+    label: str,
+    module_source: str | None,
+) -> tuple[set[str], list[str]]:
+    """Derive the migrations an artifact must carry from its own schema runner.
+
+    Args:
+        label: ``"sdist"`` or ``"wheel"``, used in error text.
+        module_source: The artifact's packaged ``ChaChaNotes_DB.py`` text, or
+            ``None`` when the module itself is missing.
+
+    Returns:
+        The required migration paths, and any errors that block derivation.
+    """
+    if module_source is None:
+        return set(), [f"{label}: missing required path: {CHACHANOTES_DB_MODULE_PATH}"]
+    try:
+        return runtime_migration_paths(module_source), []
+    except ValueError as error:
+        return set(), [f"{label}: {error}"]
 
 
 def _common_forbidden_reason(name: str) -> str | None:
@@ -344,11 +421,30 @@ def check_distribution(dist_dir: Path = Path("dist")) -> bool:
     sdist_members, sdist_errors = _sdist_members(sdist)
     wheel_members = _wheel_members(wheel)
     errors.extend(sdist_errors)
+
+    # Migration requirements are derived, not listed (task-19860): the source
+    # tree states what the artifacts owe, and each artifact's own schema
+    # runner states what it cannot start without. Both derivations fail
+    # closed, so a broken derivation is a red check rather than an empty one.
+    try:
+        source_migrations = source_migration_paths()
+    except FileNotFoundError as error:
+        source_migrations = set()
+        errors.append(f"source tree: {error}")
+    sdist_migrations, sdist_migration_errors = _archive_migration_requirements(
+        "sdist", _sdist_member_text(sdist, CHACHANOTES_DB_MODULE_PATH)
+    )
+    wheel_migrations, wheel_migration_errors = _archive_migration_requirements(
+        "wheel", _wheel_member_text(wheel, CHACHANOTES_DB_MODULE_PATH)
+    )
+    errors.extend(sdist_migration_errors)
+    errors.extend(wheel_migration_errors)
+
     errors.extend(
         _validate_content(
             "sdist",
             sdist_members,
-            required_paths=REQUIRED_SDIST_PATHS,
+            required_paths=REQUIRED_SDIST_PATHS | source_migrations | sdist_migrations,
             required_globs=REQUIRED_SDIST_GLOBS,
         )
     )
@@ -356,7 +452,7 @@ def check_distribution(dist_dir: Path = Path("dist")) -> bool:
         _validate_content(
             "wheel",
             wheel_members,
-            required_paths=REQUIRED_WHEEL_PATHS,
+            required_paths=REQUIRED_WHEEL_PATHS | source_migrations | wheel_migrations,
             required_globs=REQUIRED_WHEEL_GLOBS,
             forbidden_paths=FORBIDDEN_WHEEL_PATHS,
         )

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -817,8 +817,10 @@ print(package_root)
 """
 
 INSTALLED_MIGRATION_PROBE = r"""
+from contextlib import closing
 from pathlib import Path
 import os
+import sqlite3
 
 expected_target = Path(os.environ["EXPECTED_TARGET"]).resolve(strict=True)
 
@@ -846,11 +848,18 @@ assert current_schema_version > 35
 fresh_path = validate_path("installed-fresh-probe.sqlite", home_path)
 assert not fresh_path.exists()
 fresh_db = CharactersRAGDB(fresh_path, client_id="installed-probe-fresh")
-fresh_version = fresh_db.get_connection().execute(
-    "SELECT version FROM db_schema_version WHERE schema_name = ?",
-    (CharactersRAGDB._SCHEMA_NAME,),
-).fetchone()[0]
 fresh_db.close_connection()
+# Read the reached version with a RAW sqlite3 connection on the closed file,
+# not through the class that just wrote it. Qodo flagged the earlier
+# `get_connection().execute(...)` for bypassing `transaction()`; going raw is
+# the better answer than wrapping it, because this assertion's whole value is
+# that it does not agree with itself -- neither the constant nor the class's
+# own accessor is in the path.
+with closing(sqlite3.connect(fresh_path)) as fresh_probe:
+    fresh_version = fresh_probe.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (CharactersRAGDB._SCHEMA_NAME,),
+    ).fetchone()[0]
 assert fresh_version == current_schema_version, (fresh_version, current_schema_version)
 print(f"installed-wheel-fresh-init-ok v{fresh_version}")
 CharactersRAGDB._CURRENT_SCHEMA_VERSION = 35
@@ -2007,6 +2016,21 @@ def test_release_checker_rejects_missing_database_migration(
     archive_kind: str,
     missing: str,
 ) -> None:
+    """Dropping any single migration from one archive is caught, named, and refused.
+
+    Parametrized across every migration the runtime opens rather than a
+    representative one: the defect this task closed (task-19860) hid because
+    the old checker aborted at the first gap, so a per-file sweep is the
+    point, not thoroughness for its own sake.
+
+    Args:
+        built_distributions: The wheel and sdist built once per session.
+        tmp_path: Scratch directory for the doctored dist tree.
+        archive_kind: Which archive to drop the file from -- ``wheel`` or
+            ``sdist``; both must be checked, since ``package-data`` and
+            ``MANIFEST.in`` are separate lists that have drifted apart before.
+        missing: Repo-relative path of the migration script to remove.
+    """
     dist_dir = _dist_dir_without(
         built_distributions,
         tmp_path,

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -8,12 +8,13 @@ from importlib import metadata
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import stat
 import subprocess
 import sys
 import tarfile
-from typing import Iterator, NamedTuple
+from typing import Iterable, Iterator, NamedTuple
 import venv
 import zipfile
 
@@ -31,52 +32,38 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # deleted (spec §8.1.2): no tldw_chatbook/Chunking/templates/ path may ship
 # in either artifact, and the installed tree must not carry the directory.
 CHUNKING_TEMPLATES_PREFIX = "tldw_chatbook/Chunking/templates/"
-CITATION_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v26_to_v27_citation_provenance.sql"
-)
-CHARACTER_AUTHORITY_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v27_to_v28_character_authority.sql"
-)
-CONSOLE_CONTEXT_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v32_to_v33_console_context_memory.sql"
-)
-VISUAL_COMPACTION_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v33_to_v34_visual_compaction_policy.sql"
-)
-DICTIONARY_ATTACHMENTS_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/"
-    "chachanotes_v34_to_v35_conversation_dictionary_attachments.sql"
-)
-NOTE_FOLDER_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v35_to_v36_note_folders.sql"
-)
-PROVIDER_CONTINUATION_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v36_to_v37_provider_continuation.sql"
-)
-VISUAL_IDENTITY_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v38_to_v39_visual_identity.sql"
-)
-TRANSCRIPT_ANNOTATIONS_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v39_to_v40_transcript_annotations.sql"
-)
-MESSAGE_TRAJECTORY_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/"
-    "chachanotes_v37_to_v38_message_trajectory_metadata.sql"
-)
-TRANSCRIPT_ANNOTATIONS_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/"
-    "chachanotes_v39_to_v40_transcript_annotations.sql"
-)
-MESSAGE_EXCHANGES_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/"
-    "chachanotes_v42_to_v43_message_exchanges.sql"
-)
-SYNC_CONFLICT_PRESERVATION_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/"
-    "chachanotes_v43_to_v44_sync_conflict_preservation.sql"
-)
-ACTOR_PACK_MIGRATION_PATH = (
-    "tldw_chatbook/DB/migrations/chachanotes_v44_to_v45_actor_packs.sql"
+# Migration expectations are DERIVED, never listed (task-19860). The
+# fifteen hand-written constants this replaced had drifted to thirteen files
+# (one was even defined twice), and the app cannot start without two of the
+# ones nobody added: a wheel built from that list died at V40->V41 with a
+# SchemaError, and the two later gaps were invisible because the chain
+# aborts at the first.
+MIGRATIONS_PREFIX = "tldw_chatbook/DB/migrations/"
+CHACHANOTES_DB_MODULE_PATH = "tldw_chatbook/DB/ChaChaNotes_DB.py"
+# Matches ``Path(__file__).parent / "migrations" / "<name>.sql"``, the form
+# every file-backed migration step uses to locate its script.
+RUNTIME_MIGRATION_READ = re.compile(r'"migrations"\s*/\s*"([^"\n]+\.sql)"')
+
+
+def _source_migration_paths(repo_root: Path) -> frozenset[str]:
+    """Return every migration script present in a checkout."""
+    directory = repo_root / "tldw_chatbook" / "DB" / "migrations"
+    return frozenset(
+        f"{MIGRATIONS_PREFIX}{path.name}" for path in directory.glob("*.sql")
+    )
+
+
+def _runtime_migration_paths(module_source: str) -> frozenset[str]:
+    """Return the migrations a schema-runner source text opens at runtime."""
+    return frozenset(
+        f"{MIGRATIONS_PREFIX}{name}"
+        for name in RUNTIME_MIGRATION_READ.findall(module_source)
+    )
+
+
+SOURCE_MIGRATION_PATHS = _source_migration_paths(REPO_ROOT)
+RUNTIME_MIGRATION_PATHS = _runtime_migration_paths(
+    (REPO_ROOT / CHACHANOTES_DB_MODULE_PATH).read_text(encoding="utf-8")
 )
 SAMIRA_RESOURCE_ROOT = "tldw_chatbook/assets/characters/samira"
 SAMIRA_REACTION_LABELS = (
@@ -127,21 +114,6 @@ SAMIRA_RESOURCE_PATHS = {
 AUDIO_CPP_ARTIFACT_MANIFEST_PATH = "tldw_chatbook/TTS/audio_cpp_artifact_manifest.json"
 AUDIO_CPP_ARTIFACT_REPOSITORY = "audio-cpp/audio.cpp-gguf"
 AUDIO_CPP_ARTIFACT_COMMIT = "597048d9a920592808d7d4e2acd7b9c4596a143a"
-RUNTIME_MIGRATION_PATHS = {
-    CITATION_MIGRATION_PATH,
-    CHARACTER_AUTHORITY_MIGRATION_PATH,
-    CONSOLE_CONTEXT_MIGRATION_PATH,
-    VISUAL_COMPACTION_MIGRATION_PATH,
-    DICTIONARY_ATTACHMENTS_MIGRATION_PATH,
-    NOTE_FOLDER_MIGRATION_PATH,
-    PROVIDER_CONTINUATION_MIGRATION_PATH,
-    MESSAGE_TRAJECTORY_MIGRATION_PATH,
-    VISUAL_IDENTITY_MIGRATION_PATH,
-    TRANSCRIPT_ANNOTATIONS_MIGRATION_PATH,
-    MESSAGE_EXCHANGES_MIGRATION_PATH,
-    SYNC_CONFLICT_PRESERVATION_MIGRATION_PATH,
-    ACTOR_PACK_MIGRATION_PATH,
-}
 _PRIVATE_CHILD_BASELINE_ENV_KEYS = (
     "PATH",
     "LANG",
@@ -838,6 +810,22 @@ migration_path = validate_path("installed-migration-probe.sqlite", home_path)
 # is that the fixed v35 baseline below remains a genuine downgrade.
 current_schema_version = CharactersRAGDB._CURRENT_SCHEMA_VERSION
 assert current_schema_version > 35
+
+# A from-scratch initialization first: this is precisely what a user gets
+# after `pip install tldw_chatbook`, and it walks the WHOLE v4->current
+# chain, reading every file-backed migration off the installed tree. A wheel
+# short of one script dies here with a SchemaError (task-19860). The reached
+# version is read back out of the database, never asserted from the constant.
+fresh_path = validate_path("installed-fresh-probe.sqlite", home_path)
+assert not fresh_path.exists()
+fresh_db = CharactersRAGDB(fresh_path, client_id="installed-probe-fresh")
+fresh_version = fresh_db.get_connection().execute(
+    "SELECT version FROM db_schema_version WHERE schema_name = ?",
+    (CharactersRAGDB._SCHEMA_NAME,),
+).fetchone()[0]
+fresh_db.close_connection()
+assert fresh_version == current_schema_version, (fresh_version, current_schema_version)
+print(f"installed-wheel-fresh-init-ok v{fresh_version}")
 CharactersRAGDB._CURRENT_SCHEMA_VERSION = 35
 try:
     legacy_db = CharactersRAGDB(migration_path, client_id="installed-probe-v35")
@@ -1181,6 +1169,94 @@ def _wheel_members(path: Path) -> set[str]:
         return {name for name in archive.namelist() if not name.endswith("/")}
 
 
+def _sdist_member_text(path: Path, member: str) -> str:
+    with tarfile.open(path, "r:gz") as archive:
+        item = next(
+            entry
+            for entry in archive.getmembers()
+            if entry.isfile() and entry.name.split("/", 1)[-1] == member
+        )
+        stream = archive.extractfile(item)
+        assert stream is not None, member
+        return stream.read().decode("utf-8")
+
+
+def _wheel_member_text(path: Path, member: str) -> str:
+    with zipfile.ZipFile(path) as archive:
+        return archive.read(member).decode("utf-8")
+
+
+def _link_or_copy(source: Path, destination: Path) -> None:
+    """Hard link an unmodified archive, falling back to a copy across devices."""
+    try:
+        os.link(source, destination)
+    except OSError:
+        shutil.copy2(source, destination)
+
+
+def _dist_dir_without(
+    built: BuiltDistributions,
+    tmp_path: Path,
+    *,
+    drop_from_wheel: Iterable[str] = (),
+    drop_from_sdist: Iterable[str] = (),
+) -> Path:
+    """Copy the built dist directory, omitting the named archive members.
+
+    Only the archive that is actually mutated is rewritten; the other is hard
+    linked, so a parametrized mutation sweep does not re-copy tens of
+    megabytes per case.
+
+    Args:
+        built: The module-scoped build under test.
+        tmp_path: Per-test temporary directory.
+        drop_from_wheel: Wheel member names to omit.
+        drop_from_sdist: Sdist member names (archive-relative, without the
+            top-level directory) to omit.
+
+    Returns:
+        Path to the new distribution directory.
+    """
+    dropped_wheel = set(drop_from_wheel)
+    dropped_sdist = set(drop_from_sdist)
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+
+    wheel = dist_dir / built.wheel.name
+    if dropped_wheel:
+        with (
+            zipfile.ZipFile(built.wheel) as source,
+            zipfile.ZipFile(wheel, "w") as destination,
+        ):
+            present = set(source.namelist())
+            assert dropped_wheel <= present, sorted(dropped_wheel - present)
+            for member in source.infolist():
+                if member.filename not in dropped_wheel:
+                    destination.writestr(member, source.read(member.filename))
+    else:
+        _link_or_copy(built.wheel, wheel)
+
+    sdist = dist_dir / built.sdist.name
+    if dropped_sdist:
+        seen: set[str] = set()
+        with (
+            tarfile.open(built.sdist, "r:gz") as source,
+            tarfile.open(sdist, "w:gz") as destination,
+        ):
+            for member in source.getmembers():
+                relative = member.name.split("/", 1)[-1]
+                if member.isfile() and relative in dropped_sdist:
+                    seen.add(relative)
+                    continue
+                stream = source.extractfile(member) if member.isfile() else None
+                destination.addfile(member, stream)
+        assert seen == dropped_sdist, sorted(dropped_sdist - seen)
+    else:
+        _link_or_copy(built.sdist, sdist)
+
+    return dist_dir
+
+
 def _run_manifest_checker(
     built: BuiltDistributions,
     dist_dir: Path,
@@ -1459,7 +1535,6 @@ def test_built_artifacts_match_distribution_contract(
             "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
             AUDIO_CPP_ARTIFACT_MANIFEST_PATH,
         }
-        | RUNTIME_MIGRATION_PATHS
         | SAMIRA_RESOURCE_PATHS
     )
     required_wheel = (
@@ -1471,7 +1546,6 @@ def test_built_artifacts_match_distribution_contract(
             "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
             AUDIO_CPP_ARTIFACT_MANIFEST_PATH,
         }
-        | RUNTIME_MIGRATION_PATHS
         | SAMIRA_RESOURCE_PATHS
     )
     assert not required_sdist - sdist_members
@@ -1560,6 +1634,14 @@ def test_installed_distribution_migrates_v35_database_to_current(
     tmp_path: Path,
     wheel_source: str,
 ) -> None:
+    """Install the wheel into an empty tree and drive the schema for real.
+
+    Two databases, both created inside the installed distribution: one from
+    scratch -- the fresh-install path, which walks the entire v4->current
+    chain -- and one pinned back to v35 to prove the upgrade path. Each reads
+    its reached version out of ``db_schema_version`` rather than asserting the
+    constant back at itself (task-19044, task-19860).
+    """
     wheel, build_source_root = (
         (built_distributions.wheel, built_distributions.source_root)
         if wheel_source == "source"
@@ -1584,6 +1666,7 @@ def test_installed_distribution_migrates_v35_database_to_current(
             env,
         )
 
+    assert "installed-wheel-fresh-init-ok" in result.stdout
     assert "installed-wheel-v35-to-current-ok" in result.stdout
 
 
@@ -1743,51 +1826,116 @@ def test_release_checker_rejects_missing_samira_reaction(
     assert missing in result.stdout + result.stderr
 
 
+def test_migration_expectations_are_derived_not_enumerated() -> None:
+    """The expectations must come from reality, or they cannot catch drift."""
+    assert SOURCE_MIGRATION_PATHS, "no migration scripts found in the checkout"
+    assert RUNTIME_MIGRATION_PATHS, (
+        "no migration reads detected in ChaChaNotes_DB.py; "
+        "RUNTIME_MIGRATION_READ no longer matches the schema runner"
+    )
+    orphans = sorted(RUNTIME_MIGRATION_PATHS - SOURCE_MIGRATION_PATHS)
+    assert not orphans, f"schema runner opens missing scripts: {orphans}"
+
+
+@pytest.mark.parametrize("archive_kind", ["wheel", "sdist"])
+def test_built_artifact_contains_every_migration_script(
+    built_distributions: BuiltDistributions,
+    archive_kind: str,
+) -> None:
+    """Every ``.sql`` in the tree must be inside the artifact -- all reported.
+
+    The assertion reads the ARCHIVE's members, never the text of
+    ``pyproject.toml`` or ``MANIFEST.in``: swapping the build backend cannot
+    make it pass vacuously. Every missing file is named at once; the enumerated
+    lists this replaced were 19 files behind and the runtime symptom showed
+    only the first (task-19860).
+    """
+    members = (
+        _wheel_members(built_distributions.wheel)
+        if archive_kind == "wheel"
+        else _sdist_members(built_distributions.sdist)
+    )
+
+    missing = sorted(SOURCE_MIGRATION_PATHS - members)
+
+    assert not missing, (
+        f"{len(missing)} migration script(s) present in the source tree are "
+        f"absent from the {archive_kind}:\n  " + "\n  ".join(missing)
+    )
+
+
+@pytest.mark.parametrize("archive_kind", ["wheel", "sdist"])
+def test_built_artifact_ships_the_migrations_its_own_code_opens(
+    built_distributions: BuiltDistributions,
+    archive_kind: str,
+) -> None:
+    """Self-consistency: the packaged schema runner's reads must resolve.
+
+    Derived from the artifact's own ``ChaChaNotes_DB.py``, so this holds for
+    any artifact from anywhere -- no checkout required. This is the property a
+    user's install actually depends on.
+    """
+    archive, members = (
+        (built_distributions.wheel, _wheel_members(built_distributions.wheel))
+        if archive_kind == "wheel"
+        else (built_distributions.sdist, _sdist_members(built_distributions.sdist))
+    )
+    read_text = _wheel_member_text if archive_kind == "wheel" else _sdist_member_text
+    required = _runtime_migration_paths(read_text(archive, CHACHANOTES_DB_MODULE_PATH))
+
+    assert required, "packaged schema runner exposed no migration reads"
+    missing = sorted(required - members)
+
+    assert not missing, (
+        f"the {archive_kind}'s own ChaChaNotes_DB.py opens "
+        f"{len(missing)} script(s) the {archive_kind} does not carry:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+@pytest.mark.parametrize("archive_kind", ["wheel", "sdist"])
+def test_release_checker_reports_every_missing_database_migration(
+    built_distributions: BuiltDistributions,
+    tmp_path: Path,
+    archive_kind: str,
+) -> None:
+    """Removing several migrations must name all of them, not just the first.
+
+    Aborting at the first gap is exactly how 19 missing files stayed invisible
+    behind one reported symptom (task-19860).
+    """
+    dropped = set(sorted(SOURCE_MIGRATION_PATHS)[:3]) | {
+        max(SOURCE_MIGRATION_PATHS)
+    }
+    dist_dir = _dist_dir_without(
+        built_distributions,
+        tmp_path,
+        drop_from_wheel=dropped if archive_kind == "wheel" else (),
+        drop_from_sdist=dropped if archive_kind == "sdist" else (),
+    )
+
+    result = _run_manifest_checker(built_distributions, dist_dir, tmp_path)
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    unreported = sorted(name for name in dropped if name not in output)
+    assert not unreported, f"checker stayed silent about {unreported}\n{output}"
+
+
+@pytest.mark.parametrize("archive_kind", ["wheel", "sdist"])
 @pytest.mark.parametrize("missing", sorted(RUNTIME_MIGRATION_PATHS))
 def test_release_checker_rejects_missing_database_migration(
     built_distributions: BuiltDistributions,
     tmp_path: Path,
+    archive_kind: str,
     missing: str,
 ) -> None:
-    dist_dir = tmp_path / "dist"
-    shutil.copytree(built_distributions.dist_dir, dist_dir)
-    wheel = next(dist_dir.glob("*.whl"))
-    rewritten = wheel.with_suffix(".rewritten")
-    with (
-        zipfile.ZipFile(wheel) as source,
-        zipfile.ZipFile(rewritten, "w") as destination,
-    ):
-        for member in source.infolist():
-            if member.filename != missing:
-                destination.writestr(member, source.read(member.filename))
-    rewritten.replace(wheel)
-
-    result = _run_manifest_checker(built_distributions, dist_dir, tmp_path)
-
-    assert result.returncode == 1
-    assert missing in result.stdout + result.stderr
-
-
-@pytest.mark.parametrize("missing", sorted(RUNTIME_MIGRATION_PATHS))
-def test_release_checker_rejects_missing_database_migration_from_sdist(
-    built_distributions: BuiltDistributions,
-    tmp_path: Path,
-    missing: str,
-) -> None:
-    dist_dir = tmp_path / "dist"
-    shutil.copytree(built_distributions.dist_dir, dist_dir)
-    sdist = next(dist_dir.glob("*.tar.gz"))
-    rewritten = sdist.with_name(f"{sdist.name}.rewritten")
-    with (
-        tarfile.open(sdist, "r:gz") as source,
-        tarfile.open(rewritten, "w:gz") as destination,
-    ):
-        for member in source.getmembers():
-            if member.name.endswith(f"/{missing}"):
-                continue
-            stream = source.extractfile(member) if member.isfile() else None
-            destination.addfile(member, stream)
-    rewritten.replace(sdist)
+    dist_dir = _dist_dir_without(
+        built_distributions,
+        tmp_path,
+        drop_from_wheel=[missing] if archive_kind == "wheel" else (),
+        drop_from_sdist=[missing] if archive_kind == "sdist" else (),
+    )
 
     result = _run_manifest_checker(built_distributions, dist_dir, tmp_path)
 

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -65,6 +65,33 @@ SOURCE_MIGRATION_PATHS = _source_migration_paths(REPO_ROOT)
 RUNTIME_MIGRATION_PATHS = _runtime_migration_paths(
     (REPO_ROOT / CHACHANOTES_DB_MODULE_PATH).read_text(encoding="utf-8")
 )
+# The migrations were not the only runtime read of a non-.py asset that the
+# packaging config had missed (task-19860 review). `Evals/eval_templates/
+# research.py` builds an absolute path into this directory and hands it to the
+# runner as `dataset_name`; `eval_runner.py` then does `Path(...).exists()`, so
+# an absent file degrades the bundled template silently instead of raising.
+# Derived from the directory, never listed, for the same reason.
+EVAL_DATASETS_PREFIX = "tldw_chatbook/Evals/eval_datasets/"
+
+
+def _source_eval_dataset_paths(repo_root: Path) -> frozenset[str]:
+    """Return every bundled eval dataset present in a checkout."""
+    directory = repo_root / "tldw_chatbook" / "Evals" / "eval_datasets"
+    return frozenset(
+        f"{EVAL_DATASETS_PREFIX}{path.name}" for path in directory.glob("*.json")
+    )
+
+
+SOURCE_EVAL_DATASET_PATHS = _source_eval_dataset_paths(REPO_ROOT)
+# Subtrees this project re-licenses under Apache-2.0 (see the README in each).
+# Their modules ship in the wheel, so §4(a) requires the licence text to ship
+# with them; both were absent from every artifact until task-19860's review.
+APACHE_SUBTREE_LICENSE_PATHS = frozenset(
+    {
+        "tldw_chatbook/LLM_Calls/LICENSE",
+        "tldw_chatbook/tldw_api/LICENSE",
+    }
+)
 SAMIRA_RESOURCE_ROOT = "tldw_chatbook/assets/characters/samira"
 SAMIRA_REACTION_LABELS = (
     "admiration",
@@ -1533,6 +1560,7 @@ def test_built_artifacts_match_distribution_contract(
             "tldw_chatbook/Evals/config/eval_config.yaml",
             "tldw_chatbook/Third_Party/aider/LICENSE.txt",
             "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
+            *APACHE_SUBTREE_LICENSE_PATHS,
             AUDIO_CPP_ARTIFACT_MANIFEST_PATH,
         }
         | SAMIRA_RESOURCE_PATHS
@@ -1544,6 +1572,7 @@ def test_built_artifacts_match_distribution_contract(
             "tldw_chatbook/Evals/config/eval_config.yaml",
             "tldw_chatbook/Third_Party/aider/LICENSE.txt",
             "tldw_chatbook/Third_Party/textual_fspicker/LICENSE",
+            *APACHE_SUBTREE_LICENSE_PATHS,
             AUDIO_CPP_ARTIFACT_MANIFEST_PATH,
         }
         | SAMIRA_RESOURCE_PATHS
@@ -1890,6 +1919,54 @@ def test_built_artifact_ships_the_migrations_its_own_code_opens(
         f"the {archive_kind}'s own ChaChaNotes_DB.py opens "
         f"{len(missing)} script(s) the {archive_kind} does not carry:\n  "
         + "\n  ".join(missing)
+    )
+
+
+@pytest.mark.parametrize("archive_kind", ["wheel", "sdist"])
+def test_built_artifact_contains_every_bundled_eval_dataset(
+    built_distributions: BuiltDistributions,
+    archive_kind: str,
+) -> None:
+    """The other runtime-read asset directory, held to the same rule.
+
+    ``Evals/eval_templates/research.py`` resolves a path into
+    ``Evals/eval_datasets/`` and passes it to the runner as ``dataset_name``;
+    the runner probes it with ``Path(...).exists()``, so a file missing from
+    the artifact costs the bundled template its dataset with no error at all.
+    That silence is why it outlived the migrations defect (task-19860 review).
+    """
+    assert SOURCE_EVAL_DATASET_PATHS, "no eval datasets found in the checkout"
+    members = (
+        _wheel_members(built_distributions.wheel)
+        if archive_kind == "wheel"
+        else _sdist_members(built_distributions.sdist)
+    )
+
+    missing = sorted(SOURCE_EVAL_DATASET_PATHS - members)
+
+    assert not missing, (
+        f"{len(missing)} bundled eval dataset(s) present in the source tree "
+        f"are absent from the {archive_kind}:\n  " + "\n  ".join(missing)
+    )
+
+
+@pytest.mark.parametrize("archive_kind", ["wheel", "sdist"])
+def test_built_artifact_carries_apache_subtree_licences(
+    built_distributions: BuiltDistributions,
+    archive_kind: str,
+) -> None:
+    """Apache-2.0 §4(a): the licence ships wherever its modules ship."""
+    members = (
+        _wheel_members(built_distributions.wheel)
+        if archive_kind == "wheel"
+        else _sdist_members(built_distributions.sdist)
+    )
+
+    missing = sorted(APACHE_SUBTREE_LICENSE_PATHS - members)
+
+    assert not missing, (
+        f"the {archive_kind} ships Apache-2.0 licensed modules without their "
+        f"licence text:\n  " + "\n  ".join(missing)
     )
 
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6922,3 +6922,29 @@ one real defect (migrations), one deliberate partial
 three deliberately explicit single-file lists (the pinned TTS manifest and the
 vendored `LICENSE` notices). Recording *why* each of those stays enumerated is
 the part that keeps the next person from "helpfully" globbing them.
+
+**Addendum from the independent review: "absent from both artifacts" is not
+evidence of "excluded by design".** The group audit above sorts every group
+into shipped / absent / partial, and the *absent* bucket was read as
+intentional. Two of its members were not. `Evals/eval_datasets/*.json` is read
+at runtime — `Evals/eval_templates/research.py` resolves an absolute path into
+it and passes it to the runner as `dataset_name`, which the runner probes with
+`Path(...).exists()`; absent from the artifact, the bundled research template
+loses its dataset and **nothing raises**, which is exactly why it outlived the
+migrations, whose absence at least produced a `SchemaError`. And
+`LLM_Calls/LICENSE` / `tldw_api/LICENSE` — Apache-2.0 texts for two subtrees
+this project deliberately re-licenses — shipped in neither artifact while the
+modules they cover shipped in both. Note the shape of that second one: the
+reason recorded for keeping licences enumerated ("a fixed legal obligation per
+package, not a growing directory") is *true*, and it is precisely what makes an
+incomplete list a breach rather than an oversight. A stated reason justifies
+the mechanism; it says nothing about whether the list is complete, and both
+have to be checked separately.
+
+So the audit needs a positive probe, not only a grouping: for every non-`.py`
+file under the package, grep the packaged Python for its basename, and treat
+any hit that is missing from the wheel as guilty until explained. That sweep is
+~20 lines, ran in a second over 190 assets and 1,813 modules, and it is what
+surfaced both. Filter the noise by hand — generic names (`README.md`,
+`LICENSE`, `pyproject.toml`, `.DS_Store`) match string literals all over the
+tree — 15 raw hits, 3 real.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6865,3 +6865,60 @@ phantom tables — `IF`, `column`, `as` — from prose in `#` comments that says
 new oracle against the old one rather than asserting it alone: the static scan
 and a live fully-migrated `CharactersRAGDB(":memory:")` agree exactly, 69
 substantive tables, symmetric difference empty.
+
+## A packaging test that reads the packaging config is the identity function; assert against the built artifact (TASK-19860, 2026-08-22)
+
+**Incident.** `tldw_chatbook/DB/migrations/` held 32 `.sql` files. Four separate
+hand-maintained lists said which of them ship: `pyproject.toml`'s
+`package-data` (13), `MANIFEST.in` (11), `Packaging/check_manifest.py` (13),
+and `Tests/Packaging/test_installed_distribution.py`'s
+`RUNTIME_MIGRATION_PATHS` (13 -- one of its fifteen constants was even defined
+twice, with the same value). A wheel built from that config carried 13 files.
+`pip install` + first launch died with
+`SchemaError: Migration from V40 to V41 failed ... No such file or directory:
+chachanotes_v40_to_v41_persona_visual.sql`. **The application did not start
+after a normal install, and had not been able to for two schema bumps.**
+
+**Two things made it survive a packaging suite that already had ~90 tests.**
+
+1. *The tests agreed with the config instead of with reality.* `check_manifest`
+   and the test both required exactly the 13 names the config shipped, so a
+   green run meant "the wheel contains what we listed", never "the wheel
+   contains what exists". Adding a migration and forgetting the lists produced
+   no red anywhere.
+2. *The runtime symptom under-reported by 19 files.* `_initialize_schema` walks
+   v4 -> current and aborts at the FIRST missing script, so one `SchemaError`
+   named one file. Fixing only that file would have moved the wall to v45, and
+   the next report would have looked like a new bug. Aborting-at-first is a
+   reporting property, and here it hid 95% of the defect.
+
+**The rule.** Build the wheel and the sdist and read the members out of the
+`ZipFile`/`TarFile`. If the assertion can be satisfied by editing
+`pyproject.toml`, it is testing the config, not the artifact -- and it goes on
+passing the day someone changes build backends. Report *every* missing file in
+one assertion message; a per-file `parametrize` that stops at the first still
+tells you one name at a time.
+
+**This does not contradict TASK-19045's "do not generate the literal".** That
+rule forbids re-deriving an expectation from *the artifact it guards*. The
+derivation has to come from somewhere independent: here the expectation is the
+`.sql` files in the source tree, and -- separately -- the `.sql` names the
+artifact's own `ChaChaNotes_DB.py` opens, parsed out of the shipped module.
+Neither is the packaging config, so neither can be satisfied by editing it.
+Both fail closed: an empty derivation is a red check ("no migration reads
+detected; the detector has drifted"), never a vacuous pass.
+
+**Mutation-check it against the artifact, not the test.** Enumerating 31 of 32
+files in `pyproject.toml` and rebuilding made four independent tests name
+`chachanotes_v45_to_v46_sync_log_retention.sql` and made the installed-wheel
+probe die with the real `SchemaError` -- which is what proves the test is
+wired to the build and not to a fixture.
+
+**Audit the neighbours, and do it against the artifact too.** Grouping every
+non-`.py` file under `tldw_chatbook/` by directory and extension and diffing
+each group against the wheel and sdist took one script and cleared 60 groups:
+one real defect (migrations), one deliberate partial
+(`embedding_configs_examples.toml`, forbidden in the wheel on purpose), and
+three deliberately explicit single-file lists (the pinned TTS manifest and the
+vendored `LICENSE` notices). Recording *why* each of those stays enumerated is
+the part that keeps the next person from "helpfully" globbing them.

--- a/backlog/tasks/task-19860 - Migration SQL files are missing from the built wheel and sdist.md
+++ b/backlog/tasks/task-19860 - Migration SQL files are missing from the built wheel and sdist.md
@@ -2,7 +2,7 @@
 id: TASK-19860
 title: >-
   Migration SQL files are missing from the built wheel and sdist
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-22'
 labels:
@@ -60,23 +60,119 @@ ask for.
 
 ## Acceptance Criteria
 
-- [ ] A wheel built from a clean checkout contains every `.sql` file present
+- [x] A wheel built from a clean checkout contains every `.sql` file present
       under `tldw_chatbook/DB/migrations/`
-- [ ] An sdist built from a clean checkout contains every `.sql` file present
+- [x] An sdist built from a clean checkout contains every `.sql` file present
       under `tldw_chatbook/DB/migrations/`
-- [ ] Installing the built wheel into an empty environment and initializing the
+- [x] Installing the built wheel into an empty environment and initializing the
       ChaChaNotes database from scratch reaches the current schema version
       without a `SchemaError`
-- [ ] A test fails when a migration file exists in the source tree but is
+- [x] A test fails when a migration file exists in the source tree but is
       absent from the built artifact, and it reports **all** missing files
       rather than aborting at the first — mutation-checked by removing one
       migration from the packaging config and confirming the test names it
-- [ ] The test asserts against the contents of the built artifact, not against
+- [x] The test asserts against the contents of the built artifact, not against
       the text of `pyproject.toml` / `MANIFEST.in`, so a future packaging
       mechanism change cannot make it vacuously pass
-- [ ] Other hand-enumerated asset lists in `pyproject.toml` / `MANIFEST.in` are
+- [x] Other hand-enumerated asset lists in `pyproject.toml` / `MANIFEST.in` are
       audited for the same enumeration-trails-reality shape and the result is
       recorded (either globbed, or documented as deliberately explicit)
+
+## Implementation Plan
+
+1. Re-measure at the base commit: count `.sql` files in the source tree and in
+   **every** hand-enumerated list, then build a wheel and an sdist from a clean
+   `git archive` export and enumerate the missing files from the artifacts'
+   own contents (born-red evidence).
+2. Replace the enumerations with globs: `migrations/*.sql` in
+   `pyproject.toml`'s `package-data`, `recursive-include ... *.sql` in
+   `MANIFEST.in`.
+3. Make `Packaging/check_manifest.py` derive its required migration set
+   instead of listing it: from the adjacent source tree, and independently
+   from the `.sql` names the artifact's own `ChaChaNotes_DB.py` opens. Fail
+   closed when either source is unavailable or empty.
+4. Make `Tests/Packaging/test_installed_distribution.py` derive the same two
+   sets and assert them against wheel and sdist **members**, reporting every
+   missing file at once instead of aborting at the first.
+5. Extend the installed-wheel probe to initialize a ChaChaNotes database
+   **from scratch** (no version pin) and read the reached schema version back
+   out of `db_schema_version`.
+6. Mutation-check: drop one migration from the packaging config, rebuild,
+   confirm the test names that file, Edit-restore, confirm a clean `git diff`.
+7. Audit every other hand-enumerated asset list in `pyproject.toml` /
+   `MANIFEST.in` against the built artifacts and record the verdict for each.
+
+## Implementation Notes
+
+Replaced four hand-maintained migration lists with two derivations, and moved
+the packaging assertion off the config text onto the built artifacts.
+
+**Re-measured at `d60ebe1d0` (the numbers in the Description were already
+stale, which is the defect).** 32 `.sql` files exist; `pyproject.toml` named
+13, `MANIFEST.in` named 11, and **two further lists the task did not know
+about** named 13 each: `Packaging/check_manifest.py`'s
+`REQUIRED_SDIST_PATHS`/`REQUIRED_WHEEL_PATHS`, and
+`Tests/Packaging/test_installed_distribution.py`'s `RUNTIME_MIGRATION_PATHS`
+(built from 15 constants, one of which — `TRANSCRIPT_ANNOTATIONS_MIGRATION_PATH`
+— was defined twice). All four agreed with each other and with nothing else,
+which is why ~90 packaging tests were green over a release blocker. Wheel and
+sdist each carried 13 of 32 (`MANIFEST.in`'s 11 is masked: setuptools also
+folds `package-data` into the sdist). `ChaChaNotes_DB.py` opens **15** scripts
+at runtime; two of them — `chachanotes_v40_to_v41_persona_visual.sql` and
+`chachanotes_v45_to_v46_sync_log_retention.sql` — were in no list at all.
+
+**Changes.** `pyproject.toml` → `"tldw_chatbook.DB" = ["migrations/*.sql"]`;
+`MANIFEST.in` → `recursive-include tldw_chatbook/DB/migrations *.sql`.
+`check_manifest.py` no longer lists migrations: it derives them from the
+source tree beside it *and*, independently, from the `.sql` names the
+**artifact's own** `ChaChaNotes_DB.py` opens (so the requirement survives
+being run where no checkout exists). Both derivations fail closed — an absent
+migrations directory or a regex that stops matching is a reported error, not
+an empty requirement. The test file derives the same two sets and asserts them
+against `ZipFile`/`TarFile` members, listing every missing file in one
+message.
+
+**Evidence.** Born-red at base: a wheel and sdist built from a clean
+`git archive` export each omitted the same **19** files (named in full in the
+run log); the base `check_manifest.py` accepted that wheel, the new one names
+all 19 per archive. A clean-environment install of the base wheel
+(`pip install --no-deps --no-index` into an empty venv) reproduced the user's
+failure exactly — `SchemaError: Migration from V40 to V41 failed ... No such
+file or directory: chachanotes_v40_to_v41_persona_visual.sql` — confirming the
+chain walls at v40 and under-reports 18 further gaps. The same probe on the
+fixed wheel imported from the fresh venv's `site-packages`, initialized a
+ChaChaNotes DB **from scratch**, and read **version 46 out of
+`db_schema_version`** (130 tables), matching `_CURRENT_SCHEMA_VERSION` without
+that constant being the assertion's source. Mutation: enumerating 31 of 32 in
+`pyproject.toml` plus one `MANIFEST.in` `exclude`, then rebuilding, made four
+tests name `chachanotes_v45_to_v46_sync_log_retention.sql` and killed the
+installed-wheel probe with the real `SchemaError`; Edit-restored, `git diff`
+shows only the intended change. `Tests/Packaging/` **97 passed** (was 2 failed
+at base: `test_mcp_unified_distribution.py::test_mcp_extra_installs_and_runs_
+from_each_isolated_artifact[wheel|sdist]`, red for this defect). Repo-wide
+`--collect-only -q`: 56,668 collected, 1 error —
+`Tests/UI/test_library_file_notes_workspace.py`, the known dev red (TASK-20972).
+
+**Asset-list audit (last AC).** Every non-`.py` file under `tldw_chatbook/`
+(189) was grouped by directory + extension and diffed against both artifacts:
+60 groups, of which only two were partial. Migrations were the defect. The
+other, `Config_Files/*.toml`, is deliberate — `embedding_configs_examples.toml`
+is in `FORBIDDEN_WHEEL_PATHS`, which is exactly why `rag_pipelines.toml` must
+stay a literal rather than becoming a `*.toml` glob. Three single-file lists
+stay explicit with the reason now written beside them in `pyproject.toml`: the
+pinned `TTS/audio_cpp_artifact_manifest.json` (its repository/commit/package
+count are pinned by tests), and the vendored `LICENSE` notices (a fixed legal
+obligation per package, not a growing directory). Everything else was already
+complete or excluded from both artifacts by design.
+
+**Deliberately not done.** `test_installed_distribution_migrates_v35_database_
+to_current` keeps its name despite now also covering the from-scratch path;
+two backlog documents cite it by name and the rename buys nothing.
+
+**Files:** `pyproject.toml`, `MANIFEST.in`, `Packaging/check_manifest.py`,
+`Packaging/PACKAGING_CHECKLIST.md`,
+`Tests/Packaging/test_installed_distribution.py`,
+`backlog/docs/lessons-testing-evidence.md`.
 
 ## Notes
 

--- a/backlog/tasks/task-19860 - Migration SQL files are missing from the built wheel and sdist.md
+++ b/backlog/tasks/task-19860 - Migration SQL files are missing from the built wheel and sdist.md
@@ -174,6 +174,44 @@ two backlog documents cite it by name and the rename buys nothing.
 `Tests/Packaging/test_installed_distribution.py`,
 `backlog/docs/lessons-testing-evidence.md`.
 
+## Reviewer Addendum (independent review, 2026-08-22)
+
+The release-blocker claim holds and was re-verified end to end from scratch: a
+`git archive` export of the branch built an sdist and, from that sdist, a
+wheel; each installed into its own empty venv reached **version 46 read out of
+`db_schema_version`** (130 tables, no `SchemaError`), and at the base commit
+`d60ebe1d0` the same route died at V40→V41 on
+`chachanotes_v40_to_v41_persona_visual.sql`. A *different* mutation from the
+implementer's — dropping `chachanotes_v40_to_v41_persona_visual.sql` from
+`pyproject.toml` plus a `MANIFEST.in` `exclude` — turned **nine** tests red
+naming that file in both artifacts, including
+`test_installed_distribution_migrates_v35_database_to_current[source|sdist]`
+with the real `SchemaError`. Both derivations were probed empty and both fail
+closed. Restored by edit; `git diff` clean.
+
+Two corrections to the last AC, fixed on this branch rather than filed:
+
+1. **The "absent from both artifacts by design" bucket contained live
+   assets.** `Evals/eval_datasets/*.json` is read at runtime by the bundled
+   research eval template and shipped in neither artifact — the same defect
+   class as the migrations, but silent, because the runner probes the path
+   with `Path(...).exists()` instead of opening it.
+2. **The licence list was explicit but incomplete.** `LLM_Calls/LICENSE` and
+   `tldw_api/LICENSE` (Apache-2.0 subtrees this project deliberately
+   re-licenses) shipped in neither artifact while the modules they cover
+   shipped in both. The recorded reason — a fixed obligation per subtree — is
+   true, and is exactly what makes the omission a breach.
+
+Both are now packaged, pinned in `Packaging/check_manifest.py` (dataset by
+glob, licences as literals), and asserted against archive members by two new
+parametrized tests. `tldw_chatbook/DB/migrations/README.md` was also still
+instructing authors to list every migration "by name in all four" lists and
+saying "there is no wildcard"; it now says packaging is nothing to do.
+
+`Tests/Packaging/` **101 passed**; repo-wide `--collect-only` 56,672 with the
+one known dev error (`Tests/UI/test_library_file_notes_workspace.py`,
+TASK-20972).
+
 ## Notes
 
 Rate this as a release blocker rather than a defect: the failure mode is "the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -503,7 +503,13 @@ exclude = [
 "tldw_chatbook.Config_Files" = ["*.json", "*.md", "rag_pipelines.toml"]
 # Runtime chunking templates are DB rows now (spec §8.1.2): the deleted
 # Chunking/templates/ file store ships in neither artifact.
-"tldw_chatbook.Evals" = ["config/*.yaml"]
+# `eval_datasets/*.json` is RUNTIME data, not a sample: `Evals/eval_templates/
+# research.py` hands its absolute path to the runner as `dataset_name`, and
+# `eval_runner.py` does `Path(dataset_name).exists()` -- absent from the
+# artifact, the bundled "Research Report Self-Eval" template silently loses its
+# dataset. Found by the task-19860 reviewer sweep for runtime reads of non-.py
+# assets; it was the second instance of the same defect class.
+"tldw_chatbook.Evals" = ["config/*.yaml", "eval_datasets/*.json"]
 "tldw_chatbook.Image_Generation" = ["workflows/*.json"]
 "tldw_chatbook.Video_Generation" = ["workflows/*.json"]
 # One pinned artifact manifest, named ON PURPOSE (audited in task-19860):
@@ -522,9 +528,16 @@ exclude = [
 "tldw_chatbook.DB" = ["migrations/*.sql"]
 # Preserve the licenses for vendored packages. Named ON PURPOSE (audited in
 # task-19860): a licence notice is a fixed legal obligation per vendored
-# package, not a growing asset directory.
+# package, not a growing asset directory. The obligation is what makes the
+# list's COMPLETENESS load-bearing -- `LLM_Calls/` and `tldw_api/` re-license
+# their own modules under Apache-2.0 (see the README in each), those modules
+# ship in the wheel, and §4(a) requires the licence text to travel with them;
+# both were missing until the task-19860 reviewer diffed the tree against the
+# artifact.
 "tldw_chatbook.Third_Party.aider" = ["LICENSE.txt"]
 "tldw_chatbook.Third_Party.textual_fspicker" = ["LICENSE"]
+"tldw_chatbook.LLM_Calls" = ["LICENSE"]
+"tldw_chatbook.tldw_api" = ["LICENSE"]
 # Engine is vendored from tldw_server (GPL-3.0-only): GPLv3 §4 requires the
 # licence text itself to ship, so the scope map and the GPL text both travel
 # with the package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -495,30 +495,34 @@ exclude = [
 "tldw_chatbook.css" = ["*.tcss", "**/*.tcss"]
 # Include theme files
 "tldw_chatbook.css.Themes" = ["*.tcss"]
-# Include JSON configuration, guides, and the RAG pipeline defaults
+# Include JSON configuration, guides, and the RAG pipeline defaults.
+# `rag_pipelines.toml` stays a literal ON PURPOSE (audited in task-19860): a
+# `*.toml` glob would also ship `embedding_configs_examples.toml`, which
+# `Packaging/check_manifest.py` forbids in the wheel. Adding a *runtime*
+# `.toml` here means adding its name here too.
 "tldw_chatbook.Config_Files" = ["*.json", "*.md", "rag_pipelines.toml"]
 # Runtime chunking templates are DB rows now (spec §8.1.2): the deleted
 # Chunking/templates/ file store ships in neither artifact.
 "tldw_chatbook.Evals" = ["config/*.yaml"]
 "tldw_chatbook.Image_Generation" = ["workflows/*.json"]
 "tldw_chatbook.Video_Generation" = ["workflows/*.json"]
+# One pinned artifact manifest, named ON PURPOSE (audited in task-19860):
+# `Tests/Packaging` pins its repository, commit and package count, so a second
+# TTS `.json` appearing in the wheel is a decision, not a glob's side effect.
 "tldw_chatbook.TTS" = ["audio_cpp_artifact_manifest.json"]
-"tldw_chatbook.DB" = [
-    "migrations/chachanotes_v26_to_v27_citation_provenance.sql",
-    "migrations/chachanotes_v27_to_v28_character_authority.sql",
-    "migrations/chachanotes_v32_to_v33_console_context_memory.sql",
-    "migrations/chachanotes_v33_to_v34_visual_compaction_policy.sql",
-    "migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql",
-    "migrations/chachanotes_v35_to_v36_note_folders.sql",
-    "migrations/chachanotes_v36_to_v37_provider_continuation.sql",
-    "migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql",
-    "migrations/chachanotes_v38_to_v39_visual_identity.sql",
-    "migrations/chachanotes_v39_to_v40_transcript_annotations.sql",
-    "migrations/chachanotes_v42_to_v43_message_exchanges.sql",
-    "migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql",
-    "migrations/chachanotes_v44_to_v45_actor_packs.sql",
-]
-# Preserve the licenses for vendored packages
+# Every migration script, matched -- never enumerated (task-19860). The
+# hand-written list this replaced held 13 of the 32 files that existed;
+# `chachanotes_v40_to_v41_persona_visual.sql` and
+# `chachanotes_v45_to_v46_sync_log_retention.sql` are both read by
+# `_initialize_schema`'s v4->current chain, so a PyPI install died with a
+# SchemaError before the app could start. A new migration must ship the
+# moment it lands, and only the author of the migration knows it exists;
+# `*.sql` is the only rule that cannot go stale. README.md stays out: the
+# wheel forbids development Markdown.
+"tldw_chatbook.DB" = ["migrations/*.sql"]
+# Preserve the licenses for vendored packages. Named ON PURPOSE (audited in
+# task-19860): a licence notice is a fixed legal obligation per vendored
+# package, not a growing asset directory.
 "tldw_chatbook.Third_Party.aider" = ["LICENSE.txt"]
 "tldw_chatbook.Third_Party.textual_fspicker" = ["LICENSE"]
 # Engine is vendored from tldw_server (GPL-3.0-only): GPLv3 §4 requires the

--- a/tldw_chatbook/DB/migrations/README.md
+++ b/tldw_chatbook/DB/migrations/README.md
@@ -9,23 +9,22 @@ methods in the matching `DB/*.py` module. Filenames are
 1. Bump `_CURRENT_SCHEMA_VERSION` in the owning DB module.
 2. Add `<db>_v<n>_to_v<n+1>_<what>.sql` here **and** the
    `_migrate_from_v<n>_to_v<n+1>` step that runs it.
-3. If the step reads the `.sql` at runtime (`migration_path.read_text(...)`),
-   list the file **by name in all four** of `MANIFEST.in`,
-   `[tool.setuptools.package-data]` in `pyproject.toml`,
-   `Packaging/check_manifest.py`, and `Tests/Packaging/
-   test_installed_distribution.py`. There is no wildcard;
-   `include-package-data` is `false`. A migration missing from the built
-   distribution raises `OSError` at upgrade time and pins installed users below
-   that version.
+3. Packaging: **nothing to do** (TASK-19860). `pyproject.toml` matches
+   `migrations/*.sql` and `MANIFEST.in` does `recursive-include
+   tldw_chatbook/DB/migrations *.sql`, so a new script ships the moment it
+   lands. Do not re-introduce a per-file list, and do not add a fifth one.
 
-   This step is a known trap rather than a good design — hand enumeration
-   trails reality, and it already has: measured 2026-08-22, of the 15 migration
-   files read at runtime, `chachanotes_v40_to_v41_persona_visual.sql` and
-   `chachanotes_v45_to_v46_sync_log_retention.sql` are in none of the four
-   lists, so an installed distribution walls at v40. **TASK-19860 owns
-   replacing all four enumerations with a glob plus a test that asserts against
-   the built artifact.** When it lands, this step becomes "nothing to do";
-   delete it then rather than adding a sixth list.
+   The four hand-written lists this replaced (`MANIFEST.in`,
+   `[tool.setuptools.package-data]`, `Packaging/check_manifest.py`, and
+   `Tests/Packaging/test_installed_distribution.py`) agreed with each other
+   and with nothing else: of the 32 files present they named 13, 11, 13 and
+   13, and two files the schema runner actually reads —
+   `chachanotes_v40_to_v41_persona_visual.sql` and
+   `chachanotes_v45_to_v46_sync_log_retention.sql` — were in none of them, so
+   a `pip install` walled at V40 with a `SchemaError` and the app did not
+   start. Both checkers now *derive* the requirement (from the `.sql` files in
+   the checkout, and from the `.sql` names the artifact's own
+   `ChaChaNotes_DB.py` opens) and assert it against the built wheel and sdist.
 4. **If the migration contains `CREATE TABLE`, add every new table name to
    `VALID_TABLES['chachanotes']` in `DB/sql_validation.py`, in the same
    commit.** See below — this is the step that keeps getting missed.


### PR DESCRIPTION
Closes TASK-19860. **Release blocker**: a user installing from PyPI could not start the application.

## The defect

Migration scripts were enumerated **one file at a time** rather than globbed, so every migration added since a list was last touched was absent from the artifact. A fresh install died at the first gap:

```
SchemaError: Migration from V40 to V41 failed …
No such file or directory: chachanotes_v40_to_v41_persona_visual.sql
```

## Why ~90 packaging tests were green over it

There were **four** hand-maintained lists, and **all four agreed with each other and with nothing else**:

| list | migrations named | vs 32 in source |
|---|---|---|
| `pyproject.toml` `package-data` | 13 | 19 missing |
| `MANIFEST.in` | 11 | 21 missing |
| `Packaging/check_manifest.py` | 13 | 19 missing |
| `Tests/Packaging/test_installed_distribution.py` | 13 — from **15** constants, because `TRANSCRIPT_ANNOTATIONS_MIGRATION_PATH` was defined **twice** | 19 missing |
| what the runtime actually opens | **15** | — |

Two runtime-read scripts were in **no** list at all: `chachanotes_v40_to_v41_persona_visual.sql` and `chachanotes_v45_to_v46_sync_log_retention.sql`. `MANIFEST.in`'s shortfall was masked in practice — setuptools folds `package-data` into the sdist too, so both artifacts shipped the same 13.

The existing test also aborted at the first missing file, which is why the visible symptom under-reported the hole by eighteen.

## The fix, and the part that matters

Migrations are globbed. But a glob alone leaves the same trap for the next asset directory, so the tests now assert against the **contents of the built artifact** — `ZipFile.namelist()` / `TarFile.getmembers()` — with the expectation derived two independent ways: from the source tree, and from the `.sql` names parsed out of the **artifact's own** `ChaChaNotes_DB.py`. Neither reads `pyproject.toml` or `MANIFEST.in`, so a build-backend swap cannot make them vacuous, and `check_manifest.py` now reports **every** missing script rather than the first.

Review probed the fail-closed behaviour rather than trusting it: emptying the source dir, removing the migrations directory, rewriting the artifact's `ChaChaNotes_DB.py` so the regex matches nothing, removing that file from both archives, and pointing at an empty dist — each produces a loud non-zero exit, not a pass.

## Verified end to end, twice, offline

Clean `git archive` → `python -m build --no-isolation` (the log confirms the wheel is built *through* the sdist) → `pip install --no-index --no-deps` into its **own empty venv**, for both routes:

| route | migrations on disk | `db_schema_version` | tables | SchemaError |
|---|---|---|---|---|
| wheel | 32 | **46** | 130 | none |
| sdist → wheel | 32 | **46** | 130 | none |

The version is read with a raw `sqlite3.connect` on the database file — not through the class, and not from `_CURRENT_SCHEMA_VERSION`, so the assertion cannot agree with itself. At the base commit the same route dies with the `SchemaError` above.

Every probe printed `tldw_chatbook.__file__`, which caught a real trap: run from the repo cwd, a probe imports the **source tree** rather than the venv. All reported runs use a neutral cwd, `env -i`, and isolated `HOME`/`XDG_*`.

**Mutations, both by the reviewer and different from the implementer's**: dropping `v40_to_v41_persona_visual.sql` reds **9 tests**, naming the file 22 times, including the installed-distribution migration test in both `[source]` and `[sdist]` dying with the genuine `SchemaError`.

## The audit AC found two more instances of the same class

All ~190 non-`.py` assets were grouped by directory and extension and diffed against both artifacts. "Absent from both" had been read as "by design" — for two groups it was not:

- **`Evals/eval_datasets/research_report_verification.json`** — `eval_templates/research.py` resolves an absolute path into it and the runner does `Path(dataset_name).exists()`. `ResearchTemplates` is registered. Shipped in neither artifact, so the bundled "Research Report Self-Eval" silently loses its dataset **with no error at all** — the same defect class as the migrations, but quiet, which is why it outlived them.
- **`LLM_Calls/LICENSE` and `tldw_api/LICENSE`** — Apache-2.0 texts for two subtrees this project deliberately re-licenses. Their modules ship; the licence text did not. The audit's stated reason ("a fixed legal obligation per vendored package") is *true* — which is exactly what makes an incomplete list a breach rather than a style choice. **A true reason justifies the mechanism; it says nothing about completeness.**

Both are now packaged and pinned. A sweep of all assets against all 1,813 packaged modules found no further runtime read of an unpackaged file.

The three deliberate exclusions keep their reasons, now verified empirically rather than asserted — swapping `Config_Files` to a `*.toml` glob really does ship `embedding_configs_examples.toml`, which the wheel forbids.

## Also corrected

`tldw_chatbook/DB/migrations/README.md` still instructed authors to list every migration **by name in all four lists** and stated "there is no wildcard" — with a note to delete that step once this task landed. That is the document the next migration author reads, so it is rewritten here.

## Verification

- `Tests/Packaging/`: **101 passed** (97 before the review's additions), 204 s. At the base commit, run from a clean export, exactly **2 failed** — the `mcp_unified` isolated-artifact pair, both on the real `SchemaError`.
- Repo-wide `--collect-only`: 56,672 with 1 known dev red (`test_library_file_notes_workspace.py`, TASK-20972).
- Nothing needed network. One caveat: `test_mcp_unified_distribution.py` resolves the `mcp` extra from the network by design.

Two residual notes recorded in the task file: the artifact-side self-check only recognises the `/ "migrations" / "<name>.sql"` path shape (a reporting gap, not a packaging hole — the source-tree glob still ships it); and the task Description's claim that `v41_to_v42` sits on the file-backed chain is wrong, since it applies inline SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships every DB migration and validates the built artifacts to prevent fresh installs from failing. Old behavior: four hand-written lists shipped 13/32 migrations and installs died at V40→V41; new behavior: glob all `migrations/*.sql` and assert archive members derived from the source tree and the artifact’s own `ChaChaNotes_DB.py`. Also packages the eval dataset and Apache-2.0 `LICENSE` texts. Meets TASK-19860.

- Review notes
  - `pyproject.toml` and `MANIFEST.in`: switch migrations to `*.sql`; include `tldw_chatbook/Evals/eval_datasets/*.json`; add `tldw_chatbook/LLM_Calls/LICENSE` and `tldw_chatbook/tldw_api/LICENSE`; keep `Config_Files/rag_pipelines.toml` literal to avoid shipping the example TOML.
  - `Packaging/check_manifest.py`: derives required migrations from the source tree and from the packaged `ChaChaNotes_DB.py`; fails closed and reports all missing files.
  - `Tests/Packaging/test_installed_distribution.py`: asserts against `ZipFile`/`TarFile` members; installs the wheel into a clean env, initializes from scratch, validates the reached schema version; adds checks for eval datasets and subtree `LICENSE`s.
  - Docs: update `tldw_chatbook/DB/migrations/README.md` and packaging checklist; record the audit that found the eval dataset and LICENSE omissions.

- Developer actions
  - None for new migrations: place the `.sql` under `tldw_chatbook/DB/migrations/`.
  - If adding a new runtime `.toml` under `Config_Files`, enumerate it explicitly in `pyproject.toml`; do not broaden to `*.toml`.
  - Ensure Apache-2.0 subtrees continue to include their `LICENSE` in package data.

<sup>Written for commit e64fc91e920d1ba476d110cf7588d492c54f0fc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

