### PR TITLE
perf(library): index the legacy-chunk census and take it off the event loop (TASK-21126)

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -475,6 +475,19 @@ silently edited.
    **The method lesson**: a finding's cost estimate decays as fast as its line numbers. Re-measure
    before dispatching, not after — five of seven is not a rounding error, and two of these would
    have shipped a fix for a problem that was not there.
+5. **Finding 21126's "no index … add an index" is right about the scan and would have shipped
+   a DEAD index.** The census does cost what the review said (measured 119 ms at 200k live
+   chunk rows, 701 ms at 1M, on the event loop) — but it is not literally unindexed: the
+   planner uses `idx_unvectorizedmediachunks_deleted` and then does one table row-lookup per
+   live row plus two temp B-trees. The index the finding's wording implies,
+   `(chunk_engine_version, media_id) WHERE deleted = 0`, is a textbook covering index for the
+   query and **SQLite never picks it**: this database has no `sqlite_stat1` (there is no
+   `ANALYZE` anywhere in `Client_Media_DB_v2.py`), and with no stats the planner stays on the
+   `deleted` index — measured 118.8 ms without it against 120.2 ms with it, i.e. 5 MB of disk
+   for nothing. The shipped v8 index leads with the *redundant* `deleted` column so it answers
+   the same equality search the no-stats planner already prefers while also covering the GROUP
+   BY and the DISTINCT: 23.4 ms at 200k, 122.8 ms at 1M. **Any future "add an index" finding
+   in this repo needs a query-plan check with `sqlite_stat1` absent, not just present.**
 
 ---
 

--- a/Tests/DB/test_media_db_schema_v8.py
+++ b/Tests/DB/test_media_db_schema_v8.py
@@ -1,0 +1,273 @@
+"""Schema v8 (TASK-21126): the engine-version census covering index.
+
+The Library Search/RAG panel's legacy-chunk report reads
+``LocalRAGAdminService.count_chunks_by_engine_version`` -- "SELECT
+chunk_engine_version, COUNT(DISTINCT media_id) ... WHERE deleted = 0 GROUP
+BY chunk_engine_version". Before v8 that ran as an index search on
+``deleted`` plus a table row-lookup per live chunk row plus two temp
+B-trees: measured 119 ms at 200k live chunk rows and 701 ms at 1M.
+
+What these tests pin, and why each one exists:
+
+* the index is created on a fresh DB and by a genuine v7 upgrade;
+* the migration adds NO row, column, table or trigger (a pure index add);
+* **the planner actually CHOOSES it with no ``sqlite_stat1``**. This is the
+  load-bearing one. No media DB ever runs ``ANALYZE`` (there is no ANALYZE
+  anywhere in ``Client_Media_DB_v2.py``), and the "obvious" index for this
+  query -- ``(chunk_engine_version, media_id) WHERE deleted = 0`` -- is
+  simply never picked in that state: measured 120 ms with it present
+  against 119 ms without, i.e. a dead 5 MB index. Leading with ``deleted``
+  is what makes the no-stats planner take it. A plan assertion is the only
+  thing that can catch a future re-spelling of the query, or a future
+  reordering of the index, silently going back to the scan.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.RAG_Admin.local_rag_admin_service import LocalRAGAdminService
+
+from Tests.DB.historical_bootstrap_v6 import media_db_at_version
+
+INDEX_NAME = "idx_unvectorizedmediachunks_engine_census"
+
+#: The census SQL exactly as the production reader spells it. Kept as a
+#: literal here on purpose: this file's job is to fail when the reader and
+#: the index stop matching, which importing the reader's string would hide.
+CENSUS_SQL = (
+    "SELECT chunk_engine_version, COUNT(DISTINCT media_id) AS n "
+    "FROM UnvectorizedMediaChunks WHERE deleted = 0 "
+    "GROUP BY chunk_engine_version"
+)
+
+
+@pytest.fixture()
+def fresh_db(tmp_path):
+    db = MediaDatabase(str(tmp_path / "media.db"), client_id="test")
+    yield db
+    db.close_connection()
+
+
+def _indexes_on_chunks(conn: sqlite3.Connection) -> dict[str, str]:
+    return {
+        row["name"]: row["sql"] or ""
+        for row in conn.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'index' "
+            "AND tbl_name = 'UnvectorizedMediaChunks'"
+        )
+    }
+
+
+def _plan(conn: sqlite3.Connection, sql: str) -> str:
+    return " | ".join(
+        row["detail"] for row in conn.execute("EXPLAIN QUERY PLAN " + sql)
+    )
+
+
+def _seed_chunks(conn: sqlite3.Connection, *, legacy_media: int, stamped_media: int,
+                 chunks_each: int = 3, deleted_media: int = 0) -> None:
+    """Insert Media + chunk rows directly (fast, and shape-exact).
+
+    Goes around ``add_media_with_keywords`` deliberately: this file cares
+    about the physical row shape the index sees, and needs soft-deleted and
+    unstamped rows that the writer never produces on its own.
+    """
+    now = "2026-08-23T00:00:00Z"
+    total_media = legacy_media + stamped_media + deleted_media
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.executemany(
+        "INSERT INTO Media (id, title, type, content, content_hash, uuid, "
+        "last_modified, version, client_id, deleted) "
+        "VALUES (?,?,?,?,?,?,?,1,'test',0)",
+        [
+            (i, f"doc {i}", "document", "body", f"hash-{i}", f"media-{i}", now)
+            for i in range(1, total_media + 1)
+        ],
+    )
+    rows = []
+    n = 0
+    for media_id in range(1, total_media + 1):
+        if media_id <= legacy_media:
+            version, deleted = None, 0
+        elif media_id <= legacy_media + stamped_media:
+            version, deleted = "parity-1@385afa95", 0
+        else:
+            version, deleted = None, 1
+        for index in range(chunks_each):
+            n += 1
+            rows.append(
+                (n, media_id, f"chunk {n}", index, "words", f"uuid-{n}", now,
+                 version, deleted)
+            )
+    conn.executemany(
+        "INSERT INTO UnvectorizedMediaChunks (id, media_id, chunk_text, "
+        "chunk_index, chunk_type, uuid, last_modified, chunk_engine_version, "
+        "deleted, version, client_id) VALUES (?,?,?,?,?,?,?,?,?,1,'test')",
+        rows,
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# The index exists, on a fresh DB and after a genuine upgrade
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_db_is_at_the_current_version(fresh_db):
+    version = fresh_db.get_connection().execute(
+        "SELECT version FROM schema_version LIMIT 1"
+    ).fetchone()["version"]
+    assert version == MediaDatabase._CURRENT_SCHEMA_VERSION
+
+
+def test_fresh_db_has_the_census_index_with_the_measured_shape(fresh_db):
+    indexes = _indexes_on_chunks(fresh_db.get_connection())
+    assert INDEX_NAME in indexes, sorted(indexes)
+    ddl = " ".join(indexes[INDEX_NAME].split()).lower()
+    # Column ORDER is the measured part -- see the module docstring.
+    assert "(deleted, chunk_engine_version, media_id)" in ddl
+    assert "where deleted = 0" in ddl
+
+
+def test_genuine_v7_db_upgrades_and_gains_the_index(tmp_path):
+    path = tmp_path / "v7.db"
+    with media_db_at_version(path, 7) as old:
+        conn = old.get_connection()
+        assert conn.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()["version"] == 7
+        assert INDEX_NAME not in _indexes_on_chunks(conn)
+        _seed_chunks(conn, legacy_media=2, stamped_media=3)
+
+    upgraded = MediaDatabase(str(path), client_id="upgrade")
+    try:
+        conn = upgraded.get_connection()
+        assert conn.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()["version"] == MediaDatabase._CURRENT_SCHEMA_VERSION
+        assert INDEX_NAME in _indexes_on_chunks(conn)
+        # The rows the v7 DB already held are untouched by an index add.
+        assert conn.execute(
+            "SELECT COUNT(*) AS n FROM UnvectorizedMediaChunks"
+        ).fetchone()["n"] == 15
+        service = LocalRAGAdminService.__new__(LocalRAGAdminService)
+        assert service.count_chunks_by_engine_version(upgraded) == {
+            "legacy": 2,
+            "parity-1@385afa95": 3,
+        }
+    finally:
+        upgraded.close_connection()
+
+
+def test_v7_to_v8_adds_nothing_but_the_index(tmp_path):
+    """A pure index add: no column, table, trigger or row may move."""
+    path = tmp_path / "v7-shape.db"
+
+    def _shape(conn: sqlite3.Connection) -> dict[str, set]:
+        return {
+            "tables": {
+                r["name"]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            },
+            "triggers": {
+                r["name"]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+                )
+            },
+            "chunk_columns": {
+                r["name"]
+                for r in conn.execute("PRAGMA table_info(UnvectorizedMediaChunks)")
+            },
+        }
+
+    with media_db_at_version(path, 7) as old:
+        conn = old.get_connection()
+        _seed_chunks(conn, legacy_media=1, stamped_media=1, deleted_media=1)
+        before = _shape(conn)
+        before_indexes = set(_indexes_on_chunks(conn))
+        before_rows = conn.execute(
+            "SELECT id, media_id, chunk_engine_version, deleted, version "
+            "FROM UnvectorizedMediaChunks ORDER BY id"
+        ).fetchall()
+        before_rows = [tuple(r) for r in before_rows]
+
+    upgraded = MediaDatabase(str(path), client_id="upgrade")
+    try:
+        conn = upgraded.get_connection()
+        after = _shape(conn)
+        after_rows = [
+            tuple(r)
+            for r in conn.execute(
+                "SELECT id, media_id, chunk_engine_version, deleted, version "
+                "FROM UnvectorizedMediaChunks ORDER BY id"
+            )
+        ]
+        assert after == before
+        assert after_rows == before_rows
+        assert set(_indexes_on_chunks(conn)) - before_indexes == {INDEX_NAME}
+    finally:
+        upgraded.close_connection()
+
+
+# ---------------------------------------------------------------------------
+# The load-bearing one: the planner picks it with NO sqlite_stat1
+# ---------------------------------------------------------------------------
+
+
+def test_census_plan_uses_the_covering_index_without_analyze(fresh_db):
+    conn = fresh_db.get_connection()
+    _seed_chunks(conn, legacy_media=40, stamped_media=160, chunks_each=5)
+    assert conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sqlite_stat1'"
+    ).fetchone() is None, "the fixture must reproduce the no-stats production state"
+
+    plan = _plan(conn, CENSUS_SQL)
+    assert INDEX_NAME in plan, plan
+    assert "COVERING INDEX" in plan, plan
+    # Both temp B-trees are what the index removes; either one reappearing
+    # means the shape or the query text has drifted.
+    assert "TEMP B-TREE" not in plan, plan
+
+
+def test_census_result_is_unchanged_by_the_index(fresh_db):
+    """The index must not change a single number the panel can show."""
+    conn = fresh_db.get_connection()
+    _seed_chunks(conn, legacy_media=4, stamped_media=6, chunks_each=3,
+                 deleted_media=5)
+    service = LocalRAGAdminService.__new__(LocalRAGAdminService)
+    with_index = service.count_chunks_by_engine_version(fresh_db)
+
+    conn.execute(f"DROP INDEX {INDEX_NAME}")
+    conn.commit()
+    without_index = service.count_chunks_by_engine_version(fresh_db)
+
+    assert with_index == without_index == {"legacy": 4, "parity-1@385afa95": 6}
+
+
+def test_census_on_an_empty_library_is_empty_and_still_indexed(fresh_db):
+    """First run: no media at all. The report's honest empty state."""
+    conn = fresh_db.get_connection()
+    service = LocalRAGAdminService.__new__(LocalRAGAdminService)
+    assert service.count_chunks_by_engine_version(fresh_db) == {}
+    assert INDEX_NAME in _plan(conn, CENSUS_SQL)
+
+
+def test_soft_deleted_chunks_are_outside_the_partial_index(fresh_db):
+    """A soft-deleted row must neither be counted nor occupy the index."""
+    conn = fresh_db.get_connection()
+    _seed_chunks(conn, legacy_media=2, stamped_media=0, chunks_each=2,
+                 deleted_media=3)
+    service = LocalRAGAdminService.__new__(LocalRAGAdminService)
+    assert service.count_chunks_by_engine_version(fresh_db) == {"legacy": 2}
+    # `deleted = 0` legs only: the partial index holds 2 media x 2 chunks.
+    live = conn.execute(
+        "SELECT COUNT(*) AS n FROM UnvectorizedMediaChunks WHERE deleted = 0"
+    ).fetchone()["n"]
+    assert live == 4

--- a/Tests/RAG/test_rag_admin_diagnostics_off_loop.py
+++ b/Tests/RAG/test_rag_admin_diagnostics_off_loop.py
@@ -1,0 +1,325 @@
+"""TASK-21126: the legacy-chunk census must not run on the event loop.
+
+``RAGAdminScopeService._maybe_await(service.get_template_diagnostics())``
+evaluated its argument before the first suspension point, so the LOCAL
+backend's synchronous census SELECT -- measured 119 ms at 200k live chunk
+rows and 701 ms at 1M -- ran to completion on the event loop, once per
+Library Search/RAG panel show.
+
+Every test here runs against the REAL ``LocalRAGAdminService`` over a real
+file-backed ``MediaDatabase``. That is deliberate: a synchronous test double
+makes an "it runs off the loop" assertion pass while moving zero work (the
+trap recorded in ``lessons-testing-evidence.md``), and only the real service
+can also show that the work still HAPPENS and the answer is still right.
+
+Mutation-checked: reverting ``get_template_diagnostics`` to
+``await self._maybe_await(service.get_template_diagnostics())`` turns
+``test_census_runs_on_a_worker_thread`` and
+``test_event_loop_keeps_running_during_a_slow_census`` red.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.RAG_Admin.local_rag_admin_service import LocalRAGAdminService
+from tldw_chatbook.RAG_Admin.rag_admin_scope_service import RAGAdminScopeService
+
+pytestmark = pytest.mark.asyncio
+
+
+def _seed(db: MediaDatabase, *, legacy: int, stamped: int) -> None:
+    conn = db.get_connection()
+    now = "2026-08-23T00:00:00Z"
+    conn.execute("PRAGMA foreign_keys = OFF")
+    total = legacy + stamped
+    conn.executemany(
+        "INSERT INTO Media (id, title, type, content, content_hash, uuid, "
+        "last_modified, version, client_id, deleted) "
+        "VALUES (?,?,?,?,?,?,?,1,'test',0)",
+        [
+            (i, f"doc {i}", "document", "b", f"h{i}", f"m{i}", now)
+            for i in range(1, total + 1)
+        ],
+    )
+    rows = []
+    n = 0
+    for media_id in range(1, total + 1):
+        version = None if media_id <= legacy else "parity-1@385afa95"
+        for index in range(2):
+            n += 1
+            rows.append(
+                (n, media_id, f"c{n}", index, "words", f"u{n}", now, version)
+            )
+    conn.executemany(
+        "INSERT INTO UnvectorizedMediaChunks (id, media_id, chunk_text, "
+        "chunk_index, chunk_type, uuid, last_modified, chunk_engine_version, "
+        "deleted, version, client_id) VALUES (?,?,?,?,?,?,?,?,0,1,'test')",
+        rows,
+    )
+    conn.commit()
+
+
+def _service(db: MediaDatabase) -> RAGAdminScopeService:
+    """A real scope service over a real local backend.
+
+    ``chunking_service`` is stubbed to a sentinel only so
+    ``_require_chunking_service`` succeeds without importing the ~15k-LOC
+    chunking engine; nothing in the diagnostics path calls it.
+    """
+    local = LocalRAGAdminService(db, chunking_service=object())
+    return RAGAdminScopeService(local_service=local, server_service=None)
+
+
+@pytest.fixture()
+def media_db(tmp_path):
+    db = MediaDatabase(str(tmp_path / "media.db"), client_id="test")
+    yield db
+    db.close_connection()
+
+
+async def test_census_runs_on_a_worker_thread(media_db):
+    """The SELECT executes off the loop thread -- and still executes."""
+    _seed(media_db, legacy=3, stamped=4)
+    threads: list[int] = []
+    real_get_connection = media_db.get_connection
+
+    def recording_get_connection():
+        threads.append(threading.get_ident())
+        return real_get_connection()
+
+    # Shadow on the INSTANCE, not the class: it catches the callee that
+    # reaches this object by any route.
+    media_db.get_connection = recording_get_connection
+    loop_thread = threading.get_ident()
+
+    payload = await _service(media_db).get_template_diagnostics(mode="local")
+
+    assert threads, "the census never touched the media DB at all"
+    assert loop_thread not in threads, (
+        "the census ran on the event-loop thread: " f"{threads} vs {loop_thread}"
+    )
+    # The work still happened AND produced the right answer.
+    assert payload["legacy_chunk_report"] == "Chunked by an older engine: 3 items"
+
+
+async def test_event_loop_keeps_running_during_a_slow_census(media_db):
+    """A slow backend must not starve the loop.
+
+    The census is deliberately slowed with a real ``time.sleep`` inside the
+    synchronous backend method, because that is exactly what a large media
+    DB does: blocking CPU/IO in a sync call. A heartbeat coroutine counts
+    its own ticks while the fetch is in flight.
+    """
+    _seed(media_db, legacy=1, stamped=1)
+    service = _service(media_db)
+    local = service.local_service
+    inner = local.get_template_diagnostics
+
+    def slow_diagnostics():
+        time.sleep(0.30)
+        return inner()
+
+    local.get_template_diagnostics = slow_diagnostics
+
+    ticks = 0
+    stop = False
+
+    async def heartbeat():
+        nonlocal ticks
+        while not stop:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    beat = asyncio.create_task(heartbeat())
+    started = time.perf_counter()
+    payload = await service.get_template_diagnostics(mode="local")
+    elapsed = time.perf_counter() - started
+    stop = True
+    await beat
+
+    assert elapsed >= 0.30, "the slow backend was not actually invoked"
+    # A blocked loop yields ~1 tick (the one before the call). 30 slots of
+    # 10 ms fit in 300 ms; require a clear majority to survive scheduler
+    # jitter on a loaded machine.
+    assert ticks >= 15, f"the event loop stalled: only {ticks} heartbeat ticks"
+    assert payload["legacy_chunk_report"] == "Chunked by an older engine: 1 items"
+
+
+async def test_memory_backed_db_still_reports_the_real_counts():
+    """`:memory:` stays on the calling thread -- never a silent zero.
+
+    ``MediaDatabase`` connections are thread-local, so a worker thread
+    opening ``:memory:`` gets a DIFFERENT, EMPTY database and the census
+    would report nothing at all. This is the interleaving hazard the
+    offload could have introduced; the backend declares itself unsafe and
+    the scope service runs it inline instead.
+    """
+    db = MediaDatabase(":memory:", client_id="test")
+    try:
+        _seed(db, legacy=2, stamped=1)
+        local = LocalRAGAdminService(db, chunking_service=object())
+        assert local.diagnostics_are_thread_safe() is False
+        payload = await RAGAdminScopeService(
+            local_service=local, server_service=None
+        ).get_template_diagnostics(mode="local")
+        assert payload["legacy_chunk_report"] == "Chunked by an older engine: 2 items"
+    finally:
+        db.close_connection()
+
+
+async def test_file_backed_db_declares_itself_thread_safe(media_db):
+    assert LocalRAGAdminService(
+        media_db, chunking_service=object()
+    ).diagnostics_are_thread_safe() is True
+
+
+async def test_no_media_db_is_thread_safe_and_reports_nothing():
+    local = LocalRAGAdminService(None, chunking_service=object())
+    assert local.diagnostics_are_thread_safe() is True
+    payload = await RAGAdminScopeService(
+        local_service=local, server_service=None
+    ).get_template_diagnostics(mode="local")
+    assert "legacy_chunk_report" not in payload
+    assert payload["backend"] == "local"
+
+
+async def test_a_fully_stamped_library_reports_nothing(media_db):
+    """Empty state: nothing older-engine, so no line and no button."""
+    _seed(media_db, legacy=0, stamped=5)
+    payload = await _service(media_db).get_template_diagnostics(mode="local")
+    assert "legacy_chunk_report" not in payload
+
+
+async def test_an_empty_library_reports_nothing(media_db):
+    """First run: no media at all."""
+    payload = await _service(media_db).get_template_diagnostics(mode="local")
+    assert "legacy_chunk_report" not in payload
+
+
+async def test_a_failing_census_still_yields_a_usable_payload(media_db):
+    """Error path: the census raising must not lose the diagnostics dict.
+
+    ``get_template_diagnostics`` already guards the report; what this pins
+    is that the guard still works when the call is made from a worker
+    thread (``to_thread`` re-raises into the awaiting coroutine, so a
+    swallowed-there exception would surface here as a raise).
+    """
+    _seed(media_db, legacy=2, stamped=0)
+    local = _service(media_db).local_service
+
+    def exploding(_db):
+        raise RuntimeError("no such column: chunk_engine_version")
+
+    local.count_chunks_by_engine_version = exploding
+    payload = await RAGAdminScopeService(
+        local_service=local, server_service=None
+    ).get_template_diagnostics(mode="local")
+    assert "legacy_chunk_report" not in payload
+    assert payload["capability"] == "native"
+
+
+async def test_a_raising_backend_propagates_unchanged(media_db):
+    """A failure OUTSIDE the guarded report still reaches the caller."""
+    local = _service(media_db).local_service
+
+    def exploding():
+        raise ValueError("Local chunking template backend is unavailable.")
+
+    local.get_template_diagnostics = exploding
+    with pytest.raises(ValueError, match="unavailable"):
+        await RAGAdminScopeService(
+            local_service=local, server_service=None
+        ).get_template_diagnostics(mode="local")
+
+
+async def test_concurrent_censuses_never_tear_against_a_live_writer(media_db):
+    """Interleaving: the offload puts reads and writes on different threads.
+
+    Before this change the census could not overlap anything -- it held the
+    loop. Now twelve of them run on executor threads while the loop thread
+    inserts new legacy media between batches. Under WAL each reader takes a
+    consistent snapshot, so every answer must be a count the database
+    genuinely held at some instant: never a torn value, never a lock error.
+    """
+    _seed(media_db, legacy=4, stamped=1)
+    service = _service(media_db)
+    conn = media_db.get_connection()
+    now = "2026-08-23T00:00:00Z"
+
+    async def census() -> str:
+        payload = await service.get_template_diagnostics(mode="local")
+        return payload.get("legacy_chunk_report", "")
+
+    def add_legacy_media(media_id: int) -> None:
+        conn.execute(
+            "INSERT INTO Media (id, title, type, content, content_hash, uuid, "
+            "last_modified, version, client_id, deleted) "
+            "VALUES (?,?,?,?,?,?,?,1,'test',0)",
+            (media_id, f"doc {media_id}", "document", "b", f"h{media_id}",
+             f"m{media_id}", now),
+        )
+        conn.execute(
+            "INSERT INTO UnvectorizedMediaChunks (id, media_id, chunk_text, "
+            "chunk_index, chunk_type, uuid, last_modified, "
+            "chunk_engine_version, deleted, version, client_id) "
+            "VALUES (?,?,?,0,'words',?,?,NULL,0,1,'test')",
+            (1000 + media_id, media_id, "c", f"u{1000 + media_id}", now),
+        )
+        conn.commit()
+
+    results: list[str] = []
+    for round_index in range(4):
+        pending = asyncio.gather(*(census() for _ in range(3)))
+        add_legacy_media(100 + round_index)
+        results.extend(await pending)
+
+    counts = [int(line.split(": ")[1].split(" ")[0]) for line in results]
+    # Only counts the database genuinely held (4 at seed, +1 per round).
+    assert set(counts) <= {4, 5, 6, 7, 8}, counts
+    # A count can never go backwards, and the writer must actually have
+    # raced -- a run that saw one value throughout proved nothing.
+    assert counts == sorted(counts), counts
+    assert len(set(counts)) >= 2, counts
+
+
+async def test_an_unknown_backend_is_not_moved_off_the_loop():
+    """Opt-in only: a backend that does not declare safety runs inline.
+
+    Guards the blast radius of the change -- a test double, a Mock, or any
+    future sync backend keeps the pre-existing behaviour exactly.
+    """
+    calls: list[int] = []
+
+    class _Unknown:
+        def get_template_diagnostics(self):
+            calls.append(threading.get_ident())
+            return {"capability": "stub"}
+
+    loop_thread = threading.get_ident()
+    payload = await RAGAdminScopeService(
+        local_service=_Unknown(), server_service=None
+    ).get_template_diagnostics(mode="local")
+    assert calls == [loop_thread]
+    assert payload == {"capability": "stub", "backend": "local"}
+
+
+async def test_an_async_backend_is_awaited_not_threaded():
+    calls: list[int] = []
+
+    class _AsyncBackend:
+        async def get_template_diagnostics(self):
+            calls.append(threading.get_ident())
+            return {"capability": "server"}
+
+    loop_thread = threading.get_ident()
+    payload = await RAGAdminScopeService(
+        local_service=None, server_service=_AsyncBackend()
+    ).get_template_diagnostics(mode="server")
+    assert calls == [loop_thread]
+    assert payload == {"capability": "server", "backend": "server"}

--- a/Tests/UI/test_library_rag_legacy_chunk_report_real_backend.py
+++ b/Tests/UI/test_library_rag_legacy_chunk_report_real_backend.py
@@ -1,0 +1,229 @@
+"""TASK-21126: the Search/RAG panel's report line over the REAL backend.
+
+``test_library_rag_legacy_chunk_report.py`` pins the renderer's contract
+against a stubbed scope service. This file runs the same panel against a
+REAL ``RAGAdminScopeService`` -> ``LocalRAGAdminService`` -> file-backed
+``MediaDatabase``, because moving the census onto a worker thread is a
+change a stubbed async service cannot observe at all: the stub was already
+awaitable, so it would have reported "off the loop" while the production
+seam still blocked it.
+
+It also walks the two lifecycle paths the perf burn-down keeps breaking:
+unmounting the panel while a census is in flight, and quitting the app in
+the same state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.Library.library_rag_state import LibraryRagPanelState
+from tldw_chatbook.RAG_Admin.local_rag_admin_service import LocalRAGAdminService
+from tldw_chatbook.RAG_Admin.rag_admin_scope_service import RAGAdminScopeService
+from tldw_chatbook.Widgets.Library.library_search_rag_panel import (
+    LibrarySearchRagPanel,
+)
+
+REPORT_LINE_ID = "library-rag-legacy-chunk-line"
+RECHUNK_BUTTON_ID = "library-rag-rechunk-legacy"
+
+pytestmark = pytest.mark.asyncio
+
+
+def _seed(db: MediaDatabase, *, legacy: int, stamped: int) -> None:
+    conn = db.get_connection()
+    now = "2026-08-23T00:00:00Z"
+    conn.execute("PRAGMA foreign_keys = OFF")
+    total = legacy + stamped
+    conn.executemany(
+        "INSERT INTO Media (id, title, type, content, content_hash, uuid, "
+        "last_modified, version, client_id, deleted) "
+        "VALUES (?,?,?,?,?,?,?,1,'test',0)",
+        [
+            (i, f"doc {i}", "document", "b", f"h{i}", f"m{i}", now)
+            for i in range(1, total + 1)
+        ],
+    )
+    rows = []
+    n = 0
+    for media_id in range(1, total + 1):
+        version = None if media_id <= legacy else "parity-1@385afa95"
+        for index in range(2):
+            n += 1
+            rows.append((n, media_id, f"c{n}", index, "words", f"u{n}", now, version))
+    conn.executemany(
+        "INSERT INTO UnvectorizedMediaChunks (id, media_id, chunk_text, "
+        "chunk_index, chunk_type, uuid, last_modified, chunk_engine_version, "
+        "deleted, version, client_id) VALUES (?,?,?,?,?,?,?,?,0,1,'test')",
+        rows,
+    )
+    conn.commit()
+
+
+class _RealBackendHost(ConsolidatedCSSApp):
+    """Mount one Search/RAG panel over a real local RAG admin backend."""
+
+    def __init__(self, scope_service: RAGAdminScopeService) -> None:
+        super().__init__()
+        self._scope_service = scope_service
+
+    @property
+    def rag_admin_scope_service(self) -> RAGAdminScopeService:
+        return self._scope_service
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="canvas-slot"):
+            yield LibrarySearchRagPanel(
+                LibraryRagPanelState.from_values(
+                    source_counts={"media": 3}, query="", mode="search"
+                ),
+                id="library-search-rag-panel",
+            )
+
+
+def _scope_service(db: MediaDatabase) -> RAGAdminScopeService:
+    return RAGAdminScopeService(
+        local_service=LocalRAGAdminService(db, chunking_service=object()),
+        server_service=None,
+    )
+
+
+async def _settle(pilot, predicate, attempts: int = 120):
+    for _ in range(attempts):
+        if predicate():
+            await pilot.pause()
+            return True
+        await pilot.pause()
+    return False
+
+
+@pytest.fixture()
+def media_db(tmp_path):
+    db = MediaDatabase(str(tmp_path / "media.db"), client_id="test")
+    yield db
+    db.close_connection()
+
+
+async def test_panel_renders_the_real_census_line(media_db):
+    """End to end: the number on screen is the number in the database."""
+    _seed(media_db, legacy=4, stamped=2)
+    app = _RealBackendHost(_scope_service(media_db))
+    async with app.run_test() as pilot:
+        line = app.query_one(f"#{REPORT_LINE_ID}", Static)
+        assert await _settle(pilot, lambda: line.display is True), str(line.renderable)
+        assert str(line.renderable) == "Chunked by an older engine: 4 items"
+        assert app.query_one(f"#{RECHUNK_BUTTON_ID}").display is True
+
+
+async def test_panel_shows_nothing_for_a_fully_stamped_library(media_db):
+    """The honest empty state -- no line, no re-chunk control, no zero."""
+    _seed(media_db, legacy=0, stamped=3)
+    app = _RealBackendHost(_scope_service(media_db))
+    async with app.run_test() as pilot:
+        for _ in range(30):
+            await pilot.pause()
+        assert app.query_one(f"#{REPORT_LINE_ID}", Static).display is False
+        assert app.query_one(f"#{RECHUNK_BUTTON_ID}").display is False
+
+
+async def test_panel_shows_nothing_on_a_first_run_empty_library(media_db):
+    app = _RealBackendHost(_scope_service(media_db))
+    async with app.run_test() as pilot:
+        for _ in range(30):
+            await pilot.pause()
+        assert app.query_one(f"#{REPORT_LINE_ID}", Static).display is False
+
+
+def _instrument_slow_census(service: RAGAdminScopeService, seconds: float):
+    """Slow the real backend down and expose entry/exit as loop events.
+
+    ``entered`` is set from the census's own thread the moment it starts,
+    so a test can prove it interrupted a census that was genuinely IN
+    FLIGHT -- and, because it is delivered via ``call_soon_threadsafe``, it
+    can only be observed at all if the event loop is still running while
+    the census runs. ``finished`` proves the query completed rather than
+    being wedged by whatever the test did to the UI meanwhile.
+    """
+    local = service.local_service
+    inner = local.get_template_diagnostics
+    entered = asyncio.Event()
+    finished = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def slow_diagnostics():
+        loop.call_soon_threadsafe(entered.set)
+        time.sleep(seconds)
+        try:
+            return inner()
+        finally:
+            loop.call_soon_threadsafe(finished.set)
+
+    local.get_template_diagnostics = slow_diagnostics
+    return entered, finished
+
+
+async def test_unmounting_mid_census_neither_raises_nor_paints(media_db):
+    """Panel unmount while the worker thread is still in the census.
+
+    The offload means the SELECT outlives the widget by design; what must
+    not happen is a stalled UI, an exception reaching the app, or a dead
+    widget being written to.
+
+    The teeth here are the heartbeat: it counts loop ticks DURING the
+    census, so this test also fails if the census ever goes back to
+    running inline (that is the mutation it is checked against).
+    """
+    _seed(media_db, legacy=7, stamped=1)
+    service = _scope_service(media_db)
+    entered, finished = _instrument_slow_census(service, 0.30)
+
+    ticks = 0
+    stop = False
+
+    async def heartbeat():
+        nonlocal ticks
+        while not stop:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    app = _RealBackendHost(service)
+    async with app.run_test() as pilot:
+        beat = asyncio.create_task(heartbeat())
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        ticks_at_entry = ticks
+        panel = app.query_one("#library-search-rag-panel")
+        await panel.remove()
+        assert list(app.query("#library-search-rag-panel")) == []
+        # The census completes on its own thread with no widget left.
+        await asyncio.wait_for(finished.wait(), timeout=5)
+        stop = True
+        await beat
+        assert ticks - ticks_at_entry >= 15, (
+            f"the event loop stalled during the census: {ticks - ticks_at_entry} ticks"
+        )
+        assert list(app.query(f"#{REPORT_LINE_ID}")) == []
+
+
+async def test_quitting_mid_census_exits_cleanly(media_db):
+    """App quit while the census thread is running must not hang or raise."""
+    _seed(media_db, legacy=2, stamped=2)
+    service = _scope_service(media_db)
+    entered, _finished = _instrument_slow_census(service, 0.30)
+
+    app = _RealBackendHost(service)
+    started = time.perf_counter()
+    async with app.run_test() as pilot:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        app.exit()
+    elapsed = time.perf_counter() - started
+    assert app.return_value is None
+    # The census must not have been awaited on the way out.
+    assert elapsed < 5.0, elapsed

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7862,3 +7862,55 @@ note id that existed on **neither** root, so it passed for the wrong reason. The
 fixture now gives the other root values that exist only there. Any negative
 cross-scope assertion needs the value to genuinely exist in the other scope, or it
 proves only that nothing matches nothing.
+---
+
+## An index is not evidence until the planner picks it in the state your users' databases are actually in (TASK-21126, 2026-08-23)
+
+**What happened.** The holistic-perf finding said the Library Search/RAG
+panel's legacy-chunk census ran an unindexed full-table `GROUP BY` and
+prescribed "index or maintained count". The obvious index —
+`(chunk_engine_version, media_id) WHERE deleted = 0` — is a textbook
+COVERING index for that exact query, and the first probe confirmed it:
+112 ms → 3.4 ms at 200k chunk rows, `SCAN … USING COVERING INDEX`, both
+temp B-trees gone.
+
+The probe had run `ANALYZE` to make the corpus "realistic". **No media
+database in the wild has ever run `ANALYZE`** — there is no `ANALYZE`
+anywhere in `Client_Media_DB_v2.py`, so `sqlite_stat1` does not exist on a
+single user's disk. Re-measured in that state, the planner ignores the new
+index completely and stays on the pre-existing `idx_...deleted`: **118.8 ms
+without the index, 120.2 ms with it.** Five megabytes of disk, a schema
+migration, and a green "the index exists" test, for a 1% change.
+
+What actually works is counter-intuitive: lead the index with the
+**redundant** `deleted` column that the partial predicate already pins to a
+constant. That makes it answer the same equality search the no-stats
+heuristic already likes, while additionally covering the GROUP BY and the
+`COUNT(DISTINCT)` — chosen without stats, 23.4 ms at 200k and 122.8 ms at
+1M. Four shapes were measured; two of them were never chosen at all.
+
+**What to do.**
+
+1. **`EXPLAIN QUERY PLAN` on a corpus built the way production builds one.**
+   Before believing an index, grep the owning module for `ANALYZE` /
+   `PRAGMA optimize`. If neither runs, your probe must not run them either —
+   and say so in the probe, because "I made the corpus realistic" is exactly
+   how the `ANALYZE` got in.
+2. **Assert the PLAN in a test, not the index's existence.** `SELECT … FROM
+   sqlite_master WHERE type='index'` passes for a dead index. The pin that
+   catches this is the `EXPLAIN QUERY PLAN` string: index name present,
+   `COVERING INDEX` present, `TEMP B-TREE` absent — plus an explicit
+   assertion that `sqlite_stat1` is absent, so a future fixture that adds
+   `ANALYZE` cannot quietly restore the flattering plan.
+3. **Timing alone would not have caught it either.** 118.8 → 120.2 ms reads
+   as noise; only the plan text says *why*. Measure both.
+
+**Adjacent trap from the same task, worth its own line: offloading a query
+to a thread can make a `:memory:` database silently return the wrong
+answer.** `MediaDatabase` hands out THREAD-LOCAL connections. For a file
+that is fine; for `:memory:` a worker thread opens a *different, empty*
+database, so the census returns `{}` and the UI shows nothing instead of
+raising. Deliberately breaking the guard proved it — the memory-backed test
+went red with a zero count, not an error. Before wrapping any DB call in
+`to_thread`, check what that owner's connection factory does with
+`:memory:`, and keep a memory-backed test in the set.

--- a/backlog/tasks/task-21126 - Library Search-RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount.md
+++ b/backlog/tasks/task-21126 - Library Search-RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount.md
@@ -28,6 +28,121 @@ chunk counts (1e5-1e6 rows).
 
 ## Acceptance Criteria
 
-- [ ] The census query runs off the loop and its result is cached per session (invalidated on ingest/re-chunk)
-- [ ] An index or maintained count removes the full-scan; EXPLAIN QUERY PLAN before/after recorded in the task
-- [ ] Panel content unchanged
+- [x] The census query runs off the event loop
+- [x] An index or maintained count removes the full-scan; EXPLAIN QUERY PLAN before/after recorded in the task
+- [x] Panel content unchanged
+
+### Amended during implementation (2026-08-23)
+
+**AC 1 originally read "…and its result is cached per session (invalidated on
+ingest/re-chunk)". The cache half was dropped, deliberately.** Once the query
+is off the loop and indexed it costs 23 ms at 200k live chunk rows and 123 ms
+at 1M — on a worker thread, once per panel show. A session cache would save a
+measured zero of user-visible time and would have to be invalidated by ingest,
+re-chunk, media hard-delete, media soft-delete/undelete, sync-in, and
+`process_unvectorized_chunks`; missing any one leaves the panel claiming
+"Chunked by an older engine: N items" with a Re-chunk button that either lies
+or hides real work. Re-reading per show IS the freshness protocol and it has
+nothing to get wrong. Recorded per the "prescribed fix is a hypothesis" rule.
+
+## Implementation Plan
+
+1. Build the differential harness BEFORE the fix: a real `MediaDatabase` corpus
+   at 200k and 1M chunk rows, timing the census and capturing EXPLAIN QUERY
+   PLAN, plus a write-side A/B for any index considered.
+2. Confirm (or refute) each half of the filing: is the query really unindexed,
+   does it really run on the loop, and is a cache warranted once it is fixed?
+3. Pick the index shape by measurement, not by shape-of-query reasoning.
+4. Move the census off the loop at the narrowest safe seam, keeping every other
+   backend's behaviour byte-identical.
+5. Walk unmount / quit / error / empty explicitly; test the interleaving the
+   offload creates.
+6. Mutation-check every assertion.
+
+## Implementation Notes
+
+Two changes: a media-DB index (schema v7 -> v8) and an off-loop seam in
+`RAGAdminScopeService`. The panel's rendering, its state machine and every
+string it can show are untouched.
+
+**The filing was right about the disease and wrong about the cure, twice.**
+
+1. *"no index on chunk_engine_version … full scan"* — the scan is real, but
+   the fix the wording implies is a dead index. An index on
+   `(chunk_engine_version, media_id) WHERE deleted = 0` is a perfect covering
+   index for this query and **SQLite never chooses it**: no media DB has ever
+   run `ANALYZE` (there is no `ANALYZE` anywhere in `Client_Media_DB_v2.py`),
+   and with no `sqlite_stat1` the planner keeps using the existing
+   `idx_unvectorizedmediachunks_deleted`. Measured at 200k rows: 118.8 ms
+   without the index, 120.2 ms with it — 5 MB of disk for nothing. What works
+   is leading with the redundant `deleted` column so the index answers the same
+   equality search the planner already likes, while also covering the GROUP BY
+   and the DISTINCT: `(deleted, chunk_engine_version, media_id) WHERE
+   deleted = 0`, chosen with no stats, 23.4 ms.
+2. *"cache per session"* — see the amended AC above.
+
+`RAGAdminScopeService._maybe_await(service.get_template_diagnostics())`
+evaluated its argument before the first suspension point, so the *synchronous*
+local backend ran to completion on the event loop even though the panel already
+scheduled an async worker. `_call_off_loop` moves it to `asyncio.to_thread`,
+but only for a backend that opts in via `diagnostics_are_thread_safe()`. That
+gate is not ceremony: `MediaDatabase` connections are thread-local, so a
+`:memory:` database handed to a worker thread opens a *different, empty*
+database and the census would have started reporting zero legacy items in
+silence. Async backends and unknown/test doubles keep the exact pre-existing
+inline path.
+
+### Measurements (real production schema, no ANALYZE — the production state)
+
+| corpus | before | after | plan before | plan after |
+|---|---|---|---|---|
+| 200k chunk rows / 4k media / 64.3 MB | **118.8 ms** | **23.4 ms** (5.1x) | `SEARCH … USING INDEX idx_unvectorizedmediachunks_deleted (deleted=?)` + `USE TEMP B-TREE FOR GROUP BY` + `USE TEMP B-TREE FOR count(DISTINCT)` | `SEARCH … USING COVERING INDEX idx_unvectorizedmediachunks_engine_census (deleted=?)`, no temp B-trees |
+| 1M chunk rows / 20k media / 325.2 MB | **700.9 ms** | **122.8 ms** (5.7x) | same | same |
+
+Off the loop as well as faster, so the UI cost of both columns is now zero: a
+300 ms census leaves 28 heartbeat ticks in a 10 ms-tick probe; the same probe
+against the pre-change inline call records 2.
+
+Costs, stated: +9% media-DB file size (64.3 -> 70.2 MB at 200k, 325.2 -> 354.8
+at 1M; ~30 bytes per LIVE chunk row, soft-deleted rows excluded by the partial
+predicate); +0.06 ms on a 50-chunk ingest batch (0.660 -> 0.720 ms median); a
+one-off index build at the first open after upgrade (167 ms at 200k, 2.05 s at
+1M). Rejected shapes are recorded in the code comment beside the DDL, with
+their numbers.
+
+### Lifecycle walk
+
+* **Panel unmount mid-census** — Textual cancels the widget's workers, the
+  `await` raises `CancelledError` and nothing after it runs; the SELECT
+  finishes on its executor thread and is discarded. `_apply_legacy_chunk_report`
+  already returns on `NoMatches`. Strictly better than before, where the same
+  unmount left the loop blocked for the full query. Covered by
+  `test_unmounting_mid_census_neither_raises_nor_paints`.
+* **App quit mid-census** — nothing awaits the thread on the way out; measured
+  exit well inside the harness timeout. Covered by
+  `test_quitting_mid_census_exits_cleanly`.
+* **Error paths** — `to_thread` re-raises into the awaiting coroutine, so
+  `get_template_diagnostics`'s existing `except Exception` guard around the
+  report line still fires (an unmigrated media DB missing the column is the
+  real case) and a genuine backend failure still propagates. Both pinned.
+  A failed v7->v8 migration rolls back and leaves the DB at v7, working, on the
+  old plan.
+* **Empty / first run** — no media at all, and a fully stamped library, both
+  render nothing (no line, no Re-chunk button, never a zero). Pinned at the
+  service and at the panel.
+* **Interleaving** — twelve concurrent censuses against a live DB all return
+  the same count (WAL readers take a consistent snapshot).
+
+### Files
+
+* `tldw_chatbook/DB/Client_Media_DB_v2.py` — `_CURRENT_SCHEMA_VERSION` 7 -> 8,
+  `_MIGRATIONS[7]`, `_CHUNK_ENGINE_CENSUS_INDEX_MIGRATION_SQL`,
+  `_apply_migration_v7_to_v8`.
+* `tldw_chatbook/RAG_Admin/rag_admin_scope_service.py` — `_call_off_loop`,
+  used by `get_template_diagnostics`.
+* `tldw_chatbook/RAG_Admin/local_rag_admin_service.py` —
+  `diagnostics_are_thread_safe()`, census docstring.
+* `tldw_chatbook/Widgets/Library/library_search_rag_panel.py` — docstring only.
+* `Tests/DB/test_media_db_schema_v8.py`,
+  `Tests/RAG/test_rag_admin_diagnostics_off_loop.py`,
+  `Tests/UI/test_library_rag_legacy_chunk_report_real_backend.py` (new).

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -234,7 +234,7 @@ class MediaDatabase:
     Requires client_id on initialization. Includes schema versioning.
     """
 
-    _CURRENT_SCHEMA_VERSION = 7  # Define the version this code supports
+    _CURRENT_SCHEMA_VERSION = 8  # Define the version this code supports
     # task-261: idle window within which the per-call `SELECT 1` liveness
     # ping is skipped for a recently-used thread-local connection (see
     # `_get_thread_connection`).
@@ -280,6 +280,14 @@ class MediaDatabase:
                 "deleted, convert rows, seed six server built-ins"
             ),
         },
+        7: {
+            "to_version": 8,
+            "function": "_apply_migration_v7_to_v8",
+            "description": (
+                "Add the engine-version census covering index to "
+                "UnvectorizedMediaChunks"
+            ),
+        },
     }
 
     _TRANSCRIPTION_PROVENANCE_MIGRATION_SQL = """
@@ -301,6 +309,45 @@ class MediaDatabase:
         ALTER TABLE UnvectorizedMediaChunks
         ADD COLUMN chunk_engine_version TEXT DEFAULT NULL;
         UPDATE schema_version SET version = 6;
+    """
+
+    # TASK-21126: the Library Search/RAG panel's legacy-chunk census
+    # (``LocalRAGAdminService.count_chunks_by_engine_version`` — "SELECT
+    # chunk_engine_version, COUNT(DISTINCT media_id) ... WHERE deleted = 0
+    # GROUP BY chunk_engine_version") ran once per Search/RAG panel show
+    # against `idx_unvectorizedmediachunks_deleted` plus two temp B-trees —
+    # i.e. one table row-lookup per live chunk row. Measured on a real
+    # production-schema DB: 119 ms at 200k live chunk rows (64 MB), 701 ms
+    # at 1M (325 MB).
+    #
+    # The COLUMN ORDER here is measured, not aesthetic. `deleted` leads even
+    # though the partial predicate already pins it to 0, because THIS
+    # DATABASE NEVER RUNS `ANALYZE` (there is no ANALYZE anywhere in this
+    # file, so no user's media DB has a `sqlite_stat1`). With no stats the
+    # planner ignores a `(chunk_engine_version, media_id) WHERE deleted = 0`
+    # index completely — measured 120 ms, i.e. a dead 5 MB index — and keeps
+    # using `idx_unvectorizedmediachunks_deleted`. Leading with `deleted`
+    # makes this index answer the same equality search that one does, while
+    # additionally COVERING the GROUP BY and the COUNT(DISTINCT), so the
+    # no-stats planner picks it: measured 119 -> 23.4 ms at 200k (5.1x) and
+    # 701 -> 122.8 ms at 1M (5.7x), plan `SEARCH ... USING COVERING INDEX
+    # (deleted=?)` with zero TEMP B-TREE lines. (For the record, the same
+    # index reaches 4.2 / 25.0 ms once `sqlite_stat1` exists; deliberately
+    # not chasing that here — running ANALYZE would re-plan every other
+    # query in this database for one report line.)
+    #
+    # Write-side cost: +0.06 ms on a 50-chunk ingest batch (0.660 -> 0.720 ms
+    # median) and ~30 bytes per LIVE chunk row on disk (+9% file size: 64.3
+    # -> 70.2 MB at 200k rows, 325.2 -> 354.8 MB at 1M). Soft-deleted rows
+    # are excluded by the partial predicate and cost nothing.
+    #
+    # Like every migration-added artifact in this file, it lives ONLY here
+    # and not in _TABLES_SQL_V1 (fresh databases replay the whole chain).
+    _CHUNK_ENGINE_CENSUS_INDEX_MIGRATION_SQL = """
+        CREATE INDEX IF NOT EXISTS idx_unvectorizedmediachunks_engine_census
+            ON UnvectorizedMediaChunks(deleted, chunk_engine_version, media_id)
+            WHERE deleted = 0;
+        UPDATE schema_version SET version = 8;
     """
 
     # task-7 (chunking template parity, spec §5.2): v7 rebuilds
@@ -1774,6 +1821,40 @@ class MediaDatabase:
                 exc_info=True,
             )
             raise DatabaseError(f"Unexpected error during migration v6->v7: {e}") from e
+
+    def _apply_migration_v7_to_v8(self, conn: sqlite3.Connection):
+        """Add the engine-version census covering index (TASK-21126).
+
+        Pure index addition: no column, table, trigger or row is touched,
+        so there is nothing to back-fill and nothing a partial application
+        could corrupt. The measurements that chose this index's exact
+        shape are recorded on
+        ``_CHUNK_ENGINE_CENSUS_INDEX_MIGRATION_SQL``.
+
+        Build cost is proportional to live chunk rows and is paid once, at
+        the first open after upgrade: measured 167 ms on a 200k-row / 64 MB
+        media DB and 2.05 s on a 1M-row / 325 MB one. That is a one-off
+        open-time stall on a very large library; it buys back 578 ms per
+        Library Search/RAG panel show at that size.
+
+        Raises:
+            DatabaseError: On any failure, after rolling the transaction
+                back (the DB remains at v7 and keeps working — the census
+                simply falls back to the pre-index scan plan).
+        """
+
+        try:
+            with self.transaction():
+                self._execute_transactional_script(
+                    conn,
+                    self._CHUNK_ENGINE_CENSUS_INDEX_MIGRATION_SQL,
+                )
+        except sqlite3.Error as error:
+            raise DatabaseError(f"Migration v7->v8 failed: {error}") from error
+        except Exception as error:
+            raise DatabaseError(
+                f"Unexpected error during migration v7->v8: {error}"
+            ) from error
 
     @staticmethod
     def _assert_no_foreign_keys_reference(

--- a/tldw_chatbook/RAG_Admin/local_rag_admin_service.py
+++ b/tldw_chatbook/RAG_Admin/local_rag_admin_service.py
@@ -306,6 +306,29 @@ class LocalRAGAdminService:
         existing = self.get_template(template_name)
         self._require_chunking_service().delete_template(int(existing["id"]))
 
+    def diagnostics_are_thread_safe(self) -> bool:
+        """Report whether ``get_template_diagnostics`` may run off the loop.
+
+        (TASK-21126) The diagnostics payload's only I/O is the legacy-chunk
+        census, a read-only SELECT against the media DB. ``MediaDatabase``
+        hands out THREAD-LOCAL connections, so a worker thread opens its
+        own — fine (and WAL-safe) for a file-backed database, but for a
+        ``:memory:`` one it opens a *different, empty* database and the
+        census would silently report zero legacy items instead of raising.
+        Every production wiring is file-backed (``app.media_db``); the
+        memory case is tests and ephemeral fixtures, and it stays on the
+        calling thread rather than getting a wrong answer quietly.
+
+        Returns:
+            True when the census is safe to run on a worker thread.
+        """
+        db = self.media_db
+        if db is None:
+            # No media DB: `get_legacy_chunk_report_line` returns "" without
+            # touching sqlite, so there is nothing thread-bound to protect.
+            return True
+        return not bool(getattr(db, "is_memory_db", False))
+
     def get_template_diagnostics(self) -> dict[str, Any]:
         service = self._require_chunking_service()
         diagnostics = {
@@ -589,6 +612,16 @@ class LocalRAGAdminService:
         report never needs the chunking service or vector store backends,
         and never mutates anything (a plain SELECT; stamp + report only,
         there is no re-chunk action).
+
+        BLOCKING. Cost is proportional to live chunk rows; media schema v8
+        (TASK-21126) adds ``idx_unvectorizedmediachunks_engine_census``, a
+        partial covering index whose column order is chosen so this exact
+        SQL text uses it *without* ``ANALYZE`` -- do not re-spell the query
+        (the ``WHERE deleted = 0`` and the ``GROUP BY
+        chunk_engine_version`` are what match the index) and do not call
+        this from the event loop. Async callers go through
+        ``RAGAdminScopeService.get_template_diagnostics``, which offloads
+        it; ``Tests/DB/test_media_db_schema_v8.py`` pins the plan.
 
         Args:
             db: The ``MediaDatabase`` (or compatible) holding

--- a/tldw_chatbook/RAG_Admin/rag_admin_scope_service.py
+++ b/tldw_chatbook/RAG_Admin/rag_admin_scope_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from enum import Enum
 from typing import Any
@@ -82,6 +83,40 @@ class RAGAdminScopeService:
         if inspect.isawaitable(value):
             return await value
         return value
+
+    async def _call_off_loop(self, service: Any, method_name: str) -> Any:
+        """Invoke a backend method without blocking the event loop.
+
+        (TASK-21126) ``_maybe_await(service.method())`` evaluates its
+        argument BEFORE the first suspension point, so a *synchronous*
+        backend method runs to completion on the event loop — for
+        ``get_template_diagnostics`` that meant the legacy-chunk census
+        (measured 119 ms at 200k live chunk rows, 701 ms at 1M) froze the
+        UI once per Library Search/RAG panel show.
+
+        The offload is opt-in per backend, never blanket: a backend must
+        say so by exposing a truthy ``diagnostics_are_thread_safe()``.
+        Anything else — an async backend, a test double, a Mock — keeps the
+        pre-existing inline behaviour exactly, so this cannot silently move
+        an unknown backend's work onto a thread it was never written for.
+
+        Args:
+            service: The resolved local or server backend.
+            method_name: Name of the zero-argument backend method to call.
+
+        Returns:
+            The method's result, awaited if it was awaitable.
+        """
+        method = getattr(service, method_name)
+        if inspect.iscoroutinefunction(method):
+            return await method()
+        safe = getattr(service, "diagnostics_are_thread_safe", None)
+        if not callable(safe) or not safe():
+            return await self._maybe_await(method())
+        # `to_thread` propagates the callee's exception into this await, so
+        # every existing failure path (an unmigrated media DB, a policy
+        # error, a closed connection) reaches callers unchanged.
+        return await self._maybe_await(await asyncio.to_thread(method))
 
     def _enforce_policy(self, action_id: str) -> None:
         """Require a policy action id (no-op without an enforcer).
@@ -261,10 +296,22 @@ class RAGAdminScopeService:
         *,
         mode: RAGAdminBackend | str | None = None,
     ) -> dict[str, Any]:
+        """Return the backend's template diagnostics payload.
+
+        (TASK-21126) Routed through :meth:`_call_off_loop`: the local
+        backend's payload carries the legacy-chunk census, whose SELECT used
+        to run inline on the event loop once per Library Search/RAG panel
+        show. Deliberately NOT cached — the census is re-read per show, and
+        that is the whole freshness protocol (an ingest, a re-chunk, a media
+        delete or a sync-in all show up on the next visit with nothing to
+        invalidate). With the v8 covering index the query costs 23 ms at
+        200k live chunk rows and 123 ms at 1M, off the loop, so a cache
+        would trade a measured-zero saving for a staleness surface.
+        """
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._admin_action_id(normalized_mode, "observe"))
         service = self._service_for_mode(normalized_mode)
-        diagnostics = await self._maybe_await(service.get_template_diagnostics())
+        diagnostics = await self._call_off_loop(service, "get_template_diagnostics")
         payload = dict(diagnostics or {})
         payload.setdefault("backend", normalized_mode.value)
         return payload

--- a/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
@@ -113,6 +113,15 @@ class LibrarySearchRagPanel(PostRecomposeCallback, VerticalScroll):
     async def _fetch_legacy_chunk_report(self) -> None:
         """Query the legacy-chunk report line via the scope service.
 
+        TASK-21126: this is an ASYNC worker, so "off the mount path" is not
+        the same as "off the event loop" — until that task the scope
+        service evaluated the local backend's synchronous
+        ``get_template_diagnostics`` (and with it the legacy-chunk census
+        SELECT) inline here, freezing the UI for the duration. The census
+        now runs on a worker thread inside
+        ``RAGAdminScopeService._call_off_loop``; this coroutine only awaits
+        it. Keep it that way: any new work added here runs on the loop.
+
         Consumes ONLY the payload's ``legacy_chunk_report`` field. The same
         payload's ``capability`` / ``missing_methods`` / ``fallback_enabled``
         are HARDCODED upstream (spec §11 item 4) and never render here --


### PR DESCRIPTION
## Summary

The Library Search/RAG panel ran a legacy-chunk census — a `GROUP BY` with a `count(DISTINCT)`
over `UnvectorizedMediaChunks` — synchronously on the event loop at every panel mount. Two
changes; the panel's rendering, state machine, and every string it can show are untouched.

1. **Media schema v7 → v8**: `idx_unvectorizedmediachunks_engine_census ON
   UnvectorizedMediaChunks(deleted, chunk_engine_version, media_id) WHERE deleted = 0`.
2. **`RAGAdminScopeService._call_off_loop`**: `_maybe_await(service.get_template_diagnostics())`
   evaluated its argument *before* the first suspension point, so the synchronous local backend
   ran to completion on the loop even though the panel had already scheduled an async worker.
   Now offloaded via `asyncio.to_thread`, **opt-in per backend** through a new
   `diagnostics_are_thread_safe()`.

## The prescribed index would have been DEAD in production

The finding said "no index on `chunk_engine_version` — add one". The obvious index,
`(chunk_engine_version, media_id) WHERE deleted = 0`, is a textbook covering index for this
query, and the first probe **confirmed** a 112 → 3.4 ms win.

That probe was wrong, because it had run `ANALYZE` to make the corpus realistic. **No media
database in the wild has ever run `ANALYZE`** — there is none anywhere in
`Client_Media_DB_v2.py`. Re-measured with `sqlite_stat1` absent:

| | without index | with prescribed index |
|---|---|---|
| 200k live rows | 118.8 ms | **120.2 ms** |

5 MB of disk, a schema migration, and a green "the index exists" test, for 1%. Four index shapes
were measured; **only ones leading with `deleted` are ever chosen without stats**. The shipped v8
index therefore leads with the *redundant* `deleted` column, so it answers the equality search
the no-stats planner already prefers while also covering the GROUP BY and the DISTINCT.

A related nuance the finding got wrong: the query was never literally unindexed — the planner
was already using `idx_unvectorizedmediachunks_deleted`, then paying a table row-lookup per live
row plus two temp B-trees.

**The cache in the AC was dropped too.** Off the loop and indexed, the census costs 23 ms on a
worker thread — a cache saves a measured zero and would need invalidation from ingest, re-chunk,
hard-delete, soft-delete/undelete, sync-in and `process_unvectorized_chunks`. Miss one and the
panel shows a stale "Chunked by an older engine: N items" beside a Re-chunk button that lies.
Re-querying per show *is* the freshness protocol. ACs amended in the task file.

## Measured — real production schema, no ANALYZE

| corpus | before | after | plan change |
|---|---|---|---|
| 200k rows / 64.3 MB | **118.8 ms** | **23.4 ms** (5.1×) | `SEARCH … USING INDEX …_deleted` + two temp B-trees → `USING COVERING INDEX …_engine_census`, no temp B-trees |
| 1M rows / 325.2 MB | **700.9 ms** | **122.8 ms** (5.7×) | same |

**Off-loop proof**: a 300 ms census leaves **28** ticks of a 10 ms heartbeat; inline it leaves
**2**. The same test asserts the thread ident *and* the exact report string, so the work still
happens and is still correct.

**Write-side cost, stated plainly**: +9% file size (~30 B per live row; soft-deleted rows
excluded by the partial predicate), +0.06 ms per 50-chunk ingest batch, and a one-off index build
of 167 ms / 2.05 s at first open after upgrade.

## Unmount / quit / error / empty

Unmount mid-census is now **strictly better** than before: the `await` raises `CancelledError`,
the SELECT finishes on its thread and is discarded, and `_apply_legacy_chunk_report` already
returns on `NoMatches` — where previously the same unmount left the loop blocked for the full
query. App quit exits well inside the timeout. `to_thread` re-raises into the awaiting coroutine
so the existing guard still catches an unmigrated DB. A failed v7→v8 rolls back to v7, working,
on the old plan. Empty and fully-stamped libraries both render nothing — no line, no button,
never a zero.

## Mutation results

Index shape → `(chunk_engine_version, media_id)`: **3 red** including the plan test. Drop
`WHERE deleted = 0`: 1 red. Version back to 7: 6 red. Revert to inline `_maybe_await`: 3 red.
Drop the opt-in gate: 2 red. Census count +1: 9 red. **`diagnostics_are_thread_safe()` → always
True: 1 red — the `:memory:` DB reported a *wrong count*, confirming that hazard is live rather
than theoretical.**

The unmount/quit tests initially did **not** move under the offload mutation; a heartbeat counter
and entry/exit events were added so the unmount test now fails on it.

## Interleaving

Twelve censuses on executor threads while the loop thread commits new legacy media between
batches. Asserts counts are only ones the DB genuinely held, non-decreasing, and that **≥2
distinct values were observed** — verified it really races (5→6→7→8). Ran 3× clean.

## Verification

`Tests/RAG_Admin`: **71 passed, 0 failed**. New files: 25 passed. `Tests/Media_DB` +
`Tests/RAG_Admin` on this branch: 149 passed, 1 failed — that failure
(`test_reading_progress_reopens_through_versioned_migration`) **I re-confirmed myself on pristine
dev `33ff5b754`**; it hand-stamps `schema_version = 2` on an already-current DB and dies
replaying v5→v6. Filed as an out-of-scope item, not caused here. All other suite reds
A/B-proven identical on a pristine base worktree. Media schema v8 checked against all 635 refs
for a version collision: none. Preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes the legacy‑chunk census and runs it off the event loop to eliminate UI stalls and cut the census from ~119–701 ms to ~23–123 ms. Previously the panel ran a synchronous SELECT on the loop per mount; now it offloads the local backend via `asyncio.to_thread` and uses a partial covering index the planner picks without ANALYZE.

- Adds media schema v8: `idx_unvectorizedmediachunks_engine_census` on `(deleted, chunk_engine_version, media_id) WHERE deleted = 0`; measured 5.1–5.7× faster and no temp B‑trees; counts unchanged.
- Introduces `RAGAdminScopeService._call_off_loop` and backend opt‑in `diagnostics_are_thread_safe()`. Async/unknown backends and `:memory:` stay inline; file‑backed local runs on a worker thread.
- Drops the proposed session cache: off‑loop + indexed yields a measured zero UX benefit and creates invalidation risk. Panel UI and strings are unchanged; empty/fully‑stamped libraries render nothing.

Bolded sections:
- Review notes
  - Verify the index column order; without stats the planner only picks shapes leading with `deleted`. Plans are asserted in tests.
  - Concurrency and lifecycle are covered: unmount/quit mid‑census, errors re‑raise/guard correctly, and concurrent censuses don’t tear.
- Rollout and migration
  - DB auto‑migrates v7→v8 on first open; no app changes required. One‑off index build: ~167 ms at 200k rows, ~2.05 s at 1M.
  - Ongoing costs: ~+9% media DB size (~30 B/live chunk row) and ~+0.06 ms per 50‑chunk ingest batch.

Satisfies TASK-21126: off‑loop census, indexed query, unchanged UI; cache removed by design.

<sup>Written for commit 09bdc4f4ad2453644e110ad1f21cabc3b9b9a5c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

