### PR TITLE
perf(tts): stop snapshotting the reference-BLOB table twice per migration (TASK-21130)

### DIFF
--- a/Tests/TTS/test_profile_reference_storage.py
+++ b/Tests/TTS/test_profile_reference_storage.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import gc
 import hashlib
 import io
+import os
+import signal
 import sqlite3
+import subprocess
+import sys
+import time
+import tracemalloc
 import wave
 from datetime import UTC, datetime
 from pathlib import Path
@@ -781,3 +788,646 @@ def test_schema_v4_migration_registration_is_exact() -> None:
     assert set(profile_schema.MIGRATIONS) == {0, 1, 2, 3}
     assert profile_schema.MIGRATIONS[2] is v2_to_v3.migrate
     assert profile_schema.MIGRATIONS[3] is v3_to_v4.migrate
+
+
+# --- TASK-21130: the v3->v4 migration must not snapshot the BLOB table -------
+
+
+def _canonical_wav(seconds: float, rate: int, channels: int, seed: int) -> bytes:
+    """One valid canonical reference WAV, deterministic in ``seed``."""
+
+    pattern = bytes((seed * 7 + index) % 251 for index in range(2 * channels))
+    output = io.BytesIO()
+    with wave.open(output, "wb") as writer:
+        writer.setnchannels(channels)
+        writer.setsampwidth(2)
+        writer.setframerate(rate)
+        writer.writeframes(pattern * int(seconds * rate))
+    return output.getvalue()
+
+
+def _create_populated_v3_references(
+    path: Path,
+    *,
+    count: int,
+    seconds: float = 1.0,
+    rate: int = 96_000,
+    channels: int = 2,
+) -> int:
+    """Build a schema-v3 store with ``count`` references; return total bytes.
+
+    Every payload goes through the production canonical-WAV validator, and
+    every metadata column is taken from what that validator reports, so the
+    fixture is real data on the production path rather than hand-rolled rows.
+    """
+
+    from tldw_chatbook.TTS.profile_reference_audio import (
+        validate_canonical_reference_wav,
+    )
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = ON")
+    v0_to_v1.migrate(connection)
+    v1_to_v2.migrate(connection)
+    for index in range(count):
+        connection.execute(
+            """
+            INSERT INTO tts_generation_profiles (
+                profile_id, display_name, normalized_name, provider_id, model_id,
+                voice_id, response_format, speed, options_json, revision,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(UUID(int=(index + 1) | (0x8 << 60))),
+                f"Private Voice {index}",
+                f"private voice {index}",
+                "audio_cpp",
+                "model-a",
+                None,
+                "wav",
+                1.0,
+                "{}",
+                4,
+                NOW,
+                NOW,
+            ),
+        )
+    v2_to_v3.migrate(connection)
+    total = 0
+    for index in range(count):
+        wav_bytes = _canonical_wav(seconds, rate, channels, index)
+        metadata = validate_canonical_reference_wav(wav_bytes)
+        total += len(wav_bytes)
+        connection.execute(
+            f"INSERT INTO {REFERENCE_TABLE} "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(UUID(int=(index + 1) | (0x8 << 60))),
+                str(UUID(int=(index + 1) | (0x4 << 60) | (0x8 << 76))),
+                wav_bytes,
+                f"Private transcript {index}",
+                hashlib.sha256(wav_bytes).hexdigest(),
+                len(wav_bytes),
+                metadata.duration_ms,
+                metadata.sample_rate_hz,
+                metadata.channels,
+                metadata.sample_encoding,
+                NOW,
+                NOW,
+            ),
+        )
+    connection.commit()
+    connection.close()
+    return total
+
+
+def _reference_content_digest(path: Path) -> str:
+    """Length-framed hash of every reference column, WAV payload included."""
+
+    connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    digest = hashlib.sha256()
+    try:
+        for row in connection.execute(
+            f"SELECT profile_id, reference_id, wav_bytes, reference_text, sha256,"
+            f" byte_length, duration_ms, sample_rate_hz, channels, sample_encoding,"
+            f" created_at, updated_at FROM {REFERENCE_TABLE} ORDER BY profile_id"
+        ):
+            for value in row:
+                raw = value if type(value) is bytes else repr(value).encode("utf-8")
+                digest.update(len(raw).to_bytes(8, "big"))
+                digest.update(raw)
+    finally:
+        connection.close()
+    return digest.hexdigest()
+
+
+def _migrate_under_tracemalloc(path: Path) -> int:
+    gc.collect()
+    tracemalloc.start()
+    try:
+        connection = open_profile_store(path)
+        peak = tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 4
+    finally:
+        connection.close()
+    return peak
+
+
+def test_v3_to_v4_migration_peak_allocation_does_not_scale_with_the_table(
+    tmp_path: Path,
+) -> None:
+    """TASK-21130: peak allocation must track one reference, not the table.
+
+    Two stores of the same per-reference size and different row counts are
+    migrated. Before the fix the migration held two full projections of
+    ``wav_bytes``, so the peak tracked the TOTAL payload and the difference
+    between the two arms was ~2x the extra bytes; it must now be a rounding
+    error against them.
+    """
+    small_path = tmp_path / "small.sqlite3"
+    large_path = tmp_path / "large.sqlite3"
+    small_bytes = _create_populated_v3_references(small_path, count=4)
+    large_bytes = _create_populated_v3_references(large_path, count=32)
+    extra_bytes = large_bytes - small_bytes
+    assert extra_bytes > 8 * 1024 * 1024
+
+    small_peak = _migrate_under_tracemalloc(small_path)
+    large_peak = _migrate_under_tracemalloc(large_path)
+
+    assert large_peak - small_peak < extra_bytes // 4, (
+        f"peak grew {large_peak - small_peak} bytes for {extra_bytes} extra "
+        "reference bytes -- the migration is still retaining the table"
+    )
+    assert large_peak < large_bytes, (
+        f"peak {large_peak} exceeds the {large_bytes}-byte reference table"
+    )
+
+
+def test_v3_to_v4_migration_evidence_never_holds_a_reference_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The captured evidence itself must contain no WAV bytes and no transcript."""
+
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=3)
+    real_evidence = profile_schema._migration_reference_evidence
+    captured: list[object] = []
+
+    def tracked(connection: sqlite3.Connection):
+        evidence = real_evidence(connection)
+        captured.append(evidence)
+        return evidence
+
+    monkeypatch.setattr(profile_schema, "_migration_reference_evidence", tracked)
+
+    connection = open_profile_store(path)
+    connection.close()
+
+    assert len(captured) == 2
+    for evidence in captured:
+        assert len(evidence) == 3
+        assert not _nested_contains_bytes(evidence)
+        assert "Private transcript" not in repr(evidence)
+    assert captured[0] == captured[1]
+
+
+def test_v3_to_v4_migration_result_is_byte_identical_to_the_v3_payloads(
+    tmp_path: Path,
+) -> None:
+    """Identity is asserted with a content hash over the BLOBs, not a row count."""
+
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=5)
+    before = _reference_content_digest(path)
+    before_rows = sqlite3.connect(path)
+    try:
+        raw_before = [
+            tuple(row)
+            for row in before_rows.execute(
+                f"SELECT * FROM {REFERENCE_TABLE} ORDER BY profile_id"
+            )
+        ]
+    finally:
+        before_rows.close()
+
+    connection = open_profile_store(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert [row[0] for row in connection.execute("PRAGMA integrity_check")] == [
+            "ok"
+        ]
+        raw_after = [
+            tuple(row)
+            for row in connection.execute(
+                f"SELECT * FROM {REFERENCE_TABLE} ORDER BY profile_id"
+            )
+        ]
+    finally:
+        connection.close()
+
+    assert _reference_content_digest(path) == before
+    assert [row[:12] for row in raw_after] == raw_before
+    assert {row[12:] for row in raw_after} == {(None, None)}
+
+
+def test_v3_to_v4_migration_rejects_a_payload_only_mutation_and_rolls_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The payload-free evidence must still fail closed on a BLOB-only change.
+
+    The injected mutation swaps in a different but equally valid canonical WAV
+    of the SAME length, leaving ``sha256``, ``byte_length`` and every other
+    projected column untouched -- the one mutation class the removed
+    ``wav_bytes`` projection used to be the only guard against. It is caught
+    because ``_validate_migration_reference_rows`` re-derives the digest from
+    the stored BLOB on both sides of the climb.
+    """
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=2)
+    before = _reference_content_digest(path)
+    replacement = _canonical_wav(1.0, 96_000, 2, seed=99)
+    real_migration = profile_schema.MIGRATIONS[3]
+
+    def mutate_payload(connection: sqlite3.Connection) -> None:
+        real_migration(connection)
+        target = connection.execute(
+            f"SELECT profile_id, byte_length FROM {REFERENCE_TABLE} "
+            "ORDER BY profile_id LIMIT 1"
+        ).fetchone()
+        assert len(replacement) == target[1]
+        connection.execute(
+            f"UPDATE {REFERENCE_TABLE} SET wav_bytes = ? WHERE profile_id = ?",
+            (replacement, target[0]),
+        )
+
+    monkeypatch.setitem(profile_schema.MIGRATIONS, 3, mutate_payload)
+
+    with _safe_error("migration_failed") as caught:
+        open_profile_store(path)
+
+    raw = sqlite3.connect(path)
+    try:
+        assert raw.execute("PRAGMA user_version").fetchone()[0] == 3
+        assert [row[0] for row in raw.execute("PRAGMA integrity_check")] == ["ok"]
+    finally:
+        raw.close()
+    assert _reference_content_digest(path) == before
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("updated_at", "2026-08-11T12:34:56.123456Z"),
+        # Same UTF-8 length as "Private transcript 0", so only the digest half
+        # of the projection can catch it.
+        ("reference_text", "Private transcript X"),
+        ("reference_id", "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"),
+        ("duration_ms", 4_321),
+    ],
+)
+def test_v3_to_v4_migration_rejects_a_metadata_only_mutation_and_rolls_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    column: str,
+    value: object,
+) -> None:
+    """Every projected column is still compared across the climb.
+
+    ``reference_text`` matters most here: nothing else in the migration
+    compares transcripts across the boundary, so the UTF-8 length + digest
+    that replaced the raw text in the evidence is the only guard on it.
+    """
+
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=2)
+    before = _reference_content_digest(path)
+    real_migration = profile_schema.MIGRATIONS[3]
+
+    def mutate_metadata(connection: sqlite3.Connection) -> None:
+        real_migration(connection)
+        target = connection.execute(
+            f"SELECT profile_id FROM {REFERENCE_TABLE} ORDER BY profile_id LIMIT 1"
+        ).fetchone()[0]
+        connection.execute(
+            f"UPDATE {REFERENCE_TABLE} SET {column} = ? WHERE profile_id = ?",
+            (value, target),
+        )
+
+    monkeypatch.setitem(profile_schema.MIGRATIONS, 3, mutate_metadata)
+
+    with _safe_error("migration_failed"):
+        open_profile_store(path)
+
+    raw = sqlite3.connect(path)
+    try:
+        assert raw.execute("PRAGMA user_version").fetchone()[0] == 3
+    finally:
+        raw.close()
+    assert _reference_content_digest(path) == before
+
+
+def test_v3_store_whose_digest_column_disagrees_with_its_blob_never_migrates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First link of the payload-identity chain, isolated from the closing one.
+
+    The evidence no longer carries ``wav_bytes``, so it stands on the stored
+    ``sha256`` column being a true digest of the payload BEFORE the climb
+    starts. Asserting only that such a store fails to reach v4 would prove
+    nothing about that link -- the post-migration validation catches the same
+    poisoned digest on its own (verified by mutation). So this also requires
+    that the v3->v4 migration is never *entered*: the pre-migration
+    validation has to reject the store first.
+    """
+
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=2)
+    before = _reference_content_digest(path)
+    raw = sqlite3.connect(path)
+    try:
+        raw.execute("PRAGMA ignore_check_constraints = ON")
+        raw.execute(
+            f"UPDATE {REFERENCE_TABLE} SET sha256 = ? WHERE profile_id = "
+            f"(SELECT MIN(profile_id) FROM {REFERENCE_TABLE})",
+            ("0" * 64,),
+        )
+        raw.commit()
+    finally:
+        raw.close()
+    poisoned = _reference_content_digest(path)
+    assert poisoned != before
+
+    attempts: list[int] = []
+    real_migration = profile_schema.MIGRATIONS[3]
+
+    def spy(connection: sqlite3.Connection) -> None:
+        attempts.append(1)
+        real_migration(connection)
+
+    monkeypatch.setitem(profile_schema.MIGRATIONS, 3, spy)
+
+    with _safe_error("migration_failed"):
+        open_profile_store(path)
+
+    assert attempts == [], "the climb started before the payload was validated"
+    check = sqlite3.connect(path)
+    try:
+        assert check.execute("PRAGMA user_version").fetchone()[0] == 3
+    finally:
+        check.close()
+    assert _reference_content_digest(path) == poisoned
+
+
+def test_v3_store_with_a_structurally_corrupt_payload_never_migrates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The BLOB-corrupt error path: rejected before the climb, left at v3.
+
+    Here the digest column agrees with the stored bytes -- they are simply not
+    a canonical WAV any more. The payload is still streamed and decoded on the
+    way in, so the migration must refuse to start.
+    """
+
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=2)
+    raw = sqlite3.connect(path)
+    try:
+        target, length = raw.execute(
+            f"SELECT profile_id, byte_length FROM {REFERENCE_TABLE} "
+            "ORDER BY profile_id LIMIT 1"
+        ).fetchone()
+        rubbish = bytes((index * 31) % 256 for index in range(length))
+        raw.execute(
+            f"UPDATE {REFERENCE_TABLE} SET wav_bytes = ?, sha256 = ? "
+            "WHERE profile_id = ?",
+            (rubbish, hashlib.sha256(rubbish).hexdigest(), target),
+        )
+        raw.commit()
+    finally:
+        raw.close()
+    corrupted = _reference_content_digest(path)
+
+    attempts: list[int] = []
+    real_migration = profile_schema.MIGRATIONS[3]
+
+    def spy(connection: sqlite3.Connection) -> None:
+        attempts.append(1)
+        real_migration(connection)
+
+    monkeypatch.setitem(profile_schema.MIGRATIONS, 3, spy)
+
+    with _safe_error("migration_failed"):
+        open_profile_store(path)
+
+    assert attempts == []
+    check = sqlite3.connect(path)
+    try:
+        assert check.execute("PRAGMA user_version").fetchone()[0] == 3
+    finally:
+        check.close()
+    assert _reference_content_digest(path) == corrupted
+
+
+def test_v3_to_v4_migration_is_reenterable_after_a_failed_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed attempt leaves v3 intact; the next open completes the climb."""
+
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=3)
+    before = _reference_content_digest(path)
+    real_migration = profile_schema.MIGRATIONS[3]
+
+    def fail_after_migrating(connection: sqlite3.Connection) -> None:
+        real_migration(connection)
+        raise RuntimeError("PRIVATE injected failure")
+
+    monkeypatch.setitem(profile_schema.MIGRATIONS, 3, fail_after_migrating)
+    with _safe_error("migration_failed"):
+        open_profile_store(path)
+    raw = sqlite3.connect(path)
+    try:
+        assert raw.execute("PRAGMA user_version").fetchone()[0] == 3
+    finally:
+        raw.close()
+    assert _reference_content_digest(path) == before
+
+    monkeypatch.setitem(profile_schema.MIGRATIONS, 3, real_migration)
+    connection = open_profile_store(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert [row[0] for row in connection.execute("PRAGMA integrity_check")] == [
+            "ok"
+        ]
+    finally:
+        connection.close()
+    assert _reference_content_digest(path) == before
+
+
+_KILL_CHILD_TEMPLATE = """
+import sys
+import time
+from pathlib import Path
+sys.path.insert(0, {repo!r})
+import tldw_chatbook.TTS.profile_schema as profile_schema
+
+real = profile_schema.MIGRATIONS[3]
+
+
+def park(connection):
+    real(connection)
+    with open({marker!r}, "w") as handle:
+        handle.write("in-transaction")
+    while True:
+        time.sleep(0.05)
+
+
+profile_schema.MIGRATIONS[3] = park
+profile_schema.open_profile_store(Path({path!r}))
+"""
+
+
+def test_v3_to_v4_migration_survives_sigkill_mid_transaction(tmp_path: Path) -> None:
+    """A real SIGKILL inside the climb must leave v3, then re-enter cleanly.
+
+    The child parks INSIDE the migration transaction, after the v4 table has
+    been rebuilt and ``PRAGMA user_version = 4`` executed but before commit,
+    so the kill lands at the worst possible instant. Recovery must roll the
+    whole climb back to v3 with byte-identical payloads, and the next open
+    must finish the migration.
+    """
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=3)
+    before = _reference_content_digest(path)
+    marker = tmp_path / "parked.marker"
+    repo_root = str(Path(__file__).resolve().parents[2])
+
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            _KILL_CHILD_TEMPLATE.format(
+                repo=repo_root,
+                marker=str(marker),
+                path=str(path),
+            ),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 120.0
+        while time.monotonic() < deadline:
+            if marker.exists():
+                break
+            if child.poll() is not None:
+                break
+            time.sleep(0.02)
+        assert child.poll() is None, (
+            "child exited before it reached the migration "
+            f"(stdout={child.stdout.read()!r} stderr={child.stderr.read()!r})"
+        )
+        assert marker.exists(), "child never parked inside the migration"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=60)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=60)
+
+    recovered = sqlite3.connect(path)
+    try:
+        assert recovered.execute("PRAGMA user_version").fetchone()[0] == 3
+        assert [row[0] for row in recovered.execute("PRAGMA integrity_check")] == ["ok"]
+    finally:
+        recovered.close()
+    assert _reference_content_digest(path) == before
+
+    connection = open_profile_store(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert [row[0] for row in connection.execute("PRAGMA integrity_check")] == [
+            "ok"
+        ]
+    finally:
+        connection.close()
+    assert _reference_content_digest(path) == before
+
+
+def test_already_migrated_v4_store_captures_no_migration_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reopening a current store must not run the evidence projection at all."""
+
+    path = tmp_path / "profiles.sqlite3"
+    _create_populated_v3_references(path, count=2)
+    open_profile_store(path).close()
+    digest = _reference_content_digest(path)
+
+    calls: list[int] = []
+    real_evidence = profile_schema._migration_reference_evidence
+
+    def tracked(connection: sqlite3.Connection):
+        calls.append(1)
+        return real_evidence(connection)
+
+    monkeypatch.setattr(profile_schema, "_migration_reference_evidence", tracked)
+
+    connection = open_profile_store(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 4
+    finally:
+        connection.close()
+
+    assert calls == []
+    assert _reference_content_digest(path) == digest
+
+
+def test_fresh_and_empty_stores_migrate_with_empty_reference_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A brand-new store and a populated v2 store both end with no references."""
+
+    captured: list[object] = []
+    real_evidence = profile_schema._migration_reference_evidence
+
+    def tracked(connection: sqlite3.Connection):
+        evidence = real_evidence(connection)
+        captured.append(evidence)
+        return evidence
+
+    monkeypatch.setattr(profile_schema, "_migration_reference_evidence", tracked)
+
+    fresh = open_profile_store(tmp_path / "fresh.sqlite3")
+    try:
+        assert fresh.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert (
+            fresh.execute(f"SELECT count(*) FROM {REFERENCE_TABLE}").fetchone()[0] == 0
+        )
+    finally:
+        fresh.close()
+
+    v2_path = tmp_path / "v2.sqlite3"
+    _create_populated_v2(v2_path)
+    upgraded = open_profile_store(v2_path)
+    try:
+        assert upgraded.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert (
+            upgraded.execute(f"SELECT count(*) FROM {REFERENCE_TABLE}").fetchone()[0]
+            == 0
+        )
+    finally:
+        upgraded.close()
+
+    assert captured == [(), ()]
+
+
+def test_candidate_and_live_migration_share_one_reference_evidence_shape(
+    tmp_path: Path,
+) -> None:
+    """The candidate stepper and the live opener must project identically."""
+
+    path = tmp_path / "shared.sqlite3"
+    _create_populated_v3_references(path, count=2)
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        assert migration_candidate._compact_reference_evidence(
+            connection
+        ) == profile_schema._migration_reference_evidence(connection)
+    finally:
+        connection.close()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7914,3 +7914,46 @@ raising. Deliberately breaking the guard proved it — the memory-backed test
 went red with a zero count, not an error. Before wrapping any DB call in
 `to_thread`, check what that owner's connection factory does with
 `:memory:`, and keep a memory-backed test in the set.
+## A subsystem can have several migration entry points, and the product may not use the one you were pointed at (TASK-21130, 2026-08-23)
+
+**What happened.** The finding cited `TTS/profile_schema.py:1439,1468` —
+`_run_migrations`, reached from `open_profile_store` — as the place the v3→v4
+climb snapshots the whole reference-BLOB table twice. That was accurate about
+the code. It was wrong about the product: `TTSProfileRepository.
+_worker_initialize_store` never lets `open_profile_store` migrate a populated
+store. A below-current store is routed to `_worker_publish_migrated_store` →
+`migrate_profile_store_to_candidate` → `step_profile_migration_candidate`, and
+only *then* reopened, already at v4 (`profile_repository.py:1636-1638`). The
+user-visible upgrade ran through `_step_candidate`, which carried the
+**identical** double snapshot at different line numbers. Fixing only the cited
+lines would have measured as a 966 MiB → 88 MiB win on a path a real upgrade
+never takes, and shipped nothing.
+
+**What to do.** Before optimising or hardening a migration, enumerate every
+caller of the migration runner and find which one the app reaches at runtime —
+`grep` the runner's name, then walk *up* from each hit to a boot or lifecycle
+owner. Subsystems here routinely have three: an in-place opener, a disposable
+candidate/validation copy, and a publish-through-a-candidate upgrade. They are
+easy to mistake for one because they share the `MIGRATIONS` table and the same
+helper functions. Fix the defect in the shared helper, not at the call sites
+the filing happened to name.
+
+## Sequential A/B arms measured a regression that interleaving erased (TASK-21130, 2026-08-23)
+
+**What happened.** The candidate-path timings were taken as three base runs
+then three fixed runs: base 10.38 / 10.57 / 10.77 s, fixed 11.43 / 11.58 /
+12.87 s. Tight distributions, no overlap — it read as a clean ~1 s regression
+caused by the change, which would have been reported as one. Re-running the
+same two arms **alternating base, fixed, base, fixed** across five pairs gave
+base 10.12 / 10.92 / 11.09 / 11.26 / 12.18 and fixed 9.62 / 9.68 / 10.05 /
+10.47 / 10.75 — the fixed arm consistently ~1 s *faster*. Nothing about either
+build changed; the machine's load simply drifted between the two blocks, and a
+block design charges all of that drift to whichever arm ran second.
+
+**What to do.** Interleave A/B arms, always. A block of N runs per arm gives
+tight-looking intervals that measure *when* you ran, not *what* you ran, and
+tightness inside a block is not evidence against between-block drift. This
+matters most for the wall-clock half of a perf claim: the memory numbers here
+were byte-stable across every ordering (1,013,84x,xxx vs 92,24x,xxx every
+single run), which is exactly why an allocation-peak claim survives sloppy
+scheduling and a wall-time claim does not.

--- a/backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md
+++ b/backlog/tasks/task-21130 - TTS profile v3-to-v4 migration snapshots the entire reference-BLOB table into memory twice.md
@@ -2,8 +2,9 @@
 id: TASK-21130
 title: >-
   TTS profile v3->v4 migration snapshots the entire reference-BLOB table into memory twice
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-22'
 labels:
   - performance
@@ -25,5 +26,132 @@ TTS opens.
 
 ## Acceptance Criteria
 
-- [ ] The migration compares projections without wav_bytes (sibling profile_migration_candidate.py:320 already does) using hashes; peak memory during v3->v4 is bounded and asserted by a test with synthetic large references
-- [ ] Migration outcomes byte-identical for the existing fixtures
+- [x] The migration compares projections without wav_bytes (sibling profile_migration_candidate.py:320 already does) using hashes; peak memory during v3->v4 is bounded and asserted by a test with synthetic large references
+- [x] Migration outcomes byte-identical for the existing fixtures
+- [x] **The same defect is fixed on the path the live repository actually
+      upgrades through** (`_step_candidate`), not only on the call sites the
+      finding cited - see "Where the finding was wrong" below
+- [x] The climb stays atomic, re-enterable and interrupt-safe: proved by a
+      SIGKILL-mid-transaction test, a failed-attempt re-entry test, and
+      `PRAGMA integrity_check` after every arm
+- [x] Every new assertion is killed by at least one deliberately broken
+      implementation (12-mutation matrix)
+
+## Where the finding was wrong
+
+The finding cited `profile_schema.py:1439/1468` (`_run_migrations`) as the
+boot-path cost. Measured truth: `TTSProfileRepository._worker_initialize_store`
+**never** lets `open_profile_store` migrate a populated store - a store below
+the current version is routed to `_worker_publish_migrated_store` ->
+`migrate_profile_store_to_candidate` -> `step_profile_migration_candidate`, and
+only then reopened at v4 (profile_repository.py:1636-1638). The live upgrade a
+user actually pays for therefore ran through `_step_candidate`
+(profile_migration_candidate.py:413/431), which carried the **identical**
+double-snapshot - measured at the same 966 MiB peak. Fixing only the cited
+lines would have left the whole user-visible cost in place. Both sites are
+fixed; the finding's diagnosis was right and its call-site attribution was
+incomplete.
+
+The AC's prescribed shape ("compare projections without wav_bytes using
+hashes") was verified rather than assumed before it was implemented, because
+dropping the payload from the comparison removes the only direct check on the
+BLOBs. It holds, but only as a three-link chain that has to be kept intact -
+documented at `_migration_reference_evidence` and pinned by mutation arms M2
+and M3.
+
+## Implementation Plan
+
+1. Build the measurement + differential harness first, at the merge base:
+   a v3 store of real canonical WAV references at the 512 MiB store bound,
+   migrated in its own process, reporting wall time, `tracemalloc` peak, RSS
+   high-water and a content hash of every reference column.
+2. Baseline it on pinned dev `f49956038` in a second worktree.
+3. Replace the payload-carrying projection with the sibling's payload-free
+   evidence, as one shared definition used by both migration paths.
+4. Re-measure interleaved against the same pinned base; prove the peak stops
+   scaling with the table by holding total bytes constant and varying the
+   per-reference size.
+5. Add tests for peak scaling, payload-free evidence, byte identity,
+   payload-only and metadata-only mutation rejection, corrupt-payload and
+   poisoned-digest rejection, re-entry after failure, SIGKILL mid-transaction,
+   already-migrated and fresh/empty stores.
+6. Run every new test against deliberately broken implementations and require
+   each to go red.
+
+## Implementation Notes
+
+`_migration_reference_snapshot` selected `wav_bytes` for every row and was
+called twice with the first result still referenced, so peak allocation was
+2x the whole reference table. It is replaced by
+`_migration_reference_evidence`, which projects every column **except** the
+payload and substitutes the transcript with its UTF-8 length + digest. The
+sibling `_compact_reference_evidence` in `profile_migration_candidate` now
+delegates to it, so both migration paths share one definition, and
+`_step_candidate` - the path the live repository upgrades through - uses it
+too.
+
+Byte-for-byte identity is preserved by transitivity instead of retention:
+`_validate_migration_reference_rows` streams each BLOB and re-derives
+`sha256(wav_bytes)` against the stored `sha256` column on **both** sides of
+the climb, and that column travels verbatim in the evidence. `blob_before ==
+sha_before`, `sha_before == sha_after`, `sha_after == blob_after`. Mutation
+arms M2/M3 exist precisely to keep both ends of that chain from being deleted
+by a later change.
+
+Measured on an M-series laptop, 22 references x 23.04 MB = 483 MiB (the
+512 MiB `MAX_REFERENCE_TOTAL_BYTES` bound), 5 interleaved runs per arm,
+each arm in its own process, A/B against merge-base `f49956038`:
+
+| path | metric | before | after |
+|---|---|---|---|
+| `open_profile_store` | tracemalloc peak | **966.9 MiB** | **88.0 MiB** (11.0x) |
+| `open_profile_store` | RSS growth (median) | 1,218 MB | 262 MB (4.6x) |
+| `open_profile_store` | wall (median) | 5.92 s | 5.49 s |
+| `step_profile_migration_candidate` (live path) | tracemalloc peak | **966.9 MiB** | **88.0 MiB** |
+| `step_profile_migration_candidate` | wall (median) | 11.09 s | 10.05 s |
+
+The second snapshot is gone rather than relocated: holding total reference
+bytes constant at 483 MiB and changing only the per-reference size, the base
+peak is unchanged (1,013.8 MB at 22x23 MB vs 1,014.3 MB at 220x2.3 MB - it
+tracks the TOTAL) while the fixed peak falls with it (92.2 MB -> 9.7 MB - it
+tracks the LARGEST SINGLE reference). The residual 88 MiB is the pre-existing
+per-row payload validation (`read_reference_blob` + canonical-WAV re-encode),
+now bounded by `MAX_REFERENCE_CANONICAL_BYTES` (32 MiB) instead of
+`MAX_REFERENCE_TOTAL_BYTES` (512 MiB).
+
+Migration outcome is byte-identical: the content hash over all twelve
+reference columns including `wav_bytes` is the same value before and after
+migration, and the same value in the base and fixed arms, for both stores.
+`PRAGMA integrity_check` is clean in every arm.
+
+Fifteen new test cases in `Tests/TTS/test_profile_reference_storage.py`
+(4,090 -> 4,105 passing in `Tests/TTS/`). The one red,
+`test_app_lifecycle_shutdown_drains_all_owners_in_authority_order`, fails with
+a byte-identical `AttributeError: 'types.SimpleNamespace' object has no
+attribute '_shutdown_actor_pack_import'` on pristine `f49956038` - pre-existing
+dev red, filed separately.
+
+Mutation matrix (12 arms, each run against the whole file): M1 restore the
+BLOB projection, M2/M3 delete either end of the payload-identity chain, M4
+delete the evidence comparison, M5 blind the transcript digest, M6 detach the
+candidate projection, M7 commit before validation, M8 remove the transaction,
+M9 rewrite payloads during the migration, M10 migrate an already-current
+store, M11 skip the evidence for pre-v3 sources, M12 remove the failure
+rollback. Every new test is killed by at least one arm. M12 killed nothing:
+the explicit `connection.rollback()` is redundant with the connection close
+that follows it under `sqlite3` - pre-existing belt-and-braces, no new claim
+depends on it. M3 initially killed nothing either; the poisoned-digest test
+was corrected to require that the migration is never *entered*, which isolates
+the link it claims to guard.
+
+`Docs/security/production-diagnostic-inventory.json` was regenerated for
+pre-existing drift in `UI/Screens/library_screen.py` (a file this task does
+not touch). All eight drifted rows were read first: they are pure line
+re-wraps with byte-identical message text and arguments, no new interpolation
+of user content, secrets or paths. The same preflight failure reproduces on
+pristine `f49956038`.
+
+Modified: `tldw_chatbook/TTS/profile_schema.py`,
+`tldw_chatbook/TTS/profile_migration_candidate.py`,
+`Tests/TTS/test_profile_reference_storage.py`,
+`Docs/security/production-diagnostic-inventory.json`.

--- a/tldw_chatbook/TTS/profile_migration_candidate.py
+++ b/tldw_chatbook/TTS/profile_migration_candidate.py
@@ -6,7 +6,6 @@ import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from hashlib import sha256
 from typing import TypeAlias
 
 import tldw_chatbook.TTS.profile_schema as _profile_schema
@@ -307,26 +306,13 @@ def _capture_boundary_evidence(
 def _compact_reference_evidence(
     connection: sqlite3.Connection,
 ) -> _ReferenceDomain:
-    """Capture exact reference identity/metadata without retaining WAV bytes."""
+    """Capture exact reference identity/metadata without retaining WAV bytes.
 
-    return tuple(
-        (
-            row[0],
-            row[1],
-            len(row[2].encode("utf-8")),
-            sha256(row[2].encode("utf-8")).hexdigest(),
-            *tuple(row[3:]),
-        )
-        for row in connection.execute(
-            f"""
-            SELECT profile_id, reference_id, reference_text, sha256,
-                   byte_length, duration_ms, sample_rate_hz, channels,
-                   sample_encoding, created_at, updated_at
-            FROM {_profile_schema._REFERENCE_TABLE}
-            ORDER BY profile_id
-            """
-        )
-    )
+    One shared definition with the live opener's migration evidence
+    (TASK-21130) so both paths carry the same payload-free projection.
+    """
+
+    return _profile_schema._migration_reference_evidence(connection)
 
 
 def _require_boundary_evidence(
@@ -423,11 +409,14 @@ def _step_candidate(connection: sqlite3.Connection, version: int) -> None:
     profile_domain = (
         None if version == 0 else _profile_schema._migration_domain_snapshot(connection)
     )
-    reference_domain = (
-        _profile_schema._migration_reference_snapshot(connection)
-        if version >= 3
-        else ()
-    )
+    # Payload-free evidence (TASK-21130). ``version >= 3`` implies
+    # ``version == 3``, which always has a downgrade boundary, so
+    # ``_capture_boundary_evidence`` -> ``_validate_candidate_version`` has
+    # just re-derived sha256(wav_bytes) for every row; the post-step
+    # ``validate_profile_store_version`` below re-derives it again. Those two
+    # bracket this comparison of the sha256 column and give exact payload
+    # identity without ever holding a second copy of the table.
+    reference_domain = _compact_reference_evidence(connection) if version >= 3 else ()
     try:
         connection.execute("BEGIN IMMEDIATE")
         migration = _profile_schema.MIGRATIONS.get(version)
@@ -441,8 +430,7 @@ def _step_candidate(connection: sqlite3.Connection, version: int) -> None:
         ):
             raise ValueError
         if version >= 3 and (
-            _profile_schema._migration_reference_snapshot(connection)
-            != reference_domain
+            _compact_reference_evidence(connection) != reference_domain
         ):
             raise ValueError
         if (

--- a/tldw_chatbook/TTS/profile_schema.py
+++ b/tldw_chatbook/TTS/profile_schema.py
@@ -1297,16 +1297,44 @@ def _migration_domain_snapshot(
     return profiles, assignments
 
 
-def _migration_reference_snapshot(
+def _migration_reference_evidence(
     connection: sqlite3.Connection,
 ) -> tuple[tuple[object, ...], ...]:
-    """Capture every schema-v3 reference field in deterministic order."""
+    """Project every reference field except the WAV payload, in row order.
+
+    The projection is deliberately payload-free (TASK-21130): selecting
+    ``wav_bytes`` here materialised the whole reference table in Python, and
+    the migration held two such projections at once -- measured at 966 MiB of
+    peak allocation for a store at the 512 MiB
+    :data:`~tldw_chatbook.TTS.profile_reference_types.MAX_REFERENCE_TOTAL_BYTES`
+    bound, against this subsystem's own 256 KiB streaming norm.
+
+    Byte-for-byte payload identity is still proved, by transitivity rather
+    than by retention: the stored ``sha256`` column travels in this projection
+    verbatim, and :func:`_validate_migration_reference_rows` re-derives
+    ``sha256(wav_bytes)`` from the streamed BLOB and requires it to equal that
+    column on *both* sides of the migration (see
+    ``TTSCloneReference.__post_init__``). So ``blob_before == sha_before``,
+    ``sha_before == sha_after`` (this projection), ``sha_after == blob_after``
+    together give ``blob_before == blob_after``, and any caller comparing two
+    of these projections must run that validation at both boundaries.
+
+    ``reference_text`` is replaced by its UTF-8 length and digest so the
+    evidence retains no private transcript either; the same shape is used for
+    the downgrade-boundary evidence in ``profile_migration_candidate``.
+    """
 
     return tuple(
-        tuple(row)
+        (
+            row[0],
+            row[1],
+            len(row[2].encode("utf-8")),
+            hashlib.sha256(row[2].encode("utf-8")).hexdigest(),
+            *tuple(row[3:]),
+        )
         for row in connection.execute(
             f"""
-            SELECT profile_id, reference_id, wav_bytes, reference_text, sha256,
+            SELECT profile_id, reference_id, reference_text, sha256,
                    byte_length, duration_ms, sample_rate_hz, channels,
                    sample_encoding, created_at, updated_at
             FROM {_REFERENCE_TABLE}
@@ -1433,10 +1461,14 @@ def _run_migrations(connection: sqlite3.Connection, from_version: int) -> None:
         domain_snapshot = (
             ((), ()) if from_version == 0 else _migration_domain_snapshot(connection)
         )
-        reference_snapshot: tuple[tuple[object, ...], ...] = ()
+        reference_evidence: tuple[tuple[object, ...], ...] = ()
         if from_version >= 3:
+            # First link of the payload-identity chain: this proves
+            # sha256(wav_bytes) == the sha256 column for every row BEFORE the
+            # migration. The evidence captured on the next line then carries
+            # that column (never the payload) across the climb.
             _validate_migration_reference_rows(connection, schema_version=from_version)
-            reference_snapshot = _migration_reference_snapshot(connection)
+            reference_evidence = _migration_reference_evidence(connection)
         while version < CURRENT_PROFILE_SCHEMA_VERSION:
             if version == 2:
                 validate_profile_store_rows(connection)
@@ -1465,9 +1497,13 @@ def _run_migrations(connection: sqlite3.Connection, from_version: int) -> None:
             raise RuntimeError
         if _migration_domain_snapshot(connection) != domain_snapshot:
             raise RuntimeError
-        if _migration_reference_snapshot(connection) != reference_snapshot:
+        if _migration_reference_evidence(connection) != reference_evidence:
             raise RuntimeError
         validate_profile_store_rows(connection)
+        # Closing link of the payload-identity chain: re-derives
+        # sha256(wav_bytes) from the streamed BLOB and requires it to equal
+        # the sha256 column the evidence above just proved unchanged. Neither
+        # side ever holds more than one payload at a time.
         _validate_migration_reference_rows(
             connection,
             schema_version=CURRENT_PROFILE_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary

The TTS profile v3→v4 migration selected `wav_bytes` for every row and did it **twice with the
first result still referenced**, so the climb peaked at 2× the whole reference table.
`_migration_reference_snapshot` is replaced by `_migration_reference_evidence`, which projects
every column *except* the payload and substitutes the transcript with its UTF-8 length + digest.
Finding 21130 of the 2026-08-22 review.

## The filing pointed at a path real upgrades never take

It cited `profile_schema.py:1439,1468` under `open_profile_store`. But
`TTSProfileRepository._worker_initialize_store` **never lets that path migrate a populated
store** — a below-current store is routed to `migrate_profile_store_to_candidate` →
`step_profile_migration_candidate` and reopened already at v4. The live upgrade ran through
`_step_candidate`, which carried the **identical** double snapshot at the same measured 966 MiB.
Fixing only the cited lines would have shipped a real-looking win on a path a real upgrade never
takes. Both are fixed and now share one definition. ACs amended in the task file.

## Measured (A/B vs merge-base, 22 × 23.04 MB = 483 MiB, 5 interleaved runs per arm, each arm its own process)

| path | metric | before | after |
|---|---|---|---|
| `open_profile_store` | tracemalloc peak | 966.9 MiB | **88.0 MiB (11.0×)** |
| `open_profile_store` | RSS growth (median) | 1,218 MB | 262 MB (4.6×) |
| `step_profile_migration_candidate` (live path) | tracemalloc peak | 966.9 MiB | **88.0 MiB** |
| `step_profile_migration_candidate` | wall (median) | 11.09 s | 10.05 s |

**The second snapshot is gone, not relocated** — and the proof is a scaling argument, not a
single number. Holding total reference bytes constant at 483 MiB and varying only per-reference
size: the base peak is unchanged (1,013.8 MB at 22×23 MB vs 1,014.3 MB at 220×2.3 MB — it tracks
the **total**), while the fixed peak falls with it (92.2 MB → 9.7 MB — it tracks the **largest
single reference**). The residual 88 MiB is the pre-existing per-row payload validation, now
bounded by `MAX_REFERENCE_CANONICAL_BYTES` (32 MiB) rather than `MAX_REFERENCE_TOTAL_BYTES`
(512 MiB).

## Migration correctness

- **Atomic** — SIGKILL parked *inside* the transaction after `PRAGMA user_version = 4` but
  before commit; recovery lands at v3, byte-identical. Killed by the `BEGIN IMMEDIATE` mutant.
- **Re-enterable** — injected failure leaves v3 intact; the next open completes.
- **Interrupt-safe** — real `os.kill(SIGKILL)`, technique borrowed from the v47 FTS backfill test.
- **Byte-identical** — content hash over all twelve reference columns *including* `wav_bytes`,
  equal before/after and across base and fixed arms, for both store shapes.
- **Integrity** — `PRAGMA integrity_check` clean in every arm of every test.

## Quit / error / already-migrated / empty

Quit mid-migration is covered by the SIGKILL test (strictly harder than a graceful close, which
rolls back on connection close). BLOB error paths: a poisoned `sha256` column and a structurally
corrupt payload, both required to be rejected *before* the climb is entered. An already-migrated
v4 store runs the evidence projection zero times. Fresh v0 and populated v2 both end with empty
evidence.

## Mutation: 12 arms, and two honest negatives

Every new test is killed by at least one arm. Reported rather than hidden:
**M3 initially killed nothing** — the poisoned-digest test was passing via *post*-validation, so
it was corrected to require the migration is never entered. **M12 kills nothing**: the explicit
`connection.rollback()` is redundant with the connection close that follows under `sqlite3`;
pre-existing, and no claim here depends on it.

## Verification

`Tests/TTS`: **4,105 passed / 1 failed / 16 skipped** — exactly +15 over base, all mine. The
single red (`test_app_lifecycle_shutdown_drains_all_owners_in_authority_order`) fails with a
byte-identical `AttributeError` on pristine dev. Preflight green; ruff clean.

Two lessons added: the multiple-migration-entry-points trap, and a sequential-A/B-block artifact
(the first candidate-path block read as a clean ~1 s *regression*; interleaving the arms showed a
consistent ~1 s *improvement*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops loading `wav_bytes` twice during the TTS v3→v4 migration by replacing the payload snapshot with a shared, payload‑free evidence projection. Old behavior took two full‑table BLOB snapshots; new behavior compares non‑payload columns and proves payload identity via sha256 before and after, cutting peak memory ~11x with identical outcomes.

- Introduces `tldw_chatbook.TTS.profile_schema._migration_reference_evidence` and makes `tldw_chatbook.TTS.profile_migration_candidate._compact_reference_evidence` delegate to it so `_run_migrations` and `_step_candidate` share one payload‑free shape.
- Enforces payload identity transitively: re-derive sha256(wav_bytes) pre‑migration, carry the sha256 column in evidence, re-derive post‑migration; transcripts use UTF‑8 length + digest.
- Measured on a 483 MiB reference set: tracemalloc peak 966.9 MiB → 88.0 MiB on both paths; RSS growth 1,218 MB → 262 MB; live candidate wall median 11.09 s → 10.05 s.
- Tests cover peak scaling, payload‑free evidence, byte‑identical outcomes, rejection of metadata‑only and payload‑only mutations, poisoned digest and corrupt BLOB rejection before entry, re‑entry after failure, SIGKILL mid‑transaction, already‑v4, and empty/fresh stores.

**Rollout**
- No action required. Opening a store migrates as before; already‑v4 stores capture no evidence.
- Review focus: the shared `_migration_reference_evidence` shape, the sha256 validations at both boundaries, and candidate‑path evidence comparisons.
- Satisfies TASK‑21130 ACs and applies the fix to the live candidate path.

<sup>Written for commit cd332e3af1019b58c0c48ccd3fdb3121ba2d6cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

