### PR TITLE
fix(chunking): stop the vendoring sync test leaking 1 GiB clones, and cross-check the vendor pin

### DIFF
--- a/Helper_Scripts/sync_chunking_engine.py
+++ b/Helper_Scripts/sync_chunking_engine.py
@@ -769,6 +769,15 @@ def main() -> int:
     finally:
         if tmp is not None:
             shutil.rmtree(tmp, ignore_errors=True)
+            # ignore_errors=True deliberately never raises here -- this is a
+            # `finally`, and raising could mask whatever exception/SystemExit
+            # is already propagating through it. But silent-on-failure would
+            # be a leak wearing a `finally`: if removal genuinely failed
+            # (e.g. a permission-denied subtree), say so on stderr instead of
+            # returning as if nothing happened.
+            if Path(tmp).exists():
+                print(f"WARNING: failed to fully remove temp clone {tmp} "
+                      f"-- remove it manually", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/Helper_Scripts/sync_chunking_engine.py
+++ b/Helper_Scripts/sync_chunking_engine.py
@@ -4,7 +4,7 @@
 Spec §5.2: idempotent, SHA-verifying, loud on local modifications, never
 syncs from an unverified local path.
 """
-import argparse, hashlib, subprocess, sys, tempfile
+import argparse, hashlib, shutil, subprocess, sys, tempfile
 from pathlib import Path
 
 REPO = "https://github.com/rmusser01/tldw_server.git"
@@ -675,75 +675,100 @@ def main() -> int:
                     help="Existing tldw_server worktree already at the pinned SHA")
     args = ap.parse_args()
 
+    # TASK-19574: any temp clone this script creates for the no-arg path is
+    # removed on EVERY exit -- success, a FATAL sys.exit() (SystemExit still
+    # runs `finally`), or an uncaught exception. Before this fix nothing ever
+    # removed it: three leaked ~1.0 GiB clones per test-suite run, 17 found
+    # on one machine in a single day (~17 GiB).
     tmp = None
-    if args.source:
-        worktree = Path(args.source).resolve()
-        verify_clean(worktree)
-    else:
-        tmp = tempfile.mkdtemp(prefix="tldw_server_sync_")
-        worktree = Path(tmp)
-        subprocess.run(["git", "clone", "--no-checkout", REPO, str(worktree)], check=True)
-        subprocess.run(["git", "-C", str(worktree), "checkout", PIN], check=True)
+    try:
+        if args.source:
+            worktree = Path(args.source).resolve()
+            verify_clean(worktree)
+        else:
+            tmp = tempfile.mkdtemp(prefix="tldw_server_sync_")
+            worktree = Path(tmp)
+            subprocess.run(["git", "clone", "--no-checkout", REPO, str(worktree)], check=True)
+            subprocess.run(["git", "-C", str(worktree), "checkout", PIN], check=True)
 
-    # 1. Refuse to overwrite local modifications (loud, spec §5.2). The
-    # canonical vendored state is upstream-at-pin + rewrite + ENGINE_PATCHES,
-    # so anything else in the tree is a local modification.
-    for rel in VENDORED + ["__init__.py"]:
-        dst = TARGET_ROOT / rel
-        if dst.exists():
-            if rel == "__init__.py":
-                continue  # chatbook-authored, never touched by sync
-            expected = patch_vendored_file(rel, rewrite_imports(git_show(worktree, rel)))
-            if dst.read_text() != expected:
-                sys.exit(f"FATAL: local modification to vendored file {rel}; "
-                         f"revert it or move the change to a shim/subclass")
+        # 1. Refuse to overwrite local modifications (loud, spec §5.2). The
+        # canonical vendored state is upstream-at-pin + rewrite + ENGINE_PATCHES,
+        # so anything else in the tree is a local modification.
+        for rel in VENDORED + ["__init__.py"]:
+            dst = TARGET_ROOT / rel
+            if dst.exists():
+                if rel == "__init__.py":
+                    continue  # chatbook-authored, never touched by sync
+                expected = patch_vendored_file(rel, rewrite_imports(git_show(worktree, rel)))
+                if dst.read_text() != expected:
+                    sys.exit(f"FATAL: local modification to vendored file {rel}; "
+                             f"revert it or move the change to a shim/subclass")
 
-    # 2. Copy + rewrite + chatbook-side engine patches
-    for rel in VENDORED:
-        dst = TARGET_ROOT / rel
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        dst.write_text(patch_vendored_file(rel, rewrite_imports(git_show(worktree, rel))))
+        # 2. Copy + rewrite + chatbook-side engine patches. Compute every
+        # output FIRST -- this can still FATAL on a missing patch anchor for a
+        # file step 1 had no prior local copy to diff (e.g. a first-time sync
+        # of a newly-vendored file) -- and only write once every output has
+        # been computed successfully, so a drift failure here can never leave
+        # a partially-rewritten vendored tree on disk.
+        vendored_writes = [
+            (TARGET_ROOT / rel, patch_vendored_file(rel, rewrite_imports(git_show(worktree, rel))))
+            for rel in VENDORED
+        ]
+        for dst, content in vendored_writes:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(content)
 
-    # 3. Manifest + licence (GPLv3 §4: licence text ships in-subtree)
-    for rel in EXTRA_FILES:
-        dst = TARGET_ROOT / rel
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        dst.write_bytes(
-            subprocess.run(["git", "-C", str(worktree), "show", f"{PIN}:{rel}"],
-                           capture_output=True).stdout)
-    print(f"Synced {len(VENDORED)} files from {REPO} @ {PIN}")
+        # 3. Manifest + licence (GPLv3 §4: licence text ships in-subtree)
+        for rel in EXTRA_FILES:
+            dst = TARGET_ROOT / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(
+                subprocess.run(["git", "-C", str(worktree), "show", f"{PIN}:{rel}"],
+                               capture_output=True).stdout)
+        print(f"Synced {len(VENDORED)} files from {REPO} @ {PIN}")
 
-    # 4. Tests (spec §10.1): port with the same import rewrite + chatbook-side
-    # patches (see TESTS_MODULE_SKIPPED / TEST_PATCHES above) so a re-sync
-    # reproduces the ported tree exactly.
-    r = subprocess.run(
-        ["git", "-C", str(worktree), "ls-tree", "-r", "--name-only", PIN,
-         f"{UPSTREAM_TESTS_ROOT}/"],
-        capture_output=True, text=True)
-    if r.returncode != 0:
-        sys.exit(f"FATAL: could not list upstream tests at {PIN}: {r.stderr}")
-    upstream_tests = sorted(
-        line[len(UPSTREAM_TESTS_ROOT) + 1:]
-        for line in r.stdout.splitlines()
-        if line.startswith(f"{UPSTREAM_TESTS_ROOT}/") and "/test_" in line
-        and line.endswith(".py") and line.split("/")[-1].startswith("test_")
-    )
-    to_port = [t for t in upstream_tests if t.split("/")[-1] not in TESTS_EXCLUDED]
-    for rel in to_port:
-        rel_path = Path(rel)
-        dst_name = TEST_RENAMES.get(rel_path.name, rel_path.name)
-        dst = TARGET_TESTS_ROOT / rel_path.parent / dst_name if rel_path.parent != Path(".") \
-            else TARGET_TESTS_ROOT / dst_name
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        src = subprocess.run(
-            ["git", "-C", str(worktree), "show", f"{PIN}:{UPSTREAM_TESTS_ROOT}/{rel}"],
+        # 4. Tests (spec §10.1): port with the same import rewrite + chatbook-side
+        # patches (see TESTS_MODULE_SKIPPED / TEST_PATCHES above) so a re-sync
+        # reproduces the ported tree exactly. Same validate-then-write split as
+        # step 2: every ported file is read + patched first (may FATAL on a
+        # missing upstream file or patch anchor), and only written once the
+        # full set has been computed.
+        r = subprocess.run(
+            ["git", "-C", str(worktree), "ls-tree", "-r", "--name-only", PIN,
+             f"{UPSTREAM_TESTS_ROOT}/"],
             capture_output=True, text=True)
-        if src.returncode != 0:
-            sys.exit(f"FATAL: {rel} not found at pinned SHA {PIN}: {src.stderr}")
-        dst.write_text(patch_ported_test(rel_path.name, rewrite_imports(src.stdout)))
-    print(f"Ported {len(to_port)} test files into {TARGET_TESTS_ROOT} "
-          f"({len(upstream_tests) - len(to_port)} excluded per spec §10.1)")
-    return 0
+        if r.returncode != 0:
+            sys.exit(f"FATAL: could not list upstream tests at {PIN}: {r.stderr}")
+        upstream_tests = sorted(
+            line[len(UPSTREAM_TESTS_ROOT) + 1:]
+            for line in r.stdout.splitlines()
+            if line.startswith(f"{UPSTREAM_TESTS_ROOT}/") and "/test_" in line
+            and line.endswith(".py") and line.split("/")[-1].startswith("test_")
+        )
+        to_port = [t for t in upstream_tests if t.split("/")[-1] not in TESTS_EXCLUDED]
+        test_writes = []
+        for rel in to_port:
+            rel_path = Path(rel)
+            dst_name = TEST_RENAMES.get(rel_path.name, rel_path.name)
+            dst = TARGET_TESTS_ROOT / rel_path.parent / dst_name if rel_path.parent != Path(".") \
+                else TARGET_TESTS_ROOT / dst_name
+            src = subprocess.run(
+                ["git", "-C", str(worktree), "show", f"{PIN}:{UPSTREAM_TESTS_ROOT}/{rel}"],
+                capture_output=True, text=True)
+            if src.returncode != 0:
+                sys.exit(f"FATAL: {rel} not found at pinned SHA {PIN}: {src.stderr}")
+            test_writes.append(
+                (dst, patch_ported_test(rel_path.name, rewrite_imports(src.stdout)))
+            )
+        for dst, content in test_writes:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(content)
+        print(f"Ported {len(to_port)} test files into {TARGET_TESTS_ROOT} "
+              f"({len(upstream_tests) - len(to_port)} excluded per spec §10.1)")
+        return 0
+    finally:
+        if tmp is not None:
+            shutil.rmtree(tmp, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/Helper_Scripts/sync_chunking_engine.py
+++ b/Helper_Scripts/sync_chunking_engine.py
@@ -660,6 +660,26 @@ def git_show(worktree: Path, path: str) -> str:
     return r.stdout
 
 
+def git_show_bytes(worktree: Path, repo_relative_path: str) -> bytes:
+    """Like git_show(), but for a repo-root-relative path (EXTRA_FILES),
+    returned as raw bytes.
+
+    TASK-19574 Qodo review (PR #1999 finding 1): step 3 used to write
+    `subprocess.run(...).stdout` straight to disk without checking
+    `returncode`, so a missing path or failed `git show` silently wrote an
+    empty/truncated file while the script went on to print "Synced" --
+    breaking this script's own fail-loudly contract. Match git_show()'s
+    FATAL idiom instead of inventing a new one.
+    """
+    r = subprocess.run(
+        ["git", "-C", str(worktree), "show", f"{PIN}:{repo_relative_path}"],
+        capture_output=True)
+    if r.returncode != 0:
+        sys.exit(f"FATAL: {repo_relative_path} not found at pinned SHA {PIN}: "
+                  f"{r.stderr.decode(errors='replace')}")
+    return r.stdout
+
+
 def verify_clean(worktree: Path) -> None:
     """Wrong-tree hazard (spec §0): the source must match the pin exactly."""
     r = subprocess.run(["git", "-C", str(worktree), "rev-parse", "HEAD"],
@@ -680,10 +700,45 @@ def main() -> int:
     # runs `finally`), or an uncaught exception. Before this fix nothing ever
     # removed it: three leaked ~1.0 GiB clones per test-suite run, 17 found
     # on one machine in a single day (~17 GiB).
+    # TASK-19574 Qodo review (PR #1999 finding 4): --source and
+    # TLDW_SERVER_SYNC_SOURCE are a maintainer's own local filesystem path
+    # to a tldw_server worktree on their own machine -- a developer-supplied
+    # CLI flag to a Helper_Scripts/ tool, not user- or model-supplied input
+    # reaching the app at runtime. path_validation.py's helpers exist to
+    # confine untrusted, potentially adversarial paths inside an
+    # app-managed workspace root; that relationship doesn't hold here (the
+    # whole point of --source is a path deliberately OUTSIDE this repo), so
+    # routing it through validate_path_simple()/validate_path() would be
+    # the wrong tool -- e.g. validate_path_simple() rejects any path
+    # containing "~/", which a maintainer typing --source ~/repos/tldw_server
+    # could reasonably supply. What the failure mode actually needed was
+    # clarity: expanduser() so a literal "~" works when the shell hasn't
+    # already expanded it, and explicit checks so a bad path fails with a
+    # direct message instead of surfacing through verify_clean()'s pin-
+    # mismatch wording (which used to be the only diagnostic: a missing
+    # --source path made `git -C <path> rev-parse HEAD` fail with empty
+    # stdout, which read as "worktree HEAD  != pin 385afa95" -- technically
+    # fatal, but not an honest description of what was actually wrong).
     tmp = None
     try:
-        if args.source:
-            worktree = Path(args.source).resolve()
+        if args.source is not None:
+            # `if args.source:` was a truthy check -- `--source ""` on a
+            # direct CLI invocation fell through to the no-arg network-clone
+            # path below instead of failing. `is not None` catches an
+            # explicit empty value too.
+            if not args.source:
+                sys.exit("FATAL: --source was given an empty value; pass a "
+                          "path to a local tldw_server worktree checked out "
+                          "at the pin, or omit --source entirely")
+            worktree = Path(args.source).expanduser().resolve()
+            if not worktree.exists():
+                sys.exit(f"FATAL: --source {worktree} does not exist")
+            if not worktree.is_dir():
+                sys.exit(f"FATAL: --source {worktree} is not a directory")
+            if not (worktree / ".git").exists():
+                sys.exit(f"FATAL: --source {worktree} is not a git repository "
+                          f"(no .git found) -- checkout tldw_server at the "
+                          f"pin first")
             verify_clean(worktree)
         else:
             tmp = tempfile.mkdtemp(prefix="tldw_server_sync_")
@@ -718,13 +773,18 @@ def main() -> int:
             dst.parent.mkdir(parents=True, exist_ok=True)
             dst.write_text(content)
 
-        # 3. Manifest + licence (GPLv3 §4: licence text ships in-subtree)
-        for rel in EXTRA_FILES:
-            dst = TARGET_ROOT / rel
+        # 3. Manifest + licence (GPLv3 §4: licence text ships in-subtree).
+        # Same validate-then-write split as steps 2/4: every EXTRA_FILES
+        # entry is read (and FATALs loudly via git_show_bytes() on a missing
+        # path or failed `git show`) before anything is written, so a
+        # mid-loop failure can never leave a partially-synced extra file.
+        extra_writes = [
+            (TARGET_ROOT / rel, git_show_bytes(worktree, rel))
+            for rel in EXTRA_FILES
+        ]
+        for dst, content in extra_writes:
             dst.parent.mkdir(parents=True, exist_ok=True)
-            dst.write_bytes(
-                subprocess.run(["git", "-C", str(worktree), "show", f"{PIN}:{rel}"],
-                               capture_output=True).stdout)
+            dst.write_bytes(content)
         print(f"Synced {len(VENDORED)} files from {REPO} @ {PIN}")
 
         # 4. Tests (spec §10.1): port with the same import rewrite + chatbook-side

--- a/Tests/Architecture/test_vendor_pin_consistency.py
+++ b/Tests/Architecture/test_vendor_pin_consistency.py
@@ -1,0 +1,190 @@
+# Tests/Architecture/test_vendor_pin_consistency.py
+"""Cross-checks the upstream ``tldw_server`` provenance pins (TASK-19574).
+
+Two INDEPENDENT provenance pins live in this repo and currently happen to
+share the same commit SHA (``385afa951922c8a9dc2002c675bb6cad65e4ac23``):
+
+  * the Chunking-engine VENDORING pin -- the commit actual vendored *code*
+    under ``tldw_chatbook/Chunking/engine`` is copied from. Source of truth:
+    the ``PIN`` constant in ``Helper_Scripts/sync_chunking_engine.py`` (the
+    script that performs the sync and fails loudly, via
+    ``verify_clean()``/``git_show()``, on a mismatch).
+  * the Samira visual-identity COMPATIBILITY pin -- the commit the local
+    expression-normalization contract (byte-for-byte copied constants) and
+    the bundled ``visual_identity_pack.json`` asset are verified against.
+    Source of truth: the ``SAMIRA_SERVER_COMMIT`` constant in
+    ``tldw_chatbook/Character_Chat/visual_identity.py``.
+
+They pin different upstream subsystems (``app/core/Chunking`` vs.
+``app/core/Visual_Identities``) for different reasons and are **not**
+required to move together -- bumping one does not imply bumping the other,
+and this test does not assert they equal each other. What it DOES assert:
+every other hand-maintained copy of EACH pin agrees with that pin's own
+designated source of truth, so a hand-edit to one copy that misses a sibling
+copy fails loudly here instead of silently drifting (2026-08-21 holistic
+review, Lane 7 F4: "the pin is duplicated in six authoritative places with
+nothing cross-checking them").
+
+Upgrade path (bumping the Chunking vendoring pin to a new upstream commit):
+  1. Update ``PIN`` in ``Helper_Scripts/sync_chunking_engine.py`` (the source
+     of truth) to the new 40-char commit SHA.
+  2. Update ``commit =`` in ``tldw_chatbook/Chunking/engine/VENDOR_MANIFEST.toml``
+     to match -- the sync script does NOT regenerate the manifest file.
+  3. Update ``PIN`` in ``Tests/Chunking/test_sync_script.py`` to match.
+  4. Run ``python Helper_Scripts/sync_chunking_engine.py --source <local
+     tldw_server worktree checked out at the new pin>`` to re-vendor the 38
+     engine files + re-port the test suite.
+  5. Run ``Tests/Chunking/`` (with ``TLDW_SERVER_SYNC_SOURCE`` set to that
+     worktree) and this file to confirm everything lines up.
+
+Upgrade path (bumping the Samira compatibility pin):
+  1. Update ``SAMIRA_SERVER_COMMIT`` (and the "Begin pinned server
+     normalization block" docstring comment a few lines above it) in
+     ``tldw_chatbook/Character_Chat/visual_identity.py`` -- the source of
+     truth.
+  2. Update the hardcoded literal in
+     ``Tests/Character_Chat/test_visual_identity_contract.py``'s
+     ``test_samira_inventory_mapping_and_contract_constants_are_exact``.
+  3. Regenerate ``tldw_chatbook/assets/characters/samira/visual_identity_pack.json``
+     (its ``normalization_contract.source_commit`` and top-level
+     ``source_server_commit`` fields, and ``pack_content_sha256``) against the
+     new pin.
+  4. Run ``Tests/Character_Chat/`` and this file to confirm everything lines
+     up.
+
+Out of scope by design: ~19 further copies of this SHA across ``backlog/``
+decision records and ``Docs/superpowers/`` planning docs are historical,
+point-in-time snapshots of past decisions, not live configuration -- rewriting
+them on every future pin bump would misrepresent history. Only the six
+authoritative, behavior-affecting copies enumerated above are cross-checked.
+
+These are raw-text/JSON assertions on purpose (matching
+``Tests/Chunking/test_descope_ledger.py``'s convention): a couple of these
+files are read as source text rather than imported, so drift is caught
+without importing modules for their side effects alone.
+"""
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+SYNC_SCRIPT = REPO / "Helper_Scripts" / "sync_chunking_engine.py"
+VENDOR_MANIFEST = REPO / "tldw_chatbook" / "Chunking" / "engine" / "VENDOR_MANIFEST.toml"
+SYNC_TEST = REPO / "Tests" / "Chunking" / "test_sync_script.py"
+
+VISUAL_IDENTITY = REPO / "tldw_chatbook" / "Character_Chat" / "visual_identity.py"
+SAMIRA_PACK = (
+    REPO / "tldw_chatbook" / "assets" / "characters" / "samira" / "visual_identity_pack.json"
+)
+VISUAL_IDENTITY_CONTRACT_TEST = (
+    REPO / "Tests" / "Character_Chat" / "test_visual_identity_contract.py"
+)
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _extract_one(text: str, pattern: str, *, where: str) -> str:
+    match = re.search(pattern, text, re.MULTILINE)
+    assert match, f"pin pattern {pattern!r} not found in {where}"
+    shas = _SHA_RE.findall(match.group(0))
+    assert len(shas) == 1, (
+        f"expected exactly one SHA in the matched text from {where}: {match.group(0)!r}"
+    )
+    return shas[0]
+
+
+def _chunking_pin() -> str:
+    text = SYNC_SCRIPT.read_text()
+    return _extract_one(text, r'^PIN = "[0-9a-f]{40}"', where=str(SYNC_SCRIPT))
+
+
+def _samira_pin() -> str:
+    from tldw_chatbook.Character_Chat.visual_identity import SAMIRA_SERVER_COMMIT
+
+    assert _SHA_RE.fullmatch(SAMIRA_SERVER_COMMIT), (
+        f"SAMIRA_SERVER_COMMIT is not a 40-char hex SHA: {SAMIRA_SERVER_COMMIT!r}"
+    )
+    return SAMIRA_SERVER_COMMIT
+
+
+# ---------------------------------------------------------------------------
+# Chunking-engine vendoring pin: 3 authoritative copies + the source of truth.
+# ---------------------------------------------------------------------------
+
+def test_chunking_pin_is_a_valid_sha():
+    assert _SHA_RE.fullmatch(_chunking_pin())
+
+
+def test_vendor_manifest_matches_sync_script_pin():
+    manifest = tomllib.loads(VENDOR_MANIFEST.read_text())
+    assert manifest["upstream"]["commit"] == _chunking_pin(), (
+        f"{VENDOR_MANIFEST} upstream.commit is out of sync with the source of "
+        f"truth PIN in {SYNC_SCRIPT} -- see this file's docstring for the "
+        "upgrade path"
+    )
+
+
+def test_sync_test_pin_matches_sync_script_pin():
+    text = SYNC_TEST.read_text()
+    test_pin = _extract_one(text, r'^PIN = "[0-9a-f]{40}"', where=str(SYNC_TEST))
+    assert test_pin == _chunking_pin(), (
+        f"{SYNC_TEST} PIN is out of sync with the source of truth PIN in "
+        f"{SYNC_SCRIPT} -- see this file's docstring for the upgrade path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Samira visual-identity compatibility pin: 3 authoritative copies + the
+# source of truth (SAMIRA_SERVER_COMMIT in visual_identity.py itself).
+# ---------------------------------------------------------------------------
+
+def test_samira_pin_is_a_valid_sha():
+    assert _SHA_RE.fullmatch(_samira_pin())
+
+
+def test_visual_identity_docstring_matches_its_own_constant():
+    """Bonus check beyond the task's six: visual_identity.py carries the pin
+    TWICE in one file (the "pinned server normalization block" docstring
+    comment, and the SAMIRA_SERVER_COMMIT constant a few lines below it) --
+    cheap to keep those two from drifting from each other too."""
+    text = VISUAL_IDENTITY.read_text()
+    docstring_pin = _extract_one(
+        text, r"commit [0-9a-f]{40}\.", where=f"{VISUAL_IDENTITY} docstring comment"
+    )
+    assert docstring_pin == _samira_pin(), (
+        f"{VISUAL_IDENTITY}'s docstring comment SHA is out of sync with its "
+        "own SAMIRA_SERVER_COMMIT constant"
+    )
+
+
+def test_samira_pack_matches_visual_identity_pin():
+    data = json.loads(SAMIRA_PACK.read_text())
+    pin = _samira_pin()
+    assert data["normalization_contract"]["source_commit"] == pin, (
+        f"{SAMIRA_PACK} normalization_contract.source_commit is out of sync "
+        f"with the source of truth SAMIRA_SERVER_COMMIT in {VISUAL_IDENTITY} "
+        "-- see this file's docstring for the upgrade path"
+    )
+    assert data["source_server_commit"] == pin, (
+        f"{SAMIRA_PACK} source_server_commit is out of sync with the source "
+        f"of truth SAMIRA_SERVER_COMMIT in {VISUAL_IDENTITY} -- see this "
+        "file's docstring for the upgrade path"
+    )
+
+
+def test_visual_identity_contract_test_matches_visual_identity_pin():
+    text = VISUAL_IDENTITY_CONTRACT_TEST.read_text()
+    literal_pin = _extract_one(
+        text,
+        r"assert SAMIRA_SERVER_COMMIT == \"[0-9a-f]{40}\"",
+        where=str(VISUAL_IDENTITY_CONTRACT_TEST),
+    )
+    assert literal_pin == _samira_pin(), (
+        f"{VISUAL_IDENTITY_CONTRACT_TEST}'s hardcoded literal is out of sync "
+        f"with the source of truth SAMIRA_SERVER_COMMIT in {VISUAL_IDENTITY} "
+        "-- see this file's docstring for the upgrade path"
+    )

--- a/Tests/Architecture/test_vendor_pin_consistency.py
+++ b/Tests/Architecture/test_vendor_pin_consistency.py
@@ -115,11 +115,14 @@ def _samira_pin() -> str:
 # Chunking-engine vendoring pin: 3 authoritative copies + the source of truth.
 # ---------------------------------------------------------------------------
 
-def test_chunking_pin_is_a_valid_sha():
+def test_chunking_pin_is_a_valid_sha() -> None:
+    """The Chunking-engine vendoring pin itself is a 40-char hex SHA."""
     assert _SHA_RE.fullmatch(_chunking_pin())
 
 
-def test_vendor_manifest_matches_sync_script_pin():
+def test_vendor_manifest_matches_sync_script_pin() -> None:
+    """VENDOR_MANIFEST.toml's upstream.commit agrees with the sync script's
+    PIN, the source of truth (see this file's docstring upgrade path)."""
     manifest = tomllib.loads(VENDOR_MANIFEST.read_text())
     assert manifest["upstream"]["commit"] == _chunking_pin(), (
         f"{VENDOR_MANIFEST} upstream.commit is out of sync with the source of "
@@ -128,7 +131,9 @@ def test_vendor_manifest_matches_sync_script_pin():
     )
 
 
-def test_sync_test_pin_matches_sync_script_pin():
+def test_sync_test_pin_matches_sync_script_pin() -> None:
+    """test_sync_script.py's hardcoded PIN agrees with the sync script's own
+    PIN, the source of truth (see this file's docstring upgrade path)."""
     text = SYNC_TEST.read_text()
     test_pin = _extract_one(text, r'^PIN = "[0-9a-f]{40}"', where=str(SYNC_TEST))
     assert test_pin == _chunking_pin(), (
@@ -142,11 +147,12 @@ def test_sync_test_pin_matches_sync_script_pin():
 # source of truth (SAMIRA_SERVER_COMMIT in visual_identity.py itself).
 # ---------------------------------------------------------------------------
 
-def test_samira_pin_is_a_valid_sha():
+def test_samira_pin_is_a_valid_sha() -> None:
+    """The Samira compatibility pin itself is a 40-char hex SHA."""
     assert _SHA_RE.fullmatch(_samira_pin())
 
 
-def test_visual_identity_docstring_matches_its_own_constant():
+def test_visual_identity_docstring_matches_its_own_constant() -> None:
     """Bonus check beyond the task's six: visual_identity.py carries the pin
     TWICE in one file (the "pinned server normalization block" docstring
     comment, and the SAMIRA_SERVER_COMMIT constant a few lines below it) --
@@ -161,7 +167,10 @@ def test_visual_identity_docstring_matches_its_own_constant():
     )
 
 
-def test_samira_pack_matches_visual_identity_pin():
+def test_samira_pack_matches_visual_identity_pin() -> None:
+    """visual_identity_pack.json's two commit fields agree with
+    SAMIRA_SERVER_COMMIT, the source of truth (see this file's docstring
+    upgrade path)."""
     data = json.loads(SAMIRA_PACK.read_text())
     pin = _samira_pin()
     assert data["normalization_contract"]["source_commit"] == pin, (
@@ -176,7 +185,10 @@ def test_samira_pack_matches_visual_identity_pin():
     )
 
 
-def test_visual_identity_contract_test_matches_visual_identity_pin():
+def test_visual_identity_contract_test_matches_visual_identity_pin() -> None:
+    """test_visual_identity_contract.py's hardcoded literal agrees with
+    SAMIRA_SERVER_COMMIT, the source of truth (see this file's docstring
+    upgrade path)."""
     text = VISUAL_IDENTITY_CONTRACT_TEST.read_text()
     literal_pin = _extract_one(
         text,

--- a/Tests/Chunking/test_sync_script.py
+++ b/Tests/Chunking/test_sync_script.py
@@ -4,22 +4,36 @@ import importlib
 import os, subprocess, sys, tomllib
 from pathlib import Path
 
+import pytest
+
 REPO = Path(__file__).resolve().parents[2]
 ENGINE = REPO / "tldw_chatbook" / "Chunking" / "engine"
 SYNC = REPO / "Helper_Scripts" / "sync_chunking_engine.py"
 PIN = "385afa951922c8a9dc2002c675bb6cad65e4ac23"
 
 # The sync flow documents checking out a local worktree at the pin and running
-# the script with --source (the no-arg path git-clones the ~532 MiB upstream
-# repo and never cleans up its temp dir). Use the local worktree when it is
-# available; otherwise exercise the default GitHub-clone path.
-SOURCE = os.environ.get("TLDW_SERVER_SYNC_SOURCE", "/tmp/tldw_server_sync")
+# the script with --source. TASK-19574: there is deliberately no built-in
+# fallback location any more (the old default, /tmp/tldw_server_sync, is a
+# /private/tmp path -- the standing rule here is never to keep work there,
+# since the macOS cleaner has destroyed a worktree in it three times). Point
+# TLDW_SERVER_SYNC_SOURCE at a local tldw_server worktree checked out at PIN
+# to run test_sync_idempotent_and_rejects_local_edits; when it is unset (or
+# the path is gone), that test SKIPS instead of falling through to
+# sync_chunking_engine.py's no-arg path -- which git-clones the ~1.0 GiB
+# upstream repo per invocation (three times for this one test) and, before
+# this task, never cleaned its temp clone up. This module must never itself
+# trigger that network clone.
+SOURCE = os.environ.get("TLDW_SERVER_SYNC_SOURCE")
 
 
 def _run_sync() -> subprocess.CompletedProcess:
-    cmd = [sys.executable, str(SYNC)]
-    if Path(SOURCE).exists():
-        cmd += ["--source", SOURCE]
+    assert SOURCE and Path(SOURCE).exists(), (
+        "_run_sync() must only be called once the caller has confirmed SOURCE "
+        "exists (see the pytest.skip guard in "
+        "test_sync_idempotent_and_rejects_local_edits) -- it never falls "
+        "through to the script's no-arg network-clone path."
+    )
+    cmd = [sys.executable, str(SYNC), "--source", SOURCE]
     return subprocess.run(cmd, capture_output=True, text=True, cwd=str(REPO))
 
 
@@ -169,6 +183,17 @@ def test_no_server_imports_remain():
 
 
 def test_sync_idempotent_and_rejects_local_edits():
+    if not SOURCE or not Path(SOURCE).exists():
+        pytest.skip(
+            "TLDW_SERVER_SYNC_SOURCE is not set to an existing local "
+            f"tldw_server worktree checked out at pin {PIN}; skipping rather "
+            "than falling through to sync_chunking_engine.py's no-arg "
+            "network-clone path (TASK-19574 -- this test must never itself "
+            "trigger a ~1.0 GiB clone from GitHub). Set up a worktree with, "
+            "e.g.: git -C <tldw_server checkout> worktree add "
+            f"<dest> {PIN} && TLDW_SERVER_SYNC_SOURCE=<dest> pytest "
+            "Tests/Chunking/test_sync_script.py"
+        )
     r1 = _run_sync()
     assert r1.returncode == 0, r1.stderr
     # second run is a no-op

--- a/Tests/Chunking/test_sync_script.py
+++ b/Tests/Chunking/test_sync_script.py
@@ -23,10 +23,26 @@ PIN = "385afa951922c8a9dc2002c675bb6cad65e4ac23"
 # upstream repo per invocation (three times for this one test) and, before
 # this task, never cleaned its temp clone up. This module must never itself
 # trigger that network clone.
+#
+# TASK-19574 Qodo review (PR #1999 finding 4): TLDW_SERVER_SYNC_SOURCE is a
+# maintainer-set env var pointing at their own local tldw_server worktree --
+# not user- or model-supplied input reaching the app at runtime -- so it is
+# deliberately not routed through path_validation.py's confine-to-a-
+# workspace-root helpers (see the matching disposition note in
+# sync_chunking_engine.py's main()). The `Path(SOURCE).exists()` check below
+# and the pytest.skip guard it feeds are the whole of what this seam needs:
+# a clear skip instead of a confusing failure or an accidental network clone.
 SOURCE = os.environ.get("TLDW_SERVER_SYNC_SOURCE")
 
 
 def _run_sync() -> subprocess.CompletedProcess:
+    """Run sync_chunking_engine.py --source SOURCE and capture the result.
+
+    Returns:
+        subprocess.CompletedProcess: the finished sync-script invocation
+            (returncode/stdout/stderr), so callers can assert on either a
+            successful sync or a FATAL failure message.
+    """
     assert SOURCE and Path(SOURCE).exists(), (
         "_run_sync() must only be called once the caller has confirmed SOURCE "
         "exists (see the pytest.skip guard in "
@@ -182,7 +198,14 @@ def test_no_server_imports_remain():
         assert "from app.core" not in src, f"{py.name} still references app.core"
 
 
-def test_sync_idempotent_and_rejects_local_edits():
+def test_sync_idempotent_and_rejects_local_edits() -> None:
+    """Two --source runs are a no-op, and a hand-edited vendored file fails
+    the third run loudly instead of being silently overwritten (spec §5.2).
+
+    Skips (rather than falling through to the no-arg network-clone path --
+    TASK-19574) when TLDW_SERVER_SYNC_SOURCE isn't set to an existing local
+    tldw_server worktree.
+    """
     if not SOURCE or not Path(SOURCE).exists():
         pytest.skip(
             "TLDW_SERVER_SYNC_SOURCE is not set to an existing local "

--- a/backlog/tasks/task-19574 - A test clones 1GB from GitHub with no cleanup and vendored trees carry no provenance.md
+++ b/backlog/tasks/task-19574 - A test clones 1GB from GitHub with no cleanup and vendored trees carry no provenance.md
@@ -281,3 +281,66 @@ test for `aider`/`textual_fspicker`, and the wrong `repomap.py:1` comment) and
 repo hygiene (rr-cache expiry, merged-worktree pruning, clearing `gc.log`)
 remain — same task, To Do. The 17 GiB of leaked clones listed above are
 reported, not deleted, per instruction (owner's call).
+
+**Qodo review fix round (PR #1999).** Four findings.
+
+- **Finding 1 (Bug, unchecked `git show`).** Step 3's EXTRA_FILES loop wrote
+  `subprocess.run(...).stdout` straight to disk without checking
+  `returncode` — the same shape as the already-fixed silent-`rmtree`
+  defect. Checked every other `git show` call site in the script
+  (`git_show()` at the vendored-file steps, the test-porting loop's inline
+  `git show`): both already FATAL on a non-zero return code; EXTRA_FILES was
+  the only unchecked one. Added `git_show_bytes()` (matches `git_show()`'s
+  FATAL idiom) and switched step 3 to the same validate-then-write split
+  already used in steps 2/4. Born-red proof: a sandboxed namespace-rebinding
+  harness (rebinds `subprocess`/`tempfile` inside the loaded module's own
+  namespace only; no real git/network at any point) faked `git show` to
+  return code 1 with empty stdout for the one EXTRA_FILES entry. At the
+  pre-fix commit (`8e4081c40`, reconstructed via a local `git show <sha>:
+  <path>` blob read — not a clone) this reproduced the bug exactly: an empty
+  `LICENSE` file was written to disk, `main()` returned 0, and stdout
+  contained "Synced ...". Against the fixed script the same harness now hits
+  `SystemExit` from `git_show_bytes()` before any write happens (no file on
+  disk).
+- **Finding 4 (path validation on `--source`/`TLDW_SERVER_SYNC_SOURCE`).**
+  Declined `path_validation.py` on the merits: both inputs are a
+  maintainer's own local filesystem path on their own machine, not user- or
+  model-supplied input reaching the app at runtime, and `validate_path_
+  simple()`/`validate_path()` exist to confine untrusted paths inside an
+  app-managed workspace root — the opposite relationship of `--source`,
+  which is deliberately a path *outside* this repo (and `validate_path_
+  simple()` would actively reject a legitimate `--source ~/repos/
+  tldw_server`). Instead improved the actual failure mode: `--source` is
+  now `.expanduser()`d, and `main()` gives an explicit FATAL for "does not
+  exist" / "is not a directory" / "is not a git repository (no .git)" before
+  ever reaching `verify_clean()`, which previously was the only diagnostic —
+  a missing path made `git -C <path> rev-parse HEAD` fail with empty stdout,
+  surfacing as the misleading "worktree HEAD  != pin 385afa95" pin-mismatch
+  message. Folded in the reviewer's separate residual: `if args.source:` was
+  a truthy check, so `--source ""` on a direct CLI run (not reachable from
+  the test module, which always passes a real path) silently fell through to
+  the no-arg network-clone path; changed to `if args.source is not None:`
+  with an explicit empty-value FATAL. Added matching disposition comments at
+  both call sites (the script's `main()` and `Tests/Chunking/
+  test_sync_script.py`'s `SOURCE` env-var read) so the reasoning doesn't need
+  rediscovering next review.
+- **Findings 2/3 (rule violations — missing docstrings/type hints).** Added
+  Google-style docstrings and `-> None` return annotations to all 7
+  `test_*` functions in `Tests/Architecture/test_vendor_pin_consistency.py`
+  (all new in this branch), plus to the parts of `Tests/Chunking/
+  test_sync_script.py` this branch actually changed: `_run_sync()` (gained a
+  docstring; already had its return type hint) and
+  `test_sync_idempotent_and_rejects_local_edits()` (gained both). Left every
+  other pre-existing test in both files untouched, per instruction not to
+  sweep unrelated tests.
+
+**Re-verification.** `Tests/Chunking/` + `Tests/Architecture/
+test_vendor_pin_consistency.py`: **607 passed, 26 skipped, 1 xfailed**, plus
+the same 2 pre-existing failures as the prior verification pass
+(`test_chunker_v2.py::test_process_text_tokenizer_override`,
+`test_golden_parity.py::test_golden_parity[tokens-cjk]`) — reconfirmed
+unrelated to this branch via a 3-dot merge-base diff
+(`origin/dev...HEAD -- Tests/Chunking/test_chunker_v2.py Tests/Chunking/
+test_golden_parity.py` is empty). The new pin-consistency guard stayed 7/7.
+Leaked-clone count under `$TMPDIR` after this run: still **17** — unchanged,
+confirming the cleanup fix still holds and this round didn't add any.

--- a/backlog/tasks/task-19574 - A test clones 1GB from GitHub with no cleanup and vendored trees carry no provenance.md
+++ b/backlog/tasks/task-19574 - A test clones 1GB from GitHub with no cleanup and vendored trees carry no provenance.md
@@ -3,7 +3,7 @@ id: TASK-19574
 title: >-
   A test clones 1 GiB from GitHub with no cleanup, vendored trees carry no
   provenance, and the repo is 47 GiB with gc suppressed
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-21 20:27'
 labels:
@@ -106,15 +106,17 @@ to remove them."*
 
 ## Acceptance Criteria
 
-- [ ] `Tests/Chunking/test_sync_script.py` **skips** when its source clone is
+- [x] `Tests/Chunking/test_sync_script.py` **skips** when its source clone is
       absent; it never initiates a network clone from inside a test
-- [ ] Any temporary clone the sync script creates is removed on both success
+- [x] Any temporary clone the sync script creates is removed on both success
       and failure paths
 - [ ] The test cannot leave a corrupted vendored tree if it dies mid-run
+      (partially addressed — see Implementation Notes for the residual risk)
 - [ ] The 3.9 GiB of leaked clones under `TMPDIR` are removed **after** being
       confirmed as leaked temp clones (inspect, then delete — do not glob-delete)
-- [ ] The default source path moves off `/private/tmp`, per the standing rule
-- [ ] The six copies of the vendor pin are reduced to one source of truth, or a
+      (inspected and reported, NOT deleted — see Implementation Notes)
+- [x] The default source path moves off `/private/tmp`, per the standing rule
+- [x] The six copies of the vendor pin are reduced to one source of truth, or a
       test cross-checks them; a documented upgrade path exists for bumping it
 - [ ] `Third_Party/` gains provenance: upstream URL and a **commit SHA** per
       vendored tree, and a drift test that fails when a vendored file diverges
@@ -128,3 +130,154 @@ to remove them."*
 - [ ] The 12 dirty-but-merged worktrees are individually inspected and their
       owners consulted before anything is removed
 - [ ] Before/after sizes are recorded
+
+## Implementation Plan
+
+This pass scopes to the description's **A** section (the leaking test/clone)
+plus the six-copy vendor-pin duplication called out at the end of A. The
+Third_Party/ provenance work (description's B) and repo-hygiene work
+(description's C — `rr-cache`, worktree pruning, `gc.log`) are explicitly
+out of scope for this pass; task stays **In Progress** rather than Done.
+
+1. Reproduce born-red: with `subprocess.run` monkeypatched (no real clone),
+   confirm the CURRENT `test_sync_script.py::_run_sync()` builds a command
+   with no `--source` when the source path is absent — i.e. it would fall
+   through to the script's no-arg network-clone path.
+2. Fix `Tests/Chunking/test_sync_script.py`: remove the `/tmp/tldw_server_sync`
+   default (moves the default off `/private/tmp` entirely — no default at
+   all), and make `test_sync_idempotent_and_rejects_local_edits` `pytest.skip`
+   explicitly when `TLDW_SERVER_SYNC_SOURCE` is unset or the path doesn't
+   exist, instead of silently falling through.
+3. Fix `Helper_Scripts/sync_chunking_engine.py`: wrap the no-arg temp-clone
+   path in `try`/`finally` so `shutil.rmtree` always removes it (success,
+   loud `sys.exit`, or an uncaught exception). Split the vendored-file and
+   ported-test write loops into validate-then-write passes (mirroring the
+   existing step-1 local-modification check) so a FATAL patch-anchor failure
+   can't happen mid-write.
+4. Prove cleanup on both the success path and a forced mid-sync failure path,
+   with everything network-related mocked and all writes redirected to an
+   isolated sandbox (never touching the real vendored tree).
+5. Run the real end-to-end sync against a local `tldw_server` worktree at the
+   pin (no network — the commit is already present in a local `tldw_server2`
+   checkout) to confirm the refactor doesn't change output.
+6. Investigate the "six authoritative pin copies" claim: confirm they are
+   actually TWO independent pins (Chunking vendoring vs. Samira visual-identity
+   compatibility) that coincidentally share one value today. Add a guard test
+   cross-checking each cluster against its own designated source of truth,
+   plus a documented upgrade path for bumping either one.
+7. Bite-proof the guard: mutate one copy in each cluster, confirm the
+   corresponding (and only that) test reds, Edit-restore, confirm clean diff.
+8. Inspect and report leaked clones under `$TMPDIR` — do not delete.
+9. Run `Tests/Chunking/`, the new guard test, and a repo-wide
+   `--collect-only` sweep; hand-edit this task file (no `backlog` CLI on a
+   five-digit id).
+
+## Implementation Notes
+
+**Scope.** This pass covers the leaking-test/clone problem and the
+vendor-pin-duplication guard only. `Third_Party/` provenance and repo-hygiene
+(rr-cache/worktree pruning/gc.log) are untouched — separate work, left To Do
+on this same task; status stays In Progress rather than Done since not all
+ACs are met.
+
+**A — test skip + script cleanup.**
+- `Tests/Chunking/test_sync_script.py`: `SOURCE` no longer defaults to
+  `/tmp/tldw_server_sync` (a `/private/tmp` path — the standing rule is never
+  to keep work there). It now reads only `TLDW_SERVER_SYNC_SOURCE`.
+  `test_sync_idempotent_and_rejects_local_edits` (the only caller of
+  `_run_sync()`) `pytest.skip`s with an actionable message when that path is
+  unset or absent; `_run_sync()` itself now asserts the source exists rather
+  than silently omitting `--source`, so this module can never trigger the
+  no-arg network-clone path from any test.
+  Born-red proof (against the unedited file, `subprocess.run` monkeypatched
+  so nothing real ran): absent source → `_run_sync()` built
+  `[python, sync_chunking_engine.py]` with no `--source` — confirmed the
+  vulnerable fallthrough existed, including on THIS machine right now (the
+  local reference worktree the review's snapshot referenced,
+  `/private/tmp/tldw_server_sync`, is gone as of this session — probably
+  reaped by the same tmp cleaner the standing rule warns about).
+- `Helper_Scripts/sync_chunking_engine.py`: chose to make the script clean up
+  after itself (a `finally: shutil.rmtree(tmp, ignore_errors=True)` around the
+  whole sync flow) rather than relying solely on the test-level fix, since the
+  script is invoked outside tests too and every other caller was equally
+  exposed to the leak. `SystemExit` (the script's own `sys.exit(...)` FATAL
+  path) still runs `finally`, so both the happy path and a loud failure clean
+  up. Also split the two write loops (vendored-file copy, step 2; ported-test
+  copy, step 4) into validate-then-write passes, matching the pattern the
+  existing step 1 (local-modification check) already used for the vendored
+  files: every output is computed first (a missing patch anchor can still
+  FATAL here, e.g. on a first-time sync of a newly-vendored file with no
+  local copy for step 1 to diff against), and only written once the full set
+  succeeds. This closes the most likely real trigger for "crash mid-test
+  corrupts the tree" (a `_fail()`/`sys.exit` firing partway through a write
+  loop) but does **not** make the write itself atomic — a true `kill -9` or
+  power loss mid-write-loop can still leave a partial tree; a full
+  transactional swap (write to staging dir, then rename into place) would be
+  needed to close that residual gap and was judged out of proportion for this
+  pass, hence that AC is left unticked with this caveat rather than claimed.
+  Cleanup proof: a sandboxed harness (writes redirected via `TARGET_ROOT`/
+  `TARGET_TESTS_ROOT` monkeypatch, `subprocess.run` replaced with an
+  in-process fake — no real clone/network at any point) exercised both the
+  success path and a forced mid-sync FATAL (missing upstream file), and
+  confirmed no `tldw_server_sync_*` temp dir survived either scenario.
+  A real end-to-end run against a local `tldw_server` worktree at the pin
+  (created from the pre-existing local `~/Documents/GitHub/tldw_server2`
+  checkout, which already had the pin commit — no network touched) confirmed
+  the refactor is byte-identical: `Tests/Chunking/test_sync_script.py` 10/10
+  passed, `git status` clean afterward (idempotent re-sync).
+- **Leaked clones found, NOT deleted (owner's call):** 17 directories under
+  `$TMPDIR` (`/var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/`), each 1.0
+  GiB, **17 GiB total** — worse than the review's 4/3.9 GiB snapshot, and all
+  dated *today* (18:47–21:06), confirming other concurrent sessions on this
+  machine kept hitting the bug throughout the day:
+  `tldw_server_sync_{te2lh67f,0bcgwtmx,lj_0wrm8,9uskt8c1,5ty_150w,hwyawdaj,
+  mp3v13pz,hddj3sqk,uyp403d9,34uk7snw,p6g2i9cn,h3wg9z7c,vsuoltrq,8pi4b5ux,
+  vd4394v7,v9xrvg2o,eel_6wvp}`.
+
+**B (pin duplication) — cross-check guard.** Investigated the "six
+authoritative places" claim: they are actually **two independent pins**
+that happen to share one commit SHA today — the Chunking-engine vendoring
+pin (code copied from `app/core/Chunking`) and the Samira visual-identity
+compatibility pin (`app/core/Visual_Identities/expression_slots.py`
+normalization contract + bundled asset pack). Nothing requires them to move
+together, so the new guard (`Tests/Architecture/test_vendor_pin_consistency.py`)
+does **not** assert cross-cluster equality — only that every hand-maintained
+copy in each cluster agrees with that cluster's own source of truth:
+`Helper_Scripts/sync_chunking_engine.py`'s `PIN` for Chunking (checked
+against `VENDOR_MANIFEST.toml` and `test_sync_script.py`'s own `PIN`), and
+`Character_Chat/visual_identity.py`'s `SAMIRA_SERVER_COMMIT` for Samira
+(checked against its own docstring comment, `visual_identity_pack.json`'s
+two fields, and `test_visual_identity_contract.py`'s hardcoded literal). The
+module docstring documents the upgrade path for bumping either pin. The
+further ~19 copies scattered across `backlog/` decision records and
+`Docs/superpowers/` planning docs are deliberately excluded — they are
+point-in-time historical snapshots, not live configuration; rewriting them on
+every future pin bump would misrepresent history.
+Bite-proof: mutated `VENDOR_MANIFEST.toml`'s `commit` (Chunking cluster) —
+exactly `test_vendor_manifest_matches_sync_script_pin` reddened, the other 6
+guard tests stayed green; Edit-restored, `git diff` clean. Repeated for
+`visual_identity_pack.json`'s `source_server_commit` (Samira cluster) —
+exactly `test_samira_pack_matches_visual_identity_pin` reddened; Edit-restored,
+`git diff` clean.
+
+**Verification.** `Tests/Chunking/` (no `TLDW_SERVER_SYNC_SOURCE`): 600
+passed, 26 skipped (incl. the new explicit skip), 1 xfailed, **2 pre-existing
+failures unrelated to this change** (`test_process_text_tokenizer_override`,
+`test_golden_parity[tokens-cjk]` — both fail on this machine's stale/missing
+real gpt2 tokenizer cache reaching out to huggingface.co; `git diff origin/dev`
+on the touched files is empty, confirming they're environmental, not caused
+by this branch). `Tests/Architecture/test_vendor_pin_consistency.py`: 7/7
+passed. Repo-wide `--collect-only -q`: 56862 tests collected, 1 collection
+error — `Tests/UI/test_library_file_notes_workspace.py` (TASK-20972, a
+pre-existing dev red, not from this branch).
+
+**Files changed:**
+- `Tests/Chunking/test_sync_script.py`
+- `Helper_Scripts/sync_chunking_engine.py`
+- `Tests/Architecture/test_vendor_pin_consistency.py` (new)
+
+**Follow-up.** `Third_Party/` provenance (upstream URL + commit SHA + drift
+test for `aider`/`textual_fspicker`, and the wrong `repomap.py:1` comment) and
+repo hygiene (rr-cache expiry, merged-worktree pruning, clearing `gc.log`)
+remain — same task, To Do. The 17 GiB of leaked clones listed above are
+reported, not deleted, per instruction (owner's call).


### PR DESCRIPTION
Addresses TASK-19574 parts A and B. **The task stays In Progress**: the `Third_Party/` provenance and repo-hygiene criteria are unmet, each marked with a reason rather than left as a silent unticked box.

## A test cloned 1 GiB from GitHub, three times per run, and never cleaned up

`Tests/Chunking/test_sync_script.py` had **no `pytest.skip`**. An absent source fell through to the no-arg path, and the sync script then did `tempfile.mkdtemp(...)` + `git clone --no-checkout` — and never removed it.

**Measured on this machine at review time: 17 directories, 1.0 GiB each, 17 GiB total, all dated today** — up from the 4 directories / 3.9 GiB the original review found, because concurrent sessions kept running the suite. They are left in place; deleting them is the owner's call.

Two things kept this invisible. The repo's **network guard cannot stop it** — the guard patches sockets, and this is a `git` subprocess. And the fallthrough was masked locally by a reference worktree at `/private/tmp/tldw_server_sync`, which **has since been removed by the macOS cleaner** — exactly the hazard behind this repo's "never keep work in `/private/tmp`" rule. So the condition that hid the bug has expired, and the default pointed there.

`SOURCE` now reads only `TLDW_SERVER_SYNC_SOURCE`, the test skips with an actionable message when it is unset or absent, and `_run_sync()` **asserts** the source exists rather than silently omitting `--source`.

Review drove eight adversarial inputs through `_run_sync()` with `subprocess.run` monkeypatched — including the classic hole, an **empty string**, which is set but falsy — and confirmed **no path can construct an argv without `--source`**. All four env states also produce a clean `SKIPPED` under real pytest, never an error or a silent pass.

## The script cleans up after itself too

The test skipping fixes today's symptom while leaving the script a leak for anyone who runs it by hand, so the no-arg temp-clone flow is wrapped in `try/finally` with an `rmtree`. Verified across success, a real `sys.exit`, an uncaught exception, and `KeyboardInterrupt` — no temp directory survives any of them.

**Review found a real gap in that cleanup and fixed it.** `shutil.rmtree(..., ignore_errors=True)` can silently fail: planting a `chmod 0o000` subdirectory inside the clone makes it return normally, raise nothing, and leave the gigabyte behind **with no diagnostic anywhere** — a leak wearing a `finally`. There is now a post-hoc existence check that warns to stderr, deliberately non-raising so it cannot mask an exception already propagating through the `finally`.

The write loops are also split into validate-then-write passes so a mid-run FATAL cannot leave a half-written tree. Instrumented per phase: a crash during validation leaves zero files; a crash between phases leaves the earlier phase complete and the later one untouched. This is scoped honestly as protection against a **controlled** exit — no Python runs during `kill -9`, so no `finally` could close that gap, and it is not presented as crash-safety.

## The pin: a correction to the task's own framing

The task describes the vendoring pin as duplicated across **six authoritative places**. It is really **two independent pins** that coincidentally share one SHA today — a Chunking-engine vendoring pin and a Samira visual-identity compatibility pin, from different upstream subsystems, not required to move together. Review verified this in both directions: zero cross-references either way, and blame shows the two were pinned five days apart from the same local upstream checkout.

That matters, because had they been coupled, splitting them into two clusters would let a real drift through — worse than the duplication. The new guard designates one source of truth per cluster and cross-checks the rest against **its own** cluster, with the upgrade path documented.

Bite-proved twice with copies the implementer did not mutate: changing the test module's `PIN` reds exactly the Chunking guard; changing the visual-identity contract literal reds exactly the Samira guard — and **no Chunking test reacts**, which is the independence claim demonstrated rather than asserted.

Review also found **three more live-code references to the SHA** the enumeration missed (`RAG_Admin/template_validation.py`, `DB/Client_Media_DB_v2.py`, and a fixture's `_header.upstream_source.pin`), each confirmed inert documentation — the fixture's field is never read. Recorded for the follow-up rather than swept in here.

## Verification

- `Tests/Chunking/` + the new guard: **600 passed / 26 skipped / 1 xfailed**, with 2 failures attributed to a stale local HuggingFace gpt2 tokenizer cache. That attribution was **verified via the 3-dot merge-base diff**, not accepted: this branch touches exactly four files, with zero diff on either failing test or anything under `Chunking/engine/`. (Note for future reviewers: 2-dot `git diff origin/dev..HEAD` is misleading here, since dev has advanced independently.)
- New guard 7/7, before and after both mutation restores.
- Repo-wide `--collect-only`: 56,862 with the one known dev red (TASK-20972).
- **No real clone and no network at any point**, in either the implementation or the review — reproducing this defect for real would have made it worse.
- Confirmed after a full suite run on the fixed branch: still 17 leaked directories, not 20. The three this run would previously have added did not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Chunking vendoring test from cloning/leaking ~1 GiB repos and adds a pin-consistency guard. The sync script now always cleans up temp clones, validates `--source`, checks `git show` return codes, and warns if cleanup fails.

- Skips `Tests/Chunking/test_sync_script.py::test_sync_idempotent_and_rejects_local_edits` when `TLDW_SERVER_SYNC_SOURCE` is unset/missing; no default path and no fallthrough to a network clone. `_run_sync()` always passes `--source` and asserts it exists.
- `Helper_Scripts/sync_chunking_engine.py`: wraps temp-clone path in `try/finally` with `shutil.rmtree(..., ignore_errors=True)` and a post-hoc existence WARNING; rejects empty `--source`, expands `~`, and fails explicitly for missing/non-dir/non-git paths before pin checks; switches all writes to validate-then-write; new `git_show_bytes()` fails loudly on `git show` errors.
- New `Tests/Architecture/test_vendor_pin_consistency.py`: cross-checks two independent upstream pins. Each cluster must match its own source of truth (Chunking vendoring PIN vs. Samira visual-identity PIN); they are not required to equal each other.

**Required actions**
- To run the idempotency test, set `TLDW_SERVER_SYNC_SOURCE` to a local `tldw_server` worktree at the pinned commit; there is no default path.
- When bumping the Chunking vendoring PIN, update `PIN` in `Helper_Scripts/sync_chunking_engine.py`, `upstream.commit` in `tldw_chatbook/Chunking/engine/VENDOR_MANIFEST.toml`, and the `PIN` in `Tests/Chunking/test_sync_script.py`, then re-run the sync.
- When bumping the Samira compatibility PIN, update `SAMIRA_SERVER_COMMIT` (and its nearby doc comment) in `tldw_chatbook/Character_Chat/visual_identity.py`, the literal in `Tests/Character_Chat/test_visual_identity_contract.py`, and regenerate `tldw_chatbook/assets/characters/samira/visual_identity_pack.json`.

<sup>Written for commit 6f8536b8839304e9f63efe9fcd533fad5b8ee947. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

