### PR TITLE
fix(backlog): restore Windows-safe task checkout

### DIFF
--- a/Docs/superpowers/plans/2026-08-23-task-21139-windows-safe-backlog-paths.md
+++ b/Docs/superpowers/plans/2026-08-23-task-21139-windows-safe-backlog-paths.md
@@ -1,0 +1,562 @@
+# TASK-21139 Windows-Safe Backlog Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore Windows checkout by renaming TASK-21130 without changing its contents and make the existing stdlib Backlog guard reject future Windows-incompatible task filenames.
+
+**Architecture:** Keep the policy in `scripts/check_backlog_task_ids.py`, the existing owner of all three Backlog task buckets and all current local/CI entry points. Add one pure basename classifier and one non-recursive bucket scanner, compose their result with the unchanged duplicate-ID result in `main()`, and repair only the incompatible TASK-21130 path.
+
+**Tech Stack:** Python 3.11+ standard library, pytest, Ruff, Backlog.md task files, GitHub Actions, Git/GitHub CLI
+
+---
+
+## File map
+
+- Modify `scripts/check_backlog_task_ids.py`: define the Windows basename policy, scan the existing task buckets, report every incompatible path, and combine that result with duplicate-ID validation.
+- Modify `Tests/Architecture/test_derived_artifact_checkers.py`: focused unit and CLI-composition coverage for the classifier and scanner.
+- Rename `backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md` to `backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md`: remove the checkout blocker while preserving task bytes.
+- Modify `backlog/docs/lessons-backlog-hygiene.md`: record the concrete Windows-checkout incident and the new authoring-time guard.
+- Modify `backlog/tasks/task-21139 - Restore Windows checkout for Backlog task paths.md`: track this plan, checked acceptance criteria, implementation notes, and final status.
+- Create `Docs/superpowers/plans/2026-08-23-task-21139-windows-safe-backlog-paths.md`: this executable plan.
+- No workflow file changes: `scripts/preflight.sh`, `.github/workflows/backlog-guard.yml`, and `.github/workflows/derived-artifacts.yml` already invoke the shared checker.
+
+## ADR check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a focused CI-portability repair within an existing stdlib guard. It does not alter storage, schemas, runtime ownership, security boundaries, dependencies, or cross-module contracts.
+
+## Execution constraints
+
+- Follow `@superpowers:test-driven-development` for behavior changes and `@ponytail` full: add only the two small functions and reporting composition required by the approved design.
+- Run only tests and static checks related to the modified checker/workflows. Do not run the broad local suite.
+- If a scoped local or CI test fails for a reason unrelated to this task, capture the evidence and create a Backlog task; do not broaden TASK-21139 to repair it.
+- Preserve `duplicate_ids()` and its return contract exactly.
+- Use `apply_patch` for every repository edit, including the filename move.
+
+### Task 1: Pin the Windows basename contract with failing focused tests
+
+**Files:**
+- Modify: `Tests/Architecture/test_derived_artifact_checkers.py:12-14,337-403`
+- Test: `Tests/Architecture/test_derived_artifact_checkers.py`
+
+- [ ] **Step 1: Add pytest for compact table-driven policy coverage**
+
+Add the existing test dependency beside the current standard-library imports:
+
+```python
+import pytest
+```
+
+- [ ] **Step 2: Add a failing test for every forbidden-character class**
+
+Add direct pure-classifier tests so `/` and NUL are testable even though POSIX cannot create basenames containing them:
+
+```python
+@pytest.mark.parametrize("character", '<>:"/\\|?*')
+def test_windows_task_name_rejects_every_reserved_character(character):
+    reason = backlog_ids.windows_incompatible_reason(f"task-1 - Bad{character}Name.md")
+    assert reason == f"contains Windows-reserved character {character!r}"
+
+
+@pytest.mark.parametrize("character", ["\x00", "\x01", "\x1f"])
+def test_windows_task_name_rejects_ascii_controls(character):
+    reason = backlog_ids.windows_incompatible_reason(f"task-1 - Bad{character}Name.md")
+    assert reason == f"contains ASCII control U+{ord(character):04X}"
+```
+
+- [ ] **Step 3: Add failing tests for trailing characters and device stems**
+
+Cover case-insensitivity, every device family, superscript aliases, the first-period rule, and valid boundaries:
+
+```python
+@pytest.mark.parametrize("name", ["task-1 - Bad.md.", "task-1 - Bad.md "])
+def test_windows_task_name_rejects_trailing_dot_or_space(name):
+    assert backlog_ids.windows_incompatible_reason(name) == "ends with a dot or space"
+
+
+@pytest.mark.parametrize(
+    "name, stem",
+    [
+        ("CON", "CON"), ("prn.md", "PRN"), ("Aux.notes.md", "AUX"),
+        ("NUL.tar.gz", "NUL"), ("com1.md", "COM1"), ("COM9.log", "COM9"),
+        ("com¹.log", "COM¹"), ("COM².log", "COM²"),
+        ("Com³.tar.gz", "COM³"),
+        ("lpt1.md", "LPT1"), ("LPT9.log", "LPT9"),
+        ("lpt¹.log", "LPT¹"), ("LPT².log", "LPT²"),
+        ("Lpt³.tar.gz", "LPT³"),
+    ],
+)
+def test_windows_task_name_rejects_reserved_device_stems(name, stem):
+    assert backlog_ids.windows_incompatible_reason(name) == (
+        f"uses reserved Windows device name {stem!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "task-1 - Ordinary title.md", "task-2 - Version v3-to-v4 (safe).md",
+        "task-3 - CON appears after the task prefix.md", "COM0.md", "COM10.md",
+        "COM⁴.md", "LPT0.md", "LPT10.md", "LPT⁴.md",
+    ],
+)
+def test_windows_task_name_accepts_valid_names(name):
+    assert backlog_ids.windows_incompatible_reason(name) is None
+```
+
+- [ ] **Step 4: Add a failing scanner test using POSIX-creatable invalid files**
+
+Exercise direct bucket contents, absent optional buckets, stable full-path labels outside the repository, and directory exclusion:
+
+```python
+def test_windows_incompatible_paths_scan_files_in_each_existing_bucket(tmp_path):
+    tasks = tmp_path / "tasks"
+    completed = tmp_path / "completed"
+    archive = tmp_path / "archive" / "tasks"
+    tasks.mkdir()
+    completed.mkdir()
+    archive.mkdir(parents=True)
+    invalid = {
+        tasks / "task-1 - Bad>Name.md": "contains Windows-reserved character '>'",
+        completed / "task-2 - Control\x1f.md": "contains ASCII control U+001F",
+        archive / "NUL.tar.gz": "uses reserved Windows device name 'NUL'",
+        archive / "task-3 - Trailing.md ": "ends with a dot or space",
+    }
+    for path in invalid:
+        path.write_text("id: TASK-1\n", encoding="utf-8")
+    (tasks / "task-4 - Safe.md").write_text("id: TASK-4\n", encoding="utf-8")
+    (tasks / "task-5 - Directory?.md").mkdir()
+
+    assert backlog_ids.windows_incompatible_paths(
+        tasks, completed, archive, tmp_path / "absent"
+    ) == {path.resolve().as_posix(): reason for path, reason in invalid.items()}
+```
+
+- [ ] **Step 5: Add a failing CLI-composition test**
+
+Prove one invocation reports duplicate IDs and incompatible paths rather than short-circuiting after the first problem:
+
+```python
+def test_main_reports_duplicate_ids_and_windows_paths_together(tmp_path, capsys):
+    first = tmp_path / "task-42 - First?.md"
+    second = tmp_path / "task-42 - Second.md"
+    first.write_text("id: TASK-42\n", encoding="utf-8")
+    second.write_text("id: TASK-42\n", encoding="utf-8")
+
+    assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    report = captured.out + captured.err
+    assert "Duplicate backlog task IDs" in report
+    assert "Windows-incompatible Backlog task paths" in report
+    assert first.resolve().as_posix() in report
+    assert "Keep punctuation in task content" in report
+```
+
+- [ ] **Step 6: Run only the new tests and verify RED for the missing API**
+
+Run:
+
+```bash
+pytest -q \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_every_reserved_character \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_ascii_controls \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_trailing_dot_or_space \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_reserved_device_stems \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_accepts_valid_names \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_incompatible_paths_scan_files_in_each_existing_bucket \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_main_reports_duplicate_ids_and_windows_paths_together
+```
+
+Expected: FAIL because `windows_incompatible_reason` and `windows_incompatible_paths` do not exist. Confirm the failure is the intended missing-behavior failure, not fixture or collection breakage.
+
+- [ ] **Step 7: Commit the RED tests**
+
+```bash
+git add Tests/Architecture/test_derived_artifact_checkers.py
+git commit -m "test(backlog): pin Windows-safe task filenames"
+```
+
+### Task 2: Implement the minimal stdlib classifier and scanner
+
+**Files:**
+- Modify: `scripts/check_backlog_task_ids.py:1-55,91-191`
+- Test: `Tests/Architecture/test_derived_artifact_checkers.py`
+
+- [ ] **Step 1: Extend the module contract and define the policy constants**
+
+Update the module docstring to cover duplicate IDs and Windows-representable paths. Add only these constants after the existing regexes:
+
+```python
+WINDOWS_RESERVED_CHARACTERS = frozenset('<>:"/\\|?*')
+WINDOWS_RESERVED_DEVICE_NAMES = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{suffix}" for suffix in (*map(str, range(1, 10)), "¹", "²", "³")}
+    | {f"lpt{suffix}" for suffix in (*map(str, range(1, 10)), "¹", "²", "³")}
+)
+WINDOWS_PATH_RESOLUTION = (
+    "Keep punctuation in task content, but rename the task file with a "
+    "Windows-safe spelling and update live path references."
+)
+```
+
+- [ ] **Step 2: Add the pure basename classifier**
+
+Place it before `duplicate_ids()` so scanner and tests share one source of truth:
+
+```python
+def windows_incompatible_reason(name: str) -> str | None:
+    """Return why a basename cannot be represented by Win32, else ``None``."""
+    for character in name:
+        if ord(character) <= 0x1F:
+            return f"contains ASCII control U+{ord(character):04X}"
+        if character in WINDOWS_RESERVED_CHARACTERS:
+            return f"contains Windows-reserved character {character!r}"
+    if name.endswith((".", " ")):
+        return "ends with a dot or space"
+    device_stem = name.split(".", 1)[0].casefold()
+    if device_stem in WINDOWS_RESERVED_DEVICE_NAMES:
+        return f"uses reserved Windows device name {device_stem.upper()!r}"
+    return None
+```
+
+- [ ] **Step 3: Add the non-recursive bucket scanner**
+
+Use `iterdir()` rather than `glob("*.md")` so invalid extensions/trailing characters cannot hide from the portability guard. Keep directories out of scope:
+
+```python
+def windows_incompatible_paths(*task_dirs: Path) -> dict[str, str]:
+    """Return directly contained files whose basenames Win32 rejects."""
+    invalid: dict[str, str] = {}
+    for task_dir in task_dirs:
+        if not task_dir.is_dir():
+            continue
+        for path in sorted(task_dir.iterdir()):
+            if not path.is_file():
+                continue
+            reason = windows_incompatible_reason(path.name)
+            if reason:
+                invalid[_label(path)] = reason
+    return invalid
+```
+
+- [ ] **Step 4: Compose path reporting with duplicate-ID reporting**
+
+Add a focused reporter and update `main()` without altering `duplicate_ids()`:
+
+```python
+def _report_windows_incompatible(invalid: dict[str, str]) -> None:
+    print("::error::Windows-incompatible Backlog task paths:")
+    for path, reason in sorted(invalid.items()):
+        print(f"  {path}: {reason}")
+
+
+# Inside main(), after duplicate_ids(...):
+invalid_paths = windows_incompatible_paths(*task_dirs)
+# Report filename_dupes, frontmatter_dupes, and invalid_paths independently.
+# Print RESOLUTION only when duplicate IDs exist.
+# Print WINDOWS_PATH_RESOLUTION only when invalid_paths exists.
+# Return 1 when any of the three collections is non-empty.
+```
+
+Update `main()`'s docstring and success text to say IDs are unique and paths are Windows-compatible.
+
+- [ ] **Step 5: Run the new tests and verify GREEN**
+
+Run the exact seven-node command from Task 1, Step 6.
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 6: Run the existing Backlog checker regression tests**
+
+Run:
+
+```bash
+pytest -q \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_duplicate_task_ids_are_caught_in_both_namespaces \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_duplicate_task_ids_are_caught_across_buckets \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_default_scope_is_every_bucket_the_cli_resolves \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_an_absent_optional_bucket_is_not_an_error \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_unique_task_ids_pass
+```
+
+Expected: 5 passed; `duplicate_ids()` behavior remains unchanged.
+
+- [ ] **Step 7: Demonstrate the real repository now fails for the intended path**
+
+Run:
+
+```bash
+python3 scripts/check_backlog_task_ids.py
+```
+
+Expected: exit 1 and output naming TASK-21130's `v3->v4` path with `contains Windows-reserved character '>'`. This is the integration RED before the repair.
+
+- [ ] **Step 8: Commit the minimal guard**
+
+```bash
+git add scripts/check_backlog_task_ids.py
+git commit -m "fix(backlog): reject Windows-incompatible task paths"
+```
+
+### Task 3: Repair TASK-21130 without changing task content
+
+**Files:**
+- Rename: `backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md` -> `backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md`
+- Verify: repository references to the old path
+
+- [ ] **Step 1: Record the source task's byte hash and identity**
+
+Run:
+
+```bash
+shasum -a 256 'backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md'
+sed -n '1,45p' 'backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md'
+```
+
+Expected: record the SHA-256 and confirm frontmatter `id: TASK-21130`. Do not edit any bytes inside the task.
+
+- [ ] **Step 2: Move the file with apply_patch**
+
+Use an `apply_patch` move from the old path to the new `v3-to-v4` path with no content edits.
+
+- [ ] **Step 3: Prove the task bytes and identity are unchanged**
+
+Run:
+
+```bash
+shasum -a 256 'backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md'
+git add -- \
+  'backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md' \
+  'backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md'
+git diff --cached --summary -- \
+  'backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md' \
+  'backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md'
+git diff --cached -- \
+  'backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md' \
+  'backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md'
+```
+
+Expected: SHA-256 exactly matches Step 1; the staged diff identifies a pure rename and shows no content hunk. Leave the verified rename staged for the Task 3 commit.
+
+- [ ] **Step 4: Audit references to the old path**
+
+Run:
+
+```bash
+git grep -n -F \
+  'task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md' \
+  -- . \
+  ':!Docs/superpowers/specs/2026-08-23-task-21139-windows-safe-backlog-paths-design.md' \
+  ':!Docs/superpowers/plans/2026-08-23-task-21139-windows-safe-backlog-paths.md'
+```
+
+Expected: no matches outside the approved design and this implementation plan, which intentionally retain the old literal as historical evidence and as the rename procedure. Update any resolvable link, command, or live path value with `apply_patch`; do not rewrite unrelated `v3->v4` prose or TASK-21130's content.
+
+- [ ] **Step 5: Demonstrate integration GREEN on the real inventory**
+
+Run:
+
+```bash
+python3 scripts/check_backlog_task_ids.py
+pytest -q Tests/CI/test_backlog_task_id_uniqueness.py
+```
+
+Expected: checker exits 0 with no false positive across live/completed/archive; the focused local uniqueness module passes.
+
+- [ ] **Step 6: Commit the pure path repair**
+
+```bash
+git add 'backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md' 'backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md'
+git commit -m "fix(backlog): make TASK-21130 path Windows-safe"
+```
+
+### Task 4: Document the incident and run the complete scoped local gate
+
+**Files:**
+- Modify: `backlog/docs/lessons-backlog-hygiene.md`
+- Test: `Tests/Architecture/test_derived_artifact_checkers.py`
+- Test: `Tests/CI/test_backlog_task_id_uniqueness.py`
+- Test: `Tests/CI/test_derived_artifacts_workflow.py`
+
+- [ ] **Step 1: Add the evidence-based Backlog hygiene lesson**
+
+Append a short entry following the existing file's format:
+
+```markdown
+### Backlog filenames must survive every supported checkout platform (TASK-21139)
+
+**Incident:** On 2026-08-22, commit `46cb7bc1f` added TASK-21130 with `>` in its
+tracked filename. Git for Windows fetched the repository but `actions/checkout`
+failed with exit 128 before project tests in runs `32617893248` and `32617893237`.
+
+**Lesson:** Keep task content expressive, but keep files directly inside the live,
+completed, and archived Backlog buckets Win32-compatible. The shared stdlib
+Backlog guard is the authoring-time source of truth; a Windows job cannot report
+this cleanly because checkout fails before repository code can run.
+```
+
+- [ ] **Step 2: Run the focused architecture tests for the modified checker**
+
+Run:
+
+```bash
+pytest -q \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_every_reserved_character \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_ascii_controls \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_trailing_dot_or_space \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_reserved_device_stems \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_accepts_valid_names \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_incompatible_paths_scan_files_in_each_existing_bucket \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_main_reports_duplicate_ids_and_windows_paths_together \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_duplicate_task_ids_are_caught_in_both_namespaces \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_duplicate_task_ids_are_caught_across_buckets \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_default_scope_is_every_bucket_the_cli_resolves \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_an_absent_optional_bucket_is_not_an_error \
+  Tests/Architecture/test_derived_artifact_checkers.py::test_unique_task_ids_pass
+```
+
+Expected: all 12 selected Backlog checker nodes pass, including every new test and the five existing regressions.
+
+- [ ] **Step 3: Run the focused CI contract tests**
+
+Run:
+
+```bash
+pytest -q \
+  Tests/CI/test_backlog_task_id_uniqueness.py \
+  Tests/CI/test_derived_artifacts_workflow.py::test_every_checker_runs \
+  Tests/CI/test_derived_artifacts_workflow.py::test_backlog_guard_delegates_to_the_shared_script
+```
+
+Expected: all selected tests pass; both workflows still delegate to the modified shared script.
+
+- [ ] **Step 4: Run static checks only on modified Python files**
+
+Run:
+
+```bash
+ruff check scripts/check_backlog_task_ids.py Tests/Architecture/test_derived_artifact_checkers.py
+ruff format --check scripts/check_backlog_task_ids.py Tests/Architecture/test_derived_artifact_checkers.py
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Commit the lesson**
+
+```bash
+git add backlog/docs/lessons-backlog-hygiene.md
+git commit -m "docs(backlog): record Windows checkout filename trap"
+```
+
+### Task 5: Independently review, rebase, and open the focused PR
+
+**Files:**
+- Review: all files changed from `origin/dev...HEAD`
+- Modify only if a review finding is verified and within TASK-21139's acceptance criteria
+
+- [ ] **Step 1: Request independent correctness and simplification reviews**
+
+Use `@superpowers:requesting-code-review` for a correctness/spec review and the repository's `@ponytail-review` for deletion/simplification opportunities. Give each reviewer the approved spec, plan, and `origin/dev...HEAD` diff. Resolve only concrete, reproducible findings; do not add speculative abstractions.
+
+- [ ] **Step 2: Apply verified review findings through focused RED/GREEN changes**
+
+For each accepted behavior change, first add or tighten the smallest focused test, run it RED, implement the minimal fix, and rerun the same test GREEN. Commit review fixes separately. If a finding is inaccurate, document the exact code/test evidence rather than changing correct code.
+
+- [ ] **Step 3: Rebase onto the latest dev**
+
+Run:
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+```
+
+Expected: branch is based on current `origin/dev`. Resolve conflicts without dropping unrelated dev changes or changing TASK-21130's contents.
+
+- [ ] **Step 4: Rerun the complete scoped local gate after rebase**
+
+Repeat Task 3, Step 5 and Task 4, Steps 2-4.
+
+Expected: checker, focused pytest nodes, Ruff, format, and `git diff --check` all exit 0. Create a Backlog task for any unrelated failure rather than repairing it here.
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push --force-with-lease -u origin codex/task-21139-windows-backlog-paths
+gh pr create --base dev --head codex/task-21139-windows-backlog-paths \
+  --title "fix(backlog): restore Windows-safe task checkout" \
+  --body-file /tmp/task-21139-pr.md
+```
+
+The PR body must link TASK-21139 and its approved spec, explain the pure TASK-21130 rename, list the exact scoped commands/results, state `ADR required: no`, and call out the two Windows evidence jobs.
+
+### Task 6: Address Qodo and prove Windows checkout
+
+**Files:**
+- Modify only files required by verified, in-scope review findings
+
+- [ ] **Step 1: Wait for Qodo and required checks to post**
+
+Inspect the PR review threads and checks with `gh pr view`, `gh api`, and `gh pr checks`. Do not infer approval from a queued or absent review.
+
+- [ ] **Step 2: Evaluate Qodo feedback rigorously**
+
+Use `@superpowers:receiving-code-review`: reproduce each finding against the approved contract. For an accepted behavior finding, add a focused failing test before the fix; for a documentation-only finding, edit only the affected text. Reply with evidence and resolve each addressed thread.
+
+- [ ] **Step 3: Rerun only the impacted focused test plus the complete scoped gate**
+
+Run the smallest test that proves each fix, then repeat Task 3, Step 5 and Task 4, Steps 2-4 once after all review changes.
+
+Expected: all scoped checks pass. File a Backlog task for every unrelated failing test or check, including the exact run/job evidence.
+
+- [ ] **Step 4: Verify both formerly blocked Windows job types pass checkout**
+
+Inspect logs for the PR's current head and verify `actions/checkout` succeeds before project steps in:
+
+- `GGUF source evidence - windows-latest` (the job type that failed in run `32617893248`)
+- `Artifact leases - Python 3.11 - windows-latest` (the job type that failed in Tests run `32617893237`)
+
+Expected: neither log contains `error: invalid path`; both advance beyond checkout. A later unrelated failure does not invalidate the acceptance criterion, but it must receive its own Backlog task before continuing.
+
+### Task 7: Close TASK-21139 and merge
+
+**Files:**
+- Modify: `backlog/tasks/task-21139 - Restore Windows checkout for Backlog task paths.md`
+
+- [ ] **Step 1: Complete the task record only after current-head evidence exists**
+
+Use `apply_patch` to check all acceptance criteria and add concise Implementation Notes covering the classifier/scanner and unchanged `duplicate_ids()` contract; byte-identical TASK-21130 rename and reference audit; focused test/Ruff evidence; both Windows job URLs; review/Qodo disposition; the lesson file; and `ADR required: no`, `ADR path: N/A`, with its reason.
+
+Then use the Backlog CLI to set the task to Done:
+
+```bash
+backlog task edit 21139 -s Done
+```
+
+- [ ] **Step 2: Verify the closeout diff and rerun the guard**
+
+Run:
+
+```bash
+python3 scripts/check_backlog_task_ids.py
+git diff --check
+git status --short
+```
+
+Expected: checker and whitespace gate pass; status contains only the intentional TASK-21139 closeout edit.
+
+- [ ] **Step 3: Commit and push closeout**
+
+```bash
+git add 'backlog/tasks/task-21139 - Restore Windows checkout for Backlog task paths.md'
+git commit -m "docs(backlog): complete TASK-21139"
+git push --force-with-lease
+```
+
+- [ ] **Step 4: Confirm current-head reviews/checks and merge**
+
+Confirm all configured required checks and review threads are terminal and acceptable on the new head. Merge the PR using the repository's accepted method, then confirm the PR reports merged and `dev` contains the Windows-safe TASK-21130 path.

--- a/Docs/superpowers/specs/2026-08-23-task-21139-windows-safe-backlog-paths-design.md
+++ b/Docs/superpowers/specs/2026-08-23-task-21139-windows-safe-backlog-paths-design.md
@@ -1,0 +1,125 @@
+# TASK-21139 Windows-Safe Backlog Paths Design
+
+## Status
+
+Approved for implementation planning on 2026-08-23.
+
+## Problem
+
+Windows CI fetches the repository successfully but cannot check out commit
+`1a81909eed20ffaa64220f9d2eb16930dd151710`. Git for Windows exits 128 before
+any project setup or test because this tracked path contains `>`:
+
+`backlog/tasks/task-21130 - TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice.md`
+
+The file arrived in commit `46cb7bc1f531e76162d8dfa86993882d75f691c4`.
+The existing Backlog guard checks filename/frontmatter ID uniqueness but does
+not check whether task paths are representable on Windows. Because the guard
+runs on Ubuntu, it can inspect and reject such names as a merge gate without
+needing a Windows checkout; GitHub may still schedule Windows jobs concurrently.
+
+## Scope
+
+This task covers files directly inside the three Backlog task buckets already
+owned by `scripts/check_backlog_task_ids.py`:
+
+- `backlog/tasks`
+- `backlog/completed`
+- `backlog/archive/tasks`
+
+It does not establish a repository-wide filename policy, enforce checkout-root
+dependent path-length limits, change task IDs/content, or alter Windows runner
+configuration.
+
+## Selected approach
+
+Extend `scripts/check_backlog_task_ids.py` rather than adding a second checker.
+The script is already stdlib-only, scans all three task buckets, runs from local
+preflight, Backlog Guard, and Derived Artifacts, and is covered by focused
+architecture tests. Reusing it gives every existing entry point the same rule
+without workflow changes or dependencies.
+
+Rename only TASK-21130's path, replacing `v3->v4` with `v3-to-v4`. Preserve its
+frontmatter, title, description, acceptance criteria, and ID byte-for-byte.
+Update every resolvable link, command, or path-valued reference to the old path.
+Historical incident evidence may retain the literal failing path when it is
+clearly quoted as past evidence rather than presented as a live repository path.
+
+## Validation contract
+
+For each file directly inside a configured task bucket, the guard reports a
+Windows-incompatible path when its basename:
+
+- contains `<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, or `*`;
+- contains an ASCII control character (`U+0000` through `U+001F`);
+- ends in a dot or space; or
+- has a Windows device-name stem (`CON`, `PRN`, `AUX`, `NUL`, `COM1` through
+  `COM9`, `COM¹` through `COM³`, `LPT1` through `LPT9`, or `LPT¹` through
+  `LPT³`), case-insensitively. The device stem is the portion before the first
+  period, so every extension depth remains invalid (`NUL.txt` and
+  `NUL.tar.gz`).
+
+These rules follow Microsoft's Win32 file-naming contract:
+<https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file>.
+
+The implementation exposes a small pure basename classifier plus a bucket
+scanner that returns each invalid repo-relative path and reason. Existing
+`duplicate_ids()` callers and return values remain unchanged. `main()` reports
+both duplicate-ID and incompatible-path failures in one invocation and exits 1
+if either class exists.
+
+Directories are not recursively scanned: the Backlog CLI's task records live
+directly in the three existing buckets, matching the current guard contract.
+
+## Failure reporting
+
+The report must identify every incompatible path and the reason it failed, then
+state that task content may retain punctuation while the filename must use a
+Windows-safe spelling. This makes the repair actionable without needing a
+Windows machine to rediscover the rule.
+
+## Testing
+
+Focused TDD will add tests to
+`Tests/Architecture/test_derived_artifact_checkers.py` before implementation:
+
+1. Invalid-character/control/trailing/reserved cases fail with their paths and
+   reasons.
+2. Ordinary task filenames pass, including punctuation that Windows allows.
+3. Duplicate-ID reporting continues to work when path validation is enabled.
+4. The real repository inventory passes after TASK-21130 is renamed.
+
+Filesystem fixtures on POSIX cover names Linux can create. `/` and NUL are
+exercised against the pure basename classifier because POSIX cannot create a
+single basename containing either character. Reserved-name tests include
+superscript COM/LPT aliases and a multi-extension `NUL.tar.gz` case.
+
+Verification is limited to the checker tests, local uniqueness gate, checker
+script, Ruff/format, and affected CI. On the repair PR, both previously failing
+job types must show `actions/checkout` completing successfully before their
+project steps:
+
+- `GGUF source evidence - windows-latest` (failed in run `32617893248`); and
+- `Artifact leases - Python 3.11 - windows-latest` (failed in Tests run
+  `32617893237`).
+
+No broad local suite is needed.
+
+## Alternatives rejected
+
+- **Rename only:** restores checkout but permits immediate recurrence and does
+  not satisfy TASK-21139's prevention criterion.
+- **Separate Windows-path checker:** duplicates the same bucket discovery,
+  workflow triggers, preflight wiring, and tests for no independent benefit.
+- **Repository-wide path policy:** substantially broadens ownership and edge
+  cases beyond the observed Backlog failure.
+
+## ADR check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a focused CI portability bugfix inside an existing guard and
+does not change storage, runtime, security, dependency, or cross-module
+architecture.

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -502,7 +502,9 @@ def test_main_reports_duplicate_ids_and_windows_paths_together(
     assert "Keep punctuation in task content" in report
 
 
-def test_main_reports_windows_paths_without_duplicate_ids(tmp_path, capsys, monkeypatch):
+def test_main_reports_windows_paths_without_duplicate_ids(
+    tmp_path, capsys, monkeypatch
+):
     task = tmp_path / "task-7 - Safe.md"
     task.write_text("id: TASK-7\n", encoding="utf-8")
     offending = tmp_path / "task-8 - Synthetic.md"

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -259,7 +259,9 @@ def test_next_steps_sends_the_reader_to_statements_not_git_diff():
     as changed and a line diff buries it in unrelated edits."""
     assert "--statements" in inventory.NEXT_STEPS
     assert "--since" in inventory.NEXT_STEPS
-    assert "git diff" not in inventory.NEXT_STEPS.replace("Do NOT reach for `git diff`", "")
+    assert "git diff" not in inventory.NEXT_STEPS.replace(
+        "Do NOT reach for `git diff`", ""
+    )
 
 
 _MOVED_BEFORE = """
@@ -302,10 +304,13 @@ def test_a_re_indented_statement_is_reported_as_needing_no_review():
 def test_an_added_statement_is_printed_in_full_for_reading():
     """The whole point: the pin cannot carry statement text, and the
     interpolation check needs it."""
-    after = _MOVED_AFTER + """
+    after = (
+        _MOVED_AFTER
+        + """
 def other(path):
     logger.error(f"export failed for {path}")
 """
+    )
     report = inventory.render_statement_diff(_MOVED_AFTER, after, "m.py")
 
     assert "added: 1" in report
@@ -379,7 +384,9 @@ def test_duplicate_task_ids_are_caught_across_buckets(tmp_path):
 
     assert set(by_filename) == {"task-9"}
     assert set(by_frontmatter) == {"task-9"}
-    assert backlog_ids.main(["--tasks-dir", str(tasks), "--tasks-dir", str(archive)]) == 1
+    assert (
+        backlog_ids.main(["--tasks-dir", str(tasks), "--tasks-dir", str(archive)]) == 1
+    )
 
 
 @pytest.mark.parametrize("character", '<>:"/\\|?*')
@@ -527,7 +534,8 @@ def test_main_reports_windows_paths_without_duplicate_ids(
 def test_default_scope_is_every_bucket_the_cli_resolves():
     """Pin the scope: narrowing it back to tasks/ is the bug this guard had."""
     assert {
-        path.relative_to(backlog_ids.REPO_ROOT).as_posix() for path in backlog_ids.TASK_DIRS
+        path.relative_to(backlog_ids.REPO_ROOT).as_posix()
+        for path in backlog_ids.TASK_DIRS
     } == {"backlog/tasks", "backlog/completed", "backlog/archive/tasks"}
 
 
@@ -537,7 +545,12 @@ def test_an_absent_optional_bucket_is_not_an_error(tmp_path):
     tasks.mkdir()
     (tasks / "task-1 - A.md").write_text("id: TASK-1\n", encoding="utf-8")
 
-    assert backlog_ids.main(["--tasks-dir", str(tasks), "--tasks-dir", str(tmp_path / "absent")]) == 0
+    assert (
+        backlog_ids.main(
+            ["--tasks-dir", str(tasks), "--tasks-dir", str(tmp_path / "absent")]
+        )
+        == 0
+    )
 
 
 def test_unique_task_ids_pass(tmp_path):
@@ -548,9 +561,9 @@ def test_unique_task_ids_pass(tmp_path):
 
 
 def test_repo_relative_accepts_a_relative_path_inside_the_repo():
-    assert inventory._repo_relative(
+    assert inventory._repo_relative("scripts/check_backlog_task_ids.py") == Path(
         "scripts/check_backlog_task_ids.py"
-    ) == Path("scripts/check_backlog_task_ids.py")
+    )
 
 
 def test_repo_relative_accepts_an_absolute_path_inside_the_repo():

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -435,12 +436,20 @@ def test_windows_task_name_rejects_reserved_device_stems(name, stem):
         "LPT0.md",
         "LPT10.md",
         "LPT⁴.md",
+        "CONSOLE.md",
+        "PRN1.md",
+        "AUXILIARY.md",
+        "NULL.md",
     ],
 )
 def test_windows_task_name_accepts_valid_names(name):
     assert backlog_ids.windows_incompatible_reason(name) is None
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only fixture creates filenames that Win32 cannot represent",
+)
 def test_windows_incompatible_paths_scan_files_in_each_existing_bucket(tmp_path):
     tasks = tmp_path / "tasks"
     completed = tmp_path / "completed"
@@ -457,25 +466,59 @@ def test_windows_incompatible_paths_scan_files_in_each_existing_bucket(tmp_path)
     for path in invalid:
         path.write_text("id: TASK-1\n", encoding="utf-8")
     (tasks / "task-4 - Safe.md").write_text("id: TASK-4\n", encoding="utf-8")
-    (tasks / "task-5 - Directory?.md").mkdir()
+    invalid_directory = tasks / "task-5 - Directory?.md"
+    invalid_directory.mkdir()
+    (invalid_directory / "task-6 - Nested>Invalid.md").write_text(
+        "id: TASK-6\n", encoding="utf-8"
+    )
 
     assert backlog_ids.windows_incompatible_paths(
         tasks, completed, archive, tmp_path / "absent"
     ) == {path.resolve().as_posix(): reason for path, reason in invalid.items()}
 
 
-def test_main_reports_duplicate_ids_and_windows_paths_together(tmp_path, capsys):
-    first = tmp_path / "task-42 - First?.md"
+def test_main_reports_duplicate_ids_and_windows_paths_together(
+    tmp_path, capsys, monkeypatch
+):
+    first = tmp_path / "task-42 - First.md"
     second = tmp_path / "task-42 - Second.md"
     first.write_text("id: TASK-42\n", encoding="utf-8")
     second.write_text("id: TASK-42\n", encoding="utf-8")
+    offending = tmp_path / "task-42 - Synthetic.md"
+    reason = "contains Windows-reserved character '?'"
+    monkeypatch.setattr(
+        backlog_ids,
+        "windows_incompatible_paths",
+        lambda *task_dirs: {offending.resolve().as_posix(): reason},
+    )
 
     assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 1
     captured = capsys.readouterr()
     report = captured.out + captured.err
     assert "Duplicate backlog task IDs" in report
     assert "Windows-incompatible Backlog task paths" in report
-    assert first.resolve().as_posix() in report
+    assert offending.resolve().as_posix() in report
+    assert reason in report
+    assert "Keep punctuation in task content" in report
+
+
+def test_main_reports_windows_paths_without_duplicate_ids(tmp_path, capsys, monkeypatch):
+    task = tmp_path / "task-7 - Safe.md"
+    task.write_text("id: TASK-7\n", encoding="utf-8")
+    offending = tmp_path / "task-8 - Synthetic.md"
+    reason = "ends with a dot or space"
+    monkeypatch.setattr(
+        backlog_ids,
+        "windows_incompatible_paths",
+        lambda *task_dirs: {offending.resolve().as_posix(): reason},
+    )
+
+    assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    report = captured.out + captured.err
+    assert "Windows-incompatible Backlog task paths" in report
+    assert offending.resolve().as_posix() in report
+    assert reason in report
     assert "Keep punctuation in task content" in report
 
 

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -12,6 +12,8 @@ import copy
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts import check_backlog_task_ids as backlog_ids
 from scripts import check_persistent_diagnostic_inventory as inventory
 
@@ -377,6 +379,104 @@ def test_duplicate_task_ids_are_caught_across_buckets(tmp_path):
     assert set(by_filename) == {"task-9"}
     assert set(by_frontmatter) == {"task-9"}
     assert backlog_ids.main(["--tasks-dir", str(tasks), "--tasks-dir", str(archive)]) == 1
+
+
+@pytest.mark.parametrize("character", '<>:"/\\|?*')
+def test_windows_task_name_rejects_every_reserved_character(character):
+    reason = backlog_ids.windows_incompatible_reason(f"task-1 - Bad{character}Name.md")
+    assert reason == f"contains Windows-reserved character {character!r}"
+
+
+@pytest.mark.parametrize("character", ["\x00", "\x01", "\x1f"])
+def test_windows_task_name_rejects_ascii_controls(character):
+    reason = backlog_ids.windows_incompatible_reason(f"task-1 - Bad{character}Name.md")
+    assert reason == f"contains ASCII control U+{ord(character):04X}"
+
+
+@pytest.mark.parametrize("name", ["task-1 - Bad.md.", "task-1 - Bad.md "])
+def test_windows_task_name_rejects_trailing_dot_or_space(name):
+    assert backlog_ids.windows_incompatible_reason(name) == "ends with a dot or space"
+
+
+@pytest.mark.parametrize(
+    "name, stem",
+    [
+        ("CON", "CON"),
+        ("prn.md", "PRN"),
+        ("Aux.notes.md", "AUX"),
+        ("NUL.tar.gz", "NUL"),
+        ("com1.md", "COM1"),
+        ("COM9.log", "COM9"),
+        ("com¹.log", "COM¹"),
+        ("COM².log", "COM²"),
+        ("Com³.tar.gz", "COM³"),
+        ("lpt1.md", "LPT1"),
+        ("LPT9.log", "LPT9"),
+        ("lpt¹.log", "LPT¹"),
+        ("LPT².log", "LPT²"),
+        ("Lpt³.tar.gz", "LPT³"),
+    ],
+)
+def test_windows_task_name_rejects_reserved_device_stems(name, stem):
+    assert backlog_ids.windows_incompatible_reason(name) == (
+        f"uses reserved Windows device name {stem!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "task-1 - Ordinary title.md",
+        "task-2 - Version v3-to-v4 (safe).md",
+        "task-3 - CON appears after the task prefix.md",
+        "COM0.md",
+        "COM10.md",
+        "COM⁴.md",
+        "LPT0.md",
+        "LPT10.md",
+        "LPT⁴.md",
+    ],
+)
+def test_windows_task_name_accepts_valid_names(name):
+    assert backlog_ids.windows_incompatible_reason(name) is None
+
+
+def test_windows_incompatible_paths_scan_files_in_each_existing_bucket(tmp_path):
+    tasks = tmp_path / "tasks"
+    completed = tmp_path / "completed"
+    archive = tmp_path / "archive" / "tasks"
+    tasks.mkdir()
+    completed.mkdir()
+    archive.mkdir(parents=True)
+    invalid = {
+        tasks / "task-1 - Bad>Name.md": "contains Windows-reserved character '>'",
+        completed / "task-2 - Control\x1f.md": "contains ASCII control U+001F",
+        archive / "NUL.tar.gz": "uses reserved Windows device name 'NUL'",
+        archive / "task-3 - Trailing.md ": "ends with a dot or space",
+    }
+    for path in invalid:
+        path.write_text("id: TASK-1\n", encoding="utf-8")
+    (tasks / "task-4 - Safe.md").write_text("id: TASK-4\n", encoding="utf-8")
+    (tasks / "task-5 - Directory?.md").mkdir()
+
+    assert backlog_ids.windows_incompatible_paths(
+        tasks, completed, archive, tmp_path / "absent"
+    ) == {path.resolve().as_posix(): reason for path, reason in invalid.items()}
+
+
+def test_main_reports_duplicate_ids_and_windows_paths_together(tmp_path, capsys):
+    first = tmp_path / "task-42 - First?.md"
+    second = tmp_path / "task-42 - Second.md"
+    first.write_text("id: TASK-42\n", encoding="utf-8")
+    second.write_text("id: TASK-42\n", encoding="utf-8")
+
+    assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    report = captured.out + captured.err
+    assert "Duplicate backlog task IDs" in report
+    assert "Windows-incompatible Backlog task paths" in report
+    assert first.resolve().as_posix() in report
+    assert "Keep punctuation in task content" in report
 
 
 def test_default_scope_is_every_bucket_the_cli_resolves():

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -602,7 +602,7 @@ renumbering, grep the repo for `NNN-<slug>` AND both header forms — `ADR-NNN`
 references the ADR by number and path, and stale references in either form
 mislead the next session.
 
-### Backlog filenames must survive every supported checkout platform (TASK-21139)
+## Backlog filenames must survive every supported checkout platform (TASK-21139)
 
 **What happened.** On 2026-08-22, commit `46cb7bc1f` added TASK-21130 with `>`
 in its tracked filename. Git for Windows fetched the repository, but

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -602,6 +602,18 @@ renumbering, grep the repo for `NNN-<slug>` AND both header forms — `ADR-NNN`
 references the ADR by number and path, and stale references in either form
 mislead the next session.
 
+### Backlog filenames must survive every supported checkout platform (TASK-21139)
+
+**What happened.** On 2026-08-22, commit `46cb7bc1f` added TASK-21130 with `>`
+in its tracked filename. Git for Windows fetched the repository, but
+`actions/checkout` exited 128 before project tests ran in runs `32617893248` and
+`32617893237`.
+
+**What to do.** Content may stay expressive, but direct files in the live,
+completed, and archived Backlog buckets must use Win32-compatible basenames.
+The shared stdlib guard is the authoring-time source of truth because Windows
+cannot run repository code before checkout succeeds.
+
 ---
 
 ## Related

--- a/backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md
+++ b/backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-21130
 title: >-
-  TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice
+  TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice
 status: To Do
 assignee: []
 created_date: '2026-08-22'

--- a/backlog/tasks/task-21139 - Restore Windows checkout for Backlog task paths.md
+++ b/backlog/tasks/task-21139 - Restore Windows checkout for Backlog task paths.md
@@ -32,3 +32,20 @@ a supported CI platform while preserving task IDs and task content.
 ## References
 
 - `Docs/superpowers/specs/2026-08-23-task-21139-windows-safe-backlog-paths-design.md`
+
+## Implementation Plan
+
+Follow `Docs/superpowers/plans/2026-08-23-task-21139-windows-safe-backlog-paths.md`:
+
+1. Add focused RED tests for the Win32 basename contract and combined reporting.
+2. Add the minimal stdlib classifier/scanner to the existing Backlog guard without changing `duplicate_ids()`.
+3. Rename TASK-21130 byte-for-byte and verify the tracked Backlog inventory passes.
+4. Record the checkout incident and run only checker-related tests/static analysis.
+5. Independently review, rebase on current `dev`, address Qodo feedback, and verify the two affected Windows job types pass checkout.
+6. Complete TASK-21139 and merge only after current-head evidence is green.
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a focused CI-portability repair within an existing stdlib guard; it changes no architectural boundary, dependency, schema, storage, security, or runtime policy.

--- a/backlog/tasks/task-21139 - Restore Windows checkout for Backlog task paths.md
+++ b/backlog/tasks/task-21139 - Restore Windows checkout for Backlog task paths.md
@@ -1,0 +1,34 @@
+---
+id: TASK-21139
+title: 'Restore Windows checkout for Backlog task paths'
+status: In Progress
+assignee: []
+created_date: '2026-08-23'
+updated_date: '2026-08-23'
+labels:
+  - backlog
+  - ci
+  - windows
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore Windows CI checkout after TASK-21130 introduced a tracked Backlog
+filename containing `>`, which Windows rejects before any project test can run.
+Prevent another Backlog task path from making the repository uncheckoutable on
+a supported CI platform while preserving task IDs and task content.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] TASK-21130 retains its ID and content under a Windows-compatible filename, and every repository reference to its previous path is updated
+- [ ] The existing stdlib-only Backlog guard rejects Windows-incompatible filenames across live, completed, and archived task buckets, with focused tests for invalid characters, control characters, reserved device names, trailing dots/spaces, and valid names
+- [ ] The affected Windows GitHub Actions jobs progress past checkout, and the guard produces no false positive for the tracked Backlog inventory
+<!-- AC:END -->
+
+## References
+
+- `Docs/superpowers/specs/2026-08-23-task-21139-windows-safe-backlog-paths-design.md`

--- a/scripts/check_backlog_task_ids.py
+++ b/scripts/check_backlog_task_ids.py
@@ -128,7 +128,9 @@ def windows_incompatible_paths(*task_dirs: Path) -> dict[str, str]:
     return invalid
 
 
-def duplicate_ids(*task_dirs: Path) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+def duplicate_ids(
+    *task_dirs: Path,
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     """Collect ids claimed by more than one task file, across every bucket given.
 
     Args:
@@ -215,7 +217,9 @@ def main(argv: list[str] | None = None) -> int:
 
     task_dirs = tuple(args.tasks_dirs) if args.tasks_dirs else TASK_DIRS
     if not any(task_dir.is_dir() for task_dir in task_dirs):
-        print(f"::error::no backlog task directory at {', '.join(str(d) for d in task_dirs)}")
+        print(
+            f"::error::no backlog task directory at {', '.join(str(d) for d in task_dirs)}"
+        )
         return 1
 
     filename_dupes, frontmatter_dupes = duplicate_ids(*task_dirs)

--- a/scripts/check_backlog_task_ids.py
+++ b/scripts/check_backlog_task_ids.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Guard: no two backlog task files may claim the same task id.
+"""Guard: backlog task ids are unique and task paths are Windows-compatible.
 
 Task files are named ``task-<id> - <Title>.md``; subtask ids may be multi-dotted
 (``task-3.1``, ``task-10.6.1``). Two branches minting the same id and merging
@@ -46,6 +46,16 @@ TASK_DIRS = (
 
 FILENAME_ID_RE = re.compile(r"^(task-\d+(?:\.\d+)*) - .*\.md$")
 FRONTMATTER_ID_RE = re.compile(r"^id:\s*(\S+)", re.IGNORECASE)
+WINDOWS_RESERVED_CHARACTERS = frozenset('<>:"/\\|?*')
+WINDOWS_RESERVED_DEVICE_NAMES = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{suffix}" for suffix in (*map(str, range(1, 10)), "¹", "²", "³")}
+    | {f"lpt{suffix}" for suffix in (*map(str, range(1, 10)), "¹", "²", "³")}
+)
+WINDOWS_PATH_RESOLUTION = (
+    "Keep punctuation in task content, but rename the task file with a "
+    "Windows-safe spelling and update live path references."
+)
 
 RESOLUTION = (
     "Resolve per the 2026-08-21 owner rule (TASK-19601): the OLDER arrival "
@@ -88,6 +98,36 @@ def _label(path: Path) -> str:
         return path.resolve().as_posix()
 
 
+def windows_incompatible_reason(name: str) -> str | None:
+    """Return why a basename cannot be represented by Win32, else ``None``."""
+    for character in name:
+        if ord(character) <= 0x1F:
+            return f"contains ASCII control U+{ord(character):04X}"
+        if character in WINDOWS_RESERVED_CHARACTERS:
+            return f"contains Windows-reserved character {character!r}"
+    if name.endswith((".", " ")):
+        return "ends with a dot or space"
+    device_stem = name.split(".", 1)[0].casefold()
+    if device_stem in WINDOWS_RESERVED_DEVICE_NAMES:
+        return f"uses reserved Windows device name {device_stem.upper()!r}"
+    return None
+
+
+def windows_incompatible_paths(*task_dirs: Path) -> dict[str, str]:
+    """Return directly contained files whose basenames Win32 rejects."""
+    invalid: dict[str, str] = {}
+    for task_dir in task_dirs:
+        if not task_dir.is_dir():
+            continue
+        for path in sorted(task_dir.iterdir()):
+            if not path.is_file():
+                continue
+            reason = windows_incompatible_reason(path.name)
+            if reason:
+                invalid[_label(path)] = reason
+    return invalid
+
+
 def duplicate_ids(*task_dirs: Path) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     """Collect ids claimed by more than one task file, across every bucket given.
 
@@ -126,12 +166,18 @@ def _report(label: str, duplicates: dict[str, list[str]]) -> None:
             print(f"  {name}")
 
 
+def _report_windows_incompatible(invalid: dict[str, str]) -> None:
+    print("::error::Windows-incompatible Backlog task paths:")
+    for path, reason in sorted(invalid.items()):
+        print(f"  {path}: {reason}")
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Fail when any task id is claimed twice.
+    """Fail when ids collide or a task path is incompatible with Windows.
 
     Returns:
-        int: ``0`` when every id is unique, ``1`` otherwise (with ``::error::``
-            annotations naming each colliding id and its files).
+        int: ``0`` when ids are unique and paths are Windows-compatible, ``1``
+            otherwise (with ``::error::`` annotations naming each violation).
     """
     # NOTE (Qodo PR #1947 finding 2, "Unvalidated --tasks-dir used"): this is
     # deliberately NOT routed through Utils/path_validation.py. Three reasons:
@@ -173,12 +219,18 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     filename_dupes, frontmatter_dupes = duplicate_ids(*task_dirs)
+    invalid_paths = windows_incompatible_paths(*task_dirs)
     if filename_dupes:
         _report("filenames", filename_dupes)
     if frontmatter_dupes:
         _report("frontmatter id: fields", frontmatter_dupes)
+    if invalid_paths:
+        _report_windows_incompatible(invalid_paths)
     if filename_dupes or frontmatter_dupes:
         print(RESOLUTION, file=sys.stderr)
+    if invalid_paths:
+        print(WINDOWS_PATH_RESOLUTION, file=sys.stderr)
+    if filename_dupes or frontmatter_dupes or invalid_paths:
         return 1
 
     scanned = [task_dir for task_dir in task_dirs if task_dir.is_dir()]
@@ -186,7 +238,7 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"No duplicate task IDs across {total} task files in "
         f"{', '.join(_label(task_dir) for task_dir in scanned)} "
-        "(filenames + frontmatter)."
+        "(filenames + frontmatter); all task paths are Windows-compatible."
     )
     return 0
 

--- a/scripts/check_backlog_task_ids.py
+++ b/scripts/check_backlog_task_ids.py
@@ -99,7 +99,14 @@ def _label(path: Path) -> str:
 
 
 def windows_incompatible_reason(name: str) -> str | None:
-    """Return why a basename cannot be represented by Win32, else ``None``."""
+    """Return why a basename cannot be represented by Win32, else ``None``.
+
+    Args:
+        name: Basename to validate against the Windows filename contract.
+
+    Returns:
+        The incompatibility reason, or ``None`` when the basename is valid.
+    """
     for character in name:
         if ord(character) <= 0x1F:
             return f"contains ASCII control U+{ord(character):04X}"
@@ -114,7 +121,16 @@ def windows_incompatible_reason(name: str) -> str | None:
 
 
 def windows_incompatible_paths(*task_dirs: Path) -> dict[str, str]:
-    """Return directly contained files whose basenames Win32 rejects."""
+    """Return directly contained files whose basenames Win32 rejects.
+
+    Args:
+        *task_dirs: Direct task-bucket directories to scan; absent directories
+            are skipped.
+
+    Returns:
+        Mapping of labeled invalid paths to their Windows incompatibility
+        reasons.
+    """
     invalid: dict[str, str] = {}
     for task_dir in task_dirs:
         if not task_dir.is_dir():


### PR DESCRIPTION
## TASK-21139: Windows-safe Backlog task paths

Task record: [TASK-21139](https://github.com/rmusser01/tldw_chatbook/blob/codex/task-21139-windows-backlog-paths/backlog/tasks/task-21139%20-%20Restore%20Windows%20checkout%20for%20Backlog%20task%20paths.md)  
Design: [Windows-safe Backlog paths design](https://github.com/rmusser01/tldw_chatbook/blob/codex/task-21139-windows-backlog-paths/Docs/superpowers/specs/2026-08-23-task-21139-windows-safe-backlog-paths-design.md)  
Implementation plan: [TASK-21139 implementation plan](https://github.com/rmusser01/tldw_chatbook/blob/codex/task-21139-windows-backlog-paths/Docs/superpowers/plans/2026-08-23-task-21139-windows-safe-backlog-paths.md)

### Change

- Extends the existing stdlib-only Backlog checker with the small Win32-basename guard, preserving the `duplicate_ids()` API and existing workflow delegation.
- Restores TASK-21130 with the Windows-safe `v3-to-v4` filename while retaining the approved original file bytes/content (SHA-256 `2be97ab0319ac27c6df0427794ca17d9a5ec9d755018bcfd0ac59e66e073e467`; internal title remains `v3->v4`).

### Scoped results

Executed on current head `118d5c4a8` in the project Python 3.12 development environment:

```bash
python3 scripts/check_backlog_task_ids.py
```

Pass — 2,483 task files, no duplicate IDs, all paths Windows-compatible.

```bash
pytest -q \
  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_every_reserved_character \
  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_ascii_controls \
  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_trailing_dot_or_space \
  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_rejects_reserved_device_stems \
  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_task_name_accepts_valid_names \
  Tests/Architecture/test_derived_artifact_checkers.py::test_windows_incompatible_paths_scan_files_in_each_existing_bucket \
  Tests/Architecture/test_derived_artifact_checkers.py::test_main_reports_duplicate_ids_and_windows_paths_together \
  Tests/Architecture/test_derived_artifact_checkers.py::test_main_reports_windows_paths_without_duplicate_ids \
  Tests/Architecture/test_derived_artifact_checkers.py::test_duplicate_task_ids_are_caught_in_both_namespaces \
  Tests/Architecture/test_derived_artifact_checkers.py::test_duplicate_task_ids_are_caught_across_buckets \
  Tests/Architecture/test_derived_artifact_checkers.py::test_default_scope_is_every_bucket_the_cli_resolves \
  Tests/Architecture/test_derived_artifact_checkers.py::test_an_absent_optional_bucket_is_not_an_error \
  Tests/Architecture/test_derived_artifact_checkers.py::test_unique_task_ids_pass
```

Pass — 13 focused architecture nodes, 49 passed.

```bash
pytest -q \
  Tests/CI/test_backlog_task_id_uniqueness.py \
  Tests/CI/test_derived_artifacts_workflow.py::test_every_checker_runs \
  Tests/CI/test_derived_artifacts_workflow.py::test_backlog_guard_delegates_to_the_shared_script
```

Pass — 5 focused CI contracts.

```bash
ruff check scripts/check_backlog_task_ids.py Tests/Architecture/test_derived_artifact_checkers.py
ruff format --check scripts/check_backlog_task_ids.py Tests/Architecture/test_derived_artifact_checkers.py
git diff --check origin/dev...HEAD
```

All static and diff checks passed. No broad local suite was run, per instruction.

### Warnings

- Test runs emitted the environment's Requests dependency warning and pytest temporary-directory cleanup permission warnings after successful completion; neither gate failed.
- The PR must include checkout-passing evidence for **GGUF source evidence - windows-latest** and **Artifact leases - Python 3.11 - windows-latest** before merge.

### Review / ADR

- Independent correctness review: approved; Ponytail review: “Lean already. Ship.”
- Qodo's one medium finding was addressed in `118d5c4a8`: both public helpers now have repository-standard Google-style `Args:`/`Returns:` docstrings. The inline thread contains current-head verification evidence.
- ADR required: no. ADR path: N/A. Reason: focused CI-portability repair inside an existing stdlib guard; no architectural boundary, dependency, schema, storage, security, or runtime-policy change.
