### PR TITLE
docs(perf): re-verify the seven unstarted findings before dispatch

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -451,6 +451,31 @@ silently edited.
    (task-21128; authored as v47 → v48 and renumbered when the Console Library policy step took
    48 by merging first), one line different from v47's trigger.
 
+4. **Seven unstarted findings were re-verified before dispatch, and five needed correcting.**
+   After three of this doc's findings turned out wrong at implementation time, the remaining
+   queue was re-read against dev `2be18842a` before any more of it was dispatched. That pass
+   changed the plan more than the three earlier corrections did:
+
+   | finding | as filed | after re-verification |
+   |---|---|---|
+   | 21107 | ~44 ms; TYPE_CHECKING the import | ~19 ms warm; that fix **cannot compile** — the spec table stores the schema classes as runtime values, and a test already allowlists the import as deliberate. Needs a lazy spec table instead. |
+   | 21109 | 5 s lease stall in `__init__` | **sub-millisecond** for a user with no videos; the 5 s case needs a second instance mid-save. Deferring it past first paint would let the default `session` sweep delete a video published *that session*. |
+   | 21110 | medium | **highest-value item left** — ~305 modules / ~232k LOC imported on the loop after a 1.5 s splash during which nothing else is scheduled. |
+   | 21120 | three per-keystroke legs | mis-stated on all three; two fixes remove ~nothing (the "skip unchanged" guard can never fire while typing). Only the ghost-scan cap survives. |
+   | 21123 | ~421 recompose sites; relocate the hook | count is ~111 (98 in `library_screen.py`); **under**-billed — the widget import precedes the enabled check and drags PIL onto the loop. The relocation would **break** the enabled case: `recompose()` removes the mounted buddy and an app-level owner would miss that signal. Split: early-return shipped, relocation deferred. |
+   | 21127 | three legs | all three hold, cites drifted; `_update_row` opens **three** connections per update, worse than filed. Trap: `:memory:` mode shares one connection — closing it destroys the database. |
+   | 21132 | per-interaction closure walk | recursion walks **upward**, so it is bounded by managed folders × depth and is **empty for the default profile**; already off-loop. Recommend cancel. |
+
+   The pass also surfaced a finding worth more than the task it was found under: the composer's
+   cursor-blink tick calls `Static.update()`, whose `layout` parameter **defaults to `True`**, so
+   it arms a layout pass every 0.53 s while the composer is merely focused and idle — directly
+   contradicting its own docstring ("must not trigger a layout recompute on every blink phase").
+   Filed as task-21501.
+
+   **The method lesson**: a finding's cost estimate decays as fast as its line numbers. Re-measure
+   before dispatching, not after — five of seven is not a rounding error, and two of these would
+   have shipped a fix for a problem that was not there.
+
 ---
 
 ## Verified clean — do not re-fix

--- a/backlog/tasks/task-21107 - Kanban_Interop defeats tldw_api's lazy facade - 76 pydantic models forced at every boot.md
+++ b/backlog/tasks/task-21107 - Kanban_Interop defeats tldw_api's lazy facade - 76 pydantic models forced at every boot.md
@@ -9,7 +9,7 @@ labels:
   - performance
   - startup
   - imports
-priority: medium
+priority: low
 dependencies: []
 ---
 
@@ -25,3 +25,31 @@ otherwise-lazy PEP-562 facade - one of exactly two leaks (the other is fixed by 
 
 - [ ] The import is TYPE_CHECKING/function-local; kanban behavior (such as it is - zero UI consumers found) unchanged
 - [ ] A test asserts `tldw_chatbook.tldw_api.kanban_schemas` is not in sys.modules after importing the app module
+
+## Re-verification against dev 2be18842a (2026-08-23)
+
+An independent read-only pass re-checked this finding before implementation. **Still true, but
+the cost is over-billed ~2x and the acceptance criteria as written cannot be met.**
+
+**Confirmed**: `Kanban_Interop/server_kanban_service.py:10-42` is a module-level import of 31
+names from `..tldw_api`, reached from `app.py:542` via `Kanban_Interop/__init__.py:5` →
+`kanban_scope_service.py:9`. The 76 pydantic classes in `kanban_schemas.py` is exact. It is a
+*sole* leak — `tldw_api.client` is not in the eager boot closure, so nothing else drags it in.
+
+**Cost corrected**: ~19 ms warm, not ~44 ms. The original number was measured with pydantic's
+own internals cold and charged to this module; 19 of the boot closure's modules already import
+pydantic, so that cost is paid regardless.
+
+**Why the prescribed fix does not work**: `KANBAN_OPERATION_SPECS` stores the schema *classes*
+as runtime values (`request_model=KanbanBoardCreate`), and two siblings read that dict at their
+own module scope (`local_kanban_service.py:29-32`, `kanban_scope_service.py:43`). A
+TYPE_CHECKING or function-local import breaks the import outright. There is already a test
+documenting this as deliberate — `Tests/Utils/test_tldw_api_schema_deferral.py:40-48` allowlists
+`kanban_schemas` as "a genuine module-scope need, not an oversight".
+
+**Revised direction**: store the model *name* in the spec table and resolve it lazily in
+`_coerce_request_args` (`server_kanban_service.py:702-723`, the only runtime reader). The house
+pattern already exists — `local_kanban_service.py:336,430,558` do function-local
+`from ..tldw_api import Kanban...`. This also requires updating the allowlist test. That is a
+larger and riskier change than the original filing implies; treat it as such, and if it does not
+justify ~19 ms for a feature with no UI consumers, close this instead.

--- a/backlog/tasks/task-21109 - Generated-video store retention runs in __init__ behind a 5s interprocess lease - move it to deferred startup.md
+++ b/backlog/tasks/task-21109 - Generated-video store retention runs in __init__ behind a 5s interprocess lease - move it to deferred startup.md
@@ -9,7 +9,7 @@ labels:
   - performance
   - startup
   - video-generation
-priority: medium
+priority: low
 dependencies: []
 ---
 
@@ -28,3 +28,30 @@ up to 5 s.
 - [ ] App construction only resolves paths; `enforce_retention()` runs from `_schedule_deferred_startup_work` after first paint
 - [ ] A probe holding the lease from a second process shows boot is no longer blocked
 - [ ] Retention semantics (including the session default) unchanged; existing video-store tests green
+
+## Re-verification against dev 2be18842a (2026-08-23)
+
+An independent read-only pass re-checked this finding. **Mechanism still true; severity badly
+over-billed; and the prescribed fix introduces a data-loss race unless guarded.**
+
+**Confirmed**: `app.py:5737` (in `TldwCli.__init__`) → `app.py:5365-5375` constructs `VideoStore()`
+and calls `enforce_retention()`. `video_store.py:57` sets a 5.0 s lease timeout;
+`_root_lease()` (`:190-233`) spins a non-blocking exclusive lock at 10 ms intervals to that
+deadline. Boot-only — nothing else calls `enforce_retention`.
+
+**Cost corrected**: for a user who has never generated a video, `_snapshot()` returns empty
+immediately and the whole pass is one `mkdir`, one lock-file create, one flock, one failed
+`scandir`, one unlock — **sub-millisecond**. The 5 s stall requires a second instance holding the
+lease at that exact moment, which only happens during its own sub-ms boot pass or an in-flight
+save. `app.py:5369` already catches `VideoStoreBusyError`, so boot does not fail either way.
+
+**The fix as written is unsafe**: the default retention mode is `"session"`, which means *delete
+everything* (`video_store.py:795-800`). Moving the pass after first paint opens a window in which
+a video published during this session is wiped by the session sweep, because the sweep has no
+notion of process start. Any deferral MUST either capture a process-start timestamp and skip
+files newer than it, or run before the video adapter can publish. Secondary: deferring means a
+prior-session video marker can briefly resolve to a file that is about to vanish.
+
+**Revised severity: low, bordering on not-worth-doing.** If something here is worth shipping, it
+is the smaller honest win — stop creating `.generated_videos.capacity.lock` in every profile's
+data dir at every boot for users who have never generated a video.

--- a/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
+++ b/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
@@ -28,3 +28,34 @@ render AND per 0.5 s blink tick (:4214-4240).
 
 - [ ] The reason strip updates only when reason_changed; the hidden-input mirror skips unchanged text; the ghost-text history scan is capped or cached
 - [ ] Composer behavior (send gating, ARIA announcements, ghost suggestions) unchanged - existing composer tests green
+
+## Re-verification against dev 2be18842a (2026-08-23)
+
+An independent read-only pass re-checked all three legs. **Mis-stated on all three, and two of
+the three prescribed fixes remove essentially nothing.** The file has moved to
+`tldw_chatbook/Widgets/Console/console_composer_bar.py`.
+
+**Leg 1 (reason strip) — drop it.** The mechanism is real (`_sync_send_disabled_reason` at
+`:1566-1607` runs unconditionally from `:1717`), but the claim that the `reason_changed` gate
+"covers only the ARIA announcement" is false: there is no ARIA announcement there. `reason_changed`
+gates a draft re-window at `:1750-1757`. The ungated part costs one `query_one`, one `Content("")`,
+six style writes that Textual already no-ops when unchanged, and a `refresh(layout=True)` that
+folds into a layout pass `_refresh_visible_draft` has already armed on the same keystroke.
+Gating it removes microseconds.
+
+**Leg 2 (hidden-input mirror) — real cost, wrong fix.** "Skip unchanged text" can never fire while
+typing, since the value always differs; Textual already skips unchanged reactive sets. The actual
+O(draft) cost is `Input._watch_value` recomputing `virtual_size` via `cell_len` over the whole
+draft on every key. And the mirror cannot simply be removed: `chat_screen.py:16395` has a live
+`@on(Input.Changed)` consumer, and `draft_text()` / `_has_any_draft_content()` /
+`_display_draft_text()` still read the Input as the pre-initialisation fallback.
+
+**Leg 3 (ghost scan) — keep.** `_ghost_suffix` (`:4214-4240`) → `PromptHistory.complete`
+(`Chat/prompt_history.py:247-265`) is a reverse linear scan over up to 1000 entries, and the
+worst case (novel prefix, no match) is the common case: ~1000 `startswith`, order 50-100 us.
+Blink interval is 0.53 s, not 0.5, and the timer is paused unless the composer is focused.
+
+**Split out**: the biggest cost found in this file is not in this task at all — the blink tick
+arms a full layout pass ~2x/second while merely focused and idle. Filed separately as TASK-21501.
+
+**Action**: rewrite this task down to the ghost-scan cap, or close it and keep only 21501.

--- a/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
+++ b/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
@@ -28,3 +28,32 @@ on the loop while a run is active.
 - [ ] The service holds a thread-local connection; engine service calls route through to_thread
 - [ ] The 30 s keepalive is batched with progress writes; the 2 s auto-refresh reads off-loop
 - [ ] Research behavior unchanged - existing tests green
+
+## Re-verification against dev 2be18842a (2026-08-23)
+
+An independent read-only pass re-checked this finding. **All three legs still true; line cites
+have drifted; one prescribed fix has a data-loss shape.**
+
+**Confirmed, with corrected cites** (the filed `99-123` is now the schema-deferral block):
+- `Research_Interop/local_research_service.py:124-158` — fresh connection per operation in
+  file-backed mode, re-running `PRAGMA journal_mode = WAL` and `synchronous = NORMAL` on every
+  open. **21** `with self._connect() as conn:` sites, **one** `.close()` in the file; `with conn:`
+  is a transaction manager, not a closer, so the rest are GC-leaked.
+- **Worse than filed**: `_update_row` (`:429-450`) opens **three** connections per single update
+  (`_require_one`, the UPDATE, then `_require_one` again), each paying the private seam's
+  owner-policy validation and `verify_trusted_directory`.
+- `UI/Research_Window.py:595-600` — `run_worker(_run_engine(), ...)` with no `thread=True`.
+- Every DB method on `LocalResearchService` is synchronous and the engine calls ~40 of them
+  directly, so unlike an earlier finding in this programme, **an offload here would move real
+  work** rather than zero.
+- Keepalive: `local_research_engine.py:371-400` — a synchronous WRITE on the loop every 30 s for
+  the life of a run. 2 s poll confirmed at `Research_Window.py:816`, correctly gated to an active
+  non-terminal local run, reaching a `_call_service` seam that evaluates the method synchronously
+  before its `await` plus an uncached `inspect.signature()` per call.
+
+**Trap for the implementer**: do NOT naively add `conn.close()` to the 21 sites. In `:memory:`
+mode `_open_connection` (`:137-148`) returns the **shared** `self._memory_conn`, and closing it
+destroys the database; `close()` (`:161-165`) is the only legitimate closer.
+
+**Revised severity**: every leg is real, but the whole surface is gated behind "user opens the
+Research screen and starts a local run" — not a boot, keystroke or per-frame cost.

--- a/backlog/tasks/task-21132 - Note-folder managed-membership CTE anchors on the whole closure instead of the requested subtrees.md
+++ b/backlog/tasks/task-21132 - Note-folder managed-membership CTE anchors on the whole closure instead of the requested subtrees.md
@@ -26,3 +26,33 @@ so latency not freeze).
 
 - [ ] The CTE anchor is seeded from the requested ids' subtrees; results identical on existing fixtures
 - [ ] A timing probe on a deep synthetic tree shows the reduction
+
+## Re-verification against dev 2be18842a (2026-08-23) — RECOMMEND CANCEL
+
+An independent read-only pass re-checked this finding. **The mechanism is real; the cost is
+effectively zero for the default user; and the rewrite is a query inversion, not a filter.**
+
+**Confirmed**: `Notes/note_folder_repository.py:1889-1919` — the recursive anchor selects all
+managed memberships and applies the requested ids only at the end. Called twice per tree refresh
+(`:383-385`, `:654-656`, with `library_screen.py:12096-12180` issuing two `load_batch` calls).
+
+**But the magnitude does not hold up.** The recursion walks **upward** (child → parent), so the
+closure is bounded by *distinct managed folders x tree depth* — not by the folder tree and not by
+note count. Managed memberships exist only where a notes-sync owner has placed notes. For a user
+with no sync owners — the default, and TASK-21112 has since made zero-profile boots create no sync
+state at all — the anchor is **empty**, served by the partial index
+`idx_note_folder_memberships_managed_owner`, and the query costs one index probe. It is also
+already off the event loop: `Notes/notes_scope_service.py:248-250` wraps the call in
+`asyncio.to_thread`. So "every Notes-tree interaction walks the entire managed-membership closure"
+is true only for a heavy sync user, and even then it is milliseconds on a worker thread.
+
+**And the fix is riskier than billed.** Because the recursion runs upward, seeding it with the
+requested ids means *inverting* it to descend via `parent_id` — a different query, not a filtered
+one. Equivalence hinges on a quirk: the current query tests `folder.deleted = 0` on the *source*
+row, so a deleted parent still enters the result set but cannot recurse further. A naive downward
+rewrite will not reproduce that, and "results identical on existing fixtures" is too weak a bar —
+it would need fixtures with a deleted intermediate folder, a deleted leaf-managed folder, and a
+managed membership under a deleted ancestor.
+
+**Recommendation**: cancel, or downgrade to a "clean this up when someone is next in this file"
+note. This is a correctness-of-shape improvement, not a performance fix.

--- a/backlog/tasks/task-21531 - Four-dev-reds-from-test-doubles-that-production-outgrew.md
+++ b/backlog/tasks/task-21531 - Four-dev-reds-from-test-doubles-that-production-outgrew.md
@@ -1,0 +1,43 @@
+---
+id: TASK-21531
+title: >-
+  Four dev reds from test doubles that production outgrew - Notes library and
+  lasting-sync flow
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - testing
+  - dev-red
+  - stale-doubles
+priority: medium
+---
+
+## Description
+
+Four tests are red on pristine dev because their doubles were never updated when the
+production signatures they stand in for changed. They are not testing anything real in this
+state, and they sit in the red baseline every branch inherits. Same class as the test-suite
+programme's "stale test doubles production has outgrown" finding.
+
+## Acceptance Criteria
+
+- [ ] `Tests/Notes/test_notes_library_unit.py::TestNotesInteropService::test_get_db_new_instance` and `::TestLibraryNotesInteropDelegates::test_get_db_new_instance` pass, with the double updated to the real constructor signature rather than the assertion relaxed
+- [ ] Both `Tests/UI/test_library_notes_lasting_sync_flow.py::test_activation_result_routes_to_truthful_receipt_or_root_recovery` parameterisations pass, with the `activate_root` double matching the production signature
+- [ ] Each repaired double is verified to still fail when the behaviour it guards is broken -- a double updated only far enough to stop raising is not a fix
+- [ ] A brief note records whether either double had drifted far enough that it was passing vacuously before the signature change
+
+## Evidence (verified first-hand on dev 022b67fc7, 2026-08-23)
+
+```
+pytest Tests/Notes/test_notes_library_unit.py -k test_get_db_new_instance
+  -> 2 failed, 62 deselected
+pytest Tests/UI/test_library_notes_lasting_sync_flow.py -k activation_result_routes
+  -> 2 failed, 5 deselected  (TypeError at test_library_notes_lasting_sync_flow.py:164)
+```
+
+Mechanisms: the Notes doubles' mock `CharactersRAGDB` signature was outgrown by TASK-19900's
+`console_library_migration_seed` argument; the sync-flow double's `activate_root` is missing a
+now-required positional argument.
+
+Surfaced by the TASK-21129 implementer while A/B-baselining its own reds against dev.

--- a/backlog/tasks/task-21532 - Two-remaining-read-all-list-bindings-sites-in-the-notes-sync-runtime.md
+++ b/backlog/tasks/task-21532 - Two-remaining-read-all-list-bindings-sites-in-the-notes-sync-runtime.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21532
+title: >-
+  Two remaining read-all list_bindings sites in the notes-sync runtime
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - performance
+  - notes-sync
+  - database
+priority: low
+---
+
+## Description
+
+TASK-21129 replaced the executor's read-all `list_bindings` calls with narrow store
+projections. Two sites in the runtime still hydrate every binding of a root to keep one field.
+Both are already `asyncio.to_thread`-wrapped, so this is latency and allocation only -- it does
+not block the event loop. Worth doing only when a root gets large or someone is next in the file.
+
+## Acceptance Criteria
+
+- [ ] `notes_sync_runtime.py:2564` uses a narrow projection for CANDIDATE `binding_id`s instead of hydrating full binding records
+- [ ] `notes_sync_runtime.py:509`'s state check is served without materialising every binding, or the task records why the full read is required there
+- [ ] The projections reuse the store methods TASK-21129 added rather than adding parallel query shapes
+- [ ] Measured before/after allocation counts are recorded; if the win is not measurable at a realistic root size, the task is closed rather than shipped
+
+## Evidence (verified first-hand on dev 022b67fc7, 2026-08-23)
+
+`notes_sync_runtime.py:509`:
+```python
+bindings = await asyncio.to_thread(self._store.list_bindings, root.root_id)
+if any(
+    binding.state
+```
+
+`notes_sync_runtime.py:2564` keeps only `binding.binding_id` for CANDIDATE bindings from a full
+hydration -- exactly the shape TASK-21129 measured, where **88% of the read cost was
+`_binding_from_row` building a dataclass, nested profile and enum per row**, not the query.
+
+Surfaced by the TASK-21129 implementer as explicitly out of its scope.


### PR DESCRIPTION
## Summary

Documents only. Re-verifies the seven unstarted findings of the 2026-08-22 performance review
against dev before any more of them are dispatched, and files two follow-ups surfaced during
implementation.

## Why

Three findings in this review turned out wrong when someone actually implemented them — one
prescribed a fix that would have introduced a data-retention bug, one was a plain false
positive, one miscounted the work it claimed to remove. So the rest of the queue was re-read
against dev before dispatch. **Five of the seven needed correcting**, which is not a rounding
error:

| finding | as filed | after re-verification |
|---|---|---|
| 21107 | ~44 ms; TYPE_CHECKING the import | ~19 ms warm; that fix **cannot compile** — the spec table stores schema classes as runtime values, and a test already allowlists the import as deliberate |
| 21109 | 5 s lease stall in `__init__` | **sub-millisecond** in practice; deferring it would let the default `session` sweep delete a video published *that session* |
| 21110 | medium | **best remaining item** — ~305 modules / ~232k LOC imported on the loop after a 1.5 s splash during which nothing else is scheduled |
| 21120 | three per-keystroke legs | mis-stated on all three; two fixes remove ~nothing (the "skip unchanged" guard can never fire while typing) |
| 21123 | ~421 sites; relocate the hook | count is ~111; **under**-billed (PIL reaches the loop), but the relocation would **break** the enabled case |
| 21127 | three legs | all hold, cites drifted; `_update_row` opens **three** connections per update |
| 21132 | per-interaction closure walk | recursion runs **upward** — empty for the default profile, already off-loop. Recommend cancel |

Priorities in the task files are adjusted to match, and each file carries a dated
re-verification section with the evidence.

## New finding

The pass surfaced something worth more than the task it was found under: the composer's
cursor-blink tick calls `Static.update()`, whose `layout` parameter **defaults to `True`**, so
it arms a layout pass every 0.53 s while the composer is merely focused and idle — directly
contradicting its own docstring ("must not trigger a layout recompute on every blink phase").
I confirmed both the call site and Textual's signature by hand. Filed as TASK-21501 and being
implemented separately, with a requirement to prove the two blink phases genuinely cannot
change row count before a blanket `layout=False` is accepted.

## Two follow-ups filed

- **TASK-21531** — four tests red on pristine dev from doubles production outgrew
  (`CharactersRAGDB`'s `console_library_migration_seed` argument; `activate_root`'s signature).
  All four reproduced first-hand on `022b67fc7`.
- **TASK-21532** — the two remaining read-all `list_bindings` sites in the sync runtime. Filed
  low, and its AC says to close it rather than ship it if the win does not measure, since both
  are already off the event loop.

Preflight green; diagnostic inventory verified. Task ids swept case-insensitively across all
remote refs and worktrees before assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-verifies seven unstarted findings from the 2026‑08‑22 performance review against dev and updates the design doc and task priorities; five required corrections. This prevents dispatching fixes that were wrong or risky and adds two follow-ups surfaced during implementation.

- No runtime changes.
- Design doc: adds a summary of re-verification outcomes; promotes 21110 as highest-value; records a new cursor‑blink layout issue filed separately as TASK-21501.
- Task updates:
  - 21107: cost corrected (~19 ms warm); prescribed `TYPE_CHECKING` import cannot compile; proposes lazy spec resolution; priority lowered.
  - 21109: sub‑ms in practice; deferral would risk same‑session data loss unless guarded; priority lowered.
  - 21120: two legs remove ~nothing; keep only ghost‑scan cap; notes the blink‑tick layout problem split to TASK-21501.
  - 21127: all legs still hold; cites corrected; warns against closing the shared `:memory:` connection.
  - 21132: recommend cancel; cost is effectively zero for default users; already off‑loop.
- New tasks added:
  - TASK-21531: repair four dev‑red tests caused by stale doubles; includes evidence and AC to ensure tests still catch regressions.
  - TASK-21532: replace two read‑all `list_bindings` reads with narrow projections; low priority and close if no measurable win.

<sup>Written for commit 4309602732ef28378f7594fc3bf03b3b286ddd33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

