### PR TITLE
ci(backlog): fail when a task file cannot be read

### DIFF
--- a/.github/workflows/backlog-guard.yml
+++ b/.github/workflows/backlog-guard.yml
@@ -11,6 +11,7 @@ on:
       - 'backlog/completed/**'
       - 'backlog/archive/tasks/**'
       - 'scripts/check_backlog_task_ids.py'
+      - 'scripts/check_backlog_task_files.py'
   push:
     branches: [dev, main]
     paths:
@@ -20,6 +21,7 @@ on:
       - 'backlog/completed/**'
       - 'backlog/archive/tasks/**'
       - 'scripts/check_backlog_task_ids.py'
+      - 'scripts/check_backlog_task_files.py'
 
 # One PUSH run per workflow per ref: a new push supersedes the previous run instead of
 # queueing another alongside it. Without this, every push to `dev` stacked a full
@@ -49,3 +51,10 @@ jobs:
           # prefix and the YAML frontmatter `id:` -- since they disagree after a
           # hand-edited rename and the backlog CLI resolves by frontmatter.
           python scripts/check_backlog_task_ids.py
+
+      - name: Fail on unreadable backlog task files
+        if: ${{ !cancelled() }}
+        run: |
+          # Frontmatter that does not load makes a task invisible to every
+          # reader without failing anything. Same script the required check runs.
+          python scripts/check_backlog_task_files.py

--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -155,6 +155,15 @@ jobs:
           # workflow nobody is gated on.
           python scripts/check_backlog_task_ids.py
 
+      - name: Backlog task files are readable
+        if: ${{ !cancelled() }}
+        run: |
+          # A task whose frontmatter does not load is skipped by every reader
+          # with one log line, so it silently stops existing. Thirty-two files
+          # had accumulated that way before PR #1954 repaired them; nothing
+          # stopped them coming back.
+          python scripts/check_backlog_task_files.py
+
       - name: ChaChaNotes table allowlist covers every migrated table
         if: ${{ !cancelled() }}
         run: |

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -636,6 +636,36 @@ def test_unreadable_task_files_catch_the_shapes_that_broke_dev(tmp_path):
     assert backlog_files.main(["--tasks-dir", str(tasks)]) == 1
 
 
+RESERVED_SEQUENCE_ITEM = """---
+id: TASK-5
+title: Fine
+status: Done
+assignee:
+  - @zcode
+labels:
+  - console
+---
+
+x
+"""
+
+
+def test_a_bare_at_sign_in_a_list_is_caught(tmp_path):
+    """`- @zcode` stops the whole file loading; every other file quotes it.
+
+    Three task files on dev were written this way and were invisible to every
+    reader until the real parser was asked. The first version of this checker
+    passed them, which is why it now judges sequence items too.
+    """
+    tasks = tmp_path / "tasks"
+    _task_file(tasks, "task-5 - Reserved.md", RESERVED_SEQUENCE_ITEM)
+
+    unreadable = backlog_files.unreadable_task_files(tasks)
+
+    assert list(unreadable) == [(tasks / "task-5 - Reserved.md").resolve().as_posix()]
+    assert "reserved character" in unreadable[(tasks / "task-5 - Reserved.md").resolve().as_posix()][0]
+
+
 def test_readable_task_file_shapes_are_not_flagged(tmp_path):
     """No false positives on the shapes dev actually carries.
 

--- a/Tests/Architecture/test_derived_artifact_checkers.py
+++ b/Tests/Architecture/test_derived_artifact_checkers.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts import check_backlog_task_files as backlog_files
 from scripts import check_backlog_task_ids as backlog_ids
 from scripts import check_persistent_diagnostic_inventory as inventory
 
@@ -558,6 +559,115 @@ def test_unique_task_ids_pass(tmp_path):
     (tmp_path / "task-2 - B.md").write_text("id: TASK-2\n", encoding="utf-8")
     assert backlog_ids.duplicate_ids(tmp_path) == ({}, {})
     assert backlog_ids.main(["--tasks-dir", str(tmp_path)]) == 0
+
+
+def _task_file(directory, name: str, body: str):
+    """Write one task file into `directory`, creating it if needed."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+UNQUOTED_COLON_TITLE = """---
+id: TASK-1
+title: Console transcript: skip move_child for rows already in position
+status: To Do
+---
+
+x
+"""
+
+APOSTROPHE_TITLE = """---
+id: TASK-2
+title: 'Impersonate drafts the user's next reply'
+status: To Do
+---
+
+x
+"""
+
+UNTERMINATED_SECTION = """---
+id: TASK-3
+title: Fine
+status: To Do
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Body that never closes.
+"""
+
+WRAPPED_QUOTED_TITLE = """---
+id: TASK-4
+title: 'Fix character avatar rendering: Console rail 0x0 collapse + Roleplay thumb
+  fold stripes'
+status: Done
+labels:
+  - ui
+assignee: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Body.
+<!-- SECTION:DESCRIPTION:END -->
+
+<!-- SECTION:NOTES:END -->
+"""
+
+
+def test_unreadable_task_files_catch_the_shapes_that_broke_dev(tmp_path):
+    """The three shapes behind the 32 files PR #1954 repaired."""
+    tasks = tmp_path / "tasks"
+    _task_file(tasks, "task-1 - Colon.md", UNQUOTED_COLON_TITLE)
+    _task_file(tasks, "task-2 - Apostrophe.md", APOSTROPHE_TITLE)
+    _task_file(tasks, "task-3 - Unterminated.md", UNTERMINATED_SECTION)
+
+    unreadable = backlog_files.unreadable_task_files(tasks)
+
+    assert set(unreadable) == {
+        (tasks / "task-1 - Colon.md").resolve().as_posix(),
+        (tasks / "task-2 - Apostrophe.md").resolve().as_posix(),
+        (tasks / "task-3 - Unterminated.md").resolve().as_posix(),
+    }
+    assert backlog_files.main(["--tasks-dir", str(tasks)]) == 1
+
+
+def test_readable_task_file_shapes_are_not_flagged(tmp_path):
+    """No false positives on the shapes dev actually carries.
+
+    A wrapped quoted title, a key introducing a block sequence, an empty flow
+    sequence, and a stray `:END` are all things the real parser accepts; each
+    one broke an earlier draft of this checker.
+    """
+    tasks = tmp_path / "tasks"
+    _task_file(tasks, "task-4 - Wrapped.md", WRAPPED_QUOTED_TITLE)
+
+    assert backlog_files.unreadable_task_files(tasks) == {}
+    assert backlog_files.main(["--tasks-dir", str(tasks)]) == 0
+
+
+def test_a_file_that_is_not_utf8_is_reported_not_raised(tmp_path):
+    """A decode error must name the file, not fail the required check with a traceback."""
+    tasks = tmp_path / "tasks"
+    tasks.mkdir(parents=True)
+    (tasks / "task-9 - Bad.md").write_bytes(b"\xff\xfe not utf8\n")
+
+    unreadable = backlog_files.unreadable_task_files(tasks)
+
+    assert list(unreadable) == [(tasks / "task-9 - Bad.md").resolve().as_posix()]
+    assert "codec can't decode" in unreadable[(tasks / "task-9 - Bad.md").resolve().as_posix()][0]
+    assert backlog_files.main(["--tasks-dir", str(tasks)]) == 1
+
+
+def test_task_file_scope_is_every_bucket_the_cli_resolves():
+    """The readability check must cover the same buckets as the id check."""
+    assert {
+        path.relative_to(backlog_files.REPO_ROOT).as_posix() for path in backlog_files.TASK_DIRS
+    } == {"backlog/tasks", "backlog/completed", "backlog/archive/tasks"}
 
 
 def test_repo_relative_accepts_a_relative_path_inside_the_repo():

--- a/Tests/CI/test_derived_artifacts_workflow.py
+++ b/Tests/CI/test_derived_artifacts_workflow.py
@@ -26,6 +26,7 @@ CHECKERS = (
     "scripts/check_profile_owned_path_inventory.py",
     "scripts/check_persistent_diagnostic_inventory.py",
     "scripts/check_backlog_task_ids.py",
+    "scripts/check_backlog_task_files.py",
     # TASK-20971. VALID_TABLES['chachanotes'] went stale, was repaired, and
     # went stale again 14.5 hours later; this is its authoring-time half.
     "scripts/check_schema_table_allowlist.py",

--- a/backlog/tasks/task-24415 - Console-composer-draft-invisible-at-narrow-widths-when-a-send-disabled-reason-shows.md
+++ b/backlog/tasks/task-24415 - Console-composer-draft-invisible-at-narrow-widths-when-a-send-disabled-reason-shows.md
@@ -5,7 +5,7 @@ title: >-
   shows
 status: Done
 assignee:
-  - @zcode
+  - '@zcode'
 created_date: '2026-08-29'
 updated_date: '2026-08-29'
 labels:

--- a/backlog/tasks/task-24416 - Slash-command-popup-etiquette-sticky-Escape-dismissal-bare-slash-Enter-guard-undo-safe-accept.md
+++ b/backlog/tasks/task-24416 - Slash-command-popup-etiquette-sticky-Escape-dismissal-bare-slash-Enter-guard-undo-safe-accept.md
@@ -5,7 +5,7 @@ title: >-
   guard, undo-safe accept
 status: Done
 assignee:
-  - @zcode
+  - '@zcode'
 created_date: '2026-08-29'
 updated_date: '2026-08-29'
 labels:

--- a/backlog/tasks/task-24417 - Console-hands-free-Escape-exits-the-loop-before-dismissing-an-open-slash-popup.md
+++ b/backlog/tasks/task-24417 - Console-hands-free-Escape-exits-the-loop-before-dismissing-an-open-slash-popup.md
@@ -5,7 +5,7 @@ title: >-
   popup
 status: Done
 assignee:
-  - @zcode
+  - '@zcode'
 created_date: '2026-08-29'
 updated_date: '2026-08-29'
 labels:

--- a/scripts/check_backlog_task_files.py
+++ b/scripts/check_backlog_task_files.py
@@ -46,6 +46,12 @@ TASK_DIRS = (
 FRONTMATTER_DELIMITER = "---"
 # A frontmatter mapping line: an unindented key, then the value.
 MAPPING_LINE_RE = re.compile(r"^(?P<key>[A-Za-z_][A-Za-z0-9_-]*):(?P<value>.*)$")
+SEQUENCE_ITEM_RE = re.compile(r"^\s+-\s+(?P<value>\S.*)$")
+# YAML reserves these as the first character of a plain scalar. `@` is the one
+# that bites here: three task files were written with `- @zcode` for an
+# assignee, which every other file spells `- '@zcode'`, and the whole file
+# stopped loading.
+RESERVED_SCALAR_STARTS = "@`"
 SECTION_BEGIN_RE = re.compile(r"^<!-- SECTION:(?P<name>[A-Z0-9_ -]+):BEGIN -->\s*$")
 SECTION_END_RE = re.compile(r"^<!-- SECTION:(?P<name>[A-Z0-9_ -]+):END -->\s*$")
 
@@ -141,6 +147,29 @@ def frontmatter_problems(text: str) -> list[str]:
         problem = _scalar_problem(value)
         if problem is not None:
             problems.append(f"{match.group('key')}: {problem}")
+
+    problems.extend(_sequence_item_problems(lines, closing))
+    return problems
+
+
+def _sequence_item_problems(lines: list[str], closing: int) -> list[str]:
+    """Block-sequence items that YAML cannot read as plain scalars.
+
+    Only the reserved first characters are judged. Everything else in a sequence
+    item -- colons, quotes, punctuation -- is the caller's business and loads
+    fine, so it is left alone.
+    """
+    problems: list[str] = []
+    for index in range(1, closing):
+        match = SEQUENCE_ITEM_RE.match(lines[index])
+        if match is None:
+            continue
+        value = match.group("value").strip()
+        if value[:1] in RESERVED_SCALAR_STARTS:
+            problems.append(
+                f"list item starts with the reserved character {value[0]!r} "
+                f"and must be quoted: {value[:60]}"
+            )
     return problems
 
 

--- a/scripts/check_backlog_task_files.py
+++ b/scripts/check_backlog_task_files.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Guard: every backlog task file can actually be read.
+
+A task file with broken frontmatter is not a loud failure. Every backlog reader
+-- ``task list``, the board, search, the MCP read tools -- skips it with one log
+line and carries on, so the task simply stops existing. Thirty-two files had
+accumulated in that state before anyone noticed (repaired in PR #1954); the
+warnings interleave with output, so the damage read as two or three files.
+
+Only the shapes that provably break a reader are checked, and only with the
+standard library, because the workflows that run this install nothing:
+
+* the frontmatter block must open on line 1 and close;
+* a plain (unquoted) scalar must not contain ``": "`` -- YAML reads the second
+  colon as another mapping key, which is what ``title: Console transcript: skip
+  move_child`` did to twenty-eight files;
+* a quoted scalar must actually close, with interior quotes escaped -- what
+  ``title: 'Impersonate drafts the user's next reply'`` did to three more;
+* an owned ``<!-- SECTION:NAME:BEGIN -->`` must be closed, since an
+  unterminated section is a hard parse error and swallows every heading below
+  it. A stray ``:END`` with no BEGIN is *not* flagged: the real parser ignores
+  it, and nine files on dev carry one.
+
+Deliberately NOT a YAML parser. PyYAML is a project dependency but is not
+installed in `derived-artifacts.yml` (see its "nothing is installed" note), and
+a partial re-implementation would fail differently from the real readers. These
+four rules are the ones with evidence behind them; anything subtler is left to
+``backlog-py doctor``, which uses the real parser.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+# The buckets a task file can live in, mirroring check_backlog_task_ids.py.
+TASK_DIRS = (
+    REPO_ROOT / "backlog" / "tasks",
+    REPO_ROOT / "backlog" / "completed",
+    REPO_ROOT / "backlog" / "archive" / "tasks",
+)
+
+FRONTMATTER_DELIMITER = "---"
+# A frontmatter mapping line: an unindented key, then the value.
+MAPPING_LINE_RE = re.compile(r"^(?P<key>[A-Za-z_][A-Za-z0-9_-]*):(?P<value>.*)$")
+SECTION_BEGIN_RE = re.compile(r"^<!-- SECTION:(?P<name>[A-Z0-9_ -]+):BEGIN -->\s*$")
+SECTION_END_RE = re.compile(r"^<!-- SECTION:(?P<name>[A-Z0-9_ -]+):END -->\s*$")
+
+RESOLUTION = (
+    "Run `backlog-py doctor --fix` (backlog-md-py >= 2.0.2), which repairs these "
+    "shapes and re-parses each file before writing it, or quote the title by hand."
+)
+
+
+def _label(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _scalar_problem(value: str) -> str | None:
+    """Why a single-line frontmatter value would not load, or None.
+
+    Multi-line values are handled by the caller, which owns the surrounding
+    lines; this only judges what fits on one.
+    """
+    scalar = value.strip()
+    if not scalar or scalar in {">", ">-", "|", "|-", "[]", "{}"}:
+        return None
+    quote = scalar[0]
+    if quote in "'\"":
+        interior = scalar[1:-1]
+        # A single-quoted scalar escapes a quote by doubling it, a double-quoted
+        # one with a backslash. An odd one out means the scalar ended early and
+        # the remainder is stray tokens -- `title: 'the user's next reply'`.
+        if quote == "'" and interior.replace("''", "").count("'"):
+            return f"single-quoted value has an unescaped apostrophe: {scalar[:60]}"
+        if quote == '"' and re.search(r'(?<!\\)"', interior):
+            return f"double-quoted value has an unescaped quote: {scalar[:60]}"
+        return None
+    if ": " in scalar or scalar.endswith(":"):
+        return f"unquoted value contains a colon and must be quoted: {scalar[:60]}"
+    return None
+
+
+def _closes_on_a_continuation_line(lines: list[str], start: int, stop: int, quote: str) -> bool:
+    """Whether a wrapped quoted scalar closes before the next key.
+
+    YAML lets a quoted scalar run across indented continuation lines, which is
+    how the backlog writers emit a long title. Judging only the first line would
+    report every wrapped title as unterminated.
+    """
+    for index in range(start, stop):
+        line = lines[index]
+        if line[:1] not in (" ", "\t"):
+            return False
+        if line.strip().endswith(quote):
+            return True
+    return False
+
+
+def frontmatter_problems(text: str) -> list[str]:
+    """Find frontmatter that would not survive a YAML load.
+
+    Args:
+        text: Full task-file source, frontmatter included.
+
+    Returns:
+        list[str]: One reason per problem, in reading order. Empty when the
+            frontmatter block is well formed.
+    """
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
+        return ["no frontmatter block: the file does not open with ---"]
+    closing = next(
+        (i for i in range(1, len(lines)) if lines[i].strip() == FRONTMATTER_DELIMITER),
+        None,
+    )
+    if closing is None:
+        return ["frontmatter block is never closed by a second ---"]
+
+    problems: list[str] = []
+    for index in range(1, closing):
+        match = MAPPING_LINE_RE.match(lines[index])
+        if match is None:
+            continue
+        value = match.group("value").strip()
+        quote = value[:1]
+        # `quote and` matters: "" is a substring of every string, so an empty
+        # value (a key introducing a block sequence) would take the quoted path.
+        if quote and quote in "'\"" and not (len(value) > 1 and value.endswith(quote)):
+            if not _closes_on_a_continuation_line(lines, index + 1, closing, quote):
+                problems.append(
+                    f"{match.group('key')}: quoted value is never closed: {value[:60]}"
+                )
+            continue
+        problem = _scalar_problem(value)
+        if problem is not None:
+            problems.append(f"{match.group('key')}: {problem}")
+    return problems
+
+
+def section_problems(text: str) -> list[str]:
+    """Find owned sections that never close.
+
+    A stray ``:END`` without a BEGIN is deliberately not reported: the real
+    parser ignores it, and flagging it would fail nine files on dev that every
+    reader handles fine.
+
+    Args:
+        text: Full task-file source.
+
+    Returns:
+        list[str]: One reason per unterminated section, in reading order.
+    """
+    open_names: list[str] = []
+    for line in text.split("\n"):
+        begin = SECTION_BEGIN_RE.match(line)
+        if begin is not None:
+            open_names.append(begin.group("name"))
+            continue
+        end = SECTION_END_RE.match(line)
+        if end is not None and end.group("name") in open_names:
+            open_names.remove(end.group("name"))
+    return [f"SECTION:{name}:BEGIN is never closed" for name in open_names]
+
+
+def unreadable_task_files(*task_dirs: Path) -> dict[str, list[str]]:
+    """Collect the task files no backlog reader can parse.
+
+    Args:
+        *task_dirs: Directories of ``task-<id> - <Title>.md`` files. One that
+            does not exist is skipped, so a project without ``completed/`` or
+            ``archive/tasks/`` is not an error.
+
+    Returns:
+        dict[str, list[str]]: Labeled path -> every reason that file is
+            unreadable. Empty when every file parses.
+    """
+    unreadable: dict[str, list[str]] = {}
+    for task_dir in task_dirs:
+        if not task_dir.is_dir():
+            continue
+        for path in sorted(task_dir.glob("task-*.md")):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as error:
+                # A file that is not valid UTF-8 is exactly what this checker
+                # exists to name. Letting UnicodeDecodeError escape would fail
+                # the required check with a traceback and hide which file it was.
+                unreadable[_label(path)] = [str(error)]
+                continue
+            problems = frontmatter_problems(text) + section_problems(text)
+            if problems:
+                unreadable[_label(path)] = problems
+    return unreadable
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Fail when any task file cannot be read by the backlog tooling.
+
+    Args:
+        argv: Command-line arguments, or None to read ``sys.argv``.
+
+    Returns:
+        int: ``0`` when every task file parses, ``1`` otherwise (with
+            ``::error::`` annotations naming each file and its problems).
+    """
+    # NOTE (Qodo, "Unvalidated --tasks-dir used"): deliberately NOT routed
+    # through Utils/path_validation.py, for the same three reasons recorded in
+    # check_backlog_task_ids.py, where this finding was first declined on
+    # PR #1947:
+    #   1. path_validation.py imports Metrics.metrics_logger -> psutil. These
+    #      checkers are stdlib-only and install-free by design; derived-
+    #      artifacts.yml installs nothing.
+    #   2. Neither workflow passes --tasks-dir; both invoke the script bare, so
+    #      there is no CI-reachable externally-controlled input and no privilege
+    #      boundary for a traversal to cross.
+    #   3. --tasks-dir is intentionally usable outside the repo, which is how
+    #      Tests/Architecture/test_derived_artifact_checkers.py exercises it
+    #      with a pytest tmp_path.
+    # Every operation here (glob, read_text) is read-only.
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        action="append",
+        dest="tasks_dirs",
+        help="directory of backlog task files; repeatable. Defaults to every bucket.",
+    )
+    args = parser.parse_args(argv)
+
+    task_dirs = tuple(args.tasks_dirs) if args.tasks_dirs else TASK_DIRS
+    if not any(task_dir.is_dir() for task_dir in task_dirs):
+        print(f"::error::no backlog task directory at {', '.join(str(d) for d in task_dirs)}")
+        return 1
+
+    unreadable = unreadable_task_files(*task_dirs)
+    if unreadable:
+        print("::error::Backlog task files that no reader can parse:")
+        for label in sorted(unreadable):
+            print(f"--- {label} ---")
+            for problem in unreadable[label]:
+                print(f"  {problem}")
+        print(RESOLUTION, file=sys.stderr)
+        return 1
+
+    scanned = [task_dir for task_dir in task_dirs if task_dir.is_dir()]
+    total = sum(1 for task_dir in scanned for _ in task_dir.glob("task-*.md"))
+    print(
+        f"All {total} task files in {', '.join(_label(d) for d in scanned)} are readable "
+        "(frontmatter + owned-section markers)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

The duplicate-id guard stops two files claiming one id. **Nothing stops a task
file becoming unparsable**, and that failure is silent: every reader —
`task list`, the board, search, the MCP read tools — skips it with one log line
and the task stops existing.

32 files had accumulated that way before #1954 repaired them. Nothing prevents
the next one; the same agents and hand edits that produced these are still
writing task files daily.

## What it checks

`scripts/check_backlog_task_files.py`, stdlib-only because these workflows
install nothing (per `derived-artifacts.yml`'s own note). Only shapes with
evidence behind them:

| rule | files it would have caught |
|---|---|
| frontmatter opens on line 1 and closes | — |
| a plain scalar must not contain `": "` | 28 |
| a quoted scalar must close (across wrapped continuation lines) with interior quotes escaped | 3 |
| an owned `SECTION:BEGIN` must be closed | 1 |

Deliberately **not** a YAML parser. PyYAML is a project dependency but is not
installed in the required check, and a partial re-implementation would fail
differently from the real readers. Anything subtler is left to `backlog-py
doctor`, which uses the actual parser.

## Validated in both directions

```
current dev (2496 files):    exit 0 — all readable
the 32 pre-#1954 files:      32 of 32 caught
```

Getting to zero false positives took three iterations, and each one is now a
test:

- a **wrapped quoted title** (`title: 'Fix …: … thumb\n  fold stripes'`) is legal
  YAML and was reported as unterminated;
- `labels:` introducing a block sequence tripped `"" in "'\""` — the empty string
  is a substring of everything — and flagged 80 files;
- a stray `SECTION:X:END` with no BEGIN is **ignored by the real parser**, and
  nine files on dev carry one, so it is not reported.

## Wiring

Added to `derived-artifacts.yml` (the required check) and `backlog-guard.yml`,
next to the id guard, with `backlog/**` path triggers already widened by #1957.
`Tests/CI/test_derived_artifacts_workflow.py`'s checker inventory updated.

Local run of all six derived-artifact checkers on this branch: **all exit 0**.
Tests: 84 pass across the two affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail CI when a backlog task file is unreadable so tasks no longer disappear silently. Previously readers skipped files with broken frontmatter or unterminated sections; now the required `derived-artifacts.yml` check and `backlog-guard.yml` job fail with diagnostics.

- Add stdlib-only `scripts/check_backlog_task_files.py` and run it in `derived-artifacts.yml` and `backlog-guard.yml` across `backlog/tasks`, `backlog/completed`, and `backlog/archive/tasks`.
- Validate only proven failure shapes: frontmatter opens on line 1 and closes; unquoted scalars don't contain ": "; quoted scalars close across wrapped lines with escaped interior quotes; block-sequence items don't start with a YAML reserved character (caught three files with unquoted `- @zcode`, now quoted); owned SECTION:BEGIN closes; ignore stray :END. Also report non-UTF-8 files without stack traces.
- Update tests in `Tests/Architecture/test_derived_artifact_checkers.py` and checker inventory in `Tests/CI/test_derived_artifacts_workflow.py`.
- Required action on failure: run `backlog-py doctor --fix` (`backlog-md-py` >= 2.0.2) or quote the title by hand.

<sup>Written for commit 206e75adf985aff846df9f27c0e600f37a05c83d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

