### PR TITLE
chore(ci): re-pin the diagnostic inventory; file TASK-21700; backlog hygiene

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1616,7 +1616,7 @@
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "3cee829e6123c4b4a6ad",
+      "diagnostic_digest": "76afdae81a0153cbdb01",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1644,14 +1644,14 @@
     },
     {
       "call_count": 68,
-      "diagnostic_digest": "42c500b834592cef5cf5",
+      "diagnostic_digest": "4fdc85d5341fd96f8785",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/rag_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 5,
-      "diagnostic_digest": "57ac009dd80f8d7028b8",
+      "call_count": 2,
+      "diagnostic_digest": "476a665d542b0aac504a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/search_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3948,6 +3948,6 @@
     "owner_files": 534,
     "persistent_sink_files": 8,
     "task_492_calls": 1238,
-    "task_494_calls": 7307
+    "task_494_calls": 7304
   }
 }

--- a/backlog/tasks/task-21126 - Library Search-RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount.md
+++ b/backlog/tasks/task-21126 - Library Search-RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount.md
@@ -2,7 +2,7 @@
 id: TASK-21126
 title: >-
   Library Search/RAG panel runs an unindexed full-table GROUP BY on the event loop per panel mount
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-22'
 labels:

--- a/backlog/tasks/task-21700 - RAG cache-hit log writes the user search query into a persistent sink.md
+++ b/backlog/tasks/task-21700 - RAG cache-hit log writes the user search query into a persistent sink.md
@@ -1,0 +1,52 @@
+---
+id: TASK-21700
+title: >-
+  RAG cache-hit log writes the user search query into a persistent sink
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - privacy
+  - diagnostics
+  - rag
+priority: medium
+---
+
+## Description
+
+`RAG_Search/simplified/rag_service.py` logs a cache hit at INFO level with the first 50
+characters of the user's search query interpolated into the message. Search queries are user
+content. The diagnostic-privacy work in this repo (TASK-15103/15600, and the persistent
+diagnostic inventory that guards it) exists to keep exactly this class of value out of
+persistent sinks.
+
+Pre-existing — it was noticed while re-pinning the inventory after an unrelated RAG refactor
+re-wrapped the line, and the statement text is byte-identical to what was there before. Filing
+rather than fixing in that commit, because the fix is a behaviour change and deserves its own
+review.
+
+## Acceptance Criteria
+
+- [ ] It is determined and recorded whether this statement actually reaches a persistent sink at the shipped default log level, or is filtered before it lands
+- [ ] If it does reach one, the query text is removed, hashed, or length-only — the diagnostic keeps its debugging value without carrying user content
+- [ ] The whole `RAG_Search` tree is swept for the same shape: any diagnostic interpolating a query, a document body, a chunk, or a filename
+- [ ] Anything found is fixed in the same pass, or filed with a reason it is safe
+- [ ] A test or census guard pins the outcome so a future refactor cannot reintroduce it
+- [ ] If the conclusion is that this is acceptable, that reasoning is written down — an unreviewed "it's fine" is what let it sit this long
+
+## Evidence (verified on dev 1daa47f0a, 2026-08-24)
+
+`tldw_chatbook/RAG_Search/simplified/rag_service.py:1340`:
+
+```python
+logger.info(
+    f"[{correlation_id}] Cache hit for query: '{query[:50]}...'"
+)
+```
+
+The inventory checker flags added statements with exactly this prompt — *"does it interpolate
+user content, a secret, a path, or a URL?"* — and this one does. It was previously at line 1315
+with identical text, so the refactor moved it rather than introducing it.
+
+Note the truncation to 50 characters limits the volume but not the kind: a 50-character prefix of
+a search query is still the user's words.


### PR DESCRIPTION
## Summary

Three small commits, no production code.

## 1. Unblocks the dev gate (again)

The required `Derived artifacts reproduce from their sources` check is red on **pristine dev
`1daa47f0a`** — the second time today — so it currently fails every PR, not just this one. A
RAG_Search refactor changed diagnostics without re-pinning the inventory.

Reviewed with `--statements` before writing, as the tool requires:

- `search_service.py` 5 → 2: four statements removed, one added. The added line interpolates an
  exception message, which is the established shape in this file.
- `enhanced_rag_service_v2.py`: three added warnings, interpolating a reranker strategy name (a
  config value) and an exception *type* name.
- `rag_service.py`: **no semantic change at all** — its cache-hit line merely re-wrapped across
  two lines. Text byte-identical; only the digest moved.

No user content, secret, path or URL newly enters a persistent sink.

## 2. TASK-21700 — filed, not fixed here

While reading those rows: `rag_service.py:1340` logs the user's **search query** (first 50
characters) at INFO.

```python
logger.info(f"[{correlation_id}] Cache hit for query: '{query[:50]}...'")
```

The checker prompts for exactly this — *"does it interpolate user content, a secret, a path, or a
URL?"* — and it does. It is **pre-existing**: the statement text is byte-identical to what sat at
line 1315 before the refactor moved it, so the re-pin above does not change it either way. Filed
rather than fixed in a re-pin commit, because the fix is a behaviour change that deserves its own
review, and because the interesting part is the sweep: the AC requires checking the rest of
`RAG_Search` for any diagnostic carrying a query, document body, chunk or filename.

Truncating to 50 characters bounds the volume but not the kind — a 50-character prefix of a search
query is still the user's words.

## 3. Backlog hygiene

TASK-21126 merged as #2048 but its status still read `To Do` — its implementer deliberately left
it that way because nothing was merged at the time. It is on dev now (`f9a941344`; media schema is
at v8). Swept the rest of the 21100–21134 range for the same lag: none.

Preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pins the production diagnostic inventory to reflect a recent `RAG_Search` refactor and unblock the “Derived artifacts reproduce from their sources” CI gate; no runtime behavior change. Also updates backlog status and files `TASK-21700` to track a pre-existing INFO log that includes a 50‑char user‑query prefix.

- Updates Docs/security/production-diagnostic-inventory.json to match enhanced_rag_service_v2.py, rag_service.py, and search_service.py (digest/call_count shifts only; net `task_494_calls` 7307 → 7304). New/moved statements interpolate only config or exception metadata; no user content, secrets, paths, or URLs newly land in persistent sinks.
- Backlog hygiene: marks `TASK-21126` Done. Adds `TASK-21700` to address the cache‑hit log in rag_service.py and to sweep `RAG_Search` for similar diagnostics.

<sup>Written for commit 2ee9fc7f604e92158208761cb868f6905f45a2b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

