### PR TITLE
[EXPERIMENT — DO NOT MERGE] Does a push-triggered run satisfy the required gate? (TASK-21967)

### DIFF
--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -20,7 +20,22 @@ name: Derived Artifacts
 on:
   pull_request:
   push:
-    branches: [dev, main]
+# TASK-21967 EXPERIMENT -- NOT FOR MERGE.
+#
+# Question: does a run triggered by `push` (github.ref = refs/heads/<branch>,
+# a ref nothing recreates) satisfy the REQUIRED status context for a head
+# commit that also carries a cancelled result from the pull_request run
+# (github.ref = refs/pull/N/merge, which GitHub recreates whenever the base
+# moves)?
+#
+# If it does, watching pushes on all branches fixes the ~47% cancellation rate
+# for the required gate. If GitHub instead reports the most recent check run of
+# that name regardless of which trigger produced it, this buys nothing and the
+# task should record that.
+#
+# The branch filter is removed rather than widened so the answer is not
+# confounded by which branches happen to match.
+    branches: ['**']
 
 # Deliberately NOT path-filtered, unlike css-bundle-guard/backlog-guard.
 #


### PR DESCRIPTION
**Draft, not for merge.** This exists to answer one question that decides whether TASK-21967
is fixable, and which cannot be answered from documentation.

## The question

The required gate is cancelled on ~47% of its runs (50 of the last 100) because a
`pull_request` run is tied to `refs/pull/N/merge`, which GitHub recreates whenever the base
branch moves — which on this repo happens faster than a queued run gets to start.

A `push` run is tied to `refs/heads/<branch>`, which nothing recreates.

**Does a successful push-triggered run satisfy the required status context for a head commit
that also carries a cancelled result of the same name from the pull_request run?**

- If **yes** — watching pushes on all branches fixes the cancellation rate.
- If **no** — GitHub reports the most recent check run of that name regardless of trigger,
  this buys nothing, and TASK-21967 should record that so nobody tries it again.

## Method

The only change is removing the branch filter on the workflow's `push:` trigger. Done on a
throwaway branch, because the alternative is experimenting on the one check every merge in
the repository depends on.

The filter is removed rather than widened so the result is not confounded by which branches
happen to match.

## Result

To be recorded here, then folded into TASK-21967 and this branch deleted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Watches pushes on all branches in the Derived Artifacts workflow to test whether a push-triggered success satisfies the required gate when the PR-triggered run is cancelled. Previously it watched only `dev` and `main`; now it watches every branch to isolate the effect.

**Review notes**
- Change: set on.push.branches to ['**']; no job logic or path filters changed.
- Purpose (TASK-21967): determine if watching pushes can reduce the ~47% cancellation rate of the required gate.
- Do not merge. Run on this branch, record the outcome in TASK-21967, then restore the previous branch filter.

<sup>Written for commit 1869bd9e7547f239d22329dbd95cca2395005810. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

