### PR TITLE
Build test apps as returning Library users — recovers 130 of 143 failing UI nodes (TASK-21280)

### DIFF
--- a/Tests/UI/app_factory.py
+++ b/Tests/UI/app_factory.py
@@ -167,6 +167,7 @@ def _build_test_app(
     configured_default: str | None = None,
     *,
     first_run_setup_completed: bool = True,
+    preserve_profile_admission: bool = False,
     config_overrides: Mapping[str, Any] | None = None,
 ) -> TldwCli:
     """Build a TldwCli instance with every real I/O seam faked out.
@@ -178,6 +179,24 @@ def _build_test_app(
             this app's snapshot only -- see `build_test_app_config`, and
             prefer `save_setting_to_cli_config` for anything a refreshing
             seam must also see.
+        preserve_profile_admission: Defaults to False, which clears
+            ``library_new_profile_admission``. `app.py` sets that flag from
+            `first_profile_created_this_session()`, and the per-test config
+            sandbox creates a profile for every test -- so every factory-built
+            app claimed to be a brand-new profile. The Library rail answers
+            that claim by composing a compact starter rail (two rows plus
+            "Explore all tools") and returning before the search input, the
+            Browse/Create sections and the Details disclosure, which made
+            rows like ``#library-row-browse-media`` unreachable for the many
+            tests written before progressive disclosure existed.
+            Three Library test modules had already hand-rolled exactly this
+            clearing in local `_build_test_app` wrappers; this hoists it to
+            the one factory they all go through. Cleared rather than pinning
+            a lifecycle value, so the screen still derives its own state --
+            an existing profile with no persisted lifecycle settles to
+            Expanded, which is the product's own contract (see
+            `test_library_real_existing_config_without_lifecycle_defaults_expanded`).
+            Pass ``True`` for a test that is *about* new-profile admission.
         first_run_setup_completed: Defaults to True: task-11 added a
             first-run setup wizard that FirstRunSetupWizard.first_run_setup_state.
             should_offer_wizard() auto-offers (pushed on top of whatever the
@@ -350,4 +369,9 @@ def _build_test_app(
         # shipping app must use). A test that wants generation assigns its
         # own fake callable.
         app.library_rag_answer_chat = None
+        # See `preserve_profile_admission` above: the config sandbox creates a
+        # profile per test, so this flag is True for every factory-built app
+        # and the Library rail answers it with the compact starter rail.
+        if not preserve_profile_admission:
+            app.library_new_profile_admission = False
         return app

--- a/Tests/UI/test_library_rail_profile_admission.py
+++ b/Tests/UI/test_library_rail_profile_admission.py
@@ -50,6 +50,11 @@ BROWSE_ROWS = (
 
 
 def test_the_factory_clears_new_profile_admission() -> None:
+    """The default: a factory-built app is not a newly created profile.
+
+    This is the mechanism the other two tests depend on, asserted on its own so
+    a failure here points at the factory rather than at the rail.
+    """
     assert _build_test_app().library_new_profile_admission is False
 
 

--- a/Tests/UI/test_library_rail_profile_admission.py
+++ b/Tests/UI/test_library_rail_profile_admission.py
@@ -1,0 +1,84 @@
+"""A factory-built test app is a returning Library user, not a new profile.
+
+`app.py` sets `library_new_profile_admission` from
+`first_profile_created_this_session()`. The per-test config sandbox creates a
+profile for *every* test, so the flag was True for every app the shared factory
+built -- each one claiming to be a brand-new profile.
+
+The Library rail answers that claim correctly, with progressive disclosure: it
+composes a compact starter rail (two rows plus "Explore all tools") and returns
+before the search input, before every Browse/Create section, and before the
+Details disclosure (`Widgets/Library/library_rail.py`). Rows such as
+`#library-row-browse-media` are therefore not in the DOM at all -- which is why
+~143 Library tests written before progressive disclosure failed with
+`NoMatches ... on LibraryScreen()`.
+
+Three Library modules had already hand-rolled this same clearing in local
+`_build_test_app` wrappers. TASK-21280 hoisted it to the one factory they all
+go through. These tests pin the default, and pin that a test which is *about*
+new-profile admission can still get one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Library.library_rail_state import LibraryLifecycle
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_library_shell import (
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _active_library_screen,
+    _two_conversations,
+    _two_media_items,
+    _seed_conversations,
+    _wait_for_library_shell,
+)
+
+#: Every selector the failing cluster queried, so a future change that
+#: re-strands them names them rather than reporting one arbitrary miss.
+BROWSE_ROWS = (
+    "#library-row-browse-media",
+    "#library-row-browse-notes",
+    "#library-row-browse-conversations",
+    "#library-row-browse-collections",
+    "#library-row-browse-prompts",
+    "#library-row-browse-search",
+    "#library-search-input",
+)
+
+
+def test_the_factory_clears_new_profile_admission() -> None:
+    assert _build_test_app().library_new_profile_admission is False
+
+
+def test_a_new_profile_can_still_be_requested() -> None:
+    """The flag is what `first_profile_created_this_session()` produced, not a
+    value this factory invented, so a new-profile test must be able to keep it."""
+    app = _build_test_app(preserve_profile_admission=True)
+    assert app.library_new_profile_admission is True
+
+
+@pytest.mark.asyncio
+async def test_the_rail_composes_its_full_sections_for_a_factory_app() -> None:
+    """The behaviour the default exists for, asserted on the DOM rather than on
+    the flag -- the flag is the mechanism, this is the contract.
+
+    Note this asserts no lifecycle *value*: the factory deliberately does not
+    pin one, so the screen still derives its own. An existing profile with no
+    persisted lifecycle settling to Expanded is the product's contract, pinned
+    by `test_library_real_existing_config_without_lifecycle_defaults_expanded`.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        assert screen._library_lifecycle is not LibraryLifecycle.UNKNOWN
+        assert screen._library_lifecycle is not LibraryLifecycle.STARTER
+        missing = [sel for sel in BROWSE_ROWS if not screen.query(sel)]
+        assert not missing, f"rail did not compose: {missing}"

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -177,8 +177,17 @@ def _build_test_app(
     Forwards ``configured_default`` to the shared factory (TASK-19602: two
     call sites pass it; this local wrapper used to shadow the shared
     signature and reject it).
+
+    ``preserve_profile_admission`` is now forwarded too (TASK-21280). The
+    shared factory clears ``library_new_profile_admission`` by default, so a
+    wrapper that swallowed this flag left a new-profile test with the
+    admission still cleared underneath it -- which is how
+    ``test_library_real_config_creation_admits_fresh_profile_to_starter``
+    stopped settling to Starter.
     """
-    app = _build_tldw_test_app(configured_default)
+    app = _build_tldw_test_app(
+        configured_default, preserve_profile_admission=preserve_profile_admission
+    )
     if not preserve_profile_admission:
         app.library_new_profile_admission = False
     return app

--- a/backlog/tasks/task-21280 - Library-tests-see-the-compact-starter-rail-because-the-test-app-factory-builds-a-brand-new-profile.md
+++ b/backlog/tasks/task-21280 - Library-tests-see-the-compact-starter-rail-because-the-test-app-factory-builds-a-brand-new-profile.md
@@ -1,0 +1,124 @@
+---
+id: TASK-21280
+title: >-
+  Library tests see the compact starter rail because the test app factory builds
+  a brand-new profile
+status: Done
+assignee: []
+created_date: '2026-08-23 22:05'
+updated_date: '2026-08-23 22:57'
+labels:
+  - testing
+  - test-integrity
+  - library
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The single largest failure cluster in the UI suite. Library tests cannot find the rail
+rows they drive, failing with `NoMatches: No nodes match '#library-row-browse-*' on
+LibraryScreen()` and equivalents for the rail search input and the Details disclosure.
+
+The rail is behaving correctly. Progressive disclosure composes a compact starter rail —
+two rows and an "Explore all tools" button — for a genuinely new profile, and returns
+before composing the search input, the Browse and Create sections, and the Details
+disclosure. What is wrong is the profile the test harness presents: the shared factory
+never writes the persisted lifecycle key, so every app it builds looks brand new, and
+the many Library tests written before progressive disclosure existed address rows that
+are deliberately not composed for such a profile.
+
+This is the same class of defect the factory already solved once for the first-run setup
+wizard, and for the same reason: a test app should present a returning, already-configured
+user unless a test asks otherwise.
+
+Note for anyone searching by symptom: TASK-14800 (Done) reports the same exception on the
+same selector, but a different and genuine defect — a transient unmount during a rail
+recompose, intermittent and load-sensitive. This cluster is deterministic and reproduces
+on an idle machine. Same message, different cause.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A factory-built test app presents a Library profile whose rail composes its full Browse and Create sections, its search input and its Details disclosure
+- [x] #2 A test that wants a genuinely new profile and the starter rail can still ask for one, and the suites that exercise progressive disclosure are unaffected
+- [x] #3 The cause is established by evidence rather than inferred from the message: it is shown to be deterministic rather than a recompose race, and shown to be the disclosure branch rather than a renamed or missing widget
+- [x] #4 The recovery is measured on the exact set of nodes that were failing, not asserted from a sample
+- [x] #5 The default the fix introduces is itself guarded, including against drift between the value the factory spells and the value the product persists
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce one failing node locally and dump the rail's actual contents, to separate
+   "row is late" from "row is never composed".
+2. Read the rail composer to find what gates the missing rows.
+3. Confirm the gate by flipping it in a probe and re-listing the rail.
+4. Fix at the shared factory rather than per test file, mirroring the existing
+   `first_run_setup_completed` default.
+5. Guard the default, then measure recovery against the harvested failing-node list.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Cleared `library_new_profile_admission` in `Tests/UI/app_factory._build_test_app`, and
+forwarded the existing `preserve_profile_admission` flag from `test_library_shell.py`'s local
+wrapper, which accepted it and then dropped it.
+
+**Cause (AC#3), established rather than inferred.** `app.py:5702` sets
+`library_new_profile_admission` from `first_profile_created_this_session()`. The per-test
+config sandbox creates a profile for every test, so the flag was True for every app the
+shared factory built — each one claiming to be brand new. `Widgets/Library/library_rail.py`
+answers that claim correctly: for lifecycle `unknown`/`starter` it composes two rows plus
+"Explore all tools" and `return`s, *before* the search input, every Browse/Create section
+and the Details disclosure. That early return is why `#library-search-input` and
+`#console-rail-section-toggle-library-details` were in the same failure set as the rows.
+
+Two things were ruled out by probe rather than assumed. **Not a recompose race:** with the
+shell loaded the rail holds only `library-rail-heading`, `ingest-import-media`,
+`create-note`, `rail-explore-all`, and is byte-identical after two further seconds of
+pumping. **Not a rename or a missing widget:** clearing the admission flag yields all 15
+rows including every selector in the failing set.
+
+**Fix shape.** The first attempt pinned `library.rail_state.lifecycle = "expanded"` in the
+config. It worked, but `build_test_app_config` returns `load_settings()`'s cached dict *by
+reference*, so it mutated shared settings state, and it pinned a value the screen is meant
+to derive. Clearing the admission flag instead lets the screen derive its own: an existing
+profile with no persisted lifecycle settles to Expanded, which is the product's own
+contract, already pinned by
+`test_library_real_existing_config_without_lifecycle_defaults_expanded`. This is also not a
+new idea — `test_library_shell.py`, `test_library_file_notes_workspace.py` and
+`test_library_prompts_canvas.py` had each hand-rolled the same clearing locally. This
+hoists it to the one factory all three go through.
+
+**AC#5 note:** the stated drift risk was between a value the factory spells and the value
+the product persists. The final fix spells no lifecycle value at all, so that risk is
+dissolved by construction rather than guarded. What is guarded, in
+`Tests/UI/test_library_rail_profile_admission.py`, is the default itself, the opt-out, and
+— on the DOM rather than on the flag — that the rail composes all seven previously-stranded
+selectors.
+
+**Evidence (AC#4), measured on the exact failing set, not a sample.**
+The 143 CI nodes carrying the `NoMatches ... on LibraryScreen()` signature were harvested
+per-node from all 12 shards of run 32647831275 and committed under
+`backlog/docs/test-health-baseline-2026-08-23/ui-cluster-a-nodes.txt`.
+- Of the 138 outside `test_library_shell.py`: **130 pass (94.2%)**. The 8 remaining are
+  distinct pre-existing causes — 3 are network-egress errors correctly refused by the guard.
+- Regression check on `Tests/UI/test_library_shell.py` (the largest shared consumer, 728
+  nodes, 23 min): **12 red before, 12 red after, identical sets — zero regressions, zero
+  recoveries.** That file was never affected because it already had the local wrapper.
+- Every non-passing node in the verification run was cross-checked against the CI red list;
+  none is new.
+
+**A caution worth recording.** An earlier diff against the CI list showed "2 regressions".
+Re-running one on the pre-change baseline showed it fails there too: it is a pre-existing
+local failure that CI's list does not contain, because that run's head is `ac1aa2da5` on a
+PR branch and on Linux. Only one of the two was real, and the admission-based fix resolved
+it. **A/B against your own before-state; a CI list from another commit is not a baseline.**
+
+Added: `Tests/UI/test_library_rail_profile_admission.py`.
+Modified: `Tests/UI/app_factory.py`, `Tests/UI/test_library_shell.py`.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
> **Stacked on #2030.** Base is `fix/test-suite-phase0-baseline`; retarget to `dev` once
> that merges. The diff here is one factory change, one wrapper fix, and one guard test.

The largest single failure cluster in the UI suite — **143 nodes** failing with `NoMatches`
on `#library-row-browse-*`, on `#library-search-input`, and on the Details disclosure toggle.

## The rail is right; the harness was lying to it

`app.py` sets `library_new_profile_admission` from `first_profile_created_this_session()`.
The per-test config sandbox creates a profile for *every* test, so the flag was True for
every app the shared factory built — each one claiming to be brand new.

`Widgets/Library/library_rail.py` answers that claim correctly, with progressive disclosure:
for lifecycle `unknown`/`starter` it composes two rows plus "Explore all tools" and
`return`s — before the search input, before every Browse/Create section, and before the
Details disclosure. Those three groups are exactly the failing selectors, and that early
return is why they fail together.

Two alternatives were ruled out by probe rather than assumed:

- **Not a recompose race.** With the shell loaded, the rail holds only
  `library-rail-heading`, `ingest-import-media`, `create-note`, `rail-explore-all` — and is
  byte-identical after two further seconds of pumping.
- **Not a rename or a missing widget.** Clearing the admission flag yields all 15 rows,
  including every selector in the failing set.

## Why clear the flag rather than pin a lifecycle

An earlier attempt set `library.rail_state.lifecycle = "expanded"`. It worked, but
`build_test_app_config` returns `load_settings()`'s cached dict **by reference**, so it
mutated shared settings state — and it pinned a value the screen is supposed to derive.
Clearing the flag lets the screen derive its own: an existing profile with no persisted
lifecycle settles to Expanded, which is the product's own contract, already pinned by
`test_library_real_existing_config_without_lifecycle_defaults_expanded`.

It is also not a new idea. `test_library_shell.py`, `test_library_file_notes_workspace.py`
and `test_library_prompts_canvas.py` had each hand-rolled exactly this clearing in a local
`_build_test_app` wrapper. This hoists it to the one factory all three go through.
`test_library_shell.py`'s wrapper accepted `preserve_profile_admission` and then dropped it,
leaving a new-profile test with the admission cleared underneath it — now forwarded.

## Measured on the exact failing set, not a sample

The 143 nodes were harvested per-node from all 12 shards of run 32647831275 and are
committed in #2030 as `ui-cluster-a-nodes.txt`.

- **130 of 138 targeted nodes pass (94.2%).** The 8 remaining are distinct pre-existing
  causes; 3 are egress errors the network guard correctly refuses.
- **Regression A/B on `Tests/UI/test_library_shell.py`** — the largest shared consumer,
  728 nodes, 23 minutes each side: **12 red before, 12 red after, identical sets. Zero
  regressions.** That file was never affected, because it already had the local wrapper.
- Every non-passing node in the verification run was cross-checked against the CI red list;
  none is new.

One caution recorded in the task: an earlier diff against the CI list showed "2 regressions".
Re-running one against the pre-change baseline showed it fails there too — a pre-existing
local failure absent from CI's list, because that run's head is `ac1aa2da5` on a PR branch
and on Linux. Only one was real, and the admission-based fix resolved it. **A CI list from
another commit is not a baseline.**

## Not TASK-14800

TASK-14800 (Done) reports the same exception on the same selector, but is a genuine
intermittent recompose race — load-sensitive, and fixed. This one is deterministic on an
idle machine.

Test-only; no product code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds UI test apps as returning Library users by default so the Library rail composes full browse/search/details. Previously every factory app looked new; `_build_test_app` now clears `library_new_profile_admission` unless a test opts in.

- Adds `preserve_profile_admission` to `Tests/UI/app_factory._build_test_app`; clears `library_new_profile_admission` when False.
- Forwards this flag from `Tests/UI/test_library_shell._build_test_app`, restoring correct behavior for new-profile tests that expect the Starter rail.
- Adds `Tests/UI/test_library_rail_profile_admission.py` to pin the default and the opt-in; asserts full rail composition on the DOM.
- Recovers 130/138 targeted nodes; no regressions in `Tests/UI/test_library_shell.py`. Test-only; no product code changes.
- Linear TASK-21280: factory apps must compose the full rail by default. Tests needing the Starter rail must pass `preserve_profile_admission=True`.

<sup>Written for commit 90414c5917596fbbd43febe10f4bf11f2f43040b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

