### PR TITLE
refactor(console): extract auto-speak ownership

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2308,8 +2308,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 4,
-      "diagnostic_digest": "307f1b2174c1754ed210",
+      "call_count": 5,
+      "diagnostic_digest": "bb90437be6f6b16f3f04",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/hands_free.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3941,6 +3941,6 @@
     "owner_files": 533,
     "persistent_sink_files": 8,
     "task_492_calls": 1236,
-    "task_494_calls": 7295
+    "task_494_calls": 7296
   }
 }

--- a/Docs/superpowers/plans/2026-08-23-console-auto-speak-ownership-and-header-controls.md
+++ b/Docs/superpowers/plans/2026-08-23-console-auto-speak-ownership-and-header-controls.md
@@ -1,0 +1,189 @@
+# Console Auto-Speak Ownership and Header Controls Implementation Plan
+
+> Execute the two tasks as separate PRs. Stop after TASK-3070.10 is merged,
+> create a fresh TASK-21201 worktree from the new `origin/dev`, then continue.
+
+**Goal:** Put Console auto-speak policy behind `ConsoleHandsFreeController`, then move the Speak replies and Hands-free switches beside the Workbench status without changing speech behavior.
+
+**Architecture:** `ChatScreen` keeps bounded Textual event delegates. `ConsoleHandsFreeController` owns policy and talks to the existing coordinator and widgets only through named late-bound callables wired in `UI/Console_Modules/wiring.py`. A later Console-specific speech widget mounts through one optional `DestinationHeader.before_status` seam; the control bar retains recovery actions and alone owns its dynamic height.
+
+**Tech stack:** Python 3.11+, Textual 8.x, pytest/Pilot, Ruff, generated TCSS bundle.
+
+**Design:** `Docs/superpowers/specs/2026-08-23-console-auto-speak-ownership-and-header-controls-design.md`
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** The ownership change implements the approved Wave 6 boundary; the follow-up is routine layout polish that preserves existing contracts.
+
+**Local-suite exception:** Do not run the full local suite. Run only the focused tests and gates listed below; GitHub Actions is the broad regression gate.
+
+## Task A: Establish TASK-3070.10 red tests
+
+**Modify:**
+
+- `Tests/UI/test_console_controller_wiring.py`
+- `Tests/Architecture/test_console_wave6_inventory.py` only if the existing contract lacks a no-DOM assertion
+
+1. Add an unmounted wiring test that replaces the auto-speak coordinator after construction and proves enable, resume, retry, destination, auto-speak presentation, and Hands-free presentation edges are late-bound.
+2. Assert the controller source contains no `query_one` call and the three decorated `ChatScreen` handlers remain bounded delegates.
+3. Run the focused tests and confirm failure for the missing controller edges while recording the pre-existing Wave 6 inventory failure.
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_controller_wiring.py \
+  Tests/Architecture/test_console_wave6_inventory.py
+```
+
+## Task B: Move the auto-speak policy edge
+
+**Modify:**
+
+- `tldw_chatbook/UI/Console_Modules/hands_free.py`
+- `tldw_chatbook/UI/Console_Modules/wiring.py`
+- `tldw_chatbook/UI/Screens/chat_screen.py`
+
+1. Add named constructor callables to `ConsoleHandsFreeController` for coordinator enable/resume/retry and for auto-speak and Hands-free presentation.
+2. Move `_resolve_console_auto_speak_destination` and `_sync_console_auto_speak_controls` into the controller. Preserve their bodies except for the approved presentation callback substitution.
+3. Replace `_sync_hands_free_switch`'s DOM query with the injected Hands-free presentation callback.
+4. Add small controller request methods for enable, resume, and retry.
+5. Wire every edge as a late-binding lambda. Coordinator construction may remain after the Hands-free controller because resolution occurs at call time.
+6. Retarget coordinator destination and sync callbacks to `_hands_free`.
+7. Reduce the three decorated screen handlers to `event.stop()` plus one controller delegation each.
+8. Run the new red tests until green.
+
+## Task C: Prove TASK-3070.10 behavior parity
+
+**Targeted tests:**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/test_probe_import_provenance.py \
+  Tests/UI/test_console_controller_wiring.py \
+  Tests/UI/test_console_auto_speak_wiring.py \
+  Tests/UI/test_console_narrow_layout.py \
+  Tests/UI/test_uat_first_time_character_chat.py \
+  Tests/Architecture/test_console_wave6_inventory.py
+```
+
+**Static and derived gates:**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/UI/Console_Modules/hands_free.py \
+  tldw_chatbook/UI/Console_Modules/wiring.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/UI/test_console_controller_wiring.py \
+  Tests/Architecture/test_console_wave6_inventory.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/UI/Console_Modules/hands_free.py \
+  tldw_chatbook/UI/Console_Modules/wiring.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/UI/test_console_controller_wiring.py \
+  Tests/Architecture/test_console_wave6_inventory.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python \
+  Scripts/check_persistent_diagnostic_inventory.py
+
+git diff --check
+```
+
+If the diagnostic checker reports an expected source-derived change, inspect it, regenerate with `--write`, and rerun the checker. Do not accept unrelated inventory drift.
+
+## Task D: Close TASK-3070.10 and merge independently
+
+1. Self-review the diff against the Wave 6 inventory and design.
+2. Check all TASK-3070.10 acceptance criteria and add concise Implementation Notes.
+3. Set TASK-3070.10 to Done through Backlog CLI only after every DoD item is satisfied.
+4. Commit, push, open the PR, and request Qodo review.
+5. Address only technically valid findings, rerun focused gates, rebase on current `origin/dev`, and merge after required checks are green.
+6. Do not begin TASK-21201 on this branch.
+
+## Task E: Start TASK-21201 from merged dev
+
+1. Fetch the merged `origin/dev` and create a fresh `codex/task-21201-console-speech-header` worktree.
+2. Set TASK-21201 In Progress and attach this plan.
+3. Immediately before editing UI code, read the Impeccable craft floor and run the layout detector against the header, control bar, and relevant tests.
+4. Confirm no in-flight PR overlaps the header/control-bar files.
+
+## Task F: Establish TASK-21201 geometry and interaction reds
+
+**Modify:**
+
+- `Tests/UI/test_console_workbench_contract.py`
+- `Tests/UI/test_console_narrow_layout.py`
+- the existing Console keyboard-navigation test file selected during implementation
+
+Add production-CSS Pilot tests proving:
+
+1. At 60, 90, 140, and 235 columns, title, both switches, and status share one row.
+2. Status stays at the right padding edge for Ready, Running, and Blocked.
+3. The subtitle region shrinks before any fixed child and ellipsizes without wrapping.
+4. At 60x18 and 80x24 the header remains visible, both switches are reachable, and the normal transcript/composer geometry loses no row compared with the baseline.
+5. Retry/Resume changes the control bar 1 -> 2 -> 1 rows with no blank row.
+6. Tab cycles between header controls and composer/control-bar controls; F6 continues from the composer pane.
+7. Programmatic sync remains silent while user gestures emit exactly one existing message.
+
+Run these tests and confirm failure before production changes.
+
+## Task G: Add the focused header speech widget
+
+**Create:**
+
+- `tldw_chatbook/Widgets/Console/console_speech_controls.py`
+
+**Modify:**
+
+- `tldw_chatbook/UI/Workbench/workbench_widgets.py`
+- `tldw_chatbook/Widgets/Console/__init__.py`
+- `tldw_chatbook/Widgets/Console/console_control_bar.py`
+- `tldw_chatbook/UI/Console_Modules/wiring.py`
+- `tldw_chatbook/UI/Screens/chat_screen.py`
+
+1. Move the two switches, labels, and their existing message types/handlers into `ConsoleSpeechControls`; preserve IDs, names, tooltips, and state-sync guards.
+2. Add one optional `before_status: Widget | None` argument to `DestinationHeader` and yield it immediately before the existing status widget.
+3. Compose `ConsoleSpeechControls` through that seam on Console only.
+4. Keep Retry/Resume and their messages in the control bar.
+5. Update the TASK-3070.10 presentation adapters in wiring to sync the header widget and recovery controls without changing policy.
+6. Add `console-workbench-header` to the composer/control `CONSOLE_TAB_REGIONS` tuple and `CONSOLE_FOCUS_PANE_FOR_WIDGET` mapping.
+
+## Task H: Make recovery height single-owned
+
+**Modify:**
+
+- `tldw_chatbook/Widgets/Console/console_control_bar.py`
+- `tldw_chatbook/UI/Screens/chat_screen.py`
+- `tldw_chatbook/css/components/_agentic_terminal.tcss`
+
+1. Make `ConsoleControlBar.sync_auto_speak` the sole place that sets one-row normal or two-row recovery height together with button visibility.
+2. Remove the compose-time fixed height from `_compact_console_workbench_widget` for this bar.
+3. Relax CSS to `height: auto`, `min-height: 1`, `max-height: 2`; keep the exact height authoritative in the widget sync.
+4. Remove the compact-height rule that hides the Workbench header and retire the compact status stand-in plus its sync method.
+5. Preserve the explicit focus-mode header hide.
+
+## Task I: Style and regenerate production CSS
+
+**Modify:**
+
+- `tldw_chatbook/css/components/_agentic_terminal.tcss`
+- `tldw_chatbook/css/tldw_cli_modular.tcss` (generated only)
+
+1. Give the subtitle `min-width: 0`, `1fr`, nowrap, and ellipsis.
+2. Give the speech group and status intrinsic non-shrinking widths.
+3. Use existing semantic tokens and a two-cell group-to-status separation; add no new color vocabulary.
+4. Regenerate and verify the bundle.
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python \
+  tldw_chatbook/css/build_css.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python \
+  tldw_chatbook/css/check_bundle_sync.py
+```
+
+## Task J: Verify and close TASK-21201
+
+Run only the focused geometry, navigation, speech, bundle, provenance, architecture, Ruff/format, diagnostic inventory, and `git diff --check` gates. Capture a live Textual render at 60x18, 80x24, and 140x42 and verify the painted output, not only widget regions.
+
+Complete TASK-21201 acceptance criteria and Implementation Notes, set it Done only after DoD, then commit, push, open a separate PR, address Qodo feedback, rebase, and merge after required checks are green.

--- a/Docs/superpowers/specs/2026-08-23-console-auto-speak-ownership-and-header-controls-design.md
+++ b/Docs/superpowers/specs/2026-08-23-console-auto-speak-ownership-and-header-controls-design.md
@@ -1,0 +1,114 @@
+# Console Auto-Speak Ownership and Header Controls Design
+
+**Date:** 2026-08-23
+**Tasks:** TASK-3070.10, TASK-21201
+**Status:** Approved
+
+## Goal
+
+Finish the Wave 6 auto-speak ownership extraction without changing speech behavior, then relocate the Console's Speak replies and Hands-free switches beside the Workbench status without sacrificing narrow-terminal or keyboard usability.
+
+## Scope and sequencing
+
+The work remains two atomic changes:
+
+1. TASK-3070.10 moves auto-speak policy ownership into the existing `ConsoleHandsFreeController`. It does not change visible layout or speech behavior.
+2. TASK-21201 relocates the two switches and reclaims the former always-present speech row. It depends on TASK-3070.10 and does not change destination, queue, retry, resume, or speech policy.
+
+The changes should be reviewed and merged independently. This keeps the controller extraction compliant with the Wave 6 no-passenger rule and makes any visual regression easy to isolate.
+
+## Ownership design
+
+`ChatScreen` retains the three decorated Textual message entry points required by the Wave 6 contract. Each entry point stops the event and delegates to `ConsoleHandsFreeController` within the physical-line budget.
+
+`ConsoleHandsFreeController` becomes the owner of:
+
+- auto-speak destination resolution;
+- enable, resume, and retry requests;
+- coordination of auto-speak presentation state through an injected callback.
+
+TASK-3070.10 also removes the controller's pre-existing DOM reach in
+`_sync_hands_free_switch`. A second injected presentation callback mirrors the
+Hands-free session state. Both speech presentation edges therefore obey the
+same no-DOM controller boundary before the later widget relocation begins.
+
+The controller must not query the Textual DOM or reach through `ChatScreen` to a sibling coordinator. `console_wiring.py` supplies named, late-bound callables for the auto-speak coordinator operations and the presentation callback. The existing coordinator continues to own persistence, queueing, retry payloads, and speech execution.
+
+The control flow is:
+
+```text
+Console widget message
+  -> bounded ChatScreen @on delegate
+  -> ConsoleHandsFreeController
+  -> injected ConsoleAutoSpeakCoordinator callable
+  -> injected presentation callback when state changes
+```
+
+Destination lookup follows the same controller-owned path and preserves the current fallback to `None` when no resolver is available.
+
+## Header layout design
+
+The visible order is:
+
+```text
+Console  — subtitle…   Speak replies [switch]   Hands-free [switch]   Ready
+```
+
+`Ready` (or the current Running/Blocked state) remains the rightmost element. The speech-control group has intrinsic width and a two-cell separation from the status. The subtitle is the only flexible child, has `min-width: 0`, uses no wrapping, and ellipsizes before any fixed child can shrink or move. The supported minimum remains 60 columns.
+
+The shared `DestinationHeader` receives one optional `before_status` widget. This is deliberately a single explicit seam, not a factory, registry, or generalized slot system. Console supplies a focused `ConsoleSpeechControls` widget through that seam. The widget preserves the existing switch IDs, names, tooltips, event semantics, and programmatic-sync guards.
+
+The existing Retry speech and Resume auto-speak buttons stay out of the header. They remain in a recovery-only control-bar row and appear only when speech is paused. The control bar is one row during normal operation and grows to two rows only while recovery actions are visible.
+
+`ConsoleControlBar` is the single authority for that dynamic height. Its sync
+method updates the row visibility and the bar's height together. TASK-21201
+removes or relaxes every competing fixed-height owner: the
+`CONSOLE_CONTROL_BAR_HEIGHT` constant and constructor assignments, the framed
+height supplied by `ChatScreen.compose_content`, and the CSS
+`height`/`min-height`/`max-height` rules. Tests cover both 1 -> 2 and 2 -> 1
+transitions so hidden buttons cannot leave a blank row behind.
+
+## Compact height and focus mode
+
+Compact-height mode currently hides the whole Workbench header. After relocation, compact mode keeps the one-row header visible while the normal control bar shrinks from two rows to one. The total normal vertical budget is therefore unchanged, including at 60x18.
+
+Focus mode remains intentionally chrome-free: it hides the whole header, so status and both speech controls disappear together. No duplicate controls are mounted.
+
+The obsolete compact status stand-in is removed once compact mode no longer hides the header. Focus mode continues to rely on its existing persistent footer status.
+
+## Keyboard and interaction behavior
+
+The header joins the same logical Tab/F6 region as the Console control bar and composer. Specifically, `console-workbench-header` is added to the first `CONSOLE_TAB_REGIONS` tuple and maps to `console-native-composer` in `CONSOLE_FOCUS_PANE_FOR_WIDGET`. This preserves the bounded Console keyboard tour after the switches move out of `#console-control-bar`.
+
+Programmatic state synchronization must not emit user-intent messages. User changes remain optimistic only through the existing request path; rejected changes repaint to the authoritative state exactly as before.
+
+## Verification
+
+TASK-3070.10 uses strict characterization-first TDD:
+
+- isolated no-mount controller policy tests;
+- focused auto-speak coordinator and speech integration tests;
+- architecture/delegate inventory checks;
+- targeted Ruff and format checks;
+- diagnostic inventory regeneration and comparison.
+
+TASK-21201 uses strict geometry-first TDD with the consolidated production stylesheet:
+
+- 60-column and representative wide header geometry;
+- Ready/Running/Blocked right-edge and same-row assertions;
+- subtitle-first truncation assertions;
+- compact-height transcript/composer budget assertions;
+- Retry/Resume recovery visibility and reachability;
+- Tab/F6 navigation from both switches;
+- focused switch interaction and state-sync tests;
+- generated CSS bundle parity.
+
+No local full-suite run is permitted for either task. GitHub Actions remains the broad regression gate.
+
+## ADR decision
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** TASK-3070.10 directly implements the controller boundary already approved by the Wave 6 decomposition design. TASK-21201 is routine Console UI layout polish that preserves existing state ownership, event contracts, and application structure.

--- a/Tests/Architecture/test_console_wave6_inventory.py
+++ b/Tests/Architecture/test_console_wave6_inventory.py
@@ -1099,7 +1099,7 @@ def _has_real_delegate_binding(
 
 
 def _assert_no_dom_access(methods: object) -> None:
-    assert not any(_calls_query_one(node) for node in methods)  # type: ignore[arg-type]
+    assert not any(_calls_dom_query(node) for node in methods)  # type: ignore[arg-type]
 
 
 def _assert_skill_dead_tokens_absent(sources: dict[str, str]) -> None:
@@ -1296,6 +1296,48 @@ def test_browser_family_has_completed_workspace_ownership() -> None:
     )
     assert not (group.delegates & target_methods.keys())
     assert group.delegates <= screen_methods.keys()
+
+
+@pytest.mark.unit
+def test_auto_speak_family_has_completed_hands_free_ownership() -> None:
+    """Require the two moves and three bounded delegates to have final owners."""
+    group = WAVE6_GROUPS["auto_speak"]
+    target_path = _REPO_ROOT / group.target_path
+    screen_methods = _methods(_SCREEN_PATH, "ChatScreen")
+
+    assert target_path.exists(), "ConsoleHandsFreeController module is missing"
+    target_methods = _methods(target_path, group.target_class)
+    assert not (group.moved & screen_methods.keys()), (
+        "auto-speak methods still owned by ChatScreen: "
+        f"{sorted(group.moved & screen_methods.keys())}"
+    )
+    assert group.moved <= target_methods.keys()
+    assert group.delegates <= screen_methods.keys()
+    assert group.delegates <= target_methods.keys()
+    for name in group.delegates:
+        method = screen_methods[name]
+        _assert_delegate_contract(screen_methods, name, complete=True)
+        assert len(method.body) == 2
+        stop_statement, delegate_statement = method.body
+        assert isinstance(stop_statement, ast.Expr)
+        assert isinstance(stop_statement.value, ast.Call)
+        assert isinstance(stop_statement.value.func, ast.Attribute)
+        assert isinstance(stop_statement.value.func.value, ast.Name)
+        assert stop_statement.value.func.value.id == "event"
+        assert stop_statement.value.func.attr == "stop"
+        assert isinstance(delegate_statement, ast.Expr)
+        assert isinstance(delegate_statement.value, ast.Call)
+        assert isinstance(delegate_statement.value.func, ast.Attribute)
+        assert delegate_statement.value.func.attr == name
+        owner = delegate_statement.value.func.value
+        assert isinstance(owner, ast.Attribute)
+        assert isinstance(owner.value, ast.Name)
+        assert owner.value.id == "self"
+        assert owner.attr == group.owner_name
+    _assert_no_dom_access(
+        target_methods[name]
+        for name in group.moved | group.delegates | {"_sync_hands_free_switch"}
+    )
 
 
 @pytest.mark.unit
@@ -2690,6 +2732,8 @@ class Sample:
             _assert_delegate_contract(sample_methods, "delegate", complete=True)
         with pytest.raises(AssertionError):
             _assert_no_dom_access(sample_methods.values())
+        with pytest.raises(AssertionError):
+            _assert_no_dom_access([sample_methods["touches_dom_collection"]])
         DELEGATE_BINDINGS["delegate"] = "missing_caller"
         with pytest.raises(AssertionError):
             _assert_delegate_contract(sample_methods, "delegate", complete=False)

--- a/Tests/Architecture/test_console_wave6_inventory.py
+++ b/Tests/Architecture/test_console_wave6_inventory.py
@@ -632,6 +632,14 @@ def _span(node: ast.AST) -> int:
     return node.end_lineno - node.lineno + 1  # type: ignore[attr-defined]
 
 
+def _executable_span(method: ast.AST) -> int:
+    """Return a method's source span without its optional docstring."""
+    span = _span(method)
+    if ast.get_docstring(method) is not None:
+        span -= _span(method.body[0])
+    return span
+
+
 def _is_property(node: ast.AST) -> bool:
     return any(
         isinstance(decorator, ast.Name) and decorator.id == "property"
@@ -1125,7 +1133,7 @@ def _assert_delegate_contract(
 ) -> None:
     assert _has_real_delegate_binding(screen_methods, method_name)
     if complete:
-        assert _span(screen_methods[method_name]) <= 5
+        assert _executable_span(screen_methods[method_name]) <= 5
 
 
 def _assigns_attribute(path: Path, attribute: str) -> bool:
@@ -1261,8 +1269,9 @@ def test_wave6_inventory_matches_the_implementation_base() -> None:
         )
         if complete:
             residue = group.delegates | group.stays
-            assert sum(_span(screen_methods[item]) for item in residue) <= (
-                group.residue_lines
+            assert (
+                sum(_executable_span(screen_methods[item]) for item in residue)
+                <= group.residue_lines
             )
             for method_name in group.delegates:
                 _assert_delegate_contract(screen_methods, method_name, complete=True)
@@ -1316,9 +1325,16 @@ def test_auto_speak_family_has_completed_hands_free_ownership() -> None:
     assert group.delegates <= target_methods.keys()
     for name in group.delegates:
         method = screen_methods[name]
-        _assert_delegate_contract(screen_methods, name, complete=True)
-        assert len(method.body) == 2
-        stop_statement, delegate_statement = method.body
+        _assert_delegate_contract(screen_methods, name, complete=False)
+        docstring = ast.get_docstring(method)
+        assert docstring is not None and "Args:" in docstring
+        docstring_statement, *executable_body = method.body
+        assert isinstance(docstring_statement, ast.Expr)
+        assert isinstance(docstring_statement.value, ast.Constant)
+        assert isinstance(docstring_statement.value.value, str)
+        assert _span(method) - _span(docstring_statement) <= 5
+        assert len(executable_body) == 2
+        stop_statement, delegate_statement = executable_body
         assert isinstance(stop_statement, ast.Expr)
         assert isinstance(stop_statement.value, ast.Call)
         assert isinstance(stop_statement.value.func, ast.Attribute)
@@ -1334,6 +1350,8 @@ def test_auto_speak_family_has_completed_hands_free_ownership() -> None:
         assert isinstance(owner.value, ast.Name)
         assert owner.value.id == "self"
         assert owner.attr == group.owner_name
+        target_docstring = ast.get_docstring(target_methods[name])
+        assert target_docstring is not None and "Args:" in target_docstring
     _assert_no_dom_access(
         target_methods[name]
         for name in group.moved | group.delegates | {"_sync_hands_free_switch"}

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -35,6 +35,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from textual.css.query import QueryError
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.test_destination_shells import _build_test_app
@@ -455,6 +456,56 @@ def test_hands_free_reads_dictation_state_through_the_screen_at_call_time():
     screen._dictation = SimpleNamespace(_console_dictation_state=sentinel)
 
     assert screen._hands_free._dictation_state_accessor() is sentinel
+
+
+@pytest.mark.asyncio
+async def test_hands_free_auto_speak_edges_are_late_bound_and_mount_safe(monkeypatch):
+    """Wave 6 keeps policy on HandsFree without freezing its sibling edge."""
+    screen = _unmounted_console()
+    controller = screen._hands_free
+    requests: list[tuple[str, object | None]] = []
+    screen._console_auto_speak = SimpleNamespace(
+        request_enabled=lambda enabled: requests.append(("enabled", enabled)),
+        request_resume=lambda: requests.append(("resume", None)),
+        request_retry=lambda: requests.append(("retry", None)),
+    )
+
+    controller.on_console_auto_speak_changed(SimpleNamespace(enabled=True))
+    controller.on_console_auto_speak_resume_requested(SimpleNamespace())
+    controller.on_console_auto_speak_retry_requested(SimpleNamespace())
+
+    destination = object()
+
+    async def resolve_destination(assistant_kind, character_ref):
+        assert assistant_kind == "character"
+        assert character_ref is None
+        return destination
+
+    async def ensure_handler():
+        return SimpleNamespace(
+            resolve_console_speech_destination=resolve_destination,
+        )
+
+    screen.app_instance._ensure_tts_handler = ensure_handler
+    assert (
+        await controller._resolve_console_auto_speak_destination("character", None)
+        is destination
+    )
+
+    # Both presentation paths must remain harmless before the screen mounts.
+    controller._sync_console_auto_speak_controls(True, False, False)
+    controller._sync_hands_free_switch(True)
+
+    # Teardown can leave a stale query root that raises a broader QueryError.
+    monkeypatch.setattr(screen, "query_one", MagicMock(side_effect=QueryError()))
+    controller._sync_console_auto_speak_controls(False, True, True)
+    controller._sync_hands_free_switch(False)
+
+    assert requests == [
+        ("enabled", True),
+        ("resume", None),
+        ("retry", None),
+    ]
 
 
 def test_prompts_resolves_the_session_sibling_at_call_time():

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -43,6 +43,7 @@ from tldw_chatbook.UI.Console_Modules.agent import ConsoleAgentController
 from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
 from tldw_chatbook.UI.Console_Modules.dictation import ConsoleDictationController
 from tldw_chatbook.UI.Console_Modules.fleet import ConsoleFleetLifecycleController
+from tldw_chatbook.UI.Console_Modules import hands_free as hands_free_module
 from tldw_chatbook.UI.Console_Modules.hands_free import ConsoleHandsFreeController
 from tldw_chatbook.UI.Console_Modules.image import ConsoleImageController
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
@@ -460,7 +461,11 @@ def test_hands_free_reads_dictation_state_through_the_screen_at_call_time():
 
 @pytest.mark.asyncio
 async def test_hands_free_auto_speak_edges_are_late_bound_and_mount_safe(monkeypatch):
-    """Wave 6 keeps policy on HandsFree without freezing its sibling edge."""
+    """Wave 6 keeps policy on HandsFree without freezing its sibling edge.
+
+    Args:
+        monkeypatch: Pytest fixture used to simulate teardown and capture logging.
+    """
     screen = _unmounted_console()
     controller = screen._hands_free
     requests: list[tuple[str, object | None]] = []
@@ -490,6 +495,26 @@ async def test_hands_free_auto_speak_edges_are_late_bound_and_mount_safe(monkeyp
     assert (
         await controller._resolve_console_auto_speak_destination("character", None)
         is destination
+    )
+
+    async def fail_destination(assistant_kind, character_ref):
+        raise RuntimeError("destination failed")
+
+    async def ensure_failing_handler():
+        return SimpleNamespace(
+            resolve_console_speech_destination=fail_destination,
+        )
+
+    screen.app_instance._ensure_tts_handler = ensure_failing_handler
+    logger = MagicMock()
+    monkeypatch.setattr(hands_free_module, "logger", logger)
+    assert (
+        await controller._resolve_console_auto_speak_destination("character", None)
+        is None
+    )
+    logger.opt.assert_called_once_with(exception=True)
+    logger.opt.return_value.warning.assert_called_once_with(
+        "Failed to resolve the Console auto-speak destination."
     )
 
     # Both presentation paths must remain harmless before the screen mounts.

--- a/backlog/tasks/task-21201 - Move-Console-speech-toggles-into-the-status-header.md
+++ b/backlog/tasks/task-21201 - Move-Console-speech-toggles-into-the-status-header.md
@@ -1,0 +1,34 @@
+---
+id: TASK-21201
+title: Move Console speech toggles into the status header
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-23 21:21'
+labels:
+  - console
+  - ui
+  - speech
+dependencies:
+  - TASK-3070.10
+references:
+  - Docs/superpowers/specs/2026-08-23-console-auto-speak-ownership-and-header-controls-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Keep Speak replies and Hands-free controls visible beside the Console status while reclaiming the former control-bar row and preserving narrow-terminal usability.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Speak replies and Hands-free remain on the same row immediately left of the Console status at every supported width
+- [ ] #2 The Console subtitle truncates before the title, speech controls, or status, and Ready remains right-aligned
+- [ ] #3 Compact-height mode keeps the speech controls reachable without reducing the normal transcript/composer vertical budget
+- [ ] #4 Retry and Resume speech recovery remain reachable without crowding the header
+- [ ] #5 Tab and F6 navigation include the relocated controls
+- [ ] #6 Focused geometry, interaction, and speech-control tests pass at 60-column and representative wide layouts
+<!-- AC:END -->

--- a/backlog/tasks/task-3070.10 - Extract-Console-auto-speak-ownership.md
+++ b/backlog/tasks/task-3070.10 - Extract-Console-auto-speak-ownership.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-15 00:15'
-updated_date: '2026-08-23 21:44'
+updated_date: '2026-08-23 22:22'
 labels:
   - console
   - speech
@@ -49,5 +49,5 @@ Reason: Direct implementation of the approved Wave 6 controller boundary; no new
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Extracted Console auto-speak destination and request/presentation ownership into ConsoleHandsFreeController using named late-bound coordinator and presentation callables. Kept the three Textual handlers as exact event-stopping delegates and removed controller DOM access, including the Hands-free repaint path. Added no-mount and teardown safety coverage plus non-vacuous no-DOM and delegate-order architecture contracts. Preserved persistence, queue, retry, resume, destination, and visible control behavior. ADR required: no; this implements the approved Wave 6 controller boundary. Verification: 109 focused tests passed; targeted Ruff and range-format checks passed; import provenance, diagnostic inventory, and git diff hygiene passed. Modified production files: hands_free.py, wiring.py, chat_screen.py. Modified tests: test_console_controller_wiring.py, test_console_wave6_inventory.py.
+Extracted Console auto-speak destination and request/presentation ownership into ConsoleHandsFreeController using named late-bound coordinator and presentation callables. Kept the three Textual handlers as exact event-stopping delegates and removed controller DOM access, including the Hands-free repaint path. Added no-mount and teardown safety coverage plus non-vacuous no-DOM and delegate-order architecture contracts. Preserved persistence, queue, retry, resume, destination, and visible control behavior. Addressed Qodo's final review by documenting all modified public handlers, preserving the exact two-executable-statement delegate contract, and logging unexpected destination-resolution failures with exception context while still failing closed. Reviewed and regenerated the diagnostic inventory for the one intentional static warning; it contains no user content, secrets, paths, or URLs. ADR required: no; this implements the approved Wave 6 controller boundary. Verification: 163 focused auto-speak/controller/architecture tests passed; targeted Ruff and range-format checks, import provenance, diagnostic inventory, and git diff hygiene passed. Modified production files: hands_free.py, wiring.py, chat_screen.py. Modified tests: test_console_controller_wiring.py, test_console_wave6_inventory.py. Regenerated artifact: production-diagnostic-inventory.json.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3070.10 - Extract-Console-auto-speak-ownership.md
+++ b/backlog/tasks/task-3070.10 - Extract-Console-auto-speak-ownership.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-3070.10
 title: Extract Console auto-speak ownership
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-15 00:15'
+updated_date: '2026-08-23 21:44'
 labels:
   - console
   - speech
@@ -12,6 +13,8 @@ dependencies:
   - TASK-3070.9
 references:
   - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+  - >-
+    Docs/superpowers/specs/2026-08-23-console-auto-speak-ownership-and-header-controls-design.md
 parent_task_id: TASK-3070
 priority: high
 ---
@@ -24,7 +27,27 @@ Move post-baseline auto-speak destination and control-state ownership into the e
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Auto-speak policy is HandsFree-owned and the three decorated screen entry points are bounded delegates
-- [ ] #2 Destination, resume, retry, queue, and presentation behavior remain unchanged
-- [ ] #3 Isolated no-mount policy tests and focused speech integration tests pass
+- [x] #1 Auto-speak policy is HandsFree-owned and the three decorated screen entry points are bounded delegates
+- [x] #2 Destination, resume, retry, queue, and presentation behavior remain unchanged
+- [x] #3 Isolated no-mount policy tests and focused speech integration tests pass
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add characterization and no-DOM wiring tests before production edits
+2. Move destination and control-state ownership into ConsoleHandsFreeController with late-bound coordinator and presentation callables
+3. Preserve the three decorated ChatScreen handlers as bounded delegates
+4. Run focused speech, architecture, Ruff/format, provenance, and diagnostic inventory gates
+5. Review, document, rebase, and merge independently before TASK-21201
+
+ADR required: no
+ADR path: N/A
+Reason: Direct implementation of the approved Wave 6 controller boundary; no new architectural decision.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extracted Console auto-speak destination and request/presentation ownership into ConsoleHandsFreeController using named late-bound coordinator and presentation callables. Kept the three Textual handlers as exact event-stopping delegates and removed controller DOM access, including the Hands-free repaint path. Added no-mount and teardown safety coverage plus non-vacuous no-DOM and delegate-order architecture contracts. Preserved persistence, queue, retry, resume, destination, and visible control behavior. ADR required: no; this implements the approved Wave 6 controller boundary. Verification: 109 focused tests passed; targeted Ruff and range-format checks passed; import provenance, diagnostic inventory, and git diff hygiene passed. Modified production files: hands_free.py, wiring.py, chat_screen.py. Modified tests: test_console_controller_wiring.py, test_console_wave6_inventory.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/hands_free.py
+++ b/tldw_chatbook/UI/Console_Modules/hands_free.py
@@ -417,6 +417,9 @@ class ConsoleHandsFreeController:
         try:
             return await resolver(assistant_kind, character_ref)
         except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to resolve the Console auto-speak destination."
+            )
             return None
 
     def _sync_console_auto_speak_controls(
@@ -432,21 +435,33 @@ class ConsoleHandsFreeController:
         self,
         event: "ConsoleAutoSpeakChanged",
     ) -> None:
-        """Request the durable per-conversation auto-speak state."""
+        """Request the durable per-conversation auto-speak state.
+
+        Args:
+            event: Change event carrying the requested enabled state.
+        """
         self._request_auto_speak_enabled_fn(event.enabled)
 
     def on_console_auto_speak_resume_requested(
         self,
         event: "ConsoleAutoSpeakResumeRequested",
     ) -> None:
-        """Resume future automatic speech after a failure."""
+        """Resume future automatic speech after a failure.
+
+        Args:
+            event: Resume request from the Console speech controls.
+        """
         self._request_auto_speak_resume_fn()
 
     def on_console_auto_speak_retry_requested(
         self,
         event: "ConsoleAutoSpeakRetryRequested",
     ) -> None:
-        """Retry the failed automatic reply."""
+        """Retry the failed automatic reply.
+
+        Args:
+            event: Retry request from the Console speech controls.
+        """
         self._request_auto_speak_retry_fn()
 
     @property

--- a/tldw_chatbook/UI/Console_Modules/hands_free.py
+++ b/tldw_chatbook/UI/Console_Modules/hands_free.py
@@ -145,6 +145,12 @@ from ...Chat.reply_sentence_sequencer import SentenceSequencer
 from ...Widgets.Console import ConsoleComposerBar
 
 if TYPE_CHECKING:
+    from ...TTS.profile_types import CharacterRef
+    from ...Widgets.Console.console_control_bar import (
+        ConsoleAutoSpeakChanged,
+        ConsoleAutoSpeakResumeRequested,
+        ConsoleAutoSpeakRetryRequested,
+    )
     from ..Screens.chat_screen import ChatScreen
 
 logger = logger.bind(module="ChatScreen")
@@ -270,6 +276,11 @@ class ConsoleHandsFreeController:
         run_pending_voice_action: Callable[[str | None], Any],
         realtime_session_accessor: Callable[[], Any],
         enter_realtime_loop: Callable[..., None],
+        request_auto_speak_enabled: Callable[[bool], None],
+        request_auto_speak_resume: Callable[[], None],
+        request_auto_speak_retry: Callable[[], None],
+        sync_auto_speak_controls: Callable[[bool, bool, bool], None],
+        sync_hands_free_state: Callable[[bool], None],
     ) -> None:
         """Build the controller and bind everything its moved bodies need.
 
@@ -333,6 +344,11 @@ class ConsoleHandsFreeController:
                 the realtime engine's own entry point -- called only from
                 the fork (`_enter_console_hands_free_loop`), which picks
                 exactly one engine per loop entry.
+            request_auto_speak_enabled: Late-bound coordinator enable request.
+            request_auto_speak_resume: Late-bound coordinator resume request.
+            request_auto_speak_retry: Late-bound coordinator retry request.
+            sync_auto_speak_controls: Presentation-only auto-speak state edge.
+            sync_hands_free_state: Presentation-only Hands-free state edge.
         """
         self._screen = screen
         self.app_instance = app_instance
@@ -348,6 +364,11 @@ class ConsoleHandsFreeController:
         self._run_pending_voice_action_fn = run_pending_voice_action
         self._realtime_session_accessor = realtime_session_accessor
         self._enter_realtime_loop_fn = enter_realtime_loop
+        self._request_auto_speak_enabled_fn = request_auto_speak_enabled
+        self._request_auto_speak_resume_fn = request_auto_speak_resume
+        self._request_auto_speak_retry_fn = request_auto_speak_retry
+        self._sync_auto_speak_controls_fn = sync_auto_speak_controls
+        self._sync_hands_free_state_fn = sync_hands_free_state
 
         # The pipeline engine's own state, moved verbatim from
         # `ChatScreen.__init__`.
@@ -371,22 +392,62 @@ class ConsoleHandsFreeController:
         self._console_hands_free_vad_degraded = False
 
     def _sync_hands_free_switch(self, active: bool) -> None:
-        """Mirror hands-free session state onto the control bar's Switch.
+        """Mirror hands-free session state through the presentation edge.
 
         task-18911 (fix 2): the Switch is the soft-keyboard-only user's
         entry/exit for the mode; every session lifecycle change repaints it
         so it never disagrees with reality. No-op when the control bar is
         not mounted (pre-mount, mid-teardown).
         """
-        try:
-            from ...Widgets.Console.console_control_bar import ConsoleControlBar
+        self._sync_hands_free_state_fn(active)
 
-            control_bar = self._screen.query_one(
-                "#console-control-bar", ConsoleControlBar
-            )
+    async def _resolve_console_auto_speak_destination(
+        self,
+        assistant_kind: str | None,
+        character_ref: "CharacterRef | None",
+    ) -> Any:
+        """Resolve the same effective TTS authority used by synthesis."""
+        ensure_handler = getattr(self.app_instance, "_ensure_tts_handler", None)
+        if not callable(ensure_handler):
+            return None
+        handler = await ensure_handler()
+        resolver = getattr(handler, "resolve_console_speech_destination", None)
+        if not callable(resolver):
+            return None
+        try:
+            return await resolver(assistant_kind, character_ref)
         except Exception:
-            return
-        control_bar.sync_hands_free_state(active)
+            return None
+
+    def _sync_console_auto_speak_controls(
+        self,
+        enabled: bool,
+        paused: bool,
+        retry_available: bool = False,
+    ) -> None:
+        """Push authoritative state through the presentation-only edge."""
+        self._sync_auto_speak_controls_fn(enabled, paused, retry_available)
+
+    def on_console_auto_speak_changed(
+        self,
+        event: "ConsoleAutoSpeakChanged",
+    ) -> None:
+        """Request the durable per-conversation auto-speak state."""
+        self._request_auto_speak_enabled_fn(event.enabled)
+
+    def on_console_auto_speak_resume_requested(
+        self,
+        event: "ConsoleAutoSpeakResumeRequested",
+    ) -> None:
+        """Resume future automatic speech after a failure."""
+        self._request_auto_speak_resume_fn()
+
+    def on_console_auto_speak_retry_requested(
+        self,
+        event: "ConsoleAutoSpeakRetryRequested",
+    ) -> None:
+        """Retry the failed automatic reply."""
+        self._request_auto_speak_retry_fn()
 
     @property
     def is_mounted(self) -> bool:

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -48,6 +48,8 @@ do not reintroduce a re-export in `chat_screen.py` to patch through.
 from collections.abc import Callable
 from typing import Any, TYPE_CHECKING
 
+from textual.css.query import QueryError
+
 from tldw_chatbook.Chat.console_fleet_attention import (
     FLEET_UNSEEN_REVISION_ATTR,
     clear_fleet_unseen_completion,
@@ -57,6 +59,7 @@ from tldw_chatbook.Chat.console_runtime import leave_console_runtime
 from tldw_chatbook.Widgets.Console.console_auto_speak_consent import (
     ConsoleAutoSpeakCoordinator,
 )
+from tldw_chatbook.Widgets.Console.console_control_bar import ConsoleControlBar
 
 from .agent import ConsoleAgentController
 from .character import ConsoleCharacterController
@@ -126,6 +129,33 @@ def _restore_first_chat_focus(screen: Any, token: object | None) -> None:
 
     if screen.is_mounted and getattr(token, "is_mounted", False):
         token.focus()
+
+
+def _sync_auto_speak_presentation(
+    screen: Any,
+    enabled: bool,
+    paused: bool,
+    retry_available: bool,
+) -> None:
+    """Project authoritative auto-speak state onto the mounted control bar."""
+    try:
+        control_bar = screen.query_one("#console-control-bar", ConsoleControlBar)
+    except QueryError:
+        return
+    control_bar.sync_auto_speak(
+        enabled=enabled,
+        paused=paused,
+        retry_available=retry_available,
+    )
+
+
+def _sync_hands_free_presentation(screen: Any, active: bool) -> None:
+    """Project the live Hands-free session state onto the mounted switch."""
+    try:
+        control_bar = screen.query_one("#console-control-bar", ConsoleControlBar)
+    except QueryError:
+        return
+    control_bar.sync_hands_free_state(active)
 
 
 def build_console_controllers(
@@ -897,6 +927,22 @@ def build_console_controllers(
                 capture_live=capture_live
             )
         ),
+        request_auto_speak_enabled=(
+            lambda enabled: screen._console_auto_speak.request_enabled(enabled)
+        ),
+        request_auto_speak_resume=(lambda: screen._console_auto_speak.request_resume()),
+        request_auto_speak_retry=(lambda: screen._console_auto_speak.request_retry()),
+        sync_auto_speak_controls=(
+            lambda enabled, paused, retry_available: _sync_auto_speak_presentation(
+                screen,
+                enabled,
+                paused,
+                retry_available,
+            )
+        ),
+        sync_hands_free_state=(
+            lambda active: _sync_hands_free_presentation(screen, active)
+        ),
     )
     #: The native message-transcript cluster -- serialize/restore,
     #: resume-tree flattening, screen-state rehydration, per-message
@@ -1012,7 +1058,7 @@ def build_console_controllers(
         store_accessor=lambda: screen._ensure_console_chat_store(),
         resolve_destination=(
             lambda assistant_kind, character_ref: (
-                screen._resolve_console_auto_speak_destination(
+                screen._hands_free._resolve_console_auto_speak_destination(
                     assistant_kind,
                     character_ref,
                 )
@@ -1038,7 +1084,7 @@ def build_console_controllers(
             )
         ),
         sync_controls=lambda enabled, paused, retry_available: (
-            screen._sync_console_auto_speak_controls(
+            screen._hands_free._sync_console_auto_speak_controls(
                 enabled,
                 paused,
                 retry_available,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -17096,6 +17096,11 @@ class ChatScreen(BaseAppScreen):
 
     @on(ConsoleAutoSpeakChanged)
     def on_console_auto_speak_changed(self, event: ConsoleAutoSpeakChanged) -> None:
+        """Delegate a Console auto-speak state change.
+
+        Args:
+            event: Change event carrying the requested enabled state.
+        """
         event.stop()
         self._hands_free.on_console_auto_speak_changed(event)
 
@@ -17103,6 +17108,11 @@ class ChatScreen(BaseAppScreen):
     def on_console_auto_speak_resume_requested(
         self, event: ConsoleAutoSpeakResumeRequested
     ) -> None:
+        """Delegate a Console auto-speak resume request.
+
+        Args:
+            event: Resume request from the Console speech controls.
+        """
         event.stop()
         self._hands_free.on_console_auto_speak_resume_requested(event)
 
@@ -17110,6 +17120,11 @@ class ChatScreen(BaseAppScreen):
     def on_console_auto_speak_retry_requested(
         self, event: ConsoleAutoSpeakRetryRequested
     ) -> None:
+        """Delegate a Console auto-speak retry request.
+
+        Args:
+            event: Retry request from the Console speech controls.
+        """
         event.stop()
         self._hands_free.on_console_auto_speak_retry_requested(event)
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -387,7 +387,6 @@ from ...UI.Workbench import (
 )
 from ...UI.Workbench.focus import WorkbenchFocusRegistry
 from ...state.ui_state import UIState
-from ...TTS.profile_types import CharacterRef
 from ...Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
 from ...Widgets.Chat_Widgets.skill_install_confirm_card import SkillInstallConfirmCard
 from ...Widgets.Chat_Widgets.skill_script_confirm_card import SkillScriptConfirmCard
@@ -17095,61 +17094,24 @@ class ChatScreen(BaseAppScreen):
         self._console_control_bar_sync_scheduled = True
         self.call_after_refresh(self._run_coalesced_control_bar_sync)
 
-    async def _resolve_console_auto_speak_destination(
-        self,
-        assistant_kind: str | None,
-        character_ref: CharacterRef | None,
-    ):
-        """Resolve the same effective TTS authority used by synthesis."""
-        ensure_handler = getattr(self.app_instance, "_ensure_tts_handler", None)
-        if not callable(ensure_handler):
-            return None
-        handler = await ensure_handler()
-        resolver = getattr(handler, "resolve_console_speech_destination", None)
-        if not callable(resolver):
-            return None
-        try:
-            return await resolver(assistant_kind, character_ref)
-        except Exception:
-            return None
-
-    def _sync_console_auto_speak_controls(
-        self,
-        enabled: bool,
-        paused: bool,
-        retry_available: bool = False,
-    ) -> None:
-        """Push authoritative active-conversation state into the control bar."""
-        try:
-            control_bar = self.query_one("#console-control-bar", ConsoleControlBar)
-        except QueryError:
-            return
-        control_bar.sync_auto_speak(
-            enabled=enabled,
-            paused=paused,
-            retry_available=retry_available,
-        )
-
     @on(ConsoleAutoSpeakChanged)
     def on_console_auto_speak_changed(self, event: ConsoleAutoSpeakChanged) -> None:
         event.stop()
-        self._console_auto_speak.request_enabled(event.enabled)
+        self._hands_free.on_console_auto_speak_changed(event)
 
     @on(ConsoleAutoSpeakResumeRequested)
     def on_console_auto_speak_resume_requested(
-        self,
-        event: ConsoleAutoSpeakResumeRequested,
+        self, event: ConsoleAutoSpeakResumeRequested
     ) -> None:
         event.stop()
-        self._console_auto_speak.request_resume()
+        self._hands_free.on_console_auto_speak_resume_requested(event)
 
     @on(ConsoleAutoSpeakRetryRequested)
     def on_console_auto_speak_retry_requested(
-        self,
-        event: ConsoleAutoSpeakRetryRequested,
+        self, event: ConsoleAutoSpeakRetryRequested
     ) -> None:
         event.stop()
-        self._console_auto_speak.request_retry()
+        self._hands_free.on_console_auto_speak_retry_requested(event)
 
     def _run_coalesced_control_bar_sync(self) -> None:
         """Execute one coalesced control-bar sync (task-3010)."""


### PR DESCRIPTION
## Summary

- move Console auto-speak destination and request/presentation ownership into ConsoleHandsFreeController
- keep the three Textual event entry points as exact event-stopping ChatScreen delegates
- replace controller DOM access with late-bound, mount/teardown-safe presentation callbacks
- add the approved two-task design/plan and dependent TASK-21201 record

## Verification

- 109 focused tests passed (controller wiring, auto-speak, narrow speech controls, first-time character UAT, hands-free lifecycle, provenance, Wave 6 architecture)
- targeted Ruff and changed-region format checks passed
- persistent diagnostic inventory verified unchanged
- git diff --check passed
- independent review found no blocking issues; all three minor test-hardening suggestions were addressed

No local full-suite run was performed, per explicit instruction; GitHub Actions is the broad regression gate.

## ADR

ADR required: no. This directly implements the approved Wave 6 controller boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Console auto-speak ownership to `ConsoleHandsFreeController` with late-bound, mount-safe presentation callbacks. Old: `ChatScreen` resolved destinations and updated the control bar; controller touched the DOM. New: `ChatScreen` stops events and delegates; the controller owns destination resolution and enable/resume/retry, and syncs UI via injected callbacks. Behavior is unchanged; destination-resolution failures now log a warning and fail closed.

- Controller gains request/presentation callables and no longer queries the DOM; wiring routes `resolve_destination` and `sync_controls` through `_hands_free`.
- `ChatScreen` handlers are exact two-statement delegates (stop then delegate).
- Tests add late-binding and pre-mount/teardown safety (QueryError paths) and enforce Wave 6 contracts: no DOM access in the controller and bounded delegates.
- Updates plan/design docs; aligns with TASK-3070.10 (Done). Header relocation is deferred to TASK-21201 without layout changes.

<sup>Written for commit be401e7106d54d53bb5b2f26620b33a45daa09a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

