### PR TITLE
Forbid model downloads in the test sandbox — 188 of one CI shard's 189 errors (TASK-21562)

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -17,6 +17,7 @@ _SANDBOXED_ENV_NAMES = (
     "XDG_CONFIG_HOME",
     "TLDW_CONFIG_PATH",
     "PYTHON_KEYRING_BACKEND",
+    "HF_HUB_OFFLINE",
     _TEST_CONFIG_ROOT_ENV,
     _TEST_CONFIG_OWNER_ENV,
 )
@@ -79,6 +80,27 @@ os.environ["TLDW_CONFIG_PATH"] = str(_BOOTSTRAP_CONFIG_PATH)
 # unpatched. `TLDW_TEST_REAL_KEYRING=1` is the deliberate opt-out.
 if os.environ.get("TLDW_TEST_REAL_KEYRING") != "1":
     os.environ["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+
+# TASK-21562: no test downloads a model. `huggingface_hub` freezes
+# `constants.HF_HUB_OFFLINE` at ITS import time, so this has to be written here
+# -- in the pre-import bootstrap -- to be read at all; an env var set from a
+# fixture arrives far too late (the measurement is in
+# `Tests/RAG_Eval/conftest.py`'s offline-latch comment).
+#
+# Why globally, when two sub-conftests already do it for their own scope: the
+# HF cache resolves INTO this sandbox (`.../home/.cache/huggingface/hub`), which
+# never exists, so any code path reaching the hub attempts a real download. That
+# is invisible on a developer machine -- whatever triggers it locally is not
+# triggered -- and very visible in CI, where one core shard alone recorded 188
+# egress-blocked errors against `huggingface.co:443` and a CDN address, each one
+# `huggingface_hub` retrying five times before the guard's record failed the
+# test at teardown. Offline turns that into an immediate, deterministic, local
+# failure instead of a slow CI-only one.
+#
+# `TLDW_TEST_ALLOW_HF_DOWNLOADS=1` opts out, for a test that genuinely needs a
+# live fetch.
+if os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS") != "1":
+    os.environ["HF_HUB_OFFLINE"] = "1"
 
 import pytest  # noqa: E402
 import pytest_asyncio  # noqa: E402
@@ -492,6 +514,34 @@ def fd_leak_sentinel() -> Iterator[None]:
         # survives even -W ignore.
         warnings.warn(message, UserWarning, stacklevel=0)
         print(f"[fd_leak_sentinel] {message}", file=sys.stderr)
+
+
+@pytest.fixture(autouse=True)
+def _huggingface_hub_is_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Close the other half of the offline latch (TASK-21562).
+
+    The bootstrap above sets ``HF_HUB_OFFLINE`` before anything imports
+    ``huggingface_hub``, which is the case that matters and the cheap one. This
+    covers the case where the module was somehow imported first: its
+    ``constants.HF_HUB_OFFLINE`` is frozen at import, so the env var would have
+    been read before we wrote it, while ``is_offline_mode()`` consults the
+    constant on every request and therefore still honours a write here.
+
+    Looked up through ``sys.modules`` rather than imported. Importing
+    ``huggingface_hub`` in every test session to assert a property of sessions
+    that never touch it would cost more than the guard is worth, and would drag
+    the whole hub stack into the import closure of the entire suite.
+
+    ``monkeypatch.setattr`` rather than assignment, so a session that opted out
+    per-test is restored -- the same reasoning as
+    ``Tests/RAG_Eval/conftest.py``'s fixture, which does this for its own scope.
+    """
+    if os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS") == "1":
+        return
+    constants = sys.modules.get("huggingface_hub.constants")
+    if constants is None:
+        return
+    monkeypatch.setattr(constants, "HF_HUB_OFFLINE", True, raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/Tests/test_huggingface_offline.py
+++ b/Tests/test_huggingface_offline.py
@@ -1,0 +1,77 @@
+"""No test downloads a model (TASK-21562).
+
+The HuggingFace cache resolves *into* the per-test sandbox
+(`.../home/.cache/huggingface/hub`), a directory that never exists, so any code
+path that reaches the hub attempts a real download. That is close to invisible
+on a developer machine and very visible in CI: one core shard alone recorded
+188 egress-blocked errors against `huggingface.co:443` and a CDN address, each
+one `huggingface_hub` retrying five times before the network guard's record
+failed the test at teardown.
+
+`huggingface_hub` freezes `constants.HF_HUB_OFFLINE` at its own import time, so
+an env var written from a fixture arrives too late to be read. The bootstrap in
+`Tests/conftest.py` therefore writes it before any import, and an autouse
+fixture patches the constant for the case where the module got in first. These
+tests pin both halves, because a latch that is only half closed reads exactly
+like one that is closed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+OPT_OUT = "TLDW_TEST_ALLOW_HF_DOWNLOADS"
+
+#: Opting out is a legitimate choice, so these skip rather than fail -- a
+#: developer who asked for live fetches should not get a red suite for it. They
+#: skip rather than `return`, so the opt-out is visible in the run's summary
+#: instead of looking like three tests that passed while asserting nothing.
+pytestmark = pytest.mark.skipif(
+    os.environ.get(OPT_OUT) == "1",
+    reason=f"{OPT_OUT}=1: this session deliberately permits model downloads",
+)
+
+
+def test_the_environment_declares_offline_before_any_import() -> None:
+    """The half that does the work: set pre-import, so the constant reads True."""
+    assert os.environ.get("HF_HUB_OFFLINE") == "1"
+
+
+def test_huggingface_hub_actually_reports_itself_offline() -> None:
+    """The property, not the mechanism.
+
+    Imports the module directly rather than through `sys.modules`, because this
+    test is the one place that should pay that cost: asserting the env var is
+    set proves what we wrote, while `is_offline_mode()` proves what the library
+    concluded -- and it is the library's conclusion that decides whether a
+    request goes out.
+
+    `is_offline_mode` is imported from the package root, which is where
+    huggingface_hub 1.12 exports it -- not from `.utils`, where it used to live.
+    Deliberately not wrapped in a try/except: if this import breaks on a future
+    version, that should be a loud failure telling us to re-check how offline
+    mode is decided, not a silently skipped assertion.
+    """
+    from huggingface_hub import constants, is_offline_mode
+
+    assert constants.HF_HUB_OFFLINE is True
+    assert is_offline_mode() is True
+
+
+def test_the_autouse_fixture_covers_an_already_imported_module() -> None:
+    """Once the module is in `sys.modules`, the fixture must have patched it.
+
+    The previous test imports it, so by the time any later test runs the
+    fixture's `sys.modules` lookup succeeds. Ordering makes this cheap: nothing
+    here imports the hub stack on its own account.
+    """
+    constants = sys.modules.get("huggingface_hub.constants")
+    assert constants is not None, (
+        "the previous test imported huggingface_hub, so it must be in sys.modules "
+        "-- if it is not, these tests were reordered and this one no longer "
+        "checks the already-imported path it exists for"
+    )
+    assert constants.HF_HUB_OFFLINE is True

--- a/backlog/tasks/task-21562 - Tests-reach-HuggingFace-for-model-assets-visibly-only-in-CI.md
+++ b/backlog/tasks/task-21562 - Tests-reach-HuggingFace-for-model-assets-visibly-only-in-CI.md
@@ -1,0 +1,124 @@
+---
+id: TASK-21562
+title: 'Tests reach HuggingFace for model assets, visibly only in CI'
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-08-24 06:06'
+labels:
+  - testing
+  - test-integrity
+  - ci
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The test sandbox points the HuggingFace cache at a directory inside itself, which never
+exists, so any code path that reaches the hub attempts a real download. Nothing forbids that
+download, so the attempt goes out, the network guard refuses it, and the client retries
+several times before the guard's record fails the test during teardown.
+
+The cost is almost entirely hidden from developers. A single core shard in CI recorded 188
+such errors; a full local run of the same tests records none, because whatever triggers the
+hub path in CI is not triggered on a machine with the full optional dependency set installed.
+So this is a failure mode that only the gate can see — and until recently the gate could not
+report at all, which is why a defect worth roughly a fifth of a shard's outcomes went
+unexamined.
+
+Two suites already forbid downloads for their own scope, and one of them explains why the
+environment variable has to be set before the client is imported rather than from a fixture.
+That reasoning applies to the whole suite, not just to those two directories.
+
+The immediate goal is not to make those tests pass. It is to make them fail the same way on
+a laptop as they do in CI, because a defect that only one environment can see is one nobody
+will fix.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 No test can download a model asset, and this holds for code that reads the setting at import time as well as code that consults it per request
+- [x] #2 The guarantee is a property of the run rather than a claim in a docstring: both halves of it are asserted, and each is shown to fail when removed
+- [x] #3 A test that genuinely needs a live fetch can still ask for one, and asking does not turn the suite red
+- [x] #4 Turning the guarantee off is visible in a run's summary rather than looking like tests that passed without asserting anything
+- [x] #5 Forbidding downloads does not change the outcome of the suites most likely to touch model assets
+- [x] #6 The claim that this is CI-visible-only is stated with the evidence for it, and the part that remains unexplained is named rather than glossed
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Establish where the cache resolves under test and whether downloads are currently forbidden.
+2. Confirm from a CI log what is actually being reached, and how often, rather than inferring it.
+3. Check that forbidding downloads is neutral locally before changing anything.
+4. Set the environment before any client import; patch the frozen constant for the case where
+   the client got in first.
+5. Assert both halves, prove each fails when removed, and make the opt-out skip visibly.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Set `HF_HUB_OFFLINE=1` in `Tests/conftest.py`'s pre-import bootstrap, and added an autouse
+fixture that patches `huggingface_hub.constants.HF_HUB_OFFLINE` when the module is already
+in `sys.modules`.
+
+**Why two halves (AC#1).** `huggingface_hub` freezes `constants.HF_HUB_OFFLINE` at *its* import
+time, so an env var written from a fixture is read too late to matter, while
+`is_offline_mode()` consults the constant on every request. The bootstrap covers the normal
+case (nothing has imported the client yet); the fixture covers the case where something got
+in first. `Tests/RAG_Eval/conftest.py` already documents this split for its own scope, with
+the measurement — this generalises it. The fixture looks the module up through `sys.modules`
+and never imports it: importing the hub stack in every session to assert a property of
+sessions that never touch it would cost more than the guard is worth.
+
+**What was measured (AC#6).** Under pytest the cache resolves to
+`<sandbox>/home/.cache/huggingface/hub`, which does **not exist**, and `HF_HUB_OFFLINE` was
+**False** — so any code path reaching the hub attempted a real download. From CI core shard
+0/6 of run 32676835700: **188 of its 189 errors** were the network guard refusing egress —
+709 recorded attempts to a CDN address and 65 to `huggingface.co:443`, the excess over the
+error count being `huggingface_hub` retrying five times per call (visible as
+`Retrying in 2s [Retry 2/5]`).
+
+**Named rather than glossed:** the same tests record **zero** egress attempts locally
+(`test_console_agent_bridge.py`: 254 passed, 0 blocks; CI: 19 errors). The cache is cold in
+both, so the cold cache is not the differentiator, and I did not establish what is. The most
+likely candidate is the dependency set — CI installs `.[embeddings_rag,websearch,chunker]`
+while this venv has every optional group, and optional-dependency branches decide whether the
+hub path is entered at all. **This is not confirmed.** What is confirmed is that the hub path
+runs in CI, that nothing forbade the download, and that this change forbids it.
+
+An earlier hypothesis — that tiktoken's temp-dir cache was responsible — was **wrong** and is
+recorded so it is not retried: a cold `TIKTOKEN_CACHE_DIR` reproduced nothing (269 passed),
+and the CI log shows `huggingface_hub` retrying, not tiktoken. The tiktoken `ERROR` lines in
+that log are incidental.
+
+**AC#3/#4.** `TLDW_TEST_ALLOW_HF_DOWNLOADS=1` opts out. The guard module carries a
+`pytestmark` skipif on it rather than asserting the flag is unset — a developer who asks for
+live fetches should not get a red suite — and it *skips* rather than returning early, so the
+opt-out shows up in the run summary instead of looking like three tests that passed while
+asserting nothing. Verified: 3 passed normally, **3 skipped** when opted out.
+
+**AC#2 — mutation-proven.** Replacing the bootstrap condition with `if False` reddens
+`test_the_environment_declares_offline_before_any_import`. Notably the *other* two tests still
+passed under that mutation, because the autouse fixture patched the constant — the two halves
+are genuinely belt-and-braces rather than one guard written twice.
+
+**AC#5 — neutral locally.** Two A/Bs, offline forced on versus opted out:
+`test_console_agent_bridge` + `test_fleet_runtime` + `test_console_provider_gateway`:
+**633 passed** both ways. `Tests/RAG_Search` + `Tests/Chunking` + `Tests/Transcription`:
+**4 failed / 1214 passed / 74 skipped / 1 xfailed** both ways, identical.
+
+**Not claimed:** that this makes CI green. It makes the failure mode reproducible and
+deterministic instead of CI-only, which is the precondition for fixing whatever those tests
+then do. Whether the affected tests pass offline or fail fast can only be answered by a CI
+run, so the PR is opened for that evidence rather than merged on local results.
+
+A broader local sweep was attempted and discarded rather than reported: concurrent sessions
+had 12–21 pytest processes running and it crashed xdist workers repeatedly. CI shard logs show
+**zero** `node down` events, so those crashes are this machine, not the code.
+
+Added: `Tests/test_huggingface_offline.py`. Modified: `Tests/conftest.py`.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
> **Opened for CI evidence, not ready to merge on local results.** The point of this change is
> a CI-only failure mode; only a CI run can show whether the affected tests then pass offline
> or fail fast. Local results below establish only that the change is *neutral* here.

## What CI was doing

The sandbox points the HuggingFace cache at a directory inside itself
(`<sandbox>/home/.cache/huggingface/hub`) which **never exists**, and `HF_HUB_OFFLINE` was
**False** — so any code path reaching the hub attempted a real download, the network guard
refused it, and `huggingface_hub` retried five times before the guard's record failed the
test at teardown.

From core shard 0/6 of run `32676835700`:

| | |
|---|---|
| errors in that shard | **189** |
| of which egress-blocked | **188** |
| recorded attempts, CDN address | 709 |
| recorded attempts, `huggingface.co:443` | 65 |

The attempt count exceeds the error count because each call retries — `Retrying in 2s
[Retry 2/5]` is in the log. One shard of six.

## Why nobody has seen it

The same tests record **zero** egress attempts locally: `test_console_agent_bridge.py` is 254
passed / 0 blocks here against 19 errors in CI. This was invisible for as long as the core job
could not finish — which, until #2033, was always.

## The fix, and why it has two halves

`huggingface_hub` freezes `constants.HF_HUB_OFFLINE` at *its own* import time, so an env var
written from a fixture is read too late to matter; `is_offline_mode()` consults the constant
on every request. So:

- the **pre-import bootstrap** sets `HF_HUB_OFFLINE=1` before anything imports the client
- an **autouse fixture** patches the constant when the module is already in `sys.modules`

`Tests/RAG_Eval/conftest.py` already documents exactly this split, with the measurement, for
its own scope; this generalises it. The fixture uses a `sys.modules` lookup and never imports
the hub stack — importing it in every session to assert a property of sessions that never
touch it would cost more than the guard is worth.

## What I could not establish, stated plainly

**Why the hub path runs in CI and not here.** The cache is cold in both, so the cold cache is
not the differentiator, and I did not find what is. The likely candidate is the dependency
set — CI installs `.[embeddings_rag,websearch,chunker]` while this venv has every optional
group, and optional-dependency branches decide whether the hub path is entered — but that is
**unconfirmed**.

An earlier hypothesis blaming tiktoken's temp-dir cache was **wrong**, recorded so it is not
retried: a cold `TIKTOKEN_CACHE_DIR` reproduced nothing (269 passed), and the CI log shows
`huggingface_hub` retrying, not tiktoken. The tiktoken `ERROR` lines there are incidental.

## Evidence

**Neutral locally** — two A/Bs, offline forced on versus opted out:

| suites | offline on | opted out |
|---|---|---|
| the three CI-erroring files | 633 passed | 633 passed |
| `RAG_Search` + `Chunking` + `Transcription` | 4 failed / 1214 passed / 74 skipped / 1 xfailed | identical |

**Mutation-proven.** Replacing the bootstrap condition with `if False` reddens the
environment assertion. Notably the other two guard tests still passed under that mutation,
because the autouse fixture patched the constant — the halves are genuinely belt-and-braces,
not one guard written twice.

**Opt-out.** `TLDW_TEST_ALLOW_HF_DOWNLOADS=1`. The guard module carries a `pytestmark` skipif
on it rather than asserting the flag is unset, so asking for live fetches does not redden the
suite — and it *skips* rather than returning early, so the opt-out appears in the run summary
instead of looking like three tests that passed while asserting nothing. Verified: 3 passed
normally, 3 skipped when opted out.

## A local measurement I discarded rather than report

A broader local sweep crashed xdist workers repeatedly. Concurrent sessions had 12–21 pytest
processes running at the time, and **CI shard logs show zero `node down` events**, so those
crashes are this machine and not the code. Reporting that sweep's numbers would have been
reporting contention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forbids model downloads in the test sandbox to resolve CI-only network retries and make failures deterministic (TASK-21562). Previously, CI tests attempted real `huggingface_hub` downloads and retried before the network guard failed at teardown; now tests run offline and fail fast if they reach the hub.

- Sets `HF_HUB_OFFLINE=1` in `Tests/conftest.py` before any import; adds an autouse fixture that patches `huggingface_hub.constants.HF_HUB_OFFLINE` if the module was imported early (the client freezes the constant at import; `is_offline_mode()` reads it per request).
- Adds `Tests/test_huggingface_offline.py` to assert both halves and to skip clearly when opted out; the fixture uses a `sys.modules` lookup and avoids importing the hub stack.
- CI context: one shard saw 188/189 errors from blocked egress to `huggingface.co:443` and a CDN; local runs were neutral on targeted suites.
- Opt-out for tests that need live fetches: set `TLDW_TEST_ALLOW_HF_DOWNLOADS=1` (skips appear in the summary).

<sup>Written for commit f9128f9bc493904f37e8bac8f78d28f9c3f0b139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

