### PR TITLE
Derive the MCP private-tool inventory from the code — and the write tool three docs omitted (TASK-21501)

### DIFF
--- a/Docs/Design/MCP.md
+++ b/Docs/Design/MCP.md
@@ -145,11 +145,11 @@ persistent URL or file ingestion.
 - **Built-in tools (9):** `chat_with_llm`, `chat_with_character`, `search_rag`, `search_conversations`, `create_note`, `search_notes`, `list_characters`, `get_conversation_history`, `export_conversation`
 - **Resource templates (5):** `conversation://{conversation_id}`, `note://{note_id}`, `character://{character_id}`, `media://{media_id}`, `rag-chunk://{chunk_uuid}`
 - **Prompts (5):** `summarize_conversation`, `generate_document`, `analyze_media`, `search_and_synthesize`, `character_writing`
-- **Library tools excluded from standalone (18):** `library_list_media`, `library_get_media`, `library_search_media`, `library_list_notes`, `library_get_note`, `library_search_notes`, `library_list_prompts`, `library_get_prompt`, `library_search_prompts`, `library_list_skills`, `library_get_skill`, `library_search_skills`, `library_list_conversations`, `library_get_conversation`, `library_search_conversations`, `library_list_collections`, `library_get_collection`, `library_search_collections`
+- **Library tools excluded from standalone (24):** `library_list_media`, `library_get_media`, `library_search_media`, `library_get_media_structure`, `library_get_media_chunk`, `library_list_chunk_specs`, `library_save_chunk_spec`, `library_rechunk_media`, `library_list_notes`, `library_get_note`, `library_search_notes`, `library_save_note`, `library_list_prompts`, `library_get_prompt`, `library_search_prompts`, `library_list_skills`, `library_get_skill`, `library_search_skills`, `library_list_conversations`, `library_get_conversation`, `library_search_conversations`, `library_list_collections`, `library_get_collection`, `library_search_collections`
 
 ### Standalone behavior and controls
 
-All 18 Library tools are excluded from the standalone stdio catalog. They
+All 24 Library tools are excluded from the standalone stdio catalog. They
 remain available only through the app's gated, logged direct Library execution
 path, whose raw in-app `tools/call` route is refused.
 

--- a/Docs/Development/release-recovery-setup.md
+++ b/Docs/Development/release-recovery-setup.md
@@ -40,11 +40,11 @@ persistent URL or file ingestion.
 - **Built-in tools (9):** `chat_with_llm`, `chat_with_character`, `search_rag`, `search_conversations`, `create_note`, `search_notes`, `list_characters`, `get_conversation_history`, `export_conversation`
 - **Resource templates (5):** `conversation://{conversation_id}`, `note://{note_id}`, `character://{character_id}`, `media://{media_id}`, `rag-chunk://{chunk_uuid}`
 - **Prompts (5):** `summarize_conversation`, `generate_document`, `analyze_media`, `search_and_synthesize`, `character_writing`
-- **Library tools excluded from standalone (18):** `library_list_media`, `library_get_media`, `library_search_media`, `library_list_notes`, `library_get_note`, `library_search_notes`, `library_list_prompts`, `library_get_prompt`, `library_search_prompts`, `library_list_skills`, `library_get_skill`, `library_search_skills`, `library_list_conversations`, `library_get_conversation`, `library_search_conversations`, `library_list_collections`, `library_get_collection`, `library_search_collections`
+- **Library tools excluded from standalone (24):** `library_list_media`, `library_get_media`, `library_search_media`, `library_get_media_structure`, `library_get_media_chunk`, `library_list_chunk_specs`, `library_save_chunk_spec`, `library_rechunk_media`, `library_list_notes`, `library_get_note`, `library_search_notes`, `library_save_note`, `library_list_prompts`, `library_get_prompt`, `library_search_prompts`, `library_list_skills`, `library_get_skill`, `library_search_skills`, `library_list_conversations`, `library_get_conversation`, `library_search_conversations`, `library_list_collections`, `library_get_collection`, `library_search_collections`
 
 ### Standalone behavior and controls
 
-All 18 Library tools are excluded from the standalone stdio catalog and remain
+All 24 Library tools are excluded from the standalone stdio catalog and remain
 behind the gated and logged direct Library action; raw in-app `tools/call` is
 refused.
 

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -38,11 +38,11 @@ persistent URL or file ingestion.
 - **Built-in tools (9):** `chat_with_llm`, `chat_with_character`, `search_rag`, `search_conversations`, `create_note`, `search_notes`, `list_characters`, `get_conversation_history`, `export_conversation`
 - **Resource templates (5):** `conversation://{conversation_id}`, `note://{note_id}`, `character://{character_id}`, `media://{media_id}`, `rag-chunk://{chunk_uuid}`
 - **Prompts (5):** `summarize_conversation`, `generate_document`, `analyze_media`, `search_and_synthesize`, `character_writing`
-- **Library tools excluded from standalone (23):** `library_list_media`, `library_get_media`, `library_search_media`, `library_list_notes`, `library_get_note`, `library_search_notes`, `library_list_prompts`, `library_get_prompt`, `library_search_prompts`, `library_list_skills`, `library_get_skill`, `library_search_skills`, `library_list_conversations`, `library_get_conversation`, `library_search_conversations`, `library_list_collections`, `library_get_collection`, `library_search_collections`, `library_get_media_structure`, `library_get_media_chunk`, `library_list_chunk_specs`, `library_save_chunk_spec`, `library_rechunk_media`
+- **Library tools excluded from standalone (24):** `library_list_media`, `library_get_media`, `library_search_media`, `library_get_media_structure`, `library_get_media_chunk`, `library_list_chunk_specs`, `library_save_chunk_spec`, `library_rechunk_media`, `library_list_notes`, `library_get_note`, `library_search_notes`, `library_save_note`, `library_list_prompts`, `library_get_prompt`, `library_search_prompts`, `library_list_skills`, `library_get_skill`, `library_search_skills`, `library_list_conversations`, `library_get_conversation`, `library_search_conversations`, `library_list_collections`, `library_get_collection`, `library_search_collections`
 
 ### Standalone behavior and controls
 
-All 23 Library tools are excluded from the standalone stdio catalog. They
+All 24 Library tools are excluded from the standalone stdio catalog. They
 remain behind the in-app gated and logged direct Library action; raw in-app
 `tools/call` is refused.
 

--- a/Tests/MCP/test_mcp_documentation_contract.py
+++ b/Tests/MCP/test_mcp_documentation_contract.py
@@ -7,6 +7,10 @@ import re
 
 import pytest
 
+from tldw_chatbook.Library.library_tool_contract import (
+    LIBRARY_TOOL_DESCRIPTORS,
+)
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCUMENTS = (
@@ -75,26 +79,18 @@ PROMPTS = (
     "search_and_synthesize",
     "character_writing",
 )
-PRIVATE_LIBRARY_TOOLS = (
-    "library_list_media",
-    "library_get_media",
-    "library_search_media",
-    "library_list_notes",
-    "library_get_note",
-    "library_search_notes",
-    "library_list_prompts",
-    "library_get_prompt",
-    "library_search_prompts",
-    "library_list_skills",
-    "library_get_skill",
-    "library_search_skills",
-    "library_list_conversations",
-    "library_get_conversation",
-    "library_search_conversations",
-    "library_list_collections",
-    "library_get_collection",
-    "library_search_collections",
-)
+#: Derived, never transcribed. ``LIBRARY_TOOL_DESCRIPTORS`` is the contract the
+#: local MCP manifest is itself built from -- ``MCP/server.py``'s
+#: ``_describe_local_library_tools`` iterates it unfiltered, and its docstring
+#: says outright that it is "never hand-maintained here". A second hand-kept
+#: copy in this test is what let the surface and the documents drift apart in
+#: four directions at once (TASK-21501): the code carried 24 tools while
+#: `Docs/Design/MCP.md` said 18, `Docs/User_Guide/mcp.md` said 23, and this
+#: tuple said 18. Deriving removes the drift class rather than resetting it.
+#:
+#: A tuple rather than a view: ``_mutate_inventory`` indexes element 0 to pick
+#: the token it perturbs.
+PRIVATE_LIBRARY_TOOLS = tuple(LIBRARY_TOOL_DESCRIPTORS)
 INVENTORY_CONTRACT = {
     "Built-in tools": BUILTIN_TOOLS,
     "Resource templates": RESOURCE_TEMPLATES,
@@ -356,12 +352,30 @@ def test_watchlists_tools_document_privacy_and_external_mcp_permission() -> None
 
 
 def test_expanded_local_tool_group_copy_names_watchlists_everywhere() -> None:
+    """The master-switch label names all three tool groups on every surface.
+
+    Whitespace-normalized, like every other prose assertion in this module, and
+    for two reasons rather than one. The obvious one is that these are wrapped
+    Markdown paragraphs: the label spans a line break in
+    `Docs/User_Guide/console/agent-runs-and-tools.md` ("Local workspace,\nweb,
+    and Watchlists tools"), so a raw substring check reported the copy missing
+    when it was present and correct.
+
+    The reason that actually matters is the *stale* half. Checking raw text for
+    the retired label means a retired label that happens to wrap escapes the
+    check -- the guard would pass on exactly the content it exists to catch.
+    Reflowing a paragraph must not be able to switch this guard off.
+
+    Raises:
+        AssertionError: If a surface still carries the retired two-group label,
+            or does not carry the three-group one.
+    """
     stale = "Local workspace + web tools"
     expected = "workspace, web, and Watchlists"
     for path in LOCAL_TOOL_COPY_SURFACES:
-        text = path.read_text(encoding="utf-8")
-        assert stale not in text, path
-        assert expected in text, path
+        normalized = " ".join(path.read_text(encoding="utf-8").split())
+        assert stale not in normalized, path
+        assert expected in normalized, path
 
 
 def test_builtin_gate_rejects_two_category_master_switch_copy() -> None:

--- a/backlog/tasks/task-21501 - Three-documents-and-the-code-disagree-about-the-private-MCP-tool-surface.md
+++ b/backlog/tasks/task-21501 - Three-documents-and-the-code-disagree-about-the-private-MCP-tool-surface.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-21501
-title: >-
-  Three documents and the code disagree about the private MCP tool surface
-status: In Progress
+title: Three documents and the code disagree about the private MCP tool surface
+status: Done
 assignee: []
+created_date: ''
+updated_date: '2026-08-24 05:11'
 labels:
   - testing
   - test-integrity
@@ -37,12 +38,12 @@ page that enumerates what the private surface contains did not mention it at all
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The inventory the contract checks against is obtained from the code that defines it, not restated
-- [ ] #2 Every document the contract governs agrees with the code, and the count each one states matches the list it prints
-- [ ] #3 The code's own prose description of the surface is corrected where it is stale
-- [ ] #4 Any tool absent from the documents is identified and reported rather than quietly added, and its significance is stated
-- [ ] #5 The contract is shown to reject a document that falls behind the code again
-- [ ] #6 Prose assertions in this module cannot be switched off by reflowing a paragraph
+- [x] #1 The inventory the contract checks against is obtained from the code that defines it, not restated
+- [x] #2 Every document the contract governs agrees with the code, and the count each one states matches the list it prints
+- [x] #3 The code's own prose description of the surface is corrected where it is stale
+- [x] #4 Any tool absent from the documents is identified and reported rather than quietly added, and its significance is stated
+- [x] #5 The contract is shown to reject a document that falls behind the code again
+- [x] #6 Prose assertions in this module cannot be switched off by reflowing a paragraph
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,3 +55,63 @@ page that enumerates what the private surface contains did not mention it at all
 4. Correct the documents and the code's stale prose from the derived truth.
 5. Mutation-prove both the doc-versus-code link and the prose assertions.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The withheld-from-standalone Library tool set is declared once, in
+`LIBRARY_TOOL_DESCRIPTORS` — the table `MCP/server.py`'s `_describe_local_library_tools`
+iterates **unfiltered**, whose docstring states it is "never hand-maintained here". Four
+restatements existed and all four were behind, by different amounts:
+
+| restatement | count |
+|---|---|
+| code (`LIBRARY_TOOL_DESCRIPTORS`) | **24** |
+| `Docs/User_Guide/mcp.md` | 23 |
+| `Docs/Design/MCP.md` | 18 |
+| `Docs/Development/release-recovery-setup.md` | 18 |
+| this test's `PRIVATE_LIBRARY_TOOLS` | 18 |
+
+**Why only part of it was visible.** The test agreed with two of the three documents, so only
+`mcp.md`'s parametrizations failed; the two documents that matched the test were equally
+wrong and passed. Eleven of the fourteen failures were the contract's own mutation
+self-checks, which cannot demonstrate that extra/missing/duplicate entries are rejected while
+the text they mutate is already non-conforming. A red contract test was concealing two further
+wrong documents.
+
+**AC#1** — `PRIVATE_LIBRARY_TOOLS = tuple(LIBRARY_TOOL_DESCRIPTORS)`. Derived, not restated,
+so the drift class is removed rather than reset by six. Kept a tuple because
+`_mutate_inventory` indexes element 0.
+
+**AC#4 — the finding, stated rather than absorbed.** The tool missing from **all three**
+documents is `library_save_note`: the only **write** tool in the set, carrying its own
+`library.notes/save` policy. It was added by `6e04d3199`, after `b8592cfa4` wrote
+`server.py`'s "23", and `grep` found it **nowhere** in `Docs/User_Guide/mcp.md`. A page whose
+job is to enumerate what the private surface contains omitted its only write capability. Had
+this been closed by editing the test's 18 up to 23 to match `mcp.md`, that omission would
+have survived and the suite would have gone green over it.
+
+**AC#3** — `server.py`'s own prose said 23; corrected to 24 and it now names the write tool
+explicitly rather than leaving it inside an "and siblings" gloss.
+
+**AC#6** — `test_expanded_local_tool_group_copy_names_watchlists_everywhere` read **raw** file
+text while every neighbouring prose assertion in the module normalizes whitespace. It reported
+the three-group label missing from `agent-runs-and-tools.md` when the label is present and
+correct, merely wrapped across a newline. The half that matters is the *stale*-label check:
+demonstrated directly that with raw text the retired label "Local workspace + web tools",
+reintroduced wrapped, is **not** detected (`False`) and is detected once normalized (`True`).
+Reflowing a paragraph could switch that guard off.
+
+**Evidence.** 69 passed / 0 failed, up from 55 passed / 14 failed — and now checking 24
+entries across three documents instead of 18. Mutation-proven three ways: removing one tool
+from `Docs/Design/MCP.md` → 13 failed; making a document's stated count disagree with its own
+list → 13 failed; reintroducing the retired label wrapped → 1 failed. Restored: 69 passed.
+Regression sweep `Tests/MCP` + `Tests/QA` + `Tests/CI` + `test_library_tool_contract.py`:
+**1,431 passed, 1 failed**, and that one
+(`test_console_notes_workspace_uat.py::test_console_agent_reads_then_updates_configured_workspace_note`)
+fails identically on a clean `dev` checkout.
+
+Modified: `Tests/MCP/test_mcp_documentation_contract.py`, `Docs/User_Guide/mcp.md`,
+`Docs/Design/MCP.md`, `Docs/Development/release-recovery-setup.md`,
+`tldw_chatbook/MCP/server.py` (docstring only).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21501 - Three-documents-and-the-code-disagree-about-the-private-MCP-tool-surface.md
+++ b/backlog/tasks/task-21501 - Three-documents-and-the-code-disagree-about-the-private-MCP-tool-surface.md
@@ -1,0 +1,56 @@
+---
+id: TASK-21501
+title: >-
+  Three documents and the code disagree about the private MCP tool surface
+status: In Progress
+assignee: []
+labels:
+  - testing
+  - test-integrity
+  - documentation
+  - mcp
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The contract test that exists to stop the MCP documentation drifting from the code had itself
+drifted, and while it was red nobody could see what it was hiding.
+
+The set of Library tools withheld from the standalone server is declared once in the code, in
+a descriptor table the local capability manifest is generated from — the manifest builder's
+own docstring says the table is never to be hand-maintained. Three documents restate that set
+for readers, and the contract test restates it a fourth time in order to check them.
+
+Every restatement had fallen behind, and by different amounts, so the three documents and the
+test disagreed with the code and with each other. The failure the suite reported was the one
+document that disagreed with the test; the two that agreed with the test were equally wrong
+and passed. Most of the reported failures were the contract's own self-checks, which cannot
+demonstrate that mutations are rejected while the text they mutate is already non-conforming.
+
+Worth stating separately, because it is the part that matters to a user rather than to the
+suite: the tool missing from all three documents is the only **write** tool in the set. The
+page that enumerates what the private surface contains did not mention it at all.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The inventory the contract checks against is obtained from the code that defines it, not restated
+- [ ] #2 Every document the contract governs agrees with the code, and the count each one states matches the list it prints
+- [ ] #3 The code's own prose description of the surface is corrected where it is stale
+- [ ] #4 Any tool absent from the documents is identified and reported rather than quietly added, and its significance is stated
+- [ ] #5 The contract is shown to reject a document that falls behind the code again
+- [ ] #6 Prose assertions in this module cannot be switched off by reflowing a paragraph
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Establish what the code actually declares, from the table the manifest is generated from.
+2. Compare all four restatements against it and record how each differs.
+3. Replace the test's restatement with a derivation.
+4. Correct the documents and the code's stale prose from the derived truth.
+5. Mutation-prove both the doc-versus-code link and the prose assertions.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/MCP/server.py
+++ b/tldw_chatbook/MCP/server.py
@@ -34,9 +34,10 @@ the retired `todo_write` tool is also absent.
 
 ## Exposed local Library tools (task-1337)
 
-The 23 descriptor-backed `library_*` tools (media/notes/prompts/skills/
+The 24 descriptor-backed `library_*` tools (media/notes/prompts/skills/
 conversations/collections list+get+search, plus the chunking-agent-tools
-siblings: structure/chunk/spec-list/spec-save/re-chunk) are part of the
+siblings: structure/chunk/spec-list/spec-save/re-chunk, and the note WRITE
+tool `library_save_note`) are part of the
 local MCP surface: they are locally served and contract-governed by
 `Library/library_tool_contract.py`. The capability manifest appends them from
 the descriptor table (`_describe_local_library_tools`), and the in-app direct


### PR DESCRIPTION
The contract test that exists to stop the MCP docs drifting from the code had drifted itself,
and while it was red it was hiding what it was for.

## Four restatements, all behind, by different amounts

The withheld-from-standalone Library tool set is declared once, in `LIBRARY_TOOL_DESCRIPTORS`
— the table `MCP/server.py`'s `_describe_local_library_tools` iterates **unfiltered**, and
whose docstring says it is *"never hand-maintained here"*.

| restatement | count |
|---|---|
| **code** (`LIBRARY_TOOL_DESCRIPTORS`) | **24** |
| `Docs/User_Guide/mcp.md` | 23 |
| `Docs/Design/MCP.md` | 18 |
| `Docs/Development/release-recovery-setup.md` | 18 |
| this test's `PRIVATE_LIBRARY_TOOLS` | 18 |

**Why only part of it was visible.** The test agreed with two of the three documents, so only
`mcp.md`'s parametrizations failed — the two that matched the test were equally wrong and
passed. And 11 of the 14 failures were the contract's own mutation self-checks, which cannot
demonstrate that extra/missing/duplicate entries get rejected while the text they mutate is
already non-conforming. A red contract test was concealing two further wrong documents.

## The finding

The tool missing from **all three** documents is **`library_save_note` — the only write tool
in the set**, with its own `library.notes/save` policy. It was added *after* `server.py`'s
"23" was written, and it appears **nowhere** in `Docs/User_Guide/mcp.md`. A page whose job is
to enumerate what the private surface contains omitted its only write capability.

This is the reason not to close a drift like this by bumping a number. Editing the test's 18
up to 23 to match `mcp.md` would have gone green and left that omission in place.

## The fix

`PRIVATE_LIBRARY_TOOLS = tuple(LIBRARY_TOOL_DESCRIPTORS)` — derived, not restated, so the
drift class is removed rather than reset by six. All three documents and `server.py`'s own
prose corrected to 24, with the write tool named explicitly rather than folded into an
"and siblings" gloss.

## Also: a prose guard that a line-wrap could switch off

`test_expanded_local_tool_group_copy_names_watchlists_everywhere` read **raw** file text while
every neighbouring prose assertion in the module normalizes whitespace. It reported the
three-group tool-group label missing from `agent-runs-and-tools.md` when the label is present
and correct, merely wrapped across a newline.

The half that matters is the *stale*-label check. Demonstrated directly:

```
retired label present in document (as prose): True
OLD guard (raw text)      flags it: False
NEW guard (normalized)    flags it: True
```

Reflowing a paragraph could turn that guard off — on exactly the content it exists to catch.

## Evidence

**69 passed / 0 failed**, from 55 passed / 14 failed — and now checking 24 entries across
three documents rather than 18.

Mutation-proven three ways, each restoring to 69 green:

| mutation | result |
|---|---|
| remove one tool from `Docs/Design/MCP.md` | 13 failed |
| make a document's stated count disagree with its own list | 13 failed |
| reintroduce the retired label, wrapped across a newline | 1 failed |

Regression sweep — `Tests/MCP` + `Tests/QA` + `Tests/CI` + `test_library_tool_contract.py`:
**1,431 passed, 1 failed**. That one
(`test_console_notes_workspace_uat.py::test_console_agent_reads_then_updates_configured_workspace_note`)
fails identically on a clean `dev` checkout — verified in a separate worktree.

Test, docs, and one product docstring; no behavioural product change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the MCP private-library tool inventory from the code and updates three docs and one docstring to list 24 tools, fixing the omission of the write tool. Previously the test restated 18 tools and two docs matched that; now the test derives from `LIBRARY_TOOL_DESCRIPTORS`, so docs cannot drift independently.

- Test: `PRIVATE_LIBRARY_TOOLS = tuple(LIBRARY_TOOL_DESCRIPTORS)` in `Tests/MCP/test_mcp_documentation_contract.py`; adds mutation checks and normalizes whitespace in the label guard to avoid false negatives on wrapped text.
- Docs: `Docs/User_Guide/mcp.md`, `Docs/Design/MCP.md`, and `Docs/Development/release-recovery-setup.md` now list 24 and include `library_save_note`; counts match lists.
- Code comment: `tldw_chatbook/MCP/server.py` docstring updated to 24 and names the write tool.
- Scope: tests, docs, and a docstring only; no runtime behavior change. Satisfies TASK-21501.

<sup>Written for commit ff4c7593b983b0a4a7b5b3668ae43dd5c78a812f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

