### PR TITLE
perf(research): hold the store's connections and take the UI path off the event loop (TASK-21127)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1692,6 +1692,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 5,
+      "diagnostic_digest": "d3bc18cb06a6ba885923",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Research_Interop/local_research_service.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 1,
       "diagnostic_digest": "3d659da222ba81b9c89d",
       "owner": "TASK-494",
@@ -3708,8 +3715,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 336,
-      "diagnostic_digest": "32c1c49c24fad8bd01aa",
+      "call_count": 337,
+      "diagnostic_digest": "8d91c794ec3a3e893423",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3945,9 +3952,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 534,
+    "owner_files": 535,
     "persistent_sink_files": 8,
     "task_492_calls": 1238,
-    "task_494_calls": 7304
+    "task_494_calls": 7310
   }
 }

--- a/Tests/DB/test_private_sqlite_interop_owners.py
+++ b/Tests/DB/test_private_sqlite_interop_owners.py
@@ -50,7 +50,9 @@ def _research_owner(path: Path) -> tuple[object, Callable[[], None]]:
     # TASK-21105: see _writing_owner.
     service = local_research_service.LocalResearchService(path)
     service.list_runs()
-    return service, lambda: None
+    # TASK-21127: the connection opened above is now HELD, so the owner has a
+    # real closer to hand back.
+    return service, service.close
 
 
 def _notes_mirror_owner(path: Path) -> tuple[object, Callable[[], None]]:

--- a/Tests/Research/test_app_research_wiring.py
+++ b/Tests/Research/test_app_research_wiring.py
@@ -10,6 +10,12 @@ set exactly once, and a second `_wire_research_services()` call never
 reconstructs them (the guard holds -- no torn/duplicate wiring).
 """
 
+import asyncio
+import threading
+import time
+
+import pytest
+
 from Tests.UI.app_factory import _build_test_app
 
 
@@ -39,3 +45,104 @@ def test_second_wire_research_services_call_reuses_existing_services():
     assert app.research_scope_service is scope_before
     assert app.research_search_scope_service is search_scope_before
     assert app.local_research_service is local_before
+
+
+# ---------------------------------------------------------------------------
+# TASK-21127: unmount releases the research store's held connections, and does
+# it OFF the event loop.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_app_unmount_close_never_freezes_the_loop_or_breaks_a_run_write(
+    tmp_path,
+):
+    """``close()`` waits for an operation still running on the backend thread.
+
+    Called inline from the async ``on_unmount``, that wait would run ON the
+    event loop -- freezing the UI for the whole settle timeout and starving the
+    very operation it is waiting for, which then hits a closed connection and
+    surfaces as ``Task exception was never retrieved`` (the TASK-21125 review's
+    MAJOR-3 finding, reproduced here for the research store).
+    """
+    import types
+
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.Research_Interop.local_research_service import (
+        LocalResearchService,
+    )
+
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="unmount")
+
+    entered = threading.Event()
+    release = threading.Event()
+    failures: list[BaseException] = []
+
+    def _park_then_write():
+        try:
+            with service._transaction(immediate=True) as conn:
+                entered.set()
+                assert release.wait(10)
+                conn.execute(
+                    "UPDATE research_runs SET progress_message = ? WHERE id = ?",
+                    ("in flight", run["id"]),
+                )
+        except BaseException as exc:  # pragma: no cover - failure path
+            failures.append(exc)
+
+    worker = threading.Thread(target=_park_then_write)
+    worker.start()
+    assert entered.wait(10), "the parked transaction never started"
+
+    ticks = 0
+
+    async def _ticker():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.05)
+            ticks += 1
+
+    unhandled: list[dict] = []
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+
+    app = object.__new__(TldwCli)
+    app.loguru_logger = types.SimpleNamespace(error=lambda *_a, **_k: None)
+    app.local_research_service = service
+
+    ticker = asyncio.create_task(_ticker())
+    try:
+        releaser = threading.Timer(0.3, release.set)
+        releaser.start()
+        started = time.perf_counter()
+        await app._close_local_research_service()
+        waited = time.perf_counter() - started
+        releaser.join(10)
+        worker.join(10)
+        await asyncio.sleep(0.05)
+    finally:
+        ticker.cancel()
+        loop.set_exception_handler(previous_handler)
+
+    assert not failures, f"the in-flight operation was broken by close(): {failures}"
+    assert waited >= 0.25, "close() did not wait for the in-flight operation"
+    assert ticks >= 3, f"the event loop was frozen during close() ({ticks} ticks)"
+    assert not unhandled, f"an exception escaped to the loop: {unhandled}"
+    assert service.get_run(run["id"])["progress_message"] == "in flight"
+    service.close()
+
+
+@pytest.mark.asyncio
+async def test_unmount_close_is_a_no_op_without_a_wired_research_service():
+    """A service that was never wired must not be constructed just to close it."""
+    import types
+
+    from tldw_chatbook.app import TldwCli
+
+    app = object.__new__(TldwCli)
+    app.loguru_logger = types.SimpleNamespace(error=lambda *_a, **_k: None)
+    app.local_research_service = None
+
+    await app._close_local_research_service()  # must not raise

--- a/Tests/Research/test_local_research_service.py
+++ b/Tests/Research/test_local_research_service.py
@@ -1,7 +1,12 @@
 import sqlite3
+import threading
+import time
 
 import pytest
 
+from tldw_chatbook.Research_Interop import (
+    local_research_service as local_research_service_module,
+)
 from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
 
 
@@ -503,3 +508,303 @@ def test_a_database_from_a_future_schema_version_is_refused(tmp_path):
     service = LocalResearchService(db_path)
     with pytest.raises(RuntimeError, match="newer"):
         service.list_runs()
+
+
+# ---------------------------------------------------------------------------
+# TASK-21127: held connections, transaction atomicity, shutdown lifecycle.
+# ---------------------------------------------------------------------------
+
+
+def _count_opens(monkeypatch):
+    """Count connections opened through the private-sqlite seam."""
+    opened: list[str] = []
+    real = local_research_service_module.connect_private_sqlite
+
+    def _counting(*args, **kwargs):
+        opened.append(threading.current_thread().name)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(
+        local_research_service_module, "connect_private_sqlite", _counting
+    )
+    return opened
+
+
+def test_file_backed_service_holds_one_connection_for_many_operations(
+    tmp_path, monkeypatch
+):
+    """TASK-21127: the store used to open (and GC-leak) a fresh connection per
+    operation -- 87 per engine run. One held connection per thread now serves
+    every operation, so the seam is entered once."""
+    service = LocalResearchService(tmp_path / "research.db")
+    service.list_runs()  # first use: schema + this thread's held connection
+
+    opened = _count_opens(monkeypatch)
+    run = service.launch_run(query="held connections")
+    for index in range(10):
+        service.save_artifact(
+            run["id"],
+            artifact_name=f"a{index}.json",
+            content_type="application/json",
+            content={"i": index},
+        )
+        service.update_run_progress(run["id"], progress_percent=float(index))
+        service.get_run(run["id"])
+
+    assert opened == [], f"expected zero further opens, got {opened}"
+    assert len(service.list_artifacts(run["id"])) == 10
+    service.close()
+
+
+def test_held_connection_keeps_wal_and_normal_synchronous(tmp_path):
+    """The pragmas must hold on the LIVE held connection, not merely be issued
+    once at open, and WAL must be persistent in the file itself."""
+    db_path = tmp_path / "research.db"
+    service = LocalResearchService(db_path)
+    service.list_runs()
+
+    conn = service._connect()
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+    assert conn.isolation_level is None
+
+    independent = sqlite3.connect(db_path)
+    try:
+        assert independent.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    finally:
+        independent.close()
+    service.close()
+
+
+def test_close_waits_for_an_in_flight_operation_on_another_thread(tmp_path):
+    """TASK-21101's class: shutdown must not close a connection out from under
+    an operation still running on a worker thread."""
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="in flight")
+
+    entered = threading.Event()
+    release = threading.Event()
+    worker_error: list[BaseException] = []
+
+    def _slow_operation():
+        try:
+            with service._transaction(immediate=True) as conn:
+                entered.set()
+                release.wait(5)
+                conn.execute(
+                    "UPDATE research_runs SET progress_message = ? WHERE id = ?",
+                    ("done", run["id"]),
+                )
+        except BaseException as exc:  # noqa: BLE001 - reported to the assertion
+            worker_error.append(exc)
+
+    worker = threading.Thread(target=_slow_operation)
+    worker.start()
+    assert entered.wait(5)
+
+    closed = threading.Event()
+
+    def _close():
+        service.close()
+        closed.set()
+
+    closer = threading.Thread(target=_close)
+    closer.start()
+    assert not closed.wait(0.3), "close() returned while an operation was in flight"
+    release.set()
+    worker.join(5)
+    closer.join(5)
+    assert closed.is_set()
+    assert not worker_error, worker_error
+    assert service.get_run(run["id"])["progress_message"] == "done"
+    service.close()
+
+
+def test_close_leaves_a_wedged_operations_connection_open(tmp_path, monkeypatch):
+    """On a settle timeout the busy thread KEEPS its connection: closing it
+    anyway turns a slow shutdown into ProgrammingError inside live work."""
+    monkeypatch.setattr(
+        local_research_service_module, "_LIFECYCLE_SETTLE_TIMEOUT", 0.15
+    )
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="wedged")
+
+    entered = threading.Event()
+    release = threading.Event()
+    worker_error: list[BaseException] = []
+
+    def _wedged():
+        try:
+            with service._transaction(immediate=True) as conn:
+                entered.set()
+                release.wait(5)
+                conn.execute(
+                    "UPDATE research_runs SET progress_message = ? WHERE id = ?",
+                    ("survived", run["id"]),
+                )
+        except BaseException as exc:  # noqa: BLE001
+            worker_error.append(exc)
+
+    worker = threading.Thread(target=_wedged)
+    worker.start()
+    assert entered.wait(5)
+
+    service.close()  # settle wait expires; the busy connection must survive
+    release.set()
+    worker.join(5)
+
+    assert not worker_error, worker_error
+    assert service.get_run(run["id"])["progress_message"] == "survived"
+    service.close()
+
+
+def test_close_rearms_the_store_for_later_operations(tmp_path):
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="re-arm")
+    service.close()
+
+    reopened = service.get_run(run["id"])
+    assert reopened is not None and reopened["query"] == "re-arm"
+    service.close()
+
+
+def test_memory_mode_survives_close_and_reuse():
+    """``:memory:`` shares ONE connection; closing it destroys the database, so
+    the re-armed store must rebuild the schema rather than raise."""
+    service = LocalResearchService(":memory:")
+    service.launch_run(query="memory")
+    service.close()
+
+    assert list(service.list_runs()) == []
+    fresh = service.launch_run(query="after close")
+    assert fresh["query"] == "after close"
+    service.close()
+
+
+def test_release_lease_reads_then_writes_in_one_transaction(tmp_path):
+    """release_lease SELECTs and then UPDATEs. With isolation_level=None a
+    DEFERRED begin opens a read snapshot whose later write raises
+    BUSY_SNAPSHOT ("database is locked") -- which SQLite's busy handler does
+    NOT retry. It must take the write lock up front."""
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="lease")
+    lease = service.claim_run(run["id"], worker_id="w1", lease_seconds=60.0)
+
+    # A second connection to the same file, holding a write transaction open,
+    # is what turns a deferred begin into an unretryable failure.
+    contender = LocalResearchService(tmp_path / "research.db")
+    other_run = contender.launch_run(query="contender")
+    with contender._transaction(immediate=True) as conn:
+        conn.execute(
+            "UPDATE research_runs SET progress_message = ? WHERE id = ?",
+            ("holding", other_run["id"]),
+        )
+        # release_lease must WAIT for this (busy_timeout), not fail outright.
+        released: list[object] = []
+
+        def _release():
+            released.append(service.release_lease(run["id"], lease_id=lease))
+
+        releaser = threading.Thread(target=_release)
+        releaser.start()
+        time.sleep(0.05)
+    releaser.join(6)
+
+    assert released == [True]
+    assert service.get_run(run["id"])["lease_id"] is None
+    service.close()
+    contender.close()
+
+
+def test_concurrent_run_updates_never_lose_a_version_bump(tmp_path):
+    """Rule C: moving work off the loop removes the serialization the loop was
+    silently providing.
+
+    Every writer parks on a barrier released at the same instant, then all of
+    them race ``update_run_progress`` -- which reads ``version`` and writes
+    ``version + 1``. Under the shipped shape that pair is ONE ``BEGIN
+    IMMEDIATE`` transaction, so SQLite serialises them and the counter must
+    advance exactly once per call. The barrier is deliberately OUTSIDE the
+    transaction: parking inside it would wedge on the write lock the fix takes
+    up front, which is itself the proof there is no longer a window there.
+    """
+    writers = 8
+    rounds = 5
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="interleaving")
+    start_version = int(service.get_run(run["id"])["version"])
+
+    barrier = threading.Barrier(writers, timeout=15)
+    results: list[object] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def _writer(index: int):
+        try:
+            barrier.wait()
+            for attempt in range(rounds):
+                updated = service.update_run_progress(
+                    run["id"],
+                    progress_message=f"w{index}-{attempt}",
+                    event="progress",
+                )
+                with lock:
+                    results.append(updated)
+        except BaseException as exc:  # noqa: BLE001 - reported to the assertion
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=_writer, args=(i,)) for i in range(writers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(30)
+
+    assert not errors, errors
+    assert len(results) == writers * rounds
+    final_version = int(service.get_run(run["id"])["version"])
+    assert final_version == start_version + writers * rounds, (
+        f"{writers * rounds} writes all reported success but version advanced "
+        f"{final_version - start_version} time(s): a lost update"
+    )
+    service.close()
+
+
+class _RollbackRefusingConnection:
+    """Wraps a real connection and refuses exactly the ROLLBACK statement."""
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def execute(self, sql, *args, **kwargs):
+        if sql.strip().upper().startswith("ROLLBACK"):
+            raise sqlite3.OperationalError("rollback refused by the probe")
+        return self._inner.execute(sql, *args, **kwargs)
+
+
+def test_transaction_error_is_not_masked_by_a_failing_rollback(tmp_path):
+    """A ROLLBACK that itself fails must never replace the original error."""
+    service = LocalResearchService(tmp_path / "research.db")
+    service.list_runs()
+
+    class _Boom(RuntimeError):
+        pass
+
+    real_begin = LocalResearchService._begin
+
+    def _wrapping_begin(self, *, immediate=False):
+        return _RollbackRefusingConnection(real_begin(self, immediate=immediate))
+
+    LocalResearchService._begin = _wrapping_begin
+    try:
+        with pytest.raises(_Boom, match="the real error"):
+            with service._transaction():
+                raise _Boom("the real error")
+    finally:
+        LocalResearchService._begin = real_begin
+    # The connection is left mid-transaction; _begin's heal path clears it.
+    assert service.get_run("nope") is None
+    service.close()

--- a/Tests/Research/test_local_research_service_lifecycle.py
+++ b/Tests/Research/test_local_research_service_lifecycle.py
@@ -1,0 +1,300 @@
+"""TASK-21127: the four lifecycle paths a connection refactor keeps breaking.
+
+The held-connection change is exercised elsewhere on happy paths; this file
+walks the ones that have historically broken in this burn-down -- quit with work
+in flight, a database error mid-run, a cancelled run, and the empty/first-run
+case -- against a FILE-BACKED store, which is the shape production uses and the
+one the engine tests (``:memory:``) never touch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import threading
+
+import pytest
+
+from tldw_chatbook.Research_Interop.local_research_engine import LocalResearchEngine
+from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+
+
+def _pipeline(question: str):
+    """The two injectable seams, faked; everything else runs real."""
+
+    def search_fn(query, params):
+        return (
+            {
+                "results": [
+                    {"title": "One", "url": "https://one.example/"},
+                    {"title": "Two", "url": "https://two.example/"},
+                ],
+                "warnings": [],
+            },
+            {"sub_questions": ["sub q1"], "main_goal": question},
+        )
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        return {
+            "final_answer": {
+                "text": "Answer citing [1].",
+                "evidence": [
+                    {
+                        "id": 1,
+                        "url": "https://one.example/",
+                        "title": "One",
+                        "content": "c1",
+                        "original_content": "o1",
+                        "reasoning": "r1",
+                        "chunk_index": 1,
+                    }
+                ],
+                "confidence": 0.8,
+                "chunks": [],
+                "citation_verification": {
+                    "markers_total": 1,
+                    "markers_resolved": 1,
+                    "unknown_marker_ids": [],
+                    "quotes_checked": 0,
+                    "quotes_verified": 0,
+                    "quotes_misquoted": 0,
+                    "uncited_sentences": 0,
+                },
+            },
+            "relevant_results": {"1": {}},
+            "web_search_results_dict": wsr,
+        }
+
+    return search_fn, analyze_fn
+
+
+# --- 1. quit while a run is in flight ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_during_a_live_run_lets_the_run_finish(tmp_path):
+    """Shutdown must not hand the engine a closed database mid-run.
+
+    ``close()`` re-arms the store, so the run's next operation reopens
+    transparently instead of raising ``ProgrammingError: Cannot operate on a
+    closed database`` -- the TASK-21101 signature this whole lifecycle gate
+    exists to prevent.
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="quit mid-run", autonomy_mode="autonomous")
+    search_fn, analyze_fn = _pipeline(run["query"])
+    closed = threading.Event()
+
+    def _closing_search(query, params):
+        # Fires from the engine's worker thread, mid-run, the way a user
+        # quitting the app would.
+        closer = threading.Thread(target=service.close)
+        closer.start()
+        closer.join(10)
+        closed.set()
+        return search_fn(query, params)
+
+    engine = LocalResearchEngine(
+        service, search_fn=_closing_search, analyze_fn=analyze_fn
+    )
+    final = await engine.execute_run(run["id"])
+
+    assert closed.is_set(), "the probe never closed the store"
+    assert final["status"] == "completed", final.get("error_msg")
+    assert service.get_run(run["id"])["status"] == "completed"
+    service.close()
+
+
+# --- 2. a database error mid-run --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_database_error_mid_run_fails_the_run_and_heals_the_store(tmp_path):
+    """A failing DB op must fail the RUN legibly, not poison the connection.
+
+    A transaction abandoned mid-flight would otherwise leave every later
+    operation on that thread failing with "cannot start a transaction within a
+    transaction".
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="db error", autonomy_mode="autonomous")
+    search_fn, analyze_fn = _pipeline(run["query"])
+
+    real_save = LocalResearchService.save_artifact
+    calls = {"n": 0}
+
+    def _exploding_save(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise sqlite3.OperationalError("disk I/O error (injected)")
+        return real_save(self, *args, **kwargs)
+
+    LocalResearchService.save_artifact = _exploding_save
+    try:
+        engine = LocalResearchEngine(
+            service, search_fn=search_fn, analyze_fn=analyze_fn
+        )
+        final = await engine.execute_run(run["id"])
+    finally:
+        LocalResearchService.save_artifact = real_save
+
+    assert final["status"] == "failed"
+    # ``fail_run`` records the message on ``progress_message`` -- the runs table
+    # has no error_msg column.
+    assert "injected" in str(final.get("progress_message") or "")
+    # The store is still usable: the abandoned transaction was rolled back.
+    later = service.launch_run(query="after the error")
+    assert service.get_run(later["id"])["query"] == "after the error"
+    assert service.list_run_events(run["id"])
+    service.close()
+
+
+# --- 3. a cancelled run ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_between_phases_resolves_once_on_a_file_backed_store(tmp_path):
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="cancel me", autonomy_mode="autonomous")
+    search_fn, analyze_fn = _pipeline(run["query"])
+
+    def _cancelling_search(query, params):
+        service.update_run_progress(run["id"], control_state="cancel_requested")
+        return search_fn(query, params)
+
+    engine = LocalResearchEngine(
+        service, search_fn=_cancelling_search, analyze_fn=analyze_fn
+    )
+    final = await engine.execute_run(run["id"])
+
+    assert final["status"] == "cancelled"
+    stored = service.get_run(run["id"])
+    assert stored["status"] == "cancelled"
+    events = [event["event"] for event in service.list_run_events(run["id"])]
+    assert events.count("cancelled") == 1, events
+    service.close()
+
+
+# --- 4. the empty / first-run case ------------------------------------------
+
+
+def test_a_never_used_store_creates_no_file_and_lists_nothing(tmp_path):
+    """TASK-21105's lazy-open contract must survive the held-connection change:
+    construction resolves the path only."""
+    db_path = tmp_path / "research.db"
+    service = LocalResearchService(db_path)
+
+    assert not db_path.exists(), "construction created the database file"
+    assert list(service.list_runs()) == []
+    assert service.list_sessions() == []
+    assert db_path.exists(), "first use did not create the database"
+    service.close()
+
+
+def test_close_before_any_use_is_a_no_op(tmp_path):
+    db_path = tmp_path / "research.db"
+    service = LocalResearchService(db_path)
+    service.close()
+    assert not db_path.exists()
+    # ... and the store still works afterwards.
+    assert list(service.list_runs()) == []
+    service.close()
+
+
+@pytest.mark.asyncio
+async def test_two_close_calls_race_without_deadlocking(tmp_path):
+    """A second closer must wait out the first, not double-close."""
+    service = LocalResearchService(tmp_path / "research.db")
+    service.launch_run(query="double close")
+
+    await asyncio.gather(
+        asyncio.to_thread(service.close), asyncio.to_thread(service.close)
+    )
+    assert len(list(service.list_runs())) == 1
+    service.close()
+
+
+def test_close_releases_every_connection_including_the_schema_one(tmp_path):
+    """``_init_schema`` used to open a connection and leak it in file mode.
+
+    The oracle is the ``-wal`` sidecar: SQLite checkpoints and removes it only
+    when the LAST connection to the database closes, so a surviving schema
+    connection leaves it on disk. Asserting on the held-connection map alone
+    could not see that connection at all.
+    """
+    db_path = tmp_path / "research.db"
+    service = LocalResearchService(db_path)
+    service.launch_run(query="wal witness")
+    wal = db_path.with_name(db_path.name + "-wal")
+    assert wal.exists(), "the store is not in WAL mode; the oracle is vacuous"
+
+    service.close()
+
+    assert not wal.exists(), (
+        "a connection to the research database outlived close(): the -wal "
+        "sidecar was not checkpointed away"
+    )
+
+
+def test_a_second_store_on_the_same_file_sees_the_first_stores_writes(tmp_path):
+    """Held connections must not hide committed data from another opener."""
+    db_path = tmp_path / "research.db"
+    writer = LocalResearchService(db_path)
+    run = writer.launch_run(query="cross-connection")
+
+    reader = LocalResearchService(db_path)
+    assert reader.get_run(run["id"])["query"] == "cross-connection"
+
+    writer.update_run_progress(run["id"], progress_message="second write")
+    assert reader.get_run(run["id"])["progress_message"] == "second write"
+    writer.close()
+    reader.close()
+
+
+def test_a_held_connection_closed_behind_the_stores_back_self_heals(tmp_path):
+    """``_begin``'s ProgrammingError arm, exercised directly.
+
+    ``close()`` normally POPS what it closes, so a later operation opens a fresh
+    connection and never meets a closed handle -- which is why the end-to-end
+    quit-mid-run walk stays green even with this arm removed. The arm is the
+    second line of defence, and this is the only scenario that reaches it: a
+    connection closed while it is still mapped.
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="stale handle")
+
+    stale = service._connect()
+    stale.close()  # closed, but deliberately left in _connections
+    assert service._connections[threading.get_ident()] is stale
+
+    recovered = service.get_run(run["id"])
+
+    assert recovered["query"] == "stale handle"
+    assert service._connections[threading.get_ident()] is not stale
+    service.close()
+
+
+def test_a_failed_transaction_leaves_no_open_transaction(tmp_path):
+    """The rollback must happen AT the failure, not be deferred to the next
+    ``_begin``'s heal: a connection left mid-transaction holds the write lock
+    against every other opener of the file until something else touches it."""
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="rollback now")
+
+    class _Boom(RuntimeError):
+        pass
+
+    with pytest.raises(_Boom):
+        with service._transaction(immediate=True) as conn:
+            conn.execute(
+                "UPDATE research_runs SET progress_message = ? WHERE id = ?",
+                ("partial", run["id"]),
+            )
+            raise _Boom("mid-transaction failure")
+
+    held = service._connections[threading.get_ident()]
+    assert held.in_transaction is False, (
+        "the failed transaction was left open; the write lock is still held"
+    )
+    assert service.get_run(run["id"])["progress_message"] != "partial"
+    service.close()

--- a/Tests/Research/test_local_research_service_lifecycle.py
+++ b/Tests/Research/test_local_research_service_lifecycle.py
@@ -298,3 +298,60 @@ def test_a_failed_transaction_leaves_no_open_transaction(tmp_path):
     )
     assert service.get_run(run["id"])["progress_message"] != "partial"
     service.close()
+
+
+def test_a_nested_immediate_transaction_inside_a_deferred_one_is_refused(tmp_path):
+    """Joining a DEFERRED outer would silently downgrade a nested immediate.
+
+    SQLite cannot upgrade a transaction's lock once it has begun, so the nested
+    read-then-write would run under the outer's read snapshot and fail
+    BUSY_SNAPSHOT -- only ever under contention, so it would pass every
+    single-threaded test and then appear in the field as "database is locked",
+    the one failure SQLite's busy handler does NOT retry. Refusing makes it
+    deterministic and names the mistake.
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="nesting")
+
+    with pytest.raises(RuntimeError, match="IMMEDIATE"):
+        with service._transaction():  # deferred outer
+            with service._transaction(immediate=True):  # must be refused
+                pass  # pragma: no cover - the guard fires first
+
+    # The outer transaction unwound cleanly: the store is still usable and no
+    # transaction was left open on this thread's connection.
+    assert service._connections[threading.get_ident()].in_transaction is False
+    assert service.get_run(run["id"])["query"] == "nesting"
+    service.close()
+
+
+def test_the_legal_transaction_nestings_are_still_allowed(tmp_path):
+    """The guard must refuse ONLY immediate-inside-deferred.
+
+    Deferred-inside-immediate is the shipped hot path -- ``_require_one`` runs
+    inside ``save_artifact``'s write transaction on every artifact the engine
+    saves -- so over-restricting here would break real behaviour rather than
+    protect it.
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    run = service.launch_run(query="legal nesting")
+
+    with service._transaction(immediate=True):  # deferred inside immediate
+        assert service._require_one("research_runs", run["id"], "run")
+        with service._transaction():
+            pass
+        with service._transaction(immediate=True):  # immediate inside immediate
+            pass
+    with service._transaction():  # deferred inside deferred
+        with service._transaction():
+            pass
+
+    # And the real call graph that relies on it still works end to end.
+    saved = service.save_artifact(
+        run["id"],
+        artifact_name="nested.json",
+        content_type="application/json",
+        content={"ok": True},
+    )
+    assert saved["content"] == {"ok": True}
+    service.close()

--- a/Tests/Research/test_research_scope_service.py
+++ b/Tests/Research/test_research_scope_service.py
@@ -1,3 +1,6 @@
+import asyncio
+import threading
+
 import pytest
 
 from tldw_chatbook.Research_Interop import LocalResearchService
@@ -507,3 +510,104 @@ def test_research_scope_service_rejects_local_sync_mirror_report():
             mode="local",
             server_profile_id="server-a",
         )
+
+
+# ---------------------------------------------------------------------------
+# TASK-21127: the local backend runs off the Textual event loop.
+# ---------------------------------------------------------------------------
+
+
+def _record_db_threads(monkeypatch):
+    """Record the thread every database operation actually runs on."""
+    seen: list[str] = []
+    real_connect = LocalResearchService._connect
+
+    def _recording(self):
+        seen.append(threading.current_thread().name)
+        return real_connect(self)
+
+    monkeypatch.setattr(LocalResearchService, "_connect", _recording)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_local_backend_database_work_runs_off_the_event_loop(
+    tmp_path, monkeypatch
+):
+    """The whole point of the offload: no SQLite on the loop thread.
+
+    Driven through the REAL object graph (scope service -> real
+    LocalResearchService on a temp file), because a synchronous test double
+    would satisfy a thread assertion without proving anything about the
+    shipped app (TASK-21125 lesson).
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    scope = ResearchScopeService(local_service=service, server_service=None)
+    run = await scope.create_run(mode="local", query="off the loop")
+
+    loop_thread = threading.current_thread().name
+    seen = _record_db_threads(monkeypatch)
+    await scope.get_run(run["id"], mode="local")
+    await scope.list_runs(mode="local")
+    await scope.get_bundle(run["id"], mode="local")
+
+    assert seen, "no database operation was observed"
+    assert loop_thread not in seen, f"SQLite ran on the event loop thread: {seen}"
+    assert all(name.startswith("research-backend") for name in seen), seen
+    service.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_scope_calls_share_one_backend_thread(tmp_path, monkeypatch):
+    """A SINGLE-thread executor, not the default pool: it restores exactly the
+    ordering the event loop was providing for free before the offload."""
+    service = LocalResearchService(tmp_path / "research.db")
+    scope = ResearchScopeService(local_service=service, server_service=None)
+    run = await scope.create_run(mode="local", query="serialised")
+
+    seen = _record_db_threads(monkeypatch)
+    await asyncio.gather(*(scope.get_run(run["id"], mode="local") for _ in range(12)))
+
+    assert len(set(seen)) == 1, f"backend work fanned out across threads: {set(seen)}"
+    service.close()
+
+
+@pytest.mark.asyncio
+async def test_stream_run_events_async_generator_is_not_offloaded(tmp_path):
+    """``LocalResearchService.stream_run_events`` is an ``async def ... yield``.
+
+    ``inspect.iscoroutinefunction`` is False for such a function, so a
+    passthrough predicate that only checks for coroutines would route it
+    through a thread and hand the caller a coroutine wrapping the generator
+    object instead of the generator.
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    scope = ResearchScopeService(local_service=service, server_service=None)
+    run = await scope.create_run(mode="local", query="streaming")
+
+    events = [event async for event in scope.stream_run_events(run["id"], mode="local")]
+
+    assert events and any(event.get("event") == "created" for event in events)
+    observed = await scope.observe_run_events(mode="local", run_id=run["id"])
+    assert observed and observed[0]["run_id"] == run["id"]
+    service.close()
+
+
+def test_offload_preserves_the_wired_local_service_identity(tmp_path):
+    """Only the DISPATCH path is wrapped: app wiring still sees what it passed."""
+    service = LocalResearchService(tmp_path / "research.db")
+    scope = ResearchScopeService(local_service=service, server_service=None)
+
+    assert scope.local_service is service
+    service.close()
+
+
+@pytest.mark.asyncio
+async def test_backend_exceptions_survive_the_offload(tmp_path):
+    """A proxy must not swallow or re-wrap the backend's error type."""
+    service = LocalResearchService(tmp_path / "research.db")
+    scope = ResearchScopeService(local_service=service, server_service=None)
+
+    with pytest.raises(ValueError, match="research run not found"):
+        await scope.get_bundle("no-such-run", mode="local")
+    service.close()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8064,3 +8064,83 @@ discovered by mutation, not by reading: breaking the reserved cell changed the p
 row count from 1 to 2 between phases while `outer_size` stayed `Size(93, 2)`. A test
 asserting only `outer_size` would have called that safe. Assert the **painted row
 count and per-row cell widths** too.
+## Fix the leak first: the per-op connect WAS the cost, so the offload the filing also prescribed banked nothing (TASK-21127, 2026-08-24)
+
+**What happened.** The finding named three legs — per-op leaked connections, an
+engine running as a loop coroutine, and a 30 s lease write plus a 2 s poll on
+the loop — and prescribed a fix for each: held connection, `to_thread` the
+engine's ~40 service calls, batch the keepalive. All three legs were real. Built
+before any code changed, the harness put numbers on them: **one
+`connect_private_sqlite` open with its pragmas costs 0.631 ms; the SELECT it was
+opened to run costs 0.002 ms.** The connect was not a share of the cost, it was
+99.7% of it. Holding the connection took an engine run's loop-side database time
+from 877–906 ms to 29–33 ms per 20 runs (worst contiguous loop stall 46–51 ms →
+2.0–2.5 ms) — and left the two remaining prescribed fixes with **1.6 ms per run**
+and **0.020 ms per 30 s** to work on. Offloading the engine would have meant a
+nested event loop (or ~40 cascading `await`s through 8 synchronous methods),
+cross-thread Textual dispatch and notification dispatch from a worker thread, at
+two separate call sites, to move 1.6 ms. Batching the keepalive would have
+entangled the lease that prevents double execution to save 0.02 ms per half
+minute. Both were declined with the measurement recorded in the ACs.
+
+**What to do.** When a filing names a per-operation *leak* and an *offload* of
+the same code path, treat them as sequenced, not parallel: fix the leak,
+re-measure, and only then size the offload. The offload's apparent value is
+usually the leak's cost wearing its clothes. Two corollaries. Keep the leg the
+numbers *do* justify even when its headline reason evaporates: here the 2 s poll
+was worth 0.023 ms a tick and would not have shipped on its own, but the same
+one-line proxy also covers a bundle load that costs ~15 ms of loop time at 5.5 MB
+and grows with artifact size — that, not the poll, is the case for the UI-side
+offload. And measure the loop with an independent ticker, not with the awaited
+call's wall time: once work is on a thread the coroutine's duration *includes*
+the thread's work and stops being a loop-blocking measure at all. The sharpest
+number in this task came from that ticker — at 1 ms it got **zero** wakeups
+across the whole base-arm window, i.e. the shipped UI research path never
+yielded to the event loop even once.
+
+## Two mutations stayed green because a SECOND line of defence covered the walk — the fix was more tests, not a weaker assertion (TASK-21127, 2026-08-24)
+
+**What happened.** Fifteen mutations were run against the new guards; thirteen
+went red immediately. Two did not: removing `_begin`'s stale-connection heal, and
+removing `_transaction`'s rollback-on-failure. Both were aimed at end-to-end walk
+tests ("quit mid-run still completes", "a DB error mid-run leaves the store
+usable"). Investigating instead of rewriting the assertion showed why: `close()`
+POPS every connection it closes, so a later operation opens a fresh one and never
+meets a closed handle — the heal is a genuine second line of defence and
+unreachable through the shipped `close()`. Likewise a transaction left open by a
+missing rollback is cleared by `_begin`'s *other* heal arm on the next operation,
+so the end state matched either way. The walks were correct; they were just not
+single-mechanism guards.
+
+**What to do.** A surviving mutant has a third hypothesis beyond "wrong scenario"
+and "something else fixed it for me": **the code is deliberately
+belt-and-braces, and no single-point mutation can red a whole-path assertion.**
+That is a property worth having, not a defect — but it means the redundant
+mechanism needs its own test at its own level. Here: a connection closed *while
+still mapped* (reaching the heal directly), and `conn.in_transaction` after a
+failed body (proving the rollback happens AT the failure, not on the next
+`_begin`). Both mutations then went red. Keep the walk as well; deleting it to
+satisfy a mutation score would trade the property for the proof of it.
+
+## `inspect.iscoroutinefunction` is False for an async GENERATOR — a thread-offload proxy must pass those through too (TASK-21127, 2026-08-24)
+
+**What happened.** `ResearchScopeService` got the same `_ThreadOffloadedBackend`
+proxy TASK-21125 built for the writing suite: `__getattr__` returns the attribute
+unchanged when it is already async, and wraps it in `asyncio.to_thread` otherwise.
+Copied verbatim, the predicate (`inspect.iscoroutinefunction`) reported **False**
+for `LocalResearchService.stream_run_events`, which is `async def ... yield`. The
+proxy therefore "offloaded" it, handing `stream_run_events`/`observe_run_events`
+a coroutine wrapping the generator object instead of the generator, and both
+consumers' `inspect.isasyncgen(result)` branch silently stopped matching. The
+writing service has no async generators, so its predicate had never been wrong.
+Mutation-confirmed: dropping `inspect.isasyncgenfunction` from the predicate
+fails the test with `TypeError: 'async_generator' object is not iterable`.
+
+**What to do.** Any "is this already async?" predicate guarding a thread offload
+must test `inspect.iscoroutinefunction(x) or inspect.isasyncgenfunction(x)`, on
+the callable *and* on its `__call__`. When cloning a proxy between services — and
+this burn-down does that repeatedly (21125 → 21127 → 21131) — inventory the target
+service's method KINDS first (`async def`, `async def ... yield`, plain `def`,
+plain generator), because the predicate is only as complete as the service it was
+written against. A plain sync generator has the mirror-image problem: routing it
+through a thread returns the generator without running any of it.

--- a/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
+++ b/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
@@ -262,10 +262,46 @@ at `d589c56c5`, arms **interleaved** per the TASK-21130 lesson.
   `close()` (which pops every connection it closes). It is kept as a documented
   guard and now has a direct test, mirroring the TASK-21125 MINOR-2 precedent.
 
+### Review fix round (coordinator review, pre-merge)
+
+One finding, taken as reported: **`_transaction()`'s nested branch silently
+ignored `immediate`.** A body inside a deferred transaction that opened
+`_transaction(immediate=True)` would JOIN the deferred outer, running its
+read-then-write under a read snapshot -- exactly the `BUSY_SNAPSHOT` the flag
+exists to prevent.
+
+I re-derived the reachability claim independently before changing anything, with
+an AST pass over the class that walks the self-call graph **transitively** rather
+than checking direct calls: 9 methods open a deferred transaction, 12 open an
+immediate one, and there are **0 live deferred -> immediate paths**. Confirmed
+latent, not live.
+
+Shipped the loud option -- a nested `immediate=True` inside a deferred outer
+raises `RuntimeError`; the outer's mode is recorded on `_tx_state` so
+immediate-inside-immediate still joins normally. The decisive argument for
+raising over documenting is the *failure mode of the alternative*:
+`BUSY_SNAPSHOT` only occurs when another writer holds the lock, so a silent
+downgrade survives every single-threaded test and then appears intermittently in
+the field as "database is locked" -- a message that reads like a transient
+condition to retry, and is the one failure SQLite's busy handler will NOT retry.
+Refusing converts that into a deterministic failure on the first execution, with
+a message naming the actual mistake and the actual fix (open the OUTER
+transaction as immediate). No lock upgrade is attempted; SQLite cannot do that.
+
+Deferred-inside-immediate stays legal and is deliberately pinned by a second
+test: it is the shipped hot path (`_require_one` inside `save_artifact`, on every
+artifact the engine saves), so over-restricting here would break real behaviour
+rather than protect it. Both new tests are mutation-verified: removing the guard
+gives `Failed: DID NOT RAISE <class 'RuntimeError'>`, and failing to record the
+outer's mode makes the guard misfire on a LEGAL nesting, reddening the
+over-restriction test. Research set **349 -> 351 passed / 0 failed**; full
+mutation set now **17 of 17 RED, 0 vacuous**; `./scripts/preflight.sh` green
+(the guard is a `raise`, not a diagnostic, so the inventory is unchanged).
+
 **Files**: `tldw_chatbook/Research_Interop/local_research_service.py`,
 `tldw_chatbook/Research_Interop/research_scope_service.py`,
 `tldw_chatbook/app.py`, `Tests/Research/test_local_research_service.py` (+11),
-`Tests/Research/test_local_research_service_lifecycle.py` (new, 10),
+`Tests/Research/test_local_research_service_lifecycle.py` (new, 12),
 `Tests/Research/test_research_scope_service.py` (+5),
 `Tests/Research/test_app_research_wiring.py` (+2),
 `Tests/DB/test_private_sqlite_interop_owners.py` (the research owner factory now

--- a/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
+++ b/backlog/tasks/task-21127 - Research runs - per-op leaked connects and loop-side periodic reads-writes while a run is active.md
@@ -2,9 +2,11 @@
 id: TASK-21127
 title: >-
   Research runs - per-op leaked connects and loop-side periodic reads/writes while a run is active
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-22'
+updated_date: '2026-08-24'
 labels:
   - performance
   - research
@@ -25,9 +27,29 @@ on the loop while a run is active.
 
 ## Acceptance Criteria
 
-- [ ] The service holds a thread-local connection; engine service calls route through to_thread
-- [ ] The 30 s keepalive is batched with progress writes; the 2 s auto-refresh reads off-loop
-- [ ] Research behavior unchanged - existing tests green
+Amended at implementation time (2026-08-24) after the measurement harness was built
+BEFORE the fix. Two of the three original criteria prescribed work that banks
+essentially nothing once the connection is held; they are struck through with the
+measurement that retired them, and the replacements are what shipped. See
+"Where the brief was wrong" in the Implementation Notes.
+
+- [x] #1 The service holds ONE connection per thread instead of opening (and GC-leaking)
+      one per operation; `close()` releases every one, including the schema connection
+- [x] #2 ~~engine service calls route through to_thread~~ **NOT SHIPPED** -- after #1 the
+      engine's whole loop-side DB cost is 1.6 ms per run with a 2.3 ms worst stall.
+      Offloading it needs a nested loop or ~40 cascading `await`s, cross-thread UI
+      dispatch and notification dispatch from a worker thread, to move 1.6 ms. Measured,
+      recorded, and deliberately declined
+- [x] #3 Every read-modify-write in the store is ONE `BEGIN IMMEDIATE` transaction, so a
+      caller on the backend thread and the engine on the loop cannot interleave into a
+      lost update (this is the prerequisite the offload creates, not optional polish)
+- [x] #4 ~~The 30 s keepalive is batched with progress writes~~ **NOT SHIPPED** -- after #1
+      one keepalive tick costs 0.020 ms (was 0.55 ms). Batching it would bank 0.02 ms per
+      30 s while putting the double-execution lease guard at risk
+- [x] #5 The 2 s auto-refresh, and every other UI-driven research call, runs off the loop:
+      the scope service dispatches a synchronous backend on a single-thread executor
+- [x] #6 Research behavior unchanged - existing tests green, and the quit / DB-error /
+      cancel / empty-first-run paths are walked explicitly on a file-backed store
 
 ## Re-verification against dev 2be18842a (2026-08-23)
 
@@ -57,3 +79,194 @@ destroys the database; `close()` (`:161-165`) is the only legitimate closer.
 
 **Revised severity**: every leg is real, but the whole surface is gated behind "user opens the
 Research screen and starts a local run" — not a boot, keystroke or per-frame cost.
+
+## Implementation Plan
+
+1. Build the measurement harness BEFORE the fix: a probe running the real
+   `LocalResearchEngine` against a real FILE-BACKED `LocalResearchService`
+   (the engine tests use `:memory:`, which never opens per-op connections at
+   all), counting connection opens through the private seam, attributing every
+   service call to a thread, and measuring loop stalls with an independent
+   ticker. A second probe for the UI path (2 s poll + bundle load) through the
+   real controller -> scope service -> service graph.
+2. A/B against a pinned base worktree at `d589c56c5`, arms interleaved.
+3. Held connection per thread (`dict[thread_ident, Connection]`, not
+   `threading.local`), `isolation_level=None`, explicit `_transaction()`
+   BEGIN/COMMIT/ROLLBACK, lifecycle gate + re-arming `close()`. Reuse
+   TASK-21125's shape; keep `:memory:` sharing exactly one connection.
+4. Decide the offload legs from the re-measured numbers, not the brief.
+5. Make every read-modify-write one `BEGIN IMMEDIATE` transaction before any
+   offload can interleave them.
+6. Scope-service offload on a SINGLE-thread executor; shutdown wiring through
+   `asyncio.to_thread`.
+7. Mutation-verify every new test against a deliberately broken implementation;
+   walk quit / error / cancel / empty explicitly.
+
+## Implementation Notes
+
+`LocalResearchService` now holds ONE connection per thread for the life of the
+service instead of opening (and GC-leaking) a fresh one per operation, every
+read-modify-write is a single `BEGIN IMMEDIATE` transaction, and the UI-driven
+half of the research surface runs on a worker thread instead of the Textual
+loop. The engine offload and the keepalive batching the ACs asked for were
+measured and deliberately NOT shipped.
+
+**Connection lifecycle.** `_connect()` returns a held connection from a
+`dict[thread_ident, Connection]` (not a `threading.local`: shutdown has to reach
+connections it does not own), opened through the same `connect_private_sqlite`
+seam with `check_same_thread=False` and `isolation_level=None`. All 21
+`with self._connect() as conn:` sites became `with self._transaction(...)`, an
+explicit BEGIN / COMMIT / ROLLBACK manager -- sqlite3's connection context
+manager is a *transaction* manager, not a closer, which is what leaked the
+connections. `:memory:` still shares exactly one connection (closing it destroys
+the database) and serialises its transactions under an RLock; `close()` there
+also clears `_schema_ready` so the re-armed store rebuilds. `_init_schema` now
+CLOSES its own connection in file mode rather than leaking it, and fences the
+migration span in an explicit transaction (`apply()` documents that the caller
+owns it, and with `isolation_level=None` nothing opens one implicitly).
+
+**Atomicity is a prerequisite, not polish.** `_update_row`, `_soft_delete`,
+`_update_run_state`, `update_run_progress`, `claim_run`, `release_lease`,
+`patch_and_approve_checkpoint`, `create_session`, `launch_run`,
+`create_checkpoint`, `save_artifact` and `record_run_event` each read and then
+write. Splitting that across transactions was harmless only while every caller
+ran inline on the event loop; the moment ANY caller moves to a thread it is a
+live lost update (TASK-21125 measured 0/60 -> 59/60). They are now one
+`BEGIN IMMEDIATE` transaction each -- which also removes two of the three
+connections `_update_row` was opening per update. `release_lease` is the case
+where IMMEDIATE is mandatory rather than preferred: it SELECTs then UPDATEs, and
+a deferred BEGIN under `isolation_level=None` opens a read snapshot whose later
+write fails `BUSY_SNAPSHOT` ("database is locked"), which SQLite's busy handler
+does NOT retry.
+
+**Thread offload, scoped by measurement.** `ResearchScopeService._service_for_mode`
+returns a `_ThreadOffloadedBackend` proxy dispatching non-coroutine callables on
+a **single-thread** executor -- one worker deliberately, so the ordering the
+event loop was silently providing survives the move. `scope.local_service` keeps
+its identity for the wiring tests. Two research-specific details the writing
+precedent did not have: the passthrough predicate must also accept async
+GENERATOR functions (`LocalResearchService.stream_run_events` is
+`async def ... yield`, for which `inspect.iscoroutinefunction` is False, so a
+coroutine-only predicate hands `observe_run_events` a coroutine wrapping the
+generator -- mutation-confirmed, `TypeError: 'async_generator' object is not
+iterable`); and `_call_service`'s per-call `inspect.signature` is now cached on
+the CLASS (a bound method is a fresh object per access, so caching on it would
+never hit), with a fallback for test doubles the class lookup cannot describe.
+
+**Shutdown.** `TldwCli._close_local_research_service()` peeks the slot (never
+constructs a service to close it) and runs `close()` through
+`asyncio.to_thread` -- inline it would freeze the loop for the whole settle
+timeout and starve the very operation it waits for. On a settle timeout a busy
+thread KEEPS its connection; closing it anyway produces
+`ProgrammingError: Cannot operate on a closed database` inside live work.
+
+### Where the brief was wrong
+
+The re-verification's three legs are all real, but **two of the three prescribed
+FIXES bank essentially nothing once the connection is held** -- the per-op
+connect was 99.7% of the cost, not a share of it:
+
+| | base `d589c56c5` | after |
+|---|---|---|
+| one `connect_private_sqlite` open + pragmas + close | **0.631 ms** | -- |
+| one SELECT on a held connection | 0.002 ms | 0.002 ms |
+
+- **Engine offload (AC #1, second half): declined.** 20 engine runs, 5
+  interleaved A/B pairs: loop-side DB **877-906 ms -> 29-33 ms** (~29x), worst
+  contiguous loop stall **46-51 ms -> 2.0-2.5 ms**, with the 800 service calls
+  still on the loop thread in both arms. That residue is 1.6 ms per run. Moving
+  it needs a nested event loop (or ~40 cascading `await`s through 8 currently
+  synchronous engine methods), cross-thread Textual dispatch, and notification
+  dispatch from a worker thread -- and it applies to two call sites, since
+  Console's `/research` builds the engine the same way. Not worth it.
+- **Keepalive batching (AC #2, first half): declined.** One 30 s tick:
+  **0.55 ms -> 0.020 ms**. Batching it with progress writes would save 0.02 ms
+  per 30 s while entangling the lease that prevents double execution.
+- **The 2 s poll (AC #2, second half) is worth ~nothing ON ITS OWN** -- 0.023 ms
+  of loop time per tick after the held connection. It ships because the same
+  one-line proxy also covers the bundle load, which is **~15 ms of loop time at
+  a 5.5 MB bundle even with the connection held** and grows with artifact size.
+  That, not the poll, is the UI-side case for an offload.
+
+### Evidence
+
+Probes and logs in `test-logs/` (gitignored); A/B against a pinned base worktree
+at `d589c56c5`, arms **interleaved** per the TASK-21130 lesson.
+
+- **Engine, 20 runs x 5 interleaved pairs:** connection opens **1741 -> 3**
+  (87/run -> 0 marginal; the 3 are schema + one per thread), loop-side DB
+  **877-906 ms -> 29-33 ms**, worst loop stall **46-51 ms -> 2.0-2.5 ms**, all
+  runs `completed` in both arms. Work is GONE, not relocated: the service-call
+  count on the loop thread is 800 in BOTH arms.
+- **UI path (30 poll ticks + one bundle load, 5.5 MB of artifacts):** connection
+  opens **33 -> 0**; database operations on the loop thread **33/33 -> 0/32**
+  (all on `research-backend_0`); an independent 1 ms ticker got **0 wakeups in
+  the base arm** across the whole ~33 ms window -- the shipped UI research path
+  never yields to the loop at all -- versus **10-11 wakeups, worst stall
+  0.17-0.24 ms** after.
+- **Pragmas read back on the LIVE held connection:** `journal_mode=wal`,
+  `synchronous=1`, `isolation_level=None`, `busy_timeout=5000` (so IMMEDIATE
+  contention is retried); WAL confirmed persistent in the file through an
+  independent connection.
+- **Mutation results: 15 of 15 new guards go RED against a deliberately broken
+  implementation, 0 vacuous** (`__pycache__` cleared per mutation). Signatures
+  worth naming: reverting `update_run_progress` to separate read/write
+  transactions gives *"40 writes all reported success but version advanced 11
+  time(s): a lost update"*; letting `close()` close a wedged thread's connection
+  gives the exact TASK-21101 `ProgrammingError('Cannot operate on a closed
+  database.')`; closing inline from unmount gives *"the event loop was frozen
+  during close() (0 ticks)"*; dropping `isasyncgenfunction` gives
+  *"TypeError: 'async_generator' object is not iterable"*; leaking
+  `_init_schema`'s connection is caught by the `-wal` sidecar surviving
+  `close()`.
+- **Two mutations initially stayed GREEN and were investigated rather than
+  written off.** `_begin`'s stale-handle heal and `_transaction`'s rollback are
+  both second lines of defence behind mechanisms that already covered the
+  end-to-end walks (`close()` POPS what it closes; `_begin` re-rolls-back a
+  stray transaction), so no single-point mutation could red a walk assertion.
+  Two targeted tests were added for the mechanisms themselves -- a connection
+  closed while still mapped, and `in_transaction` after a failed body -- and
+  both mutations then went red.
+- **Lifecycle walk, file-backed** (`test_local_research_service_lifecycle.py`):
+  quit mid-run (`close()` from another thread during a live engine run -> the
+  run still completes), a DB error mid-run (run fails legibly, store still
+  usable afterwards), cancel between phases (resolved exactly once), and the
+  empty/first-run case (construction creates no file; TASK-21105's lazy-open
+  contract survives).
+- **Tests:** research set **323 passed -> 349 passed / 0 failed** (+26).
+  `Tests/App` + `Tests/ProductionApp`: **243 passed / 4 failed**, the same four
+  A/B-proven on pristine base `d589c56c5` with byte-identical signatures
+  (console-stop root state, two reactive-maturity scanners, retired-destination
+  state -- the scanner names `Tests/ProductionApp/test_notes_sync_runtime_lifecycle.py`,
+  not any file this task touched). Collect sweep **59,592 -> 59,618, zero
+  collection errors on both sides**.
+- `ruff check` clean on every touched file. `ruff format --check` reports
+  `local_research_service.py` and `test_local_research_service.py` as
+  unformatted -- **both are already unformatted at base**, and every hunk in the
+  diff sits on pre-existing lines (verified hunk by hunk); the added regions are
+  format-clean.
+- `./scripts/preflight.sh` green after reviewing the 6 new diagnostic-inventory
+  rows individually (5 in `local_research_service.py`, 1 in `app.py`): all are
+  log constants, an integer connection count, or `type(exc).__name__` -- none
+  interpolates the database path, user content, a secret, or a URL.
+
+### Out-of-scope findings (not fixed here)
+
+- `Research_Window._start_local_engine` and Console's `/research` handler
+  (`chat_screen.py:16068`) each build a `LocalResearchEngine` around the RAW
+  `local_research_service`, bypassing `ResearchScopeService` entirely -- so the
+  scope service's policy enforcement and normalisation do not apply to engine
+  writes, and neither does this task's offload. That is a design question, not a
+  perf one.
+- `_begin`'s `sqlite3.ProgrammingError` arm is unreachable through the shipped
+  `close()` (which pops every connection it closes). It is kept as a documented
+  guard and now has a direct test, mirroring the TASK-21125 MINOR-2 precedent.
+
+**Files**: `tldw_chatbook/Research_Interop/local_research_service.py`,
+`tldw_chatbook/Research_Interop/research_scope_service.py`,
+`tldw_chatbook/app.py`, `Tests/Research/test_local_research_service.py` (+11),
+`Tests/Research/test_local_research_service_lifecycle.py` (new, 10),
+`Tests/Research/test_research_scope_service.py` (+5),
+`Tests/Research/test_app_research_wiring.py` (+2),
+`Tests/DB/test_private_sqlite_interop_owners.py` (the research owner factory now
+returns a real closer), `Docs/security/production-diagnostic-inventory.json`.

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -6,9 +6,12 @@ import json
 import sqlite3
 import threading
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Iterator
+
+from loguru import logger
 
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
 
@@ -20,6 +23,12 @@ from .research_normalizers import (
 )
 
 __all__ = ["LocalResearchService", "LeaseBudgetExhausted", "TERMINAL_RUN_STATUSES"]
+
+# How long close() waits for operations still running on other threads, and how
+# long a new operation waits out an in-flight close. Bounded so a wedged
+# operation degrades to a warning instead of hanging application shutdown
+# (TASK-21127, mirroring the writing store's lifecycle gate).
+_LIFECYCLE_SETTLE_TIMEOUT = 5.0
 
 #: Statuses from which a run cannot be claimed or further executed. The
 #: single source of truth: ``local_research_engine.py`` imports this rather
@@ -101,7 +110,26 @@ class LocalResearchService:
         # connection must stay bound to the constructing thread, as before.
         self._schema_ready = False
         self._schema_lock = threading.Lock()
-        if self.db_path is not None and str(self.db_path) == ":memory:":
+        self._is_memory = self.db_path is not None and str(self.db_path) == ":memory:"
+        # TASK-21127: one HELD connection per thread, keyed by thread id so
+        # close() can reach connections it does not own (a ``threading.local``
+        # cannot be cleared from another thread, which is what shutdown needs).
+        # ``:memory:`` keeps sharing the single ``_memory_conn`` -- closing it
+        # destroys the database, so it is never entered in this map.
+        self._connections: dict[int, sqlite3.Connection] = {}
+        # Lifecycle gate: operations register here and close() waits for them
+        # to settle before it touches any connection.
+        self._lifecycle = threading.Condition()
+        self._active_operations: dict[int, int] = {}
+        self._closing = False
+        # Re-entrancy: a nested _transaction() joins the transaction its caller
+        # already opened instead of issuing a second BEGIN.
+        self._tx_state = threading.local()
+        # ``:memory:`` shares one connection across threads, so its
+        # transactions must be serialised; file-backed threads each hold their
+        # own connection and never contend here.
+        self._memory_tx_lock = threading.RLock()
+        if self._is_memory:
             self._init_schema()
             self._schema_ready = True
 
@@ -122,10 +150,53 @@ class LocalResearchService:
             self._schema_ready = True
 
     def _connect(self) -> sqlite3.Connection:
+        """Return this thread's held connection, opening it on first use.
+
+        TASK-21127: the service used to open (and GC-leak) a fresh connection
+        per operation -- ~87 opens for a single engine run, each paying the
+        private seam's owner-policy validation and ``verify_trusted_directory``
+        plus a re-run of the WAL/synchronous pragmas (measured 0.63 ms per open
+        against 0.002 ms for the statement it was opened to run). Callers now
+        share one connection per thread for the life of the service.
+        """
         if self.db_path is None:
             raise RuntimeError("Path-backed research database is not configured.")
         self._ensure_schema()
-        return self._open_connection()
+        if self._is_memory:
+            # close() drops the connection AND clears _schema_ready, so the
+            # _ensure_schema() above has already rebuilt both. The fallback is
+            # defensive only.
+            conn = self._memory_conn
+            if conn is None:
+                conn = self._open_connection()
+            return conn
+
+        ident = threading.get_ident()
+        with self._lifecycle:
+            held = self._connections.get(ident)
+            if held is not None:
+                return held
+
+        opened = self._open_connection()
+        superseded: sqlite3.Connection | None = None
+        with self._lifecycle:
+            existing = self._connections.get(ident)
+            if existing is not None:
+                superseded = opened
+                opened = existing
+            else:
+                self._connections[ident] = opened
+        if superseded is not None:
+            self._close_quietly(superseded)
+        return opened
+
+    def _discard_connection(self, conn: sqlite3.Connection) -> None:
+        """Detach a connection this thread can no longer use, and close it."""
+        ident = threading.get_ident()
+        with self._lifecycle:
+            if self._connections.get(ident) is conn:
+                self._connections.pop(ident, None)
+        self._close_quietly(conn)
 
     def _open_connection(self) -> sqlite3.Connection:
         """Open a raw connection without the first-use schema ensure.
@@ -133,12 +204,20 @@ class LocalResearchService:
         ``_init_schema`` must use this directly: it runs inside
         ``_ensure_schema``'s lock, and going through ``_connect`` there
         would deadlock on the non-reentrant lock.
+
+        ``check_same_thread=False`` because held connections are handed to
+        whichever worker thread the caller ran on, and ``isolation_level=None``
+        because ``_transaction`` issues explicit BEGIN/COMMIT rather than
+        relying on sqlite3's implicit transactions (the sanctioned template;
+        exemplar ``DB/Library_Ingest_Jobs_DB.py``).
         """
-        if str(self.db_path) == ":memory:":
+        if self._is_memory:
             if self._memory_conn is None:
                 self._memory_conn = connect_private_sqlite(
                     "research.local",
                     self.db_path,
+                    check_same_thread=False,
+                    isolation_level=None,
                 )
                 self._memory_conn.row_factory = sqlite3.Row
                 # synchronous is harmless (and a no-op performance-wise) on an
@@ -146,22 +225,217 @@ class LocalResearchService:
                 # branch below (task-15465).
                 self._memory_conn.execute("PRAGMA synchronous = NORMAL")
             return self._memory_conn
-        conn = connect_private_sqlite("research.local", self.db_path)
+        conn = connect_private_sqlite(
+            "research.local",
+            self.db_path,
+            check_same_thread=False,
+            isolation_level=None,
+        )
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode = WAL")
         # NORMAL is safe under WAL (app-crash-safe; only an OS/power crash can
         # lose the last commit, acceptable for this local research
-        # session/run store) and avoids an fsync per commit. This DB opens a
-        # fresh connection per operation, so synchronous must be re-applied
-        # on every open, not just the first (task-15465).
+        # session/run store) and avoids an fsync per commit (task-15465). The
+        # connection is now HELD, so this runs once per thread rather than once
+        # per operation.
         conn.execute("PRAGMA synchronous = NORMAL")
         return conn
 
+    @contextmanager
+    def _transaction(self, *, immediate: bool = False) -> Iterator[sqlite3.Connection]:
+        """Run one explicit transaction on this thread's held connection.
+
+        Replaces the old ``with self._connect() as conn:`` form. sqlite3's
+        connection context manager is a *transaction* manager, not a closer, so
+        that form both leaked the connection and depended on implicit
+        transaction control; this issues BEGIN/COMMIT/ROLLBACK itself.
+
+        Args:
+            immediate: Take the write lock at BEGIN. Required for any body that
+                READS and then WRITES: with ``isolation_level=None`` a deferred
+                BEGIN starts a read snapshot, and SQLite's busy handler does not
+                retry ``BUSY_SNAPSHOT``, so the later write fails outright with
+                "database is locked" instead of waiting (TASK-21125 review,
+                MINOR-1). It is also what makes read-check-write sequences
+                atomic now that callers can run on more than one thread.
+
+        A rollback that fails is swallowed (type name only) so it can never
+        mask the exception that caused it.
+        """
+        state = self._tx_state
+        if getattr(state, "depth", 0):
+            # Nested use joins the open transaction: a second BEGIN on the same
+            # connection is an error, and splitting the commit would break the
+            # caller's atomicity.
+            yield state.conn
+            return
+
+        self._begin_operation()
+        try:
+            serialise = self._memory_tx_lock if self._is_memory else None
+            if serialise is not None:
+                serialise.acquire()
+            try:
+                conn = self._begin(immediate=immediate)
+                state.depth = 1
+                state.conn = conn
+                try:
+                    yield conn
+                    conn.execute("COMMIT")
+                except BaseException:
+                    self._rollback_quietly(conn)
+                    raise
+                finally:
+                    state.depth = 0
+                    state.conn = None
+            finally:
+                if serialise is not None:
+                    serialise.release()
+        finally:
+            self._end_operation()
+
+    def _begin(self, *, immediate: bool = False) -> sqlite3.Connection:
+        """Open a transaction on this thread's connection, healing it if needed.
+
+        Two states can outlive an operation and would otherwise poison the held
+        connection for the rest of the process:
+
+        - the connection was closed by ``close()`` between operations -- the
+          store re-arms, so the stale handle is dropped and a fresh one opened;
+        - a transaction was left open because a COMMIT *and* its ROLLBACK both
+          failed -- rolling back here clears it instead of failing every later
+          operation on this thread with "within a transaction".
+
+        Both heal once and then retry; a second failure propagates.
+        """
+        statement = "BEGIN IMMEDIATE" if immediate else "BEGIN"
+        conn = self._connect()
+        try:
+            conn.execute(statement)
+            return conn
+        except sqlite3.ProgrammingError:
+            self._discard_connection(conn)
+            conn = self._connect()
+        except sqlite3.OperationalError as exc:
+            if "within a transaction" not in str(exc):
+                raise
+            logger.debug(
+                "Local research store found a transaction left open; clearing it"
+            )
+            self._rollback_quietly(conn)
+        conn.execute(statement)
+        return conn
+
+    def _begin_operation(self) -> None:
+        """Admit one operation, waiting out an in-flight close()."""
+        ident = threading.get_ident()
+        with self._lifecycle:
+            if self._closing and not self._lifecycle.wait_for(
+                lambda: not self._closing, timeout=_LIFECYCLE_SETTLE_TIMEOUT
+            ):
+                logger.warning(
+                    "Local research store close() did not settle in "
+                    f"{_LIFECYCLE_SETTLE_TIMEOUT}s; proceeding with the operation"
+                )
+            self._active_operations[ident] = self._active_operations.get(ident, 0) + 1
+
+    def _end_operation(self) -> None:
+        ident = threading.get_ident()
+        with self._lifecycle:
+            remaining = self._active_operations.get(ident, 0) - 1
+            if remaining > 0:
+                self._active_operations[ident] = remaining
+            else:
+                self._active_operations.pop(ident, None)
+            self._lifecycle.notify_all()
+
+    @staticmethod
+    def _rollback_quietly(conn: sqlite3.Connection) -> None:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception as exc:
+            # Type name only: rollback failures must never mask (or leak the
+            # message of) the error that triggered them.
+            logger.debug(f"Local research store rollback failed: {type(exc).__name__}")
+
+    @staticmethod
+    def _close_quietly(conn: sqlite3.Connection) -> None:
+        try:
+            conn.close()
+        except Exception as exc:
+            logger.debug(
+                f"Local research store connection close failed: {type(exc).__name__}"
+            )
+
     def close(self) -> None:
-        """Close the persistent in-memory connection, when present."""
-        if self._memory_conn is not None:
-            self._memory_conn.close()
-            self._memory_conn = None
+        """Close every held connection once in-flight operations have settled.
+
+        TASK-21127: shutdown must not close a connection out from under a
+        research run still writing on a worker thread, so this waits for
+        operations owned by other threads before it touches anything. The store
+        re-arms: a later operation transparently reopens.
+
+        If the wait expires, the still-busy threads KEEP their connections
+        (TASK-21125 review: closing them anyway produced ``ProgrammingError:
+        Cannot operate on a closed database`` inside the wedged operation,
+        surfacing as an unretrieved-task traceback). Committed data is already
+        durable under WAL and an open transaction rolls back at process exit.
+
+        Blocking: this waits up to ``_LIFECYCLE_SETTLE_TIMEOUT``. Callers on the
+        event loop must run it through ``asyncio.to_thread`` -- see
+        ``TldwCli._close_local_research_service``.
+        """
+        ident = threading.get_ident()
+        with self._lifecycle:
+            if self._closing:
+                # Another thread is already closing; let it finish.
+                self._lifecycle.wait_for(
+                    lambda: not self._closing, timeout=_LIFECYCLE_SETTLE_TIMEOUT
+                )
+                return
+            self._closing = True
+
+        try:
+            with self._lifecycle:
+                settled = self._lifecycle.wait_for(
+                    lambda: (
+                        not any(owner != ident for owner in self._active_operations)
+                    ),
+                    timeout=_LIFECYCLE_SETTLE_TIMEOUT,
+                )
+                busy = {owner for owner in self._active_operations if owner != ident}
+                connections = [
+                    conn
+                    for owner, conn in list(self._connections.items())
+                    if owner not in busy
+                ]
+                for owner in list(self._connections):
+                    if owner not in busy:
+                        self._connections.pop(owner, None)
+                # The shared in-memory connection can only be released when no
+                # other thread is mid-transaction on it.
+                memory_conn = None
+                if not busy:
+                    memory_conn = self._memory_conn
+                    self._memory_conn = None
+                    if self._is_memory:
+                        # The in-memory database dies with its connection, so
+                        # the re-armed store has to rebuild the schema.
+                        self._schema_ready = False
+            if not settled:
+                logger.warning(
+                    f"Local research store left {len(busy)} connection(s) open: "
+                    "operations were still in flight after "
+                    f"{_LIFECYCLE_SETTLE_TIMEOUT}s"
+                )
+            for conn in connections:
+                self._close_quietly(conn)
+            if memory_conn is not None:
+                self._close_quietly(memory_conn)
+        finally:
+            with self._lifecycle:
+                self._closing = False
+                self._lifecycle.notify_all()
 
     @staticmethod
     def _format_timestamp(moment: datetime) -> str:
@@ -290,7 +564,12 @@ class LocalResearchService:
 
     def _init_schema(self) -> None:
         # Raw connection: runs under _ensure_schema's lock (TASK-21105).
-        with self._open_connection() as conn:
+        # TASK-21127: file-backed mode closes this connection rather than
+        # leaking it -- the per-thread held connection is opened separately by
+        # _connect(). ``:memory:`` must NOT close it: _open_connection returns
+        # the shared _memory_conn and closing that destroys the database.
+        conn = self._open_connection()
+        try:
             conn.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS research_sessions (
@@ -365,7 +644,19 @@ class LocalResearchService:
             # The base script above ships the v0 shape (CREATE TABLE IF NOT
             # EXISTS never revisits an existing database); the versioned
             # migrations below take it from there (Qodo PR-1822 finding 7).
-            self._apply_migrations(conn)
+            # ``apply`` documents that the CALLER owns the transaction, and
+            # with isolation_level=None nothing opens one implicitly, so the
+            # migration span is fenced explicitly here.
+            conn.execute("BEGIN")
+            try:
+                self._apply_migrations(conn)
+            except BaseException:
+                self._rollback_quietly(conn)
+                raise
+            conn.execute("COMMIT")
+        finally:
+            if not self._is_memory:
+                self._close_quietly(conn)
 
     def _apply_migrations(self, conn: sqlite3.Connection) -> None:
         """Upgrade the database to the newest known schema version.
@@ -398,7 +689,7 @@ class LocalResearchService:
                 apply_step(conn)
 
     def _fetch_one(self, table: str, item_id: str) -> dict[str, Any] | None:
-        with self._connect() as conn:
+        with self._transaction() as conn:
             row = conn.execute(
                 f"SELECT * FROM {table} WHERE id = ? AND deleted = 0",
                 (item_id,),
@@ -435,27 +726,33 @@ class LocalResearchService:
         expected_version: int | None,
         fields: dict[str, Any],
     ) -> dict[str, Any]:
-        row = self._require_one(table, item_id, label)
-        self._check_version(row, expected_version)
-        updates = dict(fields)
-        if not updates:
-            return row
-        updates["updated_at"] = self._now()
-        updates["version"] = int(row["version"]) + 1
-        assignments = ", ".join(f"{key} = ?" for key in updates)
-        with self._connect() as conn:
+        # TASK-21127: one IMMEDIATE transaction, not three separate connections
+        # (read, write, re-read). Besides the two connection opens it removes,
+        # this makes the version check and the write it authorises atomic: the
+        # split shape was harmless only while every caller ran inline on the
+        # event loop, and is a silent lost update the moment two callers can be
+        # on different threads (TASK-21125 review, MAJOR-1).
+        with self._transaction(immediate=True) as conn:
+            row = self._require_one(table, item_id, label)
+            self._check_version(row, expected_version)
+            updates = dict(fields)
+            if not updates:
+                return row
+            updates["updated_at"] = self._now()
+            updates["version"] = int(row["version"]) + 1
+            assignments = ", ".join(f"{key} = ?" for key in updates)
             conn.execute(
                 f"UPDATE {table} SET {assignments} WHERE id = ?",
                 (*updates.values(), item_id),
             )
-        return self._require_one(table, item_id, label)
+            return self._require_one(table, item_id, label)
 
     def _soft_delete(
         self, table: str, item_id: str, label: str, expected_version: int | None
     ) -> bool:
-        row = self._require_one(table, item_id, label)
-        self._check_version(row, expected_version)
-        with self._connect() as conn:
+        with self._transaction(immediate=True) as conn:
+            row = self._require_one(table, item_id, label)
+            self._check_version(row, expected_version)
             conn.execute(
                 f"UPDATE {table} SET deleted = 1, updated_at = ?, version = ? WHERE id = ?",
                 (self._now(), int(row["version"]) + 1, item_id),
@@ -517,7 +814,7 @@ class LocalResearchService:
     ) -> dict[str, Any]:
         session_id = kwargs.get("id") or self._new_id()
         now = self._now()
-        with self._connect() as conn:
+        with self._transaction(immediate=True) as conn:
             conn.execute(
                 """
                 INSERT INTO research_sessions (
@@ -534,9 +831,9 @@ class LocalResearchService:
                     now,
                 ),
             )
-        return self._normalize_session(
-            self._require_one("research_sessions", session_id, "research session")
-        )
+            return self._normalize_session(
+                self._require_one("research_sessions", session_id, "research session")
+            )
 
     def list_sessions(
         self, *, limit: int = 100, offset: int = 0, status: str | None = None
@@ -548,7 +845,7 @@ class LocalResearchService:
             params.append(status)
         sql += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
-        with self._connect() as conn:
+        with self._transaction() as conn:
             rows = conn.execute(sql, params).fetchall()
         return [self._normalize_session(dict(row)) for row in rows]
 
@@ -640,17 +937,17 @@ class LocalResearchService:
         follow_up: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        session = (
-            self._require_one("research_sessions", session_id, "research session")
-            if session_id
-            else None
-        )
-        run_query = query or (session["query"] if session else None)
-        if not run_query:
-            raise ValueError("query is required")
-        run_id = kwargs.get("id") or self._new_id()
-        now = self._now()
-        with self._connect() as conn:
+        with self._transaction(immediate=True) as conn:
+            session = (
+                self._require_one("research_sessions", session_id, "research session")
+                if session_id
+                else None
+            )
+            run_query = query or (session["query"] if session else None)
+            if not run_query:
+                raise ValueError("query is required")
+            run_id = kwargs.get("id") or self._new_id()
+            now = self._now()
             conn.execute(
                 """
                 INSERT INTO research_runs (
@@ -680,9 +977,9 @@ class LocalResearchService:
                 ),
             )
             self._record_event(conn, run_id, "created")
-        return self._normalize_run(
-            self._require_one("research_runs", run_id, "research run")
-        )
+            return self._normalize_run(
+                self._require_one("research_runs", run_id, "research run")
+            )
 
     def list_runs(
         self,
@@ -709,7 +1006,7 @@ class LocalResearchService:
             params.append(status)
         sql += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
-        with self._connect() as conn:
+        with self._transaction() as conn:
             rows = conn.execute(sql, params).fetchall()
         return self._awaitable_list(self._normalize_run(dict(row)) for row in rows)
 
@@ -775,24 +1072,30 @@ class LocalResearchService:
             ``_quiet_lease_lost_return``'s "return the truth, not a lie"
             contract elsewhere in the lease design.
         """
-        row = self._require_one("research_runs", run_id, "research run")
-        updates = dict(fields)
-        updates["updated_at"] = self._now()
-        updates["version"] = int(row["version"]) + 1
-        assignments = ", ".join(f"{key} = ?" for key in updates)
-        sql = f"UPDATE research_runs SET {assignments} WHERE id = ?"
-        params: list[Any] = [*updates.values(), run_id]
-        if lease_id is not None:
-            sql += " AND lease_id = ?"
-            params.append(lease_id)
-        with self._connect() as conn:
+        # TASK-21127: read, write and re-read in ONE immediate transaction. The
+        # version bump is derived from the row read here, so on the old
+        # three-transaction shape a concurrent writer between the read and the
+        # UPDATE silently collapsed two bumps into one.
+        with self._transaction(immediate=True) as conn:
+            row = self._require_one("research_runs", run_id, "research run")
+            updates = dict(fields)
+            updates["updated_at"] = self._now()
+            updates["version"] = int(row["version"]) + 1
+            assignments = ", ".join(f"{key} = ?" for key in updates)
+            sql = f"UPDATE research_runs SET {assignments} WHERE id = ?"
+            params: list[Any] = [*updates.values(), run_id]
+            if lease_id is not None:
+                sql += " AND lease_id = ?"
+                params.append(lease_id)
             cursor = conn.execute(sql, params)
             landed = cursor.rowcount == 1
             if landed:
                 self._record_event(conn, run_id, event)
-        updated = self._normalize_run(
-            self._require_one("research_runs", run_id, "research run")
-        )
+            updated = self._normalize_run(
+                self._require_one("research_runs", run_id, "research run")
+            )
+        # Outside the transaction: the dispatcher reaches the app/UI, and must
+        # never run with the write lock held.
         if landed:
             self._dispatch_terminal_run_notification(updated)
         return updated
@@ -889,6 +1192,31 @@ class LocalResearchService:
                 lease_seconds=lease_seconds,
                 max_attempts=max_attempts,
             )
+        with self._transaction(immediate=True) as conn:
+            return self._claim_run_locked(
+                conn,
+                run_id,
+                worker_id=worker_id,
+                lease_seconds=lease_seconds,
+                max_attempts=max_attempts,
+            )
+
+    def _claim_run_locked(
+        self,
+        conn: sqlite3.Connection,
+        run_id: str,
+        *,
+        worker_id: str,
+        lease_seconds: float,
+        max_attempts: int,
+    ) -> str | None:
+        """``claim_run``'s body, inside the caller's write transaction.
+
+        TASK-21127: the reclaim/budget decision reads the row and the claim
+        writes it; those were two separate connections, so the "is this lease
+        live" judgement could be made against a row another claimant had
+        already taken. One IMMEDIATE transaction closes that.
+        """
         row = self._require_one("research_runs", run_id, "research run")
         if str(row["status"] or "") in TERMINAL_RUN_STATUSES:
             # Nothing to reclaim and nothing to budget-check -- a terminal
@@ -910,29 +1238,28 @@ class LocalResearchService:
         expires = self._timestamp_after(lease_seconds)
         next_attempts = attempts + 1
         status_placeholders = ", ".join("?" for _ in TERMINAL_RUN_STATUSES)
-        with self._connect() as conn:
-            cursor = conn.execute(
-                f"""
-                UPDATE research_runs
-                   SET lease_owner = ?, lease_id = ?, leased_until = ?,
-                       lease_attempts = ?, updated_at = ?
-                 WHERE id = ?
-                   AND (leased_until IS NULL OR leased_until <= ?)
-                   AND status NOT IN ({status_placeholders})
-                """,
-                (
-                    worker_id,
-                    lease_id,
-                    expires,
-                    next_attempts,
-                    now,
-                    run_id,
-                    now,
-                    *sorted(TERMINAL_RUN_STATUSES),
-                ),
-            )
-            if cursor.rowcount != 1:
-                return None
+        cursor = conn.execute(
+            f"""
+            UPDATE research_runs
+               SET lease_owner = ?, lease_id = ?, leased_until = ?,
+                   lease_attempts = ?, updated_at = ?
+             WHERE id = ?
+               AND (leased_until IS NULL OR leased_until <= ?)
+               AND status NOT IN ({status_placeholders})
+            """,
+            (
+                worker_id,
+                lease_id,
+                expires,
+                next_attempts,
+                now,
+                run_id,
+                now,
+                *sorted(TERMINAL_RUN_STATUSES),
+            ),
+        )
+        if cursor.rowcount != 1:
+            return None
         return lease_id
 
     def _claim_run_external(
@@ -1007,7 +1334,7 @@ class LocalResearchService:
             )
         now = self._now()
         expires = self._timestamp_after(lease_seconds)
-        with self._connect() as conn:
+        with self._transaction() as conn:
             cursor = conn.execute(
                 """
                 UPDATE research_runs
@@ -1059,7 +1386,12 @@ class LocalResearchService:
         if self._uses_external_db:
             return self._release_lease_external(run_id, lease_id=lease_id)
         now = self._now()
-        with self._connect() as conn:
+        # IMMEDIATE is mandatory here, not a preference: this body SELECTs and
+        # then UPDATEs, and with isolation_level=None a deferred BEGIN opens a
+        # read snapshot whose later write fails with BUSY_SNAPSHOT ("database is
+        # locked") -- which SQLite's busy handler does NOT retry (TASK-21125
+        # review, MINOR-1).
+        with self._transaction(immediate=True) as conn:
             row = conn.execute(
                 "SELECT leased_until FROM research_runs WHERE id = ? AND lease_id = ?",
                 (run_id, lease_id),
@@ -1107,7 +1439,7 @@ class LocalResearchService:
         """
         if self._uses_external_db:
             return self._holds_lease_external(run_id, lease_id=lease_id)
-        with self._connect() as conn:
+        with self._transaction() as conn:
             row = conn.execute(
                 "SELECT lease_id, leased_until FROM research_runs WHERE id = ?",
                 (run_id,),
@@ -1275,10 +1607,10 @@ class LocalResearchService:
         proposed_payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Create a pending review checkpoint for a run (task-16482)."""
-        self._require_one("research_runs", run_id, "research run")
         checkpoint_id = f"chk-{self._new_id()}"
         now = self._now()
-        with self._connect() as conn:
+        with self._transaction(immediate=True) as conn:
+            self._require_one("research_runs", run_id, "research run")
             conn.execute(
                 """
                 INSERT INTO research_checkpoints (
@@ -1301,13 +1633,15 @@ class LocalResearchService:
                 "checkpoint_created",
                 {"checkpoint_id": checkpoint_id, "checkpoint_type": checkpoint_type},
             )
-        return self._normalize_checkpoint(
-            self._require_one("research_checkpoints", checkpoint_id, "research checkpoint")
-        )
+            return self._normalize_checkpoint(
+                self._require_one(
+                    "research_checkpoints", checkpoint_id, "research checkpoint"
+                )
+            )
 
     def list_checkpoints(self, run_id: str) -> list[dict[str, Any]]:
-        self._require_one("research_runs", run_id, "research run")
-        with self._connect() as conn:
+        with self._transaction() as conn:
+            self._require_one("research_runs", run_id, "research run")
             rows = conn.execute(
                 "SELECT * FROM research_checkpoints WHERE run_id = ? ORDER BY rowid ASC",
                 (run_id,),
@@ -1343,6 +1677,25 @@ class LocalResearchService:
         """Approve a pending checkpoint with a type-validated patch
         (task-16482). Raises ValueError on non-pending state, unexpected
         patch keys, or sources patches referencing unknown/overlapping ids.
+        """
+        with self._transaction(immediate=True) as conn:
+            return self._patch_and_approve_checkpoint_locked(
+                conn, run_id, checkpoint_id, patch_payload=patch_payload
+            )
+
+    def _patch_and_approve_checkpoint_locked(
+        self,
+        conn: sqlite3.Connection,
+        run_id: str,
+        checkpoint_id: str,
+        *,
+        patch_payload: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """``patch_and_approve_checkpoint``'s body, inside the write transaction.
+
+        TASK-21127: the pending-state guard, the version bump and the approving
+        write were three separate transactions, so two approvals of the same
+        checkpoint could both read ``pending`` and both write ``approved``.
         """
         self._require_one("research_runs", run_id, "research run")
         row = self._require_one(
@@ -1391,14 +1744,13 @@ class LocalResearchService:
             "version": int(row["version"]) + 1,
         }
         assignments = ", ".join(f"{key} = ?" for key in updates)
-        with self._connect() as conn:
-            conn.execute(
-                f"UPDATE research_checkpoints SET {assignments} WHERE id = ?",
-                (*updates.values(), checkpoint_id),
-            )
-            self._record_event(
-                conn, run_id, "checkpoint_approved", {"checkpoint_id": checkpoint_id}
-            )
+        conn.execute(
+            f"UPDATE research_checkpoints SET {assignments} WHERE id = ?",
+            (*updates.values(), checkpoint_id),
+        )
+        self._record_event(
+            conn, run_id, "checkpoint_approved", {"checkpoint_id": checkpoint_id}
+        )
         return self._normalize_checkpoint(
             self._require_one(
                 "research_checkpoints", checkpoint_id, "research checkpoint"
@@ -1473,24 +1825,24 @@ class LocalResearchService:
             )
             if value is not None
         }
-        row = self._require_one("research_runs", run_id, "research run")
-        updates = dict(fields)
-        updates["updated_at"] = self._now()
-        updates["version"] = int(row["version"]) + 1
-        assignments = ", ".join(f"{key} = ?" for key in updates)
-        event_data = dict(data or {})
-        for key in ("phase", "progress_percent"):
-            if fields.get(key) is not None:
-                event_data.setdefault(key, fields[key])
-        with self._connect() as conn:
+        with self._transaction(immediate=True) as conn:
+            row = self._require_one("research_runs", run_id, "research run")
+            updates = dict(fields)
+            updates["updated_at"] = self._now()
+            updates["version"] = int(row["version"]) + 1
+            assignments = ", ".join(f"{key} = ?" for key in updates)
+            event_data = dict(data or {})
+            for key in ("phase", "progress_percent"):
+                if fields.get(key) is not None:
+                    event_data.setdefault(key, fields[key])
             conn.execute(
                 f"UPDATE research_runs SET {assignments} WHERE id = ?",
                 (*updates.values(), run_id),
             )
             self._record_event(conn, run_id, event, event_data or None)
-        return self._normalize_run(
-            self._require_one("research_runs", run_id, "research run")
-        )
+            return self._normalize_run(
+                self._require_one("research_runs", run_id, "research run")
+            )
 
     def _dispatch_terminal_run_notification(self, run: dict[str, Any]) -> None:
         status = str(run.get("status") or "").strip()
@@ -1546,13 +1898,13 @@ class LocalResearchService:
                 ),
                 run_id=run_id,
             )
-        self._require_one("research_runs", run_id, "research run")
         content_text = content if isinstance(content, str) else None
         content_json = (
             None if isinstance(content, str) else json.dumps(content, sort_keys=True)
         )
         now = self._now()
-        with self._connect() as conn:
+        with self._transaction(immediate=True) as conn:
+            self._require_one("research_runs", run_id, "research run")
             conn.execute(
                 """
                 INSERT INTO research_artifacts (
@@ -1569,7 +1921,7 @@ class LocalResearchService:
             self._record_event(
                 conn, run_id, "artifact_saved", {"artifact_name": artifact_name}
             )
-        return self.get_artifact(run_id, artifact_name)
+            return self.get_artifact(run_id, artifact_name)
 
     def get_artifact(self, run_id: str, artifact_name: str) -> dict[str, Any] | None:
         if self._uses_external_db:
@@ -1579,8 +1931,8 @@ class LocalResearchService:
                 )
             except KeyError:
                 return None
-        self._require_one("research_runs", run_id, "research run")
-        with self._connect() as conn:
+        with self._transaction() as conn:
+            self._require_one("research_runs", run_id, "research run")
             row = conn.execute(
                 """
                 SELECT * FROM research_artifacts
@@ -1607,8 +1959,8 @@ class LocalResearchService:
                 )
                 for name, content in bundle.items()
             )
-        self._require_one("research_runs", run_id, "research run")
-        with self._connect() as conn:
+        with self._transaction() as conn:
+            self._require_one("research_runs", run_id, "research run")
             rows = conn.execute(
                 """
                 SELECT * FROM research_artifacts
@@ -1647,8 +1999,8 @@ class LocalResearchService:
         """
         if self._uses_external_db:
             return
-        self._require_one("research_runs", run_id, "research run")
-        with self._connect() as conn:
+        with self._transaction(immediate=True) as conn:
+            self._require_one("research_runs", run_id, "research run")
             self._record_event(conn, run_id, event, data)
 
     def list_run_events(
@@ -1658,8 +2010,8 @@ class LocalResearchService:
             return self._awaitable_list(
                 self._external_run_events(run_id, after_id=after_id)
             )
-        self._require_one("research_runs", run_id, "research run")
-        with self._connect() as conn:
+        with self._transaction() as conn:
+            self._require_one("research_runs", run_id, "research run")
             rows = conn.execute(
                 """
                 SELECT * FROM research_run_events

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -259,6 +259,10 @@ class LocalResearchService:
                 MINOR-1). It is also what makes read-check-write sequences
                 atomic now that callers can run on more than one thread.
 
+        Raises:
+            RuntimeError: When an ``immediate=True`` transaction is opened
+                INSIDE a deferred one. See the nesting rules below.
+
         A rollback that fails is swallowed (type name only) so it can never
         mask the exception that caused it.
         """
@@ -267,6 +271,32 @@ class LocalResearchService:
             # Nested use joins the open transaction: a second BEGIN on the same
             # connection is an error, and splitting the commit would break the
             # caller's atomicity.
+            #
+            # But the JOIN inherits the OUTER transaction's locking, and SQLite
+            # cannot upgrade a deferred transaction to a write one -- so a
+            # nested immediate body inside a deferred outer would run its
+            # read-then-write under a read snapshot and fail BUSY_SNAPSHOT,
+            # which is the exact failure ``immediate`` exists to prevent.
+            # Silently downgrading it is the worst option available: the fault
+            # only appears when another writer holds the lock, so it survives
+            # every single-threaded test and then surfaces intermittently in
+            # the field as "database is locked" -- a message that reads like a
+            # transient condition to retry, and is precisely the one SQLite
+            # will NOT retry. Refusing turns that into a deterministic failure
+            # on the first execution, naming the actual mistake.
+            #
+            # Deferred-inside-anything stays legal and is the common shipped
+            # case (``_require_one`` inside ``save_artifact``): a read under an
+            # already-held write lock is always safe.
+            if immediate and not getattr(state, "immediate", False):
+                raise RuntimeError(
+                    "cannot open an IMMEDIATE research transaction inside a "
+                    "DEFERRED one: the nested call would join the outer read "
+                    "snapshot and its write would fail BUSY_SNAPSHOT under "
+                    "contention. Open the OUTER transaction with "
+                    "immediate=True instead -- SQLite cannot upgrade a "
+                    "transaction's lock once it has begun."
+                )
             yield state.conn
             return
 
@@ -279,6 +309,9 @@ class LocalResearchService:
                 conn = self._begin(immediate=immediate)
                 state.depth = 1
                 state.conn = conn
+                # Recorded so a nested call can tell whether the lock it needs
+                # is already held (see the nesting rules above).
+                state.immediate = immediate
                 try:
                     yield conn
                     conn.execute("COMMIT")
@@ -288,6 +321,7 @@ class LocalResearchService:
                 finally:
                     state.depth = 0
                     state.conn = None
+                    state.immediate = False
             finally:
                 if serialise is not None:
                     serialise.release()

--- a/tldw_chatbook/Research_Interop/research_scope_service.py
+++ b/tldw_chatbook/Research_Interop/research_scope_service.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextvars
+import functools
 import inspect
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Any
 
@@ -54,6 +59,98 @@ class ResearchBackend(str, Enum):
     SERVER = "server"
 
 
+def _is_async_callable(candidate: Any) -> bool:
+    """True when calling ``candidate`` returns an awaitable OR an async generator.
+
+    The async-generator arm is not decoration: ``LocalResearchService`` defines
+    ``stream_run_events`` as ``async def ... yield``, and
+    ``inspect.iscoroutinefunction`` is **False** for such a function. Routing it
+    through a thread would hand ``stream_run_events``/``observe_run_events`` a
+    coroutine wrapping the generator object, defeating their
+    ``inspect.isasyncgen`` branch (TASK-21127).
+    """
+
+    def _async(target: Any) -> bool:
+        return inspect.iscoroutinefunction(target) or inspect.isasyncgenfunction(target)
+
+    if _async(candidate):
+        return True
+    call = getattr(candidate, "__call__", None)
+    return call is not None and _async(call)
+
+
+_BACKEND_EXECUTOR: ThreadPoolExecutor | None = None
+_BACKEND_EXECUTOR_LOCK = threading.Lock()
+
+
+def _backend_executor() -> ThreadPoolExecutor:
+    """The single thread every synchronous research-backend call runs on.
+
+    ONE worker, deliberately (the TASK-21125 review's MAJOR-1 finding). Before
+    the offload every scope call ran inline on the event loop, which silently
+    serialised them against each other; a default-pool dispatch would hand that
+    guarantee back and turn each read-check-write in the local service into a
+    live lost update. Serialising on one thread restores the loop's ordering and
+    keeps the whole latency win -- the point was getting OFF the loop, not going
+    wide.
+    """
+    global _BACKEND_EXECUTOR
+    if _BACKEND_EXECUTOR is None:
+        with _BACKEND_EXECUTOR_LOCK:
+            if _BACKEND_EXECUTOR is None:
+                _BACKEND_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="research-backend",
+                )
+    return _BACKEND_EXECUTOR
+
+
+async def _run_on_backend_thread(call: Any) -> Any:
+    """Await ``call()`` on the shared single backend thread.
+
+    Mirrors ``asyncio.to_thread``'s contextvar propagation, which
+    ``run_in_executor`` does not do on its own.
+    """
+    loop = asyncio.get_running_loop()
+    context = contextvars.copy_context()
+    return await loop.run_in_executor(
+        _backend_executor(), functools.partial(context.run, call)
+    )
+
+
+class _ThreadOffloadedBackend:
+    """Runs a synchronous research backend's calls on the backend thread.
+
+    TASK-21127: ``LocalResearchService`` is plain blocking SQLite and every
+    scope method invoked it inline, so the window's 2 s auto-refresh poll and a
+    bundle load both read and decoded on the Textual event loop (measured: a
+    5.5 MB bundle costs ~15 ms of loop time even once the connection is held).
+    Wrapping the backend here rather than at each of the ~25 call sites keeps
+    every scope method's ``_maybe_await`` seam working unchanged: the wrapper
+    returns a coroutine.
+
+    Backends that are already asynchronous -- including async *generators* --
+    pass straight through, so the server backend never pays a thread hop and
+    ``stream_run_events`` keeps yielding.
+    """
+
+    __slots__ = ("_backend",)
+
+    def __init__(self, backend: Any) -> None:
+        self._backend = backend
+
+    def __getattr__(self, name: str) -> Any:
+        attribute = getattr(self._backend, name)
+        if not callable(attribute) or _is_async_callable(attribute):
+            return attribute
+
+        @functools.wraps(attribute)
+        def _offloaded(*args: Any, **kwargs: Any) -> Any:
+            return _run_on_backend_thread(functools.partial(attribute, *args, **kwargs))
+
+        return _offloaded
+
+
 class ResearchScopeService:
     """Route research operations to local or server backends with policy enforcement."""
 
@@ -81,13 +178,19 @@ class ResearchScopeService:
             raise ValueError(f"Invalid research backend: {mode}") from exc
 
     def _service_for_mode(self, mode: ResearchBackend) -> Any:
+        """Return the backend for ``mode``, offloading synchronous calls.
+
+        ``self.local_service`` / ``self.server_service`` keep their identity --
+        callers (and the app-wiring tests) still see the objects that were
+        passed in; only the dispatch path is wrapped (TASK-21127).
+        """
         if mode == ResearchBackend.LOCAL:
             if self.local_service is None:
                 raise ValueError("Local research backend is unavailable.")
-            return self.local_service
+            return _ThreadOffloadedBackend(self.local_service)
         if self.server_service is None:
             raise ValueError("Server research backend is unavailable.")
-        return self.server_service
+        return _ThreadOffloadedBackend(self.server_service)
 
     async def _maybe_await(self, value: Any) -> Any:
         if inspect.isawaitable(value):
@@ -217,21 +320,47 @@ class ResearchScopeService:
             remote_records=remote_records or [],
         )
 
+    @staticmethod
+    @functools.lru_cache(maxsize=256)
+    def _accepted_parameters(
+        owner: type, method_name: str
+    ) -> tuple[frozenset[str], bool]:
+        """Parameter names of ``owner.method_name``, and whether it takes ``**kwargs``.
+
+        Keyed on the CLASS, not the bound method: a bound method is a fresh
+        object per attribute access, so caching on it would never hit and would
+        pin every instance alive. TASK-21127: this ran an uncached
+        ``inspect.signature`` on every scope call, including each 2 s
+        auto-refresh tick.
+        """
+        method = getattr(owner, method_name)
+        parameters = inspect.signature(method).parameters
+        accepts_kwargs = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+        return frozenset(parameters), accepts_kwargs
+
     async def _call_service(
         self, service: Any, method_name: str, *args: Any, **kwargs: Any
     ) -> Any:
         method = getattr(service, method_name)
-        signature = inspect.signature(method)
-        accepts_kwargs = any(
-            parameter.kind == inspect.Parameter.VAR_KEYWORD
-            for parameter in signature.parameters.values()
-        )
+        try:
+            accepted, accepts_kwargs = self._accepted_parameters(
+                type(getattr(service, "_backend", service)), method_name
+            )
+        except (AttributeError, TypeError, ValueError):
+            # Callables the class lookup cannot describe (test doubles built
+            # from instance attributes, C-implemented callables) fall back to
+            # the uncached bound-method signature, as before.
+            parameters = inspect.signature(method).parameters
+            accepted = frozenset(parameters)
+            accepts_kwargs = any(
+                parameter.kind == inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters.values()
+            )
         if not accepts_kwargs:
-            kwargs = {
-                key: value
-                for key, value in kwargs.items()
-                if key in signature.parameters
-            }
+            kwargs = {key: value for key, value in kwargs.items() if key in accepted}
         return await self._maybe_await(method(*args, **kwargs))
 
     @staticmethod

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -12821,6 +12821,33 @@ class TldwCli(
                 f"Error closing local writing service: {type(exc).__name__}"
             )
 
+    async def _close_local_research_service(self) -> None:
+        """Release the research store's held SQLite connections (TASK-21127).
+
+        Peeks the slot rather than reading through any accessor: a service that
+        was never wired must not be constructed purely to close it. A close
+        failure is logged (type name only) and never allowed to abort the rest
+        of unmount.
+
+        Runs on a thread, NOT inline. ``close()`` waits for an operation still
+        running on the research backend thread (a run's progress write, say),
+        and a synchronous call here would freeze the event loop for the whole
+        settle timeout -- which also starves the very operation it is waiting
+        for (the TASK-21125 review's MAJOR-3 finding).
+        """
+        service = getattr(self, "local_research_service", None)
+        if service is None:
+            return
+        close = getattr(service, "close", None)
+        if not callable(close):
+            return
+        try:
+            await asyncio.to_thread(close)
+        except Exception as exc:
+            self.loguru_logger.error(
+                f"Error closing local research service: {type(exc).__name__}"
+            )
+
     async def _shutdown_file_notes_session_owner(self) -> None:
         """Settle the process-owned File Notes Git lifecycle exactly once."""
         owner = getattr(self, "file_notes_session_owner", None)
@@ -13435,6 +13462,9 @@ class TldwCli(
 
         # Release the writing suite's held SQLite connections (TASK-21125).
         await self._close_local_writing_service()
+
+        # Release the research store's held SQLite connections (TASK-21127).
+        await self._close_local_research_service()
 
         # Nothing this app owns is left to ask; a signal from here on has
         # no orderly path to offer and should unwind the main thread.


### PR DESCRIPTION
## Summary

`LocalResearchService` opened a **fresh connection per operation** in file-backed mode — re-running
`PRAGMA journal_mode = WAL` and `synchronous = NORMAL` on every open — across 21 `with
self._connect() as conn:` sites, of which only one ever closed anything (sqlite3's `with conn:` is
a transaction manager, not a closer). Every one of those ran on the Textual event loop. Finding
21127 of the 2026-08-22 review.

- **Held connection per thread** (`dict[thread_ident, Connection]`, so shutdown can reach
  connections it does not own), `isolation_level=None`, through the audited private-sqlite seam.
  All 21 sites became an explicit `_transaction()` BEGIN/COMMIT/ROLLBACK manager. `:memory:` still
  shares exactly one connection — closing it destroys the database, so that trap held.
- **Every read-modify-write is one `BEGIN IMMEDIATE`.** A prerequisite, not polish: under
  `isolation_level=None` a deferred BEGIN that SELECTs then UPDATEs fails `BUSY_SNAPSHOT`, which
  SQLite's busy handler does **not** retry. It also collapses `_update_row`'s three connections
  into one.
- **Scope-service offload** on a single-thread executor, plus a class-keyed `inspect.signature`
  cache. **Unmount** closes the store via `asyncio.to_thread`.

## Measured — 5 interleaved A/B pairs

| | base | after |
|---|---|---|
| Engine, 20 runs — connection opens | 1741 | **3** |
| Engine — loop-side DB time | 877–906 ms | **29–33 ms** |
| Engine — worst contiguous loop stall | 46–51 ms | **2.0–2.5 ms** |
| UI (30 poll ticks + 5.5 MB bundle) — opens | 33 | **0** |
| UI — DB ops on the loop thread | **33/33** | **0/32** |

**Work is gone, not relocated**: the engine's service-call count on the loop thread is 800 in
*both* arms while loop time fell 30×. Loop stalls were measured by an independent ticker — once
work is on a thread, the awaited call's wall time includes that thread's work and stops being a
loop measure.

## Two of the three prescribed fixes were declined, with numbers

One `connect_private_sqlite` open + pragmas costs **0.631 ms**; the SELECT it was opened to run
costs **0.002 ms**. The connect was **99.7%** of the cost, not a share of it — so once the
connection is held, the rest banks almost nothing:

- **Engine offload — declined.** Residue after the held connection is **1.6 ms/run**, worst stall
  2.3 ms. Moving it would need a nested event loop (or ~40 cascading `await`s through 8 synchronous
  methods), cross-thread Textual dispatch, and notification dispatch from a worker thread, at
  **two** call sites — Console's `/research` builds the engine the same way.
- **Keepalive batching — declined.** One 30 s tick goes **0.55 ms → 0.020 ms** from the held
  connection alone. Batching would save 0.02 ms per half-minute while entangling the
  double-execution lease guard.
- The 2 s poll is worth ~nothing by itself (0.023 ms/tick); it ships only because the same proxy
  covers the bundle load, which is **~15 ms of loop time at 5.5 MB even with the connection held**
  and grows with artifact size.

ACs were amended in the task file before implementing, with the retiring measurements recorded.

## Review round: a latent locking hazard, closed

I reviewed the branch and found that `_transaction()`'s nested branch silently ignored `immediate`
— a read-then-write nested inside a deferred transaction would run under a read snapshot, the exact
`BUSY_SNAPSHOT` case IMMEDIATE exists to prevent. **Not reachable today** (a transitive AST walk of
the class's self-call graph found 9 deferred methods, 12 immediate, and 0 deferred→immediate paths),
but it sits in a lifecycle seam where a future caller would silently downgrade its locking.

It now **raises**, because the alternative fails in the worst possible way: a silent downgrade
passes every single-threaded test and every uncontended run, then appears intermittently in the
field as `database is locked` — a message that reads as transient and retryable, and is precisely
the one SQLite will not retry.

The implementer also found what I had missed: the mirror-image nesting, **deferred-inside-immediate,
is the shipped hot path** (`_require_one` inside `save_artifact`, on every artifact the engine
saves). Over-restricting would have broken live behaviour, so all three legal nestings are pinned,
plus an end-to-end `save_artifact` call. Removing the guard reds; never recording the outer's mode
also reds, on a *legal* nesting — which is what proves the guard is scoped to the unsafe case
rather than to nesting in general.

## Quit / error / cancel / empty

All four walked on a **file-backed** store, because the existing engine tests use `:memory:`, which
never opens per-op connections and so cannot exercise this. Quit mid-run (`close()` from another
thread during a live run → the run still completes); DB error mid-run (fails legibly, store usable
afterwards, no poisoned transaction); cancel between phases (resolved exactly once); empty/first-run
(construction creates no file, so TASK-21105's lazy-open contract survives). Plus `close()` before
any use, a double-`close()` race, and a `-wal`-sidecar witness proving no connection outlives
`close()`.

## Mutation: 17 of 17 red, 0 vacuous

Headline: reverting `update_run_progress` to separate read/write transactions yields *"40 writes all
reported success but version advanced 11 time(s): a lost update"* — the hazard proven live, not
argued. Also: closing a wedged thread's connection reproduces the exact TASK-21101
`ProgrammingError`; an inline unmount close gives *"the event loop was frozen during close()
(0 ticks)"*.

**Two mutations initially stayed green.** Rather than weakening the assertions, both were traced to
a redundant second line of defence and pinned with mechanism-level tests — a connection closed
while still mapped, and `conn.in_transaction` after a failed body — after which both went red.

## Verification

`Tests/Research` after rebase: **249 passed, 0 failed** (the full research set including lifecycle
was 351 passed / 0 failed pre-rebase, +26 and +2 from this task). `Tests/App` +
`Tests/ProductionApp` reds A/B-proven identical on base with byte-identical signatures. Collect
sweep clean both sides. Preflight green — the 5 added diagnostic rows were reviewed individually
and carry only `type(exc).__name__` and a timeout constant.

## Out of scope, worth filing

`Research_Window._start_local_engine` and Console's `/research` (`chat_screen.py:16068`) build
`LocalResearchEngine` around the **raw** service, bypassing `ResearchScopeService` entirely — so
policy enforcement and record normalisation do not apply to engine writes. A design question rather
than a bug, but it means the scope layer is not the chokepoint it looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates per-operation SQLite connects and event-loop stalls in research storage. LocalResearchService now holds one connection per thread and uses explicit transactions; ResearchScopeService runs synchronous backend calls on a single-thread executor so the UI path no longer blocks the loop.

- Old vs new: each operation opened and leaked a loop-thread connection; now a thread-held connection (`isolation_level=None`) with explicit BEGIN/COMMIT/ROLLBACK. `:memory:` still uses a single shared connection; `_init_schema` now closes its own connection.
- Locking: read‑modify‑write runs as one BEGIN IMMEDIATE. Calling an IMMEDIATE transaction inside a deferred one now raises; immediate→immediate and deferred‑inside‑immediate still join and are tested.
- UI path: synchronous backend calls dispatch off‑loop on a single-thread executor (ordering preserved); async generators pass through. App unmount closes the store via `asyncio.to_thread` with a bounded settle timeout to avoid freezing the loop.
- Impact: engine opens 1741→3; loop‑side DB time ~900 ms→~30 ms; worst stall ~50 ms→~2 ms. UI opens 33→0; loop DB ops 33/33→0/32.
- Tests/diagnostics: adds lifecycle, threading, and shutdown tests on file‑backed stores; updates a DB interop owner to return a real closer; pins minimal production diagnostics for shutdown/stray‑transaction paths.
- TASK-21127 scope: offloading the engine and batching keepalives were declined based on measurements and documented in the task.

**Migration**
- Call LocalResearchService.close() on shutdown to release held connections.
- Do not open an IMMEDIATE transaction inside a deferred one; open the outer transaction as IMMEDIATE instead.

<sup>Written for commit 74b1c6f5f90f82d7c012a0a739dd4a50b605cb4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

