### PR TITLE
docs(perf): close out the 2026-08-22 review burn-down — 20 follow-up tasks + evidence-doc corrections

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -33,7 +33,9 @@ is red for an unrelated reason (below) while CI hasn't completed since June.
 
 The filed backlog for this review is **task-21100 – task-21134**. This document is the durable
 evidence record those tasks cite (the backlog CLI drops custom sections, so measurements live
-here).
+here). The burn-down's own follow-ups, filed at close-out on 2026-08-23, are **task-21230 –
+task-21249**; what shipped, and the two findings the implementations proved wrong, are recorded
+in "What the burn-down changed" and "Corrections found during implementation" below.
 
 ---
 
@@ -247,7 +249,10 @@ Severity is stated for constrained hardware (×3–5). "REGRESSION" = absent at 
 - **21116** · library_screen.py still performs whole-screen `refresh(recompose=True)` on
   per-click paths — ~105 statement-level sites (99 `self.`) on a screen that grew 26k→34.8k
   lines; confirmed hot: `_open_library_item_by_id` (rail row / RAG result / media open),
-  `_apply_library_row_toggle`, media-viewer back, skills/prompts import open/cancel, export
+  ~~`_apply_library_row_toggle`~~ (**FALSE POSITIVE — corrected during implementation**;
+  instrumented at the base commit it performs **0 recomposes and 0 widget constructions** per
+  click, because the cited recompose statement sits inside an exception-fallback arm that a
+  normal toggle never reaches), media-viewer back, skills/prompts import open/cancel, export
   open. Continue the 15457 canvas-scoped conversion (`library_canvas_sync` seam, 82 call
   sites) + a ratchet test on the count. PRE-EXISTING pattern, cost-per-event regressed with
   screen growth (9 sites added post-fix are low-frequency admin flows).
@@ -262,10 +267,14 @@ Severity is stated for constrained hardware (×3–5). "REGRESSION" = absent at 
   (repair side-effects move to session-start/workspace-switch); also cache staged-launch
   `EvidenceBundle.from_payload` (re-parsed ≥2× per keystroke during staged launches).
   PRE-EXISTING, partially mitigated by 15452/15465.
-- **21119** · Chat-screen click dismissal walks the whole screen DOM twice
-  (`query(ConsoleTranscript)` + `query(ConsoleSelectionMenu)`) on BOTH MouseDown and Click of
-  every physical press (chat_screen.py:18939-18990). Fix: mounted-menu flag / cached
-  transcript ref, early-return when nothing is mounted. REGRESSION.
+- **21119** · Chat-screen click dismissal walks the whole screen DOM **three times per handler
+  invocation** — `query(ConsoleTranscript)`, `query(ConsoleSelectionMenu)`, and a third inside
+  `_remove_selection_menu`, which runs its own query (chat_screen.py:18939-18990). The handler
+  runs **once or twice per physical press** depending on who swallows the Click: a composer
+  press is 1 invocation = **3 walks**; a rail press is 2 invocations = **6 walks**. Fix:
+  mounted-menu flag / cached transcript ref, early-return when nothing is mounted. REGRESSION.
+  **CORRECTED during implementation** — the original text said "twice … on BOTH MouseDown and
+  Click … (~4 traversals per click)". See "Corrections found during implementation" below.
 - **21120** · Composer per-key residue: `_sync_send_disabled_reason` does an unconditional
   `strip.update(Content(...))` per key (the `reason_changed` gate covers only the ARIA
   announcement — the audit's half-gate pattern, console_composer_bar.py:1582-1607); hidden
@@ -363,6 +372,56 @@ Severity is stated for constrained hardware (×3–5). "REGRESSION" = absent at 
   (`Sync_Interop/notes_mirror.py`, `Widgets/Tamagotchi/tamagotchi_storage.py` never imported,
   Kanban boot connect with no UI, `Third_Party/aider/repomap.py` diskcache with no prod
   caller).
+
+---
+
+## What the burn-down changed (added 2026-08-23 at close-out)
+
+Fifteen merges closed every P0 and P1 in this review. Numbers below are the measurements
+recorded when each PR merged; a cell reads "—" where no before/after number was measured, and
+none has been inferred or estimated here.
+
+| Task | PR / merge | Measured before → after |
+|---|---|---|
+| 21100 first-boot migration wall | #2001 `41a240ccd` | `TldwCli` construction @100k messages **1.248 s → 0.693 s**, with FTS fully off the boot path; backfill made SIGKILL-resumable |
+| 21101 notes device-state store | #1992 `56e2de875` | receipt transaction **92× faster**; statements per read **~60 → 3** |
+| 21102 Chunking import chains | #1994 `d60ebe1d0` | import closure **1831 → 1757** modules; Chunking modules at boot **43 → 0**; warm app import **~811 ms → 731 ms** (7 chains broken; the survey had found 6) |
+| 21103 Persona_Buddy / PIL defer | #2002 `6c0abdba7` | **−80 modules**, **−1.28 s cold import**; 4 independent PIL chains broken (the buddy chain had masked three) |
+| 21104 bs4 boot guard | #1985 `3c3c919fc` | — (outcome: a base install can import the app; new ratchet `Tests/Packaging/test_extras_import_closure.py`) |
+| 21105 lazy feature databases | #2008 `92f9dba52` | boot files opened **35 → 27**; **~90 DDL statements** off boot |
+| 21106 Actor_Packs recovery | #1988 `908b802da` | CSS cliff guard re-armed **green at 47 sources**; nav tests **99 red → 130 passed**; cleared ~286 pre-existing Scheduling/Watchlists reds |
+| 21112 notes-sync gate + watcher backoff | #2009 `30c7e1fe9` | zero-profile boots create **no state file at all**; quiet watcher **60 → 8 scans/min** |
+| 21114 transcript drag-selection | #2007 `898cd8852` | body wraps per drag **151 → 1**; mouse-move handler **32× / 213× faster** |
+| 21115 CSS bundle-ride + ratchet | #2004 `82650cc1f` | modal-heavy session stylesheet sources **70 → 45** (cliff 64; ~19 headroom) — the cliff was confirmed crossed pre-fix; new-class count honestly corrected **34 → 25** |
+| 21117 Inspector right-rail scroll | #2016 `7489a0ec8` | — (pure-scroll path split from the layout reconcile; no before/after number recorded) |
+| 21118 keystroke workspace memo | #2010 `736359202` | registry calls per 20 keys **25 + 25 → 0 + 0**; staged-launch evidence-bundle parses **11 → ≤1** |
+| 21124 `get_cli_setting` fast path | #2005 `8e949873e` | warm reads **100 → 0** lock acquisitions; worst reader stall **18.2 ms → 3.7 ms**; write-path parses **4 → 2** |
+| 21160 config_profiles circular import (hotfix) | #2003 `ae018308b` | — (unmasked by 21102's facade; three edges deferred to use-site) |
+| 21200 restore the 21103 boot-path guard | #2019 `99005884` | — (another session's Actor Packs activation had put PIL and `Persona_Visual` back on the boot path, undoing 21103's win; the guard existed at their merge, CI simply was not enforcing yet) |
+
+Two defects were found and fixed **because of** this work rather than being on its list: a
+latent pre-existing FTS corruption (an unguarded `messages_ad` trigger on a tombstoned hard
+delete, silent doclist poisoning rather than a raise), and `v45_to_v46` missing from every
+packaging list (part of TASK-19860) — both inside 21100.
+
+## Corrections found during implementation (added 2026-08-23 at close-out)
+
+Two statements in the findings above were proved wrong by the implementations they produced.
+They are corrected in place and listed here so the record stays trustworthy rather than
+silently edited.
+
+1. **Finding 21119 undercounted the walks and miscounted the invocations.** The review said the
+   dismissal handler runs "two" full-screen queries and is invoked on both MouseDown and Click
+   of every press (~4 traversals). Measured truth: each handler invocation costs **three**
+   walks — `_remove_selection_menu` runs its own query in addition to the two the review
+   counted — and the handler runs **once or twice per physical press depending on who swallows
+   the Click**. A composer press is 1 invocation = **3 walks**; a rail press is 2 invocations =
+   **6 walks**. The finding's direction and its fix were right; its arithmetic was not.
+2. **Finding 21116 listed `_apply_library_row_toggle` as a hot per-click whole-screen
+   recompose site. It is a false positive.** Instrumented at the base commit,
+   `_apply_library_row_toggle` performs **0 recomposes and 0 widget constructions** per click:
+   the recompose statement the review cited sits inside an **exception-fallback arm** that a
+   normal toggle never reaches. The other sites named in that finding stand.
 
 ---
 

--- a/backlog/tasks/task-21230 - Watchlists url_list and sitemap sources hide the permanent bs4 install hint.md
+++ b/backlog/tasks/task-21230 - Watchlists url_list and sitemap sources hide the permanent bs4 install hint.md
@@ -1,0 +1,44 @@
+---
+id: TASK-21230
+title: >-
+  Watchlists url_list and sitemap sources hide the permanent bs4 install hint
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - watchlists
+  - subscriptions
+  - error-handling
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down (queue TASK-21100
+– TASK-21134). Found by the TASK-21104 adversarial review and its implementation pass.
+Base evidence doc: `Docs/Design/2026-08-22-holistic-perf-review.md`.
+
+TASK-21104 made `beautifulsoup4` a guarded import so a base install can still boot, and the
+guard reports a missing bs4 with an install hint. In
+`Subscriptions/local_watchlists_service.py` the task-1394 per-URL privacy suppression used by
+the `url_list` and `sitemap` loops (`_check_url_isolated`) reduces ANY exception — including a
+**permanent** `ImportError` — to a type-only DEBUG line plus a `DISPOSITION_ERROR` carrying
+`reason=None`. A user whose watchlist uses a `url_list` or `sitemap` source therefore sees an
+unexplained error with no reason text and never learns to install the extra. The single-`url`
+arm, which does not go through the suppression, surfaces the hint verbatim. The hint string is
+a module constant containing no user data, so surfacing it does not conflict with the privacy
+rule the suppression exists for.
+
+Second, pre-existing hygiene in the same package, found during that pass and re-confirmed on
+dev `b2b1e2e0d`: `Subscriptions/monitoring_engine.py` imports `from loguru import logger`
+twice (lines 27 and 37).
+
+## Acceptance Criteria
+
+- [ ] A `url_list` or `sitemap` watchlist source that fails because `beautifulsoup4` is not installed surfaces the same install hint a single-`url` source surfaces
+- [ ] The `DISPOSITION_ERROR` produced for that case carries a non-null reason
+- [ ] Transient and network-shaped per-URL failures still carry no URL, no exception message and no user data — the task-1394 suppression is unchanged for them
+- [ ] `Subscriptions/monitoring_engine.py` imports `logger` exactly once
+- [ ] A test fails if a permanent ImportError is re-suppressed to `reason=None` on the isolated arm

--- a/backlog/tasks/task-21231 - beautifulsoup4 is an undeclared core dependency supplied by accident through markdownify.md
+++ b/backlog/tasks/task-21231 - beautifulsoup4 is an undeclared core dependency supplied by accident through markdownify.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21231
+title: >-
+  beautifulsoup4 is an undeclared core dependency supplied by accident through
+  markdownify
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - packaging
+  - dependencies
+  - technical-debt
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; honesty note raised
+during the TASK-21104 implementation. Base evidence doc:
+`Docs/Design/2026-08-22-holistic-perf-review.md`.
+
+TASK-21104 was filed because `beautifulsoup4` is imported at boot but declared only in extras,
+so a base install could not import the app. The guard it added is correct, but the underlying
+declaration is still wrong in the other direction. Verified on dev `b2b1e2e0d`:
+`pyproject.toml` declares `markdownify` in `[project] dependencies` (line 70) while
+`beautifulsoup4` appears only under the `websearch` (line 107), `ebook` (176),
+`subscriptions` (331) and `web` (375) extras. `markdownify` transitively pins
+`beautifulsoup4<5,>=4.9`, so every healthy base install has bs4 present — by accident, not by
+declaration.
+
+Two consequences. The guard's "bs4 is not installed" branch and the extras' "install this to
+get bs4" promise are both untestable against a real base install, because a real base install
+has bs4. And a future `markdownify` release that drops the pin silently changes what a base
+install of this app can do, with nothing in the repo recording that we relied on it.
+
+## Acceptance Criteria
+
+- [ ] The repo records an explicit decision on whether `beautifulsoup4` is a core dependency or an optional one, and `pyproject.toml` matches that decision
+- [ ] If bs4 stays optional, an environment built from the declared core dependencies genuinely lacks bs4, so the TASK-21104 guard's not-installed branch is reachable in a real environment
+- [ ] If bs4 becomes core, it is declared in `[project] dependencies` and the extras stop re-declaring it as though it were their own
+- [ ] `Tests/Packaging/test_extras_import_closure.py` still passes

--- a/backlog/tasks/task-21232 - Dev red - test_library_canvas_scoped_sync harness is missing _library_prompt_browse_controller.md
+++ b/backlog/tasks/task-21232 - Dev red - test_library_canvas_scoped_sync harness is missing _library_prompt_browse_controller.md
@@ -1,0 +1,39 @@
+---
+id: TASK-21232
+title: >-
+  Dev red - test_library_canvas_scoped_sync harness is missing
+  _library_prompt_browse_controller
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - test-health
+  - dev-red
+  - library
+dependencies: []
+priority: high
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; found pre-existing
+during TASK-21101's implementation and re-confirmed at close-out.
+
+`Tests/UI/test_library_canvas_scoped_sync.py` builds its screen double from
+`types.SimpleNamespace` and never sets `_library_prompt_browse_controller`, which the
+production code under test reads. Re-run on dev `b2b1e2e0d`: **4 failed, 5 passed**, with
+`AttributeError: 'types.SimpleNamespace' object has no attribute
+'_library_prompt_browse_controller'` raised from the freshness check.
+
+The failure is in the harness, not the subject. Those four tests are not measuring the
+canvas-scoped sync behaviour they were written for, so the Library canvas seam — the seam
+TASK-21116 is converting more sites onto, and the seam TASK-21242 must repair — is
+under-covered while looking covered. That is the worst state for a guard to be in while
+another task is actively changing its subject.
+
+## Acceptance Criteria
+
+- [ ] `Tests/UI/test_library_canvas_scoped_sync.py` passes in full on dev
+- [ ] Each of the four repaired tests exercises the canvas-scoped sync assertion it was written for, shown by failing when its subject behaviour is mutated — not merely by no longer raising AttributeError
+- [ ] A missing screen attribute the subject reads fails with a message naming the attribute, or the double is derived from the real screen's attribute surface so it cannot drift again

--- a/backlog/tasks/task-21233 - Subscriptions FTS backfill carries the chunk-commit versus deferred-writer shape TASK-21100 had to fix.md
+++ b/backlog/tasks/task-21233 - Subscriptions FTS backfill carries the chunk-commit versus deferred-writer shape TASK-21100 had to fix.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21233
+title: >-
+  Subscriptions FTS backfill carries the chunk-commit versus deferred-writer
+  shape TASK-21100 had to fix
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - performance
+  - database
+  - reliability
+  - subscriptions
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; sweep candidate
+raised by the TASK-21100 review.
+
+TASK-21100's fix round found that a chunked FTS backfill which commits between chunks collides
+with a DEFERRED writer that upgrades to a write lock mid-transaction: on the ChaChaNotes DB
+this produced an **instant** `database is locked` on `add_message` during the first-boot
+backfill, and SQLite's busy timeout did not help because the lock-upgrade path bypasses it.
+Throttling the backfill was tried and proven not to be a fix; the fix was `immediate=True`
+scoped to the hot message writers (12 hot writers plus 5 outer wrappers, merged as
+`41a240ccd`).
+
+`DB/Subscriptions_DB.py:1439` `backfill_items_fts(chunk_size=500)` has the same structural
+shape — a resumable chunked backfill committing per chunk against a table other code writes.
+It was not fixed alongside TASK-21100 because the subscriptions DB is idle in the observed
+first-boot scenario, so the collision was never provoked. It is therefore a latent instance of
+a defect class this burn-down has already paid to learn, not a measured failure.
+
+## Acceptance Criteria
+
+- [ ] The subscriptions writers that can run concurrently with `backfill_items_fts` are enumerated, and each is shown either to take an immediate transaction or to be provably unable to overlap the backfill
+- [ ] A test drives a real write against `subscription_items` while a chunked backfill is in progress and fails if that writer receives `database is locked`
+- [ ] Throttling or retry is not used as the fix
+- [ ] The backfill remains resumable by rowid and its per-chunk cost is unchanged

--- a/backlog/tasks/task-21234 - test_fleet_teardown_notice killed whole-suite background runs but does not reproduce standalone.md
+++ b/backlog/tasks/task-21234 - test_fleet_teardown_notice killed whole-suite background runs but does not reproduce standalone.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21234
+title: >-
+  test_fleet_teardown_notice killed whole-suite background runs but does not
+  reproduce standalone
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - test-health
+  - dev-red
+  - needs-owner
+dependencies: []
+priority: high
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; observed during
+TASK-21100's fix round.
+
+During the burn-down, `Tests/Chat/test_fleet_teardown_notice.py` hung for **more than 420 s
+under a 60 s per-test timeout on pristine dev**, and was identified as the cause of
+whole-suite background-run kills. It was excluded identically on both sides of every A/B so
+that attribution stayed sound, which is why the burn-down's own evidence was unaffected.
+
+Re-probed at close-out on dev `b2b1e2e0d` with a hard 180 s wall: the whole file **passed —
+6 passed in 6.69 s**. The file itself has not changed since `f2e274993` (2026-08-22), i.e.
+before the hang was observed, so the difference is not in the test source.
+
+The hang is therefore conditional on something a standalone run does not reproduce — suite
+ordering, a co-imported module, or concurrency. That is precisely the shape that keeps costing
+whole-suite runs and that a green standalone run cannot close. It needs an owner with the
+whole-suite context. A second defect is visible in the original observation and should not be
+lost: a 60 s per-test timeout that lets a test run past 420 s is not doing its job.
+
+## Acceptance Criteria
+
+- [ ] The condition under which the file hangs is reproduced deterministically, or the hang is shown not to reproduce under a full whole-suite run on current dev and any exclusion for it is removed
+- [ ] If it reproduces, the blocking wait is identified and the test no longer exceeds the per-test timeout
+- [ ] A whole-suite run completes without a background kill attributable to this file
+- [ ] The per-test timeout terminates this test if it hangs again, or the reason it cannot is recorded

--- a/backlog/tasks/task-21235 - Two gaps in the TASK-21124 debounced config-write path.md
+++ b/backlog/tasks/task-21235 - Two gaps in the TASK-21124 debounced config-write path.md
@@ -1,0 +1,44 @@
+---
+id: TASK-21235
+title: >-
+  Two gaps in the TASK-21124 debounced config-write path
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - config
+  - console
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; two review findings
+from TASK-21124 (PR #2005, `8e949873e`) — one confirmed, one suspected. Filed together because
+they are the same seam: the write side of that change.
+
+TASK-21124 removed the global config-file lock from the warm read path (100 warm reads: 100 →
+**0** lock acquisitions; worst reader stall **18.2 → 3.7 ms**; write path 4 → 2 parses) and
+debounced the Logs and dictation settings writes. Two gaps were left open in the write path:
+
+1. **Confirmed.** `UI/Logs_Window.py` gates a persist on `snapshot ==
+   self._persisted_filter_state` (`:351`, `:377`, `:401`), but `_persisted_filter_state` is
+   only advanced when a debounced write completes (`:288`, `:332`). A Logs filter-chip click
+   landing while a debounced write is in flight compares against a **stale** baseline, is
+   judged a no-op, and is swallowed — the user's filter change is not persisted until unmount
+   repairs it. The dictation `_settings_dirty` shape does not have this gap; the two should
+   agree.
+2. **Suspected.** `config.py:5339` `_install_bootstrap_cache_from_raw` recomputes the config
+   path at publish time rather than using the path its caller read from. A `TLDW_CONFIG_PATH`
+   flip between read and publish would label path-A data as path-B cache.
+
+## Acceptance Criteria
+
+- [ ] A Logs filter change made while a debounced write is in flight is persisted without waiting for unmount
+- [ ] A test drives that interleaving and fails on the swallow
+- [ ] The Logs and dictation debounce gates use one shape, or the divergence is documented in code with the reason it is safe
+- [ ] The bootstrap cache is published under the path its data was read from, and a test with a config-path flip between read and publish fails if the cache is mislabelled
+- [ ] TASK-21124's warm-read measurement (0 lock acquisitions across 100 warm reads) does not regress

--- a/backlog/tasks/task-21236 - Persona Buddy lazy-controller residue - unlocked setter and an untested ensure-fallback.md
+++ b/backlog/tasks/task-21236 - Persona Buddy lazy-controller residue - unlocked setter and an untested ensure-fallback.md
@@ -1,0 +1,43 @@
+---
+id: TASK-21236
+title: >-
+  Persona Buddy lazy-controller residue - unlocked setter and an untested
+  ensure-fallback
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - personas
+  - concurrency
+  - test-coverage
+dependencies: []
+priority: low
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; the two Minors the
+TASK-21103 review ledgered rather than fixed. Both confirmed still present on dev `b2b1e2e0d`.
+
+TASK-21103 (PR #2002, `6c0abdba7`) made the Persona Buddy controller lazy, taking PIL and 93%
+of `Persona_Visual` off the boot path — **−80 modules**, and the PIL chain alone was
+**1.276 s of the 3.10 s cold import** measured by the review.
+
+1. `_build_persona_buddy_controller` guards its check-then-build with
+   `_persona_buddy_controller_lock` (`app.py:6213`). The public property setter
+   (`@persona_buddy_controller.setter`, `app.py:6289`) writes `self._persona_buddy_controller`
+   with **no lock**, so a setter call concurrent with a build can be lost, or can replace a
+   controller another caller already holds a reference to. Today the setter's only callers are
+   tests and skeletal doubles on the UI thread — so this is theoretical, but it is theoretical
+   only because of a caller property nothing enforces.
+2. The ensure-fallback arm added for explicit Buddy actions
+   (`personas_screen.py:6666-6668` — read the passive property, and when it is None call
+   `ensure_persona_buddy_controller()`) has **no screen-level test**. That arm is the entire
+   reason "Use for Buddy" works from a profile whose preferences still say disabled.
+
+## Acceptance Criteria
+
+- [ ] The controller slot cannot be written outside the lock that guards its construction, or the setter is shown unreachable from any concurrent context and that constraint is enforced rather than assumed
+- [ ] A screen-level test drives "Use for Buddy" from a profile whose preferences say disabled and asserts the action completes through the constructed controller
+- [ ] That test fails when the ensure-fallback arm is removed
+- [ ] TASK-21103's import-closure guard stays green

--- a/backlog/tasks/task-21237 - Drag-selection hardening residue from TASK-21114.md
+++ b/backlog/tasks/task-21237 - Drag-selection hardening residue from TASK-21114.md
@@ -1,0 +1,40 @@
+---
+id: TASK-21237
+title: >-
+  Drag-selection hardening residue from TASK-21114
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - console
+  - performance
+  - test-coverage
+dependencies: []
+priority: low
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; the three Minors
+from the TASK-21114 review (PR #2007, `898cd8852`). Filed as one task because all three sit in
+the same handler that change rewrote.
+
+TASK-21114 cut transcript drag-selection from **151 body re-wraps per drag to 1** and made the
+mouse-move handler **32× to 213× faster**, with equivalence proven twice independently. Three
+items were ledgered rather than fixed:
+
+1. Entering keyboard selection **mid-mouse-drag** leaves a ghost highlight. The pre-change
+   code cleared it on every mouse-move; removing that per-move sweep is what made the handler
+   fast, and removing it is what took the clear away.
+2. The arm-time sweep is not pinned by its own test. The scenario the existing test covers is
+   menu dismissal, which happens to exercise the same path — so the sweep can be deleted
+   without a red.
+3. The early-return layers in the handler are pairwise redundant and none is individually
+   pinned, so any one of them can be deleted with the suite still green.
+
+## Acceptance Criteria
+
+- [ ] Entering keyboard selection during an active mouse drag leaves no stale highlight on any row
+- [ ] A test covers the arm-time sweep in a menu-less scenario and fails when the sweep is removed
+- [ ] Each early-return layer is individually pinned by a test that fails when only that layer is deleted, or the redundant layers are removed
+- [ ] TASK-21114's per-drag wrap count (1) and handler timings do not regress

--- a/backlog/tasks/task-21238 - A corrupt notifications database can now fail unrelated Media, Research and Watchlists flows.md
+++ b/backlog/tasks/task-21238 - A corrupt notifications database can now fail unrelated Media, Research and Watchlists flows.md
@@ -1,0 +1,50 @@
+---
+id: TASK-21238
+title: >-
+  A corrupt notifications database can now fail unrelated Media, Research and
+  Watchlists flows
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - reliability
+  - database
+  - regression
+dependencies: []
+priority: high
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; MAJOR-2 from the
+TASK-21105 review (PR #2008, `92f9dba52`) — suspected there, unguarded-confirmed.
+
+TASK-21105 stopped schema-ing seven feature databases inside `TldwCli.__init__` (boot files
+**35 → 27**, roughly **90 DDL statements off boot**). That moved failure from boot — where the
+old code absorbed a corrupt DB into a `None` / `:memory:` fallback — to first use. The review
+of that change already caught one instance of the resulting class: a corrupt DB made
+`/research` **exit the app**, fixed in the fix round. Two more notification-dispatch sites
+carry the same shape and were not fixed:
+
+- `Media/local_media_reading_service.py:6501` `_dispatch_terminal_ingest_job_notification`
+- `Research_Interop/local_research_service.py:239` `_dispatch_external_run_notification` and
+  `:1495` `_dispatch_terminal_run_notification`
+
+Neither wraps its store access the way the study/quiz/evals trio does (`except Exception:
+return None`, e.g. `Study_Interop/local_quiz_service.py:62`). A corrupt notifications DB
+therefore fails a media-ingest job or a research run that the pre-TASK-21105 code completed —
+a reliability regression introduced by a performance change, which is the pattern this
+burn-down hit three times.
+
+Two Watchlists inbox workers (`watchlists_collections_screen.py:6004`, `:6022`) run without
+`exit_on_error=False`, so an exception escaping either reaches the app. The review also noted
+the lazy-store concurrency test covers **one of six** structurally identical stores.
+
+## Acceptance Criteria
+
+- [ ] A corrupt or unopenable notifications database does not fail a media ingest job, a research run, or a watchlists inbox refresh — the flow completes and the notification is skipped
+- [ ] A test injects a corrupt notifications store and asserts each of those three flows still completes
+- [ ] The two Watchlists inbox workers cannot take the app down on an escaping exception
+- [ ] The lazy-store race test covers all six stores, or the five uncovered stores are shown to be exercised by the one covered case
+- [ ] TASK-21105's boot-file count (27) does not regress

--- a/backlog/tasks/task-21239 - Kanban_Interop local store has zero consumers - retire it or justify its boot cost.md
+++ b/backlog/tasks/task-21239 - Kanban_Interop local store has zero consumers - retire it or justify its boot cost.md
@@ -1,0 +1,41 @@
+---
+id: TASK-21239
+title: >-
+  Kanban_Interop local store has zero consumers - retire it or justify its boot
+  cost
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - cleanup
+  - startup
+  - technical-debt
+  - needs-owner
+dependencies: []
+priority: low
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; evidence gathered
+while implementing TASK-21105 and recorded in that task file. Split out from the TASK-21105
+review's other finding (filed as TASK-21238) because retiring a subsystem is an owner
+decision, not a performance fix.
+
+While making the seven feature databases lazy, TASK-21105 established that the Kanban store
+has **zero consumers** — nothing in the app reads it. On dev `b2b1e2e0d` `TldwCli.__init__`
+still constructs `ServerKanbanService`, `LocalKanbanService` (pointed at
+`tldw_chatbook_kanban.db` in the user data dir) and `KanbanScopeService`
+(`app.py:7511-7526`), and no screen consumes any of them. Separately, TASK-21107 (still To Do)
+records that `Kanban_Interop` defeats `tldw_api`'s lazy facade and forces **76 pydantic
+models** at every boot.
+
+So the app creates a database file in the user's data directory, and pays a measured import
+cost, for a feature with no reachable surface.
+
+## Acceptance Criteria
+
+- [ ] An owner decision is recorded — retire the Kanban interop surface, or keep it with the intended consumer named
+- [ ] If retired, `TldwCli.__init__` constructs no Kanban service, no Kanban database file is created in the user data dir, and the modules are removed
+- [ ] If kept, its boot-time construction is deferred to first use like the other six stores, so an unused subsystem costs nothing at boot
+- [ ] Either outcome leaves the `import tldw_chatbook.app` closure no larger than it is today

--- a/backlog/tasks/task-21240 - An abandoned first-time setup leaves an empty notes-sync state DB that re-arms the start gate forever.md
+++ b/backlog/tasks/task-21240 - An abandoned first-time setup leaves an empty notes-sync state DB that re-arms the start gate forever.md
@@ -1,0 +1,41 @@
+---
+id: TASK-21240
+title: >-
+  An abandoned first-time setup leaves an empty notes-sync state DB that
+  re-arms the start gate forever
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - notes-sync
+  - startup
+  - performance
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; the residual
+recorded when TASK-21112 merged (PR #2009, `30c7e1fe9`).
+
+TASK-21112 gated the notes-sync runtime start on real evidence of configuration — a
+zero-profile boot now creates no state file at all — and backed the full-tree watcher off from
+60 to **8 scans/min** when quiet. The gate predicate (`app.py`, `start_evidence`) is
+`legacy_sync_directory_configured(settings) or state_path.exists()`, deliberately side-effect
+free: the obvious probe would have created the store it was testing for, which is the trap
+that implementation hit and recorded in the lessons.
+
+The residual: `state_path.exists()` is satisfied by an **empty** state database. A user who
+opens first-time setup — which force-starts the runtime on demand and therefore creates the
+file — and then abandons it without configuring any sync directory is left with an empty store
+on disk. Every subsequent boot sees the file, arms the gate, and pays the full start the gate
+exists to avoid, permanently, for a feature that was never configured.
+
+## Acceptance Criteria
+
+- [ ] A boot following an abandoned first-time setup does not start the notes-sync runtime
+- [ ] The gate predicate remains side-effect free — evaluating it never creates, opens for write, or migrates the state store
+- [ ] A genuinely configured profile, and the one-time legacy `[notes]` sync-directory migration path, still start exactly as they do today
+- [ ] A test covers the abandoned-setup boot and fails if the runtime starts

--- a/backlog/tasks/task-21241 - TASK-21118 residue - unlocked mutation-generation increment and a stale Settings active marker.md
+++ b/backlog/tasks/task-21241 - TASK-21118 residue - unlocked mutation-generation increment and a stale Settings active marker.md
@@ -1,0 +1,41 @@
+---
+id: TASK-21241
+title: >-
+  TASK-21118 residue - unlocked mutation-generation increment and a stale
+  Settings active marker
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - console
+  - workspaces
+  - concurrency
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; the two Minors
+ledgered when TASK-21118 merged (PR #2010, `736359202`).
+
+TASK-21118 took the Console keystroke path from ~1.25 synchronous Workspace-DB reads per key
+(measured: 20 keys → **25** `ensure_default_workspace` + **25** `get_active_workspace`) to
+**0 + 0**, by memoizing the screen's workspace-context resolution against a
+`mutation_generation` counter bumped by all seven workspace-record mutators. Staged-launch
+evidence-bundle parsing went from 11 parses across 3 keys to ≤1. Two Minors were accepted:
+
+1. `Workspaces/registry_service.py:228` increments `self._mutation_generation` with a bare
+   `+=` — an unlocked read-modify-write. Every mutator runs on the UI thread today, so a lost
+   increment is not reachable; nothing enforces that. A lost increment would serve a stale
+   workspace context to the keystroke path until the next mutation.
+2. The Settings "(active)" marker is not repainted in the edge state the memo never heals, so
+   it can name a workspace that is no longer active. Cosmetic, but it is the one place the
+   user is told which workspace is active.
+
+## Acceptance Criteria
+
+- [ ] A lost `mutation_generation` increment is impossible by construction, or the UI-thread-only constraint is enforced rather than assumed
+- [ ] The Settings active-workspace marker matches the actual active workspace in the edge state where the memo is not re-read
+- [ ] TASK-21118's keystroke measurement (0 registry calls across 20 keys) does not regress

--- a/backlog/tasks/task-21242 - Library canvas-sync seam - four correctness gaps left by the TASK-21116 conversion.md
+++ b/backlog/tasks/task-21242 - Library canvas-sync seam - four correctness gaps left by the TASK-21116 conversion.md
@@ -1,0 +1,49 @@
+---
+id: TASK-21242
+title: >-
+  Library canvas-sync seam - four correctness gaps left by the TASK-21116
+  conversion
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - library
+  - ux
+  - regression
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; four of the five
+Minors from the TASK-21116 review, deliberately not fixed in that round. The fifth (a
+remaining whole-screen recompose site) is filed separately as TASK-21243 because it is
+performance work, not correctness work.
+
+TASK-21116 continued converting `library_screen.py`'s whole-screen `refresh(recompose=True)`
+sites onto the canvas-scoped `library_canvas_sync` seam. Four correctness gaps in the new
+seams (line cites are from the review round; the symbols are the durable reference):
+
+1. Builder side effects are not undone when a sync ends SUPERSEDED or FAILED
+   (`_pop_library_media_arrival_note`, `_library_media_composed_detail`), so the ingest
+   "matched an existing item" notice can be consumed and then never shown to the user.
+2. The notes arm ignores `_library_notes_source == "files"`. Latent today because the boundary
+   arm fires first — a wrong predicate waiting for the arm ordering to change.
+3. In the `sync_kind is None` branch a `follow_up` is computed and then discarded, dropping
+   `restore_focus`; focus is not returned after that path.
+4. The armed list-entry-focus re-request that `compose_content` performed is not reproduced by
+   the new seams.
+
+Note that the harness for this seam's own test file is currently broken (TASK-21232, 4 failed
+on dev), so the seam is less covered than it looks.
+
+## Acceptance Criteria
+
+- [ ] A SUPERSEDED or FAILED canvas sync leaves the ingest arrival notice still pending, so it is shown on the next successful sync
+- [ ] The notes arm's source predicate is correct for `files` as well as `database`, independent of which arm fires first
+- [ ] Focus is restored after the `sync_kind is None` path, matching the pre-conversion behaviour
+- [ ] List-entry focus is re-requested after a canvas sync, matching what `compose_content` did
+- [ ] Each of the four has a test that fails against the current behaviour
+- [ ] TASK-21116's whole-screen recompose site ratchet stays green

--- a/backlog/tasks/task-21243 - Export from the Notes canvas still takes the whole-screen recompose arm.md
+++ b/backlog/tasks/task-21243 - Export from the Notes canvas still takes the whole-screen recompose arm.md
@@ -1,0 +1,33 @@
+---
+id: TASK-21243
+title: >-
+  Export from the Notes canvas still takes the whole-screen recompose arm
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - library
+  - performance
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; the fifth Minor
+from the TASK-21116 review. Split from TASK-21242 (the four correctness gaps) because this is
+the same class of work TASK-21116 itself did — moving another site onto the seam.
+
+The holistic review counted **~105 whole-screen `refresh(recompose=True)` sites** in
+`library_screen.py` (99 on `self.`), on a screen that grew from 26k to 34.8k lines, and
+TASK-21116 converted the confirmed-hot per-click ones to the canvas-scoped seam. Export
+initiated from the Notes canvas still routinely takes the structural whole-screen arm
+(`library_screen.py:29616` reaching `:8556` at the time of the review) rather than a
+canvas-scoped sync — so a routine user action still recomposes the largest screen in the app.
+
+## Acceptance Criteria
+
+- [ ] Export initiated from the Notes canvas performs a canvas-scoped sync, not a whole-screen recompose
+- [ ] A test asserts the recompose count for that action and fails if the whole-screen arm is taken
+- [ ] Export behaviour and the resulting UI state are unchanged
+- [ ] The whole-screen recompose site ratchet moves down and stays green

--- a/backlog/tasks/task-21244 - Console left rail still repaints its fold copy through a layout-forcing update.md
+++ b/backlog/tasks/task-21244 - Console left rail still repaints its fold copy through a layout-forcing update.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21244
+title: >-
+  Console left rail still repaints its fold copy through a layout-forcing
+  update
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - console
+  - performance
+dependencies: []
+priority: low
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; informational
+finding from the TASK-21117 review (PR #2016, `7489a0ec8`) promoted to a follow-up.
+
+TASK-21117 split the Inspector right rail's pure-scroll path from its layout reconcile and
+documented the underlying Textual trap in a new `backlog/docs/lessons-textual.md` entry:
+`Static.update(str)` schedules `refresh(layout=True)`, so a copy-only repaint costs roughly
+**two extra whole-screen layout passes**. `UI/Console_Modules/left_rail.py:1086` is now the
+**only remaining instance** of that trap in the Console rails — it repaints the fold hint with
+`hint.update(text)` on rail transitions.
+
+The same file also keeps a shadow `_outer_hint_text` field (`:323`, `:1083`, `:1085`) — the
+shape TASK-21117's AC3 forbade on the right rail. Here it is safe: the skip requires the
+shadow **and** the live renderable to match (`text == self._outer_hint_text and
+str(hint.renderable) == text`), so the worst case is one redundant write rather than a missed
+repaint. The left rail has no stand-down path and the two rails' copy predicates genuinely
+differ, so this is not a copy-paste of the right-rail fix. The TASK-21117 reviewer confirmed
+none of this is a latent left-rail bug — the cost is real but bounded to transitions, which is
+why it is low priority rather than dropped.
+
+## Acceptance Criteria
+
+- [ ] A left-rail fold-copy change does not force a whole-screen layout pass when only the text changed
+- [ ] Left-rail fold and unfold copy is unchanged in every state the existing rail tests cover
+- [ ] The shadow-field shape is brought in line with the right rail's, or the reason the left rail needs a different one is recorded in the code
+- [ ] A test fails if a copy-only left-rail update reintroduces a layout pass

--- a/backlog/tasks/task-21245 - Flake - test_overflow_focus_order_and_recovery_stay_within_context_section fails in isolation.md
+++ b/backlog/tasks/task-21245 - Flake - test_overflow_focus_order_and_recovery_stay_within_context_section fails in isolation.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21245
+title: >-
+  Flake - test_overflow_focus_order_and_recovery_stay_within_context_section
+  fails in isolation
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - test-health
+  - flake
+  - console
+  - needs-owner
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; found during
+TASK-21117 and confirmed still flaky at close-out.
+
+`Tests/UI/test_console_rail_reconciliation.py:1946`
+`test_overflow_focus_order_and_recovery_stay_within_context_section` is a pre-existing flake in
+a left-rail `_RailHarness` that mounts no Inspector. It goes green in large runs and
+misbehaves in isolation — the direction that hides it from the suite and surfaces it during
+targeted verification, i.e. exactly when a task needs a trustworthy signal.
+
+Measurements:
+
+- TASK-21117's interleaved A/B: base 3P/1F, branch 3P/1F — symmetric, so not caused by that
+  branch.
+- That implementer's larger sample: base 7P/3F, branch 10P/0F.
+- Close-out re-probe on dev `b2b1e2e0d`, **15 isolated runs: 13 passed, 2 failed**. Still
+  flaky, unchanged in character.
+
+## Acceptance Criteria
+
+- [ ] The source of the nondeterminism is identified, not suppressed with a retry, a sleep, or a skip marker
+- [ ] The test passes 30 consecutive isolated runs on dev
+- [ ] It still fails when the focus-order behaviour it names is mutated
+- [ ] If the flake proves to be a real product race rather than a harness artefact, that defect is filed separately with its own evidence

--- a/backlog/tasks/task-21246 - Privacy - the V46 to V47 migration logs the database path at INFO.md
+++ b/backlog/tasks/task-21246 - Privacy - the V46 to V47 migration logs the database path at INFO.md
@@ -1,0 +1,50 @@
+---
+id: TASK-21246
+title: >-
+  Privacy - the V46 to V47 migration logs the database path at INFO
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - privacy
+  - security
+  - diagnostics
+  - database
+dependencies: []
+priority: high
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down. Surfaced during the
+TASK-21116 fix round, while the diagnostic-inventory rows added by TASK-21100 (this
+burn-down's own merged work) were being reviewed row by row.
+
+`DB/ChaChaNotes_DB.py`'s `_migrate_from_v46_to_v47` interpolates `self.db_path_str` — an
+absolute local filesystem path, which on a default profile contains the operating-system
+username — into two **INFO**-level log lines:
+
+- `:6068` `"Migrating schema from V46 to V47 for '{...}' in DB: {self.db_path_str}..."`
+- `:6103` `"[... V46→V47] Migration completed successfully for DB: {self.db_path_str}"`
+
+Verified present on dev `b2b1e2e0d`.
+
+This is consistent with the surrounding file, which has 353 such interpolations — and that is
+the point. The pattern was invisible until TASK-21100's new rows forced a row-by-row review of
+the inventory and pinned these two. A migration runs on the **first boot after an upgrade**,
+at the default log level, for **every** user, so this is the highest-traffic instance of the
+pattern in the file. The repo's own rule is that user data never reaches the log, and a home
+directory path naming the user is user data.
+
+The fix is a scoped privacy repair, not a rewrite of 353 call sites: decide the treatment for
+a database path in a log line (omit it, reduce it to the file name, or demote to DEBUG), apply
+it to the V46→V47 pair, and record the decision so the next migration inherits it rather than
+re-deriving it.
+
+## Acceptance Criteria
+
+- [ ] No log line at INFO or above emitted by the V46→V47 migration contains a filesystem path that includes the user's home directory or username
+- [ ] The migration's log lines still identify which database was migrated well enough to diagnose a failed upgrade
+- [ ] The chosen treatment for database paths in migration logs is recorded where the next migration author will see it
+- [ ] `python3 scripts/check_persistent_diagnostic_inventory.py` is green and the inventory rows for these two sites reflect the change
+- [ ] A test fails if a migration re-introduces an absolute database path at INFO

--- a/backlog/tasks/task-21247 - Gate notes-sync runtime construction, not only its start.md
+++ b/backlog/tasks/task-21247 - Gate notes-sync runtime construction, not only its start.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21247
+title: >-
+  Gate notes-sync runtime construction, not only its start
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - notes-sync
+  - startup
+  - performance
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; finding from the
+TASK-21108 review.
+
+TASK-21112 gated the notes-sync runtime's `start()` on real evidence of configuration. Its own
+evidence shows the remaining cost is in **construction**, not start.
+
+On dev `b2b1e2e0d`, `TldwCli.__init__` builds the owner unconditionally
+(`app.py:6032` `build_notes_sync_runtime_owner(...)`, with the module-level import at `:379`),
+so the ~15-module chain is paid at boot by every user — including one with zero profiles
+configured, the exact case TASK-21112 was written for.
+
+On the in-flight TASK-21108 branch (`origin/fix/task-21108-wave5`, **not merged into dev** at
+close-out) that construction moves behind a lazy property, but `on_mount` reads the property
+unconditionally — so the chain is relocated to just before first paint rather than removed.
+
+Either way, the same `start_evidence` predicate that already decides whether to start could
+decide whether to construct. Re-confirm the exact call shape against dev after TASK-21108
+merges.
+
+## Acceptance Criteria
+
+- [ ] A boot with no notes-sync configuration constructs no notes-sync runtime owner and imports none of its dependency chain
+- [ ] A configured profile, and the one-time legacy `[notes]` sync-directory migration path, behave exactly as they do today
+- [ ] The gate predicate stays side-effect free — evaluating it never creates or opens the state store
+- [ ] An import-closure guard names the notes-sync chain and fails if a zero-profile boot pulls it in

--- a/backlog/tasks/task-21248 - The tldw module-count budget cannot catch a single-deferral regression - retire it or govern it.md
+++ b/backlog/tasks/task-21248 - The tldw module-count budget cannot catch a single-deferral regression - retire it or govern it.md
@@ -1,0 +1,48 @@
+---
+id: TASK-21248
+title: >-
+  The tldw module-count budget cannot catch a single-deferral regression -
+  retire it or govern it
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - startup
+  - test-health
+  - performance
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; finding from the
+TASK-21108 review.
+
+The TASK-21108 branch (`origin/fix/task-21108-wave5`, **not merged into dev** at close-out)
+adds `MAX_TLDW_MODULE_COUNT = 660` in `Tests/Performance/test_app_import_weight.py` as a drift
+signal over this repo's own modules. Two measured problems with it as a guard:
+
+1. **Headroom.** It leaves roughly 30 modules of room against a **measured +61 in one
+   four-day window** (604 → 665, 2026-08-12 to 2026-08-16). At the observed accretion rate the
+   budget is consumed in days, and the routine response to a red budget test is to bump the
+   number.
+2. **Sensitivity.** It does not catch a single-deferral regression. Reverting only the panel
+   deferral gives **649**; reverting only the notes deferral gives **645**. Both are under
+   budget, so either win can be undone silently.
+
+That second point is not hypothetical: TASK-21200 was filed this same week because
+TASK-21103's import guard went red only once CI started enforcing it — another session's
+Actor Packs feature had already put PIL and `Persona_Visual` back on the boot path, undoing a
+−80-module / −1.28 s win. A shipped guard only protects while something runs it, and an
+aggregate budget with 30 modules of slack does not run against any individual win.
+
+The named-module closure guards (the shape TASK-21103 and TASK-21104 shipped, and the one
+TASK-21200 restored) do catch a single deferral, and they fail with the offending import chain
+rather than a number.
+
+## Acceptance Criteria
+
+- [ ] A revert of any single import deferral shipped by this burn-down fails a test, and the failure names the chain that came back
+- [ ] The aggregate module-count budget is removed in favour of those named guards, or it stays with an explicit review process for raising it — a docstring bump is not that process
+- [ ] No guard in `Tests/Performance/test_app_import_weight.py` can be satisfied by editing a constant without a recorded decision

--- a/backlog/tasks/task-21249 - Notes-sync lazy-property residue - late-bound reads and a build failure painted as feature-unavailable.md
+++ b/backlog/tasks/task-21249 - Notes-sync lazy-property residue - late-bound reads and a build failure painted as feature-unavailable.md
@@ -1,0 +1,46 @@
+---
+id: TASK-21249
+title: >-
+  Notes-sync lazy-property residue - late-bound reads and a build failure
+  painted as feature-unavailable
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - notes-sync
+  - error-handling
+  - technical-debt
+dependencies: []
+priority: medium
+---
+
+## Description
+
+Source: close-out of the 2026-08-22 holistic performance review burn-down; two findings from
+the TASK-21108 review, filed together because both are consequences of the same change —
+turning `notes_sync_runtime_owner` into a lazily-built property.
+
+Both are against `origin/fix/task-21108-wave5`, which was **not merged into dev** at close-out.
+Re-confirm against dev after it lands.
+
+1. **Late-bound reads.** That branch's own new lesson is that a lazily-constructed owner must
+   not capture app state eagerly — and it applies that to two of six reads. Four remain in
+   `_construct_notes_sync_runtime_owner` (branch `app.py:6117`): `app_config`,
+   `_instance_lock_status.acquired`, `notes_user_id`, and the two path getters. A value read
+   at first-property-access rather than at the construction the caller believes it triggered is
+   ordering dependence that only shows up when the access point moves — which is exactly what
+   TASK-21247 proposes to do next.
+2. **A build failure shown as feature-unavailable.** `library_screen.py:3241` reads the runtime
+   with `getattr(app_instance, "notes_sync_runtime_owner", None)`. Once that name is a property
+   that builds on access, the `getattr` default swallows an `AttributeError` raised **inside**
+   the build, and the screen paints "awaiting_cutover" — a construction failure presented to
+   the user as "this feature is not available yet", with nothing distinguishing the two. On dev
+   today the name is a plain attribute (`app.py:6032`) so the swallow is unreachable; it
+   becomes reachable the moment the property lands.
+
+## Acceptance Criteria
+
+- [ ] The values the notes-sync runtime owner depends on are read at one well-defined point, and moving the property's first access does not change what it is built with
+- [ ] A build failure inside the notes-sync runtime property is not reported to the user as "awaiting cutover" — it is distinguishable in the UI and logged
+- [ ] A test raises an `AttributeError` from inside the property build and fails if the Library screen reports feature-unavailable
+- [ ] Neither change re-introduces an eager construction on a zero-profile boot


### PR DESCRIPTION
## Summary

Close-out for the 2026-08-22 holistic performance review burn-down (15 task PRs merged). Files the follow-ups the adversarial reviews surfaced, and corrects two things the implementation proved wrong in the review's own evidence doc.

## Backlog: TASK-21230 – TASK-21249 (20 tasks from 27 candidates)

Merged where a single fix covers several observations, split where one entry held two units of work, and **dropped four after verifying they no longer reproduce on dev**: the console-fence test now passes; `sql_validation`'s VALID_TABLES gap is already fixed (69/69); the backfill terminal-check cost was explicitly accepted in the 21100 review; and `test-logs/` is already gitignored.

Notable entries: **21246 (high, privacy)** — the V46→V47 migration logs the database path, which contains the username, at INFO. **21232 / 21234 (high, dev-red)** — a broken test harness and the suite-hanging test that killed background runs. **21238 (high)** — a corrupt notifications DB can now fail unrelated Media/Research/Watchlists flows, a surface the lazy-DB work widened.

Four tasks (21247–21249, 21241) cite code that exists only on the not-yet-merged 21108 branch; each says so, states what dev looks like today, and asks for re-confirmation after it lands.

## Evidence-doc corrections

The review doc is the durable record, so where implementation disproved it, it now says so rather than being silently edited:

- **Finding 21119** said the dismissal handler ran *two* full-screen queries per press. Measured: **three walks per handler invocation**, and the handler runs once or twice per physical press depending on who swallows the Click (composer = 3 walks, rail = 6).
- **Finding 21116** cited `_apply_library_row_toggle` as a per-click recompose site. Instrumented at base it does **0 recomposes and 0 widget constructions** — the cited statement sits in an exception-fallback arm. Marked FALSE POSITIVE.

Both are listed in a new "Corrections found during implementation" section, and the doc now carries a "What the burn-down changed" table of measured before/after numbers (cells left blank where the ledger holds no number — nothing invented).

## Verification

Preflight all five checks green; inventory clean; IDs re-swept at commit time (max 21200, zero hits in the new range); duplicate checker clean over 2,516 task files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes out the 2026-08-22 performance review by filing 20 follow-up tasks and updating the durable evidence with a before/after table and two corrections. Documentation and backlog only; no runtime behavior changes.

- Adds TASK-21230–TASK-21249 from 27 candidates; drops 4 that no longer reproduce. High-impact items: 21246 (privacy: V46→V47 migration logs a DB path at INFO), 21232/21234 (dev-red: broken harness and suite hang), 21238 (corrupt notifications DB can fail unrelated flows).
- Updates `Docs/Design/2026-08-22-holistic-perf-review.md` with “What the burn-down changed” (metrics for 15 merged fixes) and “Corrections found during implementation,” correcting 21119’s traversal count and marking 21116’s `_apply_library_row_toggle` as a false positive.
- Notes dependencies: 21247–21249 and 21241 reference code on `origin/fix/task-21108-wave5` and request re-confirmation after it lands.

<sup>Written for commit 1d413a83eba9a605c75a9be5a5c3622b5e883d1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

