### PR TITLE
docs(claude): require preflight.sh before opening a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,17 +435,25 @@ A task is **Done** only when **ALL** of the following are complete:
 2. **Implementation plan** was followed or deviations were documented in Implementation Notes.
 3. **Automated tests** (unit + integration) cover new logic.
 4. **Static analysis**: linter & formatter succeed.
-5. **Documentation**:
+5. **Derived artifacts**: run `./scripts/preflight.sh` before opening a PR -- it
+   runs the same four checks as the required `Derived artifacts reproduce from
+   their sources` CI job (CSS bundle sync, profile-owned-path census, production
+   diagnostic inventory, duplicate backlog task ids), and reports every failure
+   rather than stopping at the first. It takes ~35s and installs nothing. If the
+   diagnostic inventory reports drift, read the rows it names before
+   regenerating -- `--write` without reading is the failure that artifact exists
+   to prevent.
+6. **Documentation**:
     - All relevant docs updated (any relevant README file, backlog/docs, backlog/decisions, etc.).
     - Task file **MUST** have an `## Implementation Notes` section added summarising:
         - Approach taken
         - Features implemented or modified
         - Technical decisions and trade-offs
         - Modified or added files
-6. **Review**: self review code.
-7. **Task hygiene**: status set to **Done** via CLI (`backlog task edit <id> -s Done`).
-8. **No regressions**: performance, security and licence checks green.
-9. **Lessons learned**: if the task surfaced knowledge that generalises beyond it — a
+7. **Review**: self review code.
+8. **Task hygiene**: status set to **Done** via CLI (`backlog task edit <id> -s Done`).
+9. **No regressions**: performance, security and licence checks green.
+10. **Lessons learned**: if the task surfaced knowledge that generalises beyond it — a
    trap, a wrong assumption that cost time, a verification that only worked one way —
    add or update an entry in `backlog/docs/lessons-*.md`. **State the incident, not
    just the rule**: a lesson without the evidence that produced it decays into folklore


### PR DESCRIPTION
TASK-19572 owner gate item 4, now authorized by the owner.

The four derived-artifact checks have a CI job behind them (`Derived artifacts reproduce from their sources`). This is the local half, so drift is caught **before** a PR rather than by a red required check after it.

The wording names the four checks explicitly and carries the one rule that actually matters for the diagnostic inventory: **read the rows it names before regenerating**. Four separate burn-down tasks each hand-built a ~30-line diff probe because the checker used to fail with one sentence naming nothing, and a blind `--write` is precisely the failure that artifact exists to prevent.

Inserted as item 5 with the remaining items renumbered; no other section references DoD item numbers (checked).

Doc-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require running `./scripts/preflight.sh` before opening a PR to catch derived-artifact drift locally. Previously only the CI job enforced these checks; now contributors run the same four checks locally to fail fast with full diagnostics.

- Runs the same four checks: CSS bundle sync, profile-owned-path census, production diagnostic inventory, and duplicate backlog task IDs.
- Read the diagnostic inventory rows before regenerating; do not run `--write` blindly.
- Takes ~35s, installs nothing, and reports all failures.
- Inserts this as DoD item 5 and renumbers subsequent items; no cross-references change.
- Aligns with Linear TASK-19572 owner gate item 4.

<sup>Written for commit 937f7bd0e3c4b2fe5b5eb56dcea522d6e0cd1e54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

