### PR TITLE
perf(console): stop the blink tick arming a layout pass; defer the Persona Buddy import (TASK-21692, TASK-21123 partial)

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -470,7 +470,7 @@ silently edited.
    cursor-blink tick calls `Static.update()`, whose `layout` parameter **defaults to `True`**, so
    it arms a layout pass every 0.53 s while the composer is merely focused and idle — directly
    contradicting its own docstring ("must not trigger a layout recompute on every blink phase").
-   Filed as task-21501.
+   Filed as task-21692.
 
    **The method lesson**: a finding's cost estimate decays as fast as its line numbers. Re-measure
    before dispatching, not after — five of seven is not a rounding error, and two of these would

--- a/Tests/UI/test_console_composer_cursor.py
+++ b/Tests/UI/test_console_composer_cursor.py
@@ -592,7 +592,7 @@ async def test_console_prompt_insert_appends_at_end_regardless_of_caret():
 
 
 # ---------------------------------------------------------------------------
-# TASK-21501: the blink tick must not arm a layout pass
+# TASK-21692: the blink tick must not arm a layout pass
 # ---------------------------------------------------------------------------
 
 
@@ -661,7 +661,7 @@ async def _count_layout_passes(pilot, composer, rounds: int, *, blink: bool) -> 
 async def test_console_composer_blink_tick_arms_no_layout_pass():
     """A blink phase flip costs no more layout work than an idle settle.
 
-    TASK-21501: ``Static.update`` defaults to ``layout=True``, so the 0.53 s
+    TASK-21692: ``Static.update`` defaults to ``layout=True``, so the 0.53 s
     cursor-blink tick used to schedule a full ``Screen._refresh_layout`` /
     ``Compositor.reflow`` ~2x/second for as long as the composer merely held
     focus -- exactly what ``_render_visible_draft_only``'s own docstring says
@@ -706,7 +706,7 @@ async def test_console_composer_blink_tick_arms_no_layout_pass():
 async def test_console_composer_blink_phases_are_geometry_identical():
     """Both blink phases occupy identical geometry, at every wrap boundary.
 
-    This is the safety half of TASK-21501: ``layout=False`` is only sound
+    This is the safety half of TASK-21692: ``layout=False`` is only sound
     while the rendered size genuinely cannot change between phases. The
     reserved caret cell (glyph when visible, space when hidden, wrapped in
     the same pass) is what guarantees that, so the boundary cases that would

--- a/Tests/UI/test_console_composer_cursor.py
+++ b/Tests/UI/test_console_composer_cursor.py
@@ -6,7 +6,10 @@ will be sent); collapsed paste tokens are single units for movement, deletion,
 and word boundaries.
 """
 
+from pathlib import Path
+
 import pytest
+from rich.cells import cell_len
 from textual.widgets import Static
 
 from Tests.UI.test_console_native_chat_flow import (
@@ -586,3 +589,180 @@ async def test_console_prompt_insert_appends_at_end_regardless_of_caret():
 
         assert composer.draft_text() == "existing draft\nresolved body"
         assert composer.cursor_index == len("existing draft\nresolved body")
+
+
+# ---------------------------------------------------------------------------
+# TASK-21501: the blink tick must not arm a layout pass
+# ---------------------------------------------------------------------------
+
+
+class _CssTrueConsoleHarness(ConsoleHarness):
+    """ConsoleHarness that loads the real app CSS bundle.
+
+    The shared harness is a bare ``App`` -- none of the app's stylesheet
+    applies under it, so geometry conclusions made there are void (see
+    ``lessons-testing-evidence.md``). The blink-cost and blink-safety tests
+    below both assert about real geometry, so they need the real sheet.
+    """
+
+    CSS_PATH = str(
+        Path(__file__).resolve().parents[2]
+        / "tldw_chatbook"
+        / "css"
+        / "tldw_cli_modular.tcss"
+    )
+
+
+async def _focused_composer(pilot, console, draft: str) -> ConsoleComposerBar:
+    """Return a focused composer holding ``draft`` with the blink timer owned."""
+    await _wait_for_selector(console, pilot, "#console-native-composer")
+    composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+    if draft:
+        composer.load_draft(draft)
+    composer.focus()
+    await pilot.pause(0.1)
+    # Own the blink phase: the test drives ticks itself so the free-running
+    # 0.53 s timer cannot add uncounted ticks mid-measurement.
+    composer._cursor_blink_timer.pause()
+    await pilot.pause(0.1)
+    await pilot.pause()
+    return composer
+
+
+async def _count_layout_passes(pilot, composer, rounds: int, *, blink: bool) -> int:
+    """Count real screen layout passes over ``rounds`` event-loop settles.
+
+    Counts ``Screen._refresh_layout`` -- the call that reflows the whole
+    compositor -- rather than asserting on ``refresh(layout=...)`` arguments,
+    so the assertion is about work performed, not about how it was requested.
+    """
+    screen = composer.screen
+    real_refresh_layout = screen._refresh_layout
+    calls = 0
+
+    def counting_refresh_layout(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_refresh_layout(*args, **kwargs)
+
+    screen._refresh_layout = counting_refresh_layout
+    try:
+        for _ in range(rounds):
+            if blink:
+                composer._toggle_cursor_blink()
+            await pilot.pause()
+            await pilot.pause()
+    finally:
+        del screen._refresh_layout
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_console_composer_blink_tick_arms_no_layout_pass():
+    """A blink phase flip costs no more layout work than an idle settle.
+
+    TASK-21501: ``Static.update`` defaults to ``layout=True``, so the 0.53 s
+    cursor-blink tick used to schedule a full ``Screen._refresh_layout`` /
+    ``Compositor.reflow`` ~2x/second for as long as the composer merely held
+    focus -- exactly what ``_render_visible_draft_only``'s own docstring says
+    must not happen.
+
+    The idle arm is the noise floor (this harness measures 0, but asserting
+    against the measured ambient rather than a bare 0 keeps the test from
+    turning into a flake if some unrelated timer starts firing).
+    """
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = _CssTrueConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        composer = await _focused_composer(pilot, console, "hello world")
+
+        rounds = 6
+        ambient = await _count_layout_passes(pilot, composer, rounds, blink=False)
+        blinking = await _count_layout_passes(pilot, composer, rounds, blink=True)
+
+        assert blinking == ambient, (
+            f"{rounds} blink ticks cost {blinking - ambient} extra screen layout "
+            f"passes (idle floor {ambient})"
+        )
+
+        # The tick must still REPAINT -- a caret that stopped blinking would
+        # also score zero layout passes.
+        visible = composer.query_one("#console-command-visible-text", Static)
+        composer._cursor_visible = True
+        composer._toggle_cursor_blink()
+        await pilot.pause()
+        hidden_text = visible.renderable.plain
+        composer._toggle_cursor_blink()
+        await pilot.pause()
+        shown_text = visible.renderable.plain
+        assert "▌" not in hidden_text
+        assert "▌" in shown_text
+
+
+@pytest.mark.asyncio
+async def test_console_composer_blink_phases_are_geometry_identical():
+    """Both blink phases occupy identical geometry, at every wrap boundary.
+
+    This is the safety half of TASK-21501: ``layout=False`` is only sound
+    while the rendered size genuinely cannot change between phases. The
+    reserved caret cell (glyph when visible, space when hidden, wrapped in
+    the same pass) is what guarantees that, so the boundary cases that would
+    break it -- an empty draft, a draft filling the last cell, a draft
+    landing exactly at the wrap width so the caret spills a row, and a
+    double-width CJK draft -- are all exercised here.
+    """
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = _CssTrueConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        composer = await _focused_composer(pilot, console, "seed")
+        visible = composer.query_one("#console-command-visible-text", Static)
+        width = composer._draft_render_width()
+        assert width >= 8
+
+        drafts = {
+            "empty": "",
+            "short": "hello",
+            "fills-last-cell": "x" * (width - 1),
+            "exactly-at-width": "x" * width,
+            "one-past-width": "x" * (width + 1),
+            "wrapped": "word " * 40,
+            "cjk-double-width": "漢" * (width // 2),
+        }
+
+        for name, draft in drafts.items():
+            composer.load_draft(draft)
+            composer.focus()
+            await pilot.pause(0.1)
+            composer._cursor_blink_timer.pause()
+            await pilot.pause()
+
+            geometry = []
+            cell_counts = []
+            for _ in range(2):
+                composer._toggle_cursor_blink()
+                await pilot.pause()
+                await pilot.pause()
+                painted = visible.renderable.plain
+                geometry.append(
+                    (
+                        visible.outer_size,
+                        composer.outer_size,
+                        len(painted.split("\n")),
+                    )
+                )
+                cell_counts.append([cell_len(row) for row in painted.split("\n")])
+
+            assert geometry[0] == geometry[1], (
+                f"{name!r}: blink phases differ in size/row count -- "
+                f"{geometry[0]} vs {geometry[1]}"
+            )
+            assert cell_counts[0] == cell_counts[1], (
+                f"{name!r}: blink phases differ in painted cell widths -- "
+                f"{cell_counts[0]} vs {cell_counts[1]}"
+            )

--- a/Tests/Utils/test_optional_import_deferral.py
+++ b/Tests/Utils/test_optional_import_deferral.py
@@ -440,3 +440,147 @@ print(json.dumps({"imported": SwarmUIClient is not None}))
     )
     payload = json.loads(result.stdout.strip().splitlines()[-1])
     assert payload["imported"]
+
+
+# --- 4. Persona Buddy reconcile: no widget/PIL import while disabled -------
+#
+# TASK-21123 (partial). `BaseAppScreen.reconcile_persona_buddy_view` runs on
+# EVERY screen mount, screen resume and screen recompose, as a coroutine on
+# the event loop (`run_worker` with no `thread=True`) right after first
+# paint. Importing `persona_buddy_widget` pulls
+# `Persona_Buddy.controller` -> `Persona_Visual.repository`/`runtime` ->
+# `PIL`. On routes that do not already carry PIL (Home, Settings) that was a
+# measured ~25 ms of loop-blocking work per process for a feature that is
+# off by default.
+
+_BUDDY_DISABLED_SNIPPET = """
+import asyncio
+import json
+import sys
+import types
+
+# The production import route: a screen module, then the base screen that
+# owns the reconcile. Neither may drag the Buddy widget in on its own.
+import tldw_chatbook.UI.Screens.home_screen  # noqa: F401
+from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
+
+BUDDY_WIDGET = "tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget"
+BUDDY_CONTROLLER = "tldw_chatbook.Persona_Buddy.controller"
+VISUAL_RUNTIME = "tldw_chatbook.Persona_Visual.runtime"
+
+
+def _resident():
+    return {
+        "buddy_widget": BUDDY_WIDGET in sys.modules,
+        "buddy_controller": BUDDY_CONTROLLER in sys.modules,
+        "visual_runtime": VISUAL_RUNTIME in sys.modules,
+        "pil": sorted(m for m in sys.modules if m == "PIL" or m.startswith("PIL.")),
+    }
+
+
+class _Screen:
+    \"\"\"Duck-typed stand-in exercising the real reconcile coroutine.
+
+    A real Textual screen is deliberately NOT used: building one imports
+    enough of the app that the sys.modules assertion below would stop
+    measuring this code path. Every attribute the coroutine touches on the
+    disabled path is provided here.
+    \"\"\"
+
+    def __init__(self, controller):
+        self.app_instance = types.SimpleNamespace(persona_buddy_controller=controller)
+        self._persona_buddy_reconcile_lock = asyncio.Lock()
+        self._persona_buddy_view = None
+        self._persona_buddy_view_generation = 0
+        self.is_attached = True
+        self.synced = 0
+
+    @property
+    def app(self):
+        return self
+
+    @property
+    def screen(self):
+        return self
+
+    def is_persona_buddy_confirmed_unavailable(self, controller, snapshot):
+        return False
+
+    def sync_persona_buddy_reconciled_state(self):
+        self.synced += 1
+
+
+class _DisabledController:
+    \"\"\"A controller whose snapshot reports the feature switched off.\"\"\"
+
+    def snapshot(self):
+        return types.SimpleNamespace(enabled=False, open=False, selection=None)
+
+
+async def _main():
+    results = {"before": _resident(), "cases": {}}
+    # Case A: no controller at all -- what app.py's lazy property returns for
+    # a profile whose preferences leave the Buddy disabled.
+    # Case B: a controller exists but its snapshot says disabled -- the
+    # feature was turned off at runtime.
+    for name, controller in (("no_controller", None), ("disabled", _DisabledController())):
+        screen = _Screen(controller)
+        returned = await BaseAppScreen.reconcile_persona_buddy_view(screen)
+        results["cases"][name] = {
+            "returned": returned,
+            "synced": screen.synced,
+            "resident": _resident(),
+        }
+    print(json.dumps(results))
+
+
+asyncio.run(_main())
+"""
+
+
+def test_persona_buddy_reconcile_imports_nothing_while_disabled(
+    tmp_path: Path,
+) -> None:
+    """A disabled-Buddy reconcile must not import the widget, or PIL.
+
+    Runs in a fresh interpreter: `sys.modules` is process-global, so an
+    earlier test that imported the Persona widgets would give a false pass
+    in-process.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _BUDDY_DISABLED_SNIPPET)
+    assert result.returncode == 0, (
+        f"the disabled Buddy reconcile raised in an isolated subprocess:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+
+    before = payload["before"]
+    assert not before["buddy_widget"], (
+        "importing home_screen + base_app_screen already pulls the Persona "
+        "Buddy widget -- this guard can no longer measure the reconcile"
+    )
+    assert before["pil"] == [], (
+        f"PIL is already resident before the reconcile runs: {before['pil']}"
+    )
+
+    for name, case in payload["cases"].items():
+        assert case["returned"] is True, f"{name}: reconcile did not report torn down"
+        assert case["synced"] == 1, f"{name}: screen-local sync hook was skipped"
+        resident = case["resident"]
+        assert not resident["buddy_widget"], (
+            f"{name}: reconcile imported {'persona_buddy_widget'} with the "
+            "Buddy disabled -- the import is running before the enabled check"
+        )
+        assert not resident["buddy_controller"], (
+            f"{name}: reconcile imported Persona_Buddy.controller while disabled"
+        )
+        assert not resident["visual_runtime"], (
+            f"{name}: reconcile imported Persona_Visual.runtime while disabled"
+        )
+        assert resident["pil"] == [], (
+            f"{name}: reconcile pulled PIL onto the event loop while the "
+            f"Buddy is disabled: {resident['pil']}"
+        )

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8027,3 +8027,40 @@ is for (`"no such function" in str(exc)`) so any other failure propagates.
 A broad fallback under a perf fix is worse than no fallback: it turns "this is
 now fast" into "this is fast unless one row is corrupt, in which case it is
 silently as slow as before, forever."
+## A docstring is not a measurement — and `Static.update` lays out by default
+
+**TASK-21501, 2026-08-23.** `_render_visible_draft_only` in
+`Widgets/Console/console_composer_bar.py` carried a docstring saying it "must stay
+cheap and must not trigger a layout recompute on every blink phase". Its body called
+`self.query_one(...).update(renderable)`. Textual 8's
+`Static.update(content, *, layout: bool = True)` ends in `self.refresh(layout=layout)`
+— so the default did the exact thing the docstring forbade, on a 0.53 s timer, for as
+long as the composer merely held focus. Instrumenting the layout path under a real-CSS
+harness put a number on it: 6 driven blink ticks produced **6 `Screen._refresh_layout`
+calls, 6 full `Compositor.reflow`s, 396 `Widget.arrange` calls and 6 arrangement-cache
+misses** — 3–6.5 ms of layout per tick, identical across six draft shapes. With
+`layout=False` all six counters go to 0. Nothing was red before or after; the whole
+defect lived in a keyword default nobody had to type.
+
+Two things this cost, worth stealing:
+
+- **Count the operation, do not read the source.** "Does this line cause a layout?"
+  was answerable only by wrapping `Screen._refresh_layout` / `Compositor.reflow` /
+  `Widget.arrange` and driving the tick. The wrong-looking answer (`Widget._arrange`,
+  which does not exist in Textual 8 — it is `arrange`, and it is *cached*, so calls
+  and cache-misses are different numbers) would have been reasoned about wrongly from
+  the source in either direction.
+- **Assert against a measured idle floor, not against `0`.** The committed test runs
+  an A/A arm (the same number of event-loop settles with no blink) and asserts the
+  blink arm costs no more. A bare `== 0` would become a flake the day an unrelated
+  timer starts firing in that harness.
+
+And the safety half has its own trap: `layout=False` is only sound if the size cannot
+change. Here it is sound for two independent reasons — the caret cell is reserved in
+*both* phases (glyph or space, wrapped in the same pass), and the Static's geometry is
+pinned by inline styles (`width: 1fr`, `text_wrap: nowrap`, explicit
+`height`/`min_height`/`max_height` from `_apply_draft_height`). The second reason was
+discovered by mutation, not by reading: breaking the reserved cell changed the painted
+row count from 1 to 2 between phases while `outer_size` stayed `Size(93, 2)`. A test
+asserting only `outer_size` would have called that safe. Assert the **painted row
+count and per-row cell widths** too.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8029,7 +8029,7 @@ now fast" into "this is fast unless one row is corrupt, in which case it is
 silently as slow as before, forever."
 ## A docstring is not a measurement — and `Static.update` lays out by default
 
-**TASK-21501, 2026-08-23.** `_render_visible_draft_only` in
+**TASK-21692, 2026-08-23.** `_render_visible_draft_only` in
 `Widgets/Console/console_composer_bar.py` carried a docstring saying it "must stay
 cheap and must not trigger a layout recompute on every blink phase". Its body called
 `self.query_one(...).update(renderable)`. Textual 8's

--- a/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
+++ b/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
@@ -56,6 +56,6 @@ worst case (novel prefix, no match) is the common case: ~1000 `startswith`, orde
 Blink interval is 0.53 s, not 0.5, and the timer is paused unless the composer is focused.
 
 **Split out**: the biggest cost found in this file is not in this task at all — the blink tick
-arms a full layout pass ~2x/second while merely focused and idle. Filed separately as TASK-21501.
+arms a full layout pass ~2x/second while merely focused and idle. Filed separately as TASK-21692.
 
-**Action**: rewrite this task down to the ghost-scan cap, or close it and keep only 21501.
+**Action**: rewrite this task down to the ghost-scan cap, or close it and keep only 21692.

--- a/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
+++ b/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
@@ -5,6 +5,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-22'
+updated_date: '2026-08-23'
 labels:
   - performance
   - architecture
@@ -29,5 +30,45 @@ controller is app-owned, and the widget floats via overlay: screen.
 ## Acceptance Criteria
 
 - [ ] A single app-level overlay owner reacts to screen-change events and controller generation bumps; the per-screen recompose/mount/resume hooks and per-screen buddy state are removed
-- [ ] Short-term (or as part of the move): no worker is spawned and no widget module imported when the feature is disabled
+- [x] Short-term (or as part of the move): no widget module imported when the feature is disabled (shipped separately, see Progress note below); the worker half is still open
 - [ ] Buddy behavior when enabled (placement, persistence, unavailable-fence) is unchanged - existing buddy tests green
+
+## Progress note (2026-08-23) - the import half shipped separately
+
+The AC-2 import half of this task shipped on its own, on the wave-7b branch
+(`fix/task-21470-wave7b`), because it is a one-line move with no design risk.
+`BaseAppScreen.reconcile_persona_buddy_view`'s
+`from ...Widgets.Persona_Widgets.persona_buddy_widget import PersonaBuddyWidget` used to be
+the FIRST statement of the method, executed before the enabled check. It now sits at the one
+branch that constructs the widget. Pinned by
+`Tests/Utils/test_optional_import_deferral.py::test_persona_buddy_reconcile_imports_nothing_while_disabled`,
+which runs the real coroutine in a fresh interpreter and asserts `persona_buddy_widget`,
+`Persona_Buddy.controller`, `Persona_Visual.runtime` and PIL are all absent from `sys.modules`
+afterwards, for both the no-controller and the snapshot-says-disabled case. It fails against
+the un-moved import.
+
+Measured marginal cost of the import that is now skipped (fresh interpreter, screen module
+already imported, then timing the buddy-widget import):
+
+| route | PIL already resident | marginal import |
+|---|---|---|
+| `home_screen` | no | 27.0 ms, +39 modules (+10 PIL) |
+| `settings_screen` | no | 24.6 ms, +31 modules (+10 PIL) |
+| `chat_screen` | yes (16) | 14.7 ms, +10 modules |
+| `library_screen` | yes (16) | 16.0 ms, +14 modules |
+
+(one-time per process, on the event loop, right after first paint). Note this is ~25 ms, not
+the ~1.28 s an earlier task recorded for the cold chain -- that figure did not reproduce on a
+warm filesystem here.
+
+### What remains open, and why the relocation is deferred
+
+Everything else: the app-level overlay owner, removing the per-screen recompose/mount/resume
+hooks, and removing the per-screen state. An independent review of the relocation found it
+would **break the enabled case** as specified: `super().recompose()` removes every child of the
+screen, including a mounted Buddy, so an app-level owner that reacts only to screen-CHANGE
+events would miss recomposes and the Buddy would silently vanish until the next screen switch.
+Any relocation therefore needs a recompose-aware re-mount signal designed in first, and that
+design is out of scope for a perf burn-down slice. Do not treat AC-2's import half being ticked
+as licence to ship the move without it.
+

--- a/backlog/tasks/task-21501 - Cursor-blink-tick-arms-a-full-screen-layout-pass-twice-a-second-while-the-composer-is-idle.md
+++ b/backlog/tasks/task-21501 - Cursor-blink-tick-arms-a-full-screen-layout-pass-twice-a-second-while-the-composer-is-idle.md
@@ -1,0 +1,125 @@
+---
+id: TASK-21501
+title: >-
+  Cursor blink tick arms a full screen layout pass twice a second while the composer is idle
+status: Done
+assignee: []
+created_date: '2026-08-23'
+updated_date: '2026-08-23'
+labels:
+  - performance
+  - console
+  - composer
+priority: medium
+dependencies: []
+---
+
+## Description
+
+The Console composer's cursor-blink tick repaints the visible-draft `Static` through
+`Static.update(...)`, whose `layout` parameter defaults to `True`. Every blink phase
+therefore schedules a full screen layout pass — `Screen._refresh_layout` and a whole
+`Compositor.reflow` — for as long as the composer merely holds focus, whether or not
+the user is typing. The blink interval is 0.53 s, so an idle focused composer costs
+roughly two full layout passes per second.
+
+This directly contradicts the contract the method states for itself: its docstring
+says it "must stay cheap and must not trigger a layout recompute on every blink
+phase". The cost is invisible to every existing test because nothing counts layout
+operations.
+
+Found while burning down the 2026-08-22 holistic performance review
+(`Docs/Design/2026-08-22-holistic-perf-review.md`), alongside finding 21120's note
+that the blink tick already re-scans prompt history per tick.
+
+## Acceptance Criteria
+
+- [x] A blink phase flip performs no more screen layout work than an idle event-loop settle, measured by counting real layout operations rather than by reading the source
+- [x] The caret still visibly blinks: the visible phase paints the caret glyph and the hidden phase does not
+- [x] Both blink phases occupy identical geometry at every wrap boundary — empty draft, a draft filling the last cell, a draft landing exactly at the wrap width, a multi-row wrapped draft, and a double-width CJK draft
+- [x] Draft mutation, focus/blur, resize and collapse still recompute the composer's height (the paths that legitimately need a layout pass are untouched)
+- [x] A regression test fails against the un-fixed implementation
+
+## Implementation Plan
+
+1. Instrument Textual's layout path under a real-CSS Console harness and count
+   `Screen._refresh_layout` / `Compositor.reflow` / arrangement-cache misses across a
+   fixed number of blink ticks, on a spread of draft shapes.
+2. Establish that the rendered SIZE genuinely cannot differ between blink phases
+   before choosing a blanket `layout=False`; if any phase can change the row count,
+   implement a narrower fix instead.
+3. Apply the fix, re-measure with the identical probe, and diff the two arms.
+4. Add regression tests: one that pins the layout cost against an idle control arm,
+   one that pins phase-to-phase geometry identity at the wrap boundaries.
+5. Mutation-test both tests against deliberately broken implementations.
+
+## Implementation Notes
+
+`_render_visible_draft_only` (`tldw_chatbook/Widgets/Console/console_composer_bar.py`)
+now calls `Static.update(renderable, layout=False)`. That method has exactly one
+caller — `_toggle_cursor_blink` — so the change is scoped to the blink path and does
+not touch `_refresh_visible_draft`, which still recomputes the row count and calls
+`_apply_draft_height` with `layout=True`.
+
+**Measured, under a real-CSS `ConsoleHarness` at 140x42, 6 driven blink ticks per
+draft shape (empty / short / wrapped 3-row / exactly-at-wrap-width / width-1 /
+CJK double-width):**
+
+| | before | after |
+|---|---|---|
+| `Screen._refresh_layout` calls | 6 | 0 |
+| `Compositor.reflow` calls | 6 | 0 |
+| `Widget.arrange` calls | 396 | 0 |
+| arrangement-cache misses | 6 | 0 |
+| `Static._layout_updates` delta | 6 | 0 |
+| time inside `_refresh_layout` | 3.1–6.5 ms/tick | 0 |
+
+Identical in all six shapes. At a 0.53 s interval that is ~1.9 layout passes/second
+removed from an idle focused composer.
+
+**Why `layout=False` is safe here** (two independent reasons):
+
+1. The two phases are cell-identical by construction. `_draft_renderable` reserves
+   exactly one display cell at the caret position in both phases — the glyph while
+   visible, a plain space while hidden — and wraps it in the same pass, a property
+   its own comment already documents and which `_visible_draft_row_count` budgets for
+   via `reserve_trailing_cell`. Both `CURSOR_GLYPH` (`▌`) and its ASCII fallback
+   (`|`) are single-width. The probe confirms the painted row count and per-row cell
+   widths are equal in both phases at every boundary tested, including the
+   exactly-at-wrap-width case where the caret legitimately spills onto its own row
+   (2 rows in *both* phases, because the row count is computed with the reserved cell
+   already included).
+2. Even if the content did change, the widget's size is not derived from it. The
+   visible-draft `Static` gets `width: 1fr`, `text_wrap = "nowrap"` and
+   `text_overflow = "clip"` inline at compose time, and explicit
+   `height`/`min_height`/`max_height` from `_apply_draft_height`. This was confirmed
+   accidentally during mutation testing: breaking the reserved-cell invariant changed
+   the painted row count from 1 to 2 between phases while `outer_size` stayed
+   `Size(93, 2)` — the inline height absorbed it.
+
+**Regression tests** (`Tests/UI/test_console_composer_cursor.py`):
+
+- `test_console_composer_blink_tick_arms_no_layout_pass` — counts
+  `Screen._refresh_layout` over N settles with and without blink ticks and asserts the
+  blink arm costs no more than the idle arm (an A/A control rather than a bare `== 0`,
+  so an unrelated timer cannot turn it into a flake), then asserts the caret glyph
+  still toggles so a caret that stopped blinking cannot pass.
+- `test_console_composer_blink_phases_are_geometry_identical` — asserts equal
+  `outer_size`, row count and per-row cell widths across both phases for seven draft
+  shapes, under a `CSS_PATH`-true harness (a bare `ConsoleHarness` loads none of the
+  app stylesheet, so geometry conclusions under it are void).
+
+**Mutation results:** removing `layout=False` fails the cost test with
+"6 blink ticks cost 6 extra screen layout passes (idle floor 0)". Removing the
+reserved caret cell from the hidden phase fails the geometry test — on painted cell
+widths for a short draft (`[5] vs [6]`), and on row count for the exactly-at-width
+draft (`1 vs 2`).
+
+**Shutdown/error paths:** unchanged. The timer is still created paused in `on_mount`
+and resumed only while `has_focus_within and not self._collapsed`; Textual stops a
+widget's timers on close, so no tick can outlive the composer. The `NoMatches` guard
+is untouched, and `refresh(repaint=True)` still clears the cached dimensions and the
+rich-style cache, so the repaint half is intact.
+
+**Modified files:** `tldw_chatbook/Widgets/Console/console_composer_bar.py`,
+`Tests/UI/test_console_composer_cursor.py`.

--- a/backlog/tasks/task-21692 - Cursor-blink-tick-arms-a-full-screen-layout-pass-twice-a-second-while-the-composer-is-idle.md
+++ b/backlog/tasks/task-21692 - Cursor-blink-tick-arms-a-full-screen-layout-pass-twice-a-second-while-the-composer-is-idle.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-21501
+id: TASK-21692
 title: >-
   Cursor blink tick arms a full screen layout pass twice a second while the composer is idle
 status: Done
@@ -123,3 +123,24 @@ rich-style cache, so the repaint half is intact.
 
 **Modified files:** `tldw_chatbook/Widgets/Console/console_composer_bar.py`,
 `Tests/UI/test_console_composer_cursor.py`.
+
+## Renumbering provenance
+
+Authored as **TASK-21501** and renumbered to **TASK-21692** before merge, per the 2026-08-21
+owner rule (TASK-19601): the older arrival keeps the id, the younger renumbers.
+
+`TASK-21501` was claimed concurrently by "Three documents and the code disagree about the private
+MCP tool surface", which reached dev first — it was committed and closed there on 2026-08-23
+(`ff4c7593b`) while this task was still unmerged. That task keeps 21501; this one moved.
+
+The new id was taken at max+30 after sweeping every remote ref and worktree
+case-insensitively (max was 21662). Renamed here: the file, the `id:` field, the
+`console_composer_bar.py` docstring reference, three references in
+`Tests/UI/test_console_composer_cursor.py`, the lesson in `lessons-testing-evidence.md`, the
+evidence-doc row, and the cross-reference in task-21120. The reference in
+`Tests/MCP/test_mcp_documentation_contract.py` belongs to the *other* 21501 and was deliberately
+left alone.
+
+Fourth id collision of this programme. The preflight `backlog task ids` check is what caught it —
+a sweep taken at authoring time cannot see a task that lands during review.
+

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -454,11 +454,22 @@ class BaseAppScreen(Screen):
             await flush()
 
     async def reconcile_persona_buddy_view(self) -> bool:
-        """Reconcile one generation; return whether no current view remains."""
+        """Reconcile one generation; return whether no current view remains.
 
-        from ...Widgets.Persona_Widgets.persona_buddy_widget import (  # noqa: PLC0415
-            PersonaBuddyWidget,
-        )
+        TASK-21123 (partial): the ``PersonaBuddyWidget`` import lives at the
+        one branch that constructs the widget, NOT at the top of this method.
+        Every screen mount and every screen recompose reaches this reconcile,
+        including with the Buddy disabled (the default), and importing that
+        widget pulls ``Persona_Buddy.controller`` ->
+        ``Persona_Visual.repository``/``runtime`` -> ``PIL`` -- 10 modules /
+        ~6.9k LOC, plus 10 PIL modules on the routes that do not already carry
+        them. This coroutine runs ON the event loop (``run_worker`` without
+        ``thread=True``), right after first paint, so the import blocked the
+        loop for ~25 ms on Home and Settings for a feature that was off.
+        ``app.py``'s ``persona_buddy_controller`` docstring already claimed
+        the disabled early-out was free of that cost; with the import moved,
+        it is.
+        """
 
         async with self._persona_buddy_reconcile_lock:
             controller = getattr(self.app_instance, "persona_buddy_controller", None)
@@ -498,6 +509,13 @@ class BaseAppScreen(Screen):
                 current.resume_resolution()
                 self.sync_persona_buddy_reconciled_state()
                 return False
+
+            # Only reached when the Buddy is enabled, open, has a selection
+            # and no view is mounted yet -- the one branch that needs the
+            # widget class (and therefore the Persona_Visual/PIL chain).
+            from ...Widgets.Persona_Widgets.persona_buddy_widget import (  # noqa: PLC0415
+                PersonaBuddyWidget,
+            )
 
             self._persona_buddy_view_generation += 1
             generation = self._persona_buddy_view_generation

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -2878,7 +2878,7 @@ class ConsoleComposerBar(Horizontal):
         Used by the cursor blink tick (its only caller), which must stay cheap
         and must not trigger a layout recompute on every blink phase.
 
-        TASK-21501: ``Static.update`` defaults to ``layout=True``, so this
+        TASK-21692: ``Static.update`` defaults to ``layout=True``, so this
         method used to arm a full screen layout pass ~2x/second for as long
         as the composer merely held focus -- measured at 1 ``Screen.
         _refresh_layout`` + 1 ``Compositor.reflow`` + 1 arrangement-cache

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -2875,14 +2875,37 @@ class ConsoleComposerBar(Horizontal):
     def _render_visible_draft_only(self) -> None:
         """Re-render the visible-draft Static without recomputing composer height.
 
-        Used by the cursor blink tick, which must stay cheap and must not
-        trigger a layout recompute on every blink phase.
+        Used by the cursor blink tick (its only caller), which must stay cheap
+        and must not trigger a layout recompute on every blink phase.
+
+        TASK-21501: ``Static.update`` defaults to ``layout=True``, so this
+        method used to arm a full screen layout pass ~2x/second for as long
+        as the composer merely held focus -- measured at 1 ``Screen.
+        _refresh_layout`` + 1 ``Compositor.reflow`` + 1 arrangement-cache
+        miss per tick. ``layout=False`` is sound here because the rendered
+        SIZE cannot differ between the two blink phases:
+
+        * ``_draft_renderable`` reserves exactly one display cell at the
+          caret position in BOTH phases -- the glyph while visible, a plain
+          space while hidden -- and wraps it in the same pass, so the two
+          phases are cell-identical by construction (see its comment). Both
+          ``CURSOR_GLYPH`` and its ASCII fallback ``|`` are single-width.
+        * The Static's geometry is pinned by inline styles rather than
+          derived from its content: ``width: 1fr``, ``text_wrap = "nowrap"``,
+          ``text_overflow = "clip"`` (set in ``compose``) and an explicit
+          ``height``/``min_height``/``max_height`` written by
+          ``_apply_draft_height``, which every size-changing path
+          (``_refresh_visible_draft``, resize, collapse) still goes through
+          with ``layout=True``. The blink tick changes no state those paths
+          read.
         """
         try:
             draft = self._display_draft_text()
             width = self._draft_render_width()
             renderable = self._current_visible_draft_renderable(draft, width)
-            self.query_one("#console-command-visible-text", Static).update(renderable)
+            self.query_one("#console-command-visible-text", Static).update(
+                renderable, layout=False
+            )
         except NoMatches:
             return
 


### PR DESCRIPTION
## Summary

Two small, independent fixes that each remove work from the event loop, plus a task-id renumber.

1. **TASK-21692** — the composer's cursor-blink tick armed a **full screen layout pass** ~2×/second
   while merely focused and idle.
2. **TASK-21123 (import half only)** — the Persona Buddy reconcile imported a widget chain,
   including PIL on some routes, before checking whether the feature is even enabled.

## 1. Blink tick — measured, not inferred

`_render_visible_draft_only` carries this docstring: *"Used by the cursor blink tick, which must
stay cheap and must not trigger a layout recompute on every blink phase."* It then called
`Static.update(renderable)` — and Textual's signature is
`update(content, *, layout: bool = True)`, ending in `refresh(layout=layout)`. So it did exactly
what it forbids.

Counters wrapped around `Screen._refresh_layout`, `Compositor.reflow`, `Widget.arrange` and
`Static._layout_updates`, on a real-CSS harness at 140×42, over six draft shapes:

| per 6 ticks | before | after |
|---|---|---|
| `Screen._refresh_layout` | 6 | **0** |
| `Compositor.reflow` | 6 | **0** |
| `Widget.arrange` calls | **396** | **0** |
| time inside `_refresh_layout` | 3.1–6.5 ms/tick | 0 |

One full screen reflow per blink, ~1.9/second on an idle focused composer. `_render_visible_draft_only`
has exactly one caller, so `layout=False` is scoped to the blink path by construction.

**Why a blanket `layout=False` is safe here** — two independent reasons, the second found by
mutation. (a) The phases are cell-identical: `_draft_renderable` reserves exactly one cell at the
caret in *both* phases and wraps in the same pass; `▌` and its ASCII fallback are single-width.
Probed at every boundary: empty draft, caret at end-of-line, width-1, exactly-at-wrap-width (the
caret legitimately spills to row 2 — in both phases), a wrapped 3-row draft, and double-width CJK.
(b) Size isn't derived from content anyway — the Static gets `width: 1fr`, `nowrap`, `clip` and an
explicit height pin, and every size-changing path still goes through `_apply_draft_height` with
`layout=True`.

**Mutation**: removing `layout=False` fails the layout-count test ("6 blink ticks cost 6 extra
screen layout passes, idle floor 0"); making the hidden phase reserve no cell fails the geometry
test on cell widths and row count. The count test asserts against a *measured idle floor* rather
than a bare `== 0`, and separately asserts the caret still toggles — so a caret that stopped
blinking altogether cannot score zero and pass.

Worth noting for the follow-up sweep (filed as TASK-21595): `outer_size` alone would **not** have
caught this — under mutation, painted rows went 1 → 2 while `outer_size` stayed `Size(93, 2)`.

## 2. Persona Buddy import — and a deliberate deviation from the brief

The import was the first statement of `reconcile_persona_buddy_view`, ahead of the enabled check,
and the reconcile runs as a **coroutine on the event loop** (`run_worker` with no `thread=True`)
right after first paint.

| route | PIL already resident | marginal import |
|---|---|---|
| `home_screen` | no | **27.0 ms, +39 modules (+10 PIL)** |
| `settings_screen` | no | **24.6 ms, +31 modules (+10 PIL)** |
| `chat_screen` / `library_screen` | yes | 14.7 / 16.0 ms |

**Correction to my own brief**: I cited a "~1.28 s cold chain" from an earlier task. That did not
reproduce — on a warm filesystem it is **~25 ms**. Still a real loop block for a disabled feature,
but the honest number is 25 ms, not 1.3 s.

**The instruction was to add an early return; that would have been unsafe.** The `not desired`
branch is also the *teardown* path (feature turned off at runtime → unmount the view) and calls
`sync_persona_buddy_reconciled_state()`, which `personas_screen.py` **overrides**. Returning early
would change Personas-screen behaviour. The import moved to the widget-construction branch
instead: the disabled path now returns having imported nothing, with zero semantic change.

**Mutation**: import back at the top of the method → the new test fails ("reconcile imported
persona_buddy_widget with the Buddy disabled"). Import deleted outright → the new test still
passes correctly, but `test_persona_buddy_app_mount.py` fails on `NameError`, so the enabled path
is pinned too and neither half is vacuous.

`app.py`'s docstring claiming this early-out is free of the PIL cost is now actually true.

**TASK-21123 stays open** with a note recording that the import half shipped here and why the
architectural relocation is deferred: `super().recompose()` removes every child of the screen, so
an app-level owner reacting only to screen-change events would silently lose the Buddy.

## Shutdown / error

Blink: the timer is created paused and resumed only while focused; Textual stops a widget's timers
in `_close_messages`, so no tick outlives the composer. The repaint half is intact —
`refresh(repaint=True)` still clears cached dimensions — verified by the caret-toggle assertion.
Buddy: quit is independent of the import (`_shutdown_persona_buddy` peeks the controller attribute
rather than the property, deliberately). The error case is strictly improved — an ImportError can
no longer reach the disabled path at all, and on the enabled path it now raises *before* the
view generation is bumped, so no dangling state.

## Task-id renumber

Authored as TASK-21501; renumbered to **TASK-21692** because another session claimed and closed a
different TASK-21501 on dev while this was in review. Per the owner rule the older arrival keeps
the id. Caught by preflight's duplicate-id check — a sweep taken at authoring time cannot see an
id that lands during review. Provenance is recorded in the task file; the reference in
`Tests/MCP/test_mcp_documentation_contract.py` belongs to the *other* 21501 and was left alone.

## Verification

Preflight green (all five checks). `ruff` clean. Full-tree collection: 59,530 collected, exit 0.
Fix-2 suites: 204 passed + 341 passed, 0 failed. Blink/deferral/buddy suites after rebase:
**66 passed, 1 failed** — that failure (`shift_enter_inserts_newline_enter_still_sends`) I
re-confirmed on pristine dev `a84e6ba09`; it is part of the 26-test Console-send cluster filed as
TASK-21590, not caused here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
