### PR TITLE
chore(diagnostics): re-pin the inventory after TASK-21100's FTS backfill

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -614,8 +614,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 353,
-      "diagnostic_digest": "60f0a72ab44899222c90",
+      "call_count": 356,
+      "diagnostic_digest": "4c7602cf78284ec06426",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -667,6 +667,13 @@
       "diagnostic_digest": "602cf3b68ca3fcb2f23b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/base_db.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 3,
+      "diagnostic_digest": "4631ec939c52ce71d837",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/DB/chachanotes_fts_backfill.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -2351,7 +2358,7 @@
     },
     {
       "call_count": 30,
-      "diagnostic_digest": "aa327c8e543ff0802849",
+      "diagnostic_digest": "24d209b29aa74acda6d4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/workspace.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3680,8 +3687,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 328,
-      "diagnostic_digest": "260780ad3fe242c5f3f8",
+      "call_count": 331,
+      "diagnostic_digest": "4e7c8a92722581ed62a9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3917,9 +3924,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 530,
+    "owner_files": 531,
     "persistent_sink_files": 8,
     "task_492_calls": 1222,
-    "task_494_calls": 7251
+    "task_494_calls": 7260
   }
 }


### PR DESCRIPTION
Unblocks TASK-19572's branch-protection gate.

The required `Derived artifacts reproduce from their sources` job has been **failing on dev** since TASK-21100 landed. That blocks turning on branch protection at all — a required check that is red on day one cannot be enabled without freezing every merge.

**All ten changed statements were read with `--statements` before regenerating**, per the artifact's own contract — not blind-written:

| file | delta | verdict |
|---|---|---|
| `DB/chachanotes_fts_backfill.py` | +3 (new file) | counts only — no user content, no paths |
| `app.py` | +3 | one integer count, two static strings |
| `DB/ChaChaNotes_DB.py` | +3 | the V46→V47 migration lines; two interpolate `{self.db_path_str}` |
| `UI/Console_Modules/workspace.py` | 0 (digest moved) | **moved/re-indented only**, statement text unchanged |

The two `db_path_str` interpolations are **not a new class**: they replicate the established style of the ~330 calls already in that file and fall under the open TASK-19321 / TASK-19322 repairs. Surfaced here rather than absorbed silently.

The `workspace.py` row is the known re-indentation sensitivity — the per-call digest is taken over source text, so a nesting shift moves it with no review event behind it.

`preflight.sh`: all four checks green. Guard suites: 392 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pins the production diagnostic inventory after TASK-21100’s FTS backfill so the “Derived artifacts reproduce from their sources” check passes on dev. Previously the check failed due to inventory drift; now the inventory matches sources with no runtime behavior changes.

- Adds `tldw_chatbook/DB/chachanotes_fts_backfill.py` (3 calls) and updates counts/digests for `tldw_chatbook/DB/ChaChaNotes_DB.py` (+3) and `tldw_chatbook/app.py` (+3); `tldw_chatbook/UI/Console_Modules/workspace.py` digest moved due to re-indentation only.
- Updates summary totals (owner_files 531; task_494_calls 7260). No user content or paths recorded; all ten changed statements were verified with `--statements` before regeneration.
- Outcome: the required job now passes on dev, unblocking TASK-19572 branch-protection enablement. No migration or rollout steps required.

<sup>Written for commit ac1aa2da5a153c94c6566cf9ab364a61ead8794b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

