### PR TITLE
fix(rag): break the config_profiles↔simplified circular import unmasked by the lazy facade (TASK-21160)

### DIFF
--- a/Tests/RAG/test_config_profiles_import_order.py
+++ b/Tests/RAG/test_config_profiles_import_order.py
@@ -1,0 +1,81 @@
+"""Import-order regression guard for the config_profiles <-> simplified cycle.
+
+TASK-21160: ``RAG_Search/config_profiles.py`` imports ``.simplified.config``,
+which executes ``simplified/__init__``, which (eagerly) executed
+``enhanced_rag_service_v2`` / ``rag_factory`` / ``active_config`` -- each of
+which imported ``..config_profiles`` back at module level. A
+``config_profiles``-FIRST import order therefore hit the partially-initialized
+module and raised ImportError. The cycle edges were latent for as long as the
+eager ``RAG_Search/__init__`` front-loaded ``simplified`` in the safe order;
+TASK-21102's lazy facade unmasked them (standalone collection of
+``Tests/UI/test_console_runtime_ownership.py`` failed on dev from d60ebe1d0
+until this fix).
+
+Each test runs in a fresh subprocess so this file's own import order cannot
+mask a regression.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fresh_import(statement: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", statement],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+        timeout=120,
+    )
+
+
+def test_config_profiles_first_import_succeeds():
+    """The order that reproduced the dev regression: config_profiles first."""
+    result = _fresh_import(
+        "import tldw_chatbook.RAG_Search.config_profiles as cp; "
+        "assert callable(cp.get_profile_manager)"
+    )
+    assert result.returncode == 0, (
+        "config_profiles-first import failed -- the "
+        f"config_profiles<->simplified cycle is back:\n{result.stderr[-2000:]}"
+    )
+
+
+def test_simplified_first_import_still_succeeds():
+    """The historically-safe order must keep working after the deferral."""
+    result = _fresh_import(
+        "import tldw_chatbook.RAG_Search.simplified as s; "
+        "import tldw_chatbook.RAG_Search.config_profiles as cp; "
+        "assert callable(cp.get_profile_manager); "
+        "assert s.EnhancedRAGServiceV2 is not None"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+
+
+def test_simplified_modules_do_not_import_config_profiles_at_module_level():
+    """Static edge census: no module executed by ``simplified/__init__`` may
+    re-import config_profiles at module level (function-local and
+    TYPE_CHECKING imports are the sanctioned shapes)."""
+    import ast
+
+    pkg = _REPO_ROOT / "tldw_chatbook" / "RAG_Search" / "simplified"
+    offenders = []
+    for path in sorted(pkg.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module and "config_profiles" in node.module:
+                # Module-level = the import statement is a direct child of the
+                # module body or of a plain `if TYPE_CHECKING:` block; only
+                # the former is an offense.
+                for stmt in tree.body:
+                    if stmt is node:
+                        offenders.append(f"{path.name}:{node.lineno}")
+    assert not offenders, (
+        "module-level config_profiles imports re-create the circular-import "
+        f"edge (defer to use-site or TYPE_CHECKING): {offenders}"
+    )

--- a/backlog/tasks/task-21160 - RAG_Search config_profiles circular import unmasked by the task-21102 lazy facade.md
+++ b/backlog/tasks/task-21160 - RAG_Search config_profiles circular import unmasked by the task-21102 lazy facade.md
@@ -1,0 +1,67 @@
+---
+id: TASK-21160
+title: >-
+  RAG_Search config_profiles circular import unmasked by the task-21102 lazy facade
+status: Done
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - regression
+  - rag
+  - imports
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: TASK-21103's adversarial review origin-traced a circular-import failure that the
+implementer had labeled "pre-existing": `import tldw_chatbook.RAG_Search.config_profiles`
+as the FIRST RAG_Search import raised
+`ImportError: cannot import name 'get_profile_manager' from partially initialized module`,
+and standalone collection of `Tests/UI/test_console_runtime_ownership.py` failed the same
+way. Decisive A/B (read-only `git archive` of pre-21102 `56e2de875`): both work before
+TASK-21102 (`d60ebe1d0`), both fail after — **the lazy `RAG_Search/__init__` facade
+unmasked latent cycle edges** that the old eager init had front-loaded in the safe order.
+
+Cycle: `config_profiles.py:20` → `.simplified.config` → executes `simplified/__init__` →
+eagerly executes `enhanced_rag_service_v2` / `rag_factory` / `active_config`, each of which
+imported `..config_profiles` back at module level → partially-initialized module →
+ImportError on any `config_profiles`-first order.
+
+## Acceptance Criteria (the what)
+
+- [x] `import tldw_chatbook.RAG_Search.config_profiles` succeeds as the first RAG_Search
+  import (fresh subprocess), and the historically-safe simplified-first order still works
+- [x] Standalone `pytest Tests/UI/test_console_runtime_ownership.py --collect-only`
+  collects again (13 tests)
+- [x] A regression guard pins both import orders AND statically censuses `simplified/*`
+  for module-level `config_profiles` imports so the edge class cannot silently return
+- [x] No behavior change: profile loading, active-config, and factory paths keep their
+  semantics (existing RAG suites green; annotations preserved via TYPE_CHECKING /
+  future-annotations)
+
+## Implementation Notes
+
+All three cycle edges broken by deferring the `config_profiles` import to use-site:
+
+- `simplified/enhanced_rag_service_v2.py` — added `from __future__ import annotations`
+  (module has no dataclass/pydantic/get_type_hints annotation introspection — verified);
+  the five-name module-level import became TYPE_CHECKING (typing names) + a
+  `_config_profiles()` lazy accessor for the two runtime uses (4× `get_profile_manager()`,
+  1× `isinstance(config, ProfileConfig)`). No production or test importer pulls the
+  config_profiles names from this module (census: only `EnhancedRAGServiceV2`,
+  `_tag_first_result`, factory functions).
+- `simplified/rag_factory.py` — `get_profile_manager` function-local at its two use sites
+  (in-file precedent: `pipeline_loader.py:336`).
+- `simplified/active_config.py` — module already had future-annotations; import became
+  TYPE_CHECKING (`ProfileConfig` annotation) + function-local at the three runtime sites
+  (`get_profile_manager`, `_slugify`, `ProfileConfig` constructor).
+
+Red-first: on the pre-fix tree the new guard fails 2/3 (config_profiles-first subprocess +
+static census; simplified-first passes, as expected — that order was always safe); 3/3 with
+the fix. Standalone collection of the ownership file: uncollectable → 13 collected.
+
+Evidence for the origin trace lives in TASK-21103's review record; the fix comment in
+`enhanced_rag_service_v2.py` carries the full account for future readers.

--- a/tldw_chatbook/RAG_Search/simplified/active_config.py
+++ b/tldw_chatbook/RAG_Search/simplified/active_config.py
@@ -17,7 +17,14 @@ from loguru import logger
 
 from tldw_chatbook.config import get_cli_setting, save_setting_to_cli_config
 from .config import RAGConfig, _normalized_type_setting, validate_chroma_persist_directory
-from ..config_profiles import get_profile_manager, ProfileConfig, _slugify
+# task-21160: config_profiles imported at use-sites (and TYPE_CHECKING for the
+# annotation) -- the module-level import was one edge of the
+# config_profiles<->simplified circular-import cycle (see
+# enhanced_rag_service_v2.py for the full account).
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..config_profiles import ProfileConfig
 from ..ingestion_indexing import reset_shared_rag_service
 from ..reranker import RerankingConfig
 
@@ -38,6 +45,8 @@ _LEGACY_PROCESSOR_KEYS = ("enable_reranking", "reranker_model", "reranker_top_k"
 
 
 def _manager():
+    from ..config_profiles import get_profile_manager
+
     return get_profile_manager()
 
 
@@ -321,6 +330,8 @@ def set_active_profile(profile_id: str) -> None:
             safe slug (e.g. empty, ``None``, or containing path-traversal /
             non-slug characters like ``"../x"``).
     """
+    from ..config_profiles import _slugify
+
     if not isinstance(profile_id, str) or not profile_id or profile_id != _slugify(profile_id):
         raise ValueError(
             f"set_active_profile: invalid profile_id {profile_id!r}; must be a "
@@ -585,6 +596,8 @@ def ensure_imported_profile() -> Optional[str]:
         # query-time legacy keys instead of silently discarding them --
         # never affects the fingerprint (see _LEGACY_SEARCH_KEYS docstring).
         legacy = _merge_legacy_query_time_keys(snapshot)
+        from ..config_profiles import ProfileConfig
+
         profile = ProfileConfig(id=_IMPORTED_ID, name="Imported settings",
                                 description="Snapshot of your active RAG profile (plus any RAG_* env "
                                             "overrides) captured on first run; edit freely.",

--- a/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
+++ b/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
@@ -52,6 +52,8 @@ def _config_profiles():
     from .. import config_profiles
 
     return config_profiles
+
+
 from .data_models import IndexingResult
 
 

--- a/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
+++ b/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
@@ -7,6 +7,8 @@ This extends the Phase 1 enhanced RAG service with:
 - Configuration profiles
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
 from dataclasses import replace
@@ -25,13 +27,31 @@ from ..parallel_processor import (
     create_chunking_processor,
     ProcessingConfig,
 )
-from ..config_profiles import (
-    get_profile_manager,
-    ProfileConfig,
-    ExperimentConfig,
-    ProfileType,
-    ConfigProfileManager,
-)
+# task-21160: import config_profiles lazily. The module-level from-import
+# created a circular-import edge -- ``config_profiles`` imports
+# ``.simplified.config``, which executes ``simplified/__init__``, which
+# executes THIS module; a ``config_profiles``-first import order then hit the
+# partially-initialized module and raised ImportError (latent for as long as
+# the eager ``RAG_Search/__init__`` front-loaded ``simplified`` in the safe
+# order; unmasked when task-21102 made that facade lazy). Typing-only names
+# stay importable for checkers; the two runtime uses go through
+# ``_config_profiles()``.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..config_profiles import (
+        ProfileConfig,
+        ExperimentConfig,
+        ProfileType,
+        ConfigProfileManager,
+    )
+
+
+def _config_profiles():
+    """Return the ``config_profiles`` module, imported at first use."""
+    from .. import config_profiles
+
+    return config_profiles
 from .data_models import IndexingResult
 
 
@@ -94,7 +114,7 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
         # Handle different config types
         if isinstance(config, str):
             # Load profile by name
-            self.profile_manager = profile_manager or get_profile_manager()
+            self.profile_manager = profile_manager or _config_profiles().get_profile_manager()
             profile = self.profile_manager.get_profile(config)
             if not profile:
                 raise ValueError(f"Profile '{config}' not found")
@@ -102,7 +122,7 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
             config = profile.rag_config
             self.reranking_config = profile.reranking_config
             self.processing_config = profile.processing_config
-        elif isinstance(config, ProfileConfig):
+        elif isinstance(config, _config_profiles().ProfileConfig):
             # Use provided profile. Capture reranking_config/processing_config
             # off the ProfileConfig BEFORE reassigning the local `config` name
             # to its `.rag_config` below -- reading them off the reassigned
@@ -115,13 +135,13 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
             self.reranking_config = config.reranking_config
             self.processing_config = config.processing_config
             config = config.rag_config
-            self.profile_manager = profile_manager or get_profile_manager()
+            self.profile_manager = profile_manager or _config_profiles().get_profile_manager()
         else:
             # Direct RAG config
             self.profile = None
             self.reranking_config = None
             self.processing_config = None
-            self.profile_manager = profile_manager or get_profile_manager()
+            self.profile_manager = profile_manager or _config_profiles().get_profile_manager()
 
         # Initialize base service
         super().__init__(config, enable_parent_retrieval)
@@ -186,7 +206,7 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
         Returns:
             Configured RAG service
         """
-        manager = get_profile_manager()
+        manager = _config_profiles().get_profile_manager()
         profile = manager.get_profile(profile_name)
 
         if not profile:

--- a/tldw_chatbook/RAG_Search/simplified/rag_factory.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_factory.py
@@ -12,7 +12,9 @@ from loguru import logger
 from .config import RAGConfig
 from .enhanced_rag_service_v2 import EnhancedRAGServiceV2
 from .collection_indexes import maybe_adopt_legacy_collection
-from ..config_profiles import get_profile_manager
+# task-21160: config_profiles imported at use-site -- the module-level import
+# was one edge of the config_profiles<->simplified circular-import cycle
+# (see enhanced_rag_service_v2.py for the full account).
 
 
 def create_rag_service(
@@ -32,6 +34,8 @@ def create_rag_service(
     logger.info(f"Creating RAG service with profile: {profile_name}")
 
     # Get profile manager
+    from ..config_profiles import get_profile_manager
+
     profile_manager = get_profile_manager()
     profile = profile_manager.get_profile(profile_name)
 
@@ -150,4 +154,6 @@ def create_rag_service_from_config(
 # Compatibility aliases
 create_auto_rag_service = create_rag_service_from_config
 def get_available_profiles():
+    from ..config_profiles import get_profile_manager
+
     return get_profile_manager().list_profiles()


### PR DESCRIPTION
## Summary

TASK-21103's adversarial review origin-traced a live dev regression: **TASK-21102's lazy `RAG_Search/__init__` facade unmasked a latent circular import** — `config_profiles` → `.simplified.config` → `simplified/__init__` eagerly executes `enhanced_rag_service_v2`/`rag_factory`/`active_config`, each importing `..config_profiles` back at module level. Any `config_profiles`-first import order raised ImportError on dev since `d60ebe1d0` (breaking, e.g., standalone collection of `Tests/UI/test_console_runtime_ownership.py`). Decisive A/B: pre-21102 works, post fails.

## Changes

All three cycle edges deferred to use-site: `enhanced_rag_service_v2` (future-annotations + TYPE_CHECKING typing names + `_config_profiles()` lazy accessor at the 5 runtime sites — module verified free of runtime annotation introspection, callers swept), `rag_factory` (function-local ×2), `active_config` (TYPE_CHECKING + function-local ×3). New guard `Tests/RAG/test_config_profiles_import_order.py`: both import orders in fresh subprocesses + a static AST census banning module-level `config_profiles` imports in `simplified/*`.

## Evidence

- Red-first via copy-restore: 2/3 guard tests fail on the pre-fix tree; 3/3 green after. Standalone collection: uncollectable → 13 collected.
- RAG batch 275 passed / 2 failed — both failures A/B-proven pre-existing on base (by controller AND independently by the verifying reviewer via read-only base archive).
- Verification by the origin-tracing reviewer: MERGE-READY — class-identity probed both orders (single module object, isinstance semantics preserved); census mutation bites; TYPE_CHECKING imports correctly skipped, not vacuous; future-annotations safety confirmed against the only production `get_type_hints` caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breaks a circular import between `config_profiles` and `simplified` unmasked by the lazy `RAG_Search/__init__` facade (TASK-21160). `import tldw_chatbook.RAG_Search.config_profiles` no longer fails when it is the first RAG import; both import orders now work with no behavior changes to profile loading or services.

- Defers `config_profiles` imports to use sites:
  - `simplified/enhanced_rag_service_v2.py`: adds `from __future__ import annotations`, keeps types under `typing.TYPE_CHECKING`, and routes the five runtime uses through a `_config_profiles()` lazy accessor.
  - `simplified/rag_factory.py` and `simplified/active_config.py`: move to function-local imports; `active_config` keeps type-only import under `TYPE_CHECKING`.
- Adds regression guards: two fresh-subprocess import-order tests and a static AST check that bans module-level `config_profiles` imports in `simplified/*`.
- No API or behavior changes; existing RAG flows and isinstance semantics preserved.
- Migration/rollout: none. When adding `simplified/*` modules, do not import `config_profiles` at module level; use function-local imports or `TYPE_CHECKING` only.

<sup>Written for commit 2f04e1a244dc3853a9c9857bd2c8132d7474d828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

