### PR TITLE
fix(startup): Actor Pack modules put PIL and Persona_Visual back on the app import closure (TASK-21200)

### DIFF
--- a/Tests/Packaging/test_persona_buddy_import_closure.py
+++ b/Tests/Packaging/test_persona_buddy_import_closure.py
@@ -23,6 +23,19 @@ PEP-562 lazy facades (importing ``Persona_Buddy.console_adapter`` or any
 controller lazily on the app, and converts chains 2 and 3 to function-local
 imports.
 
+TASK-21200 added a fourth chain and a second guard. The Actor Packs
+activation feature (``ac1037732``, ``a98f3c14d``) landed
+``app.py`` -> ``Actor_Packs/__init__`` -> ``Actor_Packs.activation`` ->
+``Persona_Visual.repository`` + ``Character_Chat.visual_identity`` (PIL),
+re-introducing the whole regression while this file was already on disk --
+the guard existed at their merge but CI was not yet enforcing checks. Note
+that ``app.py`` imports ``Actor_Packs.activation``/``export``/``importer``
+*directly*, so a lazy package ``__init__`` would not have helped: those three
+modules must be heavy-free themselves.
+``test_actor_pack_modules_do_not_execute_persona_visual_or_pil`` pins that
+stronger, source-level property, and both guards now report the offending
+import chain rather than only a module list.
+
 Subprocess-isolated for the same reason as
 ``test_chunking_import_closure.py`` (TASK-21102), whose pattern this file
 follows: ``sys.modules`` is process-global, so an earlier test in the
@@ -80,12 +93,59 @@ def _run_isolated_python(tmp_path: Path, code: str) -> subprocess.CompletedProce
     )
 
 
-_BUDDY_CLOSURE_SNIPPET = """
+# Installed *before* the import under test so a failure names the chain that
+# pulled the heavy module in, not just the fact that it is resident. Reading
+# `-X importtime` output instead is a known trap: its indentation nests by
+# completion order, and misreading it sent TASK-21200's first diagnosis at the
+# wrong module.
+_IMPORT_CHAIN_TRACER = '''
 import sys
 
-import tldw_chatbook.app  # noqa: F401
+_import_parent = {}
 
-forbidden_prefixes = (
+
+class _ChainTracer:
+    """Record which module's body triggered each import.
+
+    ``find_spec`` runs while the importing module is still on the stack, and
+    importlib executes a module body in a frame whose ``co_name`` is
+    ``<module>``. The nearest such frame outside this finder is therefore the
+    true importer. Returns ``None`` so the real finders still resolve.
+    """
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname not in _import_parent:
+            _import_parent[fullname] = self._importing_module()
+        return None
+
+    @staticmethod
+    def _importing_module():
+        depth = 2  # 0 = this frame, 1 = find_spec, 2 = importlib internals
+        while True:
+            try:
+                frame = sys._getframe(depth)
+            except ValueError:
+                return "<root>"
+            if frame.f_code.co_name == "<module>":
+                name = frame.f_globals.get("__name__")
+                if name and not name.startswith("importlib"):
+                    return name
+            depth += 1
+
+
+def _import_chain(module):
+    seen = {module}
+    parts = [module]
+    while True:
+        parent = _import_parent.get(parts[-1])
+        if parent is None or parent in seen:
+            break
+        seen.add(parent)
+        parts.append(parent)
+    return " -> ".join(reversed(parts))
+
+
+FORBIDDEN_PREFIXES = (
     "PIL",
     "rich_pixels",
     "textual_image",
@@ -93,12 +153,44 @@ forbidden_prefixes = (
     "tldw_chatbook.Persona_Buddy.controller",
     "tldw_chatbook.Persona_Buddy.rendering",
 )
-resident = sorted(
-    m for m in sys.modules
-    if any(m == p or m.startswith(p + ".") for p in forbidden_prefixes)
-    and sys.modules[m] is not None
-)
-assert not resident, f"heavy Buddy/visual modules resident after app import: {resident}"
+
+
+def resident_heavy_modules():
+    return sorted(
+        m for m in sys.modules
+        if any(m == p or m.startswith(p + ".") for p in FORBIDDEN_PREFIXES)
+        and sys.modules[m] is not None
+    )
+
+
+def describe_leak(resident, what):
+    lines = [
+        f"{len(resident)} heavy module(s) executed by {what}.",
+        "Each offending import chain (importer -> imported):",
+    ]
+    shown = set()
+    for module in resident:
+        chain = _import_chain(module)
+        if chain in shown:
+            continue
+        shown.add(chain)
+        lines.append(f"  {chain}")
+    lines.append(
+        "Fix by deferring the import (function-local, or TYPE_CHECKING for "
+        "annotations) at the LAST tldw_chatbook module in the chain above -- "
+        "see the TASK-21200 notes in tldw_chatbook/Actor_Packs/activation.py."
+    )
+    return "\\n".join(lines)
+
+
+sys.meta_path.insert(0, _ChainTracer())
+'''
+
+_BUDDY_CLOSURE_SNIPPET = _IMPORT_CHAIN_TRACER + """
+import tldw_chatbook.app  # noqa: F401
+
+resident = resident_heavy_modules()
+assert not resident, describe_leak(resident, "import tldw_chatbook.app")
 
 # The stdlib-only console adapter seam is ALLOWED to stay import-time (it is
 # what Chat/console_runtime.py needs at module scope); its parent package
@@ -200,3 +292,60 @@ def test_persona_package_inits_are_lazy_and_single_sourced(tmp_path: Path) -> No
         f"stderr={result.stderr[-4000:]}"
     )
     assert "PERSONA_LAZY_FACADE_OK" in result.stdout
+
+
+# The three Actor_Packs modules `app.py` imports at module scope. Naming them
+# (and their heavy dependencies) explicitly is the point: a count-only guard
+# tells the next author that something regressed, not what to defer.
+_ACTOR_PACK_SOURCE_SNIPPET = _IMPORT_CHAIN_TRACER + """
+import sys
+
+# app.py imports these three DIRECTLY (not via the package facade), so each
+# must be heavy-free on its own. Their heavy dependencies, which must all be
+# function-local or TYPE_CHECKING-only:
+#   activation -> Persona_Visual.repository, Character_Chat.visual_identity
+#   export     -> Persona_Visual.assets/.repository, Character_Chat.visual_identity
+#   importer   -> Persona_Visual.repository/.validation,
+#                 Character_Chat.visual_identity
+# `Character_Chat.visual_identity` is the PIL carrier (module-level
+# `from PIL import Image`); `Persona_Visual.*` is forbidden outright.
+import tldw_chatbook.Actor_Packs.activation as activation
+import tldw_chatbook.Actor_Packs.export as export
+import tldw_chatbook.Actor_Packs.importer as importer
+
+resident = resident_heavy_modules()
+assert not resident, describe_leak(
+    resident, "importing Actor_Packs activation/export/importer"
+)
+
+# Anti-vacuity: the modules must really have executed and still expose the
+# services app.py binds, so this guard cannot pass on a failed/no-op import.
+assert activation.ActorPackActivationService is not None
+assert export.ActorPackExportService is not None
+assert importer.ActorPackImportService is not None
+assert "tldw_chatbook.Character_Chat.visual_identity" not in sys.modules
+
+print("ACTOR_PACK_SOURCE_CLOSURE_OK")
+"""
+
+
+def test_actor_pack_modules_do_not_execute_persona_visual_or_pil(
+    tmp_path: Path,
+) -> None:
+    """Actor_Packs activation/export/importer import without PIL or Persona_Visual.
+
+    Stronger and more local than the app-closure guard above: it pins the
+    property at the source, so any future module-scope consumer of these three
+    modules inherits it. Regression guard for TASK-21200, where the Actor Packs
+    activation feature put ``Persona_Visual.repository`` and the PIL-importing
+    ``Character_Chat.visual_identity`` at module scope in all three.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _ACTOR_PACK_SOURCE_SNIPPET)
+    assert result.returncode == 0, (
+        "Actor_Packs modules must not execute Persona_Visual or PIL at import "
+        f"time:\nstdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "ACTOR_PACK_SOURCE_CLOSURE_OK" in result.stdout

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7221,3 +7221,56 @@ run against the merge-base AND the branch in the same process — `git show
 location` under a dotted name inside the real package resolves its relative
 imports fine, so both versions can be seeded and queried side by side without a
 second worktree. Closure probes alone never move on any of those rows.
+
+## A lazy package facade protects nothing that consumers import directly, and deferring at the CONSUMER can move the cost instead of removing it (TASK-21200, 2026-08-23)
+
+TASK-21103 removed PIL and `Persona_Visual` from the `import tldw_chatbook.app`
+closure and shipped a guard. Eight hours later the Actor Packs branch merged and
+put them straight back: `app.py` -> `Actor_Packs/__init__` ->
+`Actor_Packs.activation` -> `Persona_Visual.repository` +
+`Character_Chat.visual_identity` (module-level `from PIL import Image`). The
+branch was authored *before* the guard existed and merged *after* it, without a
+rebase, while CI was not enforcing checks — so a trunk invariant that was one
+commit old was silently undone by a branch that predated it. **When you land a
+new invariant, the in-flight branches are the threat, and only enforced CI
+catches them.**
+
+Two fix shapes looked right and were both wrong; the reasoning generalises to
+any import-closure repair.
+
+1. **The house lazy-facade pattern did not apply.** TASK-21103 fixed
+   `Persona_Buddy` with a PEP-562 `__getattr__` on the package `__init__`, so
+   reaching for it here was the obvious move. It would have changed nothing:
+   `app.py` imports `Actor_Packs.activation`/`.export`/`.importer`
+   **directly**, and importing a submodule executes the package init *and* the
+   submodule regardless of how lazy the init is. A facade only helps when the
+   heavy module is reached **through** the package's own re-exports. Check which
+   one your consumers actually write before copying the pattern.
+2. **Deferring at the consumer would have made the guard green while boot stayed
+   slow.** The tempting one-line-region fix was moving app.py's eight
+   `Actor_Packs` imports into `_wire_character_persona_services`, their only
+   caller. But that method runs from `TldwCli.__init__` (app.py:6076), so every
+   real boot would still have paid PIL — the guard measures *module import*, and
+   the user feels *import + construction*. Fixing the three modules at the
+   source removed PIL from both. **Before deferring an import into a function,
+   check when that function runs; if it runs during construction anyway, you
+   have satisfied the test and not the user.**
+
+The evidence shape that settled all of it: a `sys.meta_path` finder that records,
+for each module, the module whose body triggered its import (importlib executes a
+module body in a frame whose `co_name` is `<module>`, so the nearest such frame
+outside the finder is the true importer). Reading `-X importtime` instead is the
+trap it replaces — its indentation nests by *completion* order, and misreading it
+pointed the first diagnosis at the wrong module. That tracer is now installed in
+`Tests/Packaging/test_persona_buddy_import_closure.py` itself, so the guards fail
+with the offending chain printed rather than a list of resident modules; the
+mutation test (re-add one module-level import, watch it go red) printed
+`app -> Actor_Packs -> ...activation -> ...visual_identity -> PIL` verbatim.
+
+Two checks worth copying when you defer imports: read the pre-change public
+surface from `git show HEAD:<file>` (not the edited file) and assert
+`getattr(pkg, name) is <direct submodule import>` for every name — a surface that
+silently shrank cannot pass that; and re-probe import ordering in fresh
+subprocesses (submodule-first, package-first, heavy-dep-first), because
+TASK-21160 shipped a live regression when a lazy facade unmasked a cycle the
+eager init had been front-loading in a safe order.

--- a/backlog/tasks/task-21200 - Actor Pack activation re-introduced PIL and Persona_Visual to the app import closure.md
+++ b/backlog/tasks/task-21200 - Actor Pack activation re-introduced PIL and Persona_Visual to the app import closure.md
@@ -1,0 +1,180 @@
+---
+id: TASK-21200
+title: >-
+  Actor Pack activation re-introduced PIL and Persona_Visual to the app import
+  closure
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-23'
+updated_date: '2026-08-23'
+labels:
+  - bug
+  - regression
+  - performance
+  - imports
+  - actor-packs
+  - startup
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Packaging/test_persona_buddy_import_closure.py::test_app_import_does_not_execute_persona_visual_or_pil`
+is red on dev `7969089c3`. That guard was shipped by TASK-21103, which removed PIL,
+`textual_image`, `rich_pixels`, `Persona_Buddy` and `Persona_Visual` from the
+`import tldw_chatbook.app` closure. Evidence, measurements and file:line cites for the
+original defect: `Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21103).
+
+Origin trace. The Actor Packs import/activation feature re-introduced the whole chain
+across three commits on one feature branch:
+
+- `a160bbe83` "feat: export Actor Pack visual sections" — put the heavy imports at module
+  scope in `Actor_Packs/export.py`;
+- `ac1037732` "feat: import and activate Actor Packs" — did the same in
+  `Actor_Packs/activation.py` and `Actor_Packs/importer.py`;
+- `a98f3c14d` "fix: harden Actor Pack import activation" — carried them forward.
+
+Those commits were authored 2026-08-22, before the guard existed. The guard merged as
+`6c0abdba7` (#2002) at 2026-08-23 01:56, and the Actor Pack branch merged as `ae817fefe`
+(#1998) at 2026-08-23 09:20 — after the guard, without rebasing onto it, and while CI was
+not yet enforcing checks. So a branch that predated the invariant landed on a trunk that
+had just established it, and nothing failed at the merge. CI now enforces checks, so the
+regression is visible.
+
+The cost is the one TASK-21103 removed: booting the app executes PIL and most of the
+`Persona_Visual` tree to construct services the user may never invoke.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 `import tldw_chatbook.app` executes no `PIL`, `textual_image`, `rich_pixels` or `tldw_chatbook.Persona_Visual` module.
+- [x] #2 Actor Pack import, activation and export behaviour is unchanged; the Actor_Packs suites pass.
+- [x] #3 Every public name of `tldw_chatbook.Actor_Packs` still resolves to the identical object it resolved to before the change.
+- [x] #4 No import ordering (submodule-first, package-first, heavy-dependency-first) raises `ImportError`.
+- [x] #5 A regression guard names `Actor_Packs.activation`'s heavy dependencies and fails with the offending import chain, not merely a module count.
+- [x] #6 The guard is proven to fail when the regression is reintroduced.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the red guard; re-derive the chain with a `sys.meta_path` import hook rather
+   than reading `-X importtime` indentation.
+2. Decide the fix shape against the two entry paths (`Actor_Packs/__init__` and app.py's
+   direct submodule imports).
+3. Defer the heavy imports; prove every use site is still bound in its scope.
+4. Prove name parity for the package's public surface against the pre-change surface.
+5. Probe for circular imports unmasked by the deferral, in several orders.
+6. Strengthen the guard, then mutation-test it.
+7. Run the Actor_Packs, Packaging and App suites; A/B every red against `7969089c3`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Made the three Actor_Packs modules that `app.py` imports at module scope
+(`activation.py`, `export.py`, `importer.py`) import their heavy dependencies
+function-locally instead. `import tldw_chatbook.app` now executes 0 forbidden modules,
+down from 15.
+
+**Chain, re-derived with a `sys.meta_path` finder** (records the module executing at
+first-import time, so it cannot be misread the way importtime's completion-ordered
+indentation can):
+
+```
+tldw_chatbook.app -> Actor_Packs.persona_coordinator -> Actor_Packs (package init)
+  -> Actor_Packs.activation -> Persona_Visual.repository
+  -> Actor_Packs.activation -> Character_Chat.visual_identity -> PIL
+```
+
+**Why this shape.** Two alternatives were rejected on evidence:
+
+- *A PEP-562 lazy facade on `Actor_Packs/__init__.py`* (the TASK-21103 shape) does not fix
+  this. `app.py:392-396` imports `Actor_Packs.activation`, `.export` and `.importer`
+  **directly**; importing a submodule runs the package init either way, and a lazy init
+  still leaves the submodule itself executing PIL. The facade would have made the guard no
+  greener. It was also unnecessary: nothing changed about the package surface, so the
+  eager init stays and there is no facade to unmask a circular import.
+- *Moving app.py's eight `Actor_Packs` imports into `_wire_character_persona_services`*
+  would have turned the guard green while moving the cost, not removing it: that method is
+  called from `TldwCli.__init__` (app.py:6076), so every real boot would still pay PIL.
+  Fixing the three modules at the source removes PIL from module import **and** from app
+  construction (`visual_identity` is only needed when a pack is actually
+  imported/exported/activated), and gives the property to any future module-scope consumer
+  rather than to app.py alone.
+
+Deferral points, one import statement per consuming function (6 total), plus a
+`TYPE_CHECKING` import for `export.py`'s single annotation — all three modules already
+have `from __future__ import annotations`, so annotations stay strings at runtime:
+`activation.__init__`, `activation._prepare_character_sections`,
+`export._capture_persona_visual`, `export._capture_shared_visual`,
+`importer._visual_authorities`, `importer._validate_sections`.
+
+**Verification.**
+
+- *Scope binding*: an AST pass confirmed all 14 load-references of the 9 deferred names
+  resolve to a binding in their own function (or the `TYPE_CHECKING` block) — 14/14.
+- *Name parity*: the pre-change public surface was read from `git show HEAD:` and every
+  name checked with `getattr(pkg, name) is <direct submodule import>` — **33/33 identical
+  objects**. Reading the baseline from git rather than from the edited file means a
+  surface that silently shrank could not pass.
+- *Circular imports*: 16 fresh-subprocess orderings — each of the 10 submodules first and
+  alone, the package first, reverse-init order, heavy-dependency-first in both directions,
+  and every deferred target resolved after the package — **16/16 pass**, no `ImportError`.
+  (TASK-21160 is the precedent for taking this seriously: a lazy facade there unmasked a
+  latent cycle that the eager init had been front-loading in a safe order.)
+- *Guard mutation-tested*: re-adding one module-level `visual_identity` import to
+  `activation.py` turned both guards red, and the new tracer printed the exact chain
+  `__main__ -> tldw_chatbook.app -> tldw_chatbook.Actor_Packs -> ...activation ->
+  ...Character_Chat.visual_identity -> PIL`. Reverted with `Edit`, never `git checkout`.
+
+**Before/after**, 5 runs each, `import tldw_chatbook.app` in an isolated
+HOME/XDG/`TLDW_CONFIG_PATH` env, fix worktree vs a clean worktree at `7969089c3`:
+
+| | `sys.modules` | forbidden resident | min wall |
+|---|---|---|---|
+| `7969089c3` | 1700 | 15 (10 PIL + 5 Persona_Visual) | 0.741 s |
+| this change | 1684 | **0** | 0.707 s |
+
+The wall-clock delta here is ~34 ms, not the 1.28 s the holistic review measured — that
+figure came from a slower floor machine with a cold PIL. The module-count and residency
+deltas are the robust signal; the honest claim is that the closure is clean again, not
+that this machine saves a second.
+
+**Guard strengthening.** `Tests/Packaging/test_persona_buddy_import_closure.py` gained a
+`_ChainTracer` (a `sys.meta_path` finder using only `sys._getframe`, installed before the
+import under test) so both closure guards now report *which chain* pulled each heavy
+module in, plus the advice to defer at the last `tldw_chatbook` module in the chain. New
+`test_actor_pack_modules_do_not_execute_persona_visual_or_pil` pins the property at the
+source: it imports the three modules directly, names each one's heavy dependencies in a
+comment, and carries anti-vacuity assertions so it cannot pass on a failed or no-op
+import.
+
+**Test results** (venv pytest; every red A/B'd against a clean worktree at `7969089c3`):
+
+- `Tests/Actor_Packs/` + `Tests/Architecture/test_actor_pack_boundary.py` — 211 passed.
+- `Tests/Packaging/` — 1 failed, 47 passed, 58 errors; baseline 2 failed, 45 passed, 58
+  errors. The delta is exactly the guard flipping red→green plus the new guard passing.
+  `test_openai_tts_mapping_resource` and the 58 `test_mcp_unified_distribution` errors are
+  pre-existing and identical on both sides.
+- `Tests/App/` — 178 passed.
+- Actor Pack UI workflows (5 files) + `Tests/UI/test_console_runtime_ownership.py` — 1
+  failed, 59 passed. The failure,
+  `test_app_fences_console_then_drains_buddy_before_profile_teardown`, is **pre-existing**:
+  the file alone gives an identical 1 failed / 12 passed on both `7969089c3` and this
+  branch. It is an asyncio drain timeout in Persona_Buddy teardown, untouched here.
+- Full `--collect-only` sweep — 55,747 collected, 29 collection errors, byte-identical to
+  the baseline's 29. No import-time breakage introduced.
+- `scripts/check_persistent_diagnostic_inventory.py` — no drift (532 owners, 1222 TASK-492
+  calls, 7261 TASK-494 calls, 8 sink files).
+
+**Files modified**: `tldw_chatbook/Actor_Packs/activation.py`,
+`tldw_chatbook/Actor_Packs/export.py`, `tldw_chatbook/Actor_Packs/importer.py`,
+`Tests/Packaging/test_persona_buddy_import_closure.py`.
+Not modified: `tldw_chatbook/Actor_Packs/__init__.py` (surface unchanged, see above),
+`tldw_chatbook/app.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Actor_Packs/activation.py
+++ b/tldw_chatbook/Actor_Packs/activation.py
@@ -18,12 +18,15 @@ from tldw_chatbook.Character_Chat.local_character_persona_service import (
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.VisualIdentity_DB import VisualIdentityRepository
-from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
-from tldw_chatbook.Character_Chat.visual_identity import (
-    compute_pack_content_sha256,
-    validate_visual_identity_manifest,
-)
 from tldw_chatbook.Utils.private_paths import secure_private_directory
+
+# TASK-21200: ``Persona_Visual.repository`` and ``Character_Chat.visual_identity``
+# (module-level ``from PIL import Image``) are imported inside the two functions
+# that need them, never at module scope. ``app.py`` imports this module at module
+# scope, so a module-level import here puts PIL and most of Persona_Visual back on
+# the ``import tldw_chatbook.app`` path -- the exact TASK-21103 regression this
+# module re-introduced. Guarded by
+# ``Tests/Packaging/test_persona_buddy_import_closure.py``.
 
 from .importer import (
     ActorPackImportError,
@@ -100,6 +103,9 @@ class ActorPackActivationService:
         persona_coordinator: PersonaActorPackCoordinator,
         importer: ActorPackImportService,
     ) -> None:
+        # Deferred: see the TASK-21200 note at the top of this module.
+        from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
+
         if (
             not isinstance(db, CharactersRAGDB)
             or not isinstance(local_service, LocalCharacterPersonaService)
@@ -371,6 +377,12 @@ class ActorPackActivationService:
         cancel_requested: Callable[[], bool],
         published: list[_PublishedFile],
     ) -> _PreparedSharedVisual | None:
+        # Deferred: see the TASK-21200 note at the top of this module.
+        from tldw_chatbook.Character_Chat.visual_identity import (
+            compute_pack_content_sha256,
+            validate_visual_identity_manifest,
+        )
+
         if not sections:
             return None
         if len(sections) != 1 or sections[0].kind != "shared-visual-identity":

--- a/tldw_chatbook/Actor_Packs/export.py
+++ b/tldw_chatbook/Actor_Packs/export.py
@@ -11,28 +11,25 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 from tldw_chatbook import __version__
 
 from tldw_chatbook.Character_Chat.local_character_persona_service import (
     LocalCharacterPersonaService,
 )
-from tldw_chatbook.Character_Chat.visual_identity import (
-    compute_pack_content_sha256,
-    load_visual_identity_asset,
-    parse_visual_identity_manifest_json,
-)
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 from tldw_chatbook.DB.VisualIdentity_DB import VisualIdentityRepository
-from tldw_chatbook.Persona_Visual.assets import (
-    PersonaVisualAssetError,
-    PersonaVisualAssetMetadata,
-    load_persona_visual_asset,
-)
-from tldw_chatbook.Persona_Visual.repository import (
-    PersonaVisualRepository,
-)
+
+# TASK-21200: ``Persona_Visual.*`` and ``Character_Chat.visual_identity``
+# (module-level ``from PIL import Image``) are imported inside the two capture
+# functions that need them, never at module scope. ``app.py`` imports this module
+# at module scope, so a module-level import here puts PIL and most of
+# Persona_Visual back on the ``import tldw_chatbook.app`` path -- the exact
+# TASK-21103 regression this module re-introduced. Guarded by
+# ``Tests/Packaging/test_persona_buddy_import_closure.py``.
+if TYPE_CHECKING:  # pragma: no cover - typing only, never executed at runtime
+    from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
 
 from .contracts import (
     ActorPackValidationError,
@@ -245,6 +242,13 @@ class ActorPackExportService:
     def _capture_persona_visual(
         self, actor_kind: str, actor_id: int | str
     ) -> ActorPackExportSection | None:
+        # Deferred: see the TASK-21200 note at the top of this module.
+        from tldw_chatbook.Persona_Visual.assets import (
+            PersonaVisualAssetError,
+            PersonaVisualAssetMetadata,
+            load_persona_visual_asset,
+        )
+
         if actor_kind != "persona" or self.persona_visual_repository is None:
             return None
         try:
@@ -313,6 +317,13 @@ class ActorPackExportService:
     def _capture_shared_visual(
         self, actor_kind: str, actor_id: int | str
     ) -> ActorPackExportSection | None:
+        # Deferred: see the TASK-21200 note at the top of this module.
+        from tldw_chatbook.Character_Chat.visual_identity import (
+            compute_pack_content_sha256,
+            load_visual_identity_asset,
+            parse_visual_identity_manifest_json,
+        )
+
         if self.visual_identity_repository is None:
             return None
         try:

--- a/tldw_chatbook/Actor_Packs/importer.py
+++ b/tldw_chatbook/Actor_Packs/importer.py
@@ -19,16 +19,17 @@ from uuid import uuid4
 from tldw_chatbook.Character_Chat.local_character_persona_service import (
     LocalCharacterPersonaService,
 )
-from tldw_chatbook.Character_Chat.visual_identity import (
-    validate_visual_identity_manifest,
-)
 from tldw_chatbook.DB.VisualIdentity_DB import VisualIdentityRepository
-from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
-from tldw_chatbook.Persona_Visual.validation import (
-    validate_persona_visual_manifest,
-)
 from tldw_chatbook.Utils.private_paths import secure_private_directory
 from tldw_chatbook.Utils.path_validation import validate_path
+
+# TASK-21200: ``Persona_Visual.*`` and ``Character_Chat.visual_identity``
+# (module-level ``from PIL import Image``) are imported inside the two functions
+# that need them, never at module scope. ``app.py`` imports this module at module
+# scope, so a module-level import here puts PIL and most of Persona_Visual back on
+# the ``import tldw_chatbook.app`` path -- the exact TASK-21103 regression this
+# module re-introduced. Guarded by
+# ``Tests/Packaging/test_persona_buddy_import_closure.py``.
 
 from .contracts import (
     MAX_FILES,
@@ -655,6 +656,9 @@ class ActorPackImportService:
     def _visual_authorities(
         self, identity: Any | None
     ) -> tuple[tuple[Any, ...] | None, tuple[Any, ...] | None]:
+        # Deferred: see the TASK-21200 note at the top of this module.
+        from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
+
         if identity is None:
             return None, None
         shared_graph = VisualIdentityRepository(
@@ -1090,6 +1094,14 @@ def _validate_sections(
     archive_members: frozenset[str],
     read_member: Callable[[str], bytes],
 ) -> tuple[tuple[str, tuple[_ActorPackSectionAsset, ...]], ...]:
+    # Deferred: see the TASK-21200 note at the top of this module.
+    from tldw_chatbook.Character_Chat.visual_identity import (
+        validate_visual_identity_manifest,
+    )
+    from tldw_chatbook.Persona_Visual.validation import (
+        validate_persona_visual_manifest,
+    )
+
     validated: list[tuple[str, tuple[_ActorPackSectionAsset, ...]]] = []
     for section in sections:
         manifest_bytes = read_member(section.manifest_path)


### PR DESCRIPTION
## Summary

`Tests/Packaging/test_persona_buddy_import_closure.py::test_app_import_does_not_execute_persona_visual_or_pil` — the guard TASK-21103 shipped — was **red on dev**. Actor Pack work merged from a branch authored before that guard existed (`a160bbe83`, `ac1037732`, `a98f3c14d`; merged `ae817fefe` at 09:20, guard merged `6c0abdba7` at 01:56, never rebased) re-imported `Persona_Visual.*` and `Character_Chat.visual_identity` (→ PIL) at module scope. CI was not yet enforcing checks, so it merged green.

## Fix

Function-local imports at the **source**: 6 statements across the 6 consuming functions in `activation.py`, `export.py` and `importer.py`, plus one TYPE_CHECKING import for an annotation. `Actor_Packs/__init__.py` and `app.py` are untouched.

Two tempting alternatives were rejected on evidence: a PEP-562 facade on the package init **would not have fixed it** (app.py imports the submodules directly, so the init's laziness is irrelevant); deferring app.py's imports into `_wire_character_persona_services` **would have turned the guard green while boot stayed slow**, since that method runs from `TldwCli.__init__`.

## Evidence

- **15 forbidden modules → 0** (10 PIL + 5 Persona_Visual); `sys.modules` 1700 → 1684; min wall 0.741 → 0.707 s over 5 runs each vs a clean baseline worktree. (The review's 1.28 s PIL figure was a slower floor machine with cold PIL — the residency delta is the robust claim; the timing one is not inflated.)
- Name parity **33/33**, each verified `is`-identical against a direct submodule import, with the baseline surface read from `git show HEAD:` so a silently shrunken surface can't pass.
- Circular-unmask probe **16/16 clean** (each submodule first-and-alone, package-first, reverse-init, heavy-dep-first both directions) — the trap that produced TASK-21160.
- AST scope proof 14/14; guard **mutation-tested** (re-adding one module-level import reddens both guards and prints the chain).
- Both closure guards now install a chain tracer and print the offending import chain plus "defer at the last `tldw_chatbook` module in the chain"; a new guard pins the property at the source per module.
- Actor_Packs 211 passed, Tests/App 178 passed, collect-only byte-identical to baseline; two pre-existing reds A/B-confirmed at `7969089c3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `PIL` and `Persona_Visual` out of the app import closure by deferring their imports inside `Actor_Packs` modules. Previously, `activation.py`, `export.py`, and `importer.py` imported these at module scope, so `import tldw_chatbook.app` executed heavy code; now imports are function-local or `TYPE_CHECKING`, restoring the TASK-21103 guard and closing TASK-21200.

- Changes: moved six imports into their consuming functions and added one `TYPE_CHECKING` import; no changes to `Actor_Packs/__init__.py` or `app.py`. Public surface is unchanged.
- Tests/guarding: `Tests/Packaging/test_persona_buddy_import_closure.py` now installs a chain tracer and adds a source-level guard that imports `Actor_Packs.activation`/`export`/`importer` directly and prints offending chains. Reintroducing any module-level heavy import turns the guards red.
- Validation: forbidden modules in the app import path drop from 15 to 0; `sys.modules` count decreases; 33/33 public names remain identical; 16 import orderings clean (no cycles).
- Rollout: no migrations. CI will enforce the guard.

<sup>Written for commit c041a7f16ca5f7d02d8d3a227477bf5e84c53fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

