### PR TITLE
fix: keep Windows startup alive when Actor Pack cleanup is unsupported

### DIFF
--- a/Docs/superpowers/plans/2026-08-23-task-21251-windows-actor-pack-startup-cleanup.md
+++ b/Docs/superpowers/plans/2026-08-23-task-21251-windows-actor-pack-startup-cleanup.md
@@ -207,12 +207,18 @@ archive validation, activation, schema, dependency, or configuration changes.
 - [ ] **Step 5: Update TASK-21251 through the Backlog CLI**
 
 Check all four acceptance criteria, add concise implementation notes including
-the commands and results above, state that no new lesson was needed, retain the
-ADR-074 link and ADR check, and set the task to `Done` only if every required
-check is green:
+the results above, state that no new lesson was needed, retain the ADR-074 link
+and ADR check, and set the task to `Done` only if every required check is green.
+Use `backlog task edit 21251 --notes ... --plain` to write the notes. They must
+name the exact commands, actual pass counts, and warnings observed in Steps 1-3;
+do not substitute generic text and do not mark the task `Done` if that evidence
+is unavailable. Then check the acceptance criteria, inspect the rendered task to
+confirm the evidence is present, and only then change the status:
 
 ```bash
-backlog task edit 21251 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --notes "Implemented the usable-but-unverified startup cleanup no-op in ActorPackImportService, with regression coverage proving service construction succeeds, sweep returns zero, and no candidate enumeration or deletion occurs. Existing authenticated cleanup behavior remains covered. ADR required: no; ADR-074 continues to govern the fail-closed boundary. Verification: record exact passing commands and counts here. Lessons: no new general lesson; the incident is specific to the documented platform capability split." -s Done --plain
+backlog task edit 21251 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --plain
+backlog task 21251 --plain
+backlog task edit 21251 -s Done --plain
 ```
 
 - [ ] **Step 6: Commit task completion metadata**

--- a/Docs/superpowers/plans/2026-08-23-task-21251-windows-actor-pack-startup-cleanup.md
+++ b/Docs/superpowers/plans/2026-08-23-task-21251-windows-actor-pack-startup-cleanup.md
@@ -1,0 +1,237 @@
+# Windows Actor Pack Startup Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow Windows to boot when Actor Pack staging privacy cannot be verified, without inspecting or deleting unverified staged data.
+
+**Architecture:** Keep the authority decision inside `ActorPackImportService.sweep_staging()`. Treat a usable-but-unverified private-path result as a cleanup no-op returning `0`; preserve the existing cleanup error for unusable paths and the existing authenticated POSIX cleanup flow.
+
+**Tech Stack:** Python 3.11+, pytest, Backlog.md CLI, existing `PrivatePathResult` contract
+
+**Spec:** `Docs/superpowers/specs/2026-08-23-windows-actor-pack-startup-cleanup-design.md`
+
+**Backlog task:** `backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md`
+
+**ADR required:** no
+
+**ADR path:** `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`
+
+**Reason:** The fix preserves ADR-074's existing fail-closed authority boundary. Native Windows filesystem authority is separate work in TASK-21252.
+
+---
+
+## File map
+
+- Modify `Tests/Actor_Packs/test_actor_pack_import.py`: add the Windows-equivalent private-path classification regression and prove that no staging enumeration occurs.
+- Modify `tldw_chatbook/Actor_Packs/importer.py`: add the minimal early return for usable-but-unverified startup staging.
+- Modify `backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md`: record completed acceptance criteria, verification evidence, ADR disposition, and implementation notes.
+
+No new runtime module, dependency, configuration, schema, or ADR is needed.
+
+### Task 1: Pin the unsupported-platform startup contract
+
+**Files:**
+- Modify: `Tests/Actor_Packs/test_actor_pack_import.py`
+- Test: `Tests/Actor_Packs/test_actor_pack_import.py`
+
+- [ ] **Step 1: Import the existing private-path result types**
+
+Add this import after the Actor Pack repository import:
+
+```python
+from tldw_chatbook.Utils.private_paths import PrivatePathResult, PrivatePathStatus
+```
+
+- [ ] **Step 2: Write the failing regression test beside the existing startup sweep test**
+
+```python
+def test_startup_sweep_skips_usable_unverified_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = CharactersRAGDB(
+        str(tmp_path / "profile.db"), client_id="actor-pack-import-unverified"
+    )
+    repository = ActorPackRepository(db)
+    staging_root = tmp_path / "staging"
+    candidate = staging_root / f".import-{'0' * 32}"
+    candidate.mkdir(parents=True)
+    privacy = PrivatePathResult(
+        staging_root,
+        PrivatePathStatus.UNVERIFIED_PLATFORM,
+        reason="native_acl_not_verified",
+    )
+
+    monkeypatch.setattr(
+        importer_module,
+        "secure_private_directory",
+        lambda *_args, **_kwargs: privacy,
+    )
+
+    def unexpected_access(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("unverified staging contents must not be examined")
+
+    monkeypatch.setattr(importer_module.os, "scandir", unexpected_access)
+    monkeypatch.setattr(
+        importer_module, "_read_candidate_authority", unexpected_access
+    )
+
+    service = ActorPackImportService(
+        repository,
+        staging_root=staging_root,
+        profile_root=tmp_path,
+    )
+
+    assert service.sweep_staging() == 0
+    assert candidate.exists()
+```
+
+- [ ] **Step 3: Run the new test and verify the red state**
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py::test_startup_sweep_skips_usable_unverified_staging -q
+```
+
+Expected: FAIL during `ActorPackImportService` construction with
+`ActorPackImportError: actor_pack_import_cleanup_denied`.
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add Tests/Actor_Packs/test_actor_pack_import.py
+git commit -m "test: reproduce Windows Actor Pack startup failure"
+```
+
+### Task 2: Make unsupported cleanup a non-destructive no-op
+
+**Files:**
+- Modify: `tldw_chatbook/Actor_Packs/importer.py:225-233`
+- Test: `Tests/Actor_Packs/test_actor_pack_import.py`
+
+- [ ] **Step 1: Add the minimal authority guard**
+
+Replace the current unverified result check with:
+
+```python
+            if not privacy.verified_private:
+                if privacy.usable:
+                    return 0
+                raise ValueError
+```
+
+Do not catch the error in `app.py`, run candidate helpers on the early-return
+branch, or change the separate import-time private-staging checks.
+
+- [ ] **Step 2: Run the new regression and verify the green state**
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py::test_startup_sweep_skips_usable_unverified_staging -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run both startup cleanup contracts**
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py -q -k startup_sweep
+```
+
+Expected: two tests PASS: the unsupported-platform no-op and the authenticated,
+bounded supported-platform cleanup.
+
+- [ ] **Step 4: Commit the minimal runtime fix**
+
+```bash
+git add tldw_chatbook/Actor_Packs/importer.py
+git commit -m "fix: skip unverified Actor Pack startup cleanup"
+```
+
+### Task 3: Verify the Actor Pack boundary and close TASK-21251
+
+**Files:**
+- Modify: `backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md`
+- Verify: `Tests/Actor_Packs/test_actor_pack_import.py`
+- Verify: `Tests/Actor_Packs/`
+- Verify: `tldw_chatbook/Actor_Packs/importer.py`
+
+- [ ] **Step 1: Run the complete Actor Pack import test module**
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py -q
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Run the Actor Pack test package**
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs -q
+```
+
+Expected: all tests PASS. Record any pre-existing teardown warnings separately
+from test failures.
+
+- [ ] **Step 3: Run static and patch hygiene checks**
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q tldw_chatbook/Actor_Packs/importer.py Tests/Actor_Packs/test_actor_pack_import.py
+git diff --check origin/dev...HEAD
+```
+
+Expected: both commands exit `0` with no output.
+
+- [ ] **Step 4: Review the final diff for scope and security boundary**
+
+Run:
+
+```bash
+git diff --stat origin/dev...HEAD
+git diff origin/dev...HEAD -- tldw_chatbook/Actor_Packs/importer.py Tests/Actor_Packs/test_actor_pack_import.py
+```
+
+Expected: one focused test addition and one early-return guard; no `app.py`,
+archive validation, activation, schema, dependency, or configuration changes.
+
+- [ ] **Step 5: Update TASK-21251 through the Backlog CLI**
+
+Check all four acceptance criteria, add concise implementation notes including
+the commands and results above, state that no new lesson was needed, retain the
+ADR-074 link and ADR check, and set the task to `Done` only if every required
+check is green:
+
+```bash
+backlog task edit 21251 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --notes "Implemented the usable-but-unverified startup cleanup no-op in ActorPackImportService, with regression coverage proving service construction succeeds, sweep returns zero, and no candidate enumeration or deletion occurs. Existing authenticated cleanup behavior remains covered. ADR required: no; ADR-074 continues to govern the fail-closed boundary. Verification: record exact passing commands and counts here. Lessons: no new general lesson; the incident is specific to the documented platform capability split." -s Done --plain
+```
+
+- [ ] **Step 6: Commit task completion metadata**
+
+```bash
+git add "backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md"
+git commit -m "docs: complete TASK-21251"
+```
+
+- [ ] **Step 7: Confirm a clean worktree and final task state**
+
+Run:
+
+```bash
+git status --short --branch
+backlog task 21251 --plain
+backlog task 21252 --plain
+```
+
+Expected: the branch is clean, TASK-21251 is `Done` with checked acceptance
+criteria and verification notes, and deferred native Windows support remains
+`To Do` as TASK-21252.

--- a/Docs/superpowers/specs/2026-08-23-windows-actor-pack-startup-cleanup-design.md
+++ b/Docs/superpowers/specs/2026-08-23-windows-actor-pack-startup-cleanup-design.md
@@ -87,9 +87,10 @@ fallback.
 
 A regression test will arrange an existing staging candidate and make the
 private-path classifier return an unverified-but-usable result. Constructing the
-service must succeed, return no cleanup count when explicitly swept, and leave
-the candidate untouched. The test should fail against the current implementation
-with `actor_pack_import_cleanup_denied`.
+service must succeed, an explicit sweep must return `0`, and the candidate must
+remain untouched. Spies must also prove that `os.scandir()` and candidate
+authority helpers are never called on this branch. The test should fail against
+the current implementation with `actor_pack_import_cleanup_denied`.
 
 The existing authenticated startup-sweep test remains the supported-platform
 regression and must continue to pass. Focused Actor Pack import tests and static

--- a/Docs/superpowers/specs/2026-08-23-windows-actor-pack-startup-cleanup-design.md
+++ b/Docs/superpowers/specs/2026-08-23-windows-actor-pack-startup-cleanup-design.md
@@ -1,0 +1,123 @@
+# Windows Actor Pack Startup Cleanup Design
+
+**Task:** TASK-21251  
+**Deferred platform work:** TASK-21252  
+**Governing ADR:** [ADR-074](../../../backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md)
+
+## Problem
+
+`ActorPackImportService` runs a bounded staging sweep in its constructor. On
+Windows, `secure_private_directory()` can create the staging directory but
+returns `UNVERIFIED_PLATFORM` because the private-path layer does not yet verify
+native ACLs. The sweep currently treats every result that is not
+`verified_private` as a cleanup failure, converts that condition to
+`actor_pack_import_cleanup_denied`, and aborts application startup.
+
+The crash is deterministic on Windows and occurs before the user asks to import
+an Actor Pack. At the same time, the existing sweep relies on POSIX
+descriptor-relative traversal and deletion. Allowing it to continue against an
+unverified Windows path would weaken ADR-074's authority boundary and could make
+startup cleanup destructive.
+
+## Goals
+
+- Let the application finish booting when Actor Pack staging can be located but
+  the platform cannot prove that it is private.
+- Preserve fail-closed cleanup: no candidate may be enumerated, authenticated,
+  modified, or deleted without verified staging authority.
+- Preserve current authenticated cleanup behavior on supported POSIX platforms.
+- Keep Windows Actor Pack import unsupported until its native filesystem
+  security model is implemented and tested under TASK-21252.
+
+## Non-goals
+
+- Implement Windows ACL, ownership, handle-pinning, or reparse-point checks.
+- Enable Actor Pack inspection, staging, activation, or publication on Windows.
+- Catch or suppress unrelated Actor Pack initialization failures in `app.py`.
+- Change Actor Pack archive validation or activation semantics.
+
+## Decision
+
+`sweep_staging()` will distinguish an unverified-but-usable private-path result
+from an unusable staging path. When the result is usable but not
+`verified_private`, the sweep returns `0` before calling `os.scandir()` or any
+candidate helper. This makes unsupported-platform startup housekeeping a
+non-destructive no-op.
+
+All other error handling remains unchanged:
+
+- verified private staging follows the existing bounded, authenticated cleanup
+  flow;
+- unusable staging or filesystem errors still become
+  `actor_pack_import_cleanup_denied`;
+- Actor Pack import operations retain their own fail-closed private-staging
+  checks and therefore remain unavailable on Windows.
+
+The constructor continues to invoke `sweep_staging()`. The behavior change is
+localized to the sweep because that is the component which owns the cleanup
+authority decision.
+
+## Data and control flow
+
+1. Application wiring constructs `ActorPackImportService`.
+2. The constructor calls `sweep_staging()`.
+3. `secure_private_directory()` classifies the staging root.
+4. If the result is verified private, the current bounded cleanup proceeds.
+5. If the result is usable but unverified, the sweep returns `0` without
+   examining directory contents.
+6. If the result is unusable or the classification raises, the stable cleanup
+   error is preserved.
+
+No new persistent data, configuration, or user-visible state is introduced.
+
+## Error handling and observability
+
+The startup no-op does not emit a new exception because the platform limitation
+is expected and no cleanup was attempted. Existing stable Actor Pack error
+categories remain unchanged. Import attempts continue to fail at the existing
+security gate rather than pretending Windows import is supported.
+
+TASK-21252 owns any future user-facing capability messaging and native Windows
+diagnostics. This fix must not pre-empt that security design with a path-based
+fallback.
+
+## Testing
+
+A regression test will arrange an existing staging candidate and make the
+private-path classifier return an unverified-but-usable result. Constructing the
+service must succeed, return no cleanup count when explicitly swept, and leave
+the candidate untouched. The test should fail against the current implementation
+with `actor_pack_import_cleanup_denied`.
+
+The existing authenticated startup-sweep test remains the supported-platform
+regression and must continue to pass. Focused Actor Pack import tests and static
+checks will verify that the guard does not affect archive inspection or cleanup
+on supported platforms.
+
+## Alternatives considered
+
+### Catch the cleanup error in application wiring
+
+Rejected. This would hide all cleanup initialization failures, including real
+permission or filesystem errors on supported platforms, and would put Actor Pack
+security policy into the application composition root.
+
+### Treat Windows staging as verified and run the POSIX cleanup
+
+Rejected. The cleanup depends on POSIX directory descriptors and no-follow
+semantics. Windows ACL and reparse-point authority have not been proven, so this
+would violate ADR-074.
+
+### Implement native Windows Actor Pack support in this fix
+
+Deferred to TASK-21252. Native ACL validation, reparse-point handling,
+handle-relative cleanup, and Windows CI form a separate security-sensitive unit
+of work. They are not required to restore application startup safely.
+
+## ADR check
+
+ADR required: no  
+ADR path: `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`  
+Reason: This routine bug fix preserves ADR-074's existing fail-closed staging
+and cleanup authority policy. Native Windows support will require the ADR review
+and documentation captured by TASK-21252.

--- a/Docs/superpowers/specs/2026-08-23-windows-actor-pack-startup-cleanup-design.md
+++ b/Docs/superpowers/specs/2026-08-23-windows-actor-pack-startup-cleanup-design.md
@@ -1,7 +1,9 @@
 # Windows Actor Pack Startup Cleanup Design
 
-**Task:** TASK-21251  
-**Deferred platform work:** TASK-21252  
+**Task:** TASK-21251
+
+**Deferred platform work:** TASK-21252
+
 **Governing ADR:** [ADR-074](../../../backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md)
 
 ## Problem
@@ -116,8 +118,10 @@ of work. They are not required to restore application startup safely.
 
 ## ADR check
 
-ADR required: no  
-ADR path: `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`  
+ADR required: no
+
+ADR path: `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`
+
 Reason: This routine bug fix preserves ADR-074's existing fail-closed staging
 and cleanup authority policy. Native Windows support will require the ADR review
 and documentation captured by TASK-21252.

--- a/Tests/Actor_Packs/test_actor_pack_import.py
+++ b/Tests/Actor_Packs/test_actor_pack_import.py
@@ -22,6 +22,7 @@ from tldw_chatbook.Actor_Packs.importer import (
     ActorPackImportService,
 )
 from tldw_chatbook.Actor_Packs.repository import ActorPackRepository
+from tldw_chatbook.Utils.private_paths import PrivatePathResult, PrivatePathStatus
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
 
@@ -506,3 +507,44 @@ def test_startup_sweep_removes_only_authenticated_bounded_candidates(
     assert not authenticated.exists()
     assert malformed.exists()
     assert replacement.sweep_staging(max_candidates=1) == 0
+
+
+def test_startup_sweep_skips_usable_unverified_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = CharactersRAGDB(
+        str(tmp_path / "profile.db"), client_id="actor-pack-import-unverified"
+    )
+    repository = ActorPackRepository(db)
+    staging_root = tmp_path / "staging"
+    candidate = staging_root / f".import-{'0' * 32}"
+    candidate.mkdir(parents=True)
+    privacy = PrivatePathResult(
+        staging_root,
+        PrivatePathStatus.UNVERIFIED_PLATFORM,
+        reason="native_acl_not_verified",
+    )
+
+    monkeypatch.setattr(
+        importer_module,
+        "secure_private_directory",
+        lambda *_args, **_kwargs: privacy,
+    )
+
+    def unexpected_access(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("unverified staging contents must not be examined")
+
+    monkeypatch.setattr(importer_module.os, "scandir", unexpected_access)
+    monkeypatch.setattr(
+        importer_module, "_read_candidate_authority", unexpected_access
+    )
+
+    service = ActorPackImportService(
+        repository,
+        staging_root=staging_root,
+        profile_root=tmp_path,
+    )
+
+    assert service.sweep_staging() == 0
+    assert candidate.exists()

--- a/Tests/Actor_Packs/test_actor_pack_import.py
+++ b/Tests/Actor_Packs/test_actor_pack_import.py
@@ -487,6 +487,31 @@ def test_revalidation_rechecks_publication_free_space(
     assert raised.value.category == "actor_pack_import_disk_unavailable"
 
 
+def test_inspect_reports_disk_unavailable_when_staging_is_unverified(
+    import_service: ActorPackImportService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    staging_root = import_service._staging_root
+    privacy = PrivatePathResult(
+        staging_root,
+        PrivatePathStatus.UNVERIFIED_PLATFORM,
+        reason="native_acl_not_verified",
+    )
+    monkeypatch.setattr(
+        importer_module,
+        "secure_private_directory",
+        lambda *_args, **_kwargs: privacy,
+    )
+
+    with pytest.raises(ActorPackImportError) as raised:
+        import_service.inspect_archive(
+            (FIXTURES / "minimal-character.tldw-actor-pack").resolve()
+        )
+
+    assert raised.value.category == "actor_pack_import_disk_unavailable"
+    assert list(staging_root.iterdir()) == []
+
+
 def test_startup_sweep_removes_only_authenticated_bounded_candidates(
     import_service: ActorPackImportService,
 ) -> None:

--- a/Tests/Actor_Packs/test_actor_pack_import.py
+++ b/Tests/Actor_Packs/test_actor_pack_import.py
@@ -536,9 +536,7 @@ def test_startup_sweep_skips_usable_unverified_staging(
         pytest.fail("unverified staging contents must not be examined")
 
     monkeypatch.setattr(importer_module.os, "scandir", unexpected_access)
-    monkeypatch.setattr(
-        importer_module, "_read_candidate_authority", unexpected_access
-    )
+    monkeypatch.setattr(importer_module, "_read_candidate_authority", unexpected_access)
 
     service = ActorPackImportService(
         repository,

--- a/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
+++ b/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-21251
 title: Keep Windows startup alive when Actor Pack cleanup is unsupported
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-24 00:09'
-updated_date: '2026-08-24 00:09'
+updated_date: '2026-08-24 00:35'
 labels:
   - bug
   - actor-packs
@@ -24,10 +24,10 @@ Prevent Actor Pack startup housekeeping from terminating the application on plat
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Constructing the Actor Pack import service does not raise when private staging is usable but platform verification is unavailable.
-- [ ] #2 Startup cleanup does not enumerate, modify, or delete staged candidates unless private staging authority is verified.
-- [ ] #3 Authenticated startup cleanup behavior on supported platforms remains unchanged.
-- [ ] #4 Automated regression coverage exercises the unsupported-platform startup path and the supported cleanup path.
+- [x] #1 Constructing the Actor Pack import service does not raise when private staging is usable but platform verification is unavailable.
+- [x] #2 Startup cleanup does not enumerate, modify, or delete staged candidates unless private staging authority is verified.
+- [x] #3 Authenticated startup cleanup behavior on supported platforms remains unchanged.
+- [x] #4 Automated regression coverage exercises the unsupported-platform startup path and the supported cleanup path.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,3 +42,15 @@ ADR required: no
 ADR path: backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
 Reason: This routine boot bug fix preserves ADR-074’s existing fail-closed authority boundary and introduces no new architecture or security policy.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the minimal fail-closed startup guard: usable but unverified private staging now makes Actor Pack startup sweeping a non-destructive no-op, while unusable staging still fails and verified cleanup behavior remains unchanged. Added one focused regression test proving unverified staging is neither enumerated nor read and its candidate remains intact.
+
+Verification on 2026-08-23: PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py -q -> 24 passed, 0 skipped, 0 deselected, pytest exit 0; PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs -q -> 202 passed, 0 skipped, 0 deselected, pytest exit 0. Each run reported 1 RequestsDependencyWarning from the existing requests dependency version mismatch. Each run also emitted 94 post-summary PytestWarning cleanup messages while retrying immutable temporary directories; these teardown warnings were non-failures and both commands exited 0.
+
+Static and patch checks: compileall -q for tldw_chatbook/Actor_Packs/importer.py and Tests/Actor_Packs/test_actor_pack_import.py exited 0; git diff --check origin/dev...HEAD exited 0. Scope review confirmed the functional diff is one focused test plus the minimal early-return guard, with no app.py, archive, schema, dependency, or config changes.
+
+ADR required: no; ADR-074 remains governing. Lessons: no new general lesson; the incident is specific to the documented platform split.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
+++ b/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
@@ -1,0 +1,44 @@
+---
+id: TASK-21251
+title: Keep Windows startup alive when Actor Pack cleanup is unsupported
+status: In Progress
+assignee: []
+created_date: '2026-08-24 00:09'
+updated_date: '2026-08-24 00:09'
+labels:
+  - bug
+  - actor-packs
+  - windows
+dependencies: []
+references:
+  - >-
+    backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent Actor Pack startup housekeeping from terminating the application on platforms where private staging authority cannot be verified, while preserving the existing fail-closed cleanup boundary.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Constructing the Actor Pack import service does not raise when private staging is usable but platform verification is unavailable.
+- [ ] #2 Startup cleanup does not enumerate, modify, or delete staged candidates unless private staging authority is verified.
+- [ ] #3 Authenticated startup cleanup behavior on supported platforms remains unchanged.
+- [ ] #4 Automated regression coverage exercises the unsupported-platform startup path and the supported cleanup path.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Capture the approved fail-closed startup behavior and link the governing Actor Pack ADR.
+2. Add a regression test proving unsupported-platform cleanup is a non-destructive no-op during service construction.
+3. Implement the smallest guard that skips startup sweeping when platform verification is unavailable while preserving errors for unusable staging.
+4. Run focused Actor Pack tests, relevant startup coverage, and static checks.
+
+ADR required: no
+ADR path: backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
+Reason: This routine boot bug fix preserves ADR-074’s existing fail-closed authority boundary and introduces no new architecture or security policy.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
+++ b/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
@@ -4,7 +4,7 @@ title: Keep Windows startup alive when Actor Pack cleanup is unsupported
 status: In Progress
 assignee: []
 created_date: '2026-08-24 00:09'
-updated_date: '2026-08-24 02:41'
+updated_date: '2026-08-24 03:00'
 labels:
   - bug
   - actor-packs
@@ -28,6 +28,7 @@ Prevent Actor Pack startup housekeeping from terminating the application on plat
 - [x] #2 Startup cleanup does not enumerate, modify, or delete staged candidates unless private staging authority is verified.
 - [x] #3 Authenticated startup cleanup behavior on supported platforms remains unchanged.
 - [x] #4 Automated regression coverage exercises the unsupported-platform startup path and the supported cleanup path.
+- [x] #5 Attempting to inspect a valid Actor Pack when private staging is usable but unverified fails with actor_pack_import_disk_unavailable before any staging candidate is created.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,10 +38,11 @@ Prevent Actor Pack startup housekeeping from terminating the application on plat
 2. Add a regression test proving unsupported-platform cleanup is a non-destructive no-op during service construction.
 3. Implement the smallest guard that skips startup sweeping when platform verification is unavailable while preserving errors for unusable staging.
 4. Run focused Actor Pack tests, relevant startup coverage, and static checks.
+5. Address verified PR review feedback with a red-green regression that preserves the stable disk-unavailable category when private staging cannot be verified.
 
 ADR required: no
 ADR path: backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
-Reason: This routine boot bug fix preserves ADR-074’s existing fail-closed authority boundary and introduces no new architecture or security policy.
+Reason: This routine boot and error-classification fix preserves ADR-074’s existing fail-closed authority boundary and introduces no new architecture or security policy.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -55,4 +57,6 @@ Fresh current-HEAD evidence on 2026-08-23: startup selection (`PYTHONPATH=. /Use
 Repository-wide verification limitation: `PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q` produced no terminal result after roughly 100 minutes and was interrupted. This is neither a pass nor a failure and is the sole reason TASK-21251 remains In Progress.
 
 Scope review confirmed the functional diff is one focused test plus the minimal early-return guard, with no app.py, archive, schema, dependency, or config changes. ADR required: no; ADR-074 remains governing. Lessons: no new general lesson; the incident is specific to the documented platform split.
+
+PR review remediation (Qodo): verified that unverified private staging was converted through inspect_archive() to actor_pack_import_invalid. _preflight_space() now raises the existing actor_pack_import_disk_unavailable category directly, which propagates unchanged, preserves fail-closed behavior, and matches existing UI recovery copy. A red-green regression proves a valid pack receives disk-unavailable before any staging candidate is created. Verification: targeted regression passed 1/1; `PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs -q` passed 203/203; Ruff format reported both changed Python files already formatted; Ruff lint and git diff --check passed. TASK-21251 remains In Progress solely because the previously recorded repository-wide pytest run has no terminal result.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
+++ b/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-21251
 title: Keep Windows startup alive when Actor Pack cleanup is unsupported
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-08-24 00:09'
-updated_date: '2026-08-24 00:35'
+updated_date: '2026-08-24 00:43'
 labels:
   - bug
   - actor-packs

--- a/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
+++ b/backlog/tasks/task-21251 - Keep-Windows-startup-alive-when-Actor-Pack-cleanup-is-unsupported.md
@@ -4,7 +4,7 @@ title: Keep Windows startup alive when Actor Pack cleanup is unsupported
 status: In Progress
 assignee: []
 created_date: '2026-08-24 00:09'
-updated_date: '2026-08-24 00:43'
+updated_date: '2026-08-24 02:41'
 labels:
   - bug
   - actor-packs
@@ -48,9 +48,11 @@ Reason: This routine boot bug fix preserves ADR-074’s existing fail-closed aut
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the minimal fail-closed startup guard: usable but unverified private staging now makes Actor Pack startup sweeping a non-destructive no-op, while unusable staging still fails and verified cleanup behavior remains unchanged. Added one focused regression test proving unverified staging is neither enumerated nor read and its candidate remains intact.
 
-Verification on 2026-08-23: PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py -q -> 24 passed, 0 skipped, 0 deselected, pytest exit 0; PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs -q -> 202 passed, 0 skipped, 0 deselected, pytest exit 0. Each run reported 1 RequestsDependencyWarning from the existing requests dependency version mismatch. Each run also emitted 94 post-summary PytestWarning cleanup messages while retrying immutable temporary directories; these teardown warnings were non-failures and both commands exited 0.
+Prior passing evidence on 2026-08-23: the Actor Pack import module run (`PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py -q`) passed 24/24 tests; the Actor Pack package run (`PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs -q`) passed 202/202 tests. Both commands exited 0. Each run reported one existing RequestsDependencyWarning and non-failing post-summary cleanup warnings for leftover pytest temporary directories.
 
-Static and patch checks: compileall -q for tldw_chatbook/Actor_Packs/importer.py and Tests/Actor_Packs/test_actor_pack_import.py exited 0; git diff --check origin/dev...HEAD exited 0. Scope review confirmed the functional diff is one focused test plus the minimal early-return guard, with no app.py, archive, schema, dependency, or config changes.
+Fresh current-HEAD evidence on 2026-08-23: startup selection (`PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs/test_actor_pack_import.py -q -k startup_sweep`) passed 2 tests with 22 deselected; Ruff format check reported `2 files already formatted`; Ruff lint reported `All checks passed!`; exact command `PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q tldw_chatbook/Actor_Packs/importer.py Tests/Actor_Packs/test_actor_pack_import.py` exited 0; `git diff --check origin/dev...HEAD` exited 0. The startup selection also emitted the existing RequestsDependencyWarning and non-failing post-summary cleanup warnings for leftover pytest temporary directories.
 
-ADR required: no; ADR-074 remains governing. Lessons: no new general lesson; the incident is specific to the documented platform split.
+Repository-wide verification limitation: `PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q` produced no terminal result after roughly 100 minutes and was interrupted. This is neither a pass nor a failure and is the sole reason TASK-21251 remains In Progress.
+
+Scope review confirmed the functional diff is one focused test plus the minimal early-return guard, with no app.py, archive, schema, dependency, or config changes. ADR required: no; ADR-074 remains governing. Lessons: no new general lesson; the incident is specific to the documented platform split.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21252 - Support-secure-Actor-Pack-import-on-Windows.md
+++ b/backlog/tasks/task-21252 - Support-secure-Actor-Pack-import-on-Windows.md
@@ -1,0 +1,33 @@
+---
+id: TASK-21252
+title: Support secure Actor Pack import on Windows
+status: To Do
+assignee: []
+created_date: '2026-08-24 00:11'
+labels:
+  - actor-packs
+  - windows
+  - security
+dependencies: []
+references:
+  - >-
+    backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Provide native Windows staging, review, activation, and authenticated cleanup for Actor Pack imports without weakening the private-directory and link-traversal protections established for supported platforms.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A Windows user can import, review, and activate a valid Actor Pack through the existing service contract.
+- [ ] #2 Staging authority is verified using documented Windows ownership and ACL rules before any candidate is trusted or removed.
+- [ ] #3 Reparse points and other link-like filesystem objects are rejected or handled without traversal, and ambiguous candidates are left untouched.
+- [ ] #4 Startup cleanup removes only bounded candidates whose authenticity and private staging authority have both been proven on Windows.
+- [ ] #5 Failure paths return stable Actor Pack error codes and do not delete user-controlled or unverifiable data.
+- [ ] #6 Native Windows CI covers valid import, interrupted staging recovery, ACL denial, reparse-point attacks, and non-destructive cleanup refusal.
+- [ ] #7 The governing ADR and user-facing platform support documentation describe the Windows security model and limitations.
+<!-- AC:END -->

--- a/tldw_chatbook/Actor_Packs/importer.py
+++ b/tldw_chatbook/Actor_Packs/importer.py
@@ -225,6 +225,8 @@ class ActorPackImportService:
                 self._staging_root, create=True, application_owned=True
             )
             if not privacy.verified_private:
+                if privacy.usable:
+                    return 0
                 raise ValueError
             removed = 0
             examined = 0

--- a/tldw_chatbook/Actor_Packs/importer.py
+++ b/tldw_chatbook/Actor_Packs/importer.py
@@ -949,7 +949,7 @@ def _canonical_object(data: bytes) -> dict[str, Any]:
 def _preflight_space(root: Path, required: int) -> None:
     privacy = secure_private_directory(root, create=True, application_owned=True)
     if not privacy.verified_private:
-        raise ValueError
+        raise ActorPackImportError("actor_pack_import_disk_unavailable")
     if shutil.disk_usage(root).free < required * 2 + 1024 * 1024:
         raise ActorPackImportError("actor_pack_import_disk_unavailable")
 


### PR DESCRIPTION
## Summary

- treat usable-but-unverified Actor Pack staging as a non-destructive startup cleanup no-op
- preserve cleanup-denied behavior for unusable staging and authenticated cleanup on verified platforms
- add a regression proving service construction succeeds without enumerating or deleting unverified candidates
- file TASK-21252 for secure native Windows Actor Pack import, ACL, reparse-point, cleanup, and CI support

## Security boundary

The guard returns before `os.scandir()` or candidate authority helpers. Import-time `verified_private` checks remain unchanged, so this restores Windows app startup without enabling Actor Pack import on Windows. ADR-074 remains governing; no new ADR is required for this bug fix.

## Verification

- `PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Actor_Packs -q` — 202 passed, 1 dependency warning
- Ruff format check — 2 files already formatted
- Ruff lint — all checks passed
- compileall for the modified Python files — passed
- `git diff --check origin/dev...HEAD` — passed

Repository-wide `pytest -q` produced no terminal result after roughly 100 minutes and was interrupted. This is neither recorded as a pass nor a failure; TASK-21251 remains In Progress for that completion gate. Non-failing post-summary pytest cleanup warnings for leftover temporary directories were also observed.

## Backlog

- TASK-21251: In Progress pending repository-wide test completion
- TASK-21252: To Do — secure native Windows Actor Pack import support

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Windows startup alive by making startup cleanup a no‑op when Actor Pack staging is usable but unverified, and returns a stable disk‑unavailable error during import preflight when staging cannot be verified. Previously startup raised cleanup‑denied and aborted; preflight raised a generic error.

- In `sweep_staging()`, if staging is usable but not `verified_private`, return 0 before any `os.scandir()` or candidate helper calls; POSIX‑verified cleanup is unchanged; unusable staging still errors.
- `_preflight_space()` now raises `ActorPackImportError("actor_pack_import_disk_unavailable")` when staging privacy is unverified; `inspect_archive()` creates no staging candidates on this path and reports disk‑unavailable.
- Adds regressions: startup no‑op path skips enumeration and leaves candidates intact; inspect‑on‑unverified reports disk‑unavailable with an empty staging root.
- Security boundary is unchanged and Windows import remains unsupported under ADR‑074. Addresses TASK‑21251; native Windows support is tracked in TASK‑21252.

<sup>Written for commit 7c24fd3d684559e262e7cfff5f4b023a7391270f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

