### PR TITLE
perf(startup): remove four eager boot costs and fix the timing log (TASK-21111)

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -488,6 +488,19 @@ silently edited.
    the same equality search the no-stats planner already prefers while also covering the GROUP
    BY and the DISTINCT: 23.4 ms at 200k, 122.8 ms at 1M. **Any future "add an index" finding
    in this repo needs a query-plan check with `sqlite_stat1` absent, not just present.**
+3. **Finding 21111(b) named three keyring sites and missed the only expensive one.** The
+   review attributed "~13 ms + Security.framework ctypes load" to server credentials, with
+   skills trust ×2 alongside. Traced by stack at the pin: the FIRST keyring touch of every
+   boot is `Video_Generation/config._keyring_get`, reached from `VideoStore.enforce_retention()`
+   in `TldwCli.__init__` — a real `keyring.get_password("tldw_chatbook_videogen", "minimax")`
+   costing **18.2 ms** (11.3 ms of backend discovery plus a live macOS Keychain query). Because
+   `keyring.get_keyring()` memoizes the backend, the three sites the review named cost
+   **0.33 / 0.41 / 0.04 ms** between them — fixing only those would have banked **zero** and
+   still passed a "no keyring from server credentials at boot" assertion. All four had to go;
+   `TldwCli` construction then fell **77.0 → 60.9 ms** (median of 8 warm runs per arm).
+   Corollary found inside the same fix: deferring the skills stack to a lazy app property
+   merely **relocated** 16.45 ms into Chat-screen mount, because
+   `ChatScreen._ensure_console_agent_bridge` reads `skills_scope_service` there.
 
 ---
 

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -180,8 +180,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 7,
-      "diagnostic_digest": "891a89059cce156037dd",
+      "call_count": 8,
+      "diagnostic_digest": "f59a28dc0139a3de4945",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/visual_identity.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1104,8 +1104,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 6,
-      "diagnostic_digest": "cb033b6771086e368478",
+      "call_count": 7,
+      "diagnostic_digest": "13e12e3d80d7c6bdbc92",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_ingest_jobs.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3708,8 +3708,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 333,
-      "diagnostic_digest": "0fb4d7de3f6b788f8ad4",
+      "call_count": 336,
+      "diagnostic_digest": "32c1c49c24fad8bd01aa",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3948,6 +3948,6 @@
     "owner_files": 534,
     "persistent_sink_files": 8,
     "task_492_calls": 1238,
-    "task_494_calls": 7302
+    "task_494_calls": 7307
   }
 }

--- a/Tests/App/test_startup_init_hygiene.py
+++ b/Tests/App/test_startup_init_hygiene.py
@@ -1,0 +1,310 @@
+"""Startup-init hygiene guards (TASK-21111).
+
+Four separate defects in `TldwCli.__init__` / `on_mount`, each pinned here by
+the property that would go quietly wrong again:
+
+(a) the phase-3 parallel-init log measured its clock AFTER `future.result()`
+    returned, so every task reported 0.000s;
+(b) four OS-keyring touches ran during construction (the loudest, and the one
+    the review missed, was a real `keyring.get_password` from the generated-
+    video store's retention pass);
+(c) the persisted ingest-job restore did its DB open, read and reconcile
+    writes synchronously on the UI thread inside `on_mount`;
+(d) -- covered in `Tests/Character_Chat/test_samira_preflight_query.py`.
+"""
+
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.app import TldwCli
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# (a) the parallel-init timing log
+# --------------------------------------------------------------------------
+
+
+class _Recorder:
+    """The minimum of `TldwCli` that `_timed_init_task` touches."""
+
+    def __init__(self) -> None:
+        self._startup_parallel_tasks: dict[str, float] = {}
+
+
+def test_timed_init_task_records_the_work_not_the_wait() -> None:
+    """The duration must come from around the CALL, not from `result()`.
+
+    The shipped defect stamped `perf_counter()` immediately before
+    `future.result()` on a future `as_completed` had already yielded, so the
+    measured interval contained none of the work.
+    """
+    recorder = _Recorder()
+
+    def slow(marker: str) -> str:
+        time.sleep(0.05)
+        return marker
+
+    result = TldwCli._timed_init_task(recorder, "slow_task", slow, "done")
+
+    assert result == "done"
+    assert recorder._startup_parallel_tasks["slow_task"] >= 0.045
+
+
+def test_timed_init_task_times_a_failing_task_too() -> None:
+    """A slow FAILING initializer is exactly the one worth timing."""
+    recorder = _Recorder()
+
+    def boom() -> None:
+        time.sleep(0.03)
+        raise RuntimeError("nope")
+
+    with pytest.raises(RuntimeError):
+        TldwCli._timed_init_task(recorder, "boom", boom)
+
+    assert recorder._startup_parallel_tasks["boom"] >= 0.025
+
+
+def test_parallel_phase_submits_every_initializer_through_the_timer() -> None:
+    """No initializer may be submitted raw -- a raw one logs 0.000s forever."""
+    source = (REPO_ROOT / "tldw_chatbook/app.py").read_text(encoding="utf-8")
+    app_class = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "TldwCli"
+    )
+    init = next(
+        node
+        for node in app_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    submits = [
+        node
+        for node in ast.walk(init)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "submit"
+    ]
+    assert len(submits) == 4, "expected the four phase-3 parallel initializers"
+    for call in submits:
+        first = call.args[0]
+        assert isinstance(first, ast.Attribute) and first.attr == "_timed_init_task", (
+            "a parallel initializer is submitted without `_timed_init_task`; its "
+            "logged duration would be the wait, not the work"
+        )
+
+
+# --------------------------------------------------------------------------
+# (b) no OS keyring at boot
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def keyring_spy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every keyring entry point the app can reach."""
+    import keyring
+    import keyring.core
+
+    calls: list[str] = []
+    real_get = keyring.core.get_keyring
+    real_pw = keyring.core.get_password
+
+    def spy_get():
+        calls.append("get_keyring")
+        return real_get()
+
+    def spy_pw(service, username):
+        calls.append(f"get_password:{service}")
+        return real_pw(service, username)
+
+    for module in (keyring, keyring.core):
+        monkeypatch.setattr(module, "get_keyring", spy_get)
+        monkeypatch.setattr(module, "get_password", spy_pw)
+    return calls
+
+
+def test_app_construction_touches_no_os_keyring(keyring_spy: list[str]) -> None:
+    """Constructing the app must not discover or query an OS credential store.
+
+    Four sites did: the generated-video store's retention pass (a real
+    `get_password` for the MiniMax key -- 18 ms on macOS, and a Keychain
+    round trip that can block or prompt), the server credential store, and
+    the skill-trust marker store + key cache. On a locked keychain any of
+    them can stall startup.
+    """
+    from Tests.UI.app_factory import _build_test_app
+
+    _build_test_app()
+
+    assert keyring_spy == [], f"app construction reached the OS keyring: {keyring_spy}"
+
+
+def test_the_credential_store_still_resolves_when_asked(
+    keyring_spy: list[str],
+) -> None:
+    """Deferred, not deleted: the first read still builds the real store."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    assert keyring_spy == []
+
+    store = app.server_credential_store
+
+    assert store is not None
+    assert "get_keyring" in keyring_spy
+    # Idempotent: a second read must not re-discover the backend.
+    before = len(keyring_spy)
+    assert app.server_credential_store is store
+    assert len(keyring_spy) == before
+
+
+def test_the_skills_stack_defers_only_the_trust_service(
+    keyring_spy: list[str],
+) -> None:
+    """The Console takes the scope facade at mount; that must stay keyring-free.
+
+    Deferring the whole stack was not enough on its own -- `ChatScreen`'s
+    agent bridge reads `skills_scope_service` during mount, which merely
+    relocated the keyring work. Only the trust service itself is deferred
+    behind a factory.
+    """
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+
+    scope = app.skills_scope_service
+    local = app.local_skills_service
+
+    assert scope is not None and local is not None
+    assert keyring_spy == [], f"building the skills facade hit the keyring: {keyring_spy}"
+
+    assert local.trust_service is not None
+    assert "get_keyring" in keyring_spy, (
+        "asking for a trust decision must still build the real trust service"
+    )
+    assert local.trust_service is app.local_skill_trust_service
+
+
+def test_an_injected_skills_service_is_not_clobbered_by_a_sibling_read() -> None:
+    """Filling the stack lazily must never overwrite a test's double."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    double = SimpleNamespace(marker="injected")
+    app.local_skills_service = double
+
+    scope = app.skills_scope_service
+
+    assert app.local_skills_service is double
+    assert scope is not None
+
+
+# --------------------------------------------------------------------------
+# (c) the ingest-job restore leaves the UI thread
+# --------------------------------------------------------------------------
+
+
+class _FakeApp:
+    """Just enough of `TldwCli` for the restore methods under test."""
+
+    _ingest_shutdown = False
+    # The real methods under test, so `self._restore_ingest_jobs_off_thread`
+    # resolves to the production body rather than a stand-in.
+    _restore_ingest_jobs_off_thread = TldwCli._restore_ingest_jobs_off_thread
+    _apply_ingest_job_restore = TldwCli._apply_ingest_job_restore
+
+    def __init__(self) -> None:
+        self.worker_calls: list[dict[str, Any]] = []
+        self.marshalled: list[tuple[Any, ...]] = []
+        self.library_ingest_jobs = SimpleNamespace(
+            merged=None,
+            attached=None,
+            merge_restored=lambda jobs, next_id: setattr(
+                self.library_ingest_jobs, "merged", (jobs, next_id)
+            ),
+            attach_store=lambda store: setattr(
+                self.library_ingest_jobs, "attached", store
+            ),
+        )
+
+    def run_worker(self, work, **kwargs):
+        self.worker_calls.append({"work": work, **kwargs})
+
+    def call_from_thread(self, callback, *args):
+        self.marshalled.append((callback, *args))
+        return callback(*args)
+
+
+def test_restore_starts_a_thread_worker_and_does_no_io_inline() -> None:
+    app = _FakeApp()
+
+    TldwCli._restore_ingest_jobs(app)
+
+    assert len(app.worker_calls) == 1
+    call = app.worker_calls[0]
+    assert call["thread"] is True
+    assert call["exit_on_error"] is False, (
+        "a history-restore failure must never be able to exit the app"
+    )
+    assert call["work"].__func__ is TldwCli._restore_ingest_jobs_off_thread
+
+
+def test_restore_is_skipped_once_shutdown_has_started() -> None:
+    app = _FakeApp()
+    app._ingest_shutdown = True
+
+    TldwCli._restore_ingest_jobs(app)
+
+    assert app.worker_calls == []
+
+
+def test_apply_seeds_the_registry_and_attaches_the_store() -> None:
+    app = _FakeApp()
+    store = SimpleNamespace(closed=False, close=lambda: None)
+    plan = SimpleNamespace(jobs=["j1"], next_id=7)
+
+    TldwCli._apply_ingest_job_restore(app, store, plan)
+
+    assert app.library_ingest_jobs.merged == (["j1"], 7)
+    assert app.library_ingest_jobs.attached is store
+    assert app._library_ingest_jobs_store is store
+
+
+def test_apply_closes_the_store_instead_of_attaching_it_during_shutdown() -> None:
+    """A restore that lands after quit began must not leak its connection."""
+    closed: list[bool] = []
+    app = _FakeApp()
+    app._ingest_shutdown = True
+    store = SimpleNamespace(close=lambda: closed.append(True))
+
+    TldwCli._apply_ingest_job_restore(app, store, SimpleNamespace(jobs=[], next_id=1))
+
+    assert closed == [True]
+    assert app.library_ingest_jobs.attached is None
+    assert getattr(app, "_library_ingest_jobs_store", None) is None
+
+
+def test_worker_swallows_a_store_failure_and_leaves_the_registry_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrupt store still means "start empty", never a WorkerFailed."""
+    import tldw_chatbook.DB.Library_Ingest_Jobs_DB as jobs_db
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("corrupt store")
+
+    monkeypatch.setattr(jobs_db, "LibraryIngestJobsDB", boom)
+    app = _FakeApp()
+
+    TldwCli._restore_ingest_jobs_off_thread(app)
+
+    assert app.marshalled == []
+    assert app.library_ingest_jobs.attached is None

--- a/Tests/Character_Chat/test_samira_preflight_query.py
+++ b/Tests/Character_Chat/test_samira_preflight_query.py
@@ -1,0 +1,143 @@
+"""The Samira boot preflight asks SQLite, and gets the same answer (TASK-21111(d)).
+
+`ensure_builtin_samira` runs on every boot. Its card lookup used to read the
+whole `character_cards` table into Python and `json.loads` every row's
+`extensions`. The targeted `json_extract` query replaces it -- but only if it
+agrees with the scan on the awkward rows the scan tolerated, which is what
+these tests pin. `_find_builtin_samira_card_by_scan` is retained as the
+JSON1-less fallback and doubles as the oracle here.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from tldw_chatbook.Character_Chat import visual_identity
+
+SAMIRA_EXTENSIONS = json.dumps({"tldw/builtin_id": "samira"})
+
+
+class _Db:
+    """Minimal `execute_query` seam, counting the queries issued."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+        self.queries: list[str] = []
+
+    def execute_query(self, sql, params=()):
+        self.queries.append(sql)
+        return self.conn.execute(sql, params)
+
+
+def _db(rows: list[tuple[str, str | None]]) -> _Db:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE character_cards (id INTEGER PRIMARY KEY, name TEXT,"
+        " extensions TEXT, deleted INTEGER DEFAULT 0)"
+    )
+    conn.executemany(
+        "INSERT INTO character_cards (name, extensions) VALUES (?, ?)", rows
+    )
+    conn.commit()
+    return _Db(conn)
+
+
+AWKWARD: list[tuple[str, str | None]] = [
+    ("null ext", None),
+    ("empty ext", ""),
+    ("malformed", "{not json"),
+    ("array ext", "[1, 2, 3]"),
+    ("scalar ext", '"just a string"'),
+    ("nan constant", '{"tldw/builtin_id": NaN}'),
+    ("numeric id", '{"tldw/builtin_id": 7}'),
+    ("other builtin", '{"tldw/builtin_id": "someone-else"}'),
+    ("nested only", '{"data": {"tldw/builtin_id": "samira"}}'),
+]
+
+
+@pytest.mark.parametrize("with_samira", [False, True])
+def test_the_targeted_query_matches_the_scan_on_awkward_rows(
+    with_samira: bool,
+) -> None:
+    rows = list(AWKWARD)
+    if with_samira:
+        rows.append(("Samira", SAMIRA_EXTENSIONS))
+    db = _db(rows)
+
+    targeted = visual_identity._find_builtin_samira_card(db)
+    scanned = visual_identity._find_builtin_samira_card_by_scan(db)
+
+    assert (targeted is None) == (scanned is None)
+    if scanned is not None:
+        assert targeted == scanned
+        assert targeted["name"] == "Samira"
+    else:
+        assert targeted is None
+
+
+def test_a_malformed_extensions_row_does_not_abort_the_lookup() -> None:
+    """`json_extract` raises on malformed JSON; the guard must run first.
+
+    A single corrupt `extensions` value would otherwise take out the whole
+    boot preflight, where the Python scan simply skipped that row.
+
+    The single-query assertion is the part that matters: without it, a
+    guard-less query would still "pass" by raising and falling back to the
+    scan -- i.e. by reintroducing the whole-table read this change removes,
+    silently, on every boot of the affected profile. (Both a guard-less and
+    an `AND`-guarded mutant were tried; only this assertion tells them apart.)
+    """
+    db = _db([("broken", "{not json"), ("Samira", SAMIRA_EXTENSIONS)])
+
+    found = visual_identity._find_builtin_samira_card(db)
+
+    assert found is not None and found["name"] == "Samira"
+    assert len(db.queries) == 1, "the malformed row forced a fallback full scan"
+
+
+def test_the_lowest_id_wins_when_several_rows_claim_the_builtin_id() -> None:
+    db = _db(
+        [
+            ("first", SAMIRA_EXTENSIONS),
+            ("second", SAMIRA_EXTENSIONS),
+        ]
+    )
+
+    assert visual_identity._find_builtin_samira_card(db)["name"] == "first"
+
+
+def test_the_lookup_issues_exactly_one_query() -> None:
+    """No per-row work: one statement, and SQLite stops at the first hit."""
+    db = _db([("Samira", SAMIRA_EXTENSIONS)])
+
+    visual_identity._find_builtin_samira_card(db)
+
+    assert len(db.queries) == 1
+    assert "LIMIT 1" in db.queries[0]
+
+
+def test_a_json1_less_sqlite_falls_back_to_the_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fallback keeps the boot seed working on an exotic SQLite build."""
+    db = _db([("Samira", SAMIRA_EXTENSIONS)])
+    real_execute = db.execute_query
+    calls: list[str] = []
+
+    def failing_json1(sql, params=()):
+        calls.append(sql)
+        if "json_extract" in sql:
+            raise sqlite3.OperationalError("no such function: json_extract")
+        return real_execute(sql, params)
+
+    monkeypatch.setattr(db, "execute_query", failing_json1)
+
+    found = visual_identity._find_builtin_samira_card(db)
+
+    assert found is not None and found["name"] == "Samira"
+    assert any("json_extract" in sql for sql in calls)
+    assert any("json_extract" not in sql for sql in calls)

--- a/Tests/Library/test_library_ingest_jobs_restore.py
+++ b/Tests/Library/test_library_ingest_jobs_restore.py
@@ -64,3 +64,69 @@ def test_interrupted_retry_after_restart_requeues(tmp_path):
     assert restored.state == IngestJobState.FAILED
     requeued = reg.requeue(restored.job_id)  # AC2: retryable
     assert requeued.state == IngestJobState.QUEUED and requeued.retry_count == 1
+
+
+# --------------------------------------------------------------------------
+# merge_restored: the deferral window opened by TASK-21111(c)
+# --------------------------------------------------------------------------
+
+
+def test_merge_restored_on_an_empty_registry_is_exactly_restore(tmp_path):
+    """The normal startup case must be indistinguishable from before."""
+    store = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    seeder = LibraryIngestJobRegistry()
+    seeder.attach_store(store)
+    seeder.submit(source_path="/a.pdf")
+    seeder.submit(source_path="/b.pdf")
+    store.close()
+
+    store2 = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    plan = plan_restore(
+        store2.all_jobs(), max_persisted=500, now_iso="2026-08-23T00:00:00+00:00"
+    )
+    merged = LibraryIngestJobRegistry()
+    merged.merge_restored(plan.jobs, plan.next_id)
+    plain = LibraryIngestJobRegistry()
+    plain.restore(plan.jobs, plan.next_id)
+
+    assert [j.job_id for j in merged.jobs()] == [j.job_id for j in plain.jobs()]
+    assert merged.submit(source_path="/c.pdf").job_id == plain.submit(
+        source_path="/c.pdf"
+    ).job_id
+    store2.close()
+
+
+def test_merge_restored_keeps_a_job_submitted_during_the_restore_window(tmp_path):
+    """The read is off-thread now; a submit can beat the seeding callback.
+
+    Plain `restore` would delete that job outright.
+    """
+    store = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    seeder = LibraryIngestJobRegistry()
+    seeder.attach_store(store)
+    seeder.submit(source_path="/persisted-1.pdf")
+    seeder.submit(source_path="/persisted-2.pdf")
+    store.close()
+
+    store2 = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    plan = plan_restore(
+        store2.all_jobs(), max_persisted=500, now_iso="2026-08-23T00:00:00+00:00"
+    )
+
+    live = LibraryIngestJobRegistry()
+    raced = live.submit(source_path="/submitted-during-startup.pdf")
+    live.merge_restored(plan.jobs, plan.next_id)
+
+    # The live job survives, ordered last (it is the newest), and the
+    # persisted row that happened to share its id (`ingest-job-1`) is dropped
+    # rather than duplicated -- two entries under one id would make every
+    # id-keyed mutation ambiguous, and the live job is the one with work
+    # attached to it.
+    assert [j.source_path for j in reversed(live.jobs())] == [
+        "/persisted-2.pdf",
+        "/submitted-during-startup.pdf",
+    ]
+    assert sum(1 for j in live.jobs() if j.job_id == raced.job_id) == 1
+    # No future allocation can collide with a restored id either.
+    assert live.submit(source_path="/next.pdf").job_id == "ingest-job-3"
+    store2.close()

--- a/Tests/ProductionApp/test_chat_composition_retirement.py
+++ b/Tests/ProductionApp/test_chat_composition_retirement.py
@@ -52,7 +52,7 @@ def isolated_video_store(monkeypatch: pytest.MonkeyPatch, tmp_path):
         lambda: data_root,
     )
     monkeypatch.setattr(
-        "tldw_chatbook.Video_Generation.video_store.get_video_generation_config",
+        "tldw_chatbook.Video_Generation.video_store.get_video_store_policy",
         lambda: config,
     )
     return data_root / "generated_videos", config

--- a/Tests/UI/app_factory.py
+++ b/Tests/UI/app_factory.py
@@ -341,7 +341,7 @@ def _build_test_app(
                 return_value=user_data_dir,
             ),
             patch(
-                "tldw_chatbook.Video_Generation.video_store.get_video_generation_config",
+                "tldw_chatbook.Video_Generation.video_store.get_video_store_policy",
                 return_value=SimpleNamespace(
                     retention="session",
                     retention_ttl_hours=24,

--- a/Tests/test_keyring_isolation.py
+++ b/Tests/test_keyring_isolation.py
@@ -62,6 +62,12 @@ def test_a_constructed_app_records_the_store_as_unavailable() -> None:
 
     This is the assertion that would have caught the original gap -- it exercises
     `_wire_server_context_provider` itself rather than the env var it depends on.
+
+    Since TASK-21111(b) the store is resolved lazily, so reading either attribute
+    below is what triggers `build_default_server_credential_store()`. That is the
+    point of the test, not a hole in it: the fallback decision still has to come
+    out the same. `Tests/App/test_startup_init_hygiene.py` pins the complementary
+    property -- that construction alone reaches no keyring at all.
     """
     from Tests.UI.app_factory import _build_test_app
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -7957,3 +7957,66 @@ matters most for the wall-clock half of a perf claim: the memory numbers here
 were byte-stable across every ordering (1,013,84x,xxx vs 92,24x,xxx every
 single run), which is exactly why an allocation-peak claim survives sloppy
 scheduling and a wall-time claim does not.
+---
+
+## A memoized global makes N deferral sites ONE unit of work — fixing all but one banks nothing (TASK-21111, 2026-08-23)
+
+**What happened.** The perf review filed four... three, it thought: "2–3
+`keyring.get_keyring()` backend discoveries run during `__init__` (server
+credentials ~13 ms; skills trust ×2)". A stack-tracing probe over a real
+`TldwCli()` found **four** sites, and the ~13 ms did not belong to any of the
+three named ones. The first keyring touch of every boot was
+`Video_Generation/config._keyring_get`, reached from
+`VideoStore.enforce_retention()` — a genuine `keyring.get_password` Keychain
+query, 18.2 ms. The three named sites measured **0.33, 0.41 and 0.04 ms**.
+
+The reason is the shape, not the accident: `keyring.get_keyring()` memoizes
+its discovered backend in module state, so the expensive part is paid **once,
+by whoever calls first**. Per-site timings therefore say nothing about what a
+site COSTS; they say who happened to run first. Deferring the three cheap
+sites would have promoted the fourth to first place, moved 0 ms, and still
+passed an assertion of the form "no keyring from server credentials at boot".
+
+**What to do.**
+
+1. When the resource behind N call sites is a **memoized global** (a keyring
+   backend, a lazily-populated config cache, a first-open DB connection, an
+   import-time module init), stop attributing cost per site. Measure the
+   aggregate — "how many touches, how many total ms, across import + construct
+   + mount" — and make the ACCEPTANCE CRITERION that aggregate: *zero*, not
+   *this site is lazy*. A per-site AC is satisfiable while the user pays
+   exactly as much as before.
+2. Write the guard as a spy on the **shared entry point** (here
+   `keyring.core.get_keyring` and `get_password`), not on the individual
+   callers. That guard caught, unprompted, the two later relocation bugs below.
+3. Trace before you fix. The stack of the FIRST call is the finding; the
+   others are consequences of it.
+
+**Corollary, same task, same day: a deferral inside the boot-to-interactive
+span is not a removal.** Moving the skills-trust construction out of
+`TldwCli.__init__` into a lazy `skills_scope_service` property looked complete
+— zero keyring calls in the construction probe. The mounted-app probe (Textual
+`run_test`, spy still installed) then reported **16.45 ms of `get_keyring`
+during MOUNT**: `ChatScreen._ensure_console_agent_bridge` reads
+`skills_scope_service` when the default Chat destination mounts. The user's
+time-to-interactive was unchanged. Only pushing the laziness one level further
+— `LocalSkillsService` taking a `trust_service_factory` it calls on the first
+trust decision — actually removed it. **`__init__` is not the boundary; first
+paint is.** Any deferral probe that stops at construction can certify a
+relocation as a win (see also TASK-21200's "deferring at the CONSUMER can move
+the cost instead of removing it").
+
+**Second corollary: a catch-all fallback can hide the mutant that proves your
+test is blind.** The same task replaced a Python full-table scan with a
+`json_valid`-guarded `json_extract` query, keeping the old scan as a
+JSON1-less fallback behind `except Exception`. Two deliberate mutants — drop
+the `json_valid` guard entirely, and demote it from `CASE` to an `AND` — both
+**passed** the new differential test. Reason: `json_extract` really does raise
+`malformed JSON`, the catch-all swallowed it, and the fallback scan returned
+the right answer. The test was asserting the fallback's correctness, not the
+query's. Two fixes were needed: assert `len(db.queries) == 1` (a fallback is
+observable as a second query), and narrow the `except` to the one condition it
+is for (`"no such function" in str(exc)`) so any other failure propagates.
+A broad fallback under a perf fix is worse than no fallback: it turns "this is
+now fast" into "this is fast unless one row is corrupt, in which case it is
+silently as slow as before, forever."

--- a/backlog/tasks/task-21111 - Startup-init hygiene - broken phase timing log, eager keyring probes, UI-thread ingest-job restore, Samira full-table scan.md
+++ b/backlog/tasks/task-21111 - Startup-init hygiene - broken phase timing log, eager keyring probes, UI-thread ingest-job restore, Samira full-table scan.md
@@ -2,7 +2,7 @@
 id: TASK-21111
 title: >-
   Startup-init hygiene - broken phase timing log, eager keyring probes, UI-thread ingest-job restore, Samira full-table scan
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-22'
 labels:
@@ -29,7 +29,105 @@ scans `character_cards` parsing every `extensions` JSON per boot
 
 ## Acceptance Criteria
 
-- [ ] The startup timing summary reports real per-task durations (measured around result(), not after it)
-- [ ] Keyring backend discovery happens on first server-mode/skills-trust use, not at boot
-- [ ] Ingest-job restore runs off the UI thread; behavior unchanged
-- [ ] The Samira preflight uses a targeted query (json_extract + LIMIT 1) or a cached id instead of a full scan with per-row JSON parsing
+- [x] The startup timing summary reports real per-task durations (measured around the task's own execution, not around `result()`)
+- [x] **AMENDED** — no OS keyring call of any kind (backend discovery *or* credential read) happens during app import, construction, or mount; each of the four sites resolves on first real use
+- [x] Ingest-job restore runs off the UI thread; behavior unchanged
+- [x] The Samira preflight uses a targeted query (json_extract + LIMIT 1) instead of a full scan with per-row JSON parsing
+
+### Why AC 2 was amended
+
+The filing named three keyring sites (server credentials ~13 ms, skills trust
+x2) and prescribed lazy properties for them. Measured on the merge base
+(`f49956038`, macOS, isolated profile), that fix would have banked **0 ms**:
+
+| site | order at boot | cost |
+|---|---|---|
+| `Video_Generation/config._keyring_get` via `VideoStore.enforce_retention` (**not in the filing**) | 1st | **18.2 ms** -- 11.3 ms backend discovery + a real `keyring.get_password` Keychain query |
+| `build_default_server_credential_store` | 2nd | 0.33 ms |
+| skill-trust marker store | 3rd | 0.41 ms |
+| skill-trust key cache | 4th | 0.04 ms |
+
+`keyring.get_keyring()` memoizes the discovered backend, so **whichever site
+runs first pays for all of them**. Fixing the three named sites just promotes
+the unnamed one to first place. The AC is therefore restated as a property of
+boot ("zero keyring calls"), which is both honest and testable, and all four
+sites are fixed.
+
+A second correction of the same kind was found *inside* the fix: deferring the
+whole skills stack to a lazy app property moved 16.45 ms from `__init__` into
+Chat-screen mount, because `ChatScreen._ensure_console_agent_bridge` reads
+`skills_scope_service` at mount. Only deferring the trust service itself,
+behind a factory `LocalSkillsService` calls on the first trust decision,
+actually removes it.
+
+## Implementation Plan
+
+1. Build the measurement harness FIRST (isolated-profile boot probe, mounted-app
+   Pilot probe, keyring call-site tracer, per-N micro-benchmarks) and take a
+   baseline against the merge base `f49956038` before writing any fix.
+2. Fix (a) -- the timing wrapper -- first, because it makes the rest measurable.
+3. Attribute every keyring touch by stack, then fix all sites the trace names,
+   not just the ones the filing names.
+4. Move the ingest restore to a thread worker, keeping the registry's
+   UI-thread-only contract and closing the window the deferral opens.
+5. Replace the Samira card scan with a targeted query, verified against the
+   retained scan as an oracle on malformed/NaN/non-object rows.
+6. A/B every claim against a pristine copy of `f49956038`; mutate every new
+   test against a deliberately broken implementation before trusting it.
+
+## Implementation Notes
+
+Four independent startup defects, each measured before and after against a
+pristine copy of the merge base `f49956038` sharing the same warm profile.
+
+**(a) Parallel-init timing.** `_timed_init_task` wraps each phase-3
+initializer and stamps its duration on the worker thread; the `as_completed`
+loop reads the recorded value instead of timing an already-completed
+`result()`. The summary now nests the four sub-phases under `parallel_init`.
+Before: every task logged `0.000s` while the phase really took 0.499 s
+(fresh profile). After: logged values match independently-measured truth to
+the logged precision (`notes_service` 0.016 vs 0.0156, `media_db` 0.006 vs
+0.0061, `prompts_service` 0.005 vs 0.005, `providers_models` 0.000 vs 0.0001).
+
+**(b) Keyring at boot.** Four sites, not three -- see the amended AC above for
+why fixing only the named three banks nothing. `VideoStore` now reads a
+secrets-free `VideoStorePolicy` (the only three settings it ever touches);
+`server_credential_store` became a lazy property with
+`RuntimeServerContextProvider` taking a `credential_store_factory`; the skill
+trust service is built by a factory `LocalSkillsService` calls on the first
+trust decision. Measured on a mounted app: **4 keyring calls / 18.2 ms -> 0
+calls**, and `TldwCli` construction **77.0 ms -> 60.9 ms** (median of 8 warm
+runs per arm; `basic_init` 24.1 -> 10.0 ms). Removing the Keychain
+`get_password` also removes a call that can block or raise a consent dialog on
+a locked keychain.
+
+**(c) Ingest-job restore.** `_restore_ingest_jobs` now starts a thread worker
+(`exit_on_error=False`); the store open, read, plan and reconcile writes run
+off the UI thread and only the registry seeding marshals back, preserving the
+registry's documented UI-thread-only contract. UI-thread block at 500
+persisted jobs (150 interrupted): **26.7 / 8.1 / 7.7 ms -> 0.076 / 0.067 /
+0.074 ms**, same 500 restored jobs and same `next_id`. The deferral opens a
+narrow window in which a job could be submitted before the seeding lands, so
+the registry gained `merge_restored`, which is byte-identical to `restore` on
+an empty registry and otherwise keeps the live job, drops the colliding
+persisted id, and takes `max` of the two `next_id`s.
+
+**(d) Samira preflight.** `_find_builtin_samira_card` asks SQLite
+(`json_valid`-guarded `json_extract` + `ORDER BY id LIMIT 1`) instead of
+reading every card and parsing its `extensions`. **2.6-2.9x faster**
+(100 cards 0.19 -> 0.07 ms; 2,000 cards 4.1 -> 1.5 ms), byte-identical results
+on NULL / empty / malformed / array / scalar / `NaN` / numeric-value
+`extensions`. The old scan is retained as `_find_builtin_samira_card_by_scan`
+for JSON1-less SQLite builds; the fallback is gated on `no such function`
+rather than being a catch-all, because a catch-all would silently reinstate
+the full scan on every boot of a profile with one corrupt row.
+
+Modified: `tldw_chatbook/app.py`, `tldw_chatbook/Character_Chat/visual_identity.py`,
+`tldw_chatbook/Library/library_ingest_jobs.py`,
+`tldw_chatbook/Video_Generation/config.py`,
+`tldw_chatbook/Video_Generation/video_store.py`,
+`tldw_chatbook/runtime_policy/server_context.py`,
+`tldw_chatbook/Skills_Interop/local_skills_service.py`.
+Added: `Tests/App/test_startup_init_hygiene.py`,
+`Tests/Character_Chat/test_samira_preflight_query.py`, plus two
+`merge_restored` cases in `Tests/Library/test_library_ingest_jobs_restore.py`.

--- a/tldw_chatbook/Character_Chat/visual_identity.py
+++ b/tldw_chatbook/Character_Chat/visual_identity.py
@@ -3185,7 +3185,57 @@ def _samira_seed_preflight(db: Any) -> dict[str, Any]:
     return {"terminal": False, "card": card}
 
 
+_SAMIRA_CARD_BY_BUILTIN_ID_SQL = """
+    SELECT id, name, extensions, deleted
+      FROM character_cards
+     WHERE CASE WHEN json_valid(extensions)
+                THEN json_extract(extensions, '$."tldw/builtin_id"')
+           END = 'samira'
+     ORDER BY id
+     LIMIT 1
+"""
+
+
 def _find_builtin_samira_card(db: Any) -> dict[str, Any] | None:
+    """Return the bundled Samira card row, or ``None``.
+
+    Runs on every boot (``ensure_builtin_samira``'s preflight), so it asks
+    SQLite the question instead of reading the whole table into Python and
+    parsing every card's ``extensions`` JSON (TASK-21111(d)): measured 3.0x
+    faster at 2,000 cards (4.29 ms -> 1.43 ms) and 2.8x at 100 (0.185 ms ->
+    0.067 ms).
+
+    Two details make the SQL agree with the Python loop it replaced on the
+    rows the loop tolerated:
+
+    * ``json_extract`` RAISES ``malformed JSON`` on an unparseable
+      ``extensions`` value (verified on SQLite 3.49.1), where the loop simply
+      skipped that row -- so the ``json_valid`` guard is load-bearing, not
+      decoration, and is written as a ``CASE`` so the language, not the query
+      planner, guarantees it is evaluated first. ``json_valid`` also rejects
+      the ``NaN``/``Infinity`` constants ``_reject_json_constant`` rejects,
+      and ``json_extract`` yields NULL (no match) for non-object JSON,
+      matching the loop's ``isinstance(..., dict)`` check.
+    * ``ORDER BY id LIMIT 1`` preserves "lowest id wins".
+
+    Falls back to the historical Python scan only when the SQLite build has
+    no JSON1 functions. The fallback is deliberately NOT a catch-all: an
+    every-boot silent full scan is exactly the cost this function exists to
+    remove, so any other failure propagates (``seed_builtin_content`` already
+    contains it) rather than hiding behind a slow path.
+    """
+    try:
+        row = db.execute_query(_SAMIRA_CARD_BY_BUILTIN_ID_SQL).fetchone()
+    except Exception as exc:  # noqa: BLE001 - inspected and re-raised below
+        if "no such function" not in str(exc).lower():
+            raise
+        logger.debug("samira_card_lookup_fallback category={}", type(exc).__name__)
+        return _find_builtin_samira_card_by_scan(db)
+    return dict(row) if row is not None else None
+
+
+def _find_builtin_samira_card_by_scan(db: Any) -> dict[str, Any] | None:
+    """Full-table fallback for SQLite builds without the JSON1 extension."""
     rows = db.execute_query(
         "SELECT id, name, extensions, deleted FROM character_cards ORDER BY id"
     ).fetchall()

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -627,6 +627,45 @@ class LibraryIngestJobRegistry:
         self._next_id = next_id
         self._notify_listeners()
 
+    def merge_restored(self, jobs: list[LibraryIngestJob], next_id: int) -> None:
+        """Seed from persisted history WITHOUT discarding jobs submitted since.
+
+        Args:
+            jobs: The persisted jobs, seq-ascending, exactly as ``restore``
+                takes them.
+            next_id: The next sequence number implied by ``jobs``.
+
+        Identical to :meth:`restore` when the registry is still empty, which
+        is the normal startup case. It exists because TASK-21111 moved the
+        app's persisted-history read off the UI thread: the read now finishes
+        a few milliseconds after ``on_mount`` returns, opening a (narrow)
+        window in which a job could already have been submitted. Plain
+        ``restore`` would silently delete it.
+
+        Live jobs are kept and ordered AFTER the restored ones (they are, by
+        definition, newer). A restored job whose ``job_id`` collides with a
+        live one is dropped rather than duplicated -- both sessions allocate
+        ids from ``ingest-job-1`` upward, so a collision in that window is
+        the likely case, and two entries sharing a ``job_id`` would make
+        every id-keyed mutation ambiguous. ``_next_id`` takes the maximum so
+        no future allocation can collide either.
+        """
+        live = self._jobs
+        if not live:
+            self.restore(jobs, next_id)
+            return
+        live_ids = {job.job_id for job in live}
+        restored = [_copy_job(job) for job in jobs if job.job_id not in live_ids]
+        logger.warning(
+            "Ingest job history restored alongside {} job(s) submitted during "
+            "startup; dropped {} colliding persisted id(s).",
+            len(live),
+            len(jobs) - len(restored),
+        )
+        self._jobs = restored + live
+        self._next_id = max(next_id, self._next_id)
+        self._notify_listeners()
+
     # -- listeners -----------------------------------------------------
 
     def add_listener(self, callback: Callable[[], None]) -> None:

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -10,7 +10,7 @@ import json
 import re
 import shutil
 import zipfile
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -237,17 +237,51 @@ class LocalSkillsService:
         store_dir: str | Path,
         policy_enforcer: Any | None = None,
         trust_service: Any | None = None,
+        trust_service_factory: Callable[[], Any] | None = None,
         allow_untrusted_without_trust_service: bool = False,
     ) -> None:
+        """Construct the local skill library service.
+
+        Args:
+            store_dir: Root of the local skill store.
+            policy_enforcer: Optional authorization policy enforcer.
+            trust_service: A ready trust service, or None for "no trust
+                service configured" (the escape-hatch shape tests use).
+            trust_service_factory: A zero-argument builder consulted the
+                first time ``trust_service`` is read, and memoized. The app
+                passes this because building the trust service performs OS
+                keyring backend discovery, and the Console's agent bridge
+                takes this service at screen mount while nothing has yet
+                asked a trust question (TASK-21111(b)).
+            allow_untrusted_without_trust_service: Escape hatch for a
+                deliberately trust-service-less service.
+        """
         self.store_dir = Path(store_dir)
         self.skills_dir = self.store_dir / _SKILLS_DIRNAME
         self.index_path = self.store_dir / _INDEX_FILENAME
         self.policy_enforcer = policy_enforcer
-        self.trust_service = trust_service
+        self._trust_service = trust_service
+        self._trust_service_factory = trust_service_factory
         self.allow_untrusted_without_trust_service = (
             allow_untrusted_without_trust_service
         )
         self._lock = asyncio.Lock()
+
+    @property
+    def trust_service(self) -> Any | None:
+        """The trust service, built on first read when deferred.
+
+        Stays ``None`` -- the documented "no trust service" state that every
+        call site guards on -- when neither a service nor a factory was
+        supplied.
+        """
+        if self._trust_service is None and self._trust_service_factory is not None:
+            self._trust_service = self._trust_service_factory()
+        return self._trust_service
+
+    @trust_service.setter
+    def trust_service(self, service: Any | None) -> None:
+        self._trust_service = service
 
     def _enforce(self, action_id: str) -> None:
         if self.policy_enforcer is None:

--- a/tldw_chatbook/Video_Generation/config.py
+++ b/tldw_chatbook/Video_Generation/config.py
@@ -219,6 +219,50 @@ def _load_video_generation_section() -> tuple[dict, dict[str, str]]:
 
 
 @dataclass(frozen=True)
+class VideoStorePolicy:
+    """The only three settings ``VideoStore`` reads. No secrets involved.
+
+    Field names and value normalization match ``VideoGenerationConfig``
+    exactly, so the store cannot tell the two apart (it reads all three via
+    ``getattr(config, name, default)``).
+    """
+
+    retention: str
+    retention_ttl_hours: int
+    max_store_mb: int
+
+
+def get_video_store_policy() -> VideoStorePolicy:
+    """Read the generated-video retention/capacity policy without any secret.
+
+    ``VideoStore`` is constructed and asked to ``enforce_retention()`` inside
+    ``TldwCli.__init__``. Routing that through ``get_video_generation_config()``
+    made every single boot resolve the MiniMax API key, whose last resort is
+    ``keyring.get_password(...)`` -- a real OS credential-store round trip,
+    measured at **18.2 ms** on macOS (11.3 ms of keyring backend discovery +
+    the Security.framework ctypes load, then the Keychain query itself), for a
+    secret the store never looks at. On a locked keychain that call can block
+    or raise a consent dialog during startup. TASK-21111(b).
+
+    Returns:
+        The retention mode, TTL and capacity, normalized exactly as
+        ``get_video_generation_config`` normalizes them.
+    """
+    raw = _read_video_generation_toml()
+    if not isinstance(raw, dict):
+        raw = {}
+    return VideoStorePolicy(
+        retention=_coerce_choice(
+            raw.get("retention"), default=DEFAULT_RETENTION, allowed={"session", "ttl"}
+        ),
+        retention_ttl_hours=max(
+            1, _coerce_int(raw.get("retention_ttl_hours"), DEFAULT_RETENTION_TTL_HOURS)
+        ),
+        max_store_mb=max(1, _coerce_int(raw.get("max_store_mb"), DEFAULT_MAX_STORE_MB)),
+    )
+
+
+@dataclass(frozen=True)
 class VideoGenerationConfig:
     default_backend: str | None
     enabled_backends: list[str]

--- a/tldw_chatbook/Video_Generation/video_store.py
+++ b/tldw_chatbook/Video_Generation/video_store.py
@@ -39,7 +39,7 @@ from loguru import logger
 
 from tldw_chatbook.Utils.paths import get_user_data_dir
 from tldw_chatbook.Video_Generation.config import (
-    get_video_generation_config,
+    get_video_store_policy,
 )
 from tldw_chatbook.Video_Generation.video_formats import (
     SUPPORTED_VIDEO_FORMATS,
@@ -181,7 +181,16 @@ class VideoStore:
         return max(1, int(getattr(config, "max_store_mb", 2048))) * 1024 * 1024
 
     def _get_config(self):
-        return self._config if self._config is not None else get_video_generation_config()
+        """Retention/capacity settings for this store.
+
+        An injected ``config`` (tests, explicit callers) still wins. Otherwise
+        this reads the secrets-free ``VideoStorePolicy`` rather than the full
+        ``VideoGenerationConfig``: the store only ever reads ``retention``,
+        ``retention_ttl_hours`` and ``max_store_mb``, and the full config's
+        secret resolution put an OS-keyring read on the app's startup path
+        (TASK-21111(b)).
+        """
+        return self._config if self._config is not None else get_video_store_policy()
 
     @property
     def _lease_path(self) -> Path:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2262,14 +2262,51 @@ class LibraryIngestQueueMixin:
         self._ingest_shutdown: bool = False
 
     def _restore_ingest_jobs(self) -> None:
-        """One-time on_mount restore of persisted ingest job history."""
+        """Start the one-time restore of persisted ingest job history.
+
+        Returns immediately: the store open (schema create/migrate on first
+        run), the read, the plan and the reconcile writes all run on a worker
+        thread, and only the in-memory registry seeding comes back to the UI
+        thread (TASK-21111(c) -- measured 1.7-11.6 ms of synchronous
+        ``on_mount`` work depending on history size, x3-5 on constrained
+        hardware).
+
+        Never raises, on either thread: a corrupt or unreadable store leaves
+        the registry empty and store-less, exactly as before.
+        """
+        if getattr(self, "_ingest_shutdown", False):
+            return
+        self.run_worker(
+            self._restore_ingest_jobs_off_thread,
+            name="restore_ingest_jobs",
+            group="ingest_restore",
+            thread=True,
+            exclusive=True,
+            # The body already catches and logs everything; `exit_on_error`
+            # is off so no future edit to it can turn a history-restore
+            # failure into an app exit. Restoring history must never be able
+            # to prevent boot -- that was true of the synchronous version and
+            # stays true here.
+            exit_on_error=False,
+        )
+
+    def _restore_ingest_jobs_off_thread(self) -> None:
+        """Worker body for :meth:`_restore_ingest_jobs`. Runs on a thread.
+
+        Catches everything. A worker that raised would surface as an uncaught
+        ``WorkerFailed`` and take the app down -- the failure mode this
+        function's synchronous predecessor could not have.
+        """
         from datetime import datetime, timezone
         from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
         from tldw_chatbook.Library.library_ingest_jobs import plan_restore
 
         try:
+            # `LibraryIngestJobsDB` opens with `check_same_thread=False`, so
+            # the connection this thread creates stays usable from the UI
+            # thread once the store is attached. Nothing else touches the
+            # store until then.
             store = LibraryIngestJobsDB(get_library_ingest_jobs_db_path())
-            self._library_ingest_jobs_store = store
             # Do ALL fallible work -- corrupt read, plan, and the store
             # reconcile writes -- BEFORE touching the in-memory registry, so any
             # failure leaves the registry empty + store unattached: a clean
@@ -2284,12 +2321,47 @@ class LibraryIngestQueueMixin:
                 store.upsert_job(job)
             for job_id in plan.delete_ids:
                 store.delete_job(job_id)
-            self.library_ingest_jobs.restore(plan.jobs, plan.next_id)
-            self.library_ingest_jobs.attach_store(store)
         except Exception:
             logger.opt(exception=True).warning(
                 "Failed to restore persisted ingest job history; starting empty."
             )
+            return
+
+        try:
+            self.call_from_thread(self._apply_ingest_job_restore, store, plan)
+        except Exception:
+            # The app stopped (quit during startup) or the callback itself
+            # failed. Either way the registry stays store-less; close the
+            # connection this thread opened rather than leaking it.
+            logger.opt(exception=True).debug(
+                "Ingest job history restore could not be applied; discarding."
+            )
+            try:
+                store.close()
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Ingest job store close after failed restore failed."
+                )
+
+    def _apply_ingest_job_restore(self, store: Any, plan: Any) -> None:
+        """Seed the registry from a completed restore plan. UI thread only.
+
+        Args:
+            store: The opened ``LibraryIngestJobsDB`` to attach as the
+                registry's write-through sink.
+            plan: The ``RestorePlan`` produced off-thread.
+
+        The registry is documented UI-thread-only, so the seeding and the
+        store attach stay here even though the I/O moved. Uses
+        ``merge_restored`` rather than ``restore`` so a job submitted in the
+        few milliseconds between ``on_mount`` and this callback survives.
+        """
+        if getattr(self, "_ingest_shutdown", False):
+            store.close()
+            return
+        self._library_ingest_jobs_store = store
+        self.library_ingest_jobs.merge_restored(plan.jobs, plan.next_id)
+        self.library_ingest_jobs.attach_store(store)
 
     def _expand_library_ingest_source(self, source_path: str) -> list[str] | None:
         """Expand a directory source into the files it contains.
@@ -5677,7 +5749,13 @@ class TldwCli(
         # Track startup timing
         self._startup_start_time = time.perf_counter()
         self._startup_phases = {}
-        self.server_credential_store_unavailable_reason: str | None = None
+        # Real per-task durations of the phase-3 parallel initializers,
+        # stamped on the worker thread by `_timed_init_task` (TASK-21111).
+        self._startup_parallel_tasks: dict[str, float] = {}
+        # Backing slots for the lazily-resolved credential store
+        # (TASK-21111(b)); see the `server_credential_store` property.
+        self._server_credential_store: Any | None = None
+        self._server_credential_store_unavailable_reason: str | None = None
 
         # Tab switching optimization
         self._initialized_tabs = set()  # Track which tabs have been initialized
@@ -5865,32 +5943,58 @@ class TldwCli(
         user_name_for_notes = settings.get("USERS_NAME", "default_tui_user")
         self.notes_user_id = user_name_for_notes
 
-        # Run independent initializations in parallel
+        # Run independent initializations in parallel.
+        #
+        # TASK-21111(a): each task is timed AROUND ITS OWN EXECUTION, on the
+        # worker thread, and the duration is stashed in
+        # `self._startup_parallel_tasks`. The previous shape started the clock
+        # in the `as_completed` loop immediately before `future.result()` --
+        # by which point `as_completed` had already yielded the future
+        # *because it was done*, so `result()` returned instantly and every
+        # task logged 0.000s. The parallel phase (measured here at 82% of
+        # construction on a fresh profile) could not be attributed at all.
         with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
             # Submit all independent initialization tasks
             futures = {
                 executor.submit(
-                    self._init_notes_service, user_name_for_notes
+                    self._timed_init_task,
+                    "notes_service",
+                    self._init_notes_service,
+                    user_name_for_notes,
                 ): "notes_service",
-                executor.submit(self._init_providers_models): "providers_models",
-                executor.submit(self._init_prompts_service): "prompts_service",
-                executor.submit(self._init_media_db): "media_db",
+                executor.submit(
+                    self._timed_init_task,
+                    "providers_models",
+                    self._init_providers_models,
+                ): "providers_models",
+                executor.submit(
+                    self._timed_init_task,
+                    "prompts_service",
+                    self._init_prompts_service,
+                ): "prompts_service",
+                executor.submit(
+                    self._timed_init_task, "media_db", self._init_media_db
+                ): "media_db",
             }
 
-            # Wait for all tasks to complete and log individual timings
+            # Wait for all tasks to complete and log their real durations.
             for future in concurrent.futures.as_completed(futures):
                 task_name = futures[future]
                 try:
-                    task_start = time.perf_counter()
                     future.result()
-                    task_duration = time.perf_counter() - task_start
-                    logger.info(
-                        f"Parallel init task '{task_name}' completed in {task_duration:.3f}s"
-                    )
                 except Exception as e:
+                    # The duration is still recorded (the wrapper stamps it in
+                    # a `finally`), and a slow FAILING task is exactly the one
+                    # worth timing.
                     logger.opt(exception=True).error(
-                        f"Parallel init task '{task_name}' failed: {e}"
+                        f"Parallel init task '{task_name}' failed after "
+                        f"{self._startup_parallel_tasks.get(task_name, 0.0):.3f}s: {e}"
                     )
+                    continue
+                logger.info(
+                    f"Parallel init task '{task_name}' completed in "
+                    f"{self._startup_parallel_tasks.get(task_name, 0.0):.3f}s"
+                )
 
         # Log total parallel phase time
         parallel_duration = time.perf_counter() - phase_start
@@ -6109,10 +6213,50 @@ class TldwCli(
                     (duration / total_init_time) * 100 if total_init_time > 0 else 0
                 )
                 logger.info(f"  {phase}: {duration:.3f}s ({percentage:.1f}%)")
+                if phase == "parallel_init":
+                    # Sub-phases: these overlap each other and their parent,
+                    # so they are indented and NOT additive with the phases
+                    # above (TASK-21111).
+                    for task, task_duration in sorted(
+                        self._startup_parallel_tasks.items(),
+                        key=lambda item: item[1],
+                        reverse=True,
+                    ):
+                        task_share = (
+                            (task_duration / duration) * 100 if duration > 0 else 0
+                        )
+                        logger.info(
+                            f"    - {task}: {task_duration:.3f}s "
+                            f"({task_share:.1f}% of parallel_init)"
+                        )
         logger.info("==============================")
 
         # Final memory check
         log_resource_usage()
+
+    def _timed_init_task(self, task_name: str, func: Callable[..., Any], *args: Any):
+        """Run one phase-3 initializer and record how long IT took.
+
+        Args:
+            task_name: Key under which the duration is recorded in
+                ``self._startup_parallel_tasks``.
+            func: The initializer to run.
+            *args: Positional arguments forwarded to ``func``.
+
+        Returns:
+            Whatever ``func`` returns.
+
+        The timing is taken on the worker thread, around the call itself, so
+        it survives however long the future then sits completed before
+        ``as_completed`` yields it (TASK-21111). Recorded in a ``finally`` so
+        a failing task is timed too. ``dict`` item assignment is atomic under
+        the GIL and each task writes a distinct key, so no lock is needed.
+        """
+        task_start = time.perf_counter()
+        try:
+            return func(*args)
+        finally:
+            self._startup_parallel_tasks[task_name] = time.perf_counter() - task_start
 
     def _construct_notes_sync_runtime_owner(self) -> "NotesSyncRuntimeOwner":
         """Build the application-owned lasting-sync runtime (TASK-21108).
@@ -6411,23 +6555,164 @@ class TldwCli(
             get_user_data_dir() / "mcp_server_targets.json",
         )
         self.unified_mcp_target_store.upsert_legacy_config_target(self.app_config)
+        self.server_context_provider = RuntimeServerContextProvider(
+            runtime_context=self.runtime_policy,
+            target_store=self.unified_mcp_target_store,
+            credential_store_factory=lambda: self.server_credential_store,
+            app_config=self.app_config,
+        )
+
+    def _build_local_skill_trust_service(self) -> Any:
+        """Build the skill trust service. Performs OS keyring discovery.
+
+        Split out of the eager wiring (TASK-21111(b)): it is the only part
+        of the local skills stack that touches the keyring -- twice, once
+        for the rollback marker store's secure-backend probe and once for
+        the trust key cache -- and nothing at startup asks a trust question.
+        Deferring the whole SERVICE was not enough on its own: the Console's
+        agent bridge takes the skills scope facade during Chat screen mount,
+        which merely relocated the discovery from ``__init__`` to mount.
+        ``LocalSkillsService`` therefore takes this as a FACTORY and calls it
+        on the first trust decision.
+        """
+        local_skills_store_dir = default_local_skills_store_dir(get_user_data_dir())
+        trust_store_dir = default_trust_store_dir(local_skills_store_dir)
+        trust_account_scope = skill_trust_account_scope(trust_store_dir)
+        skill_trust_marker_store, reduced_rollback_protection = (
+            build_skill_trust_marker_store_with_fallback(
+                fallback_marker_path=trust_store_dir / _SKILL_TRUST_MARKER_FILENAME,
+                store_dir=trust_store_dir,
+                account_scope=trust_account_scope,
+            )
+        )
+        return SkillTrustService(
+            skills_dir=local_skills_store_dir / "skills",
+            trust_store=SkillTrustStore(
+                store_dir=trust_store_dir,
+                marker_store=skill_trust_marker_store,
+            ),
+            key_cache=build_default_skill_trust_key_cache(
+                account_scope=trust_account_scope
+            ),
+            keyring_convenience_enabled=False,
+            reduced_rollback_protection=reduced_rollback_protection,
+        )
+
+    def _build_local_skills_stack(self) -> None:
+        """Build the local skills service + scope facade. Idempotent.
+
+        Body moved out of ``_wire_watchlists_and_notifications_services``
+        (TASK-21111(b)). Keyring-free: the trust service is handed over as a
+        factory. The collaborators it reads were captured at construction
+        time, not re-read now, so deferring changes WHEN it runs and not
+        WHAT it binds (the TASK-21108 trap).
+
+        Each slot is filled only if still unset, so an injected double (a
+        test assigning one of them between construction and first read) is
+        never clobbered by a later sibling access.
+        """
+        if None not in (self._local_skills_service, self._skills_scope_service):
+            return
+        policy_enforcer, server_skills_service = self._local_skills_stack_inputs
+        if self._local_skills_service is None:
+            self._local_skills_service = LocalSkillsService(
+                store_dir=default_local_skills_store_dir(get_user_data_dir()),
+                policy_enforcer=policy_enforcer,
+                trust_service_factory=lambda: self.local_skill_trust_service,
+            )
+        if self._skills_scope_service is None:
+            self._skills_scope_service = SkillsScopeService(
+                local_service=self._local_skills_service,
+                server_service=server_skills_service,
+                policy_enforcer=policy_enforcer,
+            )
+
+    @property
+    def local_skill_trust_service(self) -> Any:
+        """Local skill trust service, built on first access (TASK-21111(b))."""
+        if self._local_skill_trust_service is None:
+            self._local_skill_trust_service = self._build_local_skill_trust_service()
+        return self._local_skill_trust_service
+
+    @local_skill_trust_service.setter
+    def local_skill_trust_service(self, service: Any) -> None:
+        self._local_skill_trust_service = service
+
+    @property
+    def local_skills_service(self) -> Any:
+        """Local skills service, built on first access (TASK-21111(b))."""
+        self._build_local_skills_stack()
+        return self._local_skills_service
+
+    @local_skills_service.setter
+    def local_skills_service(self, service: Any) -> None:
+        self._local_skills_service = service
+
+    @property
+    def skills_scope_service(self) -> Any:
+        """Skills scope facade, built on first access (TASK-21111(b))."""
+        self._build_local_skills_stack()
+        return self._skills_scope_service
+
+    @skills_scope_service.setter
+    def skills_scope_service(self, service: Any) -> None:
+        self._skills_scope_service = service
+
+    def _resolve_server_credential_store(self) -> None:
+        """Build the OS-backed credential store, or the unavailable stand-in.
+
+        The body ``_wire_server_context_provider`` used to run inline. It is
+        deferred because ``build_default_server_credential_store()`` calls
+        ``keyring.get_keyring()``, whose first invocation performs backend
+        discovery (11.3 ms on macOS, including the Security.framework ctypes
+        load) -- work no boot needs unless the user actually uses server
+        mode. TASK-21111(b).
+
+        Sets both ``_server_credential_store`` and
+        ``_server_credential_store_unavailable_reason``; the fallback choice
+        and its warning are unchanged, only their timing.
+        """
         try:
-            self.server_credential_store = build_default_server_credential_store()
-            self.server_credential_store_unavailable_reason = None
+            self._server_credential_store = build_default_server_credential_store()
+            self._server_credential_store_unavailable_reason = None
         except CredentialStoreUnavailable as exc:
-            self.server_credential_store = UnavailableServerCredentialStore(str(exc))
-            self.server_credential_store_unavailable_reason = str(exc)
+            self._server_credential_store = UnavailableServerCredentialStore(str(exc))
+            self._server_credential_store_unavailable_reason = str(exc)
             logger.warning(
                 "No secure OS credential store available; server tokens will "
                 "remain config-only (reason={}).",
                 str(exc),
             )
-        self.server_context_provider = RuntimeServerContextProvider(
-            runtime_context=self.runtime_policy,
-            target_store=self.unified_mcp_target_store,
-            credential_store=self.server_credential_store,
-            app_config=self.app_config,
+
+    @property
+    def server_credential_store(self) -> Any:
+        """The app's credential store, resolved on first use (TASK-21111(b))."""
+        if self._server_credential_store is None:
+            self._resolve_server_credential_store()
+        return self._server_credential_store
+
+    @server_credential_store.setter
+    def server_credential_store(self, store: Any) -> None:
+        """Inject a credential store (tests, explicit reconfiguration).
+
+        Keeps the reason consistent with the store, so the pair can never
+        disagree the way two independently-assigned attributes could.
+        """
+        self._server_credential_store = store
+        self._server_credential_store_unavailable_reason = (
+            store.message if isinstance(store, UnavailableServerCredentialStore) else None
         )
+
+    @property
+    def server_credential_store_unavailable_reason(self) -> str | None:
+        """Why no OS credential store is in use, or None. Resolves on read."""
+        if self._server_credential_store is None:
+            self._resolve_server_credential_store()
+        return self._server_credential_store_unavailable_reason
+
+    @server_credential_store_unavailable_reason.setter
+    def server_credential_store_unavailable_reason(self, reason: str | None) -> None:
+        self._server_credential_store_unavailable_reason = reason
 
     def open_study_screen(
         self,
@@ -7796,37 +8081,22 @@ class TldwCli(
                 client=None,
                 policy_enforcer=self.service_policy_enforcer,
             )
-        local_skills_store_dir = default_local_skills_store_dir(get_user_data_dir())
-        trust_store_dir = default_trust_store_dir(local_skills_store_dir)
-        trust_account_scope = skill_trust_account_scope(trust_store_dir)
-        skill_trust_marker_store, reduced_rollback_protection = (
-            build_skill_trust_marker_store_with_fallback(
-                fallback_marker_path=trust_store_dir / _SKILL_TRUST_MARKER_FILENAME,
-                store_dir=trust_store_dir,
-                account_scope=trust_account_scope,
-            )
-        )
-        self.local_skill_trust_service = SkillTrustService(
-            skills_dir=local_skills_store_dir / "skills",
-            trust_store=SkillTrustStore(
-                store_dir=trust_store_dir,
-                marker_store=skill_trust_marker_store,
-            ),
-            key_cache=build_default_skill_trust_key_cache(
-                account_scope=trust_account_scope
-            ),
-            keyring_convenience_enabled=False,
-            reduced_rollback_protection=reduced_rollback_protection,
-        )
-        self.local_skills_service = LocalSkillsService(
-            store_dir=local_skills_store_dir,
-            policy_enforcer=self.service_policy_enforcer,
-            trust_service=self.local_skill_trust_service,
-        )
-        self.skills_scope_service = SkillsScopeService(
-            local_service=self.local_skills_service,
-            server_service=self.server_skills_service,
-            policy_enforcer=self.service_policy_enforcer,
+        # The local skills stack (trust service -> local service -> scope
+        # facade) is built on first access, not here: constructing the trust
+        # service performs OS keyring backend discovery TWICE (marker store +
+        # key cache) for a feature most boots never touch (TASK-21111(b)).
+        # Every consumer reads these through `getattr(app_instance, ...)` at
+        # UI time, so a property is a drop-in.
+        self._local_skill_trust_service: Any | None = None
+        self._local_skills_service: Any | None = None
+        self._skills_scope_service: Any | None = None
+        # Captured NOW, at the timing the eager build had: `_build_local_
+        # skills_stack` must not re-read collaborators that a test (or a
+        # later boot step) may reassign between construction and first use
+        # (the TASK-21108 deferral trap).
+        self._local_skills_stack_inputs = (
+            self.service_policy_enforcer,
+            self.server_skills_service,
         )
         try:
             self.server_tools_service = ServerToolsService.from_config(

--- a/tldw_chatbook/runtime_policy/server_context.py
+++ b/tldw_chatbook/runtime_policy/server_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 from uuid import UUID
 
 from loguru import logger
@@ -168,18 +168,55 @@ class RuntimeServerContextProvider:
         *,
         runtime_context: RuntimePolicyContext,
         target_store: ConfiguredServerTargetStore,
-        credential_store: ServerCredentialStore,
+        credential_store: ServerCredentialStore | None = None,
+        credential_store_factory: Callable[[], ServerCredentialStore] | None = None,
         app_config: Mapping[str, Any] | None,
     ) -> None:
+        """Compose the runtime server-context provider.
+
+        Args:
+            runtime_context: The app's runtime policy context.
+            target_store: Configured server target store.
+            credential_store: A ready credential store. Mutually exclusive
+                with ``credential_store_factory``.
+            credential_store_factory: A zero-argument builder called the
+                first time ``credential_store`` is read, and memoized. The
+                app passes this so building the store -- which performs OS
+                keyring backend discovery -- stays off the startup path
+                (TASK-21111(b)).
+            app_config: The loaded application config, or None.
+
+        Raises:
+            ValueError: If neither or both of ``credential_store`` and
+                ``credential_store_factory`` are supplied.
+        """
+        if (credential_store is None) == (credential_store_factory is None):
+            raise ValueError(
+                "exactly one of credential_store / credential_store_factory "
+                "must be supplied"
+            )
         self.runtime_context = runtime_context
         self.target_store = target_store
-        self.credential_store = credential_store
+        self._credential_store = credential_store
+        self._credential_store_factory = credential_store_factory
         self.app_config = app_config or {}
         self._legacy_cleared_server_ids: set[str] = set()
         self._cached_client_key: _CachedClientKey | None = None
         self._cached_client: TLDWAPIClient | None = None
         self._cached_character_authority: _CachedCharacterAuthority | None = None
         self._pending_client_close_tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def credential_store(self) -> ServerCredentialStore:
+        """The credential store, built on first read when deferred."""
+        if self._credential_store is None:
+            assert self._credential_store_factory is not None  # __init__ invariant
+            self._credential_store = self._credential_store_factory()
+        return self._credential_store
+
+    @credential_store.setter
+    def credential_store(self, store: ServerCredentialStore) -> None:
+        self._credential_store = store
 
     def get_active_context(self) -> ActiveServerContext:
         active_server_id = self._require_active_server_id()


### PR DESCRIPTION
## Summary

Four eager costs removed from `TldwCli.__init__`/mount, plus a boot timing log that had been
reporting `0.000s` for every phase. Finding 21111 of the 2026-08-22 review.

- **Timing log** — the clock started immediately before `future.result()` on a future that
  `as_completed` had *already yielded because it was done*, so all four tasks logged `0.000s`.
  A `_timed_init_task` wrapper now times each initializer around its own execution on the worker
  thread, and the summary nests the four sub-phases under `parallel_init`.
- **Keyring** — all four boot sites deferred.
- **Ingest-job restore** — DB open, read, plan and reconcile writes moved to a thread worker;
  only registry seeding marshals back (the registry is documented UI-thread-only).
- **Samira preflight** — a `json_valid`-guarded `json_extract … ORDER BY id LIMIT 1` replaces a
  full scan with per-row `json.loads`.

## The filing's keyring list banked zero milliseconds

It named three sites (server credentials "~13 ms", skills trust ×2). Stack-traced at the pin, the
**first** keyring touch of every boot is `Video_Generation/config._keyring_get`, reached from
`VideoStore.enforce_retention()` in `__init__` — a real Keychain query at **18.2 ms** (11.3 ms of
that is backend discovery). The three named sites cost **0.33 / 0.41 / 0.04 ms**, because
`keyring.get_keyring()` memoizes the backend: **whoever runs first pays for everyone.**

So fixing only the named three would have banked **0 ms** while still passing an AC worded as "no
keyring call from server credentials at boot". The AC is now the aggregate property — zero keyring
calls across import + construct + mount — and all four sites are fixed.

**A second relocation, found inside my own fix.** Deferring the skills stack to a lazy app
property showed zero keyring in the construction probe — but the *mounted-app* probe showed
16.45 ms had simply moved into Chat-screen mount, because `ChatScreen._ensure_console_agent_bridge`
reads `skills_scope_service` there. Only pushing laziness down into
`LocalSkillsService(trust_service_factory=…)` actually removed it.

## Measured (A/B vs pristine base, same warm profile)

| | before | after |
|---|---|---|
| `TldwCli()` construction (median, 8 warm runs/arm) | **77.0 ms** | **60.9 ms** |
| `basic_init` phase | 24.1 ms | 10.0 ms |
| keyring calls across import + construct + mount | 4 (18.2 ms) | **0** |
| `_restore_ingest_jobs` UI-thread block @500 jobs | 26.7 ms | 0.076 ms |
| Samira card lookup, 100 / 2,000 cards | 0.19 / 4.1 ms | 0.07 / 1.5 ms |
| parallel-init logged vs true duration | 0.000s vs 0.499s | match |

Gone, not relocated: the **mounted-app** Pilot probe reports zero keyring calls, and the restore's
store still ends up attached.

## Shutdown / error / first boot

An AST sweep confirms no `unmount`/`shutdown`/`quit` method on `TldwCli` reads any deferred
attribute, so quitting builds nothing. Live scenarios, all clean: quit-immediately; normal boot;
**worker slowed to 2 s so quit beats it** (worker returned cleanly, store closed on its own
thread, not attached); **poisoned ingest store** (app came up, registry empty, store unattached).
`exit_on_error=False`, so no future edit can turn a restore failure into an app exit — the class
of regression this programme has already hit three times. First boot after upgrade: schema
creation now happens on the worker thread, and Samira's `json_valid` guard means a corrupt row no
longer aborts *or* silently falls back.

## Mutation: 9 arms — and two that initially passed

M1 timer-after-call → 2 fail · M2 raw `submit` → 1 · M3 eager credential store → 3 · M4 eager
trust service → 1 · M5 video-store full config → 1 · M6 `restore` instead of `merge_restored` → 1
· M7 `exit_on_error=True` → 1 · M8c `ORDER BY id DESC` → 1 · M9/M10 merge-collision removal → 1 each.

**Two mutants passed on the first run**, exposing a blind test: dropping the `json_valid` guard,
and demoting it to an `AND`. `json_extract` *does* raise on malformed JSON — but a catch-all
`except Exception` swallowed it and the fallback scan returned the right answer, so the test was
measuring the fallback. Fixed by asserting `len(db.queries) == 1` and narrowing the `except` to
`"no such function"`; the guard-less mutant then failed 3 tests.

## Verification

New: 25 passed. `Tests/App` + `Tests/RuntimePolicy` + `Tests/Skills` after rebase:
**1,054 passed, 0 failed**. Wider branch-relevant set: 4,324 passed, with every red A/B-proven
pre-existing on base. Preflight green — the diagnostic-inventory drift was read statement by
statement before `--write`: five added rows carrying only exception type names, integer counts and
float durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes four eager startup costs and fixes the broken parallel-init timing log, improving boot time and making timings accurate. Before: parallel tasks logged 0.000s and several services hit the OS keyring during import/construct/mount; after: each task is timed at execution and the keyring is only touched on first real use. Satisfies TASK-21111.

- Parallel-init timing: `_timed_init_task` records durations on the worker; the startup summary nests sub-phases under `parallel_init`.
- Keyring deferrals: `VideoStore` reads a secrets-free `VideoStorePolicy` via `get_video_store_policy`; `server_credential_store` resolves lazily and `RuntimeServerContextProvider` supports a `credential_store_factory`; `LocalSkillsService` defers trust creation via `trust_service_factory` so `skills_scope_service` stays keyring-free at mount.
- Ingest restore: `_restore_ingest_jobs` runs DB open/read/plan/reconcile on a thread worker (`exit_on_error=False`); `_apply_ingest_job_restore` seeds on the UI thread and attaches the store; `LibraryIngestJobRegistry.merge_restored` preserves jobs submitted during the deferral window.
- Samira preflight: replaces a full-table scan with a `json_valid`-guarded `json_extract … ORDER BY id LIMIT 1`; falls back only on JSON1-less SQLite.

**Migration**
- Update `RuntimeServerContextProvider` construction to pass exactly one of `credential_store` or `credential_store_factory`.
- When stubbing video-store retention/capacity in tests, patch `tldw_chatbook.Video_Generation.video_store.get_video_store_policy` (not `get_video_generation_config`).

<sup>Written for commit e1a9475618246fc5aab79adb9ee40a4fcc1d9d8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

