### PR TITLE
docs: file seven follow-ups surfaced by wave 7 of the perf burn-down

### DIFF
--- a/backlog/tasks/task-21590 - Console-send is broadly red on dev - 26 failures in test-console-native-chat-flow.md
+++ b/backlog/tasks/task-21590 - Console-send is broadly red on dev - 26 failures in test-console-native-chat-flow.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21590
+title: >-
+  Console send is broadly red on dev   26 failures in test console native chat flow
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - testing
+  - dev-red
+  - console
+priority: high
+---
+## Description
+
+`Tests/UI/test_console_native_chat_flow.py` fails 26 tests on pristine dev. The failures span
+generic-provider send, the retry/regenerate/continue family, and the first-send-flag pair — the
+core Console send path. This is either a stale harness or a real break in sending, and until
+someone determines which, every Console branch inherits a red baseline that hides regressions in
+exactly the app's most-used flow.
+
+A scratch probe on pristine dev shows the draft is **neither sent nor cleared after Enter**, and
+a single-line control fails the same way — so it is not shift+enter specific.
+
+## Acceptance Criteria
+
+- [ ] A determination is recorded, with evidence, of whether Console send is genuinely broken in the shipped app or only in the test harness
+- [ ] If the app is broken, the send path is fixed and a test pins the behaviour that regressed
+- [ ] If the harness is stale, the harness is repaired so the tests exercise the real send path again — not deleted, and not relaxed until they pass
+- [ ] `Tests/UI/test_console_native_chat_flow.py` is green on dev
+- [ ] The fix is verified by mutation: breaking send makes these tests fail again
+
+## Evidence (verified first-hand on dev 33ff5b754, 2026-08-23)
+
+```
+pytest Tests/UI/test_console_native_chat_flow.py -q -p no:randomly
+  -> 26 failed, 271 passed  (7m 33s)
+```
+
+Surfaced by the TASK-21501/21123 implementer, which classified rather than waved through the
+composer-suite reds it inherited: 9 of its 12 composer-suite failures trace to this same root
+cause. Independently reproduced here before filing.

--- a/backlog/tasks/task-21591 - The splash skip-on-keypress setting is documented but cannot fire.md
+++ b/backlog/tasks/task-21591 - The splash skip-on-keypress setting is documented but cannot fire.md
@@ -1,0 +1,41 @@
+---
+id: TASK-21591
+title: >-
+  The splash skip on keypress setting is documented but cannot fire
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - bug
+  - ui
+  - dead-config
+priority: low
+---
+## Description
+
+`[splash_screen] skip_on_keypress` is shipped, defaulted to `true`, and documented in the config
+as "Allow users to skip with any keypress". It cannot work. `SplashScreen` is a `Container` that
+is never focusable and is never focused, and Textual routes key events to the focused widget and
+bubbles them *upward* — so the widget's `on_key` never runs and the setting is inert.
+
+Either the skip works or the setting should not be advertised. A config knob that silently does
+nothing is worse than no knob.
+
+## Acceptance Criteria
+
+- [ ] Pressing a key during the splash dismisses it when `skip_on_keypress = true`, or the setting and its documentation are removed
+- [ ] Whichever way it goes, a test pins the behaviour so it cannot silently rot again
+- [ ] If implemented, the skip is verified in a real terminal and not only under Pilot — the original observation was Pilot-only
+- [ ] `skip_on_keypress = false` is verified to leave the splash running its full duration
+
+## Evidence (verified first-hand on dev, 2026-08-23)
+
+- `Widgets/splash_screen.py:26` — `class SplashScreen(Container)`, with no `can_focus`.
+- `Widgets/splash_screen.py:454` — `async def on_key(...)`, gated on `self.skip_on_keypress`.
+- Nothing in the tree focuses the splash.
+- `config.py:3224` — `skip_on_keypress = true  # Allow users to skip with any keypress`;
+  `app.py:8759` reads it and `:8774` passes it through, so the wiring is complete right up to a
+  handler that never fires.
+
+Observed by the TASK-21110 implementer: `pilot.press("space")` at +0.05 s and +0.5 s after splash
+mount did not close the splash — it ran its full 1.5 s both times.

--- a/backlog/tasks/task-21592 - Tests-App pollutes Tests-Library in the same process - 13 to 15 errors.md
+++ b/backlog/tasks/task-21592 - Tests-App pollutes Tests-Library in the same process - 13 to 15 errors.md
@@ -1,0 +1,34 @@
+---
+id: TASK-21592
+title: >-
+  Tests App pollutes Tests Library in the same process   13 to 15 errors
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - testing
+  - flaky
+  - test-isolation
+priority: medium
+---
+## Description
+
+Running `Tests/App` and `Tests/Library` in the same process produces 13-15 errors whose node ids
+vary run to run, and zero errors when either directory runs alone. This is cross-file state
+leakage, and it is a real source of CI flakiness that will misattribute failures to whichever
+branch happens to be running.
+
+## Acceptance Criteria
+
+- [ ] The leaking state is identified by name (module-level singleton, patched global, app instance, or fixture scope) rather than worked around with ordering or `-p no:randomly`
+- [ ] `Tests/App` and `Tests/Library` run clean together in one process, repeatedly and under random ordering
+- [ ] A guard prevents the same class of leak from returning — e.g. an autouse fixture asserting the relevant global is unset at teardown
+- [ ] The error count is confirmed to be zero on several consecutive runs, since the symptom is nondeterministic
+
+## Evidence
+
+Observed by the TASK-21111 implementer while A/B-baselining: 13 errors on its branch and 15 of
+the same class on pristine dev `f49956038`, with varying node ids; running its new file alone with
+those Library files gave 306 passed and 0 errors.
+
+Pre-existing and unrelated to that task's change.

--- a/backlog/tasks/task-21593 - The media database has no statistics - audit its query plans without sqlite-stat1.md
+++ b/backlog/tasks/task-21593 - The media database has no statistics - audit its query plans without sqlite-stat1.md
@@ -1,0 +1,40 @@
+---
+id: TASK-21593
+title: >-
+  The media database has no statistics   audit its query plans without sqlite stat1
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - performance
+  - database
+  - media
+priority: medium
+---
+## Description
+
+TASK-21126 established that the media database has **no `sqlite_stat1`** — there is no `ANALYZE`
+anywhere in `Client_Media_DB_v2.py` — and that without stats SQLite's planner makes materially
+different index choices. That task proved it for one query, where the textbook covering index was
+never chosen and bought 1%. Other media-DB queries may be sitting on similarly bad plans for the
+same reason, and nobody has looked.
+
+## Acceptance Criteria
+
+- [ ] The hot media-DB queries are enumerated and each has its `EXPLAIN QUERY PLAN` captured **with `sqlite_stat1` absent**, which is the production state
+- [ ] Any query on a scan or temp B-tree plan where an index would be chosen is either fixed with a stats-independent index or recorded with the reason it was left alone
+- [ ] A decision is recorded on whether the media DB should run `ANALYZE` or `PRAGMA optimize` at all, with its cost — deliberately not taken in 21126 because it would re-plan every query in the database at once
+- [ ] Any index added states its write-side cost (file size, per-batch ingest time, one-off build time), as 21126 did
+- [ ] A guard or documented convention requires future "add an index" work in this repo to check the plan with stats absent
+
+## Evidence
+
+From TASK-21126, measured on the real production schema: the prescribed
+`(chunk_engine_version, media_id) WHERE deleted = 0` index measured 118.8 ms without it versus
+**120.2 ms with it** — 5 MB of disk for 1% — because with no stats the planner stays on the
+`deleted` index. Four index shapes were measured; only ones leading with `deleted` are ever
+chosen. The shipped index had to lead with a redundant column to be picked at all.
+
+The general rule this produced: **any "add an index" finding in this repo needs a query-plan
+check with `sqlite_stat1` absent, not just present.** A probe that runs `ANALYZE` to make its
+corpus realistic will confirm an index that production never uses.

--- a/backlog/tasks/task-21594 - Media DB migration test hand-stamps a version onto an already-current database.md
+++ b/backlog/tasks/task-21594 - Media DB migration test hand-stamps a version onto an already-current database.md
@@ -1,0 +1,38 @@
+---
+id: TASK-21594
+title: >-
+  Media DB migration test hand stamps a version onto an already current database
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - testing
+  - dev-red
+  - media
+priority: low
+---
+## Description
+
+`Tests/Media_DB/test_media_db_v2.py::TestDatabaseCRUDAndSync::test_reading_progress_reopens_through_versioned_migration`
+is red on dev. It hand-stamps `schema_version = 2` onto a database that is already current, so
+reopening replays v5→v6 against columns that exist and dies on `duplicate column name:
+chunk_engine_version`. The test will break again on every future media migration.
+
+## Acceptance Criteria
+
+- [ ] The test builds its historical database with a real historical fixture rather than stamping a version number onto a current one
+- [ ] It is green, and remains green when a new media migration is added on top
+- [ ] The repair is verified not to have made the test vacuous — it must still fail if the reading-progress migration is broken
+
+## Evidence (verified first-hand on dev 33ff5b754, 2026-08-23)
+
+```
+pytest Tests/Media_DB/test_media_db_v2.py -k reading_progress_reopens
+  -> 1 failed, 55 deselected
+  DatabaseError: Schema initialization failed: Migration v5->v6 failed:
+  duplicate column name: chunk_engine_version
+```
+
+`Tests/DB/historical_bootstrap_v6.py` already exists and is the right tool. Same family as
+TASK-21441: the shipped writer can no longer construct historical schemas, so fixtures have to
+come from a bootstrap module rather than from production code.

--- a/backlog/tasks/task-21595 - Sweep timer and tick paths for Static-update calls that lay out by default.md
+++ b/backlog/tasks/task-21595 - Sweep timer and tick paths for Static-update calls that lay out by default.md
@@ -1,0 +1,42 @@
+---
+id: TASK-21595
+title: >-
+  Sweep timer and tick paths for Static update calls that lay out by default
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - performance
+  - ui
+  - textual
+priority: medium
+---
+## Description
+
+TASK-21501 found that the Console composer's cursor-blink tick called `Static.update(renderable)`
+without `layout=False`, and since Textual's `Static.update` signature is
+`(content, *, layout: bool = True)`, every blink armed a **full screen reflow** — 396
+`Widget.arrange` calls per 6 ticks, about 1.9 reflows per second on an idle focused composer. The
+method's own docstring said it must not do that.
+
+That is unlikely to be the only place. Any `.update(` on a timer, tick, watcher or animation path
+carries the same default.
+
+## Acceptance Criteria
+
+- [ ] Every `.update(` call reachable from a `set_interval`, `set_timer`, animation or high-frequency watcher is enumerated
+- [ ] Each is either given `layout=False` with a stated reason the rendered size cannot change, or documented as legitimately needing layout
+- [ ] Each `layout=False` is justified by a geometry-equivalence check across the states the path can produce — not by inspection; TASK-21501's mutation showed `outer_size` alone is insufficient, since painted rows changed 1 → 2 while `outer_size` stayed constant
+- [ ] Layout-pass counts are measured before and after against a measured idle floor, not asserted as zero
+- [ ] A lint or guard test prevents a new timer-path `.update(` from defaulting to `layout=True`
+
+## Evidence
+
+From TASK-21501, measured with counters around `Screen._refresh_layout`, `Compositor.reflow`,
+`Widget.arrange` and `Static._layout_updates`, over six draft shapes:
+
+| per 6 blink ticks | before | after |
+|---|---|---|
+| `Screen._refresh_layout` | 6 | 0 |
+| `Widget.arrange` calls | 396 | 0 |
+| time in `_refresh_layout` | 3.1-6.5 ms/tick | 0 |

--- a/backlog/tasks/task-21596 - Video generation resolves the MiniMax secret eagerly whenever the config is read.md
+++ b/backlog/tasks/task-21596 - Video generation resolves the MiniMax secret eagerly whenever the config is read.md
@@ -1,0 +1,37 @@
+---
+id: TASK-21596
+title: >-
+  Video generation resolves the MiniMax secret eagerly whenever the config is read
+status: To Do
+assignee: []
+created_date: '2026-08-23'
+labels:
+  - performance
+  - video-generation
+  - keyring
+priority: low
+---
+## Description
+
+TASK-21111 removed the *boot* consumer that forced a Keychain query during `TldwCli.__init__`,
+but the underlying shape remains: `Video_Generation` resolves the MiniMax secret whenever anything
+asks for the full config. Opening Settings or Console video still pays the Keychain query up
+front rather than at send time.
+
+Keyring cost is easy to under-count because `keyring.get_keyring()` memoizes the backend — the
+first caller pays backend discovery for everyone, so the expensive site is whichever runs first,
+not whichever looks heaviest.
+
+## Acceptance Criteria
+
+- [ ] The MiniMax secret is resolved when it is used, not when the config is read
+- [ ] Opening Settings and opening Console video are measured to perform zero keyring calls
+- [ ] The measurement counts keyring calls across the whole interaction, not just the site being changed, so a relocation cannot pass as a removal
+- [ ] A missing or rejected credential still surfaces the same error to the user, at send time
+
+## Evidence
+
+From TASK-21111: the first keyring touch of every boot was `Video_Generation/config._keyring_get`
+at **18.2 ms** (11.3 ms backend discovery plus the query), while the three sites the original
+finding named cost 0.33, 0.41 and 0.04 ms. That task took the boot path to zero keyring calls;
+this is the remaining on-demand path.


### PR DESCRIPTION
## Summary

Seven task filings, no code. Everything surfaced by wave 7 of the 2026-08-22 performance
burn-down that was out of scope for the task that found it. Each carries evidence; the two dev
reds were reproduced first-hand before filing.

## The one that matters: TASK-21590 — Console send is broadly red on dev

`Tests/UI/test_console_native_chat_flow.py` fails **26 tests on pristine dev** — reproduced here
on `33ff5b754` (`26 failed, 271 passed`). The failures span generic-provider send, the
retry/regenerate/continue family, and the first-send-flag pair: the core Console send path.

A scratch probe shows the draft is **neither sent nor cleared after Enter**, and a single-line
control fails identically, so it is not shift+enter-specific. Filed high: this is either a stale
harness or a real break in sending, and until someone determines which, every Console branch
inherits a red baseline over the app's most-used flow. The AC explicitly forbids the easy exit —
the harness may be repaired, but not deleted and not relaxed until it passes.

## The rest

- **21591 — `[splash_screen] skip_on_keypress` cannot fire.** Shipped, defaulted true, and
  documented as "Allow users to skip with any keypress". `SplashScreen` is a `Container` that is
  never focusable and never focused, and Textual routes keys to the focused widget and bubbles
  *upward*, so its `on_key` never runs. Verified structurally here, after a Pilot observation.
  Either the skip works or the setting should not be advertised.
- **21592 — `Tests/App` leaks state into `Tests/Library`.** 13–15 errors with varying node ids in
  one process, zero when either runs alone. A real CI-flakiness source that will misattribute
  failures to whichever branch is running. The AC requires naming the leaking state, not
  reordering around it.
- **21593 — the media DB has no statistics; audit its plans without `sqlite_stat1`.** 21126
  proved for one query that the textbook covering index is **never chosen** without stats
  (118.8 ms without it vs 120.2 ms with). Other media queries may sit on the same bad plans.
  Carries the general rule: an "add an index" finding needs a plan check with stats **absent** —
  a probe that runs `ANALYZE` to look realistic will confirm an index production never uses.
- **21594 — a media migration test stamps a version onto an already-current DB**, so it replays
  v5→v6 against existing columns and dies on `duplicate column name`. Reproduced on
  `33ff5b754`. It will break again on every future media migration.
- **21595 — sweep timer-path `.update()` calls.** `Static.update`'s `layout` parameter defaults
  to `True`; 21501 found the composer's blink tick arming **396 `Widget.arrange` calls per 6
  ticks**. Any `.update(` on a timer, tick or animation path carries the same default. The AC
  requires a geometry-equivalence check per site, because 21501's mutation showed `outer_size`
  alone is insufficient — painted rows changed 1 → 2 while it stayed constant.
- **21596 — video generation still resolves its Keychain secret eagerly** off the boot path.
  21111 removed the boot consumer; opening Settings or Console video still pays it up front.

Task ids swept case-insensitively across all remote refs and worktrees — the first block I tried
was already taken, which is why these land at 2159x. Preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files seven backlog tasks from performance burn-down wave 7; docs-only, no runtime change. The headline item records a red baseline in Console send tests that affects all Console work.

**Filed tasks**
- TASK-21590 — Console send path is red on dev: 26 failures across send/retry/regenerate/continue in `Tests/UI/test_console_native_chat_flow.py`; determine harness vs real break.
- TASK-21591 — `[splash_screen] skip_on_keypress` cannot fire due to focus routing; either implement or remove and document.
- TASK-21592 — `Tests/App` leaks state into `Tests/Library` when run in one process; identify and guard against the leak.
- TASK-21593 — Media DB has no `sqlite_stat1`; audit hot queries without stats, decide on `ANALYZE`, and justify any new indexes.
- TASK-21594 — Media migration test stamps a version onto a current DB and fails on duplicate column; rebuild using historical bootstrap.
- TASK-21595 — Timer/tick `Static.update` calls default to `layout=True` and trigger reflows; sweep for `layout=False` where geometry is stable and add a guard.
- TASK-21596 — Video generation resolves the MiniMax secret eagerly on config read; make it lazy and verify zero keyring calls in Settings/Console until send time.

<sup>Written for commit dad567eff13ee4c1866f8b3986e5a7398a64563f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

