### PR TITLE
docs: file the v48 self-migration regression and two burn-down lessons (TASK-21441)

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7680,3 +7680,43 @@ stable file. This repo has many `inspect.getsource` / source-text structural
 tests, so the failure looks exactly like a pre-existing red in someone else's
 area. Do not edit the tree while a run you intend to quote is running — and
 before A/B-ing any suspicious red, re-run it once against a quiescent tree.
+## A filing's prescribed fix is a hypothesis, not a spec (TASK-21128, 2026-08-23)
+
+The finding I filed said: scope the `messages_au` FTS trigger to `AFTER UPDATE OF
+content`. The implementer built the trigger matrix *before* writing the change and
+found that `OF content` alone does not fire on `UPDATE messages SET deleted = 1`, so
+a soft-deleted message's tokens would have stayed in the index — a retention bug
+introduced by the "fix". Shipped as `OF content, deleted` instead, and the acceptance
+criteria were amended before any code was written.
+
+**The rule this produced**, now enforced by a census test: the `UPDATE OF` column set
+is *every column the index stores* ∪ *every column that decides membership or
+visibility*. Widening an fts5 table without widening its trigger now fails at
+authoring time.
+
+**The generalisation**: a prescription written by whoever *found* a problem is a
+hypothesis about the fix, and the person implementing it is the last one positioned
+to falsify it. Build the differential harness first; if it contradicts the brief,
+the brief loses. Two separate reviewers reproduced this independently — it was not
+subtle, it was simply never tested before being written down.
+
+*Scope honesty, also worth keeping:* I first wrote this up as "soft-deleted messages
+stay searchable". Review corrected it — all six production `messages_fts` consumers
+re-filter on `m.deleted = 0`, so the retention was reachable only by a direct index
+query. Still a real regression of task-19567's guarantee, but not a user-visible
+search leak. State the blast radius you can prove, not the worst one you can imagine.
+
+## A thread-assert is only as honest as the double it runs against (TASK-21125, 2026-08-23)
+
+The acceptance criterion prescribed offloading the Writing backend at the *controller*.
+Every `WritingScopeService` method is already `async def`, so a controller-level
+`to_thread` would have moved **zero** work in the shipped app — while still passing a
+"runs off the event loop" assertion, because the test fake it ran against was
+synchronous. The offload landed at `_service_for_mode` instead.
+
+The same review turned up the matching failure of a *concurrency* assertion: a plain
+`gather` of 8 writers passed against a deliberately broken single-thread pool. It only
+began discriminating once every writer parked on a barrier inside the version check —
+then the mutant failed 5/5. Before trusting either kind of assertion, **run it against
+a deliberately broken implementation**; one that still passes is measuring the double,
+not the subject.

--- a/backlog/tasks/task-21441 - Restore-the-historical-fixture-and-self-migration-surface-broken-by-schema-v48.md
+++ b/backlog/tasks/task-21441 - Restore-the-historical-fixture-and-self-migration-surface-broken-by-schema-v48.md
@@ -1,0 +1,78 @@
+---
+id: TASK-21441
+title: Restore the historical-fixture and self-migration surface broken by schema v48
+status: To Do
+assignee: []
+created_date: '2026-08-24 04:32'
+labels:
+  - perf-review-2026-08-22
+  - database
+  - migrations
+  - regression
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Schema v48 made two changes that, together, mean the shipped ChaChaNotes writer can no longer construct or upgrade a pre-v48 database. Fifteen tests are red on pristine dev as a result, including the packaging test that simulates a real installed distribution upgrading a v35 database. The shipped TUI is insulated because its two boot-path opens hand the migration a seed, but every other consumer of CharactersRAGDB -- scripts, external callers, and the migration test surface itself -- is not. Found while landing TASK-21128 during the 2026-08-22 performance burn-down; the defect belongs to v48, not to that task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A pre-v47 database can be upgraded by opening CharactersRAGDB without the caller supplying a ConsoleLibraryMigrationSeed, or the requirement is documented as an intentional API contract with a migration note and a defaulting path for non-TUI callers
+- [ ] #2 The shipped message writer can populate a pre-v48 messages table, so historical fixtures can once again be built with production code rather than hand-rolled SQL
+- [ ] #3 Tests/Packaging/test_installed_distribution.py::test_installed_distribution_migrates_v35_database_to_current passes for both source and sdist
+- [ ] #4 The 14 reds in Tests/DB and the actor-pack migration red in Tests/ChaChaNotesDB are green, with each fix addressing the mechanism rather than re-pinning the assertion around it
+- [ ] #5 test_schema_version_is_47's stale pin is updated in a way that does not require editing on every future schema bump
+- [ ] #6 A regression test proves a bare CharactersRAGDB open of an existing older database still migrates, so the next migration step cannot silently reintroduce a caller-supplied-data requirement
+<!-- AC:END -->
+
+## Evidence (measured first-hand on pristine dev `b3a7cf97b`, 2026-08-23)
+
+Two independent mechanisms, both introduced by v48:
+
+**1. The migration now demands data the caller must supply.** `_upgrade_v47_to_v48`
+(`DB/ChaChaNotes_DB.py:6225-6237`) raises `SchemaError: Console library migration seed
+is required for v47 upgrade.` unless the constructor was handed a
+`ConsoleLibraryMigrationSeed`. A *fresh* database is exempt via `fresh_without_seed`
+(initial version 0), so this only bites databases that already exist — i.e. exactly the
+upgrade case. The DB class can no longer self-migrate.
+
+**2. The shipped writer cannot write a pre-v48 schema.** `add_message`'s INSERT names
+`assistant_generation_state` unconditionally (`DB/ChaChaNotes_DB.py:10547`), so building
+an old-schema fixture with production code fails with `table messages has no column named
+assistant_generation_state`. This is the pattern the migration tests are built on.
+
+### What is red
+
+| surface | count | mechanism |
+|---|---|---|
+| `Tests/DB/test_chachanotes_v47_messages_fts_backfill.py` | 9 | both (one is a stale `test_schema_version_is_47` pin) |
+| `Tests/DB/test_chachanotes_sync_log_retention_migration.py` | 4 | seed required |
+| `Tests/DB/test_chachanotes_sync_log_retention.py` | 1 | writer/schema mismatch |
+| `Tests/ChaChaNotesDB/test_actor_pack_migration.py` | 1 | seed required |
+| `Tests/Packaging/test_installed_distribution.py` (`[source]`, `[sdist]`) | 2 | seed required |
+
+Run commands: `pytest Tests/DB/` → 14 failed, 1270 passed, 1 skipped.
+`pytest Tests/ChaChaNotesDB/ Tests/DB/test_chachanotes_console_library_policy_migration.py`
+→ 1 failed, 403 passed. `pytest Tests/Packaging/test_installed_distribution.py -k migrates`
+→ 2 failed.
+
+### Why this is not a user-facing outage today
+
+All 12 production files that construct `CharactersRAGDB` do thread the seed through,
+including both boot-path opens (`config.py:7216` eager, `config.py:7268` lazy). Verified
+by reading each site, not by grep alone. So the shipped TUI upgrades correctly.
+
+The exposure is everything *else*: the packaging test is red precisely because it opens
+the database the way an installed distribution's non-TUI consumer would. A migration step
+that requires caller-supplied data turns a self-contained upgrade into one that only works
+from inside one application. That is the part worth fixing, beyond the red tests.
+
+### Attribution
+
+Surfaced while renumbering TASK-21128 from v48 to v49 after a schema-version collision.
+Every red listed here reproduces on pristine dev with no burn-down changes applied; the
+21128 branch actually *fixes* one of them. Filed against v48, not 21128.


### PR DESCRIPTION
## Summary

Two documents, no code. Files a dev regression found while landing the 2026-08-22
performance burn-down, and records two method lessons from the wave-6 reviews.

## TASK-21441 — schema v48 broke the self-migration surface

Reproduced first-hand on pristine dev `b3a7cf97b`, with no burn-down changes applied.
Two independent mechanisms, both from v48:

1. **The migration demands data the caller must supply.** Upgrading any *existing*
   database across v47 raises `SchemaError: Console library migration seed is required`
   unless the constructor was handed a `ConsoleLibraryMigrationSeed`. Fresh databases are
   exempt, so this bites exactly the upgrade case. The DB class can no longer self-migrate.
2. **The shipped writer cannot write a pre-v48 schema.** `add_message`'s INSERT names
   `assistant_generation_state` unconditionally, so historical fixtures can no longer be
   built with production code — which is how the migration tests are constructed.

**15 tests red on pristine dev**, plus both parameterisations of the packaging test that
simulates an installed distribution upgrading a v35 database.

**Not a user-facing outage today**: all twelve production `CharactersRAGDB` construction
sites thread the seed, including both boot-path opens (`config.py:7216` eager, `:7268`
lazy) — verified by reading each site, not by grep. The exposure is every *other*
consumer, which is precisely why the packaging test is the one that caught it. A
migration step requiring caller-supplied data turns a self-contained upgrade into one
that only works from inside one application; that is the part worth fixing, beyond the
red tests. The ACs allow either restoring self-migration or documenting the requirement
as an intentional contract with a defaulting path.

Filed against v48, not against TASK-21128 — whose branch actually *fixes* one of these.

## Two lessons

**A filing's prescribed fix is a hypothesis, not a spec.** My 21128 brief said
`AFTER UPDATE OF content`; the implementer built the trigger matrix first and found that
alone does not fire on `SET deleted = 1`, so the "fix" would have retained deleted
messages' tokens in the FTS index. Shipped `OF content, deleted`. Rule now enforced by a
census test: the `UPDATE OF` set is every column the index stores ∪ every column that
decides membership. Includes a scope-honesty note — I initially overstated it as a
user-visible search leak; all six consumers re-filter on `deleted = 0`.

**A thread-assert is only as honest as the double it runs against.** 21125's AC prescribed
offloading at the controller, where every method is already `async def` — zero work would
have moved, while the assertion still passed against a synchronous fake. Same review: a
plain `gather` of 8 writers passed against a deliberately broken pool. Run both kinds of
assertion against a broken implementation before trusting them.

## Verification

Preflight green; diagnostic inventory verified. Task id swept case-insensitively across
all remote refs and worktrees and taken at max+30 (the CLI's auto-assigned max+1 was
renumbered — that is the collision pattern that has already bitten this programme three
times).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the schema v48 self‑migration regression and adds two testing‑method lessons so reviewers can track the break and intended fixes. Previously the DB self‑migrated and the shipped writer could build pre‑v48 schemas; now v48 requires a caller‑supplied seed to upgrade and `add_message` writes `assistant_generation_state`, which older schemas lack, causing 15 reds including the packaging v35‑upgrade case. The TUI is insulated because it passes the seed; non‑TUI consumers are not.

- Adds TASK-21441 with acceptance criteria to: restore self‑migration or document the seed requirement with a defaulting path; let the shipped writer populate pre‑v48 schemas; green the failing migration/packaging tests (including the v35 upgrade); and add a regression test proving a bare open still migrates.
- Expands `backlog/docs/lessons-testing-evidence.md` with two lessons: a prescribed fix is a hypothesis validated by a differential harness; thread/concurrency assertions must be validated against broken doubles.

<sup>Written for commit f6a34f3b811f65030ac330b769d070b8f3004dd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

