### PR TITLE
Make deferred-startup tests survive unrelated startup steps (TASK-21566)

### DIFF
--- a/Tests/Performance/test_app_startup_performance.py
+++ b/Tests/Performance/test_app_startup_performance.py
@@ -165,22 +165,33 @@ def test_citation_artifact_reconciliation_is_deferred_and_policy_gated(
     async def reconcile() -> None:
         return None
 
-    fake_app = SimpleNamespace(
-        set_timer=Mock(),
-        _schedule_footer_status_updates=Mock(),
-        _start_deferred_audio_service_initialization=Mock(),
-        _schedule_screen_preimport=Mock(),
-        schedule_media_cleanup=Mock(),
-        citation_artifact_ownership_coordinator=SimpleNamespace(writes_enabled=enabled),
-        _reconcile_citation_artifact_ownership=reconcile,
-        _create_deferred_startup_task=capture,
+    # A `Mock(spec=TldwCli)` rather than a hand-listed `SimpleNamespace`
+    # (TASK-21566). The namespace had to name every attribute the method
+    # touches, so each time deferred startup grew a step these tests died on
+    # the new one -- most recently `run_worker`, added by task-21106 to move
+    # Actor Pack recovery off the construction path. `spec=` tracks the class:
+    # a genuinely new dependency is satisfied, while a typo or an attribute
+    # that does not exist on TldwCli still raises. Only the seams under test
+    # are wired for real.
+    fake_app = Mock(spec=TldwCli)
+    fake_app.citation_artifact_ownership_coordinator = SimpleNamespace(
+        writes_enabled=enabled
     )
+    fake_app._reconcile_citation_artifact_ownership = reconcile
+    fake_app._create_deferred_startup_task = capture
 
     TldwCli._schedule_deferred_startup_work(fake_app)
 
-    assert len(scheduled) == expected_tasks
-    if scheduled:
-        assert scheduled[0][1] == "deferred_citation_artifact_reconciliation"
+    # Assert on this task by NAME, not by position or by the total. Deferred
+    # startup schedules unrelated work too (a subscription reconcile lands
+    # first, unconditionally), so a count or an index pins the shape of the
+    # whole method instead of the policy gate this test is about -- and breaks
+    # every time an unrelated step is added.
+    citation_tasks = [
+        name for _, name in scheduled
+        if name == "deferred_citation_artifact_reconciliation"
+    ]
+    assert len(citation_tasks) == expected_tasks
 
 
 @pytest.mark.parametrize(("enabled", "expected_tasks"), [(False, 0), (True, 1)])
@@ -201,26 +212,24 @@ def test_legacy_citation_migration_is_deferred_and_policy_gated(
     async def migrate() -> None:
         return None
 
-    fake_app = SimpleNamespace(
-        set_timer=Mock(),
-        _schedule_footer_status_updates=Mock(),
-        _start_deferred_audio_service_initialization=Mock(),
-        _schedule_screen_preimport=Mock(),
-        schedule_media_cleanup=Mock(),
-        citation_artifact_ownership_coordinator=None,
-        citation_legacy_migration_service=SimpleNamespace(
-            writes_enabled=enabled,
-            ready=enabled,
-        ),
-        _migrate_legacy_citations_idle_unit=migrate,
-        _create_deferred_startup_task=capture,
+    # See the sibling test above for why this is a spec'd Mock and why the
+    # assertion is by name rather than by count (TASK-21566).
+    fake_app = Mock(spec=TldwCli)
+    fake_app.citation_artifact_ownership_coordinator = None
+    fake_app.citation_legacy_migration_service = SimpleNamespace(
+        writes_enabled=enabled,
+        ready=enabled,
     )
+    fake_app._migrate_legacy_citations_idle_unit = migrate
+    fake_app._create_deferred_startup_task = capture
 
     TldwCli._schedule_deferred_startup_work(fake_app)
 
-    assert len(scheduled) == expected_tasks
-    if scheduled:
-        assert scheduled[0][1] == "deferred_legacy_citation_migration"
+    migration_tasks = [
+        name for _, name in scheduled
+        if name == "deferred_legacy_citation_migration"
+    ]
+    assert len(migration_tasks) == expected_tasks
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-21566 - Deferred-startup-tests-break-whenever-startup-gains-a-step.md
+++ b/backlog/tasks/task-21566 - Deferred-startup-tests-break-whenever-startup-gains-a-step.md
@@ -1,9 +1,14 @@
 ---
 id: TASK-21566
 title: Deferred startup tests break whenever startup gains a step
-status: In Progress
+status: Done
 assignee: []
-labels: [testing, test-integrity, performance]
+created_date: ''
+updated_date: '2026-08-24 15:03'
+labels:
+  - testing
+  - test-integrity
+  - performance
 dependencies: []
 priority: medium
 ---
@@ -32,8 +37,47 @@ about citation policy, and the message names an attribute neither test mentions.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Adding an unrelated step to deferred startup does not break these tests
-- [ ] #2 A dependency that does not exist on the application class is still rejected, so the stand-in cannot drift into accepting anything
-- [ ] #3 Each test asserts on the task it is about, not on the total scheduled or on ordering
-- [ ] #4 The policy gate is still enforced in both directions, demonstrated by breaking it
+- [x] #1 Adding an unrelated step to deferred startup does not break these tests
+- [x] #2 A dependency that does not exist on the application class is still rejected, so the stand-in cannot drift into accepting anything
+- [x] #3 Each test asserts on the task it is about, not on the total scheduled or on ordering
+- [x] #4 The policy gate is still enforced in both directions, demonstrated by breaking it
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the hand-built `SimpleNamespace` stand-in with `Mock(spec=TldwCli)`, and changed
+both assertions to count the task under test by name.
+
+**AC#1.** The namespace had to enumerate every attribute
+`_schedule_deferred_startup_work` touches, so the tests died whenever deferred startup gained
+an unrelated step. The one that broke them was `run_worker`, added by task-21106 to move
+Actor Pack crash recovery off the construction path — nothing to do with citations, yet it
+reddened two citation-policy tests with a message naming an attribute neither test mentions.
+
+**AC#2.** `spec=` is what makes this safe rather than merely permissive: verified directly
+that `Mock(spec=TldwCli).run_worker` is satisfied while
+`Mock(spec=TldwCli).definitely_not_a_real_attribute` still raises `AttributeError`. The
+stand-in tracks the class without becoming a thing that accepts anything.
+
+**AC#3 — the brittleness that had not surfaced yet.** Both tests asserted
+`len(scheduled) == expected_tasks` and `scheduled[0][1] == "<the task>"`. Deferred startup
+also schedules unrelated work, and `deferred_subscription_interrupt_reconcile` is now created
+**unconditionally, ahead of both** — so those assertions pinned the shape of the whole method
+rather than the policy gate. Even after adding `run_worker` they would have failed, for a
+second and unrelated reason. They now filter `scheduled` by name.
+
+**AC#4 — the gate is still enforced.** Forcing the write switch open in
+`app.py` (`if True or ...`) makes the `enabled=False` parametrization fail (1 failed,
+1 passed); restoring gives 16 passed. So the tests still detect a gate that stops gating,
+which is the property they exist for.
+
+**Evidence.** `Tests/Performance/test_app_startup_performance.py`: **16 passed**, from
+4 failed / 12 passed.
+
+Note on method: the product mutation was restored by file copy, not `git checkout --`, and
+the change was committed before mutating. Earlier in this session a `git checkout --` restore
+silently wiped an uncommitted rewrite — the standing rule about that is correct.
+
+Modified: `Tests/Performance/test_app_startup_performance.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21566 - Deferred-startup-tests-break-whenever-startup-gains-a-step.md
+++ b/backlog/tasks/task-21566 - Deferred-startup-tests-break-whenever-startup-gains-a-step.md
@@ -1,0 +1,39 @@
+---
+id: TASK-21566
+title: Deferred startup tests break whenever startup gains a step
+status: In Progress
+assignee: []
+labels: [testing, test-integrity, performance]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two tests pin a policy gate: a citation reconciliation and a legacy migration must be
+scheduled after the first interactive frame, and only when their write switch is on. That
+is a real contract and worth pinning.
+
+They exercise it by calling the deferred-startup method unbound, passing a hand-built
+namespace in place of the application. The namespace has to name every attribute the method
+touches, so the tests fail whenever deferred startup gains an unrelated step — most recently
+when Actor Pack crash recovery moved off the construction path and introduced a worker call
+the namespace did not have.
+
+They are also brittle in a second way that had not surfaced yet: each asserts on the total
+number of scheduled tasks and on which one came first. Deferred startup schedules unrelated
+work, and one such task is now created unconditionally ahead of both, so those assertions
+describe the shape of the whole method rather than the gate under test.
+
+The failure mode is the same either way — an unrelated change to startup reddens two tests
+about citation policy, and the message names an attribute neither test mentions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Adding an unrelated step to deferred startup does not break these tests
+- [ ] #2 A dependency that does not exist on the application class is still rejected, so the stand-in cannot drift into accepting anything
+- [ ] #3 Each test asserts on the task it is about, not on the total scheduled or on ordering
+- [ ] #4 The policy gate is still enforced in both directions, demonstrated by breaking it
+<!-- AC:END -->


### PR DESCRIPTION
Two tests pin a real contract — citation reconciliation and legacy migration are deferred past
the first interactive frame, and only run under their write switch. The contract is worth
pinning; the way it was pinned made an unrelated change to startup redden them.

## Why they broke

They call `_schedule_deferred_startup_work` unbound, passing a hand-built `SimpleNamespace` in
place of `self`. The namespace has to name **every** attribute the method touches, so the
tests die whenever deferred startup gains a step. The one that broke them was `run_worker`,
added by task-21106 to move Actor Pack crash recovery off the construction path — nothing to
do with citations, yet it reddened two citation-policy tests with a message naming an
attribute neither test mentions.

Replaced with `Mock(spec=TldwCli)`. `spec=` is what makes that safe rather than merely
permissive — verified directly:

| | |
|---|---|
| `Mock(spec=TldwCli).run_worker` | satisfied |
| `Mock(spec=TldwCli).definitely_not_a_real_attribute` | still raises `AttributeError` |

So the stand-in tracks the class without becoming something that accepts anything. Only the
seams under test are wired for real.

## A second brittleness, which had not surfaced yet

Both tests asserted on the **total** number of scheduled tasks and on **which came first**.
But deferred startup schedules unrelated work, and `deferred_subscription_interrupt_reconcile`
is now created **unconditionally, ahead of both**.

So those assertions pinned the shape of the whole method rather than the gate under test —
and even after adding `run_worker` they would have failed again, for a second unrelated
reason. They now count the task they are about, by name.

## The gate is still enforced

The point of a repair like this is that the test still fails when the thing it guards breaks.
Forcing the write switch open in `app.py` (`if True or …`):

| | |
|---|---|
| gate forced open | **1 failed**, 1 passed |
| restored | **16 passed** |

## Evidence

`Tests/Performance/test_app_startup_performance.py`: **16 passed**, from 4 failed / 12 passed.

Test-only; no product code changes. (The `app.py` edit above was a mutation to prove the
assertion bites, restored by file copy.)