### PR TITLE
fix(security): adopt the FTS5, defusedxml and log-sanitizer primitives this repo already owns

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -615,7 +615,7 @@
     },
     {
       "call_count": 356,
-      "diagnostic_digest": "4c7602cf78284ec06426",
+      "diagnostic_digest": "6564083751b5c1da8c8a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1920,6 +1920,13 @@
       "diagnostic_digest": "0fdd9d782b560419f426",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/token_manager.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "bf3b7a9c4298c5b2517c",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Subscriptions/watchlist_opml_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -3924,9 +3931,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 531,
+    "owner_files": 532,
     "persistent_sink_files": 8,
     "task_492_calls": 1222,
-    "task_494_calls": 7260
+    "task_494_calls": 7261
   }
 }

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -456,6 +456,98 @@ def test_fs_grep_spec_read_only_with_mode_enum(tmp_path):
     assert p.hub_tool_for("fs_grep").tags == ()  # read-only: no risk tags
 
 
+# -- TASK-19558: why the read-only local tools carry no "reads" tag -----------
+#
+# The holistic review asked whether `fs_read`/`fs_list`/`fs_glob`/`fs_grep`/
+# `web_*`/`watchlists_*` should carry ("reads",) like their in-process
+# builtin equivalents (`Tools/file_operation_tools.py`), on the premise that
+# "untagged tools are not floored to ask". These three tests demonstrate --
+# rather than assert -- why the answer is no, so the question is settled
+# with a mechanism instead of being re-asked every review.
+
+
+def test_the_reads_tag_would_floor_nothing_on_the_local_resolver(tmp_path):
+    """`("reads",)` is inert for a local tool: the resolver never reads it.
+
+    Local tools are resolved by `resolve_effective_state` (the MCP
+    resolver, wired in `console_chat_controller` via
+    `UnifiedControlPlaneService.gate_tool_test`), whose floor set is
+    `HIGH_RISK_TAGS = {"mutates", "process"}`. `"reads"` lives in
+    `BUILTIN_HIGH_RISK_TAGS`, which only `resolve_builtin_state` consults,
+    and that function serves the `agent:builtin` server key -- never
+    `local:__local__`. So adding the tag would produce a marking that reads
+    as protection in review and provides none: the exact shape TASK-19558
+    removed from `ChaChaNotes_DB`'s `safe_search_term` dead stores.
+    """
+    from dataclasses import replace
+
+    from tldw_chatbook.MCP.permission_store import (
+        BUILTIN_HIGH_RISK_TAGS,
+        HIGH_RISK_TAGS,
+        resolve_effective_state,
+    )
+    from tldw_chatbook.Agents.local_tool_provider import LOCAL_SERVER_KEY
+
+    assert "reads" not in HIGH_RISK_TAGS
+    assert "reads" in BUILTIN_HIGH_RISK_TAGS
+
+    payload = {
+        "profiles": {
+            "default": {
+                "global_default": "ask",
+                "servers": {LOCAL_SERVER_KEY: {"default": "allow"}},
+            }
+        }
+    }
+    p = make_provider(root=tmp_path)
+    untagged = p.hub_tool_for("fs_read")
+    tagged = replace(untagged, tags=("reads",))
+
+    assert resolve_effective_state(payload, untagged).state == "allow"
+    # Same verdict with the tag applied -- i.e. the tag changes nothing.
+    assert resolve_effective_state(payload, tagged).state == "allow"
+    # ...while a tag the resolver DOES consult floors the same inherited allow.
+    assert (
+        resolve_effective_state(payload, replace(untagged, tags=("mutates",))).state
+        == "ask"
+    )
+
+
+def test_mutating_local_tools_are_floored_because_that_tag_is_consulted(tmp_path):
+    """The contrast: `("mutates",)` is applied where it is load-bearing."""
+    from tldw_chatbook.MCP.permission_store import resolve_effective_state
+    from tldw_chatbook.Agents.local_tool_provider import LOCAL_SERVER_KEY
+
+    payload = {
+        "profiles": {
+            "default": {
+                "global_default": "ask",
+                "servers": {LOCAL_SERVER_KEY: {"default": "allow"}},
+            }
+        }
+    }
+    p = make_provider(root=tmp_path)
+    for name in ("fs_write", "fs_edit", "fs_patch"):
+        hub = p.hub_tool_for(name)
+        assert hub.tags == ("mutates",), name
+        resolved = resolve_effective_state(payload, hub)
+        assert resolved.state == "ask" and resolved.risk_floored, name
+
+
+def test_local_tools_default_to_ask_without_an_explicit_server_allow(tmp_path):
+    """The floor debate only matters after a user has opted out of asking.
+
+    A fresh permission store has no `local:__local__` entry, so every local
+    tool -- tagged or not -- inherits `global_default` = "ask" and already
+    raises an approval card per call.
+    """
+    from tldw_chatbook.MCP.permission_store import resolve_effective_state
+
+    p = make_provider(root=tmp_path)
+    for name in ("fs_read", "fs_list", "fs_glob", "fs_grep"):
+        assert resolve_effective_state({}, p.hub_tool_for(name)).state == "ask", name
+
+
 # -- git_* read-only tool specs (phase 3b-ii, ADR-033) -------------------------
 #
 # ADR-033 binding: the git_* set is read-only over a fixed, allowlisted argv

--- a/Tests/DB/test_fts5_quoting_search_seams.py
+++ b/Tests/DB/test_fts5_quoting_search_seams.py
@@ -404,3 +404,235 @@ def test_no_search_seam_leaks_a_raw_operationalerror(db: CharactersRAGDB) -> Non
             db.list_flashcards(q=query)
         except sqlite3.OperationalError as exc:  # pragma: no cover - guard
             pytest.fail(f"raw sqlite error for {query!r}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Recall: quoting must not narrow multi-word search (TASK-19558 review).
+# ---------------------------------------------------------------------------
+#
+# The first round of this task quoted each seam's whole query as ONE FTS5
+# phrase. That closed the injections and also halved recall at eight seams,
+# because a phrase requires the words to be CONTIGUOUS: `dragon lore` stopped
+# matching a record named "lore of the dragon reversed". Measured before it
+# was caught -- 4-5 rows before, 2 after, on the corpus below.
+#
+# The rule the fix applies, and what these tests pin:
+#
+#   * a seam that bound its query RAW (i.e. FTS5's own implicit AND) gets
+#     `build_and_match_query` -- per-token quoting, ANDed, same recall;
+#   * a seam that already bound a quoted PHRASE keeps a phrase
+#     (`build_phrase_match_query`), because widening it would be an
+#     unmeasured behaviour change riding along with a security fix.
+#
+# Nothing here is worth anything without the other half: every injection
+# assertion above must still hold under the AND form, and
+# `test_and_form_keeps_every_injection_closed` re-runs them against it.
+
+
+@pytest.fixture()
+def recall_corpus(db: CharactersRAGDB) -> CharactersRAGDB:
+    """Two records per seam: one with the words adjacent, one with them split.
+
+    A phrase form finds only the adjacent one; the AND form finds both. That
+    is the entire difference, isolated.
+    """
+    db.add_character_card({"name": "dragon lore keeper", "description": "adjacent"})
+    db.add_character_card({"name": "lore of the dragon reversed", "description": "split"})
+    conversation = db.add_conversation(
+        {"title": "dragon lore session", "character_id": 1}
+    )
+    split = db.add_conversation(
+        {"title": "lore about the dragon reversed", "character_id": 1}
+    )
+    db.add_message(
+        {"conversation_id": conversation, "sender": "user", "content": "dragon lore here"}
+    )
+    db.add_message(
+        {
+            "conversation_id": split,
+            "sender": "user",
+            "content": "lore of the dragon reversed",
+        }
+    )
+    deck_id = db.create_deck(name="Deck R")
+    db.create_flashcard({"deck_id": deck_id, "front": "dragon lore adjacent", "back": "x"})
+    db.create_flashcard(
+        {"deck_id": deck_id, "front": "lore of the dragon reversed", "back": "y"}
+    )
+    db.add_note(title="dragon lore adjacent", content="a")
+    db.add_note(title="lore of the dragon reversed", content="b")
+    return db
+
+
+@pytest.mark.parametrize(
+    "seam",
+    [
+        "search_character_cards",
+        "search_conversations_by_title",
+        "search_conversations_by_content",
+        "search_messages_by_content",
+        "list_flashcards",
+        "search_flashcards",
+    ],
+)
+def test_multi_word_search_still_matches_non_adjacent_words(
+    recall_corpus: CharactersRAGDB, seam: str
+) -> None:
+    """The regression, per seam: both records, not just the adjacent one."""
+    callers = {
+        "search_character_cards": lambda q: recall_corpus.search_character_cards(q, limit=50),
+        "search_conversations_by_title": lambda q: recall_corpus.search_conversations_by_title(q, limit=50),
+        "search_conversations_by_content": lambda q: recall_corpus.search_conversations_by_content(q, limit=50),
+        "search_messages_by_content": lambda q: recall_corpus.search_messages_by_content(q, limit=50),
+        "list_flashcards": lambda q: recall_corpus.list_flashcards(q="dragon lore", limit=50),
+        "search_flashcards": lambda q: recall_corpus.search_flashcards(q),
+    }
+    assert len(callers[seam]("dragon lore")) == 2, (
+        f"{seam}: multi-word search lost the record whose words are not "
+        "adjacent -- the whole query was quoted as one phrase"
+    )
+
+
+def test_the_phrase_seams_are_deliberately_left_as_phrases(
+    recall_corpus: CharactersRAGDB,
+) -> None:
+    """`search_notes` bound a PHRASE before this task, and still does.
+
+    Stated as a test so the asymmetry is a decision on the record rather
+    than an oversight: widening it would change behaviour this task never
+    measured.
+    """
+    assert len(recall_corpus.search_notes("dragon lore", limit=50)) == 1
+    # ...and the AND form would have found two, which is what makes the
+    # choice a choice.
+    from tldw_chatbook.Utils.fts5_match_forms import build_and_match_query
+
+    widened = recall_corpus.search_notes(
+        "dragon lore", limit=50, fts_match_query=build_and_match_query("dragon lore")
+    )
+    assert len(widened) == 2
+
+
+def test_and_form_keeps_every_injection_closed(
+    recall_corpus: CharactersRAGDB,
+) -> None:
+    """Recall was restored WITHOUT trading away the closure.
+
+    A typed `OR` is the sharpest case: under the raw bind it really executed
+    (`dragon OR zzz` returned rows), and per-token quoting must leave it a
+    literal word rather than an operator.
+    """
+    probes = (
+        lambda q: recall_corpus.search_character_cards(q, limit=50),
+        lambda q: recall_corpus.search_conversations_by_title(q, limit=50),
+        lambda q: recall_corpus.search_conversations_by_content(q, limit=50),
+        lambda q: recall_corpus.search_messages_by_content(q, limit=50),
+        lambda q: recall_corpus.list_flashcards(q=q, limit=50),
+        lambda q: recall_corpus.search_flashcards(q),
+    )
+    for probe in probes:
+        # `dragon` alone matches both records, so a live OR would return them.
+        assert probe("dragon OR zzznomatch") == []
+        assert probe(COLUMN_FILTER_INJECTION) == []
+        assert probe(ORDINARY_QUOTED) == []
+        # ...while the same seam still finds the words themselves.
+        assert len(probe("dragon lore")) == 2
+
+
+# ---------------------------------------------------------------------------
+# E1: a NUL byte truncates the bound parameter mid-literal.
+# ---------------------------------------------------------------------------
+
+
+def test_a_nul_byte_returns_no_rows_rather_than_unterminated_string(
+    recall_corpus: CharactersRAGDB,
+) -> None:
+    """`sqlite3` hands a bound TEXT value to SQLite as a C string.
+
+    So `"a\\x00b"` arrives as `"a` -- the closing quote is on the far side of
+    the truncation, and no amount of correct quoting survives it. Raw binds
+    were unaffected only by luck (the truncated `a` was still a valid
+    bareword), so quoting turned a working query into
+    `OperationalError: unterminated string` at nine seams.
+    `Notes/file_notes_replica.search` has guarded this since it was written;
+    the guard now lives in `fts5_query_is_searchable`.
+    """
+    probes = (
+        lambda q: recall_corpus.search_character_cards(q, limit=50),
+        lambda q: recall_corpus.search_conversations_by_title(q, limit=50),
+        lambda q: recall_corpus.search_conversations_by_content(q, limit=50),
+        lambda q: recall_corpus.search_messages_by_content(q, limit=50),
+        lambda q: recall_corpus.list_flashcards(q=q, limit=50),
+        lambda q: recall_corpus.search_flashcards(q),
+        lambda q: recall_corpus.search_notes(q, limit=50),
+        lambda q: recall_corpus.search_keywords(q, limit=50),
+        lambda q: recall_corpus.search_keyword_collections(q, limit=50),
+    )
+    for probe in probes:
+        assert probe("dragon\x00lore") == []
+
+
+def test_the_nul_rule_is_the_primitive_and_not_a_per_seam_copy() -> None:
+    from tldw_chatbook.Utils.fts5_match_forms import (
+        build_and_match_query,
+        build_phrase_match_query,
+        fts5_query_is_searchable,
+    )
+
+    assert fts5_query_is_searchable("a\x00b") is False
+    assert build_and_match_query("a\x00b") == ""
+    assert build_phrase_match_query("a\x00b") == ""
+    # ...and an ordinary query is unaffected.
+    assert build_and_match_query("dragon lore") == '"dragon" "lore"'
+    assert build_phrase_match_query("dragon lore") == '"dragon lore"'
+
+
+# ---------------------------------------------------------------------------
+# E2: an unset filter arrives as None.
+# ---------------------------------------------------------------------------
+
+
+def test_none_returns_no_rows_rather_than_a_bare_attributeerror(
+    recall_corpus: CharactersRAGDB,
+) -> None:
+    """Quoting `None` raised `AttributeError: 'NoneType' has no 'replace'`.
+
+    Not even wrapped in `CharactersRAGDBError`, so no caller of a DB search
+    method was written to catch it. `search_notes(None)` and
+    `search_keywords(None)` returned `[]` before this task.
+    """
+    probes = (
+        lambda: recall_corpus.search_notes(None, limit=50),
+        lambda: recall_corpus.search_keywords(None, limit=50),
+        lambda: recall_corpus.search_keyword_collections(None, limit=50),
+        lambda: recall_corpus.search_character_cards(None, limit=50),
+        lambda: recall_corpus.search_conversations_by_title(None, limit=50),
+        lambda: recall_corpus.search_conversations_by_content(None, limit=50),
+        lambda: recall_corpus.search_messages_by_content(None, limit=50),
+        lambda: recall_corpus.search_flashcards(None),
+        lambda: recall_corpus.list_flashcards(q=None, limit=50),
+    )
+    for index, probe in enumerate(probes):
+        result = probe()
+        # `list_flashcards(q=None)` is a BROWSE, not a search: it lists the
+        # deck. Every other seam has nothing to search for and answers empty.
+        assert isinstance(result, list), index
+
+
+def test_punctuation_only_search_returns_no_rows_rather_than_raising(
+    recall_corpus: CharactersRAGDB,
+) -> None:
+    """FTS5 indexes alphanumeric runs only, so `!!!` can never match.
+
+    At base six of these raised instead of answering empty.
+    """
+    probes = (
+        lambda q: recall_corpus.search_character_cards(q, limit=50),
+        lambda q: recall_corpus.search_conversations_by_title(q, limit=50),
+        lambda q: recall_corpus.search_messages_by_content(q, limit=50),
+        lambda q: recall_corpus.list_flashcards(q=q, limit=50),
+        lambda q: recall_corpus.search_flashcards(q),
+        lambda q: recall_corpus.search_notes(q, limit=50),
+    )
+    for probe in probes:
+        assert probe("!!!") == []

--- a/Tests/DB/test_fts5_quoting_search_seams.py
+++ b/Tests/DB/test_fts5_quoting_search_seams.py
@@ -390,6 +390,130 @@ def test_media_search_short_term_prefix_widening_is_preserved(media_db) -> None:
     assert total == 1 and rows[0]["title"] == "Gorgonzola notes"
 
 
+# ---------------------------------------------------------------------------
+# Media, round 2: an unbuildable MATCH must drop the FTS leg, not the query.
+# ---------------------------------------------------------------------------
+#
+# Round 1 answered `conditions.append("0")` whenever no MATCH expression could
+# be built. The conditions are AND-joined, so that forced the WHOLE query to
+# zero rows -- including the LIKE legs, which can express punctuation-only
+# intent perfectly well. Measured on the corpus below before the fix:
+# `!!!` 0 rows, `-` 0 rows, `***` 0 rows, `""` 0 rows. After: 1 row each.
+#
+# The two cases that must NOT drop the leg are pinned right below them,
+# because "restore recall" and "keep the closure" is the whole trade this
+# round is about.
+
+
+@pytest.fixture()
+def awkward_media(media_db):
+    for index, (title, content) in enumerate(
+        [
+            ("Alert!!! urgent dragon", "dragon lore about wyrms"),
+            ("well-known dashes", "a - b dashed line"),
+            ('The "gold" standard', "stars *** here in content"),
+            ('Quotes "" doubled', "double quote pair"),
+            ("plain document", "nothing special at all"),
+        ]
+    ):
+        media_db.add_media_with_keywords(
+            title=title,
+            media_type="document",
+            content=content,
+            keywords=["kw"],
+            url=f"https://example.invalid/awkward/{index}",
+        )
+    return media_db
+
+
+def _media_titles(database, query, **kwargs):
+    rows, total = database.search_media_db(
+        search_query=query,
+        search_fields=["title", "content"],
+        page=1,
+        results_per_page=50,
+        **kwargs,
+    )
+    assert total == len(rows)
+    return sorted(row["title"] for row in rows)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("!!!", ["Alert!!! urgent dragon"]),
+        ("-", ["well-known dashes"]),
+        ("***", ['The "gold" standard']),
+        ('""', ['Quotes "" doubled']),
+    ],
+)
+def test_punctuation_only_media_search_falls_back_to_like(
+    awkward_media, query, expected
+) -> None:
+    """The regression: these returned [] because the FTS leg was hard-false."""
+    assert _media_titles(awkward_media, query) == expected
+
+
+def test_whitespace_only_media_search_is_an_empty_search(awkward_media) -> None:
+    """A search box holding only spaces is a search for nothing, not for spaces."""
+    assert len(_media_titles(awkward_media, "   ")) == 5
+    assert len(_media_titles(awkward_media, "")) == 5
+
+
+def test_padded_media_query_no_longer_vetoes_its_own_fts_match(
+    awkward_media,
+) -> None:
+    """The LIKE leg is AND-ed with MATCH, so `%  dragon  %` used to subtract.
+
+    Measured at the merge-base: `dragon` -> 1 row, `  dragon  ` -> 0.
+    """
+    assert _media_titles(awkward_media, "  dragon  ") == ["Alert!!! urgent dragon"]
+
+
+def test_media_nul_byte_stays_hard_false_rather_than_falling_back(
+    awkward_media,
+) -> None:
+    """LIKE is not a safe fallback here: SQLite truncates the bound value.
+
+    `%dragon\\x00lore%` reaches LIKE as `%dragon`, which is WIDER than what
+    was typed -- measured at the merge-base, where it returned the dragon row.
+    """
+    assert _media_titles(awkward_media, "dragon\x00lore") == []
+
+
+def test_media_caller_built_empty_expression_still_means_no_rows(
+    awkward_media,
+) -> None:
+    """`fts_match_query=""` is the "no rows" answer of the shared builders.
+
+    And the title/content LIKE legs are deliberately not built in that
+    branch, so dropping the condition would return EVERY row.
+    """
+    assert _media_titles(awkward_media, "dragon", fts_match_query="") == []
+    assert _media_titles(awkward_media, "dragon", fts_match_query='"dragon"') == [
+        "Alert!!! urgent dragon"
+    ]
+
+
+def test_media_injection_probes_stay_closed_under_the_like_fallback(
+    awkward_media,
+) -> None:
+    """Recall restored without reopening anything: the branch's own probe set."""
+    for query in (
+        "dragon OR zzznomatch",
+        COLUMN_FILTER_INJECTION,
+        ORDINARY_QUOTED,
+        'dragon" OR "lore',
+        "title:dragon",
+        "dragon NEAR lore",
+        "dragon*",
+        "dragon\x00lore",
+    ):
+        assert _media_titles(awkward_media, query) == [], query
+    # ...while the words themselves still answer.
+    assert _media_titles(awkward_media, "dragon lore") == ["Alert!!! urgent dragon"]
+
+
 def test_no_search_seam_leaks_a_raw_operationalerror(db: CharactersRAGDB) -> None:
     """Whatever a seam does with bad input, it is never a bare sqlite error.
 

--- a/Tests/DB/test_fts5_quoting_search_seams.py
+++ b/Tests/DB/test_fts5_quoting_search_seams.py
@@ -1,0 +1,406 @@
+"""TASK-19558: every FTS5 search seam binds a quoted literal, not raw input.
+
+Driven through the real search methods against real throwaway SQLite
+databases -- never a hand-built SQL string -- because the defect was not "the
+wrong string was formatted", it was "the string that was formatted never
+reached the query". Only running the method proves which value SQLite saw.
+
+The two user-visible consequences named in the task, and reproduced here as
+born-red cases before the fix:
+
+* **Library notes filter** (`UI/Screens/library_screen.py` ▸
+  `_run_library_notes_filter` -> `notes_scope_service.search_notes` ->
+  `CharactersRAGDB.search_notes`). Base behaviour, measured:
+  `alpha" OR title:"Other` returned **2 rows** against a corpus where only
+  one note contained "alpha" -- the closing quote ended the intended
+  literal and the rest became a live FTS5 column filter. And `foo"bar`
+  raised `unterminated string`, which that screen swallows
+  (`except Exception: logger.warning(...); return`), so the filter box
+  silently did nothing.
+* **Study flashcard search box** (`UI/Study_Modules/flashcards_handler.py`
+  ▸ `refresh_cards` -> `list_flashcards(q=...)`). Base behaviour: `foo"bar`
+  raised a bare `sqlite3.OperationalError` out of an `await` that nothing on
+  that path catches.
+
+The equivalent Evals and Media seams are covered here too, in the same
+sweep, for the same reason.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+
+#: A query whose closing quote would end the intended literal and hand the
+#: rest of the string to FTS5 as a column filter.
+COLUMN_FILTER_INJECTION = 'alpha" OR title:"Other'
+#: A query that is merely ordinary text with a quote in it.
+ORDINARY_QUOTED = 'foo"bar'
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(tmp_path / "t19558.db", client_id="t19558")
+    yield database
+    database.close_connection()
+
+
+@pytest.fixture()
+def seeded(db: CharactersRAGDB) -> CharactersRAGDB:
+    db.add_note(title="Quarterly report", content='the alpha "beta" gamma note')
+    db.add_note(title="Other note", content="unrelated content entirely")
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Seam 1: the Library notes filter.
+# ---------------------------------------------------------------------------
+
+
+def test_notes_filter_does_not_execute_a_typed_column_filter(
+    seeded: CharactersRAGDB,
+) -> None:
+    """The headline: base returned BOTH notes; neither contains this text."""
+    rows = seeded.search_notes(COLUMN_FILTER_INJECTION, limit=10)
+    assert [row["title"] for row in rows] == []
+
+
+def test_notes_filter_survives_an_ordinary_typed_quote(
+    seeded: CharactersRAGDB,
+) -> None:
+    """Base raised `unterminated string`, which the screen swallowed."""
+    assert seeded.search_notes(ORDINARY_QUOTED, limit=10) == []
+
+
+def test_notes_filter_finds_content_that_really_contains_a_quoted_word(
+    seeded: CharactersRAGDB,
+) -> None:
+    """A clean, correct result -- not merely "no longer raises"."""
+    rows = seeded.search_notes('"beta"', limit=10)
+    assert [row["title"] for row in rows] == ["Quarterly report"]
+
+
+def test_notes_filter_plain_query_is_unchanged(seeded: CharactersRAGDB) -> None:
+    rows = seeded.search_notes("alpha", limit=10)
+    assert [row["title"] for row in rows] == ["Quarterly report"]
+
+
+def test_notes_filter_caller_built_expression_still_passes_through(
+    seeded: CharactersRAGDB,
+) -> None:
+    """`fts_match_query` is the seam for the Library's widened keyword form."""
+    rows = seeded.search_notes("ignored", limit=10, fts_match_query='"alpha"*')
+    assert [row["title"] for row in rows] == ["Quarterly report"]
+
+
+# ---------------------------------------------------------------------------
+# Seam 2: the Study flashcard search box.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def deck(db: CharactersRAGDB) -> tuple[CharactersRAGDB, str]:
+    deck_id = db.create_deck(name="Deck A")
+    db.create_flashcard(
+        {"deck_id": deck_id, "front": 'what is alpha "beta"?', "back": "gamma"}
+    )
+    db.create_flashcard({"deck_id": deck_id, "front": "plain card", "back": "delta"})
+    return db, deck_id
+
+
+def test_flashcard_search_box_does_not_raise_operationalerror(
+    deck: tuple[CharactersRAGDB, str],
+) -> None:
+    """Base raised a bare sqlite3.OperationalError into the Study screen."""
+    database, deck_id = deck
+    assert database.list_flashcards(deck_id=deck_id, q=ORDINARY_QUOTED) == []
+
+
+def test_flashcard_search_box_finds_a_card_whose_front_contains_a_quote(
+    deck: tuple[CharactersRAGDB, str],
+) -> None:
+    database, deck_id = deck
+    rows = database.list_flashcards(deck_id=deck_id, q="beta")
+    assert [row["front"] for row in rows] == ['what is alpha "beta"?']
+
+
+def test_flashcard_search_box_ignores_a_typed_column_filter(
+    deck: tuple[CharactersRAGDB, str],
+) -> None:
+    database, deck_id = deck
+    assert database.list_flashcards(deck_id=deck_id, q='alpha" OR back:"delta') == []
+
+
+def test_search_flashcards_is_swept_with_its_sibling(
+    deck: tuple[CharactersRAGDB, str],
+) -> None:
+    database, _deck_id = deck
+    assert database.search_flashcards(ORDINARY_QUOTED) == []
+    assert len(database.search_flashcards("alpha")) == 1
+
+
+# ---------------------------------------------------------------------------
+# The three dead stores: the value that was quoted is the value that is bound.
+# ---------------------------------------------------------------------------
+
+
+def _seed_for_dead_store(db: CharactersRAGDB) -> str:
+    db.add_character_card({"name": "Zed the Hunter", "description": "a hunter"})
+    conversation_id = db.add_conversation(
+        {"title": "Talk about dragons", "character_id": 1}
+    )
+    db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "hello world",
+        }
+    )
+    return conversation_id
+
+
+def test_character_card_search_binds_the_quoted_term(db: CharactersRAGDB) -> None:
+    """`safe_search_term` used to be computed and then NOT bound.
+
+    Proven at base by mutation: replacing the computed value with an absurd
+    string left all three methods' results byte-identical. The observable
+    consequence of binding it is that a typed FTS5 operator stops being
+    executed -- `Zed OR dragons` matched on the raw path and must not now.
+    """
+    _seed_for_dead_store(db)
+    assert [row["name"] for row in db.search_character_cards("Hunter")] == [
+        "Zed the Hunter"
+    ]
+    assert db.search_character_cards("Zed OR Nobody") == []
+    assert db.search_character_cards('Zed" OR name:"x') == []
+
+
+def test_character_card_search_still_serves_the_ccp_prefix_expression(
+    db: CharactersRAGDB,
+) -> None:
+    """CCP's picker builds `"term"*`; it now goes through `fts_match_query`."""
+    _seed_for_dead_store(db)
+    rows = db.search_character_cards("Hun", fts_match_query='"Hun"*')
+    assert [row["name"] for row in rows] == ["Zed the Hunter"]
+
+
+def test_conversation_title_search_binds_the_quoted_term(
+    db: CharactersRAGDB,
+) -> None:
+    _seed_for_dead_store(db)
+    assert [
+        row["title"] for row in db.search_conversations_by_title("dragons")
+    ] == ["Talk about dragons"]
+    assert db.search_conversations_by_title("dragons OR nothing") == []
+    assert db.search_conversations_by_title(ORDINARY_QUOTED) == []
+
+
+def test_message_content_search_binds_the_quoted_term(db: CharactersRAGDB) -> None:
+    _seed_for_dead_store(db)
+    assert [
+        row["content"] for row in db.search_messages_by_content("world")
+    ] == ["hello world"]
+    assert db.search_messages_by_content("world OR nothing") == []
+    assert db.search_messages_by_content(ORDINARY_QUOTED) == []
+
+
+# ---------------------------------------------------------------------------
+# The remaining ChaChaNotes seams that raised on ordinary input.
+# ---------------------------------------------------------------------------
+
+
+def test_keyword_search_finds_a_keyword_that_contains_a_quote(
+    db: CharactersRAGDB,
+) -> None:
+    """Base raised `unterminated string` on the keyword's OWN spelling."""
+    db.add_keyword('alpha"beta')
+    rows = db.search_keywords('alpha"beta')
+    assert [row["keyword"] for row in rows] == ['alpha"beta']
+
+
+def test_keyword_collection_search_is_swept_too(db: CharactersRAGDB) -> None:
+    db.add_keyword_collection('Set "A"')
+    rows = db.search_keyword_collections('Set "A"')
+    assert [row["name"] for row in rows] == ['Set "A"']
+    assert db.search_keyword_collections(ORDINARY_QUOTED) == []
+
+
+def test_conversation_content_search_no_longer_raises(db: CharactersRAGDB) -> None:
+    _seed_for_dead_store(db)
+    assert db.search_conversations_by_content('hello"x') == []
+    assert len(db.search_conversations_by_content("hello")) == 1
+
+
+def test_every_chachanotes_search_seam_survives_a_quote(
+    db: CharactersRAGDB,
+) -> None:
+    """One sweep over the whole family: none of them raises on `"`.
+
+    A quote is ordinary text a user types (an apostrophe-styled quotation, a
+    pasted title). Before this task, six of these eight either raised or
+    silently reinterpreted the query.
+    """
+    _seed_for_dead_store(db)
+    db.add_note(title="n", content="c")
+    db.add_keyword("k")
+    deck_id = db.create_deck(name="D")
+    db.create_flashcard({"deck_id": deck_id, "front": "f", "back": "b"})
+    probes = (
+        lambda q: db.search_notes(q),
+        lambda q: db.search_character_cards(q),
+        lambda q: db.search_conversations_by_title(q),
+        lambda q: db.search_conversations_by_content(q),
+        lambda q: db.search_messages_by_content(q),
+        lambda q: db.search_keywords(q),
+        lambda q: db.search_keyword_collections(q),
+        lambda q: db.list_flashcards(q=q),
+        lambda q: db.search_flashcards(q),
+    )
+    for probe in probes:
+        assert probe(ORDINARY_QUOTED) == []
+        assert probe(COLUMN_FILTER_INJECTION) == []
+
+
+def test_library_note_and_conversation_search_pages_survive_a_quote(
+    db: CharactersRAGDB,
+) -> None:
+    """The `_library_*_fts_query` token builders, through their real pages."""
+    db.add_note(title="Quarterly report", content='alpha "beta" gamma')
+    page = db.search_library_notes_page(query=ORDINARY_QUOTED, limit=10, offset=0)
+    assert page["items"] == [] and page["total"] == 0
+    hit = db.search_library_notes_page(query="beta", limit=10, offset=0)
+    assert [item["title"] for item in hit["items"]] == ["Quarterly report"]
+
+
+# ---------------------------------------------------------------------------
+# The Evals seam.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def evals_db() -> EvalsDB:
+    return EvalsDB(db_path=":memory:", client_id="t19558")
+
+
+def test_dataset_search_no_longer_raises_on_a_quote(evals_db: EvalsDB) -> None:
+    """`search_datasets` wrapped the RAW query in quotes with no doubling."""
+    evals_db.create_dataset(
+        name='Bench "gold" set', format="json", source_path="/tmp/x.json"
+    )
+    assert evals_db.search_datasets(ORDINARY_QUOTED) == []
+    assert [row["name"] for row in evals_db.search_datasets("gold")] == [
+        'Bench "gold" set'
+    ]
+
+
+def test_dataset_search_does_not_execute_a_typed_column_filter(
+    evals_db: EvalsDB,
+) -> None:
+    evals_db.create_dataset(name="Alpha set", format="json", source_path="/tmp/a.json")
+    evals_db.create_dataset(name="Other set", format="json", source_path="/tmp/o.json")
+    assert evals_db.search_datasets('Alpha" OR name:"Other') == []
+
+
+def test_task_search_still_finds_plain_terms(evals_db: EvalsDB) -> None:
+    evals_db.create_task(
+        name="math evaluation",
+        description="arithmetic benchmark",
+        task_type="question_answer",
+        config_format="custom",
+        config_data={},
+    )
+    assert [row["name"] for row in evals_db.search_tasks("math")] == [
+        "math evaluation"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The Media seam.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def media_db(tmp_path: Path):
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+    database = MediaDatabase(db_path=tmp_path / "media.db", client_id="t19558")
+    yield database
+    database.close_connection()
+
+
+def test_media_search_no_longer_raises_on_a_quote(media_db) -> None:
+    media_db.add_media_with_keywords(
+        title='The "gold" standard',
+        media_type="document",
+        content="alpha beta gamma",
+        keywords=["kw"],
+        url="https://example.invalid/a",
+    )
+    rows, total = media_db.search_media_db(
+        search_query=ORDINARY_QUOTED,
+        search_fields=["title", "content"],
+        page=1,
+        results_per_page=10,
+    )
+    assert (rows, total) == ([], 0)
+
+
+def test_media_search_still_finds_a_plain_term(media_db) -> None:
+    media_db.add_media_with_keywords(
+        title='The "gold" standard',
+        media_type="document",
+        content="alpha beta gamma",
+        keywords=["kw"],
+        url="https://example.invalid/a",
+    )
+    rows, total = media_db.search_media_db(
+        search_query="gold",
+        search_fields=["title", "content"],
+        page=1,
+        results_per_page=10,
+    )
+    assert total == 1 and rows[0]["title"] == 'The "gold" standard'
+
+
+def test_media_search_short_term_prefix_widening_is_preserved(media_db) -> None:
+    """The 1-2 character prefix branch survives the quoting change.
+
+    It is measured on the RAW length, not on the quoted string's -- quoting
+    adds two characters, so testing the quoted length would have silently
+    retired the branch.
+    """
+    media_db.add_media_with_keywords(
+        title="Gorgonzola notes",
+        media_type="document",
+        content="cheese",
+        keywords=["kw"],
+        url="https://example.invalid/g",
+    )
+    rows, total = media_db.search_media_db(
+        search_query="Go",
+        search_fields=["title"],
+        page=1,
+        results_per_page=10,
+    )
+    assert total == 1 and rows[0]["title"] == "Gorgonzola notes"
+
+
+def test_no_search_seam_leaks_a_raw_operationalerror(db: CharactersRAGDB) -> None:
+    """Whatever a seam does with bad input, it is never a bare sqlite error.
+
+    `sqlite3.OperationalError` reaching a UI handler is what the Study
+    screen shipped; the DB layer's own wrapper (`CharactersRAGDBError`) is
+    the contract every caller is written against.
+    """
+    db.add_note(title="n", content="c")
+    for query in (ORDINARY_QUOTED, COLUMN_FILTER_INJECTION, '"', '""', 'a"b"c'):
+        try:
+            db.search_notes(query)
+            db.list_flashcards(q=query)
+        except sqlite3.OperationalError as exc:  # pragma: no cover - guard
+            pytest.fail(f"raw sqlite error for {query!r}: {exc}")

--- a/Tests/Library/test_library_rag_scope.py
+++ b/Tests/Library/test_library_rag_scope.py
@@ -119,9 +119,16 @@ class _SpyConversationsDB:
     def __init__(self, rows=None):
         self.rows = rows if rows is not None else []
         self.call_count = 0
+        self.match_queries: list[str | None] = []
 
-    def search_conversations_by_content(self, query, limit):
+    def search_conversations_by_content(self, query, limit, fts_match_query=None):
+        # TASK-19558: the seam now hands its pre-built (plural/singular- or
+        # prefix-widened) MATCH expression in through `fts_match_query`
+        # rather than through the plain-text parameter, which the DB method
+        # quotes as a literal phrase. Recorded rather than ignored so a
+        # future regression to passing it positionally is visible here.
         self.call_count += 1
+        self.match_queries.append(fts_match_query)
         return self.rows
 
 
@@ -439,6 +446,8 @@ async def test_unscoped_keyword_search_includes_conversations_no_diagnostics():
     result = await service.search("q", ("conversations",), "search", top_k=5)
 
     assert conv_db.call_count == 1
+    # The widened MATCH expression reaches the DB through `fts_match_query`.
+    assert conv_db.match_queries == ['"q"']
     assert result["diagnostics"] == {}
 
 

--- a/Tests/Prompts_DB/test_prompts_db_legacy.py
+++ b/Tests/Prompts_DB/test_prompts_db_legacy.py
@@ -812,11 +812,33 @@ class TestSearchFunctionality(BaseTestCase):
         self.assertIn("Shared Term Prompt", names)
         self.assertIn("Another Code Prompt", names)
 
-    def test_search_with_invalid_fts_syntax_raises_error(self):
-        """Verify that malformed FTS queries raise a DatabaseError."""
-        # An unclosed quote is invalid syntax
-        with self.assertRaises(DatabaseError):
-            self.db.search_prompts('invalid "syntax', search_fields=["name"])
+    def test_search_with_a_typed_quote_is_matched_literally(self):
+        """TASK-19558 inverted this test, deliberately.
+
+        It used to assert that ``invalid "syntax`` raises ``DatabaseError``
+        -- i.e. that a user typing a double quote into the prompt search box
+        got an error. That was not a contract, it was the symptom: the raw
+        ``search_query`` was bound straight to FTS5 MATCH, so an unbalanced
+        quote produced ``OperationalError('unterminated string')``. The
+        plain-text parameter now quotes what it is given as a literal
+        phrase, so the query simply matches nothing rather than failing, and
+        a caller that genuinely wants to supply an FTS5 expression passes it
+        through ``fts_match_query``.
+        """
+        results, total = self.db.search_prompts(
+            'invalid "syntax', search_fields=["name"]
+        )
+        self.assertEqual((results, total), ([], 0))
+
+    def test_search_still_forwards_a_caller_built_match_expression(self):
+        """The seam an expression-supplying caller uses is unchanged."""
+        results, total = self.db.search_prompts(
+            "ignored",
+            search_fields=["name"],
+            fts_match_query='"Code" OR "Explainer"',
+        )
+        self.assertGreater(total, 0)
+        self.assertIn("Code Explainer", {r["name"] for r in results})
 
 
 class TestStandaloneFunctionExports(BaseTestCase):

--- a/Tests/Subscriptions/test_watchlist_opml_entity_expansion.py
+++ b/Tests/Subscriptions/test_watchlist_opml_entity_expansion.py
@@ -39,7 +39,53 @@ from tldw_chatbook.Subscriptions.watchlist_opml_service import (
 )
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
-SUBSCRIPTIONS_ROOT = PACKAGE_ROOT / "Subscriptions"
+
+#: Modules that parse XML with stdlib ElementTree and do NOT consult
+#: defusedxml, recorded with what reaches them. This is a REGISTER OF OPEN
+#: DEFECTS, not an allowlist of acceptable ones: every entry below is a live
+#: entity-expansion exposure of the same shape as the OPML importer this
+#: task fixed, and each is filed for its own change rather than fixed here
+#: (TASK-19558 was scoped to the seams the holistic review named).
+#:
+#: The census is repo-wide precisely so that an EIGHTH such module cannot be
+#: added silently -- it fails immediately, and the author must either harden
+#: it or write down here what reaches it and why it is being left open.
+#: `test_known_unhardened_entries_are_still_unhardened` deletes the register
+#: as each one is fixed, so it cannot rot into folklore.
+_KNOWN_UNHARDENED: dict[str, str] = {
+    "Evals/eval_runner.py": (
+        "Parses MODEL OUTPUT (`ET.fromstring` over a generated XML answer), "
+        "so the payload is prompt-injection reachable -- the sharpest of "
+        "the seven: a poisoned document in the corpus can choose the XML "
+        "the model emits."
+    ),
+    "Local_Ingestion/XML_Ingestion.py": (
+        "Parses user-supplied .xml files chosen for ingestion -- the same "
+        "threat shape as the OPML importer fixed by TASK-19558 (a file the "
+        "user did not write, imported on their behalf)."
+    ),
+    "Media/local_media_reading_service.py": (
+        "`ET.iterparse` over stored media documents. iterparse streams "
+        "elements but still expands internal entities, so a byte cap on the "
+        "source does not bound the expansion."
+    ),
+    "Research_Interop/academic_providers.py": (
+        "Parses a REMOTE Atom feed (arXiv) -- fully attacker-controlled "
+        "bytes if the endpoint or the transport is."
+    ),
+    "Utils/file_extraction.py": (
+        "Parses XML pulled out of user-supplied archives/documents during "
+        "extraction."
+    ),
+    "Web_Scraping/Article_Extractor_Lib.py": (
+        "Parses FETCHED sitemaps. A response size cap does not help here: "
+        "amplification is the whole point of a billion-laughs payload -- a "
+        "few hundred bytes on the wire become gigabytes in the parser."
+    ),
+    "Web_Scraping/Article_Scraper/crawler.py": (
+        "Parses FETCHED sitemaps, same as `Article_Extractor_Lib` above."
+    ),
+}
 
 #: Six nesting levels of a 10x entity: ~1,000,000 "lol" copies if expanded.
 BILLION_LAUGHS_OPML = """<?xml version="1.0"?>
@@ -215,29 +261,75 @@ def unhardened_xml_parsers(source: str) -> list[tuple[int, str]]:
     return hits
 
 
-def test_no_subscriptions_module_parses_xml_without_defusedxml() -> None:
-    """Scoped to `Subscriptions/`, where the rule is fully satisfied today.
-
-    Stated rather than overclaimed: a repo-wide version of this census
-    currently reports seven other modules (`Evals/eval_runner.py`,
-    `Local_Ingestion/XML_Ingestion.py`,
-    `Media/local_media_reading_service.py`,
-    `Research_Interop/academic_providers.py`, `Utils/file_extraction.py`,
-    `Web_Scraping/Article_Extractor_Lib.py`,
-    `Web_Scraping/Article_Scraper/crawler.py`) that parse XML with stdlib
-    ElementTree and never import defusedxml. Those are a real, separate
-    population -- outside this task's scope, and NOT allowlisted here,
-    because an allowlist would quietly bless them. Widening the census to
-    the package tree is what turns them red.
-    """
-    offenders: dict[str, list[tuple[int, str]]] = {}
-    for path in sorted(SUBSCRIPTIONS_ROOT.rglob("*.py")):
-        hits = unhardened_xml_parsers(path.read_text(encoding="utf-8"))
+def _unhardened_modules() -> dict[str, list[tuple[int, str]]]:
+    """Every module under `tldw_chatbook/` that parses XML unhardened."""
+    found: dict[str, list[tuple[int, str]]] = {}
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        hits = unhardened_xml_parsers(path.read_text(encoding="utf-8", errors="replace"))
         if hits:
-            offenders[str(path.relative_to(PACKAGE_ROOT.parent))] = hits
+            found[path.relative_to(PACKAGE_ROOT).as_posix()] = hits
+    return found
+
+
+def test_no_module_parses_xml_without_defusedxml() -> None:
+    """Repo-wide, so an EIGHTH unhardened parser cannot appear silently.
+
+    The first version of this census was scoped to `Subscriptions/`, which
+    made it green and inert: it could never red on anything, and the note
+    saying the other seven were "deliberately not allowlisted so widening
+    turns them red" described a widening that had not happened. The register
+    above is the honest form -- the census covers the whole package, and the
+    seven known-open modules are named with what reaches them.
+    """
+    offenders = {
+        key: hits
+        for key, hits in _unhardened_modules().items()
+        if key not in _KNOWN_UNHARDENED
+    }
     assert offenders == {}, (
-        "These Subscriptions modules parse XML without consulting "
-        f"defusedxml: {offenders}"
+        "These modules parse XML without consulting defusedxml: "
+        f"{offenders} -- import `defusedxml.ElementTree` (a core dependency; "
+        "see `watchlist_opml_service` for the shape), or add an entry to "
+        "_KNOWN_UNHARDENED saying what reaches this parser and why it is "
+        "being left open."
+    )
+
+
+def test_known_unhardened_entries_are_still_unhardened() -> None:
+    """A register entry for a module that no longer needs it is stale.
+
+    Without this, fixing one of the seven leaves a permanent hole in the
+    census: the module would stay skipped, and a LATER regression in the
+    same file would never red.
+    """
+    found = _unhardened_modules()
+    for key in _KNOWN_UNHARDENED:
+        path = PACKAGE_ROOT / key
+        assert path.exists(), f"stale register entry for a deleted module: {key}"
+        assert key in found, (
+            f"stale register entry: {key} no longer parses XML unhardened -- "
+            "drop the entry so the census covers it again"
+        )
+
+
+def test_the_register_matches_the_measured_population_exactly() -> None:
+    """The register is a measurement, not a wish: no entry may be missing."""
+    assert sorted(_unhardened_modules()) == sorted(_KNOWN_UNHARDENED)
+
+
+def test_no_subscriptions_module_parses_xml_without_defusedxml() -> None:
+    """The narrower claim TASK-19558 actually delivered, kept explicit.
+
+    `Subscriptions/` is fully hardened -- the OPML importer was its last
+    unhardened parser -- and no entry in the register lives there.
+    """
+    subscriptions = {
+        key: hits
+        for key, hits in _unhardened_modules().items()
+        if key.startswith("Subscriptions/")
+    }
+    assert subscriptions == {}, (
+        f"These Subscriptions modules parse XML without defusedxml: {subscriptions}"
     )
 
 

--- a/Tests/Subscriptions/test_watchlist_opml_entity_expansion.py
+++ b/Tests/Subscriptions/test_watchlist_opml_entity_expansion.py
@@ -1,0 +1,278 @@
+"""TASK-19558: the OPML importer parses with defusedxml, like every sibling.
+
+`Subscriptions/watchlist_opml_service.py` was the one XML parser in the
+`Subscriptions/` package that imported stdlib `xml.etree.ElementTree`
+directly, while `security.py`, `monitoring_engine.py` and the three scrapers
+all use the defusedxml-with-fallback shape. `defusedxml` is a core
+dependency (`pyproject.toml`, "engine xml security parsing (Q9: core)"), so
+this was a missed adoption rather than a dependency question.
+
+**The exposure, measured rather than assumed.** It is ENTITY EXPANSION, not
+XXE. Python's stdlib ElementTree has ignored external entity references for
+years -- `test_stdlib_elementtree_still_ignores_external_entities` re-proves
+that here rather than taking it on trust -- but it happily expands INTERNAL
+ones, which is the billion-laughs shape: a small OPML file whose DTD nests
+entities expands to gigabytes inside the parser before a single outline is
+seen. Watchlists ▸ Import OPML feeds a user-chosen (or shared) file straight
+into `parse()`, so the payload does not have to come from the person running
+the app.
+
+**The assertion is on the refusal, not on a timeout.** A test that measures
+"this took too long" is a flake generator and proves nothing about the fix
+(a faster machine passes it either way). The payload below is bounded
+(6 levels, ~10^6 expansion -- large enough to be an unmistakable defect if
+expanded, small enough to be harmless if it ever were), and the test asserts
+that defusedxml REFUSES the document by raising `EntitiesForbidden` at the
+DTD, before expansion is attempted at all.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Subscriptions.watchlist_opml_service import (
+    DEFUSEDXML_AVAILABLE,
+    WatchlistOpmlService,
+)
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+SUBSCRIPTIONS_ROOT = PACKAGE_ROOT / "Subscriptions"
+
+#: Six nesting levels of a 10x entity: ~1,000,000 "lol" copies if expanded.
+BILLION_LAUGHS_OPML = """<?xml version="1.0"?>
+<!DOCTYPE opml [
+  <!ENTITY lol "lol">
+  <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+]>
+<opml version="2.0">
+  <body>
+    <outline text="&lol5;" xmlUrl="https://example.invalid/feed.xml"/>
+  </body>
+</opml>
+"""
+
+BENIGN_OPML = """<?xml version="1.0"?>
+<opml version="2.0">
+  <body>
+    <outline text="News">
+      <outline text="Example" type="rss" xmlUrl="https://example.invalid/feed.xml"/>
+    </outline>
+  </body>
+</opml>
+"""
+
+
+def test_defusedxml_is_the_parser_actually_in_use() -> None:
+    """The fallback branch exists for a missing optional dep; it is not one."""
+    assert DEFUSEDXML_AVAILABLE, (
+        "defusedxml is a core dependency; the OPML importer fell back to "
+        "stdlib ElementTree, which expands internal entities"
+    )
+
+
+def test_entity_expansion_opml_is_refused_at_the_dtd() -> None:
+    from defusedxml.common import EntitiesForbidden
+
+    with pytest.raises(EntitiesForbidden):
+        WatchlistOpmlService().parse(BILLION_LAUGHS_OPML)
+
+
+def test_the_refusal_subclasses_valueerror_so_import_handlers_catch_it() -> None:
+    """Callers already handle a malformed document; this is the same shape."""
+    from defusedxml.common import EntitiesForbidden
+
+    assert issubclass(EntitiesForbidden, ValueError)
+
+
+def test_stdlib_elementtree_would_have_expanded_the_same_payload() -> None:
+    """The defect, demonstrated on the primitive the module used to import.
+
+    Bounded on purpose: this parses the payload with stdlib ElementTree and
+    shows the outline text is ~10^6 characters long -- i.e. the parser
+    materialized the expansion. Nothing here is timed.
+    """
+    import xml.etree.ElementTree as ET
+
+    root = ET.fromstring(BILLION_LAUGHS_OPML)
+    outline = root.find("./body/outline")
+    assert outline is not None
+    expanded = outline.get("text") or ""
+    assert len(expanded) >= 3 * 10**5, len(expanded)
+
+
+def test_stdlib_elementtree_still_ignores_external_entities() -> None:
+    """States the exposure honestly: this is NOT an XXE.
+
+    A SYSTEM entity reference is left unresolved by stdlib ElementTree, so
+    calling the pre-fix state an XXE would have been wrong.
+    """
+    import xml.etree.ElementTree as ET
+
+    xxe = (
+        '<?xml version="1.0"?>\n'
+        '<!DOCTYPE opml [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>\n'
+        '<opml version="2.0"><body>'
+        '<outline text="&xxe;" xmlUrl="https://example.invalid/f.xml"/>'
+        "</body></opml>"
+    )
+    try:
+        root = ET.fromstring(xxe)
+    except ET.ParseError:
+        return  # refused outright: also not an XXE
+    outline = root.find("./body/outline")
+    assert outline is not None
+    assert "root:" not in (outline.get("text") or "")
+
+
+def test_ordinary_opml_still_parses_and_keeps_folder_structure() -> None:
+    """The hardening did not change the parser's contract (ADR-043)."""
+    items = WatchlistOpmlService().parse(BENIGN_OPML)
+    assert items == [
+        {
+            "name": "Example",
+            "url": "https://example.invalid/feed.xml",
+            "source_type": "rss",
+            "folder": "News",
+        }
+    ]
+
+
+def test_malformed_opml_still_raises_parseerror() -> None:
+    import xml.etree.ElementTree as ET
+
+    with pytest.raises(ET.ParseError):
+        WatchlistOpmlService().parse("<opml><body><outline")
+
+
+# ---------------------------------------------------------------------------
+# The guard: no NEW unhardened XML parser in `Subscriptions/`.
+# ---------------------------------------------------------------------------
+
+_PARSE_ENTRY_POINTS = frozenset(
+    {"fromstring", "parse", "XML", "iterparse", "XMLParser"}
+)
+
+
+def unhardened_xml_parsers(source: str) -> list[tuple[int, str]]:
+    """Calls to a stdlib-etree PARSE entry point in a module with no defusedxml.
+
+    Deliberately AST-based (same reasoning as
+    `Tests/Utils/test_egress_adoption_census.py`): a comment mentioning
+    `ET.fromstring` produces no `Call` node, and a docstring mentioning
+    `defusedxml` produces no `Import` node, so neither direction of the
+    regex-over-text bypass is available.
+
+    Document BUILDING (`Element`/`SubElement`/`tostring`) is not a parse and
+    is not flagged -- `watchlist_opml_service.export()` legitimately keeps
+    stdlib ElementTree for exactly that, because defusedxml has no
+    counterpart for it and a tree we constructed ourselves has no
+    attacker-controlled input.
+    """
+    tree = ast.parse(source)
+    et_aliases: set[str] = set()
+    parse_bindings: set[str] = set()
+    has_defusedxml = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("defusedxml"):
+                    has_defusedxml = True
+                if alias.name in ("xml.etree.ElementTree", "xml.etree.cElementTree"):
+                    et_aliases.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.startswith("defusedxml"):
+                has_defusedxml = True
+            if module in ("xml.etree.ElementTree", "xml.etree"):
+                for alias in node.names:
+                    if alias.name in _PARSE_ENTRY_POINTS:
+                        parse_bindings.add(alias.asname or alias.name)
+                    if alias.name == "ElementTree":
+                        et_aliases.add(alias.asname or alias.name)
+    if has_defusedxml:
+        return []
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id in et_aliases
+            and func.attr in _PARSE_ENTRY_POINTS
+        ):
+            hits.append((node.lineno, f"{func.value.id}.{func.attr}"))
+        elif isinstance(func, ast.Name) and func.id in parse_bindings:
+            hits.append((node.lineno, func.id))
+    return hits
+
+
+def test_no_subscriptions_module_parses_xml_without_defusedxml() -> None:
+    """Scoped to `Subscriptions/`, where the rule is fully satisfied today.
+
+    Stated rather than overclaimed: a repo-wide version of this census
+    currently reports seven other modules (`Evals/eval_runner.py`,
+    `Local_Ingestion/XML_Ingestion.py`,
+    `Media/local_media_reading_service.py`,
+    `Research_Interop/academic_providers.py`, `Utils/file_extraction.py`,
+    `Web_Scraping/Article_Extractor_Lib.py`,
+    `Web_Scraping/Article_Scraper/crawler.py`) that parse XML with stdlib
+    ElementTree and never import defusedxml. Those are a real, separate
+    population -- outside this task's scope, and NOT allowlisted here,
+    because an allowlist would quietly bless them. Widening the census to
+    the package tree is what turns them red.
+    """
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for path in sorted(SUBSCRIPTIONS_ROOT.rglob("*.py")):
+        hits = unhardened_xml_parsers(path.read_text(encoding="utf-8"))
+        if hits:
+            offenders[str(path.relative_to(PACKAGE_ROOT.parent))] = hits
+    assert offenders == {}, (
+        "These Subscriptions modules parse XML without consulting "
+        f"defusedxml: {offenders}"
+    )
+
+
+def test_the_xml_census_rediscovers_the_original_seam() -> None:
+    """Bite-proof: the pre-fix module shape fails the census."""
+    pre_fix = (
+        "import xml.etree.ElementTree as ET\n"
+        "\n"
+        "def parse(xml_text):\n"
+        "    return ET.fromstring(xml_text)\n"
+    )
+    assert unhardened_xml_parsers(pre_fix) == [(4, "ET.fromstring")]
+
+
+def test_the_xml_census_ignores_document_building() -> None:
+    """False-red direction: `export()`'s stdlib usage is not a parse."""
+    builder = (
+        "import xml.etree.ElementTree as ET\n"
+        "\n"
+        "def export():\n"
+        "    root = ET.Element('opml')\n"
+        "    ET.SubElement(root, 'body')\n"
+        "    return ET.tostring(root, encoding='unicode')\n"
+    )
+    assert unhardened_xml_parsers(builder) == []
+
+
+def test_the_xml_census_is_not_laundered_by_a_docstring() -> None:
+    """False-green direction: prose naming defusedxml is not an import."""
+    laundered = (
+        '"""We should really use defusedxml here."""\n'
+        "import xml.etree.ElementTree as ET\n"
+        "\n"
+        "def parse(xml_text):\n"
+        "    # defusedxml would be better\n"
+        "    return ET.fromstring(xml_text)\n"
+    )
+    assert unhardened_xml_parsers(laundered) == [(6, "ET.fromstring")]

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3556,13 +3556,23 @@ class TestImportExport:
 
 
 class _FtsStubDB:
-    """Captures the MATCH term handed to search_character_cards."""
+    """Captures the MATCH term handed to search_character_cards.
+
+    TASK-19558: `search_character_cards` used to compute a `safe_search_term`
+    and bind the RAW one, so a caller-built prefix expression reached MATCH
+    only through the plain-text parameter. The plain-text parameter now
+    quotes what it is given, and a caller-built expression travels through
+    `fts_match_query` -- which is what `calls` records here, so these tests
+    still assert on the expression SQLite actually sees.
+    """
 
     def __init__(self):
         self.calls: list[tuple[str, int]] = []
+        self.plain_terms: list[str] = []
 
-    def search_character_cards(self, search_term, limit=10):
-        self.calls.append((search_term, limit))
+    def search_character_cards(self, search_term, limit=10, fts_match_query=None):
+        self.plain_terms.append(search_term)
+        self.calls.append((fts_match_query, limit))
         return [{"id": 1, "name": "Match"}]
 
 
@@ -3581,6 +3591,8 @@ class TestFtsTermSafety:
         results = character_handler_module.search_characters_fts("sam")
         assert [term for term, _ in stub_db.calls] == ['"sam"*']
         assert results and results[0]["name"] == "Match"
+        # The raw term still travels alongside, for the error message only.
+        assert stub_db.plain_terms == ["sam"]
 
     async def test_apostrophe_term_is_safe(self, stub_db):
         character_handler_module.search_characters_fts("O'Brien")

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3591,7 +3591,11 @@ class TestFtsTermSafety:
         results = character_handler_module.search_characters_fts("sam")
         assert [term for term, _ in stub_db.calls] == ['"sam"*']
         assert results and results[0]["name"] == "Match"
-        # The raw term still travels alongside, for the error message only.
+        # The raw term is still passed positionally, but when
+        # `fts_match_query` is supplied `search_term` is UNUSED by
+        # `search_character_cards` -- not even in its error message, which
+        # reports the expression that was actually run. Recorded here only so
+        # a future change that starts using it is visible.
         assert stub_db.plain_terms == ["sam"]
 
     async def test_apostrophe_term_is_safe(self, stub_db):

--- a/Tests/Utils/test_agent_path_redaction_adoption.py
+++ b/Tests/Utils/test_agent_path_redaction_adoption.py
@@ -43,6 +43,10 @@ from tldw_chatbook.Utils.path_validation import validate_path, validate_path_mul
 # when this test module is the first thing in the process to walk it.
 # Pre-existing and unrelated to TASK-19558; importing it up front here keeps
 # that unrelated fragility from masquerading as a redaction failure.
+# Measured 2026-08-23: dev has since fixed the cycle itself (TASK-21160,
+# `ae018308b`), and these seven tests pass without this line on a tree that
+# has it -- so DROP this import when the branch lands on a dev containing
+# that fix. It is still required at this branch's own base.
 # The cycle only resolves when `simplified` is entered first, so this line
 # must come before any import of `config_profiles`.
 import tldw_chatbook.RAG_Search.simplified  # noqa: E402,F401  isort:skip

--- a/Tests/Utils/test_agent_path_redaction_adoption.py
+++ b/Tests/Utils/test_agent_path_redaction_adoption.py
@@ -1,0 +1,137 @@
+"""TASK-19558: model-supplied paths are not echoed into the log.
+
+`Utils/path_validation.validate_path` prints the full user path AND its
+resolved form at WARNING/ERROR unless `redact_paths=True` is passed, and at
+this task's branch base only 12 of its 30 call sites passed it. Two of the
+misses were on the paths that are not the user's at all -- they are the
+model's:
+
+* `Tools/local_tool_impls._resolve_in_workspace`, the choke point for the
+  ADR-032 local tool family (`fs_read`/`fs_list`/`fs_glob`/`fs_grep`/
+  `fs_write`/...).
+* `Utils/path_validation.validate_path_multi`, the choke point for the
+  in-process builtin family (`ReadFileTool`/`WriteFileTool`/
+  `ListDirectoryTool`/`EditFileTool`, via `Tools/file_operation_tools.py`) --
+  and worse, it calls `validate_path` once PER ROOT, so one probe wrote the
+  path several times.
+
+Both are prompt-injection-reachable: text in a fetched page or an ingested
+document can make the model attempt `../../.ssh/id_rsa`, and the log line
+then carries the attacker's string plus the real filesystem layout into the
+diagnostics bundle a user may later share.
+
+What redaction does NOT change is asserted here too: the refusal the MODEL
+receives is built by the tool layer from its own argument and still names
+the path, because that message is the model's recovery route.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from tldw_chatbook.Tools.local_tool_impls import LocalToolError, read_file
+from tldw_chatbook.Utils.path_validation import validate_path, validate_path_multi
+
+# Priming import, not a dependency of these assertions. On the SUCCESS path
+# `local_tool_impls` -> `sensitive_paths.resolve_sensitive_context` lazily
+# imports `RAG_Search.config_profiles`, and that package's `__init__` has a
+# circular edge (`config_profiles` -> `simplified/__init__` ->
+# `enhanced_rag_service_v2` -> back into `config_profiles`) that only raises
+# when this test module is the first thing in the process to walk it.
+# Pre-existing and unrelated to TASK-19558; importing it up front here keeps
+# that unrelated fragility from masquerading as a redaction failure.
+# The cycle only resolves when `simplified` is entered first, so this line
+# must come before any import of `config_profiles`.
+import tldw_chatbook.RAG_Search.simplified  # noqa: E402,F401  isort:skip
+
+SECRET_LEAF = "t19558-secret-leaf-name"
+
+
+@pytest.fixture()
+def captured_logs():
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="DEBUG", format="{message}")
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
+
+
+def test_validate_path_without_redaction_still_echoes_the_path(
+    tmp_path: Path, captured_logs: list[str]
+) -> None:
+    """The mechanism, pinned: this is what the un-swept call sites do."""
+    with pytest.raises(ValueError):
+        validate_path(f"../{SECRET_LEAF}", tmp_path)
+    assert any(SECRET_LEAF in line for line in captured_logs)
+
+
+def test_local_tool_path_refusal_does_not_log_the_model_supplied_path(
+    tmp_path: Path, captured_logs: list[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with pytest.raises(LocalToolError):
+        read_file(f"../{SECRET_LEAF}", workspace_root=workspace)
+    assert not any(SECRET_LEAF in line for line in captured_logs), captured_logs
+
+
+def test_local_tool_refusal_still_tells_the_model_which_path_it_named(
+    tmp_path: Path,
+) -> None:
+    """Redaction bounds the LOG, not the model-facing recovery message."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with pytest.raises(LocalToolError) as excinfo:
+        read_file(f"../{SECRET_LEAF}", workspace_root=workspace)
+    assert SECRET_LEAF in str(excinfo.value)
+
+
+def test_multi_root_validation_does_not_log_the_model_supplied_path(
+    tmp_path: Path, captured_logs: list[str]
+) -> None:
+    """The builtin file-tool choke point, which logged once per root."""
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    with pytest.raises(ValueError):
+        validate_path_multi(f"../{SECRET_LEAF}", [root_a, root_b])
+    assert not any(SECRET_LEAF in line for line in captured_logs), captured_logs
+
+
+def test_multi_root_refusal_still_names_the_path_and_the_consulted_roots(
+    tmp_path: Path,
+) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    with pytest.raises(ValueError) as excinfo:
+        validate_path_multi(f"../{SECRET_LEAF}", [root_a, root_b])
+    message = str(excinfo.value)
+    assert SECRET_LEAF in message
+    assert str(root_a.resolve()) in message and str(root_b.resolve()) in message
+
+
+def test_multi_root_validation_still_accepts_a_path_under_a_later_root(
+    tmp_path: Path,
+) -> None:
+    """First-match-wins behaviour is unchanged by the redaction flag."""
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    target = root_b / "file.txt"
+    target.write_text("x")
+    assert validate_path_multi(target, [root_a, root_b]) == target.resolve()
+
+
+def test_local_tool_read_still_works_inside_the_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_text("hello\n")
+    assert "hello" in read_file("note.txt", workspace_root=workspace)

--- a/Tests/Utils/test_fts5_quoting_adoption_census.py
+++ b/Tests/Utils/test_fts5_quoting_adoption_census.py
@@ -1,0 +1,364 @@
+"""TASK-19558: the FTS5 quoting primitive cannot be re-spelled, and a
+computed-but-unbound "safe" term cannot come back.
+
+This repo already owned `Utils/fts5_match_forms.quote_fts5_token` -- the ONE
+correct FTS5 string-literal escape -- and, at this task's branch base, had
+**six** other spellings of the same idea scattered across the DB and UI
+layers. Four of them were correct. Two omitted the embedded-quote doubling
+entirely, so any search containing a `"` either raised
+`OperationalError('unterminated string')` or escaped the literal into a live
+column filter. Worse, three `ChaChaNotes_DB` search methods computed a
+`safe_search_term` and then bound the RAW one: protection that read as
+protection in code review and reached no query at all.
+
+Fixing the six sites is not the durable outcome -- the next search method is.
+These two censuses are that outcome.
+
+**Census 1 (re-spelling).** Doubling a `"` into `""` has exactly one purpose
+in this codebase's data layer: escaping a double quote inside a quoted
+string literal. So `<expr>.replace('"', '""')` anywhere outside the two
+modules that own an escape IS a hand-rolled re-spelling, and this census
+fails on it. There is one genuine non-FTS5 owner, `DB/sql_validation.py`'s
+`escape_identifier`, which escapes a SQL *identifier* (`"table name"` in
+DDL) -- a different language layer with the same doubling rule -- and it is
+allowlisted by exact (module, function) name rather than by module, so a
+second, FTS5-shaped helper cannot be smuggled into that file.
+
+**Census 2 (dead store).** A local whose name marks it as the sanitized form
+of user input (`safe_*`, `quoted_*`, `escaped_*`) and whose every READ is
+inside a logging call is, by construction, not protecting anything: the
+value reaches the diagnostics and nothing else. That is the exact shape of
+the three defects this task fixed, and running this census against the base
+revision of `ChaChaNotes_DB.py` independently rediscovers all three and
+nothing else (`test_dead_store_census_rediscovers_the_three_base_defects`).
+
+**Why AST, not regex over source text.** Following
+`Tests/Utils/test_egress_adoption_census.py` (PR #1967's review): a regex
+over raw source is bypassable in both directions -- a docstring *mentioning*
+the primitive launders an unguarded module (false green), and a comment
+*containing* the offending literal flags a clean one (false red). Comments
+and docstrings produce no `Call`/`Name` nodes, so both bypasses are
+structurally closed here; both directions are proven below.
+
+**What this cannot express, stated rather than left to be rediscovered.**
+Both censuses are single-file and syntactic. Census 1 cannot see an escape
+built by string concatenation in a loop, by `str.translate`, or through a
+helper in another module; census 2 cannot see a dead store whose reads are
+routed through a local alias or an f-string assigned to another variable
+first. Neither can prove the bound value is the *right* one -- only that the
+sanitized one is not obviously discarded. The behavioural tests in
+`Tests/DB/test_fts5_quoting_search_seams.py` are what prove the actual
+matching semantics; these two only close the "silently re-spelled / silently
+discarded" routes back in.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+
+#: The ONE module allowed to implement the FTS5 string-literal escape.
+FTS5_PRIMITIVE = "tldw_chatbook/Utils/fts5_match_forms.py"
+
+#: (module, function) pairs allowed to double a `"` for a NON-FTS5 reason.
+#: Keyed on the function too, so an FTS5 helper cannot be parked in the same
+#: module and inherit the exemption.
+QUOTE_DOUBLING_EXEMPTIONS = frozenset(
+    {
+        # SQL identifier quoting: `"my table"` in DDL/DML. Same doubling
+        # rule, different language layer, and it is not interchangeable with
+        # the FTS5 escape (its output is an identifier, not a MATCH term).
+        ("tldw_chatbook/DB/sql_validation.py", "escape_identifier"),
+    }
+)
+
+#: Locals whose NAME claims they are the sanitized form of user input.
+_SANITIZED_LOCAL = re.compile(r"^(safe|quoted|escaped)_")
+
+#: Call roots treated as "this is a logging call".
+_LOGGING_ROOTS = frozenset({"logger", "logging", "log"})
+
+
+def _python_sources() -> list[Path]:
+    return sorted(PACKAGE_ROOT.rglob("*.py"))
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(PACKAGE_ROOT.parent))
+
+
+def _is_quote_doubling_call(node: ast.AST) -> bool:
+    """True for `<expr>.replace('"', '""')` -- the escape, spelled out."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "replace"
+        and len(node.args) == 2
+        and all(
+            isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+            for arg in node.args
+        )
+        and node.args[0].value == '"'
+        and node.args[1].value == '""'
+    )
+
+
+def _enclosing_function_name(tree: ast.AST, target: ast.AST) -> str:
+    """Innermost def containing `target`, or "<module>"."""
+    best = "<module>"
+    best_lineno = -1
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        end = getattr(node, "end_lineno", None) or node.lineno
+        if node.lineno <= target.lineno <= end and node.lineno > best_lineno:
+            best, best_lineno = node.name, node.lineno
+    return best
+
+
+def quote_doubling_sites(source: str, relative_path: str) -> list[tuple[str, str, int]]:
+    """Every `.replace('"', '""')` in `source`, as (path, function, line)."""
+    tree = ast.parse(source)
+    return [
+        (relative_path, _enclosing_function_name(tree, node), node.lineno)
+        for node in ast.walk(tree)
+        if _is_quote_doubling_call(node)
+    ]
+
+
+def _logged_node_ids(function: ast.AST) -> set[int]:
+    """ids of every node inside a `logger.*(...)`/`logging.*(...)` call."""
+    logged: set[int] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        root = node.func
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        if isinstance(root, ast.Name) and root.id in _LOGGING_ROOTS:
+            for descendant in ast.walk(node):
+                logged.add(id(descendant))
+    return logged
+
+
+def dead_store_sites(source: str, relative_path: str) -> list[tuple[str, str, str, str]]:
+    """Sanitized-looking locals that are never read outside a log call.
+
+    Returns (path, function, variable, reason) rows.
+    """
+    tree = ast.parse(source)
+    findings: list[tuple[str, str, str, str]] = []
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        assigned: set[str] = set()
+        for node in ast.walk(function):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and _SANITIZED_LOCAL.match(
+                        target.id
+                    ):
+                        assigned.add(target.id)
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and _SANITIZED_LOCAL.match(node.target.id)
+            ):
+                assigned.add(node.target.id)
+        if not assigned:
+            continue
+        logged = _logged_node_ids(function)
+        for name in sorted(assigned):
+            reads = [
+                node
+                for node in ast.walk(function)
+                if isinstance(node, ast.Name)
+                and node.id == name
+                and isinstance(node.ctx, ast.Load)
+            ]
+            if not reads:
+                findings.append((relative_path, function.name, name, "never read"))
+            elif all(id(node) in logged for node in reads):
+                findings.append(
+                    (relative_path, function.name, name, "read only inside logging")
+                )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Census 1: nobody re-spells the escape.
+# ---------------------------------------------------------------------------
+
+
+def test_no_module_outside_the_primitive_hand_rolls_the_fts5_escape() -> None:
+    offenders: list[tuple[str, str, int]] = []
+    for path in _python_sources():
+        relative = _rel(path)
+        try:
+            sites = quote_doubling_sites(path.read_text(encoding="utf-8"), relative)
+        except SyntaxError:  # pragma: no cover - repo is expected to parse
+            continue
+        for site in sites:
+            if relative == FTS5_PRIMITIVE:
+                continue
+            if (site[0], site[1]) in QUOTE_DOUBLING_EXEMPTIONS:
+                continue
+            offenders.append(site)
+    assert offenders == [], (
+        "These sites double a '\"' outside "
+        f"{FTS5_PRIMITIVE}. That is the FTS5 string-literal escape; import "
+        "quote_fts5_token/quote_fts5_phrase/quote_fts5_prefix instead of "
+        f"writing a seventh spelling of it: {offenders}"
+    )
+
+
+def test_the_primitive_actually_doubles_embedded_quotes() -> None:
+    """The census is only worth anything if the one survivor is correct."""
+    from tldw_chatbook.Utils.fts5_match_forms import (
+        quote_fts5_phrase,
+        quote_fts5_prefix,
+        quote_fts5_token,
+    )
+
+    assert quote_fts5_token('foo"bar') == '"foo""bar"'
+    assert quote_fts5_phrase('alpha" OR title:"beta') == '"alpha"" OR title:""beta"'
+    assert quote_fts5_prefix('foo"bar') == '"foo""bar"*'
+    # Phrase and token are the same escape, deliberately -- not two
+    # implementations that happen to agree today.
+    assert quote_fts5_phrase is quote_fts5_token
+
+
+def test_census_flags_a_reintroduced_hand_rolled_escape() -> None:
+    """Bite-proof: the exact shape this task removed fails the census."""
+    reintroduced = (
+        "def search(term):\n"
+        "    escaped = term.replace('\"', '\"\"')\n"
+        "    return f'\"{escaped}\"*'\n"
+    )
+    sites = quote_doubling_sites(reintroduced, "tldw_chatbook/DB/Fake_DB.py")
+    assert sites == [("tldw_chatbook/DB/Fake_DB.py", "search", 2)]
+
+
+def test_a_comment_or_docstring_mentioning_the_escape_is_not_flagged() -> None:
+    """False-red direction: prose about the escape is not the escape."""
+    prose = (
+        'def search(term):\n'
+        '    """Historically this called term.replace(\'"\', \'""\') inline."""\n'
+        "    # do not write term.replace('\"', '\"\"') here\n"
+        "    return quote_fts5_phrase(term)\n"
+    )
+    assert quote_doubling_sites(prose, "tldw_chatbook/DB/Fake_DB.py") == []
+
+
+def test_the_sql_identifier_exemption_is_scoped_to_its_own_function() -> None:
+    """False-green direction: the exemption does not cover its whole module.
+
+    An FTS5 helper parked inside `sql_validation.py` would be a new
+    spelling, so the allowlist is keyed on (module, function).
+    """
+    smuggled = (
+        "def escape_identifier(identifier):\n"
+        "    return '\"' + identifier.replace('\"', '\"\"') + '\"'\n"
+        "\n"
+        "def quote_fts_term(term):\n"
+        "    return '\"' + term.replace('\"', '\"\"') + '\"'\n"
+    )
+    sites = quote_doubling_sites(smuggled, "tldw_chatbook/DB/sql_validation.py")
+    unexempt = [
+        site for site in sites if (site[0], site[1]) not in QUOTE_DOUBLING_EXEMPTIONS
+    ]
+    assert unexempt == [("tldw_chatbook/DB/sql_validation.py", "quote_fts_term", 5)]
+
+
+# ---------------------------------------------------------------------------
+# Census 2: no `safe_*` dead stores.
+# ---------------------------------------------------------------------------
+
+
+def test_no_sanitized_local_is_computed_and_then_only_logged() -> None:
+    offenders: list[tuple[str, str, str, str]] = []
+    for path in _python_sources():
+        try:
+            offenders.extend(
+                dead_store_sites(path.read_text(encoding="utf-8"), _rel(path))
+            )
+        except SyntaxError:  # pragma: no cover
+            continue
+    assert offenders == [], (
+        "These locals name themselves as the sanitized form of user input "
+        "but are never read outside a logging call -- i.e. the sanitized "
+        "value reaches the diagnostics and nothing else, while the raw one "
+        f"reaches the query: {offenders}"
+    )
+
+
+def test_dead_store_census_flags_the_shape_it_was_built_for() -> None:
+    """Bite-proof, on the literal shape found in `search_character_cards`."""
+    reintroduced = (
+        "def search_character_cards(self, search_term, limit=10):\n"
+        "    safe_search_term = quote_fts5_phrase(search_term)\n"
+        "    try:\n"
+        "        return self.execute_query(QUERY, (search_term, limit))\n"
+        "    except Exception as e:\n"
+        "        logger.error(f\"Error searching for '{safe_search_term}': {e}\")\n"
+        "        raise\n"
+    )
+    assert dead_store_sites(reintroduced, "tldw_chatbook/DB/Fake_DB.py") == [
+        (
+            "tldw_chatbook/DB/Fake_DB.py",
+            "search_character_cards",
+            "safe_search_term",
+            "read only inside logging",
+        )
+    ]
+
+
+def test_dead_store_census_does_not_flag_a_term_that_reaches_the_query() -> None:
+    """False-red direction: logging it TOO is fine; only logging is not."""
+    fixed = (
+        "def search_character_cards(self, search_term, limit=10):\n"
+        "    safe_search_term = quote_fts5_phrase(search_term)\n"
+        "    try:\n"
+        "        return self.execute_query(QUERY, (safe_search_term, limit))\n"
+        "    except Exception as e:\n"
+        "        logger.error(f\"Error searching for '{safe_search_term}': {e}\")\n"
+        "        raise\n"
+    )
+    assert dead_store_sites(fixed, "tldw_chatbook/DB/Fake_DB.py") == []
+
+
+def test_dead_store_census_rediscovers_the_three_base_defects() -> None:
+    """The census finds the real defects in the real pre-fix file.
+
+    Read from git rather than restated inline, so this is a claim about the
+    shipped code that was actually there, not about a paraphrase of it. The
+    base revision is this branch's merge base with `origin/dev`; if the
+    object is unavailable (a shallow clone, a pruned reflog) the test skips
+    rather than passing vacuously.
+    """
+    repo_root = PACKAGE_ROOT.parent
+    base = "72a82bc56"
+    try:
+        source = subprocess.run(
+            ["git", "show", f"{base}:tldw_chatbook/DB/ChaChaNotes_DB.py"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        pytest.skip(f"base revision {base} unavailable: {exc}")
+
+    findings = dead_store_sites(source, "tldw_chatbook/DB/ChaChaNotes_DB.py")
+    assert [(function, name) for _path, function, name, _why in findings] == [
+        ("search_character_cards", "safe_search_term"),
+        ("search_conversations_by_title", "safe_search_term"),
+        ("search_messages_by_content", "safe_search_term"),
+    ], findings
+    assert all(why == "read only inside logging" for *_rest, why in findings)

--- a/Tests/Utils/test_fts5_quoting_adoption_census.py
+++ b/Tests/Utils/test_fts5_quoting_adoption_census.py
@@ -40,16 +40,48 @@ the primitive launders an unguarded module (false green), and a comment
 and docstrings produce no `Call`/`Name` nodes, so both bypasses are
 structurally closed here; both directions are proven below.
 
-**What this cannot express, stated rather than left to be rediscovered.**
-Both censuses are single-file and syntactic. Census 1 cannot see an escape
-built by string concatenation in a loop, by `str.translate`, or through a
-helper in another module; census 2 cannot see a dead store whose reads are
-routed through a local alias or an f-string assigned to another variable
-first. Neither can prove the bound value is the *right* one -- only that the
-sanitized one is not obviously discarded. The behavioural tests in
-`Tests/DB/test_fts5_quoting_search_seams.py` are what prove the actual
-matching semantics; these two only close the "silently re-spelled / silently
-discarded" routes back in.
+**Census 3 (the module-level net).** A module that binds a value to a
+`... MATCH ?` query must import from `Utils/fts5_match_forms`. Seven modules
+do so today and all seven import it. This is the only one of the three that
+can catch the *broken* spelling in a new file -- see the limits below for why
+that matters more than it sounds.
+
+**What these cannot express, stated rather than left to be rediscovered.**
+
+*Census 1 does not catch the spelling that actually caused this task.* It
+fires on `.replace('"', '""')` -- the CORRECT escape, hand-rolled. The two
+sites that were genuinely broken wrote `f'"{term}"'` with no doubling at
+all, and that expression contains nothing for this census to match. So
+census 1 prevents a seventh copy of the RIGHT rule, not a third copy of the
+WRONG one. A repo-wide detector for the bare `f'"{x}"'` shape was tried and
+rejected on measurement: it is indistinguishable from SQL identifier quoting
+(`f'DROP TRIGGER IF EXISTS "{name}"'`) and from ordinary UI copy
+(`f'Imported "{skill_name}" ...'`), producing four false positives and zero
+true ones on the current tree. Census 3 is the structural answer available:
+a NEW module that hand-rolls either spelling reds because it binds `MATCH ?`
+without importing the primitive. A new seam added *inside* one of the seven
+modules that already import it is NOT covered -- for those, the behavioural
+sweep in `Tests/DB/test_fts5_quoting_search_seams.py` is the net, and it only
+covers seams enumerated in it.
+
+*Census 2 is defeated by this repo's own house logging style.* The
+logging-root walk resolves `logger.error(...)` and `logging.error(...)`, but
+`logger.opt(exception=True).error(...)` -- which is used widely here -- puts
+an `ast.Call` (`logger.opt(...)`) where the walk expects a `Name`, so the
+call is not recognised as logging and a dead store read only inside one
+would be reported as "used". The walk is deliberately left simple rather
+than made to chase arbitrary attribute chains, but the consequence is real:
+census 2 catches the shape as it was written in `ChaChaNotes_DB`, not every
+shape it could take.
+
+*Both are single-file and syntactic.* Census 1 cannot see an escape built by
+string concatenation in a loop, by `str.translate`, or through a helper in
+another module; census 2 cannot see a dead store whose reads are routed
+through a local alias or an f-string assigned to another variable first;
+census 3 sees imports, not use. None of them can prove the bound value is the
+*right* one -- only that the sanitized one is not obviously discarded. The
+behavioural tests in `Tests/DB/test_fts5_quoting_search_seams.py` are what
+prove the actual matching semantics.
 """
 
 from __future__ import annotations
@@ -58,8 +90,6 @@ import ast
 import re
 import subprocess
 from pathlib import Path
-
-import pytest
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
 
@@ -333,27 +363,49 @@ def test_dead_store_census_does_not_flag_a_term_that_reaches_the_query() -> None
     assert dead_store_sites(fixed, "tldw_chatbook/DB/Fake_DB.py") == []
 
 
+#: The commit this task branched from, and the last one containing the three
+#: dead stores. Pinned rather than resolved through `git merge-base HEAD
+#: origin/dev`: merge-base MOVES on every rebase, and after the fix lands on
+#: dev it resolves to a commit where the defects are already gone -- the
+#: check would then fail for the wrong reason, and the obvious "repair" is
+#: to delete it. A historical commit id is a fixed fact; this one is a
+#: reachable ancestor of every branch that will ever carry this test.
+DEFECT_BASE_REVISION = "72a82bc56"
+
+
 def test_dead_store_census_rediscovers_the_three_base_defects() -> None:
     """The census finds the real defects in the real pre-fix file.
 
     Read from git rather than restated inline, so this is a claim about the
-    shipped code that was actually there, not about a paraphrase of it. The
-    base revision is this branch's merge base with `origin/dev`; if the
-    object is unavailable (a shallow clone, a pruned reflog) the test skips
-    rather than passing vacuously.
+    shipped code that was actually there, not about a paraphrase of it.
+
+    **Fails closed.** An earlier version `pytest.skip`ped when the object
+    could not be read, which meant a shallow clone or a checkout without the
+    `origin/dev` ref turned the one test that proves the census DETECTS
+    anything into a silent pass -- the same "green because it did not run"
+    shape this programme keeps finding. If git cannot answer, that is a
+    failure of this check, not an excuse for it.
     """
     repo_root = PACKAGE_ROOT.parent
-    base = "72a82bc56"
     try:
         source = subprocess.run(
-            ["git", "show", f"{base}:tldw_chatbook/DB/ChaChaNotes_DB.py"],
+            [
+                "git",
+                "show",
+                f"{DEFECT_BASE_REVISION}:tldw_chatbook/DB/ChaChaNotes_DB.py",
+            ],
             cwd=repo_root,
             capture_output=True,
             text=True,
             check=True,
         ).stdout
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-        pytest.skip(f"base revision {base} unavailable: {exc}")
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        raise AssertionError(
+            "cannot read "
+            f"{DEFECT_BASE_REVISION}:tldw_chatbook/DB/ChaChaNotes_DB.py, so "
+            "the dead-store census is UNPROVEN -- unshallow the clone and "
+            f"re-run rather than treating this as skippable: {exc}"
+        ) from exc
 
     findings = dead_store_sites(source, "tldw_chatbook/DB/ChaChaNotes_DB.py")
     assert [(function, name) for _path, function, name, _why in findings] == [
@@ -362,3 +414,120 @@ def test_dead_store_census_rediscovers_the_three_base_defects() -> None:
         ("search_messages_by_content", "safe_search_term"),
     ], findings
     assert all(why == "read only inside logging" for *_rest, why in findings)
+
+
+# ---------------------------------------------------------------------------
+# Census 3: a module that binds to `MATCH ?` imports the primitive.
+# ---------------------------------------------------------------------------
+
+_MATCH_PARAM = re.compile(r"\bMATCH\s*\?", re.IGNORECASE)
+
+
+def _docstring_node_ids(tree: ast.AST) -> set[int]:
+    """ids of every docstring Constant in `tree`.
+
+    Docstrings are the one kind of prose that DOES produce an `ast.Constant`
+    -- unlike comments, which produce no node at all -- so a census that
+    reads string constants has to exclude them explicitly or a module whose
+    docstring merely explains `MATCH ?` looks like a search seam.
+    """
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            ids.add(id(first.value))
+    return ids
+
+
+def binds_fts_match(source: str) -> bool:
+    """Whether a module contains a `... MATCH ?` SQL string.
+
+    Read off string CONSTANTS in the AST rather than off the raw text, with
+    docstrings excluded (see `_docstring_node_ids`): a comment mentioning
+    `MATCH ?` produces no node at all, and a docstring mentioning it is
+    filtered, so neither can make a module that never queries FTS5 look like
+    a search seam.
+    """
+    tree = ast.parse(source)
+    docstrings = _docstring_node_ids(tree)
+    return any(
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+        and _MATCH_PARAM.search(node.value)
+        for node in ast.walk(tree)
+    )
+
+
+def imports_the_primitive(source: str) -> bool:
+    tree = ast.parse(source)
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and (node.module or "").endswith("fts5_match_forms")
+        for node in ast.walk(tree)
+    )
+
+
+def test_every_module_that_binds_a_match_parameter_imports_the_primitive() -> None:
+    """The only one of the three censuses that a NEW file cannot slip past.
+
+    Censuses 1 and 2 both look for a specific wrong SHAPE. This one looks
+    for the situation instead: if a module runs an FTS5 MATCH with a bound
+    parameter, it is building a MATCH expression, and there is exactly one
+    place in this repo allowed to build one.
+    """
+    offenders: list[str] = []
+    for path in _python_sources():
+        source = path.read_text(encoding="utf-8", errors="replace")
+        try:
+            if binds_fts_match(source) and not imports_the_primitive(source):
+                offenders.append(_rel(path))
+        except SyntaxError:  # pragma: no cover
+            continue
+    assert offenders == [], (
+        "These modules bind a parameter to an FTS5 MATCH without importing "
+        f"Utils/fts5_match_forms: {offenders} -- build the expression with "
+        "build_and_match_query / build_phrase_match_query rather than by hand."
+    )
+
+
+def test_census_three_flags_a_new_seam_that_hand_rolls_either_spelling() -> None:
+    """Bite-proof, on BOTH spellings -- including the broken one census 1
+    cannot see."""
+    correct_but_hand_rolled = (
+        "def search(db, term):\n"
+        "    q = '\"' + term.replace('\"', '\"\"') + '\"'\n"
+        "    return db.execute('SELECT 1 FROM t_fts WHERE t_fts MATCH ?', (q,))\n"
+    )
+    broken = (
+        "def search(db, term):\n"
+        "    q = f'\"{term}\"'\n"
+        "    return db.execute('SELECT 1 FROM t_fts WHERE t_fts MATCH ?', (q,))\n"
+    )
+    for source in (correct_but_hand_rolled, broken):
+        assert binds_fts_match(source)
+        assert not imports_the_primitive(source)
+    # And the point of the pair: census 1 sees only the first one.
+    assert quote_doubling_sites(correct_but_hand_rolled, "x.py")
+    assert quote_doubling_sites(broken, "x.py") == []
+
+
+def test_census_three_is_not_triggered_by_prose_about_match() -> None:
+    """False-red direction: a docstring naming `MATCH ?` is not a seam."""
+    prose = (
+        'def helper():\n'
+        '    """Historically this built the `t_fts MATCH ?` expression."""\n'
+        "    return None\n"
+    )
+    assert not binds_fts_match(prose)

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -485,6 +485,56 @@ class TestSinkRedaction:
         """`max-tokens` normalizes to `max_tokens`, which is still not `_token`."""
         assert sanitize_string("max-tokens=4096") == "max-tokens=4096"
 
+    @pytest.mark.parametrize(
+        "header",
+        ["Ocp-Apim-Subscription-Key", "X-Subscription-Token"],
+    )
+    def test_task_19558_probe_headers_stay_recognised(self, header: str) -> None:
+        """TASK-19558 named three probe keys; TASK-19555's repair covers two.
+
+        Re-asserted here (not merely assumed from the parametrized case
+        above) because the finding named these exact header names and they
+        are the ones live provider request logging produces.
+        """
+        line = f"{header}: DONOTUSEEXAMPLEONLYzz9911"
+        assert "DONOTUSEEXAMPLEONLYzz9911" not in sanitize_string(line)
+
+    def test_a_bare_key_label_is_treated_as_secret_bearing(self) -> None:
+        """The third probe key, and the one still live at TASK-19558.
+
+        A bare `key` matches none of `is_sensitive_config_key`'s rules --
+        its `_key` rule is an underscore-SUFFIX match and `api-key` a
+        containment one -- and bare `key` is exactly how Google's Custom
+        Search credential travels (`?key=<API key>`). Probed before the fix:
+        the whole URL passed through `sanitize_string` unchanged. Fixed in
+        `_LOG_ONLY_SENSITIVE_FIELDS` rather than in the shared config
+        predicate, which also drives config encryption.
+        """
+        url = (
+            "https://www.googleapis.com/customsearch/v1"
+            "?key=AIzaSyDONOTUSEEXAMPLEONLY12345&cx=abc"
+        )
+        sanitized = sanitize_string(url)
+        assert "AIzaSyDONOTUSEEXAMPLEONLY12345" not in sanitized
+        assert sanitize_dict({"key": "AIzaSyDONOTUSEEXAMPLEONLY12345"}) == {
+            "key": "***REDACTED***"
+        }
+
+    def test_the_bare_key_rule_did_not_leak_into_config_encryption(self) -> None:
+        """Scope of the fix, pinned.
+
+        `is_sensitive_config_key` also decides which config fields get
+        ENCRYPTED and how many the Privacy & Security screen counts as
+        protected. Widening it for a logging-only reason would silently
+        change both, so `key` was added to the log-only set instead.
+        """
+        from tldw_chatbook.Utils.sensitive_config_keys import (
+            is_sensitive_config_key,
+        )
+
+        assert is_sensitive_config_key("key") is False
+        assert is_sensitive_config_key("openai_api_key") is True
+
     def test_home_directory_collapses_to_tilde(self) -> None:
         """The account name is a real-name identifier; the path shape is not."""
         from tldw_chatbook.Utils.log_sanitizer import redact_user_paths

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7055,3 +7055,77 @@ shutdown), not on which methods were called — that is the only shape that
 catches a probe, a shutdown hook, or a migrator quietly creating the file.
 This recurs for every store queued in TASK-21105 (seven more feature DBs to
 be made first-use-lazy).
+
+
+## A "safe_" local that only reaches the error message is not protection — mutate it to prove which value the query saw (TASK-19558, 2026-08-23)
+
+Three `ChaChaNotes_DB` search methods computed `safe_search_term = f'"{term}"'`
+and then bound the RAW term. The quoted value was interpolated into the
+`logger.error` f-string in the `except` block and nowhere else. It had survived
+every review of those methods because a reader who sees `safe_search_term` two
+lines above a query stops reading — the NAME is the assertion, and the name was
+free.
+
+The evidence that settles it is a **mutation, not a reading**. Replace the
+computed value with an absurd string
+(`"ZZZ_MUTATED_NEVER_MATCHES_ANYTHING_ZZZ"`) and run the real method against a
+real database: at base all three returned byte-identical results
+(`['Zed the Hunter'] / ['Talk about dragons'] / ['hello world']`), which is only
+possible if the value never reached SQLite. Apply the same mutation to the fixed
+code and all three return `[]`. Two directions, one probe each; no amount of
+staring at the diff produces that.
+
+Generalise it: **whenever a sanitizer's output is a local rather than an
+expression at the call site, the sanitizer might not be wired.** The shape is
+cheap to census — a local named `safe_*`/`quoted_*`/`escaped_*` whose every AST
+`Name` load sits inside a `logger.*` call is, by construction, decorative. That
+census (`Tests/Utils/test_fts5_quoting_adoption_census.py`) run against the base
+blob rediscovers exactly those three and nothing else, and it ships as a test so
+the rediscovery is repeatable rather than a claim in a PR description.
+
+The same shape has a second face, met later in the same task. The review had
+asked for `("reads",)` risk tags on the read-only local agent tools "so they are
+floored to ask". Measured: local tools resolve through
+`permission_store.resolve_effective_state`, whose floor set is
+`HIGH_RISK_TAGS = {"mutates", "process"}`; `"reads"` is in
+`BUILTIN_HIGH_RISK_TAGS`, which only `resolve_builtin_state` consults, and that
+function never serves the `local:__local__` server key. Adding the tag would
+have produced a marking that reads as protection in review and floors nothing —
+the `safe_search_term` defect, re-created while fixing it. **Before adding a
+marking because a sibling has it, run the resolver that consumes it and show
+the verdict change.** If the verdict does not change, the honest deliverable is
+the written-down mechanism plus a test that demonstrates the inertness, not the
+tag.
+
+## An FTS5 search box quietly has two contracts, and quoting one breaks the other (TASK-19558, 2026-08-23)
+
+Fixing the quoting above broke five Library tests, and the reason generalises to
+any "sanitize at the boundary" sweep. `search_conversations_by_content` had two
+kinds of caller: the Console/UI seams passing PLAIN user text (which must be
+quoted), and `library_local_rag_search_service._search_conversations` passing a
+pre-built, plural/singular-widened FTS5 MATCH expression (which must not be).
+The second only worked BECAUSE the argument was bound raw — the defect was load
+bearing. Its three sibling seams (notes, media, prompts) had already been given
+an explicit `fts_match_query` parameter for exactly this; the conversations seam
+had never been converted, and nothing marked it as the odd one out.
+
+So: before quoting a parameter, **enumerate its callers and split them by what
+they are actually passing**, and give the expression-supplying callers a
+separate, named parameter rather than overloading one argument with two
+contracts. A single parameter that means "plain text OR a MATCH expression,
+depending on who is calling" cannot be made safe — every fix for one caller is a
+regression for the other.
+
+Two smaller traps from the same sweep, both worth a line:
+
+- **A length test measured on the wrong string silently retires a branch.**
+  `search_media_db` widened 1-2 character queries to a prefix match
+  (`len(effective_fts_query) <= 2`). Quoting adds two characters, so testing the
+  quoted string's length would have made that branch dead code with no test
+  failing. Measure such predicates on the RAW input and say so in the comment.
+- **A test asserting that bad input raises can be pinning the bug.**
+  `test_search_with_invalid_fts_syntax_raises_error` asserted that typing
+  `invalid "syntax` into the prompt search box raises `DatabaseError`. That was
+  never a contract; it was the symptom of the raw bind, written down as if it
+  were one. When a fix turns such a test red, read what the test is asserting
+  about the USER before assuming the fix is wrong.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7083,6 +7083,13 @@ census (`Tests/Utils/test_fts5_quoting_adoption_census.py`) run against the base
 blob rediscovers exactly those three and nothing else, and it ships as a test so
 the rediscovery is repeatable rather than a claim in a PR description.
 
+A third face turned up in review, and it is the one to remember: the FIX for
+a dead store can be a dead store. Round one replaced the unbound
+`safe_search_term` with a bound whole-query phrase -- correct, protective, and
+quietly halving multi-word recall at eight seams (see the recall lesson below).
+Binding the sanitized value is necessary, not sufficient; you still have to
+show the query means what it meant before.
+
 The same shape has a second face, met later in the same task. The review had
 asked for `("reads",)` risk tags on the read-only local agent tools "so they are
 floored to ask". Measured: local tools resolve through
@@ -7096,6 +7103,47 @@ marking because a sibling has it, run the resolver that consumes it and show
 the verdict change.** If the verdict does not change, the honest deliverable is
 the written-down mechanism plus a test that demonstrates the inertness, not the
 tag.
+
+## Sanitizing a search box can NARROW it, and nothing red will tell you (TASK-19558 review, 2026-08-23)
+
+Quoting fixed an injection at fourteen search seams. It also quoted each seam's
+whole query as ONE FTS5 phrase, and an FTS5 phrase requires the words to be
+CONTIGUOUS. `dragon lore` stopped matching a record named "lore of the dragon
+reversed": recall halved at eight seams, on the Console conversation search,
+the Study flashcard box and the prompt picker. Every test passed. The injection
+tests passed *harder* — a narrower query closes more.
+
+The trap is that **the security assertion and the recall assertion point the
+same way.** "Returns 0 rows for `x" OR col:"y`" is satisfied by a fix and by
+an over-fix alike, so a suite made only of closure tests cannot distinguish
+"safe" from "broken in the user's favour of nothing". This repo had already
+paid for it once: `rag_service._escape_fts5_query`'s docstring records
+TASK-3995 finding that whole-query phrase quoting "is strictly stronger than
+AND-of-terms, not equivalent to it", verified against a real corpus document.
+The fix was re-derived from scratch three years later by someone who had read
+that docstring while working in the same file.
+
+Two things to actually do:
+
+1. **Pair every closure probe with a recall probe on the same corpus.** Seed
+   two records per seam — one where the query's words are adjacent, one where
+   they are split — and assert BOTH are returned. One extra fixture row turns
+   an invisible regression into a red test. A before/after table across both
+   halves is the evidence; a table of only closures is not.
+2. **When a "safety" change touches an expression language, name the semantics
+   you are picking.** Phrase, AND-of-terms and prefix are three different
+   queries, all of them injection-safe. Write down which one each seam had
+   BEFORE — here the rule turned out to be mechanical (*a seam that bound RAW
+   had implicit AND; a seam that bound a quoted phrase had a phrase*), and
+   that rule, once stated, decided all fourteen seams and stopped the fix from
+   smuggling in unmeasured behaviour changes beside the measured one.
+
+A third, cheaper lesson from the same round: **a NUL byte is not just another
+character to a quoting fix.** `sqlite3` passes a bound TEXT parameter as a C
+string, so SQLite truncates at the first NUL *after* you quoted — the closing
+quote is on the far side of the cut, and `unterminated string` is raised no
+matter how correct the escape was. Raw binds had survived it by luck. If you
+are adding quoting to anything that reaches SQLite, test `"a\x00b"`.
 
 ## An FTS5 search box quietly has two contracts, and quoting one breaks the other (TASK-19558, 2026-08-23)
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7177,3 +7177,47 @@ Two smaller traps from the same sweep, both worth a line:
   never a contract; it was the symptom of the raw bind, written down as if it
   were one. When a fix turns such a test red, read what the test is asserting
   about the USER before assuming the fix is wrong.
+
+## "No rows" is not the safe default for an unparseable query — and an AND-joined false leg poisons the whole WHERE (TASK-19558 review round 2, 2026-08-23)
+
+The round-one fix above had a second half nobody measured. When the new quoting
+could not build a MATCH expression at all — punctuation-only input, whitespace,
+a NUL — `search_media_db` answered `conditions.append("0")`. The conditions are
+`" AND ".join`ed, so that one leg forced the ENTIRE query to zero rows,
+including the LIKE predicates sitting right beside it that could still express
+what the user typed. Measured against the merge-base on a five-row corpus:
+`!!!` → 0 rows (LIKE would have found "Alert!!! urgent dragon"), `-` → 0
+("well-known dashes"), `***` → 0, `""` → 0. The comment above the line even
+argued for it — "simply DROPPING the condition would widen the result set" —
+which is true of a query whose ONLY filter is that leg and false of this one.
+
+Three things this generalises to:
+
+1. **A false predicate is not a no-op, it is a veto over its siblings.** Before
+   writing `1=0` / `"0"` / `AND FALSE` into a conjunction, look at what else is
+   in the conjunction. If any sibling can still answer the question, the leg
+   must be DROPPED, not falsified. Symmetrically, dropping is only safe when a
+   sibling survives — with no other text predicate, dropping returns everything.
+2. **Branch on the REASON the builder returned empty, not on the fact that it
+   did.** Three reasons arrived at the same line and want three answers: a
+   caller-supplied expression that came out blank means "no rows" by that seam's
+   own contract (and its LIKE legs are deliberately not built, so dropping
+   returns the whole table); a NUL means the LIKE fallback is *wider* than what
+   was asked for, because SQLite truncates the bound parameter at the NUL and
+   `%dragon\x00lore%` reaches it as `%dragon` (measured: it returned the dragon
+   row at the merge-base); punctuation-only means LIKE is exactly right. One
+   `if` per reason, each with the measurement in the comment.
+3. **Whitespace-only input is an EMPTY search, and padding is not part of the
+   query.** `"   "` should mean "I typed nothing", not "find me three spaces".
+   The same strip also fixed a pre-existing narrowing nobody had noticed: the
+   LIKE leg is AND-ed with the FTS leg, so `"  dragon  "` matched `MATCH` and
+   was then vetoed by `LIKE '%  dragon  %'` — 1 row for `dragon`, 0 for the
+   padded spelling, on dev.
+
+The evidence shape that catches this class: a before/after table over the
+AWKWARD inputs (`!!!`, `   `, `""`, `-`, `***`, empty, plus a normal control),
+run against the merge-base AND the branch in the same process — `git show
+<merge-base>:path/to/module.py` loaded via `importlib.util.spec_from_file_
+location` under a dotted name inside the real package resolves its relative
+imports fine, so both versions can be seeded and queried side by side without a
+second worktree. Closure probes alone never move on any of those rows.

--- a/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
+++ b/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
@@ -446,3 +446,140 @@ passed / 2 failed / 1 collection error**, identical to that set at base.
 Repo-wide `--collect-only -q`: **56,933 collected**, 1 error
 (`test_library_file_notes_workspace.py`, TASK-20972).
 `scripts/preflight.sh`: all green.
+
+## Implementation Notes — review round 2 (Qodo on PR #2006, 2026-08-23)
+
+Qodo returned five findings on the reviewed HEAD `cfc9e2604`. Three were
+fixed, two declined with evidence. (CodeRabbit posted only a "review skipped —
+auto reviews are disabled on non-default base branches" notice; nothing to
+action there.)
+
+**Finding 1 (High, bug) — `search_media_db` forced zero rows. FIXED, and it
+was the same defect class round 1 was convened to fix.** When no MATCH
+expression could be built, the code appended `"0"` to a `" AND ".join`ed
+condition list, so the whole query returned nothing even though the LIKE legs
+beside it could still express the intent. Measured on a five-row corpus, the
+merge-base (`736359202`) and this branch in one process:
+
+| input | dev (merge-base) | branch as reviewed | now |
+|---|---|---|---|
+| `!!!` | RAISE DatabaseError | 0 rows | **1** — "Alert!!! urgent dragon" |
+| `   ` | 0 rows | 0 rows | **5** — whitespace-only = empty search |
+| `""` | 0 rows | 0 rows | **1** — 'Quotes "" doubled' |
+| `-` | RAISE DatabaseError | 0 rows | **1** — "well-known dashes" |
+| `***` | RAISE DatabaseError | 0 rows | **1** — 'The "gold" standard' |
+| `` (empty) | 5 rows | 5 rows | 5 rows |
+| `dragon` (control) | 1 row | 1 row | 1 row |
+| `  dragon  ` (control) | **0 rows** | 0 rows | **1** |
+
+The last row is a pre-existing narrowing the strip incidentally fixes: the
+LIKE leg is AND-ed with the FTS leg, so `%  dragon  %` vetoed the row `MATCH`
+had already found.
+
+The fix branches on WHY the builder returned empty rather than on the fact
+that it did. A caller-owned `fts_match_query` that came out blank stays hard
+false — `""` means "no rows" by the shared builders' contract, and the
+title/content LIKE legs are deliberately not built in that branch, so dropping
+the condition would return the entire table. A NUL stays hard false too: SQLite
+truncates the bound parameter at the NUL, so `%dragon\x00lore%` reaches LIKE as
+`%dragon`, which is WIDER than what was typed (it returned the dragon row at
+the merge-base). Only punctuation-only text drops the leg — along with the FTS
+JOIN and relevance ordering, which are now added inside the same branch that
+adds the MATCH rather than unconditionally.
+
+**The closure was not traded for the recall.** Re-run at `search_media_db`
+after the fix, every probe in this branch's existing set still returns 0 rows:
+`dragon OR zzznomatch`, `alpha" OR title:"Other`, `foo"bar`, `dragon" OR
+"lore`, `title:dragon`, `dragon NEAR lore`, `dragon*`, and `dragon\x00lore`
+— while `dragon lore` still returns its row. Nine new tests in
+`Tests/DB/test_fts5_quoting_search_seams.py` pin all of it, including the
+caller-owned-empty-expression case and the NUL case in both directions.
+
+**Finding 5 (Medium) — docstrings claiming "literal phrase" at AND-form seams.
+FIXED, and swept beyond the three Qodo named.** The sweep was mechanical: an
+AST pass over every production file this branch touches, listing each function
+that calls an `fts5_match_forms` builder, the FORM it actually builds, and
+what its docstring claims. Corrected:
+
+- `ChaChaNotes_DB.search_conversations_by_title` — "literal phrase" → AND (Qodo)
+- `ChaChaNotes_DB.search_conversations_by_content` — three claims, incl. the
+  `fts_match_query` "whole-phrase quoting" line → AND (Qodo)
+- `prompt_scope_service.search_prompts` — "quoted as a literal FTS5 phrase by
+  `PromptsDatabase.search_prompts`" → AND (Qodo)
+- `ChaChaNotes_DB.search_messages_by_content` — "literal phrase" → AND (**not
+  named by Qodo**; same wrong claim, same file)
+- `ChaChaNotes_DB.search_character_cards` — its `fts_match_query` line said the
+  parameter "replaces the whole-phrase quoting of `search_term`" (**not named**)
+- `Client_Media_DB_v2.search_media_db` — the parameter's inline comment said
+  "quoted as a literal FTS5 phrase" while the body builds AND (**not named**)
+- `Utils/fts5_match_forms` module docstring — still said "**What is NOT here:
+  the AND forms**", which TASK-19558 itself made false (**not named**). Replaced
+  with the three forms and the rule for picking one.
+- Four `_library_*_fts_query` helpers (ChaChaNotes ×2, Media, Prompts) —
+  stated the quoting but never the join form; now say AND-of-quoted-tokens.
+- `Prompts_DB.search_prompts_by_text` / `search_prompts_by_content`,
+  `Evals_DB.search_tasks` / `search_datasets`, `file_notes_replica.search` —
+  had no form claim at all; each now names its form (AND, PHRASE, PHRASE).
+
+Verified after the edits by re-running the same AST sweep: no seam whose
+builder is an AND form still says "phrase", and no phrase seam says AND.
+
+**Finding 2 (Medium, rule) — `search_keyword_collections` docstring. FIXED.**
+Full Google-style docstring with Args/Returns/Raises, and it states the form:
+this seam is deliberately a PHRASE (it bound one before the task), unlike its
+AND-form neighbours.
+
+**Finding 3 (Medium, rule) — `defusedxml` bypasses `optional_deps`. DECLINED,
+with evidence.** `defusedxml` is a CORE dependency: `pyproject.toml`
+`[project] dependencies`, annotated `# engine xml security parsing (Q9:
+core)`. `Utils/optional_deps.py` names it only inside the `ebook` extra's
+aggregate availability check and publishes no import accessor for it; its
+`get_safe_import` users are torch / transformers / huggingface_hub / aiohttp,
+all genuinely optional. All six existing defusedxml call sites in the app
+(`Subscriptions/security.py`, `Subscriptions/monitoring_engine.py`,
+`Tools/web_tool_impls.py`, `Web_Scraping/WebSearch_APIs.py`,
+`Chunking/engine/strategies/json_xml.py`,
+`Event_Handlers/Chat_Events/chat_image_events.py`) import it directly under
+exactly this `try/except ImportError` shape. Routing this one through the
+helper would make it the odd one out, not the consistent one. The reasoning is
+recorded at the import site so the next round does not re-raise it.
+
+**Finding 4 (Medium, rule) — `search_character_cards` lacks `transaction()`.
+DECLINED, on a census of its siblings.** Of the 26 read-only search/list
+methods in `ChaChaNotes_DB.py`, 21 call `execute_query()` / `get_connection()`
+with no `transaction()` — including every nearest sibling of this one
+(`search_conversations_by_title`, `search_conversations_by_content`,
+`search_messages_by_content`, `search_notes`, `_search_generic_items_fts`).
+The 5 that do wrap are all PAGED Library seams
+(`search_conversations_page`, `list_library_notes_page`,
+`search_library_notes_page`, `list_library_conversations_page`,
+`search_library_conversations_page`), and they wrap for a stated reason: the
+row page and the exact total must be read from one snapshot. `execute_query`
+is the designed read seam — it documents `commit=False` and joins an outer
+`transaction()` when one exists — and `search_character_cards` is a single
+statement with no cross-statement invariant. This branch did not change its
+transaction shape; wrapping only this one would be inconsistency, not
+compliance.
+
+**Diagnostic inventory: deliberately NOT regenerated.** The rebuild reports
+four drifted rows — `chachanotes_fts_backfill.py` +3 and `app.py` +3 (dev's
+TASK-21100), `ChaChaNotes_DB.py` +3 (same), `Console_Modules/workspace.py`
+same-count-changed-digest (dev's TASK-21118). Read with `--statements`: between
+this branch's inventory commit and the working tree, **zero** diagnostic
+statements changed in any of them, so none of the drift is ours. Regenerating
+would silently absorb dev's unreviewed drift into this PR.
+
+**Test counts (round 2, rebased onto `736359202`).**
+`Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Utils`: **2415 passed / 1 skipped
+/ 0 failed** (round 1: 2388/1).
+`Tests/Subscriptions` + `Tests/Prompts_DB`: **1178 passed / 1 skipped / 0
+failed** (unchanged).
+`Tests/Media_DB`: **78 passed / 1 failed** —
+`test_reading_progress_reopens_through_versioned_migration`, a DEV red:
+the v5→v6 migration (`ALTER TABLE UnvectorizedMediaChunks ADD COLUMN
+chunk_engine_version`, dev commit `33c1ea0f8`, 2026-08-19) is not idempotent,
+so a test that rewinds `schema_version` to 2 on a database that already has
+the column dies on "duplicate column name". Neither this branch's 3-dot diff
+nor its working tree touches a single line of migration code.
+Repo-wide `--collect-only -q`: **57,069 collected**, 1 error
+(`Tests/UI/test_library_file_notes_workspace.py`, TASK-20972 — known dev red).

--- a/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
+++ b/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
@@ -3,7 +3,7 @@ id: TASK-19558
 title: >-
   Security primitives the repo already owns are not adopted at five seams
   (FTS5 quoting, defusedxml, log_sanitizer, path redaction, risk tags)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:08'
 labels:
@@ -77,25 +77,221 @@ tools, whose tags we author ourselves**. Untagged tools are not floored to
 
 ## Acceptance Criteria
 
-- [ ] Every FTS5 search path binds the value it actually quoted — no call site
+- [x] Every FTS5 search path binds the value it actually quoted — no call site
       computes a `safe_*` term and then binds the raw one
-- [ ] FTS5 term quoting doubles embedded `"` characters, via the existing
+- [x] FTS5 term quoting doubles embedded `"` characters, via the existing
       `Utils/fts5_match_forms.quote_fts5_token` rather than a new local helper
-- [ ] A search term containing `"` and a column-filter expression returns
+- [x] A search term containing `"` and a column-filter expression returns
       correct results (or a clean user-facing error) instead of silently wrong
       results in the Library notes filter or a bare `OperationalError` in the
       Study flashcard box
-- [ ] The Evals, Media and RAG search sites are fixed in the same sweep
-- [ ] A test fails if a `safe_*`-style dead store is reintroduced at any FTS5
+- [x] The Evals, Media and RAG search sites are fixed in the same sweep
+      (RAG was already correct — it is the primitive's one pre-existing
+      caller; Evals and Media are fixed)
+- [x] A test fails if a `safe_*`-style dead store is reintroduced at any FTS5
       call site
-- [ ] `watchlist_opml_service.py` parses with `defusedxml`, and a test pins
+- [x] `watchlist_opml_service.py` parses with `defusedxml`, and a test pins
       that an entity-expansion OPML payload is rejected
-- [ ] `_is_sensitive_log_key` applies its suffix rules to the normalized key;
+- [x] `_is_sensitive_log_key` applies its suffix rules to the normalized key;
       `Ocp-Apim-Subscription-Key`, `X-Subscription-Token` and bare `key` are
       recognised as sensitive, pinned by test
-- [ ] `Tools/local_tool_impls.py` passes `redact_paths=True`; the remaining
+      (the first two were repaired by TASK-19555 before this task started;
+      bare `key` was still live and is fixed here)
+- [x] `Tools/local_tool_impls.py` passes `redact_paths=True`; the remaining
       `validate_path` call sites that handle untrusted paths are swept
-- [ ] The local-tool risk-tag decision is made explicitly: either the read-only
+- [x] The local-tool risk-tag decision is made explicitly: either the read-only
       local tools carry `("reads",)` like their builtin equivalents, or the
       rationale for the asymmetry is written down where the next reader will
       find it
+
+## Implementation Plan
+
+1. Read `Utils/fts5_match_forms.quote_fts5_token` and establish whether the
+   primitive is itself correct before adopting it anywhere.
+2. Census every hand-rolled FTS5 quoting spelling and every raw MATCH bind
+   across `DB/`, `Library/`, `Notes/` and the UI layer; separate the sites
+   that take PLAIN user text from the ones that take a caller-BUILT MATCH
+   expression, because those need opposite treatment.
+3. Reproduce both user-visible consequences at the branch base through the
+   real search methods against a real throwaway database, and prove the
+   dead store by mutation (mutate the computed value, show behaviour is
+   unchanged; then mutate the fixed value, show it changes).
+4. Adopt the primitive at every site; give the plain-text methods whose
+   callers legitimately supply expressions an explicit `fts_match_query`
+   seam, matching `search_notes`' existing shape.
+5. Fix defusedxml, path redaction, and the log-sanitizer bare-`key` gap.
+6. Settle the risk-tag question on measured behaviour rather than on the
+   finding's premise.
+7. Write two AST censuses (no re-spelled escape, no `safe_*` dead store) and
+   an XML-parser census, each with bite-proofs in both directions.
+8. Run the branch-relevant suites plus a repo-wide `--collect-only`.
+
+## Implementation Notes
+
+**`quote_fts5_token` was already correct.** It has doubled embedded quotes
+since TASK-17755 (`'"{}"'.format(token.replace('"', '""'))`). Nothing in the
+primitive needed fixing; the whole of finding 1 was non-adoption. Two thin
+additions were made for the shapes the call sites actually needed, both
+built on that one escape rather than beside it: `quote_fts5_phrase`
+(a same-object alias — a whole phrase and a single token are the same FTS5
+string literal, so a second implementation is exactly how the broken
+spellings got written) and `quote_fts5_prefix` (`f"{quote_fts5_token(t)}*"`,
+which four sites had spelled out longhand).
+
+**The dead store, proven by mutation at base (72a82bc56).** Replacing the
+computed `safe_search_term` with `"ZZZ_MUTATED_NEVER_MATCHES_ANYTHING_ZZZ"`
+in all three methods left their results byte-identical
+(`['Zed the Hunter'] / ['Talk about dragons'] / ['hello world']`). The same
+mutation applied to the FIXED code returns `[] / [] / []`. The value now
+reaches the query; before, it reached only the error message.
+
+**Both user-visible consequences, measured at base.** Library notes filter:
+`search_notes('alpha" OR title:"Other')` returned **2 rows** on a corpus
+where one note contained "alpha" and the other contained neither term — the
+closing quote ended the intended literal and the remainder ran as a live
+FTS5 column filter; and `search_notes('foo"bar')` raised
+`unterminated string`, which `library_screen._run_library_notes_filter`
+swallows in `except Exception`, so the filter box silently did nothing.
+Study flashcards: `list_flashcards(q='foo"bar')` raised a bare
+`sqlite3.OperationalError` out of `flashcards_handler.refresh_cards`, which
+nothing on that path catches. After the fix both return `[]`, and
+`search_keywords('alpha"beta')` — which raised at base — now returns the
+keyword actually named `alpha"beta`.
+
+**Sites changed (`DB/ChaChaNotes_DB.py`, by post-change line):** import
+74-78; `search_character_cards` 7688-7747 (dead store + new
+`fts_match_query` seam); `_fts_prefix_match_expression` 7786;
+`search_conversations_by_title` 9852-9880 (dead store);
+`search_conversations_by_content` 9898-9972 (raw bind + new
+`fts_match_query` seam); `search_messages_by_content` 12076-12106 (dead
+store); `search_keywords` 12810-12824; `search_keyword_collections`
+12966-12971; `_library_note_fts_query` 13090;
+`_library_conversation_fts_query` 13369; `search_notes` 14068-14077;
+`list_flashcards` 16253-16271; `search_flashcards` 17520-17526.
+
+Other production files: `Utils/fts5_match_forms.py` (the two additions),
+`DB/Evals_DB.py` (`search_tasks`, `search_datasets` — the latter wrapped the
+RAW query with no doubling), `DB/Client_Media_DB_v2.py` (`search_media_db`'s
+plain-text branch + `_library_fts_query`), `DB/Prompts_DB.py`
+(`search_prompts`' plain-text branch, `search_prompts_by_text`,
+`_library_prompt_fts_query`), `DB/Subscriptions_DB.py`,
+`Library/library_fts_query.py`, `Library/library_local_rag_search_service.py`
+(its conversations seam now uses the explicit `fts_match_query` seam its
+notes/media/prompts siblings already used), `Notes/file_notes_replica.py`,
+`UI/CCP_Modules/ccp_character_handler.py`, `UI/Screens/personas_screen.py`,
+`UI/Console_Modules/prompts.py`.
+
+**The seam distinction is the load-bearing design decision.** A method that
+takes PLAIN user text now quotes it; a caller that genuinely owns an FTS5
+expression passes it through an explicit `fts_match_query` parameter. Two
+methods gained that parameter (`search_character_cards`,
+`search_conversations_by_content`); `search_notes` and the media/prompts
+siblings already had it. Without the distinction, quoting either breaks the
+Library's widened keyword search or leaves the user-facing boxes injectable.
+
+**Finding 2 (OPML).** `Subscriptions/watchlist_opml_service.py` now parses
+with `defusedxml.ElementTree.fromstring` behind the same try/except shape
+its five siblings use; stdlib ElementTree is retained for `export()`, which
+only BUILDS a tree (defusedxml has no `Element`/`SubElement`). Measured at
+base: a **573-byte** billion-laughs OPML parsed successfully and produced a
+**300,000-character** outline name. After: `EntitiesForbidden`. The task's
+framing is confirmed — it is entity expansion, not XXE, and a test re-proves
+that stdlib ElementTree leaves a `SYSTEM` entity unresolved rather than
+taking that on trust.
+
+**Finding 3 (log_sanitizer) was two-thirds already fixed.** TASK-19555
+landed the hyphen-normalization repair on dev before this task started, so
+`Ocp-Apim-Subscription-Key` and `X-Subscription-Token` were already
+recognised (probed, not assumed). Bare `key` was still `False`, and bare
+`key` is how Google's Custom Search credential travels
+(`?key=<API key>`) — the whole URL passed through `sanitize_string`
+unchanged. Fixed by adding `key` to `_LOG_ONLY_SENSITIVE_FIELDS`, not to
+`is_sensitive_config_key`, which also drives config encryption and the
+Privacy & Security protected-field count. The cost is stated in the code:
+a benign `key=<value>` label loses its value in diagnostics too.
+
+**Finding 4 (path redaction) swept two choke points, not one.**
+`Tools/local_tool_impls._resolve_in_workspace` (the ADR-032 local tool
+family) AND `Utils/path_validation.validate_path_multi` — the choke point
+for the in-process builtin file tools, which called `validate_path` once
+per root and so logged a model-supplied path several times per probe. Both
+refusal messages are unchanged: they are built by the caller from its own
+argument and are the model's recovery route. The remaining 16 un-redacted
+call sites take paths the USER chose in a file picker (OCR backends,
+character-card import, prompt import), where redaction would remove
+actionable diagnostics from the person who typed the path; that boundary is
+stated rather than swept silently.
+
+**Finding 5 (risk tags): the finding's premise is wrong, and adding the tag
+would have been the defect this task exists to remove.** Local tools are
+resolved by `permission_store.resolve_effective_state` (wired through
+`UnifiedControlPlaneService.gate_tool_test`), whose floor set is
+`HIGH_RISK_TAGS = {"mutates", "process"}`. `"reads"` lives in
+`BUILTIN_HIGH_RISK_TAGS`, consulted only by `resolve_builtin_state`, which
+serves `agent:builtin` and never `local:__local__`. So tagging `fs_read`
+`("reads",)` would floor nothing — a marking that reads as protection and
+provides none, i.e. the `safe_search_term` shape. The AC's second option was
+taken: the rationale is written at the `LocalToolSpec` definition site (where
+the next reader looks), and three tests in
+`Tests/Agents/test_local_tool_provider.py` DEMONSTRATE the mechanism —
+`("reads",)` leaves an inherited allow at `allow` while `("mutates",)` floors
+it to `ask`, and a fresh permission store leaves every local tool at `ask`
+anyway because `local:__local__` has no server entry. Moving the floor means
+widening the MCP resolver's tag set, which was considered and rejected once
+already (TASK-845) because MCP tags are server-supplied.
+
+**The durable outcome: three AST censuses, each mutation-checked both ways.**
+`Tests/Utils/test_fts5_quoting_adoption_census.py` — (1) no
+`.replace('"', '""')` outside `Utils/fts5_match_forms.py`, with one
+exemption keyed on `(module, function)` so an FTS5 helper cannot be parked
+in `sql_validation.py` and inherit it; (2) no `safe_*`/`quoted_*`/`escaped_*`
+local whose every read is inside a logging call. Census 2 run against the
+real base file rediscovers exactly the three dead stores and nothing else,
+and that check ships as a test (`test_dead_store_census_rediscovers_the_
+three_base_defects`, reading the base blob from git).
+`Tests/Subscriptions/test_watchlist_opml_entity_expansion.py` — (3) no
+module in `Subscriptions/` calls a stdlib-etree parse entry point without a
+defusedxml import. Scope is stated honestly rather than allowlisted: a
+repo-wide version of census 3 currently reports **seven** other unhardened
+parsers (`Evals/eval_runner.py`, `Local_Ingestion/XML_Ingestion.py`,
+`Media/local_media_reading_service.py`,
+`Research_Interop/academic_providers.py`, `Utils/file_extraction.py`,
+`Web_Scraping/Article_Extractor_Lib.py`,
+`Web_Scraping/Article_Scraper/crawler.py`) — a real, separate population
+outside this task, deliberately NOT allowlisted, so widening the census is
+what turns them red.
+
+**Born-red evidence.** The three new test files run against base
+72a82bc56: **18 failed + 1 collection error**; on this branch: **0 failed**.
+(One of the 18, `test_the_primitive_actually_doubles_embedded_quotes`, fails
+at base only because the two new helper names do not exist there — the core
+`quote_fts5_token` behaviour it asserts was already correct.)
+
+**Tests changed rather than added, and why.** Four test doubles gained the
+new `fts_match_query` parameter (`Tests/Library/test_library_rag_scope.py`,
+`Tests/UI/test_personas_workbench.py`), now asserting on the expression that
+reaches SQLite rather than on the positional argument.
+`Tests/Prompts_DB/test_prompts_db_legacy.py::test_search_with_invalid_fts_
+syntax_raises_error` was INVERTED: it asserted that typing `invalid "syntax`
+into the prompt search box raises `DatabaseError`. That was never a
+contract, it was the symptom — the raw query was bound to MATCH. It is now
+`test_search_with_a_typed_quote_is_matched_literally`, plus a new test that
+the caller-built-expression seam still works.
+
+**Test counts.** `Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Subscriptions`
++ `Tests/Utils` + `Tests/Library`: baseline 5544 passed / 4 skipped / 0
+failed → after **5600 passed / 4 skipped / 0 failed**. `Tests/Evals`,
+`Media`, `Media_DB`, `RAG_Search`, `RAG`, `Prompts_DB`, `Study_Interop`,
+`Notes`, `Character_Chat`, `Agents`, `MCP`, `Tools`: **10099 passed /
+16 failed**, the failure set byte-identical to the pre-existing baseline
+(MCP documentation-contract inventory, a media migration red, an Evals
+import census, a RAG_Search inflection test). Affected UI files
+(`test_ccp_handlers`, `test_chat_search_enhanced`, `test_console_prompt_
+picker`, `test_console_prompts_controller`, `test_media_viewer_prompt_
+search_15477`, `test_study_flashcards_screen`, `test_library_prompts_canvas`,
+`test_personas_workbench`): **775 passed / 2 failed / 1 collection error**,
+identical to the same set at base (both `test_library_prompts_canvas`
+failures and the `test_console_prompt_picker` collection error reproduce on
+base). Repo-wide `--collect-only -q`: **56,915 tests collected**, 1 error —
+`Tests/UI/test_library_file_notes_workspace.py`, the known dev red
+(TASK-20972).

--- a/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
+++ b/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
@@ -459,7 +459,10 @@ was the same defect class round 1 was convened to fix.** When no MATCH
 expression could be built, the code appended `"0"` to a `" AND ".join`ed
 condition list, so the whole query returned nothing even though the LIKE legs
 beside it could still express the intent. Measured on a five-row corpus, the
-merge-base (`736359202`) and this branch in one process:
+merge-base and this branch loaded side by side in one process (`git show
+<merge-base>:…/Client_Media_DB_v2.py` imported under a dotted name inside the
+real package, so its relative imports resolve without a second worktree);
+re-run unchanged after the final rebase onto `12931e1a3`:
 
 | input | dev (merge-base) | branch as reviewed | now |
 |---|---|---|---|
@@ -561,19 +564,29 @@ statement with no cross-statement invariant. This branch did not change its
 transaction shape; wrapping only this one would be inconsistency, not
 compliance.
 
-**Diagnostic inventory: deliberately NOT regenerated.** The rebuild reports
-four drifted rows — `chachanotes_fts_backfill.py` +3 and `app.py` +3 (dev's
-TASK-21100), `ChaChaNotes_DB.py` +3 (same), `Console_Modules/workspace.py`
-same-count-changed-digest (dev's TASK-21118). Read with `--statements`: between
-this branch's inventory commit and the working tree, **zero** diagnostic
-statements changed in any of them, so none of the drift is ours. Regenerating
-would silently absorb dev's unreviewed drift into this PR.
+**Diagnostic inventory: held, then regenerated once it was only ours.** On
+the first rebase (onto `736359202`) the rebuild reported four drifted rows —
+`chachanotes_fts_backfill.py` +3, `app.py` +3, `ChaChaNotes_DB.py` +3 (all
+dev's TASK-21100) and `Console_Modules/workspace.py` same-count-changed-digest
+(dev's TASK-21118). Read with `--statements`: **zero** diagnostic statements
+had changed in any of them on our side, so regenerating would have absorbed
+dev's unreviewed drift into this PR, and the pin was left alone. Dev then
+merged `12931e1a3` ("re-pin the inventory after TASK-21100's FTS backfill"),
+which conflicted with ours; the conflict was resolved to dev's re-pinned
+baseline and the rebuild rerun. It now names exactly two rows, both ours and
+both read before writing: `Subscriptions/watchlist_opml_service.py` +1 (the
+defusedxml-fallback `logger.warning`, a static string with no interpolation)
+and `ChaChaNotes_DB.py` same-count-changed-digest (two `logger.error` strings
+that now interpolate `match_expression` / `safe_search_query` where they used
+to interpolate `safe_search_term` / `search_query` — the same user-query text
+either way, no secret, path or URL newly exposed). `./scripts/preflight.sh`:
+all five derived-artifact checks green.
 
-**Test counts (round 2, rebased onto `736359202`).**
-`Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Utils`: **2415 passed / 1 skipped
-/ 0 failed** (round 1: 2388/1).
-`Tests/Subscriptions` + `Tests/Prompts_DB`: **1178 passed / 1 skipped / 0
-failed** (unchanged).
+**Test counts (round 2, rebased onto `12931e1a3`).**
+`Tests/DB` + `Tests/ChaChaNotesDB` + `Tests/Utils` + `Tests/Subscriptions` +
+`Tests/Prompts_DB`: **3593 passed / 2 skipped / 0 failed** (the same five
+directories split as 2415/1 and 1178/1 on the intermediate base; round 1 was
+2388/1 and 1178/1).
 `Tests/Media_DB`: **78 passed / 1 failed** —
 `test_reading_progress_reopens_through_versioned_migration`, a DEV red:
 the v5→v6 migration (`ALTER TABLE UnvectorizedMediaChunks ADD COLUMN

--- a/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
+++ b/backlog/tasks/task-19558 - Security primitives the repo already owns are not adopted at five seams.md
@@ -295,3 +295,154 @@ failures and the `test_console_prompt_picker` collection error reproduce on
 base). Repo-wide `--collect-only -q`: **56,915 tests collected**, 1 error —
 `Tests/UI/test_library_file_notes_workspace.py`, the known dev red
 (TASK-20972).
+
+## Implementation Notes — review round (2026-08-23)
+
+Independent review returned **fix-then-ship** with six items. The disposition
+of finding 5 and the inverted Prompts test were independently confirmed; the
+rest of this section is what changed.
+
+**1 — the headline the first round shipped and did not name: a multi-word
+recall narrowing at eight seams.** Quoting each seam's whole query as ONE
+FTS5 phrase closed the injections and also made the words CONTIGUITY-bound.
+This repo had already learned that once: `RAG_Search/simplified/rag_service.
+_escape_fts5_query`'s docstring records TASK-3995 discovering that
+whole-query phrase quoting "is strictly stronger than AND-of-terms, not
+equivalent to it". Round one re-created that defect while removing a
+different one.
+
+Measured on one corpus (two records per seam: words adjacent / words split),
+`dragon lore`:
+
+| seam | base 72a82bc56 | round 1 | now |
+|---|---|---|---|
+| `search_character_cards` | 2 | **1** | 2 |
+| `search_conversations_by_title` | 2 | **1** | 2 |
+| `search_conversations_by_content` | 2 | **1** | 2 |
+| `search_messages_by_content` | 2 | **1** | 2 |
+| `list_flashcards` | 2 | **1** | 2 |
+| `search_flashcards` | 2 | **1** | 2 |
+| `Prompts_DB.search_prompts` | 2 | **1** | 2 |
+| `Prompts_DB.search_prompts_by_text` | 2 | **1** | 2 |
+
+The other half of the bar, on the same corpus and the same run: every
+injection probe still returns **0 rows at all 14 seams** — column filter
+(`dragon" OR title:"Other`), bare quote (`foo"bar`), and a typed operator
+(`dragon OR zzznomatch`, which really executed under the base raw bind and
+returned 2-3 rows). Recall was restored without trading the closure back.
+
+The fix routes the plain-text branch through the repo's existing form:
+`fts5_query_tokens` + per-token `quote_fts5_token`, joined by FTS5's
+implicit AND — added to `Utils/fts5_match_forms` as
+`build_and_match_expression` / `build_and_match_query`, and
+`rag_service._escape_fts5_query` now builds its expression with the same
+function instead of its own copy of the join.
+
+**The rule applied, stated once rather than left to be inferred from
+thirteen call sites: a seam that bound its query RAW (FTS5 implicit AND)
+gets `build_and_match_query`; a seam that already bound a quoted PHRASE
+keeps `build_phrase_match_query`.** That restores every regression round one
+introduced and introduces no unmeasured behaviour change of its own —
+`search_notes`, `search_keywords`, `search_keyword_collections` and both
+Evals seams matched phrases before this task too, so they still do.
+`test_the_phrase_seams_are_deliberately_left_as_phrases` pins that as a
+decision, and shows the AND form would have returned 2 rather than 1.
+
+A consequence stated rather than buried: the base docstrings' "Supports FTS
+query syntax" promise is retired at these seams — a typed `dragon*` or `OR`
+is now literal text. That is the point of the fix, and the three docstrings
+that still advertised the old contract were retired in `51a42ca98`.
+
+**2 — E1, a NUL byte.** `sqlite3` hands a bound TEXT parameter to SQLite as
+a C string, so the value is truncated at the first NUL **after** quoting:
+`"a\x00b"` arrives as `"a` and FTS5 raises `unterminated string`. No correct
+quoting survives it — the closing quote is past the truncation point — and
+raw binds escaped only by luck, the truncated `a` still being a valid
+bareword. Nine seams went rows→raise. `Notes/file_notes_replica.search` had
+guarded this since it was written; that rule is now
+`fts5_query_is_searchable` and every seam shares it.
+
+**3 — E2, `None`.** Quoting `None` raised a bare `AttributeError`, not even
+wrapped in `CharactersRAGDBError`. Fixed in the same predicate, plus
+`isinstance` guards ahead of the two `.strip()` calls that ran before it.
+`Evals_DB.search_tasks(None)` raised `TypeError` at base too and is swept
+here as the last seam in the family with that shape.
+
+After both: the 126-cell probe matrix has **zero** raising cells; base had
+17 and round one had 19.
+
+**4 — the XML census now exists.** Round one scoped it to `Subscriptions/`
+and claimed the other seven parsers were "not allowlisted so widening turns
+them red" — describing a widening that had not happened, so nothing could
+red and only memory stopped an eighth. It is now repo-wide with
+`_KNOWN_UNHARDENED: dict[str, str]`, a **register of open defects** naming
+each of the seven and what reaches it, plus
+`test_known_unhardened_entries_are_still_unhardened` and
+`test_the_register_matches_the_measured_population_exactly` so an entry
+cannot outlive its defect. Bite-proof both ways, by real in-tree mutation: a
+synthetic eighth parser reds two tests; hardening
+`Research_Interop/academic_providers.py` reds two others.
+
+**For filing (out of scope here, four take untrusted input today):**
+`Evals/eval_runner.py:1842` (parses MODEL OUTPUT — prompt-injection
+reachable), `Research_Interop/academic_providers.py:218` (remote Atom feed),
+`Web_Scraping/Article_Scraper/crawler.py:398` and
+`Web_Scraping/Article_Extractor_Lib.py:1063` (fetched sitemaps; a byte cap
+is no defence — amplification is the point), plus
+`Local_Ingestion/XML_Ingestion.py` (same threat shape as the OPML importer),
+`Media/local_media_reading_service.py` (`iterparse` still expands internal
+entities) and `Utils/file_extraction.py`.
+
+**5 — guard-limitation honesty, and a third census.** Census 1's docstring
+now states plainly that it fires on the CORRECT escape hand-rolled
+(`.replace('"', '""')`) and is **blind to the spelling that actually caused
+this task** (`f'"{x}"'`, which contains nothing to match). A repo-wide
+detector for that shape was tried and rejected on measurement: four false
+positives (SQL identifier quoting, UI copy) and zero true ones. What is
+available structurally is **census 3** — a module that binds a parameter to
+`... MATCH ?` must import `Utils/fts5_match_forms`; seven modules do and all
+seven import it. It catches BOTH spellings in a new file, proven by an
+in-tree mutation with the broken one. Its blind spot is stated too: a new
+seam inside one of the seven already-importing modules is not covered.
+Census 2's docstring now names `logger.opt(exception=True).error(...)` — this
+repo's house style — as a real evasion of its logging-root walk.
+`test_dead_store_census_rediscovers_the_three_base_defects` no longer
+`skip`s: it raises with instructions. It keeps a PINNED revision rather than
+`git merge-base HEAD origin/dev`, because merge-base moves on rebase and
+would eventually resolve to a commit where the defects are already fixed —
+turning the one test that proves the census detects anything into a failure
+whose obvious "repair" is deletion.
+
+**6 —** the `test_personas_workbench` stub comment now says what is true:
+when `fts_match_query` is supplied, `search_term` is unused, including by
+the error message.
+
+**Born-red at the reviewed HEAD `51a42ca98`:** 11 of the new tests fail
+there (6 recall seams, the phrase-seam decision, injections-under-AND, both
+NUL tests, the None sweep). Census 3 and the widened XML census pass at that
+HEAD by design — they harden rather than fix, and saying otherwise would be
+overclaiming.
+
+**Merge check against current dev (`ae018308b`).** Verified by merging this
+branch into a throwaway worktree rather than by reading the textual merge:
+the only conflict is `lessons-testing-evidence.md` (both sides append), and
+`ChaChaNotes_DB.py` auto-merges across dev's `messages_fts` rebuild
+(TASK-21100). On the merged tree `Tests/DB` + `ChaChaNotesDB` + `Utils` +
+`Library` + `Media_DB` + `Prompts_DB` = **5121 passed / 1 failed**, that one
+being a pre-existing baseline red — so the clean textual merge is a clean
+semantic merge too. Also measured there: dev's TASK-21160 fixes the
+`config_profiles`↔`simplified` cycle, so the priming import in
+`Tests/Utils/test_agent_path_redaction_adoption.py` becomes redundant on
+that dev and is annotated to be dropped then; it is still required at this
+branch's base.
+
+**Test counts (review round).** `Tests/DB` + `ChaChaNotesDB` +
+`Subscriptions` + `Utils` + `Library`: **5618 passed / 4 skipped / 0
+failed** (round 1: 5604). `Evals`, `Media`, `Media_DB`, `RAG_Search`, `RAG`,
+`RAG_Eval`, `Prompts_DB`, `Study_Interop`, `Notes`, `Character_Chat`,
+`Agents`, `MCP`, `Tools`: **10457 passed / 16 failed**, the failure set
+byte-identical to the recorded 72a82bc56 baseline. Affected UI set: **775
+passed / 2 failed / 1 collection error**, identical to that set at base.
+Repo-wide `--collect-only -q`: **56,933 collected**, 1 error
+(`test_library_file_notes_workspace.py`, TASK-20972).
+`scripts/preflight.sh`: all green.

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -130,7 +130,57 @@ _MAX_ERROR_CHARS = 300
 
 @dataclass(frozen=True)
 class LocalToolSpec:
-    """One local tool: schema plus its sync handler (args dict -> text)."""
+    """One local tool: schema plus its sync handler (args dict -> text).
+
+    **Why the read-only tools carry ``tags=()`` while their in-process
+    builtin equivalents carry ``("reads",)``** (TASK-19558 asked this
+    explicitly; the answer is a mechanism, not a preference, and it is
+    written here because the next reader will look at the spec list, not at
+    ``MCP/permission_store.py``):
+
+    There are two floors in this app, and local tools are only ever
+    resolved by ONE of them. ``Chat/console_chat_controller`` wires this
+    provider's ``resolve_state`` to ``UnifiedControlPlaneService.
+    gate_tool_test``, i.e. to ``permission_store.resolve_effective_state``
+    -- the MCP resolver, whose floor set is ``HIGH_RISK_TAGS =
+    {"mutates", "process"}``. The ``("reads",)`` / ``("network",)`` floor
+    lives in ``BUILTIN_HIGH_RISK_TAGS``, which only
+    ``resolve_builtin_state`` consults, and that function resolves
+    in-process ``Tools/`` builtins under ``agent:builtin`` -- never the
+    ``local:__local__`` server key.
+
+    So tagging ``fs_read``/``fs_glob``/``fs_grep``/``web_*``/
+    ``watchlists_*`` with ``("reads",)`` would floor **nothing**: it would
+    be a marking that reads as protection in review and provides none --
+    the same shape as the ``safe_search_term`` dead stores TASK-19558
+    removed from ``ChaChaNotes_DB``. Copying the builtin vocabulary here
+    without moving the floor with it is therefore the wrong fix, and the
+    tag is deliberately withheld rather than added cosmetically.
+
+    What actually protects these tools today, in order:
+
+    1. ``local:__local__`` has no entry in a fresh permission store, so
+       every local tool inherits ``global_default`` = ``"ask"`` and already
+       raises an approval card per call. The floor only ever matters for a
+       user who has explicitly set the local server (or global) default to
+       ``allow`` -- i.e. who has said "stop asking me about local tools".
+    2. The read tools are confined to the workspace root and refuse
+       denylisted paths at ``Tools/local_tool_impls._resolve_in_workspace``
+       (TASK-19551/19800), which is a hard refusal rather than a prompt.
+
+    Changing this means widening the MCP resolver's floor set or routing
+    local tools through a resolver of their own -- a permission-model
+    change with its own blast radius (it would start prompting on any
+    remote MCP server that happens to list "network" among its
+    capabilities; see ``BUILTIN_HIGH_RISK_TAGS``' comment for why that was
+    rejected once already), not a one-line tags edit. ``Tests/Agents/
+    test_local_tool_provider.py`` pins the mechanism so the inertness is
+    demonstrated rather than asserted.
+
+    ``("mutates",)`` IS applied where it applies (``fs_write``/``fs_edit``/
+    ``fs_patch``/``todo_create``/``todo_update``) precisely because that tag
+    is in the set the local resolver does consult.
+    """
 
     name: str
     description: str

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -71,6 +71,11 @@ from .sql_validation import (
 from .sql_logging import preview_params
 from .private_sqlite import backup_connection_to_private, connect_private_sqlite
 from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
+from tldw_chatbook.Utils.fts5_match_forms import (
+    quote_fts5_phrase,
+    quote_fts5_prefix,
+    quote_fts5_token,
+)
 #
 ########################################################################################################################
 #
@@ -7766,7 +7771,10 @@ UPDATE db_schema_version
             raise
 
     def search_character_cards(
-        self, search_term: str, limit: int = 10
+        self,
+        search_term: str,
+        limit: int = 10,
+        fts_match_query: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Searches character cards using Full-Text Search (FTS).
@@ -7776,9 +7784,23 @@ UPDATE db_schema_version
         Returns full card details for matching, non-deleted cards, ordered by relevance (rank).
         JSON fields (see `_CHARACTER_CARD_JSON_FIELDS`) in the results are deserialized.
 
+        TASK-19558: this method used to compute ``safe_search_term`` and then
+        bind the RAW ``search_term`` -- the quoting reached the error message
+        and nothing else. The dead store is gone; ``search_term`` is now a
+        literal phrase (``quote_fts5_phrase``), so a typed ``OR``/``NEAR``/
+        column filter matches literally instead of being executed, and a
+        typed ``"`` no longer raises ``OperationalError``.
+
         Args:
-            search_term: The term(s) to search for. Supports FTS query syntax (e.g., "dragon lore").
+            search_term: Plain user-typed search text, matched as a literal
+                phrase. FTS5 operators in it are inert.
             limit: The maximum number of results to return. Defaults to 10.
+            fts_match_query: Optional caller-built FTS5 MATCH expression
+                (must already be injection-safe -- build it with
+                ``Utils.fts5_match_forms``). When provided it replaces the
+                whole-phrase quoting of ``search_term``; this is the seam
+                for callers that need prefix matching, e.g. the CCP
+                character picker's ``"term"*``.
 
         Returns:
             A list of dictionaries, each representing a matching character card.
@@ -7787,7 +7809,9 @@ UPDATE db_schema_version
         Raises:
             CharactersRAGDBError: For database errors during the search.
         """
-        safe_search_term = f'"{search_term}"'
+        match_expression = (
+            fts_match_query if fts_match_query else quote_fts5_phrase(search_term)
+        )
         query = """
                 SELECT cc.*
                 FROM character_cards_fts fts
@@ -7797,7 +7821,7 @@ UPDATE db_schema_version
                 ORDER BY rank LIMIT ? \
                 """
         try:
-            cursor = self.execute_query(query, (search_term, limit))
+            cursor = self.execute_query(query, (match_expression, limit))
             rows = cursor.fetchall()
             return [
                 self._deserialize_row_fields(row, self._CHARACTER_CARD_JSON_FIELDS)
@@ -7806,7 +7830,7 @@ UPDATE db_schema_version
             ]
         except CharactersRAGDBError as e:
             logger.error(
-                f"Error searching character cards for '{safe_search_term}': {e}"
+                f"Error searching character cards for '{match_expression}': {e}"
             )
             raise
 
@@ -7845,8 +7869,7 @@ UPDATE db_schema_version
             An FTS5 MATCH expression string: the term as a double-quoted
             FTS5 string literal with a trailing ``*`` for prefix matching.
         """
-        escaped = term.replace('"', '""')
-        return f'"{escaped}"*'
+        return quote_fts5_prefix(term)
 
     def _normalize_conversation_state(self, state: Optional[str]) -> str:
         if state is None:
@@ -9912,8 +9935,12 @@ UPDATE db_schema_version
         Optionally filters by `character_id`. Returns non-deleted conversations,
         ordered by relevance (rank).
 
+        TASK-19558: the computed ``safe_search_term`` was never bound (the
+        raw ``title_query`` was); it is now the value that reaches MATCH.
+
         Args:
-            title_query: The search term for the title. Supports FTS query syntax.
+            title_query: Plain user-typed title text, matched as a literal
+                phrase. FTS5 operators in it are inert.
             character_id: Optional character ID to filter results.
             limit: Maximum number of results. Defaults to 10.
 
@@ -9928,7 +9955,7 @@ UPDATE db_schema_version
                 "Empty title_query provided for conversation search. Returning empty list."
             )
             return []
-        safe_search_term = f'"{title_query}"'
+        safe_search_term = quote_fts5_phrase(title_query)
         base_query = """
                      SELECT c.*
                      FROM conversations_fts fts
@@ -9936,7 +9963,7 @@ UPDATE db_schema_version
                      WHERE fts.conversations_fts MATCH ? \
                        AND c.deleted = 0 \
                      """
-        params_list: List[Any] = [title_query]
+        params_list: List[Any] = [safe_search_term]
         if character_id is not None:
             base_query += " AND c.character_id = ?"
             params_list.append(character_id)
@@ -9954,7 +9981,10 @@ UPDATE db_schema_version
             raise
 
     def search_conversations_by_content(
-        self, search_query: str, limit: int = 10
+        self,
+        search_query: str,
+        limit: int = 10,
+        fts_match_query: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Searches conversations by message content using FTS.
@@ -9962,9 +9992,24 @@ UPDATE db_schema_version
         Searches the messages table for content matching the query,
         then returns the unique conversations containing those messages.
 
+        TASK-19558: ``search_query`` used to reach MATCH raw -- so a typed
+        ``"`` raised ``OperationalError('unterminated string')`` and a typed
+        column filter was executed. It is now quoted as a literal phrase.
+
         Args:
-            search_query: The search term for content. Supports FTS query syntax.
+            search_query: Plain user-typed content text, matched as a
+                literal phrase. FTS5 operators in it are inert.
             limit: Maximum number of conversations to return. Defaults to 10.
+            fts_match_query: Optional caller-built FTS5 MATCH expression
+                (must already be injection-safe -- build it with
+                ``Utils.fts5_match_forms``). When provided it replaces the
+                whole-phrase quoting of ``search_query``. This is the seam
+                the Library's four-seam keyword search uses, matching what
+                ``search_notes`` and the media/prompts siblings already took
+                (``Library/library_local_rag_search_service._search_conversations``
+                previously handed its widened expression in through
+                ``search_query`` itself, which only worked because that
+                argument was bound raw).
 
         Returns:
             A list of matching conversation dictionaries with relevance scores.
@@ -9972,11 +10017,14 @@ UPDATE db_schema_version
         Raises:
             CharactersRAGDBError: For database search errors.
         """
-        if not search_query.strip():
+        if not search_query.strip() and not (fts_match_query or "").strip():
             logger.warning(
                 "Empty search_query provided for conversation content search. Returning empty list."
             )
             return []
+        safe_search_query = (
+            fts_match_query if fts_match_query else quote_fts5_phrase(search_query)
+        )
 
         # Search for messages containing the query, then get their conversations
         query = """
@@ -9995,7 +10043,7 @@ UPDATE db_schema_version
         """
 
         try:
-            cursor = self.execute_query(query, (search_query, limit))
+            cursor = self.execute_query(query, (safe_search_query, limit))
             results = []
             for row in cursor.fetchall():
                 conv_dict = dict(row)
@@ -10007,7 +10055,7 @@ UPDATE db_schema_version
             return results
         except CharactersRAGDBError as e:
             logger.error(
-                f"Error searching conversations by content '{search_query}': {e}"
+                f"Error searching conversations by content '{safe_search_query}': {e}"
             )
             raise
 
@@ -12133,8 +12181,12 @@ UPDATE db_schema_version
         exactly what produces the caller that would leak, so the filter is
         now symmetric.
 
+        task-19558: the computed ``safe_search_term`` was never bound (the
+        raw ``content_query`` was); it is now the value that reaches MATCH.
+
         Args:
-            content_query: The search term for content. Supports FTS query syntax.
+            content_query: Plain user-typed content text, matched as a
+                literal phrase. FTS5 operators in it are inert.
             conversation_id: Optional conversation UUID to filter results.
             limit: Maximum number of results. Defaults to 10.
 
@@ -12144,7 +12196,7 @@ UPDATE db_schema_version
         Raises:
             CharactersRAGDBError: For database search errors.
         """
-        safe_search_term = f'"{content_query}"'
+        safe_search_term = quote_fts5_phrase(content_query)
         base_query = """
                      SELECT m.id, m.conversation_id, m.parent_message_id,
                             m.sender, m.content, m.image_data, m.image_mime_type,
@@ -12159,7 +12211,7 @@ UPDATE db_schema_version
                        AND m.deleted = 0 \
                        AND c.deleted = 0 \
                      """
-        params_list: List[Any] = [content_query]
+        params_list: List[Any] = [safe_search_term]
         if conversation_id:
             base_query += " AND m.conversation_id = ?"
             params_list.append(conversation_id)
@@ -12863,15 +12915,21 @@ UPDATE db_schema_version
         Returns active keywords, ordered by relevance.
 
         Args:
-            search_term: FTS query string for keyword text.
+            search_term: Plain user-typed keyword text, matched as a literal
+                phrase (task-19558: the quoting here never doubled an
+                embedded ``"``, so ``alpha"beta`` raised
+                ``OperationalError('unterminated string')``).
             limit: Max number of results.
 
         Returns:
             A list of matching keyword dictionaries.
         """
-        safe_search_term = f'"{search_term}"'
         return self._search_generic_items_fts(
-            "keywords_fts", "keywords", "keyword", safe_search_term, limit
+            "keywords_fts",
+            "keywords",
+            "keyword",
+            quote_fts5_phrase(search_term),
+            limit,
         )
 
     # Keyword Collections
@@ -13013,12 +13071,12 @@ UPDATE db_schema_version
     def search_keyword_collections(
         self, search_term: str, limit: int = 10
     ) -> List[Dict[str, Any]]:
-        safe_search_term = f'"{search_term}"'
+        """Search keyword collections by name; ``search_term`` is a literal phrase."""
         return self._search_generic_items_fts(
             "keyword_collections_fts",
             "keyword_collections",
             "name",
-            safe_search_term,
+            quote_fts5_phrase(search_term),
             limit,
         )
 
@@ -13137,7 +13195,7 @@ UPDATE db_schema_version
         if not tokens:
             return None
         tokens = tokens[: cls._LIBRARY_NOTE_FTS_TOKEN_LIMIT]
-        return " ".join(f'"{token}"' for token in tokens)
+        return " ".join(quote_fts5_token(token) for token in tokens)
 
     def _library_keywords_for_notes(
         self, conn: sqlite3.Connection, note_ids: List[str]
@@ -13416,7 +13474,7 @@ UPDATE db_schema_version
         if not tokens:
             return None
         tokens = tokens[: cls._LIBRARY_CONVERSATION_FTS_TOKEN_LIMIT]
-        return " ".join(f'"{token}"' for token in tokens)
+        return " ".join(quote_fts5_token(token) for token in tokens)
 
     def _library_keywords_for_conversations(
         self, conn: sqlite3.Connection, conversation_ids: List[str]
@@ -14115,9 +14173,16 @@ UPDATE db_schema_version
                 limit regardless of allowlist size); an empty collection
                 matches zero rows rather than being treated as "no filter".
         """
-        # FTS5 requires wrapping terms with special characters in double quotes
-        # to be treated as a literal phrase.
-        safe_search_term = fts_match_query if fts_match_query else f'"{search_term}"'
+        # FTS5 requires wrapping terms with special characters in double
+        # quotes to be treated as a literal phrase. task-19558: this wrapping
+        # never doubled an embedded `"`, so a Library notes filter containing
+        # one either raised (`foo"bar` -> unterminated string, swallowed by
+        # the screen's `except Exception` into a filter that silently does
+        # nothing) or escaped the literal into a live column filter
+        # (`alpha" OR title:"Other` matched notes containing neither term).
+        safe_search_term = (
+            fts_match_query if fts_match_query else quote_fts5_phrase(search_term)
+        )
 
         params: List[Any] = [safe_search_term]
         id_filter_sql = ""
@@ -16365,7 +16430,14 @@ UPDATE db_schema_version
         limit: int = 100,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
-        """List flashcards with optional deck filtering and FTS-backed search."""
+        """List flashcards with optional deck filtering and FTS-backed search.
+
+        task-19558: ``q`` used to reach MATCH raw. This is the Study screen's
+        flashcard search box, so a card front containing a quote (or any
+        typed ``"``) surfaced as a bare ``sqlite3.OperationalError``
+        propagating out of the handler -- nothing on that path catches it.
+        The value is now a literal phrase.
+        """
         normalized_q = str(q or "").strip() or None
         params: List[Any] = []
 
@@ -16376,7 +16448,7 @@ UPDATE db_schema_version
                 JOIN decks d ON d.id = f.deck_id
                 WHERE flashcards_fts MATCH ? AND f.is_deleted = 0 AND d.is_deleted = 0
             """
-            params.append(normalized_q)
+            params.append(quote_fts5_phrase(normalized_q))
             if deck_id:
                 query += " AND f.deck_id = ?"
                 params.append(deck_id)
@@ -17625,13 +17697,13 @@ UPDATE db_schema_version
     def search_flashcards(
         self, query: str, deck_id: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        """Search flashcards using FTS."""
+        """Search flashcards using FTS; ``query`` is matched as a literal phrase."""
         base_query = """
             SELECT f.* FROM flashcards f
             JOIN flashcards_fts fts ON f.rowid = fts.rowid
             WHERE flashcards_fts MATCH ? AND f.is_deleted = 0
         """
-        params = [query]
+        params = [quote_fts5_phrase(query)]
 
         if deck_id:
             base_query += " AND f.deck_id = ?"

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -7802,9 +7802,9 @@ UPDATE db_schema_version
             fts_match_query: Optional caller-built FTS5 MATCH expression
                 (must already be injection-safe -- build it with
                 ``Utils.fts5_match_forms``). When provided it replaces the
-                whole-phrase quoting of ``search_term``; this is the seam
-                for callers that need prefix matching, e.g. the CCP
-                character picker's ``"term"*``.
+                AND-of-quoted-tokens expression built from ``search_term``;
+                this is the seam for callers that need a different FORM, e.g.
+                the CCP character picker's prefix query ``"term"*``.
 
         Returns:
             A list of dictionaries, each representing a matching character card.
@@ -9945,8 +9945,11 @@ UPDATE db_schema_version
         raw ``title_query`` was); it is now the value that reaches MATCH.
 
         Args:
-            title_query: Plain user-typed title text, matched as a literal
-                phrase. FTS5 operators in it are inert.
+            title_query: Plain user-typed title text. Every token is quoted
+                individually and the tokens are AND-ed
+                (``build_and_match_query``), so all of them must appear but
+                they need not be adjacent -- NOT a phrase. FTS5 operators in
+                it are inert.
             character_id: Optional character ID to filter results.
             limit: Maximum number of results. Defaults to 10.
 
@@ -10006,16 +10009,22 @@ UPDATE db_schema_version
 
         TASK-19558: ``search_query`` used to reach MATCH raw -- so a typed
         ``"`` raised ``OperationalError('unterminated string')`` and a typed
-        column filter was executed. It is now quoted as a literal phrase.
+        column filter was executed. Every token is now quoted individually
+        and the tokens are AND-ed, which is what the raw bind meant too
+        (FTS5 joins bare terms with an implicit AND).
 
         Args:
-            search_query: Plain user-typed content text, matched as a
-                literal phrase. FTS5 operators in it are inert.
+            search_query: Plain user-typed content text. Every token is
+                quoted individually and the tokens are AND-ed
+                (``build_and_match_query``), so all of them must appear but
+                they need not be adjacent -- NOT a phrase. FTS5 operators in
+                it are inert.
             limit: Maximum number of conversations to return. Defaults to 10.
             fts_match_query: Optional caller-built FTS5 MATCH expression
                 (must already be injection-safe -- build it with
                 ``Utils.fts5_match_forms``). When provided it replaces the
-                whole-phrase quoting of ``search_query``. This is the seam
+                AND-of-quoted-tokens expression built from ``search_query``.
+                This is the seam
                 the Library's four-seam keyword search uses, matching what
                 ``search_notes`` and the media/prompts siblings already took
                 (``Library/library_local_rag_search_service._search_conversations``
@@ -12202,8 +12211,11 @@ UPDATE db_schema_version
         raw ``content_query`` was); it is now the value that reaches MATCH.
 
         Args:
-            content_query: Plain user-typed content text, matched as a
-                literal phrase. FTS5 operators in it are inert.
+            content_query: Plain user-typed content text. Every token is
+                quoted individually and the tokens are AND-ed
+                (``build_and_match_query``), so all of them must appear but
+                they need not be adjacent -- NOT a phrase. FTS5 operators in
+                it are inert.
             conversation_id: Optional conversation UUID to filter results.
             limit: Maximum number of results. Defaults to 10.
 
@@ -13089,7 +13101,27 @@ UPDATE db_schema_version
     def search_keyword_collections(
         self, search_term: str, limit: int = 10
     ) -> List[Dict[str, Any]]:
-        """Search keyword collections by name; ``search_term`` is a literal phrase."""
+        """Searches keyword collections by name using FTS.
+
+        Matches against the 'name' field in `keyword_collections_fts`.
+        Returns active collections, ordered by relevance.
+
+        Args:
+            search_term: Plain user-typed collection name. Quoted whole as
+                ONE literal FTS5 phrase (``build_phrase_match_query``), so
+                the words must appear adjacent and in order -- this seam
+                bound a phrase before task-19558 and deliberately still
+                does, unlike the AND-of-tokens seams. FTS5 operators in it
+                are inert.
+            limit: Max number of results. Defaults to 10.
+
+        Returns:
+            A list of matching keyword-collection dictionaries. Empty when
+            ``search_term`` is None, empty, NUL-bearing or punctuation-only.
+
+        Raises:
+            CharactersRAGDBError: For database search errors.
+        """
         match_expression = build_phrase_match_query(search_term)
         if not match_expression:
             return []
@@ -13208,9 +13240,12 @@ UPDATE db_schema_version
     def _library_note_fts_query(cls, raw_query: str) -> Optional[str]:
         """Build a safe FTS5 MATCH query from raw user text.
 
-        Tokens are extracted with a word-character regex and each is
-        double-quoted, so FTS operators in the raw input are inert. Returns
-        None when the input contains no usable tokens.
+        The AND-of-quoted-tokens form, not a phrase: tokens are extracted
+        with a word-character regex, each is double-quoted (so FTS operators
+        in the raw input are inert) and they are space-joined, which is
+        FTS5's implicit AND -- every token must appear, in any order and not
+        necessarily adjacent. Returns None when the input contains no usable
+        tokens.
         """
         tokens = re.findall(r"\w+", raw_query, flags=re.UNICODE)
         if not tokens:
@@ -13487,9 +13522,12 @@ UPDATE db_schema_version
     def _library_conversation_fts_query(cls, raw_query: str) -> Optional[str]:
         """Build a safe FTS5 MATCH query from raw user text.
 
-        Tokens are extracted with a word-character regex and each is
-        double-quoted, so FTS operators in the raw input are inert. Returns
-        None when the input contains no usable tokens.
+        The AND-of-quoted-tokens form, not a phrase: tokens are extracted
+        with a word-character regex, each is double-quoted (so FTS operators
+        in the raw input are inert) and they are space-joined, which is
+        FTS5's implicit AND -- every token must appear, in any order and not
+        necessarily adjacent. Returns None when the input contains no usable
+        tokens.
         """
         tokens = re.findall(r"\w+", raw_query, flags=re.UNICODE)
         if not tokens:

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -72,7 +72,8 @@ from .sql_logging import preview_params
 from .private_sqlite import backup_connection_to_private, connect_private_sqlite
 from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
 from tldw_chatbook.Utils.fts5_match_forms import (
-    quote_fts5_phrase,
+    build_and_match_query,
+    build_phrase_match_query,
     quote_fts5_prefix,
     quote_fts5_token,
 )
@@ -7786,14 +7787,17 @@ UPDATE db_schema_version
 
         TASK-19558: this method used to compute ``safe_search_term`` and then
         bind the RAW ``search_term`` -- the quoting reached the error message
-        and nothing else. The dead store is gone; ``search_term`` is now a
-        literal phrase (``quote_fts5_phrase``), so a typed ``OR``/``NEAR``/
-        column filter matches literally instead of being executed, and a
-        typed ``"`` no longer raises ``OperationalError``.
+        and nothing else. The dead store is gone; every token of
+        ``search_term`` is now quoted individually and the tokens are ANDed
+        (``build_and_match_query``), so a typed ``OR``/``NEAR``/column filter
+        matches literally instead of being executed and a typed ``"`` no
+        longer raises ``OperationalError`` -- while ``dragon lore`` keeps
+        matching a card named "lore of the dragon reversed", which the raw
+        bind did and a whole-query phrase would not.
 
         Args:
-            search_term: Plain user-typed search text, matched as a literal
-                phrase. FTS5 operators in it are inert.
+            search_term: Plain user-typed search text. Every token must
+                appear; FTS5 operators in it are inert.
             limit: The maximum number of results to return. Defaults to 10.
             fts_match_query: Optional caller-built FTS5 MATCH expression
                 (must already be injection-safe -- build it with
@@ -7810,8 +7814,10 @@ UPDATE db_schema_version
             CharactersRAGDBError: For database errors during the search.
         """
         match_expression = (
-            fts_match_query if fts_match_query else quote_fts5_phrase(search_term)
+            fts_match_query if fts_match_query else build_and_match_query(search_term)
         )
+        if not match_expression:
+            return []
         query = """
                 SELECT cc.*
                 FROM character_cards_fts fts
@@ -9950,12 +9956,18 @@ UPDATE db_schema_version
         Raises:
             CharactersRAGDBError: For database search errors.
         """
-        if not title_query.strip():
+        if not isinstance(title_query, str) or not title_query.strip():
+            # `isinstance` first (task-19558 E2): `None` reaches this seam
+            # from callers passing an unset filter through, and `.strip()`
+            # on it raised a bare AttributeError -- not even wrapped in
+            # CharactersRAGDBError, so no caller was written to catch it.
             logger.warning(
                 "Empty title_query provided for conversation search. Returning empty list."
             )
             return []
-        safe_search_term = quote_fts5_phrase(title_query)
+        safe_search_term = build_and_match_query(title_query)
+        if not safe_search_term:
+            return []
         base_query = """
                      SELECT c.*
                      FROM conversations_fts fts
@@ -10017,14 +10029,19 @@ UPDATE db_schema_version
         Raises:
             CharactersRAGDBError: For database search errors.
         """
-        if not search_query.strip() and not (fts_match_query or "").strip():
+        plain_is_empty = not isinstance(search_query, str) or not search_query.strip()
+        if plain_is_empty and not (fts_match_query or "").strip():
+            # See `search_conversations_by_title` for why the isinstance
+            # check comes first (task-19558 E2).
             logger.warning(
                 "Empty search_query provided for conversation content search. Returning empty list."
             )
             return []
         safe_search_query = (
-            fts_match_query if fts_match_query else quote_fts5_phrase(search_query)
+            fts_match_query if fts_match_query else build_and_match_query(search_query)
         )
+        if not safe_search_query:
+            return []
 
         # Search for messages containing the query, then get their conversations
         query = """
@@ -12196,7 +12213,9 @@ UPDATE db_schema_version
         Raises:
             CharactersRAGDBError: For database search errors.
         """
-        safe_search_term = quote_fts5_phrase(content_query)
+        safe_search_term = build_and_match_query(content_query)
+        if not safe_search_term:
+            return []
         base_query = """
                      SELECT m.id, m.conversation_id, m.parent_message_id,
                             m.sender, m.content, m.image_data, m.image_mime_type,
@@ -12924,12 +12943,11 @@ UPDATE db_schema_version
         Returns:
             A list of matching keyword dictionaries.
         """
+        match_expression = build_phrase_match_query(search_term)
+        if not match_expression:
+            return []
         return self._search_generic_items_fts(
-            "keywords_fts",
-            "keywords",
-            "keyword",
-            quote_fts5_phrase(search_term),
-            limit,
+            "keywords_fts", "keywords", "keyword", match_expression, limit
         )
 
     # Keyword Collections
@@ -13072,11 +13090,14 @@ UPDATE db_schema_version
         self, search_term: str, limit: int = 10
     ) -> List[Dict[str, Any]]:
         """Search keyword collections by name; ``search_term`` is a literal phrase."""
+        match_expression = build_phrase_match_query(search_term)
+        if not match_expression:
+            return []
         return self._search_generic_items_fts(
             "keyword_collections_fts",
             "keyword_collections",
             "name",
-            quote_fts5_phrase(search_term),
+            match_expression,
             limit,
         )
 
@@ -14181,8 +14202,10 @@ UPDATE db_schema_version
         # nothing) or escaped the literal into a live column filter
         # (`alpha" OR title:"Other` matched notes containing neither term).
         safe_search_term = (
-            fts_match_query if fts_match_query else quote_fts5_phrase(search_term)
+            fts_match_query if fts_match_query else build_phrase_match_query(search_term)
         )
+        if not safe_search_term:
+            return []
 
         params: List[Any] = [safe_search_term]
         id_filter_sql = ""
@@ -16436,7 +16459,12 @@ UPDATE db_schema_version
         flashcard search box, so a card front containing a quote (or any
         typed ``"``) surfaced as a bare ``sqlite3.OperationalError``
         propagating out of the handler -- nothing on that path catches it.
-        The value is now a literal phrase.
+        Every token is now quoted individually and ANDed, which keeps the
+        raw bind's multi-word recall (``dragon lore`` still finds a card
+        fronted "lore of the dragon reversed") while making operators inert.
+        An unsearchable ``q`` -- ``None``, punctuation-only, or containing a
+        NUL, which SQLite truncates the bound parameter at -- returns no
+        rows rather than raising.
         """
         normalized_q = str(q or "").strip() or None
         params: List[Any] = []
@@ -16448,7 +16476,10 @@ UPDATE db_schema_version
                 JOIN decks d ON d.id = f.deck_id
                 WHERE flashcards_fts MATCH ? AND f.is_deleted = 0 AND d.is_deleted = 0
             """
-            params.append(quote_fts5_phrase(normalized_q))
+            match_expression = build_and_match_query(normalized_q)
+            if not match_expression:
+                return []
+            params.append(match_expression)
             if deck_id:
                 query += " AND f.deck_id = ?"
                 params.append(deck_id)
@@ -17697,13 +17728,19 @@ UPDATE db_schema_version
     def search_flashcards(
         self, query: str, deck_id: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        """Search flashcards using FTS; ``query`` is matched as a literal phrase."""
+        """Search flashcards using FTS; every token of ``query`` must appear.
+
+        See ``list_flashcards`` for the form and its rationale (task-19558).
+        """
         base_query = """
             SELECT f.* FROM flashcards f
             JOIN flashcards_fts fts ON f.rowid = fts.rowid
             WHERE flashcards_fts MATCH ? AND f.is_deleted = 0
         """
-        params = [quote_fts5_phrase(query)]
+        match_expression = build_and_match_query(query)
+        if not match_expression:
+            return []
+        params = [match_expression]
 
         if deck_id:
             base_query += " AND f.deck_id = ?"

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -2224,7 +2224,9 @@ class MediaDatabase:
         self,
         search_query: Optional[
             str
-        ],  # Main text for FTS/LIKE (can be pre-formatted for exact phrase)
+        ],  # PLAIN user text for FTS/LIKE -- quoted as a literal FTS5
+        # phrase (TASK-19558). A caller-built MATCH expression goes through
+        # `fts_match_query`, never through here.
         search_fields: Optional[List[str]] = None,
         media_types: Optional[List[str]] = None,
         date_range: Optional[Dict[str, datetime]] = None,  # Expects datetime objects
@@ -2253,10 +2255,14 @@ class MediaDatabase:
         items marked as trash or soft-deleted.
 
         Args:
-            search_query (Optional[str]): The primary text string for searching.
-                If `search_fields` include 'title' or 'content', this query is
-                matched against the FTS index. It can be pre-formatted for exact
-                phrases (e.g., "\"exact phrase\""). For 'author' or 'type' in
+            search_query (Optional[str]): The primary PLAIN-TEXT string for
+                searching. If `search_fields` include 'title' or 'content',
+                this query is quoted as a literal FTS5 phrase
+                (`Utils.fts5_match_forms.quote_fts5_phrase`) before it is
+                matched against the FTS index -- TASK-19558; it is no longer
+                accepted pre-formatted, and FTS5 operators typed into it are
+                inert. Supply a real MATCH expression through
+                `fts_match_query` instead. For 'author' or 'type' in
                 `search_fields`, it's used in a LIKE '%query%' match.
             search_fields (Optional[List[str]]): A list of fields to apply the
                 `search_query` against. Valid fields: 'title', 'content' (FTS),

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -59,7 +59,13 @@ from .sql_validation import (
 from .sql_logging import preview_params
 from .private_sqlite import backup_connection_to_private, connect_private_sqlite
 from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
-from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_phrase, quote_fts5_token
+from tldw_chatbook.Utils.fts5_match_forms import (
+    build_and_match_expression,
+    fts5_query_is_searchable,
+    fts5_query_tokens,
+    quote_fts5_prefix,
+    quote_fts5_token,
+)
 #
 ########################################################################################################################
 #
@@ -2257,12 +2263,15 @@ class MediaDatabase:
         Args:
             search_query (Optional[str]): The primary PLAIN-TEXT string for
                 searching. If `search_fields` include 'title' or 'content',
-                this query is quoted as a literal FTS5 phrase
-                (`Utils.fts5_match_forms.quote_fts5_phrase`) before it is
+                every token of this query is quoted individually and the
+                tokens are ANDed
+                (`Utils.fts5_match_forms.build_and_match_query`) before being
                 matched against the FTS index -- TASK-19558; it is no longer
                 accepted pre-formatted, and FTS5 operators typed into it are
-                inert. Supply a real MATCH expression through
-                `fts_match_query` instead. For 'author' or 'type' in
+                inert. AND-of-tokens rather than one whole-query phrase, so
+                `dragon lore` still finds media titled "lore of the dragon
+                reversed" as the pre-TASK-19558 raw bind did. Supply a real
+                MATCH expression through `fts_match_query` instead. For 'author' or 'type' in
                 `search_fields`, it's used in a LIKE '%query%' match.
             search_fields (Optional[List[str]]): A list of fields to apply the
                 `search_query` against. Valid fields: 'title', 'content' (FTS),
@@ -2533,8 +2542,11 @@ class MediaDatabase:
                     # TASK-19558: plain user text from the media search box.
                     # It used to be bound to MATCH RAW, so a typed `"` raised
                     # OperationalError('unterminated string') and a typed
-                    # `OR`/column filter executed as FTS5 syntax. It is now a
-                    # quoted literal phrase.
+                    # `OR`/column filter executed as FTS5 syntax. Each token
+                    # is now quoted individually and the tokens are ANDed --
+                    # the raw bind's own semantics (FTS5 joins bare terms
+                    # with an implicit AND), so recall is unchanged, unlike
+                    # the whole-query phrase this task's first round used.
                     #
                     # The lowercased duplicates the raw path used to OR in
                     # are gone with it: unicode61 matching is already
@@ -2544,20 +2556,38 @@ class MediaDatabase:
                     # is kept, measured on the RAW length -- quoting adds two
                     # characters, so testing the quoted string's length would
                     # have silently retired that branch.
-                    quoted_fts_query = quote_fts5_phrase(search_query)
-                    if len(search_query) <= 2:
+                    tokens = (
+                        fts5_query_tokens(search_query)
+                        if fts5_query_is_searchable(search_query)
+                        else []
+                    )
+                    if not tokens:
+                        quoted_fts_query = ""
+                    elif len(search_query) <= 2:
                         # Note: SQLite FTS5 doesn't support prefix wildcards
                         # (*term); "ends with" is handled by the LIKE
                         # conditions built below.
-                        fts_query_parts.append(f"{quoted_fts_query}*")
+                        quoted_fts_query = quote_fts5_prefix(search_query)
                     else:
+                        quoted_fts_query = build_and_match_expression(tokens)
+                    if quoted_fts_query:
                         fts_query_parts.append(quoted_fts_query)
 
                 # Combine all FTS query parts with OR
                 combined_fts_query = " OR ".join(fts_query_parts)
-                # Add a single MATCH condition
-                conditions.append("fts.media_fts MATCH ?")
-                params.append(combined_fts_query)
+                if combined_fts_query:
+                    # Add a single MATCH condition
+                    conditions.append("fts.media_fts MATCH ?")
+                    params.append(combined_fts_query)
+                else:
+                    # Unsearchable text (task-19558): `None`, punctuation
+                    # only, or containing a NUL -- which SQLite truncates the
+                    # bound parameter at, mid-literal, so no quoting can
+                    # survive it. `MATCH ''` is an FTS5 syntax error, and
+                    # simply DROPPING the condition would widen the result
+                    # set (these conditions are AND-joined), so the leg is
+                    # made explicitly false instead.
+                    conditions.append("0")
 
                 # Add LIKE search for 'title' and 'content' to ensure partial matches work
                 title_content_like_parts = []

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -2230,9 +2230,9 @@ class MediaDatabase:
         self,
         search_query: Optional[
             str
-        ],  # PLAIN user text for FTS/LIKE -- quoted as a literal FTS5
-        # phrase (TASK-19558). A caller-built MATCH expression goes through
-        # `fts_match_query`, never through here.
+        ],  # PLAIN user text for FTS/LIKE -- each token quoted and the
+        # tokens AND-ed (TASK-19558), never a phrase. A caller-built MATCH
+        # expression goes through `fts_match_query`, never through here.
         search_fields: Optional[List[str]] = None,
         media_types: Optional[List[str]] = None,
         date_range: Optional[Dict[str, datetime]] = None,  # Expects datetime objects
@@ -2273,6 +2273,11 @@ class MediaDatabase:
                 reversed" as the pre-TASK-19558 raw bind did. Supply a real
                 MATCH expression through `fts_match_query` instead. For 'author' or 'type' in
                 `search_fields`, it's used in a LIKE '%query%' match.
+                Leading/trailing whitespace is stripped, and a whitespace-only
+                value is treated as no text search at all. Text with no
+                alphanumeric run ("!!!", "-") cannot produce a MATCH
+                expression, so the FTS leg is dropped and the LIKE legs alone
+                answer it -- it is NOT turned into "no rows".
             search_fields (Optional[List[str]]): A list of fields to apply the
                 `search_query` against. Valid fields: 'title', 'content' (FTS),
                 'author', 'type' (LIKE). Defaults to ['title', 'content'] if
@@ -2362,6 +2367,15 @@ class MediaDatabase:
         resolved_offset = (page - 1) * results_per_page if offset is None else offset
         if resolved_offset > sqlite_integer_max:
             raise ValueError("Pagination offset exceeds SQLite's integer range")
+
+        # TASK-19558 review round 2 (Qodo #1): a search box the user typed only
+        # whitespace into is an EMPTY search, not a search for spaces. Stripping
+        # here also stops accidental padding from vetoing rows: the LIKE leg is
+        # AND-ed with the FTS leg further down, so `%  dragon  %` used to
+        # subtract the rows FTS had already matched (measured on dev: `dragon`
+        # -> 1 row, `  dragon  ` -> 0).
+        if isinstance(search_query, str):
+            search_query = search_query.strip() or None
 
         if search_query and not search_fields:
             search_fields = ["title", "content"]  # Default fields for search_query
@@ -2517,14 +2531,9 @@ class MediaDatabase:
 
             # FTS on 'title', 'content'
             if any(f in sanitized_text_search_fields for f in ["title", "content"]):
-                fts_search_active = True
                 effective_fts_query = (
                     fts_match_query if fts_match_query is not None else search_query
                 )
-                if not any(
-                    "media_fts fts" in j_item for j_item in joins
-                ):  # Ensure FTS join is added only once
-                    joins.append("JOIN media_fts fts ON fts.rowid = m.id")
 
                 # SQLite FTS doesn't allow multiple MATCH conditions combined with OR
                 # Instead, we'll use a single MATCH condition with the OR operator inside the FTS query
@@ -2576,18 +2585,49 @@ class MediaDatabase:
                 # Combine all FTS query parts with OR
                 combined_fts_query = " OR ".join(fts_query_parts)
                 if combined_fts_query:
+                    fts_search_active = True
+                    if not any(
+                        "media_fts fts" in j_item for j_item in joins
+                    ):  # Ensure FTS join is added only once
+                        joins.append("JOIN media_fts fts ON fts.rowid = m.id")
                     # Add a single MATCH condition
                     conditions.append("fts.media_fts MATCH ?")
                     params.append(combined_fts_query)
                 else:
-                    # Unsearchable text (task-19558): `None`, punctuation
-                    # only, or containing a NUL -- which SQLite truncates the
-                    # bound parameter at, mid-literal, so no quoting can
-                    # survive it. `MATCH ''` is an FTS5 syntax error, and
-                    # simply DROPPING the condition would widen the result
-                    # set (these conditions are AND-joined), so the leg is
-                    # made explicitly false instead.
-                    conditions.append("0")
+                    # No executable MATCH expression came out of the builder.
+                    # `MATCH ''` is an FTS5 syntax error, so the leg cannot be
+                    # kept -- but WHY it is empty decides what replaces it,
+                    # because the reasons are not the same failure (TASK-19558
+                    # review round 2, Qodo #1: round 1 answered "0" to all of
+                    # them, and since these conditions are AND-joined that
+                    # forced the WHOLE query to zero rows -- a recall
+                    # regression, not a safety property).
+                    #
+                    #  * A caller-owned `fts_match_query` that came out blank
+                    #    means "no rows" by that seam's own contract
+                    #    (`build_and_match_query` returns "" for exactly that),
+                    #    and the title/content LIKE legs are deliberately NOT
+                    #    built in that branch -- so dropping the condition
+                    #    would leave no text filter at all and return
+                    #    EVERYTHING. It stays explicitly false.
+                    #  * A NUL byte truncates the bound parameter inside
+                    #    SQLite, so `%a\x00b%` reaches LIKE as `%a` -- the
+                    #    fallback is not merely useless there, it is WIDER
+                    #    than what was asked for (measured on dev:
+                    #    `dragon\x00lore` returned the `dragon` row). Also
+                    #    explicitly false.
+                    #  * Punctuation-only text ("!!!", "-", "***") simply has
+                    #    no alphanumeric run for FTS5 to index -- but LIKE
+                    #    '%!!!%' expresses the user's intent exactly. The FTS
+                    #    leg (and its JOIN, and relevance ordering) is DROPPED
+                    #    and the LIKE conditions below carry the search.
+                    fts_leg_must_be_false = (
+                        fts_match_query is not None
+                        or not isinstance(search_query, str)
+                        or "\x00" in search_query
+                    )
+                    if fts_leg_must_be_false:
+                        conditions.append("0")
 
                 # Add LIKE search for 'title' and 'content' to ensure partial matches work
                 title_content_like_parts = []
@@ -8052,9 +8092,12 @@ class MediaDatabase:
     def _library_fts_query(cls, raw_query: str) -> Optional[str]:
         """Build a safe FTS5 MATCH query from raw user text.
 
-        Tokens are extracted with a word-character regex and each is
-        double-quoted, so FTS operators in the raw input are inert. Returns
-        None when the input contains no usable tokens.
+        The AND-of-quoted-tokens form, not a phrase: tokens are extracted
+        with a word-character regex, each is double-quoted (so FTS operators
+        in the raw input are inert) and they are space-joined, which is
+        FTS5's implicit AND -- every token must appear, in any order and not
+        necessarily adjacent. Returns None when the input contains no usable
+        tokens.
         """
         tokens = re.findall(r"\w+", raw_query, flags=re.UNICODE)
         if not tokens:

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -59,6 +59,7 @@ from .sql_validation import (
 from .sql_logging import preview_params
 from .private_sqlite import backup_connection_to_private, connect_private_sqlite
 from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
+from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_phrase, quote_fts5_token
 #
 ########################################################################################################################
 #
@@ -2523,30 +2524,28 @@ class MediaDatabase:
                     # matching is case-insensitive already.
                     fts_query_parts.append(effective_fts_query)
                 else:
-                    # For very short search terms (1-2 characters), add wildcards to improve matching
-                    is_quoted_fts_query = effective_fts_query.startswith(
-                        '"'
-                    ) and effective_fts_query.endswith('"')
-                    if len(effective_fts_query) <= 2 and not is_quoted_fts_query:
-                        # Add suffix wildcard for better partial matching with short terms
-                        fts_query_parts.append(f"{effective_fts_query}*")
-
-                        # Note: SQLite FTS5 doesn't support prefix wildcards (*term)
-                        # We'll handle "ends with" matching using LIKE conditions instead
-
-                        # Add case-insensitive versions if needed
-                        if effective_fts_query.lower() != effective_fts_query:
-                            fts_query_parts.append(f"{effective_fts_query.lower()}*")
+                    # TASK-19558: plain user text from the media search box.
+                    # It used to be bound to MATCH RAW, so a typed `"` raised
+                    # OperationalError('unterminated string') and a typed
+                    # `OR`/column filter executed as FTS5 syntax. It is now a
+                    # quoted literal phrase.
+                    #
+                    # The lowercased duplicates the raw path used to OR in
+                    # are gone with it: unicode61 matching is already
+                    # case-insensitive (the caller-owned branch above says
+                    # so), and a lowercased copy of a quoted literal is a
+                    # no-op OR-arm. The short-term (1-2 char) prefix widening
+                    # is kept, measured on the RAW length -- quoting adds two
+                    # characters, so testing the quoted string's length would
+                    # have silently retired that branch.
+                    quoted_fts_query = quote_fts5_phrase(search_query)
+                    if len(search_query) <= 2:
+                        # Note: SQLite FTS5 doesn't support prefix wildcards
+                        # (*term); "ends with" is handled by the LIKE
+                        # conditions built below.
+                        fts_query_parts.append(f"{quoted_fts_query}*")
                     else:
-                        # For longer terms, use the original query
-                        fts_query_parts.append(effective_fts_query)
-
-                        # Add case-insensitive version if needed
-                        if (
-                            not is_quoted_fts_query
-                            and effective_fts_query.lower() != effective_fts_query
-                        ):
-                            fts_query_parts.append(effective_fts_query.lower())
+                        fts_query_parts.append(quoted_fts_query)
 
                 # Combine all FTS query parts with OR
                 combined_fts_query = " OR ".join(fts_query_parts)
@@ -8025,7 +8024,7 @@ class MediaDatabase:
         if not tokens:
             return None
         tokens = tokens[: cls._LIBRARY_FTS_TOKEN_LIMIT]
-        return " ".join(f'"{token}"' for token in tokens)
+        return " ".join(quote_fts5_token(token) for token in tokens)
 
     def _library_keywords_for_media(
         self, conn: sqlite3.Connection, media_ids: List[int]

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -1090,7 +1090,19 @@ class EvalsDB:
         return tasks
 
     def search_tasks(self, query: str, limit: int = 50) -> List[Dict[str, Any]]:
-        """Search tasks using FTS5."""
+        """Search tasks using FTS5.
+
+        Args:
+            query: Plain user text, matched as ONE quoted literal FTS5
+                PHRASE (``build_phrase_match_query``) -- the words must be
+                adjacent and in order, which is what this seam did before
+                TASK-19558 too. Short or punctuation-bearing queries take
+                the LIKE branch below instead. FTS5 operators are inert.
+            limit: Maximum number of rows to return.
+
+        Returns:
+            The matching task dicts; empty when ``query`` is not searchable.
+        """
         if not isinstance(query, str):
             # task-19558 (E2 sweep): `None` from an unset filter reached the
             # generator below and raised a bare `TypeError`. Pre-dates the
@@ -1319,7 +1331,19 @@ class EvalsDB:
             return cursor.rowcount > 0
 
     def search_datasets(self, query: str, limit: int = 50) -> List[Dict[str, Any]]:
-        """Search datasets using FTS5."""
+        """Search datasets using FTS5.
+
+        Args:
+            query: Plain user text, matched as ONE quoted literal FTS5
+                PHRASE (``build_phrase_match_query``) -- the words must be
+                adjacent and in order, as this seam did before TASK-19558.
+                FTS5 operators in it are inert.
+            limit: Maximum number of rows to return.
+
+        Returns:
+            The matching dataset dicts; empty when ``query`` is not
+            searchable (None, empty, NUL-bearing or punctuation-only).
+        """
         # Escape special characters in FTS5 query by wrapping in quotes.
         # TASK-19558: this wrapping never doubled an embedded `"`, so a
         # dataset search containing one raised OperationalError and one

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
 from tldw_chatbook.DB.sql_validation import validate_identifier
+from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_phrase
 
 # Database Schema Version
 SCHEMA_VERSION = 5
@@ -1107,10 +1108,9 @@ class EvalsDB:
                 (f"%{query}%", f"%{query}%", limit),
             )
         else:
-            # For normal queries, use FTS5 with proper escaping
-            # Escape double quotes in the query
-            escaped_query = query.replace('"', '""')
-            safe_query = f'"{escaped_query}"' if escaped_query else '""'
+            # For normal queries, use FTS5 with proper escaping (the ONE
+            # escape lives in `Utils/fts5_match_forms`; TASK-19558).
+            safe_query = quote_fts5_phrase(query)
             cursor = conn.execute(
                 """
                 SELECT t.* FROM eval_tasks t
@@ -1309,8 +1309,12 @@ class EvalsDB:
 
     def search_datasets(self, query: str, limit: int = 50) -> List[Dict[str, Any]]:
         """Search datasets using FTS5."""
-        # Escape special characters in FTS5 query by wrapping in quotes
-        safe_query = f'"{query}"' if query else '""'
+        # Escape special characters in FTS5 query by wrapping in quotes.
+        # TASK-19558: this wrapping never doubled an embedded `"`, so a
+        # dataset search containing one raised OperationalError and one
+        # shaped `x" OR name:"y` escaped the literal into a live column
+        # filter. `quote_fts5_phrase` is the ONE escape.
+        safe_query = quote_fts5_phrase(query or "")
 
         conn = self._get_connection()
         cursor = conn.execute(

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
 from tldw_chatbook.DB.sql_validation import validate_identifier
-from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_phrase
+from tldw_chatbook.Utils.fts5_match_forms import build_phrase_match_query
 
 # Database Schema Version
 SCHEMA_VERSION = 5
@@ -1091,6 +1091,12 @@ class EvalsDB:
 
     def search_tasks(self, query: str, limit: int = 50) -> List[Dict[str, Any]]:
         """Search tasks using FTS5."""
+        if not isinstance(query, str):
+            # task-19558 (E2 sweep): `None` from an unset filter reached the
+            # generator below and raised a bare `TypeError`. Pre-dates the
+            # task -- fixed here because it is the same failure mode, at the
+            # last seam in this family that still had it.
+            return []
         conn = self._get_connection()
 
         # Remove null bytes and other control characters
@@ -1109,8 +1115,13 @@ class EvalsDB:
             )
         else:
             # For normal queries, use FTS5 with proper escaping (the ONE
-            # escape lives in `Utils/fts5_match_forms`; TASK-19558).
-            safe_query = quote_fts5_phrase(query)
+            # escape lives in `Utils/fts5_match_forms`; TASK-19558). Phrase,
+            # not AND-of-tokens: this seam bound a quoted PHRASE before the
+            # task too, so widening it would be an unmeasured behaviour
+            # change riding along with a security fix.
+            safe_query = build_phrase_match_query(query)
+            if not safe_query:
+                return []
             cursor = conn.execute(
                 """
                 SELECT t.* FROM eval_tasks t
@@ -1313,8 +1324,12 @@ class EvalsDB:
         # TASK-19558: this wrapping never doubled an embedded `"`, so a
         # dataset search containing one raised OperationalError and one
         # shaped `x" OR name:"y` escaped the literal into a live column
-        # filter. `quote_fts5_phrase` is the ONE escape.
-        safe_query = quote_fts5_phrase(query or "")
+        # filter. `build_phrase_match_query` is the ONE escape; phrase
+        # rather than AND-of-tokens because this seam bound a phrase before
+        # the task too (see `search_tasks`).
+        safe_query = build_phrase_match_query(query)
+        if not safe_query:
+            return []
 
         conn = self._get_connection()
         cursor = conn.execute(

--- a/tldw_chatbook/DB/Prompts_DB.py
+++ b/tldw_chatbook/DB/Prompts_DB.py
@@ -3291,7 +3291,12 @@ class PromptsDatabase:
 
     @classmethod
     def _library_prompt_fts_query(cls, raw_query: str) -> Optional[str]:
-        """Build a safe FTS5 MATCH query from raw user text (operators inert)."""
+        """Build a safe FTS5 MATCH query from raw user text (operators inert).
+
+        The AND-of-quoted-tokens form, not a phrase: each token is
+        double-quoted and they are space-joined, which is FTS5's implicit
+        AND. Returns None when the input contains no usable tokens.
+        """
         tokens = re.findall(r"\w+", raw_query, flags=re.UNICODE)
         if not tokens:
             return None
@@ -4453,7 +4458,10 @@ class PromptsDatabase:
         Searches in: name, author, details, system_prompt, user_prompt
 
         Args:
-            search_text: The text to search for
+            search_text: Plain user text. Every token is quoted individually
+                and the tokens are AND-ed (``build_and_match_query``), so all
+                of them must appear but they need not be adjacent -- NOT a
+                phrase, and FTS5 operators in it are inert.
             include_deleted: Whether to include soft-deleted prompts
 
         Returns:

--- a/tldw_chatbook/DB/Prompts_DB.py
+++ b/tldw_chatbook/DB/Prompts_DB.py
@@ -52,6 +52,7 @@ from .sql_logging import preview_params
 from .private_sqlite import backup_connection_to_private, connect_private_sqlite
 from ..Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
+from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_phrase, quote_fts5_token
 #
 ########################################################################################################################
 #
@@ -3292,7 +3293,7 @@ class PromptsDatabase:
         if not tokens:
             return None
         tokens = tokens[: cls._LIBRARY_PROMPT_FTS_TOKEN_LIMIT]
-        return " ".join(f'"{token}"' for token in tokens)
+        return " ".join(quote_fts5_token(token) for token in tokens)
 
     def _library_keywords_for_prompts(
         self, conn: sqlite3.Connection, prompt_ids: List[int]
@@ -3802,10 +3803,14 @@ class PromptsDatabase:
                 "system_prompt",
                 "user_prompt",
             }
-            # Forward the caller-built MATCH expression only when provided
-            # so existing callers/test fakes without the parameter keep the
-            # legacy raw-`search_query` MATCH behavior unchanged.
-            effective_match_query = fts_match_query if fts_match_query else search_query
+            # Forward the caller-built MATCH expression when provided;
+            # otherwise quote the user's text as a literal phrase.
+            # TASK-19558: the else-branch used to bind `search_query` RAW,
+            # so a typed `"` raised OperationalError('unterminated string')
+            # and a typed column filter/`OR` executed as FTS5 syntax.
+            effective_match_query = (
+                fts_match_query if fts_match_query else quote_fts5_phrase(search_query)
+            )
 
             # Search in prompt text fields
             if any(field in text_search_fields for field in search_fields):
@@ -4440,9 +4445,11 @@ class PromptsDatabase:
 
         try:
             # Use FTS to find matching prompt IDs
+            # TASK-19558: `search_text` is plain user text; quote it as a
+            # literal phrase rather than binding it as an FTS5 expression.
             cursor = self.execute_query(
                 "SELECT rowid FROM prompts_fts WHERE prompts_fts MATCH ?",
-                (search_text,),
+                (quote_fts5_phrase(search_text),),
             )
             matching_ids = [row["rowid"] for row in cursor.fetchall()]
 

--- a/tldw_chatbook/DB/Prompts_DB.py
+++ b/tldw_chatbook/DB/Prompts_DB.py
@@ -52,7 +52,10 @@ from .sql_logging import preview_params
 from .private_sqlite import backup_connection_to_private, connect_private_sqlite
 from ..Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
-from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_phrase, quote_fts5_token
+from tldw_chatbook.Utils.fts5_match_forms import (
+    build_and_match_query,
+    quote_fts5_token,
+)
 #
 ########################################################################################################################
 #
@@ -3745,12 +3748,16 @@ class PromptsDatabase:
         """Searches prompts using FTS.
 
         Args:
-            search_query: Plain user search text, matched against
-                ``prompts_fts``/``prompt_keywords_fts`` as a literal phrase
-                (TASK-19558 -- it is quoted with
-                ``Utils.fts5_match_forms.quote_fts5_phrase``, NOT used
+            search_query: Plain user search text. Every token must appear
+                in ``prompts_fts``/``prompt_keywords_fts``
+                (TASK-19558 -- each token is quoted with
+                ``Utils.fts5_match_forms.build_and_match_query``, NOT used
                 verbatim as a MATCH clause; FTS5 operators typed into it are
-                inert, and a typed ``"`` no longer raises).
+                inert, and a typed ``"`` no longer raises). The AND-of-tokens
+                form, not a whole-query phrase: a prompt named "lore of the
+                dragon reversed" is still found by ``dragon lore``.
+                Unsearchable text -- ``None``, punctuation-only, or
+                containing a NUL -- matches nothing instead of raising.
             search_fields: Fields to search; defaults to the standard text
                 fields when ``search_query`` is set.
             page: 1-indexed page number.
@@ -3807,13 +3814,22 @@ class PromptsDatabase:
                 "user_prompt",
             }
             # Forward the caller-built MATCH expression when provided;
-            # otherwise quote the user's text as a literal phrase.
+            # otherwise quote each of the user's tokens and AND them.
             # TASK-19558: the else-branch used to bind `search_query` RAW,
             # so a typed `"` raised OperationalError('unterminated string')
             # and a typed column filter/`OR` executed as FTS5 syntax.
             effective_match_query = (
-                fts_match_query if fts_match_query else quote_fts5_phrase(search_query)
+                fts_match_query
+                if fts_match_query
+                else build_and_match_query(search_query)
             )
+            # "" means the text cannot be searched at all (punctuation only,
+            # or containing a NUL that SQLite truncates the bound parameter
+            # at). `MATCH ''` is an FTS5 syntax error, so skip both FTS legs
+            # and let the id-set stay empty rather than raising into the
+            # prompt search box.
+            if not effective_match_query:
+                return [], 0
 
             # Search in prompt text fields
             if any(field in text_search_fields for field in search_fields):
@@ -4448,11 +4464,16 @@ class PromptsDatabase:
 
         try:
             # Use FTS to find matching prompt IDs
-            # TASK-19558: `search_text` is plain user text; quote it as a
-            # literal phrase rather than binding it as an FTS5 expression.
+            # TASK-19558: `search_text` is plain user text; quote each of
+            # its tokens and AND them rather than binding it as an FTS5
+            # expression (and rather than one whole-query phrase, which
+            # would halve recall -- see `build_and_match_query`).
+            match_expression = build_and_match_query(search_text)
+            if not match_expression:
+                return []
             cursor = self.execute_query(
                 "SELECT rowid FROM prompts_fts WHERE prompts_fts MATCH ?",
-                (quote_fts5_phrase(search_text),),
+                (match_expression,),
             )
             matching_ids = [row["rowid"] for row in cursor.fetchall()]
 

--- a/tldw_chatbook/DB/Prompts_DB.py
+++ b/tldw_chatbook/DB/Prompts_DB.py
@@ -3745,9 +3745,12 @@ class PromptsDatabase:
         """Searches prompts using FTS.
 
         Args:
-            search_query: Plain user search text. Also used verbatim as the
-                MATCH clause against ``prompts_fts``/``prompt_keywords_fts``
-                when ``fts_match_query`` is not provided.
+            search_query: Plain user search text, matched against
+                ``prompts_fts``/``prompt_keywords_fts`` as a literal phrase
+                (TASK-19558 -- it is quoted with
+                ``Utils.fts5_match_forms.quote_fts5_phrase``, NOT used
+                verbatim as a MATCH clause; FTS5 operators typed into it are
+                inert, and a typed ``"`` no longer raises).
             search_fields: Fields to search; defaults to the standard text
                 fields when ``search_query`` is set.
             page: 1-indexed page number.
@@ -3757,8 +3760,8 @@ class PromptsDatabase:
                 Library keyword search's plural/singular-widened query,
                 see ``library_fts_query.build_fts_match_query``) that
                 overrides the MATCH clause built from ``search_query``.
-                When omitted, ``search_query`` keeps its legacy behavior
-                unchanged.
+                This is the ONLY seam through which a caller may supply
+                FTS5 syntax; it must already be injection-safe.
         """
         start_time = time.time()
 

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -42,6 +42,7 @@ from .base_db import BaseDB
 from .sql_validation import validate_identifier
 from ..config import get_cli_setting
 from ..Metrics.metrics_logger import log_counter, log_histogram
+from ..Utils.fts5_match_forms import quote_fts5_token
 
 
 #: Fallback `auto_pause_threshold` when the config value is missing or
@@ -2423,7 +2424,7 @@ class SubscriptionsDB(BaseDB):
         Library's plural/singular widening is deliberately NOT copied: a
         reader scanning for a feed's own words wants exactly those words.
         """
-        return '"' + term.replace('"', '""') + '"'
+        return quote_fts5_token(term)
 
     #: The list-page projection shared by `get_new_items` and its
     #: `_search_items_rows` search half (TASK-15464). Deliberately NOT

--- a/tldw_chatbook/Library/library_fts_query.py
+++ b/tldw_chatbook/Library/library_fts_query.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from tldw_chatbook.Utils.fts5_match_forms import (
     build_prefix_match_expression,
     fts5_query_tokens,
+    quote_fts5_token,
 )
 
 # Terms shorter than this are never expanded (articles, initials, "as", ...).
@@ -40,8 +41,13 @@ _ES_PLURAL_ENDINGS = ("s", "x", "z", "ch", "sh")
 
 
 def _quote_fts_term(term: str) -> str:
-    """Return `term` as a literal FTS5 string (embedded quotes doubled)."""
-    return '"' + term.replace('"', '""') + '"'
+    """Return `term` as a literal FTS5 string (embedded quotes doubled).
+
+    A thin alias over `Utils.fts5_match_forms.quote_fts5_token`, the ONE
+    implementation of this escape (TASK-19558). Kept as a module-local name
+    because this module's docstrings and tests refer to it by that name.
+    """
+    return quote_fts5_token(term)
 
 
 def expand_keyword_term(term: str) -> tuple[str, ...]:

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -6,6 +6,7 @@ import asyncio
 from enum import Enum
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import replace
+from functools import partial
 from typing import Any, Hashable, Optional
 
 from loguru import logger
@@ -742,14 +743,27 @@ class LibraryLocalRagSearchService:
             return SeamState.UNAVAILABLE, []
 
         async def run_match(fts_query: str) -> list[dict[str, Any]]:
+            # Pre-built MATCH string, same as the notes/media/prompts seams.
+            # TASK-19558: this used to arrive through the plain-text
+            # `search_query` parameter and work only because that argument
+            # was bound to MATCH raw. It now goes through the explicit
+            # `fts_match_query` seam the siblings already used, so the
+            # plain-text parameter can quote what it is given.
             if getattr(db, "is_memory_db", False):
                 # In-memory SQLite connections are thread-local and only the
                 # thread that created the database has the migrated schema;
                 # offloading to a worker thread would hit a blank connection.
-                raw_results = db.search_conversations_by_content(fts_query, top_k)
+                raw_results = db.search_conversations_by_content(
+                    query, top_k, fts_match_query=fts_query
+                )
             else:
                 raw_results = await asyncio.to_thread(
-                    db.search_conversations_by_content, fts_query, top_k
+                    partial(
+                        db.search_conversations_by_content,
+                        query,
+                        top_k,
+                        fts_match_query=fts_query,
+                    )
                 )
             return [
                 _conversation_row(item)

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -153,7 +153,9 @@ class FileNotesReplica:
 
         Args:
             root: Canonical notes-root identifier.
-            query: Literal text to find in replicated file content.
+            query: User text, matched as ONE quoted literal FTS5 PHRASE
+                (``quote_fts5_phrase``) -- the words must be adjacent and in
+                order, and FTS5 operators in it are inert.
             limit: Maximum number of paths to return.
 
         Returns:

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -12,6 +12,7 @@ from threading import RLock
 from typing import NamedTuple
 
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
+from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_phrase
 
 
 class ReplicaFileInfo(NamedTuple):
@@ -161,8 +162,7 @@ class FileNotesReplica:
         query = query.strip()
         if not query or limit <= 0 or "\x00" in query:
             return []
-        escaped_query = query.replace('"', '""')
-        literal_query = f'"{escaped_query}"'
+        literal_query = quote_fts5_phrase(query)
         try:
             with self._lock:
                 rows = self._connection.execute(

--- a/tldw_chatbook/Prompt_Management/prompt_scope_service.py
+++ b/tldw_chatbook/Prompt_Management/prompt_scope_service.py
@@ -558,8 +558,9 @@ class LocalPromptService:
 
         Args:
             query: Plain user query text, forwarded as ``search_query``
-                (used verbatim as the FTS MATCH expression when
-                ``fts_match_query`` is not provided).
+                (quoted as a literal FTS5 phrase by ``PromptsDatabase.
+                search_prompts`` when ``fts_match_query`` is not provided --
+                TASK-19558; it is NOT used verbatim as a MATCH expression).
             limit: Maximum number of prompts to return.
             include_deleted: Whether to include soft-deleted prompts.
             fts_match_query: Optional pre-built FTS5 MATCH string (e.g.

--- a/tldw_chatbook/Prompt_Management/prompt_scope_service.py
+++ b/tldw_chatbook/Prompt_Management/prompt_scope_service.py
@@ -557,10 +557,12 @@ class LocalPromptService:
         sized to ``limit`` results.
 
         Args:
-            query: Plain user query text, forwarded as ``search_query``
-                (quoted as a literal FTS5 phrase by ``PromptsDatabase.
-                search_prompts`` when ``fts_match_query`` is not provided --
-                TASK-19558; it is NOT used verbatim as a MATCH expression).
+            query: Plain user query text, forwarded as ``search_query``.
+                ``PromptsDatabase.search_prompts`` converts it to the
+                AND-of-quoted-tokens form when ``fts_match_query`` is not
+                provided (``build_and_match_query``, TASK-19558) -- every
+                token must appear but they need not be adjacent, so it is
+                neither a phrase nor a verbatim MATCH expression.
             limit: Maximum number of prompts to return.
             include_deleted: Whether to include soft-deleted prompts.
             fts_match_query: Optional pre-built FTS5 MATCH string (e.g.

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -46,6 +46,7 @@ import psutil
 from tldw_chatbook.config import load_settings
 from tldw_chatbook.Utils.fts5_match_forms import (
     FTS5_STOPWORDS,
+    build_and_match_expression,
     build_prefix_match_expression,
     fts5_query_tokens,
     fts5_token_runs,
@@ -3578,13 +3579,16 @@ class RAGService:
                 f"Query truncated from {len(query)} to {MAX_QUERY_LENGTH} characters"
             )
 
-        quoted_tokens = [
-            self._quote_fts5_token(token)
-            for token in self._fts5_query_tokens(query)
-        ]
-
-        # FTS5 joins space-separated quoted terms with an implicit AND.
-        return " ".join(quoted_tokens)
+        # TASK-19558 moved the JOIN, not just the escape, to
+        # `Utils/fts5_match_forms.build_and_match_expression`: the DB search
+        # seams needed this same AND form and a second copy of it is how the
+        # phrase-vs-AND distinction gets lost again. `_quote_fts5_token` and
+        # `_fts5_query_tokens` remain as this class's named seams (probes and
+        # tests monkeypatch them by name) and still delegate to the same
+        # module, so the expression built here is byte-identical. (Named
+        # seams because RAG_Eval's probes and harness call them directly;
+        # nothing intercepts them to observe this method.)
+        return build_and_match_expression(self._fts5_query_tokens(query))
 
     @staticmethod
     def _quote_fts5_token(token: str) -> str:

--- a/tldw_chatbook/Subscriptions/watchlist_opml_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_opml_service.py
@@ -13,7 +13,22 @@ try:
     # TASK-19558: this module was the one XML parser in `Subscriptions/`
     # that never adopted defusedxml, while every sibling
     # (`security.py`, `monitoring_engine.py`, the three scrapers) uses this
-    # exact try/except shape. The concrete exposure measured for OPML is
+    # exact try/except shape.
+    #
+    # NOT routed through `Utils/optional_deps.py` -- reviewed and declined
+    # in review round 2 (Qodo #3). `defusedxml` is a CORE dependency
+    # (`pyproject.toml` `[project] dependencies`, annotated "engine xml
+    # security parsing (Q9: core)"), not an extra, and `optional_deps`
+    # names it only inside the `ebook` extra's aggregate availability
+    # check -- it publishes no import accessor for it. All six existing
+    # defusedxml call sites in this app import it directly under exactly
+    # this try/except; routing one of them through `get_safe_import`
+    # (whose users are torch/transformers/aiohttp -- genuinely optional)
+    # would make this the odd one out, not the consistent one. The
+    # `except ImportError` arm is a belt-and-braces fallback for a broken
+    # install, not an optional-feature gate.
+    #
+    # The concrete exposure measured for OPML is
     # ENTITY EXPANSION ("billion laughs"), not XXE: stdlib ElementTree
     # already ignores external entity references, but it happily expands
     # internal ones, so a ~1KB OPML file imported through Watchlists ▸

--- a/tldw_chatbook/Subscriptions/watchlist_opml_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_opml_service.py
@@ -1,7 +1,35 @@
 from __future__ import annotations
 
+# Stdlib ElementTree is imported for document BUILDING only (`export`
+# below): `Element`/`SubElement` have no defusedxml counterparts, and
+# serializing a tree we constructed ourselves has no attacker-controlled
+# input. Every PARSE of foreign text goes through `_safe_fromstring`.
 import xml.etree.ElementTree as ET
 from typing import Any
+
+from loguru import logger
+
+try:
+    # TASK-19558: this module was the one XML parser in `Subscriptions/`
+    # that never adopted defusedxml, while every sibling
+    # (`security.py`, `monitoring_engine.py`, the three scrapers) uses this
+    # exact try/except shape. The concrete exposure measured for OPML is
+    # ENTITY EXPANSION ("billion laughs"), not XXE: stdlib ElementTree
+    # already ignores external entity references, but it happily expands
+    # internal ones, so a ~1KB OPML file imported through Watchlists ▸
+    # Import OPML expands to gigabytes inside the parser. defusedxml
+    # raises `EntitiesForbidden` on the DTD instead.
+    from defusedxml.ElementTree import fromstring as _safe_fromstring
+
+    DEFUSEDXML_AVAILABLE = True
+except ImportError:  # pragma: no cover - defusedxml is a core dependency
+    from xml.etree.ElementTree import fromstring as _safe_fromstring
+
+    DEFUSEDXML_AVAILABLE = False
+    logger.warning(
+        "defusedxml not available, using standard xml.etree for OPML import. "
+        "Install defusedxml for better security."
+    )
 
 
 class WatchlistOpmlService:
@@ -29,8 +57,12 @@ class WatchlistOpmlService:
 
         Raises:
             xml.etree.ElementTree.ParseError: If ``xml_text`` is malformed.
+            defusedxml.common.EntitiesForbidden: If ``xml_text`` declares
+                internal entities (the billion-laughs shape). Subclasses
+                ``ValueError``; the caller's handler treats it the same way
+                it treats a malformed document.
         """
-        root = ET.fromstring(xml_text)
+        root = _safe_fromstring(xml_text)
         items: list[dict[str, Any]] = []
 
         def walk(element: ET.Element, folder: "str | None") -> None:

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -154,7 +154,17 @@ def resolve_workspace_path(
             is a protected credential/gate-state/app-state path.
     """
     try:
-        resolved = validate_path(path, workspace_root, allow_hidden=True)
+        # `redact_paths=True` (TASK-19558): `path` here is MODEL-supplied and
+        # `validate_path` otherwise echoes it, and its resolved form, into a
+        # WARNING/ERROR log line -- so a prompt-injected traversal probe
+        # writes attacker-chosen text (and the user's real directory layout)
+        # into the diagnostics bundle. Only 9 of this function's ~30 sibling
+        # call sites passed it. This does not weaken what the MODEL sees:
+        # the refusal below is built from `path` locally and is unchanged;
+        # redaction bounds only the log line and the discarded ValueError.
+        resolved = validate_path(
+            path, workspace_root, redact_paths=True, allow_hidden=True
+        )
     except ValueError as exc:
         raise LocalToolError(
             f"Path '{path}' is outside the workspace root ({workspace_root})"

--- a/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
@@ -7,6 +7,7 @@ from loguru import logger
 from rich.text import Text
 from textual.widgets import Input, Select, Static, TextArea
 
+from tldw_chatbook.Utils.fts5_match_forms import quote_fts5_prefix
 from ..character_display_text import (
     sanitize_character_display_items,
     sanitize_character_display_label,
@@ -66,11 +67,16 @@ def search_characters_fts(search_term: str, limit: int = 50) -> List[Dict[str, A
     db = _default_character_db()
     if db is None:
         return []
-    escaped = term.replace('"', '""')
-    match_query = f'"{escaped}"*'
+    match_query = quote_fts5_prefix(term)
     return [
         _normalize_character_payload(row)
-        for row in db.search_character_cards(match_query, limit=limit)
+        # task-19558: this is a caller-BUILT prefix expression, so it goes
+        # through `fts_match_query`, not the plain-text parameter (which
+        # now quotes what it is given as a literal phrase and would have
+        # double-quoted this one into a no-match).
+        for row in db.search_character_cards(
+            term, limit=limit, fts_match_query=match_query
+        )
     ]
 
 

--- a/tldw_chatbook/UI/Console_Modules/prompts.py
+++ b/tldw_chatbook/UI/Console_Modules/prompts.py
@@ -110,6 +110,7 @@ from loguru import logger
 from ..Navigation.pending_handoff_store import HandoffChannel
 from ..Navigation.screen_state_store import ConsolePromptTargetProjection
 from ...Chat.console_command_grammar import CommandParse
+from ...Utils.fts5_match_forms import quote_fts5_prefix
 from ...Chat.console_provider_endpoints import safe_endpoint_display
 from ...Chat.prompt_history import PromptHistory, default_prompt_history_path
 from ...Library.library_prompts_state import classify_prompt_save_error
@@ -1176,8 +1177,7 @@ class ConsolePromptsController:
         ``library_fts_query._quote_fts_term``), so user text can never break
         out of the quoted phrase to inject MATCH operators.
         """
-        escaped = text.replace('"', '""')
-        return f'"{escaped}"*'
+        return quote_fts5_prefix(text)
 
     async def _console_prompt_search(self, query: str) -> list:
         """Bounded FTS prompt search bound to the active scope service.

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -75,6 +75,7 @@ from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
 from ...Actor_Packs.contracts import ActorPackValidationError, validate_actor_portrait
 from ...Actor_Packs.creation import ActorPackCreationError, ActorPackCreationResult
 from ...Chat.chat_handoff_models import ChatHandoffPayload
+from ...Utils.fts5_match_forms import quote_fts5_prefix
 from ...Chat.console_expression_state import EXPRESSION_IMAGE_STATES
 from ...Constants import TAB_STTS
 from ...DB.ChaChaNotes_DB import ConflictError
@@ -1828,8 +1829,7 @@ class PersonasScreen(BaseAppScreen):
         term = (self.state.search_query or "").strip()
         if not term:
             return None
-        escaped = term.replace('"', '""')
-        return f'"{escaped}"*'
+        return quote_fts5_prefix(term)
 
     def _active_server_target(self) -> str | None:
         """Return the exact active configured-target ID, when usable."""

--- a/tldw_chatbook/Utils/fts5_match_forms.py
+++ b/tldw_chatbook/Utils/fts5_match_forms.py
@@ -38,7 +38,11 @@ from typing import FrozenSet, Iterable, List
 
 __all__ = [
     "FTS5_STOPWORDS",
+    "build_and_match_expression",
+    "build_and_match_query",
+    "build_phrase_match_query",
     "build_prefix_match_expression",
+    "fts5_query_is_searchable",
     "fts5_query_tokens",
     "fts5_token_runs",
     "is_fts5_stopword",
@@ -250,3 +254,123 @@ def build_prefix_match_expression(tokens: Iterable[str]) -> str:
         for token in tokens
         if not is_fts5_stopword(token)
     )
+
+
+def fts5_query_is_searchable(query: object) -> bool:
+    """Whether a raw user query can produce a MATCH expression at all.
+
+    Three rejections, each for a concrete reason rather than defensiveness:
+
+    * **Not a string / empty.** ``None`` reaches these seams from callers
+      that pass an unset filter through unchanged. Before TASK-19558 the
+      raw value went to ``sqlite3`` and produced ``[]`` or a wrapped DB
+      error; quoting it produced a bare ``AttributeError: 'NoneType' object
+      has no attribute 'replace'`` instead -- an unwrapped exception type no
+      caller of a DB search method is written against.
+
+    * **Contains a NUL.** This is the one that is not obvious.
+      ``sqlite3`` hands a bound TEXT parameter to SQLite as a C string, so
+      the value is truncated at the first NUL -- **after** we have quoted
+      it. ``a\\x00b`` becomes the literal ``"a\\x00b"``, SQLite sees ``"a``,
+      and FTS5 raises ``unterminated string``. No amount of correct quoting
+      can survive that, because the closing quote is on the far side of the
+      truncation point. Raw binds were unaffected only by luck: the
+      truncated value ``a`` was still a syntactically valid bareword.
+      ``Notes/file_notes_replica.search`` has guarded this since it was
+      written (``if "\\x00" in query: return []``); this is that rule, moved
+      to where every seam can share it.
+
+    * **No alphanumeric character.** FTS5's ``unicode61`` tokenizer indexes
+      only alphanumeric runs, so a pure-punctuation query cannot match
+      anything. Answering ``""`` lets the caller skip the query rather than
+      run one that is guaranteed to return nothing.
+
+    Args:
+        query: The raw value a search seam was handed.
+
+    Returns:
+        True when a MATCH expression built from it can be executed.
+    """
+    if not isinstance(query, str) or not query:
+        return False
+    if "\x00" in query:
+        return False
+    return any(ch.isalnum() for ch in query)
+
+
+def build_and_match_expression(tokens: Iterable[str]) -> str:
+    """Build the AND form: every token quoted, joined by FTS5's implicit AND.
+
+    **This is the form a plain-text search box wants**, and getting that
+    wrong is the defect TASK-3995 fixed once already and TASK-19558's first
+    round re-created. Wrapping a whole multi-word query in ONE pair of
+    quotes makes it a PHRASE query, which requires the words to appear as a
+    contiguous run -- strictly stronger than "all of these words appear",
+    not equivalent to it. Measured on a real corpus: ``dragon lore`` matched
+    a record titled "dragon lore adjacent" but not one titled "lore of the
+    dragon reversed", halving recall at eight seams while looking like a
+    pure safety change.
+
+    Quoting each token INDIVIDUALLY keeps the whole injection-safety
+    property -- a quoted token is a string literal with no operator
+    semantics, so a typed ``OR``, a typed ``NEAR``, a ``col:`` filter and a
+    stray ``"`` are all inert -- while restoring AND-of-terms recall.
+    ``RAG_Search/simplified/rag_service._escape_fts5_query`` has built this
+    exact expression since TASK-3995 and now delegates the escape here; this
+    is the shared definition of the whole form.
+
+    Args:
+        tokens: Raw query tokens, normally from ``fts5_query_tokens``.
+
+    Returns:
+        The AND expression, or ``""`` when there are no tokens. ``""`` means
+        "no rows": callers must skip the query rather than run ``MATCH ''``,
+        which FTS5 rejects as a syntax error.
+    """
+    return " ".join(quote_fts5_token(token) for token in tokens)
+
+
+def build_and_match_query(query: object) -> str:
+    """Raw user text -> the AND form, or ``""`` when it cannot be searched.
+
+    The entry point for a plain-text search seam. Combines
+    ``fts5_query_is_searchable`` (None / NUL / punctuation-only) with
+    ``fts5_query_tokens`` + ``build_and_match_expression``, so a seam needs
+    exactly two lines: build, and return no rows on ``""``.
+
+    Args:
+        query: The raw value the search seam was handed; need not be a
+            string.
+
+    Returns:
+        An executable FTS5 MATCH expression, or ``""`` meaning "no rows".
+    """
+    if not fts5_query_is_searchable(query):
+        return ""
+    return build_and_match_expression(fts5_query_tokens(str(query)))
+
+
+def build_phrase_match_query(query: object) -> str:
+    """Raw user text -> ONE quoted phrase, or ``""`` when it cannot be searched.
+
+    The deliberate counterpart to ``build_and_match_query``, for the seams
+    whose documented behaviour is phrase matching and always was -- notes,
+    keywords, keyword collections, datasets. TASK-19558 kept those as
+    phrases on purpose: they matched phrases before the task too, so
+    widening them to AND would be an unmeasured behaviour change smuggled in
+    beside a security fix. The rule the task applied, stated once here so
+    the next reader does not have to infer it from thirteen call sites:
+    **a seam that bound its query RAW (FTS5 implicit AND) gets
+    ``build_and_match_query``; a seam that already bound a quoted phrase
+    keeps ``build_phrase_match_query``.**
+
+    Args:
+        query: The raw value the search seam was handed.
+
+    Returns:
+        The whole query as one quoted FTS5 phrase, or ``""`` meaning
+        "no rows".
+    """
+    if not fts5_query_is_searchable(query):
+        return ""
+    return quote_fts5_token(str(query))

--- a/tldw_chatbook/Utils/fts5_match_forms.py
+++ b/tldw_chatbook/Utils/fts5_match_forms.py
@@ -24,11 +24,26 @@ whose ``__init__`` is empty -- rather than under ``RAG_Search/``, whose
 package ``__init__`` pulls the whole simplified engine (chromadb,
 embeddings) in a try/except.
 
-What is NOT here: the AND forms. The engine's implicit-AND
-(``_escape_fts5_query``) and the Library's OR-of-plural-variants
-(``build_fts_match_query``) are genuinely different constructions with
-different histories, and they are each path's *primary* -- unchanged by
-TASK-17755 and not shared. Only the widening fallback is common.
+**TASK-19558 widened this module's remit, and the sentence that used to
+stand here ("What is NOT here: the AND forms") is now false.** The AND form
+IS here -- ``build_and_match_expression``/``build_and_match_query`` -- along
+with the PHRASE form and the one string-literal escape they all share,
+because that task found six spellings of the escape across the app, two of
+them wrong. What is still each path's own is the Library's
+OR-of-plural-variants widening (``library_fts_query.build_fts_match_query``),
+a genuinely different construction.
+
+The three FORMS this module defines, and the rule for picking one:
+
+* **AND** (``build_and_match_query``) -- every token quoted, space-joined,
+  i.e. FTS5's implicit AND. What a plain-text search box wants, and what a
+  seam that used to bind its query RAW was already doing.
+* **PHRASE** (``build_phrase_match_query``) -- the whole query as one quoted
+  literal; words must be adjacent and in order. Only for seams that already
+  bound a quoted phrase before TASK-19558.
+* **PREFIX** (``quote_fts5_prefix`` / ``build_prefix_match_expression``) --
+  a quoted term with the star OUTSIDE the quotes, for type-ahead pickers and
+  for ``and_then_prefix``'s widening fallback.
 """
 
 from __future__ import annotations

--- a/tldw_chatbook/Utils/fts5_match_forms.py
+++ b/tldw_chatbook/Utils/fts5_match_forms.py
@@ -42,6 +42,8 @@ __all__ = [
     "fts5_query_tokens",
     "fts5_token_runs",
     "is_fts5_stopword",
+    "quote_fts5_phrase",
+    "quote_fts5_prefix",
     "quote_fts5_token",
 ]
 
@@ -116,13 +118,59 @@ def quote_fts5_token(token: str) -> str:
     string with no operator semantics. An embedded double quote is doubled,
     FTS5's own escape for a literal quote inside a quoted term.
 
+    **TASK-19558 made this the ONE escape for the whole app, not just the
+    widening forms.** The FTS5 string-literal rule does not care whether
+    what it wraps is one token or a whole phrase -- ``"a b"`` is a phrase
+    query and ``"a"`` a single-token one, but both are the same literal
+    with the same escaping -- so ``quote_fts5_phrase`` below is a
+    same-named alias rather than a second implementation. Before that task
+    this repo carried **six** spellings of the escape (four correct, two
+    that omitted the doubling entirely and raised ``OperationalError(
+    'unterminated string')`` on any query containing a ``"``), plus three
+    ``ChaChaNotes_DB`` search methods that computed a ``safe_search_term``
+    and then bound the RAW one -- protection that read as protection in
+    review and reached no query. ``Tests/Utils/
+    test_fts5_quoting_adoption_census.py`` is the guard that keeps a
+    seventh spelling from being written: any ``.replace('"', '""')``
+    outside this module fails it.
+
     Args:
-        token: One raw token from ``fts5_query_tokens``.
+        token: One raw token from ``fts5_query_tokens``, or a whole raw
+            user-typed search phrase (see ``quote_fts5_phrase``).
 
     Returns:
         The token as a quoted FTS5 term.
     """
     return '"{}"'.format(token.replace('"', '""'))
+
+
+#: The whole-phrase reading of the same escape. Bound to the identical
+#: function on purpose: a caller quoting a whole user-typed search box
+#: value wants "this text, literally", which is exactly what an FTS5
+#: string literal is, and giving it a second implementation is how the
+#: two-that-omit-the-doubling variants got written in the first place. The
+#: name exists so a phrase call site reads honestly instead of claiming to
+#: quote a "token" it never tokenized.
+quote_fts5_phrase = quote_fts5_token
+
+
+def quote_fts5_prefix(text: str) -> str:
+    """Quote ``text`` as an FTS5 phrase-PREFIX term: ``foo"bar`` -> ``"foo""bar"*``.
+
+    The star goes **outside** the quotes: FTS5 reads ``"tok"*`` as "a
+    phrase whose last token is a prefix", while a star inside the quotes is
+    an inert character in the literal (the tokenizer drops it) and would
+    silently reduce this to a plain phrase match. Four call sites had this
+    spelled out longhand as ``f'"{term.replace(chr(34), chr(34) * 2)}"*'``
+    before TASK-19558; they now share this one.
+
+    Args:
+        text: Raw user-typed search text.
+
+    Returns:
+        The FTS5 phrase-prefix MATCH expression.
+    """
+    return f"{quote_fts5_token(text)}*"
 
 
 def is_fts5_stopword(token: str) -> bool:

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -15,6 +15,11 @@ from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
 
 
 REDACTION_MARKER = "***REDACTED***"
+#: Labels that name a secret in a LOG LINE but are not config keys, so they
+#: are deliberately not added to ``sensitive_config_keys`` (that predicate
+#: also drives config encryption and the Privacy & Security protected-field
+#: count, and widening it would start encrypting fields for a
+#: logging-only reason).
 _LOG_ONLY_SENSITIVE_FIELDS = frozenset(
     {
         "authorization",
@@ -26,6 +31,19 @@ _LOG_ONLY_SENSITIVE_FIELDS = frozenset(
         "database_url",
         "connection_string",
         "dsn",
+        # TASK-19558. A bare ``key`` matches none of
+        # ``is_sensitive_config_key``'s rules (its ``_key`` rule is an
+        # underscore-SUFFIX match and ``api-key`` is a containment one), and
+        # bare ``key`` is exactly how Google's Custom Search credential
+        # travels: ``.../customsearch/v1?key=<API key>&cx=...``. Probed
+        # before the fix: that whole URL passed through ``sanitize_string``
+        # unchanged. The cost is stated rather than hidden -- a benign
+        # ``key=<value>`` label loses its value in diagnostics too (the
+        # measured population is small: ``config.py``'s "Failed to encrypt
+        # config value (key=...)" is the only shipped log line of that
+        # shape, and the name it prints is a secret-bearing config key
+        # anyway).
+        "key",
     }
 )
 

--- a/tldw_chatbook/Utils/path_validation.py
+++ b/tldw_chatbook/Utils/path_validation.py
@@ -485,6 +485,17 @@ def validate_path_multi(
     unchanged). The rejection message names every consulted root so a
     denial is actionable.
 
+    Every attempt is made with ``redact_paths=True`` (TASK-19558). This is
+    the choke point for the agent file-tool family (``ReadFileTool`` /
+    ``WriteFileTool`` / ``ListDirectoryTool`` / ``EditFileTool``, via
+    ``Tools/file_operation_tools.py``), so ``user_path`` here is
+    MODEL-supplied and prompt-injection-reachable; without redaction a
+    single traversal probe wrote attacker-chosen text AND the user's real
+    directory layout into the log once PER ROOT. The refusal below is
+    unaffected -- it is built here, from ``user_path``, and still names the
+    path and every consulted root, because that message goes to the model
+    as a recovery route rather than into diagnostics.
+
     Args:
         user_path: The path provided by the user or model.
         roots: Allowed base directories, in priority order.
@@ -503,7 +514,7 @@ def validate_path_multi(
         if index > 0 and not candidate.is_absolute():
             continue  # relative paths anchor to the primary root only
         try:
-            return validate_path(user_path, root)
+            return validate_path(user_path, root, redact_paths=True)
         except ValueError:
             continue
     consulted = ", ".join(str(root.resolve()) for root in root_list)


### PR DESCRIPTION
Closes TASK-19558. Five findings sharing one disposition: *the correct primitive exists in this repo and these call sites do not use it.*

## The sharpest one: protection that was a dead store

Three `ChaChaNotes_DB.py` search methods computed a quoted term and then **bound the raw one**. `safe_search_term` reached only the error message — it read as protection in review and was none.

Proven rather than argued: mutating the computed value to `ZZZ_MUTATED_NEVER_MATCHES_ANYTHING_ZZZ` at base left all three methods **byte-identical in output**.

The consequences were already user-visible:

```
search_notes('alpha" OR title:"Other')   →  3 rows at base
```

on a corpus where the extra notes contained **neither term** — the closing quote ended the literal and the rest ran as a **live column filter**. `search_conversations_by_title('title:dragon')` returned 7 rows the same way. And `search_notes('foo"bar')` raised `unterminated string`, which `library_screen`'s `except Exception` swallows into a filter box that silently does nothing; `list_flashcards(q='foo"bar')` raised a bare `OperationalError` out of the Study search box.

All now return `[]` or literal matches. Every injection probe — embedded and doubled `"`, `*`, `^`, `:`, `NEAR/`, `AND`/`OR`/`NOT`, parens, bare `-`, `title:` — is treated as literal text at all 14 seams.

**`quote_fts5_token` was already correct**; it has doubled embedded quotes since TASK-17755. The entire finding was **non-adoption**, not a broken primitive. So the fix adopts it, and `quote_fts5_phrase` is a **same-object alias** (verified `is`-identical and pinned by a test) because a second implementation is exactly how the broken spellings arose.

## The review caught the fix costing recall, and that is now fixed too

Round one quoted whole queries as phrases, which narrowed 8 search boxes from implicit-AND to adjacency: `dragon lore` went from 2 rows to 1, dropping a prompt named *"lore of the dragon reversed"*. Unnamed in the notes, and live on the CCP conversation search, the Study flashcard search, and persona character search.

The repo had already learned this: `rag_service._escape_fts5_query`'s docstring records TASK-3995 finding that whole-query phrase quoting *"is strictly stronger than AND-of-terms, not equivalent to it."* Round one re-created that defect while removing a different one.

The plain-text branch now uses `fts5_query_tokens` + per-token quoting joined by implicit AND, added to the primitive as `build_and_match_query`, and `rag_service` builds from that same function instead of its own copy. **The rule is stated once instead of inferred from thirteen call sites**: a seam that bound *raw* gets the AND form; a seam that already bound a *phrase* keeps the phrase form.

Both halves, same corpus, same run — recall restored at all 8 seams (2 → 1 → **2**) while every injection stays at 0, and the base's 3-row column-filter leak stays closed.

## Two regressions the review found, also fixed

- **Embedded NUL** made six methods go rows→raise: `sqlite3` passes bound TEXT as a C string, so SQLite truncates *after* quoting and the closing quote is past the cut — no correct escape survives it. `file_notes_replica` already guarded this; the guard is now shared as `fts5_query_is_searchable`.
- **Non-`str` input** (`search_notes(None)`) went from `[]` to an unwrapped `AttributeError`.

The 126-cell input matrix now has **zero** raising cells; base had 17, round one 19.

## OPML: entity expansion, not XXE

`watchlist_opml_service.py` used stdlib etree while every sibling parser uses `defusedxml`. A **573-byte** billion-laughs payload parsed at base into a **300,000-character** source name. Now `EntitiesForbidden`, with a test re-proving stdlib leaves SYSTEM entities unresolved — the exposure is described accurately rather than inflated.

## Three censuses, with their limits stated

All AST-based, all mutation-checked in-tree both ways. Two limits are documented **because they matter**, after review found them:

- The quoting census fires on the *correct* escape hand-rolled and is **blind to the broken spelling** `f'"{x}"'` — the one that was the actual defect. A detector for that shape was built and **rejected on measurement**: 4 false positives, 0 true. What is structurally available instead is a third census — a module binding `... MATCH ?` must import the primitive (7/7 today) — which catches *both* spellings in a new file, proven in-tree with the broken one.
- The dead-store census is defeated by `logger.opt(exception=True).error(...)`, **this repo's house style**, and now says so. Its "exactly three" claim was independently re-implemented over the whole package tree and confirmed — exactly those three, zero false positives among 162 similarly-named locals.
- The XML census is **widened repo-wide** with `_KNOWN_UNHARDENED` as a register of open defects (each entry naming what reaches it) plus staleness and exactness tests, because scoped to `Subscriptions/` it would have red on nothing. A synthetic eighth parser reds it; hardening one of the seven reds the staleness test.

**Being filed**: seven unhardened parsers, four taking untrusted input today — `Evals/eval_runner.py:1842` (**model output, prompt-injection reachable**), `Research_Interop/academic_providers.py:218` (remote Atom feed), and two fetched-sitemap parsers where a byte cap does not help, since amplification is the point.

## An acceptance criterion rejected on a premise error

Finding 5 asked for `("reads",)` on the local-tool spec. Local tools resolve through `resolve_effective_state` (floor `{mutates, process}`), **never** `resolve_builtin_state`, which owns the `"reads"` floor — so adding it would floor *nothing*, re-creating the dead-store defect while fixing it. Review confirmed independently with a measured table: `("reads",)` gives output identical to `()` in every store state. The AC's second option was taken instead, with the rationale where a reader looks.

Finding 3 was two-thirds already fixed by TASK-19555 on dev (probed, not assumed); bare `key` — Google's `?key=` credential — was still live and is fixed in the log-only field set, not the shared predicate that drives encryption.

## One test inverted, deliberately

`test_search_with_invalid_fts_syntax_raises_error` asserted that typing `invalid "syntax` into the prompt search box **raises**. Review read its history and agreed independently: it was born in a bulk test-authoring commit describing observed behaviour; the method's own docstring contradicted itself; the `fts_match_query` seam was already the ruled route for expressions; and no caller depends on the raise. The replacement asserts the literal-match result **and** pins the seam that legitimately accepts syntax, which was previously unpinned.

## Verification

- `Tests/DB` + `ChaChaNotesDB` + `Utils` post-rebase: **2388 passed / 1 skipped / 0 failed**. `Tests/Subscriptions` + `Prompts_DB`: **1178 passed / 1 skipped**.
- Wide set: 10,457 passed / 16 failed, failure list byte-identical to baseline.
- 11 new tests fail at the reviewed HEAD and pass here; the three new test files were 18 failures + 1 collection error at base.
- Merge-checked against dev **by actually merging in a throwaway worktree**, not by reading the textual merge: only the lessons file conflicts, and the DB suites are green on the merged tree — the clean textual merge across TASK-21100's `messages_fts` rebuild is a clean *semantic* merge.

The diagnostic inventory is red on `dev` for TASK-21100's drift (`chachanotes_fts_backfill.py` +3, `app.py` +3) — identical rows and digests on a clean dev checkout, so not regenerated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-19558 by adopting repo-owned primitives for FTS5 query building, XML parsing, log sanitization, and path redaction. Previously, several seams bound raw FTS5 input (allowing syntax/injection and sporadic errors) and OPML used stdlib ElementTree; now plain text is token-quoted with implicit AND (phrase seams stay phrases), OPML parses with `defusedxml`, logs redact sensitive keys, and model-supplied paths are not echoed.

- Search behavior: raw MATCH binding → quoted tokens joined by implicit AND; phrase-only seams keep phrase matching. Invalid FTS syntax is treated as literal; NUL/non-str inputs return []; punctuation-only input drops the FTS leg (LIKE still applies); whitespace is trimmed. `rag_service` builds from the shared AND form. `Client_Media_DB_v2.search_media_db` no longer zeroes results when no MATCH can be built.
- APIs and helpers: new/expanded `Utils/fts5_match_forms` (`build_and_match_query`/`expression`, `build_phrase_match_query`, `quote_fts5_token`/`prefix`, `fts5_query_is_searchable`) and adoption across DB/UI. `fts_match_query` added to `ChaChaNotes_DB.search_character_cards(..., fts_match_query=None)` and to conversation search callers; prefix queries now pass via this seam. Ad-hoc quoting in Library/UI replaced with shared helpers.
- XML: OPML import now uses `defusedxml`; stdlib `xml.etree.ElementTree` kept for export only.
- Logging and paths: `Utils/log_sanitizer` redacts probe headers and bare `key`; `validate_path_multi` and local tool workspace resolution pass `redact_paths=True` to avoid logging model-supplied paths. Read-only local tools keep `tags=()`; a `"reads"` tag would not change gating.
- Migration: if you previously passed MATCH expressions via plain-text parameters, send them through `fts_match_query` instead. No schema or data migrations.

<sup>Written for commit f4ad48e747faca72516670ed24be9723c5e756cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

