### PR TITLE
fix(ci): stop the required Derived Artifacts gate from cancelling its own PR runs (TASK-21250)

### DIFF
--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -31,17 +31,30 @@ on:
 # buys nothing here, because the job is ~90 s: just run it. If you are tempted
 # to add `paths:` below, you are about to brick merges -- don't.
 
-# One run per workflow per ref: a new push supersedes the previous run instead of
-# queueing another alongside it. Without this, every push to `dev` stacked a full
-# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
-# The event name is part of the group so different trigger types (push,
-# pull_request, schedule) never cancel each other, and `main` is never cancelled
-# so its history stays complete. Cancellation is safe for a required check: a
-# merge is gated on the HEAD commit's checks, and the newest run is the one that
-# reports for HEAD.
+# One run per workflow per ref for PUSH events: a new push to `dev` supersedes
+# the previous run instead of queueing another alongside it. Without this, every
+# push to `dev` stacked a full run - 50+ obsolete runs accumulated, all competing
+# for scarce macOS runners. The event name is part of the group so different
+# trigger types never cancel each other, and `main` is never cancelled so its
+# history stays complete.
+#
+# TASK-21250: pull_request runs are deliberately NOT cancelled. The original rule
+# reasoned that cancelling is safe because "the newest run is the one that reports
+# for HEAD" - true, but it assumed the newest run gets to FINISH. For a
+# pull_request event `github.ref` is `refs/pull/N/merge`, and GitHub recreates
+# that merge ref every time the BASE branch moves. On a repo absorbing 23-50
+# merges/day, every open PR's gate was therefore cancelled repeatedly without
+# anyone touching the PR, and because queue time for the shared pool runs
+# 4-59 minutes (vs ~33 s of actual work), the newest run rarely survived long
+# enough to report. Measured over 60 consecutive runs before this change:
+# 45 cancelled / 14 success / 1 failure - a 23% success rate for a REQUIRED
+# check, i.e. merges to `dev` were blocked at random for everyone.
+#
+# The cost of not cancelling is a few redundant ~90 s ubuntu runs on a
+# rapidly-updated PR. That is the cheaper failure mode by a wide margin.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/backlog/tasks/task-21250 - The required Derived Artifacts gate cancels itself and blocks merges at random.md
+++ b/backlog/tasks/task-21250 - The required Derived Artifacts gate cancels itself and blocks merges at random.md
@@ -1,0 +1,76 @@
+---
+id: TASK-21250
+title: >-
+  The required Derived Artifacts gate cancels itself and blocks merges at random
+status: Done
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - ci
+  - process
+  - dev-red
+priority: high
+dependencies: []
+---
+
+## Description
+
+TASK-19572 introduced `Derived Artifacts` as one small, stdlib-only, ~33-second job so that
+the repo would finally have a required status check that *always reports* — replacing a
+comprehensive suite that had produced no verdict since 2026-06-26. Branch protection now
+requires exactly that one context.
+
+It is not reporting. Measured over 60 consecutive runs on 2026-08-23:
+**45 cancelled / 14 success / 1 failure — a 23% success rate.** Cancellations hit every
+branch, including other contributors' work and direct pushes to `dev`, so merges to `dev`
+are blocked at random for everyone.
+
+Root cause is the workflow's own concurrency rule:
+
+```yaml
+group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+```
+
+The rule's stated justification is sound as far as it goes — "a merge is gated on the HEAD
+commit's checks, and the newest run is the one that reports for HEAD" — but it assumes the
+newest run gets to **finish**. For a `pull_request` event `github.ref` is
+`refs/pull/N/merge`, and GitHub recreates that merge ref whenever the **base** branch moves.
+On a repo absorbing 23–50 merges/day, every open PR's gate is therefore cancelled repeatedly
+without anyone touching the PR. Because queue time on the shared pool measured 4–59 minutes
+against ~33 s of actual work, the newest run rarely survives long enough to report.
+
+Observed directly while landing the 2026-08-22 perf burn-down: three PRs sat unmergeable
+through repeated reruns and rebases, each fresh run cancelled within ~2 minutes, while the
+same workflow succeeded on a quiet branch.
+
+## Acceptance Criteria
+
+- [x] `pull_request` runs of the Derived Artifacts workflow are not cancelled by base-branch
+      movement, so an open PR's required check reaches a conclusion without intervention
+- [x] Push-event cancellation on `dev` is preserved, so the 50-obsolete-run pileup the rule
+      was written to prevent does not return
+- [x] `main` continues never to cancel, keeping its history complete
+- [x] The reasoning and the measured evidence are recorded in the workflow itself, so the
+      next person to tune concurrency sees why pull_request is exempt
+
+## Implementation Notes
+
+One-line change to the concurrency condition:
+
+```yaml
+cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+```
+
+`push` to `dev` still supersedes (the original pileup fix); `push` to `main` still never
+cancels; `pull_request` now always runs to completion.
+
+The trade-off is explicit: a rapidly-updated PR may stack a few redundant ~90-second ubuntu
+runs. That is far cheaper than a required check that blocks every merge 77% of the time, and
+it is the shape 19572 was reaching for — "small enough to run on every PR, which is what
+makes it usable as a REQUIRED status check".
+
+The workflow comment carries the 45/14/1 measurement and the merge-ref mechanism so the
+justification travels with the code.
+
+Modified: `.github/workflows/derived-artifacts.yml`.


### PR DESCRIPTION
## The problem

`Derived Artifacts` is the single context branch protection requires. It is not reporting.

Measured over 60 consecutive runs today: **45 cancelled / 14 success / 1 failure — a 23% success rate.** Cancellations hit every branch, including other contributors' work and direct pushes to `dev`, so **merges to `dev` are currently blocked at random for everyone**.

## Root cause

The workflow's own concurrency rule:

```yaml
group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Its stated justification — *"a merge is gated on the HEAD commit's checks, and the newest run is the one that reports for HEAD"* — is correct as far as it goes, but it assumes the newest run gets to **finish**.

For a `pull_request` event `github.ref` is `refs/pull/N/merge`, and GitHub recreates that merge ref **whenever the base branch moves**. With `dev` absorbing 23–50 merges/day, every open PR's gate is cancelled repeatedly *without anyone touching the PR*. Queue time on the shared pool measured **4–59 minutes** against ~33 s of actual work, so the newest run rarely survives long enough to report.

Observed directly while landing the 2026-08-22 perf burn-down: three PRs sat unmergeable through repeated reruns and rebases, each fresh run cancelled within ~2 minutes, while the same workflow succeeded on a quiet branch.

## The change

```yaml
cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
```

- `push` to `dev` still supersedes — the 50-obsolete-run pileup the rule was written to prevent does not come back.
- `push` to `main` still never cancels.
- `pull_request` now always runs to completion.

The trade-off is explicit and cheap: a rapidly-updated PR may stack a few redundant ~90-second ubuntu runs. That is far better than a required check that blocks merges 77% of the time — and it is the shape TASK-19572 was reaching for: *"small enough to run on every PR, which is what makes it usable as a REQUIRED status check."*

The measurement and the merge-ref mechanism are recorded in the workflow comment so the justification travels with the code.

This PR's own gate run is the first test of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the `Derived Artifacts` required check from cancelling its own PR runs by limiting cancellation to push events. Before: any non-`main` ref cancelled in-progress runs (including `pull_request`) when the base moved; now PR runs complete, pushes to `dev` still supersede, and pushes to `main` never cancel. Addresses TASK-21250.

- Sets `cancel-in-progress` to `${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}`; concurrency group unchanged; adds inline rationale in the workflow.
- Side effect: fast-updating PRs may run a few redundant ~90 s jobs; no rollout or config changes needed.

<sup>Written for commit 1659097e58f97cbff16040bfc961495b368c862a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

