### PR TITLE
feat(console): add per-chat private scratch spaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Key sections:
 - `Agents/tool_catalog.py` is the provider seam: builtin/local/skill/MCP providers register with one `ToolCatalogRegistry`
 - Local fs_* tools (fs_list/fs_read/fs_write/fs_edit/fs_glob/fs_grep) in `Tools/local_tool_impls.py`, exposed via `Agents/local_tool_provider.py`
 - Approvals flow through the MCP permission store; local tools sit under the `local:__local__` hub
-- Config: `[console] local_tools_enabled` / `workspace_root` (fallback confinement root for disabled/legacy project-instruction sessions; empty = app cwd). An enabled session's selected project-instruction binding takes precedence as the tool and instruction authority root.
+- Console file authority: every live Chat gets private temporary scratch. Named Workspaces may add explicit folder bindings; local `fs_*`/Git uses scratch unless project instructions explicitly select one binding. `[console] workspace_root` is compatibility-only outside this Console path and never grants a Console Chat access.
 
 ### Console Project Instructions
 - `AGENTS.override.md` / `AGENTS.md` startup and lazy nested guidance is untrusted, ephemeral user context bounded by one selected local-filesystem binding; it never grants tool permission.

--- a/Docs/UAT/2026-08-23-console-deepseek-private-scratch.md
+++ b/Docs/UAT/2026-08-23-console-deepseek-private-scratch.md
@@ -1,0 +1,70 @@
+# Console DeepSeek private-scratch UAT
+
+Date: 2026-08-23  
+Task: TASK-21161  
+Provider: DeepSeek (`deepseek-chat`)
+
+## Claim under test
+
+Ordinary Console Chats must send without a folder, receive only one private
+temporary file sandbox per live chat, and never recover another chat's files.
+Named Workspaces retain the same private scratch space and may additionally
+reach only folders the user explicitly binds. Closing and reopening a saved
+conversation must create fresh scratch authority. The run must not mutate the
+real user configuration.
+
+## Isolation and safety
+
+The app ran with a disposable owner-only profile, an explicit disposable data
+directory, and a mode-0600 copy of the configured DeepSeek credentials. The
+named Workspace bound a separate disposable owner-only folder. No credential,
+scratch locator, session identifier, or copied config content is recorded in
+this report.
+
+The real config SHA-256 was captured before and after the mounted app lifecycle:
+
+```text
+before 4b4a5c250ad439952eea04e41041b2ca576ceb18505ce72ea228bd967ec8315b
+after  4b4a5c250ad439952eea04e41041b2ca576ceb18505ce72ea228bd967ec8315b
+```
+
+The two disposable profiles and bound-folder fixture were deleted after the
+hash comparison.
+
+## Observed scenarios
+
+| Scenario | Live observation | Result |
+| --- | --- | --- |
+| New ordinary Chat | Default Chat mounted and sent a plain DeepSeek prompt without selecting a folder or opening folder setup. | Pass |
+| Private scratch read/write | Chat A used approved `fs_write` and `fs_read` calls against a relative marker in its private scratch directory. | Pass |
+| Concurrent-chat isolation | Chat B received approval for `fs_read` of Chat A's relative marker; the tool reported it missing and DeepSeek returned the expected isolation marker. | Pass |
+| Close and reopen | Chat A was closed, the saved conversation was reopened, and the former relative marker could no longer be read. | Pass |
+| Named Workspace access | A Workspace with one explicit read/write folder binding used approved built-in `read_file` and `write_file` calls; the seeded content and exact written canary were independently verified on disk. | Pass |
+| Chat cannot read Workspace | Back in Default Chat, the approval card warned that the bound-folder path was outside allowed folders; approving once still produced a failed `read_file`, and DeepSeek returned the expected denial marker. | Pass |
+| Visible authority copy | The Details section identified Default Chat file authority as private scratch; named Workspace selection remained distinct from Chats. | Pass with polish fix |
+
+## Issues found and addressed
+
+1. **Folderless sends were blocked by optional project-instruction setup.** An
+   unselected session with no eligible binding entered a folder-recovery modal
+   after send. The controller now treats that state as a valid scratch-only
+   session while preserving fail-closed recovery for a previously selected
+   binding that disappears or changes.
+2. **Workspace creation copy contradicted the scratch model.** It said an agent
+   had no file access without a bound folder. The explainer now states that
+   every chat has private scratch and that Workspace folder access is optional.
+3. **The narrow Details rail clipped the security-relevant value.** Live output
+   painted `Private scratch` as `Priva…`. The rendered label is now the concise
+   `Local files`, leaving the full authority value visible; the underlying
+   detailed status remains unchanged.
+
+The first issue was fixed before the complete scenario matrix was rerun. The
+copy and narrow-rail polish are also pinned by targeted mounted-widget tests.
+
+## Automated evidence
+
+The implementation was verified with targeted authority, lifecycle, retained
+artifact, Console UI, and project-instruction suites. The final command set and
+pass counts are recorded in TASK-21161's implementation notes. No full
+repository sweep was run, in accordance with repository policy.
+

--- a/Docs/UAT/2026-08-23-console-deepseek-private-scratch.md
+++ b/Docs/UAT/2026-08-23-console-deepseek-private-scratch.md
@@ -1,8 +1,20 @@
 # Console DeepSeek private-scratch UAT
 
-Date: 2026-08-23  
-Task: TASK-21161  
+Date: 2026-08-23
+Task: TASK-21161
 Provider: DeepSeek (`deepseek-chat`)
+
+## Execution metadata
+
+- Live terminal: 180 columns × 55 rows.
+- Live branch: `codex/console-per-chat-sandbox`.
+- Live code: `6c6844290b498c05f88bfdfd65cd72fcab2badcb`, based on the
+  then-current `origin/dev` commit
+  `ae817fefed519921d7da5047e22634756337fc34`.
+- Final integration base: the branch was subsequently rebased cleanly onto
+  latest `origin/dev` at `be0a1694696b7b2296dcb79017696dd79c56f677`.
+  The intervening upstream changes did not overlap the Console implementation;
+  fresh post-rebase targeted gates are recorded below.
 
 ## Claim under test
 
@@ -57,14 +69,35 @@ hash comparison.
    painted `Private scratch` as `Priva…`. The rendered label is now the concise
    `Local files`, leaving the full authority value visible; the underlying
    detailed status remains unchanged.
+4. **Private scratch locators could enter tool results and run logs.** An
+   independent code review traced absolute scratch-owned paths from built-in
+   success results and local `fs_*` errors into model history and persisted
+   tool-result records. Both provider boundaries now convert only the private
+   scratch locator to relative text before those shared sinks. Explicit
+   Workspace folder paths retain their existing behavior. Success, error, and
+   real run-log regressions pin the boundary.
+5. **The Workspace-create modal's legacy test harness omitted production
+   CSS.** A broad UI pass found ten off-screen Pilot clicks. Untouched latest
+   `dev` reproduced the same ten failures. Widening the screen moved the
+   controls farther out, identifying missing layout CSS rather than a narrow
+   terminal defect. Mounting `WorkspaceCreateModal.BUNDLED_CSS` restored the
+   real geometry and all 23 modal tests pass.
 
 The first issue was fixed before the complete scenario matrix was rerun. The
 copy and narrow-rail polish are also pinned by targeted mounted-widget tests.
 
 ## Automated evidence
 
-The implementation was verified with targeted authority, lifecycle, retained
-artifact, Console UI, and project-instruction suites. The final command set and
-pass counts are recorded in TASK-21161's implementation notes. No full
-repository sweep was run, in accordance with repository policy.
+On the final latest-`dev` base:
 
+- 388 authority, lifecycle, provider, project-instruction, run-log, and
+  retained-skill tests passed.
+- The broad affected UI-module diagnostic reached 576 passes and the ten
+  pre-existing modal-harness failures described above. Untouched latest `dev`
+  reproduced those failures at 10 failed / 12 passed; after loading the
+  production modal CSS, the complete branch modal module passed 23 / 23.
+- The final focused mounted Console/Workspace UI gate passed 56 / 56.
+- Ruff and Python compile checks passed for every changed Python file;
+  `git diff --check` and the diff secret-pattern scan were clean.
+
+No full repository sweep was run, in accordance with repository policy.

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -96,8 +96,9 @@ appears above the transcript:
 - Watch the badges on a row's header: **(definition changed)** means the
   tool's definition differs from what you previously approved; **(high risk)**
   flags reads that could exfiltrate file contents; and a path warning —
-  "path outside allowed folders; will fail even if approved" — means the file
-  path will be rejected regardless of your decision.
+  "path outside private scratch and bound Workspace folders; will fail even
+  if approved" — means the file path will be rejected regardless of your
+  decision.
 
 An armed approval card does not expire — the run waits for your decision
 however long you take. Stopping the run or closing the session withdraws a
@@ -995,6 +996,36 @@ in a conversation you were not watching, that session's tab shows the
 finished-and-unvisited `✓` instead. Both mean "there is something here
 you haven't seen"; viewing the conversation clears either.
 
+### Local file authority
+
+Every live Console Chat owns an independent private temporary scratch space.
+No folder setup is required. Relative paths used by Chatbook's built-in file
+tools and local `fs_*`/Git tools resolve in that Chat's scratch space unless a
+named Workspace explicitly adds authority:
+
+| Console context | Built-in file tools | Local `fs_*` / Git |
+|---|---|---|
+| Chat in Default | Private scratch only | Private scratch only |
+| Named Workspace, no selected project folder | Private scratch plus live explicit folder bindings | Private scratch only |
+| Named Workspace, selected project folder | Private scratch plus live explicit folder bindings | The selected binding only |
+
+Workspace folders are optional and start read-only. Approval still applies:
+path confinement cannot turn Ask into Allow, bypass a tool kill switch, expose
+a protected credential path, or make a read-only binding writable. A denial
+outside every allowed root says that Chats do not need a folder and points to a
+named Workspace only when access to that external folder is intended.
+
+Scratch belongs to the live tab, not the saved conversation. Two tabs for the
+same conversation have different scratch spaces; closing and reopening starts
+empty. Retained skill-script output and fallback agent run logs stay with the
+owning Chat's scratch instead of a shared container. Normal cleanup is
+best-effort deletion, not secure erase. A hard crash can leave unreferenced OS
+temporary residue, but a later process never discovers or attaches it.
+
+This boundary describes Chatbook-managed local tools only. Attachments,
+Library/RAG content, generated media, provider-hosted tools, and external MCP
+servers keep their own storage and authority contracts.
+
 ### Project instructions before tools run
 
 When project instructions are enabled for a session, Chatbook treats the
@@ -1044,7 +1075,9 @@ appears above the transcript:
 - **Skill script** — "An agent wants to run a script from a skill:" with the
   target and arguments, buttons **Allow once** / **Always allow this skill** /
   **Deny**, and the note: "It runs with a scrubbed environment in a temporary
-  folder (not the skill's own folder); only its output comes back."
+  folder (not the skill's own folder); only its output comes back." Files the
+  script intentionally produces are retained inside the owning Chat's private
+  scratch space for that live session.
 
 ### MCP tools
 
@@ -1052,18 +1085,21 @@ Servers you configure on the [MCP screen](../mcp.md) 🚧 surface in Console as
 extra tools the agent can call. The Inspector's **MCP** row (under Tools)
 shows their state: "N tools ready", or "N servers enabled, not connected" when
 servers are configured but unreachable. MCP tool calls go through the same
-"Approval required" card as everything else.
+"Approval required" card as everything else. An external MCP server is not
+confined by the Chatbook-local scratch boundary unless that server implements
+an equivalent boundary itself; review its arguments and permission policy.
 
 ### Web research tools
 
 Console's standard web tools are `web_search` (find links), `web_fetch`
 (extract one URL), and `web_crawl` (bounded same-host crawl). They are local
 agent tools, not tools supplied by an external MCP server. They are registered
-by default. Configure the master switch and confinement directory in **MCP →
-Tools → Local workspace, web, and Watchlists tools**, then choose Allow, Ask, or Off for each
-tool in MCP Permissions. Master/root changes apply to the next Console agent
-run. `[mcp] expose_local_tools` is only for external MCP clients and does not
-enable these tools in Console.
+by default. Configure their master switch in **MCP → Tools → Local workspace,
+web, and Watchlists tools**, then choose Allow, Ask, or Off for each tool in MCP
+Permissions. Console file authority comes from the Chat's private scratch plus
+explicit Workspace bindings, not a global confinement-directory field.
+`[mcp] expose_local_tools` is only for external MCP clients and does not enable
+these tools in Console.
 
 Web-tool results are ephemeral. To persist a page in Library, use **Library →
 Import…** and submit its URL; Console does not advertise the retired
@@ -1710,19 +1746,15 @@ without which `diff.external` rendered `TOTALLY FABRICATED DIFF OUTPUT`
 and a constant-output textconv driver rendered 0 bytes for a file the
 same read counted as `1 1`. One correction against this task's own brief: the
 brief described the live workspace root as driven by `[console]
-workspace_root`; on a real mounted Console session that config key is
-NOT what feeds `current` mode's live candidate root — the wired
-`_turn_context_provider`
-(`UI/Console_Modules/session.py`'s `_build_console_turn_execution_context`)
-derives it from the conversation's WORKSPACE folder bindings instead
-(`Tools/workspace_file_roots.py`'s `folder_binding_roots`), the same
-roots the change-tracker itself tracks a turn's writes against; the
-`[console] workspace_root`-only fallback in
-`Chat/console_chat_controller.py`'s `resolve_turn_execution_context`
-only runs for a controller built without that override, which a
-mounted `ChatScreen` never is. This page describes the folder-binding
-source; see [Sessions, tabs & workspaces](sessions-tabs-workspaces.md)
-for where those bindings are set. One thing this pass could NOT verify:
+workspace_root`; that config key is not Console authority. The mounted
+Console derives external roots from the conversation's explicit Workspace
+folder bindings (`Tools/workspace_file_roots.py`'s `folder_binding_roots`),
+and ADR-081 later removed the compatibility controller's config/cwd fallback
+as well: every Console Chat now starts from private scratch. This page
+describes that current authority source; see
+[Sessions, tabs & workspaces](sessions-tabs-workspaces.md) for where folders
+are optionally bound. One
+thing this pass could NOT verify:
 whether `current` mode is reachable at all from a conversation on the
 **Default** workspace, since `Workspaces/registry_service.py` refuses
 runtime bindings ("Default workspace does not allow runtime bindings")

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -1749,7 +1749,7 @@ brief described the live workspace root as driven by `[console]
 workspace_root`; that config key is not Console authority. The mounted
 Console derives external roots from the conversation's explicit Workspace
 folder bindings (`Tools/workspace_file_roots.py`'s `folder_binding_roots`),
-and ADR-081 later removed the compatibility controller's config/cwd fallback
+and ADR-082 later removed the compatibility controller's config/cwd fallback
 as well: every Console Chat now starts from private scratch. This page
 describes that current authority source; see
 [Sessions, tabs & workspaces](sessions-tabs-workspaces.md) for where folders

--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -58,7 +58,7 @@ plus a secondary line of `<workspace> - <state> - <age>` (for example
 "Chats - active session - 1m"), and ends with a star toggle ("☆" / "★").
 
 **Details section** (left rail, collapsed by default). Status lines for
-"Storage", "Sync", "File tools", "Server", and "ACP", plus a "Handoff" list.
+"Storage", "Sync", "Local file tools", "Server", and "ACP", plus a "Handoff" list.
 On a local-only setup the server lines collapse into one line:
 "Server features (sync, handoff, ACP): not configured. Chats stay local."
 
@@ -141,18 +141,34 @@ Alt+W.
 
 ### Session project folders
 
+Every live Console Chat starts with its own private temporary scratch space.
+Creating or sending a Chat never asks for a folder. Relative local file-tool
+paths use that scratch space, and closing then reopening a saved conversation
+starts with a new empty scratch space. Scratch is removed with ordinary
+best-effort deletion; it is not secure erase, and a hard process or OS crash
+can leave unreferenced temporary residue that later Chatbook processes never
+discover or attach.
+
+A named Workspace may add explicit folder bindings to its Chat's private
+scratch authority. Folders are optional: a Workspace without one still works
+with scratch only. Built-in file tools can use private scratch plus the
+Workspace's live bound folders. Local `fs_*` and Git tools use private scratch
+unless project instructions explicitly select one binding; that selected
+binding then remains their single working root and keeps its read-only or
+read-write guard.
+
 Project instructions are local per-session state. A new session starts
 enabled and asks you to choose when more than one eligible local-filesystem
 binding exists; exactly one eligible binding may be selected. That binding is
-both the instruction authority root and the working directory for local and
-built-in file/git tools. Chatbook never searches global or personal
+both the instruction authority root and the working directory for local
+`fs_*` and Git tools. Chatbook never searches global or personal
 instruction files and never ascends above the selected root.
 
-Legacy sessions and sessions where project instructions are disabled keep the
-older local-tool behavior: `[console] workspace_root` is the confinement root,
-or the app's startup working directory when it is empty. A selected
-project-instruction binding takes precedence over that fallback only while the
-feature is enabled for that session. Bindings marked read-only expose only
+When project instructions are disabled or no project folder is selected, local
+`fs_*` and Git tools return to this Chat's private scratch space. The legacy
+`[console] workspace_root` setting remains available to non-Console callers;
+it never grants a Console Chat access, and Console does not fall back to the
+app's startup working directory. Bindings marked read-only expose only
 read-capable tools. Folder names and instruction contents are not synchronized;
 the local control fields stay with the local conversation record.
 
@@ -166,11 +182,15 @@ the file that records which tools you approved.
 ### Details
 
 Open the "Details" header in the left rail to see where your chats live:
-"Storage" (local database status), "Sync", "File tools", "Server", and "ACP"
+"Storage" (local database status), "Sync", "Local file tools", "Server", and "ACP"
 lines (for example "Sync: Off", "Server: Not configured"), and a "Handoff"
 list that reads "No handoff package is ready." until a handoff package
 exists. If none of the server features are configured, the section shows the
 single summary line quoted in the layout tour instead.
+
+For Chats, the file row reads **Private scratch**. A named Workspace with live
+folder bindings reads **Private scratch + N folders**. A missing binding is
+reported separately instead of making the scratch status look unavailable.
 
 ## Common tasks
 
@@ -181,6 +201,10 @@ single summary line quoted in the layout tour instead.
    reply runs independently of the other tab.
 3. Switch back with Alt+1 (or click the first tab). A ● marker on the other
    tab means its run is still going; ✓ means it finished while you were away.
+
+Each tab's private scratch is independent. A relative file created in one Chat
+is absent from the other, even when both tabs resume the same saved
+conversation.
 
 **Rename a tab**
 
@@ -267,6 +291,8 @@ nothing is created, no matter what you had typed or added.
 - A brand-new conversation can't be starred until it has been sent or saved —
   the star's tooltip says "Send or save this conversation before starring."
 - The Default workspace can't be renamed or archived.
+- Chats never require a folder. Use a named Workspace only when local file
+  tools need access outside private scratch.
 - Launching the app from inside a project with a `.SKILLS/` folder can pop
   its own import prompt on startup, separately from anything workspace- or
   tab-related — see [Project skills](../library/skills.md#project-skills-skills).

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -386,6 +386,12 @@ annotated "— contains N project skill(s)" in the list, and creation is
 followed by a chained import prompt for it — see
 [Project skills](library/skills.md#project-skills-skills).
 
+Folders are optional. Every Console Chat already has an independent private
+temporary scratch space; a named Workspace with no folders remains fully usable
+in scratch-only mode. Bind a folder only to let local file tools reach that
+external directory. `[console] workspace_root` is retained for compatibility
+outside this Console authority path and never grants a Console Chat access.
+
 | Control | What it does |
 |---|---|
 | **Rename** | Renames the selected workspace (the box above it is pre-filled). |
@@ -395,9 +401,9 @@ followed by a chained import prompt for it — see
 | **Add folder** / **Remove** | Bind a folder for agent file tools (new bindings are read-only), or unbind it. |
 | **Allow write** / **Read-only** | Flips a bound folder's access; the button is labelled with the state you would move to. |
 
-The built-in **Default** workspace has no controls at all: "The built-in Default
-workspace keeps its identity and stays tool-less; create a workspace to bind
-folders."
+The built-in **Default** workspace has no controls at all: "Chats in the
+built-in Default workspace use private scratch. Create a named Workspace only
+to bind external folders."
 
 ### Data & Privacy — Privacy & Security
 
@@ -546,14 +552,14 @@ a note on what would have to exist before Settings could own a default.
    saved paths." Move the file yourself, then restart: until you do, the app
    keeps using the old one, which is what **Active files (resolved this
    session)** is showing you.
-5. **Create a workspace and give an agent a folder.** Open **Workspaces** and
+5. **Create a workspace and optionally give an agent a folder.** Open **Workspaces** and
    press **Create workspace…**. In the dialog, keep the prefilled name (or
-   type your own), enter a folder path and press **Add folder** — it is
-   validated and bound read-only — then leave "Switch to this workspace"
-   checked and press **Create**; the new workspace is created, bound, and
-   activated in one step. Click the new workspace's row to open its card,
-   then press **Allow write** on the folder's row if the agent needs to
-   write. Every step applies immediately; nothing to save.
+   type your own). Press **Create** immediately for a scratch-only Workspace,
+   or enter a folder path and press **Add folder** first — it is validated and
+   bound read-only. Leave "Switch to this workspace" checked to activate the
+   new Workspace in the same step. If you added a folder and the agent needs
+   to write there, open the Workspace card and press **Allow write** on that
+   folder's row. Every step applies immediately; nothing to save.
 6. **Repair a configuration you broke.** Open **Diagnostics** and press
    **Validate Config** — the error names the problem, with secrets redacted. Fix
    it in the guided pages if you can. If not, open **Advanced Config**, press

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -68,8 +68,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 16,
-      "diagnostic_digest": "10b283947607979eb8f4",
+      "call_count": 20,
+      "diagnostic_digest": "528c861ee923ba1a23bb",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/run_log.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -243,8 +243,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 47,
-      "diagnostic_digest": "1ddb75a04e1f930c2768",
+      "call_count": 48,
+      "diagnostic_digest": "33db86ed851d32c29757",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -348,10 +348,17 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 8,
-      "diagnostic_digest": "2825aaac9b91d4c3925d",
+      "call_count": 9,
+      "diagnostic_digest": "b392a3658ad70722e616",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_runtime.py",
+      "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "99d3f25bc746abb2733b",
+      "owner": "TASK-492",
+      "path": "tldw_chatbook/Chat/console_scratch_space.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
@@ -2134,7 +2141,7 @@
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "6617ce6c76c5f836ff40",
+      "diagnostic_digest": "6d1577ee8cf698f7fbcd",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/file_operation_tools.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -2176,7 +2183,7 @@
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "6be2107e3d104205c795",
+      "diagnostic_digest": "da85c2e4d69203a1a4aa",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/workspace_file_roots.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -3931,9 +3938,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 532,
+    "owner_files": 533,
     "persistent_sink_files": 8,
-    "task_492_calls": 1233,
-    "task_494_calls": 7290
+    "task_492_calls": 1236,
+    "task_494_calls": 7294
   }
 }

--- a/Docs/superpowers/plans/2026-08-23-console-per-chat-private-scratch-space.md
+++ b/Docs/superpowers/plans/2026-08-23-console-per-chat-private-scratch-space.md
@@ -1,0 +1,885 @@
+# Console Per-Chat Private Scratch Space Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every live Console chat a private temporary filesystem, keep user-folder access exclusive to explicit Workspace bindings, and verify the complete flow with DeepSeek.
+
+**Architecture:** `ConsoleRuntime` owns a thread-safe `ConsoleScratchSpaceManager`; each turn captures an immutable, generation-fenced scratch snapshot and every Chatbook-managed filesystem consumer receives that authority explicitly. Built-in tools use a run-scoped sandbox `ContextVar`, local `fs_*`/Git tools use scratch unless ADR-069 selected a project binding, and retained skill output plus fallback run logs lease the same scratch root. Session close tombstones authority synchronously and a single daemon cleanup worker removes directories only after active leases drain.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, `pathlib`, `tempfile`, `threading`, pytest, real temporary directories, existing DeepSeek provider gateway.
+
+**Spec:** `Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md`
+
+## Global Constraints
+
+- Ordinary Console Chats never require a folder and receive only private scratch authority.
+- Named Workspaces may add only active explicit folder bindings; a folder remains optional.
+- A selected ADR-069 project-instruction binding remains the sole local `fs_*`/Git root and keeps locator-identity and read-only enforcement.
+- Existing Ask/Allow/Off permissions, kill switches, sensitive-path checks, and temporary-conversation write restrictions remain unchanged.
+- Scratch paths contain no session, conversation, title, provider, or user identifier and are never persisted.
+- Scratch directories are real owner-only directories, not symlinks, and stale filesystem identity fails closed.
+- Closing a session revokes new work synchronously; recursive deletion never runs on Textual's event loop and waits for leases.
+- Third-party MCP servers, provider-hosted tools, attachments, Library/RAG data, and generated media retain separate authority contracts.
+- Non-Console callers retain the existing configured global file-tool sandbox behavior.
+- Cleanup is ordinary best-effort deletion, not secure erase; no cumulative per-chat disk quota is added in this task.
+- Targeted tests only; do not run the full repository suite without explicit user approval.
+- ADR required: yes.
+- ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`.
+- Reason: filesystem authority, temporary-data ownership, provider composition, and cross-thread teardown are security and runtime-boundary decisions.
+
+---
+
+### Task 1: Scratch authority manager
+
+**Files:**
+- Create: `tldw_chatbook/Chat/console_scratch_space.py`
+- Create: `Tests/Chat/test_console_scratch_space.py`
+
+**Interfaces:**
+- Consumes: Python `tempfile.mkdtemp`, `os.chmod`, `Path.lstat`, `threading.Condition`, and `shutil.rmtree`.
+- Produces: `ConsoleScratchSnapshot(root: Path, token: str, identity: tuple[int, int])`; `ConsoleScratchSpaceUnavailable`; `ConsoleScratchSpaceManager.snapshot(session_id) -> ConsoleScratchSnapshot`; `lease(snapshot) -> ContextManager[Path]`; `is_live(snapshot) -> bool`; `close(session_id) -> None`; `tombstone_all() -> None`; `wait_for_cleanup(timeout_seconds) -> bool`; `dispose(timeout_seconds=2.0) -> bool`.
+
+- [ ] **Step 1: Write allocation and isolation tests**
+
+```python
+def test_snapshots_are_distinct_owner_only_and_identifier_free(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    first = manager.snapshot("session-visible-id-a")
+    second = manager.snapshot("session-visible-id-b")
+    assert first.root != second.root
+    assert "session-visible-id" not in first.root.name
+    assert stat.S_IMODE(first.root.stat().st_mode) == 0o700
+    assert not first.root.is_symlink()
+
+
+def test_chat_cannot_lease_another_chat_snapshot(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    first = manager.snapshot("a")
+    second = manager.snapshot("b")
+    with manager.lease(first) as root:
+        (root / "marker.txt").write_text("a", encoding="utf-8")
+    assert not (second.root / "marker.txt").exists()
+```
+
+- [ ] **Step 2: Run the allocation tests and confirm they fail**
+
+Run: `.venv/bin/python -m pytest Tests/Chat/test_console_scratch_space.py -k 'snapshots_are_distinct or cannot_lease' -v`
+
+Expected: collection fails because `tldw_chatbook.Chat.console_scratch_space` does not exist.
+
+- [ ] **Step 3: Add the immutable snapshot, record, allocation, and lease skeleton**
+
+```python
+@dataclass(frozen=True, slots=True)
+class ConsoleScratchSnapshot:
+    root: Path
+    token: str
+    identity: tuple[int, int]
+
+
+class ConsoleScratchSpaceUnavailable(RuntimeError):
+    pass
+
+
+class ConsoleScratchSpaceManager:
+    def snapshot(self, session_id: str) -> ConsoleScratchSnapshot:
+        # Under the condition lock, reuse a live record or create a random
+        # mkdtemp directory, chmod 0700, lstat it, and index it by opaque token.
+
+    @contextmanager
+    def lease(self, snapshot: ConsoleScratchSnapshot) -> Iterator[Path]:
+        # Match token/root/device/inode, reject tombstones, increment the
+        # lease count, yield the root, and decrement in finally.
+```
+
+The concrete implementation must compare `(st_dev, st_ino)` at every lease acquisition. A missing, symlinked, or replaced root is tombstoned and rejected; cleanup must never recursively delete a replacement whose identity does not match the created directory.
+
+- [ ] **Step 4: Run the allocation tests and confirm they pass**
+
+Run: `.venv/bin/python -m pytest Tests/Chat/test_console_scratch_space.py -k 'snapshots_are_distinct or cannot_lease' -v`
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Write lifecycle, stale-generation, and cleanup-thread tests**
+
+```python
+def test_close_rejects_new_lease_and_waits_for_last_active_lease(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("a")
+    lease = manager.lease(snapshot)
+    lease.__enter__()
+    manager.close("a")
+    with pytest.raises(ConsoleScratchSpaceUnavailable):
+        with manager.lease(snapshot):
+            pass
+    assert snapshot.root.exists()
+    lease.__exit__(None, None, None)
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    assert not snapshot.root.exists()
+
+
+def test_reopen_gets_new_generation_and_empty_root(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    old = manager.snapshot("session")
+    (old.root / "marker").write_text("old", encoding="utf-8")
+    manager.close("session")
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    fresh = manager.snapshot("session")
+    assert fresh.token != old.token
+    assert fresh.root != old.root
+    assert not (fresh.root / "marker").exists()
+```
+
+Also test idempotent `close`/`dispose`, cleanup failure remaining tombstoned, filesystem identity replacement refusing a lease without deleting the replacement, and `dispose(timeout_seconds=0.01)` returning `False` while an active lease remains.
+
+- [ ] **Step 6: Implement the single daemon cleanup worker and bounded disposal**
+
+```python
+def close(self, session_id: str) -> None:
+    with self._condition:
+        record = self._by_session.pop(str(session_id), None)
+        if record is None:
+            return
+        record.tombstoned = True
+        if record.leases == 0:
+            self._schedule_cleanup_locked(record)
+
+
+def dispose(self, timeout_seconds: float = 2.0) -> bool:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    self.tombstone_all()
+    with self._condition:
+        while self._records and time.monotonic() < deadline:
+            self._condition.wait(deadline - time.monotonic())
+        return not self._records
+```
+
+`tombstone_all` sets `_disposed`, revokes every live record, and schedules zero-lease records while holding the condition; it performs no recursive I/O. The worker is capped at one daemon thread, logs only bounded failure categories and opaque tokens, removes a record after successful deletion or a confirmed already-missing root, and leaves a failed record tombstoned for a later `dispose` retry.
+
+- [ ] **Step 7: Run the complete manager suite**
+
+Run: `.venv/bin/python -m pytest Tests/Chat/test_console_scratch_space.py -v`
+
+Expected: all tests pass and no scratch directory owned by a completed test remains under `tmp_path`.
+
+- [ ] **Step 8: Commit the manager**
+
+```bash
+git add tldw_chatbook/Chat/console_scratch_space.py Tests/Chat/test_console_scratch_space.py
+git commit -m "feat(console): add private scratch authority manager"
+```
+
+---
+
+### Task 2: Runtime ownership, turn snapshots, and session lifecycle
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_turn_context.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/UI/test_console_runtime_ownership.py`
+- Modify: `Tests/Chat/test_console_turn_execution_context.py`
+- Modify: `Tests/Chat/test_console_agent_swap.py`
+
+**Interfaces:**
+- Consumes: Task 1's `ConsoleScratchSpaceManager` and `ConsoleScratchSnapshot`.
+- Produces: `ConsoleRuntime.scratch_spaces`; `ConsoleTurnExecutionContext.scratch_space`; a `scratch_spaces: ConsoleScratchSpaceManager | None = None` keyword on `ConsoleChatController.__init__`; a `scratch_snapshot_provider: Callable[[str], ConsoleScratchSnapshot]` dependency on `ConsoleSessionController`; close-before-store-removal and app-disposal cleanup.
+
+- [ ] **Step 1: Write failing runtime and turn-context tests**
+
+```python
+def test_runtime_reuses_one_scratch_manager_across_console_visits(app) -> None:
+    runtime = ConsoleRuntime(app)
+    first = runtime.scratch_spaces
+    runtime.detach_view(None)
+    assert runtime.scratch_spaces is first
+
+
+def test_turn_context_captures_frozen_scratch_snapshot(controller, scratch_manager) -> None:
+    context = controller.resolve_turn_execution_context("session-a")
+    assert context.scratch_space == scratch_manager.snapshot("session-a")
+    assert context.scratch_space.root.is_dir()
+```
+
+Extend `test_session_builder_captures_roots_rag_tools_and_generation` with a fake `scratch_snapshot_provider` and assert the mounted-session builder captured that exact immutable snapshot. Add an async runtime-disposal test proving cleanup is invoked through `asyncio.to_thread`, a navigation test proving `leave_console` preserves the root, a same-saved-conversation/two-live-sessions test proving their roots differ, and a controller close test proving `scratch_spaces.close(session_id)` occurs before `store.close_session(session_id)`.
+
+- [ ] **Step 2: Run the lifecycle tests and confirm they fail**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_runtime_ownership.py Tests/Chat/test_console_turn_execution_context.py Tests/Chat/test_console_agent_swap.py -k 'scratch or close_session_tombstones' -v`
+
+Expected: failures report missing `scratch_spaces`/`scratch_space` interfaces.
+
+- [ ] **Step 3: Wire the manager through runtime and controller**
+
+```python
+class ConsoleRuntime:
+    def __init__(self, app: Any) -> None:
+        self._scratch_spaces = ConsoleScratchSpaceManager()
+
+    @property
+    def scratch_spaces(self) -> ConsoleScratchSpaceManager:
+        return self._scratch_spaces
+
+    def ensure_chat_controller(self, **kwargs: Any) -> ConsoleChatController:
+        if self._chat_controller is not None or self._disposed:
+            return self._chat_controller
+        from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+
+        kwargs.setdefault("scratch_spaces", self._scratch_spaces)
+        self._chat_controller = ConsoleChatController(**kwargs)
+        self._bind_view_hooks()
+        return self._chat_controller
+```
+
+`ConsoleChatController` accepts an optional manager for compatibility with direct tests, records whether it owns that fallback manager, and never stores scratch paths in `ConsoleChatStore` or session metadata.
+
+- [ ] **Step 4: Add the scratch snapshot to detached turn context**
+
+```python
+@dataclass(frozen=True, slots=True)
+class ConsoleTurnExecutionContext:
+    session_id: str
+    provider_selection: ConsoleProviderSelection
+    scratch_space: ConsoleScratchSnapshot | None = None
+    session_settings: ConsoleSessionSettings | None = None
+    workspace_roots: tuple[str, ...] = ()
+    capabilities: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    rag_defaults: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    tool_configuration: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    provider_payload_settings: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+```
+
+Add the exact keyword `scratch_space=self._scratch_spaces.snapshot(session_id)` to the fallback `ConsoleTurnExecutionContext.capture` call in `ConsoleChatController.resolve_turn_execution_context`. Set that fallback's `workspace_roots=()` and remove its `[console] workspace_root` value from `tool_configuration`; it has no Workspace registry authority and must not feed the change-review root scanner. The snapshot is already immutable and must not be deep-copied into a different identity token.
+
+Add `scratch_snapshot_provider` to `ConsoleSessionController.__init__`, store it as `_scratch_snapshot_provider`, and add this keyword to the mounted builder's existing capture call:
+
+```python
+scratch_space=self._scratch_snapshot_provider(session_id),
+```
+
+`ChatScreen` wires the dependency as `lambda session_id: self._console_runtime().scratch_spaces.snapshot(session_id)`. Its existing `folder_binding_roots(workspace_id)` result remains the mounted turn's `workspace_roots`: Default yields no external roots, while named Workspaces yield only explicit bindings.
+
+- [ ] **Step 5: Fence close and disposal in the approved order**
+
+```python
+def close_session(self, session_id: str) -> ConsoleChatSession | None:
+    self._scratch_spaces.close(session_id)
+    self.prompt_queue_coordinator.mark_closing(session_id)
+```
+
+In `ConsoleRuntime.dispose`, call `self._scratch_spaces.tombstone_all()` immediately after setting `_disposed` and before controller shutdown, then insert `await asyncio.to_thread(self._scratch_spaces.dispose)` after controller shutdown and before provider-gateway close. Keep the existing exception containment around app-exit teardown.
+
+Ordinary `ConsoleRuntime.leave_console` remains unchanged and must not close scratch. A controller that created its own compatibility manager disposes it from `shutdown`; a runtime-injected controller leaves final manager disposal to `ConsoleRuntime`.
+
+- [ ] **Step 6: Run lifecycle and context tests**
+
+Run: `.venv/bin/python -m pytest Tests/Chat/test_console_scratch_space.py Tests/UI/test_console_runtime_ownership.py Tests/Chat/test_console_turn_execution_context.py Tests/Chat/test_console_agent_swap.py -k 'scratch or close_session or runtime' -v`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 7: Commit runtime ownership**
+
+```bash
+git add tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_turn_context.py tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_runtime_ownership.py Tests/Chat/test_console_turn_execution_context.py Tests/Chat/test_console_agent_swap.py
+git commit -m "feat(console): bind scratch authority to live sessions"
+```
+
+---
+
+### Task 3: Built-in and local filesystem confinement
+
+**Files:**
+- Modify: `tldw_chatbook/Tools/workspace_file_roots.py`
+- Modify: `tldw_chatbook/Tools/file_operation_tools.py`
+- Modify: `tldw_chatbook/Agents/tool_catalog.py`
+- Modify: `tldw_chatbook/Agents/local_tool_provider.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `Tests/Tools/test_workspace_file_roots.py`
+- Modify: `Tests/Tools/test_file_tools_workspace_roots.py`
+- Modify: `Tests/Agents/test_builtin_provider_workspace_binding.py`
+- Modify: `Tests/Chat/test_console_agent_bridge_local.py`
+- Modify: `Tests/Chat/test_console_local_review_hook.py`
+
+**Interfaces:**
+- Consumes: Task 2's `ConsoleTurnExecutionContext.scratch_space` and controller manager.
+- Produces: `run_file_sandbox(root)` / `current_run_sandbox_root()`; explicit `sandbox_root` and `sandbox_lease` on `BuiltinToolProvider`; optional `authority_scope` on `LocalToolProvider`; Default Chat local root selection with no config/cwd fallback.
+
+- [ ] **Step 1: Write failing run-scoped built-in isolation tests**
+
+```python
+def test_run_file_sandbox_overrides_global_only_inside_scope(tmp_path, monkeypatch) -> None:
+    global_root = tmp_path / "global"
+    scratch = tmp_path / "chat"
+    global_root.mkdir()
+    scratch.mkdir()
+    monkeypatch.setattr(file_tools, "_resolve_sandbox_config", lambda: str(global_root))
+    with run_file_sandbox(scratch):
+        assert file_tools._tool_sandbox_root() == scratch.resolve()
+    assert file_tools._tool_sandbox_root() == global_root.resolve()
+
+
+def test_builtin_provider_cannot_read_another_chat_scratch(tmp_path) -> None:
+    # Construct providers for A and B with separate roots and allowing gates;
+    # A writes a marker and B's absolute read of A returns an outside-root error.
+```
+
+Also assert a named Workspace provider resolves `(scratch, *live_bindings)` and registry failure resolves `(scratch,)`.
+
+- [ ] **Step 2: Run the built-in tests and confirm they fail**
+
+Run: `.venv/bin/python -m pytest Tests/Tools/test_workspace_file_roots.py Tests/Tools/test_file_tools_workspace_roots.py Tests/Agents/test_builtin_provider_workspace_binding.py -k 'run_file_sandbox or scratch or another_chat' -v`
+
+Expected: failures report missing run-scoped sandbox and provider constructor parameters.
+
+- [ ] **Step 3: Add the scoped sandbox and explicit built-in provider authority**
+
+```python
+_RUN_FILE_SANDBOX_ROOT: ContextVar[Path | None] = ContextVar(
+    "run_file_sandbox_root", default=None
+)
+
+
+@contextmanager
+def run_file_sandbox(root: Path | None) -> Iterator[None]:
+    token = _RUN_FILE_SANDBOX_ROOT.set(root.resolve() if root is not None else None)
+    try:
+        yield
+    finally:
+        _RUN_FILE_SANDBOX_ROOT.reset(token)
+```
+
+`_tool_sandbox_root()` returns the scoped root without creating or widening it; outside a scope it retains the existing configured global behavior. `BuiltinToolProvider.path_targets` and file-tool `invoke` enter the injected lease and both `run_file_sandbox(self._sandbox_root)` and `run_workspace(self._workspace_id)`. `path_precheck_failed` accepts the same explicit root and lease so review and dispatch consult identical roots.
+
+- [ ] **Step 4: Write failing Default/local provider tests**
+
+```python
+def test_default_chat_local_provider_uses_scratch_not_config_or_cwd(controller, turn_context, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path / "cwd")
+    turn_context = replace_tool_config(turn_context, workspace_root=str(tmp_path / "configured"))
+    provider, review = controller._compose_local_provider(
+        session_id=turn_context.session_id,
+        turn_context=turn_context,
+    )
+    assert provider.workspace_root == turn_context.scratch_space.root
+    assert review is not None
+
+
+def test_selected_project_binding_still_wins_and_read_only_omits_writes(
+    controller, turn_context, tmp_path
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    provider, review = controller._compose_local_provider(
+        session_id=turn_context.session_id,
+        turn_context=turn_context,
+        project_root=project,
+        allow_write=False,
+        project_root_guard=lambda: True,
+    )
+    assert provider.workspace_root == project.resolve()
+    assert "fs_write" not in {entry.name for entry in provider.list_catalog()}
+    assert review is not None
+```
+
+Use the existing project-root helpers and assertions in `Tests/Chat/test_console_local_review_hook.py`; repair `test_selected_root_swap_fails_closed_before_local_invoke` to call `review(calls, "run-root-swap")` so it exercises the production guard.
+
+- [ ] **Step 5: Run the local tests and confirm the Default root assertion fails**
+
+Run: `.venv/bin/python -m pytest Tests/Chat/test_console_agent_bridge_local.py Tests/Chat/test_console_local_review_hook.py -k 'default_chat_local_provider or selected_root_swap or read_only' -v`
+
+Expected: Default composition resolves configured root/cwd before the implementation; the repaired root-swap regression reaches its guard rather than raising `TypeError`.
+
+- [ ] **Step 6: Add lease-aware local invocation and remove the Console fallback**
+
+```python
+if project_root is None:
+    snapshot = turn_context.scratch_space if turn_context is not None else None
+    if snapshot is None:
+        return None, None
+    root = snapshot.root
+    authority_scope = functools.partial(self._scratch_spaces.lease, snapshot)
+else:
+    root = project_root
+    authority_scope = None
+```
+
+`LocalToolProvider` exposes a read-only `workspace_root` property for verification and accepts `authority_scope: Callable[[], ContextManager[Path]] | None`. It enters that scope around `fs_*` and Git path preflight/invocation only; lease acquisition failure returns `LOCAL_ROOT_CHANGED_REFUSAL`. Web, Watchlists, and todo calls do not hold a scratch lease. Existing project-root `root_guard`, fingerprint, and `allow_write` behavior remains byte-for-byte at the controller seam.
+
+- [ ] **Step 7: Run the complete authority regression set**
+
+Run: `.venv/bin/python -m pytest Tests/Tools/test_workspace_file_roots.py Tests/Tools/test_file_tools_workspace_roots.py Tests/Agents/test_builtin_provider_workspace_binding.py Tests/Chat/test_console_agent_bridge_local.py Tests/Chat/test_console_local_review_hook.py -v`
+
+Expected: all tests pass, including the selected-root swap fail-closed regression.
+
+- [ ] **Step 8: Commit provider confinement**
+
+```bash
+git add tldw_chatbook/Tools/workspace_file_roots.py tldw_chatbook/Tools/file_operation_tools.py tldw_chatbook/Agents/tool_catalog.py tldw_chatbook/Agents/local_tool_provider.py tldw_chatbook/Chat/console_chat_controller.py Tests/Tools/test_workspace_file_roots.py Tests/Tools/test_file_tools_workspace_roots.py Tests/Agents/test_builtin_provider_workspace_binding.py Tests/Chat/test_console_agent_bridge_local.py Tests/Chat/test_console_local_review_hook.py
+git commit -m "fix(console): confine file tools to chat scratch authority"
+```
+
+---
+
+### Task 4: Agent bridge propagation and cross-chat dispatch tests
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `Tests/Chat/test_console_agent_bridge.py`
+- Modify: `Tests/Chat/test_console_agent_swap.py`
+- Modify: `Tests/Agents/test_project_instruction_path_targets.py`
+
+**Interfaces:**
+- Consumes: Task 3's `BuiltinToolProvider` keywords `sandbox_root: Path | None` and `sandbox_lease: Callable[[], ContextManager[Path]] | None`, plus local provider composition.
+- Produces: `scratch_root`/`scratch_lease` propagation through `_compose_run_registry_and_allowed`, `build_console_first_request_plan`, and `ConsoleAgentBridge.run_reply`; identical scratch authority for review precheck and actual dispatch.
+
+- [ ] **Step 1: Write failing bridge propagation tests**
+
+```python
+def test_run_registry_binds_builtin_provider_to_captured_scratch(tmp_path) -> None:
+    registry, _, _, _ = _compose_run_registry_and_allowed(
+        {},
+        builtin_gate=_AllowGate(),
+        workspace_id=DEFAULT_WORKSPACE_ID,
+        scratch_root=tmp_path / "chat-a",
+        scratch_lease=nullcontext,
+    )
+    resolved = registry.resolve_owner_for_name("read_file")
+    assert resolved is not None
+    _, provider = resolved
+    assert provider.sandbox_root == (tmp_path / "chat-a").resolve()
+
+
+def test_two_console_runs_cannot_dispatch_across_scratch_roots(tmp_path) -> None:
+    root_a = tmp_path / "chat-a"
+    root_b = tmp_path / "chat-b"
+    root_a.mkdir()
+    root_b.mkdir()
+    (root_a / "marker.txt").write_text("chat-a", encoding="utf-8")
+    registry_b, _, _, _ = _compose_run_registry_and_allowed(
+        {},
+        builtin_gate=_AllowGate(),
+        workspace_id=DEFAULT_WORKSPACE_ID,
+        scratch_root=root_b,
+        scratch_lease=nullcontext,
+    )
+    result = registry_b.invoke_by_name(
+        "read_file", {"file_path": str(root_a / "marker.txt")}
+    )
+    assert result.ok is False
+    assert "outside" in str(result.error).lower()
+```
+
+- [ ] **Step 2: Run the bridge tests and confirm they fail**
+
+Run: `.venv/bin/python -m pytest Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_agent_swap.py Tests/Agents/test_project_instruction_path_targets.py -k 'captured_scratch or across_scratch or project_instruction_path' -v`
+
+Expected: missing `scratch_root`/`scratch_lease` parameters or the shared global sandbox remains visible.
+
+- [ ] **Step 3: Thread the immutable authority through the live run**
+
+```python
+snapshot = turn_context.scratch_space
+if snapshot is None:
+    return self._block(session_id, "Private scratch space is unavailable.")
+scratch_lease = functools.partial(self._scratch_spaces.lease, snapshot)
+
+scratch_run_kwargs = {
+    "scratch_root": snapshot.root,
+    "scratch_lease": scratch_lease,
+}
+```
+
+Add the two entries in `scratch_run_kwargs` to the existing `asyncio.to_thread` call that invokes `self._agent_bridge.run_reply`. Add matching parameters to `ConsoleAgentBridge.run_reply`, `build_console_first_request_plan`, and `_compose_run_registry_and_allowed`; pass them to every fresh `BuiltinToolProvider`. The disposable Context/preview composition must receive the same snapshot but must not create a second directory.
+
+- [ ] **Step 4: Make review precheck and dispatch authority identical**
+
+```python
+builtin_review_provider = BuiltinToolProvider(
+    gate=builtin_gate,
+    workspace_id=review_workspace_id,
+    sandbox_root=snapshot.root,
+    sandbox_lease=scratch_lease,
+)
+```
+
+`build_tool_review_hook` reads path-precheck roots through this provider authority. Add a spy test asserting precheck and invocation observed the exact same canonical scratch path and Workspace ID.
+
+- [ ] **Step 5: Run bridge and provider suites**
+
+Run: `.venv/bin/python -m pytest Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_agent_swap.py Tests/Agents/test_project_instruction_path_targets.py Tests/Chat/test_console_local_review_hook.py Tests/Agents/test_builtin_provider_workspace_binding.py -v`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit bridge propagation**
+
+```bash
+git add tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_agent_swap.py Tests/Agents/test_project_instruction_path_targets.py
+git commit -m "feat(console): propagate scratch authority through agent runs"
+```
+
+---
+
+### Task 5: Retained skill output and run-log fallback
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/local_skills_service.py`
+- Modify: `tldw_chatbook/Skills_Interop/skills_scope_service.py`
+- Modify: `tldw_chatbook/Agents/run_log.py`
+- Modify: `tldw_chatbook/Agents/agent_service.py`
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `Tests/Skills/test_skill_script_service.py`
+- Modify: `Tests/Agents/test_run_log_sandbox_isolation.py`
+- Modify: `Tests/Agents/test_run_log_workspace_isolation.py`
+- Modify: `Tests/Agents/test_run_log_service_wiring.py`
+- Modify: `Tests/Chat/test_console_agent_tool_result_cap.py`
+
+**Interfaces:**
+- Consumes: Task 4's run `scratch_root` and lease factory.
+- Produces: optional explicit `output_root` for local skill execution; explicit root/access scope for `RunLogWriter`; live in-memory run-log authority lookup scoped to the owning Console session.
+
+- [ ] **Step 1: Write failing retained-output tests**
+
+```python
+@pytest.mark.asyncio
+async def test_explicit_console_output_root_overrides_shared_skill_config(service, tmp_path) -> None:
+    chat_root = tmp_path / "chat"
+    result = await service.run_skill_script(
+        "producer", "scripts/write.py", [], output_root=chat_root / "skill_script_output"
+    )
+    assert Path(result.output_dir).is_relative_to(chat_root)
+
+
+@pytest.mark.asyncio
+async def test_two_console_skill_runs_retain_under_their_own_chat_roots(
+    service, tmp_path
+) -> None:
+    first = tmp_path / "chat-a" / "skill_script_output"
+    second = tmp_path / "chat-b" / "skill_script_output"
+    result_a = await service.run_skill_script(
+        "producer", "scripts/write.py", [], output_root=first
+    )
+    result_b = await service.run_skill_script(
+        "producer", "scripts/write.py", [], output_root=second
+    )
+    assert Path(result_a.output_dir).is_relative_to(first)
+    assert Path(result_b.output_dir).is_relative_to(second)
+    assert not Path(result_a.output_dir).is_relative_to(second)
+```
+
+Also assert the existing non-Console no-argument path still honors `[skills] script_scratch_root` or the global file-tool sandbox.
+
+- [ ] **Step 2: Run skill-output tests and confirm the new calls fail**
+
+Run: `.venv/bin/python -m pytest Tests/Skills/test_skill_script_service.py -k 'explicit_console_output_root or own_chat_roots or script_output_root' -v`
+
+Expected: `run_skill_script` rejects the unknown `output_root` keyword.
+
+- [ ] **Step 3: Add explicit output-root forwarding and lease it in the bridge**
+
+```python
+async def run_skill_script(
+    self,
+    skill_name: str,
+    script_path: str,
+    args: Sequence[str],
+    *,
+    limits: ScriptRunLimits | None = None,
+    output_root: Path | None = None,
+) -> ScriptRunResult:
+    effective_output_root = (
+        output_root.resolve() if output_root is not None else self._script_output_root()
+    )
+    return await asyncio.to_thread(_run_in_scratch_dir, effective_output_root)
+```
+
+`SkillsScopeService.run_skill_script` forwards `output_root`. The local service resolves and creates the explicit root without reading the configured shared root. `ConsoleAgentBridge.run_skill_script_tool` holds `scratch_lease()` around the whole blocking script coroutine call and passes `scratch_root / "skill_script_output"`; the existing offloaded subprocess callable still owns its child scratch lifecycle.
+
+- [ ] **Step 4: Write failing run-log authority tests**
+
+```python
+def test_writer_explicit_fallback_root_never_uses_global_sandbox(tmp_path, monkeypatch) -> None:
+    chat_root = tmp_path / "chat"
+    chat_root.mkdir()
+    writer = RunLogWriter(root=chat_root, access_scope=nullcontext)
+    writer.bind("run-a")
+    assert writer.log_dir.is_relative_to(chat_root)
+
+
+def test_console_bridge_does_not_find_another_sessions_scratch_log(
+    console_bridge, tmp_path
+) -> None:
+    root_a = tmp_path / "chat-a"
+    root_b = tmp_path / "chat-b"
+    root_a.mkdir()
+    root_b.mkdir()
+    writer = RunLogWriter(root=root_a)
+    writer.bind("run-a")
+    writer.append(run_id="run-a", kind="primary", type="model", content="secret")
+    console_bridge._remember_run_log_authority(
+        run_id="run-a", session_id="session-a", root=root_a, access_scope=nullcontext
+    )
+    console_bridge._remember_run_log_authority(
+        run_id="run-b", session_id="session-b", root=root_b, access_scope=nullcontext
+    )
+    assert console_bridge.run_log_available("run-b") is False
+```
+
+Add a lease test: close/tombstone while a writer access scope is active leaves the directory until access exits; a later append fails closed and does not recreate it. Preserve the Workspace test proving a validated writable binding remains preferred over scratch.
+
+- [ ] **Step 5: Run run-log tests and confirm they fail**
+
+Run: `.venv/bin/python -m pytest Tests/Agents/test_run_log_sandbox_isolation.py Tests/Agents/test_run_log_workspace_isolation.py Tests/Agents/test_run_log_service_wiring.py Tests/Chat/test_console_agent_tool_result_cap.py -k 'explicit_fallback_root or another_sessions or workspace_root or lease' -v`
+
+Expected: missing explicit writer root/access-scope interfaces or current global-root lookup finds the wrong container.
+
+- [ ] **Step 6: Add explicit run-log roots and live authority lookup**
+
+```python
+class RunLogWriter:
+    def __init__(
+        self,
+        *,
+        dir_name: str | None = None,
+        segment_bytes: int | None = None,
+        max_record_bytes: int | None = None,
+        root: Path | None = None,
+        access_scope: Callable[[], ContextManager[Path]] | None = None,
+        on_bound: Callable[[str, Path], None] | None = None,
+    ) -> None:
+        self._explicit_root = root.resolve() if root is not None else None
+        self._access_scope = access_scope or nullcontext
+        self._on_bound = on_bound
+```
+
+Wrap `bind`, `append`, `write_manifest`, and filesystem-touching `close` work in `access_scope()`. An unavailable scope deactivates logging without widening. `resolve_existing_log_dir(run_id, *, root=None)` uses an explicit root when supplied and retains the existing global resolver only for non-Console callers.
+
+`ConsoleAgentBridge` records an in-memory map from owning primary run ID to `(session_id, resolved_log_root, access_scope)` via `RunLogWriter.on_bound`. Its `run_log_available` and `load_run_log_text` require that explicit live authority; they never search the global sandbox for a Console run. Add `forget_session_file_authority(session_id)` and call it during controller close after tombstoning scratch. Do not persist the root or token in `AgentRunsDB`.
+
+Before constructing `AgentService`, the bridge resolves the writer root with the run's captured authority:
+
+```python
+with scratch_lease():
+    run_log_root = resolve_log_root(
+        sandbox_root=scratch_root,
+        workspace_id=run_workspace_id,
+    )
+run_log_writer = RunLogWriter(
+    root=run_log_root,
+    access_scope=scratch_lease,
+    on_bound=functools.partial(
+        self._remember_run_log_authority,
+        session_id=session_id,
+        access_scope=scratch_lease,
+    ),
+)
+```
+
+Add explicit `sandbox_root` and `workspace_id` keywords to `resolve_log_root`; it enters `run_workspace(workspace_id)` and calls the existing `allowed_file_roots(write=True, sandbox_root=sandbox_root)`, preserving the first writable Workspace binding preference and falling back only to this chat's scratch. Pass `run_log_writer=run_log_writer` into `AgentService`.
+
+- [ ] **Step 7: Run skill, run-log, bridge, and lifecycle suites**
+
+Run: `.venv/bin/python -m pytest Tests/Skills/test_skill_script_service.py Tests/Agents/test_run_log_sandbox_isolation.py Tests/Agents/test_run_log_workspace_isolation.py Tests/Agents/test_run_log_service_wiring.py Tests/Chat/test_console_agent_tool_result_cap.py Tests/Chat/test_console_scratch_space.py Tests/Chat/test_console_agent_bridge.py -v`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 8: Commit scratch-adjacent artifacts**
+
+```bash
+git add tldw_chatbook/Skills_Interop/local_skills_service.py tldw_chatbook/Skills_Interop/skills_scope_service.py tldw_chatbook/Agents/run_log.py tldw_chatbook/Agents/agent_service.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py Tests/Skills/test_skill_script_service.py Tests/Agents/test_run_log_sandbox_isolation.py Tests/Agents/test_run_log_workspace_isolation.py Tests/Agents/test_run_log_service_wiring.py Tests/Chat/test_console_agent_tool_result_cap.py
+git commit -m "fix(console): isolate retained artifacts by chat"
+```
+
+---
+
+### Task 6: Folderless UX, recovery copy, and documentation
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/display_state.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_workspace_details.py`
+- Modify: `tldw_chatbook/Utils/path_validation.py`
+- Modify: `Tests/Workspaces/test_workspace_display_state.py`
+- Modify: `Tests/UI/test_console_workspace_details_tray.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+- Modify: `Tests/Utils/test_path_validation_multi.py`
+- Modify: `Docs/User_Guide/console/sessions-tabs-workspaces.md`
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md`
+- Modify: `Docs/User_Guide/settings.md`
+- Modify: `AGENTS.md`
+
+**Interfaces:**
+- Consumes: the implemented authority semantics from Tasks 1-5.
+- Produces: truthful `Local file tools` status copy, optional-folder recovery guidance, and user/developer documentation.
+
+- [ ] **Step 1: Write failing display and new-chat tests**
+
+```python
+def test_default_workspace_reports_private_scratch(state) -> None:
+    assert state.runtime_label == "Local file tools: Private scratch"
+
+
+def test_details_tray_reports_private_scratch_plus_bound_folders() -> None:
+    friendly = ConsoleWorkspaceDetailsTray._friendly_status_label(
+        "Local file tools: Private scratch + 2 folders"
+    )
+    label, value = ConsoleWorkspaceDetailsTray._split_status_row(
+        friendly, "Local file tools"
+    )
+    assert label == "Local file tools"
+    assert value == "Private scratch + 2 folders"
+```
+
+Extend `test_console_workspace_rail_new_conversation_creates_default_workspace_session` to assert no modal/folder picker appears and the new session can resolve a scratch snapshot.
+
+- [ ] **Step 2: Run UI/display tests and confirm the old `Off in Default` copy fails**
+
+Run: `.venv/bin/python -m pytest Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_details_tray.py Tests/UI/test_console_native_chat_flow.py -k 'private_scratch or new_conversation_creates_default' -v`
+
+Expected: Default renders `Runtime: none, file tools disabled` / `File tools: Off in Default` before the copy change.
+
+- [ ] **Step 3: Implement status copy from actual folder bindings**
+
+```python
+runtime_label = (
+    "Local file tools: Private scratch"
+    if not runtime_bindings
+    else f"Local file tools: Private scratch + {len(runtime_bindings)} {_plural('folder', len(runtime_bindings))}"
+)
+```
+
+Keep missing-binding detail available in recovery text or a secondary diagnostic; do not count non-filesystem runtime bindings as folders. `_friendly_status_label` passes `Local file tools:` through and removes the `Off in Default` branch.
+
+- [ ] **Step 4: Write and implement optional-folder recovery copy**
+
+```python
+ROOT_DENIAL_RECOVERY_POINTER = "Need that folder? Add it to a named Workspace."
+ROOT_DENIAL_RECOVERY_HINT = (
+    "Chats do not need a folder. To give local file tools access outside "
+    "private scratch, bind that folder in Settings > Workspaces and use a "
+    "chat in that Workspace."
+)
+```
+
+Update `Tests/Utils/test_path_validation_multi.py` to assert the short pointer survives the real 160-character transcript truncation and the full hint says folders are optional for Chats.
+
+- [ ] **Step 5: Run UI and recovery tests**
+
+Run: `.venv/bin/python -m pytest Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_details_tray.py Tests/UI/test_console_native_chat_flow.py Tests/Utils/test_path_validation_multi.py -v`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Update user and developer documentation**
+
+Document these exact rules:
+
+```text
+Chats: private temporary scratch only; no folder setup; scratch is new after close/reopen.
+Workspaces: private scratch plus explicit bound folders; folders are optional.
+Local fs/Git: scratch unless project instructions explicitly select one binding.
+[console] workspace_root: retained for compatibility outside this Console authority path; never grants a Console Chat access.
+```
+
+The agent-tools guide must distinguish local Chatbook tools from MCP/provider-hosted tools, describe normal approval prompts, and state that normal deletion is not secure erase.
+
+- [ ] **Step 7: Commit UX and documentation**
+
+```bash
+git add tldw_chatbook/Workspaces/display_state.py tldw_chatbook/Widgets/Console/console_workspace_details.py tldw_chatbook/Utils/path_validation.py Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_details_tray.py Tests/UI/test_console_native_chat_flow.py Tests/Utils/test_path_validation_multi.py Docs/User_Guide/console/sessions-tabs-workspaces.md Docs/User_Guide/console/agent-runs-and-tools.md Docs/User_Guide/settings.md AGENTS.md
+git commit -m "docs(console): clarify private scratch and optional folders"
+```
+
+---
+
+### Task 7: Targeted verification and live DeepSeek UAT
+
+**Files:**
+- Create: `Docs/UAT/2026-08-23-console-deepseek-private-scratch.md`
+- Modify: `backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md`
+- Modify only if the implementation surfaced a reusable incident: `backlog/docs/lessons-live-verification.md` or `backlog/docs/lessons-testing-evidence.md`
+
+**Interfaces:**
+- Consumes: all prior tasks, the existing DeepSeek config through `TLDW_CONFIG_PATH`, and the targeted-test requirement in `AGENTS.md`.
+- Produces: reproducible automated evidence, sanitized live-UAT evidence, completed task acceptance criteria, implementation notes, and Done status only when every Definition-of-Done condition is satisfied.
+
+- [ ] **Step 1: Run static and focused authority verification**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chat/test_console_scratch_space.py Tests/Chat/test_console_turn_execution_context.py Tests/Tools/test_workspace_file_roots.py Tests/Tools/test_file_tools_workspace_roots.py Tests/Agents/test_builtin_provider_workspace_binding.py Tests/Agents/test_project_instruction_path_targets.py Tests/Chat/test_console_agent_bridge_local.py Tests/Chat/test_console_local_review_hook.py -q
+```
+
+Expected: all tests pass; record exact counts.
+
+- [ ] **Step 2: Run artifact, lifecycle, and UI verification**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Skills/test_skill_script_service.py Tests/Agents/test_run_log_sandbox_isolation.py Tests/Agents/test_run_log_workspace_isolation.py Tests/Agents/test_run_log_service_wiring.py Tests/Chat/test_console_agent_tool_result_cap.py Tests/UI/test_console_runtime_ownership.py Tests/Chat/test_console_agent_swap.py Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_details_tray.py Tests/UI/test_console_native_chat_flow.py Tests/Utils/test_path_validation_multi.py -q
+```
+
+Expected: all tests pass; if a pre-existing unrelated failure appears, reproduce it against `7363592020076c9508fe4a0eee0c1a1679ec7851` before classifying it as baseline.
+
+- [ ] **Step 3: Run formatting/static checks scoped to changed Python files**
+
+Run:
+
+```bash
+git diff --check "$(git merge-base origin/dev HEAD)" HEAD
+.venv/bin/python -m compileall -q tldw_chatbook/Chat/console_scratch_space.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_turn_context.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Agents/tool_catalog.py tldw_chatbook/Agents/local_tool_provider.py tldw_chatbook/Agents/run_log.py tldw_chatbook/Skills_Interop/local_skills_service.py tldw_chatbook/Skills_Interop/skills_scope_service.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Prepare a credential-safe live-UAT profile**
+
+Create a private temporary directory with `mktemp -d`, copy the user's config without printing it, set file mode `0600`, and compute and save the original config's SHA-256 before launch. In the private copy only, set `[paths].data_dir` to a directory under that temporary profile and enable the existing Console local/file-tool gates required by the scenario; do not alter the DeepSeek credential value. Launch with both `HOME` pointing at a temporary home and `TLDW_CONFIG_PATH` pointing at the private copy, so databases, permission decisions, logs, caches, and config writes cannot reach the user's live profile. Never pass or echo the DeepSeek key in a command argument, screenshot, log, or repository file.
+
+- [ ] **Step 5: Exercise the mounted Console with DeepSeek**
+
+Record pass/fail and sanitized observations for:
+
+```text
+1. Select DeepSeek and create a Chat under Chats without any folder prompt.
+2. Send a plain prompt and observe a successful streamed response.
+3. Approve a local file-tool request that writes and reads a unique relative marker.
+4. Create a second Chat and verify listing/reading the first marker is refused or absent.
+5. Bind a disposable folder to a named Workspace and verify an allowed read plus a read-write write.
+6. Return to a Chat and verify that Workspace file is outside its authority.
+7. Close the first Chat, reopen its saved conversation, and verify the old marker is absent.
+8. Verify status copy says Private scratch and no Chat folder prompt appeared.
+```
+
+If DeepSeek declines to call a tool, make the prompt explicit once and record that model tool selection is observational; deterministic tests remain the authority gate.
+
+- [ ] **Step 6: Verify configuration integrity and clean UAT artifacts**
+
+Compute the original config's SHA-256 again and require an exact match. Delete the temporary profile and disposable Workspace folder after recording only path-free outcomes and counts. Confirm no UAT marker or credential-like string is staged by `git status --short` and a focused secret-pattern scan.
+
+- [ ] **Step 7: Write the UAT report and perform final self-review**
+
+`Docs/UAT/2026-08-23-console-deepseek-private-scratch.md` records the branch/base/commit, DeepSeek provider and model identifier without credentials, terminal size/profile isolation method, each scenario outcome, targeted command counts, known hard-crash residue/no-quota limitations, and any deviations. Review the complete diff for authority widening, raw path logging, unbounded UI-thread cleanup, persisted scratch locators, and accidental changes to non-Console callers.
+
+- [ ] **Step 8: Complete Backlog task hygiene only after every gate passes**
+
+Check all nine acceptance criteria, add concise `## Implementation Notes`, include the ADR-081 link and exact verification evidence, then run:
+
+```bash
+backlog task edit 21161 -s Done
+backlog task 21161 --plain
+```
+
+Expected: TASK-21161 reports Done, all acceptance criteria checked, implementation plan and notes present.
+
+- [ ] **Step 9: Commit verification evidence**
+
+```bash
+git add Docs/UAT/2026-08-23-console-deepseek-private-scratch.md 'backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md' backlog/docs/lessons-live-verification.md backlog/docs/lessons-testing-evidence.md
+git commit -m "test(console): verify DeepSeek private scratch UAT"
+```
+
+Stage a lessons file only when a real reusable incident was added; otherwise omit it from `git add`.

--- a/Docs/superpowers/plans/2026-08-23-console-per-chat-private-scratch-space.md
+++ b/Docs/superpowers/plans/2026-08-23-console-per-chat-private-scratch-space.md
@@ -24,7 +24,7 @@
 - Cleanup is ordinary best-effort deletion, not secure erase; no cumulative per-chat disk quota is added in this task.
 - Targeted tests only; do not run the full repository suite without explicit user approval.
 - ADR required: yes.
-- ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`.
+- ADR path: `backlog/decisions/082-console-per-chat-private-scratch-space.md`.
 - Reason: filesystem authority, temporary-data ownership, provider composition, and cross-thread teardown are security and runtime-boundary decisions.
 
 ---
@@ -866,7 +866,7 @@ Compute the original config's SHA-256 again and require an exact match. Delete t
 
 - [ ] **Step 8: Complete Backlog task hygiene only after every gate passes**
 
-Check all nine acceptance criteria, add concise `## Implementation Notes`, include the ADR-081 link and exact verification evidence, then run:
+Check all nine acceptance criteria, add concise `## Implementation Notes`, include the ADR-082 link and exact verification evidence, then run:
 
 ```bash
 backlog task edit 21161 -s Done

--- a/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
+++ b/Docs/superpowers/plans/2026-08-23-model-catalog-consent-startup-order.md
@@ -17,9 +17,9 @@
 ### Task 0: Record the approved plan in Backlog.md
 
 **Files:**
-- Modify: `backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md`
+- Modify: `backlog/tasks/task-21163 - Order-model-catalog-consent-after-intro-startup.md`
 
-- [x] Add the implementation plan to TASK-21161 while it is In Progress and before changing application or test code.
+- [x] Add the implementation plan to TASK-21163 while it is In Progress and before changing application or test code.
 - [x] Include the ADR required/no, existing ADR path, and lifecycle-fix reason in the task plan.
 
 ### Task 1: Add a failing launch-order regression
@@ -71,8 +71,8 @@
 ### Task 4: Close task documentation
 
 **Files:**
-- Modify: `backlog/tasks/task-21161 - Order-model-catalog-consent-after-intro-startup.md`
+- Modify: `backlog/tasks/task-21163 - Order-model-catalog-consent-after-intro-startup.md`
 
 - [x] Check every acceptance criterion only after its verification evidence exists.
 - [x] Add concise implementation notes covering the lifecycle move, regression, ADR decision, and commands run.
-- [x] Set TASK-21161 to Done only after all Definition of Done checks are satisfied.
+- [x] Set TASK-21163 to Done only after all Definition of Done checks are satisfied.

--- a/Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md
+++ b/Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md
@@ -1,7 +1,7 @@
 # Console per-chat private scratch space design
 
 Date: 2026-08-23
-Status: Draft for user review
+Status: Approved
 Task: TASK-21161
 ADR: ADR-081
 Baseline: `origin/dev` at `7363592020076c9508fe4a0eee0c1a1679ec7851`

--- a/Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md
+++ b/Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md
@@ -1,0 +1,352 @@
+# Console per-chat private scratch space design
+
+Date: 2026-08-23
+Status: Draft for user review
+Task: TASK-21161
+ADR: ADR-081
+Baseline: `origin/dev` at `7363592020076c9508fe4a0eee0c1a1679ec7851`
+
+## Summary
+
+Every live Console chat receives an independent temporary scratch directory.
+Ordinary Chats require no folder and have no implicit access to the process
+working directory or `[console] workspace_root`. Named Workspaces retain the
+same private scratch space and may add user folders only through explicit
+Workspace bindings.
+
+The change is an authority correction, not only a copy change. It replaces the
+shared durable file-tool sandbox for Console runs, removes the local-provider
+cwd fallback, routes sandbox-adjacent outputs through the owning chat, and adds
+lifecycle fencing that remains correct when a timed-out tool thread finishes
+late.
+
+## Problem and evidence
+
+Latest `dev` has four conflicting behaviors:
+
+1. `Tools/file_operation_tools.py` creates one shared durable
+   `<user-data>/tool_sandbox` and includes it as the first root for every
+   built-in file-tool call.
+2. `ConsoleChatController._compose_local_provider()` roots the local `fs_*` and
+   Git provider at `[console] workspace_root` or `os.getcwd()` unless project
+   instructions select a folder. An ordinary Chat can therefore receive host
+   directory access that its built-in tools do not have.
+3. `Skills_Interop/local_skills_service.py` retains script output under the
+   shared sandbox, and `Agents/run_log.py` uses the same sandbox as its no-
+   Workspace fallback.
+4. `ConsoleWorkspaceDetails` says `File tools: Off in Default`, while path
+   recovery says to bind a folder. The data model permits and tests folderless
+   Chats, but the UX presents them as incomplete.
+
+The open PR #1657 / TASK-16316 makes a folder mandatory in the Console's New
+Workspace modal. It neither isolates Chats nor removes the local-provider cwd
+fallback. It is a conflicting policy, not an implementation dependency.
+
+The relevant targeted baseline on this branch produced 55 passes and one
+failure. The failure is test-only: a root-swap regression calls a review hook
+without the `run_id` argument that the hook required before that test was
+written. The implementation plan must restore that test before using the suite
+as verification evidence.
+
+## Goals
+
+- Make ordinary Chats immediately usable without Workspace or folder setup.
+- Prevent Chatbook-managed local file operations from crossing live-chat
+  scratch boundaries.
+- Preserve explicit Workspace folder access, read-only enforcement, project-
+  instruction authority, and permission review.
+- Make close, late tool completion, reopening, and application shutdown have
+  truthful and testable cleanup semantics.
+- Verify the user-visible flow with DeepSeek while retaining deterministic
+  authority tests as the acceptance gate.
+
+## Non-goals
+
+- A synchronized, persisted, or reopenable per-conversation filesystem.
+- A secure-erase guarantee after deletion.
+- A new multi-root namespace for local `fs_*` or Git tools.
+- Sandboxing third-party MCP servers or provider-hosted tools.
+- Changing attachment, Library/RAG, generated-media, or database ownership.
+- Changing existing Ask/Allow/Off permissions or sensitive-path policy.
+- Making a folder mandatory when creating either a Chat or a Workspace.
+
+## Terminology and ownership
+
+**Private scratch space** means a temporary directory owned by one live
+`ConsoleChatSession`. It is shared with that session's turns and subagents but
+not with any other live session, including another tab that resumes the same
+saved conversation.
+
+**Temporary conversation** continues to mean `ConsoleChatSession.ephemeral`, an
+unsaved conversation with additional durability restrictions. The scratch
+feature must not reuse `ephemeral` in API or UI names because every Console
+session—durable or temporary—gets private scratch.
+
+**Workspace folder access** means only active, validated folder bindings stored
+by `LocalWorkspaceRegistryService`. The implementation-only Default workspace
+continues to appear as Chats and cannot hold bindings.
+
+The application-owned `ConsoleRuntime` owns the scratch-space manager. The
+`ConsoleChatStore` remains a pure session/message owner and does not gain paths,
+cleanup callbacks, or filesystem I/O.
+
+## Authority matrix
+
+| Live session state | Built-in file roots | Local `fs_*` / Git root | Folder required |
+| --- | --- | --- | --- |
+| Chat in Default | Private scratch only | Private scratch only | No |
+| Named Workspace, no project selection | Private scratch plus explicit Workspace bindings | Private scratch only | No |
+| Named Workspace, selected project binding | Private scratch plus explicit Workspace bindings | Selected binding root, preserving read/write and fingerprint guards | No; selection requires an existing binding |
+| Non-Console caller | Existing configured behavior | Existing configured behavior | Unchanged |
+
+Relative file paths resolve inside private scratch when scratch is the working
+root. Existing absolute-path handling for explicitly bound Workspace folders is
+preserved. The design does not invent an implicit primary binding when a
+Workspace has several folders.
+
+## Components
+
+### `ConsoleScratchSpaceManager`
+
+A new Textual-free, thread-safe runtime service owns the mapping from live
+session IDs to scratch records. It provides four conceptual operations:
+
+- `snapshot(session_id)`: lazily allocate and return an immutable live snapshot;
+- `lease(snapshot)`: reject a tombstoned or replaced snapshot, otherwise count
+  one active filesystem operation until the context exits;
+- `close(session_id)`: tombstone immediately and delete after the last lease;
+- `dispose()`: tombstone all records and perform bounded best-effort cleanup.
+
+Allocation uses an OS temporary parent and an unpredictable directory
+name that contains no session or conversation identifier. The manager verifies
+the created directory is a real directory, captures canonical identity, and
+sets owner-only permissions. Records never leave process memory.
+
+The immutable snapshot contains the canonical root plus an opaque generation
+or identity token. A stale snapshot cannot become valid for a new record even
+if an operating system later reuses a path.
+
+Tombstoning is synchronous and cheap. Recursive deletion is filesystem I/O and
+must never run on Textual's event loop: the manager schedules it through an
+owned bounded cleanup worker, while application disposal drains that worker for
+a bounded interval. A cleanup failure leaves the record tombstoned and eligible
+for a later disposal retry; it never restores access.
+
+### Run-scoped file authority
+
+`ConsoleTurnExecutionContext` captures the owning session's scratch snapshot in
+the same owning-session step that already captures provider and Workspace
+configuration. The snapshot is detached from viewed-tab state and remains
+stable for the turn.
+
+The Console passes this explicit authority into each filesystem consumer:
+
+- `BuiltinToolProvider` and its path precheck use the captured scratch root
+  instead of calling the global `_tool_sandbox_root()`;
+- `ConsoleChatController._compose_local_provider()` uses scratch when there is
+  no explicitly selected project root, never config/cwd;
+- retained skill-script output receives the run's scratch root;
+- agent run-log fallback receives the run's scratch root.
+
+The non-Console default `_tool_sandbox_root()` remains available for consumers
+outside a Console run. No process-global mutation changes its meaning.
+
+### Workspace roots
+
+Built-in file tools keep `run_workspace(workspace_id)` and call-time binding
+resolution. Their roots become `(chat_scratch, *live_workspace_bindings)`.
+Registry failure still degrades to scratch-only. Deleted, drifted, symlinked, or
+read-only bindings retain existing fail-closed behavior.
+
+When project instructions are enabled and an explicit binding is selected,
+ADR-069 remains authoritative: the local provider uses that one selected root,
+checks its captured locator identity, and omits write tools for a read-only
+binding. Scratch does not silently become a second local-provider root.
+
+### Lease integration and late workers
+
+Python cannot kill the daemon thread used for a timed-out tool invocation. File
+authority therefore needs a lease around actual filesystem work, not only a
+check when composing the catalog.
+
+Every filesystem consumer of the scratch root holds a manager lease for the
+duration of its actual access, including built-in/local tools, retained skill
+output, and fallback run-log reads and writes. Closing a session proceeds in
+this order:
+
+1. tombstone scratch authority, preventing new leases;
+2. tombstone/cancel prompt queues, active runs, and subagents through existing
+   controller paths;
+3. remove the Console session state;
+4. delete scratch when its active lease count reaches zero.
+
+If a worker is abandoned, the mapping stays tombstoned and unreachable. Its
+eventual lease release triggers deletion. Application disposal retries any
+remaining cleanup. Cleanup is idempotent and a cleanup error cannot reactivate
+authority.
+
+Ordinary navigation away from Console uses `leave_console`, not session close;
+it must not delete scratch belonging to surviving runtime sessions.
+
+## Sandbox-adjacent artifacts
+
+Retained skill-script output currently defaults to a shared
+`skill_script_output` directory under the global sandbox. A Console skill run
+must instead retain output under the owning chat scratch root. An explicitly
+configured non-Console scratch root remains unchanged.
+
+Agent run logs currently prefer a writable Workspace binding and fall back to
+the global sandbox. Workspace behavior remains: logs may use the validated
+writable binding under existing hidden-directory rules. The fallback becomes
+the owning chat scratch root so Default Chat logs cannot accumulate in a
+cross-chat container.
+
+No scratch root or raw contents may be added to ordinary payload logs. Existing
+UI affordances that read a run's full retained result must receive the owning
+run/session authority instead of searching another chat's fallback root.
+
+## UX and recovery
+
+The Chats status row should use scoped, truthful copy:
+
+- label: `Local file tools`
+- Default value: `Private scratch`
+- named Workspace value: `Private scratch + N folder(s)` when bindings exist
+
+Creating a Chat never opens a folder picker or blocks on Workspace state. A
+named Workspace may still be created without a folder; it behaves as scratch-
+only until a folder is explicitly bound.
+
+When a tool requests a path outside scratch and all bound roots, recovery copy
+should explain: use or create a named Workspace and bind that external folder
+if access is intended. It must not describe the current Chat as broken or say a
+folder is required for conversation.
+
+The copy is deliberately limited to **local file tools**. MCP servers and
+provider-hosted tools may have separately configured capabilities that this
+boundary does not control.
+
+## Security and privacy invariants
+
+- Scratch paths are random and contain no chat, session, conversation, title,
+  provider, or user identifiers.
+- Root directories are owner-only and are never symlinks.
+- Snapshots are generation-fenced; stale snapshots fail closed.
+- Chat A's provider, precheck, tool invocation, skill output, and fallback run
+  log never resolve Chat B's scratch root.
+- Scratch is always an allowed root; Workspace bindings can add authority but
+  never replace or widen it by common-ancestor inference.
+- Permission decisions, kill switches, sensitive-path exclusions, and
+  read-only filtering execute as they do today.
+- The implementation passes the exact manager-owned root into existing path
+  validation; it does not add a broad `/tmp` or OS-temporary sensitive-path
+  exemption.
+- Cleanup logs bounded categories and opaque identifiers, not raw paths or
+  filenames.
+- Normal deletion is not represented as secure erase.
+
+## Persistence and crash behavior
+
+No scratch locator enters `ConsoleChatSession`, conversation metadata, SQLite,
+sync payloads, snapshots, exports, or app configuration. A saved conversation
+resumed after close or restart receives a new empty scratch directory.
+
+Clean close and app shutdown perform best-effort deletion. A hard crash may
+leave an OS-temporary directory. A later process does not enumerate or attach
+old scratch directories, preventing cross-chat reuse. Cross-process stale-root
+reclamation is deferred because safe deletion would require process ownership
+and locking semantics beyond this task.
+
+## Test strategy
+
+Implementation follows red-green TDD with real filesystem operations.
+
+### Manager and authority tests
+
+- two sessions receive distinct canonical owner-only roots;
+- relative writes in A are absent from B and direct B access to A is refused;
+- a stale/tombstoned snapshot cannot acquire a new lease;
+- close schedules off-loop deletion with no lease and defers cleanup while an active lease remains;
+- last lease release deletes a tombstoned root;
+- close/dispose are idempotent and cleanup failure never restores access;
+- reopening the same persisted conversation receives a fresh empty root.
+
+### Provider and artifact tests
+
+- Default Console local-provider composition uses scratch, not config/cwd;
+- built-in precheck and invocation use the identical captured scratch root;
+- named Workspace built-ins receive scratch plus current bindings;
+- registry failure produces scratch-only roots;
+- selected project root and read-only behavior remain unchanged;
+- skill-script output and fallback run logs use the owning chat root;
+- two simultaneous runs cannot resolve each other's retained outputs/logs;
+- non-Console global-sandbox callers retain existing behavior.
+
+The stale `test_selected_root_swap_fails_closed_before_local_invoke` invocation
+must pass an explicit run ID and continue proving that a retargeted project root
+is refused before file contents are exposed.
+
+### UI tests
+
+- New Chat in Chats creates a session without a modal or folder requirement;
+- status copy says `Private scratch` rather than `Off in Default`;
+- Workspace copy reports only actual bindings;
+- recovery copy presents folder binding as optional external-folder access.
+
+### Live DeepSeek UAT
+
+Use an isolated application profile and latest-`dev` worktree. When the user's
+DeepSeek credential lives in config rather than an environment variable, copy
+the config without printing it into a private mode-0600 temporary profile,
+point `TLDW_CONFIG_PATH` at that copy, and delete the profile after UAT. Record
+the original config hash before and after; never place the credential in a
+command argument, repository file, screenshot, or log.
+
+1. Select DeepSeek and start a Chat under Chats with no folder.
+2. Send a plain prompt and observe a successful streamed response.
+3. Ask DeepSeek to write and read a unique relative scratch file, approving the
+   normal local file-tool request.
+4. Start a second Chat and verify the first marker cannot be listed or read.
+5. Create or select a named Workspace bound to a disposable UAT folder; verify
+   an allowed read and, for an explicit read-write binding, a write.
+6. Return to a Chat and verify the Workspace file is outside its authority.
+7. Close the first Chat, reopen its saved conversation, and verify the old
+   scratch marker is absent.
+8. Confirm no folder prompt appeared for either Chat and the user config hash
+   is unchanged.
+
+The live model's exact tool-selection sequence is observational evidence, not a
+deterministic assertion. Scripted provider tests exercise the same production
+composition when a repeatable tool sequence is required.
+
+## Documentation impact
+
+Update the Console user guide, Settings/Workspace guidance, tool-calling docs,
+and AGENTS.md's Console tool-authority summary. Explicitly state that
+`[console] workspace_root` is no longer a Console Chat authority fallback.
+
+## ADR check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
+
+Reason: the change establishes filesystem authority, temporary-data ownership,
+provider composition, and teardown behavior across Console, Workspaces, tools,
+skills, and run logs.
+
+## Open risks
+
+- DeepSeek may answer a tool prompt without invoking a tool; live UAT may need
+  a more explicit instruction, while deterministic tests remain authoritative.
+- Timed-out third-party or non-cooperative code may hold a lease until process
+  exit. Tombstoning prevents reuse, but cleanup cannot force the thread to die.
+- A hard crash can leave OS-temporary residue. No later chat can discover it,
+  but secure crash cleanup is outside this design.
+- Workflows that unknowingly relied on Console's cwd fallback will lose that
+  access and must opt into a named Workspace binding. That break is intentional
+  and should be called out in release notes.
+- This task preserves existing per-call content and run-budget limits but does
+  not introduce a cumulative per-chat disk quota. A separate quota policy would
+  need its own UX and cleanup decision; existing permission prompts and bounded
+  run tool counts remain the immediate abuse controls.

--- a/Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md
+++ b/Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md
@@ -3,7 +3,7 @@
 Date: 2026-08-23
 Status: Approved
 Task: TASK-21161
-ADR: ADR-081
+ADR: ADR-082
 Baseline: `origin/dev` at `7363592020076c9508fe4a0eee0c1a1679ec7851`
 
 ## Summary
@@ -329,7 +329,7 @@ and AGENTS.md's Console tool-authority summary. Explicitly state that
 
 ADR required: yes
 
-ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
+ADR path: `backlog/decisions/082-console-per-chat-private-scratch-space.md`
 
 Reason: the change establishes filesystem authority, temporary-data ownership,
 provider composition, and teardown behavior across Console, Workspaces, tools,

--- a/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
+++ b/Docs/superpowers/specs/2026-08-23-model-catalog-consent-startup-order-design.md
@@ -1,6 +1,6 @@
 # Model Catalog Consent Startup Order Design
 
-**Task:** TASK-21161
+**Task:** TASK-21163
 **ADR required:** no
 **ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`
 **Reason:** This fixes UI lifecycle ordering while preserving ADR-020's existing consent, persistence, and network boundary.

--- a/Tests/Agents/test_builtin_provider_workspace_binding.py
+++ b/Tests/Agents/test_builtin_provider_workspace_binding.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.Tools import workspace_file_roots as wfr
+from tldw_chatbook.Tools.file_operation_tools import ReadFileTool
 
 
 class _ProbeTool:
@@ -56,6 +60,7 @@ def test_concurrent_providers_keep_distinct_workspace_bindings() -> None:
         async def execute(self, **kwargs):
             import asyncio
             from tldw_chatbook.Tools import workspace_file_roots as wfr
+
             await asyncio.sleep(0.05)  # force overlap window
             return {"workspace": wfr.current_run_workspace_id()}
 
@@ -76,3 +81,54 @@ def test_concurrent_providers_keep_distinct_workspace_bindings() -> None:
 
     assert '"workspace": "ws-alpha"' in (results["ws-alpha"] or "")
     assert '"workspace": "ws-beta"' in (results["ws-beta"] or "")
+
+
+def test_builtin_provider_cannot_read_another_chat_scratch(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root_a = tmp_path / "chat-a"
+    root_b = tmp_path / "chat-b"
+    root_a.mkdir()
+    root_b.mkdir()
+    marker = root_a / "marker.txt"
+    marker.write_text("chat-a", encoding="utf-8")
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.file_operation_tools._resolve_sandbox_config",
+        lambda: str(tmp_path),
+    )
+    provider = BuiltinToolProvider(
+        gate=_OpenGate(),
+        workspace_id="workspace-default",
+        sandbox_root=root_b,
+        sandbox_lease=lambda: nullcontext(root_b),
+    )
+    provider._tools["read_file"] = ReadFileTool()
+
+    result = provider.invoke(
+        "builtin:read_file",
+        {"file_path": str(marker)},
+    )
+
+    assert result.ok is False
+    assert "outside" in str(result.error).lower()
+
+
+def test_builtin_provider_rejects_file_access_after_scratch_close(tmp_path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("chat-a")
+    marker = snapshot.root / "marker.txt"
+    marker.write_text("chat-a", encoding="utf-8")
+    provider = BuiltinToolProvider(
+        gate=_OpenGate(),
+        workspace_id="workspace-default",
+        sandbox_root=snapshot.root,
+        sandbox_lease=lambda: manager.lease(snapshot),
+    )
+    provider._tools["read_file"] = ReadFileTool()
+
+    manager.close("chat-a")
+    result = provider.invoke("builtin:read_file", {"file_path": str(marker)})
+
+    assert result.ok is False
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)

--- a/Tests/Agents/test_builtin_provider_workspace_binding.py
+++ b/Tests/Agents/test_builtin_provider_workspace_binding.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from contextlib import nullcontext
+from pathlib import Path
 
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
@@ -17,6 +19,22 @@ class _ProbeTool:
 
     async def execute(self, **kwargs):
         return {"workspace": wfr.current_run_workspace_id()}
+
+
+class _ScratchLocatorTool:
+    name = "probe_scratch_locator"
+    description = "returns a scratch-owned path"
+    parameters = {"type": "object", "properties": {}}
+
+    def __init__(self, root, *, fail=False):
+        self._root = root
+        self._fail = fail
+
+    async def execute(self, **kwargs):
+        path = self._root / "nested" / "marker.txt"
+        if self._fail:
+            return {"error": f"could not access {path}"}
+        return {"file_path": str(path)}
 
 
 class _OpenGate:
@@ -43,6 +61,45 @@ def test_invoke_without_workspace_leaves_context_unset() -> None:
 
     assert result.ok, result.error
     assert '"workspace": null' in result.content
+
+
+def test_console_scratch_locator_is_redacted_from_builtin_results(tmp_path) -> None:
+    scratch = tmp_path / "private-scratch"
+    scratch.mkdir()
+    provider = BuiltinToolProvider(
+        gate=_OpenGate(),
+        sandbox_root=scratch,
+        sandbox_lease=lambda: nullcontext(scratch),
+    )
+    provider._tools["probe_scratch_locator"] = _ScratchLocatorTool(scratch)
+
+    result = provider.invoke("builtin:probe_scratch_locator", {})
+
+    assert result.ok, result.error
+    assert str(scratch) not in result.content
+    assert json.loads(result.content)["file_path"] == str(
+        Path(".") / "nested" / "marker.txt"
+    )
+
+
+def test_console_scratch_locator_is_redacted_from_builtin_errors(tmp_path) -> None:
+    scratch = tmp_path / "private-scratch"
+    scratch.mkdir()
+    provider = BuiltinToolProvider(
+        gate=_OpenGate(),
+        sandbox_root=scratch,
+        sandbox_lease=lambda: nullcontext(scratch),
+    )
+    provider._tools["probe_scratch_locator"] = _ScratchLocatorTool(
+        scratch,
+        fail=True,
+    )
+
+    result = provider.invoke("builtin:probe_scratch_locator", {})
+
+    assert not result.ok
+    assert str(scratch) not in result.error
+    assert str(Path(".") / "nested" / "marker.txt") in result.error
 
 
 def test_concurrent_providers_keep_distinct_workspace_bindings() -> None:

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -9,6 +9,7 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from tldw_chatbook.Agents.local_tool_provider import (
+    LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
     LOCAL_DENY_REFUSAL,
     LOCAL_GATE_ERROR_REFUSAL,
     LOCAL_KILL_SWITCH_REFUSAL,
@@ -767,6 +768,25 @@ def test_stamp_scope_isolates_nested_run(tmp_path):
 def test_execution_error_becomes_result_string(tmp_path):
     r = make_provider(root=tmp_path).invoke("local:fs_list", {"path": "../escape"})
     assert not r.ok and "outside the workspace root" in r.error
+
+
+def test_authority_scope_failure_uses_authority_refusal_not_root_drift(tmp_path):
+    class UnavailableAuthority:
+        def __enter__(self):
+            raise RuntimeError("scratch lease revoked")
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    provider = make_provider(
+        root=tmp_path,
+        authority_scope=UnavailableAuthority,
+    )
+
+    result = provider.invoke("local:fs_list", {"path": "."})
+
+    assert not result.ok
+    assert result.error == LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL
 
 
 def test_private_root_locator_is_redacted_from_local_tool_errors(tmp_path):

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -769,6 +769,21 @@ def test_execution_error_becomes_result_string(tmp_path):
     assert not r.ok and "outside the workspace root" in r.error
 
 
+def test_private_root_locator_is_redacted_from_local_tool_errors(tmp_path):
+    scratch = tmp_path / "private-scratch"
+    scratch.mkdir()
+    provider = make_provider(
+        root=scratch,
+        result_redaction_root=scratch,
+    )
+
+    result = provider.invoke("local:fs_list", {"path": "../escape"})
+
+    assert not result.ok
+    assert str(scratch) not in result.error
+    assert "workspace root (.)" in result.error
+
+
 # -- session approvals + persistence seams (Task 5) ---------------------------
 
 

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -784,6 +784,34 @@ def test_private_root_locator_is_redacted_from_local_tool_errors(tmp_path):
     assert "workspace root (.)" in result.error
 
 
+def test_private_root_locator_is_redacted_before_error_length_cap(tmp_path):
+    from tldw_chatbook.Agents.local_tool_provider import LocalToolSpec
+
+    private_root = tmp_path / ("PRIVATE_LOCATOR_" + ("x" * 350))
+
+    def fail(_args):
+        raise RuntimeError(f"{private_root}/marker.txt")
+
+    provider = make_provider(
+        root=tmp_path,
+        specs=[
+            LocalToolSpec(
+                name="fail",
+                description="fails with a long private locator",
+                parameters={},
+                handler=fail,
+            )
+        ],
+        result_redaction_root=private_root,
+    )
+
+    result = provider.invoke("local:fail", {})
+
+    assert not result.ok
+    assert "PRIVATE_LOCATOR" not in result.error
+    assert result.error == "marker.txt"
+
+
 # -- session approvals + persistence seams (Task 5) ---------------------------
 
 

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -1,6 +1,8 @@
 # Tests/Agents/test_run_log_service_wiring.py
 """The service owns the writer: one counter per run tree, every caller logged."""
 
+import contextlib
+import functools
 import json
 from pathlib import Path
 
@@ -10,6 +12,7 @@ from tldw_chatbook.Agents import agent_service as agent_service_module
 from tldw_chatbook.Agents import run_log as run_log_module
 from tldw_chatbook.Agents.agent_models import (
     RUN_DONE,
+    SEARCH_RUN_LOG_TOOL_NAME,
     SPAWN_TOOL_NAME,
     AgentConfig,
     RunBudget,
@@ -19,6 +22,7 @@ from tldw_chatbook.Agents.run_log import RunLogWriter
 from tldw_chatbook.Agents.run_log_format import iter_records
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
 from tldw_chatbook.Chat.console_fleet_wake import compose_wake_notice
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
 
@@ -73,6 +77,58 @@ def read_all(root: Path):
     for segment in sorted(run_dirs[0].glob("logs.*.txt")):
         records.extend(iter_records(segment.read_bytes()))
     return records
+
+
+def test_writer_explicit_fallback_root_never_uses_global_sandbox(
+    tmp_path,
+    monkeypatch,
+):
+    chat_root = tmp_path / "chat"
+    chat_root.mkdir()
+    monkeypatch.setattr(
+        run_log_module,
+        "resolve_log_root",
+        lambda: (_ for _ in ()).throw(AssertionError("global root consulted")),
+    )
+    writer = RunLogWriter(
+        root=chat_root,
+        access_scope=lambda: contextlib.nullcontext(chat_root),
+    )
+
+    writer.bind("run-a")
+
+    assert writer.is_active
+    assert writer.log_dir is not None
+    assert writer.log_dir.is_relative_to(chat_root)
+
+
+def test_writer_lease_revocation_fails_closed_without_recreating_root(tmp_path):
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("chat-a")
+    writer = RunLogWriter(
+        root=snapshot.root,
+        access_scope=functools.partial(manager.lease, snapshot),
+    )
+    writer.bind("run-a")
+    assert writer.append(
+        run_id="run-a",
+        kind="primary",
+        type="model",
+        content="before close",
+    ) == 1
+
+    with manager.lease(snapshot):
+        manager.close("chat-a")
+        assert snapshot.root.exists()
+
+    assert writer.append(
+        run_id="run-a",
+        kind="primary",
+        type="model",
+        content="after close",
+    ) is None
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    assert not snapshot.root.exists()
 
 
 def test_a_plain_run_writes_records_without_the_caller_wiring_anything(wired):
@@ -531,8 +587,6 @@ def test_tool_is_offered_to_the_primary_agent_only(wired, monkeypatch):
     disclosed" case, which ``test_tool_is_not_offered_when_nothing_else_is_disclosed``
     below covers.
     """
-    from tldw_chatbook.Agents.agent_models import SEARCH_RUN_LOG_TOOL_NAME
-
     db, registry, root = wired
     offered = []
 

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -131,6 +131,63 @@ def test_writer_lease_revocation_fails_closed_without_recreating_root(tmp_path):
     assert not snapshot.root.exists()
 
 
+def test_builtin_tool_result_log_does_not_persist_private_scratch_locator(tmp_path):
+    scratch = tmp_path / "private-scratch"
+    scratch.mkdir()
+    db = AgentRunsDB(tmp_path / "runs.db")
+    registry = ToolCatalogRegistry()
+    provider = BuiltinToolProvider(
+        gate=type("AllowGate", (), {"check": lambda self, tool, run_id: None})(),
+        sandbox_root=scratch,
+        sandbox_lease=lambda: contextlib.nullcontext(scratch),
+    )
+
+    class ScratchPathTool:
+        name = "scratch_path"
+        description = "returns one scratch-owned path"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self, **kwargs):
+            return {"file_path": str(scratch / "marker.txt")}
+
+    provider._tools["scratch_path"] = ScratchPathTool()
+    registry.register_provider(provider)
+    writer = RunLogWriter(
+        root=scratch,
+        access_scope=lambda: contextlib.nullcontext(scratch),
+    )
+    service = AgentService(
+        db,
+        registry,
+        chat_call=scripted_chat([fence("scratch_path", {}), "done"]),
+        run_log_writer=writer,
+    )
+
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "show the scratch path"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("scratch_path",),
+            budget=RunBudget(),
+        ),
+        api_endpoint="llama_cpp",
+    )
+
+    assert writer.log_dir is not None
+    tool_results = [
+        record
+        for record in all_records(writer.log_dir)
+        if record.type == "tool_result"
+    ]
+    assert len(tool_results) == 1
+    assert str(scratch) not in tool_results[0].content
+    assert json.loads(tool_results[0].content)["file_path"] == str(
+        Path(".") / "marker.txt"
+    )
+
+
 def test_a_plain_run_writes_records_without_the_caller_wiring_anything(wired):
     db, registry, root = wired
     service = AgentService(db, registry, chat_call=chat_call_returning("hello"))

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -131,6 +131,57 @@ def test_writer_lease_revocation_fails_closed_without_recreating_root(tmp_path):
     assert not snapshot.root.exists()
 
 
+def test_writer_failure_logs_do_not_persist_private_scratch_locator(
+    tmp_path,
+    monkeypatch,
+):
+    scratch = tmp_path / "PRIVATE_SCRATCH_LOCATOR"
+    scratch.mkdir()
+    warnings: list[str] = []
+    sink_id = run_log_module.logger.add(
+        lambda message: warnings.append(str(message)),
+        format="{message}",
+        level="WARNING",
+    )
+
+    @contextlib.contextmanager
+    def unavailable_scope():
+        raise OSError(f"lease failed at {scratch}/secret-token")
+        yield scratch
+
+    try:
+        refused = RunLogWriter(root=scratch, access_scope=unavailable_scope)
+        refused.bind("run-refused")
+
+        writer = RunLogWriter(
+            root=scratch,
+            access_scope=lambda: contextlib.nullcontext(scratch),
+        )
+        writer.bind("run-write")
+
+        def fail_write(*_args, **_kwargs):
+            raise OSError(f"write failed at {scratch}/.agent-runs/private")
+
+        monkeypatch.setattr(writer, "_write_bytes", fail_write)
+        assert (
+            writer.append(
+                run_id="run-write",
+                kind="primary",
+                type="model",
+                content="content",
+            )
+            is None
+        )
+    finally:
+        run_log_module.logger.remove(sink_id)
+
+    warning_text = "".join(warnings)
+    assert "access scope unavailable" in warning_text
+    assert "append failed" in warning_text
+    assert str(scratch) not in warning_text
+    assert "secret-token" not in warning_text
+
+
 def test_builtin_tool_result_log_does_not_persist_private_scratch_locator(tmp_path):
     scratch = tmp_path / "private-scratch"
     scratch.mkdir()

--- a/Tests/Agents/test_run_log_workspace_isolation.py
+++ b/Tests/Agents/test_run_log_workspace_isolation.py
@@ -44,6 +44,7 @@ from tldw_chatbook.Agents.agent_models import (
     AgentConfig,
     RunBudget,
 )
+from tldw_chatbook.Agents import run_log as run_log_module
 from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Agents.run_log import RunLogWriter
 from tldw_chatbook.Agents.run_log_format import RunLogRecord, encode_record
@@ -97,9 +98,45 @@ def _workspace_seams(monkeypatch, sandbox: Path, workspace: Path) -> None:
     sandbox.mkdir(parents=True, exist_ok=True)
     workspace.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(file_tools, "_tool_sandbox_root", lambda: sandbox)
-    fake_roots = lambda write=False, sandbox_root=None: (sandbox, workspace)
+
+    def fake_roots(write=False, sandbox_root=None):
+        return sandbox, workspace
+
     monkeypatch.setattr(ws_roots, "allowed_file_roots", fake_roots)
     monkeypatch.setattr(file_tools, "allowed_file_roots", fake_roots)
+
+
+def test_explicit_console_resolution_preserves_writable_workspace_preference(
+    tmp_path,
+    monkeypatch,
+):
+    from tldw_chatbook.Tools import workspace_file_roots as ws_roots
+
+    scratch = tmp_path / "chat"
+    workspace = tmp_path / "workspace"
+    scratch.mkdir()
+    workspace.mkdir()
+    observed = {}
+
+    def roots(*, write, sandbox_root):
+        observed["write"] = write
+        observed["sandbox_root"] = sandbox_root
+        observed["workspace_id"] = ws_roots.current_run_workspace_id()
+        return scratch, workspace
+
+    monkeypatch.setattr(ws_roots, "allowed_file_roots", roots)
+
+    resolved = run_log_module.resolve_log_root(
+        sandbox_root=scratch,
+        workspace_id="ws-a",
+    )
+
+    assert resolved == workspace
+    assert observed == {
+        "write": True,
+        "sandbox_root": scratch.resolve(),
+        "workspace_id": "ws-a",
+    }
 
 
 def _grep(pattern: str) -> list[dict]:

--- a/Tests/Chat/test_console_activity_presentation.py
+++ b/Tests/Chat/test_console_activity_presentation.py
@@ -15,6 +15,7 @@ from tldw_chatbook.Agents.agent_models import (
     ToolResult,
 )
 from tldw_chatbook.Agents.local_tool_provider import (
+    LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
     LOCAL_DENY_REFUSAL,
     LOCAL_GATE_ERROR_REFUSAL,
     LOCAL_KILL_SWITCH_REFUSAL,
@@ -258,6 +259,7 @@ def test_direct_controller_review_results_are_blocked(verdict: str) -> None:
         LOCAL_KILL_SWITCH_REFUSAL,
         LOCAL_GATE_ERROR_REFUSAL,
         LOCAL_ROOT_CHANGED_REFUSAL,
+        LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
         MCP_DENY_REFUSAL,
         MCP_USER_DENY_REFUSAL,
         MCP_UNRESOLVED_REFUSAL,

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -8,6 +8,7 @@ import os
 import threading
 import time
 from dataclasses import replace
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -916,9 +917,7 @@ def test_usage_accounting_failure_never_flips_a_streamed_run_to_error(
     def _boom(*_args, **_kwargs):
         raise RuntimeError("usage extraction exploded")
 
-    monkeypatch.setattr(
-        console_agent_bridge, "_openai_usage_from_provider_call", _boom
-    )
+    monkeypatch.setattr(console_agent_bridge, "_openai_usage_from_provider_call", _boom)
     warnings: list[str] = []
     sink_id = logger.add(warnings.append, level="WARNING", format="{message}")
     try:
@@ -1171,6 +1170,51 @@ def test_run_reply_threads_session_workspace_id_end_to_end(tmp_path, monkeypatch
     assert wfr.current_run_workspace_id() is None  # cleared after the run
 
 
+def test_run_reply_threads_captured_scratch_end_to_end(tmp_path, monkeypatch):
+    """The live run's file dispatch observes its captured private sandbox."""
+    import tldw_chatbook.config as config
+    from tldw_chatbook.Tools import workspace_file_roots as wfr
+    from tldw_chatbook.Tools.file_operation_tools import ReadFileTool
+
+    real_setting = config.get_cli_setting
+
+    def enable_read_file(section, key, default=None):
+        if section == "tools" and key == "read_file_enabled":
+            return True
+        return real_setting(section, key, default)
+
+    observed: list[Path | None] = []
+    real_execute = ReadFileTool.execute
+
+    async def recording_execute(self, file_path, **kwargs):
+        observed.append(wfr.current_run_sandbox_root())
+        return await real_execute(self, file_path, **kwargs)
+
+    monkeypatch.setattr(config, "get_cli_setting", enable_read_file)
+    monkeypatch.setattr(ReadFileTool, "execute", recording_execute)
+
+    scratch = tmp_path / "chat-a"
+    scratch.mkdir()
+    marker = scratch / "marker.txt"
+    marker.write_text("chat-a", encoding="utf-8")
+    scripts = [[_fence("read_file", {"file_path": str(marker)})], ["done"]]
+    bridge, _db, store, session, aid = _bridge(tmp_path / "run", scripts)
+
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        aid,
+        builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
+        scratch_root=scratch,
+        scratch_lease=lambda: contextlib.nullcontext(scratch),
+    )
+
+    assert outcome.status == "done"
+    assert observed == [scratch.resolve()]
+    assert wfr.current_run_sandbox_root() is None
+
+
 class _RecordingGateway:
     """Records each turn's system prompt (messages[0]) and answers 'ok'."""
 
@@ -1208,9 +1252,7 @@ def test_run_reply_appends_workspace_note_for_a_non_default_workspace(
     assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
 
     outcome = _run(
         bridge, store, session, assistant.id, session_system_prompt="BASE PROMPT"
@@ -1237,9 +1279,7 @@ def test_run_reply_adds_no_workspace_note_for_the_default_workspace(
     assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
 
     outcome = _run(
         bridge, store, session, assistant.id, session_system_prompt="BASE PROMPT"
@@ -1426,9 +1466,7 @@ def test_native_multi_call_round_emits_one_thinking_marker_with_resume_parity(
         "tool",
         "tool",
     ]
-    assert sum(
-        marker.activity_presentation.kind == "thinking" for marker in live
-    ) == 1
+    assert sum(marker.activity_presentation.kind == "thinking" for marker in live) == 1
     assert _activity_marker_signature(resumed) == _activity_marker_signature(live)
 
 
@@ -3500,21 +3538,15 @@ def test_live_and_resume_change_marker_inventory_has_content_and_metadata_parity
     inventory = [
         (
             CHANGE_KIND_TURN,
-            TurnChangeRecord(
-                root="/turn", files_changed=1, adds=2, dels=3
-            ),
+            TurnChangeRecord(root="/turn", files_changed=1, adds=2, dels=3),
         ),
         (
             CHANGE_KIND_SUBAGENT_POST_TURN,
-            TurnChangeRecord(
-                root="/post", files_changed=2, adds=4, dels=5
-            ),
+            TurnChangeRecord(root="/post", files_changed=2, adds=4, dels=5),
         ),
         (
             CHANGE_KIND_TURN_CONCURRENT_SUBAGENT,
-            TurnChangeRecord(
-                root="/concurrent", files_changed=3, adds=6, dels=7
-            ),
+            TurnChangeRecord(root="/concurrent", files_changed=3, adds=6, dels=7),
         ),
         (
             CHANGE_KIND_TURN,
@@ -3882,9 +3914,7 @@ def test_resume_marker_messages_heals_disclosure_when_live_append_never_happened
     assert len(blocks) == 1
     block = blocks[0][1]
     assert len(block) == 1  # no marker-worthy steps -- only the healed row
-    assert block[0].content == format_diff_feedback_disclosure(
-        db.notes_for_run(run_id)
-    )
+    assert block[0].content == format_diff_feedback_disclosure(db.notes_for_run(run_id))
     assert "healed disclosure" in block[0].content
 
 
@@ -4843,9 +4873,7 @@ def test_append_to_last_user_message_stacks_two_sequential_calls_in_order():
     messages = [original_message]
 
     after_bundle, attached_1 = _append_to_last_user_message(messages, "BUNDLE")
-    after_feedback, attached_2 = _append_to_last_user_message(
-        after_bundle, "FEEDBACK"
-    )
+    after_feedback, attached_2 = _append_to_last_user_message(after_bundle, "FEEDBACK")
 
     assert attached_1 is True
     assert attached_2 is True
@@ -5159,6 +5187,67 @@ def test_compose_run_registry_and_allowed_no_workspace_id_is_unchanged():
     result = registry.invoke_by_name("probe_workspace", {})
     assert result.ok, result.error
     assert '"workspace": null' in result.content
+
+
+def test_run_registry_binds_builtin_provider_to_captured_scratch(tmp_path):
+    scratch = tmp_path / "chat-a"
+    scratch.mkdir()
+
+    registry, _allowed, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(
+            {},
+            builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
+            workspace_id="workspace-default",
+            scratch_root=scratch,
+            scratch_lease=lambda: contextlib.nullcontext(scratch),
+        )
+    )
+
+    provider = registry._providers[0]
+    assert provider.sandbox_root == scratch.resolve()
+
+
+@pytest.mark.parametrize("missing", ["root", "lease"])
+def test_run_registry_rejects_incomplete_scratch_authority(tmp_path, missing):
+    scratch = tmp_path / "chat-a"
+    scratch.mkdir()
+    kwargs = {
+        "scratch_root": scratch,
+        "scratch_lease": lambda: contextlib.nullcontext(scratch),
+    }
+    kwargs["scratch_root" if missing == "root" else "scratch_lease"] = None
+
+    with pytest.raises(ValueError, match="supplied together"):
+        _compose_run_registry_and_allowed({}, **kwargs)
+
+
+def test_two_console_runs_cannot_dispatch_across_scratch_roots(tmp_path):
+    from tldw_chatbook.Tools.file_operation_tools import ReadFileTool
+
+    root_a = tmp_path / "chat-a"
+    root_b = tmp_path / "chat-b"
+    root_a.mkdir()
+    root_b.mkdir()
+    marker = root_a / "marker.txt"
+    marker.write_text("chat-a", encoding="utf-8")
+    registry_b, _allowed, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(
+            {},
+            builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
+            workspace_id="workspace-default",
+            scratch_root=root_b,
+            scratch_lease=lambda: contextlib.nullcontext(root_b),
+        )
+    )
+    registry_b._providers[0]._tools["read_file"] = ReadFileTool()
+
+    result = registry_b.invoke_by_name(
+        "read_file",
+        {"file_path": str(marker)},
+    )
+
+    assert result.ok is False
+    assert "outside" in str(result.error).lower()
 
 
 class _StubWriteFileTool:
@@ -5683,9 +5772,7 @@ def test_run_reply_forwards_review_tool_calls_hook_to_agent_service(tmp_path):
     # PR2a Task 5: an AgentService-wired hook takes `(calls, run_id)`.
     def hook(calls, run_id):
         captured_batches.append(list(calls))
-        return {
-            "calculator": CONTROLLER_USER_DENIED_REFUSAL.format(name="calculator")
-        }
+        return {"calculator": CONTROLLER_USER_DENIED_REFUSAL.format(name="calculator")}
 
     outcome = _run(bridge, store, session, aid, review_tool_calls=hook)
 

--- a/Tests/Chat/test_console_agent_project_instructions.py
+++ b/Tests/Chat/test_console_agent_project_instructions.py
@@ -960,6 +960,59 @@ async def test_controller_notice_uses_owning_session_and_drift_cancels_bridge_se
     assert SENTINEL not in repr(notices[0])
 
 
+@pytest.mark.asyncio
+async def test_folderless_session_skips_optional_project_instructions_and_runs(
+    tmp_path,
+):
+    store = ConsoleChatStore()
+    session = store.create_session(workspace_id="workspace-default")
+    bridge_calls = []
+    setup_calls = []
+
+    class Bridge:
+        def run_reply(self, **kwargs):
+            bridge_calls.append(kwargs)
+            return "run-1", RunOutcome(status=RUN_DONE, steps=[], final_text="")
+
+    class Gateway:
+        async def resolve_for_send(self, _selection):
+            return ConsoleProviderResolution(
+                provider="DeepSeek",
+                base_url="https://api.deepseek.com",
+                model="deepseek-chat",
+                ready=True,
+                readiness_key="deepseek",
+                execution_key="deepseek",
+                max_tokens=128,
+            )
+
+    async def select_binding(*args):
+        setup_calls.append(args)
+        return "cancel", None
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=Gateway(),
+        provider="deepseek",
+        model="deepseek-chat",
+        agent_bridge=Bridge(),
+        agent_runtime_enabled=True,
+        select_project_instruction_binding=select_binding,
+    )
+    controller.app = SimpleNamespace(
+        workspace_registry_service=_BindingRegistry([]),
+    )
+
+    result = await controller.submit_draft("question")
+
+    assert result.accepted is True
+    assert result.should_clear_draft is True
+    assert setup_calls == []
+    assert len(bridge_calls) == 1
+    assert bridge_calls[0]["startup_instruction_candidate"] is None
+    assert controller.run_state_for(session.id).status.value == "completed"
+
+
 def test_removed_or_retargeted_binding_never_silently_retargets(tmp_path):
     original = tmp_path / "original"
     retarget = tmp_path / "retarget"

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -33,6 +33,7 @@ from tldw_chatbook.Agents.agent_models import (
     SPAWN_TOOL_NAME,
     STEP_ERROR,
     STEP_TOOL_RESULT,
+    ToolCall,
     WAIT_AGENTS_TOOL_NAME,
 )
 from tldw_chatbook.Agents.mcp_tool_provider import MCPToolProvider
@@ -153,9 +154,7 @@ class _SignalGateway:
             shared synthetic-fallback signal.
     """
 
-    def __init__(
-        self, scripts, *, child_scripts=(), mark_fallback_calls=frozenset()
-    ):
+    def __init__(self, scripts, *, child_scripts=(), mark_fallback_calls=frozenset()):
         self._scripts = list(scripts)
         self._child_scripts = list(child_scripts)
         self._mark_fallback_calls = mark_fallback_calls
@@ -295,6 +294,7 @@ def _mcp_tests_keep_a_small_catalog(monkeypatch):
         return real_get_cli_setting(section, key, default, *args, **kwargs)
 
     monkeypatch.setattr(controller_module, "get_cli_setting", _small_catalog)
+
 
 def _controller(tmp_path, scripts, *, child_scripts=(), enabled=True):
     gateway = _Gateway(scripts, child_scripts)
@@ -475,9 +475,7 @@ async def test_agent_run_records_persisted_assistant_message_id(tmp_path):
     store = ConsoleChatStore(persistence=persistence)
     gateway = _Gateway([["Tok", "yo."]])
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
     controller = ConsoleChatController(
         store=store,
         provider_gateway=gateway,
@@ -1401,9 +1399,7 @@ def _fake_app(service=None):
 def _capturing_run_reply(captured, *, final_text="ok."):
     def run_reply(**kwargs):
         captured.append(kwargs)
-        return "run-test", RunOutcome(
-            status=RUN_DONE, steps=[], final_text=final_text
-        )
+        return "run-test", RunOutcome(status=RUN_DONE, steps=[], final_text=final_text)
 
     return run_reply
 
@@ -1538,6 +1534,83 @@ async def test_review_hook_and_run_reply_share_one_builtin_gate(tmp_path, monkey
 
 
 @pytest.mark.asyncio
+async def test_review_precheck_and_dispatch_share_captured_scratch(
+    tmp_path,
+    monkeypatch,
+):
+    """Approval precheck and worker dispatch receive one immutable authority."""
+    import tldw_chatbook.config as config
+
+    class ScratchReviewGate:
+        def __init__(self):
+            self.stamps = []
+
+        def begin_turn(self, _run_id):
+            return None
+
+        def resolve(self, _tool):
+            return EffectiveToolState(state="ask", origin="builtin_default")
+
+        def stamp(self, run_id, name, decision):
+            self.stamps.append((run_id, name, decision))
+
+        def is_session_approved(self, _name):
+            return False
+
+    real_setting = config.get_cli_setting
+
+    def enable_read_file(section, key, default=None):
+        if section == "tools" and key == "read_file_enabled":
+            return True
+        return real_setting(section, key, default)
+
+    observed = {}
+
+    def record_precheck(_name, _args, **kwargs):
+        observed.update(kwargs)
+        return False
+
+    controller, store, _db = _controller(tmp_path, [["ok."]])
+    captured = []
+    controller._agent_bridge.run_reply = _capturing_run_reply(captured)
+    controller.app = _fake_app()
+    controller.request_mcp_approvals = lambda pending, **_kwargs: {
+        row.call_id or row.llm_name: "approve_once" for row in pending
+    }
+    gate = ScratchReviewGate()
+    monkeypatch.setattr(config, "get_cli_setting", enable_read_file)
+    monkeypatch.setattr(controller_module, "build_builtin_gate", lambda _=None: gate)
+    monkeypatch.setattr(controller_module, "path_precheck_failed", record_precheck)
+
+    result = await controller.submit_draft("hi")
+
+    assert result.accepted is True
+    dispatch_root = captured[0]["scratch_root"]
+    dispatch_lease = captured[0]["scratch_lease"]
+    with dispatch_lease() as leased_root:
+        assert leased_root == dispatch_root
+
+    review_hook = captured[0]["review_tool_calls"]
+    review_hook(
+        [
+            ToolCall(
+                name="read_file",
+                args={"file_path": str(dispatch_root / "input.txt")},
+                call_id="read-1",
+            )
+        ],
+        "run-1",
+    )
+
+    assert observed["sandbox_root"] == dispatch_root
+    assert observed["sandbox_lease"] is dispatch_lease
+    assert observed["workspace_id"] == store.session_workspace_id(
+        store.active_session_id
+    )
+    assert controller._scratch_spaces.dispose()
+
+
+@pytest.mark.asyncio
 async def test_mcp_tool_call_executes_end_to_end_when_state_allows(tmp_path):
     """Full plumbing, real bridge: a fence call to an MCP tool name is
     registered, dispatched, and actually invoked via the real provider --
@@ -1639,7 +1712,9 @@ async def test_mcp_tool_call_session_approval_suppresses_card_on_next_turn(tmp_p
     llm_name = received[-1]["calls"][0]["llm_name"]
     assert llm_name == "mcp__srv__run"
     round_id = received[-1]["round_id"]
-    controller.resolve_pending_approval({llm_name: "approve_session"}, round_id=round_id)
+    controller.resolve_pending_approval(
+        {llm_name: "approve_session"}, round_id=round_id
+    )
     result1 = await send_task
     assert result1.accepted is True
     cards_pushed_after_turn1 = len(received)

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -60,6 +60,10 @@ def test_close_session_tombstones_scratch_before_store_removal(tmp_path):
             events.append("scratch-close")
             return super().close(session_id)
 
+    class RecordingBridge:
+        def forget_session_file_authority(self, _session_id):
+            events.append("authority-forget")
+
     store = RecordingStore()
     session = store.create_session()
     scratch_spaces = RecordingScratchSpaces(temp_parent=tmp_path)
@@ -68,11 +72,12 @@ def test_close_session_tombstones_scratch_before_store_removal(tmp_path):
         store=store,
         provider_gateway=_Gateway([]),
         scratch_spaces=scratch_spaces,
+        agent_bridge=RecordingBridge(),
     )
 
     controller.close_session(session.id)
 
-    assert events[:2] == ["scratch-close", "store-close"]
+    assert events[:3] == ["scratch-close", "authority-forget", "store-close"]
     assert scratch_spaces.wait_for_cleanup(timeout_seconds=2.0)
 
 

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -15,6 +15,7 @@ from tldw_chatbook.Chat.console_project_instructions import (
     ProjectInstructionControlState,
 )
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.Chat.citation_repair import CitationRepairContract
 from tldw_chatbook.Chat.citation_trace_models import MarkerNamespace
 from tldw_chatbook.Chat.console_provider_gateway import (
@@ -43,6 +44,35 @@ from Tests.Agents.test_mcp_tool_provider import (
     _catalog_record,
     _tool_dict,
 )
+
+
+def test_close_session_tombstones_scratch_before_store_removal(tmp_path):
+    events: list[str] = []
+
+    class RecordingStore(ConsoleChatStore):
+        def close_session(self, session_id):
+            events.append("store-close")
+            return super().close_session(session_id)
+
+    class RecordingScratchSpaces(ConsoleScratchSpaceManager):
+        def close(self, session_id):
+            events.append("scratch-close")
+            return super().close(session_id)
+
+    store = RecordingStore()
+    session = store.create_session()
+    scratch_spaces = RecordingScratchSpaces(temp_parent=tmp_path)
+    scratch_spaces.snapshot(session.id)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_Gateway([]),
+        scratch_spaces=scratch_spaces,
+    )
+
+    controller.close_session(session.id)
+
+    assert events[:2] == ["scratch-close", "store-close"]
+    assert scratch_spaces.wait_for_cleanup(timeout_seconds=2.0)
 
 
 @pytest.fixture(autouse=True)

--- a/Tests/Chat/test_console_agent_tool_result_cap.py
+++ b/Tests/Chat/test_console_agent_tool_result_cap.py
@@ -18,6 +18,9 @@ Covers:
 
 from __future__ import annotations
 
+import contextlib
+import functools
+
 import pytest
 
 from tldw_chatbook.Agents import run_log as run_log_module
@@ -33,6 +36,8 @@ from tldw_chatbook.Chat.console_agent_bridge import (
     _console_tool_result_display_cap,
     format_agent_step_marker,
 )
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
 
@@ -256,6 +261,80 @@ def test_load_run_log_text_returns_the_full_untruncated_result(bridge, log_root)
 
     assert LONG_RESULT in text
     assert "grep_files" in text
+
+
+def test_console_bridge_does_not_find_another_sessions_scratch_log(
+    tmp_path,
+    monkeypatch,
+):
+    root_a = tmp_path / "chat-a"
+    root_b = tmp_path / "chat-b"
+    root_a.mkdir()
+    root_b.mkdir()
+    writer = RunLogWriter(
+        root=root_a,
+        access_scope=lambda: contextlib.nullcontext(root_a),
+    )
+    writer.bind("run-b")
+    writer.append(
+        run_id="run-b",
+        kind="primary",
+        type="model",
+        content="chat-a secret",
+    )
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: root_a)
+    console_bridge = ConsoleAgentBridge(
+        agent_runs_db=AgentRunsDB(tmp_path / "runs-isolated.db", client_id="t"),
+        store=ConsoleChatStore(),
+        provider_gateway=None,
+    )
+    console_bridge._remember_run_log_authority(
+        run_id="run-b",
+        session_id="session-b",
+        root=root_b,
+        access_scope=lambda: contextlib.nullcontext(root_b),
+    )
+
+    assert console_bridge.run_log_available("run-b") is False
+    assert console_bridge.load_run_log_text("run-b") == ""
+
+
+def test_console_bridge_run_log_read_fails_closed_after_chat_revocation(tmp_path):
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("session-a")
+    console_bridge = ConsoleAgentBridge(
+        agent_runs_db=AgentRunsDB(tmp_path / "runs-revoked.db", client_id="t"),
+        store=ConsoleChatStore(),
+        provider_gateway=None,
+    )
+    access_scope = functools.partial(manager.lease, snapshot)
+    writer = RunLogWriter(
+        root=snapshot.root,
+        access_scope=access_scope,
+        on_bound=functools.partial(
+            console_bridge._remember_run_log_authority,
+            session_id="session-a",
+            access_scope=access_scope,
+        ),
+    )
+    writer.bind("run-a")
+    assert writer.append(
+        run_id="run-a",
+        kind="primary",
+        type="model",
+        content="private",
+    ) == 1
+    assert console_bridge.run_log_available("run-a") is True
+
+    with manager.lease(snapshot):
+        manager.close("session-a")
+        assert snapshot.root.exists()
+        assert console_bridge.run_log_available("run-a") is False
+        assert console_bridge.load_run_log_text("run-a") == ""
+
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    console_bridge.forget_session_file_authority("session-a")
+    assert console_bridge._run_log_authority_for("run-a") is None
 
 
 def test_latest_primary_run_id_resolves_the_newest_primary_run(bridge):

--- a/Tests/Chat/test_console_local_review_hook.py
+++ b/Tests/Chat/test_console_local_review_hook.py
@@ -12,7 +12,10 @@ import pytest
 
 import tldw_chatbook.Chat.console_chat_controller as controller_mod
 from tldw_chatbook.Agents.agent_models import ToolCall
-from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
+from tldw_chatbook.Agents.local_tool_provider import (
+    LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
+    LocalToolProvider,
+)
 from tldw_chatbook.Agents.run_context import use_run_id
 from tldw_chatbook.Chat.console_chat_controller import (
     ConsoleChatController,
@@ -425,7 +428,7 @@ def test_default_chat_local_provider_rejects_after_scratch_close(tmp_path):
     result = provider.invoke("local:fs_list", {"path": "."})
 
     assert result.ok is False
-    assert "root changed" in result.error.lower()
+    assert result.error == LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL
     assert scratch_spaces.wait_for_cleanup(timeout_seconds=2.0)
 
 

--- a/Tests/Chat/test_console_local_review_hook.py
+++ b/Tests/Chat/test_console_local_review_hook.py
@@ -5,6 +5,7 @@ stamps, ONE approval round trip per batch, verdicts only ever "proceed".
 """
 
 import json
+import weakref
 from types import SimpleNamespace
 
 import pytest
@@ -18,6 +19,9 @@ from tldw_chatbook.Chat.console_chat_controller import (
     build_combined_review_hook,
     build_local_review_hook,
 )
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
+from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
 from tldw_chatbook.runtime_policy.bootstrap import default_runtime_policy_path
@@ -186,9 +190,36 @@ def _bare_controller(app):
     """A controller instance with only what _compose_local_provider touches."""
     controller = object.__new__(ConsoleChatController)
     controller.app = app
+    controller._agent_bridge = None
     controller._pending_approval_event = None
     controller._pending_approval_decisions = None
+    scratch_spaces = ConsoleScratchSpaceManager()
+    scratch_snapshot = scratch_spaces.snapshot("test-chat")
+    controller._scratch_spaces = scratch_spaces
+    controller._test_turn_context = ConsoleTurnExecutionContext.capture(
+        session_id="test-chat",
+        provider_selection=ConsoleProviderSelection(provider="deepseek"),
+        scratch_space=scratch_snapshot,
+        tool_configuration={
+            "local_tools_enabled": controller_mod.get_cli_setting(
+                "console",
+                "local_tools_enabled",
+                True,
+            )
+        },
+    )
+    weakref.finalize(controller, scratch_spaces.dispose)
     return controller
+
+
+def _compose_local_provider(controller, *args, **kwargs):
+    """Call the production composer with this harness's captured scratch."""
+    kwargs.setdefault("turn_context", controller._test_turn_context)
+    return ConsoleChatController._compose_local_provider(
+        controller,
+        *args,
+        **kwargs,
+    )
 
 
 def _console_settings(enabled=True, workspace_root=""):
@@ -208,7 +239,9 @@ def test_compose_local_provider_disabled_flag(monkeypatch, tmp_path):
         controller_mod, "get_cli_setting", _console_settings(enabled=False)
     )
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
-    assert controller._compose_local_provider() == (None, None)
+    assert _compose_local_provider(
+        controller,
+    ) == (None, None)
 
 
 def test_compose_local_provider_missing_master_key_defaults_enabled(
@@ -222,7 +255,9 @@ def test_compose_local_provider_missing_master_key_defaults_enabled(
     monkeypatch.setattr(controller_mod, "get_cli_setting", missing_master_setting)
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
 
-    local_provider, hook = controller._compose_local_provider()
+    local_provider, hook = _compose_local_provider(
+        controller,
+    )
 
     assert isinstance(local_provider, LocalToolProvider)
     assert callable(hook)
@@ -243,7 +278,9 @@ def test_compose_local_provider_coerces_quoted_false_to_disabled(monkeypatch, tm
         controller_mod, "get_cli_setting", _console_settings(enabled="false")
     )
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
-    assert controller._compose_local_provider() == (None, None)
+    assert _compose_local_provider(
+        controller,
+    ) == (None, None)
 
 
 def test_compose_local_provider_coerces_quoted_true_to_enabled(monkeypatch, tmp_path):
@@ -254,7 +291,9 @@ def test_compose_local_provider_coerces_quoted_true_to_enabled(monkeypatch, tmp_
         _console_settings(enabled="true", workspace_root=str(tmp_path)),
     )
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
-    local_provider, hook = controller._compose_local_provider()
+    local_provider, hook = _compose_local_provider(
+        controller,
+    )
     assert isinstance(local_provider, LocalToolProvider)
     assert callable(hook)
 
@@ -262,14 +301,18 @@ def test_compose_local_provider_coerces_quoted_true_to_enabled(monkeypatch, tmp_
 def test_compose_local_provider_no_service(monkeypatch, tmp_path):
     monkeypatch.setattr(controller_mod, "get_cli_setting", _console_settings())
     controller = _bare_controller(SimpleNamespace())  # no unified_mcp_service
-    assert controller._compose_local_provider() == (None, None)
+    assert _compose_local_provider(
+        controller,
+    ) == (None, None)
 
 
 def test_compose_local_provider_kill_switch_on(monkeypatch, tmp_path):
     monkeypatch.setattr(controller_mod, "get_cli_setting", _console_settings())
     app = SimpleNamespace(unified_mcp_service=_FakeService(kill_switch=True))
     controller = _bare_controller(app)
-    assert controller._compose_local_provider() == (None, None)
+    assert _compose_local_provider(
+        controller,
+    ) == (None, None)
 
 
 def test_compose_local_provider_kill_switch_read_failure_fails_closed(
@@ -284,7 +327,9 @@ def test_compose_local_provider_kill_switch_read_failure_fails_closed(
     controller = _bare_controller(
         SimpleNamespace(unified_mcp_service=_RaisingService())
     )
-    assert controller._compose_local_provider() == (None, None)
+    assert _compose_local_provider(
+        controller,
+    ) == (None, None)
 
 
 def test_compose_local_provider_eligible(monkeypatch, tmp_path):
@@ -296,10 +341,14 @@ def test_compose_local_provider_eligible(monkeypatch, tmp_path):
     service = _FakeService()
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=service))
 
-    local_provider, hook = controller._compose_local_provider()
+    local_provider, hook = _compose_local_provider(
+        controller,
+    )
 
     assert isinstance(local_provider, LocalToolProvider)
-    assert local_provider._root == tmp_path.resolve()
+    assert local_provider.workspace_root == (
+        controller._test_turn_context.scratch_space.root
+    )
     assert callable(hook)
     catalog_ids = {entry.id for entry in local_provider.list_catalog()}
     assert {
@@ -312,6 +361,72 @@ def test_compose_local_provider_eligible(monkeypatch, tmp_path):
     # resolve_state is the same payload source the MCP gate uses.
     gate = local_provider.pending_gate_for("fs_list", {"path": "."})
     assert gate is not None and gate.server_key == "local:__local__"
+
+
+def test_default_chat_local_provider_uses_scratch_not_config_or_cwd(
+    monkeypatch,
+    tmp_path,
+):
+    configured = tmp_path / "configured"
+    cwd = tmp_path / "cwd"
+    configured.mkdir()
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(
+        controller_mod,
+        "get_cli_setting",
+        _console_settings(enabled=True, workspace_root=str(configured)),
+    )
+    scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = scratch_spaces.snapshot("chat-a")
+    context = ConsoleTurnExecutionContext.capture(
+        session_id="chat-a",
+        provider_selection=ConsoleProviderSelection(provider="deepseek"),
+        scratch_space=snapshot,
+        tool_configuration={
+            "local_tools_enabled": True,
+            "workspace_root": str(configured),
+        },
+    )
+    controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
+    controller._scratch_spaces = scratch_spaces
+
+    provider, review = _compose_local_provider(
+        controller,
+        session_id="chat-a",
+        turn_context=context,
+    )
+
+    assert provider.workspace_root == snapshot.root
+    assert callable(review)
+    assert scratch_spaces.dispose()
+
+
+def test_default_chat_local_provider_rejects_after_scratch_close(tmp_path):
+    scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = scratch_spaces.snapshot("chat-a")
+    context = ConsoleTurnExecutionContext.capture(
+        session_id="chat-a",
+        provider_selection=ConsoleProviderSelection(provider="deepseek"),
+        scratch_space=snapshot,
+        tool_configuration={"local_tools_enabled": True},
+    )
+    controller = _bare_controller(
+        SimpleNamespace(unified_mcp_service=_FakeService(state=ALLOW))
+    )
+    controller._scratch_spaces = scratch_spaces
+    provider, _review = _compose_local_provider(
+        controller,
+        session_id="chat-a",
+        turn_context=context,
+    )
+
+    scratch_spaces.close("chat-a")
+    result = provider.invoke("local:fs_list", {"path": "."})
+
+    assert result.ok is False
+    assert "root changed" in result.error.lower()
+    assert scratch_spaces.wait_for_cleanup(timeout_seconds=2.0)
 
 
 def test_compose_local_provider_reuses_app_database_and_loads_runtime_source_per_call(
@@ -347,7 +462,9 @@ def test_compose_local_provider_reuses_app_database_and_loads_runtime_source_per
         subscriptions_db=database,
     )
     controller = _bare_controller(app)
-    provider, hook = controller._compose_local_provider()
+    provider, hook = _compose_local_provider(
+        controller,
+    )
     watchlists_service = provider._specs["watchlists_search_items"].handler.__self__
     assert watchlists_service._db_resolver() is database
 
@@ -450,7 +567,9 @@ def test_console_watchlists_real_reads_leave_app_owned_state_unchanged(
                 subscriptions_db=database,
             )
         )
-        provider, _hook = controller._compose_local_provider()
+        provider, _hook = _compose_local_provider(
+            controller,
+        )
 
         search = provider.invoke("local:watchlists_search_items", {"query": "needle"})
         detail = provider.invoke(
@@ -466,14 +585,22 @@ def test_console_watchlists_real_reads_leave_app_owned_state_unchanged(
         database.close()
 
 
-def test_compose_local_provider_empty_workspace_root_uses_cwd(monkeypatch, tmp_path):
+def test_compose_local_provider_empty_workspace_root_uses_scratch(
+    monkeypatch,
+    tmp_path,
+):
     monkeypatch.setattr(controller_mod, "get_cli_setting", _console_settings())
     monkeypatch.chdir(tmp_path)
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
 
-    local_provider, _hook = controller._compose_local_provider()
+    local_provider, _hook = _compose_local_provider(
+        controller,
+    )
 
-    assert local_provider._root == tmp_path.resolve()
+    assert local_provider.workspace_root == (
+        controller._test_turn_context.scratch_space.root
+    )
+    assert local_provider.workspace_root != tmp_path.resolve()
 
 
 def test_local_provider_read_only_filters_write_specs_without_global_mutation(tmp_path):
@@ -504,13 +631,18 @@ def test_compose_local_provider_selected_root_overrides_disabled_fallback(
     )
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
 
-    legacy_provider, _ = controller._compose_local_provider()
-    selected_provider, _ = controller._compose_local_provider(
-        project_root=selected, allow_write=False
+    legacy_provider, _ = _compose_local_provider(
+        controller,
+    )
+    selected_provider, _ = _compose_local_provider(
+        controller, project_root=selected, allow_write=False
     )
 
-    assert legacy_provider._root == fallback.resolve()
-    assert selected_provider._root == selected.resolve()
+    assert legacy_provider.workspace_root == (
+        controller._test_turn_context.scratch_space.root
+    )
+    assert legacy_provider.workspace_root != fallback.resolve()
+    assert selected_provider.workspace_root == selected.resolve()
     selected_names = {entry.name for entry in selected_provider.list_catalog()}
     assert {"fs_write", "fs_edit", "fs_patch"}.isdisjoint(selected_names)
 
@@ -524,7 +656,8 @@ def test_selected_root_swap_fails_closed_before_local_invoke(monkeypatch, tmp_pa
     controller = _bare_controller(
         SimpleNamespace(unified_mcp_service=_FakeService(state=ALLOW))
     )
-    local_provider, review = controller._compose_local_provider(
+    local_provider, review = _compose_local_provider(
+        controller,
         project_root=selected,
         project_root_identity=identity,
     )
@@ -536,19 +669,23 @@ def test_selected_root_swap_fails_closed_before_local_invoke(monkeypatch, tmp_pa
     (outside / "secret.txt").write_text("outside")
     selected.symlink_to(outside, target_is_directory=True)
 
-    assert review([ToolCall(name="fs_read", args={"path": "secret.txt"})]) == {}
+    assert (
+        review(
+            [ToolCall(name="fs_read", args={"path": "secret.txt"})],
+            "run-root-swap",
+        )
+        == {}
+    )
     result = local_provider.invoke("fs_read", {"path": "secret.txt"})
     assert result.ok is False
     assert "root changed" in result.error.lower()
     assert "outside" not in result.error
 
 
-def test_compose_local_provider_tilde_workspace_root_expands_home(
+def test_compose_local_provider_tilde_workspace_root_does_not_grant_home_access(
     monkeypatch, tmp_path
 ):
-    """A configured ``~/repo`` must expand against HOME (PR #1352 review):
-    without expanduser() the root would resolve to a literal "~" directory
-    under the cwd."""
+    """The retired configured root cannot replace a chat's private scratch."""
     home = tmp_path / "home"
     (home / "repo").mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
@@ -560,9 +697,14 @@ def test_compose_local_provider_tilde_workspace_root_expands_home(
     )
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
 
-    local_provider, _hook = controller._compose_local_provider()
+    local_provider, _hook = _compose_local_provider(
+        controller,
+    )
 
-    assert local_provider._root == (home / "repo").resolve()
+    assert local_provider.workspace_root == (
+        controller._test_turn_context.scratch_space.root
+    )
+    assert local_provider.workspace_root != (home / "repo").resolve()
 
 
 def test_compose_local_provider_persists_session_and_always_allow(
@@ -575,7 +717,9 @@ def test_compose_local_provider_persists_session_and_always_allow(
     )
     service = _FakeService()
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=service))
-    local_provider, _hook = controller._compose_local_provider()
+    local_provider, _hook = _compose_local_provider(
+        controller,
+    )
 
     (tmp_path / "a.txt").write_text("a")
 
@@ -597,7 +741,9 @@ def test_compose_local_provider_session_approval_skips_reprompt(monkeypatch, tmp
     service = _FakeService()
     service.approve_for_session("local:__local__", "fs_list")
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=service))
-    local_provider, _hook = controller._compose_local_provider()
+    local_provider, _hook = _compose_local_provider(
+        controller,
+    )
 
     assert local_provider.pending_gate_for("fs_list", {"path": "."}) is None
     (tmp_path / "a.txt").write_text("a")
@@ -614,7 +760,9 @@ def _composed(monkeypatch, tmp_path, service):
         _console_settings(workspace_root=str(tmp_path)),
     )
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=service))
-    local_provider, _hook = controller._compose_local_provider()
+    local_provider, _hook = _compose_local_provider(
+        controller,
+    )
     assert local_provider is not None
     return local_provider
 
@@ -703,7 +851,9 @@ def test_compose_local_provider_without_session_registers_no_todo_spec(
     )
     controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
 
-    local_provider, _hook = controller._compose_local_provider()
+    local_provider, _hook = _compose_local_provider(
+        controller,
+    )
 
     assert _registered_task_tools(local_provider) == set()
     assert "todo_write" not in {entry.name for entry in local_provider.list_catalog()}
@@ -733,7 +883,7 @@ def test_compose_local_provider_wires_the_sessions_exact_todo_store(
         )
     )
 
-    local_provider, _hook = controller._compose_local_provider(session_id=target.id)
+    local_provider, _hook = _compose_local_provider(controller, session_id=target.id)
 
     created = local_provider.invoke("local:todo_create", {"content": "Ship it"})
 
@@ -758,7 +908,7 @@ def test_compose_local_provider_unknown_session_registers_no_todo_spec(
     controller.store = ConsoleChatStore()
     controller._agent_bridge = SimpleNamespace(append_todo_marker=lambda *a: None)
 
-    local_provider, _hook = controller._compose_local_provider(session_id="ghost")
+    local_provider, _hook = _compose_local_provider(controller, session_id="ghost")
 
     assert _registered_task_tools(local_provider) == set()
 
@@ -779,6 +929,6 @@ def test_compose_local_provider_without_bridge_registers_no_todo_spec(
     session = controller.store.create_session(workspace_id="ws")
     controller._agent_bridge = None
 
-    local_provider, _hook = controller._compose_local_provider(session_id=session.id)
+    local_provider, _hook = _compose_local_provider(controller, session_id=session.id)
 
     assert _registered_task_tools(local_provider) == set()

--- a/Tests/Chat/test_console_scratch_space.py
+++ b/Tests/Chat/test_console_scratch_space.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import shutil
+import stat
+import threading
+from pathlib import Path
+
+import pytest
+
+import tldw_chatbook.Chat.console_scratch_space as scratch_module
+from tldw_chatbook.Chat.console_scratch_space import (
+    ConsoleScratchSnapshot,
+    ConsoleScratchSpaceManager,
+    ConsoleScratchSpaceUnavailable,
+)
+
+
+def test_snapshots_are_distinct_owner_only_and_identifier_free(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+
+    first = manager.snapshot("session-visible-id-a")
+    second = manager.snapshot("session-visible-id-b")
+
+    assert first.root != second.root
+    assert "session-visible-id" not in first.root.name
+    assert stat.S_IMODE(first.root.stat().st_mode) == 0o700
+    assert not first.root.is_symlink()
+    assert manager.dispose()
+
+
+def test_chat_cannot_observe_another_chat_scratch_contents(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    first = manager.snapshot("a")
+    second = manager.snapshot("b")
+
+    with manager.lease(first) as root:
+        (root / "marker.txt").write_text("a", encoding="utf-8")
+
+    assert not (second.root / "marker.txt").exists()
+    assert manager.dispose()
+
+
+def test_close_rejects_new_lease_and_waits_for_last_active_lease(
+    tmp_path: Path,
+) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("a")
+    lease = manager.lease(snapshot)
+    lease.__enter__()
+
+    manager.close("a")
+
+    with pytest.raises(ConsoleScratchSpaceUnavailable):
+        with manager.lease(snapshot):
+            pass
+    assert snapshot.root.exists()
+
+    lease.__exit__(None, None, None)
+
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    assert not snapshot.root.exists()
+
+
+def test_reopen_gets_new_generation_and_empty_root(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    old = manager.snapshot("session")
+    (old.root / "marker").write_text("old", encoding="utf-8")
+
+    manager.close("session")
+
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    fresh = manager.snapshot("session")
+    assert fresh.token != old.token
+    assert fresh.root != old.root
+    assert not (fresh.root / "marker").exists()
+    assert manager.dispose()
+
+
+def test_replaced_root_fails_closed_without_deleting_replacement(
+    tmp_path: Path,
+) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("session")
+    displaced = tmp_path / "original-root"
+    snapshot.root.rename(displaced)
+    snapshot.root.mkdir(mode=0o700)
+    (snapshot.root / "keep.txt").write_text("replacement", encoding="utf-8")
+
+    with pytest.raises(ConsoleScratchSpaceUnavailable):
+        with manager.lease(snapshot):
+            pass
+
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    assert (snapshot.root / "keep.txt").read_text(encoding="utf-8") == "replacement"
+    shutil.rmtree(snapshot.root)
+    shutil.rmtree(displaced)
+
+
+def test_cleanup_failure_stays_tombstoned_for_later_dispose_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("session")
+    cleanup_attempted = threading.Event()
+    real_rmtree = scratch_module.shutil.rmtree
+
+    def fail_cleanup(path: Path) -> None:
+        cleanup_attempted.set()
+        raise OSError("simulated cleanup failure")
+
+    monkeypatch.setattr(scratch_module.shutil, "rmtree", fail_cleanup)
+    manager.close("session")
+
+    assert cleanup_attempted.wait(timeout=2.0)
+    assert not manager.wait_for_cleanup(timeout_seconds=0.01)
+    with pytest.raises(ConsoleScratchSpaceUnavailable):
+        with manager.lease(snapshot):
+            pass
+
+    monkeypatch.setattr(scratch_module.shutil, "rmtree", real_rmtree)
+    assert manager.dispose(timeout_seconds=2.0)
+    assert not snapshot.root.exists()
+
+
+def test_dispose_is_bounded_with_active_lease_and_idempotent(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("session")
+    lease = manager.lease(snapshot)
+    lease.__enter__()
+
+    assert not manager.dispose(timeout_seconds=0.01)
+    with pytest.raises(ConsoleScratchSpaceUnavailable):
+        manager.snapshot("another-session")
+
+    lease.__exit__(None, None, None)
+    assert manager.wait_for_cleanup(timeout_seconds=2.0)
+    assert manager.dispose(timeout_seconds=0.01)
+    assert manager.dispose(timeout_seconds=0.01)
+
+
+def test_snapshot_is_immutable(tmp_path: Path) -> None:
+    manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = manager.snapshot("session")
+
+    with pytest.raises((AttributeError, TypeError)):
+        snapshot.root = tmp_path  # type: ignore[misc]
+
+    assert isinstance(snapshot, ConsoleScratchSnapshot)
+    assert manager.is_live(snapshot)
+    assert manager.dispose()

--- a/Tests/Chat/test_console_scratch_space.py
+++ b/Tests/Chat/test_console_scratch_space.py
@@ -103,6 +103,12 @@ def test_cleanup_failure_stays_tombstoned_for_later_dispose_retry(
     manager = ConsoleScratchSpaceManager(temp_parent=tmp_path)
     snapshot = manager.snapshot("session")
     cleanup_attempted = threading.Event()
+    warnings: list[str] = []
+    sink_id = scratch_module.logger.add(
+        lambda message: warnings.append(str(message)),
+        format="{message}",
+        level="WARNING",
+    )
     real_rmtree = scratch_module.shutil.rmtree
 
     def fail_cleanup(path: Path) -> None:
@@ -110,13 +116,20 @@ def test_cleanup_failure_stays_tombstoned_for_later_dispose_retry(
         raise OSError("simulated cleanup failure")
 
     monkeypatch.setattr(scratch_module.shutil, "rmtree", fail_cleanup)
-    manager.close("session")
+    try:
+        manager.close("session")
 
-    assert cleanup_attempted.wait(timeout=2.0)
-    assert not manager.wait_for_cleanup(timeout_seconds=0.01)
-    with pytest.raises(ConsoleScratchSpaceUnavailable):
-        with manager.lease(snapshot):
-            pass
+        assert cleanup_attempted.wait(timeout=2.0)
+        assert not manager.wait_for_cleanup(timeout_seconds=0.01)
+        with pytest.raises(ConsoleScratchSpaceUnavailable):
+            with manager.lease(snapshot):
+                pass
+    finally:
+        scratch_module.logger.remove(sink_id)
+
+    warning_text = "".join(warnings)
+    assert "Console scratch cleanup deferred" in warning_text
+    assert snapshot.token not in warning_text
 
     monkeypatch.setattr(scratch_module.shutil, "rmtree", real_rmtree)
     assert manager.dispose(timeout_seconds=2.0)

--- a/Tests/Chat/test_console_turn_execution_context.py
+++ b/Tests/Chat/test_console_turn_execution_context.py
@@ -18,6 +18,7 @@ from tldw_chatbook.Chat.console_chat_models import (
 )
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 
@@ -171,18 +172,20 @@ def test_live_tool_kill_switch_is_not_frozen_into_turn_context():
     assert review_hook is None
 
 
-def test_legacy_session_without_settings_still_uses_own_workspace():
+def test_legacy_session_without_settings_still_uses_own_workspace(tmp_path):
     store = ConsoleChatStore()
     first = store.create_session(workspace_id="workspace-a")
     store.create_session(workspace_id="workspace-b")
     store.set_workspace_context(
         ConsoleWorkspaceContext(active_workspace_id="workspace-b")
     )
+    scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
     controller = ConsoleChatController(
         store=store,
         provider_gateway=_PausedGateway(),
         provider="anthropic",
         model="model-b",
+        scratch_spaces=scratch_spaces,
     )
 
     context = controller.resolve_turn_execution_context(first.id)
@@ -190,9 +193,99 @@ def test_legacy_session_without_settings_still_uses_own_workspace():
     assert context.provider_selection.workspace_context.active_workspace_id == (
         "workspace-a"
     )
+    assert scratch_spaces.dispose()
 
 
-def test_session_builder_captures_roots_rag_tools_and_generation(monkeypatch):
+def test_turn_context_captures_frozen_scratch_snapshot(tmp_path):
+    store = ConsoleChatStore()
+    session = store.create_session(workspace_id="workspace-a")
+    scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_PausedGateway(),
+        scratch_spaces=scratch_spaces,
+    )
+
+    context = controller.resolve_turn_execution_context(session.id)
+
+    assert context.scratch_space == scratch_spaces.snapshot(session.id)
+    assert context.scratch_space.root.is_dir()
+    assert scratch_spaces.dispose()
+
+
+def test_two_live_sessions_for_same_saved_conversation_get_distinct_scratch(
+    tmp_path,
+):
+    store = ConsoleChatStore()
+    first = store.create_session(workspace_id="workspace-a")
+    second = store.create_session(workspace_id="workspace-a")
+    first.persisted_conversation_id = "saved-conversation"
+    second.persisted_conversation_id = "saved-conversation"
+    scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_PausedGateway(),
+        scratch_spaces=scratch_spaces,
+    )
+
+    first_context = controller.resolve_turn_execution_context(first.id)
+    second_context = controller.resolve_turn_execution_context(second.id)
+
+    assert first_context.scratch_space.root != second_context.scratch_space.root
+    assert first_context.scratch_space.token != second_context.scratch_space.token
+    assert scratch_spaces.dispose()
+
+
+def test_fallback_turn_context_does_not_capture_configured_workspace_root(
+    monkeypatch,
+    tmp_path,
+):
+    store = ConsoleChatStore()
+    session = store.create_session(workspace_id="workspace-a")
+    scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+
+    def setting(section, key, default=None):
+        if section == "console" and key == "workspace_root":
+            return "/configured/root"
+        return default
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Chat.console_chat_controller.get_cli_setting",
+        setting,
+    )
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_PausedGateway(),
+        scratch_spaces=scratch_spaces,
+    )
+
+    context = controller.resolve_turn_execution_context(session.id)
+
+    assert context.workspace_roots == ()
+    assert "workspace_root" not in context.tool_configuration
+    assert scratch_spaces.dispose()
+
+
+@pytest.mark.asyncio
+async def test_compatibility_controller_disposes_its_owned_scratch_space():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_PausedGateway(),
+    )
+    snapshot = controller.resolve_turn_execution_context(session.id).scratch_space
+
+    await controller.shutdown()
+
+    assert snapshot is not None
+    assert not snapshot.root.exists()
+
+
+def test_session_builder_captures_roots_rag_tools_and_generation(
+    monkeypatch,
+    tmp_path,
+):
     store = ConsoleChatStore()
     settings = _settings(
         "openai",
@@ -237,6 +330,9 @@ def test_session_builder_captures_roots_rag_tools_and_generation(monkeypatch):
     controller._chat_store_accessor = lambda: store
     controller._rag_source_types_accessor = lambda: ["notes", "media"]
     controller._rag_top_k_accessor = lambda: 7
+    scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    scratch_snapshot = scratch_spaces.snapshot(session.id)
+    controller._scratch_snapshot_provider = lambda _session_id: scratch_snapshot
 
     context = controller._build_console_turn_execution_context(session.id)
     roots.append(Path("C:/workspace/leak"))
@@ -244,6 +340,7 @@ def test_session_builder_captures_roots_rag_tools_and_generation(monkeypatch):
     app_config["chat_defaults"]["rag_auto_retrieve_on_send"] = "false"
 
     assert context.workspace_roots == (str(Path("C:/workspace/a")),)
+    assert context.scratch_space is scratch_snapshot
     assert context.rag_defaults == {
         "auto_retrieve_on_send": True,
         "source_types": ("notes", "media"),
@@ -252,9 +349,11 @@ def test_session_builder_captures_roots_rag_tools_and_generation(monkeypatch):
     assert context.tool_configuration["agent_runtime_enabled"] is True
     assert context.tool_configuration["native_tool_calls_enabled"] is False
     assert context.tool_configuration["local_tools_enabled"] is True
+    assert "workspace_root" not in context.tool_configuration
     assert context.tool_configuration["direct_library_tools"] is False
     assert context.provider_payload_settings["temperature"] == 0.4
     assert context.provider_payload_settings["max_tokens"] == 777
+    assert scratch_spaces.dispose()
 
 
 @pytest.mark.asyncio

--- a/Tests/Skills/test_e2e_run_skill_script.py
+++ b/Tests/Skills/test_e2e_run_skill_script.py
@@ -34,6 +34,7 @@ test_skill_remote_fetch.py``.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 from dataclasses import dataclass
 from pathlib import Path
@@ -95,6 +96,9 @@ class _E2EEnv:
     tool: Callable[[str, str, list], ToolResult]
     confirm_calls: list[dict[str, Any]]
     marker_path: Path
+    scratch_root: Path
+    bridge: ConsoleAgentBridge
+    run_id: str
     _trust_service: Any
     _skill_dir: Path
 
@@ -190,6 +194,10 @@ def e2e_bridge_env(tmp_path, monkeypatch) -> Callable[..., _E2EEnv]:
             f"from pathlib import Path\nPath({str(marker_path)!r}).write_text('ran')\n",
             encoding="utf-8",
         )
+        (skill_dir / "scripts" / "produce.py").write_text(
+            "from pathlib import Path\nPath('artifact.txt').write_text('owned')\n",
+            encoding="utf-8",
+        )
         if trusted:
             trust_service.trust_current_skill(_SKILL_NAME, audit_event="e2e_setup")
 
@@ -245,6 +253,8 @@ def e2e_bridge_env(tmp_path, monkeypatch) -> Callable[..., _E2EEnv]:
             provider_gateway=_PlainTextGateway(),
             skills_service=scope_service,
         )
+        scratch_root = tmp_path / "chat-scratch"
+        scratch_root.mkdir()
         bridge.run_reply(
             conversation_id="conv-e2e-script",
             session_id=session.id,
@@ -255,7 +265,11 @@ def e2e_bridge_env(tmp_path, monkeypatch) -> Callable[..., _E2EEnv]:
             agent_messages=[{"role": "user", "content": "hi"}],
             should_cancel=lambda: False,
             request_skill_script_confirm=confirm_cb,
+            scratch_root=scratch_root,
+            scratch_lease=lambda: contextlib.nullcontext(scratch_root),
         )
+        run = db.latest_primary_run_metadata("conv-e2e-script")
+        assert run is not None
 
         assert real_agent_service is _RealAgentService  # sanity: patched the real class
         tool = captured.get("run_skill_script_tool")
@@ -265,6 +279,9 @@ def e2e_bridge_env(tmp_path, monkeypatch) -> Callable[..., _E2EEnv]:
             tool=tool,
             confirm_calls=confirm_calls,
             marker_path=marker_path,
+            scratch_root=scratch_root,
+            bridge=bridge,
+            run_id=str(run["id"]),
             _trust_service=trust_service,
             _skill_dir=skill_dir,
         )
@@ -283,6 +300,31 @@ def test_agent_call_runs_a_real_script_and_returns_its_stdout(e2e_bridge_env):
     assert result.ok is True
     assert "hello from a real skill script" in result.content
     assert "exit_code: 0" in result.content
+
+
+def test_agent_retains_output_under_chat_scratch_without_disclosing_locator(
+    e2e_bridge_env,
+):
+    env = e2e_bridge_env(confirm={"allow": True, "remember": False})
+
+    result = env.tool("demo-skill", "scripts/produce.py", [])
+
+    assert result.ok is True
+    retained = list((env.scratch_root / "skill_script_output").glob("*/artifact.txt"))
+    assert len(retained) == 1
+    assert str(env.scratch_root) not in result.content
+    assert "output directory: skill_script_output/" in result.content
+
+
+def test_console_run_registers_private_in_memory_run_log_authority(e2e_bridge_env):
+    env = e2e_bridge_env(confirm={"allow": True, "remember": False})
+
+    authority = env.bridge._run_log_authority_for(env.run_id)
+
+    assert authority is not None
+    assert authority.root.is_relative_to(env.scratch_root)
+    assert env.bridge.run_log_available(env.run_id) is True
+    assert str(env.scratch_root) not in env.bridge.load_run_log_text(env.run_id)
 
 
 def test_denied_confirm_never_runs_the_script(e2e_bridge_env):

--- a/Tests/Skills/test_skill_script_service.py
+++ b/Tests/Skills/test_skill_script_service.py
@@ -2,6 +2,7 @@
 
 import os
 import stat
+from pathlib import Path
 
 import pytest
 
@@ -212,6 +213,66 @@ async def test_script_cannot_write_into_its_own_bundle(script_service):
     result = await service.run_skill_script(name, "scripts/writer.py", [])
     assert "wrote" in result.stdout
     assert not (skill_dir / "tampered.txt").exists()
+
+
+def _add_output_producer(service, name: str) -> None:
+    """Add and trust a script that leaves one retained artifact."""
+    (service._skill_dir(name) / "scripts" / "produce.py").write_text(
+        "open('artifact.txt', 'w').write('chat-owned')",
+        encoding="utf-8",
+    )
+    service.trust_service.trust_current_skill(name, audit_event="test_setup")
+
+
+@pytest.mark.asyncio
+async def test_explicit_console_output_root_overrides_shared_skill_config(
+    script_service,
+    tmp_path,
+    monkeypatch,
+):
+    service, name = script_service
+    _add_output_producer(service, name)
+    shared = tmp_path / "shared"
+    chat_root = tmp_path / "chat"
+    monkeypatch.setattr(service, "_script_output_root", lambda: shared)
+
+    result = await service.run_skill_script(
+        name,
+        "scripts/produce.py",
+        [],
+        output_root=chat_root / "skill_script_output",
+    )
+
+    assert Path(result.output_dir).is_relative_to(chat_root)
+    assert not shared.exists()
+
+
+@pytest.mark.asyncio
+async def test_two_console_skill_runs_retain_under_their_own_chat_roots(
+    script_service,
+    tmp_path,
+):
+    service, name = script_service
+    _add_output_producer(service, name)
+    first = tmp_path / "chat-a" / "skill_script_output"
+    second = tmp_path / "chat-b" / "skill_script_output"
+
+    result_a = await service.run_skill_script(
+        name,
+        "scripts/produce.py",
+        [],
+        output_root=first,
+    )
+    result_b = await service.run_skill_script(
+        name,
+        "scripts/produce.py",
+        [],
+        output_root=second,
+    )
+
+    assert Path(result_a.output_dir).is_relative_to(first)
+    assert Path(result_b.output_dir).is_relative_to(second)
+    assert not Path(result_a.output_dir).is_relative_to(second)
 
 
 @pytest.mark.asyncio
@@ -566,6 +627,26 @@ async def test_scope_service_rejects_server_mode(script_scope_service):
     scope, name = script_scope_service
     with pytest.raises(ValueError, match="local-only"):
         await scope.run_skill_script(name, "scripts/hello.py", [], mode="server")
+
+
+@pytest.mark.asyncio
+async def test_scope_service_forwards_explicit_console_output_root(
+    script_scope_service,
+    tmp_path,
+):
+    scope, name = script_scope_service
+    service = scope.local_service
+    _add_output_producer(service, name)
+    output_root = tmp_path / "chat" / "skill_script_output"
+
+    result = await scope.run_skill_script(
+        name,
+        "scripts/produce.py",
+        [],
+        output_root=output_root,
+    )
+
+    assert Path(result.output_dir).is_relative_to(output_root)
 
 
 @pytest.mark.asyncio

--- a/Tests/Tools/test_workspace_file_roots.py
+++ b/Tests/Tools/test_workspace_file_roots.py
@@ -11,6 +11,7 @@ import pytest
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Workspaces import DEFAULT_WORKSPACE_ID, LocalWorkspaceRegistryService
 from tldw_chatbook.Tools import workspace_file_roots as wfr
+from tldw_chatbook.Tools import file_operation_tools as file_tools
 
 
 @pytest.fixture(autouse=True)
@@ -86,6 +87,68 @@ def test_registry_failure_degrades_to_sandbox_only(tmp_path, monkeypatch) -> Non
     sandbox.mkdir()
     with wfr.run_workspace("ws-a"):
         assert wfr.allowed_file_roots(write=True, sandbox_root=sandbox) == (sandbox,)
+
+
+def test_run_file_sandbox_overrides_global_only_inside_scope(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    global_root = tmp_path / "global"
+    scratch = tmp_path / "chat"
+    global_root.mkdir()
+    scratch.mkdir()
+    monkeypatch.setattr(
+        file_tools,
+        "_resolve_sandbox_config",
+        lambda: str(global_root),
+    )
+
+    with wfr.run_file_sandbox(scratch):
+        assert file_tools._tool_sandbox_root() == scratch.resolve()
+
+    assert file_tools._tool_sandbox_root() == global_root.resolve()
+
+
+def test_scratch_stays_first_when_workspace_bindings_are_available(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    registry = _registry(tmp_path)
+    binding = tmp_path / "binding"
+    binding.mkdir()
+    registry.add_folder_binding("ws-a", binding)
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    scratch = tmp_path / "chat"
+    scratch.mkdir()
+
+    with wfr.run_file_sandbox(scratch), wfr.run_workspace("ws-a"):
+        roots = wfr.allowed_file_roots(
+            write=False,
+            sandbox_root=file_tools._tool_sandbox_root(),
+        )
+
+    assert roots == (scratch.resolve(), binding.resolve())
+
+
+def test_registry_failure_keeps_captured_scratch_as_only_root(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    scratch = tmp_path / "chat"
+    scratch.mkdir()
+    monkeypatch.setattr(
+        wfr,
+        "_registry_factory",
+        lambda: (_ for _ in ()).throw(RuntimeError("registry unavailable")),
+    )
+
+    with wfr.run_file_sandbox(scratch), wfr.run_workspace("ws-a"):
+        roots = wfr.allowed_file_roots(
+            write=False,
+            sandbox_root=file_tools._tool_sandbox_root(),
+        )
+
+    assert roots == (scratch.resolve(),)
 
 
 def test_default_registry_factory_is_cached(tmp_path, monkeypatch) -> None:
@@ -175,9 +238,7 @@ def test_note_empty_for_no_workspace(tmp_path) -> None:
 
 def test_note_names_workspace_and_states_non_default(tmp_path) -> None:
     registry = _registry(tmp_path)
-    note = wfr.workspace_context_note(
-        "ws-a", launch_cwd=tmp_path, registry=registry
-    )
+    note = wfr.workspace_context_note("ws-a", launch_cwd=tmp_path, registry=registry)
     assert "NOT running in the default workspace" in note
     assert "Client A" in note
 

--- a/Tests/Tools/test_workspace_file_roots.py
+++ b/Tests/Tools/test_workspace_file_roots.py
@@ -89,6 +89,35 @@ def test_registry_failure_degrades_to_sandbox_only(tmp_path, monkeypatch) -> Non
         assert wfr.allowed_file_roots(write=True, sandbox_root=sandbox) == (sandbox,)
 
 
+def test_default_chat_ignores_folder_bindings_even_from_permissive_registry(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Default Chat stays scratch-only even if a registry violates its contract."""
+    scratch = tmp_path / "chat"
+    external = tmp_path / "external"
+    scratch.mkdir()
+    external.mkdir()
+
+    class PermissiveRegistry:
+        def list_folder_bindings(self, _workspace_id):
+            return (
+                type(
+                    "Binding",
+                    (),
+                    {"locator": str(external), "metadata": {"access": "rw"}},
+                )(),
+            )
+
+    monkeypatch.setattr(wfr, "_registry_factory", PermissiveRegistry)
+
+    with wfr.run_workspace(DEFAULT_WORKSPACE_ID):
+        roots = wfr.allowed_file_roots(write=False, sandbox_root=scratch)
+
+    assert roots == (scratch,)
+    assert wfr.folder_binding_roots(DEFAULT_WORKSPACE_ID) == ()
+
+
 def test_run_file_sandbox_overrides_global_only_inside_scope(
     tmp_path,
     monkeypatch,

--- a/Tests/UI/test_change_review_current_mode.py
+++ b/Tests/UI/test_change_review_current_mode.py
@@ -434,6 +434,7 @@ async def test_pseudo_entry_absent_without_candidate_roots(
         # CAUSE rather than asserting nothing changed. This test's subject
         # (no pseudo-entry without candidate roots) is unchanged.
         assert "No folder is bound" in screen.diff_pane_text()
+        assert "Chats still work in private scratch" in screen.diff_pane_text()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -4337,7 +4337,7 @@ async def test_console_workspace_authority_rows_are_structured_for_scanning():
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "Local file tools"
+            == "Local files"
         )
         assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)
@@ -7203,7 +7203,7 @@ async def test_console_browser_selecting_default_native_session_uses_private_scr
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "Local file tools"
+            == "Local files"
         )
         assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)
@@ -7271,7 +7271,7 @@ async def test_console_browser_selecting_default_persisted_row_uses_private_scra
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "Local file tools"
+            == "Local files"
         )
         assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)
@@ -8795,7 +8795,7 @@ async def test_console_workspace_rail_new_conversation_creates_default_workspace
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "Local file tools"
+            == "Local files"
         )
         assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -4337,9 +4337,9 @@ async def test_console_workspace_authority_rows_are_structured_for_scanning():
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "File tools"
+            == "Local file tools"
         )
-        assert "Off in Default" in _static_plain_text(
+        assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)
         )
         # TASK-715: factory-default sync/server/ACP rows collapse into one line.
@@ -7160,7 +7160,7 @@ async def test_console_browser_selecting_duplicate_membership_row_ignores_other_
 
 
 @pytest.mark.asyncio
-async def test_console_browser_selecting_default_native_session_switches_to_default_and_keeps_file_tools_disabled():
+async def test_console_browser_selecting_default_native_session_uses_private_scratch():
     app = _build_test_app()
     _configure_native_ready_console(app)
     app.conversation_local_marks_service = FakeConversationLocalMarksService()
@@ -7203,15 +7203,15 @@ async def test_console_browser_selecting_default_native_session_switches_to_defa
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "File tools"
+            == "Local file tools"
         )
-        assert "Off in Default" in _static_plain_text(
+        assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)
         )
 
 
 @pytest.mark.asyncio
-async def test_console_browser_selecting_default_persisted_row_switches_to_default_and_keeps_file_tools_disabled():
+async def test_console_browser_selecting_default_persisted_row_uses_private_scratch():
     app = _build_test_app()
     _configure_native_ready_console(app)
     app.conversation_local_marks_service = FakeConversationLocalMarksService()
@@ -7271,9 +7271,9 @@ async def test_console_browser_selecting_default_persisted_row_switches_to_defau
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "File tools"
+            == "Local file tools"
         )
-        assert "Off in Default" in _static_plain_text(
+        assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)
         )
 
@@ -8774,11 +8774,14 @@ async def test_console_workspace_rail_new_conversation_creates_default_workspace
         await pilot.click("#console-new-chat-tab")
         second = store.active_session_id
         assert second != first.id
+        assert host.screen_stack[-1] is console
 
         active_session = next(
             session for session in store.sessions() if session.id == second
         )
         assert active_session.workspace_id == DEFAULT_WORKSPACE_ID
+        scratch = console._console_runtime().scratch_spaces.snapshot(second)
+        assert scratch.root.is_dir()
         await _wait_for_workspace_conversation_text(
             console,
             pilot,
@@ -8792,9 +8795,9 @@ async def test_console_workspace_rail_new_conversation_creates_default_workspace
             _static_plain_text(
                 console.query_one("#console-workspace-runtime-label", Static)
             )
-            == "File tools"
+            == "Local file tools"
         )
-        assert "Off in Default" in _static_plain_text(
+        assert "Private scratch" in _static_plain_text(
             console.query_one("#console-workspace-runtime-value", Static)
         )
         # TASK-715: factory-default sync/server/ACP rows collapse into one line.

--- a/Tests/UI/test_console_new_workspace.py
+++ b/Tests/UI/test_console_new_workspace.py
@@ -5,11 +5,50 @@ from __future__ import annotations
 import pytest
 from textual.widgets import Button
 
+from Tests.UI.test_console_workspace_action_row_geometry import StyledConsoleHarness
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
 from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.UI.Console_Modules.left_rail import ConsoleLeftRail
+from tldw_chatbook.Widgets.Console import ConsoleBoundedSection
 from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
+
+
+async def _wait_for_create_modal(host: ConsoleHarness, pilot) -> WorkspaceCreateModal:
+    """Wait for the async screen push instead of assuming one pause is enough."""
+    for _ in range(100):
+        candidate = host.screen_stack[-1]
+        if isinstance(candidate, WorkspaceCreateModal) and candidate.query(
+            "#workspace-create-confirm"
+        ):
+            return candidate
+        await pilot.pause(0.01)
+    raise AssertionError("Workspace create modal did not open")
+
+
+async def _reveal_new_workspace_button(console, pilot) -> Button:
+    """Drive the bounded Workspace viewport before pressing its New button."""
+    if not console._current_console_rail_state().workspace_open:
+        console._toggle_console_rail_section("workspace")
+    rail = console.query_one("#console-left-rail", ConsoleLeftRail)
+    section = console.query_one(
+        "#console-bounded-section-workspace", ConsoleBoundedSection
+    )
+    button = console.query_one("#console-new-workspace", Button)
+    rail.activate_section("workspace")
+    for _ in range(100):
+        if (section.allocation or 0) > 1:
+            break
+        await pilot.pause(0.01)
+    else:
+        raise AssertionError("Workspace section did not receive a usable allocation")
+    console.query_one("#console-left-rail-body").scroll_to_widget(
+        section, animate=False, immediate=True
+    )
+    section.viewport.scroll_to_widget(button, animate=False, immediate=True)
+    await pilot.pause(0.1)
+    return button
 
 
 @pytest.mark.asyncio
@@ -24,19 +63,16 @@ async def test_console_new_workspace_creates_and_activates() -> None:
     """
     app = _build_test_app()
     registry_service = app.workspace_registry_service
-    host = ConsoleHarness(app)
+    host = StyledConsoleHarness(app)
 
     async with host.run_test(size=(160, 44)) as pilot:
         await pilot.pause(0.2)
         console = host.screen_stack[-1]
         before = len(registry_service.list_workspaces())
-        new_button = console.query_one("#console-new-workspace", Button)
+        new_button = await _reveal_new_workspace_button(console, pilot)
         assert new_button.disabled is False
         new_button.press()
-        await pilot.pause()
-
-        modal = host.screen_stack[-1]
-        assert isinstance(modal, WorkspaceCreateModal)
+        modal = await _wait_for_create_modal(host, pilot)
 
         modal.query_one("#workspace-create-confirm", Button).press()
 
@@ -61,7 +97,7 @@ async def test_console_new_workspace_announces_creation() -> None:
     see test_console_new_workspace_creates_and_activates's docstring.
     """
     app = _build_test_app()
-    host = ConsoleHarness(app)
+    host = StyledConsoleHarness(app)
 
     async with host.run_test(size=(160, 44)) as pilot:
         await pilot.pause(0.2)
@@ -70,11 +106,8 @@ async def test_console_new_workspace_announces_creation() -> None:
         app.notify = lambda message, **kwargs: notifications.append(
             (str(message), kwargs)
         )
-        console.query_one("#console-new-workspace", Button).press()
-        await pilot.pause()
-
-        modal = host.screen_stack[-1]
-        assert isinstance(modal, WorkspaceCreateModal)
+        (await _reveal_new_workspace_button(console, pilot)).press()
+        modal = await _wait_for_create_modal(host, pilot)
 
         modal.query_one("#workspace-create-confirm", Button).press()
 

--- a/Tests/UI/test_console_project_instructions.py
+++ b/Tests/UI/test_console_project_instructions.py
@@ -1251,6 +1251,12 @@ async def test_controller_preview_does_not_advance_live_session_state(
     consent.assert_not_called()
     state_setter.assert_not_called()
     exact_builder.assert_called_once()
+    preview_kwargs = exact_builder.call_args.kwargs
+    scratch_snapshot = controller._scratch_spaces.snapshot(session.id)
+    assert preview_kwargs["scratch_root"] == scratch_snapshot.root
+    with preview_kwargs["scratch_lease"]() as leased_root:
+        assert leased_root == scratch_snapshot.root
+    assert controller._scratch_spaces.dispose()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -125,7 +125,7 @@ def _workspace_state() -> ConsoleWorkspaceContextState:
         workspace_label="Workspace: Default",
         authority_label="Authority: local registry ready",
         sync_label="Sync: not configured",
-        runtime_label="Runtime: none, file tools disabled",
+        runtime_label="Local file tools: Private scratch",
         conversation_rows=(),
         conversation_empty_copy="No conversations yet.",
         conversation_browser=build_console_conversation_browser_state(

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -38,6 +38,8 @@ from tldw_chatbook.Chat.console_runtime import (
     CONSOLE_VIEW_HOOK_SLOTS,
     ConsoleRuntime,
 )
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
 from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
 from tldw_chatbook.UI.Console_Modules.fleet import (
@@ -66,6 +68,90 @@ def test_console_runtime_owns_one_screen_free_persona_buddy_sink():
     assert isinstance(runtime.persona_buddy_sink, PersonaBuddyConsoleAdapter)
     assert runtime.persona_buddy_sink is runtime.persona_buddy_sink
     assert "view" not in vars(runtime.persona_buddy_sink)
+
+
+@pytest.mark.unit
+def test_console_runtime_reuses_one_scratch_manager_across_console_visits():
+    runtime = ConsoleRuntime(type("App", (), {})())
+    first = runtime.scratch_spaces
+
+    runtime.detach_view(None)
+
+    assert runtime.scratch_spaces is first
+
+
+@pytest.mark.asyncio
+async def test_runtime_injects_its_scratch_manager_into_chat_controller():
+    runtime = ConsoleRuntime(type("App", (), {})())
+
+    controller = runtime.ensure_chat_controller(
+        store=ConsoleChatStore(),
+        provider_gateway=object(),
+    )
+
+    assert controller._scratch_spaces is runtime.scratch_spaces
+    assert controller._owns_scratch_spaces is False
+    await runtime.dispose()
+
+
+@pytest.mark.asyncio
+async def test_leaving_console_preserves_live_session_scratch(tmp_path):
+    runtime = ConsoleRuntime(type("App", (), {})())
+    runtime._scratch_spaces = ConsoleScratchSpaceManager(temp_parent=tmp_path)
+    snapshot = runtime.scratch_spaces.snapshot("session-a")
+
+    assert await runtime.leave_console() is True
+
+    assert runtime.scratch_spaces.is_live(snapshot)
+    assert snapshot.root.is_dir()
+    await runtime.dispose()
+    assert not snapshot.root.exists()
+
+
+@pytest.mark.asyncio
+async def test_runtime_tombstones_before_shutdown_and_disposes_via_to_thread(
+    monkeypatch,
+):
+    events: list[str] = []
+
+    class ScratchSpaces:
+        def tombstone_all(self) -> None:
+            events.append("scratch-tombstone")
+
+        def dispose(self) -> bool:
+            events.append("scratch-dispose")
+            return True
+
+    class Controller:
+        async def shutdown(self) -> None:
+            events.append("controller-shutdown")
+
+    class Gateway:
+        async def aclose(self) -> None:
+            events.append("gateway-close")
+
+    async def fake_to_thread(function, *args, **kwargs):
+        events.append("to-thread")
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Chat.console_runtime.asyncio.to_thread",
+        fake_to_thread,
+    )
+    runtime = ConsoleRuntime(type("App", (), {})())
+    runtime._scratch_spaces = ScratchSpaces()
+    runtime._chat_controller = Controller()
+    runtime._provider_gateway = Gateway()
+
+    await runtime.dispose()
+
+    assert events == [
+        "scratch-tombstone",
+        "controller-shutdown",
+        "to-thread",
+        "scratch-dispose",
+        "gateway-close",
+    ]
 
 
 @pytest.mark.asyncio
@@ -658,6 +744,9 @@ async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
     async def later_lifecycle() -> None:
         events.append("later-lifecycle")
 
+    async def no_op_lifecycle() -> None:
+        return None
+
     console_task: asyncio.Task[None] | None = None
 
     async def console_runner() -> None:
@@ -677,6 +766,7 @@ async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
     app._persona_buddy_shutdown_task = None
     app._audio_cpp_artifact_lease_coordinator = None
     app.audio_cpp_model_install_owner = AsyncOwner()
+    app._shutdown_notes_sync_runtime = no_op_lifecycle
     app._shutdown_console_image_edits = later_lifecycle
     app._shutdown_console_runtime = shutdown_console_runtime
     app._shutdown_file_notes_session_owner = later_lifecycle

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -2206,6 +2206,41 @@ def _find_caret_in_row_with(lines: list[str], label_text: str) -> tuple[int, int
 
 
 @pytest.mark.asyncio
+async def test_narrow_details_rail_paints_full_private_scratch_value() -> None:
+    """The human-visible rail must not reduce the authority value to ``Priva…``."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(180, 55)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-runtime-value")
+        if not console._current_console_rail_state().details_open:
+            console._toggle_console_rail_section("details")
+        await pilot.pause()
+
+        details_section = console.query_one(
+            "#console-bounded-section-details", ConsoleBoundedSection
+        )
+        left_rail = console.query_one("#console-left-rail")
+        runtime_value = console.query_one("#console-workspace-runtime-value")
+        left_rail.activate_section("details")
+        await _wait_for_condition(
+            pilot,
+            lambda: (details_section.allocation or 0) > 1,
+        )
+        details_section.viewport.scroll_to_widget(
+            runtime_value, animate=False, immediate=True
+        )
+        await pilot.pause(0.1)
+
+        rendered_rows = _render_screen_lines(console)
+        assert any(
+            "Local files" in row and "Private scratch" in row
+            for row in rendered_rows
+        ), [row for row in rendered_rows if "Local" in row or "Priva" in row]
+
+
+@pytest.mark.asyncio
 async def test_section_header_caret_is_clickable_at_its_rendered_screen_coordinates() -> (
     None
 ):
@@ -2587,7 +2622,7 @@ async def test_console_workspace_context_exposes_new_conversation_for_default_wo
             console,
             label_selector="#console-workspace-runtime-label",
             value_selector="#console-workspace-runtime-value",
-            label="Local file tools",
+            label="Local files",
             value_contains="Private scratch",
         )
         # TASK-715: unconfigured server features collapse into one line
@@ -2997,7 +3032,7 @@ async def test_console_workspace_context_renders_server_readiness_handoff_and_ac
             console,
             label_selector="#console-workspace-runtime-label",
             value_selector="#console-workspace-runtime-value",
-            label="Local file tools",
+            label="Local files",
             value_contains="Private scratch",
         )
         assert "Handoff" in text

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunStatus,
 )
 from tldw_chatbook.Widgets.Console import (
+    ConsoleBoundedSection,
     ConsoleWorkspaceContextTray,
     ConsoleWorkspaceSwitcherModal,
 )
@@ -1477,8 +1478,11 @@ async def test_console_workspace_context_keeps_status_rows_below_grouped_browser
             console._toggle_console_rail_section("details")
         await pilot.pause()
 
-        details_tray = console.query_one("#console-workspace-details")
         left_rail_body = console.query_one("#console-left-rail-body")
+        details_section = console.query_one(
+            "#console-bounded-section-details", ConsoleBoundedSection
+        )
+        left_rail = console.query_one("#console-left-rail")
         conversation_list = console.query_one("#console-workspace-conversations")
         sync_label = console.query_one("#console-workspace-sync-label")
         server_readiness = console.query_one(
@@ -1486,21 +1490,30 @@ async def test_console_workspace_context_keeps_status_rows_below_grouped_browser
         )
         handoff_label = console.query_one("#console-workspace-handoff-label")
         composer = console.query_one("#console-native-composer")
-        details_bottom = details_tray.region.y + details_tray.region.height
-
         assert _static_plain(console, "#console-workspace-sync-label") == "Sync"
         assert sync_label.region.y > conversation_list.region.y
         assert server_readiness.region.y > conversation_list.region.y
 
         assert getattr(conversation_list, "max_scroll_y", 0) == 0
         assert left_rail_body.max_scroll_y > 0
-        left_rail_body.scroll_end(animate=False)
+        left_rail.activate_section("details")
+        await _wait_for_condition(
+            pilot,
+            lambda: (details_section.allocation or 0) > 1,
+        )
+        left_rail_body.scroll_to_widget(
+            details_section, animate=False, immediate=True
+        )
+        details_section.viewport.scroll_to_widget(
+            handoff_label, animate=False, immediate=True
+        )
         await pilot.pause(0.1)
 
         assert left_rail_body.scroll_y > 0
-        assert handoff_label.region.y >= details_tray.region.y
-        assert handoff_label.region.y + handoff_label.region.height <= details_bottom
-        assert handoff_label.region.y + handoff_label.region.height <= composer.region.y
+        lines = _render_screen_lines(console)
+        handoff_x, handoff_y = _find_text_in_row(lines, "ACP")
+        assert handoff_y < composer.region.y
+        assert console.get_widget_at(handoff_x, handoff_y)[0] is handoff_label
 
 
 @pytest.mark.asyncio
@@ -1728,57 +1741,71 @@ async def test_console_workspace_many_conversations_keep_lower_status_reachable(
             console, pilot, "#console-new-workspace-conversation"
         )
 
-        workspace_context = console.query_one("#console-workspace-context")
-        details_tray = console.query_one("#console-workspace-details")
         left_rail_body = console.query_one("#console-left-rail-body")
+        conversations_section = console.query_one(
+            "#console-bounded-section-conversations", ConsoleBoundedSection
+        )
+        details_section = console.query_one(
+            "#console-bounded-section-details", ConsoleBoundedSection
+        )
+        left_rail = console.query_one("#console-left-rail")
         conversation_list = console.query_one("#console-workspace-conversations")
         new_conversation = console.query_one(
             "#console-new-workspace-conversation", Button
         )
-        # TASK-14810 adds two peer disclosure headers above Conversations.
-        # At 34 rows the action can start just below the viewport, so drive
-        # the real rail scroll affordance before checking its hit target.
-        new_conversation.scroll_visible(animate=False)
-        await pilot.pause(0.1)
-        server_readiness = console.query_one(
-            "#console-workspace-server-readiness-label"
+        # The bounded-section allocator gives large conversation lists their
+        # own viewport. Drive both current scroll owners before hit-testing.
+        left_rail.activate_section("conversations")
+        await _wait_for_condition(
+            pilot,
+            lambda: (conversations_section.allocation or 0) > 1,
         )
+        left_rail_body.scroll_to_widget(
+            conversations_section, animate=False, immediate=True
+        )
+        conversations_section.viewport.scroll_to_widget(
+            new_conversation, animate=False, immediate=True
+        )
+        await pilot.pause(0.1)
         handoff_label = console.query_one("#console-workspace-handoff-label")
         composer = console.query_one("#console-native-composer")
-        hit_x = new_conversation.region.x + max(0, new_conversation.region.width // 2)
-        hit_y = new_conversation.region.y + max(0, new_conversation.region.height // 2)
+        lines = _render_screen_lines(console)
+        hit_x, hit_y = _find_text_in_row(lines, "New conversation")
         hit_widget, _region = console.get_widget_at(hit_x, hit_y)
 
-        workspace_bottom = workspace_context.region.y + workspace_context.region.height
-        details_bottom = details_tray.region.y + details_tray.region.height
-
-        assert conversation_list.region.height > left_rail_body.region.height
         assert (
-            new_conversation.region.y + new_conversation.region.height
-            <= composer.region.y
+            conversations_section.desired_content_lines
+            > conversations_section.viewport.content_region.height
         )
-        assert (
-            new_conversation.region.y + new_conversation.region.height
-            <= workspace_bottom
+        assert hit_y < composer.region.y
+        assert hit_widget.id == new_conversation.id
+        assert _static_plain(console, "#console-workspace-server-readiness-label") == (
+            "Server"
         )
-        assert hit_widget is new_conversation
-        assert server_readiness.region.y > conversation_list.region.y
 
         assert getattr(conversation_list, "max_scroll_y", 0) == 0
-        assert left_rail_body.max_scroll_y > 0
-        left_rail_body.scroll_end(animate=False)
+        assert conversations_section.viewport.max_scroll_y > 0
+        left_rail.activate_section("details")
+        await _wait_for_condition(
+            pilot,
+            lambda: (details_section.allocation or 0) > 1,
+        )
+        left_rail_body.scroll_to_widget(
+            details_section, animate=False, immediate=True
+        )
+        details_section.viewport.scroll_to_widget(
+            handoff_label, animate=False, immediate=True
+        )
         await pilot.pause(0.1)
 
-        assert left_rail_body.scroll_y > 0
-        assert handoff_label.region.y >= details_tray.region.y
-        assert handoff_label.region.y + handoff_label.region.height <= details_bottom
-        assert handoff_label.region.y + handoff_label.region.height <= composer.region.y
+        lines = _render_screen_lines(console)
+        handoff_x, handoff_y = _find_text_in_row(lines, "ACP")
+        assert handoff_y < composer.region.y
+        assert console.get_widget_at(handoff_x, handoff_y)[0] is handoff_label
 
 
 @pytest.mark.asyncio
-async def test_console_workspace_sync_while_scrolled_keeps_scroll_range_stable() -> (
-    None
-):
+async def test_console_workspace_sync_while_local_section_scrolled_keeps_range_stable() -> None:
     app = _build_test_app()
     _configure_native_ready_console(app)
     service = app.workspace_registry_service
@@ -1808,18 +1835,20 @@ async def test_console_workspace_sync_while_scrolled_keeps_scroll_range_stable()
             "#console-workspace-context",
             ConsoleWorkspaceContextTray,
         )
-        left_rail_body = console.query_one("#console-left-rail-body")
-        assert workspace_context._nearest_scroll_parent() is left_rail_body
-        assert left_rail_body.max_scroll_y > 0
+        conversations_section = console.query_one(
+            "#console-bounded-section-conversations", ConsoleBoundedSection
+        )
+        viewport = conversations_section.viewport
+        assert viewport.max_scroll_y > 0
 
-        scroll_y = max(1, min(8, left_rail_body.max_scroll_y - 1))
-        initial_max_scroll_y = left_rail_body.max_scroll_y
+        scroll_y = max(1, min(8, viewport.max_scroll_y - 1))
+        initial_max_scroll_y = viewport.max_scroll_y
         initial_height = str(workspace_context.styles.height)
-        left_rail_body.scroll_to(y=scroll_y, animate=False)
+        viewport.scroll_to(y=scroll_y, animate=False, immediate=True)
         await pilot.pause(0.1)
-        assert left_rail_body.scroll_y == scroll_y, (
-            left_rail_body.scroll_y,
-            left_rail_body.max_scroll_y,
+        assert viewport.scroll_y == scroll_y, (
+            viewport.scroll_y,
+            viewport.max_scroll_y,
             str(workspace_context.styles.height),
             workspace_context.region.height,
             workspace_context.virtual_region.height,
@@ -1829,19 +1858,19 @@ async def test_console_workspace_sync_while_scrolled_keeps_scroll_range_stable()
         await _wait_for_condition(
             pilot,
             lambda: (
-                left_rail_body.scroll_y == scroll_y
+                viewport.scroll_y == scroll_y
                 and str(workspace_context.styles.height) == initial_height
             ),
         )
 
-        assert left_rail_body.scroll_y == scroll_y, (
-            left_rail_body.scroll_y,
-            left_rail_body.max_scroll_y,
+        assert viewport.scroll_y == scroll_y, (
+            viewport.scroll_y,
+            viewport.max_scroll_y,
             str(workspace_context.styles.height),
             workspace_context.region.height,
             workspace_context.virtual_region.height,
         )
-        assert left_rail_body.max_scroll_y == initial_max_scroll_y
+        assert viewport.max_scroll_y == initial_max_scroll_y
         assert str(workspace_context.styles.height) == initial_height
 
 
@@ -2151,6 +2180,16 @@ def _render_screen_lines(console) -> list[str]:
     ]
 
 
+def _find_text_in_row(lines: list[str], text: str) -> tuple[int, int]:
+    """Return the screen-cell coordinate of visible plain text."""
+
+    for y, line in enumerate(lines):
+        index = line.find(text)
+        if index >= 0:
+            return cell_len(line[:index]), y
+    raise AssertionError(f"No rendered row contains {text!r}")
+
+
 def _find_caret_in_row_with(lines: list[str], label_text: str) -> tuple[int, int]:
     """Return the (x, y) SCREEN coordinates of the caret glyph on the row
     containing ``label_text``, using cumulative CELL width up to the glyph
@@ -2219,18 +2258,27 @@ async def test_section_header_caret_is_clickable_at_its_rendered_screen_coordina
         await _seed_console_transcript_message(console)
         await pilot.pause(0.3)
 
-        conversations_body = console.query_one(
-            "#console-rail-section-body-conversations"
+        conversations_section = console.query_one(
+            "#console-bounded-section-conversations", ConsoleBoundedSection
         )
+        left_rail = console.query_one("#console-left-rail")
         chats_toggle = console.query_one(
             "#console-conversation-browser-section-toggle-chats", Button
         )
-        conversations_body.scroll_to_widget(chats_toggle, animate=False)
+        left_rail.activate_section("conversations")
+        await _wait_for_condition(
+            pilot,
+            lambda: (conversations_section.allocation or 0) > 1,
+        )
+        conversations_section.viewport.scroll_to_widget(
+            chats_toggle, animate=False, immediate=True
+        )
         await pilot.pause()
 
         # Click #1 at the CARET'S rendered screen coordinates: collapse.
         lines = _render_screen_lines(console)
         x, y = _find_caret_in_row_with(lines, "Chats")
+        assert console.screen.get_widget_at(x, y)[0] is chats_toggle
         landed = await pilot.click(offset=(x, y))
         assert landed, "click at the caret's rendered coordinates missed the toggle"
         await pilot.pause(0.3)
@@ -2239,7 +2287,9 @@ async def test_section_header_caret_is_clickable_at_its_rendered_screen_coordina
             for text in _conversation_row_texts(console)
         ), "collapse via glyph-coordinate click did not take effect"
 
-        conversations_body.scroll_to_widget(chats_toggle, animate=False)
+        conversations_section.viewport.scroll_to_widget(
+            chats_toggle, animate=False, immediate=True
+        )
         await pilot.pause()
 
         # Click #2: re-locate the caret in the FRESHLY rendered pane (not
@@ -2365,16 +2415,23 @@ async def test_empty_copy_estimator_handles_three_plus_line_wrap() -> None:
             == rows_height + header_count + empty_copies_height
         ), "the estimator disagrees with the real settled Static heights"
 
-        # TASK-15110 caps each expanded rail section and gives it its own
-        # scrollbar. Mirror the user action that reveals the last browser
-        # group before applying the same coordinate-honest hit-test.
-        conversations_body = console.query_one(
-            "#console-rail-section-body-conversations"
+        # The current bounded section owns local overflow. Mirror the user
+        # action that reveals the final browser group before hit-testing it.
+        conversations_section = console.query_one(
+            "#console-bounded-section-conversations", ConsoleBoundedSection
         )
+        left_rail = console.query_one("#console-left-rail")
         chats_toggle = console.query_one(
             "#console-conversation-browser-section-toggle-chats", Button
         )
-        conversations_body.scroll_to_widget(chats_toggle, animate=False)
+        left_rail.activate_section("conversations")
+        await _wait_for_condition(
+            pilot,
+            lambda: (conversations_section.allocation or 0) > 1,
+        )
+        conversations_section.viewport.scroll_to_widget(
+            chats_toggle, animate=False, immediate=True
+        )
         await pilot.pause()
 
         # Coordinate-honest: "Chats" (the LAST section, rendered after the
@@ -2422,7 +2479,7 @@ def test_console_workspace_runtime_label_is_case_insensitive() -> None:
         ConsoleWorkspaceDetailsTray._friendly_status_label(
             "Runtime: 2 bindings, 1 Ready, 1 Missing"
         )
-        == "File tools: 1 ready, 1 missing"
+        == "Local file tools: 1 ready, 1 missing"
     )
 
 
@@ -2530,8 +2587,8 @@ async def test_console_workspace_context_exposes_new_conversation_for_default_wo
             console,
             label_selector="#console-workspace-runtime-label",
             value_selector="#console-workspace-runtime-value",
-            label="File tools",
-            value_contains="Off in Default",
+            label="Local file tools",
+            value_contains="Private scratch",
         )
         # TASK-715: unconfigured server features collapse into one line
         # instead of a Server status row.
@@ -2632,25 +2689,23 @@ async def test_conversation_row_shows_placeholder_when_no_active_conversation() 
 
 
 @pytest.mark.asyncio
-async def test_status_label_width_is_thirteen() -> None:
-    """I1 (final review): "Conversation" is exactly 12 characters -- the old
-    fixed label-column width -- so at `width: 12` the label filled its whole
-    cell with zero gutter before the value column starts. Widened to 13 so
-    every label (the 12-char "Conversation" included) leaves at least one
-    blank cell of separation; see the composited-output pin below for what
-    that actually buys on screen."""
-    from textual.app import App
-
+async def test_status_label_width_preserves_one_cell_gutter() -> None:
+    """Status labels grow only enough to retain one readable gutter cell."""
     class TestApp(ConsolidatedCSSApp):
         def compose(self):
             yield ConsoleWorkspaceStatusPair(
                 "Workspace", "demo", label_id="l", value_id="v"
             )
+            yield ConsoleWorkspaceStatusPair(
+                "Local file tools", "Private scratch", label_id="fl", value_id="fv"
+            )
 
     app = TestApp()
     async with app.run_test():
-        label = app.query_one(".console-workspace-status-label")
-        assert label.styles.width.value == 13
+        assert app.query_one("#l").styles.width.value == 13
+        assert app.query_one("#fl").styles.width.value == 17
+        assert app.query_one("#v").styles.min_width.value == 10
+        assert app.query_one("#fv").styles.min_width.value == 6
 
 
 def _composited_rows(container) -> list[str]:
@@ -2776,7 +2831,6 @@ async def test_status_pair_value_truncates_instead_of_letter_stacking() -> None:
     """TASK-384: at a narrow rail the value column shrinks to a few cells; the
     value must nowrap+ellipsize (so "Default" reads "De…") rather than word-wrap
     into a "Def / aul / t" letter stack, with the full value on hover."""
-    from textual.app import App
     from textual.widgets import Static
 
     class TestApp(ConsolidatedCSSApp):
@@ -2797,7 +2851,6 @@ async def test_status_pair_value_truncates_instead_of_letter_stacking() -> None:
 async def test_status_pair_value_tooltip_escapes_markup() -> None:
     """Qodo #821: the value tooltip renders Rich markup, so a value with bracket
     tokens must be escaped (shown literally, not interpreted)."""
-    from textual.app import App
     from textual.widgets import Static
 
     class TestApp(ConsolidatedCSSApp):
@@ -2944,8 +2997,8 @@ async def test_console_workspace_context_renders_server_readiness_handoff_and_ac
             console,
             label_selector="#console-workspace-runtime-label",
             value_selector="#console-workspace-runtime-value",
-            label="File tools",
-            value_contains="0 ready, 1 missing",
+            label="Local file tools",
+            value_contains="Private scratch",
         )
         assert "Handoff" in text
         assert "Source note - copy" in text

--- a/Tests/UI/test_console_workspace_details_tray.py
+++ b/Tests/UI/test_console_workspace_details_tray.py
@@ -20,9 +20,9 @@ from tldw_chatbook.Widgets.Console.console_workspace_details import (
 )
 from tldw_chatbook.Workspaces.display_state import ConsoleWorkspaceContextState
 
-# The StatusPair label column is 12 cells; anything longer wraps into the
+# The StatusPair label column has 16 usable cells; anything longer wraps into the
 # orphaned-word defect this task fixes.
-LABEL_COLUMN_WIDTH = 12
+LABEL_COLUMN_WIDTH = 16
 
 
 def _state(**overrides) -> ConsoleWorkspaceContextState:
@@ -32,7 +32,7 @@ def _state(**overrides) -> ConsoleWorkspaceContextState:
         workspace_name="Default",
         authority_label="Authority: local registry ready",
         sync_label="Sync: not configured",
-        runtime_label="Runtime: none, file tools disabled",
+        runtime_label="Local file tools: Private scratch",
         conversation_rows=(),
         conversation_empty_copy="No active workspace conversations.",
         change_workspace_enabled=False,
@@ -122,15 +122,28 @@ async def test_configured_server_rows_use_unique_fitting_labels() -> None:
 
 @pytest.mark.asyncio
 async def test_default_workspace_file_tools_value_fits_without_truncation() -> None:
-    """'Off in Default workspace' ellipsized in its own default state; the
-    value must fit the ~23-cell value column outright."""
+    """Private-scratch status must fit outright in its default state."""
     app = TrayApp(_state())
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         value = str(
             app.query_one("#console-workspace-runtime-value", Static).renderable
         )
-        assert "off" in value.lower()
+        assert value == "Private scratch"
         assert len(value) <= 20, (
             f"file-tools value {value!r} is long enough to truncate in the rail"
         )
+
+
+def test_private_scratch_status_splits_into_truthful_label_and_value() -> None:
+    friendly = ConsoleWorkspaceDetailsTray._friendly_status_label(
+        "Local file tools: Private scratch + 2 folders"
+    )
+
+    label, value = ConsoleWorkspaceDetailsTray._split_status_row(
+        friendly,
+        "Local file tools",
+    )
+
+    assert label == "Local file tools"
+    assert value == "Private scratch + 2 folders"

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -295,7 +295,10 @@ async def test_default_workspace_card_is_protected() -> None:
 
         assert not screen.query("#settings-workspace-rename-apply")
         assert not screen.query("#settings-workspace-archive")
-        assert "stays tool-less" in _visible_text(screen)
+        visible = _visible_text(screen)
+        assert "use private scratch" in visible
+        assert "only to bind external folders" in visible
+        assert "tool-less" not in visible
 
 
 @pytest.mark.asyncio

--- a/Tests/Utils/test_path_validation_multi.py
+++ b/Tests/Utils/test_path_validation_multi.py
@@ -71,27 +71,13 @@ def test_rejection_teaches_the_recovery_route(tmp_path: Path) -> None:
     assert ROOT_DENIAL_RECOVERY_POINTER in message
     assert ROOT_DENIAL_RECOVERY_HINT in message
     assert "Settings > Workspaces" in message
-    assert "Default workspace cannot hold folder bindings" in message
+    assert "Chats do not need a folder" in message
 
 
 def test_recovery_pointer_is_accurate_for_a_non_default_workspace(
     tmp_path: Path,
 ) -> None:
-    """Qodo PR #1074 finding 3: this denial fires identically whether the
-    run's workspace is Default or an already-named workspace that simply
-    has no folder bound yet -- `validate_path_multi` has no workspace
-    context to tell the two apart (see `ROOT_DENIAL_RECOVERY_POINTER`'s own
-    docstring for why threading it in would be invasive). Pre-fix, the
-    pointer unconditionally said "create a workspace + bind a folder",
-    which is actively wrong advice for a run already in a normal
-    workspace -- it only needs a folder bound to the one it already has.
-
-    The pointer must therefore read correctly on its own regardless of
-    which workspace the run is in (just "bind a folder"); the
-    Default-specific advice is confined to the HINT and phrased as an
-    explicit conditional ("if this run is in Default"), never asserted as
-    fact.
-    """
+    """Recovery must separate optional Chat scratch from folder authority."""
     root = tmp_path / "sandbox"
     root.mkdir()
     outside = tmp_path / "outside.txt"
@@ -101,11 +87,10 @@ def test_recovery_pointer_is_accurate_for_a_non_default_workspace(
         validate_path_multi(outside, [root])
     message = str(excinfo.value)
 
-    assert "bind a folder" in ROOT_DENIAL_RECOVERY_POINTER
-    assert "create a workspace" not in ROOT_DENIAL_RECOVERY_POINTER.lower()
-    assert "if this run is in default" in ROOT_DENIAL_RECOVERY_HINT.lower()
-    # The pointer alone (before any Default-specific caveat) must already
-    # be present and correct in the composed message.
+    assert "named Workspace" in ROOT_DENIAL_RECOVERY_POINTER
+    assert "Chats do not need a folder" in ROOT_DENIAL_RECOVERY_HINT
+    assert "outside private scratch" in ROOT_DENIAL_RECOVERY_HINT
+    # The short route must appear before the fuller optional-folder guidance.
     assert message.index(ROOT_DENIAL_RECOVERY_POINTER) < message.index(
         ROOT_DENIAL_RECOVERY_HINT
     )
@@ -182,8 +167,7 @@ def test_recovery_pointer_survives_real_transcript_truncation(
     truncated = _truncate_step_text(composed, limit=_STEP_MARKER_RESULT_LIMIT)
     visible = truncated.split("…")[0]
 
-    assert "Settings > Workspaces" in visible, (
+    assert ROOT_DENIAL_RECOVERY_POINTER in visible, (
         f"recovery pointer did not survive truncation for {path_len_label} "
         f"path with prefix {tool_prefix!r}: {truncated!r}"
     )
-    assert ROOT_DENIAL_RECOVERY_POINTER in visible

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -54,6 +54,8 @@ class _FlakyBindRegistry:
 
 
 class _HarnessApp(App[None]):
+    CSS = WorkspaceCreateModal.BUNDLED_CSS
+
     def __init__(self, registry, *, description: str | None = None):
         super().__init__()
         # NOTE: `App.__init__` already defines `self._registry` (a WeakSet of

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -1,5 +1,4 @@
 import shutil
-from pathlib import Path
 
 import pytest
 from textual.app import App
@@ -77,6 +76,19 @@ class _HarnessApp(App[None]):
         if self._modal_description is not None:
             kwargs["description"] = self._modal_description
         self.push_screen(WorkspaceCreateModal(**kwargs), _done)
+
+
+@pytest.mark.asyncio
+async def test_explainer_describes_private_scratch_and_optional_folders(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        explainer = app.screen.query_one("#workspace-create-explainer", Static)
+        copy = str(explainer.renderable).lower()
+
+        assert "private scratch" in copy
+        assert "folder access is optional" in copy
+        assert "no file access" not in copy
 
 
 @pytest.mark.asyncio

--- a/Tests/Workspaces/test_workspace_display_state.py
+++ b/Tests/Workspaces/test_workspace_display_state.py
@@ -86,7 +86,7 @@ def test_console_workspace_state_explains_no_active_workspace(tmp_path: Path) ->
     assert state.change_workspace_enabled is False
     assert state.new_conversation_enabled is True
     assert state.new_conversation_recovery == ""
-    assert state.runtime_label == "Runtime: none, file tools disabled"
+    assert state.runtime_label == "Local file tools: Private scratch"
     assert state.recovery_copy == ""
     assert state.server_readiness_label == "Server: local fallback"
     assert service.list_runtime_bindings(DEFAULT_WORKSPACE_ID) == ()
@@ -107,6 +107,7 @@ def test_console_workspace_state_allows_default_conversation_in_fallback_state(
     assert state.new_conversation_enabled is True
     assert state.new_conversation_recovery == ""
     assert state.recovery_copy == "Workspace switching: locked"
+    assert state.runtime_label == "Local file tools: Private scratch"
 
 
 def test_console_workspace_state_reports_active_workspace_and_runtime(
@@ -146,7 +147,7 @@ def test_console_workspace_state_reports_active_workspace_and_runtime(
     assert state.workspace_label == "Workspace: Research Sprint"
     assert state.authority_label == "Authority: local-only"
     assert state.sync_label == "Sync: dry-run only"
-    assert state.runtime_label == "Runtime: 1 binding, 0 ready"
+    assert state.runtime_label == "Local file tools: Private scratch"
     assert state.conversation_rows[0].title == "Planning thread"
     assert state.conversation_rows[0].selected is True
     assert state.change_workspace_enabled is False
@@ -177,7 +178,7 @@ def test_console_workspace_state_recomputes_stale_filesystem_binding_status(
         registry_service=service,
         current_conversation=None,
     )
-    assert state.runtime_label == "Runtime: 1 binding, 1 ready"
+    assert state.runtime_label == "Local file tools: Private scratch + 1 folder"
 
     folder.rmdir()
 
@@ -185,7 +186,8 @@ def test_console_workspace_state_recomputes_stale_filesystem_binding_status(
         registry_service=service,
         current_conversation=None,
     )
-    assert state.runtime_label == "Runtime: 1 binding, 0 ready, 1 missing"
+    assert state.runtime_label == "Local file tools: Private scratch"
+    assert "1 bound folder is missing" in state.recovery_copy
 
 
 def test_console_workspace_state_enables_switching_with_multiple_workspaces(

--- a/backlog/decisions/081-console-per-chat-private-scratch-space.md
+++ b/backlog/decisions/081-console-per-chat-private-scratch-space.md
@@ -1,6 +1,6 @@
 # ADR-081: Give every Console chat private temporary scratch space
 
-Status: Proposed
+Status: Accepted
 Date: 2026-08-23
 Related Task: TASK-21161
 

--- a/backlog/decisions/081-console-per-chat-private-scratch-space.md
+++ b/backlog/decisions/081-console-per-chat-private-scratch-space.md
@@ -1,0 +1,146 @@
+# ADR-081: Give every Console chat private temporary scratch space
+
+Status: Proposed
+Date: 2026-08-23
+Related Task: TASK-21161
+
+## Decision
+
+Each live Console chat session owns one unpredictably named, owner-only temporary
+scratch directory. The directory is process-local authority: its locator is
+never persisted, synchronized, derived from a session or conversation ID, or
+reattached when a saved conversation is reopened.
+
+The Console runtime owns a scratch-space manager. Allocation is lazy. A turn
+captures an immutable scratch snapshot containing the canonical root and an
+opaque generation token; every Chatbook-managed local filesystem provider
+receives that explicit snapshot instead of resolving a global default. The
+manager validates that the snapshot is still live before new filesystem work
+starts.
+
+Default-workspace conversations, presented to users as **Chats**, receive only
+their private scratch root. Console composition no longer treats
+`[console] workspace_root` or the process working directory as filesystem
+authority for these sessions. Those compatibility settings may remain for
+non-Console consumers, but they do not widen a Console chat.
+
+Named Workspace sessions also receive private scratch. Their existing explicit
+folder bindings remain additional roots for the built-in multi-root file tools.
+The single-root local `fs_*` and Git provider uses private scratch unless the
+session has explicitly selected a project-instruction folder binding; when it
+has, the selected binding remains that provider's root and keeps the existing
+locator-fingerprint, read-only/read-write, and path-target guards from ADR-069.
+No implicit "first folder" or common-ancestor root is invented for a
+multi-binding Workspace.
+
+All Console paths that previously fell back to the shared file-tool sandbox
+must consume the owning chat's scratch snapshot. This includes built-in file
+tool validation and invocation, local `fs_*`/Git composition when no project
+root is selected, retained skill-script output, and fallback agent run logs.
+Non-filesystem local tools keep their current behavior.
+
+Permission review remains unchanged. Private temporary storage is a
+confinement boundary, not permission to bypass Ask/Allow/Off decisions,
+sensitive-path checks, tool kill switches, or read-only Workspace bindings.
+Third-party MCP servers, attachments, Library/RAG records, generated media,
+and provider-side tools keep their independent authority contracts; Console
+copy must describe **local file tools** rather than claiming universal
+sandboxing.
+
+Closing a chat tombstones its scratch space before session state is removed.
+Tombstoning rejects new leases immediately. Every consumer that reads or writes
+inside scratch—including file tools, retained skill output, and fallback run
+logs—holds a lease while doing so. Normal cleanup runs off the Textual event
+loop when the last lease drains. A timed-out or cancelled tool
+may continue on an abandoned daemon thread, so close must never reuse or
+reattach the directory and must defer deletion rather than claiming the thread
+was killed. Application disposal tombstones every remaining scratch space and
+performs best-effort cleanup. Ordinary navigation away from the Console does
+not close sessions and therefore does not delete their scratch spaces.
+
+Deletion is ordinary recursive cleanup, not secure erase. A hard process or OS
+crash can leave an unreferenced operating-system temporary directory. A later
+Chatbook process never discovers or attaches it, so it cannot become another
+chat's authority. Strong crash-residue reclamation would require a separate
+cross-process ownership/locking design.
+
+The Console presents Default Chats as `Local file tools: Private scratch` and
+named Workspaces as private scratch plus their explicit folder access. A path
+denial outside all allowed roots explains that an external folder can be added
+through a named Workspace; it never says a folder is required to chat.
+
+## Context
+
+ADR-027 intentionally hides the implementation-only Default workspace behind
+the user-facing Chats section so ordinary conversation does not require
+Workspace vocabulary. ADR-028 says Default is sandbox-only, while named
+Workspaces may add explicitly bound folder roots. The implementation drifted
+from that model in two directions:
+
+1. `file_operation_tools._tool_sandbox_root()` resolves one shared durable
+   `<user-data>/tool_sandbox`, allowing files to outlive and be reachable from
+   unrelated chats.
+2. `ConsoleChatController._compose_local_provider()` uses
+   `[console] workspace_root` or `os.getcwd()` when no project root is selected,
+   so an ordinary Chat can receive broader local `fs_*`/Git access than the
+   built-in sandboxed tools.
+
+Presentation then obscures both facts by rendering `File tools: Off in
+Default`, while path-denial recovery tells users to bind a folder. The result
+looks like a folder is required for chatting even though session creation and
+provider dispatch do not require one.
+
+The Console agent runtime also abandons timed-out tool calls on daemon threads
+because Python cannot kill a thread. Immediate unconditional directory removal
+on close would therefore race real work. Lifecycle fencing and leases are part
+of the authority decision, not an optional cleanup refinement.
+
+Open PR #1657 / TASK-16316 proposes a required-folder Console Workspace modal.
+That policy does not solve cross-chat sandbox leakage or the cwd fallback and
+must not be treated as this decision's implementation.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Keep the shared durable sandbox and only change Console copy | Cross-chat file discovery remains possible and "private" would be false. |
+| Persist one sandbox per conversation | Contradicts the temporary lifecycle, creates cleanup and synchronization semantics, and lets reopening recover old scratch files. |
+| Use the live session ID as the directory name | Exposes durable-looking identifiers in filesystem paths and logs without adding useful authority. |
+| Keep `[console] workspace_root`/cwd for legacy-disabled sessions | Leaves the central policy violation intact: Chats retain implicit host-folder access. |
+| Give local `fs_*` an arbitrary first Workspace binding | Makes relative paths silently retarget when bindings reorder and bypasses explicit project-root selection. |
+| Refactor local `fs_*`/Git to a new multi-root namespace | Considerably enlarges the security surface and relative-path grammar; built-in tools already own multi-root access. |
+| Delete immediately when a chat closes | Races abandoned daemon tool threads and falsely assumes cancellation kills filesystem work. |
+| Treat temporary scratch as approval-free | Conflates path confinement with user authorization and weakens the existing permission boundary. |
+| Securely erase files | Filesystem and SSD behavior cannot guarantee erasure; truthful best-effort deletion is the supportable contract. |
+
+## Consequences
+
+- A new runtime-owned scratch manager and immutable scratch snapshot become the
+  single Console authority source for temporary local files.
+- A live session, not a persisted conversation, is the ownership unit. Two
+  simultaneous tabs for the same saved conversation still receive different
+  scratch spaces.
+- Subagents and concurrent turns belonging to one live chat share its scratch
+  space; unrelated live chats never do.
+- Default Chats lose implicit `[console] workspace_root`/cwd access. This is an
+  intentional security correction and may expose workflows that relied on the
+  undocumented widening.
+- Named Workspaces retain current folder-binding and project-instruction
+  behavior. A Workspace with no folder binding still works with scratch only.
+- Cleanup needs thread-safe tombstone, lease, deferred-delete, off-loop removal,
+  and idempotent disposal behavior. Cleanup failures are bounded diagnostics and
+  never restore authority.
+- No database migration or synchronized state is introduced.
+- Live DeepSeek UAT is required for provider-facing confidence, but deterministic
+  authority and lifecycle tests remain the acceptance evidence because model
+  tool selection is nondeterministic.
+
+## Links
+
+- [Design spec](../../Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md)
+- [TASK-21161](../tasks/task-21161%20-%20Console-per-chat-private-scratch-space-and-workspace-file-authority.md)
+- [ADR-027: Default-workspace conversations live in Chats](027-default-workspace-chats-in-chats-section.md)
+- [ADR-028: Settings workspaces and folder roots](028-settings-workspaces-category-and-folder-roots.md)
+- [ADR-032: Local agent tool permission boundary](032-local-agent-tool-permission-boundary.md)
+- [ADR-069: Console project-instruction local state and preflight](069-console-project-instruction-local-state-and-preflight.md)
+- [Conflicting open PR #1657](https://github.com/rmusser01/tldw_chatbook/pull/1657)

--- a/backlog/decisions/082-console-per-chat-private-scratch-space.md
+++ b/backlog/decisions/082-console-per-chat-private-scratch-space.md
@@ -1,4 +1,4 @@
-# ADR-081: Give every Console chat private temporary scratch space
+# ADR-082: Give every Console chat private temporary scratch space
 
 Status: Accepted
 Date: 2026-08-23

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -73,7 +73,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-077](077-server-offloaded-scheduled-agent-tasks.md) | Accepted | tldw_server is the execution authority for server-scoped scheduled agent work (single-owner execution, notifications pass-back, phase-1 side-effect-free runs), amending ADR-018's execution-unavailable clause. |
 | [ADR-078](078-structured-agent-tool-outcome-provenance.md) | Accepted | Carry optional structured tool outcome provenance across the internal provider/runtime step boundary, with safe legacy fallback and no SQLite or external provider-wire migration. |
 | [ADR-081](081-mcp-prompt-reduction-recommendations.md) | Accepted | Keep MCP prompt-reduction recommendations local-only, MCP-only, telemetry-free, and routed through the existing permission-store APIs. |
-| [ADR-081](081-console-per-chat-private-scratch-space.md) | Accepted | Give each live Console chat private temporary scratch, remove implicit cwd/config authority, preserve explicit Workspace bindings, and defer cleanup safely around late tool threads. |
+| [ADR-082](082-console-per-chat-private-scratch-space.md) | Accepted | Give each live Console chat private temporary scratch, remove implicit cwd/config authority, preserve explicit Workspace bindings, and defer cleanup safely around late tool threads. |
 
 ## Historical Decision Material
 

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -73,6 +73,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-077](077-server-offloaded-scheduled-agent-tasks.md) | Accepted | tldw_server is the execution authority for server-scoped scheduled agent work (single-owner execution, notifications pass-back, phase-1 side-effect-free runs), amending ADR-018's execution-unavailable clause. |
 | [ADR-078](078-structured-agent-tool-outcome-provenance.md) | Accepted | Carry optional structured tool outcome provenance across the internal provider/runtime step boundary, with safe legacy fallback and no SQLite or external provider-wire migration. |
 | [ADR-081](081-mcp-prompt-reduction-recommendations.md) | Accepted | Keep MCP prompt-reduction recommendations local-only, MCP-only, telemetry-free, and routed through the existing permission-store APIs. |
+| [ADR-081](081-console-per-chat-private-scratch-space.md) | Proposed | Give each live Console chat private temporary scratch, remove implicit cwd/config authority, preserve explicit Workspace bindings, and defer cleanup safely around late tool threads. |
 
 ## Historical Decision Material
 

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -73,7 +73,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-077](077-server-offloaded-scheduled-agent-tasks.md) | Accepted | tldw_server is the execution authority for server-scoped scheduled agent work (single-owner execution, notifications pass-back, phase-1 side-effect-free runs), amending ADR-018's execution-unavailable clause. |
 | [ADR-078](078-structured-agent-tool-outcome-provenance.md) | Accepted | Carry optional structured tool outcome provenance across the internal provider/runtime step boundary, with safe legacy fallback and no SQLite or external provider-wire migration. |
 | [ADR-081](081-mcp-prompt-reduction-recommendations.md) | Accepted | Keep MCP prompt-reduction recommendations local-only, MCP-only, telemetry-free, and routed through the existing permission-store APIs. |
-| [ADR-081](081-console-per-chat-private-scratch-space.md) | Proposed | Give each live Console chat private temporary scratch, remove implicit cwd/config authority, preserve explicit Workspace bindings, and defer cleanup safely around late tool threads. |
+| [ADR-081](081-console-per-chat-private-scratch-space.md) | Accepted | Give each live Console chat private temporary scratch, remove implicit cwd/config authority, preserve explicit Workspace bindings, and defer cleanup safely around late tool threads. |
 
 ## Historical Decision Material
 

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -39,6 +39,15 @@ known, expensive to rediscover. Every entry states the incident that produced it
   **never pass a "next safe id" between tasks in a brief** — an ID is only safe at the
   instant it is derived, so re-derive it at filing time.
 
+- **2026-08-23, Console private scratch.** A task added at 08:11 as
+  `TASK-21161` rebased over a different `TASK-21161` added to `dev` at 10:22.
+  The first closeout command, `backlog task edit 21161 -s Done`, reported
+  success but resolved the later task file; the Console task visibly remained
+  In Progress. Add-commit provenance applied the older-arrival rule, the later
+  startup-order task moved to `TASK-21163`, and every reference moved with it.
+  The extra guard is important: after any rebase, verify the CLI's printed
+  **file path**, not merely its success message or requested ID.
+
 Checking `origin/dev` *feels* like diligence. It is not: parallel agents hold IDs on
 unmerged branches. And a *green* Backlog Guard at branch time proves nothing later —
 a duplicate can arrive from dev moving underneath you, in which case rebasing is the

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1340,3 +1340,19 @@ to the intended subview and inspect the capture itself. Here the verifier now
 captures New note honestly, sends Escape, and requires `Add from files` before
 recording the Notes-list frames. A parent-surface title proves only that the
 parent mounted; it cannot certify which retained child view is active.
+
+---
+
+## A live app launch can rewrite a tracked generated artifact (TASK-21161, 2026-08-23)
+
+**What happened.** The isolated Console/DeepSeek UAT changed only the generated
+timestamp in tracked `tldw_chatbook/css/tldw_cli_modular.tcss`. No source CSS
+had changed; app startup had rebuilt the consolidated file. Left in the
+working tree, that runtime side effect would have looked like an intentional
+implementation change and polluted the review diff.
+
+**What to do.** Capture `git status --short` before a live app launch and again
+after clean exit. For tracked generated artifacts, compare the body as well as
+the header before deciding whether a delta belongs to the task. Restore a
+timestamp-only runtime rebuild to the pre-UAT content; regenerate and commit it
+only when its source modules actually changed.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -67,6 +67,15 @@ application. Assert containment and compositor text, not only a child widget's
 declared height. A shortened DOM or partial stylesheet can make both overflow
 and clipping tests pass for a product path that still hides its controls.
 
+**Recurred, TASK-21161 (2026-08-23).** The shared Workspace-create modal's bare
+`App` harness omitted `WorkspaceCreateModal.BUNDLED_CSS`. Ten click-path tests
+failed on both the task branch and untouched latest `dev`: at 80 columns the
+Browse/Add controls landed at x=80/96, outside the viewport. Simply widening the
+Pilot screen to 120 made the same controls move to x=120/136, proving this was
+not a small-screen product defect; without the modal stylesheet, each default
+`1fr` child claimed another full row width. Mounting the production bundled CSS
+in the harness made all 23 modal tests pass at the default viewport.
+
 **Recurred, TASK-16478, 2026-08-15.** A picker-comparison investigation
 rendered `EnhancedFileOpen` in a bare `App` (widget DEFAULT_CSS only) and
 concluded the dialog was fine; the user's live app showed no Select/Cancel

--- a/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
+++ b/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
@@ -1,0 +1,89 @@
+---
+id: TASK-21161
+title: Console per-chat private scratch space and workspace file authority
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-23'
+labels:
+  - console
+  - security
+  - workspaces
+  - uat
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Ordinary Console Chats must work without choosing or binding a folder. Each live
+chat needs its own temporary file scratch space so local file operations cannot
+leak files across chats. Only named Workspaces may add access to user folders,
+and only through their explicit folder bindings.
+
+Latest `dev` currently mixes three incompatible behaviors: the built-in file
+tools always include one shared durable sandbox, the local `fs_*` provider falls
+back to `[console] workspace_root` or the process working directory, and the
+Console labels Default Chats as `File tools: Off in Default`. This task replaces
+those fallbacks with one explicit per-chat authority policy and verifies the
+result through targeted automation plus live DeepSeek UAT.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+
+- [ ] A user can create and send an ordinary Console Chat without a folder
+  prompt; the Console describes its local file capability as private scratch
+  space rather than as disabled or misconfigured.
+- [ ] Every live Console session receives an independent owner-only temporary
+  scratch directory, and local file operations in one chat cannot list, read,
+  overwrite, or infer files from another chat's scratch directory.
+- [ ] Default Chats expose only their private scratch directory to
+  Chatbook-managed built-in and local filesystem operations; neither
+  `[console] workspace_root` nor the process working directory grants them
+  filesystem authority.
+- [ ] A named Workspace retains private per-chat scratch space and may add only
+  its explicit folder bindings to the existing multi-root built-in tools;
+  selected project roots, binding fingerprints, and read-only/read-write rules
+  remain enforced for local `fs_*` and Git tools.
+- [ ] Retained skill-script output and sandbox-fallback agent run logs use the
+  owning chat's scratch space instead of the shared global sandbox.
+- [ ] Closing a chat immediately makes its scratch space unavailable to new
+  work, deletes it after outstanding file-operation leases drain, and never
+  reattaches it when a saved conversation is reopened; application disposal
+  performs best-effort cleanup of all remaining scratch spaces.
+- [ ] Folder-recovery guidance explains optional Workspace folder access and
+  never presents folder binding as a prerequisite for ordinary chatting.
+- [ ] Existing permission prompts, sensitive-path checks, Workspace binding
+  validation, and non-Console tool behavior remain intact; external MCP
+  servers, attachments, Library/RAG data, and generated media keep their
+  separate authority models.
+- [ ] Targeted authority, lifecycle, UI, and provider tests pass, including the
+  selected-root swap fail-closed regression, and live DeepSeek UAT demonstrates
+  ordinary chat, scratch write/read, cross-chat isolation, Workspace-bound
+  access, and no user-config mutation.
+<!-- AC:END -->
+
+## Design Records
+
+- ADR required: yes
+- ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
+- Reason: this task changes filesystem authority, temporary-data ownership,
+  cross-thread teardown behavior, and long-lived Console/Workspace semantics.
+- Design spec:
+  `Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md`
+
+## Baseline Evidence
+
+- Branch base after refreshing all remote heads:
+  `origin/dev` at `7363592020076c9508fe4a0eee0c1a1679ec7851`.
+- Related targeted baseline: 55 passed, 1 failed. The single failure,
+  `test_selected_root_swap_fails_closed_before_local_invoke`, is a stale test
+  invocation that omits the review hook's required `run_id`; blame shows the
+  signature predates the test. Production root-swap enforcement did not run.
+- Conflicting in-flight work: open PR #1657 / TASK-16316 requires a folder in
+  the Console New Workspace modal. This task does not reuse that policy and
+  must not be merged as though the two designs were compatible.

--- a/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
+++ b/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
@@ -134,18 +134,26 @@ ownership, provider-boundary, and cross-thread teardown decision.
   honestly classified authority-unavailable refusal; and every cited public
   API plus the adjacent scratch lifecycle APIs now has complete Google-style
   sections. Red-to-green regressions cover both behavioral fixes.
+- Reproducing the required Derived Artifacts check exposed a stale diagnostic
+  inventory and a related privacy seam: run-log I/O exception tracebacks could
+  persist a private scratch locator on failure. Scratch-adjacent diagnostics now
+  retain only fixed text plus exception-class categories; a regression injects
+  locator-bearing lease/write failures and proves neither locator nor token
+  reaches the log sink. Every inventory delta was statement-reviewed before
+  regenerating the checked-in artifact.
 - A broad UI diagnostic found ten Workspace-create Pilot failures. Untouched
   latest `dev` reproduced all ten because the bare harness omitted the modal's
   production CSS. Loading `WorkspaceCreateModal.BUNDLED_CSS` restored real
   geometry and made the complete modal module pass 23 / 23; the incident is
   recorded in `backlog/docs/lessons-testing-evidence.md`.
-- Final post-review verification on latest `dev`: 398 targeted authority/
+- Final post-review verification on latest `dev`: 399 targeted authority/
   lifecycle/provider/artifact tests passed; 137 activity-presentation tests
   passed; 56 focused mounted Console/Workspace UI tests passed; the backlog
   filename/frontmatter guard and its 3 tests passed. Ruff and Python
   compilation passed for every changed Python file; `git diff --check` and the
-  diff secret-pattern scan were clean. A full repository sweep was not run,
-  per repository policy.
+  diff secret-pattern scan were clean. The complete required Derived Artifacts
+  command sequence also reproduces cleanly. A full repository sweep was not
+  run, per repository policy.
 - ADR: implemented and linked
   `backlog/decisions/082-console-per-chat-private-scratch-space.md`; no further
   ADR was needed for the review fixes because they directly enforce ADR-082's

--- a/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
+++ b/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
@@ -112,8 +112,8 @@ ownership, provider-boundary, and cross-thread teardown decision.
 
 ## Baseline Evidence
 
-- Branch base after refreshing all remote heads:
-  `origin/dev` at `7363592020076c9508fe4a0eee0c1a1679ec7851`.
+- Branch base after refreshing all remote heads, then refreshed again before
+  UAT: `origin/dev` at `ae817fefed519921d7da5047e22634756337fc34`.
 - Related targeted baseline: 55 passed, 1 failed. The single failure,
   `test_selected_root_swap_fails_closed_before_local_invoke`, is a stale test
   invocation that omits the review hook's required `run_id`; blame shows the
@@ -121,3 +121,8 @@ ownership, provider-boundary, and cross-thread teardown decision.
 - Conflicting in-flight work: open PR #1657 / TASK-16316 requires a folder in
   the Console New Workspace modal. This task does not reuse that policy and
   must not be merged as though the two designs were compatible.
+- The refreshed clean-dev adjacent rail sweep initially had 151 passes and
+  five failures because those tests still drove the retired outer/body scroll
+  owners after the bounded-section migration. Their rendered visibility and
+  coordinate-click contracts now drive the current local section viewports;
+  the same sweep passes all 156 tests.

--- a/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
+++ b/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
@@ -76,6 +76,40 @@ result through targeted automation plus live DeepSeek UAT.
 - Design spec:
   `Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md`
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a thread-safe, generation-fenced `ConsoleScratchSpaceManager` with
+   owner-only random directories, leases, tombstones, a single off-loop cleanup
+   worker, and bounded best-effort disposal.
+2. Make `ConsoleRuntime` own the manager, capture one immutable scratch snapshot
+   in each `ConsoleTurnExecutionContext`, tombstone it before session removal,
+   preserve it across ordinary navigation, and dispose it at application exit.
+3. Thread the captured root and lease through built-in and local providers so a
+   Default Chat never falls back to `[console] workspace_root` or cwd, while
+   named Workspace bindings and ADR-069 selected-root guards remain intact.
+4. Propagate the same authority through agent review and dispatch, retained
+   skill-script output, and run-log fallback/readback without persisting paths.
+5. Replace folder-required/disabled copy with private-scratch and optional
+   Workspace-folder guidance, then update the Console, Settings, tool, and
+   developer documentation.
+6. Run the targeted authority/lifecycle/artifact/UI suites and perform live
+   DeepSeek UAT from an isolated mode-0600 config copy, verifying the original
+   configuration hash is unchanged.
+7. Complete task acceptance criteria, implementation notes, ADR links, and Done
+   status only after all targeted and live gates pass.
+
+Detailed red-green steps, exact files, interfaces, commands, and commit points:
+`Docs/superpowers/plans/2026-08-23-console-per-chat-private-scratch-space.md`.
+
+ADR required: yes
+
+ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
+
+Reason: the plan implements the accepted filesystem-authority, temporary-data
+ownership, provider-boundary, and cross-thread teardown decision.
+<!-- SECTION:PLAN:END -->
+
 ## Baseline Evidence
 
 - Branch base after refreshing all remote heads:

--- a/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
+++ b/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
@@ -93,7 +93,7 @@ Detailed red-green steps, exact files, interfaces, commands, and commit points:
 
 ADR required: yes
 
-ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
+ADR path: `backlog/decisions/082-console-per-chat-private-scratch-space.md`
 
 Reason: the plan implements the accepted filesystem-authority, temporary-data
 ownership, provider-boundary, and cross-thread teardown decision.
@@ -129,20 +129,29 @@ ownership, provider-boundary, and cross-thread teardown decision.
   Provider-boundary redaction now emits relative scratch-owned paths without
   changing explicit Workspace-path behavior; success, error, and real run-log
   regressions cover the fix.
+- Qodo review found three medium issues. Cleanup warnings no longer log opaque
+  scratch capability tokens; scratch-lease failures now use a distinct,
+  honestly classified authority-unavailable refusal; and every cited public
+  API plus the adjacent scratch lifecycle APIs now has complete Google-style
+  sections. Red-to-green regressions cover both behavioral fixes.
 - A broad UI diagnostic found ten Workspace-create Pilot failures. Untouched
   latest `dev` reproduced all ten because the bare harness omitted the modal's
   production CSS. Loading `WorkspaceCreateModal.BUNDLED_CSS` restored real
   geometry and made the complete modal module pass 23 / 23; the incident is
   recorded in `backlog/docs/lessons-testing-evidence.md`.
-- Final post-rebase verification: 388 targeted authority/lifecycle/provider/
-  artifact tests passed; 56 focused mounted Console/Workspace UI tests passed;
-  Ruff and Python compilation passed for every changed Python file;
-  `git diff --check` and the diff secret-pattern scan were clean. A full
-  repository sweep was not run, per repository policy.
+- Final post-review verification on latest `dev`: 398 targeted authority/
+  lifecycle/provider/artifact tests passed; 137 activity-presentation tests
+  passed; 56 focused mounted Console/Workspace UI tests passed; the backlog
+  filename/frontmatter guard and its 3 tests passed. Ruff and Python
+  compilation passed for every changed Python file; `git diff --check` and the
+  diff secret-pattern scan were clean. A full repository sweep was not run,
+  per repository policy.
 - ADR: implemented and linked
-  `backlog/decisions/081-console-per-chat-private-scratch-space.md`; no further
-  ADR was needed for the review fixes because they directly enforce ADR-081's
-  existing non-persistence boundary. No dependencies, schema, license, or
+  `backlog/decisions/082-console-per-chat-private-scratch-space.md`; no further
+  ADR was needed for the review fixes because they directly enforce ADR-082's
+  existing non-persistence boundary. The record was renumbered from provisional
+  ADR-081 after latest `dev` accepted the MCP prompt-reduction ADR under that
+  number; no open PR claims ADR-082. No dependencies, schema, license, or
   external service contracts changed.
 - Latest `dev` introduced a duplicate `TASK-21161` after this task's earlier
   add commit. Following the repository's older-arrival rule, the later
@@ -153,7 +162,7 @@ ownership, provider-boundary, and cross-thread teardown decision.
 ## Design Records
 
 - ADR required: yes
-- ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
+- ADR path: `backlog/decisions/082-console-per-chat-private-scratch-space.md`
 - Reason: this task changes filesystem authority, temporary-data ownership,
   cross-thread teardown behavior, and long-lived Console/Workspace semantics.
 - Design spec:

--- a/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
+++ b/backlog/tasks/task-21161 - Console-per-chat-private-scratch-space-and-workspace-file-authority.md
@@ -1,23 +1,23 @@
 ---
 id: TASK-21161
 title: Console per-chat private scratch space and workspace file authority
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-23'
+updated_date: '2026-08-23 18:36'
 labels:
   - console
   - security
   - workspaces
   - uat
-priority: high
 dependencies: []
+priority: high
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-
 Ordinary Console Chats must work without choosing or binding a folder. Each live
 chat needs its own temporary file scratch space so local file operations cannot
 leak files across chats. Only named Workspaces may add access to user folders,
@@ -32,49 +32,38 @@ result through targeted automation plus live DeepSeek UAT.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-
-- [ ] A user can create and send an ordinary Console Chat without a folder
+- [x] #1 A user can create and send an ordinary Console Chat without a folder
   prompt; the Console describes its local file capability as private scratch
   space rather than as disabled or misconfigured.
-- [ ] Every live Console session receives an independent owner-only temporary
+- [x] #2 Every live Console session receives an independent owner-only temporary
   scratch directory, and local file operations in one chat cannot list, read,
   overwrite, or infer files from another chat's scratch directory.
-- [ ] Default Chats expose only their private scratch directory to
+- [x] #3 Default Chats expose only their private scratch directory to
   Chatbook-managed built-in and local filesystem operations; neither
   `[console] workspace_root` nor the process working directory grants them
   filesystem authority.
-- [ ] A named Workspace retains private per-chat scratch space and may add only
+- [x] #4 A named Workspace retains private per-chat scratch space and may add only
   its explicit folder bindings to the existing multi-root built-in tools;
   selected project roots, binding fingerprints, and read-only/read-write rules
   remain enforced for local `fs_*` and Git tools.
-- [ ] Retained skill-script output and sandbox-fallback agent run logs use the
+- [x] #5 Retained skill-script output and sandbox-fallback agent run logs use the
   owning chat's scratch space instead of the shared global sandbox.
-- [ ] Closing a chat immediately makes its scratch space unavailable to new
+- [x] #6 Closing a chat immediately makes its scratch space unavailable to new
   work, deletes it after outstanding file-operation leases drain, and never
   reattaches it when a saved conversation is reopened; application disposal
   performs best-effort cleanup of all remaining scratch spaces.
-- [ ] Folder-recovery guidance explains optional Workspace folder access and
+- [x] #7 Folder-recovery guidance explains optional Workspace folder access and
   never presents folder binding as a prerequisite for ordinary chatting.
-- [ ] Existing permission prompts, sensitive-path checks, Workspace binding
+- [x] #8 Existing permission prompts, sensitive-path checks, Workspace binding
   validation, and non-Console tool behavior remain intact; external MCP
   servers, attachments, Library/RAG data, and generated media keep their
   separate authority models.
-- [ ] Targeted authority, lifecycle, UI, and provider tests pass, including the
+- [x] #9 Targeted authority, lifecycle, UI, and provider tests pass, including the
   selected-root swap fail-closed regression, and live DeepSeek UAT demonstrates
   ordinary chat, scratch write/read, cross-chat isolation, Workspace-bound
   access, and no user-config mutation.
 <!-- AC:END -->
-
-## Design Records
-
-- ADR required: yes
-- ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
-- Reason: this task changes filesystem authority, temporary-data ownership,
-  cross-thread teardown behavior, and long-lived Console/Workspace semantics.
-- Design spec:
-  `Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md`
 
 ## Implementation Plan
 
@@ -110,10 +99,73 @@ Reason: the plan implements the accepted filesystem-authority, temporary-data
 ownership, provider-boundary, and cross-thread teardown decision.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a runtime-owned `ConsoleScratchSpaceManager` that lazily creates random
+  owner-only roots per live session, generation-fences immutable snapshots,
+  leases active file operations, tombstones on close, cleans after lease drain,
+  and performs bounded best-effort disposal at app shutdown. Reopening a saved
+  conversation receives a fresh root.
+- Captured scratch authority once per turn and propagated it through built-in
+  file tools, local `fs_*`/Git composition, tool review/dispatch, retained skill
+  output, and fallback run logs. Default Chats no longer inherit
+  `[console] workspace_root` or cwd. Named Workspaces preserve scratch and add
+  only validated explicit bindings; selected-root identity and read/write
+  guards remain fail-closed.
+- Made folderless project-instruction setup a valid scratch-only send path while
+  preserving recovery for a selected binding that disappears or drifts.
+  Updated Console, Settings, Workspace-create, change-review, and user-guide
+  copy to describe private scratch and optional explicit folders.
+- Live DeepSeek UAT at 180×55 verified folderless send, Chat A write/read, Chat
+  B isolation, fresh scratch after close/reopen, named Workspace read/write,
+  and Default Chat denial of the Workspace path. The real user config SHA-256
+  remained exactly
+  `4b4a5c250ad439952eea04e41041b2ca576ceb18505ce72ea228bd967ec8315b`.
+  Full evidence is in
+  `Docs/UAT/2026-08-23-console-deepseek-private-scratch.md`.
+- Independent review found that built-in path metadata and local errors could
+  expose the opaque scratch locator to model history and persisted run logs.
+  Provider-boundary redaction now emits relative scratch-owned paths without
+  changing explicit Workspace-path behavior; success, error, and real run-log
+  regressions cover the fix.
+- A broad UI diagnostic found ten Workspace-create Pilot failures. Untouched
+  latest `dev` reproduced all ten because the bare harness omitted the modal's
+  production CSS. Loading `WorkspaceCreateModal.BUNDLED_CSS` restored real
+  geometry and made the complete modal module pass 23 / 23; the incident is
+  recorded in `backlog/docs/lessons-testing-evidence.md`.
+- Final post-rebase verification: 388 targeted authority/lifecycle/provider/
+  artifact tests passed; 56 focused mounted Console/Workspace UI tests passed;
+  Ruff and Python compilation passed for every changed Python file;
+  `git diff --check` and the diff secret-pattern scan were clean. A full
+  repository sweep was not run, per repository policy.
+- ADR: implemented and linked
+  `backlog/decisions/081-console-per-chat-private-scratch-space.md`; no further
+  ADR was needed for the review fixes because they directly enforce ADR-081's
+  existing non-persistence boundary. No dependencies, schema, license, or
+  external service contracts changed.
+- Latest `dev` introduced a duplicate `TASK-21161` after this task's earlier
+  add commit. Following the repository's older-arrival rule, the later
+  model-catalog startup-order task and its complete reference slice were
+  renumbered to `TASK-21163`; the duplicate-ID guard passes.
+<!-- SECTION:NOTES:END -->
+
+## Design Records
+
+- ADR required: yes
+- ADR path: `backlog/decisions/081-console-per-chat-private-scratch-space.md`
+- Reason: this task changes filesystem authority, temporary-data ownership,
+  cross-thread teardown behavior, and long-lived Console/Workspace semantics.
+- Design spec:
+  `Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md`
+
 ## Baseline Evidence
 
-- Branch base after refreshing all remote heads, then refreshed again before
-  UAT: `origin/dev` at `ae817fefed519921d7da5047e22634756337fc34`.
+- Live UAT began on the then-current `origin/dev` at
+  `ae817fefed519921d7da5047e22634756337fc34`. Before closeout the branch was
+  rebased cleanly onto latest `origin/dev` at
+  `be0a1694696b7b2296dcb79017696dd79c56f677`; the intervening upstream change
+  was isolated to the Library UI, and fresh post-rebase targeted gates passed.
 - Related targeted baseline: 55 passed, 1 failed. The single failure,
   `test_selected_root_swap_fails_closed_before_local_invoke`, is a stale test
   invocation that omits the review hook's required `run_id`; blame shows the

--- a/backlog/tasks/task-21163 - Order-model-catalog-consent-after-intro-startup.md
+++ b/backlog/tasks/task-21163 - Order-model-catalog-consent-after-intro-startup.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-21161
+id: TASK-21163
 title: Order model catalog consent after intro startup
 status: Done
 assignee: []
@@ -50,3 +50,14 @@ ADR required: no. Existing ADR: backlog/decisions/020-automatic-model-catalog-re
 
 PR review follow-up: added the missing async contract-test docstring and replaced the splash regression's short manual Pilot loops/exact default-screen assertion with the repository's bounded `_wait_until` pattern and behavior-level splash/Home ordering assertions. Focused tests and Ruff pass.
 <!-- SECTION:NOTES:END -->
+
+## Renumbering provenance
+
+- Renumbered from `TASK-21161` to `TASK-21163` on 2026-08-23 after latest
+  `dev` exposed a duplicate task ID.
+- The Console private-scratch task's add commit
+  `47a417bd13f9fc179e30d3acbec7743edaa86e96` predates this task's add commit
+  `7969089c34b163159d21f4a35f7f7a716bc289eb`, so the later claimant moves
+  under the repository's older-arrival tie-break rule.
+- Every task-file, design-spec, and implementation-plan reference shipped with
+  this startup-order slice was updated to `TASK-21163`.

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -760,12 +760,13 @@ class LocalToolProvider:
                         ),
                     )
                 except Exception as exc:  # noqa: BLE001 — protocol boundary
+                    error = redact_root_locator(
+                        str(exc) or repr(exc),
+                        self._result_redaction_root,
+                    )
                     return ToolResult(
                         ok=False,
-                        error=redact_root_locator(
-                            (str(exc) or repr(exc))[:_MAX_ERROR_CHARS],
-                            self._result_redaction_root,
-                        ),
+                        error=error[:_MAX_ERROR_CHARS],
                     )
 
             if (

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -105,6 +105,9 @@ LOCAL_GATE_ERROR_REFUSAL = (
 LOCAL_ROOT_CHANGED_REFUSAL = (
     "Selected workspace root changed after dispatch started; the tool was not run."
 )
+LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL = (
+    "Private scratch space is unavailable; the tool was not run."
+)
 
 _PATH_AUTHORITY_LOCAL_NAMES = frozenset(
     {
@@ -343,7 +346,11 @@ class LocalToolProvider:
 
     @property
     def workspace_root(self) -> Path:
-        """Return the canonical confinement root for this provider."""
+        """Return the canonical confinement root for this provider.
+
+        Returns:
+            The resolved local-tool confinement root.
+        """
         return Path(self._root).resolve()
 
     def list_catalog(self) -> list[ToolCatalogEntry]:
@@ -777,7 +784,7 @@ class LocalToolProvider:
                     with self._authority_scope():
                         return _invoke_allowed()
                 except Exception:  # noqa: BLE001 - lease failure is fail-closed
-                    return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+                    return ToolResult.blocked(LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL)
             return _invoke_allowed()
         if verdict == "timeout":
             self._record_decision_safe(self.hub_tool_for(name), "denied-timeout")

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -14,7 +14,16 @@ import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Mapping, NotRequired, TypedDict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ContextManager,
+    Iterator,
+    Mapping,
+    NotRequired,
+    TypedDict,
+)
 
 from loguru import logger
 
@@ -95,6 +104,23 @@ LOCAL_GATE_ERROR_REFUSAL = (
 )
 LOCAL_ROOT_CHANGED_REFUSAL = (
     "Selected workspace root changed after dispatch started; the tool was not run."
+)
+
+_PATH_AUTHORITY_LOCAL_NAMES = frozenset(
+    {
+        "fs_list",
+        "fs_read",
+        "fs_write",
+        "fs_edit",
+        "fs_patch",
+        "fs_glob",
+        "fs_grep",
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    }
 )
 
 _MAX_RESULT_BYTES = 32 * 1024
@@ -257,17 +283,18 @@ class LocalToolProvider:
         no_callback_refusal: str | None = None,
         allow_write: bool = True,
         root_guard: Callable[[], bool] | None = None,
+        authority_scope: Callable[[], ContextManager[Path]] | None = None,
     ) -> None:
         self._root = workspace_root
         selected_specs = (
             specs
             if specs is not None
             else _default_specs(
-                 workspace_root,
-                 todo_store=todo_store,
-                 on_todo_change=on_todo_change,
-                 watchlists_service=watchlists_service,
-             )
+                workspace_root,
+                todo_store=todo_store,
+                on_todo_change=on_todo_change,
+                watchlists_service=watchlists_service,
+            )
         )
         if not allow_write:
             selected_specs = [
@@ -275,10 +302,7 @@ class LocalToolProvider:
                 for spec in selected_specs
                 if spec.name not in {"fs_write", "fs_edit", "fs_patch"}
             ]
-        self._specs = {
-            s.name: s
-            for s in selected_specs
-        }
+        self._specs = {s.name: s for s in selected_specs}
         self._resolve_state = resolve_state or (
             lambda hub: EffectiveToolState(state="ask", origin="global_default")
         )
@@ -289,6 +313,7 @@ class LocalToolProvider:
         self._record_decision = record_decision
         self._no_callback_refusal = no_callback_refusal
         self._root_guard = root_guard
+        self._authority_scope = authority_scope
         # PR2a Task 5: keyed (run_id, tool_name), not tool_name -- one
         # provider instance is shared by a parent run and every sub-agent
         # it spawns, so a name-keyed dict let any run's turn clear or
@@ -305,6 +330,11 @@ class LocalToolProvider:
 
     def _tool_id(self, name: str) -> str:
         return f"{SOURCE}:{name}"
+
+    @property
+    def workspace_root(self) -> Path:
+        """Return the canonical confinement root for this provider."""
+        return Path(self._root).resolve()
 
     def list_catalog(self) -> list[ToolCatalogEntry]:
         """List this run's local tools as catalog entries.
@@ -426,6 +456,16 @@ class LocalToolProvider:
     def path_targets(
         self, tool_id: str, args: Mapping[str, Any]
     ) -> tuple[ToolPathTarget, ...]:
+        """Map path targets while holding scratch authority when required."""
+        name = tool_id.split(":", 1)[-1]
+        if self._authority_scope is not None and name in _PATH_AUTHORITY_LOCAL_NAMES:
+            with self._authority_scope():
+                return self._path_targets_without_authority(tool_id, args)
+        return self._path_targets_without_authority(tool_id, args)
+
+    def _path_targets_without_authority(
+        self, tool_id: str, args: Mapping[str, Any]
+    ) -> tuple[ToolPathTarget, ...]:
         """Map supported local file and git calls to validated path targets."""
         name = tool_id.split(":", 1)[-1]
         if name not in self._specs:
@@ -462,9 +502,7 @@ class LocalToolProvider:
             try:
                 plans = parse_patch_targets(args["diff"])
             except FilesystemPatchError as exc:
-                raise LocalToolError(
-                    f"fs_patch failed [{exc.reason_code}]"
-                ) from exc
+                raise LocalToolError(f"fs_patch failed [{exc.reason_code}]") from exc
             targets: list[ToolPathTarget] = []
             seen: set[Path] = set()
             for plan in plans:
@@ -697,14 +735,31 @@ class LocalToolProvider:
         # writes, so such a call resolves through the fresh gate below.
         verdict = self._verdict_for(name, args, current_run_id())
         if verdict == "allow":
-            if not self._root_is_valid():
-                return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
-            try:
-                return ToolResult(ok=True, content=_fit_result(spec.handler(args)))
-            except Exception as exc:  # noqa: BLE001 — never raises across the boundary
-                return ToolResult(
-                    ok=False, error=(str(exc) or repr(exc))[:_MAX_ERROR_CHARS]
-                )
+
+            def _invoke_allowed() -> ToolResult:
+                if not self._root_is_valid():
+                    return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+                try:
+                    return ToolResult(
+                        ok=True,
+                        content=_fit_result(spec.handler(args)),
+                    )
+                except Exception as exc:  # noqa: BLE001 — protocol boundary
+                    return ToolResult(
+                        ok=False,
+                        error=(str(exc) or repr(exc))[:_MAX_ERROR_CHARS],
+                    )
+
+            if (
+                self._authority_scope is not None
+                and name in _PATH_AUTHORITY_LOCAL_NAMES
+            ):
+                try:
+                    with self._authority_scope():
+                        return _invoke_allowed()
+                except Exception:  # noqa: BLE001 - lease failure is fail-closed
+                    return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+            return _invoke_allowed()
         if verdict == "timeout":
             self._record_decision_safe(self.hub_tool_for(name), "denied-timeout")
             return ToolResult.blocked(LOCAL_TIMEOUT_REFUSAL)

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -51,7 +51,7 @@ from .session_todo_store import (
 
 if TYPE_CHECKING:
     from tldw_chatbook.Tools.watchlists_tool_service import WatchlistsToolService
-from .tool_catalog import ToolPathTarget
+from .tool_catalog import ToolPathTarget, redact_root_locator
 
 # Module-level (not the function-local imports the other `_default_specs`
 # tool modules use) SPECIFICALLY so tests can patch this one name via
@@ -263,6 +263,10 @@ class LocalToolProvider:
             approve and the timeout copy is misleading
             (MCP/local_server_tools.EXTERNAL_NO_CALLBACK_REFUSAL). The
             "timeout" verdict ALWAYS keeps LOCAL_TIMEOUT_REFUSAL.
+        result_redaction_root: Optional process-local root whose absolute
+            locator must be replaced with relative text before results reach
+            model history or run logs. Console private scratch passes its
+            root; ordinary and explicitly bound Workspace providers omit it.
     """
 
     def __init__(
@@ -284,6 +288,7 @@ class LocalToolProvider:
         allow_write: bool = True,
         root_guard: Callable[[], bool] | None = None,
         authority_scope: Callable[[], ContextManager[Path]] | None = None,
+        result_redaction_root: Path | None = None,
     ) -> None:
         self._root = workspace_root
         selected_specs = (
@@ -314,6 +319,11 @@ class LocalToolProvider:
         self._no_callback_refusal = no_callback_refusal
         self._root_guard = root_guard
         self._authority_scope = authority_scope
+        self._result_redaction_root = (
+            Path(result_redaction_root).resolve()
+            if result_redaction_root is not None
+            else None
+        )
         # PR2a Task 5: keyed (run_id, tool_name), not tool_name -- one
         # provider instance is shared by a parent run and every sub-agent
         # it spawns, so a name-keyed dict let any run's turn clear or
@@ -742,12 +752,20 @@ class LocalToolProvider:
                 try:
                     return ToolResult(
                         ok=True,
-                        content=_fit_result(spec.handler(args)),
+                        content=_fit_result(
+                            redact_root_locator(
+                                spec.handler(args),
+                                self._result_redaction_root,
+                            )
+                        ),
                     )
                 except Exception as exc:  # noqa: BLE001 — protocol boundary
                     return ToolResult(
                         ok=False,
-                        error=(str(exc) or repr(exc))[:_MAX_ERROR_CHARS],
+                        error=redact_root_locator(
+                            (str(exc) or repr(exc))[:_MAX_ERROR_CHARS],
+                            self._result_redaction_root,
+                        ),
                     )
 
             if (

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -349,8 +349,11 @@ def resolve_log_root(
         )
         with workspace_scope:
             roots = allowed_file_roots(write=True, sandbox_root=sandbox)
-    except Exception:
-        logger.opt(exception=True).warning("run log: cannot resolve any root")
+    except Exception as exc:
+        logger.warning(
+            "run log: cannot resolve any root category={}",
+            exc.__class__.__name__,
+        )
         return None
     if not roots:
         return None
@@ -559,9 +562,10 @@ class RunLogWriter:
         try:
             with self._access_scope():
                 self._bind_under_scope(run_id)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "run log: access scope unavailable; logging disabled"
+        except Exception as exc:
+            logger.warning(
+                "run log: access scope unavailable; logging disabled category={}",
+                exc.__class__.__name__,
             )
             self._active = False
 
@@ -630,8 +634,11 @@ class RunLogWriter:
         if self._on_bound is not None:
             try:
                 self._on_bound(run_id, root)
-            except Exception:  # noqa: BLE001 -- observers never break logging
-                logger.opt(exception=True).debug("run log: on_bound callback failed")
+            except Exception as exc:  # noqa: BLE001 -- observers never break logging
+                logger.debug(
+                    "run log: on_bound callback failed category={}",
+                    exc.__class__.__name__,
+                )
 
     def _migrate_legacy_dir(self, root: Path, legacy_name: str, dotted: Path) -> None:
         """Move a pre-TASK-1270 undotted log tree under its dotted name.
@@ -731,10 +738,11 @@ class RunLogWriter:
                 legacy.rmdir()
             except OSError:
                 pass
-        except Exception:
-            logger.opt(exception=True).warning(
+        except Exception as exc:
+            logger.warning(
                 "run log: legacy directory migration failed; historical "
-                "logs may remain reachable until a future run retries"
+                "logs may remain reachable until a future run retries category={}",
+                exc.__class__.__name__,
             )
 
     def _segment_path(self) -> Path:
@@ -800,9 +808,10 @@ class RunLogWriter:
                     status=status,
                     call_id=call_id,
                 )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "run log: access scope unavailable; logging disabled"
+        except Exception as exc:
+            logger.warning(
+                "run log: access scope unavailable; logging disabled category={}",
+                exc.__class__.__name__,
             )
             self._active = False
             return None
@@ -870,15 +879,19 @@ class RunLogWriter:
                     # fsync the segment being retired; it will not be
                     # appended to again.
                     self._write_bytes(self._segment_path(), b"", sync=True)
-                except Exception:  # noqa: BLE001 — durability is best-effort
-                    logger.opt(exception=True).warning("run log: segment fsync failed")
+                except Exception as exc:  # noqa: BLE001 — durability is best-effort
+                    logger.warning(
+                        "run log: segment fsync failed category={}",
+                        exc.__class__.__name__,
+                    )
                 self._segment_index += 1
                 self._segment_size = 0
             try:
                 self._write_bytes(self._segment_path(), payload)
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "run log: append failed; logging disabled for this run"
+            except Exception as exc:
+                logger.warning(
+                    "run log: append failed; logging disabled for this run category={}",
+                    exc.__class__.__name__,
                 )
                 self._active = False
                 return None
@@ -892,9 +905,10 @@ class RunLogWriter:
         try:
             with self._access_scope():
                 self._write_manifest_under_scope(metadata)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "run log: access scope unavailable; logging disabled"
+        except Exception as exc:
+            logger.warning(
+                "run log: access scope unavailable; logging disabled category={}",
+                exc.__class__.__name__,
             )
             self._active = False
 
@@ -921,8 +935,11 @@ class RunLogWriter:
                 json.dumps(payload, indent=2, default=str).encode("utf-8"),
                 sync=True,
             )
-        except Exception:  # noqa: BLE001 — convenience metadata only
-            logger.opt(exception=True).warning("run log: manifest write failed")
+        except Exception as exc:  # noqa: BLE001 — convenience metadata only
+            logger.warning(
+                "run log: manifest write failed category={}",
+                exc.__class__.__name__,
+            )
 
     def close(self) -> None:
         """Flush the final segment while holding configured file authority."""
@@ -931,9 +948,10 @@ class RunLogWriter:
         try:
             with self._access_scope():
                 self._close_under_scope()
-        except Exception:
-            logger.opt(exception=True).warning(
-                "run log: access scope unavailable; logging disabled"
+        except Exception as exc:
+            logger.warning(
+                "run log: access scope unavailable; logging disabled category={}",
+                exc.__class__.__name__,
             )
             self._active = False
 
@@ -943,8 +961,11 @@ class RunLogWriter:
             return
         try:
             self._write_bytes(self._segment_path(), b"", sync=True)
-        except Exception:  # noqa: BLE001 — best-effort durability
-            logger.opt(exception=True).warning("run log: final fsync failed")
+        except Exception as exc:  # noqa: BLE001 — best-effort durability
+            logger.warning(
+                "run log: final fsync failed category={}",
+                exc.__class__.__name__,
+            )
 
 
 def _now_iso() -> str:

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -772,7 +772,21 @@ class RunLogWriter:
         status: str = "",
         call_id: str = "",
     ) -> int | None:
-        """Append one record while holding the configured file authority."""
+        """Append one record while holding the configured file authority.
+
+        Args:
+            run_id: Identifier of the parent or child run.
+            kind: Run kind, such as ``primary`` or ``subagent``.
+            type: Record type, such as ``model`` or ``tool_result``.
+            content: Full record content before the configured byte cap.
+            tool: Tool name when the record describes a tool operation.
+            status: Tool or run status when applicable.
+            call_id: Provider tool-call identifier when applicable.
+
+        Returns:
+            The assigned record number, or ``None`` when logging is inactive
+            or file authority cannot be acquired.
+        """
         if not self._active or self.log_dir is None:
             return None
         try:

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import os
 import threading
+from contextlib import nullcontext
 from pathlib import Path
+from typing import Callable, ContextManager
 
 from loguru import logger
 
@@ -299,7 +301,11 @@ def _validate_run_id_path_component(run_id: str) -> str | None:
     return s
 
 
-def resolve_log_root() -> Path | None:
+def resolve_log_root(
+    *,
+    sandbox_root: Path | None = None,
+    workspace_id: str | None = None,
+) -> Path | None:
     """Return the directory the log tree is created under, or ``None``.
 
     Prefers the run's first read-write workspace folder root so the log is
@@ -315,15 +321,34 @@ def resolve_log_root() -> Path | None:
     side channel had no remaining purpose and was removed. The return
     value is a bare ``Path | None``, exactly as before.
 
+    Args:
+        sandbox_root: Optional explicit fallback root. When omitted, preserve
+            the non-Console global sandbox behavior.
+        workspace_id: Optional live Workspace scope used to resolve writable
+            explicit folder bindings before the fallback root.
+
     Returns:
         The chosen root directory, or ``None`` when none is usable.
     """
     try:
         from tldw_chatbook.Tools.file_operation_tools import _tool_sandbox_root
-        from tldw_chatbook.Tools.workspace_file_roots import allowed_file_roots
+        from tldw_chatbook.Tools.workspace_file_roots import (
+            allowed_file_roots,
+            run_workspace,
+        )
 
-        sandbox = _tool_sandbox_root()
-        roots = allowed_file_roots(write=True, sandbox_root=sandbox)
+        sandbox = (
+            Path(sandbox_root).resolve()
+            if sandbox_root is not None
+            else _tool_sandbox_root()
+        )
+        workspace_scope = (
+            run_workspace(workspace_id)
+            if workspace_id is not None
+            else nullcontext()
+        )
+        with workspace_scope:
+            roots = allowed_file_roots(write=True, sandbox_root=sandbox)
     except Exception:
         logger.opt(exception=True).warning("run log: cannot resolve any root")
         return None
@@ -338,7 +363,11 @@ def resolve_log_root() -> Path | None:
     return roots[0]
 
 
-def resolve_existing_log_dir(run_id: str) -> Path | None:
+def resolve_existing_log_dir(
+    run_id: str,
+    *,
+    root: Path | None = None,
+) -> Path | None:
     """Locate an already-written run log directory for ``run_id``, if any.
 
     TASK-870: the Console's "read the full result" affordance needs to
@@ -375,6 +404,8 @@ def resolve_existing_log_dir(run_id: str) -> Path | None:
             ``AgentRunsDB`` run id -- ``AgentService._run_one`` binds the
             writer to this same id via ``self.db.create_run()``'s return
             value).
+        root: Optional explicit confinement root. When supplied, global
+            Workspace and sandbox discovery is never consulted.
 
     Returns:
         The run's log directory when it exists and holds at least one
@@ -386,13 +417,13 @@ def resolve_existing_log_dir(run_id: str) -> Path | None:
     safe_run_id = _validate_run_id_path_component(run_id)
     if safe_run_id is None:
         return None
-    root = resolve_log_root()
-    if root is None:
+    resolved_root = Path(root).resolve() if root is not None else resolve_log_root()
+    if resolved_root is None:
         return None
     configured = _setting("run_log_dir_name", DEFAULT_DIR_NAME)
     dir_name = _coerce_dir_name(configured, DEFAULT_DIR_NAME)
     for candidate_dir_name in (dir_name, f".{dir_name}"):
-        run_dir = root / candidate_dir_name / safe_run_id
+        run_dir = resolved_root / candidate_dir_name / safe_run_id
         try:
             if run_dir.is_dir() and any(run_dir.glob("logs.*.txt")):
                 return run_dir
@@ -442,6 +473,9 @@ class RunLogWriter:
         dir_name: str | None = None,
         segment_bytes: int | None = None,
         max_record_bytes: int | None = None,
+        root: Path | None = None,
+        access_scope: Callable[[], ContextManager[Path]] | None = None,
+        on_bound: Callable[[str, Path], None] | None = None,
     ) -> None:
         """Build an UNBOUND writer. Explicit args override ``[agents]`` config.
 
@@ -451,6 +485,12 @@ class RunLogWriter:
                 ``[agents] run_log_segment_bytes``.
             max_record_bytes: Per-record ceiling; defaults to
                 ``[agents] run_log_max_record_bytes``.
+            root: Optional explicit confinement root. When supplied, global
+                workspace/sandbox resolution is never consulted.
+            access_scope: Optional context manager factory required around
+                every filesystem access.
+            on_bound: Optional callback receiving the primary run id and
+                resolved confinement root after a successful bind.
         """
         # Coerce dir_name defensively using shared helper.
         if dir_name is not None:
@@ -479,6 +519,9 @@ class RunLogWriter:
             self._max_record_bytes = configured_max_record_bytes()
 
         self._lock = threading.Lock()
+        self._explicit_root = Path(root).resolve() if root is not None else None
+        self._access_scope = access_scope or nullcontext
+        self._on_bound = on_bound
         self._counter = 0
         self._segment_index = 1
         self._segment_size = 0
@@ -513,7 +556,18 @@ class RunLogWriter:
         if not _setting("run_log_enabled", True):
             self._active = False
             return
-        root = resolve_log_root()
+        try:
+            with self._access_scope():
+                self._bind_under_scope(run_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "run log: access scope unavailable; logging disabled"
+            )
+            self._active = False
+
+    def _bind_under_scope(self, run_id: str) -> None:
+        """Create the run directory while the caller holds file authority."""
+        root = self._explicit_root or resolve_log_root()
         if root is None:
             self._active = False
             return
@@ -544,44 +598,40 @@ class RunLogWriter:
             # `base` (the dotted target) is known.
             legacy_dir_name = dir_name
             dir_name = f".{dir_name}"
-        try:
-            from tldw_chatbook.Tools.file_operation_tools import is_within
+        from tldw_chatbook.Tools.file_operation_tools import is_within
 
-            base = root / dir_name
-            # Verify containment before creating any directories.
-            if not is_within(base, root):
-                logger.warning(
-                    "run log: base directory escapes root; logging disabled"
-                )
-                self._active = False
-                return
-            if legacy_dir_name is not None:
-                # Best-effort, self-contained (never raises): see
-                # `_migrate_legacy_dir` for the full upgrade-safety policy.
-                self._migrate_legacy_dir(root, legacy_dir_name, base)
-            base.mkdir(parents=True, exist_ok=True)
-            gitignore = base / ".gitignore"
-            if not gitignore.exists():
-                # Created only if absent: writing into a user's repository
-                # is itself a mutation.
-                gitignore.write_text("*\n", encoding="utf-8")
-            run_dir = base / run_id
-            # Verify containment of run_dir before creating it.
-            if not is_within(run_dir, root):
-                logger.warning(
-                    "run log: run directory escapes root; logging disabled"
-                )
-                self._active = False
-                return
-            run_dir.mkdir(parents=True, exist_ok=True)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "run log: cannot create log directory; logging disabled"
+        base = root / dir_name
+        # Verify containment before creating any directories.
+        if not is_within(base, root):
+            logger.warning("run log: base directory escapes root; logging disabled")
+            self._active = False
+            return
+        if legacy_dir_name is not None:
+            # Best-effort, self-contained (never raises): see
+            # `_migrate_legacy_dir` for the full upgrade-safety policy.
+            self._migrate_legacy_dir(root, legacy_dir_name, base)
+        base.mkdir(parents=True, exist_ok=True)
+        gitignore = base / ".gitignore"
+        if not gitignore.exists():
+            # Created only if absent: writing into a user's repository
+            # is itself a mutation.
+            gitignore.write_text("*\n", encoding="utf-8")
+        run_dir = base / run_id
+        # Verify containment of run_dir before creating it.
+        if not is_within(run_dir, root):
+            logger.warning(
+                "run log: run directory escapes root; logging disabled"
             )
             self._active = False
             return
+        run_dir.mkdir(parents=True, exist_ok=True)
         self.log_dir = run_dir
         self._active = True
+        if self._on_bound is not None:
+            try:
+                self._on_bound(run_id, root)
+            except Exception:  # noqa: BLE001 -- observers never break logging
+                logger.opt(exception=True).debug("run log: on_bound callback failed")
 
     def _migrate_legacy_dir(self, root: Path, legacy_name: str, dotted: Path) -> None:
         """Move a pre-TASK-1270 undotted log tree under its dotted name.
@@ -722,7 +772,39 @@ class RunLogWriter:
         status: str = "",
         call_id: str = "",
     ) -> int | None:
-        """Append one record and return its number.
+        """Append one record while holding the configured file authority."""
+        if not self._active or self.log_dir is None:
+            return None
+        try:
+            with self._access_scope():
+                return self._append_under_scope(
+                    run_id=run_id,
+                    kind=kind,
+                    type=type,
+                    content=content,
+                    tool=tool,
+                    status=status,
+                    call_id=call_id,
+                )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "run log: access scope unavailable; logging disabled"
+            )
+            self._active = False
+            return None
+
+    def _append_under_scope(
+        self,
+        *,
+        run_id: str,
+        kind: str,
+        type: str,
+        content: str,
+        tool: str = "",
+        status: str = "",
+        call_id: str = "",
+    ) -> int | None:
+        """Append one record after the caller acquires file authority.
 
         Args:
             run_id: Id of the run this record belongs to (parent or child).
@@ -790,6 +872,19 @@ class RunLogWriter:
             return RunLogRecordNumber(record.number, truncated=bool(truncated_from))
 
     def write_manifest(self, metadata: dict) -> None:
+        """Write run-level metadata while holding configured file authority."""
+        if self.log_dir is None:
+            return
+        try:
+            with self._access_scope():
+                self._write_manifest_under_scope(metadata)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "run log: access scope unavailable; logging disabled"
+            )
+            self._active = False
+
+    def _write_manifest_under_scope(self, metadata: dict) -> None:
         """Write run-level convenience metadata. Never raises.
 
         The manifest is deliberately NOT load-bearing: segment discovery is
@@ -816,6 +911,19 @@ class RunLogWriter:
             logger.opt(exception=True).warning("run log: manifest write failed")
 
     def close(self) -> None:
+        """Flush the final segment while holding configured file authority."""
+        if not self._active or self.log_dir is None:
+            return
+        try:
+            with self._access_scope():
+                self._close_under_scope()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "run log: access scope unavailable; logging disabled"
+            )
+            self._active = False
+
+    def _close_under_scope(self) -> None:
         """Flush the final segment to disk. Idempotent and always safe."""
         if not self._active or self.log_dir is None:
             return

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -12,13 +12,16 @@ import asyncio
 import json
 import threading
 from collections.abc import Sequence
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
 from typing import (
     Any,
     Callable,
+    ContextManager,
     Iterable,
+    Iterator,
     Literal,
     Mapping,
     NamedTuple,
@@ -142,9 +145,7 @@ WAIT_AGENTS_SCHEMA = ToolSchema(
             "ids": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": (
-                    "Handle ids to wait for (omit for all of them)."
-                ),
+                "description": ("Handle ids to wait for (omit for all of them)."),
             }
         },
         "required": [],
@@ -200,8 +201,7 @@ SEND_TO_AGENT_SCHEMA = ToolSchema(
             "message": {
                 "type": "string",
                 "description": (
-                    "The steering text to deliver. Plain text; must be "
-                    "non-empty."
+                    "The steering text to deliver. Plain text; must be non-empty."
                 ),
             },
         },
@@ -430,7 +430,8 @@ RUN_LOG_STATS_TOOL_SCHEMA = ToolSchema(
         "properties": {
             "group_by": {
                 "type": "string",
-                "description": "Dimension to group by: " + ", ".join(STATS_GROUP_BY_FIELDS)
+                "description": "Dimension to group by: "
+                + ", ".join(STATS_GROUP_BY_FIELDS)
                 + " (default: tool). An unrecognised value falls back to tool.",
             },
             "tool": {
@@ -646,6 +647,18 @@ def build_gateable_tool(entry: GateableTool) -> Any:
     return getattr(module, entry.factory_name)()
 
 
+_FILE_AUTHORITY_BUILTIN_NAMES = frozenset(
+    {
+        "read_file",
+        "write_file",
+        "list_directory",
+        "glob_files",
+        "grep_files",
+        "expand_document",
+    }
+)
+
+
 class BuiltinToolProvider:
     """Wraps tool_executor's built-in tools behind the provider interface."""
 
@@ -658,6 +671,8 @@ class BuiltinToolProvider:
         ephemeral: bool = False,
         diff_sink: Callable[[tuple[str, str, str, str]], None] | None = None,
         instruction_root: Path | None = None,
+        sandbox_root: Path | None = None,
+        sandbox_lease: Callable[[], ContextManager[Path]] | None = None,
     ) -> None:
         # settings-workspaces-folder-roots spec §3: the run's workspace,
         # bound around every tool execution (see `invoke`) so file tools
@@ -668,6 +683,10 @@ class BuiltinToolProvider:
         # in `builtin_tool_gate.builtin_permission_rows`) leaves
         # `allowed_file_roots` to fall back to the active workspace.
         self._workspace_id = workspace_id
+        self._sandbox_root = (
+            Path(sandbox_root).resolve() if sandbox_root is not None else None
+        )
+        self._sandbox_lease = sandbox_lease
         self._instruction_root = (
             Path(instruction_root).resolve() if instruction_root is not None else None
         )
@@ -749,6 +768,27 @@ class BuiltinToolProvider:
         # a `deque.append` (single-argument contract, atomic in CPython).
         self._diff_sink = diff_sink
 
+    @property
+    def sandbox_root(self) -> Path | None:
+        """Return this provider's explicit run sandbox, when one was bound."""
+        return self._sandbox_root
+
+    @contextmanager
+    def _file_authority(self) -> Iterator[None]:
+        """Keep the explicit scratch generation alive for one file access."""
+        from tldw_chatbook.Tools.workspace_file_roots import run_file_sandbox
+
+        lease = (
+            self._sandbox_lease() if self._sandbox_lease is not None else nullcontext()
+        )
+        sandbox = (
+            run_file_sandbox(self._sandbox_root)
+            if self._sandbox_root is not None
+            else nullcontext()
+        )
+        with lease, sandbox:
+            yield
+
     def _tool_id(self, name: str) -> str:
         return f"{self.SOURCE}:{name}"
 
@@ -788,16 +828,14 @@ class BuiltinToolProvider:
         from tldw_chatbook.Tools.workspace_file_roots import run_workspace
         from tldw_chatbook.Utils.path_validation import validate_path_multi
 
-        with run_workspace(self._workspace_id):
-            roots = allowed_file_roots(
-                write=write, sandbox_root=_tool_sandbox_root()
-            )
-        path = validate_path_multi(value, roots)
-        try:
-            path.relative_to(root)
-        except ValueError:
-            return (ToolPathTarget(path=path, kind="outside"),)
-        return (ToolPathTarget(path=path, kind=kind),)
+        with self._file_authority(), run_workspace(self._workspace_id):
+            roots = allowed_file_roots(write=write, sandbox_root=_tool_sandbox_root())
+            path = validate_path_multi(value, roots)
+            try:
+                path.relative_to(root)
+            except ValueError:
+                return (ToolPathTarget(path=path, kind="outside"),)
+            return (ToolPathTarget(path=path, kind=kind),)
 
     def _resolve_gate(self) -> Any:
         """Return the provider's gate, building one lazily on first use.
@@ -879,6 +917,11 @@ class BuiltinToolProvider:
             return ToolResult.blocked(refusal)
         from tldw_chatbook.Tools.workspace_file_roots import run_workspace
 
+        authority = (
+            self._file_authority()
+            if name in _FILE_AUTHORITY_BUILTIN_NAMES
+            else nullcontext()
+        )
         try:
             # Providers bridge async tools; the loop's interface is sync.
             # Safe here: the service runs in a worker thread with no
@@ -889,7 +932,7 @@ class BuiltinToolProvider:
             # concurrent run's. `self._workspace_id=None` keeps the
             # ContextVar at `None`, which is `allowed_file_roots`' own
             # documented fallback to the active workspace.
-            with run_workspace(self._workspace_id):
+            with authority, run_workspace(self._workspace_id):
                 raw = asyncio.run(tool.execute(**args))
         except Exception as exc:  # noqa: BLE001 — captured, never escapes
             return ToolResult(ok=False, error=str(exc))
@@ -1196,9 +1239,7 @@ class ToolCatalogRegistry:
     def _owner_record_for_name(self, name: str) -> _ToolOwnerRecord | None:
         return self._ensure_catalog_cache().by_name.get(name)
 
-    def resolve_owner_for_name(
-        self, name: str
-    ) -> tuple[str, ToolProvider] | None:
+    def resolve_owner_for_name(self, name: str) -> tuple[str, ToolProvider] | None:
         """Atomically resolve one LLM-facing name to its cached first owner."""
         record = self._owner_record_for_name(name)
         if record is None:

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -809,12 +809,21 @@ class BuiltinToolProvider:
 
     @property
     def sandbox_root(self) -> Path | None:
-        """Return this provider's explicit run sandbox, when one was bound."""
+        """Return this provider's explicit run sandbox, when one was bound.
+
+        Returns:
+            The resolved per-run sandbox root, or ``None`` when absent.
+        """
         return self._sandbox_root
 
     @property
     def sandbox_lease(self) -> Callable[[], ContextManager[Path]] | None:
-        """Return the lease factory paired with the explicit run sandbox."""
+        """Return the lease factory paired with the explicit run sandbox.
+
+        Returns:
+            A context-manager factory that leases the sandbox generation, or
+            ``None`` when the provider has no explicit sandbox authority.
+        """
         return self._sandbox_lease
 
     @contextmanager

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -659,6 +659,45 @@ _FILE_AUTHORITY_BUILTIN_NAMES = frozenset(
 )
 
 
+def redact_root_locator(value: Any, root: Path | None) -> Any:
+    """Replace an opaque private-root locator with model-safe relative text.
+
+    Tool-provider results are copied into both model history and run logs.
+    Console scratch roots are process-local capabilities, so their absolute
+    locator must be removed at that shared boundary. Containers are rebuilt
+    recursively because built-in tools return nested JSON-shaped values.
+
+    Args:
+        value: Tool result value or error text to sanitize.
+        root: Opaque root whose locator must not leave the provider.
+
+    Returns:
+        A value of the same JSON-compatible shape with root-owned paths made
+        relative and exact root occurrences replaced by ``.``. Non-Console
+        callers pass ``None`` and retain their existing output byte-for-byte.
+    """
+    if root is None:
+        return value
+    if isinstance(value, str):
+        locators = {str(root), root.as_posix()}
+        for locator in sorted(locators, key=len, reverse=True):
+            if locator:
+                value = value.replace(f"{locator}/", "")
+                value = value.replace(f"{locator}\\", "")
+                value = value.replace(locator, ".")
+        return value
+    if isinstance(value, dict):
+        return {
+            key: redact_root_locator(item, root)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_root_locator(item, root) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_root_locator(item, root) for item in value)
+    return value
+
+
 class BuiltinToolProvider:
     """Wraps tool_executor's built-in tools behind the provider interface."""
 
@@ -940,9 +979,15 @@ class BuiltinToolProvider:
             with authority, run_workspace(self._workspace_id):
                 raw = asyncio.run(tool.execute(**args))
         except Exception as exc:  # noqa: BLE001 — captured, never escapes
-            return ToolResult(ok=False, error=str(exc))
+            return ToolResult(
+                ok=False,
+                error=redact_root_locator(str(exc), self._sandbox_root),
+            )
         if isinstance(raw, dict) and raw.get("error"):
-            return ToolResult(ok=False, error=str(raw["error"]))
+            return ToolResult(
+                ok=False,
+                error=redact_root_locator(str(raw["error"]), self._sandbox_root),
+            )
         if isinstance(raw, dict):
             # Raw before/after contents captured for UI diff rendering
             # (TASK-1351) are live-session display state only. This is the
@@ -964,7 +1009,10 @@ class BuiltinToolProvider:
                         self._diff_sink(
                             (
                                 name,
-                                str(raw.get("file_path") or "file"),
+                                redact_root_locator(
+                                    str(raw.get("file_path") or "file"),
+                                    self._sandbox_root,
+                                ),
                                 old_content,
                                 new_content,
                             )
@@ -977,6 +1025,7 @@ class BuiltinToolProvider:
             raw = {
                 key: value for key, value in raw.items() if key not in DIFF_CONTENT_KEYS
             }
+        raw = redact_root_locator(raw, self._sandbox_root)
         content = json.dumps(raw) if isinstance(raw, (dict, list)) else str(raw)
         return ToolResult(ok=True, content=content)
 

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -773,6 +773,11 @@ class BuiltinToolProvider:
         """Return this provider's explicit run sandbox, when one was bound."""
         return self._sandbox_root
 
+    @property
+    def sandbox_lease(self) -> Callable[[], ContextManager[Path]] | None:
+        """Return the lease factory paired with the explicit run sandbox."""
+        return self._sandbox_lease
+
     @contextmanager
     def _file_authority(self) -> Iterator[None]:
         """Keep the explicit scratch generation alive for one file access."""

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -3002,6 +3002,15 @@ class ConsoleFirstRequestPlan:
     api_endpoint: str
 
 
+@dataclass(frozen=True, slots=True)
+class _ConsoleRunLogAuthority:
+    """Live, process-local authority for one Console run-log tree."""
+
+    session_id: str
+    root: Path
+    access_scope: Callable[[], ContextManager[Path]]
+
+
 def build_console_first_request_plan(
     *,
     shared_registry: ToolCatalogRegistry,
@@ -3261,6 +3270,8 @@ class ConsoleAgentBridge:
         #: the newest turn's primary run. Only `run_reply` writes it.
         self._live_primary_keys: dict[str, str] = {}
         self._historical_cache: dict[str, AgentLiveSnapshot] = {}
+        self._run_log_authorities: dict[str, _ConsoleRunLogAuthority] = {}
+        self._run_log_authority_lock = threading.Lock()
         # PR2b Task 1: published for the DURATION of one `run_reply` call
         # -- set right before `service.run_turn(...)` is invoked (below),
         # popped in the same `finally` that already tears that run down.
@@ -3988,9 +3999,26 @@ class ConsoleAgentBridge:
                                 "Failed to persist skill script grant"
                             )
                 try:
-                    outcome = asyncio.run(
-                        scope.run_skill_script(skill_name, script_path, list(args))
-                    )
+                    if scratch_root is not None and scratch_lease is not None:
+                        with scratch_lease():
+                            outcome = asyncio.run(
+                                scope.run_skill_script(
+                                    skill_name,
+                                    script_path,
+                                    list(args),
+                                    output_root=(
+                                        scratch_root / "skill_script_output"
+                                    ),
+                                )
+                            )
+                    else:
+                        outcome = asyncio.run(
+                            scope.run_skill_script(
+                                skill_name,
+                                script_path,
+                                list(args),
+                            )
+                        )
                 except Exception as exc:  # noqa: BLE001
                     return ToolResult(ok=False, error=f"run_skill_script: {exc}")
 
@@ -4017,7 +4045,17 @@ class ConsoleAgentBridge:
                     lines.append(
                         f"produced {len(outcome.output_files)} file(s): {listed}"
                     )
-                    lines.append(f"output directory: {outcome.output_dir}")
+                    display_output_dir = str(outcome.output_dir)
+                    if scratch_root is not None and outcome.output_dir is not None:
+                        try:
+                            display_output_dir = str(
+                                Path(outcome.output_dir)
+                                .resolve()
+                                .relative_to(scratch_root.resolve())
+                            )
+                        except ValueError:
+                            display_output_dir = "private scratch output"
+                    lines.append(f"output directory: {display_output_dir}")
                 return ToolResult(ok=True, content="\n".join(lines))
 
         # One event loop for the whole run (PR #629 Fix 1(c)): every turn
@@ -4333,6 +4371,29 @@ class ConsoleAgentBridge:
                     return {}
                 return _inner_review(calls, run_id)
 
+        run_log_writer = None
+        if scratch_root is not None and scratch_lease is not None:
+            from tldw_chatbook.Agents.run_log import RunLogWriter, resolve_log_root
+
+            run_log_root: Path | None = None
+            try:
+                with scratch_lease():
+                    run_log_root = resolve_log_root(
+                        sandbox_root=scratch_root,
+                        workspace_id=run_workspace_id,
+                    )
+            except Exception:  # noqa: BLE001 -- writer will fail closed on lease
+                run_log_root = None
+            run_log_writer = RunLogWriter(
+                root=run_log_root or scratch_root,
+                access_scope=scratch_lease,
+                on_bound=functools.partial(
+                    self._remember_run_log_authority,
+                    session_id=session_id,
+                    access_scope=scratch_lease,
+                ),
+            )
+
         service = AgentService(
             self._db,
             registry,
@@ -4345,6 +4406,7 @@ class ConsoleAgentBridge:
             review_state_scope=review_state_scope,
             install_skill_tool=install_skill_tool,
             run_skill_script_tool=run_skill_script_tool,
+            run_log_writer=run_log_writer,
             run_log_request_plan=first_request_plan.run_log,
             revoke_approvals=revoke_approvals,
             persist_provider_continuation=(
@@ -5701,6 +5763,43 @@ class ConsoleAgentBridge:
         record = self._db.latest_primary_run_metadata(conversation_id)
         return record["id"] if record is not None else None
 
+    def _remember_run_log_authority(
+        self,
+        run_id: str,
+        root: Path,
+        *,
+        session_id: str,
+        access_scope: Callable[[], ContextManager[Path]],
+    ) -> None:
+        """Remember one live Console run-log root without persisting it."""
+        authority = _ConsoleRunLogAuthority(
+            session_id=str(session_id),
+            root=Path(root).resolve(),
+            access_scope=access_scope,
+        )
+        with self._run_log_authority_lock:
+            self._run_log_authorities[str(run_id)] = authority
+
+    def forget_session_file_authority(self, session_id: str) -> None:
+        """Forget every scratch-adjacent run-log locator for a closed Chat."""
+        target = str(session_id)
+        with self._run_log_authority_lock:
+            stale = [
+                run_id
+                for run_id, authority in self._run_log_authorities.items()
+                if authority.session_id == target
+            ]
+            for run_id in stale:
+                self._run_log_authorities.pop(run_id, None)
+
+    def _run_log_authority_for(
+        self,
+        owner_run_id: str,
+    ) -> _ConsoleRunLogAuthority | None:
+        """Return a process-local authority snapshot for one primary run."""
+        with self._run_log_authority_lock:
+            return self._run_log_authorities.get(str(owner_run_id))
+
     def _owning_run_id_for_log(self, run_id: str) -> str:
         """Return the run id whose ON-DISK log directory holds ``run_id``'s records.
 
@@ -5762,14 +5861,29 @@ class ConsoleAgentBridge:
         from tldw_chatbook.Agents.run_log import resolve_existing_log_dir
 
         owner_run_id = self._owning_run_id_for_log(run_id)
-        log_dir = resolve_existing_log_dir(owner_run_id)
-        if log_dir is None:
+        authority = self._run_log_authority_for(owner_run_id)
+        if self._store is not None and authority is None:
             return False
-        if owner_run_id == run_id:
-            return True
-        from tldw_chatbook.Agents.run_log_search import load_records
+        try:
+            access_scope = (
+                authority.access_scope if authority is not None else contextlib.nullcontext
+            )
+            with access_scope():
+                log_dir = resolve_existing_log_dir(
+                    owner_run_id,
+                    root=(authority.root if authority is not None else None),
+                )
+                if log_dir is None:
+                    return False
+                if owner_run_id == run_id:
+                    return True
+                from tldw_chatbook.Agents.run_log_search import load_records
 
-        return any(record.run_id == run_id for record in load_records(log_dir))
+                return any(
+                    record.run_id == run_id for record in load_records(log_dir)
+                )
+        except Exception:  # noqa: BLE001 -- stale authority fails closed
+            return False
 
     def load_run_log_text(self, run_id: str) -> str:
         """Render ``run_id``'s full, untruncated run log for display.
@@ -5816,10 +5930,23 @@ class ConsoleAgentBridge:
         from tldw_chatbook.Agents.run_log_search import format_results, load_records
 
         owner_run_id = self._owning_run_id_for_log(run_id)
-        log_dir = resolve_existing_log_dir(owner_run_id)
-        if log_dir is None:
+        authority = self._run_log_authority_for(owner_run_id)
+        if self._store is not None and authority is None:
             return ""
-        records = load_records(log_dir)
+        try:
+            access_scope = (
+                authority.access_scope if authority is not None else contextlib.nullcontext
+            )
+            with access_scope():
+                log_dir = resolve_existing_log_dir(
+                    owner_run_id,
+                    root=(authority.root if authority is not None else None),
+                )
+                if log_dir is None:
+                    return ""
+                records = load_records(log_dir)
+        except Exception:  # noqa: BLE001 -- stale authority fails closed
+            return ""
         if owner_run_id != run_id:
             records = [record for record in records if record.run_id == run_id]
         if not records:

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -84,6 +84,7 @@ from tldw_chatbook.Agents.native_tools import provider_supports_native_tools
 from tldw_chatbook.Agents.agent_stream import StreamGate
 from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator, FleetHandle
 from tldw_chatbook.Agents.local_tool_provider import (
+    LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
     LOCAL_DENY_REFUSAL,
     LOCAL_GATE_ERROR_REFUSAL,
     LOCAL_KILL_SWITCH_REFUSAL,
@@ -1141,6 +1142,7 @@ _BLOCKED_PROVIDER_REFUSALS = frozenset(
         LOCAL_KILL_SWITCH_REFUSAL,
         LOCAL_GATE_ERROR_REFUSAL,
         LOCAL_ROOT_CHANGED_REFUSAL,
+        LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
         MCP_DENY_REFUSAL,
         MCP_USER_DENY_REFUSAL,
         MCP_UNRESOLVED_REFUSAL,

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -22,7 +22,7 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from collections.abc import Mapping
 from dataclasses import dataclass, replace as dataclass_replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, Sequence
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -441,6 +441,7 @@ def console_run_budget() -> RunBudget:
             MIN_CONSOLE_AGENT_MAX_TOOL_CALL_SECONDS,
         ),
     )
+
 
 _QUIET_STEP_TOOLS = {FIND_TOOLS_NAME, LOAD_TOOLS_NAME}
 
@@ -1008,9 +1009,7 @@ _TOOL_CALL_SHAPE_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
-_THINKING_PROVING_STEP_KINDS = frozenset(
-    {STEP_TOOL_CALL, STEP_SPAWN, STEP_TOOL_RESULT}
-)
+_THINKING_PROVING_STEP_KINDS = frozenset({STEP_TOOL_CALL, STEP_SPAWN, STEP_TOOL_RESULT})
 
 
 def safe_intermediate_thinking_summary(summary: str | None) -> str | None:
@@ -1132,12 +1131,8 @@ class _PendingPrimaryThinkingDeriver:
 
 _BUILTIN_KILL_SWITCH_REFUSAL = "tool execution is disabled by the kill switch"
 _BUILTIN_DENY_REFUSAL_PREFIX = "tool is set to Off: "
-_BUILTIN_UNRESOLVED_REFUSAL_PREFIX = (
-    "tool requires approval and none was granted: "
-)
-_CONTROLLER_USER_DENIED_PREFIX = CONTROLLER_USER_DENIED_REFUSAL.partition(
-    "{name}"
-)[0]
+_BUILTIN_UNRESOLVED_REFUSAL_PREFIX = "tool requires approval and none was granted: "
+_CONTROLLER_USER_DENIED_PREFIX = CONTROLLER_USER_DENIED_REFUSAL.partition("{name}")[0]
 _BLOCKED_PROVIDER_REFUSALS = frozenset(
     {
         _BUILTIN_KILL_SWITCH_REFUSAL,
@@ -1711,9 +1706,7 @@ class FleetDrainFanout:
         self._lock = threading.Lock()
         self._consumers: list[tuple[str, Callable[[FleetDrained], None]]] = []
 
-    def register(
-        self, name: str, consumer: Callable[[FleetDrained], None]
-    ) -> None:
+    def register(self, name: str, consumer: Callable[[FleetDrained], None]) -> None:
         """Register a consumer for the life of the owning bridge.
 
         Registration is BRIDGE-lifetime, not turn-scoped, because the
@@ -2831,6 +2824,8 @@ def _compose_run_registry_and_allowed(
     workspace_id: str | None = None,
     ephemeral: bool = False,
     diff_sink: Callable[[tuple[str, str, str, str]], None] | None = None,
+    scratch_root: Path | None = None,
+    scratch_lease: Callable[[], ContextManager[Path]] | None = None,
     local_provider: Any | None = None,
     library_provider: Any | None = None,
 ) -> tuple[ToolCatalogRegistry, tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
@@ -2892,6 +2887,10 @@ def _compose_run_registry_and_allowed(
         diff_sink: TASK-1366 -- this run's UI-side diff channel, threaded
             into the freshly-constructed ``BuiltinToolProvider`` (see its
             ``__init__``). ``None`` (the default) means no diff capture.
+        scratch_root: Canonical private file sandbox captured for this live
+            Console session. ``None`` preserves legacy non-Console callers.
+        scratch_lease: Context manager factory that keeps ``scratch_root``'s
+            generation live through each complete filesystem access.
         local_provider: This run's already-composed local tool provider
             (``LocalToolProvider``), or ``None`` when local tools are
             disabled this run.
@@ -2919,12 +2918,16 @@ def _compose_run_registry_and_allowed(
         skill-runner name set's collision filtering in agreement with the
         registry built here.
     """
+    if (scratch_root is None) != (scratch_lease is None):
+        raise ValueError("Console scratch root and lease must be supplied together")
     registry = ToolCatalogRegistry(ephemeral=ephemeral)
     builtin_provider = BuiltinToolProvider(
         gate=builtin_gate,
         workspace_id=workspace_id,
         ephemeral=ephemeral,
         diff_sink=diff_sink,
+        sandbox_root=scratch_root,
+        sandbox_lease=scratch_lease,
     )
     registry.register_provider(builtin_provider)
     builtin_names = tuple(entry.name for entry in builtin_provider.list_catalog())
@@ -3012,6 +3015,8 @@ def build_console_first_request_plan(
     workspace_id: str | None,
     ephemeral: bool,
     diff_sink: Callable[[tuple[str, str, str, str]], None] | None,
+    scratch_root: Path | None,
+    scratch_lease: Callable[[], ContextManager[Path]] | None,
     resolution: Any,
     fallback_model: str,
     session_system_prompt: str,
@@ -3029,6 +3034,8 @@ def build_console_first_request_plan(
         or builtin_gate is not None
         or local_provider is not None
         or library_provider is not None
+        or scratch_root is not None
+        or scratch_lease is not None
     )
     if fresh:
         registry, allowed_tools, builtin_names, local_names = (
@@ -3039,6 +3046,8 @@ def build_console_first_request_plan(
                 workspace_id=workspace_id,
                 ephemeral=ephemeral,
                 diff_sink=diff_sink,
+                scratch_root=scratch_root,
+                scratch_lease=scratch_lease,
                 local_provider=local_provider,
                 library_provider=library_provider,
             )
@@ -3087,8 +3096,7 @@ def build_console_first_request_plan(
         native_tools=native_tools,
         workspace_context_note=workspace_context_note(workspace_id),
         response_reserve_tokens=(
-            getattr(resolution, "max_tokens", None)
-            or DEFAULT_RESPONSE_RESERVATION
+            getattr(resolution, "max_tokens", None) or DEFAULT_RESPONSE_RESERVATION
         ),
     )
     messages = agent_messages
@@ -3467,6 +3475,8 @@ class ConsoleAgentBridge:
         mcp_provider: Any | None = None,
         builtin_gate: Any | None = None,
         local_provider: Any | None = None,
+        scratch_root: Path | None = None,
+        scratch_lease: Callable[[], ContextManager[Path]] | None = None,
         turn_skill_bindings: tuple[str, ...] = (),
         turn_bundle_block: str = "",
         request_skill_install_enabled: bool = False,
@@ -3511,6 +3521,8 @@ class ConsoleAgentBridge:
             workspace_id=workspace_id,
             ephemeral=ephemeral,
             diff_sink=None,
+            scratch_root=scratch_root,
+            scratch_lease=scratch_lease,
             resolution=resolution,
             fallback_model=fallback_model,
             session_system_prompt=session_system_prompt,
@@ -3518,8 +3530,7 @@ class ConsoleAgentBridge:
             turn_skill_bindings=turn_skill_bindings,
             turn_bundle_block=turn_bundle_block,
             install_skill_enabled=bool(
-                self._skills_service is not None
-                and request_skill_install_enabled
+                self._skills_service is not None and request_skill_install_enabled
             ),
             run_skill_script_enabled=script_tool_enabled,
             agent_messages=agent_messages,
@@ -3574,6 +3585,8 @@ class ConsoleAgentBridge:
         supersede_previous: bool = False,
         mcp_provider: Any | None = None,
         builtin_gate: Any | None = None,
+        scratch_root: Path | None = None,
+        scratch_lease: Callable[[], ContextManager[Path]] | None = None,
         # PR2a Task 5: `(calls, run_id)` -- forwarded straight to
         # `AgentService(review_tool_calls=...)`, which binds each run's own
         # id in before handing it to `LoopDeps`.
@@ -3604,9 +3617,7 @@ class ConsoleAgentBridge:
         continuation_target: ContinuationRestoreTarget | None = None,
         continuation_owner_key: str | None = None,
         startup_instruction_candidate: StartupInstructionCandidate | None = None,
-        confirm_project_instruction_dispatch: Callable[
-            [InstructionSnapshot], str
-        ]
+        confirm_project_instruction_dispatch: Callable[[InstructionSnapshot], str]
         | None = None,
         on_project_instruction_activation: Callable[
             [ProjectInstructionActivationEvent], None
@@ -3735,6 +3746,8 @@ class ConsoleAgentBridge:
             workspace_id=run_workspace_id,
             ephemeral=run_is_ephemeral,
             diff_sink=pending_diffs.append,
+            scratch_root=scratch_root,
+            scratch_lease=scratch_lease,
             resolution=resolution,
             fallback_model=model,
             session_system_prompt=session_system_prompt,
@@ -3795,13 +3808,12 @@ class ConsoleAgentBridge:
                 finally:
                     if decision != "proceed":
                         project_instruction_context.discard_primary_snapshot()
+
         if self._skills_service is not None:
             skill_file_bindings = SkillFileBindings(
                 authorized=set(),
                 reader=lambda skill_name, path: asyncio.run(
-                    self._skills_service.read_skill_file(
-                        skill_name, path, mode="local"
-                    )
+                    self._skills_service.read_skill_file(skill_name, path, mode="local")
                 ),
             )
             skill_runner = _BridgeSkillRunner(
@@ -4156,9 +4168,7 @@ class ConsoleAgentBridge:
                         session_id,
                         thinking_marker.content,
                         full_output=thinking_marker.tool_output_full,
-                        activity_presentation=(
-                            thinking_marker.activity_presentation
-                        ),
+                        activity_presentation=(thinking_marker.activity_presentation),
                     )
                 if step.kind == STEP_SPAWN:
                     # PR2b Task 2: this is this run's ONLY source of rows
@@ -4672,9 +4682,7 @@ class ConsoleAgentBridge:
                         self._store.append_message(
                             session_id,
                             role=ConsoleMessageRole.TOOL,
-                            content=format_diff_feedback_disclosure(
-                                disclosed_notes
-                            ),
+                            content=format_diff_feedback_disclosure(disclosed_notes),
                             activity_presentation=ConsoleActivityPresentation(
                                 "feedback", "Feedback delivered", "done"
                             ),
@@ -5221,12 +5229,10 @@ class ConsoleAgentBridge:
         # same way -- construction for a new coordinator, an in-place
         # re-size for an existing one. Replacing the coordinator would
         # drop the retained transcripts along with every live handle.
-        retained_transcripts = (
-            agent_service_module._coerce_retained_transcripts(
-                agent_service_module._setting(
-                    agent_service_module.RETAINED_TRANSCRIPTS_KEY,
-                    agent_service_module.DEFAULT_RETAINED_TRANSCRIPTS,
-                )
+        retained_transcripts = agent_service_module._coerce_retained_transcripts(
+            agent_service_module._setting(
+                agent_service_module.RETAINED_TRANSCRIPTS_KEY,
+                agent_service_module.DEFAULT_RETAINED_TRANSCRIPTS,
             )
         )
         retained_transcript_max_chars = (
@@ -5621,9 +5627,9 @@ class ConsoleAgentBridge:
             for handle in coordinator.snapshot()
             if handle.status not in TERMINAL_RUN_STATUSES
         ]
-        target = next(
-            (h for h in live if h.handle_id == row_id), None
-        ) or next((h for h in live if h.run_id == row_id), None)
+        target = next((h for h in live if h.handle_id == row_id), None) or next(
+            (h for h in live if h.run_id == row_id), None
+        )
         if target is None:
             return False
         return coordinator.post_steering(

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -5584,24 +5584,15 @@ class ConsoleChatController:
                 initiator="agent",
             )
 
-        # expanduser() before resolve(): a configured "~/repo" must land
-        # under the user's home, not literal "~" under the cwd.
         if project_root is None:
-            raw_root = str(
-                (
-                    turn_context.tool_configuration.get("workspace_root", "")
-                    if turn_context is not None
-                    else get_cli_setting("console", "workspace_root", "")
-                )
-                or ""
-            ).strip()
-            root = (
-                Path(raw_root).expanduser().resolve()
-                if raw_root
-                else Path(os.getcwd()).resolve()
-            )
+            snapshot = turn_context.scratch_space if turn_context is not None else None
+            if snapshot is None:
+                return None, None
+            root = snapshot.root
+            authority_scope = functools.partial(self._scratch_spaces.lease, snapshot)
         else:
             root = project_root
+            authority_scope = None
         subscriptions_db = getattr(self.app, "subscriptions_db", None)
         watchlists_service = WatchlistsToolService(
             db_resolver=lambda: subscriptions_db,
@@ -5612,6 +5603,7 @@ class ConsoleChatController:
         provider = LocalToolProvider(
             workspace_root=root,
             allow_write=allow_write,
+            authority_scope=authority_scope,
             root_guard=(
                 project_root_guard
                 if project_root_guard is not None

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -123,6 +123,7 @@ from tldw_chatbook.Chat.console_context_repository import (
     ConsoleContextRepository,
     ConsoleMemoryRecord,
 )
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.Chat.console_prepared_request import (
     CONTINUATION_OWNER_KEY,
     PreparedConsoleRequest,
@@ -1721,6 +1722,7 @@ class ConsoleChatController:
         ]
         | None = None,
         buddy_sink: "PersonaBuddyConsoleAdapter | None" = None,
+        scratch_spaces: ConsoleScratchSpaceManager | None = None,
     ) -> None:
         self.store = store
         self.provider_gateway = provider_gateway
@@ -1745,6 +1747,8 @@ class ConsoleChatController:
         self.system_prompt = system_prompt
         self._agent_bridge = agent_bridge
         self._buddy_sink = buddy_sink
+        self._owns_scratch_spaces = scratch_spaces is None
+        self._scratch_spaces = scratch_spaces or ConsoleScratchSpaceManager()
         self._agent_runtime_enabled = agent_runtime_enabled
         self._skills_service = skills_service
         self._skill_substitution_enabled = skill_substitution_enabled
@@ -4103,6 +4107,9 @@ class ConsoleChatController:
         Returns:
             The session activated after closing, or ``None`` when no sessions remain.
         """
+        # Revoke file authority before any close action can wake a worker or
+        # remove the owning session from the store.
+        self._scratch_spaces.close(session_id)
         # Queue tombstone MUST precede stop/cancel: cancellation can wake a
         # terminal callback, which must observe that no next claim is legal.
         self.prompt_queue_coordinator.mark_closing(session_id)
@@ -6601,6 +6608,8 @@ class ConsoleChatController:
             self.clear_original_attempt(message_id)
         tasks = dict(self._active_stream_tasks)
         if not tasks:
+            if self._owns_scratch_spaces:
+                await asyncio.to_thread(self._scratch_spaces.dispose)
             return
         current = asyncio.current_task()
         for session_id in tasks:
@@ -6648,6 +6657,8 @@ class ConsoleChatController:
                 self._active_stream_tasks.pop(session_id, None)
                 self._active_assistant_message_ids.pop(session_id, None)
                 self._active_cancel_events.pop(session_id, None)
+        if self._owns_scratch_spaces:
+            await asyncio.to_thread(self._scratch_spaces.dispose)
 
     def begin_shutdown(self) -> None:
         """Tombstone future queue work before any teardown cancellation.
@@ -8631,14 +8642,12 @@ class ConsoleChatController:
 
         selection = self._provider_selection_for_session(session_id)
         model = selection.explicit_model or selection.configured_model
-        workspace_root = str(
-            get_cli_setting("console", "workspace_root", "") or ""
-        ).strip()
         return ConsoleTurnExecutionContext.capture(
             session_id=session_id,
             provider_selection=selection,
+            scratch_space=self._scratch_spaces.snapshot(session_id),
             session_settings=self.store.session_settings(session_id),
-            workspace_roots=(workspace_root,) if workspace_root else (),
+            workspace_roots=(),
             capabilities={
                 "vision": bool(model)
                 and is_vision_capable(selection.provider, model or ""),
@@ -8659,7 +8668,6 @@ class ConsoleChatController:
                     get_cli_setting("console", "local_tools_enabled", False),
                     False,
                 ),
-                "workspace_root": workspace_root,
                 "direct_library_tools": coerce_bool_setting(
                     get_cli_setting("console", "direct_library_tools", True),
                     True,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -11850,32 +11850,46 @@ class ConsoleChatController:
                     session, registry
                 )
             except ProjectInstructionBindingRecovery as exc:
-                callback = self._select_project_instruction_binding
-                if callback is None:
-                    return ConsoleSubmitResult(False, False, str(exc))
                 expected_setup_state = session.project_instruction_state
                 try:
                     options = list_project_instruction_bindings(session, registry)
                 except ProjectInstructionBindingRecovery:
                     options = ()
-                action, binding_id = await callback(session_id, options, str(exc))
-                action, project_selection = commit_project_instruction_setup_decision(
-                    store=self.store,
-                    session_id=session_id,
-                    registry=registry,
-                    expected_state=expected_setup_state,
-                    expected_options=options,
-                    action=action,
-                    binding_id=binding_id,
-                )
-                if action == "disable":
-                    self._clear_project_instruction_delivery(session_id)
-                    return ConsoleSubmitResult(
-                        False, False, "project_instructions_disabled"
+                # An unselected session with no usable folder is a valid
+                # scratch-only Chat/Workspace, not a project-instruction
+                # setup failure. Keep the optional feature armed so a folder
+                # added later can be selected, but do not block this send or
+                # ask for one now. A previously selected folder still fails
+                # closed and reaches recovery when it disappears or changes.
+                if (
+                    expected_setup_state.working_folder_binding_id is None
+                    and not options
+                ):
+                    project_selection = None
+                else:
+                    callback = self._select_project_instruction_binding
+                    if callback is None:
+                        return ConsoleSubmitResult(False, False, str(exc))
+                    action, binding_id = await callback(session_id, options, str(exc))
+                    action, project_selection = (
+                        commit_project_instruction_setup_decision(
+                            store=self.store,
+                            session_id=session_id,
+                            registry=registry,
+                            expected_state=expected_setup_state,
+                            expected_options=options,
+                            action=action,
+                            binding_id=binding_id,
+                        )
                     )
-                if action != "select" or project_selection is None:
-                    self._clear_project_instruction_delivery(session_id)
-                    return ConsoleSubmitResult(False, False, str(exc))
+                    if action == "disable":
+                        self._clear_project_instruction_delivery(session_id)
+                        return ConsoleSubmitResult(
+                            False, False, "project_instructions_disabled"
+                        )
+                    if action != "select" or project_selection is None:
+                        self._clear_project_instruction_delivery(session_id)
+                        return ConsoleSubmitResult(False, False, str(exc))
             if project_selection is not None:
                 state = session.project_instruction_state
                 if state.working_folder_binding_id is None:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -5620,6 +5620,7 @@ class ConsoleChatController:
             workspace_root=root,
             allow_write=allow_write,
             authority_scope=authority_scope,
+            result_redaction_root=(root if project_root is None else None),
             root_guard=(
                 project_root_guard
                 if project_root_guard is not None

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -4116,6 +4116,16 @@ class ConsoleChatController:
         # Revoke file authority before any close action can wake a worker or
         # remove the owning session from the store.
         self._scratch_spaces.close(session_id)
+        forget_file_authority = getattr(
+            self._agent_bridge,
+            "forget_session_file_authority",
+            None,
+        )
+        if callable(forget_file_authority):
+            try:
+                forget_file_authority(session_id)
+            except Exception:  # noqa: BLE001 -- teardown remains best-effort
+                logger.warning("close_session could not forget run-log authority")
         # Queue tombstone MUST precede stop/cancel: cancellation can wake a
         # terminal callback, which must observe that no next claim is legal.
         self.prompt_queue_coordinator.mark_closing(session_id)

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1274,6 +1274,12 @@ def build_tool_review_hook(
                         call.args,
                         workspace_id=workspace_id,
                         roots_cache=path_roots_cache,
+                        sandbox_root=getattr(builtin_provider, "sandbox_root", None),
+                        sandbox_lease=getattr(
+                            builtin_provider,
+                            "sandbox_lease",
+                            None,
+                        ),
                     ),
                 )
             )
@@ -8109,6 +8115,17 @@ class ConsoleChatController:
             provider_selection or self._provider_selection_for_session(session_id)
         )
         try:
+            turn_context = self.resolve_turn_execution_context(session_id)
+        except Exception:  # noqa: BLE001 - preview failure stays content-free
+            return None
+        scratch_snapshot = turn_context.scratch_space
+        if scratch_snapshot is None:
+            return None
+        scratch_lease = functools.partial(
+            self._scratch_spaces.lease,
+            scratch_snapshot,
+        )
+        try:
             resolution = await self.provider_gateway.resolve_for_send(
                 owning_provider_selection
             )
@@ -8168,6 +8185,7 @@ class ConsoleChatController:
             session_id=session_id,
             project_selection=selection,
             project_authority_guard=None,
+            turn_context=turn_context,
             publish_mcp_counts=False,
         )
         try:
@@ -8186,6 +8204,8 @@ class ConsoleChatController:
                 mcp_provider=mcp_provider,
                 builtin_gate=builtin_gate,
                 local_provider=local_provider,
+                scratch_root=scratch_snapshot.root,
+                scratch_lease=scratch_lease,
                 turn_skill_bindings=turn_skill_bindings,
                 turn_bundle_block=turn_bundle_block,
                 request_skill_install_enabled=True,
@@ -11794,6 +11814,13 @@ class ConsoleChatController:
             turn_context = self.resolve_turn_execution_context(session_id)
         elif turn_context.session_id != session_id:
             raise ValueError("Console turn context does not own the assistant row.")
+        scratch_snapshot = turn_context.scratch_space
+        if scratch_snapshot is None:
+            return self._block(session_id, "Private scratch space is unavailable.")
+        scratch_lease = functools.partial(
+            self._scratch_spaces.lease,
+            scratch_snapshot,
+        )
         session = next((s for s in self.store.sessions() if s.id == session_id), None)
         startup_candidate: StartupInstructionCandidate | None = None
         project_selection: ProjectInstructionBindingSelection | None = None
@@ -12041,7 +12068,6 @@ class ConsoleChatController:
         # so it does not need to be the SAME `BuiltinToolProvider` object
         # the bridge's registry actually dispatches through (its `_tools`
         # dict is stateless data rebuilt identically by any instance).
-        builtin_review_provider = BuiltinToolProvider(gate=builtin_gate)
         # Round 1 review CRITICAL 1: resolve THIS run's OWN workspace id --
         # the SAME lookup `ConsoleAgentBridge.run_reply` makes
         # (`self._store.session_workspace_id(session_id)`) for the real
@@ -12055,6 +12081,12 @@ class ConsoleChatController:
             review_workspace_id = self.store.session_workspace_id(session_id)
         except KeyError:
             review_workspace_id = None
+        builtin_review_provider = BuiltinToolProvider(
+            gate=builtin_gate,
+            workspace_id=review_workspace_id,
+            sandbox_root=scratch_snapshot.root,
+            sandbox_lease=scratch_lease,
+        )
         # Task 9: bind THIS run's owning session id into the approval
         # bridge so `request_mcp_approvals` can (a) scope its cancellation
         # check to this run's own cancel event rather than falling back to
@@ -12129,6 +12161,8 @@ class ConsoleChatController:
                 supersede_previous=bool(prepare_retry or variant_mode),
                 mcp_provider=mcp_provider,
                 builtin_gate=builtin_gate,
+                scratch_root=scratch_snapshot.root,
+                scratch_lease=scratch_lease,
                 review_tool_calls=review_hook,
                 local_provider=local_provider,
                 library_provider=library_provider,

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -116,12 +116,14 @@ it left behind — tree, active leaf, drafts, pending attachments and all.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -464,6 +466,7 @@ class ConsoleRuntime:
         self._provider_gateway: Any | None = None
         self._agent_bridge: Any | None = None
         self._chat_controller: Any | None = None
+        self._scratch_spaces = ConsoleScratchSpaceManager()
         self._persona_buddy_sink = PersonaBuddyConsoleAdapter(
             getattr(app, "persona_buddy_controller", None)
         )
@@ -515,6 +518,11 @@ class ConsoleRuntime:
     def chat_controller(self) -> "ConsoleChatController | None":
         """The built chat controller, or `None`."""
         return self._chat_controller
+
+    @property
+    def scratch_spaces(self) -> ConsoleScratchSpaceManager:
+        """The process-lifetime scratch authority shared by Console visits."""
+        return self._scratch_spaces
 
     @property
     def persona_buddy_sink(self) -> PersonaBuddyConsoleAdapter:
@@ -738,6 +746,7 @@ class ConsoleRuntime:
         )
 
         kwargs.setdefault("buddy_sink", self.persona_buddy_sink)
+        kwargs.setdefault("scratch_spaces", self._scratch_spaces)
         self._chat_controller = ConsoleChatController(**kwargs)
         if self.view is None:
             # task-15860 Task 4: a runtime can be VIEWLESS FROM BIRTH, not
@@ -1000,6 +1009,7 @@ class ConsoleRuntime:
         is exactly the right answer at exit.
         """
         self._disposed = True
+        self._scratch_spaces.tombstone_all()
         self.detach_view(None)
         controller, gateway = self._chat_controller, self._provider_gateway
         self.generation += 1
@@ -1010,6 +1020,12 @@ class ConsoleRuntime:
                 logger.opt(exception=True).warning(
                     "Console runtime: controller shutdown failed at dispose."
                 )
+        try:
+            await asyncio.to_thread(self._scratch_spaces.dispose)
+        except Exception:  # noqa: BLE001 - quit must continue after cleanup failure
+            logger.opt(exception=True).warning(
+                "Console runtime: scratch cleanup failed at dispose."
+            )
         # Controller shutdown begins by terminally fencing the fleet-wake
         # coordinator. Only after every trusted producer is tombstoned may
         # the shared Buddy sink release its remaining owner tokens.

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -1022,9 +1022,10 @@ class ConsoleRuntime:
                 )
         try:
             await asyncio.to_thread(self._scratch_spaces.dispose)
-        except Exception:  # noqa: BLE001 - quit must continue after cleanup failure
-            logger.opt(exception=True).warning(
-                "Console runtime: scratch cleanup failed at dispose."
+        except Exception as exc:  # noqa: BLE001 - quit must continue after cleanup failure
+            logger.warning(
+                "Console runtime: scratch cleanup failed at dispose category={}",
+                type(exc).__name__,
             )
         # Controller shutdown begins by terminally fencing the fleet-wake
         # coordinator. Only after every trusted producer is tombstoned may

--- a/tldw_chatbook/Chat/console_scratch_space.py
+++ b/tldw_chatbook/Chat/console_scratch_space.py
@@ -1,0 +1,304 @@
+"""Private, process-lifetime scratch spaces for live Console chat sessions."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import shutil
+import stat
+import tempfile
+import threading
+import time
+from collections import deque
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+from loguru import logger
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleScratchSnapshot:
+    """Immutable capability identifying one live scratch-space generation."""
+
+    root: Path
+    token: str
+    identity: tuple[int, int]
+
+
+class ConsoleScratchSpaceUnavailable(RuntimeError):
+    """Raised when a scratch-space capability is stale or no longer safe."""
+
+
+@dataclass(slots=True)
+class _ScratchRecord:
+    session_id: str
+    snapshot: ConsoleScratchSnapshot
+    leases: int = 0
+    tombstoned: bool = False
+    cleanup_scheduled: bool = False
+
+
+class ConsoleScratchSpaceManager:
+    """Own isolated scratch directories and revoke them safely on chat close."""
+
+    def __init__(self, *, temp_parent: Path | None = None) -> None:
+        self._temp_parent = Path(temp_parent) if temp_parent is not None else None
+        self._condition = threading.Condition(threading.RLock())
+        self._by_session: dict[str, _ScratchRecord] = {}
+        self._records: dict[str, _ScratchRecord] = {}
+        self._cleanup_queue: deque[_ScratchRecord] = deque()
+        self._cleanup_worker: threading.Thread | None = None
+        self._disposed = False
+
+    def snapshot(self, session_id: str) -> ConsoleScratchSnapshot:
+        """Return the live capability for ``session_id``, allocating if needed.
+
+        Args:
+            session_id: Process-local identifier for the live Console session.
+
+        Returns:
+            The session's immutable scratch-space capability.
+
+        Raises:
+            ConsoleScratchSpaceUnavailable: If the manager has been disposed or
+                allocation cannot establish a private directory.
+        """
+
+        normalized_session_id = str(session_id)
+        if not normalized_session_id:
+            raise ConsoleScratchSpaceUnavailable("A live Console session is required")
+
+        with self._condition:
+            if self._disposed:
+                raise ConsoleScratchSpaceUnavailable(
+                    "Console scratch-space manager is disposed"
+                )
+            existing = self._by_session.get(normalized_session_id)
+            if existing is not None and not existing.tombstoned:
+                return existing.snapshot
+
+            try:
+                raw_root = tempfile.mkdtemp(
+                    prefix="tldw-console-",
+                    dir=str(self._temp_parent) if self._temp_parent is not None else None,
+                )
+                root = Path(raw_root)
+                os.chmod(root, 0o700)
+                metadata = root.lstat()
+                if root.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+                    raise OSError("scratch allocation did not create a directory")
+            except OSError as exc:
+                raise ConsoleScratchSpaceUnavailable(
+                    "Could not allocate a private Console scratch space"
+                ) from exc
+
+            token = secrets.token_urlsafe(24)
+            while token in self._records:
+                token = secrets.token_urlsafe(24)
+            snapshot = ConsoleScratchSnapshot(
+                root=root,
+                token=token,
+                identity=(metadata.st_dev, metadata.st_ino),
+            )
+            record = _ScratchRecord(
+                session_id=normalized_session_id,
+                snapshot=snapshot,
+            )
+            self._by_session[normalized_session_id] = record
+            self._records[token] = record
+            return snapshot
+
+    @contextmanager
+    def lease(self, snapshot: ConsoleScratchSnapshot) -> Iterator[Path]:
+        """Keep a validated scratch generation alive for one filesystem access.
+
+        Args:
+            snapshot: Capability previously issued by this manager.
+
+        Yields:
+            The validated private scratch root.
+
+        Raises:
+            ConsoleScratchSpaceUnavailable: If the capability is stale, revoked,
+                missing, symlinked, or replaced on disk.
+        """
+
+        with self._condition:
+            record = self._matching_record_locked(snapshot)
+            if record is None or record.tombstoned:
+                raise ConsoleScratchSpaceUnavailable(
+                    "Console scratch space is no longer available"
+                )
+            if not self._identity_matches(snapshot):
+                self._tombstone_locked(record)
+                raise ConsoleScratchSpaceUnavailable(
+                    "Console scratch space failed its filesystem identity check"
+                )
+            record.leases += 1
+
+        try:
+            yield snapshot.root
+        finally:
+            with self._condition:
+                record.leases = max(0, record.leases - 1)
+                if record.tombstoned and record.leases == 0:
+                    self._schedule_cleanup_locked(record)
+                self._condition.notify_all()
+
+    def is_live(self, snapshot: ConsoleScratchSnapshot) -> bool:
+        """Return whether a capability is current and safe to lease."""
+
+        with self._condition:
+            record = self._matching_record_locked(snapshot)
+            if record is None or record.tombstoned:
+                return False
+            if self._identity_matches(snapshot):
+                return True
+            self._tombstone_locked(record)
+            return False
+
+    def close(self, session_id: str) -> None:
+        """Revoke one live session and schedule cleanup after its leases drain."""
+
+        with self._condition:
+            record = self._by_session.pop(str(session_id), None)
+            if record is None:
+                return
+            self._tombstone_locked(record)
+
+    def tombstone_all(self) -> None:
+        """Synchronously revoke every live scratch space without blocking on I/O."""
+
+        with self._condition:
+            self._disposed = True
+            records = tuple(self._records.values())
+            self._by_session.clear()
+            for record in records:
+                record.tombstoned = True
+                if record.leases == 0:
+                    self._schedule_cleanup_locked(record)
+            self._condition.notify_all()
+
+    def wait_for_cleanup(self, timeout_seconds: float) -> bool:
+        """Wait up to ``timeout_seconds`` for every revoked record to retire."""
+
+        deadline = time.monotonic() + max(0.0, timeout_seconds)
+        with self._condition:
+            while self._records:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def dispose(self, timeout_seconds: float = 2.0) -> bool:
+        """Revoke all spaces, retry deferred cleanup, and wait for a bounded time."""
+
+        self.tombstone_all()
+        deadline = time.monotonic() + max(0.0, timeout_seconds)
+        with self._condition:
+            for record in tuple(self._records.values()):
+                if record.leases == 0 and not record.cleanup_scheduled:
+                    self._schedule_cleanup_locked(record)
+            while self._records:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def _matching_record_locked(
+        self,
+        snapshot: ConsoleScratchSnapshot,
+    ) -> _ScratchRecord | None:
+        record = self._records.get(snapshot.token)
+        if record is None or record.snapshot != snapshot:
+            return None
+        return record
+
+    @staticmethod
+    def _identity_matches(snapshot: ConsoleScratchSnapshot) -> bool:
+        try:
+            metadata = snapshot.root.lstat()
+        except OSError:
+            return False
+        return (
+            not stat.S_ISLNK(metadata.st_mode)
+            and stat.S_ISDIR(metadata.st_mode)
+            and (metadata.st_dev, metadata.st_ino) == snapshot.identity
+        )
+
+    def _tombstone_locked(self, record: _ScratchRecord) -> None:
+        current = self._by_session.get(record.session_id)
+        if current is record:
+            self._by_session.pop(record.session_id, None)
+        record.tombstoned = True
+        if record.leases == 0:
+            self._schedule_cleanup_locked(record)
+        self._condition.notify_all()
+
+    def _schedule_cleanup_locked(self, record: _ScratchRecord) -> None:
+        if record.cleanup_scheduled or record.snapshot.token not in self._records:
+            return
+        record.cleanup_scheduled = True
+        self._cleanup_queue.append(record)
+        if self._cleanup_worker is None or not self._cleanup_worker.is_alive():
+            self._cleanup_worker = threading.Thread(
+                target=self._cleanup_worker_main,
+                name="console-scratch-cleanup",
+                daemon=True,
+            )
+            self._cleanup_worker.start()
+
+    def _cleanup_worker_main(self) -> None:
+        while True:
+            with self._condition:
+                if not self._cleanup_queue:
+                    self._cleanup_worker = None
+                    self._condition.notify_all()
+                    return
+                record = self._cleanup_queue.popleft()
+
+            cleaned, category = self._cleanup_record(record)
+
+            with self._condition:
+                record.cleanup_scheduled = False
+                if cleaned:
+                    current = self._records.get(record.snapshot.token)
+                    if current is record:
+                        self._records.pop(record.snapshot.token, None)
+                else:
+                    logger.warning(
+                        "Console scratch cleanup deferred token={} category={}",
+                        record.snapshot.token,
+                        category,
+                    )
+                self._condition.notify_all()
+
+    @staticmethod
+    def _cleanup_record(record: _ScratchRecord) -> tuple[bool, str]:
+        snapshot = record.snapshot
+        try:
+            metadata = snapshot.root.lstat()
+        except FileNotFoundError:
+            return True, "already-missing"
+        except OSError:
+            return False, "identity-check-failed"
+
+        identity = (metadata.st_dev, metadata.st_ino)
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISDIR(metadata.st_mode)
+            or identity != snapshot.identity
+        ):
+            return True, "identity-changed"
+
+        try:
+            shutil.rmtree(snapshot.root)
+        except FileNotFoundError:
+            return True, "already-missing"
+        except OSError:
+            return False, "delete-failed"
+        return True, "deleted"

--- a/tldw_chatbook/Chat/console_scratch_space.py
+++ b/tldw_chatbook/Chat/console_scratch_space.py
@@ -148,7 +148,15 @@ class ConsoleScratchSpaceManager:
                 self._condition.notify_all()
 
     def is_live(self, snapshot: ConsoleScratchSnapshot) -> bool:
-        """Return whether a capability is current and safe to lease."""
+        """Return whether a capability is current and safe to lease.
+
+        Args:
+            snapshot: Capability previously issued by this manager.
+
+        Returns:
+            ``True`` when the capability still identifies the current private
+            directory generation and its filesystem identity is unchanged.
+        """
 
         with self._condition:
             record = self._matching_record_locked(snapshot)
@@ -160,7 +168,11 @@ class ConsoleScratchSpaceManager:
             return False
 
     def close(self, session_id: str) -> None:
-        """Revoke one live session and schedule cleanup after its leases drain."""
+        """Revoke one live session and schedule cleanup after its leases drain.
+
+        Args:
+            session_id: Process-local identifier for the live Console session.
+        """
 
         with self._condition:
             record = self._by_session.pop(str(session_id), None)
@@ -182,7 +194,14 @@ class ConsoleScratchSpaceManager:
             self._condition.notify_all()
 
     def wait_for_cleanup(self, timeout_seconds: float) -> bool:
-        """Wait up to ``timeout_seconds`` for every revoked record to retire."""
+        """Wait up to ``timeout_seconds`` for every revoked record to retire.
+
+        Args:
+            timeout_seconds: Maximum number of seconds to wait.
+
+        Returns:
+            ``True`` when every record retired before the deadline.
+        """
 
         deadline = time.monotonic() + max(0.0, timeout_seconds)
         with self._condition:
@@ -194,7 +213,14 @@ class ConsoleScratchSpaceManager:
             return True
 
     def dispose(self, timeout_seconds: float = 2.0) -> bool:
-        """Revoke all spaces, retry deferred cleanup, and wait for a bounded time."""
+        """Revoke all spaces, retry deferred cleanup, and wait for a bounded time.
+
+        Args:
+            timeout_seconds: Maximum number of seconds to wait for cleanup.
+
+        Returns:
+            ``True`` when every scratch record retired before the deadline.
+        """
 
         self.tombstone_all()
         deadline = time.monotonic() + max(0.0, timeout_seconds)
@@ -271,8 +297,7 @@ class ConsoleScratchSpaceManager:
                         self._records.pop(record.snapshot.token, None)
                 else:
                     logger.warning(
-                        "Console scratch cleanup deferred token={} category={}",
-                        record.snapshot.token,
+                        "Console scratch cleanup deferred category={}",
                         category,
                     )
                 self._condition.notify_all()

--- a/tldw_chatbook/Chat/console_scratch_space.py
+++ b/tldw_chatbook/Chat/console_scratch_space.py
@@ -84,7 +84,7 @@ class ConsoleScratchSpaceManager:
                     prefix="tldw-console-",
                     dir=str(self._temp_parent) if self._temp_parent is not None else None,
                 )
-                root = Path(raw_root)
+                root = Path(raw_root).resolve()
                 os.chmod(root, 0o700)
                 metadata = root.lstat()
                 if root.is_symlink() or not stat.S_ISDIR(metadata.st_mode):

--- a/tldw_chatbook/Chat/console_turn_context.py
+++ b/tldw_chatbook/Chat/console_turn_context.py
@@ -19,6 +19,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleWorkspaceContext,
 )
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSnapshot
 
 
 def _freeze(value: Any) -> Any:
@@ -87,6 +88,7 @@ class ConsoleTurnExecutionContext:
 
     session_id: str
     provider_selection: ConsoleProviderSelection
+    scratch_space: ConsoleScratchSnapshot | None = None
     session_settings: ConsoleSessionSettings | None = None
     workspace_roots: tuple[str, ...] = ()
     capabilities: Mapping[str, Any] = field(
@@ -134,6 +136,7 @@ class ConsoleTurnExecutionContext:
         *,
         session_id: str,
         provider_selection: ConsoleProviderSelection,
+        scratch_space: ConsoleScratchSnapshot | None = None,
         session_settings: ConsoleSessionSettings | None = None,
         workspace_roots: Sequence[object] = (),
         capabilities: Mapping[str, Any] | None = None,
@@ -145,6 +148,7 @@ class ConsoleTurnExecutionContext:
         return cls(
             session_id=str(session_id),
             provider_selection=provider_selection,
+            scratch_space=scratch_space,
             session_settings=session_settings,
             workspace_roots=tuple(workspace_roots),
             capabilities=capabilities or {},

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -2301,6 +2301,7 @@ class LocalSkillsService:
         args: Sequence[str],
         *,
         limits: ScriptRunLimits | None = None,
+        output_root: Path | None = None,
     ) -> ScriptRunResult:
         """Run a bundled script of a trusted skill under best-effort containment.
 
@@ -2322,6 +2323,9 @@ class LocalSkillsService:
                 caller's intended args would then display something
                 different from what actually runs).
             limits: Optional containment budget; defaults to ScriptRunLimits().
+            output_root: Optional explicit retained-output root supplied by a
+                run-scoped caller. When omitted, the configured legacy root is
+                resolved exactly as before.
 
         Returns:
             A ScriptRunResult; a non-zero exit or timeout is a normal result.
@@ -2358,6 +2362,11 @@ class LocalSkillsService:
             self._canonical_skill_name(skill_name), script_path, path
         )
         effective_limits = limits or resolve_script_run_limits()
+        explicit_output_root = (
+            Path(output_root).expanduser().resolve()
+            if output_root is not None
+            else None
+        )
         target_argv = (
             [str(path), *args]
             if plan.mechanism == "direct-exec"
@@ -2383,9 +2392,17 @@ class LocalSkillsService:
             # only place a script's artifacts can survive, and it stays owned by
             # this offloaded callable so a cancelled caller can never make
             # cleanup race a still-live child (see this function's docstring).
-            output_root = self._script_output_root()
+            retained_output_root = (
+                explicit_output_root
+                if explicit_output_root is not None
+                else self._script_output_root()
+            )
+            retained_output_root.mkdir(parents=True, exist_ok=True)
             run_dir = Path(
-                tempfile.mkdtemp(prefix="tldw-skill-script-", dir=output_root)
+                tempfile.mkdtemp(
+                    prefix="tldw-skill-script-",
+                    dir=retained_output_root,
+                )
             )
             result = run_script_subprocess(
                 target_argv, cwd=run_dir, limits=effective_limits
@@ -2397,7 +2414,9 @@ class LocalSkillsService:
                 _shutil.rmtree(run_dir, ignore_errors=True)
                 return replace(result, output_dir=None, output_files=())
             self._prune_output_runs(
-                output_root, SCRIPT_OUTPUT_KEEP_RUNS, protect=run_dir
+                retained_output_root,
+                SCRIPT_OUTPUT_KEEP_RUNS,
+                protect=run_dir,
             )
             return replace(
                 result, output_dir=str(run_dir), output_files=produced

--- a/tldw_chatbook/Skills_Interop/skills_scope_service.py
+++ b/tldw_chatbook/Skills_Interop/skills_scope_service.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 from collections.abc import Sequence
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from tldw_chatbook.Library.library_content_evidence import LibraryContentEvidence
@@ -473,6 +474,7 @@ class SkillsScopeService:
         args: Sequence[str],
         *,
         mode: SkillsBackend | str | None = None,
+        output_root: Path | None = None,
     ) -> ScriptRunResult:
         """Run a LOCAL trusted skill's bundled script (runtime run_skill_script seam).
 
@@ -483,6 +485,8 @@ class SkillsScopeService:
                 list/tuple of str (see the local service's
                 ``run_skill_script`` for why a bare str is rejected).
             mode: Backend selector; only local is accepted.
+            output_root: Optional explicit retained-output root forwarded to
+                the local backend.
 
         Returns:
             The local service's ScriptRunResult.
@@ -502,7 +506,12 @@ class SkillsScopeService:
         service = self._require_service(SkillsBackend.LOCAL)
         self._enforce_policy("skills.run_script.launch.local")
         return await self._maybe_await(
-            service.run_skill_script(skill_name, script_path, args)
+            service.run_skill_script(
+                skill_name,
+                script_path,
+                args,
+                output_root=output_root,
+            )
         )
 
     async def seed_builtin_skills(

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -12,8 +12,9 @@ import subprocess
 import sys
 import tempfile
 import time
+from contextlib import nullcontext
 from pathlib import Path, PureWindowsPath
-from typing import Dict, Any, Iterator, Mapping
+from typing import Any, Callable, ContextManager, Dict, Iterator, Mapping
 
 from loguru import logger
 
@@ -26,7 +27,12 @@ from ..Utils.sensitive_paths import (
     refuses_new_directory_chain,
     resolve_sensitive_context,
 )
-from .workspace_file_roots import allowed_file_roots, run_workspace
+from .workspace_file_roots import (
+    allowed_file_roots,
+    current_run_sandbox_root,
+    run_file_sandbox,
+    run_workspace,
+)
 
 # Maximum size (bytes) of file content captured for diff rendering (TASK-1351).
 # Files or writes larger than this skip before/after capture entirely and
@@ -96,6 +102,9 @@ def _tool_sandbox_root() -> Path:
     Defaults to ``<user data dir>/tool_sandbox``; override with
     ``[tools] file_sandbox_root`` in config.toml.
     """
+    scoped_root = current_run_sandbox_root()
+    if scoped_root is not None:
+        return scoped_root
     root = Path(_resolve_sandbox_config()).expanduser().resolve()
     root.mkdir(parents=True, exist_ok=True)
     return root
@@ -120,6 +129,8 @@ def path_precheck_failed(
     *,
     workspace_id: str | None = None,
     roots_cache: dict[bool, tuple[Path, ...]] | None = None,
+    sandbox_root: Path | None = None,
+    sandbox_lease: Callable[[], ContextManager[Path]] | None = None,
 ) -> bool:
     """Whether ``tool_name``'s path argument in ``args`` will fail the roots check.
 
@@ -172,6 +183,10 @@ def path_precheck_failed(
             `allowed_file_roots` every call, exactly as before this
             parameter existed -- correctness never depends on passing
             this, only the number of registry/filesystem round trips does.
+        sandbox_root: Explicit private sandbox for this run. When omitted,
+            an enclosing run sandbox is preserved.
+        sandbox_lease: Optional context manager factory that keeps the
+            sandbox generation live for the complete precheck.
 
     Returns:
         ``True`` only for a known file tool whose path argument is a
@@ -188,21 +203,26 @@ def path_precheck_failed(
     if not isinstance(path_value, str) or not path_value.strip():
         return False
     try:
-        if roots_cache is not None and write in roots_cache:
-            roots = roots_cache[write]
-        else:
-            # Bind THIS run's workspace for the duration of the check only
-            # -- mirrors BuiltinToolProvider.invoke's own `with run_
-            # workspace(...)` around the real dispatch call, so the
-            # pre-flight and the eventual enforcement resolve the
-            # IDENTICAL root set (round 1 CRITICAL 1).
-            with run_workspace(workspace_id):
+        lease_scope = sandbox_lease() if sandbox_lease is not None else nullcontext()
+        sandbox_scope = (
+            run_file_sandbox(sandbox_root)
+            if sandbox_root is not None
+            else nullcontext()
+        )
+        with (
+            lease_scope,
+            sandbox_scope,
+            run_workspace(workspace_id),
+        ):
+            if roots_cache is not None and write in roots_cache:
+                roots = roots_cache[write]
+            else:
                 roots = allowed_file_roots(
                     write=write, sandbox_root=_tool_sandbox_root()
                 )
-            if roots_cache is not None:
-                roots_cache[write] = roots
-        validate_path_multi(path_value, roots)
+                if roots_cache is not None:
+                    roots_cache[write] = roots
+            validate_path_multi(path_value, roots)
     except ValueError:
         return True
     except Exception:  # noqa: BLE001 -- a broken pre-flight must never break approval
@@ -422,7 +442,11 @@ class ListDirectoryTool(Tool):
             # the sandbox — otherwise a legitimately bound workspace folder
             # would silently refuse to recurse past its top level.
             containment_root = next(
-                (root for root in read_roots if is_within(path, root, context=sensitive_ctx)),
+                (
+                    root
+                    for root in read_roots
+                    if is_within(path, root, context=sensitive_ctx)
+                ),
                 sandbox_root,
             )
 
@@ -489,7 +513,9 @@ class ListDirectoryTool(Tool):
                                 and item.is_dir()
                                 and not item.is_symlink()
                                 and current_depth < max_depth
-                                and is_within(item, containment_root, context=sensitive_ctx)
+                                and is_within(
+                                    item, containment_root, context=sensitive_ctx
+                                )
                             ):
                                 list_dir_contents(item, current_depth + 1)
 
@@ -718,9 +744,7 @@ class WriteFileTool(Tool):
                 with open(path, "a", encoding=encoding) as f:
                     f.write(content)
                 action = "appended to"
-                new_content = (
-                    old_content + content if old_content is not None else None
-                )
+                new_content = old_content + content if old_content is not None else None
             else:
                 # Overwrite mode
                 with open(path, "w", encoding=encoding) as f:
@@ -1437,11 +1461,12 @@ def _run_grep_subprocess(
         try:
             proc.communicate(timeout=5.0)
         except subprocess.TimeoutExpired:
-            logger.error(f"grep worker (pid {proc.pid}) did not exit even after SIGKILL")
+            logger.error(
+                f"grep worker (pid {proc.pid}) did not exit even after SIGKILL"
+            )
         return {
             "error": (
-                f"grep search timed out after {timeout_seconds:g}s and was "
-                "terminated"
+                f"grep search timed out after {timeout_seconds:g}s and was terminated"
             )
         }
 

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -255,7 +255,9 @@ def folder_binding_roots(workspace_id: str | None) -> tuple[Path, ...]:
         Existing, resolved root directories; empty when the workspace has
         no usable bindings or the registry is unavailable.
     """
-    if not workspace_id:
+    from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
+
+    if not workspace_id or workspace_id == DEFAULT_WORKSPACE_ID:
         return ()
     # TASK-1979: this function exists solely as the change-review tracker's
     # root source, so the enable gates live HERE — one choke point, read
@@ -372,12 +374,16 @@ def allowed_file_roots(*, write: bool, sandbox_root: Path) -> tuple[Path, ...]:
     """
     roots: list[Path] = [sandbox_root]
     try:
-        registry = _registry_factory()
         workspace_id = current_run_workspace_id()
+        from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
+
+        if workspace_id == DEFAULT_WORKSPACE_ID:
+            return tuple(roots)
+        registry = _registry_factory()
         if workspace_id is None:
             active = registry.get_active_workspace()
             workspace_id = active.workspace_id if active is not None else None
-        if workspace_id is None:
+        if workspace_id is None or workspace_id == DEFAULT_WORKSPACE_ID:
             return tuple(roots)
         for binding in registry.list_folder_bindings(workspace_id):
             if write and str(binding.metadata.get("access", "ro")) != "rw":

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -331,7 +331,15 @@ def current_run_workspace_id() -> str | None:
 
 @contextmanager
 def run_file_sandbox(root: Path | None) -> Iterator[None]:
-    """Bind one run's private file-tool sandbox without changing global config."""
+    """Bind one run's private file-tool sandbox without changing global config.
+
+    Args:
+        root: Private sandbox root for the current run, or ``None`` to clear
+            an inherited binding within the scope.
+
+    Yields:
+        None. The wrapped block executes with ``root`` as its sandbox binding.
+    """
 
     resolved = Path(root).resolve() if root is not None else None
     token = _RUN_FILE_SANDBOX_ROOT.set(resolved)
@@ -342,7 +350,12 @@ def run_file_sandbox(root: Path | None) -> Iterator[None]:
 
 
 def current_run_sandbox_root() -> Path | None:
-    """Return the private sandbox root bound to the current run, if any."""
+    """Return the private sandbox root bound to the current run, if any.
+
+    Returns:
+        The resolved sandbox root for the current run, or ``None`` when no
+        sandbox is bound.
+    """
 
     return _RUN_FILE_SANDBOX_ROOT.get()
 

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -23,6 +23,9 @@ from loguru import logger
 _RUN_WORKSPACE_ID: ContextVar[str | None] = ContextVar(
     "tldw_run_workspace_id", default=None
 )
+_RUN_FILE_SANDBOX_ROOT: ContextVar[Path | None] = ContextVar(
+    "tldw_run_file_sandbox_root", default=None
+)
 
 #: The directory the app process was launched from, captured once at boot by
 #: ``set_launch_cwd``. The workspace-context note (``workspace_context_note``)
@@ -165,9 +168,7 @@ def workspace_context_note(
             suffix = f" ({', '.join(tags)})" if tags else ""
             root_lines.append(f"  - {display}{suffix}")
     except Exception:
-        logger.opt(exception=True).debug(
-            "workspace_context_note: registry unavailable"
-        )
+        logger.opt(exception=True).debug("workspace_context_note: registry unavailable")
         return _NOTE_UNAVAILABLE
     launch_label = f"{launch.name}/" if launch.name else (launch.anchor or "/")
     lines = [
@@ -187,6 +188,7 @@ def workspace_context_note(
     else:
         lines.append(_NOTE_NO_ROOTS)
     return "\n".join(lines)
+
 
 #: Process-wide cache for the default registry service (see
 #: ``_default_registry_factory``). Reset to ``None`` by tests that need a
@@ -285,9 +287,7 @@ def folder_binding_roots(workspace_id: str | None) -> tuple[Path, ...]:
                 continue
             roots.append(folder)
     except Exception:
-        logger.opt(exception=True).debug(
-            "folder_binding_roots: registry unavailable"
-        )
+        logger.opt(exception=True).debug("folder_binding_roots: registry unavailable")
         return ()
     return tuple(roots)
 
@@ -325,6 +325,24 @@ def current_run_workspace_id() -> str | None:
         current run/task, or ``None`` if no run has bound one.
     """
     return _RUN_WORKSPACE_ID.get()
+
+
+@contextmanager
+def run_file_sandbox(root: Path | None) -> Iterator[None]:
+    """Bind one run's private file-tool sandbox without changing global config."""
+
+    resolved = Path(root).resolve() if root is not None else None
+    token = _RUN_FILE_SANDBOX_ROOT.set(resolved)
+    try:
+        yield
+    finally:
+        _RUN_FILE_SANDBOX_ROOT.reset(token)
+
+
+def current_run_sandbox_root() -> Path | None:
+    """Return the private sandbox root bound to the current run, if any."""
+
+    return _RUN_FILE_SANDBOX_ROOT.get()
 
 
 def allowed_file_roots(*, write: bool, sandbox_root: Path) -> tuple[Path, ...]:

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -175,6 +175,7 @@ from ...Chat.console_session_settings import (
     build_console_settings_readiness,
     default_console_session_settings,
 )
+from ...Chat.console_scratch_space import ConsoleScratchSnapshot
 from ...Chat.console_turn_context import ConsoleTurnExecutionContext
 from ...Chat.provider_readiness import provider_config_key
 from ...Character_Chat.visual_identity import (
@@ -544,6 +545,7 @@ class ConsoleSessionController:
         effective_console_provider_model: Callable[[], tuple[Any, Any]],
         provider_readiness_app_config: Callable[[], Any],
         build_provider_selection: Callable[[str], Any],
+        scratch_snapshot_provider: Callable[[str], ConsoleScratchSnapshot],
         rag_source_types_accessor: Callable[[], tuple[str, ...]],
         rag_top_k_accessor: Callable[[], int],
         sync_native_console_chat_ui: Callable[[], Any],
@@ -692,6 +694,7 @@ class ConsoleSessionController:
         self._effective_console_provider_model_fn = effective_console_provider_model
         self._provider_readiness_app_config_fn = provider_readiness_app_config
         self._build_provider_selection_fn = build_provider_selection
+        self._scratch_snapshot_provider = scratch_snapshot_provider
         self._rag_source_types_accessor = rag_source_types_accessor
         self._rag_top_k_accessor = rag_top_k_accessor
         self._sync_native_console_chat_ui_fn = sync_native_console_chat_ui
@@ -1828,6 +1831,7 @@ class ConsoleSessionController:
         return ConsoleTurnExecutionContext.capture(
             session_id=session_id,
             provider_selection=selection,
+            scratch_space=self._scratch_snapshot_provider(session_id),
             session_settings=settings,
             workspace_roots=workspace_roots,
             capabilities={
@@ -1856,9 +1860,6 @@ class ConsoleSessionController:
                     console_config.get("local_tools_enabled", False),
                     False,
                 ),
-                "workspace_root": str(
-                    console_config.get("workspace_root", "") or ""
-                ).strip(),
                 "direct_library_tools": load_direct_library_tools(app_config),
             },
             provider_payload_settings={

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -663,6 +663,11 @@ def build_console_controllers(
         build_provider_selection=(
             lambda session_id: screen._build_console_provider_selection(session_id)
         ),
+        scratch_snapshot_provider=(
+            lambda session_id: screen._console_runtime().scratch_spaces.snapshot(
+                session_id
+            )
+        ),
         rag_source_types_accessor=rag_source_types_accessor,
         rag_top_k_accessor=rag_top_k_accessor,
         sync_native_console_chat_ui=lambda: screen._sync_native_console_chat_ui(),

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -3380,9 +3380,9 @@ class ChangeReviewScreen(Screen):
         return (
             "No folder is bound to this conversation's workspace, so file "
             "changes are not tracked here — this is not a report that "
-            "nothing changed. Bind a folder in Settings ▸ Workspaces; the "
-            "built-in Default workspace cannot bind folders, so use or "
-            "create another workspace."
+            "nothing changed. Chats still work in private scratch. To track "
+            "an external folder, bind it in Settings ▸ Workspaces and use a "
+            "chat in that named Workspace."
         )
 
     def _show_empty(self, copy: str) -> None:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -14965,8 +14965,9 @@ class SettingsScreen(BaseAppScreen):
 
         Renders nothing when no workspace is selected. The built-in Default
         workspace gets ONLY the protection notice -- it keeps its identity
-        (no rename/archive) and stays tool-less (no folder bindings, see
-        Task 10). An archived workspace (final review Finding 3) gets ONLY
+        (no rename/archive) and cannot add external folder bindings (see Task
+        10); its Console Chats still have private scratch. An archived
+        workspace (final review Finding 3) gets ONLY
         an explanatory note + Unarchive -- rename/set-active/archive/folder
         controls are withheld since they act on a workspace_id that is
         currently archived. Every other workspace gets rename + set-active
@@ -14993,8 +14994,9 @@ class SettingsScreen(BaseAppScreen):
         with Vertical(id="settings-workspace-card", classes="settings-focus-card"):
             if record.workspace_id == DEFAULT_WORKSPACE_ID:
                 yield Static(
-                    "The built-in Default workspace keeps its identity and "
-                    "stays tool-less; create a workspace to bind folders.",
+                    "Chats in the built-in Default workspace use private "
+                    "scratch. Create a named Workspace only to bind external "
+                    "folders.",
                     classes="settings-detail-row",
                 )
                 return

--- a/tldw_chatbook/Utils/path_validation.py
+++ b/tldw_chatbook/Utils/path_validation.py
@@ -28,11 +28,7 @@ from ..Metrics.metrics_logger import log_counter, log_histogram
 #: transcript_truncation` (Tests/Utils/test_path_validation_multi.py) for
 #: the actual truncation math, not just an estimate.
 #:
-#: Qodo PR #1074 finding 3: the ORIGINAL pointer ("create a workspace +
-#: bind a folder") baked in the Default-workspace assumption unconditionally
-#: -- misleading for the common case of a run already in a normal, named
-#: workspace, where the actual fix is just "bind a folder" (creating
-#: another workspace would be actively wrong advice there). This function's
+#: The pointer is deliberately workspace-agnostic. This function's
 #: caller, `validate_path_multi` below, has no cheap way to know which
 #: workspace the denied run belongs to: it is a generic multi-root path
 #: validator with no workspace awareness, called from three sites in
@@ -42,27 +38,18 @@ from ..Metrics.metrics_logger import log_counter, log_histogram
 #: active-workspace logic, across a Utils -> Tools/Workspaces layering
 #: boundary this module does not otherwise cross, just to pick a copy
 #: variant. So the pointer stays workspace-agnostic and universally
-#: correct instead, and the Default-specific caveat moves to
-#: `ROOT_DENIAL_RECOVERY_HINT` below, reworded as an explicit conditional
-#: rather than an assertion.
-ROOT_DENIAL_RECOVERY_POINTER = "Fix: bind a folder in Settings > Workspaces."
+#: correct instead: external-folder access belongs to named Workspaces, while
+#: an ordinary Chat remains valid with its private scratch space.
+ROOT_DENIAL_RECOVERY_POINTER = "Need that folder? Add it to a named Workspace."
 
-#: Fuller explanation appended AFTER the pointer above and the (now
-#: second-priority) path/consulted-roots detail (TASK-1231, fleet-UX review
-#: F3; reworded to a conditional per Qodo PR #1074 finding 3): on a fresh
-#: install every session starts on the Default workspace, which cannot
-#: hold folder bindings -- the FIRST file-tool call a model makes there is
-#: always rejected. Phrased as an "if" (not "you are in Default") because
-#: this exact denial also fires for a normal, already-named workspace that
-#: simply has no folder bound yet -- for that run, "create a NEW
-#: workspace" would be wrong; it only needs the bind-a-folder step the
-#: pointer above already covers. This is the part truncation is allowed to
-#: eat into (along with the consulted-roots list) -- it is not the user's
-#: only route to the fix, `ROOT_DENIAL_RECOVERY_POINTER` above is.
+#: Fuller explanation appended after the short pointer and path detail. This
+#: is the part truncation is allowed to eat into: the pointer still gives the
+#: recovery route, while this sentence makes clear that a Chat itself is not
+#: missing required setup.
 ROOT_DENIAL_RECOVERY_HINT = (
-    "The Default workspace cannot hold folder bindings -- create a named "
-    "workspace first if this run is in Default, then bind a folder to it "
-    "and use a session in that workspace."
+    "Chats do not need a folder. To give local file tools access outside "
+    "private scratch, bind that folder in Settings > Workspaces and use a "
+    "chat in that Workspace."
 )
 
 

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -410,6 +410,7 @@ class ConsoleWorkspaceStatusPair(Horizontal):
         *,
         label_id: str,
         value_id: str,
+        label_width_floor: int = 13,
         **kwargs: Any,
     ) -> None:
         """Initialize the label/value status row.
@@ -419,6 +420,7 @@ class ConsoleWorkspaceStatusPair(Horizontal):
             value: User-facing row value.
             label_id: Textual widget id for the label cell.
             value_id: Textual widget id for the value cell.
+            label_width_floor: Minimum label-column width in terminal cells.
             **kwargs: Additional keyword arguments passed to ``Horizontal``.
         """
         super().__init__(classes="console-workspace-status-pair", **kwargs)
@@ -426,6 +428,7 @@ class ConsoleWorkspaceStatusPair(Horizontal):
         self.value = value
         self.label_id = label_id
         self.value_id = value_id
+        self.label_width_floor = max(1, int(label_width_floor))
         self.styles.height = "auto"
         self.styles.min_height = 1
 
@@ -441,10 +444,13 @@ class ConsoleWorkspaceStatusPair(Horizontal):
             classes="console-workspace-status-label",
             markup=False,
         )
-        # Keep one gutter cell after the longest current label. Most status
-        # rows retain the original 13-cell column; "Local file tools" needs
-        # 17 so its authority wording remains readable instead of wrapping.
-        label_width = max(13, min(17, cell_len(self.label) + 1))
+        # Keep one gutter cell after the label. Most status rows retain the
+        # original 13-cell floor; a caller may lower it for a deliberately
+        # concise label when the security-relevant value needs the extra cell.
+        label_width = max(
+            self.label_width_floor,
+            min(17, cell_len(self.label) + 1),
+        )
         label_widget.styles.width = label_width
         label_widget.styles.min_width = label_width
         yield label_widget
@@ -456,10 +462,9 @@ class ConsoleWorkspaceStatusPair(Horizontal):
             markup=False,
         )
         value_widget.styles.width = "1fr"
-        # Preserve the established 23-cell combined floor. Ordinary labels
-        # keep the original 10-cell value minimum; the one longer authority
-        # label may shrink its value to 6 cells and use the existing ellipsis
-        # + tooltip behavior instead of widening the whole rail.
+        # Preserve the established 23-cell combined floor. Longer labels may
+        # shrink the value to 6 cells and use the existing ellipsis + tooltip
+        # behavior instead of widening the whole rail.
         value_widget.styles.min_width = max(6, 23 - label_width)
         # TASK-384: at narrow rail widths the value column shrinks to a few cells
         # and a value like "Default" word-wrapped into a "Def / aul / t" letter

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -441,15 +441,12 @@ class ConsoleWorkspaceStatusPair(Horizontal):
             classes="console-workspace-status-label",
             markup=False,
         )
-        # I1 (final review): "Conversation" (RAG-45) is exactly 12 characters
-        # -- the label column's old fixed width -- so it filled the whole
-        # cell with zero gutter before the value column, and live captures
-        # showed the two fuse into one run-on token ("Conversation—",
-        # "ConversationThis conversation"). Widened to 13 so every label
-        # (this 12-char one included) always leaves at least one blank cell
-        # of separation.
-        label_widget.styles.width = 13
-        label_widget.styles.min_width = 13
+        # Keep one gutter cell after the longest current label. Most status
+        # rows retain the original 13-cell column; "Local file tools" needs
+        # 17 so its authority wording remains readable instead of wrapping.
+        label_width = max(13, min(17, cell_len(self.label) + 1))
+        label_widget.styles.width = label_width
+        label_widget.styles.min_width = label_width
         yield label_widget
 
         value_widget = Static(
@@ -459,10 +456,11 @@ class ConsoleWorkspaceStatusPair(Horizontal):
             markup=False,
         )
         value_widget.styles.width = "1fr"
-        # Rail IA spec section 8: the value column enforces a 10-cell floor so
-        # it never collapses to a single character at the rail's minimum width
-        # (TASK-2154.3 -- it was 0, letting the value shrink to 3-6 cells).
-        value_widget.styles.min_width = 10
+        # Preserve the established 23-cell combined floor. Ordinary labels
+        # keep the original 10-cell value minimum; the one longer authority
+        # label may shrink its value to 6 cells and use the existing ellipsis
+        # + tooltip behavior instead of widening the whole rail.
+        value_widget.styles.min_width = max(6, 23 - label_width)
         # TASK-384: at narrow rail widths the value column shrinks to a few cells
         # and a value like "Default" word-wrapped into a "Def / aul / t" letter
         # stack. Truncate the whole token with an ellipsis on one line instead,

--- a/tldw_chatbook/Widgets/Console/console_workspace_details.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_details.py
@@ -108,11 +108,20 @@ class ConsoleWorkspaceDetailsTray(RecomposeCaptureGuard, Vertical):
             ComposeResult yielding the status-pair widget.
         """
         label, value = self._split_status_row(text, fallback_label)
+        # The Console rail is intentionally narrow. The former 16-cell
+        # "Local file tools" label left too little room for the authority
+        # value and painted "Private scratch" as "Priva…" in live UAT.
+        # Keep the full underlying status copy while using a concise visible
+        # label so the security-relevant value remains readable.
+        compact_runtime_label = label == "Local file tools"
+        if compact_runtime_label:
+            label = "Local files"
         yield ConsoleWorkspaceStatusPair(
             label,
             value,
             label_id=label_id,
             value_id=value_id,
+            label_width_floor=12 if compact_runtime_label else 13,
         )
 
     def _server_features_unconfigured(self) -> bool:

--- a/tldw_chatbook/Widgets/Console/console_workspace_details.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_details.py
@@ -154,7 +154,7 @@ class ConsoleWorkspaceDetailsTray(RecomposeCaptureGuard, Vertical):
             self._friendly_status_label(self.state.runtime_label),
             label_id="console-workspace-runtime-label",
             value_id="console-workspace-runtime-value",
-            fallback_label="File tools",
+            fallback_label="Local file tools",
         )
         if collapse_server_features:
             yield self._static(
@@ -226,20 +226,20 @@ class ConsoleWorkspaceDetailsTray(RecomposeCaptureGuard, Vertical):
             return f"Storage: {readable or 'unavailable'}"
         if normalized == "sync: not configured":
             return "Sync: Off"
+        if normalized.startswith("local file tools:"):
+            return f"Local file tools: {raw.partition(':')[2].strip()}"
         if normalized.startswith("runtime: none, file tools disabled"):
-            # TASK-715: "Off in Default workspace" ellipsized in the rail's
-            # ~23-cell value column even in its own default state.
-            return "File tools: Off in Default"
+            return "Local file tools: Private scratch"
         if normalized.startswith("runtime: none"):
-            return "File tools: Off"
+            return "Local file tools: Private scratch"
         if normalized.startswith("runtime:"):
             readiness = re.search(r"(\d+) ready(?:,\s+(\d+) missing)?", normalized)
             if readiness:
-                label = f"File tools: {readiness.group(1)} ready"
+                label = f"Local file tools: {readiness.group(1)} ready"
                 if readiness.group(2):
                     label = f"{label}, {readiness.group(2)} missing"
                 return label
-            return raw.replace("Runtime:", "File tools:", 1)
+            return raw.replace("Runtime:", "Local file tools:", 1)
         # TASK-715: "Server handoff" (14 cells) wrapped in the 12-cell label
         # column, leaving an orphaned lowercase "handoff" line; and mapping
         # ACP rows to "ACP handoff:" made two different rows share a label

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -31,13 +31,11 @@ from tldw_chatbook.Workspaces.registry_service import (
 )
 
 _WORKSPACE_EXPLAINER = (
-    "A workspace scopes the Console to one project. Conversations started "
-    "in it are grouped together, agents' project file access comes only "
-    "from the folders you bind here (read-only unless you grant write in "
-    "Settings), and retrieval can be narrowed to the workspace's items via "
-    "its RAG Scope. Binding your project's folder is what makes a "
-    "workspace more than a label — without one, agents have no file "
-    "access. You can add or change folders later in Settings ▸ Workspaces."
+    "A workspace groups related Console conversations and can narrow "
+    "retrieval through its RAG Scope. Every chat has private scratch space. "
+    "Bind project folders here to add explicit project-file access "
+    "(read-only unless you grant write in Settings). Folder access is "
+    "optional; add or change folders later in Settings ▸ Workspaces."
 )
 
 

--- a/tldw_chatbook/Workspaces/display_state.py
+++ b/tldw_chatbook/Workspaces/display_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
@@ -386,7 +386,7 @@ def build_console_workspace_state(
             new_workspace_enabled=True,
             authority_label="Authority: local registry ready",
             sync_label="Sync: not configured",
-            runtime_label="Runtime: none",
+            runtime_label="Local file tools: Private scratch",
             conversation_rows=(),
             conversation_empty_copy="No active workspace conversations.",
             conversation_section=None,
@@ -409,6 +409,7 @@ def build_console_workspace_state(
         )
 
     runtime_bindings = _safe_runtime_bindings(registry_service, active_workspace)
+    missing_folder_count = _missing_folder_count(runtime_bindings)
     workspaces = _safe_workspaces(registry_service)
     can_switch = len(workspaces) > 1
     is_default_workspace = active_workspace.workspace_id == DEFAULT_WORKSPACE_ID
@@ -434,8 +435,8 @@ def build_console_workspace_state(
         authority_label=f"Authority: {active_workspace.authority.value}",
         sync_label=_workspace_sync_label(active_workspace),
         runtime_label=(
-            "Runtime: none, file tools disabled"
-            if is_default_workspace and not runtime_bindings
+            "Local file tools: Private scratch"
+            if is_default_workspace
             else _runtime_label(runtime_bindings)
         ),
         conversation_rows=rows,
@@ -447,10 +448,10 @@ def build_console_workspace_state(
         ),
         new_conversation_enabled=True,
         new_conversation_recovery="",
-        recovery_copy=(
-            ""
-            if can_switch or is_default_workspace
-            else "Workspace switching: only one workspace available."
+        recovery_copy=_console_workspace_recovery_copy(
+            can_switch=can_switch,
+            is_default_workspace=is_default_workspace,
+            missing_folder_count=missing_folder_count,
         ),
         server_readiness_label=server_label,
         server_readiness_detail=server_detail,
@@ -1021,21 +1022,54 @@ def _select_conversation(
 
 
 def _runtime_label(bindings: tuple[WorkspaceRuntimeBinding, ...]) -> str:
-    if not bindings:
-        return "Runtime: none"
+    """Describe actual local-folder authority added to private scratch."""
+    folder_bindings = tuple(
+        binding
+        for binding in bindings
+        if str(binding.binding_kind)
+        in ("local-filesystem", str(RuntimeBindingKind.LOCAL_FILESYSTEM))
+    )
     ready_count = sum(
-        binding.status == RuntimeBindingStatus.READY for binding in bindings
+        binding.status == RuntimeBindingStatus.READY for binding in folder_bindings
     )
-    missing_count = sum(
-        binding.status == RuntimeBindingStatus.MISSING for binding in bindings
+    if not ready_count:
+        return "Local file tools: Private scratch"
+    return (
+        "Local file tools: Private scratch + "
+        f"{ready_count} {_plural('folder', ready_count)}"
     )
-    label = (
-        f"Runtime: {len(bindings)} {_plural('binding', len(bindings))}, "
-        f"{ready_count} ready"
+
+
+def _missing_folder_count(bindings: tuple[WorkspaceRuntimeBinding, ...]) -> int:
+    """Return how many explicit local folder bindings are currently missing."""
+    return sum(
+        str(binding.binding_kind)
+        in ("local-filesystem", str(RuntimeBindingKind.LOCAL_FILESYSTEM))
+        and binding.status == RuntimeBindingStatus.MISSING
+        for binding in bindings
     )
-    if missing_count:
-        label = f"{label}, {missing_count} missing"
-    return label
+
+
+def _console_workspace_recovery_copy(
+    *,
+    can_switch: bool,
+    is_default_workspace: bool,
+    missing_folder_count: int,
+) -> str:
+    """Build secondary Workspace diagnostics without weakening scratch status."""
+    recovery: list[str] = []
+    if not can_switch and not is_default_workspace:
+        recovery.append("Workspace switching: only one workspace available.")
+    if missing_folder_count:
+        subject = (
+            "1 bound folder is"
+            if missing_folder_count == 1
+            else f"{missing_folder_count} bound folders are"
+        )
+        recovery.append(
+            f"{subject} missing. Rebind in Settings > Workspaces to restore access."
+        )
+    return " ".join(recovery)
 
 
 def _server_readiness(


### PR DESCRIPTION
## Summary

- let ordinary Console Chats send without selecting a folder
- give every live chat an independent owner-only temporary scratch directory
- keep named Workspace folder access explicit while preserving selected-root, fingerprint, and read/write guards
- propagate the owning scratch authority through built-in and local file tools, retained skill output, run logs, close/reopen, and app disposal
- redact opaque scratch locators before tool results reach model history or persisted run logs
- update Console, Settings, Workspace, change-review, and user-guide copy to describe private scratch and optional folders

## Live DeepSeek UAT

The isolated 180×55 live run verified:

- a new Default Chat sends without folder setup
- Chat A can write and read a relative scratch file
- Chat B cannot read Chat A's marker
- closing and reopening the saved Chat A yields fresh empty scratch
- a named Workspace can read and write its explicit read/write folder
- Default Chat cannot read that Workspace folder even after approving the call
- the real user config SHA-256 remained byte-identical before and after

See [the UAT report](Docs/UAT/2026-08-23-console-deepseek-private-scratch.md).

## Review findings addressed

- An independent review traced absolute scratch-owned path metadata and local `fs_*` errors into the shared model-history/run-log result seam. Provider-boundary redaction now emits relative scratch paths; regression coverage includes success, error, error-cap ordering, and a real persisted run-log record.
- A broad affected-UI diagnostic found ten Workspace-create modal Pilot failures. Untouched latest `dev` reproduced all ten. The harness omitted `WorkspaceCreateModal.BUNDLED_CSS`; loading the production styles makes all 23 modal tests pass at the default viewport.
- Rebasing exposed two different `TASK-21161` records. Add-commit provenance showed the Console task was older, so the later model-catalog startup-order task and its complete docs slice were renumbered to `TASK-21163`. The duplicate-ID guard is green.

## Verification

- 388 targeted authority, lifecycle, provider, run-log, project-instruction, and retained-skill tests passed
- 56 focused mounted Console/Workspace UI tests passed
- 10 final scratch-locator provider/run-log regressions passed after the error-cap ordering fix
- Backlog duplicate-ID script passed across 2,486 task files; its pytest gate passed 3/3
- Ruff and Python compilation passed for changed Python files
- `git diff --check` and the diff secret-pattern scan were clean

A full repository sweep was not run, in accordance with repository policy.

## Records

- [TASK-21161](backlog/tasks/task-21161%20-%20Console-per-chat-private-scratch-space-and-workspace-file-authority.md)
- [ADR-081](backlog/decisions/081-console-per-chat-private-scratch-space.md)
- [Design](Docs/superpowers/specs/2026-08-23-console-per-chat-private-scratch-space-design.md)
- [Implementation plan](Docs/superpowers/plans/2026-08-23-console-per-chat-private-scratch-space.md)

No dependency, database schema, license, or external service contract changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-chat private scratch spaces to Console Chats and confines local file tools, skills, run logs, and diagnostics to the chat’s scratch unless a Workspace folder is bound. Previously tools used a shared sandbox and cwd/[console] workspace_root fallback; now each live chat has an owner‑only temp scratch, folderless chats can send, reopening starts a fresh scratch, and private paths are redacted before caps, logging, and diagnostics.

- Review focus
  - Scratch authority and snapshots: `tldw_chatbook/Chat/console_scratch_space.py`; injected by `ConsoleRuntime`, captured in `ConsoleTurnExecutionContext`, and used by `ConsoleAgentBridge`.
  - File tools are run-scoped: `tldw_chatbook/Tools/workspace_file_roots.py` adds a run-scoped sandbox ContextVar; `tldw_chatbook/Tools/file_operation_tools.py` resolves against the run sandbox with no global fallback. Default Chats ignore any registry-provided folder bindings.
  - Run logs bind explicit roots: `tldw_chatbook/Agents/run_log.py` accepts `sandbox_root`/`workspace_id`; the bridge passes per-run roots/leases and blocks cross-session discovery. The writer’s fallback never uses a global sandbox.
  - Redaction and refusals: `tldw_chatbook/Agents/tool_catalog.py` redacts scratch locators; `tldw_chatbook/Agents/local_tool_provider.py` emits `LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL` when a scratch lease is invalid. Redaction runs before truncation/persistence, error caps, and diagnostics.
  - Retained artifacts stay in chat: `tldw_chatbook/Skills_Interop/*` accept `output_root` so skill outputs land in the chat scratch.
  - UI/copy: runtime reuses one scratch manager across visits; controller injects snapshots; Details rail shows “Local files: Private scratch”; Workspace and change-review copy explains private scratch and optional folders.

- Rollout
  - No migrations. Existing Workspaces continue to work; Chats without folders run entirely in private scratch.
  - Operators: Console ignores `[console] workspace_root` for Chat file access; bind folders per Workspace to allow external directory access.

<sup>Written for commit 85a26f844975d557445f100cca3a53b60d0f2628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

