### PR TITLE
Stop cancelling pull-request test runs when the base moves (TASK-21969)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,28 @@ on:
 # The event name is part of the group so different trigger types (push,
 # pull_request, schedule) never cancel each other, and `main` is never cancelled
 # so its history stays complete.
+#
+# TASK-21969: pull_request runs are NOT cancelled, matching the rule
+# derived-artifacts.yml adopted in TASK-21250 for the same reason. For a
+# pull_request event `github.ref` is `refs/pull/N/merge`, and GitHub recreates
+# that ref every time the BASE branch moves -- so on a repo taking 23-50
+# merges/day, every open PR's run was cancelled repeatedly without anyone
+# touching the PR.
+#
+# That cost nothing while the core job could not finish inside its budget
+# anyway. TASK-21411 sharded it, and the waste became measurable: on run
+# 32696030401 one slice completed in 32 minutes and FIVE were cancelled after
+# 55-86 minutes each, none reaching a verdict, all well inside the 120-minute
+# cap. Several runner-hours per run, spent and discarded.
+#
+# The cost of not cancelling is different here than it was for the 90-second
+# gate: with `cancel-in-progress: false` a rapidly-updated PR QUEUES its runs
+# rather than replacing them, so the pool sees them serially instead of not at
+# all. That is the trade being taken deliberately -- spending the compute and
+# getting nothing was the worse of the two.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -310,6 +310,50 @@ def _shard_ids(job_block: str) -> list[int]:
     ]
 
 
+def test_pull_request_runs_are_not_cancelled_when_the_base_moves() -> None:
+    """A run that is always cancelled is worse than no run at all.
+
+    For a `pull_request` event `github.ref` is `refs/pull/N/merge`, and GitHub
+    recreates that ref every time the BASE branch moves. Cancelling on anything
+    that is not `main` therefore cancelled every open PR's run repeatedly,
+    without anyone touching the PR -- the mechanism TASK-21250 documented and
+    fixed for `derived-artifacts.yml`.
+
+    It cost nothing while the core job could not finish inside its budget
+    anyway. TASK-21411 sharded it, and the waste became measurable: one slice
+    completed in 32 minutes while five were cancelled after 55-86 minutes each,
+    none reaching a verdict, all inside the 120-minute cap.
+
+    Pinned because the two workflows must not drift back apart: the small gate
+    already carries this rule, and a copy-paste from an older revision of either
+    file would silently restore the behaviour.
+
+    Raises:
+        AssertionError: If cancellation is not restricted to push events, or if
+            `main` loses its exemption.
+    """
+    workflow = _workflow_text()
+    block = workflow[workflow.index("concurrency:") :].splitlines()
+    rule = next(l for l in block if "cancel-in-progress:" in l)
+
+    assert "github.event_name == 'push'" in rule, (
+        "pull_request runs must not be cancelled: their merge ref is recreated "
+        f"whenever the base moves. Got: {rule.strip()}"
+    )
+    assert "refs/heads/main" in rule, "main must keep its exemption"
+
+    # The sibling gate must carry the same rule, for the same reason.
+    sibling = (
+        PROJECT_ROOT / ".github" / "workflows" / "derived-artifacts.yml"
+    ).read_text()
+    sibling_rule = next(
+        l for l in sibling.splitlines() if "cancel-in-progress:" in l
+    )
+    assert "github.event_name == 'push'" in sibling_rule, (
+        "derived-artifacts.yml lost the TASK-21250 rule; the two must not drift"
+    )
+
+
 def test_core_tests_job_is_sharded_to_fit_its_time_budget() -> None:
     """TASK-21411: one job could not finish the core suite either.
 

--- a/backlog/tasks/task-21969 - Test-workflow-cancels-every-pull-request-run-when-the-base-moves.md
+++ b/backlog/tasks/task-21969 - Test-workflow-cancels-every-pull-request-run-when-the-base-moves.md
@@ -1,0 +1,40 @@
+---
+id: TASK-21969
+title: Test workflow cancels every pull-request run when the base moves
+status: In Progress
+assignee: []
+labels: [ci, infrastructure]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The test workflow supersedes an in-flight run for any reference other than the default
+branch. For a pull request the reference is the merge reference, which the platform recreates
+every time the base branch moves — so on a repository taking this many merges a day, every
+open pull request's run is cancelled repeatedly without anyone touching the branch.
+
+The smaller required gate had the same rule and it was changed for exactly this reason. The
+test workflow kept the original.
+
+This cost nothing while the core job could not finish inside its budget anyway: cancelling a
+run that was going to be killed by its own timeout loses nothing. Splitting that job changed
+the arithmetic. The slices now finish comfortably inside the budget, so cancellation is the
+only thing stopping them reporting, and each cancelled run discards most of an hour of runner
+time on the pool that is already the scarcest resource here.
+
+The trade is not free and is being taken deliberately. Not superseding means a rapidly
+updated pull request queues its runs instead of replacing them, so the pool sees them one
+after another rather than not at all. That is more total time than cancelling — but
+cancelling spends the same compute and produces no verdict, which is worse on both counts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A pull-request run is not superseded when the base branch moves
+- [ ] #2 Pushes to the development branch still supersede, and the default branch keeps its exemption, so neither of the behaviours the original rule existed for is lost
+- [ ] #3 The two workflows cannot drift apart on this again without something failing
+- [ ] #4 Each half of that guard is shown to fail when the rule it pins is reverted
+<!-- AC:END -->


### PR DESCRIPTION
`test.yml` supersedes an in-flight run for any ref that is not `main`. For a `pull_request`
event that ref is `refs/pull/N/merge`, which GitHub recreates **every time the base branch
moves** — so on a repo taking 23–50 merges/day, every open PR's run is cancelled repeatedly
without anyone touching it.

This is the mechanism TASK-21250 documented and fixed for `derived-artifacts.yml`. `test.yml`
kept the original rule.

| workflow | before | after |
|---|---|---|
| `derived-artifacts.yml` | `event_name == 'push' && ref != main` | unchanged |
| **`test.yml`** | `ref != 'refs/heads/main'` | `event_name == 'push' && ref != main` |

## Why it only started costing anything now

While the core job could not finish inside its budget, cancelling it lost nothing — it was
going to be killed by its own timeout regardless. #2033 sharded it, and the arithmetic
changed. From run `32696030401`:

| slice | duration | outcome |
|---|---|---|
| shard 5/6 | 32 min | **completed** — 60 failed, 7,200 passed |
| shard 0/6 | 86 min | cancelled |
| shard 3/6 | 84 min | cancelled |
| shard 2/6 | 83 min | cancelled |
| shard 4/6 | 57 min | cancelled |
| shard 1/6 | 55 min | cancelled |

All five killed **well inside** the 120-minute cap, none reaching a verdict. Several
runner-hours per run, spent and discarded, on the pool that is already the scarcest resource
here.

## The trade, taken deliberately

Not superseding means a rapidly-updated PR **queues** its runs rather than replacing them, so
the pool sees them serially instead of not at all. That is more total time than cancelling.
But cancelling spends the same compute and returns no verdict — worse on both counts.

Pushes to `dev` still supersede, and `main` keeps its exemption, so neither behaviour the
original rule existed for is lost.

## Guard

Pinned in `Tests/CI/test_github_actions_test_workflow.py`, including that
`derived-artifacts.yml` must carry the same rule — so the two cannot drift apart again from a
copy-paste off an older revision of either file.

Mutation-proven both ways: reverting `test.yml`'s rule fails the new test; drifting
`derived-artifacts.yml`'s rule back fails it too; restored, **19 pass**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop cancelling PR test runs when the base branch moves. Previously `test.yml` cancelled any in-flight run for non-`main` refs (including `refs/pull/N/merge` recreated on base updates); now it only cancels on push events to non-`main`, so PR runs complete and yield verdicts. Aligns with TASK-21969.

- Update `concurrency.cancel-in-progress` in `.github/workflows/test.yml` to `${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}`. `main` stays exempt; pushes to `dev` still supersede.
- Add a guard in `Tests/CI/test_github_actions_test_workflow.py` that pins this rule and asserts `derived-artifacts.yml` carries the same rule, preventing drift.
- Impact: fewer cancelled shards and more completed PR runs; active PRs may queue longer. No migration or config changes required.

<sup>Written for commit 7464d27d39ac7ce9d874206e1207345293736dde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

