### PR TITLE
Shard the core test job and give the summary check a verdict (TASK-21411)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,30 +42,40 @@ jobs:
     # task-1465: full coverage on every PR replaces `-m unit` (which selected
     # 27 of ~950 files while ~590 files ran in no PR-triggered job). The UI
     # shard is its own job below; OS/Python breadth lives in nightly-deep.
-    name: Core Tests (all but UI) - Python ${{ matrix.python-version }} - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    # 120, not 60: the suite grew past the old budget -- the ubuntu leg was
-    # killed by the 60-minute cap mid-run (TASK-18608) while the macOS leg
-    # finished at ~58m. 2x headroom over the observed ~60m worst leg.
+    #
+    # TASK-21411: sharded, because the 120-minute budget stopped being the
+    # question. Read from a killed run's own log: the ubuntu leg started
+    # pytest at 15:44:55 and was still emitting progress steadily -- no
+    # stall -- when the cap killed it at 17:39 having reached **60%**. So the
+    # suite needs ~190 minutes on a 4-vCPU runner, and no timeout this side
+    # of GitHub's 6-hour ceiling makes a single job a sane place to put it.
+    # Six deterministic pytest-shard slices are ~32 min each, roughly a
+    # quarter of the budget, and xdist still parallelizes within each slice.
+    #
+    # ubuntu only, on purpose. macOS runners are the scarce ones -- queue
+    # waits of 42-90 minutes are routine here -- and multiplying the scarcest
+    # pool by six would cost more in queueing than it buys in coverage. macOS
+    # breadth already lives in nightly-deep, which is where it belongs.
+    name: Core Tests (all but UI) - shard ${{ matrix.shard }}/${{ strategy.job-total }}
+    runs-on: ubuntu-latest
+    # Kept at 120 as headroom: the per-shard estimate is ~32 min, so this is
+    # ~4x margin rather than a target. A shard that approaches it is a signal
+    # to resize the matrix, not to raise the cap again.
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: "3.12"
-          - os: macos-latest
-            python-version: "3.12"
+        shard: [0, 1, 2, 3, 4, 5]
 
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.12"
         cache: 'pip'
 
     - name: Install all dependencies
@@ -86,18 +96,23 @@ jobs:
         python -c "import nltk; nltk.download('punkt_tab', quiet=True)"
 
     - name: Run core tests in parallel
+      # pytest-shard slices the collected list deterministically, so the union
+      # of the six shards is exactly the set one unsharded job would have run
+      # -- the same contract the UI job below relies on.
       run: |
         pytest Tests --ignore=Tests/UI \
           -n auto --dist loadscope --max-worker-restart=3 \
+          --shard-id=${{ matrix.shard }} --num-shards=6 \
           --timeout=300 \
           --json-report --json-report-omit log \
-          --json-report-file=core-test-results-${{ matrix.os }}-${{ matrix.python-version }}.json
+          --json-report-file=core-test-results-${{ matrix.shard }}.json
 
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: core-test-results-${{ matrix.os }}-${{ matrix.python-version }}
+        # Per-shard, so matrix siblings cannot overwrite each other's report.
+        name: core-test-results-${{ matrix.shard }}
         path: |
           core-test-results-*.json
 
@@ -432,3 +447,26 @@ jobs:
             repo: context.repo.repo,
             body: summary
           });
+
+    # TASK-21411: this job declares `needs:` and `if: always()`, which makes it
+    # RUN after those jobs whatever they did -- it never inspected what they
+    # did. On run 32647831275 it reported `success` while all twelve UI shards
+    # were red. A summary that cannot go red is not a gate, and this is the
+    # check most likely to be marked required.
+    #
+    # `always()` stays: the summary is worth publishing on failure too. The
+    # verdict is the LAST step, after the comment is posted above,
+    # so a red suite still leaves a readable PR comment behind.
+    - name: Require every gated job to have succeeded
+      if: >-
+        needs.core-tests.result != 'success' ||
+        needs.ui-tests.result != 'success' ||
+        needs.textual-minimum.result != 'success' ||
+        needs.artifact-lease-gate.result != 'success'
+      run: |
+        echo "core-tests:          ${{ needs.core-tests.result }}"
+        echo "ui-tests:            ${{ needs.ui-tests.result }}"
+        echo "textual-minimum:     ${{ needs.textual-minimum.result }}"
+        echo "artifact-lease-gate: ${{ needs.artifact-lease-gate.result }}"
+        echo "::error::A gated test job did not succeed; see the results above."
+        exit 1

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -280,8 +280,13 @@ def test_ui_job_is_sharded_to_fit_its_time_budget() -> None:
     # 12 shards numbered 0..11. A mismatch (e.g. ids 1..12 against
     # num-shards 12, or a stale id list after resizing) would silently
     # duplicate or drop a slice of the suite.
-    ids = workflow[workflow.index("shard: [") :].splitlines()[0]
-    id_values = [int(part.strip()) for part in ids[ids.index("[") + 1 : ids.rindex("]")].split(",")]
+    # Read the ids from the UI JOB, not the whole workflow. This used to
+    # search `workflow` for the first "shard: [" -- which was the UI job only
+    # because it was then the only sharded job. TASK-21411 sharded core-tests
+    # too, and core's ids were suddenly being checked against the UI job's
+    # divisor. A partition assertion that can silently start describing a
+    # different job is worse than no assertion.
+    id_values = _shard_ids(ui_job)
     divisor = int(ui_job.split("--num-shards=")[1].split()[0].rstrip("'\""))
     assert id_values == list(range(divisor)), "shard ids must be 0..N-1"
     assert divisor >= 10, (
@@ -294,6 +299,58 @@ def test_ui_job_is_sharded_to_fit_its_time_budget() -> None:
     # matrix siblings cannot overwrite each other's artifacts.
     assert "ui-test-results-${{ matrix.shard }}.json" in ui_job
     assert "name: ui-test-results-${{ matrix.shard }}" in ui_job
+
+
+def _shard_ids(job_block: str) -> list[int]:
+    """The `shard: [...]` id list declared inside one job block."""
+    line = job_block[job_block.index("shard: [") :].splitlines()[0]
+    return [
+        int(part.strip())
+        for part in line[line.index("[") + 1 : line.rindex("]")].split(",")
+    ]
+
+
+def test_core_tests_job_is_sharded_to_fit_its_time_budget() -> None:
+    """TASK-21411: one job could not finish the core suite either.
+
+    Diagnosed from a killed run's own log rather than from the outcome: the
+    ubuntu leg started pytest at 15:44:55 and was still emitting progress
+    steadily when the 120-minute cap killed it at 17:39, having reached 60%.
+    Steady progress at the kill is what separates "too slow" from "hung" --
+    the suite needs ~190 minutes on a 4-vCPU runner, so no timeout below
+    GitHub's 6-hour ceiling makes one job the right container.
+
+    The contract mirrors the UI job's: a deterministic pytest-shard split
+    covering every test exactly once, xdist still parallelizing within each
+    slice, and per-shard artifact names so matrix siblings cannot overwrite
+    each other's report.
+    """
+    core = _core_tests_job_block()
+
+    assert "--shard-id=${{ matrix.shard }}" in core
+    divisor = int(core.split("--num-shards=")[1].split()[0].rstrip("'\""))
+    assert _shard_ids(core) == list(range(divisor)), "shard ids must be 0..N-1"
+    assert divisor >= 4, (
+        "the core suite needs ~190 minutes on a standard runner; fewer than "
+        "~4 shards puts a slice back within reach of the 120-minute cap"
+    )
+    assert "-n auto --dist loadscope" in core
+    assert "core-test-results-${{ matrix.shard }}.json" in core
+    assert "name: core-test-results-${{ matrix.shard }}" in core
+
+
+def test_core_tests_job_does_not_multiply_the_scarcest_runner_pool() -> None:
+    """macOS breadth belongs to nightly-deep, not to a six-way PR matrix.
+
+    macOS runners are the constrained pool here -- queue waits of 42 to 90
+    minutes were observed while ubuntu jobs started promptly -- so sharding
+    core across them would spend more in queueing than it buys. This pins the
+    intent, and pins that the coverage it gives up still exists elsewhere.
+    """
+    core = _core_tests_job_block()
+    assert "runs-on: ubuntu-latest" in core
+    assert "macos" not in core
+    assert "macos-latest" in _nightly_deep_job_block()
 
 
 def test_core_tests_job_budget_covers_the_suite() -> None:
@@ -375,4 +432,34 @@ def test_every_json_report_invocation_omits_log_capture() -> None:
     assert activations >= 4, (
         f"expected at least 4 json-report activations (core, UI, full, "
         f"nightly); found {activations} — the pin may have gone inert"
+    )
+
+
+def test_the_test_summary_job_can_actually_fail() -> None:
+    """TASK-21411: `needs:` + `if: always()` schedules a job; it does not judge one.
+
+    On run 32647831275 the Test Summary check reported success while all
+    twelve UI shards were red -- it ran after them, read their artifacts, and
+    never looked at their conclusions. Since this is the check most likely to
+    be marked required, a summary that cannot go red is worse than no summary.
+
+    The verdict must also be the last step, so a failing suite still leaves
+    the PR comment behind rather than exiting before it is posted.
+    """
+    summary = _test_summary_job_block()
+
+    for job in ("core-tests", "ui-tests", "textual-minimum", "artifact-lease-gate"):
+        assert f"needs.{job}.result != 'success'" in summary, (
+            f"the summary does not fail when {job} fails"
+        )
+    assert "exit 1" in summary
+
+    step_names = [
+        line.split("- name:", 1)[1].strip()
+        for line in summary.splitlines()
+        if line.strip().startswith("- name:")
+    ]
+    assert step_names[-1] == "Require every gated job to have succeeded", (
+        "the verdict must be the final step, after the PR comment is posted; "
+        f"steps end with {step_names[-2:]}"
     )

--- a/backlog/tasks/task-21411 - The-core-test-job-cannot-finish-and-the-summary-check-cannot-fail.md
+++ b/backlog/tasks/task-21411 - The-core-test-job-cannot-finish-and-the-summary-check-cannot-fail.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-21411
-title: >-
-  The core test job cannot finish and the summary check cannot fail
-status: In Progress
+title: The core test job cannot finish and the summary check cannot fail
+status: Done
 assignee: []
+created_date: ''
+updated_date: '2026-08-24 00:28'
 labels:
   - ci
   - testing
@@ -37,13 +38,13 @@ precondition for anything else.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The core suite runs in containers it can finish in, sized from measured evidence rather than from raising a cap again
-- [ ] #2 The diagnosis distinguishes "too slow" from "stalled" on evidence, because the two have different fixes and the outcome looks identical
-- [ ] #3 The split covers every test exactly once and stays deterministic, and parallelism within each slice is retained
-- [ ] #4 The change does not worsen contention for the scarcest runner pool, and any coverage it moves is shown to still exist elsewhere
-- [ ] #5 The summary check fails when a job it gates on failed, and still publishes its report when that happens
-- [ ] #6 The workflow-shape test is updated in the same change and each new assertion is proven to fail when what it pins is removed
-- [ ] #7 Anything that cannot be fixed from a branch to the development line is stated as such rather than left implied
+- [x] #1 The core suite runs in containers it can finish in, sized from measured evidence rather than from raising a cap again
+- [x] #2 The diagnosis distinguishes "too slow" from "stalled" on evidence, because the two have different fixes and the outcome looks identical
+- [x] #3 The split covers every test exactly once and stays deterministic, and parallelism within each slice is retained
+- [x] #4 The change does not worsen contention for the scarcest runner pool, and any coverage it moves is shown to still exist elsewhere
+- [x] #5 The summary check fails when a job it gates on failed, and still publishes its report when that happens
+- [x] #6 The workflow-shape test is updated in the same change and each new assertion is proven to fail when what it pins is removed
+- [x] #7 Anything that cannot be fixed from a branch to the development line is stated as such rather than left implied
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -55,3 +56,66 @@ precondition for anything else.
 4. Give the summary check a verdict step, placed so the report is still published.
 5. Update the shape test in lockstep, then mutate each new assertion to prove it bites.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Split `core-tests` six ways with pytest-shard, and gave `test-summary` a verdict step.
+
+**AC#2 — too slow, or stalled?** These look identical from the outcome and have different
+fixes, so it was read from the killed job's own log (run 32647831275, ubuntu leg). The job
+started at 15:39:14, pytest began emitting at 15:44:55 after ~5.7 min of checkout and
+install, and was **still printing progress steadily** — no stall, no gap — when the
+120-minute cap killed it at 17:39 having reached **60%**. Steady progress at the kill means
+too slow, not hung. Extrapolated: ~190 minutes on a 4-vCPU runner (public repos get 4, so
+`-n auto` is 4 workers; the same work takes 30.8 min locally on 8 faster cores).
+
+This also **corrects the baseline document's guess**, which said a hang was likely because
+190 min seemed too far from 30.8. The runner arithmetic accounts for it without a hang.
+
+**AC#1/#3 — the split.** Six shards at ~32 min each, roughly a quarter of the budget, so the
+cap is headroom rather than a target. Verified empirically rather than assumed: collecting
+each shard and unioning them gives **42,811 node ids, zero overlap between shards, and a set
+identical to the unsharded collection**. Nothing is dropped and nothing runs twice. xdist
+still parallelizes within each slice.
+
+(An early version of that check reported 35 duplicates. They were seven
+`PytestCollectionWarning` location lines repeated in every shard's warning summary, which a
+`^Tests/` grep caught alongside real node ids. Real ids contain `::`.)
+
+**AC#4 — runner contention.** ubuntu only. macOS is the scarce pool here: on run
+32673270908 the macOS core job waited **42 minutes** to start, and in an earlier run a UI
+shard waited ~90. Sharding the scarcest pool six ways would spend more in queueing than it
+buys. macOS breadth already lives in nightly-deep, and
+`test_core_tests_job_does_not_multiply_the_scarcest_runner_pool` pins both halves of that
+trade — ubuntu-only here, macOS still present there.
+
+**AC#5 — the summary.** It declared `needs:` and `if: always()`, which schedules it after
+those jobs whatever they did; it never inspected what they did, and reported `success` while
+all twelve UI shards were red. The verdict is now its own step, placed **last** so a red
+suite still leaves the PR comment behind rather than exiting before it is posted.
+
+**AC#6 — the shape test, and a finding inside it.** Three new tests, each mutation-proven:
+removing the verdict step, breaking the shard partition to ids 1..6, moving the verdict ahead
+of the PR comment, and putting macOS back — each fails exactly one test, and the restored
+tree is 18/18 green.
+
+Fixing an existing test was itself a finding. `test_ui_job_is_sharded_to_fit_its_time_budget`
+located the shard id list by searching the **whole workflow** for the first `shard: [`, which
+was the UI job only because it was then the only sharded job. With core sharded it began
+checking core's ids against the UI job's divisor. A partition assertion that can silently
+start describing a different job is worse than no assertion; it now reads from the UI job
+block.
+
+**AC#7 — what this cannot fix.** `nightly-deep` has still never run, and no branch to `dev`
+can change that. GitHub registers `schedule:` only from the **default branch**, which is
+`main`; `main`'s workflow has no schedule block, and `main` is **11,528 commits behind
+`dev`**. Since cron would execute *main's* workflow, main would have to carry the
+nightly-deep job itself. That is a decision about `main`, not a workflow edit, and is left to
+the owner. Until it is made, `--run-slow` (41 marks), the thorough Hypothesis profile, the
+CSS-cache-off soak, Windows, and Python 3.11/3.13 run nowhere.
+
+This change does not make the suite green. It makes it legible, which everything else needs.
+
+Modified: `.github/workflows/test.yml`, `Tests/CI/test_github_actions_test_workflow.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21411 - The-core-test-job-cannot-finish-and-the-summary-check-cannot-fail.md
+++ b/backlog/tasks/task-21411 - The-core-test-job-cannot-finish-and-the-summary-check-cannot-fail.md
@@ -1,0 +1,57 @@
+---
+id: TASK-21411
+title: >-
+  The core test job cannot finish and the summary check cannot fail
+status: In Progress
+assignee: []
+labels:
+  - ci
+  - testing
+  - test-integrity
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The repository's test workflow has not produced a verdict since 2026-06-26. Two independent
+faults keep it that way, and neither is visible from the outcome alone.
+
+The core job — everything outside the UI directory, roughly three quarters of the test files
+— has never finished. It is killed by its own time budget on every run, and because GitHub
+reports a timeout as a cancellation rather than a failure, this reads from the outside like
+a run being superseded by a newer push. It is not. The job is simply larger than any single
+container the budget allows, and the fix is to split it the way the UI job was already split
+for the same reason.
+
+Independently, the summary check that aggregates the test jobs cannot fail. It is scheduled
+to run after them regardless of what they did, but it never inspects what they did — so it
+reported success on a run where every one of the twelve UI shards was red. That is the check
+most likely to be marked as required, which makes a summary that cannot go red worse than no
+summary at all.
+
+Fixing these does not make the suite green. It makes the suite legible, which is the
+precondition for anything else.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The core suite runs in containers it can finish in, sized from measured evidence rather than from raising a cap again
+- [ ] #2 The diagnosis distinguishes "too slow" from "stalled" on evidence, because the two have different fixes and the outcome looks identical
+- [ ] #3 The split covers every test exactly once and stays deterministic, and parallelism within each slice is retained
+- [ ] #4 The change does not worsen contention for the scarcest runner pool, and any coverage it moves is shown to still exist elsewhere
+- [ ] #5 The summary check fails when a job it gates on failed, and still publishes its report when that happens
+- [ ] #6 The workflow-shape test is updated in the same change and each new assertion is proven to fail when what it pins is removed
+- [ ] #7 Anything that cannot be fixed from a branch to the development line is stated as such rather than left implied
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read a killed job's own log to establish whether it was progressing or stalled at the kill.
+2. Size the split from how far it got and the runner it got there on.
+3. Split the job; keep the deterministic slicing contract the UI job already uses.
+4. Give the summary check a verdict step, placed so the report is still published.
+5. Update the shape test in lockstep, then mutate each new assertion to prove it bites.
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
The Tests workflow has produced no verdict since 2026-06-26. Two independent faults keep it
that way, and neither is visible from the outcome alone. This does not make the suite green
— it makes it legible, which everything else needs.

## 1. `core-tests` has never finished

Every leg ends at *exactly* 2h00m. That is `timeout-minutes: 120` expiring — and **GitHub
reports a timeout as `cancelled`**, so from the outside it reads like the run being
superseded by a newer push. It isn't.

**Too slow, or hung?** Those look identical from the outcome and have different fixes, so I
read the killed job's own log (run 32647831275, ubuntu leg):

- job starts `15:39:14`
- pytest begins emitting `15:44:55` (~5.7 min checkout + install)
- **still printing progress steadily, no stall,** when the cap kills it at `17:39` — at **60%**

Steady progress at the kill means slow, not hung. Extrapolated: **~190 minutes** on a 4-vCPU
runner. (Public repos get 4 vCPU, so `-n auto` is 4 workers; the same work takes 30.8 min
locally on 8 faster cores — the arithmetic accounts for the gap without a hang.)

No timeout below GitHub's 6-hour ceiling makes one job the right container for that. **Split
six ways with pytest-shard** — the same deterministic contract the UI job has used since
TASK-18608 — at ~32 min per slice, with xdist still parallelizing within each.

**Verified rather than assumed.** Collecting each shard and unioning them:

| | |
|---|---|
| unsharded core collection | **42,811** node ids |
| union of the 6 shards | **42,811**, zero overlap |
| union vs unsharded | **identical** |

Nothing dropped, nothing run twice.

**ubuntu only, deliberately.** macOS is the scarce pool here — on run 32673270908 the macOS
core job waited **42 minutes** to start, and in an earlier run a UI shard waited ~90.
Sharding the scarcest pool six ways would spend more in queueing than it buys. macOS breadth
already lives in `nightly-deep`, and a new test pins both halves of that trade.

## 2. `test-summary` could not fail

It declares `needs:` and `if: always()`, which schedules it after those jobs *whatever they
did* — it never inspected what they did. On run 32647831275 it reported **`success` while
all twelve UI shards were red**. It is also the check most likely to be marked required, so
a summary that cannot go red is worse than no summary.

The verdict is now its own step, placed **last**, so a red suite still leaves the PR comment
behind rather than exiting before it is posted.

## Shape test updated in lockstep — and one finding inside it

Three new tests, each mutation-proven. Removing the verdict step, breaking the shard
partition to ids `1..6`, moving the verdict ahead of the PR comment, and putting macOS back
each fail exactly one test; the restored tree is 18/18 green.

Fixing an existing test was itself a finding. `test_ui_job_is_sharded_to_fit_its_time_budget`
located the shard id list by searching the **whole workflow** for the first `shard: [` —
which was the UI job only because it was then the only sharded job. With core sharded, it
began checking core's ids against the UI job's divisor. A partition assertion that can
silently start describing a different job is worse than no assertion. It now reads from the
UI job block.

## What this cannot fix, and why

`nightly-deep` has still never run, and **no branch to `dev` can change that**. GitHub
registers `schedule:` only from the default branch, which is `main`; main's workflow has no
schedule block, and **main is 11,528 commits behind dev**. Because cron would execute
*main's* workflow, main would have to carry the nightly-deep job itself. That is a decision
about `main`, not a workflow edit, so I've left it to you. Until it's made, `--run-slow`
(41 marks), the thorough Hypothesis profile, the CSS-cache-off soak, Windows and Python
3.11/3.13 run nowhere.

## Note on required checks

Sharding renames the core job, so the check names change to
`Core Tests (all but UI) - shard N/6`. Nothing currently requires them — worth knowing before
any are marked required, which is best done per-job as each goes green rather than all at
once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shards the core test job into six deterministic pytest slices on Ubuntu and gives the test-summary job a real verdict. Previously, core-tests always timed out at 120m and test-summary always reported success; now each core shard completes in ~32m and the summary fails when any gated job fails while still posting its comment.

- Satisfies TASK-21411 by making the suite finishable and the summary truthful.

**Review notes**
- Core: 6 shards (ids 0–5) on `ubuntu-latest`; `pytest-xdist` stays enabled; per-shard artifact names prevent clobbering; 120m remains headroom; job name is Core Tests (all but UI) - shard N/6; macOS runs stay in nightly-deep to avoid queue contention.
- Summary: adds a final “Require every gated job to have succeeded” step; it fails on any non-success among core-tests, ui-tests, textual-minimum, and artifact-lease-gate; the verdict step runs last so the PR comment is always posted.
- Tests: workflow-shape tests pin core sharding, Ubuntu-only choice, per-shard artifacts, and the summary’s fail/positioning; the UI test now reads shard ids from the UI block.

**Rollout / required actions**
- Update branch protections to the new per-shard core job names and/or the summary check.
- Nightly remains disabled from `dev`; enable `schedule:` on the default branch to run nightly-deep.

<sup>Written for commit 3c6e83f0418ea7ad7072e7f78fe02e1e7241f8b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

