### PR TITLE
Wire a fleet controller into bare ChatScreen shells — recovers 115 tests (TASK-21381)

### DIFF
--- a/Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py
+++ b/Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py
@@ -1,0 +1,146 @@
+"""A bypassed-``__init__`` ChatScreen shell that sets its store must wire ``_fleet``.
+
+`ChatScreen.__init__` installs `_fleet` via
+`Console_Modules/wiring.build_console_controllers`, so a
+`ChatScreen.__new__(ChatScreen)` shell never has one. That stays invisible until
+the shell touches a seam that reaches it — and one of the most ordinary lines a
+Console test writes does. `screen._console_chat_store = store` is a property
+whose setter calls `self._console_runtime().set_chat_store(...)`, which builds
+the chat controller's kwargs, which reads
+`self._fleet._console_wake_user_priority`.
+
+The result is a test that dies while being *set up*, with an `AttributeError`
+naming an attribute the test file never mentions. TASK-21381 found 115 of them
+across 8 files, and the count only grew because each new bare-screen helper was
+written by copying one that already worked — before production grew the
+dependency.
+
+This guard is the ratchet: a new shell that assigns the store without wiring a
+fleet controller fails here, naming its own function, rather than 20 tests
+failing later on an unrelated-looking attribute.
+
+There are two ways to satisfy this. Wire a fleet controller with
+`Tests/UI/console_controller_stubs.stub_fleet_controller`, whose raiser defaults
+keep the shell fail-loud at any seam it has not wired; or hand the shell its own
+`_console_runtime_ref`, which `_console_runtime()` returns verbatim so the
+kwargs build never happens. The guard accepts either, because the invariant is
+"do not let the store setter build a runtime this shell cannot satisfy", not
+"call this one helper".
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parents[1]
+
+#: Functions allowed to build a store-setting shell without a fleet controller.
+#: Shrink-only: an entry may be removed when its function is fixed, never added.
+#: Empty on purpose — every known case was repaired in TASK-21381.
+ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _is_chat_screen_new(node: ast.AST) -> bool:
+    """``ChatScreen.__new__(...)``, however the module spells the attribute."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "__new__"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "ChatScreen"
+    )
+
+
+def _sets_console_chat_store(node: ast.AST) -> bool:
+    targets: list[ast.expr] = []
+    if isinstance(node, ast.Assign):
+        targets = list(node.targets)
+    elif isinstance(node, ast.AnnAssign):
+        targets = [node.target]
+    return any(
+        isinstance(t, ast.Attribute) and t.attr == "_console_chat_store"
+        for t in targets
+    )
+
+
+def _supplies_own_runtime(node: ast.AST) -> bool:
+    """``screen._console_runtime_ref = ...`` — the other way to be safe.
+
+    `_console_runtime()` returns a pre-set `_console_runtime_ref` verbatim and
+    only calls `ensure_console_runtime` when it finds none. A shell that
+    supplies its own runtime therefore never reaches the kwargs build, so it
+    needs no fleet controller at all. `Tests/UI/test_console_native_chat_flow.py`
+    does exactly this, and it is arguably the cleaner of the two fixes.
+    """
+    targets: list[ast.expr] = []
+    if isinstance(node, ast.Assign):
+        targets = list(node.targets)
+    elif isinstance(node, ast.AnnAssign):
+        targets = [node.target]
+    return any(
+        isinstance(t, ast.Attribute) and t.attr == "_console_runtime_ref"
+        for t in targets
+    )
+
+
+def _calls_fleet_stub(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return name == "stub_fleet_controller"
+
+
+def _offending_functions(tree: ast.AST, rel: str) -> list[str]:
+    out: list[str] = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = list(ast.walk(fn))
+        if not any(_is_chat_screen_new(n) for n in body):
+            continue
+        if not any(_sets_console_chat_store(n) for n in body):
+            continue
+        if any(_calls_fleet_stub(n) or _supplies_own_runtime(n) for n in body):
+            continue
+        out.append(f"{rel}::{fn.name}")
+    return out
+
+
+def test_no_bare_chat_screen_shell_sets_its_store_without_a_fleet_controller() -> None:
+    offenders: list[str] = []
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        # Cheap reject before paying for a parse: both spellings must appear.
+        if "ChatScreen.__new__" not in text or "_console_chat_store" not in text:
+            continue
+        rel = path.relative_to(TESTS_ROOT.parent).as_posix()
+        offenders.extend(_offending_functions(ast.parse(text), rel))
+
+    new = sorted(set(offenders) - ALLOWLIST)
+    assert not new, (
+        "These functions build a ChatScreen shell with __new__ and assign "
+        "_console_chat_store without wiring a fleet controller. The assignment "
+        "is a property whose setter reaches _fleet._console_wake_user_priority, "
+        "so the shell will die during setup with an AttributeError that names "
+        "neither this function nor the behaviour under test. Either call "
+        "Tests.UI.console_controller_stubs.stub_fleet_controller(screen) before "
+        "the assignment, or give the shell its own _console_runtime_ref.\n  " + "\n  ".join(new)
+    )
+
+
+def test_the_allowlist_does_not_name_a_function_that_is_already_clean() -> None:
+    """A ratchet that keeps stale entries stops ratcheting. Anything listed must
+    still be a real violation, or the list is hiding nothing and should shrink."""
+    if not ALLOWLIST:
+        return
+    live: set[str] = set()
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "ChatScreen.__new__" not in text or "_console_chat_store" not in text:
+            continue
+        rel = path.relative_to(TESTS_ROOT.parent).as_posix()
+        live.update(_offending_functions(ast.parse(text), rel))
+    stale = sorted(ALLOWLIST - live)
+    assert not stale, f"allowlist entries no longer violate; remove them: {stale}"

--- a/Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py
+++ b/Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py
@@ -109,6 +109,18 @@ def _offending_functions(tree: ast.AST, rel: str) -> list[str]:
 
 
 def test_no_bare_chat_screen_shell_sets_its_store_without_a_fleet_controller() -> None:
+    """Fail on any shell that assigns the store without satisfying the runtime.
+
+    Scans every test module that mentions both spellings, and reports the
+    offending functions by name rather than the first one found -- a sweep that
+    stops at one violation makes a multi-file regression take as many rounds to
+    clear as it has files.
+
+    Raises:
+        AssertionError: If any function outside `ALLOWLIST` builds a shell with
+            `ChatScreen.__new__` and assigns `_console_chat_store` without
+            either wiring a fleet controller or supplying `_console_runtime_ref`.
+    """
     offenders: list[str] = []
     for path in sorted(TESTS_ROOT.rglob("*.py")):
         text = path.read_text(encoding="utf-8", errors="replace")
@@ -131,8 +143,17 @@ def test_no_bare_chat_screen_shell_sets_its_store_without_a_fleet_controller() -
 
 
 def test_the_allowlist_does_not_name_a_function_that_is_already_clean() -> None:
-    """A ratchet that keeps stale entries stops ratcheting. Anything listed must
-    still be a real violation, or the list is hiding nothing and should shrink."""
+    """Refuse allowlist entries that no longer describe a violation.
+
+    A ratchet that keeps stale entries stops ratcheting: the list grows a
+    reputation for being noise, and the next real entry is waved through with
+    it. Anything listed must still be a genuine violation, or the list should
+    shrink.
+
+    Raises:
+        AssertionError: If an `ALLOWLIST` entry names a function that no longer
+            violates the rule.
+    """
     if not ALLOWLIST:
         return
     live: set[str] = set()

--- a/Tests/Chat/test_console_attachment_riders.py
+++ b/Tests/Chat/test_console_attachment_riders.py
@@ -167,6 +167,7 @@ class TestSaveImageToastEscaping:
     def _screen_with_message(tmp_path, monkeypatch, attachment_count=1):
         from tldw_chatbook.UI.Console_Modules import message as message_module
         from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
+        from Tests.UI.console_controller_stubs import stub_fleet_controller
         from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
         markup_dir = tmp_path / "sav[e]dir"
@@ -198,6 +199,10 @@ class TestSaveImageToastEscaping:
         )
         notices: list[str] = []
         screen = ChatScreen.__new__(ChatScreen)
+        # The `_console_chat_store` setter reaches
+        # `_console_runtime().set_chat_store`, which reads
+        # `self._fleet._console_wake_user_priority` (TASK-21381).
+        stub_fleet_controller(screen, context="attachment riders bare screen")
         screen._console_chat_store = store
         screen._ensure_console_chat_store = lambda: store
         screen.app_instance = SimpleNamespace(

--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -49,6 +49,7 @@ from tldw_chatbook.UI.Console_Modules.image import ConsoleImageController
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from Tests.UI.console_controller_stubs import stub_fleet_controller
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 
@@ -129,6 +130,13 @@ def _bare_generation_screen(store: ConsoleChatStore) -> ChatScreen:
     silently-wrong no-op.
     """
     screen = ChatScreen.__new__(ChatScreen)
+    # Must precede the `_console_chat_store` assignment below: that is a
+    # property whose setter reaches `_console_runtime().set_chat_store`, which
+    # builds the chat controller's kwargs, which reads
+    # `self._fleet._console_wake_user_priority`. Without a fleet controller the
+    # shell dies during SETUP with an AttributeError naming an attribute this
+    # file never mentions (TASK-21381).
+    stub_fleet_controller(screen, context="_bare_generation_screen")
     screen._console_chat_store = store
     screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._session._chat_store_accessor = lambda: screen._console_chat_store

--- a/Tests/Chat/test_console_video_actions.py
+++ b/Tests/Chat/test_console_video_actions.py
@@ -16,6 +16,7 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage, ConsoleMe
 from tldw_chatbook.Chat.console_message_actions import ConsoleMessageActionService
 from tldw_chatbook.UI.Console_Modules import video as video_controller_module
 from tldw_chatbook.UI.Console_Modules.wiring import build_console_controllers
+from Tests.UI.console_controller_stubs import stub_fleet_controller
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Video_Generation.video_metadata import VideoGenerationMetadata
 from tldw_chatbook.Video_Generation.video_store import VideoStore
@@ -74,6 +75,10 @@ def _video_action_screen(tmp_path, *, container="mp4"):
         notify=lambda *args, **kwargs: notifications.append((args, kwargs)),
         push_screen=pushed.append,
     )
+    # Precedes the `_console_chat_store` assignment: that setter reaches
+    # `_console_runtime().set_chat_store`, which reads
+    # `self._fleet._console_wake_user_priority` (TASK-21381).
+    stub_fleet_controller(screen, context="video actions bare screen")
     screen._console_chat_store = store
     screen._ensure_console_chat_store = lambda: store
     screen._sync_native_console_chat_ui = AsyncMock()

--- a/Tests/UI/console_controller_stubs.py
+++ b/Tests/UI/console_controller_stubs.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from tldw_chatbook.UI.Console_Modules.fleet import ConsoleFleetLifecycleController
 from tldw_chatbook.UI.Console_Modules.image import ConsoleImageController
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 
@@ -66,6 +67,47 @@ IMAGE_CONTROLLER_CALLABLES = (
     "request_console_control_bar_sync",
     "default_console_session_settings",
     "clear_console_composer_draft",
+)
+
+#: Every keyword-only dependency of
+#: ``ConsoleFleetLifecycleController.__init__``. Unlike the two controllers
+#: above it takes no positional ``screen``: it reaches the screen only through
+#: these callables, so a shell can hold one without the controller holding the
+#: shell back.
+FLEET_CONTROLLER_CALLABLES = (
+    "pending_handoffs_accessor",
+    "ensure_chat_store",
+    "ensure_chat_controller",
+    "activate_workspace_for_session",
+    "switch_chat_session",
+    "schedule_native_console_sync",
+    "ensure_agent_bridge",
+    "wire_wake_coordinator",
+    "seed_wake_from_marks",
+    "retry_wake_soon",
+    "wake_has_pending",
+    "wake_delivering_conversation_id",
+    "displayed_composer_draft_accessor",
+    "screen_displayed_accessor",
+    "screen_mounted_accessor",
+    "active_session_id_accessor",
+    "chat_sessions_accessor",
+    "defer_on_message_pump",
+    "start_transcript_sync_timer",
+    "transcript_sync_timer_active",
+    "sync_native_console_ui",
+    "create_interval",
+    "record_timer_created",
+    "record_timer_stopped",
+    "chat_controller_available",
+    "fleet_has_unsettled_children",
+    "run_marker_for_session",
+    "fleet_teardown_split",
+    "leave_runtime",
+    "stage_teardown_notices",
+    "fleet_unseen_revision_accessor",
+    "read_fleet_unseen_ids",
+    "clear_fleet_unseen",
 )
 
 
@@ -183,4 +225,61 @@ def stub_image_controller(
         },
     )
     screen._image = controller
+    return controller
+
+
+def stub_fleet_controller(
+    screen: Any,
+    *,
+    context: str = "stub_fleet_controller",
+    **wired: Any,
+) -> ConsoleFleetLifecycleController:
+    """Attach a ``ConsoleFleetLifecycleController`` to a bare ``ChatScreen`` shell.
+
+    ``ChatScreen.__init__`` installs ``_fleet`` through
+    ``Console_Modules/wiring.build_console_controllers``, so a
+    ``ChatScreen.__new__(ChatScreen)`` shell never gets one. That is only
+    invisible until a shell touches a seam that reaches it -- and one of the
+    most ordinary lines a Console test writes does:
+    ``screen._console_chat_store = store`` is a property whose setter calls
+    ``self._console_runtime().set_chat_store(...)``, which builds the chat
+    controller's kwargs, which reads
+    ``self._fleet._console_wake_user_priority``. So the shell dies while being
+    *set up*, before the scenario under test has begun, with an
+    ``AttributeError`` naming an attribute the test never mentions.
+
+    Attaching a real controller wired to raisers is what makes that legible:
+    the ten ``_fleet.<x>`` members ``chat_screen.py`` reads are all real
+    methods, so merely *referencing* them succeeds, and a test that actually
+    invokes an unwired seam fails at that seam by name instead of at setup.
+
+    Args:
+        screen: The ``ChatScreen.__new__(ChatScreen)`` shell. Gets its
+            ``_fleet`` attribute set as a side effect.
+        context: Label used in the failure message of unwired callables, so a
+            fail-loud trip names the fixture it came from.
+        **wired: Any subset of ``FLEET_CONTROLLER_CALLABLES``, wired for real.
+            Everything omitted raises ``AssertionError`` when called.
+
+    Returns:
+        The controller, already assigned to ``screen._fleet``.
+
+    Raises:
+        TypeError: If ``wired`` names something that is not a constructor
+            callable -- a typo would otherwise silently leave that seam
+            raising.
+    """
+    unknown = set(wired) - set(FLEET_CONTROLLER_CALLABLES)
+    if unknown:
+        raise TypeError(
+            f"stub_fleet_controller got unknown callable(s) {sorted(unknown)}; "
+            f"expected a subset of {list(FLEET_CONTROLLER_CALLABLES)}"
+        )
+
+    kwargs = {
+        name: wired.get(name, _raiser(name, context))
+        for name in FLEET_CONTROLLER_CALLABLES
+    }
+    controller = ConsoleFleetLifecycleController(**kwargs)
+    screen._fleet = controller
     return controller

--- a/Tests/UI/test_console_citation_sources.py
+++ b/Tests/UI/test_console_citation_sources.py
@@ -69,6 +69,7 @@ from tldw_chatbook.Constants import (
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
 )
 from Tests.UI.console_controller_stubs import (
+    stub_fleet_controller,
     stub_image_controller,
     stub_message_controller,
 )
@@ -474,6 +475,11 @@ def _bare_screen(
     app_db: object | None = None,
 ) -> ChatScreen:
     screen = ChatScreen.__new__(ChatScreen)
+    # Precedes the `_console_chat_store` assignment on purpose: that setter
+    # reaches `_console_runtime().set_chat_store`, which reads
+    # `self._fleet._console_wake_user_priority` while building the chat
+    # controller's kwargs (TASK-21381).
+    stub_fleet_controller(screen, context="_bare_screen")
     screen._console_chat_store = _FakeStore(messages)
     screen._console_citation_counts = {}
     screen._console_annotation_previews = {}
@@ -1309,6 +1315,11 @@ def _citation_harness(
     )
     screen = ChatScreen.__new__(ChatScreen)
     Screen.__init__(screen)
+    # Precedes the `_console_chat_store` assignment on purpose: that setter
+    # reaches `_console_runtime().set_chat_store`, which reads
+    # `self._fleet._console_wake_user_priority` while building the chat
+    # controller's kwargs (TASK-21381).
+    stub_fleet_controller(screen, context="citation harness screen")
     screen._console_chat_store = _FakeStore([message])
     screen._console_citation_counts = {"assistant-1": 2}
     screen._console_citation_request_generation = 1

--- a/Tests/UI/test_console_composer_menu.py
+++ b/Tests/UI/test_console_composer_menu.py
@@ -232,6 +232,7 @@ def test_caption_entry_requires_an_IMAGE_attachment():
 @pytest.mark.unit
 def test_attachment_kind_reads_the_staged_records():
     """The screen classifies real staged attachments, not the chip label."""
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     class _A:
@@ -291,6 +292,7 @@ def test_impersonate_appends_then_replaces_its_own_text():
     appended on a new line after existing text, and a second suggestion
     replaces the first rather than stacking.
     """
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     class _Composer:
@@ -331,6 +333,7 @@ def test_impersonate_appends_then_replaces_its_own_text():
 @pytest.mark.unit
 def test_impersonate_appends_when_the_user_edited_our_text():
     """If the user changed our suggestion, appending beats rewriting it."""
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     class _Composer:
@@ -373,6 +376,7 @@ def test_draft_addition_never_doubles_a_newline():
 
     That put inserted text after a blank line instead of on the next one.
     """
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     assert ChatScreen._draft_addition("", "x") == "x"
@@ -589,6 +593,7 @@ def test_temporary_tab_has_no_chord_but_keeps_the_palette_entry():
     and that both remaining paths (palette entry, underlying action) are
     still wired, so nobody re-adds a chord that doesn't work.
     """
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
     from tldw_chatbook.UI.console_command_provider import ConsoleCommandProvider
 
@@ -643,9 +648,14 @@ def test_console_active_session_is_ephemeral_reads_the_active_flag():
     """
     from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
     from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
+    # The `_console_chat_store` setter below reaches
+    # `_console_runtime().set_chat_store`, which reads
+    # `self._fleet._console_wake_user_priority` (TASK-21381).
+    stub_fleet_controller(screen, context="composer menu bare screen")
     screen._console_chat_store = None
     session = ConsoleSessionController.__new__(ConsoleSessionController)
     session._current_chat_store_accessor = lambda: screen._console_chat_store
@@ -954,9 +964,14 @@ def _bare_promote_screen(store):
     runs against the same fakes as before.
     """
     from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
+    # The `_console_chat_store` setter below reaches
+    # `_console_runtime().set_chat_store`, which reads
+    # `self._fleet._console_wake_user_priority` (TASK-21381).
+    stub_fleet_controller(screen, context="composer menu bare screen")
     screen._console_chat_store = store
     screen._ensure_console_chat_store = lambda: store
 
@@ -1170,6 +1185,7 @@ def test_save_chat_menu_choice_dispatches_to_the_promote_handler():
     dispatch path (F5: now a worker-kicking wrapper, not the save coroutine
     itself)."""
     from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
@@ -1187,6 +1203,7 @@ def test_save_chat_menu_choice_dispatches_to_the_promote_handler():
 @pytest.mark.unit
 def test_prompts_menu_choice_opens_exactly_one_browse_modal():
     """The existing callback dispatch owns the one modal entry point."""
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
@@ -1203,6 +1220,7 @@ def test_temporary_chip_save_requested_reaches_the_promote_handler():
     """The chip's activation message (task-7) drives the same save
     dispatch path (F5: now a worker-kicking wrapper)."""
     from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
     from tldw_chatbook.Widgets.Console.console_status_chips import (
         ConsoleTemporaryChip,
@@ -1236,6 +1254,7 @@ def test_dispatch_promote_console_temporary_session_uses_its_own_worker_group():
     cancelled by an overlapping sync kick).
     """
     from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+    from Tests.UI.console_controller_stubs import stub_fleet_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1945,6 +1945,7 @@ def _bare_console_screen_for_restore(app_instance=None) -> ChatScreen:
     """
     from Tests.UI.console_controller_stubs import (
         NO_APP,
+        stub_fleet_controller,
         stub_image_controller,
         stub_message_controller,
     )
@@ -1952,6 +1953,10 @@ def _bare_console_screen_for_restore(app_instance=None) -> ChatScreen:
     screen = ChatScreen.__new__(ChatScreen)
     screen.app_instance = app_instance
     screen._retrieval = SimpleNamespace(_capture_console_staged_rag=Mock())
+    # Precedes the `_console_chat_store` assignment: that setter reaches
+    # `_console_runtime().set_chat_store`, which reads
+    # `self._fleet._console_wake_user_priority` (TASK-21381).
+    stub_fleet_controller(screen, context="live work handoffs screen")
     screen._console_chat_store = ConsoleChatStore()
     screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._console_visible_draft_session_id = None

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -477,11 +477,19 @@ def test_source_scope_survives_a_screen_state_round_trip():
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
     from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 
-    from Tests.UI.console_controller_stubs import NO_APP, stub_message_controller
+    from Tests.UI.console_controller_stubs import (
+        NO_APP,
+        stub_fleet_controller,
+        stub_message_controller,
+    )
 
     def _bare_screen(store: ConsoleChatStore) -> ChatScreen:
         screen = ChatScreen.__new__(ChatScreen)
         screen._retrieval = Mock()
+        # Precedes the `_console_chat_store` assignment: that setter reaches
+        # `_console_runtime().set_chat_store`, which reads
+        # `self._fleet._console_wake_user_priority` (TASK-21381).
+        stub_fleet_controller(screen, context="rag settings bare screen")
         screen._console_chat_store = store
         screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
         screen._console_visible_draft_session_id = None

--- a/backlog/tasks/task-21381 - Bare-ChatScreen-test-shells-die-during-setup-on-a-fleet-controller-they-never-mention.md
+++ b/backlog/tasks/task-21381 - Bare-ChatScreen-test-shells-die-during-setup-on-a-fleet-controller-they-never-mention.md
@@ -1,0 +1,121 @@
+---
+id: TASK-21381
+title: >-
+  Bare ChatScreen test shells die during setup on a fleet controller they never
+  mention
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-08-24 00:14'
+labels:
+  - testing
+  - test-integrity
+  - console
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The second-largest failure cluster across the suite, and the only one that spans both the
+UI and core halves.
+
+Many Console tests build their screen with `ChatScreen.__new__(ChatScreen)` and hand-set
+the few attributes the code under test reads, rather than mounting an app. That shell never
+runs `__init__`, so it never receives the sub-controllers the Console decomposition
+introduced — including the fleet lifecycle controller.
+
+That stays invisible until a shell touches a seam that reaches one, and one of the most
+ordinary lines such a test writes does: assigning the Console chat store is a property whose
+setter builds the chat controller's dependencies, and one of those reads through the fleet
+controller. So the shell dies while it is still being *set up*, raising an error that names
+an attribute the test file never mentions and has nothing to do with the behaviour under
+test. Every affected file was written by copying a helper that worked at the time.
+
+The repository already has the right home for the fix — a shared module of controller stubs
+whose stated preference is that new controller wiring be added there rather than hand-rolled
+per test file. It simply has no fleet entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A bypassed-`__init__` ChatScreen shell can set its Console chat store without dying on a controller the test does not mention
+- [x] #2 The shared stub is fail-loud by default in the same way its siblings are: a shell gets working behaviour only for seams its caller wired, and wandering into an unwired one names that seam
+- [x] #3 Recovery is measured as a node-level before/after on the exact affected set, and shows no test newly failing
+- [x] #4 A latent case that is not currently failing is distinguished from a safe one by evidence, not by whether it happens to be red today
+- [x] #5 The pattern cannot silently return: a guard fails on a newly-introduced instance, names the offending function, and is itself proven to fail when the pattern is reintroduced
+- [x] #6 The guard encodes the real invariant rather than one preferred call, so an equally safe alternative does not register as a violation
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce on pinned dev and confirm the seam from the traceback rather than the symptom.
+2. Check every member the screen reads through the controller is real, so a raiser-wired
+   controller satisfies references without hiding invocations.
+3. Add the stub to the shared module, deriving its parameter list from the constructor
+   signature so it cannot drift by typo.
+4. Wire it at each affected shell, before the assignment that trips the seam.
+5. Sweep for files carrying the pattern but not currently failing; verify rather than assume.
+6. Add the ratchet guard, then prove it fires.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `stub_fleet_controller` to `Tests/UI/console_controller_stubs.py` and wired it at
+every bare-shell helper that assigns the Console chat store, plus an architecture ratchet.
+
+**The seam.** `ChatScreen.__init__` installs `_fleet` through
+`Console_Modules/wiring.build_console_controllers`, so a `ChatScreen.__new__(ChatScreen)`
+shell never has one. `screen._console_chat_store = store` is a property whose setter calls
+`self._console_runtime().set_chat_store(...)`, which builds the chat controller's kwargs,
+which reads `self._fleet._console_wake_user_priority` (`chat_screen.py:5577`). The shell
+therefore dies during **setup**, with an `AttributeError` naming an attribute the test file
+never mentions.
+
+**Why a real controller rather than a mock (AC#2).** All ten `_fleet.<x>` members
+`chat_screen.py` reads are real methods on `ConsoleFleetLifecycleController`, so a
+controller constructed with raiser callables satisfies every *reference* while still failing
+loudly, by name, at any seam a test actually *invokes*. That matches the module's existing
+contract for its two sibling stubs. The 33 constructor parameters were derived from
+`inspect.signature` rather than transcribed, so the list cannot drift by typo, and unknown
+keywords raise `TypeError` rather than silently leaving a seam raising.
+
+**Evidence (AC#3), node-level A/B on pinned dev `fb0a9601e`.**
+- The ten files carrying the signature: **122 red before → 9 red after. 113 recovered,
+  0 regressions.** The 9 residuals are distinct causes — seven compositor-paint assertions
+  in the fleet panel and steering bar, one citation-caching assertion.
+- `Tests/Chat` + `Tests/Architecture` after the change: 23 red / 7,140 passed, and **none
+  of the 23 is in a file this task touched**.
+
+**AC#4 — the latent cases.** Seven further files carry `ChatScreen.__new__` *and* a store
+assignment without a stub. Rather than assume they were safe because they were green, they
+were run: six are genuinely safe, and `Tests/Chat/test_console_attachment_riders.py` was
+not — it had two failures of exactly this shape that the UI shard list did not contain.
+Fixed, 8/8 pass. Total recovery **115**.
+
+**AC#5/#6 — the ratchet.**
+`Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py` fails on any function
+that builds such a shell and assigns the store without wiring one, naming the offending
+function. Mutation-proven: with a reintroduced offender it fails and names it; with the
+offender removed it passes. Its allowlist is empty and shrink-only, and a second test
+refuses stale allowlist entries so the ratchet cannot quietly stop ratcheting.
+
+The guard's first draft was wrong in an instructive way. It flagged
+`Tests/UI/test_console_native_chat_flow.py::_bare_console_screen`, which is green — because
+it pre-assigns `screen._console_runtime_ref`, and `_console_runtime()` returns a pre-set ref
+verbatim, so the kwargs build never happens. That is an equally valid, arguably cleaner fix.
+The guard now encodes the invariant — *do not let the store setter build a runtime this
+shell cannot satisfy* — rather than mandating one helper. A guard that fires on a safe
+pattern gets allowlisted into uselessness.
+
+Added: `Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py`.
+Modified: `Tests/UI/console_controller_stubs.py`, and the shells in
+`test_console_generation_actions.py`, `test_console_citation_sources.py`,
+`test_console_composer_menu.py`, `test_console_live_work_handoffs.py`,
+`test_console_rag_settings_modal.py`, `test_console_video_actions.py`,
+`test_console_attachment_riders.py`. (`test_console_h3_image_edit.py` imports the
+generation helper, so it was fixed by that one line.)
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
The second-largest failure cluster in the suite, and the only one spanning both the UI and
core halves. **115 tests were dying during setup on an attribute their own files never
mention.** Independent of #2030/#2031 — branches off `dev` directly.

## The seam

`ChatScreen.__init__` installs `_fleet` through
`Console_Modules/wiring.build_console_controllers`, so a `ChatScreen.__new__(ChatScreen)`
shell never has one. That stays invisible until a shell touches a seam that reaches it —
and one of the most ordinary lines such a test writes does:

```
screen._console_chat_store = store          # a property, not an attribute
  -> _console_runtime().set_chat_store(...)
  -> builds the chat controller's kwargs
  -> reads self._fleet._console_wake_user_priority     # chat_screen.py:5577
```

So the shell dies while still being *set up*, with an `AttributeError` naming something
unrelated to the behaviour under test. Every affected helper was written by copying one
that worked — before production grew the dependency.

## The fix

`Tests/UI/console_controller_stubs.py` already exists for precisely this, and its docstring
asks for new controller wiring to be added there rather than hand-rolled per test file. It
simply had no fleet entry.

All ten `_fleet.<x>` members `chat_screen.py` reads are real methods, so a controller wired
to raisers satisfies every *reference* while still failing loudly, **by name**, at any seam
a test actually *invokes* — the same fail-loud contract its two siblings keep. The 33
constructor parameters are derived from `inspect.signature` rather than transcribed, so the
list cannot drift by typo, and unknown keywords raise `TypeError` instead of silently
leaving a seam raising.

## Measured, node-level, on dev `fb0a9601e`

| | before | after |
|---|---|---|
| the ten files carrying the signature | **122 red** | **9 red** |

**113 recovered, 0 regressions.** The 9 residuals are distinct causes: seven
compositor-paint assertions in the fleet panel and steering bar, one citation-caching
assertion.

Wider check — `Tests/Chat` + `Tests/Architecture` after the change: 23 red / 7,140 passed,
and **none of the 23 is in a file this PR touches**.

## The latent cases

Seven further files carry `ChatScreen.__new__` *and* a store assignment without a stub.
Rather than assume they were safe for being green, they were run. Six are;
`Tests/Chat/test_console_attachment_riders.py` was not — two failures of exactly this shape
that the UI shard list did not contain, because they live in the core half that CI has never
reported on. Total recovery **115**.

## The ratchet

`Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py` fails on any function
that builds such a shell and assigns the store without wiring one, naming the offending
function rather than letting twenty tests fail later on an unrelated-looking attribute.
Empty, shrink-only allowlist; a second test refuses stale entries so the ratchet cannot
quietly stop ratcheting. Mutation-proven both ways.

Its first draft was wrong in a way worth keeping. It flagged
`test_console_native_chat_flow.py::_bare_console_screen`, which is green — because it
pre-assigns `screen._console_runtime_ref`, and `_console_runtime()` returns a pre-set ref
verbatim, so the kwargs build never happens. That is an equally valid and arguably cleaner
fix. The guard now encodes the invariant — *do not let the store setter build a runtime this
shell cannot satisfy* — rather than mandating one helper. A guard that fires on a safe
pattern gets allowlisted into uselessness.

Test-only; no product code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops setup-time crashes in bare `ChatScreen` test shells by wiring a fleet lifecycle controller and adds a ratchet to prevent regressions. Previously, shells built with `ChatScreen.__new__` crashed when the `_console_chat_store` setter reached `_fleet`; now they use a shared stub or an explicit runtime and only fail at invoked seams.

- Adds `stub_fleet_controller(screen, ...)` in `Tests/UI/console_controller_stubs.py` and wires it before `_console_chat_store` is set. Builds a real `ConsoleFleetLifecycleController` with raiser callables; enumerates constructor callables and raises `TypeError` on unknown kwargs.
- Introduces `Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py` to fail when a shell uses `__new__` and sets `_console_chat_store` without wiring `stub_fleet_controller` or setting `_console_runtime_ref` (empty, shrink-only allowlist; docstrings clarify Raises).
- Measured: 115 tests recovered in the 10 affected files (122 red → 9 red), no regressions; remaining reds are unrelated. Test-only; no product code changes. Addresses TASK-21381.

- Migration: In new tests that construct `ChatScreen` via `__new__` and assign `_console_chat_store`, first call `stub_fleet_controller(screen)` or set `screen._console_runtime_ref`.

<sup>Written for commit 5747968ffa07e84c44d09e08d14b8b7b83481ed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

