### PR TITLE
Fix model catalog consent startup ordering

### DIFF
--- a/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
+++ b/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
@@ -8,8 +8,8 @@
 
 **Tech Stack:** Python 3.11+, Textual 8, pytest, pytest-asyncio, Backlog.md
 
-**ADR required:** no  
-**ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`  
+**ADR required:** no
+**ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`
 **Reason:** This is a lifecycle ordering bug fix that preserves ADR-020's storage, consent, and network boundaries.
 
 ---

--- a/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
+++ b/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
@@ -1,0 +1,65 @@
+# Model Catalog Consent Startup Order Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Guarantee that launch finishes the intro, mounts the configured initial screen, then presents one actionable model-catalog consent modal before the app becomes usable.
+
+**Architecture:** Keep ADR-020's existing consent and refresh state machine intact. Relocate its single startup scheduling call from the app mount lifecycle to `_push_initial_screen()`, the shared post-intro choke point for splash and no-splash launches, and lock the screen-stack ordering down with a real Textual Pilot regression.
+
+**Tech Stack:** Python 3.11+, Textual 8, pytest, pytest-asyncio, Backlog.md
+
+**ADR required:** no  
+**ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`  
+**Reason:** This is a lifecycle ordering bug fix that preserves ADR-020's storage, consent, and network boundaries.
+
+---
+
+### Task 0: Record the approved plan in Backlog.md
+
+**Files:**
+- Modify: `backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md`
+
+- [ ] Add the implementation plan to TASK-21161 while it is In Progress and before changing application or test code.
+- [ ] Include the ADR required/no, existing ADR path, and lifecycle-fix reason in the task plan.
+
+### Task 1: Add a failing launch-order regression
+
+**Files:**
+- Modify: `Tests/UI/test_model_catalog_consent_modal.py`
+
+- [ ] Add a splash-enabled full-app test using `Tests.UI.app_factory._build_test_app(configured_default="home")`.
+- [ ] Override only `_push_model_catalog_consent_modal` so `run_test()` can display the real modal despite production's headless guard.
+- [ ] Suppress project-skills discovery and keep first-run setup completed so unrelated startup overlays cannot affect the assertion.
+- [ ] Observe the real screen-stack transitions and assert the final ordered stack is initial screen below a topmost `ModelCatalogConsentModal`, never consent buried below the initial screen.
+- [ ] Click Deny through Pilot and assert the modal dismisses to the same usable initial screen.
+- [ ] Run the new test against the current call site and confirm it fails because the initial screen covers the modal.
+
+### Task 2: Move consent scheduling behind initial-screen startup
+
+**Files:**
+- Modify: `tldw_chatbook/app.py`
+
+- [ ] Remove `_schedule_startup_model_catalog_refresh()` from `on_mount()`.
+- [ ] Call `_schedule_startup_model_catalog_refresh()` at the end of `_push_initial_screen()` after the initial screen and startup notices have been mounted/offered.
+- [ ] Preserve the setup-ownership gate, one-shot guard, consent callback, persistence behavior, and refresh worker unchanged.
+- [ ] Run the new regression and confirm it passes.
+
+### Task 3: Verify adjacent startup and consent behavior
+
+**Files:**
+- Test: `Tests/UI/test_model_catalog_consent_modal.py`
+- Test: `Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py`
+- Test: `Tests/UI/test_product_maturity_phase1_first_run.py`
+
+- [ ] Run the complete focused consent, catalog wiring, and first-run startup test files.
+- [ ] Run Ruff on the changed Python files and `git diff --check`.
+- [ ] Review the final diff for accidental changes to ADR-020 behavior.
+
+### Task 4: Close task documentation
+
+**Files:**
+- Modify: `backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md`
+
+- [ ] Check every acceptance criterion only after its verification evidence exists.
+- [ ] Add concise implementation notes covering the lifecycle move, regression, ADR decision, and commands run.
+- [ ] Set TASK-21161 to Done only after all Definition of Done checks are satisfied.

--- a/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
+++ b/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
@@ -44,6 +44,19 @@
 - [ ] Preserve the setup-ownership gate, one-shot guard, consent callback, persistence behavior, and refresh worker unchanged.
 - [ ] Run the new regression and confirm it passes.
 
+### Task 2A: Cover and fix competing startup overlays
+
+**Files:**
+- Modify: `Tests/UI/test_model_catalog_consent_modal.py`
+- Modify: `tldw_chatbook/app.py`
+
+- [ ] Extend the full-app consent regression to prove an eligible project-skills startup offer is deferred when catalog consent is unrecorded.
+- [ ] Add a first-run completion regression that navigates to its valid exit route before showing consent and proves no callback value is produced until Pilot clicks Yes or No.
+- [ ] Confirm both regressions fail against the current partial fix for the reviewed race conditions.
+- [ ] Record when startup scheduling selects the unrecorded-consent branch, schedule before optional project-skills discovery, and skip that optional offer for this launch.
+- [ ] Sequence completed first-run exit navigation before scheduling the deferred catalog decision; keep the same-tab Console shortcut and no-route completion behavior intact.
+- [ ] Preserve explicit consent persistence and refresh behavior unchanged, then run both regressions green.
+
 ### Task 3: Verify adjacent startup and consent behavior
 
 **Files:**

--- a/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
+++ b/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
@@ -19,30 +19,30 @@
 **Files:**
 - Modify: `backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md`
 
-- [ ] Add the implementation plan to TASK-21161 while it is In Progress and before changing application or test code.
-- [ ] Include the ADR required/no, existing ADR path, and lifecycle-fix reason in the task plan.
+- [x] Add the implementation plan to TASK-21161 while it is In Progress and before changing application or test code.
+- [x] Include the ADR required/no, existing ADR path, and lifecycle-fix reason in the task plan.
 
 ### Task 1: Add a failing launch-order regression
 
 **Files:**
 - Modify: `Tests/UI/test_model_catalog_consent_modal.py`
 
-- [ ] Add a splash-enabled full-app test using `Tests.UI.app_factory._build_test_app(configured_default="home")`.
-- [ ] Override only `_push_model_catalog_consent_modal` so `run_test()` can display the real modal despite production's headless guard.
-- [ ] Suppress project-skills discovery and keep first-run setup completed so unrelated startup overlays cannot affect the assertion.
-- [ ] Observe the real screen-stack transitions and assert the final ordered stack is initial screen below a topmost `ModelCatalogConsentModal`, never consent buried below the initial screen.
-- [ ] Click Deny through Pilot and assert the modal dismisses to the same usable initial screen.
-- [ ] Run the new test against the current call site and confirm it fails because the initial screen covers the modal.
+- [x] Add a splash-enabled full-app test using `Tests.UI.app_factory._build_test_app(configured_default="home")`.
+- [x] Override only `_push_model_catalog_consent_modal` so `run_test()` can display the real modal despite production's headless guard.
+- [x] Keep first-run setup completed and make the optional project-skills offer observable so it cannot silently compete with consent.
+- [x] Observe the real screen-stack transitions and assert the final ordered stack is initial screen below a topmost `ModelCatalogConsentModal`, never consent buried below the initial screen.
+- [x] Click Deny through Pilot and assert the modal dismisses to the same usable initial screen.
+- [x] Run the new test against the current call site and confirm it fails because the initial screen covers the modal.
 
 ### Task 2: Move consent scheduling behind initial-screen startup
 
 **Files:**
 - Modify: `tldw_chatbook/app.py`
 
-- [ ] Remove `_schedule_startup_model_catalog_refresh()` from `on_mount()`.
-- [ ] Call `_schedule_startup_model_catalog_refresh()` at the end of `_push_initial_screen()` after the initial screen and startup notices have been mounted/offered.
-- [ ] Preserve the setup-ownership gate, one-shot guard, consent callback, persistence behavior, and refresh worker unchanged.
-- [ ] Run the new regression and confirm it passes.
+- [x] Remove `_schedule_startup_model_catalog_refresh()` from `on_mount()`.
+- [x] Call `_schedule_startup_model_catalog_refresh()` from `_push_initial_screen()` after the initial screen is mounted and before optional startup offers can compete.
+- [x] Preserve the setup-ownership gate, one-shot guard, consent callback, persistence behavior, and refresh worker unchanged.
+- [x] Run the new regression and confirm it passes.
 
 ### Task 2A: Cover and fix competing startup overlays
 
@@ -50,12 +50,12 @@
 - Modify: `Tests/UI/test_model_catalog_consent_modal.py`
 - Modify: `tldw_chatbook/app.py`
 
-- [ ] Extend the full-app consent regression to prove an eligible project-skills startup offer is deferred when catalog consent is unrecorded.
-- [ ] Add a first-run completion regression that navigates to its valid exit route before showing consent and proves no callback value is produced until Pilot clicks Yes or No.
-- [ ] Confirm both regressions fail against the current partial fix for the reviewed race conditions.
-- [ ] Record when startup scheduling selects the unrecorded-consent branch, schedule before optional project-skills discovery, and skip that optional offer for this launch.
-- [ ] Sequence completed first-run exit navigation before scheduling the deferred catalog decision; keep the same-tab Console shortcut and no-route completion behavior intact.
-- [ ] Preserve explicit consent persistence and refresh behavior unchanged, then run both regressions green.
+- [x] Extend the full-app consent regression to prove an eligible project-skills startup offer is deferred when catalog consent is unrecorded.
+- [x] Add a deterministic first-run completion regression that requires valid exit-route navigation to finish before consent scheduling.
+- [x] Confirm both regressions fail against the current partial fix for the reviewed race conditions.
+- [x] Record when startup scheduling selects the unrecorded-consent branch, schedule before optional project-skills discovery, and skip that optional offer for this launch.
+- [x] Sequence completed first-run exit navigation before scheduling the deferred catalog decision; keep the same-tab Console shortcut and no-route completion behavior intact.
+- [x] Preserve explicit consent persistence and refresh behavior unchanged, then run both regressions green.
 
 ### Task 3: Verify adjacent startup and consent behavior
 
@@ -64,15 +64,15 @@
 - Test: `Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py`
 - Test: `Tests/UI/test_product_maturity_phase1_first_run.py`
 
-- [ ] Run the complete focused consent, catalog wiring, and first-run startup test files.
-- [ ] Run Ruff on the changed Python files and `git diff --check`.
-- [ ] Review the final diff for accidental changes to ADR-020 behavior.
+- [x] Run the complete focused consent, catalog wiring, and first-run startup test files.
+- [x] Run Ruff on the changed Python files and `git diff --check`.
+- [x] Review the final diff for accidental changes to ADR-020 behavior.
 
 ### Task 4: Close task documentation
 
 **Files:**
 - Modify: `backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md`
 
-- [ ] Check every acceptance criterion only after its verification evidence exists.
-- [ ] Add concise implementation notes covering the lifecycle move, regression, ADR decision, and commands run.
-- [ ] Set TASK-21161 to Done only after all Definition of Done checks are satisfied.
+- [x] Check every acceptance criterion only after its verification evidence exists.
+- [x] Add concise implementation notes covering the lifecycle move, regression, ADR decision, and commands run.
+- [x] Set TASK-21161 to Done only after all Definition of Done checks are satisfied.

--- a/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
+++ b/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
@@ -1,0 +1,54 @@
+# Model Catalog Consent Startup Order Design
+
+**Task:** TASK-21161  
+**ADR required:** no  
+**ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`  
+**Reason:** This fixes UI lifecycle ordering while preserving ADR-020's existing consent, persistence, and network boundary.
+
+## Problem
+
+Startup currently schedules the model-catalog consent decision from `TldwCli.on_mount`, while the splash widget can still be active. The scheduled modal may become topmost before the splash finishes. When splash close later pushes the initial app screen, that screen covers the still-mounted modal. This creates three user-visible failures: the intro appears skipped, the prompt appears inconsistently or briefly, and the prompt can become impossible to answer.
+
+## Required sequence
+
+For a normal interactive launch with unrecorded model-catalog consent:
+
+1. The configured splash/intro completes.
+2. The initial application screen is mounted.
+3. The model-catalog consent modal is pushed topmost and requires Yes or No.
+4. Either answer dismisses the modal and leaves the initial application screen usable.
+
+When splash is disabled, steps 1 and 2 collapse to the existing no-splash initial-screen path; consent still appears only after that screen is mounted.
+
+## Design
+
+Move the existing initial startup call to `_schedule_startup_model_catalog_refresh()` from `on_mount` to the end of `_push_initial_screen()`. That method is already the shared choke point reached by both splash-enabled and no-splash launches, after the initial screen has been pushed.
+
+Keep all existing gates unchanged:
+
+- `setup_owns_startup_networking(...)` continues to defer the decision while first-run setup owns startup networking.
+- `_startup_model_catalog_refresh_scheduled` continues to enforce one scheduling attempt.
+- `_handle_first_run_wizard_result(...)` continues to schedule after completed setup.
+- `_refresh_model_catalogs()` continues to enforce recorded consent at the network boundary.
+- The consent modal and its persistence behavior remain unchanged.
+
+No new queue, startup coordinator, modal state, or timing delay is introduced.
+
+## Error handling
+
+Existing error handling remains authoritative. A settings-load failure leaves startup unscheduled and logs a bounded error; a consent persistence failure preserves the existing warning and session behavior. This correction adds no new failure path.
+
+## Test strategy
+
+Add one splash-enabled full-app Textual Pilot regression. Override only the production headless suppression so the real consent modal can be exercised under `run_test()`; keep real scheduling and screen-stack behavior.
+
+Pin first-run setup as completed and suppress project-skills discovery in this regression so no unrelated startup overlay can compete with the consent screen-stack assertions.
+
+The test records screen-stack transitions and requires:
+
+- the initial splash/default screen is observed before consent;
+- the initial app screen is directly below the topmost consent modal;
+- consent is never present below another pushed app screen;
+- pressing a consent action dismisses to the same usable initial screen.
+
+The test must fail against the pre-fix call site by observing the modal below the initial screen, then pass after the lifecycle move.

--- a/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
+++ b/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
@@ -1,8 +1,8 @@
 # Model Catalog Consent Startup Order Design
 
-**Task:** TASK-21161  
-**ADR required:** no  
-**ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`  
+**Task:** TASK-21161
+**ADR required:** no
+**ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`
 **Reason:** This fixes UI lifecycle ordering while preserving ADR-020's existing consent, persistence, and network boundary.
 
 ## Problem

--- a/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
+++ b/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
@@ -32,7 +32,12 @@ Keep all existing gates unchanged:
 - `_refresh_model_catalogs()` continues to enforce recorded consent at the network boundary.
 - The consent modal and its persistence behavior remain unchanged.
 
-No new queue, startup coordinator, modal state, or timing delay is introduced.
+Two existing startup competitors receive explicit precedence:
+
+- When first-run setup completes with an exit route, route navigation finishes before the deferred catalog decision is scheduled. Navigation must never dismiss the consent modal with `None`, because only an explicit Yes or No may resolve this required decision.
+- When the catalog decision is still unrecorded, optional project-skills discovery is not started on that launch. Its prompt may be offered on the next launch after consent has been recorded; it may not cover consent or appear immediately after consent instead of the usable initial screen.
+
+Track only whether this launch required catalog consent so `_push_initial_screen()` can suppress the optional project-skills offer. No general modal queue, startup coordinator, or timing delay is introduced.
 
 ## Error handling
 
@@ -42,9 +47,7 @@ Existing error handling remains authoritative. A settings-load failure leaves st
 
 Add one splash-enabled full-app Textual Pilot regression. Override only the production headless suppression so the real consent modal can be exercised under `run_test()`; keep real scheduling and screen-stack behavior.
 
-Pin first-run setup as completed and suppress project-skills discovery in this regression so no unrelated startup overlay can compete with the consent screen-stack assertions.
-
-The test records screen-stack transitions and requires:
+The completed-setup launch test records screen-stack transitions and requires:
 
 - the initial splash/default screen is observed before consent;
 - the initial app screen is directly below the topmost consent modal;
@@ -52,3 +55,8 @@ The test records screen-stack transitions and requires:
 - pressing a consent action dismisses to the same usable initial screen.
 
 The test must fail against the pre-fix call site by observing the modal below the initial screen, then pass after the lifecycle move.
+
+Add focused regressions for the competing startup paths:
+
+- an eligible project-skills offer is not started on an unconsented launch, so consent dismisses directly to the initial screen;
+- completing first-run setup with a valid exit route settles on that destination before consent appears, and the callback receives no value until the user explicitly selects Yes or No.

--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -1601,6 +1601,7 @@ def test_first_run_result_callback_keeps_same_tab_context_navigation():
 
 @pytest.mark.asyncio
 async def test_first_run_result_callback_remounts_same_tab_home_after_completion():
+    """Await Home remount before scheduling the deferred catalog decision."""
     from tldw_chatbook.app import TldwCli
 
     events: list[str] = []

--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -1893,7 +1893,6 @@ async def test_rerun_over_settings_start_chatting_navigates_to_chat(
     _persist_complete_custom_provider_setup()
     app = _build_test_app(first_run_setup_completed=True)
     app._initial_tab_value = "chat"
-    navigation_messages = _capture_navigation_messages(monkeypatch, app)
 
     with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
         async with app.run_test(size=(180, 55)) as pilot:
@@ -1907,20 +1906,15 @@ async def test_rerun_over_settings_start_chatting_navigates_to_chat(
                 == "Start chatting",
             )
 
-            navigation_messages.clear()
             _press(app.screen, "#setup-exit-chat")
             await _wait_until(
                 pilot, lambda: type(app.screen).__name__ != "FirstRunSetupWizard"
             )
-            # Dismiss pops back to Settings first; the exit_route is applied
-            # via a separately-queued NavigateToScreen message (same race
-            # noted in test_back_next_mashing_... above) -- wait for the
-            # final tab rather than racing the first screen-stack pop.
             await _wait_until(pilot, lambda: app.current_tab == TAB_CHAT)
+            await _wait_until(pilot, lambda: isinstance(app.screen, ChatScreen))
             assert app.current_tab == TAB_CHAT
-            assert len(navigation_messages) == 1
-            assert navigation_messages[0].screen_name == TAB_CHAT
-            assert navigation_messages[0].screen_context == {}
+            assert isinstance(app.screen, ChatScreen)
+            assert app.screen.is_mounted
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -43,7 +43,7 @@ from copy import deepcopy
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from textual.widgets import (
@@ -1599,31 +1599,68 @@ def test_first_run_result_callback_keeps_same_tab_context_navigation():
     assert message.screen_context == {"category": "providers-models"}
 
 
-def test_first_run_result_callback_remounts_same_tab_home_after_completion():
+@pytest.mark.asyncio
+async def test_first_run_result_callback_remounts_same_tab_home_after_completion():
     from tldw_chatbook.app import TldwCli
+
+    events: list[str] = []
+    worker_coroutines = []
+
+    async def record_navigation(_message) -> None:
+        await asyncio.sleep(0)
+        events.append("navigation-complete")
+
+    def record_schedule(**_kwargs) -> None:
+        events.append("catalog-scheduled")
+
+    def capture_worker(work, **kwargs) -> None:
+        worker_coroutines.append(work)
+        assert kwargs == {
+            "group": "first-run-exit-navigation",
+            "exclusive": True,
+            "exit_on_error": False,
+        }
 
     receiver = SimpleNamespace(
         current_tab=TAB_HOME,
-        post_message=MagicMock(),
-        _schedule_startup_model_catalog_refresh=MagicMock(),
+        handle_screen_navigation=AsyncMock(side_effect=record_navigation),
+        _schedule_startup_model_catalog_refresh=MagicMock(
+            side_effect=record_schedule
+        ),
+        post_message=MagicMock(
+            side_effect=AssertionError("completed navigation must use its worker")
+        ),
+        run_worker=capture_worker,
     )
-    TldwCli._handle_first_run_wizard_result(
-        receiver,
-        {
-            "completed": True,
-            "exit_route": TAB_HOME,
-            "exit_context": None,
-        },
-    )
+    try:
+        TldwCli._handle_first_run_wizard_result(
+            receiver,
+            {
+                "completed": True,
+                "exit_route": TAB_HOME,
+                "exit_context": None,
+            },
+        )
 
-    receiver._schedule_startup_model_catalog_refresh.assert_called_once_with(
-        after_setup_completion=True
-    )
-    receiver.post_message.assert_called_once()
-    message = receiver.post_message.call_args.args[0]
-    assert isinstance(message, NavigateToScreen)
-    assert message.screen_name == TAB_HOME
-    assert message.screen_context == {}
+        assert len(worker_coroutines) == 1
+        receiver.handle_screen_navigation.assert_not_awaited()
+        receiver._schedule_startup_model_catalog_refresh.assert_not_called()
+
+        await worker_coroutines[0]
+
+        receiver.handle_screen_navigation.assert_awaited_once()
+        message = receiver.handle_screen_navigation.await_args.args[0]
+        assert isinstance(message, NavigateToScreen)
+        assert message.screen_name == TAB_HOME
+        assert message.screen_context == {}
+        receiver._schedule_startup_model_catalog_refresh.assert_called_once_with(
+            after_setup_completion=True
+        )
+        assert events == ["navigation-complete", "catalog-scheduled"]
+        receiver.post_message.assert_not_called()
+    finally:
+        for worker in worker_coroutines:
+            worker.close()
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_model_catalog_consent_modal.py
+++ b/Tests/UI/test_model_catalog_consent_modal.py
@@ -209,3 +209,49 @@ async def test_first_run_completion_finishes_chat_navigation_before_consent():
     finally:
         for worker in host.worker_coroutines:
             worker.close()
+
+
+@pytest.mark.asyncio
+async def test_first_run_navigation_failure_still_schedules_consent_after_attempt():
+    """A failed first-run route still releases the pending consent offer."""
+    from tldw_chatbook.app import TldwCli
+
+    class FailingNavigationHost:
+        current_tab = "home"
+        focus_mode = False
+
+        def __init__(self) -> None:
+            self.events: list[str] = []
+            self.worker_coroutines = []
+            self._schedule_startup_model_catalog_refresh = MagicMock(
+                side_effect=lambda **_kwargs: self.events.append("consent")
+            )
+
+        async def handle_screen_navigation(self, _message) -> None:
+            self.events.append("navigation-attempt")
+            raise RuntimeError("injected navigation failure")
+
+        def run_worker(self, work, **_kwargs) -> None:
+            self.worker_coroutines.append(work)
+
+        def post_message(self, _message) -> None:
+            raise AssertionError("completed navigation must use its worker")
+
+    host = FailingNavigationHost()
+    try:
+        TldwCli._handle_first_run_wizard_result(
+            host,
+            {"completed": True, "exit_route": "chat", "exit_context": None},
+        )
+
+        assert len(host.worker_coroutines) == 1
+        with pytest.raises(RuntimeError, match="injected navigation failure"):
+            await host.worker_coroutines[0]
+
+        host._schedule_startup_model_catalog_refresh.assert_called_once_with(
+            after_setup_completion=True
+        )
+        assert host.events == ["navigation-attempt", "consent"]
+    finally:
+        for worker in host.worker_coroutines:
+            worker.close()

--- a/Tests/UI/test_model_catalog_consent_modal.py
+++ b/Tests/UI/test_model_catalog_consent_modal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Callable
 from types import MethodType
 from unittest.mock import MagicMock
 
@@ -14,6 +15,39 @@ from textual.screen import Screen
 from Tests.UI.app_factory import _build_test_app
 from tldw_chatbook.UI.Screens.home_screen import HomeScreen
 from tldw_chatbook.UI.Screens.model_catalog_consent import ModelCatalogConsentModal
+
+
+async def _wait_until(
+    pilot,
+    condition: Callable[[], bool],
+    *,
+    context: str,
+    timeout_seconds: float = 10.0,
+    interval_seconds: float = 0.05,
+) -> None:
+    """Wait for an asynchronous Textual test condition.
+
+    Args:
+        pilot: Textual test pilot driving the running app.
+        condition: Zero-argument predicate that returns true when ready.
+        context: Human-readable state included in timeout failures.
+        timeout_seconds: Maximum time to wait before failing.
+        interval_seconds: Delay between event-loop polls.
+
+    Raises:
+        AssertionError: If the condition remains false after the timeout.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await pilot.pause()
+        await asyncio.sleep(interval_seconds)
+    if condition():
+        return
+    raise AssertionError(
+        f"condition was not met within {timeout_seconds:.1f}s for {context}"
+    )
 
 
 class _ConsentHost(App):
@@ -98,19 +132,18 @@ async def test_splash_finishes_before_catalog_consent_and_deny_returns_home():
     app._push_model_catalog_consent_modal = MethodType(push_catalog_consent, app)
 
     async with app.run_test(size=(120, 40)) as pilot:
-        deadline = time.monotonic() + 5.0
-        while time.monotonic() < deadline:
+        def startup_ready() -> bool:
             stack = observe_stack()
-            if any(screen is HomeScreen for screen in stack) and any(
+            return any(screen is HomeScreen for screen in stack) and any(
                 screen is ModelCatalogConsentModal for screen in stack
-            ):
-                break
-            await pilot.pause(0.01)
-        else:
-            pytest.fail(
-                "startup did not mount both Home and model-catalog consent; "
-                f"observed={[(active, [item.__name__ for item in stack]) for active, stack in observed]}"
             )
+
+        await _wait_until(
+            pilot,
+            startup_ready,
+            context="startup to mount Home beneath model-catalog consent; "
+            f"observed={[(active, [item.__name__ for item in stack]) for active, stack in observed]}",
+        )
 
         final_stack = tuple(app.screen_stack)
         assert isinstance(final_stack[-2], HomeScreen), (
@@ -127,10 +160,13 @@ async def test_splash_finishes_before_catalog_consent_and_deny_returns_home():
             for index, (_, stack) in enumerate(observed)
             if ModelCatalogConsentModal in stack
         )
+        assert any(active for active, _ in observed[:first_consent]), (
+            f"active splash was not observed before consent: {observed}"
+        )
         assert any(
-            active and stack == (Screen,)
-            for active, stack in observed[:first_consent]
-        ), f"splash/default Screen was not observed before consent: {observed}"
+            HomeScreen in stack and ModelCatalogConsentModal not in stack
+            for _, stack in observed[:first_consent]
+        ), f"Home was not mounted before consent was pushed: {observed}"
         assert not observed[first_consent][0], (
             "consent appeared before the splash completed; "
             f"observed={observed}"
@@ -144,17 +180,16 @@ async def test_splash_finishes_before_catalog_consent_and_deny_returns_home():
         home = final_stack[-2]
         assert await pilot.click("#model-catalog-consent-deny") is True
 
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline:
+        def deny_dismissed() -> bool:
             observe_stack()
-            if app.screen is home:
-                break
-            await pilot.pause(0.01)
-        else:
-            pytest.fail(
-                "Deny did not dismiss consent back to the same HomeScreen; "
-                f"stack={[type(screen).__name__ for screen in app.screen_stack]}"
-            )
+            return app.screen is home
+
+        await _wait_until(
+            pilot,
+            deny_dismissed,
+            context="Deny to dismiss consent back to the same HomeScreen; "
+            f"stack={[type(screen).__name__ for screen in app.screen_stack]}",
+        )
 
         assert app.screen is home
         assert home.is_mounted

--- a/Tests/UI/test_model_catalog_consent_modal.py
+++ b/Tests/UI/test_model_catalog_consent_modal.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from types import MethodType
+from unittest.mock import MagicMock
 
 import pytest
 from textual.app import App
 from textual.screen import Screen
 
 from Tests.UI.app_factory import _build_test_app
-from tldw_chatbook import config as config_module
 from tldw_chatbook.UI.Screens.home_screen import HomeScreen
 from tldw_chatbook.UI.Screens.model_catalog_consent import ModelCatalogConsentModal
 
@@ -73,20 +74,11 @@ async def test_app_push_suppresses_modal_in_headless_runs():
 
 
 @pytest.mark.asyncio
-async def test_splash_finishes_before_catalog_consent_and_deny_returns_home(
-    monkeypatch: pytest.MonkeyPatch,
-):
+async def test_splash_finishes_before_catalog_consent_and_deny_returns_home():
     """Consent stays topmost after splash startup and dismisses to Home."""
     app = _build_test_app(configured_default="home")
-
-    get_cli_setting = config_module.get_cli_setting
-
-    def suppress_project_skills(section, *args, **kwargs):
-        if section == "skills" and args[:1] == ("project_skills_prompt_enabled",):
-            return False
-        return get_cli_setting(section, *args, **kwargs)
-
-    monkeypatch.setattr(config_module, "get_cli_setting", suppress_project_skills)
+    project_skills_offer = MagicMock(name="project_skills_offer")
+    app._maybe_offer_project_skills_import = project_skills_offer
 
     observed: list[tuple[bool, tuple[type[Screen], ...]]] = []
 
@@ -167,3 +159,53 @@ async def test_splash_finishes_before_catalog_consent_and_deny_returns_home(
         assert app.screen is home
         assert home.is_mounted
         assert home.query("#home-triage-grid")
+        project_skills_offer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_first_run_completion_finishes_chat_navigation_before_consent():
+    """Completed first-run navigation finishes before consent can be offered."""
+    from tldw_chatbook.app import TldwCli
+
+    class CompletionHost:
+        current_tab = "home"
+        focus_mode = False
+
+        def __init__(self) -> None:
+            self.events: list[str] = []
+            self.worker_coroutines = []
+
+        async def handle_screen_navigation(self, _message) -> None:
+            self.events.append("navigation-start")
+            await asyncio.sleep(0)
+            self.events.append("navigation-finish")
+
+        def run_worker(self, work, **_kwargs) -> None:
+            self.worker_coroutines.append(work)
+
+        def _schedule_startup_model_catalog_refresh(self, **_kwargs) -> None:
+            self.events.append("consent")
+
+        def post_message(self, _message) -> None:
+            raise AssertionError(
+                "first-run completion must not post navigation; "
+                f"events={self.events!r}, workers={len(self.worker_coroutines)}"
+            )
+
+    host = CompletionHost()
+    try:
+        TldwCli._handle_first_run_wizard_result(
+            host,
+            {"completed": True, "exit_route": "chat", "exit_context": None},
+        )
+
+        assert len(host.worker_coroutines) == 1
+        await host.worker_coroutines[0]
+        assert host.events == [
+            "navigation-start",
+            "navigation-finish",
+            "consent",
+        ]
+    finally:
+        for worker in host.worker_coroutines:
+            worker.close()

--- a/Tests/UI/test_model_catalog_consent_modal.py
+++ b/Tests/UI/test_model_catalog_consent_modal.py
@@ -1,8 +1,17 @@
 """ModelCatalogConsentModal dismisses with the user's allow/deny choice."""
 
+from __future__ import annotations
+
+import time
+from types import MethodType
+
 import pytest
 from textual.app import App
+from textual.screen import Screen
 
+from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook import config as config_module
+from tldw_chatbook.UI.Screens.home_screen import HomeScreen
 from tldw_chatbook.UI.Screens.model_catalog_consent import ModelCatalogConsentModal
 
 
@@ -61,3 +70,100 @@ async def test_app_push_suppresses_modal_in_headless_runs():
         TldwCli._push_model_catalog_consent_modal(app)
         await pilot.pause()
         assert not isinstance(app.screen, ModelCatalogConsentModal)
+
+
+@pytest.mark.asyncio
+async def test_splash_finishes_before_catalog_consent_and_deny_returns_home(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Consent stays topmost after splash startup and dismisses to Home."""
+    app = _build_test_app(configured_default="home")
+
+    get_cli_setting = config_module.get_cli_setting
+
+    def suppress_project_skills(section, *args, **kwargs):
+        if section == "skills" and args[:1] == ("project_skills_prompt_enabled",):
+            return False
+        return get_cli_setting(section, *args, **kwargs)
+
+    monkeypatch.setattr(config_module, "get_cli_setting", suppress_project_skills)
+
+    observed: list[tuple[bool, tuple[type[Screen], ...]]] = []
+
+    def observe_stack() -> tuple[type[Screen], ...]:
+        stack = tuple(type(screen) for screen in app.screen_stack)
+        snapshot = (bool(app.splash_screen_active), stack)
+        if not observed or observed[-1] != snapshot:
+            observed.append(snapshot)
+        return stack
+
+    def push_catalog_consent(self) -> None:
+        observe_stack()
+        self.push_screen(
+            ModelCatalogConsentModal(), self._handle_model_catalog_consent
+        )
+
+    app._push_model_catalog_consent_modal = MethodType(push_catalog_consent, app)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            stack = observe_stack()
+            if any(screen is HomeScreen for screen in stack) and any(
+                screen is ModelCatalogConsentModal for screen in stack
+            ):
+                break
+            await pilot.pause(0.01)
+        else:
+            pytest.fail(
+                "startup did not mount both Home and model-catalog consent; "
+                f"observed={[(active, [item.__name__ for item in stack]) for active, stack in observed]}"
+            )
+
+        final_stack = tuple(app.screen_stack)
+        assert isinstance(final_stack[-2], HomeScreen), (
+            "Home must be immediately below consent after startup; "
+            f"stack={[type(screen).__name__ for screen in final_stack]}"
+        )
+        assert isinstance(final_stack[-1], ModelCatalogConsentModal), (
+            "consent must remain the topmost actionable screen; "
+            f"stack={[type(screen).__name__ for screen in final_stack]}"
+        )
+
+        first_consent = next(
+            index
+            for index, (_, stack) in enumerate(observed)
+            if ModelCatalogConsentModal in stack
+        )
+        assert any(
+            active and stack == (Screen,)
+            for active, stack in observed[:first_consent]
+        ), f"splash/default Screen was not observed before consent: {observed}"
+        assert not observed[first_consent][0], (
+            "consent appeared before the splash completed; "
+            f"observed={observed}"
+        )
+        assert not any(
+            ModelCatalogConsentModal in stack
+            and stack[-1] is not ModelCatalogConsentModal
+            for _, stack in observed
+        ), f"consent was buried by a later startup screen: {observed}"
+
+        home = final_stack[-2]
+        assert await pilot.click("#model-catalog-consent-deny") is True
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            observe_stack()
+            if app.screen is home:
+                break
+            await pilot.pause(0.01)
+        else:
+            pytest.fail(
+                "Deny did not dismiss consent back to the same HomeScreen; "
+                f"stack={[type(screen).__name__ for screen in app.screen_stack]}"
+            )
+
+        assert app.screen is home
+        assert home.is_mounted
+        assert home.query("#home-triage-grid")

--- a/Tests/UI/test_model_catalog_consent_modal.py
+++ b/Tests/UI/test_model_catalog_consent_modal.py
@@ -255,3 +255,42 @@ async def test_first_run_navigation_failure_still_schedules_consent_after_attemp
     finally:
         for worker in host.worker_coroutines:
             worker.close()
+
+
+@pytest.mark.asyncio
+async def test_first_run_navigation_cancellation_does_not_schedule_consent():
+    """Cancelling first-run navigation also cancels its pending consent offer."""
+    from tldw_chatbook.app import TldwCli
+
+    class CancelledNavigationHost:
+        current_tab = "home"
+        focus_mode = False
+
+        def __init__(self) -> None:
+            self.worker_coroutines = []
+            self._schedule_startup_model_catalog_refresh = MagicMock()
+
+        async def handle_screen_navigation(self, _message) -> None:
+            raise asyncio.CancelledError
+
+        def run_worker(self, work, **_kwargs) -> None:
+            self.worker_coroutines.append(work)
+
+        def post_message(self, _message) -> None:
+            raise AssertionError("completed navigation must use its worker")
+
+    host = CancelledNavigationHost()
+    try:
+        TldwCli._handle_first_run_wizard_result(
+            host,
+            {"completed": True, "exit_route": "chat", "exit_context": None},
+        )
+
+        assert len(host.worker_coroutines) == 1
+        with pytest.raises(asyncio.CancelledError):
+            await host.worker_coroutines[0]
+
+        host._schedule_startup_model_catalog_refresh.assert_not_called()
+    finally:
+        for worker in host.worker_coroutines:
+            worker.close()

--- a/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
+++ b/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-21161
 title: Order model catalog consent after intro startup
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-23 15:09'
-updated_date: '2026-08-23 15:51'
+updated_date: '2026-08-23 16:47'
 labels: []
 dependencies: []
 priority: high
@@ -18,10 +18,10 @@ Fix startup ordering so an unconfigured model-catalog consent decision appears a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Splash/intro completes before model-catalog consent is shown.
-- [ ] #2 Unrecorded consent produces one topmost Yes/No modal that cannot be buried by initial-screen startup.
-- [ ] #3 Either consent choice dismisses to a usable initial app screen while preserving the existing persistence and refresh semantics.
-- [ ] #4 Focused regression coverage drives the real splash-enabled screen stack and fails under the pre-fix ordering.
+- [x] #1 Splash/intro completes before model-catalog consent is shown.
+- [x] #2 Unrecorded consent produces one topmost Yes/No modal that cannot be buried by initial-screen startup.
+- [x] #3 Either consent choice dismisses to a usable initial app screen while preserving the existing persistence and refresh semantics.
+- [x] #4 Focused regression coverage drives the real splash-enabled screen stack and fails under the pre-fix ordering.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -38,3 +38,13 @@ ADR required: no
 ADR path: backlog/decisions/020-automatic-model-catalog-refresh.md
 Reason: This is a lifecycle ordering bug fix that preserves ADR-020 storage, consent, and network boundaries; optional startup prompts are deferred rather than introducing a new modal coordinator.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the startup lifecycle fix so model-catalog consent is scheduled only after the intro and initial routed screen are mounted. Unrecorded consent now owns the launch, deferring the optional project-skills offer; completed first-run exit navigation is awaited before consent, while navigation failures still release consent over the surviving screen and cancellation during shutdown does not. Existing Yes/No persistence, one-shot scheduling, setup ownership, and catalog refresh behavior remain unchanged.
+
+Regression coverage now drives the real splash-enabled Textual screen stack, explicit Deny interaction, project-skills precedence, first-run route sequencing, navigation failure, and cancellation. The original ordering failed with Screen -> ModelCatalogConsentModal -> HomeScreen; the corrected modal suite passes 8/8. Catalog wiring passes 23/23; focused first-run callback/live and focus tests pass. Ruff and git diff --check pass. The complete product-maturity first-run file has one pre-existing navigation-copy timeout at line 552, reproduced identically on base 80e8b50e6; all other tests in that file pass.
+
+ADR required: no. Existing ADR: backlog/decisions/020-automatic-model-catalog-refresh.md. This change preserves that decision and corrects UI lifecycle ordering only. No new dependency, schema, security boundary, or generalized modal coordinator was introduced. No reusable lessons document update was warranted.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
+++ b/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
@@ -4,7 +4,7 @@ title: Order model catalog consent after intro startup
 status: Done
 assignee: []
 created_date: '2026-08-23 15:09'
-updated_date: '2026-08-23 16:47'
+updated_date: '2026-08-23 17:04'
 labels: []
 dependencies: []
 priority: high
@@ -47,4 +47,6 @@ Implemented the startup lifecycle fix so model-catalog consent is scheduled only
 Regression coverage now drives the real splash-enabled Textual screen stack, explicit Deny interaction, project-skills precedence, first-run route sequencing, navigation failure, and cancellation. The original ordering failed with Screen -> ModelCatalogConsentModal -> HomeScreen; the corrected modal suite passes 8/8. Catalog wiring passes 23/23; focused first-run callback/live and focus tests pass. Ruff and git diff --check pass. The complete product-maturity first-run file has one pre-existing navigation-copy timeout at line 552, reproduced identically on base 80e8b50e6; all other tests in that file pass.
 
 ADR required: no. Existing ADR: backlog/decisions/020-automatic-model-catalog-refresh.md. This change preserves that decision and corrects UI lifecycle ordering only. No new dependency, schema, security boundary, or generalized modal coordinator was introduced. No reusable lessons document update was warranted.
+
+PR review follow-up: added the missing async contract-test docstring and replaced the splash regression's short manual Pilot loops/exact default-screen assertion with the repository's bounded `_wait_until` pattern and behavior-level splash/Home ordering assertions. Focused tests and Ruff pass.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
+++ b/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
@@ -4,6 +4,7 @@ title: Order model catalog consent after intro startup
 status: In Progress
 assignee: []
 created_date: '2026-08-23 15:09'
+updated_date: '2026-08-23 15:16'
 labels: []
 dependencies: []
 priority: high
@@ -22,3 +23,17 @@ Fix startup ordering so an unconfigured model-catalog consent decision appears a
 - [ ] #3 Either consent choice dismisses to a usable initial app screen while preserving the existing persistence and refresh semantics.
 - [ ] #4 Focused regression coverage drives the real splash-enabled screen stack and fails under the pre-fix ordering.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a splash-enabled full-app Textual Pilot regression that forces the real consent modal under run_test(), pins setup complete, suppresses project-skills discovery, verifies the ordered screen stack, and exercises Deny.
+2. Confirm the regression fails because the current on_mount scheduling lets the initial screen cover consent.
+3. Move the existing startup scheduler call from on_mount to the end of _push_initial_screen without changing ADR-020 gates, persistence, callbacks, or refresh workers.
+4. Run the complete focused consent, catalog-wiring, and first-run startup tests; run Ruff and git diff --check; self-review the diff.
+5. Check acceptance criteria, add implementation notes, and set the task Done only after verification.
+
+ADR required: no
+ADR path: backlog/decisions/020-automatic-model-catalog-refresh.md
+Reason: This is a lifecycle ordering bug fix that preserves ADR-020 storage, consent, and network boundaries.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
+++ b/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
@@ -4,7 +4,7 @@ title: Order model catalog consent after intro startup
 status: In Progress
 assignee: []
 created_date: '2026-08-23 15:09'
-updated_date: '2026-08-23 15:16'
+updated_date: '2026-08-23 15:51'
 labels: []
 dependencies: []
 priority: high
@@ -27,13 +27,14 @@ Fix startup ordering so an unconfigured model-catalog consent decision appears a
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a splash-enabled full-app Textual Pilot regression that forces the real consent modal under run_test(), pins setup complete, suppresses project-skills discovery, verifies the ordered screen stack, and exercises Deny.
-2. Confirm the regression fails because the current on_mount scheduling lets the initial screen cover consent.
-3. Move the existing startup scheduler call from on_mount to the end of _push_initial_screen without changing ADR-020 gates, persistence, callbacks, or refresh workers.
-4. Run the complete focused consent, catalog-wiring, and first-run startup tests; run Ruff and git diff --check; self-review the diff.
-5. Check acceptance criteria, add implementation notes, and set the task Done only after verification.
+1. Add a splash-enabled full-app Textual Pilot regression for intro -> Home -> consent, prove the old stack is Screen/Consent/Home, and exercise explicit Deny back to Home.
+2. Move startup scheduling from on_mount to the shared post-intro _push_initial_screen path without changing ADR-020 consent persistence or refresh semantics.
+3. Add red regressions for the reviewed competing paths: eligible project-skills startup discovery must defer when consent is unrecorded, and completed first-run exit navigation must settle before consent without any implicit None decision.
+4. Record the unrecorded-consent startup branch so _push_initial_screen can skip the optional project-skills offer for that launch; sequence completed first-run exit navigation before scheduling consent while preserving no-route and same-Console behavior.
+5. Run the complete focused consent, catalog-wiring, first-run startup, and live first-run contract tests; run Ruff and git diff --check; complete independent review.
+6. Check acceptance criteria, add implementation notes, and set the task Done only after verification.
 
 ADR required: no
 ADR path: backlog/decisions/020-automatic-model-catalog-refresh.md
-Reason: This is a lifecycle ordering bug fix that preserves ADR-020 storage, consent, and network boundaries.
+Reason: This is a lifecycle ordering bug fix that preserves ADR-020 storage, consent, and network boundaries; optional startup prompts are deferred rather than introducing a new modal coordinator.
 <!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
+++ b/backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md
@@ -1,0 +1,24 @@
+---
+id: TASK-21161
+title: Order model catalog consent after intro startup
+status: In Progress
+assignee: []
+created_date: '2026-08-23 15:09'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix startup ordering so an unconfigured model-catalog consent decision appears after the splash/intro, remains topmost and actionable, and reveals a usable initial app screen after Yes or No.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Splash/intro completes before model-catalog consent is shown.
+- [ ] #2 Unrecorded consent produces one topmost Yes/No modal that cannot be buried by initial-screen startup.
+- [ ] #3 Either consent choice dismisses to a usable initial app screen while preserving the existing persistence and refresh semantics.
+- [ ] #4 Focused regression coverage drives the real splash-enabled screen stack and fails under the pre-fix ordering.
+<!-- AC:END -->

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10989,6 +10989,7 @@ class TldwCli(
             not catalog_settings.refresh_consent_recorded
         ):
             self._startup_model_catalog_refresh_scheduled = True
+            self._startup_model_catalog_consent_required = True
             self.call_after_refresh(self._push_model_catalog_consent_modal)
             return True
 
@@ -11414,9 +11415,6 @@ class TldwCli(
         else:
             return
 
-        if completed is True:
-            self._schedule_startup_model_catalog_refresh(after_setup_completion=True)
-
         # Dismissing a rerun over Console already uncovers that same mounted
         # Console. Replacing it here would interrupt first-chat rollback and
         # focus resync. Other destinations still remount to refresh their state.
@@ -11433,11 +11431,29 @@ class TldwCli(
                 )
                 if callable(apply_chrome):
                     apply_chrome()
+            self._schedule_startup_model_catalog_refresh(after_setup_completion=True)
             return
 
         from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 
-        self.post_message(NavigateToScreen(exit_route, screen_context))
+        if completed is not True:
+            self.post_message(NavigateToScreen(exit_route, screen_context))
+            return
+
+        async def navigate_then_schedule_catalog_consent() -> None:
+            await self.handle_screen_navigation(
+                NavigateToScreen(exit_route, screen_context)
+            )
+            self._schedule_startup_model_catalog_refresh(
+                after_setup_completion=True
+            )
+
+        self.run_worker(
+            navigate_then_schedule_catalog_consent(),
+            group="first-run-exit-navigation",
+            exclusive=True,
+            exit_on_error=False,
+        )
 
     def handle_first_run_wizard_result(self, result: dict | None) -> None:
         """Public alias for ``_handle_first_run_wizard_result``.
@@ -11535,7 +11551,13 @@ class TldwCli(
             self._maybe_warn_second_instance()
         except Exception as e:
             logger.error(f"Second-instance warning failed: {e}")
-        if not wizard_offered:
+
+        # Schedule after splash and the initial screen, before optional startup
+        # offers; ADR-020 consent owns this launch when it is still required.
+        self._schedule_startup_model_catalog_refresh()
+        if not wizard_offered and not getattr(
+            self, "_startup_model_catalog_consent_required", False
+        ):
             # Spec 2026-08-17 §5.4: wizard wins; .SKILLS offer defers to next launch.
             self._maybe_offer_project_skills_import()
         try:
@@ -11545,10 +11567,6 @@ class TldwCli(
                 "Config load failure warning failed (error_type=%s)",
                 type(e).__name__,
             )
-
-        # Schedule after splash, initial screen, and startup offers; ADR-020
-        # still keeps setup as the owner of startup networking until completion.
-        self._schedule_startup_model_catalog_refresh()
 
     async def _run_no_splash_post_mount_setup(self) -> None:
         """Run screen startup and post-mount setup when the splash screen is disabled."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -11441,9 +11441,17 @@ class TldwCli(
             return
 
         async def navigate_then_schedule_catalog_consent() -> None:
-            await self.handle_screen_navigation(
-                NavigateToScreen(exit_route, screen_context)
-            )
+            try:
+                await self.handle_screen_navigation(
+                    NavigateToScreen(exit_route, screen_context)
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self._schedule_startup_model_catalog_refresh(
+                    after_setup_completion=True
+                )
+                raise
             self._schedule_startup_model_catalog_refresh(
                 after_setup_completion=True
             )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10835,10 +10835,6 @@ class TldwCli(
             group="scheduling",
         )
 
-        # ADR-020: setup owns startup networking until it completes, so a
-        # stale configured cloud provider cannot be contacted behind it.
-        self._schedule_startup_model_catalog_refresh()
-
         # task-688: index subscription_items rows scraped before the FTS5
         # index existed, so search covers a user's whole back catalogue
         # without any action on their part. thread=True because this does
@@ -11549,6 +11545,10 @@ class TldwCli(
                 "Config load failure warning failed (error_type=%s)",
                 type(e).__name__,
             )
+
+        # Schedule after splash, initial screen, and startup offers; ADR-020
+        # still keeps setup as the owner of startup networking until completion.
+        self._schedule_startup_model_catalog_refresh()
 
     async def _run_no_splash_post_mount_setup(self) -> None:
         """Run screen startup and post-mount setup when the splash screen is disabled."""


### PR DESCRIPTION
## Summary
- schedule the one-time model catalog consent only after the intro and initial routed screen are mounted
- defer optional project-skills startup prompts while required consent owns the launch
- sequence first-run exit navigation before consent, preserving the prompt on navigation failures and skipping it only during cancellation/shutdown
- add full-app Textual screen-stack and lifecycle regression coverage

## Test plan
- `PYTHON=.venv/bin/python ./scripts/preflight.sh`
- `pytest -q Tests/UI/test_model_catalog_consent_modal.py Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py` — 31 passed
- `pytest -q Tests/UI/test_first_run_wizard_live_contract.py -k "first_run_result_callback or rerun_over_settings_start_chatting"` — passed
- Ruff on all changed Python files
- `git diff --check origin/dev..HEAD`

## Known baseline issue
- `Tests/UI/test_product_maturity_phase1_first_run.py::test_clean_first_run_launches_home_and_exposes_setup_orientation` still times out waiting for navigation copy. The identical failure was reproduced on the untouched base commit, so it is not introduced by this PR.

## Governance
- Backlog task: TASK-21161 (Done)
- ADR required: no; this preserves ADR-020 and corrects UI lifecycle ordering only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the model catalog consent only after the intro and initial screen, keeps it topmost, and returns to the same initial screen after an explicit Yes/No. Previously, consent was scheduled in `on_mount`, could appear during the splash, and could be buried by the initial screen.

- Move consent scheduling from `on_mount()` to `_push_initial_screen()` and set `_startup_model_catalog_consent_required` to suppress the optional project-skills offer while consent is pending.
- Defer the optional project-skills startup offer on unconsented launches; offer it on a later launch after consent is recorded.
- Serialize first-run completion and consent: run exit-route navigation in a worker and schedule consent only after navigation completes; if navigation fails, still schedule consent; if navigation is cancelled, do not schedule consent.
- Preserve ADR-020 behavior unchanged: one-shot scheduling, consent persistence, setup ownership gate, and catalog refresh.
- Harden full-app Textual regressions to assert ordered stack (intro → initial screen → consent) and Deny interaction, and to cover first-run navigation success, failure, and cancellation.

<sup>Written for commit d6bf90cd569ef03daf0b1c211fcde40595869ef0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

