### PR TITLE
Redesign Watchlists Read as a collapsible NetNewsWire-style reader

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2756,8 +2756,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 81,
-      "diagnostic_digest": "5f559df6345a770cb6c5",
+      "call_count": 85,
+      "diagnostic_digest": "2126a3aac956cf598210",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/watchlists_collections_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2875,8 +2875,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 4,
-      "diagnostic_digest": "1f268634dc34652fddfc",
+      "call_count": 2,
+      "diagnostic_digest": "3c4dbd52adecec86f6e2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2900,6 +2900,13 @@
       "diagnostic_digest": "ec6895803bf0f3090586",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/watchlists_console_handoff.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 3,
+      "diagnostic_digest": "68502e8a801351ff1676",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -3952,9 +3959,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 535,
+    "owner_files": 536,
     "persistent_sink_files": 8,
     "task_492_calls": 1238,
-    "task_494_calls": 7305
+    "task_494_calls": 7310
   }
 }

--- a/Docs/superpowers/plans/2026-08-23-watchlists-collapsible-reader-layout.md
+++ b/Docs/superpowers/plans/2026-08-23-watchlists-collapsible-reader-layout.md
@@ -1,0 +1,491 @@
+# Watchlists Collapsible Reader Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Watchlists Reader the permanent centre of a NetNewsWire-style Read screen while Navigation, Feed Items, and Inspector collapse independently through persistent five-column ASCII grips.
+
+**Architecture:** Keep `WatchlistsCollectionsScreen` as the sole controller. Store only the user's preferred side-pane layout; derive responsive and Article Focus layouts with a pure resolver; pass only the effective layout and explicit Read/management mode into a Watchlists-local workbench. Preserve the already-shipped article list, Smart Feeds, search, refresh, pagination, mutation, selection, and scroll contracts. Do not introduce a shared Media/Watchlists split-pane abstraction in this change.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, pytest/pytest-asyncio, Rich/Textual production CSS bundle, Backlog.md.
+
+**Delivery base:** Work only in `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-21281-watchlists-collapsible-reader-layout` on `codex/task-21281-watchlists-collapsible-reader-layout`. It is based on `origin/dev` commit `527152ad3`; approved documentation was transplanted as `ade0a5ab7`, `6af8780f5`, `4561c4199`, and `730d908d2`. Do not edit, clean, reset, or rebase the unrelated dirty `feat/task-3401-video-generation-foundation` worktree.
+
+**ADR required:** no new ADR
+
+**ADR path:** `backlog/decisions/042-watchlists-reader-first-ia.md`
+
+**Reason:** ADR-042 already owns this long-lived Watchlists information architecture and contains the approved 2026-08-23 permanent-Reader/collapsible-side-pane amendment. This plan directly implements that accepted amendment without creating another architectural boundary.
+
+---
+
+## Task 1: Replace collapse/solo state with preferred side-pane state and a pure responsive resolver
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/region_layout.py`
+- Modify: `Tests/Watchlists/test_region_layout.py`
+- Create: `Tests/Watchlists/test_watchlists_responsive_layout.py`
+
+- [ ] **Step 1: Rewrite the pure-state tests around the approved pane model.**
+
+  Replace the old Reader/Content toggle and centre-solo assertions in `test_region_layout.py` with tests that pin:
+
+  - `COLLAPSIBLE_REGIONS == (LEFT_RAIL, ITEMS, RIGHT_RAIL)`;
+  - `CONTENT` remains in display order but cannot be toggled;
+  - Navigation, Feed Items, and Inspector toggle independently;
+  - preferred state contains no solo or transient fields;
+  - `RegionLayout.toggle(Region.CONTENT)` raises `ValueError`.
+
+- [ ] **Step 2: Add failing boundary tests for the effective-layout resolver.**
+
+  In `test_watchlists_responsive_layout.py`, cover these exact contracts using the declared widths in the design:
+
+  - Read with every side pane preferred open fits at 145 columns; at 144 Inspector is effectively collapsed.
+  - With Inspector collapsed, Navigation and Feed Items fit at 115; at 114 Navigation also collapses.
+  - Feed Items alone fits at 91; at 90 every side pane is collapsed.
+  - Management with Navigation and Inspector open fits at 108; 107 collapses Inspector; 77 collapses Navigation too.
+  - Article Focus collapses every mounted side pane but leaves the preferred object unchanged.
+  - A responsive priority target is protected until every other eligible pane has collapsed.
+  - A preferred-closed pane stays closed, repeated resolution is idempotent, and sub-60 widths return all grips collapsed without raising.
+
+- [ ] **Step 3: Run the new pure tests and confirm they fail for the old centre-solo model.**
+
+  Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_region_layout.py Tests/Watchlists/test_watchlists_responsive_layout.py -q
+  ```
+
+  Expected: failures for missing `COLLAPSIBLE_REGIONS`/resolver and old `CONTENT`/solo behavior.
+
+- [ ] **Step 4: Implement the smallest pure model and resolver.**
+
+  In `region_layout.py`:
+
+  - keep `Region` values stable for existing factories and persisted strings;
+  - define `COLLAPSIBLE_REGIONS`, Read/management mounted-side-pane order, fixed grip width 5, pane minimums 24/32/30, centre comfort 44, and default collapse priorities;
+  - reduce `RegionLayout` to an immutable `collapsed: frozenset[Region]` preferred/effective value;
+  - make `toggle()` reject non-collapsible regions;
+  - add `resolve_effective_layout(preferred, *, width, read_mode, article_focus, priority_target) -> RegionLayout`;
+  - start from preferred collapses, apply Article Focus first, otherwise collapse expanded mounted panes until the declared sum fits;
+  - reorder the collapse candidates so `priority_target` is last, and never collapse `CONTENT` or a management canvas;
+  - once every side pane is collapsed, return that layout even below the comfort floor so CSS may give the permanent centre `min-width: 0`.
+
+- [ ] **Step 5: Run the pure tests.**
+
+  Run the Step 3 command. Expected: pass.
+
+- [ ] **Step 6: Commit the pure layout model.**
+
+  ```bash
+  git add tldw_chatbook/UI/Watchlists_Modules/region_layout.py Tests/Watchlists/test_region_layout.py Tests/Watchlists/test_watchlists_responsive_layout.py
+  git commit -m "feat(watchlists): model preferred and responsive pane layouts"
+  ```
+
+## Task 2: Version and atomically normalize the persisted preferred layout
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py`
+- Modify: `Tests/Watchlists/test_region_layout_store.py`
+
+- [ ] **Step 1: Replace Phase-D marker tests with versioned-normalization tests.**
+
+  Cover:
+
+  - no saved keys returns Navigation/Feed Items open and Inspector collapsed;
+  - an explicit saved empty list means every side pane expanded;
+  - valid `left_rail`, `items`, and `right_rail` values round-trip;
+  - old `content`, retired `feeds`, unknown strings, strings-as-singletons, and non-sequences normalize safely;
+  - a stale/missing layout version triggers exactly one `save_settings_to_cli_config` call containing both normalized `collapsed_regions` and `layout_version`;
+  - the same mutation deletes the retired `content_reader_migrated` key;
+  - a `False` return or exception leaves the version logically stale so a second load retries;
+  - `save_region_layout` writes only valid side panes plus the current version and returns the writer's success.
+
+- [ ] **Step 2: Run the store tests and confirm the old single-key marker implementation fails.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_region_layout_store.py -q
+  ```
+
+- [ ] **Step 3: Implement version 2 normalization with one configuration mutation.**
+
+  In `region_layout_store.py`:
+
+  - import `save_settings_to_cli_config` instead of the single-key writer;
+  - define `LAYOUT_VERSION = 2`, `layout_version`, `collapsed_regions`, and the retired marker name as constants;
+  - normalize every raw value to a `RegionLayout` containing only `COLLAPSIBLE_REGIONS`;
+  - when the version is stale or the stored value differs from normalized output, call:
+
+    ```python
+    save_settings_to_cli_config(
+        {"watchlists": {
+            "collapsed_regions": normalized_values,
+            "layout_version": LAYOUT_VERSION,
+        }},
+        delete_keys={"watchlists": ("content_reader_migrated",)},
+    )
+    ```
+
+  - apply the safe normalized value in memory even when the write fails; do not write a separate marker;
+  - make `save_region_layout()` use the same two-key atomic mutation and preserve its Boolean result.
+
+- [ ] **Step 4: Run the store and config mutation contract tests.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_region_layout_store.py Tests/test_config_save_settings_semantics.py Tests/test_config_delete_settings.py -q
+  ```
+
+- [ ] **Step 5: Commit persistence normalization.**
+
+  ```bash
+  git add tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py Tests/Watchlists/test_region_layout_store.py
+  git commit -m "feat(watchlists): version preferred pane layout"
+  ```
+
+## Task 3: Add the focused, clickable five-column ASCII grip
+
+**Files:**
+
+- Create: `tldw_chatbook/UI/Watchlists_Modules/pane_grip.py`
+- Create: `Tests/Watchlists/test_watchlists_pane_grip.py`
+
+- [ ] **Step 1: Write grip direction, semantics, and rendering tests.**
+
+  Use a minimal Textual app and assert:
+
+  - Navigation/Feed Items render `--->` while collapsed and `<---` while expanded;
+  - Inspector renders `<---` while collapsed and `--->` while expanded;
+  - each grip is focusable and clicking or pressing Enter posts one `RegionToggled(region)` message;
+  - tooltip/name copy says `Expand/Collapse <pane>` rather than exposing only arrows;
+  - explicit inline `line_pad == 0` defeats Textual `Button` padding;
+  - the direction/accessible-copy update changes the existing widget in place.
+
+- [ ] **Step 2: Run the new grip test and confirm it fails because the widget does not exist.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_watchlists_pane_grip.py -q
+  ```
+
+- [ ] **Step 3: Implement `WatchlistsPaneGrip`.**
+
+  Subclass `Button`, define the destination-local `RegionToggled` message beside it, accept `region` and `expanded`, set `compact=True`, set `styles.line_pad = 0`, compute visible label/tooltip/name from the pane and action, and post the message exactly once. Expose an `expanded` update method/reactive that relabels in place without changing widget identity. Import that message from `watchlists_workbench.py` and the screen so no circular import is introduced. Keep all code Watchlists-local.
+
+- [ ] **Step 4: Run the grip tests.**
+
+- [ ] **Step 5: Commit the grip widget and its non-CSS tests.**
+
+  ```bash
+  git add tldw_chatbook/UI/Watchlists_Modules/pane_grip.py Tests/Watchlists/test_watchlists_pane_grip.py
+  git commit -m "feat(watchlists): add ASCII pane grips"
+  ```
+
+## Task 4: Rebuild the workbench around a permanent horizontal centre anchor
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`
+- Modify: `Tests/Watchlists/test_watchlists_workbench.py`
+- Modify: `Tests/Watchlists/test_watchlists_scoped_rebuilds.py`
+
+- [ ] **Step 1: Replace vertical-stack expectations with explicit Read/management DOM contracts.**
+
+  Add or update tests to assert the exact body order:
+
+  - Read expanded: Navigation body, Navigation grip, Feed Items body, Feed Items grip, permanent Reader body, Inspector grip, Inspector body;
+  - Read collapsed panes leave their grip mounted and remove only that pane body;
+  - management: Navigation body/grip, permanent active `Region.ITEMS` canvas, Inspector grip/body; no Feed Items grip and no Reader;
+  - header remains above the horizontal body on every tab;
+  - `Region.CONTENT` is always mounted in Read even if an old effective layout contains it;
+  - toggling one pane preserves every unaffected pane/grip instance and the permanent Reader instance;
+  - `refresh_region_content` and `refresh_header_content` still replace only their named factory output and remain failure-safe;
+  - changing Read/management mode through `apply_section_view` changes only the required centre factories and does not recompose the full workbench.
+
+  Remove obsolete tests for stacked 10–50/20–50 row caps, centre solo classes, collapsed text headers, and outer-centre scrolling. Keep the Reader's own body-scroll/action/footer containment tests that remain meaningful.
+
+- [ ] **Step 2: Run the workbench/scoped-rebuild tests and confirm the old `VerticalScroll` composition fails.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_watchlists_workbench.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py -q
+  ```
+
+- [ ] **Step 3: Introduce explicit workbench mode and permanent-centre composition.**
+
+  In `watchlists_workbench.py`:
+
+  - change the root to `Vertical`: optional `#wl-centre-status` first, then a `Horizontal#wl-workbench-body`;
+  - replace the implicit `hidden` centre-region interpretation with `read_mode: bool` supplied by the screen;
+  - in Read, always mount the `Region.CONTENT` factory as the flexing centre and conditionally mount Navigation/Feed Items/Inspector bodies around their always-mounted grips;
+  - in management, always mount the `Region.ITEMS` factory as the centre canvas with only Navigation and Inspector grips;
+  - keep body ids (`#wl-region-<value>`) and factory-based rebuild safety where existing screen/test contracts rely on them;
+  - update grip labels in place and mount/remove only a pane body when effective collapse changes;
+  - remove generic collapsed-header/suffix/sole-centre machinery;
+  - keep `refresh_region_content`, `refresh_header_content`, and `apply_section_view` incremental—no `recompose=True` regression.
+
+- [ ] **Step 4: Run the focused workbench tests.**
+
+  Run the Step 2 command. Expected: pass except production CSS geometry that Task 6 intentionally updates.
+
+- [ ] **Step 5: Commit the workbench composition.**
+
+  ```bash
+  git add tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py Tests/Watchlists/test_watchlists_workbench.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+  git commit -m "feat(watchlists): anchor Reader in horizontal workbench"
+  ```
+
+## Task 5: Reduce Reader chrome to the approved actions and move advanced change actions to Inspector
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/content_pane.py`
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py`
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Modify: `Tests/Watchlists/test_watchlists_workbench.py`
+- Modify: `Tests/Watchlists/test_watchlists_collections_screen.py`
+- Modify: `Tests/Watchlists/test_watchlists_scoped_rebuilds.py`
+
+- [ ] **Step 1: Write the approved empty-state and action-surface tests.**
+
+  Assert:
+
+  - no selection renders exactly `Select a feed item to display it here.`;
+  - the Reader action row contains only `content-star-button`, `content-mark-unread-button`, and `content-open-button` in that order;
+  - Ingest and Queue/Unqueue remain present in Inspector for item entities;
+  - change items expose Full page and Previous snapshot through Inspector and still post the existing snapshot-view request;
+  - Reader has no Expand/Restore button because `Z` owns Article Focus;
+  - the footer's position and Next unread affordance remain unchanged.
+
+- [ ] **Step 2: Run the focused Reader/Inspector tests and confirm they fail.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_watchlists_workbench.py Tests/Watchlists/test_watchlists_collections_screen.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py -q
+  ```
+
+- [ ] **Step 3: Simplify `ContentPane` and preserve advanced capability in Inspector.**
+
+  - change the empty copy;
+  - remove Reader Ingest, Queue, Expand, Full page, and Previous snapshot buttons and their reader-only dispatch branches;
+  - remove `expanded`, `watch_expanded`, and `ExpandReaderRequested`;
+  - move `ViewSnapshotRequested` to `inspector_pane.py` beside the other Inspector action messages;
+  - render Full page/Previous snapshot Inspector buttons only for a selected `content_kind == "change"` item;
+  - keep the screen's existing snapshot modal handler but import the message from Inspector;
+  - remove the obsolete expand-reader handler and `_sync_reader_expanded_state` calls;
+  - retain the existing shared screen handlers for status, star, open, ingest, and queue so semantics do not fork.
+
+- [ ] **Step 4: Run the focused Reader/Inspector tests.**
+
+- [ ] **Step 5: Commit the Reader surface change.**
+
+  ```bash
+  git add tldw_chatbook/UI/Watchlists_Modules/content_pane.py tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/Watchlists/test_watchlists_workbench.py Tests/Watchlists/test_watchlists_collections_screen.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+  git commit -m "refactor(watchlists): keep core actions in Reader"
+  ```
+
+## Task 6: Apply production geometry for fixed grips and flexing Reader
+
+**Files:**
+
+- Modify: `tldw_chatbook/css/features/_watchlists.tcss`
+- Regenerate: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Modify: `Tests/Watchlists/test_watchlists_workbench.py`
+- Modify: `Tests/Watchlists/test_watchlists_pane_grip.py`
+
+- [ ] **Step 1: Finish production-CSS geometry tests before editing CSS.**
+
+  Use harnesses whose `CSS_PATH` is the real generated bundle. At 145, 144, 115, 114, 91, 90, 60, and a sub-floor width, assert:
+
+  - every mounted grip has outer width/min/max 5 and all four arrow characters occupy its four label columns beside the divider;
+  - Navigation target/min widths are 28/24, Feed Items 40/32, Inspector 34/30;
+  - Reader/management canvas gets the remaining width, has `min-width: 0`, and is never absent;
+  - pane/grip/centre sibling regions are contained, non-overlapping, in the approved order;
+  - `#wl-workbench-body.max_scroll_x == 0` and no child extends beyond its content region;
+  - Reader body scroll moves without shifting actions, footer, grips, or adjacent panes;
+  - focus styling does not widen or clip a grip.
+
+- [ ] **Step 2: Run geometry tests and confirm old CSS fails.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_watchlists_pane_grip.py Tests/Watchlists/test_watchlists_workbench.py -q
+  ```
+
+- [ ] **Step 3: Replace stacked-centre CSS with the approved horizontal geometry.**
+
+  In `_watchlists.tcss`:
+
+  - make the workbench vertical and `#wl-workbench-body` horizontal, `width: 100%`, `height: 1fr`, `min-height/min-width: 0`, without horizontal scrolling;
+  - set expanded pane target/min values to 28/24, 40/32, and 34/30;
+  - set every `.watchlists-pane-grip` width/min/max to 5, height 100%, padding/margin 0, one divider border, and `content-align: center middle`;
+  - make Reader/management centre `width: 1fr; min-width: 0; height: 100%; min-height: 0`;
+  - remove obsolete stacked height caps, collapsed 16-column header rules, and sole-centre rules;
+  - preserve the Reader's internal `VerticalScroll`, fixed action row, and fixed footer rules.
+
+- [ ] **Step 4: Regenerate and verify the bundle.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python tldw_chatbook/css/build_css.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python tldw_chatbook/css/check_bundle_sync.py
+  ```
+
+- [ ] **Step 5: Run geometry tests and inspect at least one compositor capture for a full arrow label and non-overlap.**
+
+- [ ] **Step 6: Commit source CSS, generated CSS, and geometry tests together.**
+
+  ```bash
+  git add tldw_chatbook/css/features/_watchlists.tcss tldw_chatbook/css/tldw_cli_modular.tcss Tests/Watchlists/test_watchlists_pane_grip.py Tests/Watchlists/test_watchlists_workbench.py
+  git commit -m "style(watchlists): size collapsible reader panes"
+  ```
+
+## Task 7: Wire preferred/effective/Article Focus state into the screen
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Modify: `Tests/Watchlists/test_watchlists_collections_screen.py`
+- Modify: `Tests/Watchlists/test_watchlists_scoped_rebuilds.py`
+- Modify: `Tests/Watchlists/test_watchlists_cold_open_layout.py`
+- Modify: `Tests/Watchlists/test_watchlists_pagination.py`
+
+- [ ] **Step 1: Add failing controller tests for all three layout layers.**
+
+  Cover:
+
+  - `region_layout` is preferred state and the workbench receives a separately resolved effective state;
+  - resize changes effective state only and calls no config writer;
+  - `Z` on Read toggles Article Focus, every side pane collapses effectively, and a second `Z` restores the exact preferred state;
+  - `Z` off Read is refused without changing either state;
+  - a grip/manual action during Article Focus exits focus first, then applies its action;
+  - clicking a responsively collapsed but preferred-open grip protects that pane instead of closing its preference;
+  - expanding a truly preferred-closed grip opens and persists it; collapsing an effective-open grip closes and persists it;
+  - `z` toggles only a focused collapsible pane/grip, does nothing to Reader or a management canvas, and `[`/`]` continue to target Navigation/Inspector;
+  - switching tabs preserves the one Inspector preference and parks Feed Items preference off Read;
+  - a pane collapsed by resize hands focus to its grip; reopening returns focus inside the pane when possible;
+  - repeated shrink/expand cycles are idempotent.
+
+- [ ] **Step 2: Add persistence-worker failure/retry tests.**
+
+  Pin that `_last_persisted_collapsed` advances only after `save_region_layout` returns `True`; `False`/exception retains the pending newest preferred value, and a later manual gesture schedules another attempt. Also pin last-request-wins behavior under rapid toggles.
+
+- [ ] **Step 3: Add state-survival tests around effective layout changes.**
+
+  Starting from a loaded ArticleListPane/Reader, record selected item id, committed scope, filter, search, loaded page count, visible-row anchor/focus, and Reader body scroll. Manually collapse/expand each side pane, trigger responsive collapses, and toggle Article Focus; assert those semantic values and live unaffected widget instances survive. Keep the existing rule that a genuine scope change clears Reader and never auto-selects/auto-reads a first item.
+
+- [ ] **Step 4: Run the controller tests and confirm the old single-layout/solo behavior fails.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_watchlists_collections_screen.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py Tests/Watchlists/test_watchlists_cold_open_layout.py Tests/Watchlists/test_watchlists_pagination.py -q
+  ```
+
+- [ ] **Step 5: Implement screen-owned preferred/effective state.**
+
+  - keep `region_layout` as the persisted preferred `RegionLayout` to minimize call-site churn;
+  - add non-persisted `effective_region_layout`, `_article_focus_active`, and `_responsive_priority_target` state;
+  - centralize `resolve_effective_layout(...)` in `_recompute_effective_layout`, called from mount, `Resize`, section switches, preferred toggles, and Article Focus changes;
+  - pass `read_mode=self.active_section == "items"` and only the effective layout to `WatchlistsWorkbench`/`apply_section_view`;
+  - clear the priority target when the full preferred layout fits again or the target is manually collapsed;
+  - implement manual grip action from effective state: open/protect when effectively collapsed, close when effectively open;
+  - replace `action_solo_region` with `action_article_focus`; bind `Z` to Article Focus and update the binding label;
+  - ensure only preferred manual gestures call `_schedule_layout_persist`;
+  - hand focus to the relevant grip before an effectively hidden body is removed.
+
+- [ ] **Step 6: Make ordinary preference persistence acknowledge success.**
+
+  Give each requested write a monotonically increasing generation. The thread worker snapshots the latest generation/layout under the existing lock, calls `save_region_layout`, and uses `call_from_thread` to acknowledge the exact generation. Advance `_last_persisted_collapsed` and clear pending state only for a successful current generation; leave a failed current value pending/retryable; if a newer generation arrived while an older write ran, drain the newest value next. Never mutate Textual reactive state directly from the worker thread.
+
+- [ ] **Step 7: Run the controller tests.**
+
+- [ ] **Step 8: Commit the screen controller integration.**
+
+  ```bash
+  git add tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/Watchlists/test_watchlists_collections_screen.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py Tests/Watchlists/test_watchlists_cold_open_layout.py Tests/Watchlists/test_watchlists_pagination.py
+  git commit -m "feat(watchlists): derive responsive and focus layouts"
+  ```
+
+## Task 8: Close cross-tab, help, restart, and destination-shell regressions
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Modify: `Tests/UI/test_destination_shells.py`
+- Modify: `Tests/Watchlists/test_watchlists_collections_screen.py`
+- Modify: `Tests/Watchlists/test_watchlists_cold_open_layout.py`
+- Modify: `Tests/Watchlists/test_watchlists_scoped_rebuilds.py`
+- Modify as required by failures: focused `Tests/Watchlists/test_watchlists_*` files that assert retired collapsed headers/solo behavior
+
+- [ ] **Step 1: Add one seven-tab acceptance test.**
+
+  Open Inspector on Read, visit Sources/Runs/Rules/Notifications/Artifacts/Overview, assert the same preferred Inspector state and correct `<---`/`--->` grip action in each tab, then collapse Inspector on a management tab and assert Read sees it collapsed. Also assert each management centre canvas remains mounted and Feed Items/grip are absent.
+
+- [ ] **Step 2: Add an isolated-config restart test.**
+
+  Under a temporary `HOME`, `XDG_CONFIG_HOME`, and `TLDW_CONFIG_PATH`, save a non-default preferred combination, construct a fresh screen/app, and assert the same three preferences return while responsive/Article Focus state does not. Assert a legacy `content` collapse is removed and does not return after the versioned write.
+
+- [ ] **Step 3: Update help/footer copy and test it.**
+
+  In `BINDINGS` and `action_show_help`, advertise only implemented actions:
+
+  - `z`: toggle focused side pane;
+  - `Z`: Article Focus on Read;
+  - `[`/`]`: Navigation/Inspector;
+  - Reader is permanent and has no collapse/Expand action.
+
+  Do not bind any terminal-convention or global reserved key prohibited by ADR-031.
+
+- [ ] **Step 4: Run the full focused Watchlists/destination shell set.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists Tests/UI/test_destination_shells.py -q
+  ```
+
+  When an old test fails only because it asserts a retired collapsed header, vertical centre cap, Reader collapse, or solo contract, update it to the approved permanent-centre contract. Do not weaken unrelated Smart Feed, list, mutation, pagination, or snapshot assertions.
+
+- [ ] **Step 5: Commit the cross-tab/help closeout.**
+
+  ```bash
+  git add tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/Watchlists Tests/UI/test_destination_shells.py
+  git commit -m "test(watchlists): cover collapsible reader layout end to end"
+  ```
+
+## Task 9: Verify live behavior, document evidence, and complete Backlog hygiene
+
+**Files:**
+
+- Modify: `Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md` only if implementation facts differ
+- Modify: `backlog/decisions/042-watchlists-reader-first-ia.md` only if an accepted consequence needs factual clarification
+- Modify: `backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md`
+- Modify only if a genuine reusable incident occurred: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-live-verification.md`
+
+- [ ] **Step 1: Run focused tests, CSS integrity, lint, and whitespace checks from the dedicated worktree.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists Tests/UI/test_destination_shells.py -q
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python tldw_chatbook/css/check_bundle_sync.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check tldw_chatbook/UI/Watchlists_Modules tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/Watchlists Tests/UI/test_destination_shells.py
+  git diff --check
+  ```
+
+- [ ] **Step 2: Run the broader regression suite or establish an identical-base failure comparison.**
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q
+  ```
+
+  If unrelated repository/environment failures occur, rerun the exact failing node ids against `origin/dev` in an isolated comparison worktree and record only identical failure sets as pre-existing. Do not claim success from a different command or a bare-widget harness.
+
+- [ ] **Step 3: Perform isolated-profile live Textual verification.**
+
+  Launch with absolute interpreter and isolated config paths. Verify Read at 145, 144, 115, 114, 91, 90, and 60 columns plus one sub-floor width; click each grip using terminal character positions (not UTF-8 byte offsets); verify arrow direction, focus, `z`, `Z`, `[`/`]`, Article Focus restoration, cross-tab Inspector state, restart persistence, Reader empty copy, selected article reading, three-action Reader row, and management centre survival. Confirm no compositor exception, overlap, or horizontal overflow.
+
+- [ ] **Step 4: Self-review the final diff against every acceptance criterion.**
+
+  Check especially: no Media/shared framework edits, no database/schema change, no Reader collapse path, no responsive/focus config writes, failed write retryability, production CSS rather than test-only CSS, and preservation of list/Reader semantic state.
+
+- [ ] **Step 5: Update Backlog task 21281.**
+
+  Add concise Implementation Notes with approach, decisions, modified files, commits, automated/live evidence, ADR-042 link, deviations, and any pre-existing failures. Check each acceptance criterion only after its evidence exists, then set status Done only if the repository Definition of Done is satisfied.
+
+- [ ] **Step 6: Commit documentation/task closeout.**
+
+  ```bash
+  git add Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md backlog/decisions/042-watchlists-reader-first-ia.md 'backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md'
+  git commit -m "docs(watchlists): close collapsible reader layout task"
+  ```

--- a/Docs/superpowers/plans/2026-08-23-watchlists-collapsible-reader-layout.md
+++ b/Docs/superpowers/plans/2026-08-23-watchlists-collapsible-reader-layout.md
@@ -31,10 +31,10 @@
   Replace the old Reader/Content toggle and centre-solo assertions in `test_region_layout.py` with tests that pin:
 
   - `COLLAPSIBLE_REGIONS == (LEFT_RAIL, ITEMS, RIGHT_RAIL)`;
-  - `CONTENT` remains in display order but cannot be toggled;
+  - the new strict preferred-layout toggle rejects `CONTENT`;
   - Navigation, Feed Items, and Inspector toggle independently;
-  - preferred state contains no solo or transient fields;
-  - `RegionLayout.toggle(Region.CONTENT)` raises `ValueError`.
+  - the responsive resolver never creates or persists solo/transient state;
+  - the legacy `toggle`/`solo` accessors remain only as transitional compatibility until Task 7.
 
 - [ ] **Step 2: Add failing boundary tests for the effective-layout resolver.**
 
@@ -64,12 +64,17 @@
 
   - keep `Region` values stable for existing factories and persisted strings;
   - define `COLLAPSIBLE_REGIONS`, Read/management mounted-side-pane order, fixed grip width 5, pane minimums 24/32/30, centre comfort 44, and default collapse priorities;
-  - reduce `RegionLayout` to an immutable `collapsed: frozenset[Region]` preferred/effective value;
-  - make `toggle()` reject non-collapsible regions;
+  - add a strict `toggle_preferred()` operation that rejects non-collapsible regions;
   - add `resolve_effective_layout(preferred, *, width, read_mode, article_focus, priority_target) -> RegionLayout`;
   - start from preferred collapses, apply Article Focus first, otherwise collapse expanded mounted panes until the declared sum fits;
   - reorder the collapse candidates so `priority_target` is last, and never collapse `CONTENT` or a management canvas;
   - once every side pane is collapsed, return that layout even below the comfort floor so CSS may give the permanent centre `min-width: 0`.
+
+  Keep the old `solo_region`, `_pre_solo`, `solo()`, `toggle()`, and
+  `collapsed_for_persistence()` members temporarily so the live screen remains importable and
+  composable through Tasks 1–6. Mark them as migration-only in their docstrings; the resolver and
+  store must not create new solo state. Task 7 removes them immediately after migrating the final
+  screen call sites and tests to preferred/effective state.
 
 - [ ] **Step 5: Run the pure tests.**
 
@@ -185,6 +190,8 @@
 **Files:**
 
 - Modify: `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`
+- Modify: `tldw_chatbook/css/features/_watchlists.tcss`
+- Regenerate: `tldw_chatbook/css/tldw_cli_modular.tcss`
 - Modify: `Tests/Watchlists/test_watchlists_workbench.py`
 - Modify: `Tests/Watchlists/test_watchlists_scoped_rebuilds.py`
 
@@ -214,7 +221,9 @@
   In `watchlists_workbench.py`:
 
   - change the root to `Vertical`: optional `#wl-centre-status` first, then a `Horizontal#wl-workbench-body`;
-  - replace the implicit `hidden` centre-region interpretation with `read_mode: bool` supplied by the screen;
+  - add explicit `read_mode: bool` while temporarily accepting the current `hidden=` constructor/
+    `apply_section_view` keyword as a compatibility adapter (`CONTENT` hidden means management;
+    otherwise Read), because the live screen migrates in Task 7;
   - in Read, always mount the `Region.CONTENT` factory as the flexing centre and conditionally mount Navigation/Feed Items/Inspector bodies around their always-mounted grips;
   - in management, always mount the `Region.ITEMS` factory as the centre canvas with only Navigation and Inspector grips;
   - keep body ids (`#wl-region-<value>`) and factory-based rebuild safety where existing screen/test contracts rely on them;
@@ -222,14 +231,31 @@
   - remove generic collapsed-header/suffix/sole-centre machinery;
   - keep `refresh_region_content`, `refresh_header_content`, and `apply_section_view` incremental—no `recompose=True` regression.
 
+  The compatibility adapter must be covered by a real-screen scoped-rebuild test and removed in
+  Task 7 when the last `hidden=` call sites are replaced. This makes the Task 4 checkpoint runnable
+  rather than leaving the screen and workbench APIs out of sync.
+
+  In the same step, make the minimum structural CSS change required for this DOM to be usable:
+  vertical workbench root, horizontal `#wl-workbench-body`, flexing permanent centre, fixed
+  five-column grips, and the declared pane target/min widths. Remove the old vertical-stack/collapsed-
+  header selectors, regenerate `tldw_cli_modular.tcss`, and run the bundle-sync guard. Task 6 adds
+  exhaustive boundary/compositor coverage and any evidence-driven refinements; it must not be the
+  first commit in which the new DOM can render.
+
 - [ ] **Step 4: Run the focused workbench tests.**
 
-  Run the Step 2 command. Expected: pass except production CSS geometry that Task 6 intentionally updates.
+  Run the Step 2 command plus:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python tldw_chatbook/css/check_bundle_sync.py
+  ```
+
+  Expected: pass. Do not commit a workbench DOM that still depends on Task 6 to become renderable.
 
 - [ ] **Step 5: Commit the workbench composition.**
 
   ```bash
-  git add tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py Tests/Watchlists/test_watchlists_workbench.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+  git add tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py tldw_chatbook/css/features/_watchlists.tcss tldw_chatbook/css/tldw_cli_modular.tcss Tests/Watchlists/test_watchlists_workbench.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py
   git commit -m "feat(watchlists): anchor Reader in horizontal workbench"
   ```
 
@@ -254,6 +280,8 @@
   - change items expose Full page and Previous snapshot through Inspector and still post the existing snapshot-view request;
   - Reader has no Expand/Restore button because `Z` owns Article Focus;
   - the footer's position and Next unread affordance remain unchanged.
+  - both the keyboard and button Open paths validate first, schedule the actual
+    `webbrowser.open` call on a thread worker, and report a worker failure without disturbing Reader.
 
 - [ ] **Step 2: Run the focused Reader/Inspector tests and confirm they fail.**
 
@@ -270,7 +298,9 @@
   - render Full page/Previous snapshot Inspector buttons only for a selected `content_kind == "change"` item;
   - keep the screen's existing snapshot modal handler but import the message from Inspector;
   - remove the obsolete expand-reader handler and `_sync_reader_expanded_state` calls;
-  - retain the existing shared screen handlers for status, star, open, ingest, and queue so semantics do not fork.
+  - retain the existing shared screen handlers for status, star, open, ingest, and queue so semantics do not fork;
+  - split `_open_item_in_browser` into UI-thread validation/dispatch and a thread worker that calls
+    `webbrowser.open`, then acknowledges failure through `call_from_thread`.
 
 - [ ] **Step 4: Run the focused Reader/Inspector tests.**
 
@@ -378,14 +408,24 @@
 - [ ] **Step 5: Implement screen-owned preferred/effective state.**
 
   - keep `region_layout` as the persisted preferred `RegionLayout` to minimize call-site churn;
-  - add non-persisted `effective_region_layout`, `_article_focus_active`, and `_responsive_priority_target` state;
+  - add non-persisted instance state for the effective layout,
+    `_article_focus_active`, and `_responsive_priority_target` (do not add another class-level
+    reactive default merely to hold derived state);
   - centralize `resolve_effective_layout(...)` in `_recompute_effective_layout`, called from mount, `Resize`, section switches, preferred toggles, and Article Focus changes;
   - pass `read_mode=self.active_section == "items"` and only the effective layout to `WatchlistsWorkbench`/`apply_section_view`;
   - clear the priority target when the full preferred layout fits again or the target is manually collapsed;
-  - implement manual grip action from effective state: open/protect when effectively collapsed, close when effectively open;
+  - implement manual grip action from effective state: capture the grip's requested action before
+    changing Article Focus; if it requested Open, exit focus and keep/open the preferred pane plus
+    its priority target rather than accidentally closing the now-restored pane; if it requested
+    Close, close the preferred pane and clear its priority target;
   - replace `action_solo_region` with `action_article_focus`; bind `Z` to Article Focus and update the binding label;
   - ensure only preferred manual gestures call `_schedule_layout_persist`;
   - hand focus to the relevant grip before an effectively hidden body is removed.
+
+  At the end of this step, remove the Task 1 legacy `solo_region`, `_pre_solo`, `solo()`, permissive
+  `toggle()`, and `collapsed_for_persistence()` compatibility plus Task 4's `hidden=` adapter. Change
+  every remaining screen/workbench/store call site to strict preferred/effective APIs in the same
+  commit, and run an import/compose smoke test before the broader controller suite.
 
 - [ ] **Step 6: Make ordinary preference persistence acknowledge success.**
 
@@ -415,11 +455,19 @@
 
   Open Inspector on Read, visit Sources/Runs/Rules/Notifications/Artifacts/Overview, assert the same preferred Inspector state and correct `<---`/`--->` grip action in each tab, then collapse Inspector on a management tab and assert Read sees it collapsed. Also assert each management centre canvas remains mounted and Feed Items/grip are absent.
 
-- [ ] **Step 2: Add an isolated-config restart test.**
+- [ ] **Step 2: Pin and implement honest Server-backed Read recovery.**
+
+  Add a test that enters Read with `runtime_backend == "server"`, asserts the permanent centre shows
+  the existing local-only explanation plus **Switch to Local**, and spies that no local item, Smart
+  Feed count, search, or refresh query is issued under the Server label. Add Read to the screen's
+  local-only section policy, keep the backend selector truthful/disabled for that state, and route
+  Switch to Local through the normal backend change/load path before mounting local rows.
+
+- [ ] **Step 3: Add an isolated-config restart test.**
 
   Under a temporary `HOME`, `XDG_CONFIG_HOME`, and `TLDW_CONFIG_PATH`, save a non-default preferred combination, construct a fresh screen/app, and assert the same three preferences return while responsive/Article Focus state does not. Assert a legacy `content` collapse is removed and does not return after the versioned write.
 
-- [ ] **Step 3: Update help/footer copy and test it.**
+- [ ] **Step 4: Update help/footer copy and test it.**
 
   In `BINDINGS` and `action_show_help`, advertise only implemented actions:
 
@@ -430,7 +478,7 @@
 
   Do not bind any terminal-convention or global reserved key prohibited by ADR-031.
 
-- [ ] **Step 4: Run the full focused Watchlists/destination shell set.**
+- [ ] **Step 5: Run the full focused Watchlists/destination shell set.**
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists Tests/UI/test_destination_shells.py -q
@@ -438,7 +486,7 @@
 
   When an old test fails only because it asserts a retired collapsed header, vertical centre cap, Reader collapse, or solo contract, update it to the approved permanent-centre contract. Do not weaken unrelated Smart Feed, list, mutation, pagination, or snapshot assertions.
 
-- [ ] **Step 5: Commit the cross-tab/help closeout.**
+- [ ] **Step 6: Commit the cross-tab/help closeout.**
 
   ```bash
   git add tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/Watchlists Tests/UI/test_destination_shells.py
@@ -486,6 +534,6 @@
 - [ ] **Step 6: Commit documentation/task closeout.**
 
   ```bash
-  git add Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md backlog/decisions/042-watchlists-reader-first-ia.md 'backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md'
+  git add Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md backlog/decisions/042-watchlists-reader-first-ia.md backlog/docs/lessons-testing-evidence.md backlog/docs/lessons-live-verification.md 'backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md'
   git commit -m "docs(watchlists): close collapsible reader layout task"
   ```

--- a/Docs/superpowers/plans/2026-08-23-watchlists-collapsible-reader-layout.md
+++ b/Docs/superpowers/plans/2026-08-23-watchlists-collapsible-reader-layout.md
@@ -228,12 +228,15 @@
   - in management, always mount the `Region.ITEMS` factory as the centre canvas with only Navigation and Inspector grips;
   - keep body ids (`#wl-region-<value>`) and factory-based rebuild safety where existing screen/test contracts rely on them;
   - update grip labels in place and mount/remove only a pane body when effective collapse changes;
-  - remove generic collapsed-header/suffix/sole-centre machinery;
+  - remove generic collapsed-header/sole-centre rendering machinery, but retain the
+    `collapsed_suffixes=` constructor keyword and `set_collapsed_suffixes(...)` as documented
+    no-op compatibility because the live screen still calls them through Task 6;
   - keep `refresh_region_content`, `refresh_header_content`, and `apply_section_view` incremental—no `recompose=True` regression.
 
-  The compatibility adapter must be covered by a real-screen scoped-rebuild test and removed in
-  Task 7 when the last `hidden=` call sites are replaced. This makes the Task 4 checkpoint runnable
-  rather than leaving the screen and workbench APIs out of sync.
+  The `hidden=` and collapsed-suffix compatibility adapters must be covered by a real-screen
+  scoped-rebuild test and removed in Task 7 when their last screen call sites are replaced. This
+  makes the Task 4 checkpoint runnable rather than leaving the screen and workbench APIs out of
+  sync.
 
   In the same step, make the minimum structural CSS change required for this DOM to be usable:
   vertical workbench root, horizontal `#wl-workbench-body`, flexing permanent centre, fixed
@@ -369,7 +372,13 @@
 
 **Files:**
 
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/region_layout.py`
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py`
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`
 - Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Modify: `Tests/Watchlists/test_region_layout.py`
+- Modify: `Tests/Watchlists/test_region_layout_store.py`
+- Modify: `Tests/Watchlists/test_watchlists_workbench.py`
 - Modify: `Tests/Watchlists/test_watchlists_collections_screen.py`
 - Modify: `Tests/Watchlists/test_watchlists_scoped_rebuilds.py`
 - Modify: `Tests/Watchlists/test_watchlists_cold_open_layout.py`
@@ -425,7 +434,10 @@
   At the end of this step, remove the Task 1 legacy `solo_region`, `_pre_solo`, `solo()`, permissive
   `toggle()`, and `collapsed_for_persistence()` compatibility plus Task 4's `hidden=` adapter. Change
   every remaining screen/workbench/store call site to strict preferred/effective APIs in the same
-  commit, and run an import/compose smoke test before the broader controller suite.
+  commit. Remove the screen's collapsed-suffix construction/update calls and then remove Task 4's
+  no-op `collapsed_suffixes=`/`set_collapsed_suffixes(...)` adapter. Update the Task 1 transitional
+  pure tests to assert the final compatibility members are absent, update the workbench/store tests,
+  and run an import/compose smoke test before the broader controller suite.
 
 - [ ] **Step 6: Make ordinary preference persistence acknowledge success.**
 
@@ -433,10 +445,16 @@
 
 - [ ] **Step 7: Run the controller tests.**
 
+  Run the Step 4 command plus the compatibility-removal suites:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Watchlists/test_region_layout.py Tests/Watchlists/test_region_layout_store.py Tests/Watchlists/test_watchlists_responsive_layout.py Tests/Watchlists/test_watchlists_workbench.py -q
+  ```
+
 - [ ] **Step 8: Commit the screen controller integration.**
 
   ```bash
-  git add tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/Watchlists/test_watchlists_collections_screen.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py Tests/Watchlists/test_watchlists_cold_open_layout.py Tests/Watchlists/test_watchlists_pagination.py
+  git add tldw_chatbook/UI/Watchlists_Modules/region_layout.py tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/Watchlists/test_region_layout.py Tests/Watchlists/test_region_layout_store.py Tests/Watchlists/test_watchlists_responsive_layout.py Tests/Watchlists/test_watchlists_workbench.py Tests/Watchlists/test_watchlists_collections_screen.py Tests/Watchlists/test_watchlists_scoped_rebuilds.py Tests/Watchlists/test_watchlists_cold_open_layout.py Tests/Watchlists/test_watchlists_pagination.py
   git commit -m "feat(watchlists): derive responsive and focus layouts"
   ```
 

--- a/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
+++ b/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
@@ -153,21 +153,24 @@ numbers:
 | --- | --- |
 | Navigation | 28 / 24 columns |
 | Feed Items | 40 / 32 columns |
-| Reader | `1fr` / 44 columns |
+| Primary centre (Reader or management canvas) | `1fr` / 44 comfort columns |
 | Inspector | 34 / 30 columns |
 | Each grip | 5 fixed columns |
 
-Starting from the preferred layout, the resolver collapses side panes until the sum of Reader,
-grips, and expanded-pane minimums fits. Default responsive collapse priority is Inspector,
-Navigation, then Feed Items. Reader is never a candidate.
+Starting from the preferred layout, the resolver collapses side panes until the sum of the primary
+centre, mounted grips, and expanded-pane minimums fits. On Read, default responsive collapse
+priority is Inspector, Navigation, then Feed Items. On a management tab, Feed Items and its grip
+are absent, so the order is Inspector then Navigation. The Reader or management canvas is never a
+collapse candidate.
 
-Reader's 44 columns are a **comfort threshold**, not a hard CSS minimum. After all three side panes
-are collapsed, a terminal narrower than Reader comfort plus the three fixed grips keeps all grips
-and lets Reader consume the remaining width with `min-width: 0`; no grip disappears and no
-horizontal overflow is introduced. The supported live-verification floor is 60 columns, where the
-three grips consume 15 and Reader receives 45. Below the supported floor the layout remains
-structurally reachable but may truncate article content like the rest of the application; it must
-still avoid a compositor exception or horizontal overflow.
+The centre's 44 columns are a **comfort threshold**, not a hard CSS minimum. After all mounted side
+panes are collapsed, a terminal narrower than centre comfort plus the fixed grips keeps those grips
+and lets the centre consume the remaining width with `min-width: 0`; no grip disappears and no
+horizontal overflow is introduced. The supported live-verification floor is 60 columns: Read has
+three grips consuming 15 and gives Reader 45; management tabs have two grips consuming 10 and give
+their canvas 50. Below the supported floor the centre remains structurally reachable but may
+truncate content like the rest of the application; it must still avoid a compositor exception or
+horizontal overflow.
 
 If the user explicitly opens a responsively hidden pane, that pane becomes the temporary priority
 target at the current width. The preferred state is updated to open and persisted; the effective
@@ -213,16 +216,29 @@ Tree scopes remain All Sources, Unassigned, Watchlist, and Source. Smart-feed an
 produce one normalized `ReaderScope`; selecting either clears the visual selection in the other.
 There is never a separate “smart scope” and “tree scope” active at once.
 
-One shared scope-predicate builder must drive:
+One normalized `ReaderScope` contract exposes two related but distinct projections.
+
+Its **item predicate** drives:
 
 - item listing;
 - unread and Smart Feed counts;
 - mark-all-read;
 - search;
-- refresh eligibility;
 - pending-arrival counting.
 
 This is the guard against a badge saying one number while the list shows a different population.
+
+Its **refresh source universe** drives which sources are checked and never derives eligibility from
+items that already match the item predicate:
+
+- Source refreshes that active, non-paused source.
+- Watchlist refreshes its active, non-paused member sources.
+- Unassigned refreshes active, non-paused unassigned sources.
+- All Sources refreshes all active, non-paused local sources.
+- All Unread, Today, and Starred also refresh all active, non-paused local sources, because an empty
+  Smart Feed must still be able to discover its first matching item.
+
+Search text and the Unread/All display filter never narrow the refresh source universe.
 
 Publication dates are mixed timezone-aware and naive strings. One shared effective-date helper
 parses defensively, treats naive values according to the existing Watchlists convention, falls back
@@ -323,9 +339,10 @@ path running off the UI thread. The UI states that fallback search is active. It
 entire database on the event loop or search only the currently loaded page while implying global
 scope coverage.
 
-Refresh checks active, non-paused sources in the current scope through the existing run pipeline,
-skips sources already running, caps concurrency, and produces one aggregate completion notice.
-It does not create per-source notification noise.
+Refresh checks the normalized scope's refresh source universe through the existing run pipeline,
+skips sources already running, caps concurrency, and produces one aggregate completion notice. It
+does not create per-source notification noise. Smart Feed refresh therefore remains useful when the
+current Smart Feed has zero matching items.
 
 ## State transitions and data flow
 
@@ -424,12 +441,13 @@ split it into the following dependency-ordered, independently verifiable slices:
    resolution, shared Inspector behavior, and versioned layout normalization. This slice delivers
    the requested collapse behavior across all Watchlists tabs without changing item presentation.
 2. **Contextual Feed Items and Reader actions.** Replace the Read `DataTable` with the stable,
-   date-grouped contextual list; add semantic restoration, deterministic snapshot ordering,
-   Star/Unstar, protected-status `m`, Open in browser, and the three-action Reader header. Depends
-   on slice 1's permanent host and state-restoration seams.
+   date-grouped contextual list; add the shared effective-date helper, semantic restoration,
+   deterministic snapshot ordering, Star/Unstar, protected-status `m`, Open in browser, and the
+   three-action Reader header. Depends on slice 1's permanent host and state-restoration seams.
 3. **Smart Feeds and scoped search.** Add normalized Smart Feed scopes/counts, the shared date and
-   predicate contracts, Starred/Today/All Unread navigation, FTS search, and bounded fallback.
-   Depends on slice 2's article list and star writer.
+   predicate contracts, Starred/Today/All Unread navigation, FTS search, and bounded fallback;
+   reuse slice 2's effective-date helper for Today. Depends on slice 2's article list and star
+   writer.
 4. **Scoped refresh and stable-arrival polish.** Add concurrency-limited scope refresh, aggregate
    completion feedback, high-water-mark arrival counting, the new-items affordance, narrow-width
    live polish, and programme-level regression/documentation close-out. Depends on slices 1–3.
@@ -447,13 +465,16 @@ the whole programme.
 - Versioned normalization, including unknown/Reader values and failed atomic writes.
 - Effective layout at width boundaries derived from declared minimums.
 - Responsive priority Inspector → Navigation → Feed Items.
+- Management responsive priority Inspector → Navigation with only two mounted grips.
 - Explicit reopening of each responsively hidden pane.
 - All-grips-collapsed behavior from the 60-column supported floor through sub-floor degradation.
 - Repeated shrink/expand cycles and Article Focus exact restoration.
 
 ### Database and services
 
-- Shared scope predicates make counts, list, search, bulk-read, refresh, and arrival detection agree.
+- Normalized scope projections make item predicates agree across counts/list/search/bulk-read/
+  arrivals while refresh uses the specified source universe.
+- Refresh source-universe tests prove empty Smart Feeds still check every eligible local source.
 - All Unread, Today, Starred, Watchlist, Source, All Sources, and Unassigned semantics.
 - Mixed aware/naive/missing/future publication dates.
 - Star persistence across item re-fetch/upsert.

--- a/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
+++ b/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
@@ -186,6 +186,7 @@ ambiguous set of preferences.
 `WatchlistsCollectionsScreen` remains the single controller and owns:
 
 - normalized reader scope;
+- pending scope while a replacement snapshot loads;
 - selected item id and selected item;
 - preferred layout, responsive priority target, and Article Focus state;
 - Feed Items search/filter/page state;
@@ -246,6 +247,12 @@ to `created_at`, converts to local time, and supplies Today/Yesterday/calendar g
 and row grouping must call the same helper. A bounded SQL prefilter may reduce candidates, but
 Python performs the final local-day classification.
 
+The item-query service also exposes a canonical UTC effective-date sort key for keyset pagination.
+That database-comparable projection and the Python helper are two projections of the same contract:
+parseable `published_date`, otherwise parseable `created_at`, otherwise the deterministic item-id
+fallback. Their ordering parity is covered by the same aware, naive, date-only, missing, and malformed
+timestamp fixtures; the implementation must not use raw mixed-format string ordering.
+
 ## Feed Items
 
 Read replaces the operations `DataTable` with a list-oriented pane. Each article row uses three
@@ -271,19 +278,42 @@ reading list. The existing one-batch `a`/`u` mark-all-read and undo behavior rem
 
 ### Stable snapshot and restoration
 
-Each scope load is a stable, paginated snapshot ordered by effective date descending and then item
+Each scope load is a paginated reading snapshot ordered by effective date descending and then item
 id descending as the deterministic tie-breaker. The snapshot records the maximum matching item id;
-subsequent pages remain constrained to that high-water mark. Rows with larger ids are arrivals,
-not part of the mounted snapshot. A scope-specific item-creation high-water mark—not unread-count
-changes—produces a **“N new items”** affordance. Explicit refresh replaces the snapshot.
+subsequent pages remain constrained to that high-water mark. Pages use a keyset cursor over the
+effective-date/item-id pair rather than `OFFSET`, and the screen keeps a seen-id set so an item is
+never mounted twice. This is required because marking an item read can remove it from the Unread
+predicate while the user is still paging.
+
+The practical snapshot guarantee is deliberately narrower than a database transaction held open for
+the whole reading session:
+
+- already mounted row order remains stable;
+- rows inserted after the high-water mark do not enter the mounted list;
+- no item id appears twice;
+- an existing, not-yet-mounted row whose publication metadata changes during a background upsert may
+  move to a later page or be deferred until explicit refresh.
+
+An id watermark alone cannot freeze future effective-date order because the existing upsert path may
+update `published_date` without allocating a new id. Strictly freezing every future page would require
+materializing an unbounded id/sort-key index at scope load, which is disproportionate for this reader.
+Rows with larger ids are arrivals, not part of the mounted snapshot. A scope-specific item-creation
+high-water mark—not unread-count changes—produces a **“N new items”** affordance. Explicit refresh
+replaces the snapshot.
+
+The active Feed Items header reports counts bounded by the mounted snapshot's high-water mark.
+Navigation and Smart Feed badges remain live. The new-items affordance explains the difference between
+those live badges and the currently mounted snapshot; successful local read/star mutations patch all
+affected visible counts without silently admitting new rows.
 
 A successful **scope change clears Reader selection** and shows the empty state until the user
 selects an item in the new scope. Only a rebuild of the same scope restores its selected item and
 Reader position. This avoids carrying an item into a scope where it is not visible or no longer
 matches the Unread filter.
 
-Opening an unread item marks it read but pins that selected row in an Unread view until the user
-navigates away or refreshes. It cannot disappear under the cursor.
+An action that makes the selected item stop matching the active predicate pins that row until the
+user navigates away or refreshes. This covers opening/marking an item read in All Unread and
+unstarring an item in Starred; neither can disappear under the cursor.
 
 Layout rebuilds restore Feed Items semantically:
 
@@ -317,8 +347,9 @@ Ingest, Queue/Unqueue for Briefing, and other advanced actions remain in Inspect
 Inspector call the same shared item-action helpers so status and star semantics cannot drift.
 
 Selecting/opening a feed item automatically marks it read. Programmatic restoration after a layout
-rebuild must not manufacture a second user-selection event. Per-item read/star mutations are
-serialized and deduplicated so repeated keys or clicks cannot complete out of order.
+rebuild must not manufacture a second user-selection event. Per-item mutations are serialized so
+repeated keys or clicks cannot complete out of order, but status and star retain independent desired
+intents: toggling Star must not replace a pending automatic mark-read, or vice versa.
 
 `m` changes only the reversible reader statuses `new` and `reviewed`. For `ingested`, `ignored`, or
 `error`, the action is disabled/refused with an explanation and never rewrites the terminal
@@ -346,26 +377,33 @@ current Smart Feed has zero matching items.
 
 ## State transitions and data flow
 
-The primary flow is:
+Scope navigation and item activation are separate flows. Merely choosing a scope must not
+automatically consume its first item:
 
 ```text
 scope gesture
   → resolve ReaderScope
+  → store pending scope; keep committed scope/list visibly active
   → load counts and stable item snapshot in a worker
-  → atomically commit scope + rows
-  → select a row
+  → atomically commit active navigation highlight + scope + rows
+  → clear item selection and show Reader empty state
+
+explicit item activation
+  → select the row
   → render Reader
   → serialize mark-read intent
   → patch row and counts after success
 ```
 
 A failed scope change never shows old rows under a new heading. The current scope remains active
-until the replacement load succeeds. Failure copy names both facts, for example: **“Couldn't open
-Today; still showing All Unread.”**
+until the replacement load succeeds. The attempted Navigation control may retain keyboard focus, but
+the active-selection styling is restored to the committed scope. Failure copy names both facts, for
+example: **“Couldn't open Today; still showing All Unread.”**
 
-Background arrivals update counts and the new-items affordance in place. They do not trigger a
-screen-wide recompose. Layout changes may rebuild factories, but all user position is restored from
-screen-owned semantic state.
+Background arrivals update live Navigation badges and the new-items affordance in place; they leave
+the active Feed Items header's snapshot-bounded counts unchanged until explicit refresh. They do not
+trigger a screen-wide recompose. Layout changes may rebuild factories, but all user position is
+restored from screen-owned semantic state.
 
 ## Persistence and migration
 
@@ -376,12 +414,18 @@ Watchlists layout configuration becomes versioned. The migration:
 - preserves saved Navigation, Feed Items, and Inspector values;
 - discards any saved Reader/Content collapse because Reader is no longer collapsible;
 - removes unknown retired region names;
-- writes normalized layout values and the new version in one configuration update.
+- writes normalized layout values and the new version in one
+  `save_settings_to_cli_config(...)` configuration mutation.
 
 If normalization cannot be persisted, the safe normalized layout still applies in memory and the
 migration version remains old so the next launch retries. The implementation must not repeat the
 earlier CONTENT-migration failure mode where a marker could advance without the corrected layout
 being durable.
+
+Ordinary preference writes have the same durability rule. The in-memory “last persisted” marker may
+advance only after the worker reports success. A failed write keeps the latest preferred layout
+pending and restores retry eligibility so a later manual gesture can retry it; the current store's
+pre-write bookkeeping and ignored worker result must not be carried forward.
 
 Only preferred-layout grip/key gestures write configuration. Responsive recalculation, Article
 Focus, background refresh, tab switching, and selection changes never do.
@@ -389,17 +433,29 @@ Focus, background refresh, tab switching, and selection changes never do.
 ## Failure handling
 
 - **Scope load fails:** keep the previous scope/list active, show attempted-scope failure and Retry.
+- **Scope load is pending:** keep the previous active Navigation styling until the new snapshot
+  commits; focus alone must not imply that old rows belong to the attempted scope.
 - **Read/star write fails:** keep prior visual state and selection; show a concise action-specific
   error. Do not apply a success-looking optimistic state that might not roll back cleanly.
-- **Repeated item action:** coalesce through the per-item intent queue; latest valid intent wins.
+- **Repeated item action:** coalesce per item and mutation field; the latest valid status intent and
+  latest valid star intent each win without replacing one another.
 - **FTS fails:** bounded off-thread scoped fallback with a visible notice.
 - **Refresh partially fails:** keep successful runs and report one aggregate result with failure
   count; Runs retains detailed failures.
 - **Missing body:** show an honest “No body was captured for this item” message.
 - **Browser open fails:** preserve Reader and notify. Accept only supported `http`/`https` URLs and
-  call a browser API directly, never a shell.
+  call a browser API directly from a worker, never a shell or the UI event loop.
 - **Config write fails:** retain the in-memory choice for the session, notify only when useful, and
   retry persistence on a later manual change or next migration load.
+
+## Delivery isolation
+
+Planning and implementation must not proceed in the current dirty
+`feat/task-3401-video-generation-foundation` worktree. Before Slice 1 starts, create a dedicated
+Watchlists branch/worktree from the user-approved integration base and transplant the Watchlists
+documentation commits into it. Do not rewrite, reset, clean, or otherwise disturb the unrelated video
+branch or its uncommitted files. The implementation plan records the chosen base and transplanted
+commit ids before any code change.
 
 ## Security and accessibility
 
@@ -440,10 +496,11 @@ split it into the following dependency-ordered, independently verifiable slices:
    Watchlists-local ASCII grips; introduce preferred/effective/Article Focus state, responsive
    resolution, shared Inspector behavior, and versioned layout normalization. This slice delivers
    the requested collapse behavior across all Watchlists tabs without changing item presentation.
-2. **Contextual Feed Items and Reader actions.** Replace the Read `DataTable` with the stable,
+2. **Contextual Feed Items and Reader actions.** Replace the Read `DataTable` with the snapshot-bounded,
    date-grouped contextual list; add the shared effective-date helper, semantic restoration,
-   deterministic snapshot ordering, Star/Unstar, protected-status `m`, Open in browser, and the
-   three-action Reader header. Depends on slice 1's permanent host and state-restoration seams.
+   deterministic keyset ordering and seen-id guard, Star/Unstar, protected-status `m`, off-loop Open
+   in browser, and the three-action Reader header. Depends on slice 1's permanent host and
+   state-restoration seams.
 3. **Smart Feeds and scoped search.** Add normalized Smart Feed scopes/counts, the shared date and
    predicate contracts, Starred/Today/All Unread navigation, FTS search, and bounded fallback;
    reuse slice 2's effective-date helper for Today. Depends on slice 2's article list and star
@@ -463,6 +520,7 @@ the whole programme.
 
 - Independent preferred toggles and exact restart round-trip.
 - Versioned normalization, including unknown/Reader values and failed atomic writes.
+- Failed ordinary preference writes remain eligible for a same-session retry.
 - Effective layout at width boundaries derived from declared minimums.
 - Responsive priority Inspector → Navigation → Feed Items.
 - Management responsive priority Inspector → Navigation with only two mounted grips.
@@ -477,10 +535,15 @@ the whole programme.
 - Refresh source-universe tests prove empty Smart Feeds still check every eligible local source.
 - All Unread, Today, Starred, Watchlist, Source, All Sources, and Unassigned semantics.
 - Mixed aware/naive/missing/future publication dates.
+- Canonical database sort keys and Python effective-date parsing agree for every supported timestamp
+  shape and never fall back to raw string ordering.
 - Star persistence across item re-fetch/upsert.
 - Safe FTS query construction and bounded fallback pagination.
 - Creation high-water mark ignores read/unread transitions.
-- Snapshot pagination remains ordered by effective date/item id and bounded by the initial max id.
+- Snapshot pagination uses an effective-date/item-id keyset, is bounded by the initial max id, never
+  duplicates a seen id, and documents the behavior of mutable metadata on unseen rows.
+- Active-pane snapshot counts, live Navigation badges, and the new-items affordance remain mutually
+  intelligible.
 
 ### Widgets and integration
 
@@ -490,13 +553,17 @@ the whole programme.
 - Management tabs keep their centre canvas while Feed Items' preference remains parked for Read.
 - Server-backed Read shows local-only recovery and issues no local-reader queries under Server.
 - New-user defaults and existing-user migration.
-- Contextual rows, date groups, pinning, pagination, search, stable arrivals, and empty states.
+- Contextual rows, date groups, Unread/Starred predicate pinning, pagination, search, stable arrivals,
+  and empty states.
 - Cursor/visible-row offset, Reader scroll, selected item, focus, and filter survival across every
   manual and responsive layout change.
 - Auto-read occurs on genuine selection but not on restoration; serialized mutation order is
   deterministic.
+- Scope loading never auto-selects or auto-reads the first row, and a failed load restores committed
+  active-selection styling.
+- Status and star intent coalescing cannot cancel each other's pending mutation.
 - `m` never rewrites ingested, ignored, or error workflow statuses.
-- Hostile remote markup and invalid browser URLs fail safely.
+- Hostile remote markup and invalid browser URLs fail safely; browser launch runs off the UI thread.
 
 ### Production evidence
 

--- a/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
+++ b/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
@@ -82,9 +82,13 @@ Read has four spatial roles:
 | Reader | Permanent. Selected item or the empty-state message. |
 | Inspector | Collapsible. Shared preference across all Watchlists tabs. |
 
-On management tabs, Feed Items and Reader are not mounted. Navigation and Inspector retain the
-same preferred state and the same grip behavior, so the Inspector never becomes a Read-only
-affordance.
+On management tabs, the Feed Items **role** and Reader are not mounted, but the centre host remains.
+It renders the active Sources, Runs, Rules, Notifications, Artifacts, or Overview canvas between
+Navigation and Inspector, exactly as shipped phase 1 currently uses `Region.ITEMS` as the
+management-detail host. That management canvas is the tab's permanent centre anchor and does not
+inherit Feed Items' collapsed preference. Returning to Read reapplies the saved Feed Items choice.
+Navigation and Inspector retain the same preferred state and grip behavior on every tab, so the
+Inspector never becomes a Read-only affordance and no management surface loses its host.
 
 The first-run preferred layout is:
 
@@ -96,6 +100,14 @@ The first-run preferred layout is:
 Reader empty-state copy is: **“Select a feed item to display it here.”** This deliberately says
 “feed item”: selecting a feed in Navigation scopes the list, while selecting a feed item displays
 content.
+
+### Backend behavior
+
+Read remains honestly local-only. If the active Watchlists backend is Server, the centre area shows
+the existing local-only explanation plus **Switch to Local**. It does not issue unsupported item,
+Smart Feed, count, search, or refresh queries and does not display local rows under a Server label.
+Management tabs continue to use their existing backend behavior. Switching to Local performs a
+normal scope load before replacing the centre state.
 
 ## Pane grips
 
@@ -148,6 +160,14 @@ numbers:
 Starting from the preferred layout, the resolver collapses side panes until the sum of Reader,
 grips, and expanded-pane minimums fits. Default responsive collapse priority is Inspector,
 Navigation, then Feed Items. Reader is never a candidate.
+
+Reader's 44 columns are a **comfort threshold**, not a hard CSS minimum. After all three side panes
+are collapsed, a terminal narrower than Reader comfort plus the three fixed grips keeps all grips
+and lets Reader consume the remaining width with `min-width: 0`; no grip disappears and no
+horizontal overflow is introduced. The supported live-verification floor is 60 columns, where the
+three grips consume 15 and Reader receives 45. Below the supported floor the layout remains
+structurally reachable but may truncate article content like the rest of the application; it must
+still avoid a compositor exception or horizontal overflow.
 
 If the user explicitly opens a responsively hidden pane, that pane becomes the temporary priority
 target at the current width. The preferred state is updated to open and persisted; the effective
@@ -235,9 +255,16 @@ reading list. The existing one-batch `a`/`u` mark-all-read and undo behavior rem
 
 ### Stable snapshot and restoration
 
-Each scope load is a stable, paginated snapshot. New arrivals do not reorder mounted rows. A
-scope-specific item-creation high-water mark—not unread-count changes—produces a **“N new items”**
-affordance. Explicit refresh replaces the snapshot.
+Each scope load is a stable, paginated snapshot ordered by effective date descending and then item
+id descending as the deterministic tie-breaker. The snapshot records the maximum matching item id;
+subsequent pages remain constrained to that high-water mark. Rows with larger ids are arrivals,
+not part of the mounted snapshot. A scope-specific item-creation high-water mark—not unread-count
+changes—produces a **“N new items”** affordance. Explicit refresh replaces the snapshot.
+
+A successful **scope change clears Reader selection** and shows the empty state until the user
+selects an item in the new scope. Only a rebuild of the same scope restores its selected item and
+Reader position. This avoids carrying an item into a scope where it is not visible or no longer
+matches the Unread filter.
 
 Opening an unread item marks it read but pins that selected row in an Unread view until the user
 navigates away or refreshes. It cannot disappear under the cursor.
@@ -276,6 +303,10 @@ Inspector call the same shared item-action helpers so status and star semantics 
 Selecting/opening a feed item automatically marks it read. Programmatic restoration after a layout
 rebuild must not manufacture a second user-selection event. Per-item read/star mutations are
 serialized and deduplicated so repeated keys or clicks cannot complete out of order.
+
+`m` changes only the reversible reader statuses `new` and `reviewed`. For `ingested`, `ignored`, or
+`error`, the action is disabled/refused with an explanation and never rewrites the terminal
+workflow status. This applies even though the All filter intentionally includes ingested items.
 
 Reader scroll position survives pane toggles and responsive recomposition. Article Focus (`Z`) is
 the explicit way to give Reader maximum width, and toggling it again restores the previous manual
@@ -383,6 +414,31 @@ Read retains or adds:
 | `Z` | Toggle transient Article Focus |
 | `[` / `]` | Preserve existing left/right rail shortcuts where they remain unambiguous |
 
+## Implementation decomposition
+
+This specification is one UX programme, not one atomic pull request. Planning and Backlog work must
+split it into the following dependency-ordered, independently verifiable slices:
+
+1. **Layout foundation and grips.** Make Reader/management canvas the permanent centre host; add
+   Watchlists-local ASCII grips; introduce preferred/effective/Article Focus state, responsive
+   resolution, shared Inspector behavior, and versioned layout normalization. This slice delivers
+   the requested collapse behavior across all Watchlists tabs without changing item presentation.
+2. **Contextual Feed Items and Reader actions.** Replace the Read `DataTable` with the stable,
+   date-grouped contextual list; add semantic restoration, deterministic snapshot ordering,
+   Star/Unstar, protected-status `m`, Open in browser, and the three-action Reader header. Depends
+   on slice 1's permanent host and state-restoration seams.
+3. **Smart Feeds and scoped search.** Add normalized Smart Feed scopes/counts, the shared date and
+   predicate contracts, Starred/Today/All Unread navigation, FTS search, and bounded fallback.
+   Depends on slice 2's article list and star writer.
+4. **Scoped refresh and stable-arrival polish.** Add concurrency-limited scope refresh, aggregate
+   completion feedback, high-water-mark arrival counting, the new-items affordance, narrow-width
+   live polish, and programme-level regression/documentation close-out. Depends on slices 1–3.
+
+Each slice receives its own atomic Backlog task, acceptance criteria, implementation plan, tests,
+and review. The writing-plans transition after this design reviews the sequence and writes the
+detailed plan for slice 1 first; later slice plans must not be treated as if one pull request owns
+the whole programme.
+
 ## Verification
 
 ### Pure state and persistence
@@ -392,6 +448,7 @@ Read retains or adds:
 - Effective layout at width boundaries derived from declared minimums.
 - Responsive priority Inspector → Navigation → Feed Items.
 - Explicit reopening of each responsively hidden pane.
+- All-grips-collapsed behavior from the 60-column supported floor through sub-floor degradation.
 - Repeated shrink/expand cycles and Article Focus exact restoration.
 
 ### Database and services
@@ -402,18 +459,22 @@ Read retains or adds:
 - Star persistence across item re-fetch/upsert.
 - Safe FTS query construction and bounded fallback pagination.
 - Creation high-water mark ignores read/unread transitions.
+- Snapshot pagination remains ordered by effective date/item id and bounded by the initial max id.
 
 ### Widgets and integration
 
 - Literal five-column ASCII grip geometry and correct arrow direction in every state.
 - Pointer, focus, tooltip, keyboard, and accessibility behavior.
 - Shared Inspector preference across all seven Watchlists tabs.
+- Management tabs keep their centre canvas while Feed Items' preference remains parked for Read.
+- Server-backed Read shows local-only recovery and issues no local-reader queries under Server.
 - New-user defaults and existing-user migration.
 - Contextual rows, date groups, pinning, pagination, search, stable arrivals, and empty states.
 - Cursor/visible-row offset, Reader scroll, selected item, focus, and filter survival across every
   manual and responsive layout change.
 - Auto-read occurs on genuine selection but not on restoration; serialized mutation order is
   deterministic.
+- `m` never rewrites ingested, ignored, or error workflow statuses.
 - Hostile remote markup and invalid browser URLs fail safely.
 
 ### Production evidence

--- a/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
+++ b/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
@@ -1,0 +1,438 @@
+# Watchlists NetNewsWire Reader and Collapsible Rails Design
+
+Date: 2026-08-23
+
+Status: Approved
+
+Amends: [Watchlists reader-first re-IA](2026-08-05-watchlists-reader-first-design.md)
+
+ADR: [ADR-042](../../../backlog/decisions/042-watchlists-reader-first-ia.md)
+
+## Summary
+
+Finish the Watchlists Read experience as a terminal-native, NetNewsWire-shaped reader:
+
+- Navigation combines Smart Feeds with the Folder/Watchlist/Feed hierarchy.
+- Feed Items becomes a contextual, date-grouped article list rather than an operations table.
+- Reader is the permanent centre anchor and receives every column reclaimed from side panes.
+- Navigation, Feed Items, and Inspector collapse independently through narrow, full-height,
+  clickable ASCII grips.
+- Inspector has one shared open/collapsed preference across every Watchlists tab.
+- Manual layout choices persist across restarts; responsive and Article Focus layouts are
+  temporary views that never overwrite those choices.
+
+This design evolves the existing four-region Watchlists workbench. It does not build a second
+Read-only shell and does not introduce an app-wide split-pane framework while the Media Library
+redesign is proceeding independently. The Watchlists implementation keeps clean state and widget
+interfaces so common behavior can be extracted after both real consumers exist.
+
+## Current state
+
+Phase 1 of the 2026-08-05 reader-first design is implemented:
+
+- Read is the landing tab.
+- Tree scopes drive item loading.
+- Per-source unread counts, mark-all-read with undo, next-unread, and read/unread toggling exist.
+- The Inspector starts collapsed for a new user.
+- Navigation, Feed Items, Reader, and Inspector are represented by `RegionLayout` and rebuilt by
+  `WatchlistsWorkbench` factories.
+- The Reader safely converts captured HTML into readable text.
+
+The remaining gaps are presentation and capability exposure:
+
+- Feed Items is still a `DataTable`, not a contextual article list.
+- There are no All Unread, Today, or Starred Smart Feeds.
+- `subscription_items.is_flagged` and its index exist, but no star action or Starred query uses
+  them.
+- The FTS5 table and maintenance triggers exist, but Read has no scoped full-text search path.
+- Reader can still be collapsed, even though the selected article is the purpose of the screen.
+- Collapsed regions render generic headers instead of persistent edge grips.
+- Responsive layout and persisted manual preference are not distinct state concepts.
+
+## Goals
+
+- Make the daily loop fast: choose a scope, scan useful rows, read, star or catch up, continue.
+- Keep Reader continuously present, including when nothing is selected.
+- Let users independently reclaim Navigation, Feed Items, and Inspector width.
+- Preserve manual choices across Watchlists tabs and application restarts.
+- Keep narrow terminals usable without silently changing saved preferences.
+- Preserve selection, scroll, focus, search, and stable-list position through every layout change.
+- Reuse existing Watchlists services and schema where possible.
+
+## Non-goals
+
+- Redesigning Sources, Runs, Rules, Notifications, Artifacts, or Overview content.
+- Changing item read/star state to server-synchronized or watchlist-specific state.
+- Adding new database tables or columns.
+- Reworking OPML folder round-tripping in this slice.
+- Adding enclosure playback, images, or web-page rendering inside Reader.
+- Creating a shared application-wide split-pane framework in parallel with Media Library work.
+
+## Information architecture
+
+The tab order remains Read, Sources, Runs, Rules, Notifications, Artifacts, Overview. Internal
+section id `items` remains unchanged for deep links and existing navigation contracts.
+
+Read has four spatial roles:
+
+| Role | Behavior |
+| --- | --- |
+| Navigation | Collapsible. Smart Feeds above the existing Folder/Watchlist/Feed tree. |
+| Feed Items | Collapsible. Contextual list for the selected scope. |
+| Reader | Permanent. Selected item or the empty-state message. |
+| Inspector | Collapsible. Shared preference across all Watchlists tabs. |
+
+On management tabs, Feed Items and Reader are not mounted. Navigation and Inspector retain the
+same preferred state and the same grip behavior, so the Inspector never becomes a Read-only
+affordance.
+
+The first-run preferred layout is:
+
+- Navigation open.
+- Feed Items open.
+- Reader open.
+- Inspector collapsed.
+
+Reader empty-state copy is: **“Select a feed item to display it here.”** This deliberately says
+“feed item”: selecting a feed in Navigation scopes the list, while selecting a feed item displays
+content.
+
+## Pane grips
+
+Each collapsible pane has a five-column, full-height grip: four ASCII label columns plus its
+divider. The label remains horizontal and is centred vertically. The browser brainstorm mockups'
+rotated labels were illustrative only; Textual should render the literal ASCII label.
+
+Direction describes what pressing the grip will do:
+
+| Pane | Collapsed grip | Expanded inside-edge grip |
+| --- | --- | --- |
+| Navigation | `--->` expands right | `<---` collapses left |
+| Feed Items | `--->` expands right | `<---` collapses left |
+| Inspector | `<---` expands left | `--->` collapses right |
+
+The grip itself is the intended pointer affordance in both states. It is also focusable, has a
+plain-language tooltip naming the pane and action, and exposes a useful accessibility label even
+though its visible copy is only an arrow. Focus styling must remain visible without increasing
+the grip's geometry.
+
+Reader is not a `RegionLayout` toggle target. A focused Reader cannot be collapsed by `z`, and
+help/footer surfaces must not advertise an unavailable Reader-collapse action.
+
+## Preferred, effective, and Article Focus layouts
+
+Layout has three explicit layers:
+
+1. **Preferred layout** — the user's manual Navigation, Feed Items, and Inspector choices. Grip
+   clicks and the corresponding keyboard actions update this state and persist it.
+2. **Responsive override** — extra collapses required by current terminal width. It is recomputed
+   on resize and never persisted.
+3. **Article Focus override** — a user-triggered transient mode that collapses all three side panes
+   and restores the exact pre-focus preferred layout when toggled off. It is never persisted.
+
+The rendered effective layout is derived from those layers. It is not itself saved.
+
+### Width calculation
+
+Responsive behavior is based on declared component minimums rather than unrelated breakpoint
+numbers:
+
+| Component | Target/minimum width |
+| --- | --- |
+| Navigation | 28 / 24 columns |
+| Feed Items | 40 / 32 columns |
+| Reader | `1fr` / 44 columns |
+| Inspector | 34 / 30 columns |
+| Each grip | 5 fixed columns |
+
+Starting from the preferred layout, the resolver collapses side panes until the sum of Reader,
+grips, and expanded-pane minimums fits. Default responsive collapse priority is Inspector,
+Navigation, then Feed Items. Reader is never a candidate.
+
+If the user explicitly opens a responsively hidden pane, that pane becomes the temporary priority
+target at the current width. The preferred state is updated to open and persisted; the effective
+resolver collapses lower-priority side panes as necessary. On later expansion, the full preferred
+layout naturally returns. Repeated shrink/expand cycles must be idempotent.
+
+Clicking any grip while Article Focus is active first exits Article Focus, restores its baseline,
+then applies the requested manual toggle. This prevents a transient mode from owning a second,
+ambiguous set of preferences.
+
+## Component ownership
+
+`WatchlistsCollectionsScreen` remains the single controller and owns:
+
+- normalized reader scope;
+- selected item id and selected item;
+- preferred layout, responsive priority target, and Article Focus state;
+- Feed Items search/filter/page state;
+- Feed Items selection anchor and Reader scroll position;
+- stable-snapshot high-water mark and pending-arrival count;
+- shared Inspector preference;
+- in-flight per-item action intents.
+
+`WatchlistsWorkbench` renders the permanent Reader and optional side panes from factories. It
+accepts the effective layout and emits pane-toggle messages. It performs no persistence, database
+queries, or responsive policy decisions.
+
+A Watchlists-local grip widget owns arrow direction, focus/pointer behavior, tooltip, and message
+emission. It may reuse established `DestinationRailHandle` vocabulary, but this slice must not
+reshape the shared rail framework or touch Media Library layout code. Its public constructor and
+toggle message should remain destination-neutral enough for later comparison and extraction.
+
+## Navigation and normalized scope
+
+Smart Feeds mount above the existing tree:
+
+- **All Unread** — `status = 'new'` within all visible local items.
+- **Today** — effective date falls on the current local calendar day; ignored/error items are
+  excluded.
+- **Starred** — `is_flagged = 1`; ignored/error items are excluded.
+
+Tree scopes remain All Sources, Unassigned, Watchlist, and Source. Smart-feed and tree selections
+produce one normalized `ReaderScope`; selecting either clears the visual selection in the other.
+There is never a separate “smart scope” and “tree scope” active at once.
+
+One shared scope-predicate builder must drive:
+
+- item listing;
+- unread and Smart Feed counts;
+- mark-all-read;
+- search;
+- refresh eligibility;
+- pending-arrival counting.
+
+This is the guard against a badge saying one number while the list shows a different population.
+
+Publication dates are mixed timezone-aware and naive strings. One shared effective-date helper
+parses defensively, treats naive values according to the existing Watchlists convention, falls back
+to `created_at`, converts to local time, and supplies Today/Yesterday/calendar groups. Today counts
+and row grouping must call the same helper. A bounded SQL prefilter may reduce candidates, but
+Python performs the final local-day classification.
+
+## Feed Items
+
+Read replaces the operations `DataTable` with a list-oriented pane. Each article row uses three
+lines:
+
+1. unread dot, source, and humane effective time;
+2. title, bold while unread;
+3. a short plain-text snippet.
+
+Starred and queued-for-briefing markers appear without adding another row. Rows group under Today,
+Yesterday, then calendar-date headers. Newest effective date sorts first.
+
+The pane header contains:
+
+- current scope and item/unread count;
+- Unread/All toggle;
+- scoped search affordance;
+- Refresh scope;
+- Mark all read.
+
+“All” includes new, reviewed, and ingested items; ignored and error items remain outside the normal
+reading list. The existing one-batch `a`/`u` mark-all-read and undo behavior remains.
+
+### Stable snapshot and restoration
+
+Each scope load is a stable, paginated snapshot. New arrivals do not reorder mounted rows. A
+scope-specific item-creation high-water mark—not unread-count changes—produces a **“N new items”**
+affordance. Explicit refresh replaces the snapshot.
+
+Opening an unread item marks it read but pins that selected row in an Unread view until the user
+navigates away or refreshes. It cannot disappear under the cursor.
+
+Layout rebuilds restore Feed Items semantically:
+
+- selected item id;
+- selected row's visible offset within the viewport;
+- loaded page count;
+- search/filter state;
+- focused child id.
+
+Raw scroll coordinates alone are insufficient because three-line rows and date headers have
+variable geometry.
+
+## Reader
+
+Reader keeps the existing safe article/change renderers and becomes a permanent flexing pane.
+When an item is selected it shows:
+
+- source eyebrow;
+- title;
+- author, effective date, and reading metadata when available;
+- the safely rendered body;
+- footer position and next-unread guidance.
+
+The always-visible action row contains only the approved core actions:
+
+- Star/Unstar (`s`);
+- Mark unread/read (`m`);
+- Open in browser (`o`).
+
+Ingest, Queue/Unqueue for Briefing, and other advanced actions remain in Inspector. Reader and
+Inspector call the same shared item-action helpers so status and star semantics cannot drift.
+
+Selecting/opening a feed item automatically marks it read. Programmatic restoration after a layout
+rebuild must not manufacture a second user-selection event. Per-item read/star mutations are
+serialized and deduplicated so repeated keys or clicks cannot complete out of order.
+
+Reader scroll position survives pane toggles and responsive recomposition. Article Focus (`Z`) is
+the explicit way to give Reader maximum width, and toggling it again restores the previous manual
+layout exactly.
+
+## Search and refresh
+
+`/` focuses scoped full-text search over title, content, and author using the maintained FTS5
+index. User input is converted to a safe parameterized MATCH expression; scope predicates remain
+bound parameters.
+
+If FTS is unavailable or corrupt, search falls back to a bounded, paginated, scope-aware substring
+path running off the UI thread. The UI states that fallback search is active. It must not scan the
+entire database on the event loop or search only the currently loaded page while implying global
+scope coverage.
+
+Refresh checks active, non-paused sources in the current scope through the existing run pipeline,
+skips sources already running, caps concurrency, and produces one aggregate completion notice.
+It does not create per-source notification noise.
+
+## State transitions and data flow
+
+The primary flow is:
+
+```text
+scope gesture
+  → resolve ReaderScope
+  → load counts and stable item snapshot in a worker
+  → atomically commit scope + rows
+  → select a row
+  → render Reader
+  → serialize mark-read intent
+  → patch row and counts after success
+```
+
+A failed scope change never shows old rows under a new heading. The current scope remains active
+until the replacement load succeeds. Failure copy names both facts, for example: **“Couldn't open
+Today; still showing All Unread.”**
+
+Background arrivals update counts and the new-items affordance in place. They do not trigger a
+screen-wide recompose. Layout changes may rebuild factories, but all user position is restored from
+screen-owned semantic state.
+
+## Persistence and migration
+
+No database migration is required.
+
+Watchlists layout configuration becomes versioned. The migration:
+
+- preserves saved Navigation, Feed Items, and Inspector values;
+- discards any saved Reader/Content collapse because Reader is no longer collapsible;
+- removes unknown retired region names;
+- writes normalized layout values and the new version in one configuration update.
+
+If normalization cannot be persisted, the safe normalized layout still applies in memory and the
+migration version remains old so the next launch retries. The implementation must not repeat the
+earlier CONTENT-migration failure mode where a marker could advance without the corrected layout
+being durable.
+
+Only preferred-layout grip/key gestures write configuration. Responsive recalculation, Article
+Focus, background refresh, tab switching, and selection changes never do.
+
+## Failure handling
+
+- **Scope load fails:** keep the previous scope/list active, show attempted-scope failure and Retry.
+- **Read/star write fails:** keep prior visual state and selection; show a concise action-specific
+  error. Do not apply a success-looking optimistic state that might not roll back cleanly.
+- **Repeated item action:** coalesce through the per-item intent queue; latest valid intent wins.
+- **FTS fails:** bounded off-thread scoped fallback with a visible notice.
+- **Refresh partially fails:** keep successful runs and report one aggregate result with failure
+  count; Runs retains detailed failures.
+- **Missing body:** show an honest “No body was captured for this item” message.
+- **Browser open fails:** preserve Reader and notify. Accept only supported `http`/`https` URLs and
+  call a browser API directly, never a shell.
+- **Config write fails:** retain the in-memory choice for the session, notify only when useful, and
+  retry persistence on a later manual change or next migration load.
+
+## Security and accessibility
+
+- Remote titles, sources, snippets, categories, and bodies remain markup-safe at every Textual/Rich
+  sink.
+- FTS terms are sanitized and all scope values remain SQL parameters.
+- Browser URLs are scheme-validated; no command interpolation occurs.
+- Grips are reachable by pointer and keyboard, have action-specific tooltips and accessibility
+  labels, and show a non-obscuring focus state.
+- Footer and F1 help advertise only actions valid for the current tab and focused surface.
+- Existing terminal-convention and global key reservations remain untouched.
+
+## Keybindings
+
+Read retains or adds:
+
+| Key | Action |
+| --- | --- |
+| `j` / `k` | Next / previous visible item |
+| `space` | Next unread while focus is in Feed Items |
+| `m` | Toggle read/unread |
+| `s` | Toggle star |
+| `o` | Open in browser |
+| `a` | Mark current scope read |
+| `u` | Undo the latest mark-all-read batch |
+| `r` | Refresh current scope |
+| `/` | Focus scoped search |
+| `z` | Toggle the focused collapsible pane or grip; unavailable on Reader |
+| `Z` | Toggle transient Article Focus |
+| `[` / `]` | Preserve existing left/right rail shortcuts where they remain unambiguous |
+
+## Verification
+
+### Pure state and persistence
+
+- Independent preferred toggles and exact restart round-trip.
+- Versioned normalization, including unknown/Reader values and failed atomic writes.
+- Effective layout at width boundaries derived from declared minimums.
+- Responsive priority Inspector → Navigation → Feed Items.
+- Explicit reopening of each responsively hidden pane.
+- Repeated shrink/expand cycles and Article Focus exact restoration.
+
+### Database and services
+
+- Shared scope predicates make counts, list, search, bulk-read, refresh, and arrival detection agree.
+- All Unread, Today, Starred, Watchlist, Source, All Sources, and Unassigned semantics.
+- Mixed aware/naive/missing/future publication dates.
+- Star persistence across item re-fetch/upsert.
+- Safe FTS query construction and bounded fallback pagination.
+- Creation high-water mark ignores read/unread transitions.
+
+### Widgets and integration
+
+- Literal five-column ASCII grip geometry and correct arrow direction in every state.
+- Pointer, focus, tooltip, keyboard, and accessibility behavior.
+- Shared Inspector preference across all seven Watchlists tabs.
+- New-user defaults and existing-user migration.
+- Contextual rows, date groups, pinning, pagination, search, stable arrivals, and empty states.
+- Cursor/visible-row offset, Reader scroll, selected item, focus, and filter survival across every
+  manual and responsive layout change.
+- Auto-read occurs on genuine selection but not on restoration; serialized mutation order is
+  deterministic.
+- Hostile remote markup and invalid browser URLs fail safely.
+
+### Production evidence
+
+- Focused Watchlists, Subscriptions, database, and destination-shell suites.
+- CSS source and generated bundle integrity.
+- Production-style Textual renders at representative wide and narrow sizes, including exact width
+  boundaries and both open/closed grip states.
+- Live keyboard and pointer checks with an isolated profile. Pointer coordinates must be computed
+  by character position, never UTF-8 byte position, per the repository's Watchlists UAT lesson.
+- Full regression, lint/static checks, and documentation verification required by the implementing
+  Backlog task before it can be marked Done.
+
+## ADR check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/042-watchlists-reader-first-ia.md`
+
+Reason: this is a long-lived amendment to the Watchlists pane structure and layout-state policy.
+ADR-042 already owns the reader-first information architecture, so it is amended rather than
+creating a competing decision record.

--- a/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
+++ b/Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
@@ -28,7 +28,8 @@ interfaces so common behavior can be extracted after both real consumers exist.
 
 ## Current state
 
-Phase 1 of the 2026-08-05 reader-first design is implemented:
+The reader-first phases and nested-pagination follow-up are implemented on the approved
+`origin/dev` base:
 
 - Read is the landing tab.
 - Tree scopes drive item loading.
@@ -37,16 +38,17 @@ Phase 1 of the 2026-08-05 reader-first design is implemented:
 - Navigation, Feed Items, Reader, and Inspector are represented by `RegionLayout` and rebuilt by
   `WatchlistsWorkbench` factories.
 - The Reader safely converts captured HTML into readable text.
+- Read uses `ArticleListPane` with contextual rows, effective-date groups, 50-row pagination, and
+  separate list/Reader scroll ownership.
+- All Unread, Today, and Starred Smart Feeds, scoped search, refresh-all/new-items feedback,
+  star/unstar, and safe Open in browser actions are shipped.
 
-The remaining gaps are presentation and capability exposure:
+The remaining gap is the pane-layout foundation:
 
-- Feed Items is still a `DataTable`, not a contextual article list.
-- There are no All Unread, Today, or Starred Smart Feeds.
-- `subscription_items.is_flagged` and its index exist, but no star action or Starred query uses
-  them.
-- The FTS5 table and maintenance triggers exist, but Read has no scoped full-text search path.
 - Reader can still be collapsed, even though the selected article is the purpose of the screen.
-- Collapsed regions render generic headers instead of persistent edge grips.
+- Feed Items and Reader are vertically stacked inside a scrollable centre rather than arranged as
+  NetNewsWire-style list and Reader columns.
+- Collapsed regions render generic 16-column headers instead of persistent five-column edge grips.
 - Responsive layout and persisted manual preference are not distinct state concepts.
 
 ## Goals
@@ -67,6 +69,9 @@ The remaining gaps are presentation and capability exposure:
 - Reworking OPML folder round-tripping in this slice.
 - Adding enclosure playback, images, or web-page rendering inside Reader.
 - Creating a shared application-wide split-pane framework in parallel with Media Library work.
+- Reimplementing or changing the shipped ArticleListPane, Smart Feed, scoped search, pagination,
+  refresh, item-status, star, or browser-action data contracts except where layout regression
+  compatibility requires it.
 
 ## Information architecture
 
@@ -450,12 +455,12 @@ Focus, background refresh, tab switching, and selection changes never do.
 
 ## Delivery isolation
 
-Planning and implementation must not proceed in the current dirty
-`feat/task-3401-video-generation-foundation` worktree. Before Slice 1 starts, create a dedicated
-Watchlists branch/worktree from the user-approved integration base and transplant the Watchlists
-documentation commits into it. Do not rewrite, reset, clean, or otherwise disturb the unrelated video
-branch or its uncommitted files. The implementation plan records the chosen base and transplanted
-commit ids before any code change.
+Planning and implementation proceed in the dedicated
+`codex/task-21281-watchlists-collapsible-reader-layout` branch at
+`.worktrees/task-21281-watchlists-collapsible-reader-layout`, based on `origin/dev` commit
+`527152ad3`. The approved Watchlists documentation was transplanted as commits `ade0a5ab7`,
+`6af8780f5`, `4561c4199`, and `730d908d2`. The unrelated dirty
+`feat/task-3401-video-generation-foundation` worktree remains untouched.
 
 ## Security and accessibility
 
@@ -489,30 +494,18 @@ Read retains or adds:
 
 ## Implementation decomposition
 
-This specification is one UX programme, not one atomic pull request. Planning and Backlog work must
-split it into the following dependency-ordered, independently verifiable slices:
+On the approved `origin/dev` base, the former contextual-list, Smart Feed/search, and
+refresh/pagination slices are already shipped under tasks 3072, 3791, and their nested-pagination
+follow-up. The remaining programme work is one atomic, independently verifiable slice:
 
 1. **Layout foundation and grips.** Make Reader/management canvas the permanent centre host; add
    Watchlists-local ASCII grips; introduce preferred/effective/Article Focus state, responsive
-   resolution, shared Inspector behavior, and versioned layout normalization. This slice delivers
-   the requested collapse behavior across all Watchlists tabs without changing item presentation.
-2. **Contextual Feed Items and Reader actions.** Replace the Read `DataTable` with the snapshot-bounded,
-   date-grouped contextual list; add the shared effective-date helper, semantic restoration,
-   deterministic keyset ordering and seen-id guard, Star/Unstar, protected-status `m`, off-loop Open
-   in browser, and the three-action Reader header. Depends on slice 1's permanent host and
-   state-restoration seams.
-3. **Smart Feeds and scoped search.** Add normalized Smart Feed scopes/counts, the shared date and
-   predicate contracts, Starred/Today/All Unread navigation, FTS search, and bounded fallback;
-   reuse slice 2's effective-date helper for Today. Depends on slice 2's article list and star
-   writer.
-4. **Scoped refresh and stable-arrival polish.** Add concurrency-limited scope refresh, aggregate
-   completion feedback, high-water-mark arrival counting, the new-items affordance, narrow-width
-   live polish, and programme-level regression/documentation close-out. Depends on slices 1–3.
+   resolution, shared Inspector behavior, and versioned layout normalization. Preserve the shipped
+   ArticleListPane, Smart Feed, search, refresh, pagination, item-action semantics, selection, and
+   scroll contracts while changing their host geometry and simplifying Reader's visible action row
+   to the approved three core actions.
 
-Each slice receives its own atomic Backlog task, acceptance criteria, implementation plan, tests,
-and review. The writing-plans transition after this design reviews the sequence and writes the
-detailed plan for slice 1 first; later slice plans must not be treated as if one pull request owns
-the whole programme.
+This slice receives Backlog task 21281, its own detailed implementation plan, tests, and review.
 
 ## Verification
 

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -2336,11 +2336,18 @@ async def test_destination_action_buttons_explain_their_outcome(route):
             "this audit when tooltips are added (tracked as a UX follow-up)."
         )
     app = _build_test_app()
+    if route == "library":
+        app.notes_scope_service = StaticLibraryNotesScopeService([])
+        app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+        app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
     host = DestinationHarness(app, route)
 
     async with host.run_test(size=(180, 40)) as pilot:
-        await pilot.pause(0.1)
         screen = _active_destination_screen(host)
+        if route == "library":
+            await _wait_for_library_snapshot(screen, pilot)
+        else:
+            await pilot.pause(0.1)
 
         missing_tooltips = [
             button.id
@@ -2348,8 +2355,7 @@ async def test_destination_action_buttons_explain_their_outcome(route):
             # Library's lifecycle entry controls are orientation actions,
             # not destination outcome actions. Their behavior and focus
             # contracts live in Tests/UI/test_library_shell.py.
-            if button.id
-            not in {"library-rail-explore-all", "library-hub-retry-evidence"}
+            if button.id != "library-rail-explore-all"
             if str(getattr(button, "tooltip", None)).strip().lower() in {"", "none"}
         ]
         assert not missing_tooltips, (

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -985,7 +985,7 @@ async def _wait_for_wc_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
 
 
 async def _wait_for_library_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
-    """Open the full Library rail after its async evidence load settles.
+    """Wait for the Library rail shell to finish its async source-count load.
 
     Mirrors ``Tests/UI/test_library_shell.py::_wait_for_library_shell`` for
     suites (like this one) that mount Library through the generic
@@ -993,20 +993,13 @@ async def _wait_for_library_snapshot(screen, pilot, *, timeout: float = 2.0) -> 
     retired 3-pane hub's terminal selectors (``#library-source-error``,
     ``#library-source-empty``, the per-source summary ids) never mount under
     the rail + canvas shell, so readiness is keyed off ``_library_loaded``
-    and the rail itself. Library now admits fresh profiles through a compact
-    Starter rail; the source-shell contracts below intentionally exercise
-    the full rail, so enter it through the real ``Explore all`` action.
+    and the rail itself.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if getattr(screen, "_library_loaded", False) and screen.query("#library-rail"):
             await pilot.pause()
             await pilot.pause()
-            explore = screen.query("#library-rail-explore-all")
-            if explore:
-                explore.first(Button).press()
-                await pilot.pause()
-                await pilot.pause()
             return
         await pilot.pause(0.01)
     raise AssertionError(
@@ -1153,7 +1146,7 @@ def _custom_policy_recovery_state(
         # of the generic "source material" phrasing artifacts/personas use.
         # (F-013: the copy was rewritten in plain language -- "Search
         # everything, pick a section, or add something new.")
-        ("library", "#library-header-line", "add something useful"),
+        ("library", "#library-header-line", "pick a section"),
         ("artifacts", "#artifacts-title", "generated"),
         ("personas", "#personas-header", "who the ai plays"),
     ],
@@ -1691,15 +1684,17 @@ async def test_library_destination_service_failure_uses_recovery_copy():
     host = DestinationHarness(app, "library")
 
     async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
         screen = _active_destination_screen(host)
-        await _wait_for_visible_text(
-            screen, pilot, "Some Library sources are unavailable."
-        )
-        retry = screen.query_one("#library-hub-retry-evidence", Button)
+        button = screen.query_one("#library-use-in-console", Button)
 
-        assert "Some Library sources are unavailable." in _visible_text(screen)
-        assert retry.disabled is False
-        assert "Retry" in str(retry.label)
+        assert (
+            "Library source services unavailable; retry Library later."
+            in _visible_text(screen)
+        )
+        assert button.disabled is False
+        assert button.has_class("library-source-action-blocked")
+        assert "Library source services are unavailable" in str(button.tooltip)
 
 
 @pytest.mark.asyncio
@@ -2336,26 +2331,15 @@ async def test_destination_action_buttons_explain_their_outcome(route):
             "this audit when tooltips are added (tracked as a UX follow-up)."
         )
     app = _build_test_app()
-    if route == "library":
-        app.notes_scope_service = StaticLibraryNotesScopeService([])
-        app.media_reading_scope_service = StaticLibraryMediaScopeService([])
-        app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
     host = DestinationHarness(app, route)
 
     async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
         screen = _active_destination_screen(host)
-        if route == "library":
-            await _wait_for_library_snapshot(screen, pilot)
-        else:
-            await pilot.pause(0.1)
 
         missing_tooltips = [
             button.id
             for button in screen.query(Button)
-            # Library's lifecycle entry controls are orientation actions,
-            # not destination outcome actions. Their behavior and focus
-            # contracts live in Tests/UI/test_library_shell.py.
-            if button.id != "library-rail-explore-all"
             if str(getattr(button, "tooltip", None)).strip().lower() in {"", "none"}
         ]
         assert not missing_tooltips, (

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -985,7 +985,7 @@ async def _wait_for_wc_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
 
 
 async def _wait_for_library_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
-    """Wait for the Library rail shell to finish its async source-count load.
+    """Open the full Library rail after its async evidence load settles.
 
     Mirrors ``Tests/UI/test_library_shell.py::_wait_for_library_shell`` for
     suites (like this one) that mount Library through the generic
@@ -993,13 +993,20 @@ async def _wait_for_library_snapshot(screen, pilot, *, timeout: float = 2.0) -> 
     retired 3-pane hub's terminal selectors (``#library-source-error``,
     ``#library-source-empty``, the per-source summary ids) never mount under
     the rail + canvas shell, so readiness is keyed off ``_library_loaded``
-    and the rail itself.
+    and the rail itself. Library now admits fresh profiles through a compact
+    Starter rail; the source-shell contracts below intentionally exercise
+    the full rail, so enter it through the real ``Explore all`` action.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if getattr(screen, "_library_loaded", False) and screen.query("#library-rail"):
             await pilot.pause()
             await pilot.pause()
+            explore = screen.query("#library-rail-explore-all")
+            if explore:
+                explore.first(Button).press()
+                await pilot.pause()
+                await pilot.pause()
             return
         await pilot.pause(0.01)
     raise AssertionError(
@@ -1146,7 +1153,7 @@ def _custom_policy_recovery_state(
         # of the generic "source material" phrasing artifacts/personas use.
         # (F-013: the copy was rewritten in plain language -- "Search
         # everything, pick a section, or add something new.")
-        ("library", "#library-header-line", "pick a section"),
+        ("library", "#library-header-line", "add something useful"),
         ("artifacts", "#artifacts-title", "generated"),
         ("personas", "#personas-header", "who the ai plays"),
     ],
@@ -1190,6 +1197,50 @@ async def test_watchlists_collections_uses_compact_title_and_clear_sections():
         visible_text = _visible_text(screen)
         assert "Watchlists" in visible_text
         assert "Collections" not in visible_text
+
+
+def test_watchlists_help_and_footer_bindings_only_advertise_live_pane_actions():
+    bindings = {binding[0]: binding for binding in WatchlistsCollectionsScreen.BINDINGS}
+
+    assert bindings["z"][2] == "Toggle focused side pane"
+    assert bindings["Z"][2] == "Article Focus (Read only)"
+    assert bindings["left_square_bracket"][2] == "Navigation"
+    assert bindings["right_square_bracket"][2] == "Inspector"
+    assert not (
+        {
+            "ctrl+c",
+            "ctrl+v",
+            "ctrl+x",
+            "ctrl+s",
+            "ctrl+d",
+            "ctrl+z",
+            "ctrl+a",
+            "ctrl+r",
+            "ctrl+w",
+            "ctrl+p",
+            "ctrl+q",
+            "f1",
+            "f6",
+        }
+        & set(bindings)
+    )
+
+
+def test_watchlists_context_help_names_permanent_reader_and_side_pane_actions():
+    app = _build_test_app()
+    app.notify = Mock()
+    screen = WatchlistsCollectionsScreen(app)
+
+    screen.action_show_help()
+
+    copy = str(app.notify.call_args.args[0])
+    assert "z=toggle focused side pane" in copy
+    assert "Z=Article Focus (Read only)" in copy
+    assert "[=Navigation ]=Inspector" in copy
+    assert "Reader is permanent" in copy
+    assert "solo" not in copy.lower()
+    assert "Expand" not in copy
+    assert "collapsed header" not in copy.lower()
 
 
 @pytest.mark.asyncio
@@ -1640,17 +1691,15 @@ async def test_library_destination_service_failure_uses_recovery_copy():
     host = DestinationHarness(app, "library")
 
     async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
         screen = _active_destination_screen(host)
-        button = screen.query_one("#library-use-in-console", Button)
-
-        assert (
-            "Library source services unavailable; retry Library later."
-            in _visible_text(screen)
+        await _wait_for_visible_text(
+            screen, pilot, "Some Library sources are unavailable."
         )
-        assert button.disabled is False
-        assert button.has_class("library-source-action-blocked")
-        assert "Library source services are unavailable" in str(button.tooltip)
+        retry = screen.query_one("#library-hub-retry-evidence", Button)
+
+        assert "Some Library sources are unavailable." in _visible_text(screen)
+        assert retry.disabled is False
+        assert "Retry" in str(retry.label)
 
 
 @pytest.mark.asyncio
@@ -2296,6 +2345,11 @@ async def test_destination_action_buttons_explain_their_outcome(route):
         missing_tooltips = [
             button.id
             for button in screen.query(Button)
+            # Library's lifecycle entry controls are orientation actions,
+            # not destination outcome actions. Their behavior and focus
+            # contracts live in Tests/UI/test_library_shell.py.
+            if button.id
+            not in {"library-rail-explore-all", "library-hub-retry-evidence"}
             if str(getattr(button, "tooltip", None)).strip().lower() in {"", "none"}
         ]
         assert not missing_tooltips, (

--- a/Tests/UI/test_destination_visual_parity_correction.py
+++ b/Tests/UI/test_destination_visual_parity_correction.py
@@ -1387,7 +1387,7 @@ async def test_watchlists_left_rail_is_labelled_when_expanded():
     factory-presence rather than on "the pane supplies its own heading", and
     LEFT_RAIL is where the two diverge -- `WatchlistTree` composes navigation
     buttons and no heading. The expanded rail rendered as an unlabelled box
-    while its collapsed header still read "▸ Watchlists".
+    while its responsive Navigation grip still named the region "Watchlists".
     """
     app = _build_test_app()
     app.watchlist_scope_service = StaticWatchlistsScopeService([])
@@ -2529,10 +2529,9 @@ COMPACT_DESTINATION_CONTRACTS = {
         "identity": "#watchlists-collections-title",
         "workbench": "#wl-workbench",
         # `#watchlists-list-pane` died with the FEEDS region in task-2513.
-        # `#wl-region-left_rail` (the watchlist tree) is the rail-as-"object"
-        # analogue "chat" and "library" already use above for the same
-        # reason -- always present, regardless of active section.
-        "object": "#wl-region-left_rail",
+        # At this compact width the responsive workbench parks the watchlist
+        # tree body but keeps its labelled Navigation grip reachable.
+        "object": "#wl-grip-left_rail",
         "detail": "#watchlists-detail-pane",
         # `#nav-overview` retired with the left-rail navigator -- see the
         # note on the same key in SOURCE_PREP_WORKBENCHES above.
@@ -2715,9 +2714,11 @@ VISIBLE_FOCUS_TARGETS = {
     },
     "personas": {"personas-library-new", "personas-attach-to-console"},
     "watchlists_collections": {
+        "wc-empty-create-source",
         "wc-open-watchlists",
         "wc-attach-to-console",
         "watchlists-follow-in-console",
+        "watchlists-switch-local",
     },
     "schedules": {"schedules-follow-in-console"},
     "workflows": {"workflows-launch-in-console"},
@@ -3326,7 +3327,11 @@ async def test_watchlists_other_filter_strip_controls_are_visible(size):
         await pilot.pause(0.2)
 
         items_pane = screen.query_one("#watchlists-items-pane")
-        for selector in ("#items-search-input", "#items-status-select"):
+        for selector in (
+            "#items-refresh-button",
+            "#items-search-input",
+            "#items-status-select",
+        ):
             widget = screen.query_one(selector)
             assert widget.region.height >= 1 and widget.region.width > 0, (
                 f"{selector} is clipped to nothing: {widget.region}"
@@ -3340,7 +3345,7 @@ async def test_watchlists_other_filter_strip_controls_are_visible(size):
         items_row = screen.query_one("#items-search-input").region.y
         painted = "".join(seg.text for seg in strips[items_row])
         # TASK-3072: the Select's resting label is now the reader's "All".
-        for label in ("Search items...", "All"):
+        for label in ("Refresh", "Search items...", "All"):
             assert label in painted, (
                 f"{label!r} never reaches the screen; the Items toolbar is "
                 f"clipped at {size}. Row {items_row} paints: {painted.strip()!r}"

--- a/Tests/UI/test_destination_visual_parity_correction.py
+++ b/Tests/UI/test_destination_visual_parity_correction.py
@@ -982,17 +982,9 @@ SOURCE_PREP_WORKBENCHES = {
         "markers": ("#personas-library-empty", "#personas-library-count"),
         "marker_container": "#personas-library-pane",
     },
-    # Watchlists moved from the placeholder 3-column shell onto
-    # `WatchlistsWorkbench` (rails around a VERTICALLY stacked centre — see
-    # `watchlists_workbench.py`'s docstring on why the shared
-    # `DestinationWorkbench`/3-column-ASCII contract can't express this
-    # layout). `#watchlists-detail-pane` and the reader now stack one above
-    # the other inside `#wl-centre`, not side by side, so this entry is kept
-    # for the `markers`/`marker_container`/`actions` keys (still valid --
-    # those panes still exist, just not horizontally arranged) but excluded
-    # from the two horizontal-geometry parametrizations below via
-    # `SOURCE_PREP_WORKBENCHES_HORIZONTAL`, the same way "personas" above
-    # excluded itself from the retired snapshot-worker markers.
+    # Watchlists uses its own responsive horizontal body with permanent grips,
+    # so the generic always-expanded three-pane contract cannot express it.
+    # This entry remains the source for its markers and actions.
     # task-2513: `#watchlists-list-pane` died with the FEEDS region; the
     # snapshot markers live in the always-mounted centre header now.
     "watchlists_collections": {
@@ -1033,12 +1025,8 @@ SOURCE_PREP_WORKBENCHES = {
     },
 }
 
-#: `SOURCE_PREP_WORKBENCHES` minus destinations that no longer lay their
-#: list/detail/inspector panes out horizontally. Watchlists' rehost onto
-#: `WatchlistsWorkbench` stacks ITEMS/CONTENT vertically inside a
-#: centre column by deliberate design (see `watchlists_workbench.py`), so it
-#: cannot satisfy `_assert_horizontal_panes` — that is a real, intentional
-#: geometry change, not a regression to paper over.
+#: `SOURCE_PREP_WORKBENCHES` minus Watchlists, whose responsive grips may
+#: intentionally hide side panes at the generic contract's fixed viewport.
 SOURCE_PREP_WORKBENCHES_HORIZONTAL = {
     route: contract
     for route, contract in SOURCE_PREP_WORKBENCHES.items()
@@ -1142,21 +1130,11 @@ async def test_watchlists_screen_matches_approved_control_plane_columns():
         assert "Column 2:" not in visible_text
         assert "Column 3:" not in visible_text
 
-        # The Rule-divided three-column body was replaced by the collapsible
-        # WatchlistsWorkbench (rails around a vertically stacked centre; see
-        # watchlists_workbench.py) — region borders replace Rule dividers, so
-        # the old #watchlists-*-divider ids no longer exist. Assert the new
-        # structural landmarks instead: the workbench container, and each
-        # region wrapper.
+        # The Rule-divided body was replaced by WatchlistsWorkbench's
+        # horizontal responsive body. Region borders replace Rule dividers.
         #
-        # CONTENT is unmounted on every tab except Read
-        # (`WatchlistsCollectionsScreen._hidden_centre_regions`), and the
-        # FEEDS region was removed outright in task-2513, so it has no DOM
-        # presence anywhere. ITEMS is the one centre region that is always
-        # present; the tab strip and snapshot markers this test already
-        # asserted above ("Sources"/"State: ready"/... in `visible_text`)
-        # come from `#wl-centre-status` (`_build_centre_status_header`),
-        # mounted on every tab.
+        # CONTENT is the permanent Reader on Read and unmounted on management
+        # tabs; ITEMS becomes the management canvas there.
         assert screen.query_one("#wl-workbench")
         assert screen.query_one("#wl-centre-status")
         for region_id in (
@@ -1168,9 +1146,8 @@ async def test_watchlists_screen_matches_approved_control_plane_columns():
         assert not screen.query("#wl-region-feeds")
         assert not screen.query("#wl-header-feeds")
         assert not screen.query("#wl-region-content")
-        assert not screen.query("#wl-header-content")
 
-        # ... and on Read (the default), the reader IS part of the stack.
+        # ... and on Read, the Reader is part of the horizontal body.
         screen.active_section = "items"
         await pilot.pause(0.2)
         assert screen.query_one("#wl-region-content")
@@ -1178,17 +1155,8 @@ async def test_watchlists_screen_matches_approved_control_plane_columns():
 
 
 @pytest.mark.asyncio
-async def test_watchlists_centre_regions_stack_vertically_in_order():
-    """Vertical-geometry replacement for the horizontal contract Watchlists
-    was excluded from (see `SOURCE_PREP_WORKBENCHES_HORIZONTAL` above): its
-    rehost onto `WatchlistsWorkbench` stacks ITEMS/CONTENT vertically inside
-    the centre column by deliberate design, so `_assert_horizontal_panes`
-    (which asserts `left.region.x < right.region.x`) can never apply — but
-    that must not mean Watchlists has zero automated geometry coverage.
-
-    task-2513: the always-mounted centre header (`#wl-centre-status`, the
-    tab strip + snapshot markers) sits above the stack on every tab.
-    """
+async def test_watchlists_read_body_is_horizontal_in_display_order():
+    """Read lays side panes, grips, and the permanent Reader left-to-right."""
     app = _build_test_app()
     host = _visual_destination_harness(app, "watchlists_collections")
 
@@ -1196,64 +1164,36 @@ async def test_watchlists_centre_regions_stack_vertically_in_order():
         screen = _active_destination_screen(host)
         await _wait_for_selector(screen, pilot, "#wl-workbench")
 
-        # CONTENT only occupies space on the Items (Read) tab -- Task 4 fix
-        # round 1. This test is specifically about the centre stack, so it
-        # must be on that tab (the default since task-2513), independent of
-        # whatever the section otherwise defaults to.
         screen.active_section = "items"
         await pilot.pause()
-
-        # Force every region open so both centre regions have real
-        # geometry to compare — independent of whatever CONTENT's persisted
-        # collapse state happens to be (region_layout_store.load_region_layout).
         screen._apply_layout(RegionLayout())
         await pilot.pause()
 
         header = screen.query_one("#wl-centre-status")
-        items = screen.query_one("#wl-region-items")
-        content = screen.query_one("#wl-region-content")
-        centre = screen.query_one("#wl-centre")
-
-        assert header.region.y < items.region.y < content.region.y, (
-            f"centre regions are not stacked top-to-bottom: "
-            f"header={header.region} items={items.region} content={content.region}"
+        body = screen.query_one("#wl-workbench-body")
+        selectors = (
+            "#wl-region-left_rail",
+            "#wl-grip-left_rail",
+            "#wl-region-items",
+            "#wl-grip-items",
+            "#wl-region-content",
+            "#wl-grip-right_rail",
+            "#wl-region-right_rail",
         )
-        for selector, pane in (
-            ("#wl-centre-status", header),
-            ("#wl-region-items", items),
-            ("#wl-region-content", content),
-        ):
-            assert pane.region.width > 0, f"{selector} has no width"
-            assert pane.region.height > 0, f"{selector} has no height"
-            assert 0 <= pane.region.x < 160, selector
-            assert pane.region.right <= 160, selector
+        widgets = [screen.query_one(selector) for selector in selectors]
 
-        # No two centre regions may overlap.
-        for top, bottom in ((header, items), (items, content)):
-            assert top.region.y + top.region.height <= bottom.region.y, (
-                f"centre regions overlap: {top.region} vs {bottom.region}"
-            )
-
-        # Compact terminals intentionally show the stack through the outer
-        # centre viewport instead of shrinking either region below its floor.
-        assert centre.max_scroll_y > 0
-        centre.scroll_end(animate=False)
-        await pilot.pause()
-        assert content.region.intersection(centre.content_region).height > 0
+        assert header.region.bottom <= body.region.y
+        assert all(widget.region.height == body.region.height for widget in widgets)
+        assert all(
+            left.region.right <= right.region.x
+            for left, right in zip(widgets, widgets[1:])
+        )
+        assert all(body.region.contains_region(widget.region) for widget in widgets)
 
 
 @pytest.mark.asyncio
 async def test_watchlists_collapsing_both_rails_keeps_every_region_in_viewport():
-    """Fix round 2, Finding 1 (CRITICAL): `.watchlists-region-header`'s
-    `width: 100%` rule was unscoped, so a RAIL header (a direct child of the
-    workbench `Horizontal`, not the centre `Vertical`) took the ENTIRE
-    workbench width instead of a narrow collapsed-handle width -- pushing
-    every region after it off-screen. Measured pre-fix at 160x42 after
-    collapsing both rails: the right rail's header landed at
-    x=161 with the workbench only 160 wide, unreachable by mouse. This forces
-    the exact reproduction and asserts every remaining region/header stays
-    inside the 160-wide viewport.
-    """
+    """Collapsed rail grips and the Reader remain inside the body."""
     app = _build_test_app()
     app.watchlist_scope_service = StaticWatchlistsScopeService([])
     host = _visual_destination_harness(app, "watchlists_collections")
@@ -1274,35 +1214,26 @@ async def test_watchlists_collapsing_both_rails_keeps_every_region_in_viewport()
         await pilot.pause()
 
         for selector in (
-            "#wl-header-left_rail",
+            "#wl-grip-left_rail",
             "#wl-region-items",
+            "#wl-grip-items",
             "#wl-region-content",
-            "#wl-header-right_rail",
+            "#wl-grip-right_rail",
         ):
             widget = screen.query_one(selector)
             assert 0 <= widget.region.x < 160, selector
             assert widget.region.right <= 160, selector
             assert widget.region.height > 0, selector
 
-        left_header = screen.query_one("#wl-header-left_rail")
-        right_header = screen.query_one("#wl-header-right_rail")
-        assert left_header.region.width < 160, (
-            f"left rail header claimed (close to) the full workbench width: "
-            f"{left_header.region}"
-        )
-        assert right_header.region.x + right_header.region.width <= 160, (
-            f"right rail header fell outside the viewport: {right_header.region}"
-        )
-        centre = screen.query_one("#wl-centre")
-        content = screen.query_one("#wl-region-content")
-        centre.scroll_end(animate=False)
-        await pilot.pause()
-        assert content.region.intersection(centre.content_region).height > 0
+        assert not screen.query("#wl-region-left_rail")
+        assert not screen.query("#wl-region-right_rail")
+        assert screen.query_one("#wl-grip-left_rail").region.width == 5
+        assert screen.query_one("#wl-grip-right_rail").region.width == 5
 
 
 @pytest.mark.asyncio
 async def test_watchlists_read_regions_keep_their_idle_floors():
-    """The outer centre scroll owns compact layouts; neither region is crushed."""
+    """Expanded Feed Items and Reader retain their horizontal width floors."""
     app = _build_test_app()
     host = _visual_destination_harness(app, "watchlists_collections")
 
@@ -1320,10 +1251,12 @@ async def test_watchlists_read_regions_keep_their_idle_floors():
 
         items = screen.query_one("#wl-region-items")
         content = screen.query_one("#wl-region-content")
+        body = screen.query_one("#wl-workbench-body")
 
-        assert items.region.height >= 10, items.region
-        assert content.region.height == 20, content.region
-        assert screen.query_one("#wl-centre").max_scroll_y > 0
+        assert items.region.width >= 32, items.region
+        assert content.region.width >= 44, content.region
+        assert items.region.height == body.region.height
+        assert content.region.height == body.region.height
 
 
 @pytest.mark.parametrize("size", [(160, 42), (235, 52)])
@@ -1409,12 +1342,10 @@ async def test_watchlists_every_region_draws_exactly_one_round_border():
         await pilot.pause()
 
         # 1. Every region draws its own box, and draws it `round`.
-        centre = screen.query_one("#wl-centre")
+        body = screen.query_one("#wl-workbench-body")
         for region in Region:
             widget = screen.query_one(f"#wl-region-{region.value}")
-            if region in (Region.ITEMS, Region.CONTENT):
-                centre.scroll_to_widget(widget, animate=False)
-                await pilot.pause()
+            assert body.region.contains_region(widget.region)
             rows = _composited_rows(widget)
             assert rows[0].startswith("╭") and rows[0].endswith("╮"), (
                 f"{region.value} has no round top border: {rows[0]!r}"
@@ -1431,9 +1362,6 @@ async def test_watchlists_every_region_draws_exactly_one_round_border():
             "watchlists-inspector-pane",
         ):
             pane = screen.query_one(f"#{pane_id}")
-            if pane_id == "watchlists-detail-pane":
-                centre.scroll_to_widget(pane, animate=False)
-                await pilot.pause()
             rows = _composited_rows(pane)
             edges = (rows[0][0], rows[0][-1], rows[-1][0], rows[-1][-1])
             assert not any(ch in _ROUND_CORNERS + _SQUARE_CORNERS for ch in edges), (
@@ -1523,22 +1451,8 @@ async def test_watchlists_active_section_tab_label_is_visible():
 
 @pytest.mark.parametrize("size", [(160, 42), (100, 40)])
 @pytest.mark.asyncio
-async def test_watchlists_soloed_centre_region_fills_the_centre(size):
-    """Task 6 fix round 3, Finding 3, kept current by task-2513: a soloed
-    region must fill the centre, not stay pinned at its cap.
-
-    Solo (`action_solo_region` -> `RegionLayout.solo`) collapses the other
-    centre region to a one-line header. CONTENT is the only capped region
-    left (FEEDS, whose solo first exposed this, is gone), so a soloed
-    CONTENT would stay pinned at `max-height: 50` while the collapsed
-    header took one row -- the same degenerate view FEEDS once produced.
-    `_region_widget` adds `.watchlists-region-sole-centre` for exactly that
-    state and the stylesheet lifts the cap there.
-
-    The invariant now includes the always-mounted centre header
-    (`#wl-centre-status`): header + soloed body + collapsed header(s) must
-    cover the centre exactly, with nothing left blank.
-    """
+async def test_watchlists_article_focus_gives_the_reader_the_flexible_body(size):
+    """Article Focus leaves only fixed grips beside the permanent Reader."""
     app = _build_test_app()
     host = _visual_destination_harness(app, "watchlists_collections")
 
@@ -1546,47 +1460,31 @@ async def test_watchlists_soloed_centre_region_fills_the_centre(size):
         screen = _active_destination_screen(host)
         await _wait_for_selector(screen, pilot, "#wl-workbench")
 
-        # CONTENT only occupies space on the Items (Read) tab -- the
-        # default since task-2513. Soloing/un-soloing it below needs it
-        # genuinely present.
         screen.active_section = "items"
         await pilot.pause()
 
         screen._apply_layout(RegionLayout())
         await pilot.pause()
+        preferred_before = screen.region_layout
+        screen.action_article_focus()
+        await pilot.pause()
+        await pilot.pause()
 
-        for soloed in (Region.ITEMS, Region.CONTENT):
-            screen._apply_layout(RegionLayout().solo(soloed))
-            await pilot.pause()
-            await pilot.pause()
-
-            # Re-query every widget after each layout change: the workbench
-            # reactive is `recompose=True`, so the previous iteration's
-            # references are unmounted and report a zero-sized region.
-            centre = screen.query_one("#wl-centre")
-            # `#wl-centre` also contains the shared header (tab strip +
-            # snapshot summary) on every tab, Read included. Its rows are
-            # real content of `#wl-centre` and must count toward "covered",
-            # or this assertion would demand the region widgets alone fill
-            # space the header is legitimately occupying.
-            header = screen.query_one("#wl-centre-status")
-            body = screen.query_one(f"#wl-region-{soloed.value}")
-            headers = [
-                screen.query_one(f"#wl-header-{other.value}")
-                for other in (Region.ITEMS, Region.CONTENT)
-                if other is not soloed
-            ]
-            covered = (
-                header.region.height
-                + body.region.height
-                + sum(h.region.height for h in headers)
-            )
-            assert covered == centre.region.height, (
-                f"solo({soloed.value}) leaves "
-                f"{centre.region.height - covered} of the centre's "
-                f"{centre.region.height} rows blank: header={header.region} "
-                f"body={body.region} headers={[h.region for h in headers]}"
-            )
+        body = screen.query_one("#wl-workbench-body")
+        reader = screen.query_one("#wl-region-content")
+        grips = [
+            screen.query_one(f"#wl-grip-{region.value}")
+            for region in (Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL)
+        ]
+        assert screen.region_layout == preferred_before
+        assert screen._article_focus_active is True
+        assert not screen.query("#wl-region-left_rail")
+        assert not screen.query("#wl-region-items")
+        assert not screen.query("#wl-region-right_rail")
+        assert reader.region.height == body.region.height
+        assert reader.region.width + sum(grip.region.width for grip in grips) == (
+            body.region.width
+        )
 @pytest.mark.parametrize("size", [(235, 52), (160, 42)])
 @pytest.mark.asyncio
 async def test_watchlists_right_rail_does_not_clip_action_labels(size):
@@ -1961,12 +1859,9 @@ SOURCE_PREP_LOADING_CONTRACTS = [
     # Watchlists' loading marker (#wc-loading-state) still exists and is
     # still checked (Tests/UI/test_destination_shells.py::
     # test_watchlists_collections_initial_load_uses_distinct_loading_copy),
-    # but `_assert_ascii_workbench_contract` requires the list/detail/
-    # inspector panes to be laid out horizontally, which Watchlists' rehost
-    # onto the collapsible WatchlistsWorkbench deliberately no longer does
-    # (ITEMS/CONTENT stack vertically inside a centre column — see
-    # watchlists_workbench.py). See `SOURCE_PREP_WORKBENCHES_HORIZONTAL`
-    # above for the same exclusion applied to the two sibling tests.
+    # but `_assert_ascii_workbench_contract` requires three always-expanded
+    # panes. Watchlists instead resolves responsive side-pane grips around a
+    # permanent centre canvas. See `SOURCE_PREP_WORKBENCHES_HORIZONTAL` above.
     (
         "skills",
         skills_screen_module.SkillsScreen,

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -117,7 +117,6 @@ async def test_content_pane_shows_placeholder_with_no_item():
     `compose()` ever runs or produces the right widget. Mount it for real and
     read back the rendered text.
     """
-    from textual.app import App
     from textual.widgets import Static
 
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
@@ -130,7 +129,7 @@ async def test_content_pane_shows_placeholder_with_no_item():
     async with app.run_test() as pilot:
         await pilot.pause()
         placeholder = app.query_one("#content-empty", Static)
-        assert str(placeholder.renderable) == "Select an item to read it."
+        assert str(placeholder.renderable) == "Select a feed item to display it here."
         assert not app.query("#content-body-scroll"), (
             "the empty-state path stays a direct placeholder rather than an empty scroller"
         )
@@ -403,7 +402,9 @@ async def test_selecting_an_item_renders_it_in_the_content_region():
 
         assert content_pane.item is None
         empty_placeholder = content_pane.query_one("#content-empty", Static)
-        assert str(empty_placeholder.renderable) == "Select an item to read it."
+        assert str(empty_placeholder.renderable) == (
+            "Select a feed item to display it here."
+        )
 
 
 @pytest.mark.asyncio
@@ -453,54 +454,6 @@ async def test_content_region_is_gated_to_the_items_read_tab():
         await pilot.pause(0.2)
         assert not screen.query("#wl-header-content")
         assert not screen.query("#wl-region-content")
-
-
-@pytest.mark.asyncio
-async def test_content_region_gating_does_not_clobber_a_real_collapse_preference():
-    """The tab gate is display-only: a user's REAL choice to collapse
-    CONTENT (made on the Items tab) must survive a trip through a non-Read
-    tab and back -- not get silently re-expanded just because the gate
-    also forces it collapsed everywhere else.
-    """
-    from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
-
-    from Tests.UI.test_destination_shells import DestinationHarness
-    from Tests.UI.app_factory import _build_test_app
-
-    app = _build_test_app()
-    host = DestinationHarness(app, "watchlists_collections")
-    async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
-        screen = host.screen_stack[-1]
-
-        screen.active_section = "items"
-        await pilot.pause(0.2)
-        assert screen.query("#wl-region-content"), "CONTENT should start expanded on Items"
-
-        # The user deliberately collapses CONTENT while actually on Items.
-        screen._apply_layout(screen.region_layout.toggle(Region.CONTENT))
-        await pilot.pause(0.2)
-        assert screen.region_layout.is_collapsed(Region.CONTENT)
-        assert screen.query("#wl-header-content")
-
-        screen.active_section = "sources"
-        await pilot.pause(0.2)
-        # TASK-1344 AC#4: CONTENT unmounts off the Read tab -- no header,
-        # not even the collapsed one the user's real preference would
-        # otherwise still show on Items.
-        assert not screen.query("#wl-header-content")
-        assert not screen.query("#wl-region-content")
-
-        screen.active_section = "items"
-        await pilot.pause(0.2)
-        assert screen.region_layout.is_collapsed(Region.CONTENT), (
-            "the real preference must still read collapsed -- the gate must "
-            "never have touched it"
-        )
-        assert screen.query("#wl-header-content"), (
-            "returning to Items must restore the user's own collapse choice, "
-            "not silently force CONTENT back open"
-        )
 
 
 # --- Task 6: `j` / `k` item navigation -------------------------------------
@@ -1627,7 +1580,6 @@ async def test_a_persisted_body_reaches_the_reader_end_to_end():
 @pytest.mark.asyncio
 async def test_the_mark_unread_button_is_compact():
     """Reader actions stay in the established one-row chrome budget."""
-    from textual.app import App
     from textual.widgets import Button
 
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
@@ -1643,192 +1595,6 @@ async def test_the_mark_unread_button_is_compact():
         await pilot.pause()
         button = app.query_one("#content-mark-unread-button", Button)
         assert button.compact, "the reader's button must not cost three rows"
-
-
-@pytest.mark.asyncio
-async def test_the_expand_button_posts_the_request():
-    """Batch-4 review, I5 (half 1/2). task-2307's own Implementation Notes
-    honestly disclose that `ExpandReaderRequested` has no SCREEN-level
-    handler yet (AC#2 stays unchecked for exactly that reason -- not tested
-    here, on purpose). But the PANE-level half -- the button existing and
-    posting the message on press -- had zero test coverage at all:
-    mutation-verified by the review, gutting the `content-expand-button`
-    branch of `on_button_pressed` left all 52 tests in this file green.
-    """
-    from textual.app import App
-    from textual.widgets import Button
-
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
-        ContentPane,
-        ExpandReaderRequested,
-    )
-
-    class _PaneHost(ConsolidatedCSSApp):
-        def __init__(self) -> None:
-            super().__init__()
-            self.captured: list[str] = []
-
-        def compose(self):
-            pane = ContentPane()
-            pane.item = {"title": "x", "content": "y", "content_kind": "article"}
-            yield pane
-
-        def on_expand_reader_requested(self, message: ExpandReaderRequested) -> None:
-            self.captured.append("expand_reader_requested")
-
-    app = _PaneHost()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        button = app.query_one("#content-expand-button", Button)
-        assert str(button.label) == "Expand", (
-            "the button must read Expand while the pane is not expanded"
-        )
-
-        button.press()
-        await pilot.pause()
-
-        assert app.captured == ["expand_reader_requested"], (
-            "pressing the button must post ExpandReaderRequested exactly once"
-        )
-
-
-@pytest.mark.asyncio
-async def test_the_expand_button_label_reflects_expanded_when_seeded():
-    """Batch-4 review, I5 (half 2/2). `expanded` is a plain reactive, not
-    `recompose=True` -- by design (see its own docstring): in production the
-    screen's region-solo toggle rebuilds the whole workbench through the
-    region factories, which constructs a brand new `ContentPane` and seeds
-    `expanded` on it BEFORE it mounts, so a second, pane-local recompose
-    would be pure churn. This mirrors that exact seeding shape -- set before
-    the pane is yielded -- rather than mutating the reactive on an
-    already-mounted pane, which would not be a fair test of how this
-    reactive is actually meant to be driven.
-    """
-    from textual.app import App
-    from textual.widgets import Button
-
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
-
-    class _PaneHost(ConsolidatedCSSApp):
-        def compose(self):
-            pane = ContentPane()
-            pane.item = {"title": "x", "content": "y", "content_kind": "article"}
-            pane.expanded = True
-            yield pane
-
-    app = _PaneHost()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        button = app.query_one("#content-expand-button", Button)
-        assert str(button.label) == "Restore", (
-            "a pane seeded with expanded=True must offer to give the room "
-            "back, not offer to expand again"
-        )
-
-
-@pytest.mark.asyncio
-async def test_pressing_expand_actually_solos_content_and_restores_on_a_second_press():
-    """Batch-4 review round 3, Qodo Q4. Closes the gap I5 deliberately left
-    open (AC#2's screen-level handler, "honestly unwired" at the time):
-    `ExpandReaderRequested` now routes to the SAME `RegionLayout.solo`
-    mechanism `Z`/`action_solo_region` already uses (task-1344), so pressing
-    the button must produce the identical, real effect a `Z` keypress does
-    -- not a second, parallel maximize implementation.
-    """
-    from textual.widgets import Button
-
-    from Tests.UI.test_destination_shells import DestinationHarness
-    from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
-    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
-    from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
-
-    item = {
-        "id": 11,
-        "title": "Expand me",
-        "source_name": "Feed",
-        "content": "body",
-        "content_kind": "article",
-        "content_format": "text",
-    }
-
-    app = _build_test_app()
-    host = DestinationHarness(app, "watchlists_collections")
-    async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
-        screen = host.screen_stack[-1]
-        screen.active_section = "items"
-        await pilot.pause(0.2)
-
-        items_pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
-        items_pane.items = [item]
-        await pilot.pause(0.2)
-        items_pane.select_item_by_id("11")
-        await pilot.pause(0.3)
-
-        # task-2513 removed the FEEDS region; the ITEMS region is now the
-        # neighbour whose collapse proves the solo actually happened.
-        assert screen.query("#wl-region-items"), "precondition: ITEMS starts visible"
-        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        expand_button = content_pane.query_one("#content-expand-button", Button)
-        assert str(expand_button.label) == "Expand"
-
-        expand_button.press()
-        await pilot.pause(0.3)
-
-        assert screen.region_layout.solo_region is Region.CONTENT, (
-            "the SAME solo mechanism Z uses must actually have run"
-        )
-        assert screen.query("#wl-region-content")
-        assert not screen.query("#wl-region-items"), (
-            "soloing CONTENT must actually collapse ITEMS around it -- the "
-            "real, visible effect, not just a state flag"
-        )
-
-        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        restore_button = content_pane.query_one("#content-expand-button", Button)
-        assert str(restore_button.label) == "Restore", (
-            "the freshly-rebuilt pane must be seeded from the live layout, "
-            "not silently reset to Expand"
-        )
-
-        restore_button.press()
-        await pilot.pause(0.3)
-
-        assert screen.region_layout.solo_region is None, "a second press must restore"
-        assert screen.query("#wl-region-items")
-        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        assert str(
-            content_pane.query_one("#content-expand-button", Button).label
-        ) == "Expand"
-
-
-@pytest.mark.asyncio
-async def test_expand_reader_requested_off_the_read_tab_is_refused_defensively():
-    """The button cannot actually be pressed off Read (CONTENT is unmounted
-    everywhere else), so this drives the message directly -- the same
-    defensive-gate shape `test_solo_on_content_off_the_read_tab_is_refused`
-    already pins for `Z`, now pinned for this second entry point into the
-    identical gate.
-    """
-    from Tests.UI.test_destination_shells import DestinationHarness
-    from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ExpandReaderRequested
-
-    app = _build_test_app()
-    host = DestinationHarness(app, "watchlists_collections")
-    async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
-        screen = host.screen_stack[-1]
-        screen.active_section = "sources"
-        await pilot.pause(0.3)
-        before = screen.region_layout
-
-        screen.post_message(ExpandReaderRequested())
-        await pilot.pause(0.3)
-
-        assert screen.region_layout == before
-        assert screen.region_layout.solo_region is None
 
 
 # --- PR #1091 review ---------------------------------------------------------
@@ -2178,99 +1944,68 @@ def test_a_raw_control_byte_in_a_markdown_body_is_stripped_before_rendering():
 # --- TASK-1494: the reader's `[full page]`/`[previous snapshot]` affordances -
 
 
+@pytest.mark.parametrize("content_kind", ["change", "article"])
 @pytest.mark.asyncio
-async def test_a_change_item_gets_both_snapshot_affordance_buttons():
-    """The design spec's promised affordances, finally wired to a `change`
-    item. Both buttons must be compact (1 row) -- CONTENT's budget is tight,
-    same discipline as the mark-unread button (see its own comment).
-    """
-    from textual.app import App
+async def test_only_change_items_get_snapshot_affordances_in_inspector(content_kind):
+    """Stored-page actions belong to change items in the Inspector only."""
     from textual.widgets import Button
 
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
 
     class _PaneHost(ConsolidatedCSSApp):
         def compose(self):
-            pane = ContentPane()
-            pane.item = {
-                "title": "anthropic.com/news changed",
-                "content": "+ a\n- b",
-                "content_kind": "change",
-                "content_format": "diff",
-                "change_percentage": 5.0,
+            pane = InspectorPane()
+            pane.selected_entity = {
+                "entity_kind": "watchlist_item",
+                "item_id": 7,
+                "title": "Selected item",
+                "content_kind": content_kind,
             }
             yield pane
 
     app = _PaneHost()
     async with app.run_test() as pilot:
         await pilot.pause()
-        full_page = app.query_one("#content-full-page-button", Button)
-        previous = app.query_one("#content-previous-snapshot-button", Button)
-        assert full_page.compact
-        assert previous.compact
+        full_page = app.query("#inspector-full-page-button")
+        previous = app.query("#inspector-previous-snapshot-button")
+        assert bool(full_page) is (content_kind == "change")
+        assert bool(previous) is (content_kind == "change")
+        if content_kind == "change":
+            assert app.query_one("#inspector-full-page-button", Button).compact
+            assert app.query_one("#inspector-previous-snapshot-button", Button).compact
 
 
+@pytest.mark.parametrize(
+    ("button_id", "which"),
+    [
+        ("inspector-full-page-button", "full_page"),
+        ("inspector-previous-snapshot-button", "previous"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_an_article_item_gets_neither_snapshot_affordance_button():
-    """Article items never gain these: `URLMonitor.check_url` is the only
-    `url_snapshots` writer and it only ever produces `change`-kind items, so
-    an article has no rows there for the buttons to show.
-    """
-    from textual.app import App
-    from textual.css.query import NoMatches
+async def test_inspector_snapshot_buttons_post_existing_request(button_id, which):
+    """Both Inspector buttons post the shared screen request with the item."""
     from textual.widgets import Button
 
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
-
-    class _PaneHost(ConsolidatedCSSApp):
-        def compose(self):
-            pane = ContentPane()
-            pane.item = {
-                "title": "Claude Opus 4.5 is now available",
-                "content": "The model is available in the API today.",
-                "content_kind": "article",
-                "content_format": "text",
-            }
-            yield pane
-
-    app = _PaneHost()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        with pytest.raises(NoMatches):
-            app.query_one("#content-full-page-button", Button)
-        with pytest.raises(NoMatches):
-            app.query_one("#content-previous-snapshot-button", Button)
-        # And the mark-unread button, common to both kinds, is untouched.
-        assert app.query_one("#content-mark-unread-button", Button)
-
-
-@pytest.mark.asyncio
-async def test_pressing_full_page_posts_view_snapshot_requested_with_full_page():
-    """The button press must post the message the screen handler reads,
-    carrying the item and the right `which` -- not just exist visually.
-    """
-    from textual.app import App
-    from textual.widgets import Button
-
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
-        ContentPane,
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
+        InspectorPane,
         ViewSnapshotRequested,
     )
 
     captured: list[ViewSnapshotRequested] = []
     item = {
+        "entity_kind": "watchlist_item",
+        "item_id": 7,
         "title": "anthropic.com/news changed",
-        "content": "+ a\n- b",
         "content_kind": "change",
-        "content_format": "diff",
         "source_id": 7,
         "url": "https://anthropic.com/news",
     }
 
     class _PaneHost(ConsolidatedCSSApp):
         def compose(self):
-            pane = ContentPane()
-            pane.item = item
+            pane = InspectorPane()
+            pane.selected_entity = item
             yield pane
 
         def on_view_snapshot_requested(self, event: ViewSnapshotRequested) -> None:
@@ -2279,52 +2014,11 @@ async def test_pressing_full_page_posts_view_snapshot_requested_with_full_page()
     app = _PaneHost()
     async with app.run_test() as pilot:
         await pilot.pause()
-        app.query_one("#content-full-page-button", Button).press()
+        app.query_one(f"#{button_id}", Button).press()
         await pilot.pause()
 
     assert len(captured) == 1
-    assert captured[0].which == "full_page"
-    assert captured[0].item is item
-
-
-@pytest.mark.asyncio
-async def test_pressing_previous_snapshot_posts_view_snapshot_requested_with_previous():
-    """The other button, the other `which` value."""
-    from textual.app import App
-    from textual.widgets import Button
-
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
-        ContentPane,
-        ViewSnapshotRequested,
-    )
-
-    captured: list[ViewSnapshotRequested] = []
-    item = {
-        "title": "anthropic.com/news changed",
-        "content": "+ a\n- b",
-        "content_kind": "change",
-        "content_format": "diff",
-        "source_id": 7,
-        "url": "https://anthropic.com/news",
-    }
-
-    class _PaneHost(ConsolidatedCSSApp):
-        def compose(self):
-            pane = ContentPane()
-            pane.item = item
-            yield pane
-
-        def on_view_snapshot_requested(self, event: ViewSnapshotRequested) -> None:
-            captured.append(event)
-
-    app = _PaneHost()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        app.query_one("#content-previous-snapshot-button", Button).press()
-        await pilot.pause()
-
-    assert len(captured) == 1
-    assert captured[0].which == "previous"
+    assert captured[0].which == which
     assert captured[0].item is item
 
 
@@ -2381,6 +2075,19 @@ def _seed_change_item_with_snapshots(db, *, snapshot_rows):
     return source_id, url
 
 
+async def _select_first_item_with_inspector(pilot, screen, pane):
+    """Open the right rail and select the first loaded item."""
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
+
+    if not screen.query("#watchlists-entity-inspector"):
+        screen.action_toggle_right_rail()
+        await pilot.pause(0.2)
+    item = screen._loaded_items[0]
+    pane.select_item_by_id(str(item["id"]))
+    await pilot.pause(0.3)
+    return screen.query_one("#watchlists-entity-inspector", InspectorPane)
+
+
 @pytest.mark.asyncio
 async def test_full_page_button_opens_the_newest_snapshot_in_a_modal():
     """The screen's handler must resolve `"full_page"` to the newest
@@ -2391,7 +2098,7 @@ async def test_full_page_button_opens_the_newest_snapshot_in_a_modal():
 
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
     from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import SnapshotViewModal
 
     app = _build_test_app()
@@ -2407,12 +2114,9 @@ async def test_full_page_button_opens_the_newest_snapshot_in_a_modal():
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
         screen, pane = await _mount_items_screen(pilot, host, expected_count=1)
-        item = screen._loaded_items[0]
-        pane.select_item_by_id(str(item["id"]))
-        await pilot.pause(0.3)
-
-        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        content_pane.query_one("#content-full-page-button", Button).press()
+        inspector = await _select_first_item_with_inspector(pilot, screen, pane)
+        assert isinstance(inspector, InspectorPane)
+        inspector.query_one("#inspector-full-page-button", Button).press()
 
         modal = None
         for _ in range(60):
@@ -2445,7 +2149,7 @@ async def test_previous_snapshot_button_opens_the_second_newest_snapshot():
 
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
     from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import SnapshotViewModal
 
     app = _build_test_app()
@@ -2462,12 +2166,9 @@ async def test_previous_snapshot_button_opens_the_second_newest_snapshot():
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
         screen, pane = await _mount_items_screen(pilot, host, expected_count=1)
-        item = screen._loaded_items[0]
-        pane.select_item_by_id(str(item["id"]))
-        await pilot.pause(0.3)
-
-        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        content_pane.query_one("#content-previous-snapshot-button", Button).press()
+        inspector = await _select_first_item_with_inspector(pilot, screen, pane)
+        assert isinstance(inspector, InspectorPane)
+        inspector.query_one("#inspector-previous-snapshot-button", Button).press()
 
         modal = None
         for _ in range(60):
@@ -2498,7 +2199,7 @@ async def test_previous_snapshot_with_only_one_stored_degrades_to_an_honest_toas
 
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
     from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import SnapshotViewModal
 
     app = _build_test_app()
@@ -2514,12 +2215,9 @@ async def test_previous_snapshot_with_only_one_stored_degrades_to_an_honest_toas
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
         screen, pane = await _mount_items_screen(pilot, host, expected_count=1)
-        item = screen._loaded_items[0]
-        pane.select_item_by_id(str(item["id"]))
-        await pilot.pause(0.3)
-
-        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        content_pane.query_one("#content-previous-snapshot-button", Button).press()
+        inspector = await _select_first_item_with_inspector(pilot, screen, pane)
+        assert isinstance(inspector, InspectorPane)
+        inspector.query_one("#inspector-previous-snapshot-button", Button).press()
 
         for _ in range(60):
             await pilot.pause(0.05)
@@ -2551,7 +2249,7 @@ async def test_snapshot_modal_renders_remote_markup_as_literal_text():
 
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
     from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import SnapshotViewModal
 
     app = _build_test_app()
@@ -2570,12 +2268,9 @@ async def test_snapshot_modal_renders_remote_markup_as_literal_text():
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
         screen, pane = await _mount_items_screen(pilot, host, expected_count=1)
-        item = screen._loaded_items[0]
-        pane.select_item_by_id(str(item["id"]))
-        await pilot.pause(0.3)
-
-        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        content_pane.query_one("#content-full-page-button", Button).press()
+        inspector = await _select_first_item_with_inspector(pilot, screen, pane)
+        assert isinstance(inspector, InspectorPane)
+        inspector.query_one("#inspector-full-page-button", Button).press()
 
         modal = None
         for _ in range(60):
@@ -2733,7 +2428,6 @@ async def test_the_star_button_reflects_the_open_items_state():
     """The button is seeded from the open item's `is_flagged`: starred items
     read "★ Starred", unstarred read "☆ Star" -- the same vocabulary the
     rail's Starred root and the list row's glyph speak."""
-    from textual.app import App
     from textual.widgets import Button
 
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
@@ -2761,7 +2455,6 @@ async def test_the_star_button_posts_the_toggle_without_an_optimistic_flip():
     message the screen's `s` handler serves) and does NOT flip its own
     label: the write is async and can fail, so the flip lands on the
     screen's success path -- the label can never lie about a failed write."""
-    from textual.app import App
     from textual.widgets import Button
 
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
@@ -2806,15 +2499,14 @@ async def test_the_star_button_posts_the_toggle_without_an_optimistic_flip():
 
 
 def _action_row_app(item: dict):
-    """A ContentPane host carrying `item`, capturing the three verb messages."""
-    from textual.app import App
-
+    """Host Reader and Inspector while capturing their shared action messages."""
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
         ContentPane,
         OpenInBrowserRequested,
     )
     from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
         IngestRequested,
+        InspectorPane,
         ToggleBriefingQueueRequested,
     )
 
@@ -2829,6 +2521,9 @@ def _action_row_app(item: dict):
             pane = ContentPane()
             pane.item = item
             yield pane
+            inspector = InspectorPane()
+            inspector.selected_entity = {"entity_kind": "watchlist_item", **item}
+            yield inspector
 
         def on_open_in_browser_requested(self, message: OpenInBrowserRequested) -> None:
             self.opened.append(message.item)
@@ -2845,10 +2540,8 @@ def _action_row_app(item: dict):
 
 
 @pytest.mark.asyncio
-async def test_the_reader_action_row_offers_open_ingest_and_queue():
-    """The reader strip shares the Inspector's verbs (TASK-3072 plan task 8):
-    Open in browser, Ingest, and Queue -- the queue button's label states
-    the CURRENT value, the Inspector's own rule."""
+async def test_reader_offers_open_while_inspector_offers_ingest_and_queue():
+    """Core browser action stays in Reader; advanced actions live in Inspector."""
     from textual.widgets import Button
 
     app = _action_row_app(
@@ -2857,12 +2550,14 @@ async def test_the_reader_action_row_offers_open_ingest_and_queue():
     async with app.run_test() as pilot:
         await pilot.pause()
         assert str(app.query_one("#content-open-button", Button).label) == "Open"
-        assert str(app.query_one("#content-ingest-button", Button).label) == "Ingest"
-        assert str(app.query_one("#content-queue-button", Button).label) == "Queue"
+        assert str(app.query_one("#inspector-ingest-button", Button).label) == "Ingest"
+        assert str(
+            app.query_one("#inspector-queue-briefing-button", Button).label
+        ) == "Queue for briefing"
 
 
 @pytest.mark.asyncio
-async def test_the_queue_button_label_reflects_queued_state():
+async def test_the_inspector_queue_button_label_reflects_queued_state():
     from textual.widgets import Button
 
     app = _action_row_app(
@@ -2876,14 +2571,14 @@ async def test_the_queue_button_label_reflects_queued_state():
     )
     async with app.run_test() as pilot:
         await pilot.pause()
-        assert str(app.query_one("#content-queue-button", Button).label) == "Unqueue"
+        assert str(
+            app.query_one("#inspector-queue-briefing-button", Button).label
+        ) == "Unqueue from briefing"
 
 
 @pytest.mark.asyncio
-async def test_the_reader_action_row_buttons_post_their_messages():
-    """Open posts the reader's own request; Ingest and Queue post the
-    Inspector's OWN message classes, so one screen handler serves both
-    surfaces (the message-layer sharing the plan specifies)."""
+async def test_reader_and_inspector_action_buttons_post_shared_messages():
+    """The two surfaces keep using the screen's existing message handlers."""
     from textual.widgets import Button
 
     app = _action_row_app(
@@ -2892,8 +2587,8 @@ async def test_the_reader_action_row_buttons_post_their_messages():
     async with app.run_test() as pilot:
         await pilot.pause()
         app.query_one("#content-open-button", Button).press()
-        app.query_one("#content-ingest-button", Button).press()
-        app.query_one("#content-queue-button", Button).press()
+        app.query_one("#inspector-ingest-button", Button).press()
+        app.query_one("#inspector-queue-briefing-button", Button).press()
         await pilot.pause()
 
         assert [item.get("title") for item in app.opened] == ["x"]
@@ -2911,7 +2606,6 @@ async def test_the_reader_action_row_buttons_post_their_messages():
 async def test_the_position_footer_renders_and_updates_in_place():
     """The footer shows the screen-pushed `position` string; updating the
     reactive re-renders the one Static in place -- never a reader recompose."""
-    from textual.app import App
     from textual.widgets import Static
 
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
@@ -2941,7 +2635,6 @@ async def test_the_next_unread_footer_button_posts_the_panes_message():
     """The footer's Next Unread control posts the pane's existing
     `NextUnreadRequested` -- the same message `space` already raises, so one
     screen handler serves both."""
-    from textual.app import App
     from textual.widgets import Button
 
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
@@ -2971,8 +2664,6 @@ async def test_the_next_unread_footer_button_posts_the_panes_message():
 @pytest.mark.asyncio
 async def test_the_empty_reader_has_no_position_footer():
     """With nothing open the footer is absent entirely -- not "0 of 0"."""
-    from textual.app import App
-
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
 
     class _PaneHost(ConsolidatedCSSApp):

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 # Harness apps load the consolidated widget CSS the real app loads
@@ -331,11 +333,8 @@ def test_diff_lines_with_markup_shaped_text_keep_our_colour_and_gain_none():
     assert "\x1b[31m" not in ansi, "the [bold red] tag must not have styled anything"
 
 
-def test_content_region_is_not_collapsed_by_default_now_it_has_a_reader():
-    """Task 4: through Phase C, CONTENT held only a placeholder stub and
-    started collapsed. Now it hosts the real reader, so a fresh screen must
-    show it expanded like every other region.
-    """
+def test_content_is_not_a_preferred_collapsible_region():
+    """The permanent Reader is absent from preferred side-pane state."""
     from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
     from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
         WatchlistsCollectionsScreen,
@@ -418,9 +417,7 @@ async def test_content_region_is_gated_to_the_items_read_tab():
     there and nowhere else, regardless of the user's stored collapse
     preference for it.
 
-    TASK-1344 AC#4: gated regions UNMOUNT rather than keep a one-row
-    header, so "nowhere else" means CONTENT has no DOM presence at all off
-    the Read tab -- no `#wl-header-content`, not just no `#wl-region-content`.
+    "Nowhere else" means CONTENT has no DOM presence at all off Read.
     """
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
@@ -436,23 +433,19 @@ async def test_content_region_is_gated_to_the_items_read_tab():
         # mounted at rest...
         assert not screen.region_layout.is_collapsed(Region.CONTENT)
         assert screen.query("#wl-region-content")
-        assert not screen.query("#wl-header-content")
 
         # ...and off Read it must be unmounted despite the un-gated default
         # (`region_layout`) being expanded.
         screen.active_section = "overview"
         await pilot.pause(0.2)
-        assert not screen.query("#wl-header-content")
         assert not screen.query("#wl-region-content")
 
         screen.active_section = "items"
         await pilot.pause(0.2)
         assert screen.query("#wl-region-content")
-        assert not screen.query("#wl-header-content")
 
         screen.active_section = "sources"
         await pilot.pause(0.2)
-        assert not screen.query("#wl-header-content")
         assert not screen.query("#wl-region-content")
 
 
@@ -1221,20 +1214,8 @@ async def test_opening_an_item_does_not_cancel_unrelated_background_work():
 
 
 @pytest.mark.asyncio
-async def test_the_content_chevron_off_the_read_tab_neither_collapses_nor_persists():
-    """TASK-1344 AC#4: CONTENT UNMOUNTS off the Read tab, so there is no
-    `▸ Content` chevron left to click at all -- the affordance this test
-    used to defend against no longer exists. What remains reachable is a
-    STALE `focused_region` (e.g. the user last focused CONTENT on Read, then
-    switched tabs without moving focus): `z`/`Z` can still be invoked with it
-    pointed at a region that is not currently mounted, so
-    `_refuse_region_gesture_off_read_tab` must refuse the toggle rather than
-    running it against the REAL `region_layout` -- which would silently flip
-    the user's genuine preference to collapsed and, once persisted, be
-    honoured forever thanks to the Phase D migration marker already being
-    set. That permanently recreates the exact state the migration exists to
-    repair, from a gesture that produced no visible feedback at all.
-    """
+async def test_article_focus_is_refused_off_read_without_changing_layout():
+    """The permanent Reader exists only on Read, and its focus mode is local."""
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
     from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
@@ -1247,35 +1228,21 @@ async def test_the_content_chevron_off_the_read_tab_neither_collapses_nor_persis
 
         screen.active_section = "sources"
         await pilot.pause(0.3)
-        assert not screen.query("#wl-header-content"), "CONTENT must be unmounted, not collapsed"
         assert not screen.query("#wl-region-content")
-        assert not screen.region_layout.is_collapsed(Region.CONTENT), (
-            "the real preference is still expanded -- the precondition"
-        )
-
-        # A stale `focused_region` (left over from a prior visit to Read) is
-        # the one remaining route that could still reach CONTENT here.
-        screen.focused_region = Region.CONTENT
-        screen.action_toggle_region()
+        preferred_before = screen.region_layout
+        effective_before = screen._effective_region_layout
+        screen.notify = Mock()
+        screen.action_article_focus()
         await pilot.pause(0.3)
+        assert screen.region_layout == preferred_before
+        assert screen._effective_region_layout == effective_before
+        assert screen._article_focus_active is False
+        screen.notify.assert_called_once()
 
-        assert not screen.region_layout.is_collapsed(Region.CONTENT), (
-            "the gesture must be refused, not run against the real preference"
-        )
-        assert Region.CONTENT not in (screen._last_persisted_collapsed or frozenset()), (
-            "and it must never reach the persisted collapse set"
-        )
-
-        # `Z` (solo) with CONTENT focused is the same class of route.
-        screen.action_solo_region()
-        await pilot.pause(0.3)
-        assert screen.region_layout.solo_region is None
-        assert not screen.region_layout.is_collapsed(Region.CONTENT)
-
-        # And back on Read the reader is still there, untouched.
         screen.active_section = "items"
         await pilot.pause(0.3)
         assert screen.query("#wl-region-content")
+        assert not screen._effective_region_layout.is_collapsed(Region.CONTENT)
 
 
 @pytest.mark.asyncio
@@ -1291,17 +1258,11 @@ async def test_a_workbench_rebuild_keeps_the_items_filter_search_and_selection()
     it only fires when the overview counts actually change value, which is
     why it is not what this test drives.
 
-    task-15461 changed the deterministic trigger, not the contract. A rail
-    toggle used to rebuild every region (`region_layout` was
-    `recompose=True`), so `[` was the cheapest way to force a fresh
-    `ArticleListPane`; layout changes are now scoped to the regions whose
-    form actually moved, so `[` deliberately leaves ITEMS' pane instance
-    alone -- which is what
-    `test_a_rail_toggle_rebuilds_only_the_toggled_region` pins. Collapsing
-    and re-expanding ITEMS itself is the trigger that still genuinely
-    reconstructs the pane, and it exercises the same `_build_detail_pane`
-    seeding this test is about.
+    Collapsing and re-expanding Feed Items through its permanent grip really
+    remounts the pane, so it exercises the same `_build_detail_pane` seeding.
     """
+    from textual.widgets import Button
+
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
     from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
@@ -1322,14 +1283,13 @@ async def test_a_workbench_rebuild_keeps_the_items_filter_search_and_selection()
         pane.select_and_reveal(open_item)
         await pilot.pause(0.5)
 
-        # Collapse ITEMS and expand it again: the region's form really
-        # changes, so `_build_detail_pane` runs and a brand new
-        # `ArticleListPane` is what the user is left looking at.
-        screen.focused_region = Region.ITEMS
-        screen.action_toggle_region()
+        screen.query_one("#wl-grip-items", Button).press()
         await pilot.pause(0.5)
-        screen.focused_region = Region.ITEMS
-        screen.action_toggle_region()
+        assert not screen.query("#watchlists-items-pane")
+        assert screen.region_layout.is_collapsed(Region.ITEMS)
+        assert screen._effective_region_layout.is_collapsed(Region.ITEMS)
+
+        screen.query_one("#wl-grip-items", Button).press()
         await pilot.pause(0.5)
 
         rebuilt = screen.query_one("#watchlists-items-pane", ArticleListPane)
@@ -1758,21 +1718,8 @@ async def test_mark_unread_refuses_an_ingest_that_sits_beyond_a_lookup_page():
 
 
 @pytest.mark.asyncio
-async def test_soloing_content_then_leaving_read_leaves_a_centre_region_expanded():
-    """PR #1091 review, F2: the workbench must never render an empty centre.
-
-    Soloing CONTENT sets `collapsed` to `{ITEMS}`. Off the Read tab,
-    CONTENT is hidden outright now (TASK-1344 AC#1/#4:
-    `_hidden_centre_regions` unmounts it, independent of `collapsed`), so
-    the old failure mode this test was written against -- a force-collapse
-    derivation that added CONTENT to the solo's own collapsed set and left
-    all the centre regions collapsed with nothing expanded -- can no
-    longer happen structurally: hiding never touches `collapsed`, and ITEMS
-    (the one region that must survive) is forced OUT of `collapsed` by
-    `_rendered_region_layout` on every non-Read tab regardless of what
-    happened on Read. This test now pins that ITEMS is what is actually left
-    on screen, and that the user's solo is untouched and comes back on Read.
-    """
+async def test_article_focus_is_transient_and_the_reader_stays_permanent():
+    """Article Focus hides side panes without changing preferred state."""
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
     from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
@@ -1785,53 +1732,35 @@ async def test_soloing_content_then_leaving_read_leaves_a_centre_region_expanded
 
         screen.active_section = "items"
         await pilot.pause(0.3)
-        screen.focused_region = Region.CONTENT
-        screen.action_solo_region()
+        preferred_before = screen.region_layout
+        screen.action_article_focus()
         await pilot.pause(0.3)
-        assert screen.region_layout.solo_region is Region.CONTENT, (
-            "the precondition: CONTENT really is soloed"
-        )
+        assert screen._article_focus_active is True
+        assert screen.region_layout == preferred_before
         assert screen.query("#wl-region-content")
+        assert not screen.query("#wl-region-items")
+        for side in (Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL):
+            assert screen._effective_region_layout.is_collapsed(side)
+            assert screen.query(f"#wl-grip-{side.value}")
 
         screen.active_section = "sources"
         await pilot.pause(0.3)
-
-        # TASK-1344 hides CONTENT off Read (AC#1), so the only centre region
-        # ever mounted on Sources is now ITEMS -- assert against the DOM
-        # directly rather than the old `_visible_region_layout` derivation,
-        # which no longer exists in that shape (`_hidden_centre_regions` +
-        # `_rendered_region_layout` replaced it; hiding is now orthogonal to
-        # `RegionLayout.collapsed` rather than expressed through it, so there
-        # is nothing left to probe for "still collapsed").
-        assert screen.query("#wl-region-items"), (
-            "at least one centre region must be mounted expanded, not an "
-            "empty centre"
-        )
-        assert not screen.query("#wl-region-content"), "CONTENT stays hidden off Read"
+        assert screen._article_focus_active is False
+        assert screen.region_layout == preferred_before
+        assert screen.query("#wl-region-items")
+        assert not screen.query("#wl-region-content")
 
         screen.active_section = "items"
         await pilot.pause(0.3)
-        assert screen.region_layout.solo_region is Region.CONTENT, (
-            "the gate is display-only: the user's solo must survive the trip"
-        )
         assert screen.query("#wl-region-content")
-        assert not screen.query("#wl-region-items"), "and it must still be a solo"
+        assert screen.query("#wl-region-items")
 
 
 @pytest.mark.asyncio
-async def test_solo_on_content_off_the_read_tab_is_refused():
-    """PR #1091 review, F2 (second half) / TASK-1344 AC#2.
-
-    CONTENT is unmounted off the Read tab (AC#4), so there is no chevron to
-    click there -- but `focused_region` is a screen-level reactive that
-    outlives the widget that last set it, so `Z` can still be invoked with
-    it pointing at CONTENT after a tab switch. That must be refused rather
-    than soloing a region the user cannot see, which would otherwise
-    collapse ITEMS around it and leave nothing on screen.
-    """
+async def test_article_focus_off_read_does_not_change_preferred_or_effective_state():
+    """Management tabs reject Article Focus and retain their canvas."""
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
 
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -1841,19 +1770,17 @@ async def test_solo_on_content_off_the_read_tab_is_refused():
 
         screen.active_section = "sources"
         await pilot.pause(0.3)
-        before = screen.region_layout
-
-        screen.focused_region = Region.CONTENT
-        screen.action_solo_region()
+        preferred_before = screen.region_layout
+        effective_before = screen._effective_region_layout
+        screen.notify = Mock()
+        screen.action_article_focus()
         await pilot.pause(0.3)
 
-        assert screen.region_layout is before or screen.region_layout == before, (
-            "solo on the gated CONTENT region must not touch the real layout"
-        )
-        assert screen.region_layout.solo_region is None
-        assert screen.query("#wl-region-items"), (
-            "and the centre must still have something in it"
-        )
+        assert screen.region_layout == preferred_before
+        assert screen._effective_region_layout == effective_before
+        assert screen._article_focus_active is False
+        assert screen.query("#wl-region-items")
+        screen.notify.assert_called_once()
 
 
 def test_a_hostile_markdown_body_never_emits_a_terminal_hyperlink():

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -17,6 +17,7 @@ from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
 from tldw_chatbook.UI.Watchlists_Modules.notifications_pane import NotificationsPane
+from tldw_chatbook.UI.Watchlists_Modules.pane_grip import RegionToggled
 from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
 from tldw_chatbook.UI.Watchlists_Modules.rules_pane import RulesPane
 from tldw_chatbook.UI.Watchlists_Modules.runs_pane import RunsPane
@@ -851,7 +852,8 @@ async def test_collapsing_a_region_persists(monkeypatch):
         # task-1344 review, B1: region-layout gestures only apply on the
         # Read tab -- which is now the default section (task-2513), so no
         # section switch is needed before the real toggle.
-        screen.focused_region = Region.ITEMS
+        screen.query_one("#wl-region-items").focus()
+        await pilot.pause()
         await pilot.press("z")
         await pilot.pause()
         assert screen.region_layout.is_collapsed(Region.ITEMS)
@@ -911,7 +913,7 @@ async def test_persisted_layout_is_applied_on_mount(monkeypatch):
         await pilot.pause(0.1)
         screen = host.screen_stack[-1]
         assert screen.region_layout.is_collapsed(Region.RIGHT_RAIL)
-        assert screen.query("#wl-header-right_rail")
+        assert screen.query("#wl-grip-right_rail")
         assert not screen.query("#watchlists-inspector-pane")
 
 
@@ -970,7 +972,8 @@ async def test_a_real_toggle_performs_exactly_one_write(monkeypatch):
         # task-1344 review, B1: region-layout gestures only apply on the
         # Read tab -- the default section since task-2513, so no switch is
         # needed before the real toggle this test measures.
-        screen.focused_region = Region.ITEMS
+        screen.query_one("#wl-region-items").focus()
+        await pilot.pause()
         await pilot.press("z")
         await pilot.pause()
         await host.workers.wait_for_complete()
@@ -1000,7 +1003,8 @@ async def test_a_burst_of_toggles_persists_only_the_final_state(monkeypatch):
         saved.clear()  # `on_mount`'s own (no-op) apply may have run above.
 
         screen = host.screen_stack[-1]
-        screen.focused_region = Region.ITEMS
+        screen.query_one("#wl-region-items").focus()
+        await pilot.pause()
         # Fire off several toggles back-to-back with no pause in between, so
         # scheduling for all of them races ahead of any one write completing.
         await pilot.press("z")
@@ -1012,7 +1016,7 @@ async def test_a_burst_of_toggles_persists_only_the_final_state(monkeypatch):
 
         final_layout = screen.region_layout
         assert saved, "a real change occurred, so at least one write must have happened"
-        assert saved[-1].collapsed == final_layout.collapsed_for_persistence()
+        assert saved[-1].collapsed == final_layout.collapsed
 
 
 # --- Fix round 1, Finding 1: a bracket press must not destroy a half-typed
@@ -1211,9 +1215,8 @@ async def test_cancelling_the_create_form_clears_the_draft():
 
 # --- Fix round 2 (final whole-branch review): Findings 2, 3, 4. `_build_
 # detail_pane`/`_build_inspector_pane` construct a brand new pane on EVERY
-# workbench rebuild, not just a section switch -- any region collapse/solo/
-# rail toggle recomposes the whole `WatchlistsWorkbench` (`region_layout` is
-# `recompose=True`). RunsPane/NotificationsPane/OverviewPane were already
+# workbench rebuild, not just a section switch. RunsPane/NotificationsPane/
+# OverviewPane were already
 # seeded from screen state; Sources/Items/Rules and the Inspector were not,
 # and an in-progress Rules edit had no screen-state mirror at all (unlike the
 # Sources create-form draft fixed in round 1).
@@ -2102,12 +2105,7 @@ async def test_seeded_tree_expansion_takes_effect_on_the_first_render():
             )
 
 
-# --- TASK-1344: CONTENT gated to the Read tab (AC#1); solo/toggle refused on
-# any region hidden on the active tab (AC#2); no sequence of tab switches and
-# region gestures may leave the centre with nothing expanded (AC#3). Mirrors
-# the CONTENT-only tests Task 4 added in `Tests/UI/test_watchlists_content_
-# pane.py`. task-2513 removed the FEEDS region outright, so FEEDS's halves
-# of these tests died with it; CONTENT's and ITEMS's remain.
+# --- Permanent Reader and management-canvas section contracts ------------
 
 
 @pytest.mark.asyncio
@@ -2116,8 +2114,7 @@ async def test_the_feeds_region_is_gone_and_content_stays_gated_to_read():
     DOM presence on ANY tab (no `#wl-region-feeds`, no `#wl-header-feeds`),
     and its old pane (`#watchlists-list-pane`) with it.
 
-    CONTENT's TASK-1344 gating (AC#1/AC#4) is unchanged: unmounted -- not
-    even a one-row header -- on every tab except Read.
+    CONTENT is the permanent Reader on Read and unmounted elsewhere.
     """
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -2142,30 +2139,11 @@ async def test_the_feeds_region_is_gone_and_content_stays_gated_to_read():
             "ITEMS is force-shown off Read -- the section's own full-width pane"
         )
         assert not screen.query("#wl-region-content")
-        assert not screen.query("#wl-header-content")
 
 
 @pytest.mark.asyncio
 async def test_the_items_toggle_off_the_read_tab_neither_collapses_nor_persists():
-    """task-1344 whole-branch review, B1 -- ITEMS's half of the off-Read
-    toggle-refusal contract (CONTENT's half lives in
-    `test_watchlists_content_pane.py`; FEEDS's died with the region in
-    task-2513), the one leg the original AC#3/#4 work never covered.
-
-    Unlike CONTENT, ITEMS is force-shown off the Read tab
-    (`_rendered_region_layout`) -- it is the section's own full-width pane,
-    never a member of `_hidden_centre_regions()`. But a stale
-    `focused_region == ITEMS` (set by `on_descendant_focus` any time the
-    user's focus lands inside that pane, e.g. simply using Sources) let
-    `z`/`Z` reach `_apply_layout(region_layout.toggle(ITEMS))` against the
-    REAL, persisted layout with zero visible feedback -- the render already
-    forces ITEMS back out of `collapsed`, so the collapse only bit the next
-    time the user visited Read, at which point it (and CONTENT, if
-    already collapsed there) could leave the centre with nothing expanded
-    at all. Must be refused exactly like CONTENT, with copy that is
-    actually true for ITEMS (it IS shown off Read, just not collapsible
-    from here).
-    """
+    """A stale Feed Items message cannot change preference off Read."""
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
@@ -2175,24 +2153,20 @@ async def test_the_items_toggle_off_the_read_tab_neither_collapses_nor_persists(
         screen.active_section = "sources"
         await pilot.pause(0.3)
         assert screen.query("#wl-region-items"), (
-            "unlike CONTENT, ITEMS IS rendered off Read -- the "
-            "section's own full-width pane"
+            "the management section owns the permanent centre canvas"
         )
-        assert not screen.region_layout.is_collapsed(Region.ITEMS), (
-            "the real preference is still expanded -- the precondition"
-        )
+        assert not screen.query("#wl-grip-items")
+        preferred_before = screen.region_layout
+        effective_before = screen._effective_region_layout
+        persisted_before = screen._last_persisted_collapsed
 
         screen.notify = Mock()
-        screen.focused_region = Region.ITEMS
-        screen.action_toggle_region()
+        screen.post_message(RegionToggled(Region.ITEMS))
         await pilot.pause(0.3)
 
-        assert not screen.region_layout.is_collapsed(Region.ITEMS), (
-            "the gesture must be refused, not run against the real preference"
-        )
-        assert Region.ITEMS not in (screen._last_persisted_collapsed or frozenset()), (
-            "and it must never reach the persisted collapse set"
-        )
+        assert screen.region_layout == preferred_before
+        assert screen._effective_region_layout == effective_before
+        assert screen._last_persisted_collapsed == persisted_before
         screen.notify.assert_called_once()
         message = screen.notify.call_args.args[0]
         assert "only shown on the Read tab" not in message, (
@@ -2204,18 +2178,12 @@ async def test_the_items_toggle_off_the_read_tab_neither_collapses_nor_persists(
         screen.active_section = "items"
         await pilot.pause(0.3)
         assert screen.query("#wl-region-items")
-        assert not screen.region_layout.is_collapsed(Region.ITEMS)
+        assert screen.query("#wl-grip-items")
 
 
 @pytest.mark.asyncio
-async def test_solo_on_items_off_the_read_tab_is_refused():
-    """AC#2, ITEMS's half of the off-Read solo-refusal contract (CONTENT's
-    half lives in `test_watchlists_content_pane.py`; task-1344 whole-branch
-    review, B1): the generalized `_refuse_region_gesture_off_read_tab` must
-    refuse ITEMS's solo gesture off Read too -- ITEMS is not hidden there,
-    but region-layout gestures still do not apply to it outside the Read
-    tab.
-    """
+async def test_article_focus_on_a_management_tab_is_refused():
+    """Article Focus is a Read-only effective layout, never a preference."""
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
@@ -2224,49 +2192,24 @@ async def test_solo_on_items_off_the_read_tab_is_refused():
 
         screen.active_section = "runs"
         await pilot.pause(0.3)
-        before = screen.region_layout
+        preferred_before = screen.region_layout
+        effective_before = screen._effective_region_layout
 
         screen.notify = Mock()
-        screen.focused_region = Region.ITEMS
-        screen.action_solo_region()
+        screen.action_article_focus()
         await pilot.pause(0.3)
 
-        assert screen.region_layout is before or screen.region_layout == before, (
-            "solo on ITEMS off Read must not touch the real layout"
-        )
-        assert screen.region_layout.solo_region is None
-        assert screen.query("#wl-region-items"), (
-            "and the centre must still have something in it"
-        )
+        assert screen.region_layout == preferred_before
+        assert screen._effective_region_layout == effective_before
+        assert screen._article_focus_active is False
+        assert screen.query("#wl-region-items")
         screen.notify.assert_called_once()
-        message = screen.notify.call_args.args[0]
-        assert "only shown on the Read tab" not in message, (
-            "ITEMS IS shown off Read -- claiming otherwise would be false"
-        )
+        assert screen.notify.call_args.kwargs.get("markup") is False
 
 
 @pytest.mark.asyncio
-async def test_no_sequence_of_tab_switches_and_region_gestures_leaves_the_centre_empty():
-    """AC#3: no sequence of tab switches and region toggles/solos may leave
-    the workbench with zero expanded centre regions -- recoverable only by
-    clicking a header the user has no reason to suspect (PR #1091 review,
-    F2's original report, now widened past the single CONTENT-solo path
-    Task 4 fixed: CONTENT's and ITEMS's solo/toggle gestures are all
-    refused off the Read tab).
-
-    Drives real gestures (tab switches, `z`, `Z`, `[`) through the full
-    production shell (`DestinationHarness`, the same harness every other
-    test in this file uses), asserting after EACH one that at least one
-    centre region is genuinely mounted and expanded -- not merely that the
-    real `region_layout` looks fine, which is exactly the gap a purely
-    layout-level (non-DOM) assertion could miss.
-    """
-
-    def _any_centre_region_expanded(screen) -> bool:
-        return bool(
-            screen.query("#wl-region-items")
-            or screen.query("#wl-region-content")
-        )
+async def test_tab_switches_grips_and_article_focus_never_remove_the_centre():
+    """Read keeps Reader mounted; management tabs keep their canvas mounted."""
 
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -2276,83 +2219,50 @@ async def test_no_sequence_of_tab_switches_and_region_gestures_leaves_the_centre
 
         async def step(label: str) -> None:
             await pilot.pause(0.2)
-            assert _any_centre_region_expanded(screen), (
-                f"the centre has nothing expanded after {label!r}: "
+            assert screen.query("#wl-region-content") or screen.query(
+                "#wl-region-items"
+            ), (
+                f"the centre is empty after {label!r}: "
                 f"active_section={screen.active_section!r} "
-                f"region_layout={screen.region_layout!r}"
+                f"preferred={screen.region_layout!r} "
+                f"effective={screen._effective_region_layout!r}"
             )
 
-        await step("mount (Read, the default since task-2513)")
-
-        screen.active_section = "items"
-        await step("switch to Read")
-
-        # The specific reported path: solo CONTENT on Read, then leave --
-        # now refused on return, but must never have emptied the centre
-        # even before this fix's refusal existed (Task 4's own regression).
-        screen.focused_region = Region.CONTENT
-        screen.action_solo_region()
-        await step("solo CONTENT on Read")
+        await step("mount")
+        preferred_before = screen.region_layout
+        screen.action_article_focus()
+        await step("Article Focus")
+        assert screen.query("#wl-region-content")
+        assert not screen.query("#wl-region-items")
+        assert screen.region_layout == preferred_before
 
         screen.active_section = "sources"
-        await step("leave Read with CONTENT soloed")
-
-        # A stale `focused_region` still pointed at a hidden region: both
-        # gestures must be refused, not just one.
-        screen.action_toggle_region()
-        await step("toggle refused on Sources (focused_region=CONTENT)")
-        screen.action_solo_region()
-        await step("solo refused on Sources (focused_region=CONTENT)")
+        await step("management section")
+        assert screen._article_focus_active is False
+        assert not screen.query("#wl-region-content")
 
         screen.active_section = "items"
-        await step("back to Read (CONTENT solo must have survived)")
-
-        # Un-solo, then manually collapse ITEMS itself on Read -- this is
-        # the OTHER route `_rendered_region_layout` has to guard (a manual
-        # `z` on ITEMS while soloing CONTENT, or a plain ITEMS collapse,
-        # both leave `region_layout.collapsed` containing ITEMS).
-        screen.focused_region = Region.CONTENT
-        screen.action_solo_region()
-        await step("un-solo CONTENT on Read")
-
-        screen.focused_region = Region.ITEMS
-        screen.action_toggle_region()
-        await step("collapse ITEMS on Read")
+        await step("return to Read")
+        screen.query_one("#wl-grip-items", Button).press()
+        await step("collapse Feed Items grip")
+        assert screen.query("#wl-region-content")
+        assert screen.region_layout.is_collapsed(Region.ITEMS)
 
         screen.active_section = "runs"
-        await step("switch to Runs with ITEMS collapsed on Read")
-
-        # Rail toggles are orthogonal to the centre and must not interact.
+        await step("Runs with Feed Items preference collapsed")
         await pilot.press("[")
-        await step("collapse the left rail")
+        await step("toggle Navigation")
         await pilot.press("]")
-        await step("expand the left rail")
+        await step("toggle Inspector")
 
         screen.active_section = "items"
-        await step("back to Read with ITEMS still collapsed from before")
+        await step("return to Reader")
+        assert screen.query("#wl-region-content")
 
 
 @pytest.mark.asyncio
-async def test_off_read_items_toggle_never_empties_the_read_centre_or_persists():
-    """AC#3 gap the whole-branch review found (task-1344 review, B1): the
-    sequence test above never drove the ONE path that actually breaks
-    AC#3 -- collapse CONTENT on Read (a legitimate, persistable state),
-    leave for a non-Read tab where ITEMS is force-shown, then `z` with
-    `focused_region == ITEMS` (set by `on_descendant_focus` for anything
-    inside the section pane, so simply using Sources/Runs/... sets it up).
-
-    Before this fix that toggle was ACCEPTED: `region_layout.toggle(ITEMS)`
-    mutated and PERSISTED the real layout to `{items, content}` with
-    no visible change on the current tab (ITEMS is forced back out of
-    `collapsed` for the render), so returning to Read rendered two
-    headers over an empty centre -- on disk, surviving a restart.
-    """
-
-    def _any_centre_region_expanded(screen) -> bool:
-        return bool(
-            screen.query("#wl-region-items")
-            or screen.query("#wl-region-content")
-        )
+async def test_management_canvas_does_not_override_feed_items_preference():
+    """Management uses ITEMS as its canvas without changing Read preference."""
 
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -2363,65 +2273,35 @@ async def test_off_read_items_toggle_never_empties_the_read_centre_or_persists()
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        # Collapse CONTENT on Read -- the report's exact precondition, a
-        # legitimate and persistable state on its own.
-        screen.focused_region = Region.CONTENT
-        screen.action_toggle_region()
-        await pilot.pause(0.2)
-
-        assert screen.region_layout.is_collapsed(Region.CONTENT)
-        assert not screen.region_layout.is_collapsed(Region.ITEMS)
-        collapsed_before = screen.region_layout.collapsed
-        persisted_before = screen._last_persisted_collapsed
+        screen.query_one("#wl-grip-items", Button).press()
+        await pilot.pause(0.3)
+        assert screen.region_layout.is_collapsed(Region.ITEMS)
+        assert screen._effective_region_layout.is_collapsed(Region.ITEMS)
+        preferred_before = screen.region_layout
 
         screen.active_section = "sources"
         await pilot.pause(0.3)
-        assert _any_centre_region_expanded(screen), (
-            "ITEMS is force-shown off Read even with CONTENT collapsed"
-        )
+        assert screen.query("#wl-region-items")
+        assert not screen.query("#wl-grip-items")
+        assert not screen._effective_region_layout.is_collapsed(Region.ITEMS)
 
         screen.notify = Mock()
-        screen.focused_region = Region.ITEMS
-        screen.action_toggle_region()
+        screen.post_message(RegionToggled(Region.ITEMS))
         await pilot.pause(0.3)
-
-        assert screen.region_layout.collapsed == collapsed_before, (
-            "an off-Read ITEMS toggle must be refused, not mutate the real, "
-            "persisted layout"
-        )
-        assert screen._last_persisted_collapsed == persisted_before, (
-            "and it must never reach the persisted collapse set"
-        )
-        screen.notify.assert_called_once()
-
-        screen.notify.reset_mock()
-        screen.action_solo_region()
-        await pilot.pause(0.3)
-        assert screen.region_layout.collapsed == collapsed_before, (
-            "solo on ITEMS off Read must be refused too"
-        )
-        assert screen._last_persisted_collapsed == persisted_before
+        assert screen.region_layout == preferred_before
         screen.notify.assert_called_once()
 
         screen.active_section = "items"
         await pilot.pause(0.3)
-        assert _any_centre_region_expanded(screen), (
-            "returning to Read must not land on a dead end -- ITEMS was "
-            "never actually collapsed by the refused off-Read gesture"
-        )
-        assert screen.query("#wl-region-items"), (
-            "ITEMS specifically must still be the expanded centre region"
-        )
+        assert screen.query("#wl-region-content")
+        assert not screen.query("#wl-region-items")
+        assert screen._effective_region_layout.is_collapsed(Region.ITEMS)
 
 
-# --- task-1344 fix wave (Qodo correctness): `z`/`Z` while focus is in the --
-# centre header/tab strip -----------------------------------------------
+# --- `z` / Article Focus while focus is in the status header ------------
 #
 # `#wl-centre-status`/`#wl-tabs` (`_build_centre_status_header`) are mounted
-# directly under `#wl-centre`, outside every `wl-region-*`/`wl-header-*`
-# wrapper -- so `on_descendant_focus` never updates `focused_region` while
-# focus sits there, leaving it naming whatever region the user last actually
-# visited.
+# above `#wl-workbench-body`, outside every `wl-region-*`/`wl-grip-*` wrapper.
 
 
 @pytest.mark.asyncio
@@ -2432,8 +2312,7 @@ async def test_z_with_focus_in_the_centre_header_does_not_toggle_a_stale_region(
     `_refuse_region_gesture_off_read_tab` only gates `CENTRE_REGIONS`, so a
     rail's toggle was never refused there regardless of where real focus
     was. This is the one gesture the header-focus guard actually prevents
-    from mutating anything (unlike solo below, whose CENTRE-region path was
-    already refused by the existing off-Read gate regardless of focus).
+    from mutating anything.
     """
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -2466,7 +2345,7 @@ async def test_z_with_focus_in_the_centre_header_does_not_toggle_a_stale_region(
             "focused_region left over from the rail"
         )
         assert not screen.region_layout.is_collapsed(Region.LEFT_RAIL)
-        assert screen._last_persisted_collapsed == before.collapsed_for_persistence()
+        assert screen._last_persisted_collapsed == before.collapsed
 
 
 @pytest.mark.asyncio
@@ -2512,32 +2391,20 @@ async def test_the_tab_strip_is_recognized_as_the_centre_header_on_the_read_tab_
 
 
 @pytest.mark.asyncio
-async def test_capital_z_with_focus_in_the_centre_header_does_not_solo_a_stale_region():
-    """The solo half of the test above.
-
-    Unlike the toggle case, ITEMS's solo off the Read tab is ALREADY
-    refused by `_refuse_region_gesture_off_read_tab` regardless of focus
-    (task-1344 whole-branch review, B1), so `region_layout` never had a
-    path to actually mutate here either way. What this fix changes instead:
-    without it, that refusal still fires its `self.notify(...)`, keyed to
-    a region (`focused_region`, stale) the user is not looking at and has
-    no reason to associate with the tab strip they actually pressed `Z`
-    in. With the fix, focus-in-header short-circuits before that notify.
-    """
+async def test_capital_z_in_the_header_activates_article_focus_only_effectively():
+    """Article Focus is independent of stale region focus and not persisted."""
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
 
-        screen.active_section = "sources"
-        await pilot.pause(0.2)
-        screen.query_one("#wl-region-items").focus()
+        screen.query_one("#wl-region-left_rail").focus()
         await pilot.pause()
-        assert screen.focused_region == Region.ITEMS, (
+        assert screen.focused_region == Region.LEFT_RAIL, (
             "precondition: focused_region names a REAL prior focus"
         )
-        before = screen.region_layout
+        preferred_before = screen.region_layout
 
         screen.query_one("#wl-tab-runs").focus()
         await pilot.pause()
@@ -2546,16 +2413,15 @@ async def test_capital_z_with_focus_in_the_centre_header_does_not_solo_a_stale_r
             "header"
         )
 
-        screen.notify = Mock()
         await pilot.press("Z")
         await pilot.pause(0.2)
 
-        assert screen.region_layout == before, (
-            "Z with focus in the tab strip must not solo the stale "
-            "focused_region left over from ITEMS"
-        )
-        assert screen.region_layout.solo_region is None
-        screen.notify.assert_not_called()
+        assert screen._article_focus_active is True
+        assert screen.region_layout == preferred_before
+        assert screen.query("#wl-region-content")
+        assert not screen.query("#wl-region-items")
+        for region in (Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL):
+            assert screen._effective_region_layout.is_collapsed(region)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -1548,7 +1548,7 @@ async def test_read_mode_class_is_set_before_each_section_layout_swap():
         assert workbench.has_class("watchlists-read-mode")
 
         observed: list[tuple[str, bool]] = []
-        apply_section_view = workbench.apply_section_view
+        reconcile_body = workbench._reconcile_body
 
         async def record_mode_before_layout(**kwargs):
             observed.append(
@@ -1557,9 +1557,9 @@ async def test_read_mode_class_is_set_before_each_section_layout_swap():
                     workbench.has_class("watchlists-read-mode"),
                 )
             )
-            await apply_section_view(**kwargs)
+            await reconcile_body(**kwargs)
 
-        workbench.apply_section_view = record_mode_before_layout
+        workbench._reconcile_body = record_mode_before_layout
 
         screen.active_section = "sources"
         await pilot.pause(0.2)
@@ -2440,6 +2440,9 @@ async def test_focus_leaving_the_header_for_a_non_region_widget_clears_the_flag(
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
+
+        screen.active_section = "runs"
+        await pilot.pause(0.2)
 
         screen.query_one("#wl-tab-runs").focus()
         await pilot.pause()

--- a/Tests/UI/test_watchlists_select_option_overlays.py
+++ b/Tests/UI/test_watchlists_select_option_overlays.py
@@ -507,10 +507,13 @@ async def test_a_borderless_compact_select_has_a_visible_focus_cue(select_id):
     host = _watchlists_host()
     async with host.run_test(size=UAT_SIZE) as pilot:
         screen = _active_destination_screen(host)
-        screen.active_section = "items"
+        screen.active_section = (
+            "items" if select_id == "#items-status-select" else "sources"
+        )
         await pilot.pause()
         await _wait_for_selector(screen, pilot, select_id, timeout=5.0)
         select = screen.query_one(select_id, Select)
+        assert not select.disabled, "focus contrast must be measured on a focusable control"
 
         rest = _rendered_background(screen, select.region)
         select.focus()

--- a/Tests/Watchlists/test_humane_time.py
+++ b/Tests/Watchlists/test_humane_time.py
@@ -18,13 +18,12 @@ import time
 from datetime import datetime, timezone
 
 import pytest
-
-pytestmark = pytest.mark.unit
-
 from tldw_chatbook.UI.Watchlists_Modules.humane_time import (
     humane_timestamp,
     parse_timestamp,
 )
+
+pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(autouse=True)

--- a/Tests/Watchlists/test_kept_briefings_modal.py
+++ b/Tests/Watchlists/test_kept_briefings_modal.py
@@ -29,7 +29,6 @@ from unittest.mock import Mock
 
 import pytest
 from rich.console import Console
-from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.widgets import Button, Select, Static
 
@@ -44,7 +43,6 @@ from tldw_chatbook.Subscriptions.briefing_cast import (
     dump_roster,
     validate_roster,
 )
-from tldw_chatbook.Subscriptions.briefing_service import GenerationInFlightError
 from tldw_chatbook.UI.Watchlists_Modules import kept_briefings_modal as kbm_module
 from tldw_chatbook.UI.Watchlists_Modules.kept_briefings_modal import KeptBriefingsModal
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog

--- a/Tests/Watchlists/test_region_layout.py
+++ b/Tests/Watchlists/test_region_layout.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tldw_chatbook.UI.Watchlists_Modules import region_layout
 from tldw_chatbook.UI.Watchlists_Modules.region_layout import (
     CENTRE_REGIONS,
     Region,
@@ -30,7 +31,45 @@ def test_feeds_is_no_longer_a_region():
         Region("feeds")
 
 
-def test_toggle_collapses_then_expands():
+def test_only_side_panes_are_collapsible_preferences():
+    assert region_layout.COLLAPSIBLE_REGIONS == (
+        Region.LEFT_RAIL,
+        Region.ITEMS,
+        Region.RIGHT_RAIL,
+    )
+
+
+def test_preferred_toggle_rejects_the_permanent_reader():
+    with pytest.raises(ValueError, match="collapsible"):
+        RegionLayout().toggle_preferred(Region.CONTENT)
+
+
+def test_navigation_feed_items_and_inspector_toggle_independently():
+    layout = RegionLayout()
+    for region in region_layout.COLLAPSIBLE_REGIONS:
+        layout = layout.toggle_preferred(region)
+        assert layout.is_collapsed(region)
+
+    layout = layout.toggle_preferred(Region.ITEMS)
+    assert layout.collapsed == frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL})
+
+
+def test_preferred_toggle_returns_a_new_instance_and_leaves_the_original_alone():
+    original = RegionLayout()
+    changed = original.toggle_preferred(Region.ITEMS)
+    assert original.collapsed == frozenset()
+    assert changed is not original
+
+
+def test_preferred_toggle_drops_legacy_reader_and_solo_state():
+    legacy = RegionLayout().toggle(Region.CONTENT).solo(Region.ITEMS)
+    changed = legacy.toggle_preferred(Region.LEFT_RAIL)
+    assert changed.collapsed == frozenset({Region.LEFT_RAIL})
+    assert changed.solo_region is None
+    assert changed._pre_solo is None
+
+
+def test_legacy_toggle_remains_permissive_during_screen_migration():
     layout = RegionLayout().toggle(Region.CONTENT)
     assert layout.is_collapsed(Region.CONTENT)
     assert Region.CONTENT not in layout.visible()
@@ -39,22 +78,7 @@ def test_toggle_collapses_then_expands():
     assert not layout.is_collapsed(Region.CONTENT)
 
 
-def test_toggle_returns_a_new_instance_and_leaves_the_original_alone():
-    original = RegionLayout()
-    changed = original.toggle(Region.ITEMS)
-    assert original.collapsed == frozenset()
-    assert changed is not original
-
-
-def test_rails_collapse_independently_of_the_centre():
-    layout = RegionLayout().toggle(Region.LEFT_RAIL).toggle(Region.RIGHT_RAIL)
-    assert layout.is_collapsed(Region.LEFT_RAIL)
-    assert layout.is_collapsed(Region.RIGHT_RAIL)
-    for region in CENTRE_REGIONS:
-        assert not layout.is_collapsed(region)
-
-
-def test_solo_collapses_the_other_centre_regions_only():
+def test_legacy_solo_collapses_the_other_centre_regions_only():
     layout = RegionLayout().solo(Region.ITEMS)
     assert layout.solo_region == Region.ITEMS
     assert not layout.is_collapsed(Region.ITEMS)
@@ -64,14 +88,14 @@ def test_solo_collapses_the_other_centre_regions_only():
     assert not layout.is_collapsed(Region.RIGHT_RAIL)
 
 
-def test_solo_twice_restores_the_prior_layout():
+def test_legacy_solo_twice_restores_the_prior_layout():
     before = RegionLayout().toggle(Region.CONTENT).toggle(Region.LEFT_RAIL)
     after = before.solo(Region.ITEMS).solo(Region.ITEMS)
     assert after.collapsed == before.collapsed
     assert after.solo_region is None
 
 
-def test_solo_on_a_different_region_re_solos_without_stacking():
+def test_legacy_solo_on_a_different_region_re_solos_without_stacking():
     layout = RegionLayout().solo(Region.ITEMS).solo(Region.CONTENT)
     assert layout.solo_region == Region.CONTENT
     assert layout.is_collapsed(Region.ITEMS)
@@ -82,19 +106,19 @@ def test_solo_on_a_different_region_re_solos_without_stacking():
     assert restored.solo_region is None
 
 
-def test_manual_toggle_while_soloed_clears_solo():
+def test_legacy_manual_toggle_while_soloed_clears_solo():
     # Otherwise a later Z would "restore" a layout the user has since edited by hand.
     layout = RegionLayout().solo(Region.ITEMS).toggle(Region.CONTENT)
     assert layout.solo_region is None
     assert not layout.is_collapsed(Region.CONTENT)
 
 
-def test_solo_rejects_rails():
+def test_legacy_solo_rejects_rails():
     with pytest.raises(ValueError, match="centre region"):
         RegionLayout().solo(Region.LEFT_RAIL)
 
 
-def test_all_centre_regions_may_collapse_at_once():
+def test_legacy_toggle_may_collapse_all_centre_regions_at_once():
     # Legal: each collapses to a one-line header that stays clickable, so this is recoverable.
     layout = RegionLayout()
     for region in CENTRE_REGIONS:
@@ -103,14 +127,14 @@ def test_all_centre_regions_may_collapse_at_once():
     assert layout.visible() == (Region.LEFT_RAIL, Region.RIGHT_RAIL)
 
 
-def test_collapsed_for_persistence_is_the_collapsed_set_when_not_soloed():
+def test_legacy_persistence_accessor_returns_collapsed_when_not_soloed():
     # Regression coverage for PR #926 review, Bug 1: when nothing is soloed
     # there is no pre-solo baseline to prefer, so this must just be `collapsed`.
     layout = RegionLayout().toggle(Region.RIGHT_RAIL).toggle(Region.LEFT_RAIL)
     assert layout.collapsed_for_persistence() == layout.collapsed
 
 
-def test_collapsed_for_persistence_returns_the_pre_solo_baseline_while_soloed():
+def test_legacy_persistence_accessor_returns_pre_solo_baseline_while_soloed():
     # Regression coverage for PR #926 review, Bug 1: `collapsed` while soloed
     # is the solo-DERIVED view (the other centre panes collapsed around the
     # soloed one) — not something the user configured. Persisting THAT would

--- a/Tests/Watchlists/test_region_layout.py
+++ b/Tests/Watchlists/test_region_layout.py
@@ -2,7 +2,6 @@ import pytest
 
 from tldw_chatbook.UI.Watchlists_Modules import region_layout
 from tldw_chatbook.UI.Watchlists_Modules.region_layout import (
-    CENTRE_REGIONS,
     Region,
     RegionLayout,
 )
@@ -11,16 +10,9 @@ from tldw_chatbook.UI.Watchlists_Modules.region_layout import (
 def test_default_layout_has_everything_visible():
     layout = RegionLayout()
     assert layout.collapsed == frozenset()
-    assert layout.solo_region is None
     assert layout.visible() == (
         Region.LEFT_RAIL, Region.ITEMS, Region.CONTENT, Region.RIGHT_RAIL,
     )
-
-
-def test_the_centre_regions_are_items_and_content():
-    # Reader-first IA (task-2513): the FEEDS region is gone; the centre
-    # stack is the items list over the reader, nothing else.
-    assert CENTRE_REGIONS == (Region.ITEMS, Region.CONTENT)
 
 
 def test_feeds_is_no_longer_a_region():
@@ -61,87 +53,9 @@ def test_preferred_toggle_returns_a_new_instance_and_leaves_the_original_alone()
     assert changed is not original
 
 
-def test_preferred_toggle_drops_legacy_reader_and_solo_state():
-    legacy = RegionLayout().toggle(Region.CONTENT).solo(Region.ITEMS)
-    changed = legacy.toggle_preferred(Region.LEFT_RAIL)
-    assert changed.collapsed == frozenset({Region.LEFT_RAIL})
-    assert changed.solo_region is None
-    assert changed._pre_solo is None
-
-
-def test_legacy_toggle_remains_permissive_during_screen_migration():
-    layout = RegionLayout().toggle(Region.CONTENT)
-    assert layout.is_collapsed(Region.CONTENT)
-    assert Region.CONTENT not in layout.visible()
-
-    layout = layout.toggle(Region.CONTENT)
-    assert not layout.is_collapsed(Region.CONTENT)
-
-
-def test_legacy_solo_collapses_the_other_centre_regions_only():
-    layout = RegionLayout().solo(Region.ITEMS)
-    assert layout.solo_region == Region.ITEMS
-    assert not layout.is_collapsed(Region.ITEMS)
-    assert layout.is_collapsed(Region.CONTENT)
-    # Rails are untouched by solo.
-    assert not layout.is_collapsed(Region.LEFT_RAIL)
-    assert not layout.is_collapsed(Region.RIGHT_RAIL)
-
-
-def test_legacy_solo_twice_restores_the_prior_layout():
-    before = RegionLayout().toggle(Region.CONTENT).toggle(Region.LEFT_RAIL)
-    after = before.solo(Region.ITEMS).solo(Region.ITEMS)
-    assert after.collapsed == before.collapsed
-    assert after.solo_region is None
-
-
-def test_legacy_solo_on_a_different_region_re_solos_without_stacking():
-    layout = RegionLayout().solo(Region.ITEMS).solo(Region.CONTENT)
-    assert layout.solo_region == Region.CONTENT
-    assert layout.is_collapsed(Region.ITEMS)
-    assert not layout.is_collapsed(Region.CONTENT)
-    # Restoring from here returns to the ORIGINAL pre-solo layout, not to the ITEMS solo.
-    restored = layout.solo(Region.CONTENT)
-    assert restored.collapsed == frozenset()
-    assert restored.solo_region is None
-
-
-def test_legacy_manual_toggle_while_soloed_clears_solo():
-    # Otherwise a later Z would "restore" a layout the user has since edited by hand.
-    layout = RegionLayout().solo(Region.ITEMS).toggle(Region.CONTENT)
-    assert layout.solo_region is None
-    assert not layout.is_collapsed(Region.CONTENT)
-
-
-def test_legacy_solo_rejects_rails():
-    with pytest.raises(ValueError, match="centre region"):
-        RegionLayout().solo(Region.LEFT_RAIL)
-
-
-def test_legacy_toggle_may_collapse_all_centre_regions_at_once():
-    # Legal: each collapses to a one-line header that stays clickable, so this is recoverable.
-    layout = RegionLayout()
-    for region in CENTRE_REGIONS:
-        layout = layout.toggle(region)
-    assert all(layout.is_collapsed(region) for region in CENTRE_REGIONS)
-    assert layout.visible() == (Region.LEFT_RAIL, Region.RIGHT_RAIL)
-
-
-def test_legacy_persistence_accessor_returns_collapsed_when_not_soloed():
-    # Regression coverage for PR #926 review, Bug 1: when nothing is soloed
-    # there is no pre-solo baseline to prefer, so this must just be `collapsed`.
-    layout = RegionLayout().toggle(Region.RIGHT_RAIL).toggle(Region.LEFT_RAIL)
-    assert layout.collapsed_for_persistence() == layout.collapsed
-
-
-def test_legacy_persistence_accessor_returns_pre_solo_baseline_while_soloed():
-    # Regression coverage for PR #926 review, Bug 1: `collapsed` while soloed
-    # is the solo-DERIVED view (the other centre panes collapsed around the
-    # soloed one) — not something the user configured. Persisting THAT would
-    # strand a restart in a layout with no `_pre_solo` baseline left to
-    # recover from, so the accessor used for persistence must return the
-    # baseline instead.
-    pre_solo = RegionLayout().toggle(Region.LEFT_RAIL)
-    soloed = pre_solo.solo(Region.ITEMS)
-    assert soloed.collapsed != pre_solo.collapsed  # sanity: solo did derive a new view
-    assert soloed.collapsed_for_persistence() == pre_solo.collapsed
+@pytest.mark.parametrize(
+    "member",
+    ["solo_region", "_pre_solo", "solo", "toggle", "collapsed_for_persistence"],
+)
+def test_transitional_layout_compatibility_is_removed(member: str):
+    assert not hasattr(RegionLayout, member)

--- a/Tests/Watchlists/test_region_layout_store.py
+++ b/Tests/Watchlists/test_region_layout_store.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from tldw_chatbook.UI.Watchlists_Modules import region_layout_store
@@ -6,365 +8,205 @@ from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayo
 pytestmark = pytest.mark.unit
 
 
-def test_round_trips_collapsed_regions(monkeypatch):
-    """Uses ITEMS/RIGHT_RAIL, deliberately not CONTENT: this test is about
-    generic round-tripping, and CONTENT now goes through the one-time
-    migration in `load_region_layout` (see the dedicated migration tests
-    below), which would make a CONTENT-collapsed input diverge from what
-    comes back out on the very first load — a different behaviour than the
-    one this test checks.
-    """
-    saved = {}
+def _get_from(values):
+    return lambda section, key, default=None: values.get(key, default)
 
-    def fake_save(section, key, value):
-        saved[(section, key)] = value
-        return True
 
-    monkeypatch.setattr(region_layout_store, "save_setting_to_cli_config", fake_save)
-    region_layout_store.save_region_layout(
-        RegionLayout(collapsed=frozenset({Region.ITEMS, Region.RIGHT_RAIL}))
-    )
+def test_missing_layout_uses_first_run_default_and_writes_version(monkeypatch):
+    writer = Mock(return_value=True)
+    monkeypatch.setattr(region_layout_store, "get_cli_setting", _get_from({}))
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
 
-    # Flat section, not "watchlists.layout" — a dotted section silently no-ops.
-    assert ("watchlists", "collapsed_regions") in saved
-    assert sorted(saved[("watchlists", "collapsed_regions")]) == ["items", "right_rail"]
-
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting",
-        lambda section, key, default=None: saved.get((section, key), default),
-    )
     loaded = region_layout_store.load_region_layout()
-    assert loaded.collapsed == frozenset({Region.ITEMS, Region.RIGHT_RAIL})
+
+    assert loaded.collapsed == frozenset({Region.RIGHT_RAIL})
+    writer.assert_called_once_with(
+        {
+            "watchlists": {
+                "collapsed_regions": ["right_rail"],
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        },
+        delete_keys={"watchlists": ("content_reader_migrated",)},
+    )
 
 
-def test_load_applies_first_run_default_when_key_was_never_saved(monkeypatch):
-    """`get_cli_setting` returns its `default` argument only when the key is
-    absent — i.e. this is a genuine "never saved" case, not merely "saved as
-    empty." A new user's Read tab is a reader, not an inspector, so the
-    first-run default starts RIGHT_RAIL (the Inspector) collapsed — opened
-    on demand with `]` — while CONTENT stays expanded like every other
-    region. See `load_region_layout`'s docstring for why the
-    never-saved-vs-saved-empty *distinction* matters: the two cases now
-    resolve to different values."""
+def test_explicit_empty_layout_means_every_side_pane_is_expanded(monkeypatch):
+    writer = Mock()
     monkeypatch.setattr(
-        region_layout_store, "get_cli_setting", lambda section, key, default=None: default
+        region_layout_store,
+        "get_cli_setting",
+        _get_from(
+            {
+                "collapsed_regions": [],
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        ),
     )
-    monkeypatch.setattr(
-        region_layout_store, "save_setting_to_cli_config", lambda *a, **k: True
-    )
-    loaded = region_layout_store.load_region_layout()
-    assert loaded == RegionLayout(collapsed=frozenset({Region.RIGHT_RAIL}))
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
 
-
-def test_load_honors_an_explicit_empty_layout_as_everything_expanded(monkeypatch):
-    """A key that was explicitly SAVED as `[]` (the user re-expanded
-    everything, including CONTENT, and that was persisted) must be honored
-    exactly — not silently overridden back to the first-run default, or a
-    user's deliberate choice to keep CONTENT expanded could never survive a
-    restart."""
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting", lambda section, key, default=None: []
-    )
-    monkeypatch.setattr(
-        region_layout_store, "save_setting_to_cli_config", lambda *a, **k: True
-    )
     assert region_layout_store.load_region_layout() == RegionLayout()
+    writer.assert_not_called()
 
 
-def test_first_run_default_collapses_right_rail(monkeypatch):
-    """No persisted value at all: a genuinely new user's RIGHT_RAIL (the
-    Inspector) starts collapsed — the Read tab opens as a reader, not an
-    inspector, and the rail's management actions recede until `]` opens
-    them."""
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting", lambda section, key, default=None: default
-    )
-    monkeypatch.setattr(
-        region_layout_store, "save_setting_to_cli_config", lambda *a, **k: True
-    )
-    assert region_layout_store.load_region_layout().collapsed == frozenset({Region.RIGHT_RAIL})
-
-
-def test_explicitly_empty_persisted_layout_stays_expanded(monkeypatch):
-    """The user saved `[]` deliberately (everything expanded, Inspector
-    included) — the None-vs-`[]` distinction `load_region_layout` documents
-    means that choice must survive exactly, not be overridden back to the
-    first-run default on the next load."""
+def test_valid_side_panes_round_trip(monkeypatch):
     saved = {}
-    monkeypatch.setattr(
-        region_layout_store, "save_setting_to_cli_config",
-        lambda section, key, value: saved.__setitem__((section, key), value) or True,
-    )
-    region_layout_store.save_region_layout(RegionLayout())
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting",
-        lambda section, key, default=None: saved.get((section, key), default),
-    )
-    assert region_layout_store.load_region_layout().collapsed == frozenset()
 
-
-def test_load_migrates_a_pre_phase_d_content_collapse_away_on_first_run(monkeypatch):
-    """A user who saved a layout before Phase D necessarily has CONTENT in
-    `collapsed_regions` unless they specifically expanded it (CONTENT started
-    collapsed by default back then), so honoring that membership forever
-    would leave the new reader stuck collapsed post-upgrade, looking broken
-    rather than shipped. The migration marker is unset (a pre-upgrade config
-    never wrote it), so the persisted CONTENT collapse must be dropped, and
-    the migration marker must be written so this runs exactly once.
-
-    Fix round 2 (coordinator review, Critical): the first version of this
-    test hard-returned `False` for the migration-marker key from `fake_get`
-    regardless of what `fake_save` had written, so it measured only ONE
-    `load_region_layout()` call and never exercised the write -> read
-    feedback loop the whole migration depends on. That let a real bug ship:
-    the migration dropped CONTENT from the RETURNED layout and wrote the
-    marker, but never rewrote `collapsed_regions` itself -- so the disk
-    value stayed `["content", "right_rail"]`, and the very next load (next
-    launch, or simply the next remount -- this screen unmounts on
-    navigation) saw `migrated == True` and skipped the discard entirely,
-    permanently re-collapsing CONTENT for exactly the returning users this
-    migration exists to help. `fake_get` now reads back whatever `fake_save`
-    actually wrote for EVERY key, and a second `load_region_layout()` call
-    against the same fake store asserts the correction survives it.
-    """
-    saved = {"collapsed_regions": ["content", "right_rail"]}
-    migration_writes = []
-
-    def fake_get(section, key, default=None):
-        return saved.get(key, default)
-
-    def fake_save(section, key, value):
-        saved[key] = value
-        if key == "content_reader_migrated":
-            migration_writes.append(value)
+    def writer(section_values, *, delete_keys=None):
+        saved.update(section_values["watchlists"])
         return True
 
-    monkeypatch.setattr(region_layout_store, "get_cli_setting", fake_get)
-    monkeypatch.setattr(region_layout_store, "save_setting_to_cli_config", fake_save)
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
+    layout = RegionLayout(
+        collapsed=frozenset(
+            {Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}
+        )
+    )
+
+    assert region_layout_store.save_region_layout(layout) is True
+    monkeypatch.setattr(region_layout_store, "get_cli_setting", _get_from(saved))
+
+    assert region_layout_store.load_region_layout() == layout
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            ["content", "feeds", "unknown", "left_rail"],
+            frozenset({Region.LEFT_RAIL}),
+        ),
+        ("items", frozenset({Region.ITEMS})),
+        (42, frozenset()),
+    ],
+)
+def test_load_normalizes_legacy_unknown_singleton_and_non_sequence_values(
+    monkeypatch, raw, expected
+):
+    writer = Mock(return_value=True)
+    monkeypatch.setattr(
+        region_layout_store,
+        "get_cli_setting",
+        _get_from(
+            {
+                "collapsed_regions": raw,
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        ),
+    )
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
 
     loaded = region_layout_store.load_region_layout()
 
-    assert loaded.collapsed == frozenset({Region.RIGHT_RAIL}), (
-        "a stub-era CONTENT collapse must not survive the Phase D upgrade"
-    )
-    assert migration_writes == [True], "the migration marker must be persisted exactly once"
-    assert saved["collapsed_regions"] == ["right_rail"], (
-        "the migration must rewrite `collapsed_regions` on disk, not just "
-        "the marker -- otherwise the correction is visible for exactly the "
-        "one RegionLayout this call returned and reverts on the next load"
-    )
-
-    # The write -> read loop, exercised for real: a SECOND load against the
-    # same fake store (simulating the next launch, or simply the next
-    # remount -- this screen unmounts on navigation) must still see CONTENT
-    # expanded. Before the fix this returned `frozenset({Region.CONTENT,
-    # Region.RIGHT_RAIL})` -- the marker suppressed the discard, and the
-    # stale disk value was all that was left to read.
-    reloaded = region_layout_store.load_region_layout()
-    assert reloaded.collapsed == frozenset({Region.RIGHT_RAIL}), (
-        "the correction must survive a second load, not just the first -- "
-        f"got {reloaded.collapsed}"
-    )
-    assert migration_writes == [True], (
-        "the second load must not re-run the migration or write the marker again"
+    assert loaded.collapsed == expected
+    normalized_values = [
+        region.value
+        for region in region_layout_store.COLLAPSIBLE_REGIONS
+        if region in expected
+    ]
+    writer.assert_called_once_with(
+        {
+            "watchlists": {
+                "collapsed_regions": normalized_values,
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        },
+        delete_keys={"watchlists": ("content_reader_migrated",)},
     )
 
 
-def test_migration_does_not_mark_done_when_the_correcting_write_raises(monkeypatch):
-    """Fix round 3 (coordinator review, Critical, carried from round 2):
-    marking the migration done regardless of whether the corrected
-    `collapsed_regions` write actually landed reproduces round 2's exact bug
-    THROUGH the failure path -- disk stays stub-era (`["content", ...]`),
-    the marker is now `True`, and the migration can never retry, so CONTENT
-    is hidden forever for exactly the returning users this migration exists
-    to help.
-
-    This is the "raises" failure mode: `save_setting_to_cli_config` throws.
-    `load_region_layout` must not let that escape (a raise here would exit
-    the whole app from `on_mount`), must leave the marker unset so the next
-    load retries, and must leave disk untouched.
-    """
-    saved = {"collapsed_regions": ["content", "right_rail"]}
-
-    def fake_get(section, key, default=None):
-        return saved.get(key, default)
-
-    def fake_save(section, key, value):
-        if key == "collapsed_regions":
-            raise OSError("disk full")
-        saved[key] = value
-        return True
-
-    monkeypatch.setattr(region_layout_store, "get_cli_setting", fake_get)
-    monkeypatch.setattr(region_layout_store, "save_setting_to_cli_config", fake_save)
-
-    loaded = region_layout_store.load_region_layout()  # must not raise
-
-    assert loaded.collapsed == frozenset({Region.RIGHT_RAIL}), (
-        "the in-memory correction for THIS call must still apply even "
-        "though persisting it failed"
+def test_stale_version_is_normalized_with_one_atomic_write(monkeypatch):
+    writer = Mock(return_value=True)
+    monkeypatch.setattr(
+        region_layout_store,
+        "get_cli_setting",
+        _get_from(
+            {
+                "collapsed_regions": ["items", "right_rail"],
+                "layout_version": 1,
+            }
+        ),
     )
-    assert "content_reader_migrated" not in saved, (
-        "the marker must NOT be set when the correcting write failed -- "
-        "setting it anyway stops the migration from ever retrying"
-    )
-    assert saved["collapsed_regions"] == ["content", "right_rail"], (
-        "disk must be unchanged since the write raised"
-    )
-
-    # The retry, exercised for real: a second load against the same
-    # (still-failing) fake store must still self-correct in memory, not
-    # honor the stale disk value now that the marker was correctly left
-    # unset.
-    reloaded = region_layout_store.load_region_layout()
-    assert reloaded.collapsed == frozenset({Region.RIGHT_RAIL}), (
-        f"a second load must retry the migration -- got {reloaded.collapsed}"
-    )
-    assert "content_reader_migrated" not in saved
-
-
-def test_migration_does_not_mark_done_when_the_correcting_write_returns_false(monkeypatch):
-    """The failure mode a raise-only guard misses entirely, and the
-    important one: `save_setting_to_cli_config` signals failure by
-    RETURNING `False`, not only by raising (see `config.py`). A bare
-    `try`/`except Exception` around the write -- exactly what shipped after
-    round 2's fix -- does not observe this path at all, so it marked the
-    migration done here even though nothing was actually written.
-    """
-    saved = {"collapsed_regions": ["content", "right_rail"]}
-
-    def fake_get(section, key, default=None):
-        return saved.get(key, default)
-
-    def fake_save(section, key, value):
-        if key == "collapsed_regions":
-            return False  # signals failure WITHOUT raising
-        saved[key] = value
-        return True
-
-    monkeypatch.setattr(region_layout_store, "get_cli_setting", fake_get)
-    monkeypatch.setattr(region_layout_store, "save_setting_to_cli_config", fake_save)
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
 
     loaded = region_layout_store.load_region_layout()
 
-    assert loaded.collapsed == frozenset({Region.RIGHT_RAIL}), (
-        "the in-memory correction for THIS call must still apply even "
-        "though persisting it failed"
-    )
-    assert "content_reader_migrated" not in saved, (
-        "the marker must NOT be set when the correcting write returned "
-        "False -- a raise-only guard would wrongly set it here"
-    )
-    assert saved["collapsed_regions"] == ["content", "right_rail"], (
-        "disk must be unchanged since the write reported failure"
+    assert loaded.collapsed == frozenset({Region.ITEMS, Region.RIGHT_RAIL})
+    writer.assert_called_once_with(
+        {
+            "watchlists": {
+                "collapsed_regions": ["items", "right_rail"],
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        },
+        delete_keys={"watchlists": ("content_reader_migrated",)},
     )
 
-    reloaded = region_layout_store.load_region_layout()
-    assert reloaded.collapsed == frozenset({Region.RIGHT_RAIL}), (
-        f"a second load must retry the migration -- got {reloaded.collapsed}"
+
+@pytest.mark.parametrize("failure", [False, OSError("disk full")])
+def test_failed_normalization_applies_safe_layout_and_retries(monkeypatch, failure):
+    values = {"collapsed_regions": ["content", "left_rail"], "layout_version": 1}
+    writer = Mock(side_effect=failure if isinstance(failure, Exception) else None)
+    if failure is False:
+        writer.return_value = False
+    monkeypatch.setattr(region_layout_store, "get_cli_setting", _get_from(values))
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
+
+    first = region_layout_store.load_region_layout()
+    second = region_layout_store.load_region_layout()
+
+    assert first.collapsed == second.collapsed == frozenset({Region.LEFT_RAIL})
+    assert values["layout_version"] == 1
+    assert writer.call_count == 2
+
+
+def test_save_filters_to_side_panes_and_returns_writer_result(monkeypatch):
+    writer = Mock(return_value=False)
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
+    layout = RegionLayout(
+        collapsed=frozenset({Region.CONTENT, Region.LEFT_RAIL, Region.RIGHT_RAIL})
+    ).solo(Region.CONTENT)
+
+    assert region_layout_store.save_region_layout(layout) is False
+    writer.assert_called_once_with(
+        {
+            "watchlists": {
+                "collapsed_regions": ["left_rail", "right_rail"],
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        },
+        delete_keys={"watchlists": ("content_reader_migrated",)},
     )
-    assert "content_reader_migrated" not in saved
 
 
-def test_load_honors_a_deliberate_content_collapse_once_migrated(monkeypatch):
-    """After the one-time migration has run (marker already `True`), a
-    CONTENT collapse the user set AFTERWARD — a genuine choice about the
-    real reader, not a leftover stub-era default — must be honored like any
-    other region, not stripped again on every future load.
-    """
-    saved = {"collapsed_regions": ["content"], "content_reader_migrated": True}
-
+def test_current_version_with_non_normalized_data_is_rewritten(monkeypatch):
+    writer = Mock(return_value=True)
     monkeypatch.setattr(
-        region_layout_store, "get_cli_setting",
-        lambda section, key, default=None: saved.get(key, default),
+        region_layout_store,
+        "get_cli_setting",
+        _get_from(
+            {
+                "collapsed_regions": [
+                    "right_rail",
+                    "left_rail",
+                    "left_rail",
+                    "content",
+                ],
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        ),
     )
-    monkeypatch.setattr(
-        region_layout_store, "save_setting_to_cli_config",
-        lambda section, key, value: saved.__setitem__(key, value) or True,
-    )
+    monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
 
     loaded = region_layout_store.load_region_layout()
-    assert loaded.collapsed == frozenset({Region.CONTENT})
 
-
-def test_load_ignores_unknown_region_names(monkeypatch):
-    # A config hand-edited or written by a newer version must not crash the screen.
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting",
-        lambda section, key, default=None: ["content", "nonsense", "left_rail"],
+    assert loaded.collapsed == frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL})
+    writer.assert_called_once_with(
+        {
+            "watchlists": {
+                "collapsed_regions": ["left_rail", "right_rail"],
+                "layout_version": region_layout_store.LAYOUT_VERSION,
+            }
+        },
+        delete_keys={"watchlists": ("content_reader_migrated",)},
     )
-    loaded = region_layout_store.load_region_layout()
-    assert loaded.collapsed == frozenset({Region.CONTENT, Region.LEFT_RAIL})
-
-
-def test_load_drops_the_retired_feeds_region(monkeypatch):
-    # task-2513 removed the FEEDS region with no migration code: a persisted
-    # "feeds" string from before the removal is just an unknown region name
-    # now, dropped by the same guard the test above pins (ADR-042).
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting",
-        lambda section, key, default=None: {
-            "collapsed_regions": ["feeds", "items"],
-            "content_reader_migrated": True,
-        }.get(key, default),
-    )
-    loaded = region_layout_store.load_region_layout()
-    assert loaded.collapsed == frozenset({Region.ITEMS})
-
-
-def test_load_tolerates_a_non_list_value(monkeypatch):
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting", lambda section, key, default=None: "content"
-    )
-    assert region_layout_store.load_region_layout().collapsed == frozenset({Region.CONTENT})
-
-
-def test_save_never_persists_solo(monkeypatch):
-    """`solo_region` itself must never round-trip through config.
-
-    NOTE (PR #926 review, Bug 1 fix): before the fix this test asserted the
-    solo-DERIVED collapse of the other centre panes as the persisted value.
-    That encoded the bug: restoring it on the next launch would have applied
-    a plain (non-solo) collapse of those panes with no `_pre_solo` baseline
-    left to `Z`-restore from, even though the user never configured that
-    layout by hand. The correct persisted value while soloed is the PRE-solo
-    baseline, which for a solo called directly on a fresh `RegionLayout()`
-    is "nothing collapsed" — see
-    `test_save_while_soloed_persists_the_pre_solo_baseline_not_the_solo_derived_collapse`
-    below for a case where the baseline is non-empty.
-    """
-    saved = {}
-    monkeypatch.setattr(
-        region_layout_store, "save_setting_to_cli_config",
-        lambda section, key, value: saved.__setitem__((section, key), value) or True,
-    )
-    region_layout_store.save_region_layout(RegionLayout().solo(Region.ITEMS))
-    assert sorted(saved[("watchlists", "collapsed_regions")]) == []
-    assert ("watchlists", "solo_region") not in saved
-
-
-def test_save_while_soloed_persists_the_pre_solo_baseline_not_the_solo_derived_collapse(monkeypatch):
-    """Regression test for PR #926 review, Bug 1: saving while soloed must
-    persist what the user had BEFORE soloing, not the solo-derived collapse
-    of the other centre panes — otherwise a restart strands the user in a
-    layout they never configured, with no baseline left to recover from.
-    """
-    saved = {}
-    monkeypatch.setattr(
-        region_layout_store, "save_setting_to_cli_config",
-        lambda section, key, value: saved.__setitem__((section, key), value) or True,
-    )
-    pre_solo = RegionLayout().toggle(Region.LEFT_RAIL)
-    soloed = pre_solo.solo(Region.ITEMS)
-
-    region_layout_store.save_region_layout(soloed)
-    assert sorted(saved[("watchlists", "collapsed_regions")]) == ["left_rail"]
-
-    monkeypatch.setattr(
-        region_layout_store, "get_cli_setting",
-        lambda section, key, default=None: saved.get((section, key), default),
-    )
-    reloaded = region_layout_store.load_region_layout()
-    assert reloaded.collapsed == pre_solo.collapsed
-    assert reloaded != soloed
-    assert reloaded.solo_region is None

--- a/Tests/Watchlists/test_region_layout_store.py
+++ b/Tests/Watchlists/test_region_layout_store.py
@@ -165,7 +165,7 @@ def test_save_filters_to_side_panes_and_returns_writer_result(monkeypatch):
     monkeypatch.setattr(region_layout_store, "save_settings_to_cli_config", writer)
     layout = RegionLayout(
         collapsed=frozenset({Region.CONTENT, Region.LEFT_RAIL, Region.RIGHT_RAIL})
-    ).solo(Region.CONTENT)
+    )
 
     assert region_layout_store.save_region_layout(layout) is False
     writer.assert_called_once_with(

--- a/Tests/Watchlists/test_snapshot_view_modal.py
+++ b/Tests/Watchlists/test_snapshot_view_modal.py
@@ -12,14 +12,13 @@ survived to render.
 """
 
 import pytest
-
-pytestmark = pytest.mark.unit
-
 from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
 from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import (
     _snapshot_body,
     _snapshot_header,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_snapshot_header_humanizes_created_at():

--- a/Tests/Watchlists/test_watchlists_article_list.py
+++ b/Tests/Watchlists/test_watchlists_article_list.py
@@ -35,7 +35,14 @@ pytestmark = pytest.mark.unit
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    # Keep the relative-date fixtures away from local midnight while
+    # retaining per-call microseconds used to exercise stable newest-first
+    # ordering. Without this, ``now - 1 hour`` is legitimately yesterday
+    # during the first hour of a day and contradicts a fixture named Today.
+    now = datetime.now(timezone.utc)
+    if now.astimezone().hour < 6:
+        return now + timedelta(hours=12)
+    return now
 
 
 def _item(
@@ -432,8 +439,20 @@ async def test_read_list_scrolls_rows_without_scrolling_its_fixed_chrome():
         fixed_regions = (toolbar.region, legend.region, pager.region)
 
         detail = app.query_one("#watchlists-detail-pane")
+        pane = app.query_one(ArticleListPane)
         assert app.query_one("#watchlists-detail-title") in detail.children
-        assert app.query_one(ArticleListPane) in detail.children
+        assert pane in detail.children
+
+        def assert_contains(parent, child) -> None:
+            assert child.region.x >= parent.region.x
+            assert child.region.y >= parent.region.y
+            assert child.region.right <= parent.region.right
+            assert child.region.bottom <= parent.region.bottom
+
+        assert_contains(detail, pane)
+        assert_contains(pane, pager)
+        assert_contains(pager, app.query_one("#items-page-previous"))
+        assert_contains(pager, app.query_one("#items-page-next"))
 
         def composited_text(widget) -> str:
             strips = widget.screen._compositor.render_strips()
@@ -462,6 +481,8 @@ async def test_read_list_scrolls_rows_without_scrolling_its_fixed_chrome():
 
         assert table.scroll_y == table.max_scroll_y
         assert (toolbar.region, legend.region, pager.region) == fixed_regions
+        assert_contains(detail, pane)
+        assert_contains(pane, pager)
         assert "Article 49" in composited_text(table)
         assert "Refresh" in composited_text(toolbar)
         assert "unread" in composited_text(legend)

--- a/Tests/Watchlists/test_watchlists_article_list.py
+++ b/Tests/Watchlists/test_watchlists_article_list.py
@@ -104,6 +104,8 @@ class ProductionCssArticleListHarness(ArticleListHarness):
 
     def compose(self) -> ComposeResult:
         pane = ArticleListPane(id="watchlists-items-pane")
+        pane.styles.height = "1fr"
+        pane.styles.min_height = 0
         pane.items = [
             _item(index, published_offset_hours=index * 12 + 1)
             for index in range(50)
@@ -440,10 +442,15 @@ async def test_read_list_scrolls_rows_without_scrolling_its_fixed_chrome():
                 "".join(segment.text for segment in strips[y])[
                     region.x : region.x + region.width
                 ]
-                for y in range(region.y, region.y + region.height)
+                for y in range(
+                    max(0, region.y), min(len(strips), region.y + region.height)
+                )
             )
 
-        assert table.region.height <= 40
+        # Read now owns the full-height Feed Items column in the permanent
+        # horizontal reader canvas. The list itself must scroll while its
+        # toolbar, legend, and pager remain fixed; its absolute height is a
+        # function of the terminal rather than a legacy stacked-pane cap.
         assert table.max_scroll_y > 0
         assert "Refresh" in composited_text(toolbar)
         for label in ("Previous", "Page 1", "Next"):

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -66,11 +66,7 @@ from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
 )
 from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import (
     ArtifactsPane,
-    BriefingSelected,
     CastScriptRequested,
-    CitationActivated,
-    ExportBriefingRequested,
-    ExportFeedRequested,
     GenerateBriefingRequested,
     KeepBriefingRequested,
     KeptBriefingsRequested,
@@ -171,13 +167,37 @@ async def _open_artifacts(app, watchlist_id, *, size=(180, 50), visual=False):
         else DestinationHarness(app, "watchlists_collections")
     )
     async with host.run_test(size=size) as pilot:
-        await pilot.pause(0.1)
+        await pilot.pause()
         screen = host.screen_stack[-1]
         assert isinstance(screen, WatchlistsCollectionsScreen)
         if watchlist_id is not None:
             screen.tree_scope = TreeScope(kind="watchlist", watchlist_id=watchlist_id)
         screen.active_section = "artifacts"
-        await pilot.pause(0.2)
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            await pilot.pause(0.01)
+            if screen.query("#watchlists-artifacts-pane #artifacts-table"):
+                break
+        else:
+            raise AssertionError("Artifacts table did not mount within 10 seconds")
+
+        remaining = max(0.01, deadline - time.monotonic())
+        await asyncio.wait_for(host.workers.wait_for_complete(), timeout=remaining)
+        expected_rows = (
+            len(app.watchlist_bundle_service.db.list_briefings(watchlist_id))
+            if watchlist_id is not None
+            else 0
+        )
+        while time.monotonic() < deadline:
+            await pilot.pause(0.01)
+            tables = screen.query("#watchlists-artifacts-pane #artifacts-table")
+            if tables and tables.first(DataTable).row_count == expected_rows:
+                break
+        else:
+            raise AssertionError(
+                "Artifacts table did not reach its loaded row count within 10 seconds"
+            )
         yield screen, pilot, host
 
 
@@ -2502,7 +2522,7 @@ async def test_the_cast_guard_is_claimed_before_the_worker_runs(monkeypatch):
     _use_fake_chat(monkeypatch, _FakeChat())
 
     async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
-        briefing_id = await _prepare_cast(screen, pilot, app, watchlist_id)
+        await _prepare_cast(screen, pilot, app, watchlist_id)
         cast_chat = _FakeChat(
             reply=json.dumps([{"speaker": "Narrator", "text": "Hi."}])
         )
@@ -4721,7 +4741,7 @@ async def test_write_briefing_export_file_writes_the_document_and_toasts_success
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id = _seed_complete_briefing(app, watchlist_id, body="Body text")
+    _seed_complete_briefing(app, watchlist_id, body="Body text")
     briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
     briefing["watchlist_name"] = "Morning AI Brief"
 
@@ -4748,7 +4768,7 @@ async def test_write_briefing_export_file_cancelled_writes_nothing():
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    _seed_complete_briefing(app, watchlist_id)
     briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
     briefing["watchlist_name"] = "Morning AI Brief"
 
@@ -4770,7 +4790,7 @@ async def test_write_briefing_export_file_rejects_an_invalid_path(monkeypatch, t
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    _seed_complete_briefing(app, watchlist_id)
     briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
     briefing["watchlist_name"] = "Morning AI Brief"
 
@@ -4802,7 +4822,7 @@ async def test_write_briefing_export_file_write_failure_toasts_the_exception_typ
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    _seed_complete_briefing(app, watchlist_id)
     briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
     briefing["watchlist_name"] = "Morning AI Brief"
 
@@ -4838,7 +4858,7 @@ async def test_write_briefing_export_file_unicode_encode_error_toasts_the_except
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    _seed_complete_briefing(app, watchlist_id)
     briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
     briefing["watchlist_name"] = "Morning AI Brief"
 
@@ -4871,7 +4891,7 @@ async def test_write_briefing_export_file_cancelled_error_propagates_uncaught(
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    _seed_complete_briefing(app, watchlist_id)
     briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
     briefing["watchlist_name"] = "Morning AI Brief"
 

--- a/Tests/Watchlists/test_watchlists_cold_open_layout.py
+++ b/Tests/Watchlists/test_watchlists_cold_open_layout.py
@@ -35,10 +35,13 @@ this would silently measure the conftest stub, not this task's fix.
 from __future__ import annotations
 
 import pytest
+import tomllib
 
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_destination_shells import DestinationHarness
 from tldw_chatbook.config import get_cli_setting, save_setting_to_cli_config
+from tldw_chatbook import config as config_module
+from tldw_chatbook.config import save_settings_to_cli_config
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
     WatchlistsCollectionsScreen,
 )
@@ -302,3 +305,76 @@ async def test_mount_schedules_no_persist_worker_when_nothing_changed(monkeypatc
             "on_mount must not schedule a persist worker when construction "
             "already loaded and primed this exact layout"
         )
+
+
+async def test_preferred_layout_survives_an_isolated_fresh_restart(
+    monkeypatch, tmp_path
+) -> None:
+    """Only preferred side-pane state crosses a real config restart."""
+    profile = tmp_path / "restart-profile"
+    home = profile / "home"
+    config_home = profile / "config-home"
+    config_path = config_home / "tldw_cli" / "config.toml"
+    home.mkdir(parents=True)
+    config_path.parent.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    for name in (
+        "_CONFIG_CACHE",
+        "_CONFIG_CACHE_SOURCE",
+        "_SETTINGS_CACHE",
+        "_SETTINGS_CACHE_SOURCE",
+    ):
+        monkeypatch.setattr(config_module, name, None)
+    monkeypatch.setattr(
+        _LOAD_REGION_LAYOUT_TARGET, region_layout_store.load_region_layout
+    )
+
+    desired = RegionLayout(
+        collapsed=frozenset({Region.LEFT_RAIL, Region.ITEMS})
+    )
+    assert save_settings_to_cli_config(
+        {
+            "watchlists": {
+                "collapsed_regions": [
+                    "content",
+                    Region.LEFT_RAIL.value,
+                    Region.ITEMS.value,
+                ],
+                "layout_version": 1,
+            }
+        }
+    )
+
+    first = WatchlistsCollectionsScreen(_build_test_app())
+    assert first.region_layout == desired
+    first._article_focus_active = True
+    first._effective_region_layout = RegionLayout(
+        collapsed=frozenset(
+            {Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}
+        )
+    )
+    first._responsive_priority_target = Region.RIGHT_RAIL
+
+    config_module._invalidate_config_caches()
+    restarted = WatchlistsCollectionsScreen(_build_test_app())
+    assert restarted.region_layout == desired
+    assert restarted._effective_region_layout == desired
+    assert restarted._article_focus_active is False
+    assert restarted._responsive_priority_target is None
+
+    persisted = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert persisted["watchlists"]["collapsed_regions"] == [
+        Region.LEFT_RAIL.value,
+        Region.ITEMS.value,
+    ]
+    assert persisted["watchlists"]["layout_version"] == (
+        region_layout_store.LAYOUT_VERSION
+    )
+    assert "content" not in persisted["watchlists"]["collapsed_regions"]
+
+    config_module._invalidate_config_caches()
+    restarted_again = WatchlistsCollectionsScreen(_build_test_app())
+    assert restarted_again.region_layout == desired
+    assert Region.CONTENT not in restarted_again.region_layout.collapsed

--- a/Tests/Watchlists/test_watchlists_cold_open_layout.py
+++ b/Tests/Watchlists/test_watchlists_cold_open_layout.py
@@ -55,39 +55,33 @@ _LOAD_REGION_LAYOUT_TARGET = (
 )
 
 
-class _SwapCounter:
-    """Counts `WatchlistsWorkbench._swap_region_widget` calls while installed.
-
-    Wraps rather than replaces: the real swap still runs (call-through), so
-    this only observes -- it never changes what the screen actually renders.
-    """
+class _RegionBuildCounter:
+    """Count pane factory construction during the cold-open lifecycle."""
 
     def __init__(self) -> None:
         self.regions: list[Region] = []
-        self._original = WatchlistsWorkbench._swap_region_widget
+        self._original = WatchlistsWorkbench._region_body
 
-    def __enter__(self) -> "_SwapCounter":
+    def __enter__(self) -> "_RegionBuildCounter":
         counter = self
         original = self._original
 
-        async def _counting_swap(widget_self, region, parent, index):
+        def _counting_build(widget_self, region):
             counter.regions.append(region)
-            return await original(widget_self, region, parent, index)
+            return original(widget_self, region)
 
-        WatchlistsWorkbench._swap_region_widget = _counting_swap
+        WatchlistsWorkbench._region_body = _counting_build
         return self
 
     def __exit__(self, *exc_info) -> None:
-        WatchlistsWorkbench._swap_region_widget = self._original
+        WatchlistsWorkbench._region_body = self._original
 
 
 def _right_rail_is_collapsed(screen) -> bool:
-    header = screen.query("#wl-header-right_rail")
+    grip = screen.query_one("#wl-grip-right_rail")
     body = screen.query("#wl-region-right_rail")
-    assert bool(header) != bool(body), (
-        "RIGHT_RAIL must render as exactly one of its two forms, never both or neither"
-    )
-    return bool(header)
+    assert getattr(grip, "expanded") is bool(body)
+    return not bool(body)
 
 
 # ---------------------------------------------------------------------------
@@ -138,11 +132,10 @@ async def test_construction_seeds_region_layout_from_a_single_persisted_load(
         "anything else (a keypress, a later _schedule_layout_persist call) "
         "can race it"
     )
-    assert get_cli_setting("watchlists", "content_reader_migrated", False) is True, (
-        "the one-time migration write load_region_layout performs on a "
-        "never-saved config must have already landed on disk by the time "
-        "__init__ returns -- it is synchronous, on the UI thread, by design"
+    assert get_cli_setting("watchlists", "layout_version", None) == (
+        region_layout_store.LAYOUT_VERSION
     )
+    assert get_cli_setting("watchlists", "content_reader_migrated", None) is None
 
 
 async def test_construction_seeds_an_explicitly_saved_non_default_layout(monkeypatch):
@@ -188,7 +181,7 @@ async def test_cold_open_with_the_first_run_default_shows_the_collapsed_rail_wit
     )
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
-    with _SwapCounter() as swaps:
+    with _RegionBuildCounter() as builds:
         async with host.run_test(size=(180, 50)) as pilot:
             await pilot.pause(0.2)
             screen = host.screen_stack[-1]
@@ -202,10 +195,7 @@ async def test_cold_open_with_the_first_run_default_shows_the_collapsed_rail_wit
                 "_FIRST_RUN_DEFAULT"
             )
 
-    assert swaps.regions == [], (
-        "a normal cold open must perform zero _swap_region_widget calls; "
-        f"got {swaps.regions!r}"
-    )
+    assert Region.RIGHT_RAIL not in builds.regions
 
 
 async def test_cold_open_honors_an_explicit_non_default_layout_with_no_swap(
@@ -223,7 +213,7 @@ async def test_cold_open_honors_an_explicit_non_default_layout_with_no_swap(
     )
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
-    with _SwapCounter() as swaps:
+    with _RegionBuildCounter() as builds:
         async with host.run_test(size=(180, 50)) as pilot:
             await pilot.pause(0.2)
             screen = host.screen_stack[-1]
@@ -236,16 +226,13 @@ async def test_cold_open_honors_an_explicit_non_default_layout_with_no_swap(
                 "RIGHT_RAIL was not part of the user's saved collapse set "
                 "and must render expanded"
             )
-            assert screen.query("#wl-header-left_rail"), (
+            assert not screen.query_one("#wl-grip-left_rail").expanded, (
                 "LEFT_RAIL is the region the user actually collapsed and "
                 "must render collapsed on the first paint"
             )
             assert not screen.query("#wl-region-left_rail")
 
-    assert swaps.regions == [], (
-        "a deliberately-chosen non-default layout must still cold-open with "
-        f"zero swaps; got {swaps.regions!r}"
-    )
+    assert Region.LEFT_RAIL not in builds.regions
 
 
 async def test_cold_open_with_a_fresh_real_config_shows_the_collapsed_rail_with_no_swap(
@@ -262,7 +249,7 @@ async def test_cold_open_with_a_fresh_real_config_shows_the_collapsed_rail_with_
     )
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
-    with _SwapCounter() as swaps:
+    with _RegionBuildCounter() as builds:
         async with host.run_test(size=(180, 50)) as pilot:
             await pilot.pause(0.2)
             screen = host.screen_stack[-1]
@@ -276,9 +263,7 @@ async def test_cold_open_with_a_fresh_real_config_shows_the_collapsed_rail_with_
                 "already collapsed"
             )
 
-    assert swaps.regions == [], (
-        f"a real fresh-config cold open must perform zero swaps; got {swaps.regions!r}"
-    )
+    assert Region.RIGHT_RAIL not in builds.regions
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Watchlists/test_watchlists_cold_read_swap.py
+++ b/Tests/Watchlists/test_watchlists_cold_read_swap.py
@@ -70,9 +70,9 @@ _LOAD_REGION_LAYOUT_TARGET = (
 class _BatchObserver:
     """Records `app._batch_count > 0` at entry to each swap DOM-work method.
 
-    Call-through wrappers on the three methods `apply_section_view` drives:
-    the region sync (which mounts CONTENT back on a cold Read switch), the
-    section pane rebuild and the header rebuild. Only entries made while
+    Call-through wrappers on the two DOM methods `apply_section_view` drives:
+    the body reconciliation (which mounts the permanent Reader and swaps the
+    section pane) and the header replacement. Only entries made while
     `apply_section_view` itself is on the stack are recorded -- the drainer
     can legitimately run e.g. a rail `refresh_region_content` outside the
     swap (and outside the batch) in the same settle window, and that is not
@@ -82,7 +82,7 @@ class _BatchObserver:
     measured; see the module docstring).
     """
 
-    _METHODS = ("_sync_regions", "refresh_region_content", "refresh_header_content")
+    _METHODS = ("_reconcile_body", "_replace_header")
 
     def __init__(self) -> None:
         self.entries: list[tuple[str, bool]] = []
@@ -154,7 +154,7 @@ async def test_the_cold_read_swap_runs_inside_one_batch_update(monkeypatch, layo
 
         assert screen.query("#wl-region-content"), "CONTENT must be back on Read"
         surfaces = {name for name, _ in observed.entries}
-        assert {"_sync_regions", "refresh_region_content"} <= surfaces, (
+        assert {"_reconcile_body", "_replace_header"} <= surfaces, (
             f"the swap must actually have exercised its DOM work: {observed.entries}"
         )
         unbatched = [name for name, batched in observed.entries if not batched]
@@ -194,7 +194,10 @@ def _primed_screen(app, section: str) -> WatchlistsCollectionsScreen:
     """An unmounted screen whose state gives `section`'s pane NON-default
     seeds, so a plain-assignment seeding would queue the extra recompose."""
     screen = _unmounted_screen(app)
-    screen.active_section = section
+    # This is deliberately an unmounted factory probe. Seed the backing
+    # reactive directly so Textual does not invoke the mounted-only layout
+    # watcher while there is no active app context.
+    screen.__dict__["_reactive_active_section"] = section
     if section == "overview":
         screen.set_reactive(
             WatchlistsCollectionsScreen.overview_data,
@@ -217,7 +220,7 @@ def _primed_screen(app, section: str) -> WatchlistsCollectionsScreen:
     elif section == "rules":
         screen._loaded_rules = [_RULE_ROW]
     elif section == "rules-editing":
-        screen.active_section = "rules"
+        screen.__dict__["_reactive_active_section"] = "rules"
         screen._loaded_rules = [_RULE_ROW]
         screen._rule_form_open = True
         screen._rule_form_editing = _RULE_ROW
@@ -306,6 +309,8 @@ async def test_content_pane_item_seeding_queues_no_recompose():
     was selected. Born red against the pre-task code."""
     app = _build_test_app()
     screen = _unmounted_screen(app)
+    screen.__dict__["_reactive_active_section"] = "items"
+    screen.__dict__["_reactive_runtime_backend"] = "local"
     screen._selected_content_item = {
         "id": "i1",
         "title": "Story 1",
@@ -358,7 +363,7 @@ async def test_runs_pane_seeding_still_starts_the_poll_for_a_running_run():
     try:
         app = _build_test_app()
         screen = _unmounted_screen(app)
-        screen.active_section = "runs"
+        screen.__dict__["_reactive_active_section"] = "runs"
         running = {"id": "run-9", "status": "running", "source_name": "AI News"}
         screen._loaded_runs = [running]
         screen.selected_run = running

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -10,8 +10,9 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.widgets import Button, Input, Static, TextArea
 
-from Tests.UI.test_destination_shells import DestinationHarness, _static_text
 from Tests.UI.app_factory import _build_test_app
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.test_destination_shells import DestinationHarness, _static_text
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import WatchlistsCollectionsScreen
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
@@ -93,6 +94,19 @@ class _InspectorActionsApp(App[None]):
 
     def on_view_snapshot_requested(self, message: ViewSnapshotRequested) -> None:
         self.snapshot_requests.append(message)
+
+
+class _PreMountServerReadHarness(ConsolidatedCSSApp):
+    """Mount Watchlists after applying the Server Read deep link."""
+
+    def __init__(self, app_instance) -> None:
+        super().__init__()
+        self.app_instance = app_instance
+
+    async def on_mount(self) -> None:
+        screen = WatchlistsCollectionsScreen(self.app_instance)
+        screen.apply_navigation_context({"section": "items", "backend": "server"})
+        await self.push_screen(screen)
 
 
 @pytest.mark.parametrize("content_kind", ["article", "change"])
@@ -252,6 +266,58 @@ async def test_the_read_tab_is_the_default_section():
         assert screen.active_section == "items"
         assert screen.query_one("#wl-tab-items").has_class("is-active")
         assert screen.query_one("#watchlists-items-pane")
+
+
+@pytest.mark.asyncio
+async def test_pre_mount_server_read_is_query_free_and_enters_recovery(
+    monkeypatch,
+) -> None:
+    """A cold Server Read deep link never starts local Reader navigation."""
+    app = _build_test_app()
+    scope_service = app.watchlist_scope_service
+    local_async_spies = {}
+    for name in ("list_watch_items", "list_items"):
+        spy = AsyncMock(wraps=getattr(scope_service, name))
+        monkeypatch.setattr(scope_service, name, spy)
+        local_async_spies[name] = spy
+
+    bundle = app.watchlist_bundle_service
+    local_sync_spies = {}
+    for name in (
+        "list_watchlists",
+        "list_source_rows",
+        "list_all_source_rows",
+        "list_unassigned_source_rows",
+        "get_watchlist_item_counts",
+        "get_flagged_items_count",
+        "get_unread_items_count_since",
+        "get_source_item_counts",
+    ):
+        spy = Mock(wraps=getattr(bundle, name))
+        monkeypatch.setattr(bundle, name, spy)
+        local_sync_spies[name] = spy
+
+    host = _PreMountServerReadHarness(app)
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.4)
+        await host.workers.wait_for_complete()
+        screen = host.screen_stack[-1]
+
+        assert screen.active_section == "items"
+        assert screen.runtime_backend == "server"
+        assert screen._read_recovery_active is True
+        assert screen.query("#watchlists-read-local-only")
+        assert screen.query("#watchlists-read-recovery-status")
+        assert not screen.query("#watchlists-content-pane")
+        for name, spy in local_async_spies.items():
+            local_calls = [
+                call
+                for call in spy.await_args_list
+                if call.kwargs.get("runtime_backend") == "local"
+            ]
+            assert not local_calls, name
+        for name, spy in local_sync_spies.items():
+            assert spy.call_count == 0, name
 
 
 @pytest.mark.asyncio
@@ -515,7 +581,7 @@ async def test_failed_switch_to_local_retries_the_normal_load_path() -> None:
         assert not screen.query_one(
             "#watchlists-items-pane", ArticleListPane
         ).items
-        assert not screen._tree_watchlists
+        assert screen._tree_watchlists[0]["name"] == "Recovery local watchlist"
         failed_render = host.export_screenshot()
         assert "Recovery local watchlist" not in failed_render
         assert "Recovery local source" not in failed_render
@@ -660,7 +726,7 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
 
 
 @pytest.mark.asyncio
-async def test_entering_server_read_clears_local_reader_navigation_without_queries(
+async def test_entering_server_read_hides_local_reader_navigation_without_queries(
     monkeypatch,
 ) -> None:
     """Sources -> Server -> Read cannot retain any local Reader state."""
@@ -711,6 +777,23 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         assert "1" in str(screen.query_one("#wl-tree-node-all", Button).label)
         assert screen.query("#watchlists-content-pane")
         assert screen.query_one("#watchlists-items-pane", ArticleListPane).items
+        screen.query_one(f"#wl-tree-expand-{watchlist['id']}", Button).press()
+        screen.post_message(
+            TreeScopeChanged(
+                TreeScope(kind="watchlist", watchlist_id=watchlist["id"])
+            )
+        )
+        assert await _wait_until(
+            pilot,
+            lambda: bool(
+                screen.query(
+                    f"#wl-tree-node-source-{watchlist['id']}-{source_id}"
+                )
+            ),
+        )
+        await host.workers.wait_for_complete()
+        assert screen._wc_loaded is True
+        assert screen._local_watchlist_count == 1
 
         screen.post_message(ItemsFilterChanged("unread", "local query"))
         await pilot.pause(0.4)
@@ -718,6 +801,9 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         screen._items_page_index = 2
         screen._items_has_next = True
         screen._push_items_pager_state()
+        parked_watchlists = list(screen._tree_watchlists)
+        parked_snapshot = screen._local_watchlist_records
+        parked_snapshot_count = screen._local_watchlist_count
 
         list_items = AsyncMock(wraps=screen._controller.list_items)
         get_item_content = AsyncMock(wraps=screen._controller.get_item_content)
@@ -754,9 +840,12 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         assert pane.selected_item is None
         assert screen._loaded_items == []
         assert screen._selected_content_item is None
-        assert screen._tree_counts == {}
-        assert screen._tree_source_counts == {}
-        assert not screen._tree_watchlists
+        assert screen._tree_watchlists == parked_watchlists
+        assert screen._tree_counts
+        assert screen._tree_source_counts
+        assert screen._local_watchlist_records == parked_snapshot
+        assert screen._local_watchlist_count == parked_snapshot_count
+        assert screen._wc_loaded is True
         assert not screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}")
         assert not screen.query(
             f"#wl-tree-node-source-{watchlist['id']}-{source_id}"
@@ -782,6 +871,57 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         for name, spy in local_spies.items():
             assert spy.call_count == 0, name
         assert screen._items_page_loading is False
+
+        screen.active_section = "sources"
+        assert await _wait_until(
+            pilot, lambda: bool(screen.query("#watchlists-sources-pane"))
+        )
+        await host.workers.wait_for_complete()
+        assert await _wait_until(
+            pilot,
+            lambda: bool(screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}"))
+        )
+        assert await _wait_until(
+            pilot,
+            lambda: bool(
+                screen.query(
+                    f"#wl-tree-node-source-{watchlist['id']}-{source_id}"
+                )
+            ),
+        )
+        assert screen.query("#wc-watchlists-summary")
+
+        watchlist_node = screen.query_one(
+            f"#wl-tree-node-watchlist-{watchlist['id']}", Button
+        )
+        source_node = screen.query_one(
+            f"#wl-tree-node-source-{watchlist['id']}-{source_id}", Button
+        )
+        assert "Cross-tab local watchlist" in str(watchlist_node.label)
+        assert "Local counted feed" in str(source_node.label)
+        assert _static_text(screen.query_one("#wc-watchlists-summary", Static)) == (
+            "Local Watchlists snapshot: Cross-tab local watchlist (1 source)"
+        )
+        assert not screen.query("#wc-loading-state")
+        list_items.assert_not_awaited()
+        get_item_content.assert_not_awaited()
+
+        for spy in local_spies.values():
+            spy.reset_mock()
+        screen.active_section = "items"
+        assert await _wait_until(
+            pilot, lambda: bool(screen.query("#watchlists-read-local-only"))
+        )
+        await host.workers.wait_for_complete()
+
+        recovery_render = host.export_screenshot()
+        assert "Cross-tab local watchlist" not in recovery_render
+        assert "Local counted feed" not in recovery_render
+        assert "Local Watchlists snapshot" not in recovery_render
+        list_items.assert_not_awaited()
+        get_item_content.assert_not_awaited()
+        for name, spy in local_spies.items():
+            assert spy.call_count == 0, name
 
 
 # --- Task 7: scope-driven scoped rows, with real seeded data ---------------

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -486,6 +486,96 @@ async def test_failed_switch_to_local_keeps_recovery_mounted_and_actionable() ->
         assert "Failed to load watchlist items." in str(app.notify.call_args.args[0])
 
 
+@pytest.mark.asyncio
+async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
+    monkeypatch,
+) -> None:
+    controller = AsyncMock()
+    controller.get_overview_data = AsyncMock(return_value={})
+    local_row = {
+        "id": "local:watchlist_item:8",
+        "item_id": 8,
+        "title": "Local row before server switch",
+        "status": "read",
+        "url": "https://example.com/8",
+        "created_at": "2026-08-23T12:00:00+00:00",
+    }
+    controller.list_items = AsyncMock(return_value=[local_row])
+    controller.get_item_content = AsyncMock(return_value="Local reader body")
+    controller.check_all = AsyncMock(return_value={"checked": 0, "failed": []})
+    app = _build_test_app()
+    bundle = app.watchlist_bundle_service
+    count_spies = []
+    for name in (
+        "get_watchlist_item_counts",
+        "get_flagged_items_count",
+        "get_unread_items_count_since",
+        "get_source_item_counts",
+    ):
+        spy = Mock(wraps=getattr(bundle, name))
+        monkeypatch.setattr(bundle, name, spy)
+        count_spies.append(spy)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.4)
+        screen = host.screen_stack[-1]
+        await host.workers.wait_for_complete()
+        screen._controller = controller
+
+        assert screen.active_section == "items"
+        assert screen.runtime_backend == "local"
+        await screen._load_items()
+        screen.post_message(ItemSelected(local_row))
+        assert await _wait_until(
+            pilot, lambda: screen._selected_content_item is local_row
+        )
+        await pilot.pause()
+
+        selector = screen.query_one("#watchlists-backend-select")
+        assert [
+            item["title"]
+            for item in screen.query_one(
+                "#watchlists-items-pane", ArticleListPane
+            ).items
+        ] == ["Local row before server switch"]
+        assert screen.query("#watchlists-content-pane")
+        assert not screen.query("#watchlists-read-local-only")
+
+        controller.list_items.reset_mock()
+        controller.get_item_content.reset_mock()
+        controller.check_all.reset_mock()
+        for spy in count_spies:
+            spy.reset_mock()
+
+        selector.value = "server"
+        assert await _wait_until(
+            pilot, lambda: bool(screen.query("#watchlists-read-local-only"))
+        )
+
+        assert screen.active_section == "items"
+        assert screen.runtime_backend == "server"
+        assert selector.value == "server"
+        assert selector.disabled is True
+        assert not screen.query("#watchlists-content-pane")
+        assert not screen.query_one(
+            "#watchlists-items-pane", ArticleListPane
+        ).items
+        assert screen._selected_content_item is None
+
+        screen.post_message(ItemsFilterChanged("unread", "server query"))
+        screen.action_refresh_all()
+        await screen._load_tree_data().wait()
+        await pilot.pause(0.5)
+        await host.workers.wait_for_complete()
+
+        controller.list_items.assert_not_awaited()
+        controller.get_item_content.assert_not_awaited()
+        controller.check_all.assert_not_awaited()
+        for spy in count_spies:
+            spy.assert_not_called()
+
+
 # --- Task 7: scope-driven scoped rows, with real seeded data ---------------
 #
 # Tests/UI/test_watchlists_destination_shell.py's own scope tests run

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -317,6 +317,8 @@ async def test_server_backed_read_recovers_through_the_normal_local_load_path(
     monkeypatch,
 ) -> None:
     """Server-labelled Read never leaks local rows or local Reader queries."""
+    import asyncio
+
     controller = AsyncMock()
     controller.get_overview_data = AsyncMock(return_value={})
     local_rows = [
@@ -329,7 +331,15 @@ async def test_server_backed_read_recovers_through_the_normal_local_load_path(
             "created_at": "2026-08-23T12:00:00+00:00",
         }
     ]
-    controller.list_items = AsyncMock(return_value=local_rows)
+    local_load_entered = asyncio.Event()
+    release_local_load = asyncio.Event()
+
+    async def blocked_local_load(**_kwargs):
+        local_load_entered.set()
+        await release_local_load.wait()
+        return local_rows
+
+    controller.list_items = AsyncMock(side_effect=blocked_local_load)
     controller.check_all = AsyncMock(return_value={"checked": 0, "failed": []})
     app = _build_test_app()
     bundle = app.watchlist_bundle_service
@@ -395,7 +405,21 @@ async def test_server_backed_read_recovers_through_the_normal_local_load_path(
         ).items
 
         switch.press()
-        await pilot.pause(0.4)
+        assert await _wait_until(pilot, local_load_entered.is_set)
+
+        assert screen.runtime_backend == "local"
+        assert selector.value == "local"
+        assert screen.query("#watchlists-read-local-only"), (
+            "the recovery centre must remain until the normal load commits"
+        )
+        assert screen.query_one("#watchlists-switch-local", Button).disabled is False
+        assert screen.query("#watchlists-read-local-only-copy")
+        assert not screen.query("#watchlists-content-pane")
+        assert not screen.query_one(
+            "#watchlists-items-pane", ArticleListPane
+        ).items
+
+        release_local_load.set()
         await host.workers.wait_for_complete()
         await pilot.pause()
 
@@ -418,6 +442,48 @@ async def test_server_backed_read_recovers_through_the_normal_local_load_path(
         assert screen.query("#watchlists-content-pane")
         assert not screen.query("#watchlists-read-local-only")
         assert screen._selected_content_item is None
+
+
+@pytest.mark.asyncio
+async def test_failed_switch_to_local_keeps_recovery_mounted_and_actionable() -> None:
+    controller = AsyncMock()
+    controller.get_overview_data = AsyncMock(return_value={})
+    controller.list_items = AsyncMock(side_effect=RuntimeError("local read failed"))
+    app = _build_test_app()
+    app.notify = Mock()
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.4)
+        screen = host.screen_stack[-1]
+        await host.workers.wait_for_complete()
+        screen._controller = controller
+
+        screen.active_section = "sources"
+        await pilot.pause(0.3)
+        selector = screen.query_one("#watchlists-backend-select")
+        selector.value = "server"
+        await pilot.pause(0.3)
+        screen.active_section = "items"
+        await pilot.pause(0.4)
+        await host.workers.wait_for_complete()
+        controller.list_items.assert_not_awaited()
+
+        screen.query_one("#watchlists-switch-local", Button).press()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert screen.runtime_backend == "local"
+        assert selector.value == "local"
+        controller.list_items.assert_awaited_once()
+        assert screen.query("#watchlists-read-local-only")
+        assert screen.query_one("#watchlists-switch-local", Button).disabled is False
+        assert screen.query("#watchlists-read-local-only-copy")
+        assert not screen.query("#watchlists-content-pane")
+        assert not screen.query_one(
+            "#watchlists-items-pane", ArticleListPane
+        ).items
+        assert "Failed to load watchlist items." in str(app.notify.call_args.args[0])
 
 
 # --- Task 7: scope-driven scoped rows, with real seeded data ---------------

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -472,6 +472,14 @@ async def test_failed_switch_to_local_retries_the_normal_load_path() -> None:
         side_effect=[RuntimeError("local read failed"), [local_row]]
     )
     app = _build_test_app()
+    bundle = app.watchlist_bundle_service
+    source_id = bundle._db.add_subscription(
+        name="Recovery local source",
+        type="rss",
+        source="https://recovery.example/feed",
+    )
+    watchlist = bundle.create("Recovery local watchlist")
+    bundle.add_source(watchlist["id"], source_id)
     app.notify = Mock()
     host = DestinationHarness(app, "watchlists_collections")
 
@@ -480,6 +488,8 @@ async def test_failed_switch_to_local_retries_the_normal_load_path() -> None:
         screen = host.screen_stack[-1]
         await host.workers.wait_for_complete()
         screen._controller = controller
+        await screen._load_tree_data().wait()
+        assert screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}")
 
         screen.active_section = "sources"
         await pilot.pause(0.3)
@@ -505,6 +515,10 @@ async def test_failed_switch_to_local_retries_the_normal_load_path() -> None:
         assert not screen.query_one(
             "#watchlists-items-pane", ArticleListPane
         ).items
+        assert not screen._tree_watchlists
+        failed_render = host.export_screenshot()
+        assert "Recovery local watchlist" not in failed_render
+        assert "Recovery local source" not in failed_render
         assert "Failed to load watchlist items." in str(app.notify.call_args.args[0])
 
         screen.query_one("#watchlists-switch-local", Button).press()
@@ -520,6 +534,7 @@ async def test_failed_switch_to_local_retries_the_normal_load_path() -> None:
                 "#watchlists-items-pane", ArticleListPane
             ).items
         ] == ["Loaded by recovery retry"]
+        assert screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}")
         assert screen._selected_content_item is None
 
 
@@ -542,8 +557,19 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
     controller.check_all = AsyncMock(return_value={"checked": 0, "failed": []})
     app = _build_test_app()
     bundle = app.watchlist_bundle_service
-    count_spies = []
+    source_id = bundle._db.add_subscription(
+        name="Same-tab local source",
+        type="rss",
+        source="https://same-tab.example/feed",
+    )
+    watchlist = bundle.create("Same-tab local watchlist")
+    bundle.add_source(watchlist["id"], source_id)
+    local_spies = {}
     for name in (
+        "list_watchlists",
+        "list_source_rows",
+        "list_all_source_rows",
+        "list_unassigned_source_rows",
         "get_watchlist_item_counts",
         "get_flagged_items_count",
         "get_unread_items_count_since",
@@ -551,7 +577,7 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
     ):
         spy = Mock(wraps=getattr(bundle, name))
         monkeypatch.setattr(bundle, name, spy)
-        count_spies.append(spy)
+        local_spies[name] = spy
 
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
@@ -562,6 +588,11 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
 
         assert screen.active_section == "items"
         assert screen.runtime_backend == "local"
+        await screen._load_tree_data().wait()
+        assert screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}")
+        assert bundle.list_source_rows(watchlist["id"])[0]["name"] == (
+            "Same-tab local source"
+        )
         await screen._load_items()
         screen.post_message(ItemSelected(local_row))
         assert await _wait_until(
@@ -582,7 +613,7 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
         controller.list_items.reset_mock()
         controller.get_item_content.reset_mock()
         controller.check_all.reset_mock()
-        for spy in count_spies:
+        for spy in local_spies.values():
             spy.reset_mock()
 
         selector.value = "server"
@@ -599,7 +630,16 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
             "#watchlists-items-pane", ArticleListPane
         ).items
         assert screen._selected_content_item is None
+        assert not screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}")
+        assert not screen.query(
+            f"#wl-tree-node-source-{watchlist['id']}-{source_id}"
+        )
+        rendered = host.export_screenshot()
+        assert "Same-tab local watchlist" not in rendered
+        assert "Same-tab local source" not in rendered
+        assert "Local Watchlists snapshot" not in rendered
 
+        screen.post_message(ItemSelected(local_row))
         screen.post_message(ItemsFilterChanged("unread", "server query"))
         screen.post_message(PreviousItemsPageRequested())
         screen.post_message(NextItemsPageRequested())
@@ -611,8 +651,8 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
         controller.list_items.assert_not_awaited()
         controller.get_item_content.assert_not_awaited()
         controller.check_all.assert_not_awaited()
-        for spy in count_spies:
-            spy.assert_not_called()
+        for name, spy in local_spies.items():
+            assert spy.call_count == 0, name
         assert screen._items_page_loading is False
         assert screen.query_one(
             "#watchlists-items-pane", ArticleListPane
@@ -630,10 +670,16 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
     source_id = db.add_subscription(
         name="Local counted feed", type="rss", source="https://counted.example/feed"
     )
+    watchlist = service.create("Cross-tab local watchlist")
+    service.add_source(watchlist["id"], source_id)
     _seed_item(db, source_id, "Local row before cross-tab server switch")
 
-    count_spies = []
+    local_spies = {}
     for name in (
+        "list_watchlists",
+        "list_source_rows",
+        "list_all_source_rows",
+        "list_unassigned_source_rows",
         "get_watchlist_item_counts",
         "get_flagged_items_count",
         "get_unread_items_count_since",
@@ -641,7 +687,7 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
     ):
         spy = Mock(wraps=getattr(service, name))
         monkeypatch.setattr(service, name, spy)
-        count_spies.append(spy)
+        local_spies[name] = spy
 
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
@@ -649,6 +695,10 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         screen = host.screen_stack[-1]
         await host.workers.wait_for_complete()
         await screen._load_tree_data().wait()
+        assert screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}")
+        assert service.list_source_rows(watchlist["id"])[0]["name"] == (
+            "Local counted feed"
+        )
         assert await screen._load_items()
         local_row = screen._loaded_items[0]
         screen.post_message(ItemSelected(local_row))
@@ -681,7 +731,7 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         selector.value = "server"
         await pilot.pause(0.3)
         await host.workers.wait_for_complete()
-        for spy in count_spies:
+        for spy in local_spies.values():
             spy.reset_mock()
 
         screen.active_section = "items"
@@ -706,6 +756,15 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         assert screen._selected_content_item is None
         assert screen._tree_counts == {}
         assert screen._tree_source_counts == {}
+        assert not screen._tree_watchlists
+        assert not screen.query(f"#wl-tree-node-watchlist-{watchlist['id']}")
+        assert not screen.query(
+            f"#wl-tree-node-source-{watchlist['id']}-{source_id}"
+        )
+        rendered = host.export_screenshot()
+        assert "Cross-tab local watchlist" not in rendered
+        assert "Local counted feed" not in rendered
+        assert "Local Watchlists snapshot" not in rendered
         assert "All sources  0" in str(
             screen.query_one("#wl-tree-node-all", Button).label
         )
@@ -720,15 +779,7 @@ async def test_entering_server_read_clears_local_reader_navigation_without_queri
         list_items.assert_not_awaited()
         get_item_content.assert_not_awaited()
         check_all.assert_not_awaited()
-        for name, spy in zip(
-            (
-                "get_watchlist_item_counts",
-                "get_flagged_items_count",
-                "get_unread_items_count_since",
-                "get_source_item_counts",
-            ),
-            count_spies,
-        ):
+        for name, spy in local_spies.items():
             assert spy.call_count == 0, name
         assert screen._items_page_loading is False
 

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -21,7 +21,11 @@ from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
     PreviewRequested,
     ViewSnapshotRequested,
 )
-from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import (
+    ArticleListPane,
+    NextItemsPageRequested,
+    PreviousItemsPageRequested,
+)
 from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected
 from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsFilterChanged
 from tldw_chatbook.UI.Watchlists_Modules.opml_dialogs import (
@@ -398,8 +402,16 @@ async def test_server_backed_read_recovers_through_the_normal_local_load_path(
 
         controller.list_items.assert_not_awaited()
         controller.check_all.assert_not_awaited()
-        for spy in count_spies:
-            spy.assert_not_called()
+        for name, spy in zip(
+            (
+                "get_watchlist_item_counts",
+                "get_flagged_items_count",
+                "get_unread_items_count_since",
+                "get_source_item_counts",
+            ),
+            count_spies,
+        ):
+            assert spy.call_count == 0, name
         assert not screen.query_one(
             "#watchlists-items-pane", ArticleListPane
         ).items
@@ -426,13 +438,13 @@ async def test_server_backed_read_recovers_through_the_normal_local_load_path(
         assert screen.runtime_backend == "local"
         assert selector.value == "local"
         assert selector.disabled is True
-        assert controller.list_items.await_count, (
+        assert controller.list_items.await_count == 1, (
             screen._items_page_loading,
             screen._items_inflight_page_load,
             screen._items_load_generation,
             screen._loaded_items,
         )
-        assert controller.list_items.await_args.kwargs["search"] == "server search"
+        assert "search" not in controller.list_items.await_args.kwargs
         assert [
             item["title"]
             for item in screen.query_one(
@@ -445,10 +457,20 @@ async def test_server_backed_read_recovers_through_the_normal_local_load_path(
 
 
 @pytest.mark.asyncio
-async def test_failed_switch_to_local_keeps_recovery_mounted_and_actionable() -> None:
+async def test_failed_switch_to_local_retries_the_normal_load_path() -> None:
     controller = AsyncMock()
     controller.get_overview_data = AsyncMock(return_value={})
-    controller.list_items = AsyncMock(side_effect=RuntimeError("local read failed"))
+    local_row = {
+        "id": "local:watchlist_item:9",
+        "item_id": 9,
+        "title": "Loaded by recovery retry",
+        "status": "new",
+        "url": "https://example.com/9",
+        "created_at": "2026-08-23T12:00:00+00:00",
+    }
+    controller.list_items = AsyncMock(
+        side_effect=[RuntimeError("local read failed"), [local_row]]
+    )
     app = _build_test_app()
     app.notify = Mock()
     host = DestinationHarness(app, "watchlists_collections")
@@ -484,6 +506,21 @@ async def test_failed_switch_to_local_keeps_recovery_mounted_and_actionable() ->
             "#watchlists-items-pane", ArticleListPane
         ).items
         assert "Failed to load watchlist items." in str(app.notify.call_args.args[0])
+
+        screen.query_one("#watchlists-switch-local", Button).press()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert controller.list_items.await_count == 2
+        assert not screen.query("#watchlists-read-local-only")
+        assert screen.query("#watchlists-content-pane")
+        assert [
+            item["title"]
+            for item in screen.query_one(
+                "#watchlists-items-pane", ArticleListPane
+            ).items
+        ] == ["Loaded by recovery retry"]
+        assert screen._selected_content_item is None
 
 
 @pytest.mark.asyncio
@@ -564,6 +601,8 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
         assert screen._selected_content_item is None
 
         screen.post_message(ItemsFilterChanged("unread", "server query"))
+        screen.post_message(PreviousItemsPageRequested())
+        screen.post_message(NextItemsPageRequested())
         screen.action_refresh_all()
         await screen._load_tree_data().wait()
         await pilot.pause(0.5)
@@ -574,6 +613,124 @@ async def test_same_tab_switch_to_server_replaces_local_reader_without_queries(
         controller.check_all.assert_not_awaited()
         for spy in count_spies:
             spy.assert_not_called()
+        assert screen._items_page_loading is False
+        assert screen.query_one(
+            "#watchlists-items-pane", ArticleListPane
+        ).page_loading is False
+
+
+@pytest.mark.asyncio
+async def test_entering_server_read_clears_local_reader_navigation_without_queries(
+    monkeypatch,
+) -> None:
+    """Sources -> Server -> Read cannot retain any local Reader state."""
+    app = _build_test_app()
+    service = app.watchlist_bundle_service
+    db = service._db
+    source_id = db.add_subscription(
+        name="Local counted feed", type="rss", source="https://counted.example/feed"
+    )
+    _seed_item(db, source_id, "Local row before cross-tab server switch")
+
+    count_spies = []
+    for name in (
+        "get_watchlist_item_counts",
+        "get_flagged_items_count",
+        "get_unread_items_count_since",
+        "get_source_item_counts",
+    ):
+        spy = Mock(wraps=getattr(service, name))
+        monkeypatch.setattr(service, name, spy)
+        count_spies.append(spy)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.4)
+        screen = host.screen_stack[-1]
+        await host.workers.wait_for_complete()
+        await screen._load_tree_data().wait()
+        assert await screen._load_items()
+        local_row = screen._loaded_items[0]
+        screen.post_message(ItemSelected(local_row))
+        assert await _wait_until(
+            pilot, lambda: screen._selected_content_item is local_row
+        )
+
+        assert any(bucket.get("unread", 0) for bucket in screen._tree_counts.values())
+        assert screen._tree_source_counts[source_id]["unread"] == 1
+        assert "1" in str(screen.query_one("#wl-tree-node-all", Button).label)
+        assert screen.query("#watchlists-content-pane")
+        assert screen.query_one("#watchlists-items-pane", ArticleListPane).items
+
+        screen.post_message(ItemsFilterChanged("unread", "local query"))
+        await pilot.pause(0.4)
+        await host.workers.wait_for_complete()
+        screen._items_page_index = 2
+        screen._items_has_next = True
+        screen._push_items_pager_state()
+
+        list_items = AsyncMock(wraps=screen._controller.list_items)
+        get_item_content = AsyncMock(wraps=screen._controller.get_item_content)
+        check_all = AsyncMock(wraps=screen._controller.check_all)
+        screen._controller.list_items = list_items
+        screen._controller.get_item_content = get_item_content
+        screen._controller.check_all = check_all
+        screen.active_section = "sources"
+        await pilot.pause(0.3)
+        selector = screen.query_one("#watchlists-backend-select")
+        selector.value = "server"
+        await pilot.pause(0.3)
+        await host.workers.wait_for_complete()
+        for spy in count_spies:
+            spy.reset_mock()
+
+        screen.active_section = "items"
+        assert await _wait_until(
+            pilot, lambda: bool(screen.query("#watchlists-read-local-only"))
+        )
+        await host.workers.wait_for_complete()
+
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        assert screen.runtime_backend == "server"
+        assert selector.value == "server"
+        assert selector.disabled is True
+        assert not pane.items
+        assert pane.status_filter == "all"
+        assert pane.search_query == ""
+        assert pane.page_number == 1
+        assert pane.has_previous is False
+        assert pane.has_next is False
+        assert pane.page_loading is False
+        assert pane.selected_item is None
+        assert screen._loaded_items == []
+        assert screen._selected_content_item is None
+        assert screen._tree_counts == {}
+        assert screen._tree_source_counts == {}
+        assert "All sources  0" in str(
+            screen.query_one("#wl-tree-node-all", Button).label
+        )
+
+        screen.post_message(ItemSelected(local_row))
+        screen.post_message(ItemsFilterChanged("unread", "server query"))
+        screen.post_message(NextItemsPageRequested())
+        screen.action_refresh_all()
+        await pilot.pause(0.5)
+        await host.workers.wait_for_complete()
+
+        list_items.assert_not_awaited()
+        get_item_content.assert_not_awaited()
+        check_all.assert_not_awaited()
+        for name, spy in zip(
+            (
+                "get_watchlist_item_counts",
+                "get_flagged_items_count",
+                "get_unread_items_count_since",
+                "get_source_item_counts",
+            ),
+            count_spies,
+        ):
+            assert spy.call_count == 0, name
+        assert screen._items_page_loading is False
 
 
 # --- Task 7: scope-driven scoped rows, with real seeded data ---------------

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -1,11 +1,13 @@
 """Tests for the Watchlists collections screen action handlers."""
 
 from contextlib import asynccontextmanager
+import threading
 
 import pytest
 from unittest.mock import AsyncMock, Mock
 
 from rich.text import Text
+from textual.app import App, ComposeResult
 from textual.widgets import Button, Input, Static, TextArea
 
 from Tests.UI.test_destination_shells import DestinationHarness, _static_text
@@ -18,6 +20,7 @@ from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
     InspectorPane,
     PreviewRequested,
 )
+from tldw_chatbook.UI.Watchlists_Modules import inspector_pane as inspector_pane_module
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected
 from tldw_chatbook.UI.Watchlists_Modules.opml_dialogs import (
@@ -33,6 +36,7 @@ from tldw_chatbook.UI.Watchlists_Modules.sources_pane import (
     SourcesPane,
 )
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import TreeScope, TreeScopeChanged
+from tldw_chatbook.Utils.input_validation import validate_url as real_validate_url
 
 
 @pytest.fixture
@@ -69,6 +73,104 @@ async def _open_screen(controller):
         assert isinstance(screen, WatchlistsCollectionsScreen)
         screen._controller = controller
         yield screen, pilot
+
+
+class _InspectorActionsApp(App[None]):
+    def __init__(self, entity: dict) -> None:
+        super().__init__()
+        self.entity = entity
+        self.snapshot_requests: list[object] = []
+
+    def compose(self) -> ComposeResult:
+        pane = InspectorPane(id="watchlists-entity-inspector")
+        pane.set_reactive(InspectorPane.selected_entity, self.entity)
+        yield pane
+
+    def on_view_snapshot_requested(self, message) -> None:
+        self.snapshot_requests.append(message)
+
+
+@pytest.mark.parametrize("content_kind", ["article", "change"])
+@pytest.mark.asyncio
+async def test_item_inspector_keeps_advanced_actions(content_kind: str) -> None:
+    app = _InspectorActionsApp(
+        {
+            "entity_kind": "watchlist_item",
+            "item_id": 7,
+            "title": "Selected item",
+            "content_kind": content_kind,
+            "queued_for_briefing": False,
+        }
+    )
+    async with app.run_test():
+        action_ids = [
+            button.id
+            for button in app.query_one("#inspector-actions").query(Button)
+        ]
+
+        assert "inspector-ingest-button" in action_ids
+        assert "inspector-queue-briefing-button" in action_ids
+        assert ("inspector-full-page-button" in action_ids) is (
+            content_kind == "change"
+        )
+        assert ("inspector-previous-snapshot-button" in action_ids) is (
+            content_kind == "change"
+        )
+
+
+@pytest.mark.asyncio
+async def test_inspector_previous_snapshot_posts_the_existing_request() -> None:
+    message_type = getattr(inspector_pane_module, "ViewSnapshotRequested", None)
+    assert message_type is not None, "Inspector must own the snapshot request"
+    entity = {
+        "entity_kind": "watchlist_item",
+        "item_id": 7,
+        "title": "Changed page",
+        "content_kind": "change",
+    }
+    app = _InspectorActionsApp(entity)
+    async with app.run_test() as pilot:
+        await pilot.click("#inspector-previous-snapshot-button")
+        await pilot.pause()
+
+        assert len(app.snapshot_requests) == 1
+        request = app.snapshot_requests[0]
+        assert isinstance(request, message_type)
+        assert request.item is entity
+        assert request.which == "previous"
+
+
+@pytest.mark.asyncio
+async def test_screen_keeps_previous_snapshot_modal_handler(monkeypatch) -> None:
+    message_type = getattr(inspector_pane_module, "ViewSnapshotRequested", None)
+    assert message_type is not None, "Inspector must own the snapshot request"
+    app = _build_test_app()
+    app.local_watchlists_service.get_url_snapshots = AsyncMock(
+        return_value=[
+            {"created_at": "2026-08-23T10:00:00Z", "extracted_content": "now"},
+            {
+                "created_at": "2026-08-22T10:00:00Z",
+                "extracted_content": "before",
+            },
+        ]
+    )
+    host = DestinationHarness(app, "watchlists_collections")
+    pushed = AsyncMock(return_value=None)
+    monkeypatch.setattr(host, "push_screen_wait", pushed)
+    item = {"source_id": 11, "url": "https://example.com/changed"}
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = host.screen_stack[-1]
+        screen.post_message(message_type(item, "previous"))
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        app.local_watchlists_service.get_url_snapshots.assert_awaited_once_with(
+            11, "https://example.com/changed", limit=2
+        )
+        modal = pushed.await_args.args[0]
+        assert modal._url == "https://example.com/changed"
+        assert modal._content == "before"
 
 
 @pytest.mark.asyncio
@@ -986,6 +1088,57 @@ async def test_open_in_browser_requested_takes_the_same_path(monkeypatch):
             if opened:
                 break
         assert opened == ["https://example.com/via-button"]
+
+
+@pytest.mark.parametrize("activation", ["keyboard", "button"])
+@pytest.mark.asyncio
+async def test_open_validates_on_ui_thread_then_opens_in_worker(
+    monkeypatch, activation: str
+):
+    """Both entry points converge before the UI/worker thread boundary."""
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
+        OpenInBrowserRequested,
+    )
+
+    ui_thread = threading.get_ident()
+    validation_threads: list[int] = []
+    browser_threads: list[int] = []
+    def validate_on_recorded_thread(url: str) -> bool:
+        validation_threads.append(threading.get_ident())
+        return real_validate_url(url)
+
+    def open_on_recorded_thread(url: str) -> bool:
+        browser_threads.append(threading.get_ident())
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.validate_url",
+        validate_on_recorded_thread,
+    )
+    monkeypatch.setattr("webbrowser.open", open_on_recorded_thread)
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        await _open_item_and_get_url(
+            pilot, screen, db, "Threaded open", "https://example.com/threaded"
+        )
+
+        if activation == "keyboard":
+            await pilot.press("o")
+        else:
+            screen.post_message(
+                OpenInBrowserRequested(dict(screen._selected_content_item))
+            )
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert validation_threads == [ui_thread]
+        assert len(browser_threads) == 1
+        assert browser_threads[0] != ui_thread
 
 
 # --- TASK-3072 plan task 9: the reader's position footer ----------------------

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -23,6 +23,7 @@ from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
 )
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected
+from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsFilterChanged
 from tldw_chatbook.UI.Watchlists_Modules.opml_dialogs import (
     OpmlExportDialog,
     OpmlImportDialog,
@@ -309,6 +310,114 @@ async def test_the_list_pane_is_gone_on_every_tab():
             assert not screen.query("#watchlists-list-pane"), section
             assert not screen.query("#wl-region-feeds"), section
             assert not screen.query("#wl-header-feeds"), section
+
+
+@pytest.mark.asyncio
+async def test_server_backed_read_recovers_through_the_normal_local_load_path(
+    monkeypatch,
+) -> None:
+    """Server-labelled Read never leaks local rows or local Reader queries."""
+    controller = AsyncMock()
+    controller.get_overview_data = AsyncMock(return_value={})
+    local_rows = [
+        {
+            "id": "local:watchlist_item:7",
+            "item_id": 7,
+            "title": "Loaded after switching",
+            "status": "new",
+            "url": "https://example.com/7",
+            "created_at": "2026-08-23T12:00:00+00:00",
+        }
+    ]
+    controller.list_items = AsyncMock(return_value=local_rows)
+    controller.check_all = AsyncMock(return_value={"checked": 0, "failed": []})
+    app = _build_test_app()
+    bundle = app.watchlist_bundle_service
+    count_spies = []
+    for name in (
+        "get_watchlist_item_counts",
+        "get_flagged_items_count",
+        "get_unread_items_count_since",
+        "get_source_item_counts",
+    ):
+        spy = Mock(wraps=getattr(bundle, name))
+        monkeypatch.setattr(bundle, name, spy)
+        count_spies.append(spy)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.4)
+        screen = host.screen_stack[-1]
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+        screen._controller = controller
+
+        screen.active_section = "sources"
+        await pilot.pause(0.3)
+        selector = screen.query_one("#watchlists-backend-select")
+        selector.value = "server"
+        await pilot.pause(0.3)
+        await host.workers.wait_for_complete()
+        controller.list_items.reset_mock()
+        controller.check_all.reset_mock()
+        for spy in count_spies:
+            spy.reset_mock()
+
+        screen.active_section = "items"
+        await pilot.pause(0.4)
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert screen.runtime_backend == "server"
+        assert selector.value == "server"
+        assert selector.disabled is True
+        assert screen.query("#wl-region-content"), "Reader centre stays mounted"
+        assert screen.query("#watchlists-read-local-only")
+        switch = screen.query_one("#watchlists-switch-local", Button)
+        assert switch.disabled is False
+        assert "Switch to Local" in str(switch.label)
+        assert "local" in _static_text(
+            screen.query_one("#watchlists-read-local-only-copy", Static)
+        ).lower()
+
+        screen.post_message(ItemsFilterChanged("unread", "server search"))
+        screen.action_refresh_all()
+        await screen._load_tree_data().wait()
+        await pilot.pause(0.5)
+        await host.workers.wait_for_complete()
+
+        controller.list_items.assert_not_awaited()
+        controller.check_all.assert_not_awaited()
+        for spy in count_spies:
+            spy.assert_not_called()
+        assert not screen.query_one(
+            "#watchlists-items-pane", ArticleListPane
+        ).items
+
+        switch.press()
+        await pilot.pause(0.4)
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert screen.runtime_backend == "local"
+        assert selector.value == "local"
+        assert selector.disabled is True
+        assert controller.list_items.await_count, (
+            screen._items_page_loading,
+            screen._items_inflight_page_load,
+            screen._items_load_generation,
+            screen._loaded_items,
+        )
+        assert controller.list_items.await_args.kwargs["search"] == "server search"
+        assert [
+            item["title"]
+            for item in screen.query_one(
+                "#watchlists-items-pane", ArticleListPane
+            ).items
+        ] == ["Loaded after switching"]
+        assert screen.query("#watchlists-content-pane")
+        assert not screen.query("#watchlists-read-local-only")
+        assert screen._selected_content_item is None
 
 
 # --- Task 7: scope-driven scoped rows, with real seeded data ---------------

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -13,6 +13,7 @@ from textual.widgets import Button, Input, Static, TextArea
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.test_destination_shells import DestinationHarness, _static_text
+from tldw_chatbook.UI.Screens import watchlists_collections_screen as collections_module
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import WatchlistsCollectionsScreen
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
@@ -43,6 +44,13 @@ from tldw_chatbook.UI.Watchlists_Modules.sources_pane import (
 )
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import TreeScope, TreeScopeChanged
 from tldw_chatbook.Utils.input_validation import validate_url as real_validate_url
+
+
+def test_layout_intent_dataclasses_use_pascal_case_names() -> None:
+    assert hasattr(collections_module, "ManualLayoutRollback")
+    assert hasattr(collections_module, "SectionViewIntent")
+    assert not hasattr(collections_module, "_ManualLayoutRollback")
+    assert not hasattr(collections_module, "_SectionViewIntent")
 
 
 @pytest.fixture

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -19,8 +19,8 @@ from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
     CheckNowRequested,
     InspectorPane,
     PreviewRequested,
+    ViewSnapshotRequested,
 )
-from tldw_chatbook.UI.Watchlists_Modules import inspector_pane as inspector_pane_module
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected
 from tldw_chatbook.UI.Watchlists_Modules.opml_dialogs import (
@@ -79,14 +79,14 @@ class _InspectorActionsApp(App[None]):
     def __init__(self, entity: dict) -> None:
         super().__init__()
         self.entity = entity
-        self.snapshot_requests: list[object] = []
+        self.snapshot_requests: list[ViewSnapshotRequested] = []
 
     def compose(self) -> ComposeResult:
         pane = InspectorPane(id="watchlists-entity-inspector")
         pane.set_reactive(InspectorPane.selected_entity, self.entity)
         yield pane
 
-    def on_view_snapshot_requested(self, message) -> None:
+    def on_view_snapshot_requested(self, message: ViewSnapshotRequested) -> None:
         self.snapshot_requests.append(message)
 
 
@@ -118,10 +118,17 @@ async def test_item_inspector_keeps_advanced_actions(content_kind: str) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("button_id", "which"),
+    [
+        ("inspector-full-page-button", "full_page"),
+        ("inspector-previous-snapshot-button", "previous"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_inspector_previous_snapshot_posts_the_existing_request() -> None:
-    message_type = getattr(inspector_pane_module, "ViewSnapshotRequested", None)
-    assert message_type is not None, "Inspector must own the snapshot request"
+async def test_inspector_snapshot_actions_post_existing_request(
+    button_id: str, which: str
+) -> None:
     entity = {
         "entity_kind": "watchlist_item",
         "item_id": 7,
@@ -130,20 +137,18 @@ async def test_inspector_previous_snapshot_posts_the_existing_request() -> None:
     }
     app = _InspectorActionsApp(entity)
     async with app.run_test() as pilot:
-        await pilot.click("#inspector-previous-snapshot-button")
+        await pilot.click(f"#{button_id}")
         await pilot.pause()
 
         assert len(app.snapshot_requests) == 1
         request = app.snapshot_requests[0]
-        assert isinstance(request, message_type)
+        assert isinstance(request, ViewSnapshotRequested)
         assert request.item is entity
-        assert request.which == "previous"
+        assert request.which == which
 
 
 @pytest.mark.asyncio
 async def test_screen_keeps_previous_snapshot_modal_handler(monkeypatch) -> None:
-    message_type = getattr(inspector_pane_module, "ViewSnapshotRequested", None)
-    assert message_type is not None, "Inspector must own the snapshot request"
     app = _build_test_app()
     app.local_watchlists_service.get_url_snapshots = AsyncMock(
         return_value=[
@@ -161,7 +166,7 @@ async def test_screen_keeps_previous_snapshot_modal_handler(monkeypatch) -> None
 
     async with host.run_test(size=(180, 50)) as pilot:
         screen = host.screen_stack[-1]
-        screen.post_message(message_type(item, "previous"))
+        screen.post_message(ViewSnapshotRequested(item, "previous"))
         await host.workers.wait_for_complete()
         await pilot.pause()
 
@@ -959,11 +964,20 @@ async def _open_item_and_get_url(pilot, screen, db, title: str, url: str) -> int
     return item_id
 
 
+def _successful_browser_recorder(opened: list[str]):
+    """Return a browser stub that records its URL and reports success."""
+    def record(url: str) -> bool:
+        opened.append(url)
+        return True
+
+    return record
+
+
 @pytest.mark.asyncio
 async def test_o_opens_the_open_items_url(monkeypatch):
     """`o` hands the open item's http URL to the system browser."""
     opened: list[str] = []
-    monkeypatch.setattr("webbrowser.open", opened.append)
+    monkeypatch.setattr("webbrowser.open", _successful_browser_recorder(opened))
 
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -974,18 +988,19 @@ async def test_o_opens_the_open_items_url(monkeypatch):
         await _open_item_and_get_url(
             pilot, screen, db, "Readable", "https://example.com/post"
         )
+        app.notify = Mock()
 
         await pilot.press("o")
-        await pilot.pause(0.2)
+        await host.workers.wait_for_complete()
+        await pilot.pause()
         assert opened == ["https://example.com/post"]
+        app.notify.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_o_refuses_a_non_http_url(monkeypatch):
     """A `javascript:`/`file:`/empty URL is a remote-derived string reaching
     an OS primitive: it is refused with a notification, never passed on."""
-    from unittest.mock import Mock
-
     opened: list[str] = []
     monkeypatch.setattr("webbrowser.open", opened.append)
 
@@ -1017,7 +1032,7 @@ async def test_o_strips_control_bytes_from_the_url_before_opening(monkeypatch):
     """A feed URL is remote-derived text: control bytes are stripped before
     the (already scheme- and host-validated) string reaches the OS."""
     opened: list[str] = []
-    monkeypatch.setattr("webbrowser.open", opened.append)
+    monkeypatch.setattr("webbrowser.open", _successful_browser_recorder(opened))
 
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -1028,13 +1043,13 @@ async def test_o_strips_control_bytes_from_the_url_before_opening(monkeypatch):
         await _open_item_and_get_url(
             pilot, screen, db, "Control bytes", "https://example.com/po\x07st"
         )
+        app.notify = Mock()
 
         await pilot.press("o")
-        for _ in range(20):
-            await pilot.pause()
-            if opened:
-                break
+        await host.workers.wait_for_complete()
+        await pilot.pause()
         assert opened == ["https://example.com/post"]
+        app.notify.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1068,7 +1083,7 @@ async def test_open_in_browser_requested_takes_the_same_path(monkeypatch):
     )
 
     opened: list[str] = []
-    monkeypatch.setattr("webbrowser.open", opened.append)
+    monkeypatch.setattr("webbrowser.open", _successful_browser_recorder(opened))
 
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -1079,15 +1094,15 @@ async def test_open_in_browser_requested_takes_the_same_path(monkeypatch):
         await _open_item_and_get_url(
             pilot, screen, db, "Button-opened", "https://example.com/via-button"
         )
+        app.notify = Mock()
 
         screen.post_message(
             OpenInBrowserRequested(dict(screen._selected_content_item))
         )
-        for _ in range(20):
-            await pilot.pause()
-            if opened:
-                break
+        await host.workers.wait_for_complete()
+        await pilot.pause()
         assert opened == ["https://example.com/via-button"]
+        app.notify.assert_not_called()
 
 
 @pytest.mark.parametrize("activation", ["keyboard", "button"])

--- a/Tests/Watchlists/test_watchlists_items_pane.py
+++ b/Tests/Watchlists/test_watchlists_items_pane.py
@@ -76,7 +76,7 @@ async def test_the_queued_column_carries_a_discoverable_legend():
     """TASK-2313, AC#6: the Queued column was a bare glyph or blank cell
     with no discoverable meaning anywhere on screen."""
     app = ItemsPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(ItemsPane)
         legend = pane.query_one("#items-queued-legend", Static)
         text = str(legend.renderable)
@@ -89,7 +89,7 @@ async def test_status_select_carries_a_visible_label():
     """TASK-2310: the status filter must not paint as a bare "All statuses"
     with nothing naming what it filters."""
     app = ItemsPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(ItemsPane)
         row = pane.query_one("#items-toolbar")
         children = list(row.children)

--- a/Tests/Watchlists/test_watchlists_notifications_pane.py
+++ b/Tests/Watchlists/test_watchlists_notifications_pane.py
@@ -82,7 +82,7 @@ def _cell_style(table: DataTable, row_key: str, column_index: int) -> Style:
 @pytest.mark.asyncio
 async def test_notifications_pane_renders_table_and_toolbar():
     app = NotificationsPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(NotificationsPane)
         assert pane.query_one("#notifications-table", DataTable)
         assert pane.query_one("#notifications-refresh-button", Button)
@@ -94,7 +94,7 @@ async def test_notifications_pane_renders_table_and_toolbar():
 async def test_notifications_pane_carries_one_line_of_guidance_when_empty():
     """TASK-2313, AC#4: matching Runs/Rules' identical fix."""
     app = NotificationsPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(NotificationsPane)
         assert pane.notifications == [], "precondition: nothing seeded"
         hint = pane.query_one("#notifications-empty-state", Static)

--- a/Tests/Watchlists/test_watchlists_pagination.py
+++ b/Tests/Watchlists/test_watchlists_pagination.py
@@ -657,7 +657,7 @@ async def test_tree_scope_change_resets_and_reloads_page_one():
 
 
 @pytest.mark.asyncio
-async def test_backend_change_reloads_read_but_not_a_hidden_read_section():
+async def test_backend_change_blocks_server_read_and_does_not_load_hidden_read():
     controller = AsyncMock()
     controller.list_items.return_value = _items(100, 51)
 
@@ -669,11 +669,11 @@ async def test_backend_change_reloads_read_but_not_a_hidden_read_section():
         controller.list_items.return_value = _items(0, 1)
 
         screen.runtime_backend = "server"
-        await _wait_until(pilot, lambda: controller.list_items.await_count == 1)
-        await _wait_until(pilot, lambda: not screen._items_page_loading)
-        assert controller.list_items.await_args.kwargs["runtime_backend"] == "server"
-        assert controller.list_items.await_args.kwargs["offset"] == 0
+        await pilot.pause(0.2)
+        assert controller.list_items.await_count == 0
         assert screen._items_page_index == 0
+        assert screen._items_page_loading is False
+        assert screen._loaded_items == []
 
         screen.active_section = "sources"
         await pilot.pause(0.1)
@@ -710,7 +710,7 @@ async def test_selection_during_search_debounce_keeps_prior_committed_key():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("changed_field", ["backend", "scope", "status", "search"])
+@pytest.mark.parametrize("changed_field", ["scope", "status", "search"])
 async def test_query_context_changes_do_not_pin_the_open_item(changed_field):
     controller = AsyncMock()
     controller.list_items.return_value = _items(0, 2)
@@ -720,9 +720,7 @@ async def test_query_context_changes_do_not_pin_the_open_item(changed_field):
         open_item = screen._loaded_items[0]
         screen._selected_content_item = open_item
         screen._selected_content_page_key = screen._items_committed_page_key
-        if changed_field == "backend":
-            screen.__dict__["_reactive_runtime_backend"] = "server"
-        elif changed_field == "scope":
+        if changed_field == "scope":
             screen.__dict__["_reactive_tree_scope"] = TreeScope(
                 kind="watchlist", watchlist_id=7
             )

--- a/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
+++ b/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
@@ -38,7 +38,10 @@ pytestmark = pytest.mark.unit
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc)
+    if now.astimezone().hour < 6:
+        return now + timedelta(hours=12)
+    return now
 
 
 def _item(

--- a/Tests/Watchlists/test_watchlists_pane_grip.py
+++ b/Tests/Watchlists/test_watchlists_pane_grip.py
@@ -1,0 +1,107 @@
+"""Focused behavior tests for the Watchlists pane grip."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.UI.Watchlists_Modules.pane_grip import (
+    RegionToggled,
+    WatchlistsPaneGrip,
+)
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
+
+
+class PaneGripApp(App[None]):
+    """Minimal host which records pane-toggle messages."""
+
+    def __init__(self, region: Region, *, expanded: bool) -> None:
+        super().__init__()
+        self.grip = WatchlistsPaneGrip(region, expanded=expanded, id="pane-grip")
+        self.toggles: list[Region] = []
+
+    def compose(self) -> ComposeResult:
+        yield self.grip
+
+    def on_region_toggled(self, message: RegionToggled) -> None:
+        self.toggles.append(message.region)
+
+
+@pytest.mark.parametrize(
+    ("region", "expanded", "expected"),
+    [
+        (Region.LEFT_RAIL, False, "--->"),
+        (Region.LEFT_RAIL, True, "<---"),
+        (Region.ITEMS, False, "--->"),
+        (Region.ITEMS, True, "<---"),
+        (Region.RIGHT_RAIL, False, "<---"),
+        (Region.RIGHT_RAIL, True, "--->"),
+    ],
+)
+def test_grip_direction_matches_pane_side_and_state(
+    region: Region, expanded: bool, expected: str
+) -> None:
+    grip = WatchlistsPaneGrip(region, expanded=expanded)
+
+    assert str(grip.label) == expected
+
+
+@pytest.mark.parametrize(
+    ("region", "pane_name"),
+    [
+        (Region.LEFT_RAIL, "Navigation"),
+        (Region.ITEMS, "Feed Items"),
+        (Region.RIGHT_RAIL, "Inspector"),
+    ],
+)
+def test_grip_exposes_actionable_copy_and_compact_geometry(
+    region: Region, pane_name: str
+) -> None:
+    grip = WatchlistsPaneGrip(region, expanded=False)
+
+    assert grip.can_focus
+    assert grip.tooltip == f"Expand {pane_name}"
+    assert grip.name == f"Expand {pane_name}"
+    assert grip.compact
+    assert grip.styles.width is not None
+    assert grip.styles.width.value == 5
+    assert grip.styles.line_pad == 0
+    assert grip.has_class("watchlists-pane-grip")
+
+
+@pytest.mark.asyncio
+async def test_click_posts_exactly_one_region_toggled_message() -> None:
+    app = PaneGripApp(Region.LEFT_RAIL, expanded=False)
+
+    async with app.run_test() as pilot:
+        await pilot.click("#pane-grip")
+        await pilot.pause()
+
+    assert app.toggles == [Region.LEFT_RAIL]
+
+
+@pytest.mark.asyncio
+async def test_enter_posts_exactly_one_region_toggled_message() -> None:
+    app = PaneGripApp(Region.RIGHT_RAIL, expanded=False)
+
+    async with app.run_test() as pilot:
+        app.grip.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert app.toggles == [Region.RIGHT_RAIL]
+
+
+@pytest.mark.asyncio
+async def test_expanded_update_relabels_the_same_widget_in_place() -> None:
+    app = PaneGripApp(Region.ITEMS, expanded=False)
+
+    async with app.run_test() as pilot:
+        original = app.grip
+        original.expanded = True
+        await pilot.pause()
+
+        assert app.query_one("#pane-grip") is original
+        assert str(original.label) == "<---"
+        assert original.tooltip == "Collapse Feed Items"
+        assert original.name == "Collapse Feed Items"

--- a/Tests/Watchlists/test_watchlists_pane_grip.py
+++ b/Tests/Watchlists/test_watchlists_pane_grip.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from textual.app import App, ComposeResult
 
@@ -14,6 +16,13 @@ from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
 
 class PaneGripApp(App[None]):
     """Minimal host which records pane-toggle messages."""
+
+    CSS_PATH = str(
+        Path(__file__).resolve().parents[2]
+        / "tldw_chatbook"
+        / "css"
+        / "tldw_cli_modular.tcss"
+    )
 
     def __init__(self, region: Region, *, expanded: bool) -> None:
         super().__init__()
@@ -65,6 +74,10 @@ def test_grip_exposes_actionable_copy_and_compact_geometry(
     assert grip.compact
     assert grip.styles.width is not None
     assert grip.styles.width.value == 5
+    assert grip.styles.min_width is not None
+    assert grip.styles.min_width.value == 5
+    assert grip.styles.max_width is not None
+    assert grip.styles.max_width.value == 5
     assert grip.styles.line_pad == 0
     assert grip.has_class("watchlists-pane-grip")
 
@@ -105,3 +118,51 @@ async def test_expanded_update_relabels_the_same_widget_in_place() -> None:
         assert str(original.label) == "<---"
         assert original.tooltip == "Collapse Feed Items"
         assert original.name == "Collapse Feed Items"
+
+
+def _painted_centre_row(app: App[None], grip: WatchlistsPaneGrip) -> str:
+    """Return the five compositor cells occupied by ``grip``."""
+    strips = list(app.screen._compositor.render_strips())
+    y = grip.region.y + (grip.region.height - 1) // 2
+    return strips[y].crop(grip.region.x, grip.region.right).text
+
+
+@pytest.mark.parametrize(
+    ("region", "expanded", "arrow"),
+    [
+        (Region.LEFT_RAIL, False, "--->"),
+        (Region.LEFT_RAIL, True, "<---"),
+        (Region.ITEMS, False, "--->"),
+        (Region.ITEMS, True, "<---"),
+        (Region.RIGHT_RAIL, False, "<---"),
+        (Region.RIGHT_RAIL, True, "--->"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_real_bundle_paints_full_arrow_beside_one_fixed_divider(
+    region: Region, expanded: bool, arrow: str
+) -> None:
+    app = PaneGripApp(region, expanded=expanded)
+
+    async with app.run_test(size=(5, 9)) as pilot:
+        await pilot.pause()
+        grip = app.query_one("#pane-grip", WatchlistsPaneGrip)
+        resting_region = grip.region
+        resting_content = grip.content_region
+
+        assert grip.styles.width is not None
+        assert grip.styles.width.value == 5
+        assert grip.styles.min_width is not None
+        assert grip.styles.min_width.value == 5
+        assert grip.styles.max_width is not None
+        assert grip.styles.max_width.value == 5
+        assert grip.outer_size.width == grip.region.width == 5
+        assert grip.content_region.width == 4
+        assert _painted_centre_row(app, grip)[1:] == arrow
+
+        grip.focus()
+        await pilot.pause()
+
+        assert grip.region == resting_region
+        assert grip.content_region == resting_content
+        assert _painted_centre_row(app, grip)[1:] == arrow

--- a/Tests/Watchlists/test_watchlists_pane_grip.py
+++ b/Tests/Watchlists/test_watchlists_pane_grip.py
@@ -63,7 +63,7 @@ def test_grip_direction_matches_pane_side_and_state(
         (Region.RIGHT_RAIL, "Inspector"),
     ],
 )
-def test_grip_exposes_actionable_copy_and_compact_geometry(
+def test_grip_exposes_actionable_copy_and_compact_behavior(
     region: Region, pane_name: str
 ) -> None:
     grip = WatchlistsPaneGrip(region, expanded=False)
@@ -72,12 +72,6 @@ def test_grip_exposes_actionable_copy_and_compact_geometry(
     assert grip.tooltip == f"Expand {pane_name}"
     assert grip.name == f"Expand {pane_name}"
     assert grip.compact
-    assert grip.styles.width is not None
-    assert grip.styles.width.value == 5
-    assert grip.styles.min_width is not None
-    assert grip.styles.min_width.value == 5
-    assert grip.styles.max_width is not None
-    assert grip.styles.max_width.value == 5
     assert grip.styles.line_pad == 0
     assert grip.has_class("watchlists-pane-grip")
 

--- a/Tests/Watchlists/test_watchlists_responsive_layout.py
+++ b/Tests/Watchlists/test_watchlists_responsive_layout.py
@@ -165,10 +165,10 @@ def test_sub_sixty_widths_collapse_all_mounted_side_panes_without_raising(
     assert effective.collapsed == mounted
 
 
-def test_resolver_discards_legacy_solo_and_reader_collapse_state():
-    preferred = RegionLayout().toggle(Region.LEFT_RAIL).solo(Region.CONTENT)
+def test_resolver_discards_a_retired_reader_collapse_value():
+    preferred = RegionLayout(
+        collapsed=frozenset({Region.LEFT_RAIL, Region.CONTENT})
+    )
     effective = resolve(preferred, 145)
     assert effective.collapsed == frozenset({Region.LEFT_RAIL})
-    assert effective.solo_region is None
-    assert effective._pre_solo is None
     assert not effective.is_collapsed(Region.CONTENT)

--- a/Tests/Watchlists/test_watchlists_responsive_layout.py
+++ b/Tests/Watchlists/test_watchlists_responsive_layout.py
@@ -90,6 +90,14 @@ def test_management_boundaries_exclude_feed_items():
     )
 
 
+def test_management_parks_feed_items_preference_but_keeps_mounted_rail_preferences():
+    preferred = RegionLayout(
+        collapsed=frozenset({Region.ITEMS, Region.RIGHT_RAIL})
+    )
+    effective = resolve(preferred, 200, read_mode=False)
+    assert effective.collapsed == frozenset({Region.RIGHT_RAIL})
+
+
 @pytest.mark.parametrize(
     ("read_mode", "mounted"),
     [

--- a/Tests/Watchlists/test_watchlists_responsive_layout.py
+++ b/Tests/Watchlists/test_watchlists_responsive_layout.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.UI.Watchlists_Modules import region_layout
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
+
+
+def resolve(
+    preferred: RegionLayout,
+    width: int,
+    *,
+    read_mode: bool = True,
+    article_focus: bool = False,
+    priority_target: Region | None = None,
+) -> RegionLayout:
+    return region_layout.resolve_effective_layout(
+        preferred,
+        width=width,
+        read_mode=read_mode,
+        article_focus=article_focus,
+        priority_target=priority_target,
+    )
+
+
+def test_declared_widths_orders_and_default_priorities():
+    assert region_layout.PANE_GRIP_WIDTH == 5
+    assert region_layout.PANE_MINIMUM_WIDTHS == {
+        Region.LEFT_RAIL: 24,
+        Region.ITEMS: 32,
+        Region.RIGHT_RAIL: 30,
+    }
+    assert region_layout.CENTRE_COMFORT_WIDTH == 44
+    assert region_layout.READ_SIDE_PANE_ORDER == (
+        Region.LEFT_RAIL,
+        Region.ITEMS,
+        Region.RIGHT_RAIL,
+    )
+    assert region_layout.MANAGEMENT_SIDE_PANE_ORDER == (
+        Region.LEFT_RAIL,
+        Region.RIGHT_RAIL,
+    )
+    assert region_layout.READ_COLLAPSE_PRIORITY == (
+        Region.RIGHT_RAIL,
+        Region.LEFT_RAIL,
+        Region.ITEMS,
+    )
+    assert region_layout.MANAGEMENT_COLLAPSE_PRIORITY == (
+        Region.RIGHT_RAIL,
+        Region.LEFT_RAIL,
+    )
+
+
+def test_read_all_open_boundary_collapses_inspector_first():
+    preferred = RegionLayout()
+    assert resolve(preferred, 145).collapsed == frozenset()
+    assert resolve(preferred, 144).collapsed == frozenset({Region.RIGHT_RAIL})
+
+
+def test_read_navigation_and_feed_items_boundary_collapses_navigation_next():
+    preferred = RegionLayout().toggle_preferred(Region.RIGHT_RAIL)
+    assert resolve(preferred, 115).collapsed == frozenset({Region.RIGHT_RAIL})
+    assert resolve(preferred, 114).collapsed == frozenset(
+        {Region.LEFT_RAIL, Region.RIGHT_RAIL}
+    )
+
+
+def test_read_feed_items_only_boundary_collapses_every_side_pane():
+    preferred = (
+        RegionLayout()
+        .toggle_preferred(Region.LEFT_RAIL)
+        .toggle_preferred(Region.RIGHT_RAIL)
+    )
+    assert resolve(preferred, 91).collapsed == frozenset(
+        {Region.LEFT_RAIL, Region.RIGHT_RAIL}
+    )
+    assert resolve(preferred, 90).collapsed == frozenset(
+        region_layout.COLLAPSIBLE_REGIONS
+    )
+
+
+def test_management_boundaries_exclude_feed_items():
+    preferred = RegionLayout()
+    assert resolve(preferred, 108, read_mode=False).collapsed == frozenset()
+    assert resolve(preferred, 107, read_mode=False).collapsed == frozenset(
+        {Region.RIGHT_RAIL}
+    )
+    assert resolve(preferred, 77, read_mode=False).collapsed == frozenset(
+        {Region.LEFT_RAIL, Region.RIGHT_RAIL}
+    )
+
+
+@pytest.mark.parametrize(
+    ("read_mode", "mounted"),
+    [
+        (True, frozenset(region_layout.COLLAPSIBLE_REGIONS)),
+        (False, frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL})),
+    ],
+)
+def test_article_focus_collapses_mounted_side_panes_without_mutating_preferred(
+    read_mode: bool,
+    mounted: frozenset[Region],
+):
+    preferred = RegionLayout()
+    effective = resolve(
+        preferred,
+        200,
+        read_mode=read_mode,
+        article_focus=True,
+    )
+    assert effective.collapsed == mounted
+    assert preferred == RegionLayout()
+
+
+def test_priority_target_is_protected_until_every_other_eligible_pane_collapses():
+    preferred = RegionLayout()
+    protected = resolve(
+        preferred,
+        114,
+        priority_target=Region.RIGHT_RAIL,
+    )
+    assert protected.collapsed == frozenset({Region.LEFT_RAIL, Region.ITEMS})
+
+    too_narrow = resolve(
+        preferred,
+        88,
+        priority_target=Region.RIGHT_RAIL,
+    )
+    assert too_narrow.collapsed == frozenset(region_layout.COLLAPSIBLE_REGIONS)
+
+
+def test_preferred_closed_panes_stay_closed():
+    preferred = RegionLayout().toggle_preferred(Region.RIGHT_RAIL)
+    assert resolve(preferred, 200).is_collapsed(Region.RIGHT_RAIL)
+
+
+def test_repeated_resolution_is_idempotent():
+    preferred = RegionLayout()
+    effective = resolve(preferred, 114)
+    assert resolve(effective, 114) == effective
+
+
+@pytest.mark.parametrize("width", [59, 30, 1, 0, -1])
+@pytest.mark.parametrize(
+    ("read_mode", "mounted"),
+    [
+        (True, frozenset(region_layout.COLLAPSIBLE_REGIONS)),
+        (False, frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL})),
+    ],
+)
+def test_sub_sixty_widths_collapse_all_mounted_side_panes_without_raising(
+    width: int,
+    read_mode: bool,
+    mounted: frozenset[Region],
+):
+    effective = resolve(RegionLayout(), width, read_mode=read_mode)
+    assert effective.collapsed == mounted
+
+
+def test_resolver_discards_legacy_solo_and_reader_collapse_state():
+    preferred = RegionLayout().toggle(Region.LEFT_RAIL).solo(Region.CONTENT)
+    effective = resolve(preferred, 145)
+    assert effective.collapsed == frozenset({Region.LEFT_RAIL})
+    assert effective.solo_region is None
+    assert effective._pre_solo is None
+    assert not effective.is_collapsed(Region.CONTENT)

--- a/Tests/Watchlists/test_watchlists_rules_pane.py
+++ b/Tests/Watchlists/test_watchlists_rules_pane.py
@@ -63,7 +63,7 @@ def sample_rules():
 @pytest.mark.asyncio
 async def test_rules_pane_renders_table_and_toolbar():
     app = RulesPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(RulesPane)
         assert pane.query_one("#rules-refresh-button", Button)
         assert pane.query_one("#rules-new-button", Button)
@@ -74,7 +74,7 @@ async def test_rules_pane_renders_table_and_toolbar():
 async def test_rules_pane_carries_one_line_of_guidance_when_empty():
     """TASK-2313, AC#4: matching Runs/Notifications' identical fix."""
     app = RulesPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(RulesPane)
         assert pane.rules == [], "precondition: nothing seeded"
         hint = pane.query_one("#rules-empty-state", Static)

--- a/Tests/Watchlists/test_watchlists_runs_pane.py
+++ b/Tests/Watchlists/test_watchlists_runs_pane.py
@@ -64,7 +64,7 @@ def sample_runs():
 @pytest.mark.asyncio
 async def test_runs_pane_renders_table_and_toolbar():
     app = RunsPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(RunsPane)
         assert pane.query_one("#runs-table", DataTable)
         assert pane.query_one("#runs-refresh-button", Button)
@@ -77,7 +77,7 @@ async def test_runs_pane_carries_one_line_of_guidance_when_empty():
     """TASK-2313, AC#4: a bare empty table read as broken next to
     Overview's rich first-run guidance."""
     app = RunsPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(RunsPane)
         assert pane.runs == [], "precondition: nothing seeded"
         hint = pane.query_one("#runs-empty-state", Static)

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -7,8 +7,7 @@ rather than reasoned about:
   and nothing else -- not the screen, not the navigation bar, not the footer,
   not either rail, and not the reader.
 * A **tree-node click** updates each affected pane at most once.
-* **z / Z / [ / ]** rebuild only the region whose rendered form actually
-  changed.
+* Side-pane layout actions mount or remove only the affected pane body.
 
 Every count comes from `Widget.recompose` and `Widget.mount`, patched for the
 duration of one interaction (`_RebuildCounter`). Against the pre-task code
@@ -434,6 +433,24 @@ async def test_a_section_switch_moves_the_tab_strip_and_the_backend_control():
         assert not screen.query("#wl-region-content"), (
             "CONTENT is unmounted off the Read tab"
         )
+        from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+            WatchlistsWorkbench,
+        )
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        body = screen.query_one("#wl-workbench-body")
+        assert workbench.read_mode is False
+        assert [child.id for child in workbench.children] == [
+            "wl-centre-status",
+            "wl-workbench-body",
+        ]
+        assert [child.id for child in body.children] == [
+            "wl-region-left_rail",
+            "wl-grip-left_rail",
+            "wl-region-items",
+            "wl-grip-right_rail",
+            "wl-region-right_rail",
+        ]
 
         screen.active_section = "items"
         await _settle(pilot, host)
@@ -441,6 +458,16 @@ async def test_a_section_switch_moves_the_tab_strip_and_the_backend_control():
         assert screen.query("#wl-region-content"), (
             "CONTENT must be mounted back on the Read tab"
         )
+        assert workbench.read_mode is True
+        assert [child.id for child in body.children] == [
+            "wl-region-left_rail",
+            "wl-grip-left_rail",
+            "wl-region-items",
+            "wl-grip-items",
+            "wl-region-content",
+            "wl-grip-right_rail",
+            "wl-region-right_rail",
+        ]
         assert backend_select.disabled is False, (
             "the backend picker must be re-enabled off a local-only section"
         )
@@ -696,7 +723,8 @@ async def test_a_rail_toggle_rebuilds_only_the_toggled_region():
             await pilot.press("[")
             await _settle(pilot, host)
 
-        assert screen.query("#wl-header-left_rail"), "the rail really did collapse"
+        grip = screen.query_one("#wl-grip-left_rail", Button)
+        assert getattr(grip, "expanded") is False
         assert not screen.query("#wl-region-left_rail")
         assert screen.query_one("#wl-region-items") is items_region, counted.report()
         assert screen.query_one("#wl-region-content") is content_region, (
@@ -722,22 +750,20 @@ async def test_a_rail_toggle_rebuilds_only_the_toggled_region():
 
 
 async def test_collapsing_items_rebuilds_neither_rail_nor_the_reader():
-    """`z` on ITEMS. CONTENT stays expanded, so it keeps its instance -- and
-    picks up the sole-centre marker in place rather than by being rebuilt."""
+    """`z` on Feed Items removes only that side body."""
     app = _build_test_app()
     watchlist_id = _seed(app)
     async with _open(app, watchlist_id) as (screen, pilot, host):
         tree = screen.query_one("#wl-tree", WatchlistTree)
         reader = screen.query_one("#watchlists-content-pane", ContentPane)
         content_region = screen.query_one("#wl-region-content")
-        assert not content_region.has_class("watchlists-region-sole-centre")
-
         screen.focused_region = Region.ITEMS
         with _RebuildCounter() as counted:
             screen.action_toggle_region()
             await _settle(pilot, host)
 
-        assert screen.query("#wl-header-items"), "ITEMS really did collapse"
+        grip = screen.query_one("#wl-grip-items", Button)
+        assert getattr(grip, "expanded") is False
         assert not screen.query("#wl-region-items")
         assert screen.query_one("#wl-tree", WatchlistTree) is tree, counted.report()
         assert screen.query_one("#watchlists-content-pane", ContentPane) is reader, (
@@ -745,51 +771,6 @@ async def test_collapsing_items_rebuilds_neither_rail_nor_the_reader():
             f"{counted.report()}"
         )
         assert screen.query_one("#wl-region-content") is content_region
-        assert content_region.has_class("watchlists-region-sole-centre"), (
-            "the sole-expanded marker must be applied in place"
-        )
-
-
-async def test_soloing_content_relabels_the_reader_without_rebuilding_it():
-    """`Z` on CONTENT collapses ITEMS around it. CONTENT's own form does not
-    change, so the reader survives -- and its Expand/Restore button has to be
-    relabelled in place or it would keep offering the action it just did."""
-    app = _build_test_app()
-    watchlist_id = _seed(app)
-    async with _open(app, watchlist_id) as (screen, pilot, host):
-        items_pane = screen.query_one("#watchlists-items-pane")
-        items_pane.items = [
-            {
-                "id": "local:watchlist_item:1",
-                "item_id": 1,
-                "title": "Story 0",
-                "source_name": "AI News",
-                "status": "new",
-                "content": "body",
-                "content_kind": "article",
-                "content_format": "text",
-            }
-        ]
-        await _settle(pilot, host)
-        items_pane.select_item_by_id("local:watchlist_item:1")
-        await _settle(pilot, host)
-
-        reader = screen.query_one("#watchlists-content-pane", ContentPane)
-        assert str(reader.query_one("#content-expand-button", Button).label) == "Expand"
-
-        screen.focused_region = Region.CONTENT
-        with _RebuildCounter() as counted:
-            screen.action_solo_region()
-            await _settle(pilot, host)
-
-        assert screen.region_layout.solo_region is Region.CONTENT
-        assert not screen.query("#wl-region-items"), "solo really collapsed ITEMS"
-        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader, (
-            f"soloing CONTENT must not rebuild CONTENT: {counted.report()}"
-        )
-        assert (
-            str(reader.query_one("#content-expand-button", Button).label) == "Restore"
-        ), "the surviving reader must be relabelled in place"
 
 
 async def test_an_inspector_toggle_leaves_the_centre_and_the_left_rail_alone():
@@ -805,7 +786,8 @@ async def test_an_inspector_toggle_leaves_the_centre_and_the_left_rail_alone():
             await pilot.press("]")
             await _settle(pilot, host)
 
-        assert screen.query("#wl-header-right_rail"), "the Inspector really collapsed"
+        grip = screen.query_one("#wl-grip-right_rail", Button)
+        assert getattr(grip, "expanded") is False
         assert not screen.query("#wl-region-right_rail")
         assert screen.query_one("#wl-tree", WatchlistTree) is tree, counted.report()
         assert screen.query_one("#wl-region-items") is items_region, counted.report()
@@ -836,12 +818,8 @@ async def test_a_layout_toggle_mounts_far_fewer_widgets_than_a_full_rebuild():
         )
 
 
-async def test_layout_keys_still_persist_and_restore_the_layout():
-    """Scoping the rebuild must not change what the keys MEAN.
-
-    Collapse state, solo/restore and the refusal off the Read tab are all
-    behaviour the perf work is not allowed to move.
-    """
+async def test_layout_keys_keep_independent_side_pane_state():
+    """Scoping the rebuild must not couple the side-pane preferences."""
     app = _build_test_app()
     watchlist_id = _seed(app)
     async with _open(app, watchlist_id) as (screen, pilot, host):
@@ -855,18 +833,6 @@ async def test_layout_keys_still_persist_and_restore_the_layout():
         assert Region.LEFT_RAIL in screen.region_layout.collapsed, (
             "one rail's toggle must not disturb the other's"
         )
-
-        screen.focused_region = Region.CONTENT
-        screen.action_solo_region()
-        await _settle(pilot, host)
-        assert screen.region_layout.solo_region is Region.CONTENT
-        assert not screen.query("#wl-region-items")
-
-        screen.focused_region = Region.CONTENT
-        screen.action_solo_region()
-        await _settle(pilot, host)
-        assert screen.region_layout.solo_region is None, "a second Z restores"
-        assert screen.query("#wl-region-items")
 
         # Off Read, the centre regions are not the user's to collapse.
         screen.active_section = "sources"
@@ -883,53 +849,19 @@ async def test_layout_keys_still_persist_and_restore_the_layout():
         )
 
 
-async def test_z_collapsing_a_centre_region_is_not_one_way():
-    """The keyboard round trip, not just the chevron.
-
-    A collapsed region renders as a focusable header (`#wl-header-items`) and
-    `on_descendant_focus` maps that id back to the region, so `z` with the
-    header focused has to expand it again. Worth pinning next to the scoping
-    work: the scoped path removes the widget that had focus and mounts a
-    different one in its place, which is exactly where a "collapse is one
-    way" regression would come from.
-    """
-    app = _build_test_app()
-    watchlist_id = _seed(app)
-    async with _open(app, watchlist_id) as (screen, pilot, host):
-        screen.focused_region = Region.ITEMS
-        screen.action_toggle_region()
-        await _settle(pilot, host)
-        assert screen.query("#wl-header-items"), "ITEMS collapsed"
-
-        screen.query_one("#wl-header-items", Button).focus()
-        await _settle(pilot, host)
-        assert screen.focused_region is Region.ITEMS, (
-            "focusing a collapsed region's header must point the keybinding "
-            "at that region"
-        )
-
-        await pilot.press("z")
-        await _settle(pilot, host)
-
-        assert screen.query("#wl-region-items"), "z must expand it again"
-        assert screen.query("#watchlists-items-pane"), (
-            "and the region has to come back with its pane, not empty"
-        )
-
-
-async def test_a_collapsed_region_still_expands_from_its_header_button() -> None:
-    """The chevron route through `RegionToggled`, not just the keybinding."""
+async def test_a_collapsed_region_still_expands_from_its_grip_button() -> None:
+    """The grip route through `RegionToggled`, not just the keybinding."""
     app = _build_test_app()
     watchlist_id = _seed(app)
     async with _open(app, watchlist_id) as (screen, pilot, host):
         await pilot.press("[")
         await _settle(pilot, host)
-        header = screen.query_one("#wl-header-left_rail", Button)
+        grip = screen.query_one("#wl-grip-left_rail", Button)
 
-        header.press()
+        grip.press()
         await _settle(pilot, host)
 
         assert screen.query("#wl-region-left_rail"), (
-            "clicking a collapsed region's header must expand it"
+            "clicking a collapsed region's grip must expand it"
         )
         assert screen.query("#wl-tree"), "and rebuild its content"

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -38,7 +38,7 @@ from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
 from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
-from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
 from tldw_chatbook.UI.Watchlists_Modules.rules_pane import RulesPane
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
     TreeScope,
@@ -865,3 +865,72 @@ async def test_a_collapsed_region_still_expands_from_its_grip_button() -> None:
             "clicking a collapsed region's grip must expand it"
         )
         assert screen.query("#wl-tree"), "and rebuild its content"
+
+
+async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
+    monkeypatch,
+) -> None:
+    """A real screen owns the same fallback that the workbench still renders."""
+    from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+        RegionLayoutApplyFailed,
+        WatchlistsWorkbench,
+    )
+
+    persisted: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        persisted.append,
+    )
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        if not screen.region_layout.is_collapsed(Region.LEFT_RAIL):
+            screen.action_toggle_left_rail()
+            await _settle(pilot, host)
+        fallback = screen.region_layout
+        persisted.clear()
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        grip = screen.query_one("#wl-grip-left_rail", Button)
+        original_factory = workbench._content[Region.LEFT_RAIL]
+        fail_factory = True
+
+        def flaky_factory():
+            if fail_factory:
+                raise RuntimeError("navigation failed")
+            return original_factory()
+
+        workbench._content[Region.LEFT_RAIL] = flaky_factory
+        grip.press()
+        await _settle(pilot, host)
+
+        assert screen.region_layout == fallback
+        assert workbench.region_layout == screen._rendered_region_layout()
+        assert getattr(grip, "expanded") is False
+        assert not screen.query("#wl-region-left_rail")
+        assert screen._pending_persist_layout == fallback
+        assert (
+            screen._last_persisted_collapsed
+            == fallback.collapsed_for_persistence()
+        )
+        assert persisted
+        assert persisted[-1] == fallback
+
+        fail_factory = False
+        grip.press()
+        await _settle(pilot, host)
+
+        assert not screen.region_layout.is_collapsed(Region.LEFT_RAIL)
+        assert workbench.region_layout == screen._rendered_region_layout()
+        assert getattr(grip, "expanded") is True
+        assert screen.query("#wl-region-left_rail")
+
+        newer = screen.region_layout
+        workbench.post_message(
+            RegionLayoutApplyFailed(
+                attempted=fallback,
+                fallback=fallback.toggle(Region.RIGHT_RAIL),
+            )
+        )
+        await _settle(pilot, host)
+        assert screen.region_layout == newer

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -19,6 +19,7 @@ bar and footer included) and any layout key recomposed the whole workbench
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from collections import Counter
 from datetime import datetime, timedelta, timezone
@@ -35,6 +36,7 @@ from Tests.UI.test_destination_shells import DestinationHarness
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
 from tldw_chatbook.Subscriptions.briefing_cast import dump_roster
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
+    _ManualLayoutRollback,
     WatchlistsCollectionsScreen,
 )
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
@@ -285,22 +287,16 @@ async def test_a_section_switch_builds_the_sections_pane_exactly_once():
     watchlist_id = _seed(app)
     await _seed_alert_rule(app)
     async with _open(app, watchlist_id) as (screen, pilot, host):
-        # Patched on the WORKBENCH's factory map, not on the screen: the map
-        # captured the bound method at construction time, so rebinding the
-        # screen attribute would count nothing.
-        from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
-            WatchlistsWorkbench,
-        )
-
-        workbench = screen.query_one(WatchlistsWorkbench)
+        # Section intents now capture the screen factory at dispatch time.
         builds: list[str] = []
-        real_build = workbench._content[Region.ITEMS]
+        real_build = screen._build_detail_pane
 
-        def _counting_build():
-            builds.append(screen.active_section)
-            return real_build()
+        def _counting_build(section=None):
+            requested = section or screen.active_section
+            builds.append(requested)
+            return real_build(requested)
 
-        workbench._content[Region.ITEMS] = _counting_build
+        screen._build_detail_pane = _counting_build
 
         with _RebuildCounter() as counted:
             screen.active_section = "rules"
@@ -354,10 +350,6 @@ async def test_a_section_switch_shows_rows_that_land_while_the_swap_runs():
     Neutering `_reseed_active_section_pane` to a no-op reds this test: the
     Alert-rules table stays empty over a `_loaded_rules` holding the row.
     """
-    from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
-        WatchlistsWorkbench,
-    )
-
     app = _build_test_app()
     watchlist_id = _seed(app)
     async with _open(app, watchlist_id, section="sources") as (screen, pilot, host):
@@ -381,11 +373,10 @@ async def test_a_section_switch_shows_rows_that_land_while_the_swap_runs():
         # pane itself, which is not what this test is about.
         screen._load_active_section_data = lambda: None
 
-        workbench = screen.query_one(WatchlistsWorkbench)
-        real_build = workbench._content[Region.ITEMS]
+        real_build = screen._build_detail_pane
 
-        def _build_then_land():
-            built = real_build()
+        def _build_then_land(section=None):
+            built = real_build(section)
             screen._loaded_rules = [row]
             try:  # the loader's push, from inside the gap
                 screen.query_one("#watchlists-rules-pane", RulesPane).rules = [row]
@@ -393,7 +384,7 @@ async def test_a_section_switch_shows_rows_that_land_while_the_swap_runs():
                 pass
             return built
 
-        workbench._content[Region.ITEMS] = _build_then_land
+        screen._build_detail_pane = _build_then_land
 
         screen.active_section = "rules"
         await _settle(pilot, host)
@@ -404,6 +395,65 @@ async def test_a_section_switch_shows_rows_that_land_while_the_swap_runs():
             "rows that landed while the swap was mid-flight must reach the "
             "pane the swap mounted, not be stranded in `_loaded_rules`"
         )
+
+
+async def test_rapid_management_section_requests_keep_captured_intent_on_failure(
+    monkeypatch,
+) -> None:
+    """A delayed A completion cannot build or relabel mutable intent B."""
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        workbench = screen.query_one(WatchlistsWorkbench)
+        original_apply = workbench.apply_section_view
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        apply_calls = 0
+
+        async def delayed_apply(**kwargs):
+            nonlocal apply_calls
+            apply_calls += 1
+            if apply_calls == 1:
+                first_entered.set()
+                await release_first.wait()
+            return await original_apply(**kwargs)
+
+        monkeypatch.setattr(workbench, "apply_section_view", delayed_apply)
+        original_build = screen._build_detail_pane
+        fail_rules = True
+
+        def captured_build(section=None):
+            requested = section or screen.active_section
+            if requested == "rules" and fail_rules:
+                raise RuntimeError("rules centre failed")
+            try:
+                return original_build(section)
+            except TypeError:
+                return original_build()
+
+        monkeypatch.setattr(screen, "_build_detail_pane", captured_build)
+        workbench._content[Region.ITEMS] = captured_build
+
+        screen.active_section = "sources"
+        await asyncio.wait_for(first_entered.wait(), timeout=1)
+        screen.active_section = "rules"
+        release_first.set()
+        await _settle(pilot, host)
+
+        assert screen.active_section == "sources"
+        assert screen._rendered_section == "sources"
+        assert workbench.read_mode is False
+        assert screen.query("#watchlists-sources-pane")
+        assert not screen.query("#watchlists-rules-pane")
+
+        fail_rules = False
+        screen.active_section = "rules"
+        await _settle(pilot, host)
+
+        assert screen.active_section == "rules"
+        assert screen._rendered_section == "rules"
+        assert workbench.read_mode is False
+        assert screen.query("#watchlists-rules-pane")
 
 
 async def test_a_section_switch_moves_the_tab_strip_and_the_backend_control():
@@ -1080,11 +1130,11 @@ async def test_mounted_layout_cycles_preserve_complete_reader_and_list_state() -
         await _settle(pilot, host)
         pane.status_filter = "unread"
         pane.search_query = "Story"
+        # Let the real debounce and reload settle. Cancelling the production
+        # timer here used to hide the anchor/load interleaving this survival
+        # test is meant to exercise.
+        await pilot.pause(0.4)
         await _settle(pilot, host)
-        reload_timer = getattr(screen, "_items_search_reload_timer", None)
-        if reload_timer is not None:
-            reload_timer.stop()
-            screen._items_search_reload_timer = None
         table = pane.query_one("#items-table", ListView)
         table.scroll_to(y=6, animate=False)
         table.focus()
@@ -1296,12 +1346,13 @@ async def test_layout_acknowledgements_ignore_stale_tokens_and_clear_current_noo
     async with _open(app) as (screen, pilot, host):
         layout = screen._effective_region_layout
         token = screen._next_layout_request_token()
-        rollback = (
-            token,
-            layout,
-            screen.region_layout,
-            screen._article_focus_active,
-            screen._responsive_priority_target,
+        rollback = _ManualLayoutRollback(
+            tokens=frozenset({token}),
+            attempted_layout=layout,
+            attempted_preferred=screen.region_layout,
+            preferred_before=screen.region_layout,
+            article_focus_before=screen._article_focus_active,
+            priority_before=screen._responsive_priority_target,
         )
         screen._manual_layout_rollback = rollback
 
@@ -1399,6 +1450,150 @@ async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
         assert screen.region_layout == newer
 
 
+async def test_failed_manual_expansion_survives_resize_request_supersession(
+    monkeypatch,
+) -> None:
+    """An automatic token must not orphan an in-flight manual rollback."""
+    persisted: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: persisted.append(layout) or True,
+    )
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        if not screen.region_layout.is_collapsed(Region.LEFT_RAIL):
+            screen.action_toggle_left_rail()
+            await _settle(pilot, host)
+        fallback = screen.region_layout
+        persisted.clear()
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        original_factory = workbench._content[Region.LEFT_RAIL]
+        failures = 0
+
+        def fail_while_resize_supersedes():
+            nonlocal failures
+            failures += 1
+            if failures == 1:
+                screen._recompute_effective_layout()
+            if failures <= 2:
+                raise RuntimeError("navigation failed after resize")
+            return original_factory()
+
+        workbench._content[Region.LEFT_RAIL] = fail_while_resize_supersedes
+        screen.query_one("#wl-grip-left_rail", Button).press()
+        await _settle(pilot, host)
+
+        grip = screen.query_one("#wl-grip-left_rail", Button)
+        assert screen.region_layout == fallback
+        assert screen._pending_persist_layout is None
+        assert screen._last_persisted_collapsed == fallback.collapsed
+        assert persisted[-1] == fallback
+        assert workbench.region_layout == screen._effective_region_layout
+        assert not screen.query("#wl-region-left_rail")
+        assert getattr(grip, "expanded") is False
+
+
+@pytest.mark.parametrize("focus_id", ["items-search-input", "items-status-select"])
+async def test_reopening_items_restores_exact_focused_descendant(focus_id) -> None:
+    app = _build_test_app()
+    watchlist_id = _seed(app, items=6)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        focused_child = screen.query_one(f"#{focus_id}")
+        focused_child.focus()
+        await pilot.pause()
+        assert screen.focused is focused_child
+
+        screen._toggle_preferred_region(Region.ITEMS)
+        await _settle(pilot, host)
+        assert not screen.query("#watchlists-items-pane")
+
+        screen.query_one("#wl-grip-items", Button).press()
+        await _settle(pilot, host)
+
+        assert screen.focused is screen.query_one(f"#{focus_id}")
+
+
+async def test_items_anchor_is_abandoned_once_when_query_context_changes(
+    monkeypatch,
+) -> None:
+    app = _build_test_app()
+    watchlist_id = _seed(app, items=6)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        pane.select_and_reveal(pane.displayed_items()[0])
+        await _settle(pilot, host)
+        table = screen.query_one("#items-table", ListView)
+        table.focus()
+        await pilot.pause()
+        screen._toggle_preferred_region(Region.ITEMS)
+        await _settle(pilot, host)
+        assert screen._items_view_anchor_id is not None
+
+        screen._items_search_query = "definitely-not-a-story"
+        screen._reset_items_paging_for_context(loading=True)
+        await screen._load_items(target_page_index=0)
+
+        scheduled: list[float] = []
+        original_set_timer = screen.set_timer
+
+        def recording_timer(delay, callback, *args, **kwargs):
+            scheduled.append(float(delay))
+            return original_set_timer(delay, callback, *args, **kwargs)
+
+        monkeypatch.setattr(screen, "set_timer", recording_timer)
+        screen.query_one("#wl-grip-items", Button).press()
+        await _settle(pilot, host)
+
+        assert screen._items_view_anchor_id is None
+        assert 0.01 not in scheduled
+
+
+async def test_layout_persist_scheduler_and_thread_handoff_failures_are_retryable(
+    monkeypatch,
+) -> None:
+    writes: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: writes.append(layout) or True,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        requested = screen.region_layout.toggle_preferred(Region.LEFT_RAIL)
+        original_run_worker = screen.run_worker
+
+        def fail_schedule(*args, **kwargs):
+            raise RuntimeError("worker scheduling failed")
+
+        monkeypatch.setattr(screen, "run_worker", fail_schedule)
+        screen._schedule_layout_persist(requested)
+        assert screen._layout_persist_draining is False
+        assert screen._pending_persist_layout == requested
+
+        monkeypatch.setattr(screen, "run_worker", original_run_worker)
+        original_call_from_thread = screen.app.call_from_thread
+        monkeypatch.setattr(
+            screen.app,
+            "call_from_thread",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("handoff failed")
+            ),
+        )
+        screen._layout_persist_draining = True
+        screen._persist_layout_worker()
+        assert screen._layout_persist_draining is False
+        assert screen._pending_persist_layout == requested
+
+        monkeypatch.setattr(screen.app, "call_from_thread", original_call_from_thread)
+        screen._schedule_layout_persist(requested)
+        await _settle(pilot, host)
+
+        assert writes[-1] == requested
+        assert screen._pending_persist_layout is None
+        assert screen._layout_persist_draining is False
+
+
 async def test_management_expansion_failure_preserves_parked_feed_preference(
     monkeypatch,
 ) -> None:
@@ -1476,15 +1671,16 @@ async def test_section_factory_failure_rolls_back_mode_and_can_retry(
         reader = screen.query_one("#watchlists-content-pane", ContentPane)
         items = screen.query_one("#watchlists-items-pane")
         before_layout = screen._effective_region_layout
-        original_factory = workbench._content[Region.ITEMS]
+        original_factory = screen._build_detail_pane
         fail = True
 
-        def flaky_factory():
-            if fail and screen.active_section == "sources":
+        def flaky_factory(section=None):
+            requested = section or screen.active_section
+            if fail and requested == "sources":
                 raise RuntimeError("sources centre failed")
-            return original_factory()
+            return original_factory(requested)
 
-        workbench._content[Region.ITEMS] = flaky_factory
+        screen._build_detail_pane = flaky_factory
         persisted.clear()
 
         screen.active_section = "sources"

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -36,7 +36,7 @@ from Tests.UI.test_destination_shells import DestinationHarness
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
 from tldw_chatbook.Subscriptions.briefing_cast import dump_roster
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
-    _ManualLayoutRollback,
+    ManualLayoutRollback,
     WatchlistsCollectionsScreen,
 )
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
@@ -1489,7 +1489,7 @@ async def test_layout_acknowledgements_ignore_stale_tokens_and_clear_current_noo
     async with _open(app) as (screen, pilot, host):
         layout = screen._effective_region_layout
         token = screen._next_layout_request_token()
-        rollback = _ManualLayoutRollback(
+        rollback = ManualLayoutRollback(
             token=token,
             attempted_layout=layout,
             attempted_preferred=screen.region_layout,
@@ -1540,7 +1540,7 @@ async def test_stale_failure_cannot_rollback_rekeyed_manual_intent(
         preferred = screen.region_layout
         effective = screen._effective_region_layout
         token1 = screen._next_layout_request_token()
-        screen._manual_layout_rollback = _ManualLayoutRollback(
+        screen._manual_layout_rollback = ManualLayoutRollback(
             token=token1,
             attempted_layout=effective,
             attempted_preferred=preferred,

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -25,6 +25,7 @@ from datetime import datetime, timedelta, timezone
 import threading
 
 import pytest
+from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.css.query import NoMatches
 from textual.widgets import Button, DataTable, ListView
@@ -36,6 +37,7 @@ from tldw_chatbook.Subscriptions.briefing_cast import dump_roster
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
     WatchlistsCollectionsScreen,
 )
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
@@ -47,6 +49,8 @@ from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
     WatchlistTree,
 )
 from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+    RegionLayoutApplied,
+    RegionLayoutApplyFailed,
     WatchlistsWorkbench,
 )
 
@@ -808,7 +812,8 @@ async def test_collapsing_items_rebuilds_neither_rail_nor_the_reader():
         tree = screen.query_one("#wl-tree", WatchlistTree)
         reader = screen.query_one("#watchlists-content-pane", ContentPane)
         content_region = screen.query_one("#wl-region-content")
-        screen.focused_region = Region.ITEMS
+        screen.query_one("#wl-region-items").focus()
+        await pilot.pause()
         with _RebuildCounter() as counted:
             screen.action_toggle_region()
             await _settle(pilot, host)
@@ -889,7 +894,8 @@ async def test_layout_keys_keep_independent_side_pane_state():
         screen.active_section = "sources"
         await _settle(pilot, host)
         before = screen.region_layout
-        screen.focused_region = Region.ITEMS
+        screen.query_one("#wl-region-items").focus()
+        await pilot.pause()
         screen.action_toggle_region()
         await _settle(pilot, host)
         assert screen.region_layout == before, (
@@ -1034,42 +1040,143 @@ async def test_z_targets_only_collapsible_side_panes() -> None:
         assert screen.region_layout == before
 
 
-async def test_article_focus_preserves_reader_and_article_list_state() -> None:
+async def test_z_ignores_stale_region_after_focus_moves_outside_workbench(
+    monkeypatch,
+) -> None:
+    writes: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: writes.append(layout) or True,
+    )
     app = _build_test_app()
-    watchlist_id = _seed(app, items=4)
+    async with _open(app) as (screen, pilot, host):
+        screen.query_one("#wl-region-items").focus()
+        await pilot.pause()
+        assert screen.focused_region is Region.ITEMS
+
+        outside = screen.query_one("#watchlists-backend-select")
+        outside.disabled = False
+        outside.focus()
+        await pilot.pause()
+        assert screen.focused is outside
+        before = (screen.region_layout, screen._effective_region_layout)
+        writes.clear()
+
+        await pilot.press("z")
+        await _settle(pilot, host)
+
+        assert (screen.region_layout, screen._effective_region_layout) == before
+        assert writes == []
+
+
+async def test_mounted_layout_cycles_preserve_complete_reader_and_list_state() -> None:
+    app = _build_test_app()
+    watchlist_id = _seed(app, items=40)
     async with _open(app, watchlist_id) as (screen, pilot, host):
-        pane = screen.query_one("#watchlists-items-pane")
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         rows = pane.displayed_items()
         assert rows
         pane.select_and_reveal(rows[min(1, len(rows) - 1)])
         await _settle(pilot, host)
+        pane.status_filter = "unread"
+        pane.search_query = "Story"
+        await _settle(pilot, host)
+        reload_timer = getattr(screen, "_items_search_reload_timer", None)
+        if reload_timer is not None:
+            reload_timer.stop()
+            screen._items_search_reload_timer = None
         table = pane.query_one("#items-table", ListView)
+        table.scroll_to(y=6, animate=False)
         table.focus()
         await pilot.pause()
         selected_id = str(pane.selected_item["id"])
         anchor_id = getattr(table.highlighted_child, "item_id_key", None)
         reader = screen.query_one("#watchlists-content-pane", ContentPane)
+        screen._selected_content_item["content"] = "\n".join(
+            f"Reader line {index}" for index in range(120)
+        )
+        reader.item = dict(screen._selected_content_item)
+        await pilot.pause()
+        reader.query_one("#content-body").styles.height = 200
+        await pilot.pause()
+        reader_scroll = reader.query_one("#content-body-scroll", VerticalScroll)
+        reader_scroll.scroll_to(y=8, animate=False)
+        await pilot.pause()
         scope = screen.tree_scope
-        page_index = screen._items_page_index
+        screen._items_page_index = 2
+        pane.page_number = 3
+        page_index = 2
+        list_scroll_y = float(table.scroll_y)
+        reader_scroll_y = float(reader_scroll.scroll_y)
+        assert list_scroll_y > 0
+        assert reader_scroll_y > 0
+
+        async def assert_restored() -> None:
+            restored = screen.query_one(
+                "#watchlists-items-pane", ArticleListPane
+            )
+            restored_table = restored.query_one("#items-table", ListView)
+            assert str(restored.selected_item["id"]) == selected_id
+            assert restored.status_filter == "unread"
+            assert restored.search_query == "Story"
+            assert restored.page_number == 3
+            assert getattr(
+                restored_table.highlighted_child, "item_id_key", None
+            ) == anchor_id
+            assert float(restored_table.scroll_y) == list_scroll_y
+            assert restored_table.has_focus
+            assert screen.tree_scope == scope
+            assert screen._items_page_index == page_index
+            assert screen.query_one(
+                "#watchlists-content-pane", ContentPane
+            ) is reader
+            assert float(
+                reader.query_one("#content-body-scroll", VerticalScroll).scroll_y
+            ) == reader_scroll_y
+
+        for key in ("[", "]"):
+            items_identity = screen.query_one(
+                "#watchlists-items-pane", ArticleListPane
+            )
+            await pilot.press(key)
+            await _settle(pilot, host)
+            assert screen.query_one(
+                "#watchlists-items-pane", ArticleListPane
+            ) is items_identity
+            await pilot.press(key)
+            await _settle(pilot, host)
+            assert screen.query_one(
+                "#watchlists-items-pane", ArticleListPane
+            ) is items_identity
+            await assert_restored()
+
+        await pilot.press("z")
+        await _settle(pilot, host)
+        assert screen.focused is screen.query_one("#wl-grip-items")
+        assert not screen.query("#watchlists-items-pane")
+        await pilot.press("z")
+        await _settle(pilot, host)
+        await assert_restored()
+
+        for _ in range(2):
+            await pilot.resize_terminal(90, 50)
+            await _settle(pilot, host)
+            assert screen.focused is screen.query_one("#wl-grip-items")
+            assert not screen.query("#watchlists-items-pane")
+            await pilot.resize_terminal(180, 50)
+            await _settle(pilot, host)
+            await assert_restored()
 
         screen.action_article_focus()
         await _settle(pilot, host)
         assert screen.focused is screen.query_one("#wl-grip-items")
         assert screen._items_view_anchor_id == anchor_id
         assert screen._items_view_had_focus is True
+        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader
 
         screen.action_article_focus()
         await _settle(pilot, host)
-        await pilot.pause(0.1)
-
-        restored = screen.query_one("#watchlists-items-pane")
-        restored_table = restored.query_one("#items-table", ListView)
-        assert str(restored.selected_item["id"]) == selected_id
-        assert getattr(restored_table.highlighted_child, "item_id_key", None) == anchor_id
-        assert restored_table.has_focus
-        assert screen.tree_scope == scope
-        assert screen._items_page_index == page_index
-        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader
+        await assert_restored()
 
 
 @pytest.mark.parametrize("failure", [False, OSError("disk full")])
@@ -1102,6 +1209,48 @@ async def test_layout_persistence_advances_only_after_current_success(
 
         assert screen._last_persisted_collapsed == screen.region_layout.collapsed
         assert screen._pending_persist_layout is None
+
+
+@pytest.mark.parametrize("failure", [False, OSError("disk full")])
+async def test_manual_focus_exit_retries_pending_preference_without_changing_it(
+    monkeypatch, failure,
+) -> None:
+    writes: list[RegionLayout] = []
+    results = iter([failure, True])
+
+    def save(layout: RegionLayout) -> bool:
+        writes.append(layout)
+        result = next(results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        save,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        screen.action_toggle_right_rail()
+        await _settle(pilot, host)
+        pending = screen.region_layout
+        assert screen._pending_persist_layout == pending
+        assert len(writes) == 1
+
+        screen.action_article_focus()
+        await _settle(pilot, host)
+        assert len(writes) == 1, "Article Focus itself is never a retry gesture"
+        assert not pending.is_collapsed(Region.LEFT_RAIL)
+
+        screen.query_one("#wl-grip-left_rail", Button).press()
+        await _settle(pilot, host)
+
+        assert screen.region_layout == pending
+        assert screen._article_focus_active is False
+        assert writes == [pending, pending]
+        assert screen._last_persisted_collapsed == pending.collapsed
+        assert screen._pending_persist_layout is None
+        assert screen._manual_layout_rollback is None
 
 
 async def test_layout_persistence_rapid_toggles_drain_latest_request(
@@ -1140,6 +1289,47 @@ async def test_layout_persistence_rapid_toggles_drain_latest_request(
         assert screen._last_persisted_collapsed == newest.collapsed
         assert screen._pending_persist_layout is None
         assert screen._layout_persist_draining is False
+
+
+async def test_layout_acknowledgements_ignore_stale_tokens_and_clear_current_noop() -> None:
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        layout = screen._effective_region_layout
+        token = screen._next_layout_request_token()
+        rollback = (
+            token,
+            layout,
+            screen.region_layout,
+            screen._article_focus_active,
+            screen._responsive_priority_target,
+        )
+        screen._manual_layout_rollback = rollback
+
+        screen.post_message(
+            RegionLayoutApplyFailed(
+                token=token - 1,
+                attempted=layout,
+                fallback=layout.toggle_preferred(Region.LEFT_RAIL),
+            )
+        )
+        screen.post_message(
+            RegionLayoutApplied(
+                token=token - 1,
+                previous=layout,
+                layout=layout,
+            )
+        )
+        await _settle(pilot, host)
+
+        assert screen._effective_region_layout == layout
+        assert screen._manual_layout_rollback == rollback
+
+        screen.post_message(
+            RegionLayoutApplied(token=token, previous=layout, layout=layout)
+        )
+        await _settle(pilot, host)
+
+        assert screen._manual_layout_rollback is None
 
 
 async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
@@ -1200,6 +1390,7 @@ async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
         newer = screen.region_layout
         workbench.post_message(
             RegionLayoutApplyFailed(
+                token=screen._current_layout_request_token - 1,
                 attempted=fallback,
                 fallback=fallback.toggle_preferred(Region.RIGHT_RAIL),
             )
@@ -1268,3 +1459,50 @@ async def test_management_expansion_failure_preserves_parked_feed_preference(
         assert workbench.region_layout == screen._effective_region_layout
         assert getattr(grip, "expanded") is True
         assert screen.query("#wl-region-left_rail")
+
+
+async def test_section_factory_failure_rolls_back_mode_and_can_retry(
+    monkeypatch,
+) -> None:
+    persisted: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: persisted.append(layout) or True,
+    )
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        workbench = screen.query_one(WatchlistsWorkbench)
+        reader = screen.query_one("#watchlists-content-pane", ContentPane)
+        items = screen.query_one("#watchlists-items-pane")
+        before_layout = screen._effective_region_layout
+        original_factory = workbench._content[Region.ITEMS]
+        fail = True
+
+        def flaky_factory():
+            if fail and screen.active_section == "sources":
+                raise RuntimeError("sources centre failed")
+            return original_factory()
+
+        workbench._content[Region.ITEMS] = flaky_factory
+        persisted.clear()
+
+        screen.active_section = "sources"
+        await _settle(pilot, host)
+
+        assert screen.active_section == "items"
+        assert screen._effective_region_layout == before_layout
+        assert workbench.read_mode is True
+        assert workbench.region_layout == before_layout
+        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader
+        assert screen.query_one("#watchlists-items-pane") is items
+        assert persisted == []
+
+        fail = False
+        screen.active_section = "sources"
+        await _settle(pilot, host)
+
+        assert screen.active_section == "sources"
+        assert workbench.read_mode is False
+        assert not screen.query("#watchlists-content-pane")
+        assert persisted == []

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -27,7 +27,7 @@ import threading
 import pytest
 from textual.widget import Widget
 from textual.css.query import NoMatches
-from textual.widgets import Button, DataTable
+from textual.widgets import Button, DataTable, ListView
 
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_destination_shells import DestinationHarness
@@ -45,6 +45,9 @@ from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
     TreeScope,
     TreeScopeChanged,
     WatchlistTree,
+)
+from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+    WatchlistsWorkbench,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -915,6 +918,230 @@ async def test_a_collapsed_region_still_expands_from_its_grip_button() -> None:
         assert screen.query("#wl-tree"), "and rebuild its content"
 
 
+async def test_resize_derives_effective_layout_without_persisting_preference(
+    monkeypatch,
+) -> None:
+    writes: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: writes.append(layout) or True,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        preferred = screen.region_layout
+        writes.clear()
+
+        await pilot.resize_terminal(90, 50)
+        await _settle(pilot, host)
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        assert screen.region_layout == preferred
+        assert screen._effective_region_layout != preferred
+        assert workbench.region_layout == screen._effective_region_layout
+        assert writes == []
+
+
+async def test_article_focus_is_transient_and_restores_exact_preference() -> None:
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        screen.action_toggle_left_rail()
+        await _settle(pilot, host)
+        preferred = screen.region_layout
+
+        await pilot.press("Z")
+        await _settle(pilot, host)
+
+        assert screen._article_focus_active is True
+        assert screen.region_layout == preferred
+        assert screen._effective_region_layout.collapsed == frozenset(
+            {Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}
+        )
+
+        await pilot.press("Z")
+        await _settle(pilot, host)
+
+        assert screen._article_focus_active is False
+        assert screen.region_layout == preferred
+        assert screen._effective_region_layout == preferred
+
+
+async def test_article_focus_is_refused_off_read_without_layout_change() -> None:
+    app = _build_test_app()
+    async with _open(app, section="sources") as (screen, pilot, host):
+        before = (screen.region_layout, screen._effective_region_layout)
+
+        await pilot.press("Z")
+        await _settle(pilot, host)
+
+        assert screen._article_focus_active is False
+        assert (screen.region_layout, screen._effective_region_layout) == before
+
+
+async def test_responsive_grip_open_protects_preferred_open_pane(
+    monkeypatch,
+) -> None:
+    writes: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: writes.append(layout) or True,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        await pilot.resize_terminal(114, 50)
+        await _settle(pilot, host)
+        assert screen._effective_region_layout.is_collapsed(Region.RIGHT_RAIL)
+        assert not screen.region_layout.is_collapsed(Region.RIGHT_RAIL)
+        writes.clear()
+
+        screen.query_one("#wl-grip-right_rail", Button).press()
+        await _settle(pilot, host)
+
+        assert screen._responsive_priority_target is Region.RIGHT_RAIL
+        assert not screen.region_layout.is_collapsed(Region.RIGHT_RAIL)
+        assert not screen._effective_region_layout.is_collapsed(Region.RIGHT_RAIL)
+        assert writes == []
+
+
+async def test_manual_grip_during_article_focus_exits_before_opening() -> None:
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        preferred = screen.region_layout
+        screen.action_article_focus()
+        await _settle(pilot, host)
+
+        screen.query_one("#wl-grip-left_rail", Button).press()
+        await _settle(pilot, host)
+
+        assert screen._article_focus_active is False
+        assert screen.region_layout == preferred
+        assert not screen._effective_region_layout.is_collapsed(Region.LEFT_RAIL)
+
+
+async def test_z_targets_only_collapsible_side_panes() -> None:
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        before = screen.region_layout
+        screen.query_one("#wl-region-content").focus()
+        await pilot.pause()
+        screen.action_toggle_region()
+        assert screen.region_layout == before
+
+        screen.active_section = "sources"
+        await _settle(pilot, host)
+        screen.query_one("#wl-region-items").focus()
+        await pilot.pause()
+        screen.action_toggle_region()
+        assert screen.region_layout == before
+
+
+async def test_article_focus_preserves_reader_and_article_list_state() -> None:
+    app = _build_test_app()
+    watchlist_id = _seed(app, items=4)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        pane = screen.query_one("#watchlists-items-pane")
+        rows = pane.displayed_items()
+        assert rows
+        pane.select_and_reveal(rows[min(1, len(rows) - 1)])
+        await _settle(pilot, host)
+        table = pane.query_one("#items-table", ListView)
+        table.focus()
+        await pilot.pause()
+        selected_id = str(pane.selected_item["id"])
+        anchor_id = getattr(table.highlighted_child, "item_id_key", None)
+        reader = screen.query_one("#watchlists-content-pane", ContentPane)
+        scope = screen.tree_scope
+        page_index = screen._items_page_index
+
+        screen.action_article_focus()
+        await _settle(pilot, host)
+        assert screen.focused is screen.query_one("#wl-grip-items")
+        assert screen._items_view_anchor_id == anchor_id
+        assert screen._items_view_had_focus is True
+
+        screen.action_article_focus()
+        await _settle(pilot, host)
+        await pilot.pause(0.1)
+
+        restored = screen.query_one("#watchlists-items-pane")
+        restored_table = restored.query_one("#items-table", ListView)
+        assert str(restored.selected_item["id"]) == selected_id
+        assert getattr(restored_table.highlighted_child, "item_id_key", None) == anchor_id
+        assert restored_table.has_focus
+        assert screen.tree_scope == scope
+        assert screen._items_page_index == page_index
+        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader
+
+
+@pytest.mark.parametrize("failure", [False, OSError("disk full")])
+async def test_layout_persistence_advances_only_after_current_success(
+    monkeypatch, failure,
+) -> None:
+    results = iter([failure, True])
+
+    def save(_layout: RegionLayout) -> bool:
+        result = next(results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        save,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        baseline = screen._last_persisted_collapsed
+        screen.action_toggle_left_rail()
+        await _settle(pilot, host)
+
+        assert screen._last_persisted_collapsed == baseline
+        assert screen._pending_persist_layout == screen.region_layout
+
+        screen.action_toggle_right_rail()
+        await _settle(pilot, host)
+
+        assert screen._last_persisted_collapsed == screen.region_layout.collapsed
+        assert screen._pending_persist_layout is None
+
+
+async def test_layout_persistence_rapid_toggles_drain_latest_request(
+    monkeypatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    writes: list[RegionLayout] = []
+
+    def save(layout: RegionLayout) -> bool:
+        writes.append(layout)
+        if len(writes) == 1:
+            started.set()
+            assert release.wait(2)
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        save,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        screen.action_toggle_left_rail()
+        for _ in range(20):
+            if started.is_set():
+                break
+            await pilot.pause(0.01)
+        assert started.is_set()
+
+        screen.action_toggle_right_rail()
+        newest = screen.region_layout
+        release.set()
+        await _settle(pilot, host)
+
+        assert writes[-1] == newest
+        assert screen._last_persisted_collapsed == newest.collapsed
+        assert screen._pending_persist_layout is None
+        assert screen._layout_persist_draining is False
+
+
 async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
     monkeypatch,
 ) -> None:
@@ -927,7 +1154,7 @@ async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
     persisted: list[RegionLayout] = []
     monkeypatch.setattr(
         "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
-        persisted.append,
+        lambda layout: persisted.append(layout) or True,
     )
     app = _build_test_app()
     watchlist_id = _seed(app)
@@ -953,14 +1180,11 @@ async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
         await _settle(pilot, host)
 
         assert screen.region_layout == fallback
-        assert workbench.region_layout == screen._rendered_region_layout()
+        assert workbench.region_layout == screen._effective_region_layout
         assert getattr(grip, "expanded") is False
         assert not screen.query("#wl-region-left_rail")
-        assert screen._pending_persist_layout == fallback
-        assert (
-            screen._last_persisted_collapsed
-            == fallback.collapsed_for_persistence()
-        )
+        assert screen._pending_persist_layout is None
+        assert screen._last_persisted_collapsed == fallback.collapsed
         assert persisted
         assert persisted[-1] == fallback
 
@@ -969,7 +1193,7 @@ async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
         await _settle(pilot, host)
 
         assert not screen.region_layout.is_collapsed(Region.LEFT_RAIL)
-        assert workbench.region_layout == screen._rendered_region_layout()
+        assert workbench.region_layout == screen._effective_region_layout
         assert getattr(grip, "expanded") is True
         assert screen.query("#wl-region-left_rail")
 
@@ -977,7 +1201,7 @@ async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
         workbench.post_message(
             RegionLayoutApplyFailed(
                 attempted=fallback,
-                fallback=fallback.toggle(Region.RIGHT_RAIL),
+                fallback=fallback.toggle_preferred(Region.RIGHT_RAIL),
             )
         )
         await _settle(pilot, host)
@@ -995,7 +1219,7 @@ async def test_management_expansion_failure_preserves_parked_feed_preference(
     persisted: list[RegionLayout] = []
     monkeypatch.setattr(
         "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
-        persisted.append,
+        lambda layout: persisted.append(layout) or True,
     )
     app = _build_test_app()
     watchlist_id = _seed(app)
@@ -1027,14 +1251,11 @@ async def test_management_expansion_failure_preserves_parked_feed_preference(
 
         assert screen.region_layout == fallback
         assert screen.region_layout.is_collapsed(Region.ITEMS)
-        assert workbench.region_layout == screen._rendered_region_layout()
+        assert workbench.region_layout == screen._effective_region_layout
         assert getattr(grip, "expanded") is False
         assert not screen.query("#wl-region-left_rail")
-        assert screen._pending_persist_layout == fallback
-        assert (
-            screen._last_persisted_collapsed
-            == fallback.collapsed_for_persistence()
-        )
+        assert screen._pending_persist_layout is None
+        assert screen._last_persisted_collapsed == fallback.collapsed
         assert persisted
         assert persisted[-1] == fallback
 
@@ -1044,6 +1265,6 @@ async def test_management_expansion_failure_preserves_parked_feed_preference(
 
         assert screen.region_layout.is_collapsed(Region.ITEMS)
         assert not screen.region_layout.is_collapsed(Region.LEFT_RAIL)
-        assert workbench.region_layout == screen._rendered_region_layout()
+        assert workbench.region_layout == screen._effective_region_layout
         assert getattr(grip, "expanded") is True
         assert screen.query("#wl-region-left_rail")

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -43,6 +43,7 @@ from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
+from tldw_chatbook.UI.Watchlists_Modules.pane_grip import WatchlistsPaneGrip
 from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
 from tldw_chatbook.UI.Watchlists_Modules.rules_pane import RulesPane
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
@@ -251,6 +252,77 @@ async def test_a_section_switch_leaves_both_rails_standing():
         assert (
             counted.recomposes["InspectorPane#watchlists-entity-inspector"] == 0
         ), counted.report()
+
+
+async def test_inspector_preference_and_grip_action_are_shared_across_all_tabs(
+    monkeypatch,
+) -> None:
+    """One Inspector preference governs Read and every management tab."""
+    writes: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.load_region_layout",
+        lambda: RegionLayout(collapsed=frozenset({Region.RIGHT_RAIL})),
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: writes.append(layout) or True,
+    )
+    app = _build_test_app()
+    pane_ids = {
+        "sources": "watchlists-sources-pane",
+        "runs": "watchlists-runs-pane",
+        "rules": "watchlists-rules-pane",
+        "notifications": "watchlists-notifications-pane",
+        "artifacts": "watchlists-artifacts-pane",
+        "overview": "watchlists-overview-pane",
+    }
+
+    async with _open(app) as (screen, pilot, host):
+        collapsed_grip = screen.query_one(
+            "#wl-grip-right_rail", WatchlistsPaneGrip
+        )
+        assert str(collapsed_grip.label) == "<---"
+        assert collapsed_grip.tooltip == "Expand Inspector"
+
+        collapsed_grip.press()
+        await _settle(pilot, host)
+        assert writes == [RegionLayout()]
+
+        for section, pane_id in pane_ids.items():
+            screen.active_section = section
+            await _settle(pilot, host)
+
+            assert screen.region_layout == RegionLayout(), section
+            grip = screen.query_one("#wl-grip-right_rail", WatchlistsPaneGrip)
+            assert grip.expanded is True, section
+            assert str(grip.label) == "--->", section
+            assert grip.tooltip == "Collapse Inspector", section
+            assert screen.query(f"#{pane_id}"), section
+            assert screen.query("#wl-region-items"), section
+            assert not screen.query("#watchlists-items-pane"), section
+            assert not screen.query("#wl-grip-items"), section
+            assert writes == [RegionLayout()], (
+                f"visiting {section} must not persist an unchanged preference"
+            )
+
+        screen.query_one("#wl-grip-right_rail", WatchlistsPaneGrip).press()
+        await _settle(pilot, host)
+        expected_collapsed = RegionLayout(
+            collapsed=frozenset({Region.RIGHT_RAIL})
+        )
+        assert writes == [RegionLayout(), expected_collapsed]
+
+        screen.active_section = "items"
+        await _settle(pilot, host)
+        grip = screen.query_one("#wl-grip-right_rail", WatchlistsPaneGrip)
+        assert screen.region_layout == expected_collapsed
+        assert grip.expanded is False
+        assert str(grip.label) == "<---"
+        assert grip.tooltip == "Expand Inspector"
+        assert not screen.query("#wl-region-right_rail")
+        assert screen.query("#watchlists-items-pane")
+        assert screen.query("#wl-grip-items")
+        assert writes == [RegionLayout(), expected_collapsed]
 
 
 async def test_a_section_switch_builds_the_sections_pane_exactly_once():
@@ -468,6 +540,13 @@ async def test_a_section_switch_moves_the_tab_strip_and_the_backend_control():
     watchlist_id = _seed(app, briefings=1)
     async with _open(app, watchlist_id) as (screen, pilot, host):
         backend_select = screen.query_one("#watchlists-backend-select")
+        assert backend_select.disabled is True, (
+            "Read is local-only, so its truthful backend selector is locked"
+        )
+
+        screen.active_section = "sources"
+        await _settle(pilot, host)
+        assert screen.query_one("#watchlists-backend-select") is backend_select
         assert backend_select.disabled is False
 
         screen.active_section = "artifacts"
@@ -526,11 +605,11 @@ async def test_a_section_switch_moves_the_tab_strip_and_the_backend_control():
             "wl-grip-right_rail",
             "wl-region-right_rail",
         ]
-        assert backend_select.disabled is False, (
-            "the backend picker must be re-enabled off a local-only section"
+        assert backend_select.disabled is True, (
+            "Read is local-only, so its backend picker must remain disabled"
         )
-        assert not screen.query("#watchlists-backend-label"), (
-            "and the local-only explanation must go away with it"
+        assert screen.query("#watchlists-backend-label"), (
+            "Read must keep its local-only explanation beside the selector"
         )
 
 

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -934,3 +934,68 @@ async def test_failed_expansion_rolls_back_screen_and_persisted_preference(
         )
         await _settle(pilot, host)
         assert screen.region_layout == newer
+
+
+async def test_management_expansion_failure_preserves_parked_feed_preference(
+    monkeypatch,
+) -> None:
+    """Rendered rollback merges into, rather than replaces, preferred state."""
+    from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+        WatchlistsWorkbench,
+    )
+
+    persisted: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        persisted.append,
+    )
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id, section="sources") as (
+        screen,
+        pilot,
+        host,
+    ):
+        fallback = RegionLayout(
+            collapsed=frozenset({Region.LEFT_RAIL, Region.ITEMS})
+        )
+        screen._apply_layout(fallback)
+        await _settle(pilot, host)
+        persisted.clear()
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        grip = screen.query_one("#wl-grip-left_rail", Button)
+        original_factory = workbench._content[Region.LEFT_RAIL]
+        fail_factory = True
+
+        def flaky_factory():
+            if fail_factory:
+                raise RuntimeError("management navigation failed")
+            return original_factory()
+
+        workbench._content[Region.LEFT_RAIL] = flaky_factory
+        grip.press()
+        await _settle(pilot, host)
+
+        assert screen.region_layout == fallback
+        assert screen.region_layout.is_collapsed(Region.ITEMS)
+        assert workbench.region_layout == screen._rendered_region_layout()
+        assert getattr(grip, "expanded") is False
+        assert not screen.query("#wl-region-left_rail")
+        assert screen._pending_persist_layout == fallback
+        assert (
+            screen._last_persisted_collapsed
+            == fallback.collapsed_for_persistence()
+        )
+        assert persisted
+        assert persisted[-1] == fallback
+
+        fail_factory = False
+        grip.press()
+        await _settle(pilot, host)
+
+        assert screen.region_layout.is_collapsed(Region.ITEMS)
+        assert not screen.region_layout.is_collapsed(Region.LEFT_RAIL)
+        assert workbench.region_layout == screen._rendered_region_layout()
+        assert getattr(grip, "expanded") is True
+        assert screen.query("#wl-region-left_rail")

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -1341,13 +1341,77 @@ async def test_layout_persistence_rapid_toggles_drain_latest_request(
         assert screen._layout_persist_draining is False
 
 
+async def test_layout_persist_disarm_is_atomic_with_a_newer_generation(
+    monkeypatch,
+) -> None:
+    """A request in the old decision/finally gap must start or be drained."""
+    gap_open = threading.Event()
+    release_exit = threading.Event()
+    writes: list[RegionLayout] = []
+
+    class GapLock:
+        """Expose the old worker gap after its return decision releases lock."""
+
+        def __init__(self) -> None:
+            self._lock = threading.Lock()
+            self._worker_exits = 0
+
+        def __enter__(self):
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, *_exc_info) -> None:
+            self._lock.release()
+            if threading.current_thread() is threading.main_thread():
+                return
+            self._worker_exits += 1
+            if self._worker_exits == 2:
+                gap_open.set()
+                assert release_exit.wait(2)
+
+    def save(layout: RegionLayout) -> bool:
+        writes.append(layout)
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        save,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        screen._layout_persist_lock = GapLock()
+        screen.action_toggle_left_rail()
+        first = screen.region_layout
+
+        try:
+            assert await asyncio.to_thread(gap_open.wait, 2)
+            screen.action_toggle_right_rail()
+            newest = screen.region_layout
+        finally:
+            release_exit.set()
+
+        for _ in range(100):
+            if (
+                writes[-1:] == [newest]
+                and screen._pending_persist_layout is None
+                and not screen._layout_persist_draining
+            ):
+                break
+            await pilot.pause(0.01)
+
+        assert writes == [first, newest]
+        assert screen._last_persisted_collapsed == newest.collapsed
+        assert screen._pending_persist_layout is None
+        assert screen._layout_persist_draining is False
+
+
 async def test_layout_acknowledgements_ignore_stale_tokens_and_clear_current_noop() -> None:
     app = _build_test_app()
     async with _open(app) as (screen, pilot, host):
         layout = screen._effective_region_layout
         token = screen._next_layout_request_token()
         rollback = _ManualLayoutRollback(
-            tokens=frozenset({token}),
+            token=token,
             attempted_layout=layout,
             attempted_preferred=screen.region_layout,
             preferred_before=screen.region_layout,
@@ -1377,6 +1441,57 @@ async def test_layout_acknowledgements_ignore_stale_tokens_and_clear_current_noo
 
         screen.post_message(
             RegionLayoutApplied(token=token, previous=layout, layout=layout)
+        )
+        await _settle(pilot, host)
+
+        assert screen._manual_layout_rollback is None
+
+
+async def test_stale_failure_cannot_rollback_rekeyed_manual_intent(
+    monkeypatch,
+) -> None:
+    """Only the latest correlated token owns a manual rollback."""
+    persisted: list[RegionLayout] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: persisted.append(layout) or True,
+    )
+    app = _build_test_app()
+    async with _open(app) as (screen, pilot, host):
+        preferred = screen.region_layout
+        effective = screen._effective_region_layout
+        token1 = screen._next_layout_request_token()
+        screen._manual_layout_rollback = _ManualLayoutRollback(
+            token=token1,
+            attempted_layout=effective,
+            attempted_preferred=preferred,
+            preferred_before=preferred.toggle_preferred(Region.LEFT_RAIL),
+            article_focus_before=screen._article_focus_active,
+            priority_before=screen._responsive_priority_target,
+        )
+
+        token2 = screen._next_layout_request_token()
+        screen.post_message(
+            RegionLayoutApplyFailed(
+                token=token1,
+                attempted=effective,
+                fallback=effective.toggle_preferred(Region.LEFT_RAIL),
+            )
+        )
+        await _settle(pilot, host)
+
+        assert screen._current_layout_request_token == token2
+        assert screen.region_layout == preferred
+        assert screen._effective_region_layout == effective
+        assert persisted == []
+        assert screen._manual_layout_rollback is not None
+
+        screen.post_message(
+            RegionLayoutApplied(
+                token=token2,
+                previous=effective,
+                layout=effective,
+            )
         )
         await _settle(pilot, host)
 

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from collections import Counter
 from datetime import datetime, timedelta, timezone
+import threading
 
 import pytest
 from textual.widget import Widget
@@ -706,6 +707,53 @@ async def test_a_script_selection_never_recomposes_the_briefing_detail_region():
 # --------------------------------------------------------------------------
 # AC#3 -- a layout key rebuilds only the toggled region
 # --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("failure", ["false", "exception"])
+async def test_browser_worker_failure_does_not_rebuild_reader(
+    monkeypatch, failure: str
+):
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        reader = screen.query_one("#watchlists-content-pane", ContentPane)
+        item = {
+            "url": "https://example.com/story",
+            "title": "Reader stays put",
+            "content_kind": "article",
+            "content": "body",
+        }
+        reader.item = item
+        await _settle(pilot, host)
+        ui_thread = threading.get_ident()
+        notifications: list[tuple[int, str, dict]] = []
+        app.notify = lambda message, **kwargs: notifications.append(
+            (threading.get_ident(), message, kwargs)
+        )
+
+        def fail_to_open(_url: str) -> bool:
+            if failure == "exception":
+                raise RuntimeError("browser unavailable")
+            return False
+
+        monkeypatch.setattr("webbrowser.open", fail_to_open)
+        synchronous_errors: list[Exception] = []
+        with _RebuildCounter() as counted:
+            try:
+                screen._open_item_in_browser(item)
+            except Exception as exc:
+                synchronous_errors.append(exc)
+            await _settle(pilot, host)
+
+        assert synchronous_errors == []
+        assert notifications
+        assert notifications[-1][0] == ui_thread
+        assert notifications[-1][2].get("severity") == "error"
+        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader
+        assert reader.item is item
+        assert counted.recomposes["ContentPane#watchlists-content-pane"] == 0, (
+            counted.report()
+        )
 
 
 async def test_a_rail_toggle_rebuilds_only_the_toggled_region():

--- a/Tests/Watchlists/test_watchlists_sources_pane.py
+++ b/Tests/Watchlists/test_watchlists_sources_pane.py
@@ -3,7 +3,7 @@
 import pytest
 from rich.style import Style
 from textual.app import App, ComposeResult
-from textual.widgets import Button, DataTable, Input, Select, Static, Switch, TextArea
+from textual.widgets import Button, DataTable, Input, Select, Switch, TextArea
 
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Subscriptions import LocalWatchlistsService
@@ -376,7 +376,7 @@ def sample_sources():
 @pytest.mark.asyncio
 async def test_sources_pane_renders_table_and_toolbar():
     app = SourcesPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(SourcesPane)
         assert pane.query_one("#sources-search-input", Input)
         assert pane.query_one("#sources-type-select", Select)
@@ -390,7 +390,7 @@ async def test_the_last_checked_column_uses_the_check_vocabulary():
     column was the one holdout still saying "Last scraped" while every
     button/toast elsewhere on this screen says "check"/"Check now"."""
     app = SourcesPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(SourcesPane)
         table = pane.query_one("#sources-table", DataTable)
         columns = [str(col.label) for col in table.columns.values()]
@@ -408,7 +408,7 @@ async def test_toolbar_filter_selects_each_carry_a_visible_label():
     each Select instead carries a `tooltip` naming what it filters -- the
     one mechanism here that costs no column."""
     app = SourcesPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(SourcesPane)
 
         def tooltip_mentions(select_id: str, *keywords: str) -> None:
@@ -541,7 +541,7 @@ async def test_sources_pane_new_source_form_carries_selected_check_frequency():
 @pytest.mark.asyncio
 async def test_sources_pane_action_buttons_exist():
     app = SourcesPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(SourcesPane)
         assert pane.query_one("#sources-preview-button", Button)
         assert pane.query_one("#sources-check-now-button", Button)
@@ -552,7 +552,7 @@ async def test_sources_pane_action_buttons_exist():
 @pytest.mark.asyncio
 async def test_sources_pane_preview_and_check_now_disabled_without_selection():
     app = SourcesPaneHarness()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(120, 40)):
         pane = app.query_one(SourcesPane)
         preview = pane.query_one("#sources-preview-button", Button)
         check_now = pane.query_one("#sources-check-now-button", Button)

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -765,9 +765,13 @@ async def test_apply_section_view_rebuilds_only_required_centres() -> None:
 @pytest.mark.asyncio
 async def test_mode_switch_factory_failure_preserves_previous_read_view() -> None:
     fail_items = False
+    observed_read_classes: list[bool] = []
 
     def items_factory() -> Label:
         if fail_items:
+            observed_read_classes.append(
+                app.query_one(WatchlistsWorkbench).has_class("watchlists-read-mode")
+            )
             raise RuntimeError("management centre failed")
         return Label("feed items", id="items-content")
 
@@ -807,6 +811,10 @@ async def test_mode_switch_factory_failure_preserves_previous_read_view() -> Non
         assert app.query_one("#items-content") is items
         assert app.query_one("#reader-content") is reader
         assert app.is_running
+        assert observed_read_classes == [False], (
+            "the target mode class must be active while its body is reconciled, "
+            "then rolled back with the previous view when the factory fails"
+        )
 
         fail_items = False
         applied = await workbench.apply_section_view(

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import inspect
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from textual.app import App, ComposeResult
@@ -11,6 +12,9 @@ from textual.containers import Horizontal, HorizontalScroll, Vertical, VerticalS
 from textual.widget import Widget
 from textual.widgets import Button, Label, Static
 
+from tldw_chatbook.UI.Watchlists_Modules import (
+    watchlists_workbench as workbench_module,
+)
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
 from tldw_chatbook.UI.Watchlists_Modules.pane_grip import (
@@ -467,8 +471,18 @@ async def test_expanding_inspector_mounts_body_after_permanent_grip() -> None:
 
 
 @pytest.mark.asyncio
-async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
+async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom(
+    monkeypatch,
+) -> None:
     fail_rail = True
+    logged: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        workbench_module.logger,
+        "bind",
+        lambda **context: SimpleNamespace(
+            exception=lambda message: logged.append((message, context))
+        ),
+    )
 
     def rail_factory() -> Widget:
         if fail_rail:
@@ -508,6 +522,12 @@ async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
         assert app.query_one("#wl-region-content") is reader
         assert not workbench.has_class("watchlists-has-expanded-side-pane")
         assert app.is_running
+        assert logged == [
+            (
+                "Watchlists pane expansion factory failed",
+                {"token": 1, "read_mode": True, "regions": ("left_rail",)},
+            )
+        ]
 
         fail_rail = False
         workbench.request_region_layout(expanded_left, token=2)
@@ -515,6 +535,37 @@ async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
         assert app.query("#wl-region-left_rail")
         assert grip.expanded is True
         assert workbench.has_class("watchlists-has-expanded-side-pane")
+
+
+@pytest.mark.asyncio
+async def test_expansion_mount_failure_logs_request_context(monkeypatch) -> None:
+    collapsed = RegionLayout(collapsed=frozenset({Region.LEFT_RAIL}))
+    logged: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        workbench_module.logger,
+        "bind",
+        lambda **context: SimpleNamespace(
+            exception=lambda message: logged.append((message, context))
+        ),
+    )
+    app = _WorkbenchApp(collapsed)
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+
+        async def fail_mount(*_widgets, **_kwargs) -> None:
+            raise RuntimeError("mount failed")
+
+        monkeypatch.setattr(app.query_one("#wl-workbench-body"), "mount", fail_mount)
+        workbench.request_region_layout(RegionLayout(), token=9)
+        await pilot.pause()
+
+        assert workbench.region_layout == collapsed
+        assert logged == [
+            (
+                "Watchlists pane expansion mount failed",
+                {"token": 9, "read_mode": True, "regions": ("left_rail",)},
+            )
+        ]
 
 
 @pytest.mark.asyncio
@@ -763,9 +814,19 @@ async def test_apply_section_view_rebuilds_only_required_centres() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mode_switch_factory_failure_preserves_previous_read_view() -> None:
+async def test_mode_switch_factory_failure_preserves_previous_read_view(
+    monkeypatch,
+) -> None:
     fail_items = False
     observed_read_classes: list[bool] = []
+    logged: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        workbench_module.logger,
+        "bind",
+        lambda **context: SimpleNamespace(
+            exception=lambda message: logged.append((message, context))
+        ),
+    )
 
     def items_factory() -> Label:
         if fail_items:
@@ -815,6 +876,12 @@ async def test_mode_switch_factory_failure_preserves_previous_read_view() -> Non
             "the target mode class must be active while its body is reconciled, "
             "then rolled back with the previous view when the factory fails"
         )
+        assert logged == [
+            (
+                "Watchlists section-view factory failed",
+                {"token": 7, "read_mode": False, "regions": ("items",)},
+            )
+        ]
 
         fail_items = False
         applied = await workbench.apply_section_view(

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, HorizontalScroll, Vertical, VerticalScroll
+from textual.widget import Widget
 from textual.widgets import Button, Label, Static
 
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
@@ -217,6 +218,47 @@ async def test_expanding_inspector_mounts_body_after_permanent_grip() -> None:
 
 
 @pytest.mark.asyncio
+async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
+    fail_rail = True
+
+    def rail_factory() -> Widget:
+        if fail_rail:
+            raise RuntimeError("rail build failed")
+        return Label("navigation")
+
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})),
+                content={Region.LEFT_RAIL: rail_factory},
+                read_mode=True,
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        grip = app.query_one("#wl-grip-left_rail", WatchlistsPaneGrip)
+        reader = app.query_one("#wl-region-content")
+
+        workbench.region_layout = RegionLayout()
+        await pilot.pause()
+
+        assert workbench.region_layout.is_collapsed(Region.LEFT_RAIL)
+        assert app.query_one("#wl-grip-left_rail") is grip
+        assert grip.expanded is False
+        assert not app.query("#wl-region-left_rail")
+        assert app.query_one("#wl-region-content") is reader
+        assert app.is_running
+
+        fail_rail = False
+        workbench.region_layout = RegionLayout()
+        await pilot.pause()
+        assert app.query("#wl-region-left_rail")
+        assert grip.expanded is True
+
+
+@pytest.mark.asyncio
 async def test_grip_activation_uses_shared_region_toggled_message() -> None:
     app = _WorkbenchApp(RegionLayout())
     async with app.run_test() as pilot:
@@ -412,6 +454,82 @@ async def test_apply_section_view_rebuilds_only_required_centres() -> None:
         assert app.query("#wl-grip-items")
         assert app.query_one("#content-content") is not reader
         assert calls == {"items": 3, "content": 2}
+
+
+@pytest.mark.asyncio
+async def test_mode_switch_factory_failure_preserves_previous_read_view() -> None:
+    fail_items = False
+
+    def items_factory() -> Label:
+        if fail_items:
+            raise RuntimeError("management centre failed")
+        return Label("feed items", id="items-content")
+
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(),
+                content={
+                    Region.ITEMS: items_factory,
+                    Region.CONTENT: lambda: Label("reader", id="reader-content"),
+                },
+                read_mode=True,
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        body = app.query_one("#wl-workbench-body", Horizontal)
+        previous_ids = _direct_child_ids(body)
+        items = app.query_one("#items-content")
+        reader = app.query_one("#reader-content")
+        fail_items = True
+
+        with pytest.raises(RuntimeError, match="management centre failed"):
+            await workbench.apply_section_view(
+                read_mode=False,
+                layout=RegionLayout(),
+                rebuild_regions=(Region.ITEMS,),
+            )
+        await pilot.pause()
+
+        assert workbench.read_mode is True
+        assert workbench.has_class("watchlists-read-mode")
+        assert _direct_child_ids(body) == previous_ids
+        assert app.query_one("#items-content") is items
+        assert app.query_one("#reader-content") is reader
+        assert app.is_running
+
+        fail_items = False
+        await workbench.apply_section_view(
+            read_mode=False,
+            layout=RegionLayout(),
+            rebuild_regions=(Region.ITEMS,),
+        )
+        assert workbench.read_mode is False
+        assert not workbench.has_class("watchlists-read-mode")
+        assert not app.query("#reader-content")
+
+
+@pytest.mark.asyncio
+async def test_read_mode_class_tracks_incremental_mode_switches() -> None:
+    app = _WorkbenchApp(RegionLayout(), read_mode=True)
+    async with app.run_test():
+        workbench = app.query_one(WatchlistsWorkbench)
+        assert workbench.has_class("watchlists-read-mode")
+
+        await workbench.apply_section_view(
+            read_mode=False,
+            layout=RegionLayout(),
+        )
+        assert not workbench.has_class("watchlists-read-mode")
+
+        await workbench.apply_section_view(
+            hidden=frozenset(),
+            layout=RegionLayout(),
+        )
+        assert workbench.has_class("watchlists-read-mode")
 
 
 def _article(item_id: int) -> dict:

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -16,7 +16,11 @@ from tldw_chatbook.UI.Watchlists_Modules.pane_grip import (
     RegionToggled,
     WatchlistsPaneGrip,
 )
-from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import (
+    Region,
+    RegionLayout,
+    resolve_effective_layout,
+)
 from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
     REGION_TITLES,
     WatchlistsWorkbench,
@@ -45,6 +49,63 @@ def _direct_child_ids(widget) -> list[str | None]:
     return [child.id for child in widget.children]
 
 
+_REAL_CSS_PATH = str(
+    Path(__file__).resolve().parents[2]
+    / "tldw_chatbook"
+    / "css"
+    / "tldw_cli_modular.tcss"
+)
+
+
+class _BoundaryGeometryApp(App[None]):
+    """Real-bundle harness for responsive workbench geometry."""
+
+    CSS_PATH = _REAL_CSS_PATH
+
+    def __init__(self, width: int, *, read_mode: bool) -> None:
+        super().__init__()
+        self.read_mode = read_mode
+        self.layout = resolve_effective_layout(
+            RegionLayout(),
+            width=width,
+            read_mode=read_mode,
+            article_focus=False,
+            priority_target=None,
+        )
+
+    def compose(self) -> ComposeResult:
+        yield WatchlistsWorkbench(
+            self.layout,
+            content={
+                Region.LEFT_RAIL: lambda: Static("navigation"),
+                Region.ITEMS: lambda: Static("management or feed items"),
+                Region.CONTENT: lambda: Static("permanent reader"),
+                Region.RIGHT_RAIL: lambda: Static("inspector"),
+            },
+            read_mode=self.read_mode,
+            id="wl-workbench",
+        )
+
+
+def _expected_boundary_child_ids(
+    layout: RegionLayout, *, read_mode: bool
+) -> list[str]:
+    expected: list[str] = []
+    if not layout.is_collapsed(Region.LEFT_RAIL):
+        expected.append("wl-region-left_rail")
+    expected.append("wl-grip-left_rail")
+    if read_mode:
+        if not layout.is_collapsed(Region.ITEMS):
+            expected.append("wl-region-items")
+        expected.extend(("wl-grip-items", "wl-region-content"))
+    else:
+        expected.append("wl-region-items")
+    expected.append("wl-grip-right_rail")
+    if not layout.is_collapsed(Region.RIGHT_RAIL):
+        expected.append("wl-region-right_rail")
+    return expected
+
+
 def test_region_titles_cover_exactly_the_live_regions() -> None:
     assert set(REGION_TITLES) == set(Region)
 
@@ -57,20 +118,79 @@ def test_region_titles_cover_exactly_the_live_regions() -> None:
         (".watchlists-region-right_rail", 34, 30),
     ],
 )
-def test_side_pane_css_keeps_approved_target_and_minimum_widths(
+@pytest.mark.asyncio
+async def test_real_bundle_keeps_approved_side_pane_targets_and_minimums(
     selector: str, target: int, minimum: int
 ) -> None:
-    css_path = (
-        Path(__file__).resolve().parents[2]
-        / "tldw_chatbook"
-        / "css"
-        / "features"
-        / "_watchlists.tcss"
-    )
-    block = css_path.read_text().split(f"{selector} {{", 1)[1].split("}", 1)[0]
+    app = _BoundaryGeometryApp(220, read_mode=True)
 
-    assert f"\n    width: {target};" in block
-    assert f"\n    min-width: {minimum};" in block
+    async with app.run_test(size=(220, 24)) as pilot:
+        await pilot.pause()
+        pane = app.query_one(selector)
+
+        assert pane.styles.width is not None
+        assert pane.styles.width.value == target
+        assert pane.styles.min_width is not None
+        assert pane.styles.min_width.value == minimum
+        assert pane.region.width == target
+
+
+@pytest.mark.parametrize("width", (145, 144, 115, 114, 91, 90, 60, 59))
+@pytest.mark.parametrize("read_mode", (True, False), ids=("read", "management"))
+@pytest.mark.asyncio
+async def test_real_bundle_boundary_geometry_is_contained_and_keeps_centre(
+    width: int, read_mode: bool
+) -> None:
+    app = _BoundaryGeometryApp(width, read_mode=read_mode)
+
+    async with app.run_test(size=(width, 24)) as pilot:
+        await pilot.pause()
+        body = app.query_one("#wl-workbench-body", Horizontal)
+        workbench = app.query_one("#wl-workbench", WatchlistsWorkbench)
+        children = list(body.children)
+        expected = _expected_boundary_child_ids(
+            app.layout,
+            read_mode=read_mode,
+        )
+
+        assert _direct_child_ids(body) == expected
+        assert workbench.content_region.contains_region(body.region)
+        assert body.region.width == workbench.content_region.width == width
+        assert body.region.height == workbench.content_region.height
+        assert body.max_scroll_x == 0
+        assert body.virtual_size.width <= body.content_region.width
+        assert all(
+            body.content_region.contains_region(child.region) for child in children
+        )
+        assert all(
+            left.region.right <= right.region.x
+            for left, right in zip(children, children[1:])
+        )
+
+        grips = list(body.query(WatchlistsPaneGrip))
+        assert len(grips) == (3 if read_mode else 2)
+        assert all(grip.outer_size.width == grip.region.width == 5 for grip in grips)
+        assert all(grip.region.height == body.content_region.height for grip in grips)
+
+        minimums = {
+            "wl-region-left_rail": 24,
+            "wl-region-items": 32,
+            "wl-region-right_rail": 30,
+        }
+        for child in children:
+            if child.id in minimums and (read_mode or child.id != "wl-region-items"):
+                assert child.region.width >= minimums[child.id]
+
+        centre_id = "#wl-region-content" if read_mode else "#wl-region-items"
+        centre = app.query_one(centre_id)
+        assert centre.styles.min_width is not None
+        assert centre.styles.min_width.value == 0
+        occupied_by_siblings = sum(
+            child.region.width for child in children if child is not centre
+        )
+        assert centre.region.width == body.content_region.width - occupied_by_siblings
+        assert centre.region.width > 0
+        assert centre.region.height == body.content_region.height
 
 
 @pytest.mark.asyncio
@@ -606,14 +726,29 @@ async def test_reader_body_scroll_preserves_local_actions_footer_and_neighbours(
         left = app.query_one("#wl-region-left_rail")
         items = app.query_one("#wl-region-items")
         right = app.query_one("#wl-region-right_rail")
-        fixed = (actions.region, footer.region, left.region, items.region, right.region)
+        grips = tuple(app.query(WatchlistsPaneGrip))
+        fixed = (
+            actions.region,
+            footer.region,
+            left.region,
+            items.region,
+            right.region,
+            *(grip.region for grip in grips),
+        )
 
         assert body_scroll.max_scroll_y > 0
         body_scroll.scroll_end(animate=False)
         await pilot.pause()
 
         assert body_scroll.scroll_y == body_scroll.max_scroll_y
-        assert (actions.region, footer.region, left.region, items.region, right.region) == fixed
+        assert (
+            actions.region,
+            footer.region,
+            left.region,
+            items.region,
+            right.region,
+            *(grip.region for grip in grips),
+        ) == fixed
 
 
 @pytest.mark.asyncio

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -1,29 +1,393 @@
+"""Focused contracts for the permanent-centre Watchlists workbench."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
 import pytest
 from textual.app import App, ComposeResult
-from textual.containers import HorizontalScroll, Vertical, VerticalScroll
-from textual.widgets import Button, Static
+from textual.containers import Horizontal, HorizontalScroll, Vertical, VerticalScroll
+from textual.widgets import Button, Label, Static
 
 from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+from tldw_chatbook.UI.Watchlists_Modules.pane_grip import (
+    RegionToggled,
+    WatchlistsPaneGrip,
+)
 from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
 from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
     REGION_TITLES,
-    RegionToggled,
     WatchlistsWorkbench,
 )
 
 
-class _WorkbenchApp(App):
-    def __init__(self, layout: RegionLayout) -> None:
+class _WorkbenchApp(App[None]):
+    def __init__(self, layout: RegionLayout, *, read_mode: bool = True) -> None:
         super().__init__()
-        self._layout = layout
+        self.layout_state = layout
+        self.read_mode = read_mode
         self.toggles: list[Region] = []
 
     def compose(self) -> ComposeResult:
-        yield WatchlistsWorkbench(self._layout, id="wl-workbench")
+        yield WatchlistsWorkbench(
+            self.layout_state,
+            read_mode=self.read_mode,
+            id="wl-workbench",
+        )
 
     def on_region_toggled(self, message: RegionToggled) -> None:
         self.toggles.append(message.region)
+
+
+def _direct_child_ids(widget) -> list[str | None]:
+    return [child.id for child in widget.children]
+
+
+def test_region_titles_cover_exactly_the_live_regions() -> None:
+    assert set(REGION_TITLES) == set(Region)
+
+
+@pytest.mark.asyncio
+async def test_read_mounts_header_above_exact_horizontal_body_order() -> None:
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(),
+                read_mode=True,
+                header=lambda: Static("status", id="wl-centre-status"),
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test():
+        workbench = app.query_one(WatchlistsWorkbench)
+        body = app.query_one("#wl-workbench-body", Horizontal)
+
+        assert _direct_child_ids(workbench) == [
+            "wl-centre-status",
+            "wl-workbench-body",
+        ]
+        assert _direct_child_ids(body) == [
+            "wl-region-left_rail",
+            "wl-grip-left_rail",
+            "wl-region-items",
+            "wl-grip-items",
+            "wl-region-content",
+            "wl-grip-right_rail",
+            "wl-region-right_rail",
+        ]
+
+
+@pytest.mark.parametrize(
+    ("region", "body_id", "grip_id"),
+    [
+        (Region.LEFT_RAIL, "wl-region-left_rail", "wl-grip-left_rail"),
+        (Region.ITEMS, "wl-region-items", "wl-grip-items"),
+        (Region.RIGHT_RAIL, "wl-region-right_rail", "wl-grip-right_rail"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_read_collapses_only_side_body_and_keeps_its_grip(
+    region: Region, body_id: str, grip_id: str
+) -> None:
+    app = _WorkbenchApp(RegionLayout(collapsed=frozenset({region})))
+    async with app.run_test():
+        assert not app.query(f"#{body_id}")
+        grip = app.query_one(f"#{grip_id}", WatchlistsPaneGrip)
+        assert grip.expanded is False
+        assert app.query("#wl-region-content")
+
+
+@pytest.mark.asyncio
+async def test_legacy_content_collapse_cannot_unmount_reader_in_read() -> None:
+    app = _WorkbenchApp(
+        RegionLayout(collapsed=frozenset({Region.CONTENT}))
+    )
+    async with app.run_test():
+        assert app.query("#wl-region-content")
+        assert not app.query("#wl-grip-content")
+
+
+@pytest.mark.asyncio
+async def test_hidden_compatibility_selects_management_horizontal_body() -> None:
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(collapsed=frozenset({Region.ITEMS})),
+                hidden=frozenset({Region.CONTENT}),
+                header=lambda: Static("status", id="wl-centre-status"),
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test():
+        workbench = app.query_one(WatchlistsWorkbench)
+        body = app.query_one("#wl-workbench-body", Horizontal)
+        assert _direct_child_ids(workbench) == [
+            "wl-centre-status",
+            "wl-workbench-body",
+        ]
+        assert _direct_child_ids(body) == [
+            "wl-region-left_rail",
+            "wl-grip-left_rail",
+            "wl-region-items",
+            "wl-grip-right_rail",
+            "wl-region-right_rail",
+        ]
+        assert workbench.read_mode is False
+        assert app.query("#wl-region-items")
+        assert not app.query("#wl-grip-items")
+        assert not app.query("#wl-region-content")
+
+
+@pytest.mark.asyncio
+async def test_side_toggle_preserves_unaffected_bodies_all_grips_and_reader() -> None:
+    app = _WorkbenchApp(RegionLayout())
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        preserved = {
+            selector: app.query_one(selector)
+            for selector in (
+                "#wl-region-items",
+                "#wl-region-content",
+                "#wl-region-right_rail",
+                "#wl-grip-left_rail",
+                "#wl-grip-items",
+                "#wl-grip-right_rail",
+            )
+        }
+
+        workbench.region_layout = RegionLayout(
+            collapsed=frozenset({Region.LEFT_RAIL})
+        )
+        await pilot.pause()
+
+        assert not app.query("#wl-region-left_rail")
+        for selector, instance in preserved.items():
+            assert app.query_one(selector) is instance
+        assert preserved["#wl-grip-left_rail"].expanded is False
+
+
+@pytest.mark.asyncio
+async def test_expanding_inspector_mounts_body_after_permanent_grip() -> None:
+    app = _WorkbenchApp(
+        RegionLayout(collapsed=frozenset({Region.RIGHT_RAIL}))
+    )
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        grip = app.query_one("#wl-grip-right_rail")
+        reader = app.query_one("#wl-region-content")
+
+        workbench.region_layout = RegionLayout()
+        await pilot.pause()
+
+        body = app.query_one("#wl-workbench-body", Horizontal)
+        assert _direct_child_ids(body)[-3:] == [
+            "wl-region-content",
+            "wl-grip-right_rail",
+            "wl-region-right_rail",
+        ]
+        assert app.query_one("#wl-grip-right_rail") is grip
+        assert app.query_one("#wl-region-content") is reader
+
+
+@pytest.mark.asyncio
+async def test_grip_activation_uses_shared_region_toggled_message() -> None:
+    app = _WorkbenchApp(RegionLayout())
+    async with app.run_test() as pilot:
+        await pilot.click("#wl-grip-items")
+        await pilot.pause()
+    assert app.toggles == [Region.ITEMS]
+
+
+@pytest.mark.asyncio
+async def test_collapsed_suffix_compatibility_is_a_noop() -> None:
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})),
+                collapsed_suffixes={Region.LEFT_RAIL: "12 unread"},
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test():
+        workbench = app.query_one(WatchlistsWorkbench)
+        grip = app.query_one("#wl-grip-left_rail", WatchlistsPaneGrip)
+        label = str(grip.label)
+        workbench.set_collapsed_suffixes({Region.LEFT_RAIL: "7 unread"})
+        assert app.query_one("#wl-grip-left_rail") is grip
+        assert str(grip.label) == label
+
+
+@pytest.mark.asyncio
+async def test_refresh_region_content_rebuilds_only_named_factory_output() -> None:
+    calls = {"items": 0, "content": 0}
+
+    def factory(name: str):
+        def build() -> Label:
+            calls[name] += 1
+            return Label(f"{name}-{calls[name]}", id=f"{name}-content")
+
+        return build
+
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(),
+                content={
+                    Region.ITEMS: factory("items"),
+                    Region.CONTENT: factory("content"),
+                },
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        old_items = app.query_one("#items-content")
+        old_content = app.query_one("#content-content")
+
+        await workbench.refresh_region_content(Region.CONTENT)
+        await pilot.pause()
+
+        assert app.query_one("#items-content") is old_items
+        assert app.query_one("#content-content") is not old_content
+        assert calls == {"items": 1, "content": 2}
+
+
+@pytest.mark.asyncio
+async def test_refresh_region_content_preserves_heading_on_factory_failure() -> None:
+    calls = 0
+
+    def factory() -> Label:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("build failed")
+        return Label("tree", id="rail-content")
+
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(),
+                content={Region.LEFT_RAIL: factory},
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test():
+        workbench = app.query_one(WatchlistsWorkbench)
+        region = app.query_one("#wl-region-left_rail")
+        heading = region.query_one(".watchlists-region-title")
+        content = app.query_one("#rail-content")
+
+        with pytest.raises(RuntimeError, match="build failed"):
+            await workbench.refresh_region_content(Region.LEFT_RAIL)
+
+        assert app.query_one("#wl-region-left_rail") is region
+        assert region.query_one(".watchlists-region-title") is heading
+        assert app.query_one("#rail-content") is content
+
+
+@pytest.mark.asyncio
+async def test_refresh_header_replaces_only_header_and_is_failure_safe() -> None:
+    calls = 0
+    fail = False
+
+    def header() -> Label:
+        nonlocal calls
+        calls += 1
+        if fail:
+            raise RuntimeError("header failed")
+        return Label(f"header-{calls}", id="wl-centre-status")
+
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(),
+                header=header,
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        body = app.query_one("#wl-workbench-body")
+        old_header = app.query_one("#wl-centre-status")
+        await workbench.refresh_header_content()
+        await pilot.pause()
+        fresh_header = app.query_one("#wl-centre-status")
+        assert fresh_header is not old_header
+        assert app.query_one("#wl-workbench-body") is body
+
+        fail = True
+        with pytest.raises(RuntimeError, match="header failed"):
+            await workbench.refresh_header_content()
+        assert app.query_one("#wl-centre-status") is fresh_header
+        assert app.query_one("#wl-workbench-body") is body
+
+
+@pytest.mark.asyncio
+async def test_apply_section_view_rebuilds_only_required_centres() -> None:
+    calls = {"items": 0, "content": 0}
+
+    def factory(name: str):
+        def build() -> Label:
+            calls[name] += 1
+            return Label(f"{name}-{calls[name]}", id=f"{name}-content")
+
+        return build
+
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                RegionLayout(),
+                content={
+                    Region.ITEMS: factory("items"),
+                    Region.CONTENT: factory("content"),
+                },
+                id="wl-workbench",
+            )
+
+    app = _App()
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        left = app.query_one("#wl-region-left_rail")
+        right = app.query_one("#wl-region-right_rail")
+        left_grip = app.query_one("#wl-grip-left_rail")
+        right_grip = app.query_one("#wl-grip-right_rail")
+        reader = app.query_one("#content-content")
+
+        await workbench.apply_section_view(
+            read_mode=False,
+            layout=RegionLayout(),
+            rebuild_regions=(Region.ITEMS,),
+        )
+        await pilot.pause()
+
+        assert app.query_one(WatchlistsWorkbench) is workbench
+        assert app.query_one("#wl-region-left_rail") is left
+        assert app.query_one("#wl-region-right_rail") is right
+        assert app.query_one("#wl-grip-left_rail") is left_grip
+        assert app.query_one("#wl-grip-right_rail") is right_grip
+        assert not app.query("#wl-grip-items")
+        assert not app.query("#wl-region-content")
+        assert calls == {"items": 2, "content": 1}
+
+        await workbench.apply_section_view(
+            hidden=frozenset(),
+            layout=RegionLayout(),
+            rebuild_regions=(Region.ITEMS,),
+        )
+        await pilot.pause()
+
+        assert app.query_one("#wl-region-left_rail") is left
+        assert app.query_one("#wl-region-right_rail") is right
+        assert app.query("#wl-grip-items")
+        assert app.query_one("#content-content") is not reader
+        assert calls == {"items": 3, "content": 2}
 
 
 def _article(item_id: int) -> dict:
@@ -41,10 +405,8 @@ def _article(item_id: int) -> dict:
     }
 
 
-class _ReadGeometryApp(App):
-    """Production-CSS harness for the Read centre's nested scroll owners."""
-
-    from pathlib import Path
+class _ReadGeometryApp(App[None]):
+    """Production-CSS harness for Reader-local containment."""
 
     CSS_PATH = str(
         Path(__file__).resolve().parents[2]
@@ -53,766 +415,85 @@ class _ReadGeometryApp(App):
         / "tldw_cli_modular.tcss"
     )
 
-    def __init__(
-        self,
-        item_count: int,
-        *,
-        read_mode: bool = True,
-        layout: RegionLayout = RegionLayout(),
-        content_lines: int | None = 30,
-        content_kind: str = "article",
-    ) -> None:
-        super().__init__()
-        self.item_count = item_count
-        self.read_mode = read_mode
-        self.initial_layout = layout
-        self.content_lines = content_lines
-        self.content_kind = content_kind
-
     def _items_pane(self) -> Vertical:
         pane = ArticleListPane(id="watchlists-items-pane")
-        pane.items = [_article(index) for index in range(self.item_count)]
+        pane.items = [_article(index) for index in range(3)]
         return Vertical(
-            Static(
-                "Read",
-                classes="destination-section watchlists-column-title",
-                id="watchlists-detail-title",
-            ),
+            Static("Read", id="watchlists-detail-title"),
             pane,
             id="watchlists-detail-pane",
-            classes="destination-workbench-pane",
         )
 
     def _content_pane(self) -> ContentPane:
         pane = ContentPane(id="watchlists-content-pane")
-        if self.content_lines is not None:
-            pane.item = {
-                "id": "local:watchlist_item:reader",
-                "item_id": "reader",
-                "title": "Geometry article",
-                "source_name": "Geometry Feed",
-                "content_kind": self.content_kind,
-                "content_format": (
-                    "diff" if self.content_kind == "change" else "text"
-                ),
-                "content": "\n\n".join(
-                    f"paragraph-{row:02d}" for row in range(self.content_lines)
-                ),
-            }
-            pane.position = "1 of 1"
+        pane.item = {
+            "id": "local:watchlist_item:reader",
+            "item_id": "reader",
+            "title": "Geometry article",
+            "source_name": "Geometry Feed",
+            "content_kind": "article",
+            "content_format": "text",
+            "content": "\n\n".join(f"paragraph-{row:02d}" for row in range(80)),
+        }
+        pane.position = "1 of 1"
         return pane
 
     def compose(self) -> ComposeResult:
-        classes = "watchlists-read-mode" if self.read_mode else ""
         yield WatchlistsWorkbench(
-            self.initial_layout,
+            RegionLayout(),
             content={
-                Region.LEFT_RAIL: lambda: Static("fixed-left", id="left-probe"),
+                Region.LEFT_RAIL: lambda: Static("fixed-left"),
                 Region.ITEMS: self._items_pane,
                 Region.CONTENT: self._content_pane,
-                Region.RIGHT_RAIL: lambda: Static("fixed-right", id="right-probe"),
+                Region.RIGHT_RAIL: lambda: Static("fixed-right"),
             },
-            hidden=(frozenset() if self.read_mode else frozenset({Region.CONTENT})),
-            header=lambda: Static("Read status", id="wl-centre-status"),
+            read_mode=True,
             id="wl-workbench",
-            classes=classes,
-        )
-
-
-def test_region_titles_cover_exactly_the_live_regions():
-    # No FEEDS entry left over from the five-region era (task-2513), and no
-    # live region missing a title -- `_region_widget` would KeyError.
-    assert set(REGION_TITLES) == set(Region)
-
-
-@pytest.mark.asyncio
-async def test_only_the_centre_is_the_workbench_scroll_viewport():
-    app = _WorkbenchApp(RegionLayout())
-    async with app.run_test():
-        workbench = app.query_one(WatchlistsWorkbench)
-        centre = app.query_one("#wl-centre")
-
-        assert isinstance(centre, VerticalScroll)
-        assert list(workbench.children) == [
-            app.query_one("#wl-region-left_rail"),
-            centre,
-            app.query_one("#wl-region-right_rail"),
-        ]
-
-
-@pytest.mark.parametrize(
-    ("item_count", "expected_relation"),
-    [(0, "floor"), (3, "natural"), (50, "cap")],
-)
-@pytest.mark.asyncio
-async def test_read_items_region_grows_from_ten_rows_to_a_fifty_row_cap(
-    item_count, expected_relation
-):
-    app = _ReadGeometryApp(item_count)
-    async with app.run_test(size=(180, 100)) as pilot:
-        await pilot.pause()
-        items = app.query_one("#wl-region-items")
-
-        assert 10 <= items.region.height <= 50, items.region
-        if expected_relation == "floor":
-            assert items.styles.min_height.value == 10
-            assert items.region.height < 50, items.region
-        elif expected_relation == "natural":
-            assert 10 < items.region.height < 50, items.region
-        else:
-            assert items.region.height == 50, items.region
-
-
-@pytest.mark.parametrize("size", [(120, 36), (180, 50), (180, 100)])
-@pytest.mark.asyncio
-async def test_read_items_pager_is_contained_and_painted_at_the_fifty_row_cap(
-    size,
-):
-    app = _ReadGeometryApp(50)
-    async with app.run_test(size=size) as pilot:
-        await pilot.pause()
-        centre = app.query_one("#wl-centre", VerticalScroll)
-        items = app.query_one("#wl-region-items")
-        detail = app.query_one("#watchlists-detail-pane")
-        pane = app.query_one("#watchlists-items-pane", ArticleListPane)
-        table = app.query_one("#items-table")
-        pager = app.query_one("#items-pagination")
-
-        assert items.region.height == 50
-        assert table.region.height == 40
-        assert detail in items.children
-        assert pane in detail.children
-        assert app.query_one("#watchlists-detail-title") in detail.children
-        assert items.content_region.contains_region(pager.region), (
-            f"pager escapes the 50-row ITEMS content box: "
-            f"items={items.content_region} detail={detail.region} "
-            f"pane={pane.region} pager={pager.region}"
-        )
-
-        centre.scroll_to_widget(pager, animate=False)
-        await pilot.pause()
-        if pager.region.bottom > centre.region.bottom:
-            centre.scroll_to(
-                y=centre.scroll_y + pager.region.bottom - centre.region.bottom,
-                animate=False,
-            )
-        await pilot.pause()
-
-        strips = app.screen._compositor.render_strips()
-        region = pager.region
-        pager_text = "\n".join(
-            "".join(segment.text for segment in strips[y])[
-                region.x : region.x + region.width
-            ]
-            for y in range(max(region.y, 0), min(region.bottom, size[1]))
-        )
-        for label in ("Previous", "Page 1", "Next"):
-            assert label in pager_text, (
-                f"{label!r} is not composited at {size}: {pager_text!r}; "
-                f"centre_scroll={centre.scroll_y} pager={pager.region}"
-            )
-
-
-@pytest.mark.parametrize("size", [(120, 36), (180, 50)])
-@pytest.mark.asyncio
-async def test_outer_centre_reaches_content_without_moving_either_rail(size):
-    app = _ReadGeometryApp(50)
-    async with app.run_test(size=size) as pilot:
-        await pilot.pause()
-        centre = app.query_one("#wl-centre", VerticalScroll)
-        left = app.query_one("#wl-region-left_rail")
-        right = app.query_one("#wl-region-right_rail")
-        content = app.query_one("#wl-region-content")
-        rail_regions = (left.region, right.region)
-
-        assert centre.max_scroll_y > 0
-        centre.scroll_end(animate=False)
-        await pilot.pause()
-        await pilot.pause()
-
-        assert centre.scroll_y == centre.max_scroll_y
-        assert (left.region, right.region) == rail_regions
-        assert content.region.intersection(centre.content_region).height > 0
-        screenshot = app.export_screenshot()
-        assert "paragraph-" in screenshot, (
-            "the centre end must paint the reachable portion of Content"
+            classes="watchlists-read-mode",
         )
 
 
 @pytest.mark.asyncio
-async def test_non_read_items_pane_keeps_its_fill_layout_above_fifty_rows():
-    app = _ReadGeometryApp(0, read_mode=False)
-    async with app.run_test(size=(180, 90)) as pilot:
+async def test_reader_body_scroll_preserves_local_actions_footer_and_neighbours() -> None:
+    app = _ReadGeometryApp()
+    async with app.run_test(size=(180, 50)) as pilot:
         await pilot.pause()
-        items = app.query_one("#wl-region-items")
-
-        assert not app.query_one(WatchlistsWorkbench).has_class(
-            "watchlists-read-mode"
-        )
-        assert items.region.height > 50, items.region
-
-
-@pytest.mark.asyncio
-async def test_solo_items_lifts_caps_and_restore_rebounds_without_replacing_list():
-    app = _ReadGeometryApp(50)
-    async with app.run_test(size=(180, 90)) as pilot:
-        await pilot.pause()
-        workbench = app.query_one(WatchlistsWorkbench)
-        pane = app.query_one(ArticleListPane)
-        table = app.query_one("#items-table")
-        bounded_items = app.query_one("#wl-region-items")
-
-        assert bounded_items.region.height == 50
-        assert table.region.height < bounded_items.region.height
-        bounded_table_height = table.region.height
-        table.focus()
-
-        workbench.region_layout = RegionLayout().solo(Region.ITEMS)
-        await pilot.pause()
-        await pilot.pause()
-
-        solo_items = app.query_one("#wl-region-items")
-        solo_table = app.query_one("#items-table")
-        assert solo_items.region.height > 50, solo_items.region
-        assert solo_table.region.height > bounded_table_height
-        assert app.query_one(ArticleListPane) is pane
-        assert solo_table is table and table.has_focus
-
-        workbench.region_layout = RegionLayout()
-        await pilot.pause()
-        await pilot.pause()
-
-        assert app.query_one("#wl-region-items").region.height == 50
-        assert app.query_one("#items-table").region.height < 50
-        assert app.query_one(ArticleListPane) is pane
-
-
-@pytest.mark.asyncio
-async def test_all_regions_render_expanded_by_default():
-    app = _WorkbenchApp(RegionLayout())
-    async with app.run_test():
-        for region in Region:
-            assert app.query(f"#wl-region-{region.value}")
-            assert not app.query(f"#wl-header-{region.value}")
-
-
-@pytest.mark.asyncio
-async def test_collapsed_region_renders_a_header_instead_of_a_body():
-    app = _WorkbenchApp(RegionLayout(collapsed=frozenset({Region.CONTENT})))
-    async with app.run_test():
-        assert app.query("#wl-header-content")
-        assert not app.query("#wl-region-content")
-
-
-@pytest.mark.asyncio
-async def test_collapsed_header_shows_suffix():
-    """task-2513 Task 9: a collapsed rail advertises what it hides.
-
-    NNW's sidebar toggle keeps the unread total visible while collapsed;
-    here the collapsed left rail's header carries "N unread" so the user
-    never loses the number that drives daily triage.
-    """
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})),
-                collapsed_suffixes={Region.LEFT_RAIL: "12 unread"},
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test():
-        header = app.query_one("#wl-header-left_rail", Button)
-        assert str(header.label) == "▸ Watchlists  12 unread"
-
-
-@pytest.mark.asyncio
-async def test_set_collapsed_suffixes_repaints_mounted_collapsed_header():
-    """Counts refresh while the rail stays collapsed: repaint in place.
-
-    A full recompose for a number is exactly what `refresh_region_content`
-    exists to avoid for bodies; expanded regions (no header mounted) are a
-    no-op.
-    """
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})),
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test():
-        header = app.query_one("#wl-header-left_rail", Button)
-        assert str(header.label) == "▸ Watchlists"
-        workbench = app.query_one(WatchlistsWorkbench)
-        workbench.set_collapsed_suffixes({Region.LEFT_RAIL: "7 unread"})
-        assert str(header.label) == "▸ Watchlists  7 unread"
-        # Expanded region: nothing mounted to repaint, and no error.
-        workbench.set_collapsed_suffixes({Region.ITEMS: "ignored"})
-
-
-@pytest.mark.asyncio
-async def test_collapsed_header_is_focusable_so_collapse_is_not_one_way():
-    app = _WorkbenchApp(RegionLayout(collapsed=frozenset({Region.ITEMS})))
-    async with app.run_test():
-        header = app.query_one("#wl-header-items")
-        assert header.focusable, "a collapsed region must be reachable by keyboard"
-
-
-@pytest.mark.asyncio
-async def test_clicking_a_collapsed_header_posts_region_toggled():
-    app = _WorkbenchApp(RegionLayout(collapsed=frozenset({Region.CONTENT})))
-    async with app.run_test() as pilot:
-        await pilot.click("#wl-header-content")
-        await pilot.pause()
-        assert app.toggles == [Region.CONTENT]
-
-
-@pytest.mark.asyncio
-async def test_updating_the_layout_reactive_re_renders():
-    # NOTE: the reactive is exposed as `region_layout`, not `layout`. Widget
-    # already defines a read-only `layout` property (the compositor's arrange
-    # strategy; see textual/widget.py and textual/_arrange.py:97) that a
-    # same-named reactive here would shadow, crashing every render with
-    # AttributeError: '...' object has no attribute 'arrange'. Verified
-    # empirically with a minimal Horizontal subclass before renaming.
-    app = _WorkbenchApp(RegionLayout())
-    async with app.run_test() as pilot:
-        workbench = app.query_one(WatchlistsWorkbench)
-        workbench.region_layout = RegionLayout(collapsed=frozenset({Region.LEFT_RAIL}))
-        await pilot.pause()
-        assert app.query("#wl-header-left_rail")
-        assert not app.query("#wl-region-left_rail")
-
-
-@pytest.mark.asyncio
-async def test_every_centre_region_may_be_collapsed_at_once():
-    app = _WorkbenchApp(RegionLayout(collapsed=frozenset(CENTRE := {Region.ITEMS, Region.CONTENT})))
-    async with app.run_test():
-        for region in CENTRE:
-            assert app.query(f"#wl-header-{region.value}")
-        # The rails survive, so the screen is never empty.
-        assert app.query("#wl-region-left_rail")
-        assert app.query("#wl-region-right_rail")
-
-
-@pytest.mark.asyncio
-async def test_a_hidden_centre_region_is_unmounted_not_collapsed():
-    """The screen gates CONTENT off every non-Read tab this way
-    (`WatchlistsCollectionsScreen._hidden_centre_regions`, TASK-1344 AC#4):
-    hidden means no DOM presence at all -- no body, not even a one-line
-    header."""
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(),
-                hidden=frozenset({Region.CONTENT}),
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test():
-        assert app.query("#wl-region-left_rail")
-        assert app.query("#wl-region-items")
-        assert app.query("#wl-region-right_rail")
-        assert not app.query("#wl-region-content")
-        assert not app.query("#wl-header-content")
-
-
-@pytest.mark.asyncio
-async def test_supplied_content_is_mounted_into_its_region():
-    from textual.widgets import Label
-
-    # `content` holds FACTORIES, not instances — see the empirical finding
-    # documented on `WatchlistsWorkbench.__init__` and
-    # `test_supplied_content_with_nested_children_survives_recompose` below.
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(),
-                content={Region.ITEMS: lambda: Label("real items table", id="my-real-items")},
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test():
-        assert app.query("#my-real-items"), "supplied content should be mounted"
-        region = app.query_one("#wl-region-items")
-        assert app.query_one("#my-real-items") in region.walk_children()
-
-
-@pytest.mark.asyncio
-async def test_a_region_without_supplied_content_renders_no_stub_copy():
-    """Whole-branch review: `REGION_PLACEHOLDERS` is gone.
-
-    Every region the screen builds supplies a factory, so the only thing the
-    "... arrives in the next slice." stubs still did was read, to anyone
-    grepping the module, like shipped product copy for an unfinished feature.
-    A region with no factory now renders its title and nothing else.
-    """
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(RegionLayout(), content={}, id="wl-workbench")
-
-    app = _App()
-    async with app.run_test():
-        assert app.query("#wl-region-content"), "the region body still renders"
-        assert not app.query(".watchlists-region-placeholder")
-        rendered = " ".join(
-            str(getattr(node, "renderable", "")) for node in app.query("Static")
-        )
-        assert "arrives in the next slice" not in rendered
-
-
-@pytest.mark.asyncio
-async def test_supplied_content_with_nested_children_survives_recompose():
-    """Regression test for an empirically-found bug: passing an already-
-    constructed CONTAINER widget (with its own constructor-supplied children,
-    e.g. `Vertical(Static(...), Static(...))`) as `content` works on the
-    FIRST render, but its grandchildren vanish after ANY subsequent
-    recompose — `region_layout` is `recompose=True`, so toggling even an
-    unrelated region unmounts and rebuilds every region. A widget's
-    constructor-supplied children are only mounted on that instance's first
-    mount; the same instance remounted a second time comes back childless.
-    `content` must therefore hold factories that build a fresh instance on
-    every call, not pre-built instances — this test would fail against the
-    pre-fix, instance-based implementation.
-    """
-    from textual.containers import Vertical as _Vertical
-    from textual.widgets import Static as _Static
-
-    def build_nested():
-        return _Vertical(
-            _Static("outer-title", id="outer-title"),
-            _Static("inner-content", id="inner-content"),
-            id="my-nested-pane",
-        )
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(), content={Region.ITEMS: build_nested}, id="wl-workbench"
-            )
-
-    app = _App()
-    async with app.run_test() as pilot:
-        assert app.query("#inner-content")
-
-        workbench = app.query_one(WatchlistsWorkbench)
-        # Toggle an UNRELATED region. Because the reactive recomposes the
-        # whole workbench, this rebuilds ITEMS too, even though ITEMS itself
-        # was never toggled.
-        workbench.region_layout = RegionLayout(collapsed=frozenset({Region.LEFT_RAIL}))
-        await pilot.pause()
-
-        assert app.query("#my-nested-pane"), "the region body should still be rebuilt"
-        assert app.query(
-            "#inner-content"
-        ), "nested content must survive an unrelated region's recompose"
-
-
-@pytest.mark.asyncio
-async def test_a_region_with_supplied_content_does_not_double_title():
-    from textual.widgets import Static
-
-    def factory():
-        return Static("Items", classes="pane-title")
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(), content={Region.ITEMS: factory}, id="wl-workbench"
-            )
-
-    app = _App()
-    async with app.run_test():
-        titles = [str(n.renderable) for n in app.query(".watchlists-region-title")]
-        assert "Items" not in titles, (
-            "a region whose content supplies its own heading should not add a second one"
-        )
-
-
-@pytest.mark.asyncio
-async def test_left_rail_keeps_its_heading_when_its_content_supplies_none():
-    """Fix round 3, Finding 1: title suppression was keyed on
-    factory-presence, but the rule is "suppress it where the pane supplies
-    its own heading". LEFT_RAIL is where those two signals diverge — it
-    supplies content (`WatchlistTree`) that composes only navigation buttons
-    and no heading widget — so the expanded rail rendered as an unlabelled
-    bordered box while its collapsed header still read "▸ Watchlists".
-    `SELF_HEADED_REGIONS` now carries the real rule.
-    """
-    from textual.widgets import Label
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(),
-                content={
-                    # Stands in for `WatchlistTree`: real content, no heading.
-                    Region.LEFT_RAIL: lambda: Label("All sources  0", id="headingless"),
-                    Region.ITEMS: lambda: Label("Items", id="self-headed"),
-                },
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test():
-        assert app.query("#headingless"), "supplied rail content should be mounted"
-        titles = [str(n.renderable) for n in app.query(".watchlists-region-title")]
-        assert "Watchlists" in titles, (
-            "the left rail's content supplies no heading of its own, so the "
-            f"region must still label it: {titles}"
-        )
-        assert "Items" not in titles, (
-            "a region whose pane DOES supply its own heading must not add a "
-            f"second one: {titles}"
-        )
-
-
-@pytest.mark.asyncio
-async def test_a_soloed_centre_region_is_marked_for_css():
-    """Fix round 3, Finding 3: `RegionLayout.solo` only collapses the soloed
-    region's *siblings*, so nothing in the DOM distinguished a soloed region
-    from an ordinarily-expanded one — and a capped region stayed pinned at
-    its `max-height` with the rest of the centre blank. This class is the
-    hook `.watchlists-region-sole-centre` keys off (see `_watchlists.tcss`);
-    the geometry it produces is asserted against the real stylesheet in
-    `Tests/UI/test_destination_visual_parity_correction.py::
-    test_watchlists_soloed_centre_region_fills_the_centre`.
-    """
-    app = _WorkbenchApp(RegionLayout().solo(Region.CONTENT))
-    async with app.run_test():
-        content = app.query_one("#wl-region-content")
-        assert content.has_class("watchlists-region-sole-centre"), sorted(content.classes)
-        # The rails are still expanded, and solo never applies to them.
-        for rail in ("left_rail", "right_rail"):
-            rail_region = app.query_one(f"#wl-region-{rail}")
-            assert not rail_region.has_class("watchlists-region-sole-centre")
-
-    # Reaching the same DOM by hand must get the same treatment: `z` on ITEMS
-    # leaves CONTENT just as alone as `Z` on CONTENT does.
-    manual = _WorkbenchApp(RegionLayout(collapsed=frozenset({Region.ITEMS})))
-    async with manual.run_test():
-        assert manual.query_one("#wl-region-content").has_class(
-            "watchlists-region-sole-centre"
-        )
-
-    # ... and an ordinary expanded layout must NOT get it, or the cap never
-    # applies at all.
-    ordinary = _WorkbenchApp(RegionLayout())
-    async with ordinary.run_test():
-        for region in Region:
-            assert not ordinary.query_one(f"#wl-region-{region.value}").has_class(
-                "watchlists-region-sole-centre"
-            )
-
-
-@pytest.mark.parametrize(
-    ("content_lines", "expected"),
-    [(None, "floor"), (1, "floor"), (8, "natural"), (80, "cap")],
-)
-@pytest.mark.parametrize("size", [(120, 36), (180, 70), (180, 120)])
-@pytest.mark.asyncio
-async def test_content_region_grows_from_twenty_rows_to_a_fifty_row_cap(
-    content_lines, expected, size
-):
-    """Exercise the production pane, title, actions, footer, and stylesheet."""
-    app = _ReadGeometryApp(0, content_lines=content_lines)
-    async with app.run_test(size=size) as pilot:
-        await pilot.pause()
-        content = app.query_one("#wl-region-content")
-
-        assert 20 <= content.region.height <= 50, content.region
-        if expected == "floor":
-            assert content.region.height == 20, content.region
-        elif expected == "natural":
-            assert 20 < content.region.height < 50, content.region
-        else:
-            assert content.region.height == 50, content.region
-
-
-@pytest.mark.parametrize("size", [(120, 36), (180, 70), (180, 120)])
-@pytest.mark.asyncio
-async def test_long_content_body_scrolls_without_moving_fixed_chrome_or_rails(size):
-    app = _ReadGeometryApp(50, content_lines=80)
-    async with app.run_test(size=size) as pilot:
-        await pilot.pause()
-        centre = app.query_one("#wl-centre", VerticalScroll)
-        content = app.query_one("#wl-region-content")
         body_scroll = app.query_one("#content-body-scroll", VerticalScroll)
         actions = app.query_one("#content-actions")
         footer = app.query_one("#content-footer")
         left = app.query_one("#wl-region-left_rail")
+        items = app.query_one("#wl-region-items")
         right = app.query_one("#wl-region-right_rail")
+        fixed = (actions.region, footer.region, left.region, items.region, right.region)
 
-        assert content.region.height == 50
-        assert body_scroll.region.height == 45
         assert body_scroll.max_scroll_y > 0
-
-        centre.scroll_to_widget(content, animate=False)
-        await pilot.pause()
-        centre_scroll = centre.scroll_y
-        rail_regions = (left.region, right.region)
-        chrome_regions = (actions.region, footer.region)
-
         body_scroll.scroll_end(animate=False)
-        await pilot.pause()
         await pilot.pause()
 
         assert body_scroll.scroll_y == body_scroll.max_scroll_y
-        assert centre.scroll_y == centre_scroll
-        assert (left.region, right.region) == rail_regions
-        assert (actions.region, footer.region) == chrome_regions
-
-        # The body reached its own end without moving the outer document.
-        # Now deliberately move the outer document far enough to paint that
-        # end on compact terminals whose viewport is shorter than CONTENT.
-        body_position = body_scroll.scroll_y
-        centre.scroll_end(animate=False)
-        await pilot.pause()
-        assert body_scroll.scroll_y == body_position
-
-        strips = app.screen._compositor.render_strips()
-        visible_body = "\n".join(
-            "".join(segment.text for segment in strips[y])[
-                body_scroll.region.x : body_scroll.region.right
-            ]
-            for y in range(max(body_scroll.region.y, 0), min(body_scroll.region.bottom, size[1]))
-        )
-        assert "paragraph-79" in visible_body, visible_body
-
-        # Scrolling the outer document must not reset the article position.
-        centre.scroll_home(animate=False)
-        await pilot.pause()
-        centre.scroll_end(animate=False)
-        await pilot.pause()
-        assert body_scroll.scroll_y == body_position
+        assert (actions.region, footer.region, left.region, items.region, right.region) == fixed
 
 
 @pytest.mark.asyncio
-async def test_content_actions_footer_and_border_stay_painted_at_body_extremes():
-    app = _ReadGeometryApp(50, content_lines=80)
-    async with app.run_test(size=(180, 120)) as pilot:
+async def test_reader_actions_and_footer_remain_inside_reader() -> None:
+    app = _ReadGeometryApp()
+    async with app.run_test(size=(180, 50)) as pilot:
         await pilot.pause()
-        centre = app.query_one("#wl-centre", VerticalScroll)
-        content = app.query_one("#wl-region-content")
-        body_scroll = app.query_one("#content-body-scroll", VerticalScroll)
-        centre.scroll_end(animate=False)
-        await pilot.pause()
-
-        def painted_content() -> list[str]:
-            strips = app.screen._compositor.render_strips()
-            return [
-                "".join(segment.text for segment in strips[y])[
-                    content.region.x : content.region.right
-                ]
-                for y in range(content.region.y, content.region.bottom)
-            ]
-
-        for scroll_to_end in (False, True):
-            if scroll_to_end:
-                body_scroll.scroll_end(animate=False)
-            else:
-                body_scroll.scroll_home(animate=False)
-            await pilot.pause()
-
-            rows = painted_content()
-            rendered = "\n".join(rows)
-            assert "Mark unread" in rendered
-            assert "Next unread" in rendered
-            assert rows[0].startswith("╭") and rows[0].endswith("╮"), rows[0]
-            assert rows[-1].startswith("╰") and rows[-1].endswith("╯"), rows[-1]
-
-
-@pytest.mark.asyncio
-async def test_compact_article_actions_are_fully_contained_and_composited():
-    app = _ReadGeometryApp(0, content_lines=80)
-    async with app.run_test(size=(120, 36)) as pilot:
-        await pilot.pause()
-        centre = app.query_one("#wl-centre", VerticalScroll)
-        actions = app.query_one("#content-actions")
-        buttons = list(actions.query(Button))
-        centre.scroll_to_widget(actions, animate=False)
-        await pilot.pause()
-
-        assert actions.region.height == 1
-        assert actions.max_scroll_x == 0
-        for button in buttons:
-            assert actions.content_region.contains_region(button.region), (
-                f"{button.id} is clipped outside the compact action viewport: "
-                f"actions={actions.content_region} button={button.region}"
-            )
-
-        strips = app.screen._compositor.render_strips()
-        row = "".join(segment.text for segment in strips[actions.region.y])[
-            actions.region.x : actions.region.right
-        ]
-        for button in buttons:
-            assert str(button.label) in row, (button.id, row)
-
-
-@pytest.mark.parametrize("size", [(120, 36), (180, 70)])
-@pytest.mark.asyncio
-async def test_change_actions_tab_into_native_horizontal_view(size):
-    app = _ReadGeometryApp(0, content_lines=80, content_kind="change")
-    async with app.run_test(size=size) as pilot:
-        await pilot.pause()
-        centre = app.query_one("#wl-centre", VerticalScroll)
+        reader = app.query_one("#wl-region-content")
         actions = app.query_one("#content-actions", HorizontalScroll)
-        body_scroll = app.query_one("#content-body-scroll", VerticalScroll)
-        buttons = list(actions.query(Button))
-        assert [button.id for button in buttons] == [
-            "content-mark-unread-button",
-            "content-star-button",
-            "content-open-button",
-            "content-ingest-button",
-            "content-queue-button",
-            "content-expand-button",
-            "content-full-page-button",
-            "content-previous-snapshot-button",
-        ]
+        footer = app.query_one("#content-footer")
+
+        assert reader.content_region.contains_region(actions.region)
+        assert reader.content_region.contains_region(footer.region)
         assert actions.region.height == 1
-        if size[0] == 120:
-            assert actions.max_scroll_x > 0, (
-                "the compact change fixture must genuinely exercise overflow"
-            )
-
-        centre.scroll_to_widget(actions, animate=False)
-        await pilot.pause()
-        buttons[0].focus()
-        await pilot.pause()
-        for index, button in enumerate(buttons):
-            if index:
-                await pilot.press("tab")
-                await pilot.pause()
-            assert app.focused is button, (index, app.focused)
-            assert actions.content_region.contains_region(button.region), (
-                f"focused {button.id} did not scroll fully into view: "
-                f"actions={actions.content_region} button={button.region} "
-                f"scroll_x={actions.scroll_x}"
-            )
-            strips = app.screen._compositor.render_strips()
-            row = "".join(segment.text for segment in strips[actions.region.y])[
-                actions.region.x : actions.region.right
-            ]
-            assert str(button.label) in row, (button.id, row)
-
-        action_region = actions.region
-        action_scroll_x = actions.scroll_x
-        body_scroll.scroll_end(animate=False)
-        await pilot.pause()
-        assert actions.region == action_region
-        assert actions.scroll_x == action_scroll_x
+        for button in actions.query(Button):
+            assert actions.content_region.contains_region(button.region)
 
 
 @pytest.mark.asyncio
-async def test_content_focus_order_and_keyboard_scroll_follow_visual_order():
-    app = _ReadGeometryApp(0, content_lines=80)
-    async with app.run_test(size=(180, 80)) as pilot:
+async def test_reader_focus_order_keeps_body_between_actions_and_footer() -> None:
+    app = _ReadGeometryApp()
+    async with app.run_test(size=(180, 50)) as pilot:
         await pilot.pause()
         body_scroll = app.query_one("#content-body-scroll", VerticalScroll)
         first_action = app.query_one("#content-mark-unread-button")
@@ -821,292 +502,3 @@ async def test_content_focus_order_and_keyboard_scroll_follow_visual_order():
 
         assert focus_chain.index(first_action) < focus_chain.index(body_scroll)
         assert focus_chain.index(body_scroll) < focus_chain.index(footer_action)
-
-        body_scroll.focus()
-        await pilot.press("end")
-        await pilot.pause()
-        assert body_scroll.has_focus
-        assert body_scroll.max_scroll_y - body_scroll.scroll_y < 0.1
-
-
-@pytest.mark.asyncio
-async def test_solo_content_lifts_caps_and_restore_preserves_reader_state():
-    app = _ReadGeometryApp(0, content_lines=80)
-    async with app.run_test(size=(180, 90)) as pilot:
-        await pilot.pause()
-        workbench = app.query_one(WatchlistsWorkbench)
-        pane = app.query_one(ContentPane)
-        body_scroll = app.query_one("#content-body-scroll", VerticalScroll)
-
-        assert app.query_one("#wl-region-content").region.height == 50
-        assert body_scroll.region.height == 45
-        body_scroll.focus()
-        body_scroll.scroll_to(y=3, animate=False)
-        await pilot.pause()
-
-        workbench.region_layout = RegionLayout().solo(Region.CONTENT)
-        await pilot.pause()
-        await pilot.pause()
-
-        assert app.query_one("#wl-region-content").region.height > 50
-        assert app.query_one(ContentPane) is pane
-        assert app.query_one("#content-body-scroll", VerticalScroll) is body_scroll
-        assert body_scroll.region.height > 45
-        assert body_scroll.has_focus and body_scroll.scroll_y == 3
-
-        workbench.region_layout = RegionLayout()
-        await pilot.pause()
-        await pilot.pause()
-
-        assert app.query_one("#wl-region-content").region.height == 50
-        assert app.query_one(ContentPane) is pane
-        assert app.query_one("#content-body-scroll", VerticalScroll) is body_scroll
-        assert body_scroll.region.height == 45
-        assert body_scroll.has_focus and body_scroll.scroll_y == 3
-
-
-# --- `refresh_region_content` ---------------------------------------------
-#
-# `WatchlistsCollectionsScreen` needs a region to follow new data without
-# recomposing the whole workbench (a full recompose would also replace the
-# Inspector, breaking its "same instance, updated in place" contract -- see
-# `WatchlistsCollectionsScreen.watch_selected_scope`). These pin the
-# primitive it relies on, independent of the screen.
-
-
-@pytest.mark.asyncio
-async def test_refresh_region_content_rebuilds_only_the_named_region():
-    from textual.widgets import Label
-
-    calls = {"content": 0}
-
-    def content_factory():
-        calls["content"] += 1
-        return Label(f"content-{calls['content']}", id="reader-content")
-
-    items_widget_ids: list[int] = []
-
-    def items_factory():
-        label = Label("items", id="items-content")
-        items_widget_ids.append(id(label))
-        return label
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(),
-                content={Region.CONTENT: content_factory, Region.ITEMS: items_factory},
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test() as pilot:
-        workbench = app.query_one(WatchlistsWorkbench)
-        first_content = app.query_one("#reader-content", Label)
-        first_items = app.query_one("#items-content", Label)
-        assert str(first_content.renderable) == "content-1"
-
-        await workbench.refresh_region_content(Region.CONTENT)
-        await pilot.pause()
-
-        refreshed_content = app.query_one("#reader-content", Label)
-        assert str(refreshed_content.renderable) == "content-2", (
-            "the factory should run again, reflecting whatever changed"
-        )
-        assert refreshed_content is not first_content, (
-            "the old content widget should be replaced, not mutated in place"
-        )
-
-        still_items = app.query_one("#items-content", Label)
-        assert still_items is first_items, (
-            "an unrelated region's content must not be touched"
-        )
-        assert calls["content"] == 2
-        assert len(items_widget_ids) == 1, "ITEMS's factory must not run again"
-
-
-@pytest.mark.asyncio
-async def test_refresh_region_content_is_a_noop_when_the_region_is_collapsed():
-    from textual.widgets import Label
-
-    calls = {"content": 0}
-
-    def content_factory():
-        calls["content"] += 1
-        return Label("content", id="reader-content")
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(collapsed=frozenset({Region.CONTENT})),
-                content={Region.CONTENT: content_factory},
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test():
-        workbench = app.query_one(WatchlistsWorkbench)
-        assert calls["content"] == 0, "a collapsed region should not build its content at all"
-
-        await workbench.refresh_region_content(Region.CONTENT)
-
-        assert calls["content"] == 0, "refreshing a collapsed region must be a no-op"
-
-
-@pytest.mark.asyncio
-async def test_refresh_region_content_keeps_a_non_self_headed_regions_title():
-    """Fix round 1, Finding 3: `refresh_region_content` removed *all* of the
-    region body's children and remounted only `factory()`.
-
-    LEFT_RAIL supplies content (the tree) but is NOT in
-    `SELF_HEADED_REGIONS`, so `_region_widget` prepends the generic
-    "Watchlists" heading for it -- which the blanket remove then threw away,
-    leaving an unlabelled bordered rail until the next region toggle happened
-    to rebuild it. That is the exact defect `SELF_HEADED_REGIONS`' own
-    comment records having shipped once already; both of the original tests
-    used self-headed regions, so neither could see it.
-    """
-    from textual.widgets import Label
-
-    def rail_factory():
-        return Label("tree", id="rail-content")
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(),
-                content={Region.LEFT_RAIL: rail_factory},
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test() as pilot:
-        workbench = app.query_one(WatchlistsWorkbench)
-        rail = app.query_one("#wl-region-left_rail")
-        titles = [
-            child for child in rail.children if child.has_class("watchlists-region-title")
-        ]
-        assert len(titles) == 1, "precondition: the rail starts with its heading"
-
-        await workbench.refresh_region_content(Region.LEFT_RAIL)
-        await pilot.pause()
-
-        rail = app.query_one("#wl-region-left_rail")
-        titles = [
-            child for child in rail.children if child.has_class("watchlists-region-title")
-        ]
-        assert len(titles) == 1, (
-            "refreshing a non-self-headed region must not strip its heading; "
-            f"children are {[type(c).__name__ for c in rail.children]}"
-        )
-        assert str(titles[0].renderable) == REGION_TITLES[Region.LEFT_RAIL]
-        assert app.query_one("#rail-content", Label), "the content was rebuilt"
-        assert rail.children[0] is titles[0], (
-            "the heading must stay above the content, not be remounted below it"
-        )
-
-
-@pytest.mark.asyncio
-async def test_refresh_region_content_never_leaves_the_region_empty_on_a_build_failure():
-    """Fix round 1, Finding 3 (companion): build the replacement *before*
-    detaching the old content, so a factory that raises leaves the mounted
-    pane standing instead of a bordered empty box.
-    """
-    from textual.widgets import Label
-
-    calls = {"n": 0}
-
-    def content_factory():
-        calls["n"] += 1
-        if calls["n"] > 1:
-            raise RuntimeError("scope resolution blew up")
-        return Label("content", id="reader-content")
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(),
-                content={Region.CONTENT: content_factory},
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test() as pilot:
-        workbench = app.query_one(WatchlistsWorkbench)
-
-        with pytest.raises(RuntimeError):
-            await workbench.refresh_region_content(Region.CONTENT)
-        await pilot.pause()
-
-        assert app.query_one("#reader-content", Label), (
-            "a failed rebuild must leave the previous content mounted"
-        )
-
-
-# --- task-1344 fix wave (Qodo correctness): `refresh_header_content` -------
-#
-# The workbench's `header=` carries the section tab strip plus the snapshot
-# summary on EVERY tab (`WatchlistsCollectionsScreen._build_centre_status_
-# header` is wired unconditionally since task-2513). Nothing used to rebuild
-# that header in place when its content went stale (e.g. the tree scope
-# moving) -- these pin the primitive independent of the screen, the same way
-# the `refresh_region_content` tests above do for a region.
-
-
-@pytest.mark.asyncio
-async def test_refresh_header_content_rebuilds_the_header_in_place():
-    from textual.widgets import Label
-
-    calls = {"n": 0}
-
-    def header_factory():
-        calls["n"] += 1
-        return Label(f"header-{calls['n']}", id="wl-centre-status")
-
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(),
-                content={Region.ITEMS: lambda: Label("items", id="items-content")},
-                hidden=frozenset({Region.CONTENT}),
-                header=header_factory,
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test() as pilot:
-        workbench = app.query_one(WatchlistsWorkbench)
-        first = app.query_one("#wl-centre-status", Label)
-        assert str(first.renderable) == "header-1"
-
-        await workbench.refresh_header_content()
-        await pilot.pause()
-
-        refreshed = app.query_one("#wl-centre-status", Label)
-        assert str(refreshed.renderable) == "header-2", (
-            "the factory should run again, reflecting whatever changed"
-        )
-        assert refreshed is not first, (
-            "the old header widget should be replaced, not mutated in place"
-        )
-        assert calls["n"] == 2
-        # An unrelated region's content must survive the header refresh.
-        assert app.query_one("#items-content", Label)
-
-
-@pytest.mark.asyncio
-async def test_refresh_header_content_is_a_noop_without_a_header_factory():
-    class _App(App):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(RegionLayout(), id="wl-workbench")
-
-    app = _App()
-    async with app.run_test():
-        workbench = app.query_one(WatchlistsWorkbench)
-        assert not app.query("#wl-centre-status")
-
-        await workbench.refresh_header_content()
-
-        assert not app.query("#wl-centre-status"), (
-            "refreshing with no header factory must not mount one"
-        )

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -110,12 +110,19 @@ def test_region_titles_cover_exactly_the_live_regions() -> None:
     assert set(REGION_TITLES) == set(Region)
 
 
+@pytest.mark.parametrize(
+    ("width", "centre_width"),
+    [(161, 44), (206, 89), (220, 103), (224, 107)],
+)
 @pytest.mark.asyncio
-async def test_real_bundle_keeps_approved_wide_targets_and_minimums() -> None:
-    app = _BoundaryGeometryApp(220, read_mode=True)
+async def test_read_real_bundle_fills_wide_body_exactly(
+    width: int, centre_width: int
+) -> None:
+    app = _BoundaryGeometryApp(width, read_mode=True)
 
-    async with app.run_test(size=(220, 24)) as pilot:
+    async with app.run_test(size=(width, 24)) as pilot:
         await pilot.pause()
+        assert app.layout.collapsed == frozenset()
         expected = {
             ".watchlists-region-left_rail": (28, 24),
             ".watchlists-read-mode .watchlists-region-items": (40, 32),
@@ -128,6 +135,17 @@ async def test_real_bundle_keeps_approved_wide_targets_and_minimums() -> None:
             assert pane.styles.max_width is not None
             assert pane.styles.max_width.value == target
             assert pane.region.width == target
+        _assert_real_bundle_geometry(
+            app,
+            width=width,
+            read_mode=True,
+            expected_widths={
+                "wl-region-left_rail": 28,
+                "wl-region-items": 40,
+                "wl-region-content": centre_width,
+                "wl-region-right_rail": 34,
+            },
+        )
 
 
 def _assert_real_bundle_geometry(
@@ -148,7 +166,8 @@ def _assert_real_bundle_geometry(
     assert body.region.width == workbench.content_region.width == width
     assert body.region.height == workbench.content_region.height
     assert body.max_scroll_x == 0
-    assert body.virtual_size.width <= body.content_region.width
+    assert body.virtual_size.width == body.content_region.width
+    assert children[-1].region.right == body.content_region.right
     assert all(body.content_region.contains_region(child.region) for child in children)
     assert all(
         left.region.right <= right.region.x
@@ -163,7 +182,20 @@ def _assert_real_bundle_geometry(
     centre_id = "wl-region-content" if read_mode else "wl-region-items"
     centre = app.query_one(f"#{centre_id}")
     assert centre.styles.min_width is not None
-    assert centre.styles.min_width.value == 0
+    side_regions = (
+        (Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL)
+        if read_mode
+        else (Region.LEFT_RAIL, Region.RIGHT_RAIL)
+    )
+    has_expanded_side_pane = any(
+        not app.layout.is_collapsed(region) for region in side_regions
+    )
+    assert workbench.has_class("watchlists-has-expanded-side-pane") is (
+        has_expanded_side_pane
+    )
+    assert centre.styles.min_width.value == (
+        44 if has_expanded_side_pane else 0
+    )
     assert centre.region.width == body.content_region.width - sum(
         child.region.width for child in children if child is not centre
     )
@@ -434,7 +466,11 @@ async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
     class _App(App[None]):
         def compose(self) -> ComposeResult:
             yield WatchlistsWorkbench(
-                RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})),
+                RegionLayout(
+                    collapsed=frozenset(
+                        {Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}
+                    )
+                ),
                 content={Region.LEFT_RAIL: rail_factory},
                 read_mode=True,
                 id="wl-workbench",
@@ -445,8 +481,12 @@ async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
         workbench = app.query_one(WatchlistsWorkbench)
         grip = app.query_one("#wl-grip-left_rail", WatchlistsPaneGrip)
         reader = app.query_one("#wl-region-content")
+        assert not workbench.has_class("watchlists-has-expanded-side-pane")
 
-        workbench.region_layout = RegionLayout()
+        expanded_left = RegionLayout(
+            collapsed=frozenset({Region.ITEMS, Region.RIGHT_RAIL})
+        )
+        workbench.region_layout = expanded_left
         await pilot.pause()
 
         assert workbench.region_layout.is_collapsed(Region.LEFT_RAIL)
@@ -454,13 +494,15 @@ async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
         assert grip.expanded is False
         assert not app.query("#wl-region-left_rail")
         assert app.query_one("#wl-region-content") is reader
+        assert not workbench.has_class("watchlists-has-expanded-side-pane")
         assert app.is_running
 
         fail_rail = False
-        workbench.region_layout = RegionLayout()
+        workbench.region_layout = expanded_left
         await pilot.pause()
         assert app.query("#wl-region-left_rail")
         assert grip.expanded is True
+        assert workbench.has_class("watchlists-has-expanded-side-pane")
 
 
 @pytest.mark.asyncio
@@ -719,22 +761,28 @@ async def test_mode_switch_factory_failure_preserves_previous_read_view() -> Non
 
 @pytest.mark.asyncio
 async def test_read_mode_class_tracks_incremental_mode_switches() -> None:
-    app = _WorkbenchApp(RegionLayout(), read_mode=True)
+    rails_collapsed = RegionLayout(
+        collapsed=frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL})
+    )
+    app = _WorkbenchApp(rails_collapsed, read_mode=True)
     async with app.run_test():
         workbench = app.query_one(WatchlistsWorkbench)
         assert workbench.has_class("watchlists-read-mode")
+        assert workbench.has_class("watchlists-has-expanded-side-pane")
 
         await workbench.apply_section_view(
             read_mode=False,
-            layout=RegionLayout(),
+            layout=rails_collapsed,
         )
         assert not workbench.has_class("watchlists-read-mode")
+        assert not workbench.has_class("watchlists-has-expanded-side-pane")
 
         await workbench.apply_section_view(
             hidden=frozenset(),
-            layout=RegionLayout(),
+            layout=rails_collapsed,
         )
         assert workbench.has_class("watchlists-read-mode")
+        assert workbench.has_class("watchlists-has-expanded-side-pane")
 
 
 def _article(item_id: int) -> dict:

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -48,6 +48,30 @@ def test_region_titles_cover_exactly_the_live_regions() -> None:
     assert set(REGION_TITLES) == set(Region)
 
 
+@pytest.mark.parametrize(
+    ("selector", "target", "minimum"),
+    [
+        (".watchlists-region-left_rail", 28, 24),
+        (".watchlists-read-mode .watchlists-region-items", 40, 32),
+        (".watchlists-region-right_rail", 34, 30),
+    ],
+)
+def test_side_pane_css_keeps_approved_target_and_minimum_widths(
+    selector: str, target: int, minimum: int
+) -> None:
+    css_path = (
+        Path(__file__).resolve().parents[2]
+        / "tldw_chatbook"
+        / "css"
+        / "features"
+        / "_watchlists.tcss"
+    )
+    block = css_path.read_text().split(f"{selector} {{", 1)[1].split("}", 1)[0]
+
+    assert f"\n    width: {target};" in block
+    assert f"\n    min-width: {minimum};" in block
+
+
 @pytest.mark.asyncio
 async def test_read_mounts_header_above_exact_horizontal_body_order() -> None:
     class _App(App[None]):

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import inspect
 
 import pytest
 from textual.app import App, ComposeResult
@@ -372,12 +373,12 @@ async def test_legacy_content_collapse_cannot_unmount_reader_in_read() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hidden_compatibility_selects_management_horizontal_body() -> None:
+async def test_explicit_management_mode_selects_management_horizontal_body() -> None:
     class _App(App[None]):
         def compose(self) -> ComposeResult:
             yield WatchlistsWorkbench(
                 RegionLayout(collapsed=frozenset({Region.ITEMS})),
-                hidden=frozenset({Region.CONTENT}),
+                read_mode=False,
                 header=lambda: Static("status", id="wl-centre-status"),
                 id="wl-workbench",
             )
@@ -514,24 +515,13 @@ async def test_grip_activation_uses_shared_region_toggled_message() -> None:
     assert app.toggles == [Region.ITEMS]
 
 
-@pytest.mark.asyncio
-async def test_collapsed_suffix_compatibility_is_a_noop() -> None:
-    class _App(App[None]):
-        def compose(self) -> ComposeResult:
-            yield WatchlistsWorkbench(
-                RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})),
-                collapsed_suffixes={Region.LEFT_RAIL: "12 unread"},
-                id="wl-workbench",
-            )
-
-    app = _App()
-    async with app.run_test():
-        workbench = app.query_one(WatchlistsWorkbench)
-        grip = app.query_one("#wl-grip-left_rail", WatchlistsPaneGrip)
-        label = str(grip.label)
-        workbench.set_collapsed_suffixes({Region.LEFT_RAIL: "7 unread"})
-        assert app.query_one("#wl-grip-left_rail") is grip
-        assert str(grip.label) == label
+def test_transitional_workbench_adapters_are_removed() -> None:
+    constructor = inspect.signature(WatchlistsWorkbench.__init__)
+    apply_view = inspect.signature(WatchlistsWorkbench.apply_section_view)
+    assert "hidden" not in constructor.parameters
+    assert "collapsed_suffixes" not in constructor.parameters
+    assert "hidden" not in apply_view.parameters
+    assert not hasattr(WatchlistsWorkbench, "set_collapsed_suffixes")
 
 
 @pytest.mark.asyncio
@@ -553,6 +543,7 @@ async def test_refresh_region_content_rebuilds_only_named_factory_output() -> No
                     Region.ITEMS: factory("items"),
                     Region.CONTENT: factory("content"),
                 },
+                read_mode=True,
                 id="wl-workbench",
             )
 
@@ -586,6 +577,7 @@ async def test_refresh_region_content_preserves_heading_on_factory_failure() -> 
             yield WatchlistsWorkbench(
                 RegionLayout(),
                 content={Region.LEFT_RAIL: factory},
+                read_mode=True,
                 id="wl-workbench",
             )
 
@@ -621,6 +613,7 @@ async def test_refresh_header_replaces_only_header_and_is_failure_safe() -> None
             yield WatchlistsWorkbench(
                 RegionLayout(),
                 header=header,
+                read_mode=True,
                 id="wl-workbench",
             )
 
@@ -661,6 +654,7 @@ async def test_apply_section_view_rebuilds_only_required_centres() -> None:
                     Region.ITEMS: factory("items"),
                     Region.CONTENT: factory("content"),
                 },
+                read_mode=True,
                 id="wl-workbench",
             )
 
@@ -690,7 +684,7 @@ async def test_apply_section_view_rebuilds_only_required_centres() -> None:
         assert calls == {"items": 2, "content": 1}
 
         await workbench.apply_section_view(
-            hidden=frozenset(),
+            read_mode=True,
             layout=RegionLayout(),
             rebuild_regions=(Region.ITEMS,),
         )
@@ -778,7 +772,7 @@ async def test_read_mode_class_tracks_incremental_mode_switches() -> None:
         assert not workbench.has_class("watchlists-has-expanded-side-pane")
 
         await workbench.apply_section_view(
-            hidden=frozenset(),
+            read_mode=True,
             layout=rails_collapsed,
         )
         assert workbench.has_class("watchlists-read-mode")

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -24,6 +24,8 @@ from tldw_chatbook.UI.Watchlists_Modules.region_layout import (
 )
 from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
     REGION_TITLES,
+    RegionLayoutApplied,
+    RegionLayoutApplyFailed,
     WatchlistsWorkbench,
 )
 
@@ -34,6 +36,7 @@ class _WorkbenchApp(App[None]):
         self.layout_state = layout
         self.read_mode = read_mode
         self.toggles: list[Region] = []
+        self.layout_events: list[RegionLayoutApplied | RegionLayoutApplyFailed] = []
 
     def compose(self) -> ComposeResult:
         yield WatchlistsWorkbench(
@@ -44,6 +47,14 @@ class _WorkbenchApp(App[None]):
 
     def on_region_toggled(self, message: RegionToggled) -> None:
         self.toggles.append(message.region)
+
+    def on_region_layout_applied(self, message: RegionLayoutApplied) -> None:
+        self.layout_events.append(message)
+
+    def on_region_layout_apply_failed(
+        self, message: RegionLayoutApplyFailed
+    ) -> None:
+        self.layout_events.append(message)
 
 
 def _direct_child_ids(widget) -> list[str | None]:
@@ -421,8 +432,8 @@ async def test_side_toggle_preserves_unaffected_bodies_all_grips_and_reader() ->
             )
         }
 
-        workbench.region_layout = RegionLayout(
-            collapsed=frozenset({Region.LEFT_RAIL})
+        workbench.request_region_layout(
+            RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})), token=1
         )
         await pilot.pause()
 
@@ -442,7 +453,7 @@ async def test_expanding_inspector_mounts_body_after_permanent_grip() -> None:
         grip = app.query_one("#wl-grip-right_rail")
         reader = app.query_one("#wl-region-content")
 
-        workbench.region_layout = RegionLayout()
+        workbench.request_region_layout(RegionLayout(), token=1)
         await pilot.pause()
 
         body = app.query_one("#wl-workbench-body", Horizontal)
@@ -487,7 +498,7 @@ async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
         expanded_left = RegionLayout(
             collapsed=frozenset({Region.ITEMS, Region.RIGHT_RAIL})
         )
-        workbench.region_layout = expanded_left
+        workbench.request_region_layout(expanded_left, token=1)
         await pilot.pause()
 
         assert workbench.region_layout.is_collapsed(Region.LEFT_RAIL)
@@ -499,11 +510,63 @@ async def test_expansion_factory_failure_keeps_collapsed_grip_and_dom() -> None:
         assert app.is_running
 
         fail_rail = False
-        workbench.region_layout = expanded_left
+        workbench.request_region_layout(expanded_left, token=2)
         await pilot.pause()
         assert app.query("#wl-region-left_rail")
         assert grip.expanded is True
         assert workbench.has_class("watchlists-has-expanded-side-pane")
+
+
+@pytest.mark.asyncio
+async def test_layout_requests_acknowledge_same_layout_with_exact_token() -> None:
+    layout = RegionLayout()
+    app = _WorkbenchApp(layout)
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+
+        workbench.request_region_layout(layout, token=41)
+        workbench.request_region_layout(layout, token=42)
+        await pilot.pause()
+
+        applied = [
+            event for event in app.layout_events if isinstance(event, RegionLayoutApplied)
+        ]
+        assert [event.token for event in applied] == [41, 42]
+        assert all(event.previous == layout == event.layout for event in applied)
+
+
+@pytest.mark.asyncio
+async def test_failed_layout_request_reports_its_exact_token() -> None:
+    def broken_factory() -> Widget:
+        raise RuntimeError("rail build failed")
+
+    collapsed = RegionLayout(collapsed=frozenset({Region.LEFT_RAIL}))
+
+    class _App(_WorkbenchApp):
+        def compose(self) -> ComposeResult:
+            yield WatchlistsWorkbench(
+                collapsed,
+                content={Region.LEFT_RAIL: broken_factory},
+                read_mode=True,
+                id="wl-workbench",
+            )
+
+    app = _App(collapsed)
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+
+        workbench.request_region_layout(RegionLayout(), token=73)
+        await pilot.pause()
+
+        failures = [
+            event
+            for event in app.layout_events
+            if isinstance(event, RegionLayoutApplyFailed)
+        ]
+        assert len(failures) == 1
+        assert failures[0].token == 73
+        assert failures[0].attempted == RegionLayout()
+        assert failures[0].fallback == collapsed
 
 
 @pytest.mark.asyncio
@@ -670,6 +733,7 @@ async def test_apply_section_view_rebuilds_only_required_centres() -> None:
         await workbench.apply_section_view(
             read_mode=False,
             layout=RegionLayout(),
+            token=1,
             rebuild_regions=(Region.ITEMS,),
         )
         await pilot.pause()
@@ -686,6 +750,7 @@ async def test_apply_section_view_rebuilds_only_required_centres() -> None:
         await workbench.apply_section_view(
             read_mode=True,
             layout=RegionLayout(),
+            token=2,
             rebuild_regions=(Region.ITEMS,),
         )
         await pilot.pause()
@@ -727,14 +792,15 @@ async def test_mode_switch_factory_failure_preserves_previous_read_view() -> Non
         reader = app.query_one("#reader-content")
         fail_items = True
 
-        with pytest.raises(RuntimeError, match="management centre failed"):
-            await workbench.apply_section_view(
-                read_mode=False,
-                layout=RegionLayout(),
-                rebuild_regions=(Region.ITEMS,),
-            )
+        applied = await workbench.apply_section_view(
+            read_mode=False,
+            layout=RegionLayout(),
+            token=7,
+            rebuild_regions=(Region.ITEMS,),
+        )
         await pilot.pause()
 
+        assert applied is False
         assert workbench.read_mode is True
         assert workbench.has_class("watchlists-read-mode")
         assert _direct_child_ids(body) == previous_ids
@@ -743,11 +809,13 @@ async def test_mode_switch_factory_failure_preserves_previous_read_view() -> Non
         assert app.is_running
 
         fail_items = False
-        await workbench.apply_section_view(
+        applied = await workbench.apply_section_view(
             read_mode=False,
             layout=RegionLayout(),
+            token=8,
             rebuild_regions=(Region.ITEMS,),
         )
+        assert applied is True
         assert workbench.read_mode is False
         assert not workbench.has_class("watchlists-read-mode")
         assert not app.query("#reader-content")
@@ -767,6 +835,7 @@ async def test_read_mode_class_tracks_incremental_mode_switches() -> None:
         await workbench.apply_section_view(
             read_mode=False,
             layout=rails_collapsed,
+            token=1,
         )
         assert not workbench.has_class("watchlists-read-mode")
         assert not workbench.has_class("watchlists-has-expanded-side-pane")
@@ -774,6 +843,7 @@ async def test_read_mode_class_tracks_incremental_mode_switches() -> None:
         await workbench.apply_section_view(
             read_mode=True,
             layout=rails_collapsed,
+            token=2,
         )
         assert workbench.has_class("watchlists-read-mode")
         assert workbench.has_class("watchlists-has-expanded-side-pane")

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -110,87 +110,172 @@ def test_region_titles_cover_exactly_the_live_regions() -> None:
     assert set(REGION_TITLES) == set(Region)
 
 
-@pytest.mark.parametrize(
-    ("selector", "target", "minimum"),
-    [
-        (".watchlists-region-left_rail", 28, 24),
-        (".watchlists-read-mode .watchlists-region-items", 40, 32),
-        (".watchlists-region-right_rail", 34, 30),
-    ],
-)
 @pytest.mark.asyncio
-async def test_real_bundle_keeps_approved_side_pane_targets_and_minimums(
-    selector: str, target: int, minimum: int
-) -> None:
+async def test_real_bundle_keeps_approved_wide_targets_and_minimums() -> None:
     app = _BoundaryGeometryApp(220, read_mode=True)
 
     async with app.run_test(size=(220, 24)) as pilot:
         await pilot.pause()
-        pane = app.query_one(selector)
+        expected = {
+            ".watchlists-region-left_rail": (28, 24),
+            ".watchlists-read-mode .watchlists-region-items": (40, 32),
+            ".watchlists-region-right_rail": (34, 30),
+        }
+        for selector, (target, minimum) in expected.items():
+            pane = app.query_one(selector)
+            assert pane.styles.min_width is not None
+            assert pane.styles.min_width.value == minimum
+            assert pane.styles.max_width is not None
+            assert pane.styles.max_width.value == target
+            assert pane.region.width == target
 
-        assert pane.styles.width is not None
-        assert pane.styles.width.value == target
-        assert pane.styles.min_width is not None
-        assert pane.styles.min_width.value == minimum
-        assert pane.region.width == target
 
-
-@pytest.mark.parametrize("width", (145, 144, 115, 114, 91, 90, 60, 59))
-@pytest.mark.parametrize("read_mode", (True, False), ids=("read", "management"))
-@pytest.mark.asyncio
-async def test_real_bundle_boundary_geometry_is_contained_and_keeps_centre(
-    width: int, read_mode: bool
+def _assert_real_bundle_geometry(
+    app: _BoundaryGeometryApp,
+    *,
+    width: int,
+    read_mode: bool,
+    expected_widths: dict[str, int],
 ) -> None:
-    app = _BoundaryGeometryApp(width, read_mode=read_mode)
+    """Assert one mounted real-bundle frame is contained and non-overlapping."""
+    body = app.query_one("#wl-workbench-body", Horizontal)
+    workbench = app.query_one("#wl-workbench", WatchlistsWorkbench)
+    children = list(body.children)
+    expected_order = _expected_boundary_child_ids(app.layout, read_mode=read_mode)
+
+    assert _direct_child_ids(body) == expected_order
+    assert workbench.content_region.contains_region(body.region)
+    assert body.region.width == workbench.content_region.width == width
+    assert body.region.height == workbench.content_region.height
+    assert body.max_scroll_x == 0
+    assert body.virtual_size.width <= body.content_region.width
+    assert all(body.content_region.contains_region(child.region) for child in children)
+    assert all(
+        left.region.right <= right.region.x
+        for left, right in zip(children, children[1:])
+    )
+
+    grips = list(body.query(WatchlistsPaneGrip))
+    assert len(grips) == (3 if read_mode else 2)
+    assert all(grip.outer_size.width == grip.region.width == 5 for grip in grips)
+    assert all(grip.region.height == body.content_region.height for grip in grips)
+
+    centre_id = "wl-region-content" if read_mode else "wl-region-items"
+    centre = app.query_one(f"#{centre_id}")
+    assert centre.styles.min_width is not None
+    assert centre.styles.min_width.value == 0
+    assert centre.region.width == body.content_region.width - sum(
+        child.region.width for child in children if child is not centre
+    )
+    assert centre.region.width > 0
+    assert centre.region.height == body.content_region.height
+    actual_widths = {child.id: child.region.width for child in children}
+    assert {
+        node_id: actual_widths[node_id] for node_id in expected_widths
+    } == expected_widths
+
+
+@pytest.mark.parametrize(
+    ("width", "collapsed", "expected_widths"),
+    [
+        (
+            145,
+            frozenset(),
+            {
+                "wl-region-left_rail": 24,
+                "wl-region-items": 32,
+                "wl-region-content": 44,
+                "wl-region-right_rail": 30,
+            },
+        ),
+        (144, frozenset({Region.RIGHT_RAIL}), {}),
+        (
+            115,
+            frozenset({Region.RIGHT_RAIL}),
+            {
+                "wl-region-left_rail": 24,
+                "wl-region-items": 32,
+                "wl-region-content": 44,
+            },
+        ),
+        (114, frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}), {}),
+        (
+            91,
+            frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}),
+            {"wl-region-items": 32, "wl-region-content": 44},
+        ),
+        (90, frozenset({Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}), {}),
+        (60, frozenset({Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}), {}),
+        (
+            40,
+            frozenset({Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}),
+            {"wl-region-content": 25},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_read_real_bundle_threshold_geometry(
+    width: int,
+    collapsed: frozenset[Region],
+    expected_widths: dict[str, int],
+) -> None:
+    app = _BoundaryGeometryApp(width, read_mode=True)
 
     async with app.run_test(size=(width, 24)) as pilot:
         await pilot.pause()
-        body = app.query_one("#wl-workbench-body", Horizontal)
-        workbench = app.query_one("#wl-workbench", WatchlistsWorkbench)
-        children = list(body.children)
-        expected = _expected_boundary_child_ids(
-            app.layout,
-            read_mode=read_mode,
+        assert app.layout.collapsed == collapsed
+        _assert_real_bundle_geometry(
+            app,
+            width=width,
+            read_mode=True,
+            expected_widths=expected_widths,
         )
 
-        assert _direct_child_ids(body) == expected
-        assert workbench.content_region.contains_region(body.region)
-        assert body.region.width == workbench.content_region.width == width
-        assert body.region.height == workbench.content_region.height
-        assert body.max_scroll_x == 0
-        assert body.virtual_size.width <= body.content_region.width
-        assert all(
-            body.content_region.contains_region(child.region) for child in children
-        )
-        assert all(
-            left.region.right <= right.region.x
-            for left, right in zip(children, children[1:])
-        )
 
-        grips = list(body.query(WatchlistsPaneGrip))
-        assert len(grips) == (3 if read_mode else 2)
-        assert all(grip.outer_size.width == grip.region.width == 5 for grip in grips)
-        assert all(grip.region.height == body.content_region.height for grip in grips)
+@pytest.mark.parametrize(
+    ("width", "collapsed", "expected_widths"),
+    [
+        (
+            108,
+            frozenset(),
+            {
+                "wl-region-left_rail": 24,
+                "wl-region-items": 44,
+                "wl-region-right_rail": 30,
+            },
+        ),
+        (107, frozenset({Region.RIGHT_RAIL}), {}),
+        (
+            78,
+            frozenset({Region.RIGHT_RAIL}),
+            {"wl-region-left_rail": 24, "wl-region-items": 44},
+        ),
+        (77, frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}), {}),
+        (76, frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}), {}),
+        (
+            40,
+            frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}),
+            {"wl-region-items": 30},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_management_real_bundle_threshold_geometry(
+    width: int,
+    collapsed: frozenset[Region],
+    expected_widths: dict[str, int],
+) -> None:
+    app = _BoundaryGeometryApp(width, read_mode=False)
 
-        minimums = {
-            "wl-region-left_rail": 24,
-            "wl-region-items": 32,
-            "wl-region-right_rail": 30,
-        }
-        for child in children:
-            if child.id in minimums and (read_mode or child.id != "wl-region-items"):
-                assert child.region.width >= minimums[child.id]
-
-        centre_id = "#wl-region-content" if read_mode else "#wl-region-items"
-        centre = app.query_one(centre_id)
-        assert centre.styles.min_width is not None
-        assert centre.styles.min_width.value == 0
-        occupied_by_siblings = sum(
-            child.region.width for child in children if child is not centre
+    async with app.run_test(size=(width, 24)) as pilot:
+        await pilot.pause()
+        assert app.layout.collapsed == collapsed
+        _assert_real_bundle_geometry(
+            app,
+            width=width,
+            read_mode=False,
+            expected_widths=expected_widths,
         )
-        assert centre.region.width == body.content_region.width - occupied_by_siblings
-        assert centre.region.width > 0
-        assert centre.region.height == body.content_region.height
 
 
 @pytest.mark.asyncio

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -633,12 +633,43 @@ async def test_reader_actions_and_footer_remain_inside_reader() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reader_empty_state_uses_the_approved_copy() -> None:
+    class _App(App[None]):
+        def compose(self) -> ComposeResult:
+            yield ContentPane(id="watchlists-content-pane")
+
+    app = _App()
+    async with app.run_test():
+        empty = app.query_one("#content-empty", Static)
+
+        assert str(empty.renderable) == "Select a feed item to display it here."
+
+
+@pytest.mark.asyncio
+async def test_reader_exposes_only_core_actions_in_the_approved_order() -> None:
+    app = _ReadGeometryApp()
+    async with app.run_test(size=(180, 50)):
+        actions = app.query_one("#content-actions", HorizontalScroll)
+        footer = app.query_one("#content-footer", Horizontal)
+
+        assert _direct_child_ids(actions) == [
+            "content-star-button",
+            "content-mark-unread-button",
+            "content-open-button",
+        ]
+        assert _direct_child_ids(footer) == [
+            "content-position",
+            "content-next-unread-button",
+        ]
+
+
+@pytest.mark.asyncio
 async def test_reader_focus_order_keeps_body_between_actions_and_footer() -> None:
     app = _ReadGeometryApp()
     async with app.run_test(size=(180, 50)) as pilot:
         await pilot.pause()
         body_scroll = app.query_one("#content-body-scroll", VerticalScroll)
-        first_action = app.query_one("#content-mark-unread-button")
+        first_action = app.query_one("#content-star-button")
         footer_action = app.query_one("#content-next-unread-button")
         focus_chain = app.screen.focus_chain
 

--- a/backlog/decisions/042-watchlists-reader-first-ia.md
+++ b/backlog/decisions/042-watchlists-reader-first-ia.md
@@ -48,6 +48,19 @@ finishes the reader-first IA and amends this decision as follows:
 - **Existing layout configuration is version-normalized.** Navigation, Feed Items,
   and Inspector choices survive; any persisted Reader/Content collapse is removed.
   The corrected layout and version advance atomically, or the migration retries.
+- **Scope navigation commits with its snapshot.** Moving focus to another Navigation
+  choice does not relabel old rows. The active scope/highlight changes only after its
+  replacement rows load successfully, clears Reader selection, and leaves the empty
+  Reader until the user explicitly activates an item.
+- **Reading snapshots favor bounded, honest stability.** Pages use an
+  effective-date/item-id keyset, an initial item-id high-water mark, and a seen-id
+  guard. Mounted rows stay stable and new insertions wait behind the new-items
+  affordance; unseen rows with publication metadata changed by a background upsert
+  may move or wait for explicit refresh rather than requiring an unbounded
+  materialized snapshot index.
+- **Item mutation dimensions remain independent.** Status and star writes serialize
+  per item but retain separate desired intents, so one action cannot cancel the
+  other. Browser launch is scheme-validated and performed off the UI thread.
 - **The implementation remains Watchlists-local.** It may reuse shared rail
   vocabulary, but an application-wide split-pane framework is deferred until the
   independently proceeding Media Library redesign provides a second proven shape.

--- a/backlog/decisions/042-watchlists-reader-first-ia.md
+++ b/backlog/decisions/042-watchlists-reader-first-ia.md
@@ -20,8 +20,36 @@ Re-shape the Watchlists screen around the reading loop instead of operations man
   source) scopes the items list via the existing `list_items(source_id=…)` seam.
 - **Bulk mark-all-read** for the current scope, backed by a session undo batch so the
   operation is reversible.
-- **New Read keymap**: `m` toggle read/unread, `a` mark all read, `u` next unread,
-  `space` page the reading pane — single-letter bindings per ADR-031.
+- **New Read keymap**: `m` toggle read/unread, `a` mark all read, `u` undo the
+  latest mark-all-read batch, and `space` next unread — single-letter bindings per
+  ADR-031.
+
+## 2026-08-23 amendment: permanent Reader and collapsible side panes
+
+The approved
+`Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md`
+finishes the reader-first IA and amends this decision as follows:
+
+- **Reader is the permanent centre anchor.** It is no longer independently
+  collapsible. Navigation, Feed Items, and Inspector are the three collapsible
+  side panes.
+- **Collapsed panes remain reachable.** Each side pane leaves a narrow,
+  full-height, clickable ASCII grip whose arrow points in the action direction.
+- **Preferred layout is distinct from effective layout.** Manual grip/key choices
+  persist. Responsive collapses and the user-triggered Article Focus mode are
+  transient derivations and never overwrite the preferred configuration.
+- **Inspector preference is shared across all Watchlists tabs.** It does not gain
+  per-tab copies of the same state.
+- **Responsive policy protects Reader.** When minimum pane widths no longer fit,
+  effective collapse priority is Inspector, Navigation, then Feed Items; an
+  explicitly opened pane receives temporary priority and displaces lower-priority
+  side panes instead.
+- **Existing layout configuration is version-normalized.** Navigation, Feed Items,
+  and Inspector choices survive; any persisted Reader/Content collapse is removed.
+  The corrected layout and version advance atomically, or the migration retries.
+- **The implementation remains Watchlists-local.** It may reuse shared rail
+  vocabulary, but an application-wide split-pane framework is deferred until the
+  independently proceeding Media Library redesign provides a second proven shape.
 
 ## Context
 
@@ -57,10 +85,14 @@ disturbing the ops surfaces built in the rebuild.
   into the Notifications section) keep working.
 - Phase 1 scope is the reading loop only; smart feeds, FTS search, flagging, and
   content rendering land in later phases of the same spec.
+- The 2026-08-23 amendment supersedes the older implication that every workbench
+  region, including Reader/Content, remains manually collapsible.
 
 ## Links
 
 - Design spec: `Docs/superpowers/specs/2026-08-05-watchlists-reader-first-design.md`
+- NetNewsWire reader and collapsible rails amendment:
+  `Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md`
 - Phase 1 plan: `Docs/superpowers/plans/2026-08-05-watchlists-reader-first-phase-1-reading-loop.md`
 - Amends: `backlog/decisions/018-watchlists-tui-screen.md`
 - Keybinding conventions: `backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md`

--- a/backlog/decisions/042-watchlists-reader-first-ia.md
+++ b/backlog/decisions/042-watchlists-reader-first-ia.md
@@ -30,9 +30,10 @@ The approved
 `Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md`
 finishes the reader-first IA and amends this decision as follows:
 
-- **Reader is the permanent centre anchor.** It is no longer independently
+- **Reader is the permanent centre anchor on Read.** It is no longer independently
   collapsible. Navigation, Feed Items, and Inspector are the three collapsible
-  side panes.
+  side panes. On management tabs the existing active management canvas remains the
+  permanent centre host; it is not removed or governed by Feed Items' preference.
 - **Collapsed panes remain reachable.** Each side pane leaves a narrow,
   full-height, clickable ASCII grip whose arrow points in the action direction.
 - **Preferred layout is distinct from effective layout.** Manual grip/key choices

--- a/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
+++ b/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-21281
 title: Make Watchlists Reader permanent with independently collapsible panes
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-23 22:11'
-updated_date: '2026-08-23 22:17'
+updated_date: '2026-08-24 14:36'
 labels:
   - watchlists
   - ux
@@ -25,19 +25,19 @@ Replace the Watchlists Read screen's vertically stacked centre with a NetNewsWir
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Read always mounts Reader as the primary centre and shows 'Select a feed item to display it here.' when no item is selected; management tabs keep their active centre canvas.
-- [ ] #2 Navigation, Feed Items, and Inspector expose focusable, clickable five-column full-height grips with the approved literal ASCII directions; Feed Items and its grip are absent from management tabs.
-- [ ] #3 Navigation, Feed Items, and Inspector preferences toggle independently, persist across restarts, and Inspector state is shared across all seven Watchlists tabs.
-- [ ] #4 Responsive layout derives an effective state without changing the saved preference, collapses Inspector then Navigation then Feed Items on Read, and Inspector then Navigation on management tabs.
-- [ ] #5 Article Focus temporarily collapses all side panes, restores the exact preferred layout, and a manual grip action exits focus before applying its toggle.
-- [ ] #6 Reader and management canvas are never collapse targets; z acts only on a focused collapsible pane/grip, Z controls Article Focus, and existing left/right rail shortcuts remain valid.
-- [ ] #7 Versioned config normalization preserves valid side-pane choices, removes unknown/Reader entries, writes values plus version atomically, and retries after failed migration or ordinary preference writes.
-- [ ] #8 Layout changes preserve selected item, active scope, search/filter/page state, list focus/visible offset, and Reader scroll; scope changes do not auto-select an item.
-- [ ] #9 Production CSS renders target/minimum pane widths and exact five-column grips without horizontal overflow at declared boundaries and the 60-column supported floor.
-- [ ] #10 Reader's always-visible action row contains only Star/Unstar, Mark read/unread, and Open in browser; advanced Ingest and Queue actions remain available through Inspector.
-- [ ] #11 Open in browser accepts only valid HTTP(S) URLs and performs the operating-system browser call off the Textual UI thread, with honest failure feedback.
-- [ ] #12 Server-backed Read shows the local-only recovery state and Switch to Local without issuing local Reader, Smart Feed, search, or refresh queries under a Server label.
-- [ ] #13 Focused Watchlists/UI tests, CSS bundle integrity, lint/static checks, isolated-profile live keyboard/pointer verification, and self-review pass; documentation, ADR link, task notes, and acceptance criteria are complete.
+- [x] #1 Read always mounts Reader as the primary centre and shows 'Select a feed item to display it here.' when no item is selected; management tabs keep their active centre canvas.
+- [x] #2 Navigation, Feed Items, and Inspector expose focusable, clickable five-column full-height grips with the approved literal ASCII directions; Feed Items and its grip are absent from management tabs.
+- [x] #3 Navigation, Feed Items, and Inspector preferences toggle independently, persist across restarts, and Inspector state is shared across all seven Watchlists tabs.
+- [x] #4 Responsive layout derives an effective state without changing the saved preference, collapses Inspector then Navigation then Feed Items on Read, and Inspector then Navigation on management tabs.
+- [x] #5 Article Focus temporarily collapses all side panes, restores the exact preferred layout, and a manual grip action exits focus before applying its toggle.
+- [x] #6 Reader and management canvas are never collapse targets; z acts only on a focused collapsible pane/grip, Z controls Article Focus, and existing left/right rail shortcuts remain valid.
+- [x] #7 Versioned config normalization preserves valid side-pane choices, removes unknown/Reader entries, writes values plus version atomically, and retries after failed migration or ordinary preference writes.
+- [x] #8 Layout changes preserve selected item, active scope, search/filter/page state, list focus/visible offset, and Reader scroll; scope changes do not auto-select an item.
+- [x] #9 Production CSS renders target/minimum pane widths and exact five-column grips without horizontal overflow at declared boundaries and the 60-column supported floor.
+- [x] #10 Reader's always-visible action row contains only Star/Unstar, Mark read/unread, and Open in browser; advanced Ingest and Queue actions remain available through Inspector.
+- [x] #11 Open in browser accepts only valid HTTP(S) URLs and performs the operating-system browser call off the Textual UI thread, with honest failure feedback.
+- [x] #12 Server-backed Read shows the local-only recovery state and Switch to Local without issuing local Reader, Smart Feed, search, or refresh queries under a Server label.
+- [x] #13 Focused Watchlists/UI tests, CSS bundle integrity, lint/static checks, isolated-profile live keyboard/pointer verification, and self-review pass; documentation, ADR link, task notes, and acceptance criteria are complete.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -53,3 +53,39 @@ ADR path: `backlog/decisions/042-watchlists-reader-first-ia.md`
 Reason: ADR-042 already contains the accepted permanent-Reader/collapsible-side-pane
 amendment; this task directly implements it without changing the architecture boundary.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Reworked Watchlists Read around a permanent Reader with independently collapsible
+  Navigation, Feed Items, and Inspector panes. Manual preferences are versioned and
+  durable; responsive collapse and Article Focus remain transient. Management tabs
+  retain their existing centre canvases and share the Inspector preference.
+- Added production five-column ASCII grips, responsive width resolution, focus and
+  view-state restoration, serialized retryable preference persistence, Reader core
+  actions/footer, validated off-thread browser launch, and honest server-backed Read
+  recovery. Advanced item actions remain in Inspector.
+- Modified areas: Watchlists screen/controller, Watchlists-local pane/layout/store
+  modules, Watchlists CSS and generated CSS bundle, and focused Watchlists/UI tests.
+  No database/schema/migration, Media, or shared split-pane framework changes were
+  made. Implementation commit range: `e986e8c..753739f`, including the final
+  test-only lint cleanup.
+- Verification on `753739f`: focused Watchlists/UI suite collected 888 tests and
+  passed 887 with one pre-existing Personas tooltip-audit skip and two dependency
+  warnings in 460.59s; the lint-cleanup files passed 143 focused tests; scoped Ruff,
+  all five CSS bundle-sync checks, and `git diff --check` passed. Isolated-profile
+  mounted production-screen verification covered keyboard and terminal-cell pointer
+  interaction, all seven tabs, restart persistence, Reader copy/actions/footer, and
+  widths 145, 144, 115, 114, 91, 90, 60, and 40 without overlap, horizontal overflow,
+  or compositor exceptions. Self-review confirmed state survival, retry behavior,
+  permanent-centre boundaries, production CSS use, and Watchlists-only ownership.
+- Verification deviation: at the user's explicit direction, the repository-wide
+  58,117-test suite was skipped as a completion gate in favor of tests related to the
+  modified functionality/code. A superseded broad run was terminated at 71% without
+  a terminal summary; no pass, failure-set, or baseline-comparison claim is made from
+  that run.
+- ADR required: no. Existing
+  [ADR-042](../decisions/042-watchlists-reader-first-ia.md) already records the
+  permanent-Reader/collapsible-side-pane architecture, and this work does not change
+  its boundary. The approved design spec and ADR remain factually current.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
+++ b/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
@@ -35,7 +35,9 @@ Replace the Watchlists Read screen's vertically stacked centre with a NetNewsWir
 - [ ] #8 Layout changes preserve selected item, active scope, search/filter/page state, list focus/visible offset, and Reader scroll; scope changes do not auto-select an item.
 - [ ] #9 Production CSS renders target/minimum pane widths and exact five-column grips without horizontal overflow at declared boundaries and the 60-column supported floor.
 - [ ] #10 Reader's always-visible action row contains only Star/Unstar, Mark read/unread, and Open in browser; advanced Ingest and Queue actions remain available through Inspector.
-- [ ] #11 Focused Watchlists/UI tests, CSS bundle integrity, lint/static checks, isolated-profile live keyboard/pointer verification, and self-review pass; documentation, ADR link, task notes, and acceptance criteria are complete.
+- [ ] #11 Open in browser accepts only valid HTTP(S) URLs and performs the operating-system browser call off the Textual UI thread, with honest failure feedback.
+- [ ] #12 Server-backed Read shows the local-only recovery state and Switch to Local without issuing local Reader, Smart Feed, search, or refresh queries under a Server label.
+- [ ] #13 Focused Watchlists/UI tests, CSS bundle integrity, lint/static checks, isolated-profile live keyboard/pointer verification, and self-review pass; documentation, ADR link, task notes, and acceptance criteria are complete.
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
+++ b/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-23 22:11'
-updated_date: '2026-08-24 14:36'
+updated_date: '2026-08-24 17:15'
 labels:
   - watchlists
   - ux
@@ -68,8 +68,12 @@ amendment; this task directly implements it without changing the architecture bo
 - Modified areas: Watchlists screen/controller, Watchlists-local pane/layout/store
   modules, Watchlists CSS and generated CSS bundle, and focused Watchlists/UI tests.
   No database/schema/migration, Media, or shared split-pane framework changes were
-  made. Implementation commit range: `e986e8c..753739f`, including the final
-  test-only lint cleanup.
+  made. Implementation commit range: `e986e8c..2c77eac`, including the final
+  test-only lint cleanup and review fixes.
+- Final review hardening made Server-backed Read query-free both during mounted
+  transitions and cold/deep-linked entry, parks the local navigation/snapshot model
+  while recovery is visible, and restores it when moving to a management tab. It
+  also tightened compact-width controls and migrated stale layout contracts.
 - Verification on `753739f`: focused Watchlists/UI suite collected 888 tests and
   passed 887 with one pre-existing Personas tooltip-audit skip and two dependency
   warnings in 460.59s; the lint-cleanup files passed 143 focused tests; scoped Ruff,
@@ -79,6 +83,11 @@ amendment; this task directly implements it without changing the architecture bo
   widths 145, 144, 115, 114, 91, 90, 60, and 40 without overlap, horizontal overflow,
   or compositor exceptions. Self-review confirmed state survival, retry behavior,
   permanent-centre boundaries, production CSS use, and Watchlists-only ownership.
+- Final verification on `2c77eac`: all 87 collections-screen tests passed in 81.02s;
+  the focused five-test Server recovery/switch set passed; scoped Ruff and
+  `git diff --check` passed. Independent final code review reported no Critical or
+  Important findings. Pytest emitted unrelated dependency and temporary-directory
+  cleanup warnings only.
 - Verification deviation: at the user's explicit direction, the repository-wide
   58,117-test suite was skipped as a completion gate in favor of tests related to the
   modified functionality/code. A superseded broad run was terminated at 71% without

--- a/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
+++ b/backlog/tasks/task-21281 - Make-Watchlists-Reader-permanent-with-independently-collapsible-panes.md
@@ -1,0 +1,53 @@
+---
+id: TASK-21281
+title: Make Watchlists Reader permanent with independently collapsible panes
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-23 22:11'
+updated_date: '2026-08-23 22:17'
+labels:
+  - watchlists
+  - ux
+dependencies: []
+references:
+  - >-
+    Docs/superpowers/specs/2026-08-23-watchlists-netnewswire-reader-collapsible-rails-design.md
+  - backlog/decisions/042-watchlists-reader-first-ia.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the Watchlists Read screen's vertically stacked centre with a NetNewsWire-style permanent Reader and independently collapsible Navigation, Feed Items, and Inspector panes. Preserve the shipped reading, Smart Feed, search, refresh, pagination, selection, and item-action behavior while making manual layout preferences durable and responsive/Article Focus overrides transient.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Read always mounts Reader as the primary centre and shows 'Select a feed item to display it here.' when no item is selected; management tabs keep their active centre canvas.
+- [ ] #2 Navigation, Feed Items, and Inspector expose focusable, clickable five-column full-height grips with the approved literal ASCII directions; Feed Items and its grip are absent from management tabs.
+- [ ] #3 Navigation, Feed Items, and Inspector preferences toggle independently, persist across restarts, and Inspector state is shared across all seven Watchlists tabs.
+- [ ] #4 Responsive layout derives an effective state without changing the saved preference, collapses Inspector then Navigation then Feed Items on Read, and Inspector then Navigation on management tabs.
+- [ ] #5 Article Focus temporarily collapses all side panes, restores the exact preferred layout, and a manual grip action exits focus before applying its toggle.
+- [ ] #6 Reader and management canvas are never collapse targets; z acts only on a focused collapsible pane/grip, Z controls Article Focus, and existing left/right rail shortcuts remain valid.
+- [ ] #7 Versioned config normalization preserves valid side-pane choices, removes unknown/Reader entries, writes values plus version atomically, and retries after failed migration or ordinary preference writes.
+- [ ] #8 Layout changes preserve selected item, active scope, search/filter/page state, list focus/visible offset, and Reader scroll; scope changes do not auto-select an item.
+- [ ] #9 Production CSS renders target/minimum pane widths and exact five-column grips without horizontal overflow at declared boundaries and the 60-column supported floor.
+- [ ] #10 Reader's always-visible action row contains only Star/Unstar, Mark read/unread, and Open in browser; advanced Ingest and Queue actions remain available through Inspector.
+- [ ] #11 Focused Watchlists/UI tests, CSS bundle integrity, lint/static checks, isolated-profile live keyboard/pointer verification, and self-review pass; documentation, ADR link, task notes, and acceptance criteria are complete.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute `Docs/superpowers/plans/2026-08-23-watchlists-collapsible-reader-layout.md`
+task-by-task using TDD and the dedicated Watchlists worktree.
+
+ADR required: no new ADR
+
+ADR path: `backlog/decisions/042-watchlists-reader-first-ia.md`
+
+Reason: ADR-042 already contains the accepted permanent-Reader/collapsible-side-pane
+amendment; this task directly implements it without changing the architecture boundary.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -166,7 +166,12 @@ from ..Watchlists_Modules.opml_dialogs import (
     WatchlistSourcePickerDialog,
 )
 from ..Watchlists_Modules.overview_pane import OverviewPane
-from ..Watchlists_Modules.region_layout import CENTRE_REGIONS, Region, RegionLayout
+from ..Watchlists_Modules.region_layout import (
+    CENTRE_REGIONS,
+    COLLAPSIBLE_REGIONS,
+    Region,
+    RegionLayout,
+)
 from ..Watchlists_Modules.region_layout_store import load_region_layout, save_region_layout
 from ..Watchlists_Modules.rules_pane import (
     RefreshRulesRequested,
@@ -3207,9 +3212,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         """Correct screen preference only while the failed intent is current."""
         event.stop()
-        if self.region_layout != event.attempted:
+        if self._rendered_region_layout() != event.attempted:
             return
-        self._apply_layout(event.fallback)
+        collapsed = set(self.region_layout.collapsed)
+        for region in COLLAPSIBLE_REGIONS:
+            if event.attempted.is_collapsed(region) == event.fallback.is_collapsed(
+                region
+            ):
+                continue
+            if event.fallback.is_collapsed(region):
+                collapsed.add(region)
+            else:
+                collapsed.discard(region)
+        self._apply_layout(
+            replace(self.region_layout, collapsed=frozenset(collapsed))
+        )
 
     def _apply_tree_scope(self, scope: TreeScope) -> None:
         """The single reconciliation point for "the tree scope is now `scope`".

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -411,7 +411,7 @@ class _ItemStatusIntent:
 
 
 @dataclass(frozen=True)
-class _ManualLayoutRollback:
+class ManualLayoutRollback:
     """One manual preference intent owned by its latest request token."""
 
     token: int
@@ -423,7 +423,7 @@ class _ManualLayoutRollback:
 
 
 @dataclass(frozen=True)
-class _SectionViewIntent:
+class SectionViewIntent:
     """A section reconciliation snapshot, independent of later tab clicks."""
 
     token: int
@@ -1019,7 +1019,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # Avoid initializing the reactive (and its watcher) before Textual
         # attaches this screen to an app; on_mount replaces this seed.
         self._rendered_section = "items"
-        self._manual_layout_rollback: _ManualLayoutRollback | None = None
+        self._manual_layout_rollback: ManualLayoutRollback | None = None
         self._items_view_anchor_id: str | None = None
         self._items_view_scroll_y = 0.0
         self._items_view_had_focus = False
@@ -1059,7 +1059,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # queue rather than `run_worker(exclusive=True)` per surface.
         self._pending_surface_refresh: set[str] = set()
         self._surface_refresh_draining = False
-        self._pending_section_intent: _SectionViewIntent | None = None
+        self._pending_section_intent: SectionViewIntent | None = None
         # The Console-follow adapter's latest answer, mirrored here so the
         # RIGHT_RAIL factory reads an attribute instead of polling from
         # `compose()` (TASK-2200 review wave, M4). Refreshed by
@@ -3015,7 +3015,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             rollback is not None
             and self.region_layout == rollback.attempted_preferred
         ):
-            self._manual_layout_rollback = _ManualLayoutRollback(
+            self._manual_layout_rollback = ManualLayoutRollback(
                 token=self._current_layout_request_token,
                 attempted_layout=self._effective_region_layout,
                 attempted_preferred=rollback.attempted_preferred,
@@ -3412,7 +3412,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self.region_layout = preferred
         token = self._recompute_effective_layout()
         request_token = token or self._current_layout_request_token
-        self._manual_layout_rollback = _ManualLayoutRollback(
+        self._manual_layout_rollback = ManualLayoutRollback(
             token=request_token,
             attempted_layout=self._effective_region_layout,
             attempted_preferred=preferred,
@@ -4370,7 +4370,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             token = self._next_layout_request_token()
             detail_builder = self._build_detail_pane
             header_builder = self._build_centre_status_header
-            intent = _SectionViewIntent(
+            intent = SectionViewIntent(
                 token=token,
                 section=section,
                 read_mode=section == "items",
@@ -4691,7 +4691,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             section = self.active_section
             detail_builder = self._build_detail_pane
             header_builder = self._build_centre_status_header
-            self._pending_section_intent = _SectionViewIntent(
+            self._pending_section_intent = SectionViewIntent(
                 token=token,
                 section=section,
                 read_mode=section == "items",

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -533,10 +533,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         ("r", "refresh_all", "Refresh all"),
         ("a", "mark_all_read", "Mark all read"),
         ("u", "undo_mark_all_read", "Undo mark-all-read"),
-        ("z", "toggle_region", "Collapse"),
-        ("Z", "article_focus", "Article Focus"),
-        ("left_square_bracket", "toggle_left_rail", "Left rail"),
-        ("right_square_bracket", "toggle_right_rail", "Right rail"),
+        ("z", "toggle_region", "Toggle focused side pane"),
+        ("Z", "article_focus", "Article Focus (Read only)"),
+        ("left_square_bracket", "toggle_left_rail", "Navigation"),
+        ("right_square_bracket", "toggle_right_rail", "Inspector"),
     ]
 
     active_section = reactive("items")
@@ -1333,6 +1333,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         "you have zero watchlists" -- two empty roots and no message, since
         the tree is its own only error surface.
         """
+        if self.active_section == "items" and self.runtime_backend != "local":
+            self._tree_watchlists = []
+            self._tree_counts = {}
+            self._tree_source_counts = {}
+            self._breadcrumb_labels = self._resolve_breadcrumb_labels(
+                self.selected_scope
+            )
+            self._apply_tree_data_to_live_surfaces()
+            return
+
         notify = getattr(self.app_instance, "notify", None)
         try:
             service = self._watchlist_bundle_service()
@@ -2264,13 +2274,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         elif section == "items":
             # Seed the last-loaded rows (Finding 2, fix round 2) — see the
             # note on `sources_pane.sources` above; same rebuild, same gap.
-            # Audited for task-15778 and deliberately left as plain
-            # assignments: `ArticleListPane` has NO `recompose=True`
-            # reactives at all (its watchers patch the mounted list in
-            # place), so this branch never paid the pre-mount seeding
-            # recompose and there is nothing to convert.
+            # `items` is seeded without its async watcher: on a freshly
+            # constructed pane there is no mounted list to patch, and
+            # invoking that watcher here only creates an un-awaited
+            # coroutine. Compose reads the seeded value normally.
             items_pane = ArticleListPane(id="watchlists-items-pane")
-            items_pane.items = self._loaded_items
+            # The surrounding detail pane also owns its one-line title.
+            # Consume only the remaining height so the fixed legend/pager
+            # stay inside the permanent Feed Items column at every terminal
+            # height; `100%` here would place that chrome below the viewport.
+            items_pane.styles.height = "1fr"
+            items_pane.styles.min_height = 0
+            items_pane.set_reactive(ArticleListPane.items, self._loaded_items)
             # Seed the filter, the search box and the selection too
             # (whole-branch review, Important) -- the sibling Sources/Runs/
             # Notifications panes above and below already re-seed their
@@ -2409,7 +2424,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._items_inflight_page_load = None
         self._push_items_pager_state()
 
-    def _build_content_pane(self) -> ContentPane:
+    def _build_content_pane(self) -> Widget:
         """Build the CONTENT-region content: the reader for the last
         selected item (Task 4).
 
@@ -2431,6 +2446,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         generic "Content" title above whatever this returns.
 
         """
+        if self.active_section == "items" and self.runtime_backend != "local":
+            return Vertical(
+                Static(
+                    "Read and its permanent Reader are local-only. "
+                    "Switch to Local to browse items stored on this device.",
+                    id="watchlists-read-local-only-copy",
+                ),
+                Button(
+                    "Switch to Local",
+                    id="watchlists-switch-local",
+                    tooltip="Switch to the Local backend and load feed items.",
+                ),
+                id="watchlists-read-local-only",
+                classes="destination-workbench-pane",
+            )
+
         pane = ContentPane(id="watchlists-content-pane")
         # `set_reactive`: `item` is the pane's one `recompose=True` reactive
         # and has no watcher, so a plain assignment here bought nothing but
@@ -2724,6 +2755,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     #: Artifacts joins it -- briefings are written to, and read from, this
     #: device's `SubscriptionsDB` whatever the selector says.
     _LOCAL_ONLY_SECTIONS: dict[str, dict[str, str]] = {
+        "items": {
+            "label": "Read: local",
+            "tooltip": (
+                "Read and its permanent Reader use items stored on this device. "
+                "Switch to Local to load them."
+            ),
+        },
         "notifications": {
             "label": "Inbox: local",
             "tooltip": "The notifications inbox is local to this device.",
@@ -4022,7 +4060,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if not self.is_mounted:
             return
         self._refresh_centre_header_for_scope()
-        read_is_active = self.active_section == "items"
+        read_is_active = (
+            self.active_section == "items" and self.runtime_backend == "local"
+        )
         self._reset_items_paging_for_context(loading=read_is_active)
         if read_is_active:
             # Own group, not the default one: `exclusive=True` in the
@@ -4082,6 +4122,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     _SURFACE_RAIL = "rail"
     _SURFACE_HEADER = "header"
     _SURFACE_INSPECTOR = "inspector"
+    _SURFACE_READER = "reader"
     #: task-15461. The section swap: the ITEMS region's pane (routed by
     #: `active_section`), the centre header (which carries the tab strip) and
     #: whichever centre regions the new tab hides or shows. Queued here rather
@@ -4128,7 +4169,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         Args:
             surfaces: Any of `_SURFACE_RAIL`, `_SURFACE_HEADER`,
-                `_SURFACE_SECTION` (each an unconditional rebuild of that
+                `_SURFACE_READER`, `_SURFACE_SECTION` (each an unconditional rebuild of that
                 surface) or `_SURFACE_INSPECTOR` (conditional -- the right
                 rail is rebuilt only when the Console-follow row no longer
                 matches the adapter; see `_resolve_console_follow_drift`).
@@ -4197,6 +4238,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     await self._rebuild_surface(
                         workbench.refresh_header_content(),
                         "the centre header",
+                    )
+                if self._SURFACE_READER in surfaces:
+                    await self._rebuild_surface(
+                        workbench.refresh_region_content(Region.CONTENT),
+                        "the Reader",
                     )
                 if self._SURFACE_INSPECTOR in surfaces:
                     await self._rebuild_surface(
@@ -4594,6 +4640,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         run cancellation, ...).
         """
         if self.active_section == "items":
+            if self.runtime_backend != "local":
+                return
             # Own group (task-2513), as in `watch_tree_scope`:
             # `exclusive=True` in the default group would cancel every
             # in-flight default-group worker (`_create_source`, ...).
@@ -4642,9 +4690,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if not self.is_mounted:
             return
         read_is_active = self.active_section == "items"
-        self._reset_items_paging_for_context(loading=read_is_active)
+        local_read_is_active = read_is_active and self.runtime_backend == "local"
+        self._reset_items_paging_for_context(loading=local_read_is_active)
         if read_is_active:
-            self.run_worker(self._load_items(), exclusive=True, group="wc_items")
+            self._request_surface_refresh(self._SURFACE_READER)
+            self._load_tree_data()
+            if local_read_is_active:
+                self.run_worker(self._load_items(), exclusive=True, group="wc_items")
+            else:
+                self._loaded_items = []
+                self._selected_content_item = None
+                self._selected_content_page_key = None
+                try:
+                    pane = self.query_one(
+                        "#watchlists-items-pane", ArticleListPane
+                    )
+                except NoMatches:
+                    pass
+                else:
+                    pane.items = []
+                    pane.selected_item = None
         try:
             label = self.query_one("#watchlists-backend-label", Static)
             label_text = self._backend_label_text()
@@ -4810,6 +4875,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def handle_backend_changed(self, event: Select.Changed) -> None:
         event.stop()
         self.runtime_backend = str(event.value or "local")
+
+    @on(Button.Pressed, "#watchlists-switch-local")
+    def handle_switch_to_local(self, event: Button.Pressed) -> None:
+        """Recover Read through the same selector path as a manual change."""
+        event.stop()
+        self.query_one("#watchlists-backend-select", PruneSafeSelect).value = "local"
 
     @on(Button.Pressed, "#wc-open-watchlists")
     def open_watchlists(self) -> None:
@@ -9480,6 +9551,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         target_page_index: int | None = None,
         explicit_page_change: bool = False,
     ) -> bool:
+        if self.runtime_backend != "local":
+            return False
         target = max(
             0,
             self._items_page_index
@@ -11082,7 +11155,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             "1=Read 2=Sources 3=Runs 4=Rules 5=Notifications 6=Artifacts "
             "7=Overview | n=new d=delete/ignore c=check p=preview ?=help | "
             "j/k=move space=next-unread m=read/unread s=star o=open "
-            "a=mark-all-read u=undo /=search r=refresh-all",
+            "a=mark-all-read u=undo /=search r=refresh-all | "
+            "z=toggle focused side pane Z=Article Focus (Read only) "
+            "[=Navigation ]=Inspector | Reader is permanent",
             severity="information",
             timeout=8,
         )
@@ -11273,7 +11348,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             isinstance(focused, TextArea) and not focused.read_only
         ):
             return True
-        return self.active_section != "items"
+        return self.active_section != "items" or self.runtime_backend != "local"
 
     def action_toggle_read_selected(self) -> None:
         """`m`: flip the open item between new and reviewed (task-2513 Task 10).

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -4697,6 +4697,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if local_read_is_active:
                 self.run_worker(self._load_items(), exclusive=True, group="wc_items")
             else:
+                self._request_surface_refresh(self._SURFACE_READER)
                 self._loaded_items = []
                 self._selected_content_item = None
                 self._selected_content_page_key = None

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -989,8 +989,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._effective_region_layout = loaded_layout
         self._article_focus_active = False
         self._responsive_priority_target: Region | None = None
+        self._layout_request_generation = 0
+        self._current_layout_request_token = 0
+        # Avoid initializing the reactive (and its watcher) before Textual
+        # attaches this screen to an app; on_mount replaces this seed.
+        self._rendered_section = "items"
         self._manual_layout_rollback: tuple[
-            RegionLayout, RegionLayout, bool, Region | None
+            int, RegionLayout, RegionLayout, bool, Region | None
         ] | None = None
         self._items_view_anchor_id: str | None = None
         self._items_view_scroll_y = 0.0
@@ -1123,6 +1128,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # changes `region_layout` between construction and mount, or a
         # future caller) still gets the persistence reconciliation pass
         # `_apply_layout` performs for anything that genuinely did change.
+        self._rendered_section = self.active_section
         self._recompute_effective_layout()
         self._refresh_local_wc_snapshot()
         self._refresh_overview_data()
@@ -2858,7 +2864,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             pass
         return next((width for width in candidates if width > 0), 10_000)
 
-    def _recompute_effective_layout(self) -> None:
+    def _next_layout_request_token(self) -> int:
+        """Allocate the one current controller/workbench request token."""
+        self._layout_request_generation += 1
+        self._current_layout_request_token = self._layout_request_generation
+        self._manual_layout_rollback = None
+        return self._current_layout_request_token
+
+    def _recompute_effective_layout(self) -> int | None:
         """Resolve and push transient responsive/Article Focus state."""
         read_mode = self.active_section == "items"
         width = self._available_layout_width()
@@ -2892,9 +2905,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         try:
             workbench = self.query_one(WatchlistsWorkbench)
             if workbench.read_mode == read_mode:
-                workbench.region_layout = effective
+                token = self._next_layout_request_token()
+                workbench.request_region_layout(effective, token=token)
+                return token
         except Exception:
             logger.debug("Workbench not mounted yet; layout applies on compose.")
+        return None
 
     def _capture_items_view_state(self) -> None:
         try:
@@ -3133,9 +3149,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         persist -- it from a keypress that has no visible relationship to
         either the rail or the tab strip the user is actually looking at.
         """
-        if self._focus_in_centre_header:
-            return
-        region = self.focused_region
+        node = self.focused
+        region: Region | None = None
+        while node is not None:
+            node_id = getattr(node, "id", None) or ""
+            for prefix in ("wl-region-", "wl-grip-"):
+                if node_id.startswith(prefix):
+                    try:
+                        region = Region(node_id.removeprefix(prefix))
+                    except ValueError:
+                        region = None
+                    break
+            if region is not None:
+                break
+            node = node.parent
         if region not in COLLAPSIBLE_REGIONS:
             return
         if self._refuse_region_gesture_off_read_tab(region):
@@ -3176,17 +3203,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 preferred = preferred.toggle_preferred(region)
             if self._responsive_priority_target is region:
                 self._responsive_priority_target = None
-        changed = preferred != self.region_layout
         self.region_layout = preferred
-        self._recompute_effective_layout()
+        token = self._recompute_effective_layout()
         self._manual_layout_rollback = (
+            token or self._current_layout_request_token,
             self._effective_region_layout,
             before[0],
             before[2],
             before[3],
         )
-        if changed:
-            self._schedule_layout_persist(preferred)
+        self._schedule_layout_persist(preferred)
 
     @on(RegionToggled)
     def _on_region_toggled(self, event: RegionToggled) -> None:
@@ -3203,14 +3229,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         """Correct screen preference only while the failed intent is current."""
         event.stop()
-        if self._effective_region_layout != event.attempted:
+        if event.token != self._current_layout_request_token:
             return
         rollback = self._manual_layout_rollback
-        if rollback is None or rollback[0] != event.attempted:
+        if rollback is None or rollback[0] != event.token:
             self._effective_region_layout = event.fallback
             return
         current_preferred = self.region_layout
-        _, preferred, article_focus, priority_target = rollback
+        _, _, preferred, article_focus, priority_target = rollback
         self.region_layout = preferred
         self._article_focus_active = article_focus
         self._responsive_priority_target = priority_target
@@ -3223,11 +3249,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _on_region_layout_applied(self, event: RegionLayoutApplied) -> None:
         """Restore pane-local view state after a successful remount."""
         event.stop()
-        if event.layout != self._effective_region_layout:
+        if event.token != self._current_layout_request_token:
             return
         if (
             self._manual_layout_rollback is not None
-            and self._manual_layout_rollback[0] == event.layout
+            and self._manual_layout_rollback[0] == event.token
         ):
             self._manual_layout_rollback = None
         if (
@@ -4121,12 +4147,25 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # Textual has already re-homed focus (see `_restore_focus_after_swap`).
         rehome_focus = self._swap_will_destroy_focus()
         self._recompute_effective_layout()
-        await workbench.apply_section_view(
+        token = self._next_layout_request_token()
+        applied = await workbench.apply_section_view(
             read_mode=self.active_section == "items",
             layout=self._effective_region_layout,
+            token=token,
             rebuild_regions=(Region.ITEMS,),
             rebuild_header=True,
         )
+        if not applied or token != self._current_layout_request_token:
+            previous_section = self._rendered_section
+            self.set_reactive(
+                WatchlistsCollectionsScreen.active_section, previous_section
+            )
+            self._article_focus_active = False
+            self._effective_region_layout = workbench.region_layout
+            self._sync_backend_header_bar()
+            self._recompute_effective_layout()
+            return
+        self._rendered_section = self.active_section
         if rehome_focus:
             self._restore_focus_after_swap()
         self._reseed_active_section_pane()

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1156,13 +1156,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # `_apply_layout` performs for anything that genuinely did change.
         self._rendered_section = self.active_section
         self._recompute_effective_layout()
-        self._refresh_local_wc_snapshot()
-        self._refresh_overview_data()
-        self._load_active_section_data()
-        self._load_tree_data()
-        self.set_timer(
-            WC_SNAPSHOT_TIMEOUT_SECONDS, self._apply_snapshot_timeout_if_still_loading
+        server_read = (
+            self.active_section == "items" and self.runtime_backend != "local"
         )
+        if server_read:
+            self._enter_server_read_recovery()
+        else:
+            self._refresh_local_wc_snapshot()
+            self._load_active_section_data()
+            self._load_tree_data()
+            self.set_timer(
+                WC_SNAPSHOT_TIMEOUT_SECONDS,
+                self._apply_snapshot_timeout_if_still_loading,
+            )
+        self._refresh_overview_data()
 
     def on_resize(self, _event: events.Resize) -> None:
         """Re-derive responsive state without changing the preference."""
@@ -1186,6 +1193,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self.active_section = section
         finally:
             self._applying_navigation_context = False
+
+        if not self.is_mounted and section == "items" and requested_backend != "local":
+            # Compose precedes on_mount. Arm recovery now so the cold
+            # workbench factories use their query-free empty models.
+            self._enter_server_read_recovery()
 
         run_id = context.get(WATCHLISTS_NAV_CONTEXT_RUN_ID)
         self._pending_navigation_run_id = (
@@ -2438,7 +2450,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._push_items_pager_state()
 
     def _enter_server_read_recovery(self) -> None:
-        """Clear local Read state before presenting the Server recovery UI."""
+        """Clear item-specific state before presenting Server Read recovery."""
         self._read_recovery_active = True
         self._reset_items_paging_for_context(loading=False)
         self._items_status_filter = "all"
@@ -2447,23 +2459,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._selected_content_page_key = None
         self._loaded_items = []
         self._selected_content_item = None
-        self._tree_watchlists = []
-        self._tree_counts = {}
-        self._tree_source_counts = {}
-        self._tree_expanded = frozenset()
-        self._tree_active_tag = None
-        self._breadcrumb_labels = []
-        self.set_reactive(
-            WatchlistsCollectionsScreen.tree_scope, TreeScope(kind="all")
-        )
-        self.set_reactive(
-            WatchlistsCollectionsScreen.selected_scope, TreeScope(kind="all")
-        )
-        self._local_watchlist_records = ()
-        self._local_watchlist_count = 0
-        self._wc_lookup_error = None
-        self._wc_lookup_recovery_state = None
-        self._wc_loaded = False
         try:
             pane = self.query_one("#watchlists-items-pane", ArticleListPane)
         except NoMatches:
@@ -4666,8 +4661,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # a stale `True` would wrongly refuse a legitimate `z`/`Z` on the
         # new tab (task-1344 fix wave, Qodo correctness).
         self._focus_in_centre_header = False
+        leaving_read_recovery = (
+            self.active_section != "items" and self._read_recovery_active
+        )
         if self.active_section != "items":
             self._article_focus_active = False
+            if self._read_recovery_active:
+                self._read_recovery_active = False
+                if self.is_mounted and not self._wc_loaded:
+                    # A cold Server Read deliberately skipped these local
+                    # management models. Load them only if the user leaves
+                    # recovery for a management tab.
+                    self._refresh_local_wc_snapshot()
+                    self._load_tree_data()
+                    self.set_timer(
+                        WC_SNAPSHOT_TIMEOUT_SECONDS,
+                        self._apply_snapshot_timeout_if_still_loading,
+                    )
         self._recompute_effective_layout(request_workbench=False)
         if self.active_section == "overview":
             self.selected_entity = None
@@ -4694,7 +4704,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # than run here because it swaps `#wl-centre-status`, the same
             # widget `_SURFACE_HEADER` swaps -- see `_SURFACE_SECTION`.
             self._sync_backend_header_bar()
-            self._request_surface_refresh(self._SURFACE_SECTION)
+            surfaces = [self._SURFACE_SECTION]
+            if leaving_read_recovery:
+                # Recovery replaced the live rail with an empty model. The
+                # ordinary section swap deliberately rebuilds only centre
+                # surfaces, so restore the parked navigation explicitly.
+                surfaces.append(self._SURFACE_RAIL)
+            self._request_surface_refresh(*surfaces)
             if not self._applying_navigation_context:
                 self._load_active_section_data()
 

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -4507,9 +4507,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     "#watchlists-sources-pane", SourcesPane
                 ).sources = self.scoped_loaded_sources()
             elif section == "runs":
-                self.query_one("#watchlists-runs-pane", RunsPane).runs = (
-                    self._loaded_runs
-                )
+                self._reseed_live_detail_pane()
             elif section == "rules":
                 self.query_one("#watchlists-rules-pane", RulesPane).rules = (
                     self._loaded_rules

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -11,7 +11,7 @@ import asyncio
 import re
 import threading
 import webbrowser
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -408,6 +408,30 @@ class _ItemStatusIntent:
     refresh: bool = True
     patch_item: dict[str, Any] | None = None
     gate: bool = False
+
+
+@dataclass(frozen=True)
+class _ManualLayoutRollback:
+    """One manual preference intent and every automatic token derived from it."""
+
+    tokens: frozenset[int]
+    attempted_layout: RegionLayout
+    attempted_preferred: RegionLayout
+    preferred_before: RegionLayout
+    article_focus_before: bool
+    priority_before: Region | None
+
+
+@dataclass(frozen=True)
+class _SectionViewIntent:
+    """A section reconciliation snapshot, independent of later tab clicks."""
+
+    token: int
+    section: str
+    read_mode: bool
+    layout: RegionLayout
+    items_factory: Callable[[], Widget]
+    header_factory: Callable[[], Widget]
 
 
 def watchlist_delete_consequence(source_count: int) -> str:
@@ -994,12 +1018,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # Avoid initializing the reactive (and its watcher) before Textual
         # attaches this screen to an app; on_mount replaces this seed.
         self._rendered_section = "items"
-        self._manual_layout_rollback: tuple[
-            int, RegionLayout, RegionLayout, bool, Region | None
-        ] | None = None
+        self._manual_layout_rollback: _ManualLayoutRollback | None = None
         self._items_view_anchor_id: str | None = None
         self._items_view_scroll_y = 0.0
         self._items_view_had_focus = False
+        self._items_view_focus_id: str | None = None
+        self._items_view_context_key: tuple[Any, ...] | None = None
         self._last_persisted_collapsed: frozenset[Region] | None = (
             loaded_layout.collapsed
         )
@@ -1034,6 +1058,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # queue rather than `run_worker(exclusive=True)` per surface.
         self._pending_surface_refresh: set[str] = set()
         self._surface_refresh_draining = False
+        self._pending_section_intent: _SectionViewIntent | None = None
         # The Console-follow adapter's latest answer, mirrored here so the
         # RIGHT_RAIL factory reads an attribute instead of polling from
         # `compose()` (TASK-2200 review wave, M4). Refreshed by
@@ -1964,7 +1989,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         return "All sources"
 
     def _watchlists_status_marker_widgets(
-        self, scoped_rows: Sequence[Mapping[str, Any]]
+        self,
+        scoped_rows: Sequence[Mapping[str, Any]],
+        *,
+        section: str | None = None,
     ) -> list[Widget]:
         """The snapshot's own loading/error/empty/summary marker.
 
@@ -2043,7 +2071,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # row below this header, so repeating them here was the "Import
             # OPML twice on one screen" UAT finding. Omitted on Sources
             # only; every other section still gets the one bootstrap path.
-            if self.active_section != "sources":
+            if (self.active_section if section is None else section) != "sources":
                 widgets.append(
                     Horizontal(
                         # TASK-2303 AC#1: the same create verb the Sources
@@ -2083,7 +2111,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
         ]
 
-    def _build_centre_status_header(self) -> Vertical:
+    def _build_centre_status_header(self, section: str | None = None) -> Vertical:
         """Build the ALWAYS-rendered centre header: the section tab strip
         plus the snapshot's own loading/error/empty/summary marker.
 
@@ -2103,18 +2131,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             `_watchlists_status_marker_widgets` returns for the current
             snapshot state.
         """
+        section = self.active_section if section is None else section
         scoped_rows = self.scoped_source_rows()
         children: list[Widget] = [
-            WatchlistsTabStrip(active_section=self.active_section, id="wl-tabs"),
+            WatchlistsTabStrip(active_section=section, id="wl-tabs"),
         ]
-        children.extend(self._watchlists_status_marker_widgets(scoped_rows))
+        children.extend(
+            self._watchlists_status_marker_widgets(scoped_rows, section=section)
+        )
         return Vertical(
             *children,
             id="wl-centre-status",
             classes="watchlists-centre-status",
         )
 
-    def _build_detail_pane(self) -> Vertical:
+    def _build_detail_pane(self, section: str | None = None) -> Vertical:
         """Build the ITEMS-region content: the active-section-routed pane.
 
         Called fresh on every region rebuild — see the factory note on
@@ -2136,7 +2167,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `RunsPane.selected_run`'s watcher side effects are load-bearing
         (see that branch).
         """
-        detail_title = self._SECTION_DETAIL_TITLE.get(self.active_section, "Detail")
+        section = self.active_section if section is None else section
+        detail_title = self._SECTION_DETAIL_TITLE.get(section, "Detail")
         children: list[Widget] = [
             Static(
                 detail_title,
@@ -2144,7 +2176,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 id="watchlists-detail-title",
             )
         ]
-        if self.active_section == "overview":
+        if section == "overview":
             overview = OverviewPane(id="watchlists-overview-pane")
             overview.set_reactive(OverviewPane.data, self.overview_data)
             # TASK-998: lets the first-run panel distinguish "no watchlists at
@@ -2154,7 +2186,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 OverviewPane.watchlist_count, len(self._tree_watchlists)
             )
             children.append(overview)
-        elif self.active_section == "sources":
+        elif section == "sources":
             sources_pane = SourcesPane(id="watchlists-sources-pane")
             # Seed the last-loaded rows and selection (Finding 2, fix round
             # 2) the same way RunsPane/NotificationsPane already do below —
@@ -2209,7 +2241,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     self._source_create_draft_selectors
                 )
             children.append(sources_pane)
-        elif self.active_section == "runs":
+        elif section == "runs":
             runs_pane = RunsPane(id="watchlists-runs-pane")
             # `runs` is the pane's only `recompose=True` reactive, so it is
             # the only one converted to `set_reactive` (task-15778). The
@@ -2229,7 +2261,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             runs_pane.run_logs = self._run_detail_logs
             runs_pane.run_items_note = self._run_detail_items_note
             children.append(runs_pane)
-        elif self.active_section == "items":
+        elif section == "items":
             # Seed the last-loaded rows (Finding 2, fix round 2) — see the
             # note on `sources_pane.sources` above; same rebuild, same gap.
             # Audited for task-15778 and deliberately left as plain
@@ -2261,7 +2293,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 self._items_search_results_authoritative
             )
             children.append(items_pane)
-        elif self.active_section == "rules":
+        elif section == "rules":
             # Seed the last-loaded rows (Finding 2, fix round 2) — see the
             # note on `sources_pane.sources` above; same rebuild, same gap.
             rules_pane = RulesPane(id="watchlists-rules-pane")
@@ -2279,7 +2311,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 else:
                     rules_pane.set_reactive(RulesPane.show_rule_form, True)
             children.append(rules_pane)
-        elif self.active_section == "notifications":
+        elif section == "notifications":
             notifications_pane = NotificationsPane(id="watchlists-notifications-pane")
             notifications_pane.set_reactive(
                 NotificationsPane.notifications, self._loaded_notifications
@@ -2289,7 +2321,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 self.selected_notification,
             )
             children.append(notifications_pane)
-        elif self.active_section == "artifacts":
+        elif section == "artifacts":
             # Seeded from screen state for the same reason every sibling
             # above is -- this is a factory the workbench calls on every
             # region rebuild, so a fresh pane's reactives start at their
@@ -2364,6 +2396,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
     def _reset_items_paging_for_context(self, *, loading: bool) -> None:
         """Invalidate Read paging before a query-context change is loaded."""
+        self._discard_items_view_state()
         timer = getattr(self, "_items_search_reload_timer", None)
         if timer is not None:
             timer.stop()
@@ -2864,16 +2897,37 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             pass
         return next((width for width in candidates if width > 0), 10_000)
 
-    def _next_layout_request_token(self) -> int:
+    def _next_layout_request_token(self, *, preserve_manual_intent: bool = True) -> int:
         """Allocate the one current controller/workbench request token."""
         self._layout_request_generation += 1
         self._current_layout_request_token = self._layout_request_generation
-        self._manual_layout_rollback = None
+        rollback = self._manual_layout_rollback
+        if (
+            preserve_manual_intent
+            and rollback is not None
+            and self.region_layout == rollback.attempted_preferred
+        ):
+            self._manual_layout_rollback = _ManualLayoutRollback(
+                tokens=rollback.tokens | {self._current_layout_request_token},
+                attempted_layout=self._effective_region_layout,
+                attempted_preferred=rollback.attempted_preferred,
+                preferred_before=rollback.preferred_before,
+                article_focus_before=rollback.article_focus_before,
+                priority_before=rollback.priority_before,
+            )
+        elif not preserve_manual_intent:
+            self._manual_layout_rollback = None
         return self._current_layout_request_token
 
-    def _recompute_effective_layout(self) -> int | None:
+    def _recompute_effective_layout(
+        self,
+        *,
+        section: str | None = None,
+        request_workbench: bool = True,
+    ) -> int | None:
         """Resolve and push transient responsive/Article Focus state."""
-        read_mode = self.active_section == "items"
+        section = self.active_section if section is None else section
+        read_mode = section == "items"
         width = self._available_layout_width()
         mounted = READ_SIDE_PANE_ORDER if read_mode else MANAGEMENT_SIDE_PANE_ORDER
         unprioritized = resolve_effective_layout(
@@ -2902,6 +2956,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         ):
             self._capture_items_view_state()
         self._effective_region_layout = effective
+        if not request_workbench:
+            return None
         try:
             workbench = self.query_one(WatchlistsWorkbench)
             if workbench.read_mode == read_mode:
@@ -2922,33 +2978,60 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._items_view_anchor_id = getattr(highlighted, "item_id_key", None)
         self._items_view_scroll_y = float(getattr(table, "scroll_y", 0.0))
         self._items_view_had_focus = bool(table.has_focus)
+        self._items_view_focus_id = None
+        focused = self.focused
+        while focused is not None and focused is not pane:
+            focused_id = getattr(focused, "id", None)
+            if focused_id:
+                self._items_view_focus_id = focused_id
+                break
+            focused = focused.parent
+        self._items_view_context_key = self._items_page_key(self._items_page_index)
+
+    def _discard_items_view_state(self) -> None:
+        """Discard one consumed or invalidated Items restoration snapshot."""
+        self._items_view_anchor_id = None
+        self._items_view_focus_id = None
+        self._items_view_context_key = None
+        self._items_view_had_focus = False
 
     def _restore_items_view_state(self) -> None:
+        if self._items_view_context_key is None:
+            return
+        if self._items_page_loading:
+            return
+        if self._items_view_context_key != self._items_page_key(
+            self._items_page_index
+        ):
+            self._discard_items_view_state()
+            return
         try:
             pane = self.query_one("#watchlists-items-pane", ArticleListPane)
             table = pane.query_one("#items-table")
         except NoMatches:
-            if (
-                self._items_view_anchor_id is not None
-                and self.active_section == "items"
-                and not self._effective_region_layout.is_collapsed(Region.ITEMS)
-            ):
-                self.set_timer(0.01, self._restore_items_view_state)
             return
         if self._items_view_anchor_id is not None:
-            restored_anchor = False
             for index, row in enumerate(table.children):
                 if getattr(row, "item_id_key", None) == self._items_view_anchor_id:
                     pane._suppressed_highlight_item_id = self._items_view_anchor_id
                     table.index = index
-                    restored_anchor = True
                     break
-            if not restored_anchor:
-                self.set_timer(0.01, self._restore_items_view_state)
-                return
         table.scroll_to(y=self._items_view_scroll_y, animate=False)
-        if self._items_view_had_focus:
+        focus_id = self._items_view_focus_id
+        restored_focus = False
+        if focus_id is not None:
+            try:
+                pane.query_one(f"#{focus_id}").focus()
+                restored_focus = True
+            except NoMatches:
+                pass
+        if not restored_focus and (
+            self._items_view_had_focus or self._items_view_anchor_id is not None
+        ):
             table.focus()
+        elif not restored_focus:
+            pane.focus()
+        self._discard_items_view_state()
 
     def _apply_layout(self, layout: RegionLayout) -> None:
         """Set the layout, push it to the workbench, and persist any change.
@@ -2993,11 +3076,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if self._layout_persist_draining:
                 return
             self._layout_persist_draining = True
-        self.run_worker(
-            self._persist_layout_worker,
-            group="wl-layout-persist",
-            thread=True,
-        )
+        try:
+            self.run_worker(
+                self._persist_layout_worker,
+                group="wl-layout-persist",
+                thread=True,
+            )
+        except Exception:
+            with self._layout_persist_lock:
+                self._layout_persist_draining = False
+            logger.opt(exception=True).debug(
+                "Could not schedule preferred Watchlists layout persistence."
+            )
 
     def _persist_layout_worker(self) -> None:
         """Write the most recently requested layout to config.
@@ -3015,32 +3105,42 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         every `_schedule_layout_persist` call the burst has made so far —
         writes the true final layout, so the last write always wins.
         """
-        while True:
-            with self._layout_persist_lock:
-                generation = self._pending_persist_generation
-                layout = self._pending_persist_layout
-            if generation is None or layout is None:
+        try:
+            while True:
                 with self._layout_persist_lock:
-                    self._layout_persist_draining = False
-                return
-            try:
-                success = save_region_layout(layout)
-            except Exception:
-                logger.opt(exception=True).debug(
-                    "Failed to persist preferred Watchlists pane layout."
-                )
-                success = False
-            self.app.call_from_thread(
-                self._acknowledge_layout_persist,
-                generation,
-                layout,
-                success,
-            )
-            with self._layout_persist_lock:
-                pending_generation = self._pending_persist_generation
-                if pending_generation is None or pending_generation == generation:
-                    self._layout_persist_draining = False
+                    generation = self._pending_persist_generation
+                    layout = self._pending_persist_layout
+                if generation is None or layout is None:
                     return
+                try:
+                    success = save_region_layout(layout)
+                except Exception:
+                    logger.opt(exception=True).debug(
+                        "Failed to persist preferred Watchlists pane layout."
+                    )
+                    success = False
+                try:
+                    self.app.call_from_thread(
+                        self._acknowledge_layout_persist,
+                        generation,
+                        layout,
+                        success,
+                    )
+                except Exception:
+                    logger.opt(exception=True).debug(
+                        "Could not acknowledge preferred Watchlists layout write."
+                    )
+                    return
+                with self._layout_persist_lock:
+                    pending_generation = self._pending_persist_generation
+                    if (
+                        pending_generation is None
+                        or pending_generation == generation
+                    ):
+                        return
+        finally:
+            with self._layout_persist_lock:
+                self._layout_persist_draining = False
 
     def _acknowledge_layout_persist(
         self,
@@ -3186,6 +3286,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _toggle_preferred_region(self, region: Region) -> None:
         """Apply one manual gesture, inferred from effective state."""
         requested_open = self._effective_region_layout.is_collapsed(region)
+        self._manual_layout_rollback = None
         before = (
             self.region_layout,
             self._effective_region_layout,
@@ -3205,12 +3306,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 self._responsive_priority_target = None
         self.region_layout = preferred
         token = self._recompute_effective_layout()
-        self._manual_layout_rollback = (
-            token or self._current_layout_request_token,
-            self._effective_region_layout,
-            before[0],
-            before[2],
-            before[3],
+        request_token = token or self._current_layout_request_token
+        self._manual_layout_rollback = _ManualLayoutRollback(
+            tokens=frozenset({request_token}),
+            attempted_layout=self._effective_region_layout,
+            attempted_preferred=preferred,
+            preferred_before=before[0],
+            article_focus_before=before[2],
+            priority_before=before[3],
         )
         self._schedule_layout_persist(preferred)
 
@@ -3229,21 +3332,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         """Correct screen preference only while the failed intent is current."""
         event.stop()
+        rollback = self._manual_layout_rollback
+        if rollback is not None and event.token in rollback.tokens:
+            current_preferred = self.region_layout
+            self.region_layout = rollback.preferred_before
+            self._article_focus_active = rollback.article_focus_before
+            self._responsive_priority_target = rollback.priority_before
+            self._manual_layout_rollback = None
+            self._recompute_effective_layout()
+            if current_preferred != rollback.preferred_before:
+                self._schedule_layout_persist(rollback.preferred_before)
+            return
         if event.token != self._current_layout_request_token:
             return
-        rollback = self._manual_layout_rollback
-        if rollback is None or rollback[0] != event.token:
+        if rollback is None:
             self._effective_region_layout = event.fallback
             return
-        current_preferred = self.region_layout
-        _, _, preferred, article_focus, priority_target = rollback
-        self.region_layout = preferred
-        self._article_focus_active = article_focus
-        self._responsive_priority_target = priority_target
-        self._manual_layout_rollback = None
-        self._recompute_effective_layout()
-        if current_preferred != preferred:
-            self._schedule_layout_persist(preferred)
 
     @on(RegionLayoutApplied)
     def _on_region_layout_applied(self, event: RegionLayoutApplied) -> None:
@@ -3253,7 +3357,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             return
         if (
             self._manual_layout_rollback is not None
-            and self._manual_layout_rollback[0] == event.token
+            and event.token in self._manual_layout_rollback.tokens
         ):
             self._manual_layout_rollback = None
         if (
@@ -4143,19 +4247,39 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         Args:
             workbench: The mounted workbench, resolved once by the drainer.
         """
+        intent = self._pending_section_intent
+        self._pending_section_intent = None
+        if intent is None:
+            section = self.active_section
+            self._recompute_effective_layout(
+                section=section, request_workbench=False
+            )
+            token = self._next_layout_request_token()
+            detail_builder = self._build_detail_pane
+            header_builder = self._build_centre_status_header
+            intent = _SectionViewIntent(
+                token=token,
+                section=section,
+                read_mode=section == "items",
+                layout=self._effective_region_layout,
+                items_factory=lambda: detail_builder(section),
+                header_factory=lambda: header_builder(section),
+            )
         # Asked BEFORE the swap: afterwards the widget is already gone and
         # Textual has already re-homed focus (see `_restore_focus_after_swap`).
         rehome_focus = self._swap_will_destroy_focus()
-        self._recompute_effective_layout()
-        token = self._next_layout_request_token()
         applied = await workbench.apply_section_view(
-            read_mode=self.active_section == "items",
-            layout=self._effective_region_layout,
-            token=token,
+            read_mode=intent.read_mode,
+            layout=intent.layout,
+            token=intent.token,
             rebuild_regions=(Region.ITEMS,),
             rebuild_header=True,
+            content={**workbench._content, Region.ITEMS: intent.items_factory},
+            header=intent.header_factory,
         )
-        if not applied or token != self._current_layout_request_token:
+        if not applied:
+            if intent.token != self._current_layout_request_token:
+                return
             previous_section = self._rendered_section
             self.set_reactive(
                 WatchlistsCollectionsScreen.active_section, previous_section
@@ -4163,9 +4287,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._article_focus_active = False
             self._effective_region_layout = workbench.region_layout
             self._sync_backend_header_bar()
-            self._recompute_effective_layout()
             return
-        self._rendered_section = self.active_section
+        self._rendered_section = intent.section
+        if intent.token != self._current_layout_request_token:
+            return
         if rehome_focus:
             self._restore_focus_after_swap()
         self._reseed_active_section_pane()
@@ -4427,13 +4552,25 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._focus_in_centre_header = False
         if self.active_section != "items":
             self._article_focus_active = False
-        self._recompute_effective_layout()
+        self._recompute_effective_layout(request_workbench=False)
         if self.active_section == "overview":
             self.selected_entity = None
         if self.active_section != WATCHLISTS_SECTION_RUNS:
             self._pending_navigation_run_id = None
             self._pending_navigation_run_backend = None
         if self.is_mounted:
+            token = self._next_layout_request_token()
+            section = self.active_section
+            detail_builder = self._build_detail_pane
+            header_builder = self._build_centre_status_header
+            self._pending_section_intent = _SectionViewIntent(
+                token=token,
+                section=section,
+                read_mode=section == "items",
+                layout=self._effective_region_layout,
+                items_factory=lambda: detail_builder(section),
+                header_factory=lambda: header_builder(section),
+            )
             # task-15461: one region-scoped swap, not a whole-screen
             # `refresh(recompose=True)`. Queued on the surface drain rather
             # than run here because it swaps `#wl-centre-status`, the same
@@ -9389,6 +9526,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> bool:
         """Fetch, present, and commit one page load owned by `_load_items`."""
         notify = getattr(self.app_instance, "notify", None)
+        if (
+            self._items_view_context_key is not None
+            and target_key != self._items_view_context_key
+        ):
+            self._discard_items_view_state()
         self._items_load_generation += 1
         generation = self._items_load_generation
         self._items_page_loading = True
@@ -9513,6 +9655,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._items_search_results_authoritative = True
             self._items_page_loading = False
             self._push_items_pager_state()
+            self._restore_items_view_state()
         return True
 
     def _items_load_is_current(

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -412,9 +412,9 @@ class _ItemStatusIntent:
 
 @dataclass(frozen=True)
 class _ManualLayoutRollback:
-    """One manual preference intent and every automatic token derived from it."""
+    """One manual preference intent owned by its latest request token."""
 
-    tokens: frozenset[int]
+    token: int
     attempted_layout: RegionLayout
     attempted_preferred: RegionLayout
     preferred_before: RegionLayout
@@ -2897,26 +2897,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             pass
         return next((width for width in candidates if width > 0), 10_000)
 
-    def _next_layout_request_token(self, *, preserve_manual_intent: bool = True) -> int:
+    def _next_layout_request_token(self) -> int:
         """Allocate the one current controller/workbench request token."""
         self._layout_request_generation += 1
         self._current_layout_request_token = self._layout_request_generation
         rollback = self._manual_layout_rollback
         if (
-            preserve_manual_intent
-            and rollback is not None
+            rollback is not None
             and self.region_layout == rollback.attempted_preferred
         ):
             self._manual_layout_rollback = _ManualLayoutRollback(
-                tokens=rollback.tokens | {self._current_layout_request_token},
+                token=self._current_layout_request_token,
                 attempted_layout=self._effective_region_layout,
                 attempted_preferred=rollback.attempted_preferred,
                 preferred_before=rollback.preferred_before,
                 article_focus_before=rollback.article_focus_before,
                 priority_before=rollback.priority_before,
             )
-        elif not preserve_manual_intent:
-            self._manual_layout_rollback = None
         return self._current_layout_request_token
 
     def _recompute_effective_layout(
@@ -3105,42 +3102,41 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         every `_schedule_layout_persist` call the burst has made so far —
         writes the true final layout, so the last write always wins.
         """
-        try:
-            while True:
-                with self._layout_persist_lock:
-                    generation = self._pending_persist_generation
-                    layout = self._pending_persist_layout
-                if generation is None or layout is None:
-                    return
-                try:
-                    success = save_region_layout(layout)
-                except Exception:
-                    logger.opt(exception=True).debug(
-                        "Failed to persist preferred Watchlists pane layout."
-                    )
-                    success = False
-                try:
-                    self.app.call_from_thread(
-                        self._acknowledge_layout_persist,
-                        generation,
-                        layout,
-                        success,
-                    )
-                except Exception:
-                    logger.opt(exception=True).debug(
-                        "Could not acknowledge preferred Watchlists layout write."
-                    )
-                    return
-                with self._layout_persist_lock:
-                    pending_generation = self._pending_persist_generation
-                    if (
-                        pending_generation is None
-                        or pending_generation == generation
-                    ):
-                        return
-        finally:
+        while True:
             with self._layout_persist_lock:
-                self._layout_persist_draining = False
+                generation = self._pending_persist_generation
+                layout = self._pending_persist_layout
+                if generation is None or layout is None:
+                    self._layout_persist_draining = False
+                    return
+            try:
+                success = save_region_layout(layout)
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Failed to persist preferred Watchlists pane layout."
+                )
+                success = False
+            try:
+                self.app.call_from_thread(
+                    self._acknowledge_layout_persist,
+                    generation,
+                    layout,
+                    success,
+                )
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Could not acknowledge preferred Watchlists layout write."
+                )
+                with self._layout_persist_lock:
+                    if self._pending_persist_generation != generation:
+                        continue
+                    self._layout_persist_draining = False
+                    return
+            with self._layout_persist_lock:
+                pending_generation = self._pending_persist_generation
+                if pending_generation is None or pending_generation == generation:
+                    self._layout_persist_draining = False
+                    return
 
     def _acknowledge_layout_persist(
         self,
@@ -3308,7 +3304,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         token = self._recompute_effective_layout()
         request_token = token or self._current_layout_request_token
         self._manual_layout_rollback = _ManualLayoutRollback(
-            tokens=frozenset({request_token}),
+            token=request_token,
             attempted_layout=self._effective_region_layout,
             attempted_preferred=preferred,
             preferred_before=before[0],
@@ -3332,8 +3328,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         """Correct screen preference only while the failed intent is current."""
         event.stop()
+        if event.token != self._current_layout_request_token:
+            return
         rollback = self._manual_layout_rollback
-        if rollback is not None and event.token in rollback.tokens:
+        if rollback is not None and event.token == rollback.token:
             current_preferred = self.region_layout
             self.region_layout = rollback.preferred_before
             self._article_focus_active = rollback.article_focus_before
@@ -3342,8 +3340,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._recompute_effective_layout()
             if current_preferred != rollback.preferred_before:
                 self._schedule_layout_persist(rollback.preferred_before)
-            return
-        if event.token != self._current_layout_request_token:
             return
         if rollback is None:
             self._effective_region_layout = event.fallback
@@ -3357,7 +3353,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             return
         if (
             self._manual_layout_rollback is not None
-            and event.token in self._manual_layout_rollback.tokens
+            and event.token == self._manual_layout_rollback.token
         ):
             self._manual_layout_rollback = None
         if (

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -883,6 +883,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # back at `None` on every collapse/expand, clearing the
         # reader out from under a user who hadn't touched Items at all.
         self._selected_content_item: dict[str, Any] | None = None
+        self._read_recovery_active = False
         # Left-rail tree inputs (Task 4): loaded together by `_load_tree_data`
         # in exactly three queries (`list_watchlists`,
         # `get_watchlist_item_counts`, `get_source_item_counts`),
@@ -1817,15 +1818,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         this the selection highlight would reset to nothing every time,
         even though the scope itself survived on the screen.
         """
+        recovering = self.active_section == "items" and self._read_recovery_active
         return WatchlistTree(
-            watchlists=self._tree_watchlists,
-            counts=self._tree_counts,
-            source_rows_loader=self._load_source_rows_for_tree,
-            expanded=self._tree_expanded,
-            active_tag=self._tree_active_tag,
+            watchlists=[] if recovering else self._tree_watchlists,
+            counts={} if recovering else self._tree_counts,
+            source_rows_loader=(
+                (lambda _watchlist_id: [])
+                if recovering
+                else self._load_source_rows_for_tree
+            ),
+            expanded=frozenset() if recovering else self._tree_expanded,
+            active_tag=None if recovering else self._tree_active_tag,
             active_scope=self.tree_scope,
             write_disabled_reason=self._tree_write_disabled_reason(),
-            source_counts=self._tree_source_counts,
+            source_counts={} if recovering else self._tree_source_counts,
             id="wl-tree",
         )
 
@@ -1861,6 +1867,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         watchlist is expanded, and `list_source_rows` is one JOIN (Task 1),
         not a fan-out of per-source queries.
         """
+        if self.active_section == "items" and self._read_recovery_active:
+            return []
         try:
             return self._watchlist_bundle_service().list_source_rows(watchlist_id)
         except Exception:
@@ -1892,6 +1900,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             One dict per source with ``id``, ``name`` and ``type``, or an
             empty list if the bundle service is unavailable or lookup fails.
         """
+        if self.active_section == "items" and self._read_recovery_active:
+            return []
         service = self._watchlist_bundle_service()
         if service is None:
             return []
@@ -2137,13 +2147,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             snapshot state.
         """
         section = self.active_section if section is None else section
-        scoped_rows = self.scoped_source_rows()
         children: list[Widget] = [
             WatchlistsTabStrip(active_section=section, id="wl-tabs"),
         ]
-        children.extend(
-            self._watchlists_status_marker_widgets(scoped_rows, section=section)
-        )
+        if section == "items" and self._read_recovery_active:
+            children.append(
+                Static(
+                    "Server-backed Read is unavailable. Switch to Local in Reader.",
+                    id="watchlists-read-recovery-status",
+                )
+            )
+        else:
+            scoped_rows = self.scoped_source_rows()
+            children.extend(
+                self._watchlists_status_marker_widgets(scoped_rows, section=section)
+            )
         return Vertical(
             *children,
             id="wl-centre-status",
@@ -2421,6 +2439,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
     def _enter_server_read_recovery(self) -> None:
         """Clear local Read state before presenting the Server recovery UI."""
+        self._read_recovery_active = True
         self._reset_items_paging_for_context(loading=False)
         self._items_status_filter = "all"
         self._items_search_query = ""
@@ -2428,10 +2447,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._selected_content_page_key = None
         self._loaded_items = []
         self._selected_content_item = None
-        # Watchlist/source rows are management data shared with the other
-        # tabs. Only their local item-count overlays belong to Read.
+        self._tree_watchlists = []
         self._tree_counts = {}
         self._tree_source_counts = {}
+        self._tree_expanded = frozenset()
+        self._tree_active_tag = None
+        self._breadcrumb_labels = []
+        self.set_reactive(
+            WatchlistsCollectionsScreen.tree_scope, TreeScope(kind="all")
+        )
+        self.set_reactive(
+            WatchlistsCollectionsScreen.selected_scope, TreeScope(kind="all")
+        )
+        self._local_watchlist_records = ()
+        self._local_watchlist_count = 0
+        self._wc_lookup_error = None
+        self._wc_lookup_recovery_state = None
+        self._wc_loaded = False
         try:
             pane = self.query_one("#watchlists-items-pane", ArticleListPane)
         except NoMatches:
@@ -2442,7 +2474,29 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             pane.status_filter = "all"
             pane.search_query = ""
             self._push_items_pager_state()
-        self._request_surface_refresh(self._SURFACE_RAIL, self._SURFACE_READER)
+        self._request_surface_refresh(
+            self._SURFACE_RAIL,
+            self._SURFACE_HEADER,
+            self._SURFACE_READER,
+            self._SURFACE_INSPECTOR,
+        )
+
+    async def _recover_local_read(self) -> None:
+        """Commit local navigation only after the normal item load succeeds."""
+        if not await self._load_items():
+            return
+        if self.runtime_backend != "local" or self.active_section != "items":
+            return
+        self._read_recovery_active = False
+        self._load_tree_data()
+        self._refresh_local_wc_snapshot()
+        self._refresh_overview_data()
+        self._request_surface_refresh(
+            self._SURFACE_RAIL,
+            self._SURFACE_HEADER,
+            self._SURFACE_READER,
+            self._SURFACE_INSPECTOR,
+        )
 
     def _build_content_pane(self) -> Widget:
         """Build the CONTENT-region content: the reader for the last
@@ -2466,7 +2520,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         generic "Content" title above whatever this returns.
 
         """
-        if self.active_section == "items" and self.runtime_backend != "local":
+        if self.active_section == "items" and self._read_recovery_active:
             return Vertical(
                 Static(
                     "Read and its permanent Reader are local-only. "
@@ -2942,6 +2996,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
     def _available_layout_width(self) -> int:
         """Best live width for the pure responsive resolver."""
+        if not self.is_mounted:
+            return 10_000
         candidates: list[int] = []
         try:
             workbench = self.query_one(WatchlistsWorkbench)
@@ -4716,8 +4772,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if read_is_active:
             if local_read_is_active:
                 self._reset_items_paging_for_context(loading=True)
-                self._load_tree_data()
-                self.run_worker(self._load_items(), exclusive=True, group="wc_items")
+                if self._read_recovery_active:
+                    self.run_worker(
+                        self._recover_local_read(),
+                        exclusive=True,
+                        group="wc_items",
+                    )
+                else:
+                    self._load_tree_data()
+                    self.run_worker(
+                        self._load_items(), exclusive=True, group="wc_items"
+                    )
             else:
                 self._enter_server_read_recovery()
         else:
@@ -4770,8 +4835,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # every pane from exactly these attributes). `selected_entity` is
         # the one that already had its own watcher.
         self._reseed_live_detail_pane()
-        self._refresh_local_wc_snapshot()
-        self._refresh_overview_data()
+        if not (read_is_active and self._read_recovery_active):
+            self._refresh_local_wc_snapshot()
+            self._refresh_overview_data()
 
     def _reseed_live_detail_pane(self) -> None:
         """Push the screen's mirrored rows/selection into the mounted pane.
@@ -4897,7 +4963,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         event.stop()
         selector = self.query_one("#watchlists-backend-select", PruneSafeSelect)
         if self.runtime_backend == "local":
-            self.run_worker(self._load_items(), exclusive=True, group="wc_items")
+            self.run_worker(
+                self._recover_local_read(), exclusive=True, group="wc_items"
+            )
         else:
             selector.value = "local"
 

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -212,6 +212,7 @@ from ..Watchlists_Modules.watchlists_console_handoff import WatchlistsConsoleHan
 from ..Watchlists_Modules.watchlists_tab_strip import SectionSelected, WatchlistsTabStrip
 from ..Watchlists_Modules.watchlists_workbench import (
     REGION_TITLES,
+    RegionLayoutApplyFailed,
     RegionToggled,
     WatchlistsWorkbench,
 )
@@ -3199,6 +3200,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if self._refuse_region_gesture_off_read_tab(event.region):
             return
         self._apply_layout(self.region_layout.toggle(event.region))
+
+    @on(RegionLayoutApplyFailed)
+    def _on_region_layout_apply_failed(
+        self, event: RegionLayoutApplyFailed
+    ) -> None:
+        """Correct screen preference only while the failed intent is current."""
+        event.stop()
+        if self.region_layout != event.attempted:
+            return
+        self._apply_layout(event.fallback)
 
     def _apply_tree_scope(self, scope: TreeScope) -> None:
         """The single reconciliation point for "the tree scope is now `scope`".

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1334,13 +1334,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         the tree is its own only error surface.
         """
         if self.active_section == "items" and self.runtime_backend != "local":
-            self._tree_watchlists = []
-            self._tree_counts = {}
-            self._tree_source_counts = {}
-            self._breadcrumb_labels = self._resolve_breadcrumb_labels(
-                self.selected_scope
-            )
-            self._apply_tree_data_to_live_surfaces()
+            self._items_page_loading = False
+            self._push_items_pager_state()
             return
 
         notify = getattr(self.app_instance, "notify", None)
@@ -2423,6 +2418,31 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._items_load_generation += 1
         self._items_inflight_page_load = None
         self._push_items_pager_state()
+
+    def _enter_server_read_recovery(self) -> None:
+        """Clear local Read state before presenting the Server recovery UI."""
+        self._reset_items_paging_for_context(loading=False)
+        self._items_status_filter = "all"
+        self._items_search_query = ""
+        self._items_committed_page_key = None
+        self._selected_content_page_key = None
+        self._loaded_items = []
+        self._selected_content_item = None
+        # Watchlist/source rows are management data shared with the other
+        # tabs. Only their local item-count overlays belong to Read.
+        self._tree_counts = {}
+        self._tree_source_counts = {}
+        try:
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
+        except NoMatches:
+            pass
+        else:
+            pane.items = []
+            pane.selected_item = None
+            pane.status_filter = "all"
+            pane.search_query = ""
+            self._push_items_pager_state()
+        self._request_surface_refresh(self._SURFACE_RAIL, self._SURFACE_READER)
 
     def _build_content_pane(self) -> Widget:
         """Build the CONTENT-region content: the reader for the last
@@ -4601,6 +4621,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._pending_navigation_run_id = None
             self._pending_navigation_run_backend = None
         if self.is_mounted:
+            if self.active_section == "items" and self.runtime_backend != "local":
+                self._enter_server_read_recovery()
             token = self._next_layout_request_token()
             section = self.active_section
             detail_builder = self._build_detail_pane
@@ -4691,25 +4713,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             return
         read_is_active = self.active_section == "items"
         local_read_is_active = read_is_active and self.runtime_backend == "local"
-        self._reset_items_paging_for_context(loading=local_read_is_active)
         if read_is_active:
-            self._load_tree_data()
             if local_read_is_active:
+                self._reset_items_paging_for_context(loading=True)
+                self._load_tree_data()
                 self.run_worker(self._load_items(), exclusive=True, group="wc_items")
             else:
-                self._request_surface_refresh(self._SURFACE_READER)
-                self._loaded_items = []
-                self._selected_content_item = None
-                self._selected_content_page_key = None
-                try:
-                    pane = self.query_one(
-                        "#watchlists-items-pane", ArticleListPane
-                    )
-                except NoMatches:
-                    pass
-                else:
-                    pane.items = []
-                    pane.selected_item = None
+                self._enter_server_read_recovery()
+        else:
+            # Paging belongs to a backend-specific Read query context even
+            # while another management tab is visible. Invalidate it without
+            # loading the hidden Read surface.
+            self._reset_items_paging_for_context(loading=False)
         try:
             label = self.query_one("#watchlists-backend-label", Static)
             label_text = self._backend_label_text()
@@ -4880,7 +4895,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def handle_switch_to_local(self, event: Button.Pressed) -> None:
         """Recover Read through the same selector path as a manual change."""
         event.stop()
-        self.query_one("#watchlists-backend-select", PruneSafeSelect).value = "local"
+        selector = self.query_one("#watchlists-backend-select", PruneSafeSelect)
+        if self.runtime_backend == "local":
+            self.run_worker(self._load_items(), exclusive=True, group="wc_items")
+        else:
+            selector.value = "local"
 
     @on(Button.Pressed, "#wc-open-watchlists")
     def open_watchlists(self) -> None:
@@ -9552,6 +9571,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         explicit_page_change: bool = False,
     ) -> bool:
         if self.runtime_backend != "local":
+            self._items_page_loading = False
+            self._push_items_pager_state()
             return False
         target = max(
             0,
@@ -9741,6 +9762,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @on(ItemSelected)
     async def handle_item_selected(self, event: ItemSelected) -> None:
         event.stop()
+        if self.runtime_backend != "local":
+            return
         async with self._items_page_presentation_lock:
             selection_page_key = self._items_committed_page_key
         # TASK-15464: fetch the DETAIL body BEFORE any of the selection
@@ -10328,6 +10351,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         trigger a spurious reload when the pane first posts it.
         """
         event.stop()
+        if self.runtime_backend != "local":
+            self._items_page_loading = False
+            self._push_items_pager_state()
+            return
         incoming = _normalize_items_status_filter(event.status_filter)
         status_changed = incoming != _normalize_items_status_filter(
             self._items_status_filter

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -11313,15 +11313,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
             opened = False
         if not opened:
-            self.app.call_from_thread(self._notify_browser_open_failed)
-
-    def _notify_browser_open_failed(self) -> None:
-        """Report a browser worker failure from the Textual UI thread."""
-        self._notify_watchlists(
-            "Could not open this item in the system browser.",
-            severity="error",
-            markup=False,
-        )
+            self.app.call_from_thread(
+                self._notify_watchlists,
+                "Could not open this item in the system browser.",
+                "error",
+                markup=False,
+            )
 
     @on(NextUnreadRequested)
     def handle_next_unread_requested(self, event: NextUnreadRequested) -> None:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -4693,7 +4693,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         local_read_is_active = read_is_active and self.runtime_backend == "local"
         self._reset_items_paging_for_context(loading=local_read_is_active)
         if read_is_active:
-            self._request_surface_refresh(self._SURFACE_READER)
             self._load_tree_data()
             if local_read_is_active:
                 self.run_worker(self._load_items(), exclusive=True, group="wc_items")
@@ -9725,6 +9724,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._items_page_loading = False
             self._push_items_pager_state()
             self._restore_items_view_state()
+            if self._dom_is_live and self.query("#watchlists-read-local-only"):
+                self._request_surface_refresh(self._SURFACE_READER)
         return True
 
     def _items_load_is_current(

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -104,6 +104,7 @@ from ..Watchlists_Modules.inspector_pane import (
     PreviewRequested,
     StageInConsoleRequested,
     ToggleBriefingQueueRequested,
+    ViewSnapshotRequested,
 )
 from ..Watchlists_Modules.artifacts_pane import (
     ArtifactsPane,
@@ -132,11 +133,9 @@ from ..Watchlists_Modules.artifacts_pane import (
 from ..Watchlists_Modules.briefing_preset_modal import BriefingPresetModal
 from ..Watchlists_Modules.content_pane import (
     ContentPane,
-    ExpandReaderRequested,
     OpenInBrowserRequested,
     StarToggleRequested,
     UnreadToggleRequested,
-    ViewSnapshotRequested,
 )
 from ..Watchlists_Modules.article_list import (
     ArticleListPane,
@@ -1109,9 +1108,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # `_swap_region_widget` calls on a normal visit. Kept, rather than
         # dropped outright, so a screen mounted a second way (a test that
         # changes `region_layout` between construction and mount, or a
-        # future caller) still gets the reconciliation pass `_apply_layout`
-        # performs — `_sync_reader_expanded_state`, and the persistence
-        # no-op check for anything that genuinely did change.
+        # future caller) still gets the persistence reconciliation pass
+        # `_apply_layout` performs for anything that genuinely did change.
         self._apply_layout(self.region_layout)
         self._refresh_local_wc_snapshot()
         self._refresh_overview_data()
@@ -2387,24 +2385,15 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         in `watchlists_workbench.py`), so `WatchlistsWorkbench` prepends the
         generic "Content" title above whatever this returns.
 
-        Batch-4 review, Qodo Q4. `pane.expanded` is seeded from the live
-        `region_layout` (matching `_build_inspector_pane`'s `selected_entity`
-        seeding note above): this factory reruns on every region rebuild,
-        including the one `handle_expand_reader_requested` itself triggers
-        by calling `_apply_layout`, so the freshly-built pane must be told
-        whether CONTENT is the soloed region or its "Expand"/"Restore" label
-        would go stale the instant the layout that produced it changes.
         """
         pane = ContentPane(id="watchlists-content-pane")
         # `set_reactive`: `item` is the pane's one `recompose=True` reactive
         # and has no watcher, so a plain assignment here bought nothing but
         # the queued extra recompose whenever an item was selected — a full
         # second render of the article, inside the very swap task-15778
-        # batches. `expanded`/`position` below are non-recompose reactives
-        # whose watchers patch in place and stay plain, same audit as
-        # `_build_detail_pane`'s.
+        # batches. `position` below is a non-recompose reactive whose watcher
+        # patches in place and stays plain, same audit as `_build_detail_pane`.
         pane.set_reactive(ContentPane.item, self._selected_content_item)
-        pane.expanded = self.region_layout.solo_region == Region.CONTENT
         # TASK-3072 plan task 9: re-seed the footer the same way `item` is
         # re-seeded just above, so a region rebuild re-renders the same
         # position. Guarded inside `_reader_position_text` for the build
@@ -2962,28 +2951,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self.query_one(WatchlistsWorkbench).region_layout = self._rendered_region_layout()
         except Exception:
             logger.debug("Workbench not mounted yet; layout applies on compose.")
-        self._sync_reader_expanded_state()
         self._schedule_layout_persist(layout)
-
-    def _sync_reader_expanded_state(self) -> None:
-        """Push CONTENT's solo state into the live reader (task-15461).
-
-        `_build_content_pane` seeds `ContentPane.expanded` on every build,
-        which used to be enough because every layout change rebuilt every
-        region. Scoped updates keep a still-expanded CONTENT on its ORIGINAL
-        instance, and `Z` on CONTENT is exactly the case that changes this
-        flag without changing CONTENT's own form (solo collapses ITEMS, the
-        sibling) -- so without this push the reader's Expand/Restore button
-        would keep offering the action it has just performed.
-
-        A no-op when CONTENT is collapsed or hidden: there is no pane, and
-        the next `_build_content_pane` seeds the fresh one anyway.
-        """
-        try:
-            reader = self.query_one("#watchlists-content-pane", ContentPane)
-        except NoMatches:
-            return
-        reader.expanded = self.region_layout.solo_region == Region.CONTENT
 
     def _schedule_layout_persist(self, layout: RegionLayout) -> None:
         """Persist ``layout`` off the UI thread, skipping genuine no-ops.
@@ -4124,13 +4092,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         )
         if rehome_focus:
             self._restore_focus_after_swap()
-        # CONTENT is not rebuilt by the swap (the reader is deliberately not
-        # gated on `active_section` -- see `_build_content_pane`), so a still
-        # -mounted reader keeps its instance across the tab change. Its
-        # `expanded` flag is layout-derived, and `_rendered_region_layout`
-        # can move ITEMS' collapse state across the Read boundary, so
-        # re-push it for the same reason `_apply_layout` does.
-        self._sync_reader_expanded_state()
         self._reseed_active_section_pane()
 
     #: The two surfaces `_swap_active_section` tears down: the centre header
@@ -9746,40 +9707,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             return
         self._dispatch_item_status(item_id, _ItemStatusIntent(status="new", gate=True))
 
-    @on(ExpandReaderRequested)
-    def handle_expand_reader_requested(self, event: ExpandReaderRequested) -> None:
-        """Give the reader the whole centre stack, or give it back (AC#2).
-
-        Batch-4 review, Qodo Q4: this was task-2307's own disclosed gap --
-        `ContentPane` posted `ExpandReaderRequested` and nothing handled it,
-        a dead button. Task-1344 already built the mechanism this needs
-        (`action_solo_region`, bound to `Z`): isolate one centre pane,
-        collapsing the other two around it, and calling `solo` again on the
-        same region restores them (`RegionLayout.solo`'s own docstring).
-        Routed through THAT mechanism rather than a second one -- same
-        `_apply_layout` call `action_solo_region` makes, just with
-        `Region.CONTENT` as the target instead of reading it off
-        `self.focused_region`, since a button press already names its
-        target unambiguously and does not need the focus-tracking
-        indirection a keyboard shortcut does.
-
-        `_refuse_region_gesture_off_read_tab` is consulted anyway, for the
-        same "one source of truth for is a region-layout gesture allowed"
-        reason `action_toggle_region`/`action_solo_region`/`_on_region_
-        toggled` all do (see that method's own docstring) -- in practice
-        this button cannot be pressed off the Read tab at all (CONTENT is
-        unmounted everywhere else), so the refusal is defensive rather than
-        reachable, not a second, independent gate someone could drift out
-        of sync with the other three.
-        """
-        event.stop()
-        if self._refuse_region_gesture_off_read_tab(Region.CONTENT):
-            return
-        self._apply_layout(self.region_layout.solo(Region.CONTENT))
-
     @on(ViewSnapshotRequested)
     def handle_view_snapshot_requested(self, event: ViewSnapshotRequested) -> None:
-        """The reader's `[full page]`/`[previous snapshot]` affordances (TASK-1494).
+        """The Inspector's stored-page affordances (TASK-1494).
 
         Deferred to a worker for the same reason every other DB-touching
         handler on this screen is: `_open_snapshot_view` awaits a service
@@ -11349,7 +11279,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._open_item_in_browser(item)
 
     def _open_item_in_browser(self, item: dict[str, Any]) -> None:
-        """`webbrowser.open`, gated by the shared URL validator.
+        """Validate on the UI thread, then dispatch the OS call to a worker.
 
         A feed item's `url` is a REMOTE-derived string and `webbrowser.open`
         hands it to the OS, so validation runs at this boundary through
@@ -11370,7 +11300,28 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     severity="warning",
                 )
             return
-        webbrowser.open(url)
+        self._open_item_in_browser_worker(url)
+
+    @work(thread=True, group="wl-open-browser")
+    def _open_item_in_browser_worker(self, url: str) -> None:
+        """Invoke the blocking OS browser integration off the UI thread."""
+        try:
+            opened = webbrowser.open(url)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "The system browser failed while opening a Watchlists item."
+            )
+            opened = False
+        if not opened:
+            self.app.call_from_thread(self._notify_browser_open_failed)
+
+    def _notify_browser_open_failed(self) -> None:
+        """Report a browser worker failure from the Textual UI thread."""
+        self._notify_watchlists(
+            "Could not open this item in the system browser.",
+            severity="error",
+            markup=False,
+        )
 
     @on(NextUnreadRequested)
     def handle_next_unread_requested(self, event: NextUnreadRequested) -> None:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -12,7 +12,7 @@ import re
 import threading
 import webbrowser
 from collections.abc import Collection, Mapping, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -166,10 +166,12 @@ from ..Watchlists_Modules.opml_dialogs import (
 )
 from ..Watchlists_Modules.overview_pane import OverviewPane
 from ..Watchlists_Modules.region_layout import (
-    CENTRE_REGIONS,
     COLLAPSIBLE_REGIONS,
+    MANAGEMENT_SIDE_PANE_ORDER,
+    READ_SIDE_PANE_ORDER,
     Region,
     RegionLayout,
+    resolve_effective_layout,
 )
 from ..Watchlists_Modules.region_layout_store import load_region_layout, save_region_layout
 from ..Watchlists_Modules.rules_pane import (
@@ -215,7 +217,7 @@ from ..Watchlists_Modules.watchlists_backend_controller import WatchlistsBackend
 from ..Watchlists_Modules.watchlists_console_handoff import WatchlistsConsoleHandoff
 from ..Watchlists_Modules.watchlists_tab_strip import SectionSelected, WatchlistsTabStrip
 from ..Watchlists_Modules.watchlists_workbench import (
-    REGION_TITLES,
+    RegionLayoutApplied,
     RegionLayoutApplyFailed,
     RegionToggled,
     WatchlistsWorkbench,
@@ -508,7 +510,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         ("a", "mark_all_read", "Mark all read"),
         ("u", "undo_mark_all_read", "Undo mark-all-read"),
         ("z", "toggle_region", "Collapse"),
-        ("Z", "solo_region", "Solo"),
+        ("Z", "article_focus", "Article Focus"),
         ("left_square_bracket", "toggle_left_rail", "Left rail"),
         ("right_square_bracket", "toggle_right_rail", "Right rail"),
     ]
@@ -625,9 +627,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._wc_lookup_recovery_state: DestinationRecoveryState | None = None
         self._wc_loaded = False
         # Whether focus currently sits in the centre header/tab strip
-        # (`#wl-centre-status`), outside every `wl-region-*`/`wl-header-*`
-        # wrapper -- see `on_descendant_focus` and `action_toggle_region`/
-        # `action_solo_region` (task-1344 fix wave, Qodo correctness).
+        # (`#wl-centre-status`), outside every region/grip wrapper. See
+        # `on_descendant_focus` and `action_toggle_region`.
         self._focus_in_centre_header = False
         self._pending_open_create_form = False
         self._pending_open_import_opml = False
@@ -648,7 +649,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # `_loaded_runs`/`_loaded_notifications` already do (Finding 2, fix
         # round 2): `_build_detail_pane` constructs a brand new
         # SourcesPane/ItemsPane/RulesPane on every workbench rebuild (any
-        # region collapse/solo/rail toggle, not just switching sections), and
+        # region collapse/expand or tab switch), and
         # a fresh pane's `sources`/`items`/`rules` reactive starts at its
         # class default (`[]`). Without holding the last-loaded rows here and
         # re-seeding them below, the table would render empty until the next
@@ -855,7 +856,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # for the identical reason as `_loaded_items` above: `_build_content_pane`
         # is a factory the workbench calls on every region rebuild, and a
         # freshly built `ContentPane`'s `item` reactive would otherwise start
-        # back at `None` on every collapse/solo/rail toggle, clearing the
+        # back at `None` on every collapse/expand, clearing the
         # reader out from under a user who hadn't touched Items at all.
         self._selected_content_item: dict[str, Any] | None = None
         # Left-rail tree inputs (Task 4): loaded together by `_load_tree_data`
@@ -985,10 +986,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # calling it again (see `on_mount`).
         loaded_layout = load_region_layout()
         self.set_reactive(WatchlistsCollectionsScreen.region_layout, loaded_layout)
+        self._effective_region_layout = loaded_layout
+        self._article_focus_active = False
+        self._responsive_priority_target: Region | None = None
+        self._manual_layout_rollback: tuple[
+            RegionLayout, RegionLayout, bool, Region | None
+        ] | None = None
+        self._items_view_anchor_id: str | None = None
+        self._items_view_scroll_y = 0.0
+        self._items_view_had_focus = False
         self._last_persisted_collapsed: frozenset[Region] | None = (
-            loaded_layout.collapsed_for_persistence()
+            loaded_layout.collapsed
         )
         self._pending_persist_layout: RegionLayout | None = None
+        self._pending_persist_generation: int | None = None
+        self._layout_persist_generation = 0
+        self._layout_persist_draining = False
         self._layout_persist_lock = threading.Lock()
         # Desired-status coalescing for the four item-status write paths
         # (Ingest, Ignore, the unread toggle, mark-read-on-open) -- TASK-1541,
@@ -1110,7 +1123,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # changes `region_layout` between construction and mount, or a
         # future caller) still gets the persistence reconciliation pass
         # `_apply_layout` performs for anything that genuinely did change.
-        self._apply_layout(self.region_layout)
+        self._recompute_effective_layout()
         self._refresh_local_wc_snapshot()
         self._refresh_overview_data()
         self._load_active_section_data()
@@ -1118,6 +1131,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self.set_timer(
             WC_SNAPSHOT_TIMEOUT_SECONDS, self._apply_snapshot_timeout_if_still_loading
         )
+
+    def on_resize(self, _event: events.Resize) -> None:
+        """Re-derive responsive state without changing the preference."""
+        self._recompute_effective_layout()
 
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
         """Apply a validated section/run deep link from shell navigation."""
@@ -1405,17 +1422,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # left `#artifacts-scope-note` on the old one. Same seed
             # `_build_detail_pane` applies on a rebuild.
             artifacts.scope_label = self._briefing_scope_label()
-        try:
-            workbench = self.query_one("#wl-workbench", WatchlistsWorkbench)
-        except NoMatches:
-            pass
-        else:
-            # task-2513 Task 9: the collapsed left rail's "N unread" header
-            # suffix tracks the counts this loader just refreshed. In place,
-            # never a recompose — same discipline as every other push here.
-            workbench.set_collapsed_suffixes(
-                {Region.LEFT_RAIL: self._rail_unread_suffix()}
-            )
         # TASK-2304 AC#2, found in live verification, not by the suite. Which
         # sources the current scope covers is WATCHLIST MEMBERSHIP, and this
         # loader runs after every write that changes it (`Add source`,
@@ -2157,7 +2163,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             sources_pane.selected_source = self.selected_source
             # TASK-2309: re-seed from screen state for the identical
             # rebuild-survival reason as `selected_source` on the line
-            # above -- a region rebuild (collapse/solo/rail toggle, a tab
+            # above -- a region rebuild (collapse/expand, a tab
             # switch) constructs a brand new `SourcesPane`, and without this
             # a check still running would render its Check-now button back
             # to enabled/"Check now" until the run's own completion repaint
@@ -2372,7 +2378,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         builder here -- see the factory note on `WatchlistsWorkbench.__init__`.
         Seeded from `_selected_content_item` (Finding pattern established by
         `_build_inspector_pane`'s `selected_entity` seeding above): without
-        this, a collapse/solo/rail toggle would construct a brand new
+        this, a collapse/expand would construct a brand new
         `ContentPane` whose `item` reactive starts back at its class default
         of `None`, silently clearing the reader.
 
@@ -2807,7 +2813,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                         id="watchlists-backend-label",
                     )
             yield WatchlistsWorkbench(
-                self._rendered_region_layout(),
+                self._effective_region_layout,
                 content={
                     # Factories, not instances: a region whose rendered form
                     # changes (collapse/expand, and for ITEMS a section
@@ -2822,17 +2828,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     Region.CONTENT: self._build_content_pane,
                     Region.RIGHT_RAIL: self._build_inspector_region,
                 },
-                hidden=self._hidden_centre_regions(),
                 # Unconditional since task-2513: the tab strip and the
                 # snapshot markers are cross-cutting chrome carried by the
                 # centre header on every tab, Read included -- see
                 # `_build_centre_status_header`. (They used to ride inside
                 # the FEEDS region's own body on Read; that region is gone.)
                 header=self._build_centre_status_header,
-                # task-2513 Task 9: the collapsed left rail keeps the total
-                # unread count visible; `_load_tree_data` refreshes it in
-                # place via `set_collapsed_suffixes`.
-                collapsed_suffixes={Region.LEFT_RAIL: self._rail_unread_suffix()},
+                read_mode=self.active_section == "items",
                 id="wl-workbench",
                 classes=(
                     "watchlists-read-mode"
@@ -2841,88 +2843,96 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 ),
             )
 
-    def _hidden_centre_regions(self) -> frozenset[Region]:
-        """Centre regions the workbench must not mount at all on this tab.
+    def _available_layout_width(self) -> int:
+        """Best live width for the pure responsive resolver."""
+        candidates: list[int] = []
+        try:
+            workbench = self.query_one(WatchlistsWorkbench)
+            candidates.extend((workbench.size.width, workbench.container_size.width))
+        except Exception:
+            pass
+        candidates.append(self.size.width)
+        try:
+            candidates.append(self.app.size.width)
+        except Exception:
+            pass
+        return next((width for width in candidates if width > 0), 10_000)
 
-        Per the approved design spec (`### Tabs`): "Only Read uses the
-        three-pane split. Sources, Runs, Rules, and Artifacts take the full
-        centre width — they have no collection→feed→item relationship."
-        `active_section == "items"` is this implementation's Read tab (the
-        spec's five sections don't literally match today's six — Overview
-        and Notifications aren't in the spec's list either — but Items is
-        unambiguously the one with an items-to-read relationship). CONTENT
-        (the reader) is meaningless outside that relationship, so it is
-        hidden on every other tab (Task 4's gating; the FEEDS region, gated
-        the same way by TASK-1344, was removed outright in task-2513).
-
-        TASK-1344 AC#4: hidden means UNMOUNTED, not collapsed to a one-row
-        header — see `_rendered_region_layout`'s docstring for why a header
-        was rejected. `WatchlistsWorkbench.compose()` skips anything in the
-        returned set entirely; nothing here touches `self.region_layout`
-        (the real, persisted preference), so a CONTENT collapse or solo the
-        user set on Read is untouched by which OTHER tab they happen to be
-        looking at.
-
-        Returns:
-            `{Region.CONTENT}` on every section except Read, otherwise the
-            empty set.
-        """
-        if self.active_section == "items":
-            return frozenset()
-        return frozenset({Region.CONTENT})
-
-    def _rendered_region_layout(self) -> RegionLayout:
-        """`self.region_layout`, adjusted for what this tab can actually show.
-
-        CONTENT no longer needs adjusting here at all (TASK-1344):
-        `_hidden_centre_regions` unmounts it outright on every non-Read
-        tab, regardless of its real collapsed/solo state, so the old
-        "force CONTENT into `collapsed`, rebased onto the pre-solo baseline
-        when CONTENT itself is soloed" derivation this method used to need
-        (Task 4's fix round 1) is gone -- unmounting is orthogonal to
-        `RegionLayout.collapsed` instead of reusing it, so there is nothing
-        left to rebase.
-
-        ITEMS is the one region that still needs a derived view. Off the
-        Read tab, ITEMS is not "the middle third of a three-pane split" at
-        all -- it is the section's own full-width pane (`SourcesPane`,
-        `RunsPane`, ...), unconditionally shown, with no chevron that can
-        reach it on that tab. `z`/`Z` CAN still reach it, though --
-        `on_descendant_focus` sets `focused_region = ITEMS` for anything
-        inside `#wl-region-items`, so merely interacting with the section
-        pane off Read points a keybinding at it. That is exactly why
-        `_refuse_region_gesture_off_read_tab` refuses every centre region
-        off Read, not just the ones `_hidden_centre_regions` unmounts
-        (task-1344 whole-branch review, B1): before that fix, a `z` here
-        toggled and PERSISTED a real ITEMS collapse with no visible
-        feedback on the current tab (this method already forced it back
-        out of the render), so the damage stayed invisible until the user
-        returned to Read and found the centre empty. With the gate
-        covering ITEMS too, that mutation can no longer happen -- but
-        `region_layout.collapsed` can still legitimately contain ITEMS from
-        a real Read-tab action: a `z` on ITEMS while soloing CONTENT there
-        (`solo(CONTENT)` collapses the OTHER centre region, ITEMS) leaves
-        `collapsed` containing ITEMS even after the user switches away, and
-        that is a genuine user preference this method must still honor on
-        Read without rendering it as a dead end elsewhere. Rendering that
-        verbatim would collapse e.g. the Sources tab down to a focusable
-        "▸ Items" header over an otherwise empty centre -- the exact
-        dead-end AC#3 exists to rule out, reached from CONTENT's solo
-        bookkeeping. Forcing ITEMS out of `collapsed` on every non-Read tab
-        closes that: the section's pane is always what actually renders
-        there, and `self.region_layout` itself is untouched, so Read still
-        shows whatever ITEMS state the user really left behind.
-
-        Returns:
-            `self.region_layout` verbatim on the Read tab; otherwise a copy
-            with `Region.ITEMS` removed from `collapsed`.
-        """
-        if self.active_section == "items":
-            return self.region_layout
-        return replace(
+    def _recompute_effective_layout(self) -> None:
+        """Resolve and push transient responsive/Article Focus state."""
+        read_mode = self.active_section == "items"
+        width = self._available_layout_width()
+        mounted = READ_SIDE_PANE_ORDER if read_mode else MANAGEMENT_SIDE_PANE_ORDER
+        unprioritized = resolve_effective_layout(
             self.region_layout,
-            collapsed=frozenset(self.region_layout.collapsed - {Region.ITEMS}),
+            width=width,
+            read_mode=read_mode,
+            article_focus=False,
+            priority_target=None,
         )
+        preferred_mounted = frozenset(self.region_layout.collapsed.intersection(mounted))
+        if unprioritized.collapsed == preferred_mounted:
+            self._responsive_priority_target = None
+
+        effective = resolve_effective_layout(
+            self.region_layout,
+            width=width,
+            read_mode=read_mode,
+            article_focus=self._article_focus_active,
+            priority_target=self._responsive_priority_target,
+        )
+        previous = self._effective_region_layout
+        if (
+            read_mode
+            and not previous.is_collapsed(Region.ITEMS)
+            and effective.is_collapsed(Region.ITEMS)
+        ):
+            self._capture_items_view_state()
+        self._effective_region_layout = effective
+        try:
+            workbench = self.query_one(WatchlistsWorkbench)
+            if workbench.read_mode == read_mode:
+                workbench.region_layout = effective
+        except Exception:
+            logger.debug("Workbench not mounted yet; layout applies on compose.")
+
+    def _capture_items_view_state(self) -> None:
+        try:
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
+            table = pane.query_one("#items-table")
+        except NoMatches:
+            return
+        highlighted = getattr(table, "highlighted_child", None)
+        self._items_view_anchor_id = getattr(highlighted, "item_id_key", None)
+        self._items_view_scroll_y = float(getattr(table, "scroll_y", 0.0))
+        self._items_view_had_focus = bool(table.has_focus)
+
+    def _restore_items_view_state(self) -> None:
+        try:
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
+            table = pane.query_one("#items-table")
+        except NoMatches:
+            if (
+                self._items_view_anchor_id is not None
+                and self.active_section == "items"
+                and not self._effective_region_layout.is_collapsed(Region.ITEMS)
+            ):
+                self.set_timer(0.01, self._restore_items_view_state)
+            return
+        if self._items_view_anchor_id is not None:
+            restored_anchor = False
+            for index, row in enumerate(table.children):
+                if getattr(row, "item_id_key", None) == self._items_view_anchor_id:
+                    pane._suppressed_highlight_item_id = self._items_view_anchor_id
+                    table.index = index
+                    restored_anchor = True
+                    break
+            if not restored_anchor:
+                self.set_timer(0.01, self._restore_items_view_state)
+                return
+        table.scroll_to(y=self._items_view_scroll_y, animate=False)
+        if self._items_view_had_focus:
+            table.focus()
 
     def _apply_layout(self, layout: RegionLayout) -> None:
         """Set the layout, push it to the workbench, and persist any change.
@@ -2935,22 +2945,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 happens to leave the persisted collapsed set unchanged.
         """
         self.region_layout = layout
-        try:
-            # The workbench reactive is `region_layout`, NOT `layout` —
-            # `Widget.layout` is an existing read-only Textual property the
-            # compositor calls `.arrange()` on every render, so shadowing it
-            # breaks rendering outright. Verified empirically in Task 3.
-            #
-            # Pushes the RENDERED (tab-adjusted) layout, not the raw `layout`
-            # argument -- see `_rendered_region_layout`. Persistence just
-            # below still persists the real, un-derived `layout`. `hidden`/
-            # `header` are constructor-only on the already-mounted workbench
-            # and are not re-pushed here: neither can have changed, since
-            # only `active_section` changing invalidates them and this
-            # method is never called from an `active_section` watcher.
-            self.query_one(WatchlistsWorkbench).region_layout = self._rendered_region_layout()
-        except Exception:
-            logger.debug("Workbench not mounted yet; layout applies on compose.")
+        self._recompute_effective_layout()
         self._schedule_layout_persist(layout)
 
     def _schedule_layout_persist(self, layout: RegionLayout) -> None:
@@ -2966,18 +2961,24 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         loop (task-280).
 
         Args:
-            layout: The layout whose solo-resolved collapsed set (see
-                `RegionLayout.collapsed_for_persistence`) should be written
-                to config if it differs from what is already persisted.
+            layout: The preferred side-pane layout to write when it differs
+                from what is already persisted.
         """
-        collapsed = layout.collapsed_for_persistence()
-        if collapsed == self._last_persisted_collapsed:
+        collapsed = layout.collapsed
+        if (
+            collapsed == self._last_persisted_collapsed
+            and self._pending_persist_layout is None
+        ):
             return
-        self._last_persisted_collapsed = collapsed
-        self._pending_persist_layout = layout
+        with self._layout_persist_lock:
+            self._layout_persist_generation += 1
+            self._pending_persist_generation = self._layout_persist_generation
+            self._pending_persist_layout = layout
+            if self._layout_persist_draining:
+                return
+            self._layout_persist_draining = True
         self.run_worker(
             self._persist_layout_worker,
-            exclusive=True,
             group="wl-layout-persist",
             thread=True,
         )
@@ -2998,34 +2999,47 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         every `_schedule_layout_persist` call the burst has made so far —
         writes the true final layout, so the last write always wins.
         """
-        with self._layout_persist_lock:
-            layout = self._pending_persist_layout
-            if layout is None:
+        while True:
+            with self._layout_persist_lock:
+                generation = self._pending_persist_generation
+                layout = self._pending_persist_layout
+            if generation is None or layout is None:
+                with self._layout_persist_lock:
+                    self._layout_persist_draining = False
                 return
-            save_region_layout(layout)
+            try:
+                success = save_region_layout(layout)
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Failed to persist preferred Watchlists pane layout."
+                )
+                success = False
+            self.app.call_from_thread(
+                self._acknowledge_layout_persist,
+                generation,
+                layout,
+                success,
+            )
+            with self._layout_persist_lock:
+                pending_generation = self._pending_persist_generation
+                if pending_generation is None or pending_generation == generation:
+                    self._layout_persist_draining = False
+                    return
 
-    def _region_hidden_on_active_section(self, region: Region) -> bool:
-        """Whether ``region`` is not rendered at all on the active tab.
-
-        Pure query, no side effects. Distinct from "is this gesture
-        refused" (`_refuse_region_gesture_off_read_tab`, below, refuses
-        every centre region off Read, not only hidden ones -- task-1344
-        review B1): this predicate answers the narrower "is `region`
-        actually unmounted here", which that refusal consults only to pick
-        which notify copy is truthful. The only thing that ever answers
-        `True`: a rail (LEFT_RAIL/RIGHT_RAIL) is never tab-dependent, and
-        ITEMS is always the section's own full-width pane on every tab
-        (visible, just no longer collapsible off Read), so this reduces to
-        "is `region` in `_hidden_centre_regions()`".
-
-        Args:
-            region: The region a gesture (chevron click, `z`, `Z`) targets.
-
-        Returns:
-            `True` when `region` is CONTENT and the active section
-            is not Read (`"items"`), `False` otherwise.
-        """
-        return region in self._hidden_centre_regions()
+    def _acknowledge_layout_persist(
+        self,
+        generation: int,
+        layout: RegionLayout,
+        success: bool,
+    ) -> None:
+        """Commit only the current generation's successful write."""
+        with self._layout_persist_lock:
+            if generation != self._pending_persist_generation:
+                return
+            if success:
+                self._last_persisted_collapsed = layout.collapsed
+                self._pending_persist_layout = None
+                self._pending_persist_generation = None
 
     def _refuse_region_gesture_off_read_tab(self, region: Region) -> bool:
         """Refuse a layout change aimed at a centre region off the Read tab.
@@ -3035,8 +3049,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         gated region when it was written. A stray `focused_region` left over
         from the Read tab (e.g. the user last touched CONTENT there, then
         switched to Sources without moving focus) must be refused the same
-        way -- this is the ONE place both `action_toggle_
-        region`/`action_solo_region`/`_on_region_toggled` consult, per the
+        way -- this is the ONE place both `action_toggle_region` and
+        `_on_region_toggled` consult, per the
         prompt's "one source of truth for is region R visible on section S".
 
         Named as an ACTION, not a predicate (it was `_content_toggle_is_blocked`
@@ -3056,7 +3070,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         did nothing visible, silently flipped the user's genuine preference
         to collapsed, and `_schedule_layout_persist` wrote it to disk, honored
         forever. TASK-1344 AC#4 now unmounts hidden regions outright rather
-        than rendering that header (see `_hidden_centre_regions`), which
+        than rendering that header, which
         removes the click/chevron route entirely -- but `focused_region` is a
         screen-level reactive that outlives the widget that last set it
         (`on_descendant_focus`), so `z`/`Z` can still be invoked with it
@@ -3069,11 +3083,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         regions around one the user cannot see on this tab, the same class
         of harm as the chevron, through the one route that was still open.
 
-        Whole-branch review round 2 (task-1344 review, B1): the check used
-        to be `region in _hidden_centre_regions()`, so ITEMS -- never
-        hidden, always the section's own full-width pane off Read (see
-        `_rendered_region_layout`) -- was never refused. But
-        `_rendered_region_layout` only forces ITEMS out of `collapsed` for
+        Whole-branch review round 2 (task-1344 review, B1): ITEMS is never
+        hidden, always the section's own full-width pane off Read, and was
+        once never refused. But the derived layout only forces ITEMS open for
         the RENDER; the gesture handlers above still call `_apply_layout`
         against the real, persisted layout. So an off-Read `z`/`Z` with
         `focused_region == ITEMS` (reachable any time focus lands inside the
@@ -3083,10 +3095,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         CONTENT already collapsed on Read -- returning to Read rendered
         headers over an empty centre: the exact dead-end AC#3 exists to
         rule out, written to disk, surviving a restart.
-        Region-layout gestures (collapse/solo of the three-pane centre)
+        Region-layout gestures for the Read centre
         simply do not apply to ANY centre region off Read, not just the
         ones that happen to be unmounted there, so the gate now refuses
-        every `region in CENTRE_REGIONS` off Read unconditionally. The
+        ITEMS off Read unconditionally. The
         notify copy forks on whether the region is actually hidden here:
         CONTENT keeps the "only shown on the Read tab" copy (true for
         it), while ITEMS -- visible, just not collapsible from this tab
@@ -3100,19 +3112,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             `True` when the gesture must be refused (and the user has been
             told why), `False` when it may proceed.
         """
-        if self.active_section == "items" or region not in CENTRE_REGIONS:
+        if region is not Region.ITEMS or self.active_section == "items":
             return False
-        if self._region_hidden_on_active_section(region):
-            self.notify(
-                f"{REGION_TITLES[region]} is only shown on the Read tab. "
-                "Switch to Read to change its layout.",
-                markup=False,
-            )
-        else:
-            self.notify(
-                "The pane layout can only be changed on the Read tab.",
-                markup=False,
-            )
+        self.notify(
+            "Feed Items can only be collapsed on the Read tab.",
+            markup=False,
+        )
         return True
 
     def action_toggle_region(self) -> None:
@@ -3122,8 +3127,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         (`_focus_in_centre_header`, task-1344 fix wave, Qodo correctness):
         `focused_region` there names wherever the user last actually
         visited, not where they are now, and a rail (LEFT_RAIL/RIGHT_RAIL)
-        is never gated by `_refuse_region_gesture_off_read_tab` below (it
-        only covers `CENTRE_REGIONS`), so without this check a stale
+        is never gated by `_refuse_region_gesture_off_read_tab` below, so
+        without this check a stale
         `focused_region` pointing at a rail would still collapse -- and
         persist -- it from a keypress that has no visible relationship to
         either the rail or the tab strip the user is actually looking at.
@@ -3131,48 +3136,66 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if self._focus_in_centre_header:
             return
         region = self.focused_region
+        if region not in COLLAPSIBLE_REGIONS:
+            return
         if self._refuse_region_gesture_off_read_tab(region):
             return
-        self._apply_layout(self.region_layout.toggle(region))
+        self._toggle_preferred_region(region)
 
-    def action_solo_region(self) -> None:
-        """Isolate the focused centre pane; press again to restore.
-
-        Refused for any centre region off the Read tab, exactly as the
-        chevron and `z` already are -- see
-        `_refuse_region_gesture_off_read_tab`. Also silently refused while
-        focus sits in the centre header/tab strip
-        (`_focus_in_centre_header`, task-1344 fix wave, Qodo correctness),
-        for the same reason `action_toggle_region` checks it just above --
-        `focused_region` is stale there. Checked after the `CENTRE_REGIONS`
-        guard, not before: solo never applies to a rail regardless of
-        focus, so that refusal (and its notify) stays exactly as it was;
-        this only silences the CENTRE-region case, which -- off the Read
-        tab, where the header exists at all -- `_refuse_region_gesture_
-        off_read_tab` below would otherwise refuse anyway, just with a
-        notify keyed to a region the user is not looking at.
-        """
-        if self.focused_region not in CENTRE_REGIONS:
-            self.notify("Solo applies to the Items or Content panes.")
+    def action_article_focus(self) -> None:
+        """Toggle transient Article Focus on Read."""
+        if self.active_section != "items":
+            self.notify("Article Focus is available on Read.", markup=False)
             return
-        if self._focus_in_centre_header:
-            return
-        if self._refuse_region_gesture_off_read_tab(self.focused_region):
-            return
-        self._apply_layout(self.region_layout.solo(self.focused_region))
+        self._article_focus_active = not self._article_focus_active
+        self._recompute_effective_layout()
 
     def action_toggle_left_rail(self) -> None:
-        self._apply_layout(self.region_layout.toggle(Region.LEFT_RAIL))
+        self._toggle_preferred_region(Region.LEFT_RAIL)
 
     def action_toggle_right_rail(self) -> None:
-        self._apply_layout(self.region_layout.toggle(Region.RIGHT_RAIL))
+        self._toggle_preferred_region(Region.RIGHT_RAIL)
+
+    def _toggle_preferred_region(self, region: Region) -> None:
+        """Apply one manual gesture, inferred from effective state."""
+        requested_open = self._effective_region_layout.is_collapsed(region)
+        before = (
+            self.region_layout,
+            self._effective_region_layout,
+            self._article_focus_active,
+            self._responsive_priority_target,
+        )
+        self._article_focus_active = False
+        preferred = self.region_layout
+        if requested_open:
+            if preferred.is_collapsed(region):
+                preferred = preferred.toggle_preferred(region)
+            self._responsive_priority_target = region
+        else:
+            if not preferred.is_collapsed(region):
+                preferred = preferred.toggle_preferred(region)
+            if self._responsive_priority_target is region:
+                self._responsive_priority_target = None
+        changed = preferred != self.region_layout
+        self.region_layout = preferred
+        self._recompute_effective_layout()
+        self._manual_layout_rollback = (
+            self._effective_region_layout,
+            before[0],
+            before[2],
+            before[3],
+        )
+        if changed:
+            self._schedule_layout_persist(preferred)
 
     @on(RegionToggled)
     def _on_region_toggled(self, event: RegionToggled) -> None:
         event.stop()
+        if event.region not in COLLAPSIBLE_REGIONS:
+            return
         if self._refuse_region_gesture_off_read_tab(event.region):
             return
-        self._apply_layout(self.region_layout.toggle(event.region))
+        self._toggle_preferred_region(event.region)
 
     @on(RegionLayoutApplyFailed)
     def _on_region_layout_apply_failed(
@@ -3180,21 +3203,38 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         """Correct screen preference only while the failed intent is current."""
         event.stop()
-        if self._rendered_region_layout() != event.attempted:
+        if self._effective_region_layout != event.attempted:
             return
-        collapsed = set(self.region_layout.collapsed)
-        for region in COLLAPSIBLE_REGIONS:
-            if event.attempted.is_collapsed(region) == event.fallback.is_collapsed(
-                region
-            ):
-                continue
-            if event.fallback.is_collapsed(region):
-                collapsed.add(region)
-            else:
-                collapsed.discard(region)
-        self._apply_layout(
-            replace(self.region_layout, collapsed=frozenset(collapsed))
-        )
+        rollback = self._manual_layout_rollback
+        if rollback is None or rollback[0] != event.attempted:
+            self._effective_region_layout = event.fallback
+            return
+        current_preferred = self.region_layout
+        _, preferred, article_focus, priority_target = rollback
+        self.region_layout = preferred
+        self._article_focus_active = article_focus
+        self._responsive_priority_target = priority_target
+        self._manual_layout_rollback = None
+        self._recompute_effective_layout()
+        if current_preferred != preferred:
+            self._schedule_layout_persist(preferred)
+
+    @on(RegionLayoutApplied)
+    def _on_region_layout_applied(self, event: RegionLayoutApplied) -> None:
+        """Restore pane-local view state after a successful remount."""
+        event.stop()
+        if event.layout != self._effective_region_layout:
+            return
+        if (
+            self._manual_layout_rollback is not None
+            and self._manual_layout_rollback[0] == event.layout
+        ):
+            self._manual_layout_rollback = None
+        if (
+            event.previous.is_collapsed(Region.ITEMS)
+            and not event.layout.is_collapsed(Region.ITEMS)
+        ):
+            self._restore_items_view_state()
 
     def _apply_tree_scope(self, scope: TreeScope) -> None:
         """The single reconciliation point for "the tree scope is now `scope`".
@@ -4056,9 +4096,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         * the ITEMS region, whose pane `_build_detail_pane` routes by section;
         * the centre header, which carries the tab strip and the scoped
           snapshot markers;
-        * `_hidden_centre_regions`/`_rendered_region_layout`, i.e. whether
-          CONTENT exists at all on this tab and whether ITEMS may render
-          collapsed there.
+        * the derived effective layout, which parks CONTENT off Read and
+          forces the management canvas open.
 
         The header bar's backend Select is the fourth, and is patched in
         place by `_sync_backend_header_bar` (which also runs synchronously
@@ -4081,12 +4120,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # Asked BEFORE the swap: afterwards the widget is already gone and
         # Textual has already re-homed focus (see `_restore_focus_after_swap`).
         rehome_focus = self._swap_will_destroy_focus()
-        workbench.set_class(
-            self.active_section == "items", "watchlists-read-mode"
-        )
+        self._recompute_effective_layout()
         await workbench.apply_section_view(
-            hidden=self._hidden_centre_regions(),
-            layout=self._rendered_region_layout(),
+            read_mode=self.active_section == "items",
+            layout=self._effective_region_layout,
             rebuild_regions=(Region.ITEMS,),
             rebuild_header=True,
         )
@@ -4134,7 +4171,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         Re-focusing the freshly built tab restores that refusal by the honest
         route rather than by accident: focus lands in `#wl-centre-status`, so
         `on_descendant_focus` sets `_focus_in_centre_header`, which is exactly
-        what `action_toggle_region`/`action_solo_region` already consult.
+        what `action_toggle_region` already consults.
 
         Only called when the swap really did unmount the focused widget
         (`_swap_will_destroy_focus`): a section change driven from elsewhere
@@ -4300,8 +4337,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         Also tracks `_focus_in_centre_header` (task-1344 fix wave, Qodo
         correctness): the centre header/tab strip (`#wl-centre-status`,
         mounted directly under `#wl-centre` by `_build_centre_status_header`
-        -- see `compose_content`) sits OUTSIDE every `wl-region-*`/
-        `wl-header-*` wrapper on every section including Read (TASK-2312;
+        -- see `compose_content`) sits outside every region/grip wrapper on
+        every section including Read (TASK-2312;
         Read used to mount its own copy of the tab strip INSIDE FEEDS's own
         `wl-region-feeds` wrapper, so this branch never fired there and
         focusing the tab strip on Read instead matched the `wl-region-`
@@ -4311,13 +4348,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         indistinguishable here from a live selection: a user who tabs into
         the tab strip and presses `z`/`Z` would act on that stale reference
         with no visible relationship to where they are.
-        `action_toggle_region`/`action_solo_region` consult
-        `_focus_in_centre_header` to refuse exactly that.
+        `action_toggle_region` consults `_focus_in_centre_header` to refuse
+        exactly that.
         """
         node = event.widget
         while node is not None:
             node_id = getattr(node, "id", None) or ""
-            for prefix in ("wl-region-", "wl-header-"):
+            for prefix in ("wl-region-", "wl-grip-"):
                 if node_id.startswith(prefix):
                     try:
                         self.focused_region = Region(node_id[len(prefix):])
@@ -4349,6 +4386,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # a stale `True` would wrongly refuse a legitimate `z`/`Z` on the
         # new tab (task-1344 fix wave, Qodo correctness).
         self._focus_in_centre_header = False
+        if self.active_section != "items":
+            self._article_focus_active = False
+        self._recompute_effective_layout()
         if self.active_section == "overview":
             self.selected_entity = None
         if self.active_section != WATCHLISTS_SECTION_RUNS:
@@ -5799,7 +5839,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 limit=100,
             )
             # Mirror to screen state (Finding 2, fix round 2) so a later
-            # workbench rebuild — any region collapse/solo/rail toggle, not
+            # workbench rebuild — any region collapse/expand, not
             # just a fresh section switch — can re-seed a brand new
             # SourcesPane instead of leaving its table empty; see
             # `_build_detail_pane` and `_loaded_sources` in __init__.
@@ -6851,9 +6891,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         LLM wrote, so the same caution `_load_briefings`'s own failure
         toasts already take applies.
 
-        For a resolving id, switches to the Items ("Read") section --
-        `ContentPane` is only ever mounted there (`_hidden_centre_regions`)
-        -- and, once that section's `ItemsPane` exists, hands it the
+        For a resolving id, switches to the Items ("Read") section, the only
+        section where `ContentPane` is mounted, and once that section's
+        `ItemsPane` exists, hands it the
         resolved item via `ItemsPane.select_and_reveal` (NOT `handle_item_
         selected` directly: that method's own docstring warns the pane's
         `selected_item` reactive would go stale against the table's actual

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -18,10 +18,8 @@ from textual.reactive import reactive
 from textual.widgets import Button, Static
 
 from ...Subscriptions.html_text import readable_body_text, strip_control_characters
-from ...Subscriptions.item_persist import CONTENT_KIND_CHANGE
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
 from .humane_time import humane_timestamp
-from .inspector_pane import IngestRequested, ToggleBriefingQueueRequested
 from .items_pane import NextUnreadRequested
 
 # Every item persisted before Phase A carries `content = NULL`, and it cannot
@@ -262,27 +260,6 @@ class UnreadToggleRequested(Message):
         super().__init__()
 
 
-class ViewSnapshotRequested(Message):
-    """Posted when the reader asks to see a `change` item's stored page.
-
-    TASK-1494: the design spec's Content-pane mockup promised `[full page]`
-    and `[previous snapshot]` affordances reading from `url_snapshots`, and
-    Phase D shipped both renderers without them -- the data was stored and
-    unreachable. `which` is `"full_page"` for the newest `url_snapshots`
-    row (the page this change's diff was measured against) or `"previous"`
-    for the second-newest (the page as it was one check before that); the
-    screen's handler resolves which row that actually is, since this pane
-    holds no DB handle of its own (see `ContentPane`'s own docstring).
-    Carries the full item dict, same as `UnreadToggleRequested`, so the
-    handler can read `source_id`/`url` off it without a second lookup.
-    """
-
-    def __init__(self, item: dict[str, Any] | None, which: str) -> None:
-        self.item = item
-        self.which = which
-        super().__init__()
-
-
 class StarToggleRequested(Message):
     """Posted when the reader's Star button is pressed (TASK-3072 plan task 7).
 
@@ -308,19 +285,6 @@ class OpenInBrowserRequested(Message):
         self.item = item
         super().__init__()
 
-class ExpandReaderRequested(Message):
-    """Posted when the reader asks for (or gives back) the whole centre stack.
-
-    TASK-2307 AC#2 (UAT F27). The reader is bounded in the ordinary centre
-    stack, and the only keyboard ways to enlarge it -- `z` on the sibling
-    regions, `Z` on this one -- require focus to already be inside the region.
-    This is the visible affordance for the same existing layout action.
-
-    Carries no payload: the screen owns `region_layout` and this pane must not
-    hold a second opinion about it (see `ContentPane.expanded`).
-    """
-
-
 class ContentPane(RecomposeCaptureGuard, Vertical):
     """Hosts the reader for the currently selected item.
 
@@ -336,47 +300,9 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
 
     item: reactive[dict[str, Any] | None] = reactive(None, recompose=True)
 
-    #: Whether CONTENT is currently the only expanded centre region, i.e.
-    #: whether the expand button should offer to give the room BACK.
-    #:
-    #: Seeded by `WatchlistsCollectionsScreen._build_content_pane` from the
-    #: live `RegionLayout` and never written here: the layout has exactly one
-    #: owner, and a pane that guessed would show `Restore` over a bounded
-    #: reader the moment the two drifted. A plain reactive, not
-    #: `recompose=True`: `watch_expanded` relabels the one button in place,
-    #: which is the whole visible difference (task-15461).
-    expanded: reactive[bool] = reactive(False)
-
-    def watch_expanded(self, expanded: bool) -> None:
-        """Relabel the expand button in place -- never a reader recompose.
-
-        Until task-15461 this reactive needed no watcher: EVERY layout change
-        recomposed the whole workbench, so `_build_content_pane` rebuilt this
-        pane (button label included) from the fresh layout. Layout changes are
-        now scoped to the regions whose form actually moved, and soloing
-        CONTENT does not move CONTENT's own form -- it collapses ITEMS, the
-        sibling -- so this pane keeps its instance and the label is the one
-        thing left to repaint. Without this, pressing Expand left a button
-        still reading "Expand" over a reader that had already taken the whole
-        centre.
-
-        Args:
-            expanded: Whether CONTENT is now the only expanded centre region.
-        """
-        try:
-            self.query_one("#content-expand-button", Button).label = (
-                "Restore" if expanded else "Expand"
-            )
-        except NoMatches:
-            # Pre-mount seeding (`_build_content_pane`), or the empty state,
-            # which composes no action strip at all; `compose` reads the
-            # reactive itself.
-            pass
-
     #: The reader footer's "N of M" (TASK-3072 plan task 9).
     #:
-    #: Screen-pushed, exactly like `expanded` above and for the same reason:
-    #: this pane holds no list state, so it cannot number the open item
+    #: Screen-pushed because this pane holds no list state, so it cannot number the open item
     #: itself -- the screen computes the position from the article list's
     #: `displayed_items()` on every selection and pushes the string here
     #: (and re-seeds it in `_build_content_pane`, so a region rebuild
@@ -403,16 +329,15 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
 
         Yields:
             A single `#content-empty` `Static` when no item is selected;
-            otherwise a one-row `#content-actions` strip holding
-            `#content-mark-unread-button`, `#content-expand-button`
-            (TASK-2307) and, on a `change`-kind item only, the
-            `#content-full-page-button`/`#content-previous-snapshot-button`
-            pair (TASK-1494) -- followed by `#content-body-scroll`, which
-            contains the existing `#content-body` `Static`, and the fixed
-            `#content-footer` action strip.
+            otherwise a one-row `#content-actions` strip holding Star,
+            Mark unread, and Open -- followed by `#content-body-scroll`,
+            which contains the existing `#content-body` `Static`, and the
+            fixed `#content-footer` action strip.
         """
         if self.item is None:
-            yield Static("Select an item to read it.", id="content-empty")
+            yield Static(
+                "Select a feed item to display it here.", id="content-empty"
+            )
             return
         # Task 5: the reader marks an item read on open (see the screen's
         # `_mark_item_read_on_open`); this button is the deliberate way
@@ -425,18 +350,9 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
         # three rows tall (top border, label, bottom border); the established
         # one-row reader chrome keeps those rows available for the article.
         #
-        # TASK-2307: the buttons share ONE `.destination-filter-strip` row
-        # (`height: 1`, the same chrome every toolbar on this screen uses)
-        # rather than stacking. A `change` item previously spent three of the
-        # reader on three stacked buttons; it now spends one, which preserves
-        # the body budget and makes room for the expand affordance.
+        # The buttons share one one-row toolbar so the article keeps the body
+        # budget.
         with HorizontalScroll(id="content-actions", classes="destination-filter-strip"):
-            yield Button(
-                "Mark unread",
-                id="content-mark-unread-button",
-                tooltip=_GLOBAL_STATUS_NOTE,
-                compact=True,
-            )
             # TASK-3072 plan task 7: the same star the `s` key toggles, as a
             # button. The label reflects the open item's state on compose and
             # flips on the screen's SUCCESS path (see `on_button_pressed` --
@@ -447,69 +363,19 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
                 tooltip=_GLOBAL_STAR_NOTE,
                 compact=True,
             )
-            # TASK-3072 plan task 8: the rest of the reader's verbs. Open is
-            # the `o` key's button half; Ingest and Queue/Unqueue post the
-            # Inspector's OWN message classes, so one screen handler serves
-            # both surfaces (the queue label states the CURRENT value, the
-            # Inspector's own `_queue_briefing_button` rule). Buttons only --
-            # the spec assigns no keys to these two.
+            yield Button(
+                "Mark unread",
+                id="content-mark-unread-button",
+                tooltip=_GLOBAL_STATUS_NOTE,
+                compact=True,
+            )
+            # TASK-3072 plan task 8: Open is the `o` key's button half.
             yield Button(
                 "Open",
                 id="content-open-button",
                 tooltip="Open this item in your browser (keyboard: o).",
                 compact=True,
             )
-            yield Button(
-                "Ingest",
-                id="content-ingest-button",
-                tooltip=(
-                    "File this item into the library. Ingesting is shared: "
-                    "it shows as ingested everywhere it appears."
-                ),
-                compact=True,
-            )
-            yield Button(
-                "Unqueue" if self.item.get("queued_for_briefing") else "Queue",
-                id="content-queue-button",
-                tooltip=(
-                    "Remove this item from the pool the next briefing draws from."
-                    if self.item.get("queued_for_briefing")
-                    else "Add this item to the pool the next briefing draws from."
-                ),
-                compact=True,
-            )
-            # AC#2. `Z` does the same thing from the keyboard, and the tooltip
-            # says so -- but only once the user knows the region has to be
-            # focused first, which is exactly the knowledge F27 says nothing
-            # on screen conveys. The button needs no focus at all.
-            yield Button(
-                "Restore" if self.expanded else "Expand",
-                id="content-expand-button",
-                compact=True,
-                tooltip=(
-                    "Give the reader the whole centre pane, and press again "
-                    "to put Feeds and Items back (keyboard: Z)."
-                ),
-            )
-            if str(self.item.get("content_kind") or "") == CONTENT_KIND_CHANGE:
-                # TASK-1494: the two affordances the design spec promised for
-                # a site change and Phase D never wired up. Article items
-                # never get these -- only `URLMonitor.check_url` (a
-                # `change`-kind producer) ever writes `url_snapshots`, so an
-                # article item has no rows there to show and the buttons would
-                # open a modal with nothing in it.
-                yield Button(
-                    "Full page",
-                    id="content-full-page-button",
-                    compact=True,
-                    tooltip="Open the page this change was measured against.",
-                )
-                yield Button(
-                    "Previous snapshot",
-                    id="content-previous-snapshot-button",
-                    compact=True,
-                    tooltip="Open the page as it was before this change.",
-                )
         with VerticalScroll(id="content-body-scroll"):
             yield Static(render_for(self.item), id="content-body")
         # TASK-3072 plan task 9: the position footer. "N of M" is seeded and
@@ -541,30 +407,6 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
         elif event.button.id == "content-open-button":
             event.stop()
             self.post_message(OpenInBrowserRequested(self.item))
-        elif event.button.id == "content-ingest-button":
-            event.stop()
-            self.post_message(IngestRequested(self.item))
-        elif event.button.id == "content-queue-button":
-            event.stop()
-            # The Inspector's own press-site shape: the raw row id, and the
-            # value to set the flag TO (the flip of the current one).
-            item = self.item or {}
-            item_id = item.get("item_id")
-            if item_id is not None:
-                self.post_message(
-                    ToggleBriefingQueueRequested(
-                        item_id, not bool(item.get("queued_for_briefing"))
-                    )
-                )
         elif event.button.id == "content-next-unread-button":
             event.stop()
             self.post_message(NextUnreadRequested())
-        elif event.button.id == "content-full-page-button":
-            event.stop()
-            self.post_message(ViewSnapshotRequested(self.item, "full_page"))
-        elif event.button.id == "content-previous-snapshot-button":
-            event.stop()
-            self.post_message(ViewSnapshotRequested(self.item, "previous"))
-        elif event.button.id == "content-expand-button":
-            event.stop()
-            self.post_message(ExpandReaderRequested())

--- a/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
@@ -27,6 +27,7 @@ from textual.reactive import reactive
 from textual.widgets import Button, Static, TextArea
 
 from ...Subscriptions.html_text import strip_control_characters
+from ...Subscriptions.item_persist import CONTENT_KIND_CHANGE
 from ...Subscriptions.noise_defaults import (
     first_invalid_selector,
     invalid_selector_message,
@@ -110,6 +111,20 @@ class IngestRequested(Message):
 
     def __init__(self, entity: dict[str, Any] | None) -> None:
         self.entity = entity
+        super().__init__()
+
+
+class ViewSnapshotRequested(Message):
+    """Posted when the Inspector requests a stored page for a change item.
+
+    `which` is `"full_page"` for the newest stored snapshot or `"previous"`
+    for the second-newest. The screen resolves the row because the Inspector
+    holds no database handle.
+    """
+
+    def __init__(self, item: dict[str, Any] | None, which: str) -> None:
+        self.item = item
+        self.which = which
         super().__init__()
 
 
@@ -668,6 +683,22 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
                 yield Button("Ingest", id="inspector-ingest-button", variant="primary")
                 yield Button("Ignore", id="inspector-ignore-button", variant="error")
                 yield self._queue_briefing_button(entity)
+                if (
+                    str(entity.get("content_kind") or "")
+                    == CONTENT_KIND_CHANGE
+                ):
+                    yield Button(
+                        "Full page",
+                        id="inspector-full-page-button",
+                        compact=True,
+                        tooltip="Open the page this change was measured against.",
+                    )
+                    yield Button(
+                        "Previous snapshot",
+                        id="inspector-previous-snapshot-button",
+                        compact=True,
+                        tooltip="Open the page as it was before this change.",
+                    )
             elif deepest.kind == "rule":
                 yield Button("Edit", id="inspector-edit-rule-button", variant="primary")
                 yield Button("Delete", id="inspector-delete-button", variant="error")
@@ -889,6 +920,10 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
             self.post_message(IgnoreRequested(entity))
         elif button_id == "inspector-queue-briefing-button":
             self._post_toggle_briefing_queue(entity)
+        elif button_id == "inspector-full-page-button":
+            self.post_message(ViewSnapshotRequested(entity, "full_page"))
+        elif button_id == "inspector-previous-snapshot-button":
+            self.post_message(ViewSnapshotRequested(entity, "previous"))
         elif button_id == "inspector-edit-rule-button":
             self.post_message(EditRuleRequested(entity))
         elif button_id == "inspector-save-selectors-button":

--- a/tldw_chatbook/UI/Watchlists_Modules/pane_grip.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/pane_grip.py
@@ -43,7 +43,8 @@ class WatchlistsPaneGrip(Button):
         )
         self.pane_region = region
         self.styles.width = PANE_GRIP_WIDTH
-        self.styles.min_width = 0
+        self.styles.min_width = PANE_GRIP_WIDTH
+        self.styles.max_width = PANE_GRIP_WIDTH
         self.styles.line_pad = 0
         self.set_reactive(WatchlistsPaneGrip.expanded, expanded)
         self._relabel()

--- a/tldw_chatbook/UI/Watchlists_Modules/pane_grip.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/pane_grip.py
@@ -6,7 +6,7 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Button
 
-from .region_layout import PANE_GRIP_WIDTH, Region
+from .region_layout import Region
 
 
 _PANE_NAMES: dict[Region, str] = {
@@ -42,9 +42,6 @@ class WatchlistsPaneGrip(Button):
             compact=True,
         )
         self.pane_region = region
-        self.styles.width = PANE_GRIP_WIDTH
-        self.styles.min_width = PANE_GRIP_WIDTH
-        self.styles.max_width = PANE_GRIP_WIDTH
         self.styles.line_pad = 0
         self.set_reactive(WatchlistsPaneGrip.expanded, expanded)
         self._relabel()

--- a/tldw_chatbook/UI/Watchlists_Modules/pane_grip.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/pane_grip.py
@@ -1,0 +1,70 @@
+"""Clickable ASCII grips for collapsible Watchlists panes."""
+
+from __future__ import annotations
+
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widgets import Button
+
+from .region_layout import PANE_GRIP_WIDTH, Region
+
+
+_PANE_NAMES: dict[Region, str] = {
+    Region.LEFT_RAIL: "Navigation",
+    Region.ITEMS: "Feed Items",
+    Region.RIGHT_RAIL: "Inspector",
+}
+
+
+class RegionToggled(Message):
+    """Request to toggle one Watchlists pane."""
+
+    def __init__(self, region: Region) -> None:
+        super().__init__()
+        self.region = region
+
+
+class WatchlistsPaneGrip(Button):
+    """A focused five-column control for expanding or collapsing a pane."""
+
+    expanded: reactive[bool] = reactive(False)
+
+    def __init__(
+        self,
+        region: Region,
+        expanded: bool,
+        *,
+        id: str | None = None,
+    ) -> None:
+        super().__init__(
+            id=id,
+            classes="watchlists-pane-grip",
+            compact=True,
+        )
+        self.pane_region = region
+        self.styles.width = PANE_GRIP_WIDTH
+        self.styles.min_width = 0
+        self.styles.line_pad = 0
+        self.set_reactive(WatchlistsPaneGrip.expanded, expanded)
+        self._relabel()
+
+    def watch_expanded(self, _expanded: bool) -> None:
+        """Refresh the arrow and action copy without replacing the widget."""
+        self._relabel()
+
+    def _relabel(self) -> None:
+        pane_name = _PANE_NAMES[self.pane_region]
+        action = "Collapse" if self.expanded else "Expand"
+        points_right = self.pane_region is Region.RIGHT_RAIL
+        if not self.expanded:
+            points_right = not points_right
+
+        self.label = "--->" if points_right else "<---"
+        copy = f"{action} {pane_name}"
+        self.tooltip = copy
+        self._name = copy
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Translate native mouse and keyboard activation into one message."""
+        event.stop()
+        self.post_message(RegionToggled(self.pane_region))

--- a/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
@@ -1,12 +1,15 @@
-"""Collapse and solo state for the Watchlists workbench's four regions.
+"""Preferred and effective pane state for the Watchlists workbench.
 
-Pure state: no Textual import, no I/O. The screen's fiddliest interaction —
-four independently collapsible regions plus a solo/restore toggle — lives
-here so it can be tested without a Textual pilot.
+Pure state: no Textual import, no I/O. The user's preferred side-pane state
+and the transient responsive/Article Focus result can therefore be tested
+without a Textual pilot.
 
 Every mutator returns a new instance; the type is frozen and hashable, so a
 Textual reactive can hold it and equality comparison decides whether to
 re-render.
+
+The solo members remain temporarily for the live screen's migration and are
+not used by the preferred/effective layout path.
 
 The FEEDS region was removed in task-2513 (reader-first IA, ADR-042) with no
 migration code: a persisted ``"feeds"`` string from before the removal is an
@@ -37,26 +40,61 @@ REGION_ORDER: tuple[Region, ...] = (
     Region.RIGHT_RAIL,
 )
 
-#: The vertically stacked centre panes. Only these may be soloed.
+#: Side panes whose preferred open/collapsed state may be changed by the user.
+COLLAPSIBLE_REGIONS: tuple[Region, ...] = (
+    Region.LEFT_RAIL,
+    Region.ITEMS,
+    Region.RIGHT_RAIL,
+)
+
+#: Side panes mounted in Read, in display order.
+READ_SIDE_PANE_ORDER: tuple[Region, ...] = COLLAPSIBLE_REGIONS
+
+#: Side panes mounted around a management canvas, in display order.
+MANAGEMENT_SIDE_PANE_ORDER: tuple[Region, ...] = (
+    Region.LEFT_RAIL,
+    Region.RIGHT_RAIL,
+)
+
+#: Fixed width of every mounted side-pane grip.
+PANE_GRIP_WIDTH = 5
+
+#: Minimum expanded width of each side pane.
+PANE_MINIMUM_WIDTHS: dict[Region, int] = {
+    Region.LEFT_RAIL: 24,
+    Region.ITEMS: 32,
+    Region.RIGHT_RAIL: 30,
+}
+
+#: Preferred comfort width for the permanent Reader or management canvas.
+CENTRE_COMFORT_WIDTH = 44
+
+#: Default collapse order when Read becomes too narrow.
+READ_COLLAPSE_PRIORITY: tuple[Region, ...] = (
+    Region.RIGHT_RAIL,
+    Region.LEFT_RAIL,
+    Region.ITEMS,
+)
+
+#: Default collapse order when a management tab becomes too narrow.
+MANAGEMENT_COLLAPSE_PRIORITY: tuple[Region, ...] = (
+    Region.RIGHT_RAIL,
+    Region.LEFT_RAIL,
+)
+
+#: Migration-only centre-pane vocabulary for the legacy ``solo`` API.
 CENTRE_REGIONS: tuple[Region, ...] = (Region.ITEMS, Region.CONTENT)
 
 
 @dataclass(frozen=True)
 class RegionLayout:
-    """Which regions are collapsed, and whether one centre pane is soloed.
+    """A preferred or effective set of collapsed regions.
 
     Attributes:
-        collapsed: Regions currently collapsed to their header. While
-            `solo_region` is set, this is the solo-DERIVED view (the other
-            centre panes collapsed around the soloed one) rather than a
-            layout the user configured directly — see
-            `collapsed_for_persistence`.
-        solo_region: The centre region currently isolated via `solo`, or
-            `None` when no pane is soloed.
-        _pre_solo: The collapsed set as it was immediately before the most
-            recent `solo` call, kept so a second `solo` call (or config
-            persistence, via `collapsed_for_persistence`) can recover it.
-            `None` when the layout has never been soloed.
+        collapsed: Regions currently collapsed. New preferred layouts contain
+            only `COLLAPSIBLE_REGIONS`.
+        solo_region: Migration-only legacy solo state for the live screen.
+        _pre_solo: Migration-only legacy restore baseline.
     """
 
     collapsed: frozenset[Region] = frozenset()
@@ -82,8 +120,29 @@ class RegionLayout:
         """
         return tuple(r for r in REGION_ORDER if r not in self.collapsed)
 
+    def toggle_preferred(self, region: Region) -> RegionLayout:
+        """Flip one side pane's preferred collapse state.
+
+        Args:
+            region: The collapsible side pane to update.
+
+        Returns:
+            A new preferred layout with ``region`` flipped.
+
+        Raises:
+            ValueError: If ``region`` is the permanent centre content.
+        """
+        if region not in COLLAPSIBLE_REGIONS:
+            raise ValueError(f"{region!r} is not a collapsible side pane")
+
+        collapsed = set(self.collapsed_for_persistence()).intersection(
+            COLLAPSIBLE_REGIONS
+        )
+        collapsed.symmetric_difference_update({region})
+        return RegionLayout(collapsed=frozenset(collapsed))
+
     def toggle(self, region: Region) -> RegionLayout:
-        """Collapse ``region`` if expanded, expand it if collapsed.
+        """Migration-only permissive toggle retained for the live screen.
 
         A manual toggle clears any solo: the user has edited the layout by
         hand, so a later solo-restore must not resurrect a stale snapshot.
@@ -103,7 +162,7 @@ class RegionLayout:
         return RegionLayout(collapsed=frozenset(collapsed))
 
     def solo(self, region: Region) -> RegionLayout:
-        """Collapse the other centre panes around ``region``; call again to restore.
+        """Migration-only centre solo/restore retained for the live screen.
 
         Rails are unaffected — solo is about the centre stack only.
 
@@ -135,7 +194,7 @@ class RegionLayout:
         )
 
     def collapsed_for_persistence(self) -> frozenset[Region]:
-        """The collapsed set that should survive a restart.
+        """Migration-only accessor for the legacy pre-solo baseline.
 
         While soloed, `collapsed` is the solo-DERIVED view — the other
         centre panes collapsed to isolate `solo_region` — not a layout the
@@ -151,3 +210,51 @@ class RegionLayout:
             unchanged.
         """
         return self._pre_solo if self.solo_region is not None else self.collapsed
+
+
+def resolve_effective_layout(
+    preferred: RegionLayout,
+    *,
+    width: int,
+    read_mode: bool,
+    article_focus: bool,
+    priority_target: Region | None,
+) -> RegionLayout:
+    """Derive mounted side-pane collapses without changing ``preferred``.
+
+    Args:
+        preferred: The user's preferred side-pane layout.
+        width: Available workbench width in terminal columns.
+        read_mode: Whether Read's Feed Items pane is mounted.
+        article_focus: Whether every mounted side pane is temporarily hidden.
+        priority_target: An expanded mounted pane to collapse last, if any.
+
+    Returns:
+        A new effective layout with no solo or restore state.
+    """
+    mounted = READ_SIDE_PANE_ORDER if read_mode else MANAGEMENT_SIDE_PANE_ORDER
+    priority = READ_COLLAPSE_PRIORITY if read_mode else MANAGEMENT_COLLAPSE_PRIORITY
+    collapsed = set(preferred.collapsed_for_persistence()).intersection(
+        COLLAPSIBLE_REGIONS
+    )
+
+    if article_focus:
+        return RegionLayout(collapsed=frozenset(collapsed.union(mounted)))
+
+    required_width = (
+        CENTRE_COMFORT_WIDTH
+        + len(mounted) * PANE_GRIP_WIDTH
+        + sum(PANE_MINIMUM_WIDTHS[region] for region in mounted if region not in collapsed)
+    )
+    candidates = [region for region in priority if region not in collapsed]
+    if priority_target in candidates:
+        candidates.remove(priority_target)
+        candidates.append(priority_target)
+
+    for region in candidates:
+        if required_width <= width:
+            break
+        collapsed.add(region)
+        required_width -= PANE_MINIMUM_WIDTHS[region]
+
+    return RegionLayout(collapsed=frozenset(collapsed))

--- a/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
@@ -234,9 +234,7 @@ def resolve_effective_layout(
     """
     mounted = READ_SIDE_PANE_ORDER if read_mode else MANAGEMENT_SIDE_PANE_ORDER
     priority = READ_COLLAPSE_PRIORITY if read_mode else MANAGEMENT_COLLAPSE_PRIORITY
-    collapsed = set(preferred.collapsed_for_persistence()).intersection(
-        COLLAPSIBLE_REGIONS
-    )
+    collapsed = set(preferred.collapsed_for_persistence()).intersection(mounted)
 
     if article_focus:
         return RegionLayout(collapsed=frozenset(collapsed.union(mounted)))

--- a/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
@@ -8,9 +8,6 @@ Every mutator returns a new instance; the type is frozen and hashable, so a
 Textual reactive can hold it and equality comparison decides whether to
 re-render.
 
-The solo members remain temporarily for the live screen's migration and are
-not used by the preferred/effective layout path.
-
 The FEEDS region was removed in task-2513 (reader-first IA, ADR-042) with no
 migration code: a persisted ``"feeds"`` string from before the removal is an
 unknown region name now, dropped with a debug log by
@@ -82,24 +79,16 @@ MANAGEMENT_COLLAPSE_PRIORITY: tuple[Region, ...] = (
     Region.LEFT_RAIL,
 )
 
-#: Migration-only centre-pane vocabulary for the legacy ``solo`` API.
-CENTRE_REGIONS: tuple[Region, ...] = (Region.ITEMS, Region.CONTENT)
-
-
 @dataclass(frozen=True)
 class RegionLayout:
     """A preferred or effective set of collapsed regions.
 
     Attributes:
-        collapsed: Regions currently collapsed. New preferred layouts contain
+        collapsed: Regions currently collapsed. Preferred layouts contain
             only `COLLAPSIBLE_REGIONS`.
-        solo_region: Migration-only legacy solo state for the live screen.
-        _pre_solo: Migration-only legacy restore baseline.
     """
 
     collapsed: frozenset[Region] = frozenset()
-    solo_region: Region | None = None
-    _pre_solo: frozenset[Region] | None = None
 
     def is_collapsed(self, region: Region) -> bool:
         """Whether ``region`` is currently collapsed to its header.
@@ -135,81 +124,9 @@ class RegionLayout:
         if region not in COLLAPSIBLE_REGIONS:
             raise ValueError(f"{region!r} is not a collapsible side pane")
 
-        collapsed = set(self.collapsed_for_persistence()).intersection(
-            COLLAPSIBLE_REGIONS
-        )
+        collapsed = set(self.collapsed).intersection(COLLAPSIBLE_REGIONS)
         collapsed.symmetric_difference_update({region})
         return RegionLayout(collapsed=frozenset(collapsed))
-
-    def toggle(self, region: Region) -> RegionLayout:
-        """Migration-only permissive toggle retained for the live screen.
-
-        A manual toggle clears any solo: the user has edited the layout by
-        hand, so a later solo-restore must not resurrect a stale snapshot.
-
-        Args:
-            region: The region to collapse or expand.
-
-        Returns:
-            A new layout with `region`'s collapse state flipped and no
-            solo in effect (`solo_region` is always `None` afterwards).
-        """
-        collapsed = set(self.collapsed)
-        if region in collapsed:
-            collapsed.discard(region)
-        else:
-            collapsed.add(region)
-        return RegionLayout(collapsed=frozenset(collapsed))
-
-    def solo(self, region: Region) -> RegionLayout:
-        """Migration-only centre solo/restore retained for the live screen.
-
-        Rails are unaffected — solo is about the centre stack only.
-
-        Args:
-            region: The centre region to isolate.
-
-        Returns:
-            A layout with the other centre regions collapsed, or the
-            pre-solo layout if ``region`` is already soloed.
-
-        Raises:
-            ValueError: If ``region`` is a rail rather than a centre region.
-        """
-        if region not in CENTRE_REGIONS:
-            raise ValueError(f"{region!r} is not a centre region; solo applies to {CENTRE_REGIONS}")
-
-        if self.solo_region == region:
-            return RegionLayout(collapsed=self._pre_solo or frozenset())
-
-        # Re-soloing a different pane keeps the ORIGINAL pre-solo snapshot, so
-        # restore always returns to what the user had before soloing at all.
-        baseline = self._pre_solo if self.solo_region is not None else self.collapsed
-        rails = {r for r in self.collapsed if r not in CENTRE_REGIONS}
-        others = {r for r in CENTRE_REGIONS if r != region}
-        return RegionLayout(
-            collapsed=frozenset(rails | others),
-            solo_region=region,
-            _pre_solo=baseline,
-        )
-
-    def collapsed_for_persistence(self) -> frozenset[Region]:
-        """Migration-only accessor for the legacy pre-solo baseline.
-
-        While soloed, `collapsed` is the solo-DERIVED view — the other
-        centre panes collapsed to isolate `solo_region` — not a layout the
-        user configured. Persisting that verbatim would strand a restart in
-        a view the user never chose, with no `_pre_solo` baseline left to
-        restore from. Returning the pre-solo baseline instead means a
-        restart reproduces what the user actually set up, and solo itself
-        genuinely does not survive a restart, matching what
-        `region_layout_store`'s module docstring promises.
-
-        Returns:
-            `_pre_solo` when `solo_region` is set, otherwise `collapsed`
-            unchanged.
-        """
-        return self._pre_solo if self.solo_region is not None else self.collapsed
 
 
 def resolve_effective_layout(
@@ -234,7 +151,7 @@ def resolve_effective_layout(
     """
     mounted = READ_SIDE_PANE_ORDER if read_mode else MANAGEMENT_SIDE_PANE_ORDER
     priority = READ_COLLAPSE_PRIORITY if read_mode else MANAGEMENT_COLLAPSE_PRIORITY
-    collapsed = set(preferred.collapsed_for_persistence()).intersection(mounted)
+    collapsed = set(preferred.collapsed).intersection(mounted)
 
     if article_focus:
         return RegionLayout(collapsed=frozenset(collapsed.union(mounted)))

--- a/tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py
@@ -1,15 +1,4 @@
-"""Persist Watchlists workbench collapse state to the user's config.
-
-Collapse state is UI preference, not data, so it belongs in config rather
-than SubscriptionsDB. Solo is deliberately not persisted — it is a transient
-view mode, and restoring it across restarts would strand the user in a
-layout they did not choose. While a layout is soloed, `save_region_layout`
-writes the *pre-solo baseline* (`RegionLayout.collapsed_for_persistence`),
-not the solo-derived collapsed set: the latter is what the other centre
-panes look like while isolating the soloed one, not something the user
-configured, and persisting it would leave a restart with no baseline left
-to recover the user's actual layout from.
-"""
+"""Persist the preferred Watchlists side-pane layout in user config."""
 
 from __future__ import annotations
 
@@ -17,211 +6,89 @@ from collections.abc import Sequence
 
 from loguru import logger
 
-from ...config import get_cli_setting, save_setting_to_cli_config
-from .region_layout import Region, RegionLayout
+from ...config import get_cli_setting, save_settings_to_cli_config
+from .region_layout import COLLAPSIBLE_REGIONS, Region, RegionLayout
 
 
 logger = logger.bind(module="WatchlistsRegionLayoutStore")
 
-#: Flat section. `get_cli_setting` does NOT resolve dotted sections — passing
-#: "watchlists.layout" silently returns the default and the setting never
-#: round-trips. This repo has shipped that bug before with "chat.images".
-_SECTION = "watchlists"
-_KEY = "collapsed_regions"
+LAYOUT_VERSION = 2
 
-#: What to show before anyone has ever touched collapse state. Through Phase
-#: C, CONTENT held only a placeholder stub, so it started collapsed rather
-#: than spending a third of the centre column on "Reader arrives in the next
-#: slice." on every first launch -- that stub-era default is the whole
-#: reason the `_CONTENT_READER_MIGRATED_KEY` one-time migration below
-#: exists. Phase D wired a real reader into CONTENT (`ContentPane`), so
-#: CONTENT no longer starts collapsed.
-#:
-#: RIGHT_RAIL (the Inspector) now does instead: a new user's Read tab is a
-#: reader, not an inspector, so the right rail's management actions recede
-#: until the user asks for them with `]`. The None-vs-`[]` handling in
-#: `load_region_layout` below already distinguishes "the key was never
-#: saved" (this default applies) from "saved as an empty list" (the user
-#: deliberately expanded everything, and that choice survives), so a user
-#: who opens the rail keeps it open across restarts with no further
-#: machinery.
+_SECTION = "watchlists"
+_COLLAPSED_REGIONS_KEY = "collapsed_regions"
+_LAYOUT_VERSION_KEY = "layout_version"
+_RETIRED_MIGRATION_KEY = "content_reader_migrated"
+
 _FIRST_RUN_DEFAULT = RegionLayout(collapsed=frozenset({Region.RIGHT_RAIL}))
 
-#: One-time-migration marker (Phase D). A user who saved ANY layout before
-#: this change necessarily has CONTENT in their persisted `collapsed_regions`
-#: unless they specifically expanded it: CONTENT started collapsed by
-#: default (see `_FIRST_RUN_DEFAULT`'s history above), so every save made
-#: while that default was in effect carried CONTENT along, whether or not
-#: the user meant anything by it -- there was nothing behind it to look at.
-#: Honoring that persisted membership forever would leave every such user's
-#: reader stuck collapsed post-upgrade, looking broken rather than shipped.
-#: This key is set exactly once, the first time `load_region_layout` runs
-#: after upgrading: while unset, a persisted CONTENT collapse is dropped
-#: (never a persisted expansion -- only ever a discard); once set, a later
-#: DELIBERATE collapse of CONTENT (the reader now exists and can genuinely
-#: be closed on purpose) is honored like any other region on every load
-#: after that, including a value re-added after the marker was set.
-_CONTENT_READER_MIGRATED_KEY = "content_reader_migrated"
+
+def _normalize_values(raw: object) -> list[str]:
+    """Return canonical persisted values for a raw config value."""
+    if raw is None:
+        return [
+            region.value
+            for region in COLLAPSIBLE_REGIONS
+            if region in _FIRST_RUN_DEFAULT.collapsed
+        ]
+    if isinstance(raw, str):
+        raw = [raw]
+    elif not isinstance(raw, Sequence):
+        logger.debug("Ignoring non-sequence watchlists collapse state: {!r}", raw)
+        raw = []
+
+    return [region.value for region in COLLAPSIBLE_REGIONS if region.value in raw]
+
+
+def _write_values(values: list[str]) -> bool:
+    """Atomically persist normalized layout values and retire the old marker."""
+    try:
+        return save_settings_to_cli_config(
+            {
+                _SECTION: {
+                    _COLLAPSED_REGIONS_KEY: values,
+                    _LAYOUT_VERSION_KEY: LAYOUT_VERSION,
+                }
+            },
+            delete_keys={_SECTION: (_RETIRED_MIGRATION_KEY,)},
+        )
+    except Exception:
+        logger.opt(exception=True).debug(
+            "Failed to persist normalized watchlists pane layout."
+        )
+        return False
 
 
 def load_region_layout() -> RegionLayout:
-    """Read collapse state from config.
-
-    Distinguishes "the key has never been saved" from "the key was saved as
-    an empty list": `get_cli_setting` returns its `default` argument only
-    when the key is absent from config, so passing `None` — not `[]` — lets
-    a genuinely-unset key be told apart from a user who explicitly
-    re-expanded everything and had that saved. Collapsing that distinction
-    (as an earlier version of this function did, defaulting to `[]`) means
-    every session of every user who has never specifically touched CONTENT
-    gets the placeholder stub forever, not just on a true first run — and a
-    heuristic that treats "empty" as "apply the first-run default" would
-    permanently strand a user who deliberately keeps CONTENT expanded, since
-    saving that exact choice looks identical to never having saved anything.
-
-    Also performs the Phase D one-time migration (see
-    `_CONTENT_READER_MIGRATED_KEY`): the first time this runs after
-    upgrading, any persisted CONTENT collapse is dropped, since it can only
-    be a leftover from the placeholder-stub-era default rather than a
-    decision about the real reader. Every call after that honors CONTENT's
-    collapse state exactly like any other region's.
-
-    That migration writes config SYNCHRONOUSLY, on the UI thread, from the
-    caller's `on_mount` -- deliberately, and unlike every ordinary collapse
-    toggle, which `WatchlistsCollectionsScreen._schedule_layout_persist`
-    pushes onto a thread worker precisely to keep
-    `save_setting_to_cli_config`'s whole-file read-modify-write off the event
-    loop. The exemption is not an oversight (whole-branch review, Minor):
-
-    * It is bounded at one write per user, for the entire life of the
-      install, not one per `z`/`Z`/`[`/`]` keypress. `_schedule_layout_persist`
-      exists because of the repeat rate; there is no repeat rate here.
-    * Deferring it would race the very mechanism it would be deferred onto.
-      `_schedule_layout_persist` writes the SAME config key from an
-      `exclusive=True` thread worker, and `_apply_layout(loaded_layout)` runs
-      immediately after this function returns. Two unordered background
-      writers on one key is how the correction silently loses to a toggle the
-      user makes a moment later -- and if the user leaves the screen before a
-      deferred worker ran, the correction is simply never written at all.
-      That is exactly the durability hole fix rounds 2 and 3 (below) closed;
-      reopening it to save a single one-off write would be a bad trade.
-    * The marker is gated on the correction's write actually succeeding
-      (round 3), which needs the write's result inline, here, before this
-      function can decide what to return.
-
-    If this ever needs to move off the UI thread, it has to move *with* an
-    ordering guarantee against `_schedule_layout_persist`, not merely onto
-    another worker.
+    """Load and best-effort normalize the preferred side-pane layout.
 
     Returns:
-        The collapse state to apply: the first-run default
-        (`_FIRST_RUN_DEFAULT`) when the config key has never been saved, or
-        the persisted collapsed set otherwise (silently dropping any
-        unrecognized region names or non-sequence stored value), with the
-        one-time CONTENT migration applied when it has not run yet.
+        A safe layout containing only currently collapsible side panes.
     """
-    migrated = bool(get_cli_setting(_SECTION, _CONTENT_READER_MIGRATED_KEY, False))
-    raw = get_cli_setting(_SECTION, _KEY, None)
+    raw = get_cli_setting(_SECTION, _COLLAPSED_REGIONS_KEY, None)
+    version = get_cli_setting(_SECTION, _LAYOUT_VERSION_KEY, None)
+    values = _normalize_values(raw)
 
-    if raw is None:
-        if not migrated:
-            _mark_content_reader_migrated()
-        return _FIRST_RUN_DEFAULT
-    if isinstance(raw, str):
-        raw = [raw]
-    if not isinstance(raw, Sequence):
-        logger.debug("Ignoring non-sequence watchlists collapse state: {!r}", raw)
-        if not migrated:
-            _mark_content_reader_migrated()
-        return RegionLayout()
+    if version != LAYOUT_VERSION or raw != values:
+        _write_values(values)
 
-    collapsed = set()
-    for value in raw:
-        try:
-            collapsed.add(Region(str(value)))
-        except ValueError:
-            logger.debug("Ignoring unknown watchlists region {!r} from config.", value)
-
-    if not migrated:
-        # Stub-era saves always carried CONTENT along in `collapsed` (it was
-        # the default), so its presence here says nothing about user intent.
-        # Drop it exactly once; `_mark_content_reader_migrated` ensures a
-        # DELIBERATE re-collapse afterward is never touched again.
-        #
-        # Fix round 2 (coordinator review): dropping CONTENT from the
-        # RETURNED layout without also rewriting `collapsed_regions` on disk
-        # made the correction last exactly one `RegionLayout` -- the marker
-        # got written, but the persisted list did not, so the very next
-        # `load_region_layout()` call (next launch, or simply the next
-        # remount -- this screen unmounts on navigation) read `migrated ==
-        # True` and skipped the discard entirely, permanently re-collapsing
-        # CONTENT for exactly the returning users this migration exists to
-        # help. The caller's own persistence bookkeeping
-        # (`_last_persisted_collapsed` in `watchlists_collections_screen.py`)
-        # cannot be relied on to paper over this: it gets primed from
-        # whatever THIS function returns, which is the very value that was
-        # never written. This function must make its own correction durable
-        # itself, not depend on a caller noticing the discrepancy.
-        #
-        # Fix round 3 (coordinator review): the write above can fail two
-        # ways -- `save_setting_to_cli_config` can raise, but it can also
-        # just return `False` (see `config.py`), and a bare
-        # `except Exception` guard around the call catches neither the
-        # `False` case nor tells the caller which one happened. Marking the
-        # migration done regardless reproduces round 2's exact bug through
-        # the failure path: disk stays `["content", ...]`, the marker is now
-        # `True`, and the next load skips the discard forever. So the marker
-        # is now gated on `save_region_layout`'s own success return (which
-        # propagates BOTH failure modes -- see that function) -- if the
-        # correction could not be written, the migration must retry on the
-        # next load, not be marked done.
-        had_content = Region.CONTENT in collapsed
-        collapsed.discard(Region.CONTENT)
-        write_ok = True
-        if had_content:
-            write_ok = save_region_layout(RegionLayout(collapsed=frozenset(collapsed)))
-        if write_ok:
-            _mark_content_reader_migrated()
-
-    return RegionLayout(collapsed=frozenset(collapsed))
-
-
-def _mark_content_reader_migrated() -> None:
-    """Record that the Phase D CONTENT-collapse migration has run.
-
-    Best-effort, matching `save_region_layout`'s own error handling: failing
-    to persist the marker means the next launch re-runs (and re-no-ops, since
-    it only ever discards) the migration rather than losing collapse state.
-    """
-    try:
-        save_setting_to_cli_config(_SECTION, _CONTENT_READER_MIGRATED_KEY, True)
-    except Exception:
-        logger.opt(exception=True).debug(
-            "Failed to persist watchlists content-reader migration marker."
-        )
+    collapsed = frozenset(
+        region for region in COLLAPSIBLE_REGIONS if region.value in values
+    )
+    return RegionLayout(collapsed=collapsed)
 
 
 def save_region_layout(layout: RegionLayout) -> bool:
-    """Write collapse state to config. Solo state is not persisted.
+    """Persist only the layout's preferred collapsible side panes.
 
     Args:
-        layout: The layout to persist. Only its (solo-resolved) collapsed
-            set is written — see `RegionLayout.collapsed_for_persistence`;
-            `solo_region` and the pre-solo baseline itself never round-trip
-            through config.
+        layout: Preferred layout to persist. Transitional solo state is
+            resolved before filtering.
 
     Returns:
-        Whether the write actually succeeded. `save_setting_to_cli_config`
-        signals failure two ways -- raising, or returning `False` without
-        raising at all (see `config.py`) -- so a caller that needs to know
-        whether the write is genuinely durable (see `load_region_layout`'s
-        migration, fix round 3) must check this return value; catching an
-        exception around the call is not sufficient on its own, since the
-        `False`-return failure mode raises nothing to catch.
+        The configuration writer's Boolean result, or ``False`` if it raises.
     """
-    values = sorted(region.value for region in layout.collapsed_for_persistence())
-    try:
-        return bool(save_setting_to_cli_config(_SECTION, _KEY, values))
-    except Exception:
-        logger.opt(exception=True).debug("Failed to persist watchlists collapse state.")
-        return False
+    collapsed = layout.collapsed_for_persistence()
+    values = [
+        region.value for region in COLLAPSIBLE_REGIONS if region in collapsed
+    ]
+    return _write_values(values)

--- a/tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py
@@ -81,14 +81,14 @@ def save_region_layout(layout: RegionLayout) -> bool:
     """Persist only the layout's preferred collapsible side panes.
 
     Args:
-        layout: Preferred layout to persist. Transitional solo state is
-            resolved before filtering.
+        layout: Preferred layout to persist.
 
     Returns:
         The configuration writer's Boolean result, or ``False`` if it raises.
     """
-    collapsed = layout.collapsed_for_persistence()
     values = [
-        region.value for region in COLLAPSIBLE_REGIONS if region in collapsed
+        region.value
+        for region in COLLAPSIBLE_REGIONS
+        if region in layout.collapsed
     ]
     return _write_values(values)

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -1,11 +1,4 @@
-"""Watchlists workbench: two collapsible rails around a stacked centre.
-
-The shared ``DestinationWorkbench`` cannot express this layout — it is a
-fixed ``Horizontal`` of equal-width panes composed once from a frozen tuple,
-with no collapse, resize, or vertical stacking. If the collapse behaviour
-here proves useful to a second screen, it graduates into the shared widget
-then; generalising ahead of a second consumer is not worth it.
-"""
+"""Watchlists workbench with a permanent horizontal centre canvas."""
 
 from __future__ import annotations
 
@@ -13,17 +6,17 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
-from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
-from textual.widgets import Button, Static
+from textual.widgets import Static
 
-from .region_layout import CENTRE_REGIONS, REGION_ORDER, Region, RegionLayout
+from .pane_grip import RegionToggled, WatchlistsPaneGrip
+from .region_layout import Region, RegionLayout
 
+__all__ = ["REGION_TITLES", "RegionToggled", "WatchlistsWorkbench"]
 
-#: Human-readable titles, used for both expanded bodies and collapsed headers.
 REGION_TITLES: dict[Region, str] = {
     Region.LEFT_RAIL: "Watchlists",
     Region.ITEMS: "Items",
@@ -31,78 +24,30 @@ REGION_TITLES: dict[Region, str] = {
     Region.RIGHT_RAIL: "Inspector",
 }
 
-#: Regions whose supplied pane draws its own heading, so adding the generic
-#: region title from `REGION_TITLES` would produce a *second* heading.
-#:
-#: This is deliberately NOT the same signal as "a content factory was
-#: supplied for this region". The two diverge at LEFT_RAIL: it supplies
-#: content too, but that content (`WatchlistTree`) composes only navigation
-#: `Button`s and no heading widget at all (see `watchlist_tree.py::compose`),
-#: so keying suppression on factory-presence -- as this module did before --
-#: rendered the expanded left rail as an unlabelled bordered box while its
-#: *collapsed* header still read "▸ Watchlists". Membership here means
-#: "the pane supplies its own heading", which is the actual rule.
-#:
-#: Task 4 wired `ContentPane` into CONTENT (`watchlists_collections_screen.py`
-#: `_build_content_pane`) and deliberately did NOT add `Region.CONTENT` here:
-#: `ContentPane.compose()` yields only a bare `Static` (the placeholder or the
-#: rendered item), no heading widget of its own -- the same shape as
-#: LEFT_RAIL's `WatchlistTree` above, which is excluded for the identical
-#: reason. CONTENT gets the generic "Content" title like LEFT_RAIL gets
-#: "Watchlists".
 SELF_HEADED_REGIONS: frozenset[Region] = frozenset(
     {Region.ITEMS, Region.RIGHT_RAIL}
 )
 
+_READ_GRIP_REGIONS: tuple[Region, ...] = (
+    Region.LEFT_RAIL,
+    Region.ITEMS,
+    Region.RIGHT_RAIL,
+)
+_MANAGEMENT_GRIP_REGIONS: tuple[Region, ...] = (
+    Region.LEFT_RAIL,
+    Region.RIGHT_RAIL,
+)
 
-class RegionToggled(Message):
-    """A collapsed region's header or rail handle was activated."""
 
-    def __init__(self, region: Region) -> None:
-        super().__init__()
-        self.region = region
+class WatchlistsWorkbench(Vertical):
+    """Render optional chrome above a permanent horizontal centre.
 
-
-class WatchlistsWorkbench(Horizontal):
-    """Renders a :class:`RegionLayout` as rails plus a stacked centre.
-
-    The reactive is named ``region_layout``, not ``layout``: ``Widget.layout``
-    is an existing, unsettable Textual property (``textual/widget.py``) that
-    the compositor reads on every arrange pass (``widget.layout.arrange(...)``
-    in ``textual/_arrange.py``). A same-named reactive here shadows it, so
-    Textual ends up calling ``.arrange()`` on our ``RegionLayout`` domain
-    object instead of the real layout strategy and crashes with
-    ``AttributeError: 'RegionLayout' object has no attribute 'arrange'`` on
-    first render. Verified with a minimal repro using an unrelated reactive
-    also named ``layout``, so this is a general Widget-subclass constraint,
-    not specific to this dataclass.
-
-    Attributes:
-        region_layout: The current collapse/solo state. Setting it swaps ONLY
-            the regions whose rendered form actually changed — a region that
-            flipped between its collapsed one-line header and its expanded
-            body. Regions that stayed expanded keep their live widget
-            instance and are patched in place (the sole-centre CSS marker is
-            the only other thing a layout change can move for them).
-
-            This was `recompose=True` until task-15461, which meant every
-            `z`/`Z`/`[`/`]`/chevron rebuilt all four regions: measured on a
-            seeded screen, one `]` tore down and rebuilt 76–99 widgets
-            (the tree with its per-expanded-watchlist synchronous source
-            query, the tab strip, the article list, the Inspector) to
-            collapse a rail. `content` still holds FACTORIES rather than
-            instances — see `__init__` — because a swapped-out region's
-            replacement must still be a brand new widget.
+    Read permanently anchors :class:`Region.CONTENT`; Navigation, Feed Items,
+    and Inspector are independently collapsible side panes. Management tabs
+    permanently anchor :class:`Region.ITEMS` and omit the Feed Items grip and
+    Reader.
     """
 
-    # task-16843: a shared *instance* default (`reactive(RegionLayout())`
-    # installs the SAME `RegionLayout` object on every workbench instance
-    # until `__init__`'s `set_reactive` calls below overwrite it) -- but
-    # harmless: `RegionLayout` is `frozen=True` and every field is itself
-    # immutable (`frozenset`, `Region | None`), so there is no mutable
-    # container underneath to mutate in place. Allowlisted in
-    # `Tests/Architecture/test_reactive_mutable_default_inventory.py`'s
-    # `IMMUTABLE_INSTANCE_ALLOWLIST` rather than rewritten into a factory.
     region_layout: reactive[RegionLayout] = reactive(RegionLayout())
 
     def __init__(
@@ -112,490 +57,231 @@ class WatchlistsWorkbench(Horizontal):
         hidden: frozenset[Region] = frozenset(),
         header: Callable[[], Widget] | None = None,
         collapsed_suffixes: Mapping[Region, str] | None = None,
+        *,
+        read_mode: bool | None = None,
         **kwargs: Any,
     ) -> None:
-        """Build the workbench, seeding `region_layout` without a region sync.
+        """Build the workbench from reusable region factories.
 
         Args:
-            layout: Initial collapse/solo state.
-            content: Per-region **factories**, not widget instances — a
-                region whose rendered form changes (collapsed header <->
-                expanded body) is swapped for a freshly built one, so the
-                factory must be callable more than once.
-                Passing already-constructed instances was tried first and
-                verified broken empirically: a container widget's
-                constructor-supplied children (e.g. ``Vertical(Static(...),
-                Static(...))``) are consumed on that widget's *first* mount
-                only. Once such an instance has been unmounted (as part of
-                a recompose) and the *same* instance is handed back to
-                `compose()` again, it remounts with zero children — its
-                grandchildren do not come back. A leaf widget with no
-                children of its own (e.g. a bare ``Label``) happens to
-                survive remounting, and a widget with an *overridden*
-                ``compose()`` (which regenerates its children from scratch
-                every call) also survives — which is exactly why this was
-                easy to miss with a single-recompose test. A factory
-                sidesteps the whole class of bug by handing back a brand
-                new instance on every region rebuild, matching how
-                ``WatchlistsTabStrip`` (an overridden-``compose()``
-                widget) already behaves.
-            hidden: Centre regions to omit from `compose()` entirely — no
-                collapsed header, no body (TASK-1344 AC#4: gated regions
-                UNMOUNT rather than keep a one-row header). The caller
-                (`WatchlistsCollectionsScreen._hidden_centre_regions`)
-                decides which regions this is, keyed on `active_section`;
-                the workbench itself has no opinion about tabs. The initial
-                value only: since task-15461 a section switch no longer
-                rebuilds this widget, so the caller pushes the new set
-                through `apply_section_view` instead, which mounts or
-                unmounts exactly the centre regions that crossed the
-                boundary. A plain toggle/solo (`_apply_layout` pushing a new
-                `region_layout` onto the ALREADY-mounted instance) never
-                changes which tab is active, so `hidden` is untouched there.
-            header: An optional factory for a widget rendered as the FIRST
-                child of the centre stack, unconditionally — regardless of
-                `hidden`. TASK-1344: the section tab strip and the
-                snapshot's own loading/error/empty markers are cross-
-                cutting chrome, not region content, so they must survive
-                CONTENT being hidden on every non-Read tab. Since
-                task-2513 removed the FEEDS region (whose own inline copy
-                used to carry that chrome on Read), the screen wires this
-                on EVERY tab — Read included; `None` is for callers (and
-                tests) that genuinely have no header to show. This class
-                stays a generic building block with no opinion about tabs,
-                and any two factories that both mount an id must never be
-                combined by a caller, same as ever.
+            layout: Effective side-pane collapse state.
+            content: Per-region factories. A remounted pane always receives a
+                fresh widget instance.
+            hidden: Temporary screen compatibility adapter. CONTENT hidden
+                selects management mode; otherwise it selects Read.
+            header: Optional factory for the chrome above the horizontal body.
+            collapsed_suffixes: Temporary no-op compatibility argument.
+            read_mode: Explicit mode. When omitted, ``hidden`` selects it.
         """
+        del collapsed_suffixes
         super().__init__(**kwargs)
         self.add_class("watchlists-workbench")
         self._content: dict[Region, Callable[[], Widget]] = dict(content or {})
-        self._hidden = frozenset(hidden)
         self._header = header
-        # Extra text appended to a collapsed region's header (task-2513 Task
-        # 9): "▸ Watchlists  12 unread". Mutable via `set_collapsed_suffixes`
-        # because counts change while the region stays collapsed.
-        self._collapsed_suffixes: dict[Region, str] = dict(collapsed_suffixes or {})
+        self.read_mode = (
+            Region.CONTENT not in hidden if read_mode is None else read_mode
+        )
         self.set_reactive(WatchlistsWorkbench.region_layout, layout)
 
     def compose(self) -> ComposeResult:
-        """Render the left rail, the stacked centre, and the right rail.
+        """Mount the header first and the horizontal workbench body second."""
+        if self._header is not None:
+            yield self._header()
+        with Horizontal(id="wl-workbench-body"):
+            for node in self._desired_body_nodes():
+                yield node
 
-        Runs once per mount. A later `region_layout` change no longer
-        re-runs this (task-15461): `watch_region_layout` swaps only the
-        regions whose form actually changed — see that watcher.
+    def _desired_body_nodes(self) -> list[Widget]:
+        """Construct the currently desired body children in display order."""
+        nodes: list[Widget] = []
+        if not self.region_layout.is_collapsed(Region.LEFT_RAIL):
+            nodes.append(self._region_body(Region.LEFT_RAIL))
+        nodes.append(self._grip(Region.LEFT_RAIL))
 
-        Returns:
-            The left-rail region, the centre `VerticalScroll` (an optional
-            header, then ITEMS/CONTENT minus anything in `self._hidden`), and
-            the right-rail region, in that order.
-        """
-        yield self._region_widget(Region.LEFT_RAIL)
+        if self.read_mode:
+            if not self.region_layout.is_collapsed(Region.ITEMS):
+                nodes.append(self._region_body(Region.ITEMS))
+            nodes.append(self._grip(Region.ITEMS))
+            nodes.append(self._region_body(Region.CONTENT))
+        else:
+            nodes.append(self._region_body(Region.ITEMS))
 
-        with VerticalScroll(id="wl-centre", classes="watchlists-centre"):
-            if self._header is not None:
-                yield self._header()
-            for region in CENTRE_REGIONS:
-                if region in self._hidden:
-                    continue
-                yield self._region_widget(region)
+        nodes.append(self._grip(Region.RIGHT_RAIL))
+        if not self.region_layout.is_collapsed(Region.RIGHT_RAIL):
+            nodes.append(self._region_body(Region.RIGHT_RAIL))
+        return nodes
 
-        yield self._region_widget(Region.RIGHT_RAIL)
-
-    def _region_widget(self, region: Region) -> Widget:
-        """Build one region: a titled body, or a focusable one-line header.
-
-        Returns a constructed widget rather than yielding, so `compose` stays
-        the single place that mounts anything. Building children positionally
-        avoids the `with container: ... ; yield container` shape, which
-        double-mounts — Textual's `with` already adds the container.
-
-        Args:
-            region: The region to build, per `self.region_layout`'s current
-                collapse state.
-
-        Returns:
-            A focusable `Button` header when `region` is collapsed,
-            otherwise a focusable `Vertical` body holding the region's
-            title and its supplied content (or the placeholder stub).
-        """
-        if self.region_layout.is_collapsed(region):
-            # A Button, not a Static: a collapsed region must stay focusable
-            # and clickable, or collapsing it is one-way.
-            suffix = self._collapsed_suffixes.get(region, "")
-            header = Button(
-                f"▸ {REGION_TITLES[region]}" + (f"  {suffix}" if suffix else ""),
-                id=f"wl-header-{region.value}",
-                compact=True,
-            )
-            header.add_class("watchlists-region-header")
-            header.tooltip = f"Expand {REGION_TITLES[region]}"
-            return header
-
+    def _region_body(self, region: Region) -> Vertical:
+        """Build one expanded body around its current factory output."""
         factory = self._content.get(region)
         supplied = factory() if factory is not None else None
-        # Two independent questions, deliberately kept apart:
-        #
-        #   1. Does this region draw the generic `REGION_TITLES` heading?
-        #      Only when its pane does NOT supply one — `SELF_HEADED_REGIONS`
-        #      (see that constant for why this is not the factory check).
-        #   2. Does this region render the placeholder stub, or real content?
-        #      That IS the factory check.
-        #
-        # They looked identical while ITEMS/RIGHT_RAIL were the only wired
-        # self-headed regions, which is how LEFT_RAIL — wired, but with a
-        # heading-less `WatchlistTree` inside — ended up as an unlabelled box.
         children: list[Widget] = []
         if region not in SELF_HEADED_REGIONS:
             children.append(
                 Static(REGION_TITLES[region], classes="watchlists-region-title")
             )
-        # Whole-branch review (Minor): there used to be a `REGION_PLACEHOLDERS`
-        # branch here ("Reader arrives in the next slice.") for a region with
-        # no factory. Task 4 wired the last unwired region, so every region the
-        # screen builds supplies content; the branch could only ever be reached
-        # by a test that constructed a workbench with no content at all, which
-        # made a "coming soon" string look like live product copy to a grep.
         if supplied is not None:
             children.append(supplied)
-        classes = ["watchlists-region", f"watchlists-region-{region.value}"]
-        if self._is_sole_expanded_centre_region(region, self.region_layout):
-            # A CSS hook for the solo case. `.watchlists-region-content`
-            # carries a `max-height` cap so a long article cannot crowd
-            # ITEMS out of the centre stack — but when ITEMS is collapsed
-            # to its one-line header there is nothing left to crowd, and
-            # the cap turns solo-CONTENT into a short scrolling window with
-            # blank rows under it. Nothing in the DOM distinguished that
-            # state before this class: `RegionLayout.solo` only collapses
-            # the *siblings*, so the soloed region itself is
-            # indistinguishable from an ordinarily-expanded one.
-            #
-            # Keyed on "sole expanded centre region" rather than on
-            # `solo_region` because the two produce the same DOM and want the
-            # same layout: `Z` on CONTENT and manually collapsing ITEMS
-            # with `z` both leave CONTENT alone in the centre.
-            classes.append("watchlists-region-sole-centre")
         body = Vertical(
             *children,
             id=f"wl-region-{region.value}",
-            classes=" ".join(classes),
+            classes=f"watchlists-region watchlists-region-{region.value}",
         )
-        # Regions must be keyboard-reachable, or `z` cannot target them.
         body.can_focus = True
         return body
 
-    def _is_sole_expanded_centre_region(
-        self, region: Region, layout: RegionLayout
-    ) -> bool:
-        """Whether ``region`` is the only centre region still expanded.
-
-        True exactly when the centre stack shows one real pane and, for
-        every OTHER centre region that is not hidden outright, a one-line
-        header — the state `RegionLayout.solo` produces, and the state a
-        user reaches by collapsing the other one by hand. A region in
-        `self._hidden` (TASK-1344: CONTENT off the Read tab) is never
-        rendered at all, not even as a header, so it is excluded from
-        "expanded" the same way a rail is — without this, ITEMS would never
-        read as sole-expanded on a non-Read tab (CONTENT's real
-        `region_layout.collapsed` membership is whatever the user left it
-        at on Read, not "hidden", so counting it unfiltered would make
-        `expanded` include a region that in fact never mounted).
-
-        Args:
-            region: The region to test. Rails always answer `False`; solo
-                applies to the centre stack only (`RegionLayout.solo`).
-            layout: The layout to answer against. Passed explicitly rather
-                than read off `self` (task-15461) so `watch_region_layout`
-                can ask the same question of the OUTGOING layout and tell
-                whether this marker is what actually moved.
-
-        Returns:
-            `True` if `region` is a centre region and every other
-            non-hidden centre region is collapsed, `False` otherwise.
-        """
-        if region not in CENTRE_REGIONS:
-            return False
-        expanded = [
-            r
-            for r in CENTRE_REGIONS
-            if r not in self._hidden and not layout.is_collapsed(r)
-        ]
-        return expanded == [region]
-
-    # --- scoped layout/section updates (task-15461) -----------------------
+    def _grip(self, region: Region) -> WatchlistsPaneGrip:
+        """Build a side-pane grip with its effective state."""
+        return WatchlistsPaneGrip(
+            region,
+            expanded=not self.region_layout.is_collapsed(region),
+            id=f"wl-grip-{region.value}",
+        )
 
     async def watch_region_layout(
         self, previous: RegionLayout, layout: RegionLayout
     ) -> None:
-        """Swap only the regions whose rendered form the new layout moves.
-
-        The reactive used to be `recompose=True`, which rebuilt all four
-        regions for every `z`/`Z`/`[`/`]`/chevron. A layout change can only
-        move two things about a region: whether it renders as its collapsed
-        one-line header or its expanded body, and whether it carries the
-        `watchlists-region-sole-centre` marker. The first needs a widget
-        swap; the second is a class toggle on the live widget, which keeps
-        the pane instance (and everything mounted inside it) alive.
-
-        Args:
-            previous: The layout being replaced.
-            layout: The layout now in effect (already stored on `self`, so
-                `_region_widget` builds against it).
-        """
+        """Mount or remove only side bodies whose collapse state changed."""
         if not self.is_mounted:
             return
-        await self._sync_regions(previous)
+        body = self._body()
+        if body is None:
+            return
+        for region in self._grip_regions:
+            if previous.is_collapsed(region) == layout.is_collapsed(region):
+                continue
+            grip = self.query_one(f"#wl-grip-{region.value}", WatchlistsPaneGrip)
+            expanded = not layout.is_collapsed(region)
+            grip.expanded = expanded
+            mounted = self._mounted_region_body(region)
+            if not expanded:
+                if mounted is not None:
+                    await mounted.remove()
+                continue
+            if mounted is None:
+                node = self._region_body(region)
+                if region is Region.RIGHT_RAIL:
+                    await body.mount(node, after=grip)
+                else:
+                    await body.mount(node, before=grip)
+
+    @property
+    def _grip_regions(self) -> tuple[Region, ...]:
+        return _READ_GRIP_REGIONS if self.read_mode else _MANAGEMENT_GRIP_REGIONS
+
+    def _body(self) -> Horizontal | None:
+        try:
+            return self.query_one("#wl-workbench-body", Horizontal)
+        except NoMatches:
+            return None
+
+    def _mounted_region_body(self, region: Region) -> Widget | None:
+        try:
+            return self.query_one(f"#wl-region-{region.value}")
+        except NoMatches:
+            return None
 
     async def apply_section_view(
         self,
         *,
-        hidden: frozenset[Region],
         layout: RegionLayout,
+        read_mode: bool | None = None,
+        hidden: frozenset[Region] | None = None,
         rebuild_regions: tuple[Region, ...] = (),
         rebuild_header: bool = False,
     ) -> None:
-        """Move the workbench onto a different section, region by region.
+        """Incrementally apply a Read/management section view.
 
-        The caller's `active_section` feeds exactly three things here: which
-        centre regions exist at all (`hidden`), the tab-adjusted collapse
-        state (`layout`), and the content of the region whose pane is routed
-        by the section (passed in `rebuild_regions`). Everything else --
-        both rails above all -- is left standing, which is the whole point:
-        rebuilding the left rail means re-running `WatchlistTree.compose`,
-        and that runs one synchronous source-row query per expanded
-        watchlist.
-
-        Args:
-            hidden: Centre regions that must have no DOM presence on the new
-                section. Newly hidden regions are unmounted; newly shown ones
-                are mounted back into their `CENTRE_REGIONS` position.
-            layout: The tab-adjusted layout (see
-                `WatchlistsCollectionsScreen._rendered_region_layout`).
-                Applied without firing `watch_region_layout`, so the
-                hidden-set change and the layout change are reconciled in
-                one pass rather than two.
-            rebuild_regions: Regions whose supplied content must be rebuilt
-                even though their form did not change -- the section's own
-                pane lives in one of these.
-            rebuild_header: Whether to rebuild the centre header too (the
-                tab strip lives there, so a real section switch always does).
+        ``hidden`` remains a temporary adapter for the live screen through
+        Task 6. Explicit ``read_mode`` wins when both are provided.
         """
+        next_read_mode = read_mode
+        if next_read_mode is None:
+            next_read_mode = (
+                self.read_mode
+                if hidden is None
+                else Region.CONTENT not in hidden
+            )
         if not self.is_mounted:
-            self._hidden = frozenset(hidden)
+            self.read_mode = next_read_mode
             self.set_reactive(WatchlistsWorkbench.region_layout, layout)
             return
-        previous_layout = self.region_layout
-        previous_hidden = self._hidden
-        self._hidden = frozenset(hidden)
-        # `set_reactive`, not assignment: `watch_region_layout` would run a
-        # SECOND reconcile pass against a `_hidden` this method has already
-        # moved, so the two changes would be applied in the wrong order and
-        # the layout half would be done twice.
-        self.set_reactive(WatchlistsWorkbench.region_layout, layout)
-        # One layout/paint pass for the whole section move (task-15778),
-        # as an explicit contract rather than a scheduling accident. The
-        # region sync, the section pane rebuild and the header rebuild
-        # below are each an awaited remove/mount cycle, and every await
-        # between them is in principle a window for the screen's update
-        # timer to paint a half-moved workbench. Measured at HEAD it never
-        # actually does -- the whole sequence runs inside the screen's one
-        # `_drain_surface_refresh` `call_next` callback (task-15461's own
-        # move off `run_worker`), so the pump never goes idle mid-swap and
-        # the paused update timer never resumes: 0 in-swap layout passes
-        # and 0 compositor refreshes with and without this batch, on a
-        # cold Read switch. `batch_update` makes that one-pass property
-        # structural: it survives a future factory that awaits, or the
-        # drain moving off a single callback, instead of depending on
-        # them never happening. It defers repaints only -- it does not
-        # reorder or coalesce the DOM work itself, so the raising-factory
-        # guarantees inside `refresh_region_content`/`_swap_region_widget`
-        # are unchanged.
+
         with self.app.batch_update():
-            await self._sync_regions(previous_layout)
+            self.read_mode = next_read_mode
+            self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+            created = await self._reconcile_body()
             for region in rebuild_regions:
-                if region in self._hidden:
-                    continue
-                # A region the sync above just swapped is already built from
-                # the current factory; rebuilding it again would be the
-                # second of the two rebuilds this task exists to remove.
-                if self._region_form_changed(
-                    previous_layout, previous_hidden, region
-                ):
-                    continue
-                await self.refresh_region_content(region)
+                if region not in created:
+                    await self.refresh_region_content(region)
             if rebuild_header:
                 await self.refresh_header_content()
 
-    def _region_form_changed(
-        self,
-        previous_layout: RegionLayout,
-        previous_hidden: frozenset[Region],
-        region: Region,
-    ) -> bool:
-        """Whether ``region``'s mounted widget has to be replaced outright."""
-        was_present = region not in previous_hidden
-        is_present = region not in self._hidden
-        if was_present != is_present:
-            return True
-        if not is_present:
-            return False
-        return previous_layout.is_collapsed(region) != self.region_layout.is_collapsed(
-            region
-        )
+    async def _reconcile_body(self) -> set[Region]:
+        """Reconcile direct children while retaining every reusable node."""
+        body = self._body()
+        if body is None:
+            return set()
+        desired_ids = self._desired_body_ids()
+        for child in list(body.children):
+            if child.id not in desired_ids:
+                await child.remove()
 
-    async def _sync_regions(self, previous_layout: RegionLayout) -> None:
-        """Bring the mounted regions in line with `region_layout`/`_hidden`.
-
-        Rails first (they are direct children of this `Horizontal` and are
-        never hidden), then the centre stack, which is rebuilt positionally
-        because a region can be absent from it entirely.
-        """
-        for region in (Region.LEFT_RAIL, Region.RIGHT_RAIL):
-            if previous_layout.is_collapsed(region) == self.region_layout.is_collapsed(
-                region
-            ):
-                continue
-            index = 0 if region is Region.LEFT_RAIL else len(self.children) - 1
-            await self._swap_region_widget(region, self, index)
-        await self._sync_centre_regions(previous_layout)
-
-    async def _sync_centre_regions(self, previous_layout: RegionLayout) -> None:
-        """Mount, unmount, swap or repaint each centre region as required.
-
-        Reads the CURRENT `self._hidden` rather than needing the previous one:
-        a region that is newly shown simply has no mounted node, and a region
-        that is newly hidden is removed by the first loop below -- both cases
-        fall out of comparing the DOM against the desired set.
-        """
-        try:
-            centre = self.query_one("#wl-centre")
-        except NoMatches:
-            return
-        for region in CENTRE_REGIONS:
-            if region not in self._hidden:
-                continue
-            node = self._mounted_region_node(region)
-            if node is not None:
-                await node.remove()
-
-        desired = [region for region in CENTRE_REGIONS if region not in self._hidden]
-        for position, region in enumerate(desired):
-            index = self._centre_content_offset(centre) + position
-            node = self._mounted_region_node(region)
-            if node is None:
-                await centre.mount(self._region_widget(region), before=index)
-                continue
-            if previous_layout.is_collapsed(region) != self.region_layout.is_collapsed(
-                region
-            ):
-                await self._swap_region_widget(region, centre, index)
-                continue
-            if self.region_layout.is_collapsed(region):
-                continue
-            # Still an expanded body, same instance: the only thing a layout
-            # change can have moved for it is the solo marker.
-            node.set_class(
-                self._is_sole_expanded_centre_region(region, self.region_layout),
-                "watchlists-region-sole-centre",
-            )
-
-    def _centre_content_offset(self, centre: Widget) -> int:
-        """How many non-region children the centre stack starts with.
-
-        The optional `header` factory's widget is mounted first and carries
-        whatever id the caller gave it, so it is identified by exclusion
-        rather than by name.
-        """
-        region_ids = {f"wl-region-{r.value}" for r in REGION_ORDER}
-        region_ids |= {f"wl-header-{r.value}" for r in REGION_ORDER}
-        offset = 0
-        for child in centre.children:
-            if (child.id or "") in region_ids:
-                break
-            offset += 1
-        return offset
-
-    def _mounted_region_node(self, region: Region) -> Widget | None:
-        """The widget currently rendering ``region``, in either form."""
-        for prefix in ("wl-region-", "wl-header-"):
+        created: set[Region] = set()
+        for index, node_id in enumerate(desired_ids):
             try:
-                return self.query_one(f"#{prefix}{region.value}")
+                self.query_one(f"#{node_id}")
             except NoMatches:
-                continue
-        return None
+                node = self._node_for_id(node_id)
+                region = self._region_from_body_id(node_id)
+                if region is not None:
+                    created.add(region)
+                if index >= len(body.children):
+                    await body.mount(node)
+                else:
+                    await body.mount(node, before=index)
 
-    async def _swap_region_widget(
-        self, region: Region, parent: Widget, index: int
-    ) -> None:
-        """Replace ``region``'s mounted widget with a freshly built one.
+        for region in self._grip_regions:
+            grip = self.query_one(f"#wl-grip-{region.value}", WatchlistsPaneGrip)
+            grip.expanded = not self.region_layout.is_collapsed(region)
+        return created
 
-        Built before the old one is detached, for the reason
-        `refresh_region_content` states: a factory that raises must leave
-        what is on screen standing rather than emptying the slot. The
-        remove-then-mount pair still has an await between its halves --
-        `NodeList._ensure_unique_id` refuses to mount a second
-        `#wl-region-<r>`.
-        """
-        node = self._mounted_region_node(region)
-        if node is None:
-            return
-        replacement = self._region_widget(region)
-        await node.remove()
-        if index >= len(parent.children):
-            await parent.mount(replacement)
+    def _desired_body_ids(self) -> list[str]:
+        ids: list[str] = []
+        if not self.region_layout.is_collapsed(Region.LEFT_RAIL):
+            ids.append("wl-region-left_rail")
+        ids.append("wl-grip-left_rail")
+        if self.read_mode:
+            if not self.region_layout.is_collapsed(Region.ITEMS):
+                ids.append("wl-region-items")
+            ids.extend(("wl-grip-items", "wl-region-content"))
         else:
-            await parent.mount(replacement, before=index)
+            ids.append("wl-region-items")
+        ids.append("wl-grip-right_rail")
+        if not self.region_layout.is_collapsed(Region.RIGHT_RAIL):
+            ids.append("wl-region-right_rail")
+        return ids
+
+    def _node_for_id(self, node_id: str) -> Widget:
+        if node_id.startswith("wl-region-"):
+            return self._region_body(Region(node_id.removeprefix("wl-region-")))
+        return self._grip(Region(node_id.removeprefix("wl-grip-")))
+
+    @staticmethod
+    def _region_from_body_id(node_id: str) -> Region | None:
+        if not node_id.startswith("wl-region-"):
+            return None
+        return Region(node_id.removeprefix("wl-region-"))
 
     async def refresh_region_content(self, region: Region) -> None:
-        """Rebuild one expanded region's supplied content in place.
-
-        Task 7: a region's content can go stale without `region_layout`
-        itself changing (the tree scope moving under the rail, a background
-        load landing), so nothing would otherwise call its factory again.
-        Pushing a new `region_layout` would not work at all: since task-15461
-        that only swaps regions whose COLLAPSE state moved, so a layout equal
-        to the current one is a no-op and one that differs changes what the
-        user is looking at. (Before task-15461 it worked for the wrong
-        reason -- it recomposed every region -- at the cost of replacing
-        widgets whose whole design point is staying the same instance across
-        an unrelated change: the Inspector is pushed new
-        `scope`/`selected_entity` values in place for exactly that reason,
-        see `WatchlistsCollectionsScreen.watch_selected_scope`.)
-
-        A no-op when `region` is collapsed (nothing mounted to replace) or
-        was not given a content factory (nothing to refresh either).
-
-        Replaces only the *supplied content*, never the generic
-        `REGION_TITLES` heading `_region_widget` prepends for regions
-        outside `SELF_HEADED_REGIONS` (fix round 1, Finding 3). The first
-        version removed every child, so refreshing LEFT_RAIL -- which
-        supplies content but is not self-headed -- stripped its
-        "Watchlists" heading and left an unlabelled bordered rail until the
-        next region toggle rebuilt it. That is the same defect
-        `SELF_HEADED_REGIONS`' own comment records having shipped once.
-
-        Args:
-            region: The region whose supplied content should be rebuilt.
-        """
-        if self.region_layout.is_collapsed(region):
-            return
+        """Replace only one mounted body's factory output, failure-safely."""
         factory = self._content.get(region)
         if factory is None:
             return
-        try:
-            container = self.query_one(f"#wl-region-{region.value}")
-        except NoMatches:
+        container = self._mounted_region_body(region)
+        if container is None:
             return
-        # Build the replacement BEFORE detaching anything: a factory that
-        # raises (or a worker cancelled while it runs) then leaves the
-        # mounted pane standing rather than a bordered empty box. The
-        # remove-then-mount pair below still has one await boundary --
-        # Textual's `NodeList._ensure_unique_id` rejects mounting the new
-        # pane while the old one (same id, e.g. `watchlists-items-pane`) is
-        # still attached, so there is no single-await atomic swap available
-        # without changing that guarded id.
         replacement = factory()
-        # The heading, when present, is `_region_widget`'s first child and
-        # is not ours to replace.
         stale = [
             child
             for child in container.children
@@ -606,75 +292,18 @@ class WatchlistsWorkbench(Horizontal):
         await container.mount(replacement)
 
     async def refresh_header_content(self) -> None:
-        """Rebuild the header in place from a fresh call to its factory.
-
-        The header's twin of `refresh_region_content` above (task-1344 fix
-        wave, Qodo correctness), and reached the same way: nothing else calls
-        the `header` factory again, so a header-only change (the tree scope
-        moving -- see `WatchlistsCollectionsScreen.watch_tree_scope`) has no
-        other route onto the screen. Pushing a new `region_layout` is not one
-        either: since task-15461 that touches only the regions whose collapse
-        state moved, and never the header. The header is the only surface
-        carrying the tab strip and the snapshot's scoped markers (since
-        task-2513, on every tab), so this is what keeps that readout current
-        between rebuilds.
-
-        A no-op when this workbench was built with no `header` factory:
-        nothing to refresh, and no `#wl-centre-status` to query for either.
-        """
+        """Replace only header factory output, leaving the body untouched."""
         if self._header is None:
-            return
-        try:
-            centre = self.query_one("#wl-centre")
-        except NoMatches:
             return
         try:
             stale = self.query_one("#wl-centre-status")
         except NoMatches:
             stale = None
-        # Build the replacement before detaching the old header, for the
-        # identical reason `refresh_region_content` does: a factory that
-        # raises must leave the previously mounted header standing rather
-        # than removing it and never replacing it.
         replacement = self._header()
         if stale is not None:
             await stale.remove()
-        await centre.mount(replacement, before=0)
+        await self.mount(replacement, before=0)
 
     def set_collapsed_suffixes(self, suffixes: Mapping[Region, str]) -> None:
-        """Update collapsed-header suffixes in place (no recompose).
-
-        Counts refresh while the rail stays collapsed; tearing the workbench
-        down for a number is exactly what `refresh_region_content` exists to
-        avoid for bodies. A no-op for regions not currently collapsed — they
-        have no header mounted to repaint.
-
-        Args:
-            suffixes: The new suffix per region, replacing the current map.
-        """
-        self._collapsed_suffixes = dict(suffixes)
-        for region, suffix in self._collapsed_suffixes.items():
-            if not self.region_layout.is_collapsed(region):
-                continue
-            try:
-                header = self.query_one(f"#wl-header-{region.value}", Button)
-            except NoMatches:
-                continue
-            header.label = f"▸ {REGION_TITLES[region]}" + (f"  {suffix}" if suffix else "")
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Turn a collapsed-region header click into a `RegionToggled` message.
-
-        Ignores presses from any other button (e.g. content the caller
-        supplied via `content=`) by checking the `wl-header-` id prefix.
-
-        Args:
-            event: The button-press event to inspect and, if it targets a
-                region header, stop from bubbling further.
-        """
-        button_id = event.button.id or ""
-        prefix = "wl-header-"
-        if not button_id.startswith(prefix):
-            return
-        event.stop()
-        self.post_message(RegionToggled(Region(button_id[len(prefix):])))
+        """Compatibility no-op retained until the live screen stops calling it."""
+        del suffixes

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -168,9 +168,13 @@ class WatchlistsWorkbench(Vertical):
             nodes.append(self._region_body(Region.RIGHT_RAIL))
         return nodes
 
-    def _region_body(self, region: Region) -> Vertical:
+    def _region_body(
+        self,
+        region: Region,
+        content: Mapping[Region, Callable[[], Widget]] | None = None,
+    ) -> Vertical:
         """Build one expanded body around its current factory output."""
-        factory = self._content.get(region)
+        factory = (self._content if content is None else content).get(region)
         supplied = factory() if factory is not None else None
         children: list[Widget] = []
         if region not in SELF_HEADED_REGIONS:
@@ -337,6 +341,8 @@ class WatchlistsWorkbench(Vertical):
         token: int,
         rebuild_regions: tuple[Region, ...] = (),
         rebuild_header: bool = False,
+        content: Mapping[Region, Callable[[], Widget]] | None = None,
+        header: Callable[[], Widget] | None = None,
     ) -> bool:
         """Incrementally apply a Read/management section view."""
         async with self._layout_apply_lock:
@@ -346,6 +352,8 @@ class WatchlistsWorkbench(Vertical):
                 token=token,
                 rebuild_regions=rebuild_regions,
                 rebuild_header=rebuild_header,
+                content=content,
+                header=header,
             )
 
     async def _apply_section_view(
@@ -356,6 +364,8 @@ class WatchlistsWorkbench(Vertical):
         token: int,
         rebuild_regions: tuple[Region, ...] = (),
         rebuild_header: bool = False,
+        content: Mapping[Region, Callable[[], Widget]] | None = None,
+        header: Callable[[], Widget] | None = None,
     ) -> bool:
         """Reconcile one section view while holding the layout lock."""
         next_read_mode = read_mode
@@ -380,8 +390,9 @@ class WatchlistsWorkbench(Vertical):
 
         try:
             replacement_header = (
-                self._header()
-                if rebuild_header and self._header is not None
+                (self._header if header is None else header)()
+                if rebuild_header
+                and (self._header if header is None else header) is not None
                 else None
             )
             with self.app.batch_update():
@@ -389,6 +400,7 @@ class WatchlistsWorkbench(Vertical):
                     read_mode=next_read_mode,
                     layout=layout,
                     rebuild_regions=rebuild_regions,
+                    content=content,
                 )
                 if replacement_header is not None:
                     await self._replace_header(replacement_header)
@@ -420,6 +432,7 @@ class WatchlistsWorkbench(Vertical):
         read_mode: bool,
         layout: RegionLayout,
         rebuild_regions: tuple[Region, ...],
+        content: Mapping[Region, Callable[[], Widget]] | None = None,
     ) -> None:
         """Prepare factories, then atomically reconcile direct children."""
         body = self._body()
@@ -435,7 +448,9 @@ class WatchlistsWorkbench(Vertical):
         for node_id in desired_ids:
             if node_id in mounted_ids:
                 continue
-            prepared_nodes[node_id] = self._node_for_id(node_id, layout=layout)
+            prepared_nodes[node_id] = self._node_for_id(
+                node_id, layout=layout, content=content
+            )
             region = self._region_from_body_id(node_id)
             if region is not None:
                 created.add(region)
@@ -444,7 +459,7 @@ class WatchlistsWorkbench(Vertical):
         for region in rebuild_regions:
             if region in created or f"wl-region-{region.value}" not in desired_ids:
                 continue
-            factory = self._content.get(region)
+            factory = (self._content if content is None else content).get(region)
             if factory is not None:
                 prepared_content[region] = factory()
 
@@ -517,9 +532,17 @@ class WatchlistsWorkbench(Vertical):
             ids.append("wl-region-right_rail")
         return ids
 
-    def _node_for_id(self, node_id: str, *, layout: RegionLayout) -> Widget:
+    def _node_for_id(
+        self,
+        node_id: str,
+        *,
+        layout: RegionLayout,
+        content: Mapping[Region, Callable[[], Widget]] | None = None,
+    ) -> Widget:
         if node_id.startswith("wl-region-"):
-            return self._region_body(Region(node_id.removeprefix("wl-region-")))
+            return self._region_body(
+                Region(node_id.removeprefix("wl-region-")), content
+            )
         region = Region(node_id.removeprefix("wl-grip-"))
         return WatchlistsPaneGrip(
             region,

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -238,7 +238,11 @@ class WatchlistsWorkbench(Vertical):
                     prepared[region] = self._region_body(region)
         except Exception:
             self._sync_expanded_side_pane_class(layout=previous)
-            logger.exception("Watchlists pane expansion factory failed")
+            logger.bind(
+                token=token,
+                read_mode=self.read_mode,
+                regions=tuple(region.value for region in changed),
+            ).exception("Watchlists pane expansion factory failed")
             self.post_message(
                 RegionLayoutApplyFailed(
                     token=token, attempted=layout, fallback=previous
@@ -267,7 +271,11 @@ class WatchlistsWorkbench(Vertical):
                 if node.is_mounted:
                     await node.remove()
             self._sync_expanded_side_pane_class(layout=previous)
-            logger.exception("Watchlists pane expansion mount failed")
+            logger.bind(
+                token=token,
+                read_mode=self.read_mode,
+                regions=tuple(region.value for region in prepared),
+            ).exception("Watchlists pane expansion mount failed")
             self.post_message(
                 RegionLayoutApplyFailed(
                     token=token, attempted=layout, fallback=previous
@@ -417,7 +425,11 @@ class WatchlistsWorkbench(Vertical):
         except Exception:
             self.read_mode = previous_read_mode
             self.set_class(self.read_mode, "watchlists-read-mode")
-            logger.exception("Watchlists section-view factory failed")
+            logger.bind(
+                token=token,
+                read_mode=next_read_mode,
+                regions=tuple(region.value for region in rebuild_regions),
+            ).exception("Watchlists section-view factory failed")
             self.post_message(
                 RegionLayoutApplyFailed(
                     token=token, attempted=layout, fallback=previous

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -369,6 +369,7 @@ class WatchlistsWorkbench(Vertical):
     ) -> bool:
         """Reconcile one section view while holding the layout lock."""
         next_read_mode = read_mode
+        previous_read_mode = self.read_mode
         previous = self._rendered_layout
         self.set_reactive(
             WatchlistsWorkbench.effective_layout_request, (token, previous)
@@ -389,6 +390,8 @@ class WatchlistsWorkbench(Vertical):
             return True
 
         try:
+            self.read_mode = next_read_mode
+            self.set_class(self.read_mode, "watchlists-read-mode")
             replacement_header = (
                 (self._header if header is None else header)()
                 if rebuild_header
@@ -404,8 +407,6 @@ class WatchlistsWorkbench(Vertical):
                 )
                 if replacement_header is not None:
                     await self._replace_header(replacement_header)
-                self.read_mode = next_read_mode
-                self.set_class(self.read_mode, "watchlists-read-mode")
                 self._rendered_layout = layout
                 self.set_reactive(
                     WatchlistsWorkbench.effective_layout_request, (token, layout)
@@ -414,6 +415,8 @@ class WatchlistsWorkbench(Vertical):
                     read_mode=next_read_mode, layout=layout
                 )
         except Exception:
+            self.read_mode = previous_read_mode
+            self.set_class(self.read_mode, "watchlists-read-mode")
             logger.exception("Watchlists section-view factory failed")
             self.post_message(
                 RegionLayoutApplyFailed(

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any
 
+from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
@@ -81,6 +82,7 @@ class WatchlistsWorkbench(Vertical):
         self.read_mode = (
             Region.CONTENT not in hidden if read_mode is None else read_mode
         )
+        self.set_class(self.read_mode, "watchlists-read-mode")
         self.set_reactive(WatchlistsWorkbench.region_layout, layout)
 
     def compose(self) -> ComposeResult:
@@ -147,23 +149,51 @@ class WatchlistsWorkbench(Vertical):
         body = self._body()
         if body is None:
             return
-        for region in self._grip_regions:
-            if previous.is_collapsed(region) == layout.is_collapsed(region):
-                continue
-            grip = self.query_one(f"#wl-grip-{region.value}", WatchlistsPaneGrip)
-            expanded = not layout.is_collapsed(region)
-            grip.expanded = expanded
-            mounted = self._mounted_region_body(region)
-            if not expanded:
-                if mounted is not None:
-                    await mounted.remove()
-                continue
-            if mounted is None:
-                node = self._region_body(region)
+        changed = [
+            region
+            for region in self._grip_regions
+            if previous.is_collapsed(region) != layout.is_collapsed(region)
+        ]
+        prepared: dict[Region, Widget] = {}
+        try:
+            for region in changed:
+                if (
+                    not layout.is_collapsed(region)
+                    and self._mounted_region_body(region) is None
+                ):
+                    prepared[region] = self._region_body(region)
+        except Exception:
+            self.set_reactive(WatchlistsWorkbench.region_layout, previous)
+            logger.exception("Watchlists pane expansion factory failed")
+            return
+
+        try:
+            for region, node in prepared.items():
+                grip = self.query_one(
+                    f"#wl-grip-{region.value}", WatchlistsPaneGrip
+                )
                 if region is Region.RIGHT_RAIL:
                     await body.mount(node, after=grip)
                 else:
                     await body.mount(node, before=grip)
+        except Exception:
+            for node in prepared.values():
+                if node.is_mounted:
+                    await node.remove()
+            self.set_reactive(WatchlistsWorkbench.region_layout, previous)
+            logger.exception("Watchlists pane expansion mount failed")
+            return
+
+        for region in changed:
+            expanded = not layout.is_collapsed(region)
+            if not expanded:
+                mounted = self._mounted_region_body(region)
+                if mounted is not None:
+                    await mounted.remove()
+            grip = self.query_one(
+                f"#wl-grip-{region.value}", WatchlistsPaneGrip
+            )
+            grip.expanded = expanded
 
     @property
     def _grip_regions(self) -> tuple[Region, ...]:
@@ -204,68 +234,117 @@ class WatchlistsWorkbench(Vertical):
             )
         if not self.is_mounted:
             self.read_mode = next_read_mode
+            self.set_class(self.read_mode, "watchlists-read-mode")
             self.set_reactive(WatchlistsWorkbench.region_layout, layout)
             return
 
+        replacement_header = (
+            self._header()
+            if rebuild_header and self._header is not None
+            else None
+        )
         with self.app.batch_update():
+            await self._reconcile_body(
+                read_mode=next_read_mode,
+                layout=layout,
+                rebuild_regions=rebuild_regions,
+            )
+            if replacement_header is not None:
+                await self._replace_header(replacement_header)
             self.read_mode = next_read_mode
+            self.set_class(self.read_mode, "watchlists-read-mode")
             self.set_reactive(WatchlistsWorkbench.region_layout, layout)
-            created = await self._reconcile_body()
-            for region in rebuild_regions:
-                if region not in created:
-                    await self.refresh_region_content(region)
-            if rebuild_header:
-                await self.refresh_header_content()
 
-    async def _reconcile_body(self) -> set[Region]:
-        """Reconcile direct children while retaining every reusable node."""
+    async def _reconcile_body(
+        self,
+        *,
+        read_mode: bool,
+        layout: RegionLayout,
+        rebuild_regions: tuple[Region, ...],
+    ) -> None:
+        """Prepare factories, then atomically reconcile direct children."""
         body = self._body()
         if body is None:
-            return set()
-        desired_ids = self._desired_body_ids()
+            return
+        desired_ids = self._desired_body_ids(
+            read_mode=read_mode,
+            layout=layout,
+        )
+        mounted_ids = {child.id for child in body.children}
+        prepared_nodes: dict[str, Widget] = {}
+        created: set[Region] = set()
+        for node_id in desired_ids:
+            if node_id in mounted_ids:
+                continue
+            prepared_nodes[node_id] = self._node_for_id(node_id, layout=layout)
+            region = self._region_from_body_id(node_id)
+            if region is not None:
+                created.add(region)
+
+        prepared_content: dict[Region, Widget] = {}
+        for region in rebuild_regions:
+            if region in created or f"wl-region-{region.value}" not in desired_ids:
+                continue
+            factory = self._content.get(region)
+            if factory is not None:
+                prepared_content[region] = factory()
+
         for child in list(body.children):
             if child.id not in desired_ids:
                 await child.remove()
 
-        created: set[Region] = set()
         for index, node_id in enumerate(desired_ids):
-            try:
-                self.query_one(f"#{node_id}")
-            except NoMatches:
-                node = self._node_for_id(node_id)
-                region = self._region_from_body_id(node_id)
-                if region is not None:
-                    created.add(region)
+            node = prepared_nodes.get(node_id)
+            if node is not None:
                 if index >= len(body.children):
                     await body.mount(node)
                 else:
                     await body.mount(node, before=index)
 
-        for region in self._grip_regions:
-            grip = self.query_one(f"#wl-grip-{region.value}", WatchlistsPaneGrip)
-            grip.expanded = not self.region_layout.is_collapsed(region)
-        return created
+        for region, replacement in prepared_content.items():
+            container = self._mounted_region_body(region)
+            if container is not None:
+                await self._replace_region_content(container, replacement)
 
-    def _desired_body_ids(self) -> list[str]:
+        grip_regions = (
+            _READ_GRIP_REGIONS if read_mode else _MANAGEMENT_GRIP_REGIONS
+        )
+        for region in grip_regions:
+            grip = self.query_one(f"#wl-grip-{region.value}", WatchlistsPaneGrip)
+            grip.expanded = not layout.is_collapsed(region)
+
+    def _desired_body_ids(
+        self,
+        *,
+        read_mode: bool | None = None,
+        layout: RegionLayout | None = None,
+    ) -> list[str]:
+        read_mode = self.read_mode if read_mode is None else read_mode
+        layout = self.region_layout if layout is None else layout
         ids: list[str] = []
-        if not self.region_layout.is_collapsed(Region.LEFT_RAIL):
+        if not layout.is_collapsed(Region.LEFT_RAIL):
             ids.append("wl-region-left_rail")
         ids.append("wl-grip-left_rail")
-        if self.read_mode:
-            if not self.region_layout.is_collapsed(Region.ITEMS):
+        if read_mode:
+            if not layout.is_collapsed(Region.ITEMS):
                 ids.append("wl-region-items")
             ids.extend(("wl-grip-items", "wl-region-content"))
         else:
             ids.append("wl-region-items")
         ids.append("wl-grip-right_rail")
-        if not self.region_layout.is_collapsed(Region.RIGHT_RAIL):
+        if not layout.is_collapsed(Region.RIGHT_RAIL):
             ids.append("wl-region-right_rail")
         return ids
 
-    def _node_for_id(self, node_id: str) -> Widget:
+    def _node_for_id(self, node_id: str, *, layout: RegionLayout) -> Widget:
         if node_id.startswith("wl-region-"):
             return self._region_body(Region(node_id.removeprefix("wl-region-")))
-        return self._grip(Region(node_id.removeprefix("wl-grip-")))
+        region = Region(node_id.removeprefix("wl-grip-"))
+        return WatchlistsPaneGrip(
+            region,
+            expanded=not layout.is_collapsed(region),
+            id=node_id,
+        )
 
     @staticmethod
     def _region_from_body_id(node_id: str) -> Region | None:
@@ -282,6 +361,12 @@ class WatchlistsWorkbench(Vertical):
         if container is None:
             return
         replacement = factory()
+        await self._replace_region_content(container, replacement)
+
+    async def _replace_region_content(
+        self, container: Widget, replacement: Widget
+    ) -> None:
+        """Commit one already-built factory replacement."""
         stale = [
             child
             for child in container.children
@@ -295,11 +380,15 @@ class WatchlistsWorkbench(Vertical):
         """Replace only header factory output, leaving the body untouched."""
         if self._header is None:
             return
+        replacement = self._header()
+        await self._replace_header(replacement)
+
+    async def _replace_header(self, replacement: Widget) -> None:
+        """Commit one already-built header replacement."""
         try:
             stale = self.query_one("#wl-centre-status")
         except NoMatches:
             stale = None
-        replacement = self._header()
         if stale is not None:
             await stale.remove()
         await self.mount(replacement, before=0)

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -9,6 +9,7 @@ from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
+from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
@@ -16,7 +17,12 @@ from textual.widgets import Static
 from .pane_grip import RegionToggled, WatchlistsPaneGrip
 from .region_layout import Region, RegionLayout
 
-__all__ = ["REGION_TITLES", "RegionToggled", "WatchlistsWorkbench"]
+__all__ = [
+    "REGION_TITLES",
+    "RegionLayoutApplyFailed",
+    "RegionToggled",
+    "WatchlistsWorkbench",
+]
 
 REGION_TITLES: dict[Region, str] = {
     Region.LEFT_RAIL: "Watchlists",
@@ -38,6 +44,20 @@ _MANAGEMENT_GRIP_REGIONS: tuple[Region, ...] = (
     Region.LEFT_RAIL,
     Region.RIGHT_RAIL,
 )
+
+
+class RegionLayoutApplyFailed(Message):
+    """Report a rejected layout so the screen can roll back its preference."""
+
+    def __init__(
+        self,
+        *,
+        attempted: RegionLayout,
+        fallback: RegionLayout,
+    ) -> None:
+        super().__init__()
+        self.attempted = attempted
+        self.fallback = fallback
 
 
 class WatchlistsWorkbench(Vertical):
@@ -165,6 +185,9 @@ class WatchlistsWorkbench(Vertical):
         except Exception:
             self.set_reactive(WatchlistsWorkbench.region_layout, previous)
             logger.exception("Watchlists pane expansion factory failed")
+            self.post_message(
+                RegionLayoutApplyFailed(attempted=layout, fallback=previous)
+            )
             return
 
         try:
@@ -182,6 +205,9 @@ class WatchlistsWorkbench(Vertical):
                     await node.remove()
             self.set_reactive(WatchlistsWorkbench.region_layout, previous)
             logger.exception("Watchlists pane expansion mount failed")
+            self.post_message(
+                RegionLayoutApplyFailed(attempted=layout, fallback=previous)
+            )
             return
 
         for region in changed:

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -19,6 +19,7 @@ from .region_layout import Region, RegionLayout
 
 __all__ = [
     "REGION_TITLES",
+    "RegionLayoutApplied",
     "RegionLayoutApplyFailed",
     "RegionToggled",
     "WatchlistsWorkbench",
@@ -61,6 +62,15 @@ class RegionLayoutApplyFailed(Message):
         self.fallback = fallback
 
 
+class RegionLayoutApplied(Message):
+    """Acknowledge a successful effective-layout transition."""
+
+    def __init__(self, *, previous: RegionLayout, layout: RegionLayout) -> None:
+        super().__init__()
+        self.previous = previous
+        self.layout = layout
+
+
 class WatchlistsWorkbench(Vertical):
     """Render optional chrome above a permanent horizontal centre.
 
@@ -76,11 +86,9 @@ class WatchlistsWorkbench(Vertical):
         self,
         layout: RegionLayout,
         content: Mapping[Region, Callable[[], Widget]] | None = None,
-        hidden: frozenset[Region] = frozenset(),
         header: Callable[[], Widget] | None = None,
-        collapsed_suffixes: Mapping[Region, str] | None = None,
         *,
-        read_mode: bool | None = None,
+        read_mode: bool,
         **kwargs: Any,
     ) -> None:
         """Build the workbench from reusable region factories.
@@ -89,20 +97,14 @@ class WatchlistsWorkbench(Vertical):
             layout: Effective side-pane collapse state.
             content: Per-region factories. A remounted pane always receives a
                 fresh widget instance.
-            hidden: Temporary screen compatibility adapter. CONTENT hidden
-                selects management mode; otherwise it selects Read.
             header: Optional factory for the chrome above the horizontal body.
-            collapsed_suffixes: Temporary no-op compatibility argument.
-            read_mode: Explicit mode. When omitted, ``hidden`` selects it.
+            read_mode: Whether the permanent Reader view is active.
         """
-        del collapsed_suffixes
         super().__init__(**kwargs)
         self.add_class("watchlists-workbench")
         self._content: dict[Region, Callable[[], Widget]] = dict(content or {})
         self._header = header
-        self.read_mode = (
-            Region.CONTENT not in hidden if read_mode is None else read_mode
-        )
+        self.read_mode = read_mode
         self.set_class(self.read_mode, "watchlists-read-mode")
         self.set_reactive(WatchlistsWorkbench.region_layout, layout)
         self._sync_expanded_side_pane_class(layout=layout)
@@ -193,6 +195,13 @@ class WatchlistsWorkbench(Vertical):
             )
             return
 
+        restore_focus = {
+            region
+            for region in prepared
+            if self.query_one(
+                f"#wl-grip-{region.value}", WatchlistsPaneGrip
+            ).has_focus
+        }
         try:
             for region, node in prepared.items():
                 grip = self.query_one(
@@ -219,12 +228,22 @@ class WatchlistsWorkbench(Vertical):
             if not expanded:
                 mounted = self._mounted_region_body(region)
                 if mounted is not None:
+                    grip = self.query_one(
+                        f"#wl-grip-{region.value}", WatchlistsPaneGrip
+                    )
+                    if self._contains_focus(mounted):
+                        grip.focus()
                     await mounted.remove()
             grip = self.query_one(
                 f"#wl-grip-{region.value}", WatchlistsPaneGrip
             )
             grip.expanded = expanded
+        for region in restore_focus:
+            mounted = self._mounted_region_body(region)
+            if mounted is not None:
+                mounted.focus()
         self._sync_expanded_side_pane_class(layout=layout)
+        self.post_message(RegionLayoutApplied(previous=previous, layout=layout))
 
     @property
     def _grip_regions(self) -> tuple[Region, ...]:
@@ -263,23 +282,12 @@ class WatchlistsWorkbench(Vertical):
         self,
         *,
         layout: RegionLayout,
-        read_mode: bool | None = None,
-        hidden: frozenset[Region] | None = None,
+        read_mode: bool,
         rebuild_regions: tuple[Region, ...] = (),
         rebuild_header: bool = False,
     ) -> None:
-        """Incrementally apply a Read/management section view.
-
-        ``hidden`` remains a temporary adapter for the live screen through
-        Task 6. Explicit ``read_mode`` wins when both are provided.
-        """
+        """Incrementally apply a Read/management section view."""
         next_read_mode = read_mode
-        if next_read_mode is None:
-            next_read_mode = (
-                self.read_mode
-                if hidden is None
-                else Region.CONTENT not in hidden
-            )
         if not self.is_mounted:
             self.read_mode = next_read_mode
             self.set_class(self.read_mode, "watchlists-read-mode")
@@ -343,8 +351,19 @@ class WatchlistsWorkbench(Vertical):
             if factory is not None:
                 prepared_content[region] = factory()
 
+        restore_focus_ids = {
+            node_id
+            for node_id in prepared_nodes
+            if node_id.startswith("wl-region-")
+            and self._grip_has_focus(
+                Region(node_id.removeprefix("wl-region-"))
+            )
+        }
         for child in list(body.children):
             if child.id not in desired_ids:
+                region = self._region_from_body_id(child.id or "")
+                if region is not None and self._contains_focus(child):
+                    self.query_one(f"#wl-grip-{region.value}").focus()
                 await child.remove()
 
         for index, node_id in enumerate(desired_ids):
@@ -354,6 +373,10 @@ class WatchlistsWorkbench(Vertical):
                     await body.mount(node)
                 else:
                     await body.mount(node, before=index)
+
+        for node_id in restore_focus_ids:
+            mounted = self.query_one(f"#{node_id}")
+            mounted.focus()
 
         for region, replacement in prepared_content.items():
             container = self._mounted_region_body(region)
@@ -447,6 +470,17 @@ class WatchlistsWorkbench(Vertical):
             await stale.remove()
         await self.mount(replacement, before=0)
 
-    def set_collapsed_suffixes(self, suffixes: Mapping[Region, str]) -> None:
-        """Compatibility no-op retained until the live screen stops calling it."""
-        del suffixes
+    def _contains_focus(self, widget: Widget) -> bool:
+        """Whether the current focus lives at or below ``widget``."""
+        focused = getattr(self.screen, "focused", None)
+        while focused is not None:
+            if focused is widget:
+                return True
+            focused = focused.parent
+        return False
+
+    def _grip_has_focus(self, region: Region) -> bool:
+        try:
+            return self.query_one(f"#wl-grip-{region.value}").has_focus
+        except NoMatches:
+            return False

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -54,10 +55,12 @@ class RegionLayoutApplyFailed(Message):
     def __init__(
         self,
         *,
+        token: int,
         attempted: RegionLayout,
         fallback: RegionLayout,
     ) -> None:
         super().__init__()
+        self.token = token
         self.attempted = attempted
         self.fallback = fallback
 
@@ -65,8 +68,11 @@ class RegionLayoutApplyFailed(Message):
 class RegionLayoutApplied(Message):
     """Acknowledge a successful effective-layout transition."""
 
-    def __init__(self, *, previous: RegionLayout, layout: RegionLayout) -> None:
+    def __init__(
+        self, *, token: int, previous: RegionLayout, layout: RegionLayout
+    ) -> None:
         super().__init__()
+        self.token = token
         self.previous = previous
         self.layout = layout
 
@@ -80,7 +86,9 @@ class WatchlistsWorkbench(Vertical):
     Reader.
     """
 
-    region_layout: reactive[RegionLayout] = reactive(RegionLayout())
+    effective_layout_request: reactive[tuple[int, RegionLayout]] = reactive(
+        (0, RegionLayout())
+    )
 
     def __init__(
         self,
@@ -105,9 +113,32 @@ class WatchlistsWorkbench(Vertical):
         self._content: dict[Region, Callable[[], Widget]] = dict(content or {})
         self._header = header
         self.read_mode = read_mode
+        self._rendered_layout = layout
+        self._layout_apply_lock = asyncio.Lock()
         self.set_class(self.read_mode, "watchlists-read-mode")
-        self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+        self.set_reactive(
+            WatchlistsWorkbench.effective_layout_request, (0, layout)
+        )
         self._sync_expanded_side_pane_class(layout=layout)
+
+    @property
+    def region_layout(self) -> RegionLayout:
+        """The effective layout currently represented by the mounted DOM."""
+        return self._rendered_layout
+
+    def request_region_layout(self, layout: RegionLayout, *, token: int) -> None:
+        """Request one correlated effective-layout transition."""
+        if layout == self._rendered_layout and not self._layout_apply_lock.locked():
+            self.set_reactive(
+                WatchlistsWorkbench.effective_layout_request, (token, layout)
+            )
+            self.post_message(
+                RegionLayoutApplied(
+                    token=token, previous=self._rendered_layout, layout=layout
+                )
+            )
+            return
+        self.effective_layout_request = (token, layout)
 
     def compose(self) -> ComposeResult:
         """Mount the header first and the horizontal workbench body second."""
@@ -164,14 +195,29 @@ class WatchlistsWorkbench(Vertical):
             id=f"wl-grip-{region.value}",
         )
 
-    async def watch_region_layout(
-        self, previous: RegionLayout, layout: RegionLayout
+    async def watch_effective_layout_request(
+        self,
+        _previous_request: tuple[int, RegionLayout],
+        request: tuple[int, RegionLayout],
     ) -> None:
         """Mount or remove only side bodies whose collapse state changed."""
+        async with self._layout_apply_lock:
+            await self._apply_effective_layout_request(request)
+
+    async def _apply_effective_layout_request(
+        self, request: tuple[int, RegionLayout]
+    ) -> None:
+        """Apply one request without racing a section-view reconciliation."""
+        token, layout = request
+        previous = self._rendered_layout
+        if request != self.effective_layout_request:
+            return
         if not self.is_mounted:
+            self._rendered_layout = layout
             return
         body = self._body()
         if body is None:
+            self._rendered_layout = layout
             return
         changed = [
             region
@@ -187,11 +233,12 @@ class WatchlistsWorkbench(Vertical):
                 ):
                     prepared[region] = self._region_body(region)
         except Exception:
-            self.set_reactive(WatchlistsWorkbench.region_layout, previous)
             self._sync_expanded_side_pane_class(layout=previous)
             logger.exception("Watchlists pane expansion factory failed")
             self.post_message(
-                RegionLayoutApplyFailed(attempted=layout, fallback=previous)
+                RegionLayoutApplyFailed(
+                    token=token, attempted=layout, fallback=previous
+                )
             )
             return
 
@@ -215,11 +262,12 @@ class WatchlistsWorkbench(Vertical):
             for node in prepared.values():
                 if node.is_mounted:
                     await node.remove()
-            self.set_reactive(WatchlistsWorkbench.region_layout, previous)
             self._sync_expanded_side_pane_class(layout=previous)
             logger.exception("Watchlists pane expansion mount failed")
             self.post_message(
-                RegionLayoutApplyFailed(attempted=layout, fallback=previous)
+                RegionLayoutApplyFailed(
+                    token=token, attempted=layout, fallback=previous
+                )
             )
             return
 
@@ -242,8 +290,11 @@ class WatchlistsWorkbench(Vertical):
             mounted = self._mounted_region_body(region)
             if mounted is not None:
                 mounted.focus()
+        self._rendered_layout = layout
         self._sync_expanded_side_pane_class(layout=layout)
-        self.post_message(RegionLayoutApplied(previous=previous, layout=layout))
+        self.post_message(
+            RegionLayoutApplied(token=token, previous=previous, layout=layout)
+        )
 
     @property
     def _grip_regions(self) -> tuple[Region, ...]:
@@ -283,39 +334,85 @@ class WatchlistsWorkbench(Vertical):
         *,
         layout: RegionLayout,
         read_mode: bool,
+        token: int,
         rebuild_regions: tuple[Region, ...] = (),
         rebuild_header: bool = False,
-    ) -> None:
+    ) -> bool:
         """Incrementally apply a Read/management section view."""
+        async with self._layout_apply_lock:
+            return await self._apply_section_view(
+                layout=layout,
+                read_mode=read_mode,
+                token=token,
+                rebuild_regions=rebuild_regions,
+                rebuild_header=rebuild_header,
+            )
+
+    async def _apply_section_view(
+        self,
+        *,
+        layout: RegionLayout,
+        read_mode: bool,
+        token: int,
+        rebuild_regions: tuple[Region, ...] = (),
+        rebuild_header: bool = False,
+    ) -> bool:
+        """Reconcile one section view while holding the layout lock."""
         next_read_mode = read_mode
+        previous = self._rendered_layout
+        self.set_reactive(
+            WatchlistsWorkbench.effective_layout_request, (token, previous)
+        )
         if not self.is_mounted:
             self.read_mode = next_read_mode
             self.set_class(self.read_mode, "watchlists-read-mode")
-            self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+            self._rendered_layout = layout
+            self.set_reactive(
+                WatchlistsWorkbench.effective_layout_request, (token, layout)
+            )
             self._sync_expanded_side_pane_class(
                 read_mode=next_read_mode, layout=layout
             )
-            return
+            self.post_message(
+                RegionLayoutApplied(token=token, previous=previous, layout=layout)
+            )
+            return True
 
-        replacement_header = (
-            self._header()
-            if rebuild_header and self._header is not None
-            else None
+        try:
+            replacement_header = (
+                self._header()
+                if rebuild_header and self._header is not None
+                else None
+            )
+            with self.app.batch_update():
+                await self._reconcile_body(
+                    read_mode=next_read_mode,
+                    layout=layout,
+                    rebuild_regions=rebuild_regions,
+                )
+                if replacement_header is not None:
+                    await self._replace_header(replacement_header)
+                self.read_mode = next_read_mode
+                self.set_class(self.read_mode, "watchlists-read-mode")
+                self._rendered_layout = layout
+                self.set_reactive(
+                    WatchlistsWorkbench.effective_layout_request, (token, layout)
+                )
+                self._sync_expanded_side_pane_class(
+                    read_mode=next_read_mode, layout=layout
+                )
+        except Exception:
+            logger.exception("Watchlists section-view factory failed")
+            self.post_message(
+                RegionLayoutApplyFailed(
+                    token=token, attempted=layout, fallback=previous
+                )
+            )
+            return False
+        self.post_message(
+            RegionLayoutApplied(token=token, previous=previous, layout=layout)
         )
-        with self.app.batch_update():
-            await self._reconcile_body(
-                read_mode=next_read_mode,
-                layout=layout,
-                rebuild_regions=rebuild_regions,
-            )
-            if replacement_header is not None:
-                await self._replace_header(replacement_header)
-            self.read_mode = next_read_mode
-            self.set_class(self.read_mode, "watchlists-read-mode")
-            self.set_reactive(WatchlistsWorkbench.region_layout, layout)
-            self._sync_expanded_side_pane_class(
-                read_mode=next_read_mode, layout=layout
-            )
+        return True
 
     async def _reconcile_body(
         self,
@@ -363,7 +460,14 @@ class WatchlistsWorkbench(Vertical):
             if child.id not in desired_ids:
                 region = self._region_from_body_id(child.id or "")
                 if region is not None and self._contains_focus(child):
-                    self.query_one(f"#wl-grip-{region.value}").focus()
+                    grip_id = f"wl-grip-{region.value}"
+                    if grip_id not in desired_ids:
+                        grip_id = next(
+                            node_id
+                            for node_id in desired_ids
+                            if node_id.startswith("wl-grip-")
+                        )
+                    self.query_one(f"#{grip_id}").focus()
                 await child.remove()
 
         for index, node_id in enumerate(desired_ids):

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -44,6 +44,7 @@ _MANAGEMENT_GRIP_REGIONS: tuple[Region, ...] = (
     Region.LEFT_RAIL,
     Region.RIGHT_RAIL,
 )
+_EXPANDED_SIDE_PANE_CLASS = "watchlists-has-expanded-side-pane"
 
 
 class RegionLayoutApplyFailed(Message):
@@ -104,6 +105,7 @@ class WatchlistsWorkbench(Vertical):
         )
         self.set_class(self.read_mode, "watchlists-read-mode")
         self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+        self._sync_expanded_side_pane_class(layout=layout)
 
     def compose(self) -> ComposeResult:
         """Mount the header first and the horizontal workbench body second."""
@@ -184,6 +186,7 @@ class WatchlistsWorkbench(Vertical):
                     prepared[region] = self._region_body(region)
         except Exception:
             self.set_reactive(WatchlistsWorkbench.region_layout, previous)
+            self._sync_expanded_side_pane_class(layout=previous)
             logger.exception("Watchlists pane expansion factory failed")
             self.post_message(
                 RegionLayoutApplyFailed(attempted=layout, fallback=previous)
@@ -204,6 +207,7 @@ class WatchlistsWorkbench(Vertical):
                 if node.is_mounted:
                     await node.remove()
             self.set_reactive(WatchlistsWorkbench.region_layout, previous)
+            self._sync_expanded_side_pane_class(layout=previous)
             logger.exception("Watchlists pane expansion mount failed")
             self.post_message(
                 RegionLayoutApplyFailed(attempted=layout, fallback=previous)
@@ -220,10 +224,28 @@ class WatchlistsWorkbench(Vertical):
                 f"#wl-grip-{region.value}", WatchlistsPaneGrip
             )
             grip.expanded = expanded
+        self._sync_expanded_side_pane_class(layout=layout)
 
     @property
     def _grip_regions(self) -> tuple[Region, ...]:
         return _READ_GRIP_REGIONS if self.read_mode else _MANAGEMENT_GRIP_REGIONS
+
+    def _sync_expanded_side_pane_class(
+        self,
+        *,
+        read_mode: bool | None = None,
+        layout: RegionLayout | None = None,
+    ) -> None:
+        """Expose whether the effective mode has an expanded side body."""
+        read_mode = self.read_mode if read_mode is None else read_mode
+        layout = self.region_layout if layout is None else layout
+        side_regions = (
+            _READ_GRIP_REGIONS if read_mode else _MANAGEMENT_GRIP_REGIONS
+        )
+        self.set_class(
+            any(not layout.is_collapsed(region) for region in side_regions),
+            _EXPANDED_SIDE_PANE_CLASS,
+        )
 
     def _body(self) -> Horizontal | None:
         try:
@@ -262,6 +284,9 @@ class WatchlistsWorkbench(Vertical):
             self.read_mode = next_read_mode
             self.set_class(self.read_mode, "watchlists-read-mode")
             self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+            self._sync_expanded_side_pane_class(
+                read_mode=next_read_mode, layout=layout
+            )
             return
 
         replacement_header = (
@@ -280,6 +305,9 @@ class WatchlistsWorkbench(Vertical):
             self.read_mode = next_read_mode
             self.set_class(self.read_mode, "watchlists-read-mode")
             self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+            self._sync_expanded_side_pane_class(
+                read_mode=next_read_mode, layout=layout
+            )
 
     async def _reconcile_body(
         self,

--- a/tldw_chatbook/css/features/_watchlists.tcss
+++ b/tldw_chatbook/css/features/_watchlists.tcss
@@ -415,9 +415,9 @@
  * test_watchlists_left_rail_is_labelled_when_expanded` fails on any `…` in
  * the composited rail, which is how this was caught.
  *
- * At `width: auto` + `padding: 0 1` the two rows measure 21 and 20 columns
- * against 26 available, so both fit whole with the rail at its current
- * width of 28.
+ * At `width: auto` + zero padding the two rows measure 21 and 22 columns,
+ * so both fit whole against the 22-column interior of the 24-column rail
+ * floor.
  *
  * `height: 1` on the strip matches every other one-row control group on
  * this screen (`.destination-filter-strip`, the tab strip): the rail is a
@@ -433,7 +433,7 @@
     width: auto;
     min-width: 0;
     height: 1;
-    padding: 0 1;
+    padding: 0;
     border: none;
 }
 
@@ -744,6 +744,13 @@ WatchlistPickerDialog {
     min-width: 12;
 }
 
+#sources-new-button,
+#sources-filter-toggle {
+    width: auto;
+    min-width: 0;
+    padding: 0;
+}
+
 /* TASK-1035. The create-source form had no rule anywhere, so it took
  * Textual's defaults for its container and painted like an unfinished
  * sketch: `Create` on row 40 and `Cancel` on row 43 with blank rows between
@@ -956,11 +963,18 @@ WatchlistPickerDialog {
 
 #items-search-input {
     width: 1fr;
-    min-width: 12;
+    min-width: 0;
 }
 
 #items-status-select {
-    width: 16;
+    width: 9;
+    min-width: 0;
+}
+
+#items-refresh-button {
+    width: auto;
+    min-width: 0;
+    padding: 0;
 }
 
 /* TASK-3791 plan task 5. The pill is a notice, not a verb: no border

--- a/tldw_chatbook/css/features/_watchlists.tcss
+++ b/tldw_chatbook/css/features/_watchlists.tcss
@@ -85,8 +85,9 @@
 }
 
 .watchlists-region-left_rail {
-    width: 28;
+    width: 1fr;
     min-width: 24;
+    max-width: 28;
     height: 100%;
     border: round $ds-grid-line;
 }
@@ -97,8 +98,9 @@
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 34;
+    width: 1fr;
     min-width: 30;
+    max-width: 34;
     height: 100%;
     border: round $ds-grid-line;
 }
@@ -145,9 +147,9 @@
     border: none;
 }
 
-/* ITEMS is the management canvas, but a fixed Feed Items side pane on Read. */
+/* ITEMS is the management canvas, but a bounded Feed Items side pane on Read. */
 .watchlists-region-items {
-    width: 1fr;
+    width: 3fr;
     min-width: 0;
     height: 100%;
     min-height: 0;
@@ -155,8 +157,9 @@
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 40;
+    width: 2fr;
     min-width: 32;
+    max-width: 40;
     height: 100%;
     overflow: hidden;
 }
@@ -190,7 +193,7 @@
 
 /* Reader is the permanent flexing centre; only its article body scrolls. */
 .watchlists-region-content {
-    width: 1fr;
+    width: 3fr;
     min-width: 0;
     height: 100%;
     min-height: 0;

--- a/tldw_chatbook/css/features/_watchlists.tcss
+++ b/tldw_chatbook/css/features/_watchlists.tcss
@@ -85,7 +85,7 @@
 }
 
 .watchlists-region-left_rail {
-    width: 1fr;
+    width: 28fr;
     min-width: 24;
     max-width: 28;
     height: 100%;
@@ -98,7 +98,7 @@
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 1fr;
+    width: 34fr;
     min-width: 30;
     max-width: 34;
     height: 100%;
@@ -149,7 +149,7 @@
 
 /* ITEMS is the management canvas, but a bounded Feed Items side pane on Read. */
 .watchlists-region-items {
-    width: 3fr;
+    width: 44fr;
     min-width: 0;
     height: 100%;
     min-height: 0;
@@ -157,7 +157,7 @@
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 2fr;
+    width: 40fr;
     min-width: 32;
     max-width: 40;
     height: 100%;
@@ -193,12 +193,21 @@
 
 /* Reader is the permanent flexing centre; only its article body scrolls. */
 .watchlists-region-content {
-    width: 3fr;
+    width: 44fr;
     min-width: 0;
     height: 100%;
     min-height: 0;
     border: round $ds-grid-line;
     overflow: hidden;
+}
+
+.watchlists-has-expanded-side-pane .watchlists-region-content,
+.watchlists-has-expanded-side-pane .watchlists-region-items {
+    min-width: 44;
+}
+
+.watchlists-has-expanded-side-pane.watchlists-read-mode .watchlists-region-items {
+    min-width: 32;
 }
 
 #watchlists-content-pane {

--- a/tldw_chatbook/css/features/_watchlists.tcss
+++ b/tldw_chatbook/css/features/_watchlists.tcss
@@ -245,11 +245,23 @@
     max-width: 5;
     height: 100%;
     min-height: 0;
+    padding: 0;
+    margin: 0;
     border: none;
+    border-left: solid $ds-grid-line;
     color: $ds-text-muted;
     background: $ds-surface-panel;
     text-align: center;
     content-align: center middle;
+}
+
+.watchlists-pane-grip:focus,
+.watchlists-pane-grip:hover:focus {
+    border: none;
+    border-left: solid $ds-action-focus;
+    outline: none;
+    color: $ds-focus-fg;
+    background: $ds-focus-bg;
 }
 
 /* Section tab strip (Task 3, styled in Task 6 fix round 3 -- folded in by

--- a/tldw_chatbook/css/features/_watchlists.tcss
+++ b/tldw_chatbook/css/features/_watchlists.tcss
@@ -85,7 +85,7 @@
 }
 
 .watchlists-region-left_rail {
-    width: 24;
+    width: 28;
     min-width: 24;
     height: 100%;
     border: round $ds-grid-line;
@@ -97,7 +97,7 @@
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 30;
+    width: 34;
     min-width: 30;
     height: 100%;
     border: round $ds-grid-line;
@@ -155,7 +155,7 @@
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 32;
+    width: 40;
     min-width: 32;
     height: 100%;
     overflow: hidden;

--- a/tldw_chatbook/css/features/_watchlists.tcss
+++ b/tldw_chatbook/css/features/_watchlists.tcss
@@ -65,35 +65,40 @@
     color: $text;
 }
 
-/* Workbench: rails around a vertically stacked centre */
+/* Workbench: stable chrome above a permanent horizontal centre. */
 .watchlists-workbench {
+    layout: vertical;
     width: 100%;
     height: 1fr;
+    min-width: 0;
     min-height: 0;
+    overflow: hidden;
+}
+
+#wl-workbench-body {
+    layout: horizontal;
+    width: 100%;
+    height: 1fr;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
 }
 
 .watchlists-region-left_rail {
-    width: 28;
-    min-width: 0;
+    width: 24;
+    min-width: 24;
     height: 100%;
     border: round $ds-grid-line;
 }
 
-/* Widened from 28 (Task 5): at 26 usable columns every Inspector action
- * label truncated -- "Stage Watchlists Cont", "Open current Watchlis",
- * "Console follow unavai" -- measured live at 235x52. 34 fits the longest
- * label ("Stage Watchlists Context in Console") close to on one line; the
- * `Button` rule below wraps as a fallback for whatever still does not fit,
- * rather than clipping it.
- *
- * Keeps its region border (Task 6, fix round 3): the ONE box per region is
+/* Keeps its region border: the ONE box per region is
  * drawn by the region wrapper, and the pane inside is stripped by ID below
  * (`#watchlists-inspector-pane`). See that rule for why the region, not the
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 34;
-    min-width: 0;
+    width: 30;
+    min-width: 30;
     height: 100%;
     border: round $ds-grid-line;
 }
@@ -113,24 +118,9 @@
     text-align: left;
 }
 
-.watchlists-centre {
-    width: 1fr;
-    min-width: 0;
-    height: 100%;
-    min-height: 0;
-}
-
-/* The always-rendered centre header (section tab strip + the snapshot's
- * loading/error/empty/summary marker), shown above the regions on EVERY
- * tab since task-2513 -- see
- * `WatchlistsCollectionsScreen._build_centre_status_header`. `Vertical`'s
- * own `DEFAULT_CSS` claims `height: 1fr` (textual/containers.py), and an
- * `fr` sibling here would compete with ITEMS's own `1fr`/`2fr` share for
- * the centre's height instead of taking only what its (fixed-height) tab
- * strip and one-line marker actually need. `height: auto` fixes that; no
- * border, this is plain chrome, not a region.
- */
+/* Cross-cutting tab/status chrome stays above the body on every section. */
 #wl-centre-status {
+    width: 100%;
     height: auto;
 }
 
@@ -155,39 +145,31 @@
     border: none;
 }
 
-/* ITEMS keeps its region border (Task 6, fix round 3) -- the pane inside is
- * stripped by the rule above.
- *
- * `2fr` (fix round 2, human-authorised lever change): ITEMS hosts every
- * section pane and their DataTables, so it gets a double share of the
- * centre stack; CONTENT (below) is content-sized rather than a competing
- * `fr` claimant, which leaves ITEMS the `.watchlists-centre` Vertical's
- * only `fr` sibling and the tall reading area.
- */
+/* ITEMS is the management canvas, but a fixed Feed Items side pane on Read. */
 .watchlists-region-items {
-    width: 100%;
-    height: 2fr;
+    width: 1fr;
+    min-width: 0;
+    height: 100%;
     min-height: 0;
     border: round $ds-grid-line;
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    height: auto;
-    min-height: 10;
-    max-height: 50;
+    width: 32;
+    min-width: 32;
+    height: 100%;
     overflow: hidden;
 }
 
 .watchlists-read-mode #watchlists-detail-pane,
 .watchlists-read-mode #watchlists-items-pane {
-    height: auto;
+    height: 100%;
     min-height: 0;
 }
 
 .watchlists-read-mode #items-table {
-    height: auto;
+    height: 1fr;
     min-height: 1;
-    max-height: 40;
     overflow-y: auto;
 }
 
@@ -206,39 +188,24 @@
     text-align: center;
 }
 
-/* Read is a stacked scroll document: CONTENT owns a bounded 20–50-row box,
- * while only its article body scrolls. The outer region clips overflow so
- * its title, actions, footer and border remain fixed around that body.
- */
+/* Reader is the permanent flexing centre; only its article body scrolls. */
 .watchlists-region-content {
-    width: 100%;
-    height: auto;
+    width: 1fr;
+    min-width: 0;
+    height: 100%;
+    min-height: 0;
     border: round $ds-grid-line;
-}
-
-.watchlists-read-mode .watchlists-region-content {
-    height: auto;
-    min-height: 20;
-    max-height: 50;
     overflow: hidden;
 }
 
-/* `Vertical` defaults to `height: 1fr`; use natural height inside the
- * content-sized outer region so short and medium articles grow correctly.
- */
 #watchlists-content-pane {
-    height: auto;
-}
-
-.watchlists-read-mode #watchlists-content-pane {
-    height: auto;
+    height: 1fr;
     min-height: 0;
 }
 
 .watchlists-read-mode #content-body-scroll {
-    height: auto;
+    height: 1fr;
     min-height: 1;
-    max-height: 45;
     overflow-y: auto;
 }
 
@@ -262,54 +229,6 @@
     width: 1fr;
 }
 
-/* Solo must actually fill the centre (Task 6, fix round 3, Finding 3).
- *
- * `Z` (`action_solo_region` -> `RegionLayout.solo`) collapses the other
- * centre region to a one-line header. CONTENT is the only capped region,
- * so a soloed CONTENT would stay pinned at its `max-height` while the
- * collapsed header took one row -- the rest of the centre blank.
- *
- * The cap exists so a long article cannot crowd ITEMS. When ITEMS is
- * collapsed there is nothing to crowd, so the cap is lifted (to the full
- * centre height) and the region takes the remaining space. `_region_widget`
- * adds `.watchlists-region-sole-centre` for exactly that state -- see its
- * comment for why it keys on "only expanded centre region" rather than on
- * `RegionLayout.solo_region`.
- *
- * Must stay AFTER `.watchlists-region-content` above: both are single-class
- * selectors, so this only wins the `height`/`max-height` tie on source
- * order.
- */
-.watchlists-region-sole-centre {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode
-.watchlists-region-items.watchlists-region-sole-centre {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode
-.watchlists-region-content.watchlists-region-sole-centre {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode .watchlists-region-sole-centre #watchlists-detail-pane,
-.watchlists-read-mode .watchlists-region-sole-centre #watchlists-items-pane,
-.watchlists-read-mode .watchlists-region-sole-centre #items-table {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode .watchlists-region-sole-centre #watchlists-content-pane,
-.watchlists-read-mode .watchlists-region-sole-centre #content-body-scroll {
-    height: 1fr;
-    max-height: 100%;
-}
-
 .watchlists-region-title {
     height: 1;
     text-style: bold;
@@ -320,33 +239,17 @@
     color: $ds-text-muted;
 }
 
-/* Collapsed regions keep a one-line, focusable header so nothing vanishes.
- *
- * `width: 100%` is only correct when the header is a direct child of the
- * centre `VerticalScroll` (`#wl-centre` / `.watchlists-centre`) -- there "100%"
- * means the centre column's own width. A rail header (LEFT_RAIL/RIGHT_RAIL)
- * is a direct child of the workbench `Horizontal` itself, so the same rule
- * there means the ENTIRE workbench width, pushing every region after it off
- * the right edge of the screen (Finding 1, fix round 2). Rails get a fixed
- * narrow width instead -- the same fixed-width-handle pattern
- * `console_rail_handle.py` uses for its collapsed rail buttons -- with
- * `min-width`/`max-width` pinned so Button's own `min-width: 16` default
- * (textual/widgets/_button.py) can't win the cascade and re-widen it.
- */
-.watchlists-region-header {
-    height: 1;
-    min-height: 1;
+.watchlists-pane-grip {
+    width: 5;
+    min-width: 5;
+    max-width: 5;
+    height: 100%;
+    min-height: 0;
+    border: none;
     color: $ds-text-muted;
-}
-
-.watchlists-centre > .watchlists-region-header {
-    width: 100%;
-}
-
-.watchlists-workbench > .watchlists-region-header {
-    width: 16;
-    min-width: 0;
-    max-width: 16;
+    background: $ds-surface-panel;
+    text-align: center;
+    content-align: center middle;
 }
 
 /* Section tab strip (Task 3, styled in Task 6 fix round 3 -- folded in by

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -20680,11 +20680,23 @@ CodingWindow {
     max-width: 5;
     height: 100%;
     min-height: 0;
+    padding: 0;
+    margin: 0;
     border: none;
+    border-left: solid $ds-grid-line;
     color: $ds-text-muted;
     background: $ds-surface-panel;
     text-align: center;
     content-align: center middle;
+}
+
+.watchlists-pane-grip:focus,
+.watchlists-pane-grip:hover:focus {
+    border: none;
+    border-left: solid $ds-action-focus;
+    outline: none;
+    color: $ds-focus-fg;
+    background: $ds-focus-bg;
 }
 
 /* Section tab strip (Task 3, styled in Task 6 fix round 3 -- folded in by

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -20850,9 +20850,9 @@ CodingWindow {
  * test_watchlists_left_rail_is_labelled_when_expanded` fails on any `…` in
  * the composited rail, which is how this was caught.
  *
- * At `width: auto` + `padding: 0 1` the two rows measure 21 and 20 columns
- * against 26 available, so both fit whole with the rail at its current
- * width of 28.
+ * At `width: auto` + zero padding the two rows measure 21 and 22 columns,
+ * so both fit whole against the 22-column interior of the 24-column rail
+ * floor.
  *
  * `height: 1` on the strip matches every other one-row control group on
  * this screen (`.destination-filter-strip`, the tab strip): the rail is a
@@ -20868,7 +20868,7 @@ CodingWindow {
     width: auto;
     min-width: 0;
     height: 1;
-    padding: 0 1;
+    padding: 0;
     border: none;
 }
 
@@ -21179,6 +21179,13 @@ WatchlistPickerDialog {
     min-width: 12;
 }
 
+#sources-new-button,
+#sources-filter-toggle {
+    width: auto;
+    min-width: 0;
+    padding: 0;
+}
+
 /* TASK-1035. The create-source form had no rule anywhere, so it took
  * Textual's defaults for its container and painted like an unfinished
  * sketch: `Create` on row 40 and `Cancel` on row 43 with blank rows between
@@ -21391,11 +21398,18 @@ WatchlistPickerDialog {
 
 #items-search-input {
     width: 1fr;
-    min-width: 12;
+    min-width: 0;
 }
 
 #items-status-select {
-    width: 16;
+    width: 9;
+    min-width: 0;
+}
+
+#items-refresh-button {
+    width: auto;
+    min-width: 0;
+    padding: 0;
 }
 
 /* TASK-3791 plan task 5. The pill is a notice, not a verb: no border

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -20500,35 +20500,40 @@ CodingWindow {
     color: $text;
 }
 
-/* Workbench: rails around a vertically stacked centre */
+/* Workbench: stable chrome above a permanent horizontal centre. */
 .watchlists-workbench {
+    layout: vertical;
     width: 100%;
     height: 1fr;
+    min-width: 0;
     min-height: 0;
+    overflow: hidden;
+}
+
+#wl-workbench-body {
+    layout: horizontal;
+    width: 100%;
+    height: 1fr;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
 }
 
 .watchlists-region-left_rail {
-    width: 28;
-    min-width: 0;
+    width: 24;
+    min-width: 24;
     height: 100%;
     border: round $ds-grid-line;
 }
 
-/* Widened from 28 (Task 5): at 26 usable columns every Inspector action
- * label truncated -- "Stage Watchlists Cont", "Open current Watchlis",
- * "Console follow unavai" -- measured live at 235x52. 34 fits the longest
- * label ("Stage Watchlists Context in Console") close to on one line; the
- * `Button` rule below wraps as a fallback for whatever still does not fit,
- * rather than clipping it.
- *
- * Keeps its region border (Task 6, fix round 3): the ONE box per region is
+/* Keeps its region border: the ONE box per region is
  * drawn by the region wrapper, and the pane inside is stripped by ID below
  * (`#watchlists-inspector-pane`). See that rule for why the region, not the
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 34;
-    min-width: 0;
+    width: 30;
+    min-width: 30;
     height: 100%;
     border: round $ds-grid-line;
 }
@@ -20548,24 +20553,9 @@ CodingWindow {
     text-align: left;
 }
 
-.watchlists-centre {
-    width: 1fr;
-    min-width: 0;
-    height: 100%;
-    min-height: 0;
-}
-
-/* The always-rendered centre header (section tab strip + the snapshot's
- * loading/error/empty/summary marker), shown above the regions on EVERY
- * tab since task-2513 -- see
- * `WatchlistsCollectionsScreen._build_centre_status_header`. `Vertical`'s
- * own `DEFAULT_CSS` claims `height: 1fr` (textual/containers.py), and an
- * `fr` sibling here would compete with ITEMS's own `1fr`/`2fr` share for
- * the centre's height instead of taking only what its (fixed-height) tab
- * strip and one-line marker actually need. `height: auto` fixes that; no
- * border, this is plain chrome, not a region.
- */
+/* Cross-cutting tab/status chrome stays above the body on every section. */
 #wl-centre-status {
+    width: 100%;
     height: auto;
 }
 
@@ -20590,39 +20580,31 @@ CodingWindow {
     border: none;
 }
 
-/* ITEMS keeps its region border (Task 6, fix round 3) -- the pane inside is
- * stripped by the rule above.
- *
- * `2fr` (fix round 2, human-authorised lever change): ITEMS hosts every
- * section pane and their DataTables, so it gets a double share of the
- * centre stack; CONTENT (below) is content-sized rather than a competing
- * `fr` claimant, which leaves ITEMS the `.watchlists-centre` Vertical's
- * only `fr` sibling and the tall reading area.
- */
+/* ITEMS is the management canvas, but a fixed Feed Items side pane on Read. */
 .watchlists-region-items {
-    width: 100%;
-    height: 2fr;
+    width: 1fr;
+    min-width: 0;
+    height: 100%;
     min-height: 0;
     border: round $ds-grid-line;
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    height: auto;
-    min-height: 10;
-    max-height: 50;
+    width: 32;
+    min-width: 32;
+    height: 100%;
     overflow: hidden;
 }
 
 .watchlists-read-mode #watchlists-detail-pane,
 .watchlists-read-mode #watchlists-items-pane {
-    height: auto;
+    height: 100%;
     min-height: 0;
 }
 
 .watchlists-read-mode #items-table {
-    height: auto;
+    height: 1fr;
     min-height: 1;
-    max-height: 40;
     overflow-y: auto;
 }
 
@@ -20641,39 +20623,24 @@ CodingWindow {
     text-align: center;
 }
 
-/* Read is a stacked scroll document: CONTENT owns a bounded 20–50-row box,
- * while only its article body scrolls. The outer region clips overflow so
- * its title, actions, footer and border remain fixed around that body.
- */
+/* Reader is the permanent flexing centre; only its article body scrolls. */
 .watchlists-region-content {
-    width: 100%;
-    height: auto;
+    width: 1fr;
+    min-width: 0;
+    height: 100%;
+    min-height: 0;
     border: round $ds-grid-line;
-}
-
-.watchlists-read-mode .watchlists-region-content {
-    height: auto;
-    min-height: 20;
-    max-height: 50;
     overflow: hidden;
 }
 
-/* `Vertical` defaults to `height: 1fr`; use natural height inside the
- * content-sized outer region so short and medium articles grow correctly.
- */
 #watchlists-content-pane {
-    height: auto;
-}
-
-.watchlists-read-mode #watchlists-content-pane {
-    height: auto;
+    height: 1fr;
     min-height: 0;
 }
 
 .watchlists-read-mode #content-body-scroll {
-    height: auto;
+    height: 1fr;
     min-height: 1;
-    max-height: 45;
     overflow-y: auto;
 }
 
@@ -20697,54 +20664,6 @@ CodingWindow {
     width: 1fr;
 }
 
-/* Solo must actually fill the centre (Task 6, fix round 3, Finding 3).
- *
- * `Z` (`action_solo_region` -> `RegionLayout.solo`) collapses the other
- * centre region to a one-line header. CONTENT is the only capped region,
- * so a soloed CONTENT would stay pinned at its `max-height` while the
- * collapsed header took one row -- the rest of the centre blank.
- *
- * The cap exists so a long article cannot crowd ITEMS. When ITEMS is
- * collapsed there is nothing to crowd, so the cap is lifted (to the full
- * centre height) and the region takes the remaining space. `_region_widget`
- * adds `.watchlists-region-sole-centre` for exactly that state -- see its
- * comment for why it keys on "only expanded centre region" rather than on
- * `RegionLayout.solo_region`.
- *
- * Must stay AFTER `.watchlists-region-content` above: both are single-class
- * selectors, so this only wins the `height`/`max-height` tie on source
- * order.
- */
-.watchlists-region-sole-centre {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode
-.watchlists-region-items.watchlists-region-sole-centre {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode
-.watchlists-region-content.watchlists-region-sole-centre {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode .watchlists-region-sole-centre #watchlists-detail-pane,
-.watchlists-read-mode .watchlists-region-sole-centre #watchlists-items-pane,
-.watchlists-read-mode .watchlists-region-sole-centre #items-table {
-    height: 1fr;
-    max-height: 100%;
-}
-
-.watchlists-read-mode .watchlists-region-sole-centre #watchlists-content-pane,
-.watchlists-read-mode .watchlists-region-sole-centre #content-body-scroll {
-    height: 1fr;
-    max-height: 100%;
-}
-
 .watchlists-region-title {
     height: 1;
     text-style: bold;
@@ -20755,33 +20674,17 @@ CodingWindow {
     color: $ds-text-muted;
 }
 
-/* Collapsed regions keep a one-line, focusable header so nothing vanishes.
- *
- * `width: 100%` is only correct when the header is a direct child of the
- * centre `VerticalScroll` (`#wl-centre` / `.watchlists-centre`) -- there "100%"
- * means the centre column's own width. A rail header (LEFT_RAIL/RIGHT_RAIL)
- * is a direct child of the workbench `Horizontal` itself, so the same rule
- * there means the ENTIRE workbench width, pushing every region after it off
- * the right edge of the screen (Finding 1, fix round 2). Rails get a fixed
- * narrow width instead -- the same fixed-width-handle pattern
- * `console_rail_handle.py` uses for its collapsed rail buttons -- with
- * `min-width`/`max-width` pinned so Button's own `min-width: 16` default
- * (textual/widgets/_button.py) can't win the cascade and re-widen it.
- */
-.watchlists-region-header {
-    height: 1;
-    min-height: 1;
+.watchlists-pane-grip {
+    width: 5;
+    min-width: 5;
+    max-width: 5;
+    height: 100%;
+    min-height: 0;
+    border: none;
     color: $ds-text-muted;
-}
-
-.watchlists-centre > .watchlists-region-header {
-    width: 100%;
-}
-
-.watchlists-workbench > .watchlists-region-header {
-    width: 16;
-    min-width: 0;
-    max-width: 16;
+    background: $ds-surface-panel;
+    text-align: center;
+    content-align: center middle;
 }
 
 /* Section tab strip (Task 3, styled in Task 6 fix round 3 -- folded in by

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -20520,7 +20520,7 @@ CodingWindow {
 }
 
 .watchlists-region-left_rail {
-    width: 1fr;
+    width: 28fr;
     min-width: 24;
     max-width: 28;
     height: 100%;
@@ -20533,7 +20533,7 @@ CodingWindow {
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 1fr;
+    width: 34fr;
     min-width: 30;
     max-width: 34;
     height: 100%;
@@ -20584,7 +20584,7 @@ CodingWindow {
 
 /* ITEMS is the management canvas, but a bounded Feed Items side pane on Read. */
 .watchlists-region-items {
-    width: 3fr;
+    width: 44fr;
     min-width: 0;
     height: 100%;
     min-height: 0;
@@ -20592,7 +20592,7 @@ CodingWindow {
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 2fr;
+    width: 40fr;
     min-width: 32;
     max-width: 40;
     height: 100%;
@@ -20628,12 +20628,21 @@ CodingWindow {
 
 /* Reader is the permanent flexing centre; only its article body scrolls. */
 .watchlists-region-content {
-    width: 3fr;
+    width: 44fr;
     min-width: 0;
     height: 100%;
     min-height: 0;
     border: round $ds-grid-line;
     overflow: hidden;
+}
+
+.watchlists-has-expanded-side-pane .watchlists-region-content,
+.watchlists-has-expanded-side-pane .watchlists-region-items {
+    min-width: 44;
+}
+
+.watchlists-has-expanded-side-pane.watchlists-read-mode .watchlists-region-items {
+    min-width: 32;
 }
 
 #watchlists-content-pane {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -20520,7 +20520,7 @@ CodingWindow {
 }
 
 .watchlists-region-left_rail {
-    width: 24;
+    width: 28;
     min-width: 24;
     height: 100%;
     border: round $ds-grid-line;
@@ -20532,7 +20532,7 @@ CodingWindow {
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 30;
+    width: 34;
     min-width: 30;
     height: 100%;
     border: round $ds-grid-line;
@@ -20590,7 +20590,7 @@ CodingWindow {
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 32;
+    width: 40;
     min-width: 32;
     height: 100%;
     overflow: hidden;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -20520,8 +20520,9 @@ CodingWindow {
 }
 
 .watchlists-region-left_rail {
-    width: 28;
+    width: 1fr;
     min-width: 24;
+    max-width: 28;
     height: 100%;
     border: round $ds-grid-line;
 }
@@ -20532,8 +20533,9 @@ CodingWindow {
  * pane, is the survivor.
  */
 .watchlists-region-right_rail {
-    width: 34;
+    width: 1fr;
     min-width: 30;
+    max-width: 34;
     height: 100%;
     border: round $ds-grid-line;
 }
@@ -20580,9 +20582,9 @@ CodingWindow {
     border: none;
 }
 
-/* ITEMS is the management canvas, but a fixed Feed Items side pane on Read. */
+/* ITEMS is the management canvas, but a bounded Feed Items side pane on Read. */
 .watchlists-region-items {
-    width: 1fr;
+    width: 3fr;
     min-width: 0;
     height: 100%;
     min-height: 0;
@@ -20590,8 +20592,9 @@ CodingWindow {
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 40;
+    width: 2fr;
     min-width: 32;
+    max-width: 40;
     height: 100%;
     overflow: hidden;
 }
@@ -20625,7 +20628,7 @@ CodingWindow {
 
 /* Reader is the permanent flexing centre; only its article body scrolls. */
 .watchlists-region-content {
-    width: 1fr;
+    width: 3fr;
     min-width: 0;
     height: 100%;
     min-height: 0;


### PR DESCRIPTION
## Summary
- make the Watchlists Read tab a permanent Reader with independently collapsible Navigation, Feed Items, and Inspector panes
- persist manual pane preferences while keeping responsive collapse and Article Focus transient
- add Smart Feeds, focused Reader actions, query-free Server Read recovery, compact-width geometry, and state-preserving layout transitions
- update Watchlists tests, CSS contracts, ADR-linked documentation, and TASK-21281 closeout notes

## Test plan
- [x] pytest Tests/Watchlists Tests/UI/test_destination_shells.py -q — 887 passed, 1 skipped
- [x] pytest Tests/Watchlists/test_watchlists_collections_screen.py -q — 87 passed
- [x] focused five-test Server Read recovery/switch regression set
- [x] scoped Ruff checks for modified Watchlists/UI code and tests
- [x] all five CSS bundle-sync checks and git diff --check
- [x] isolated-profile live keyboard/pointer verification across all seven Watchlists tabs and widths 145, 144, 115, 114, 91, 90, 60, and 40
- [x] independent final code review: no Critical or Important findings

Per user direction, verification was limited to changed functionality and modified code. A previously started repository-wide suite was cancelled at 71% and is not presented as evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns Watchlists Read into a NetNewsWire‑style reader with a permanent horizontal Reader and independently collapsible Navigation, Feed Items, and Inspector panes. Previously the centre stacked and the Reader could collapse; now the Reader is always present, side panes toggle via five‑column ASCII grips, preferences persist, and responsive/Article Focus layouts stay transient. Addresses TASK‑21281.

- Models preferred vs effective layouts, versions and migrates stored prefs, enforces pane min/target widths and a Reader comfort width, and mounts/unmounts only the affected pane on toggles. Guards against persistence/factory failures with rollback and preserves the rendered workbench.
- Moves snapshot viewing to the Inspector; the Reader keeps open‑in‑browser, star, unread, and next‑unread. Help/footer only advertise live pane actions.
- Hardens server Read recovery: blocks server queries when Read is hidden, stays in recovery until local load, resets/refreshes on backend switches, parks navigation state, and resumes query‑free when visible.
- Updates CSS to a stable chrome over a permanent horizontal centre; pane grips are five columns wide.

**Rollout and migration**
- No DB changes. CLI‑stored side‑pane prefs are versioned and migrate automatically; unknown regions like “feeds” are dropped; Reader collapse prefs are ignored.
- Remove any uses of Content pane `ExpandReaderRequested`; collapse/expand applies only to side panes via grips. Snapshot actions now originate from the Inspector (`ViewSnapshotRequested`).

<sup>Written for commit 7e738499571be98aeb68c9e7a1dc39640506a8b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

