### PR TITLE
perf(startup): take Chunking, RAG_Search.simplified and Internal_Prompts off the boot and Chat-mount paths (TASK-21731)

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -412,6 +412,7 @@ Findings that were still open when the table above was written, measured the sam
 | Task | Measured before → after |
 |---|---|
 | 21121 changed-files guard per run tick | Per 25 simulated run ticks with a reply streaming, the guard alone: `messages_for_session` **25 → 0**, message copies **10,025 → 0** (400-message session; **1,025 → 0** at 40), guard wall time **32.1 ms → 0.02 ms** (**2.87 ms → 0.01 ms** at 40). Identical with a marker present (10,050 → 0) and the reported scope byte-identical in every arm, before and after. |
+| 21731 — **21102's guarantee had regressed** | PR #2049 (`codex/task-3500-mcp-profile-rag`) put one module-scope `normalize_rag_search_mode` import into `Library/library_local_rag_search_service.py`, and with it the whole `simplified` tree → `chunking_service` → the Chunking engine → `Internal_Prompts`: app-import own-module count **636 → 703**, with `test_app_import_weight.py`'s budget AND `Tests/Packaging/test_chunking_import_closure.py` both red on dev, unnoticed. Restored: **703 → 637**. **The import count was only half of it** — the same modules were also imported during the initial Chat screen mount (`chat_rag_events`'s module-scope availability probe, **50 ms** on the loop), so removing the boot import alone would have left time-to-interactive unchanged. With both deferred, residency at `_ui_ready` goes **Chunking 33 → 0, simplified 19 → 0**, total `tldw_chatbook.*` **984 → 928**. |
 
 ## Corrections found during implementation (added 2026-08-23 at close-out)
 

--- a/Tests/Packaging/test_rag_boot_import_closure.py
+++ b/Tests/Packaging/test_rag_boot_import_closure.py
@@ -1,0 +1,417 @@
+"""Import-closure guards for the RAG stack on the boot path (TASK-21731).
+
+Two eager module-scope imports put ~67 of this repo's modules -- the whole
+``RAG_Search.simplified`` service tree, the ~15k-LOC ``Chunking`` engine it
+drags through ``chunking_service``, and ``Internal_Prompts`` -- in front of
+the user, twice over:
+
+* ``Library/library_local_rag_search_service.py`` imported
+  ``normalize_rag_search_mode`` from ``simplified.active_config``. That
+  module is on ``import tldw_chatbook.app``'s path, so the whole tree
+  executed before a single pixel was painted (703 own modules, up from 636).
+* ``Event_Handlers/Chat_Events/chat_rag_events.py`` ran a module-scope
+  ``try: from ...RAG_Search.simplified import ...`` feature probe. That
+  module is imported during the initial **Chat screen mount** (via
+  ``UI/Console_Modules/retrieval.py``), on the event loop -- so removing the
+  first chain alone would only have MOVED the cost from the import phase to
+  the mount phase (measured: 50 ms), leaving time-to-interactive unchanged.
+
+Both are guarded here, because a fix for either one alone reads as a win on
+the module count while the user waits exactly as long.
+
+Subprocess-isolated for the same reason as
+``test_chunking_import_closure.py`` (TASK-21102) and
+``test_extras_import_closure.py`` (TASK-21104): ``sys.modules`` is
+process-global, so an earlier test in the session that legitimately imported
+the RAG stack would make an in-process check pass or fail for reasons that
+have nothing to do with the boot path.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: The three package prefixes this task removed from the boot path.
+DEFERRED_PREFIXES = (
+    "tldw_chatbook.RAG_Search.simplified",
+    "tldw_chatbook.Chunking",
+    "tldw_chatbook.Internal_Prompts",
+)
+
+
+def _run_isolated_python(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in a fresh interpreter with isolated config/data dirs.
+
+    Args:
+        tmp_path: Per-test scratch directory for the subprocess's HOME/XDG so
+            the app import can never read or write the live user config.
+        code: The Python source to execute with ``python -c``.
+
+    Returns:
+        The completed process (never raises on nonzero exit).
+    """
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env.pop("TLDW_CONFIG_PATH", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=180,
+    )
+
+
+_RESIDENT_HELPER = """
+import sys
+
+DEFERRED_PREFIXES = {prefixes!r}
+
+
+def resident():
+    out = []
+    for name in sorted(sys.modules):
+        if sys.modules[name] is None:
+            continue
+        for prefix in DEFERRED_PREFIXES:
+            if name == prefix or name.startswith(prefix + "."):
+                out.append(name)
+                break
+    return out
+""".format(prefixes=DEFERRED_PREFIXES)
+
+
+_APP_IMPORT_SNIPPET = _RESIDENT_HELPER + """
+import tldw_chatbook.app  # noqa: F401
+
+loaded = resident()
+assert not loaded, f"deferred packages resident after app import: {loaded}"
+
+# Anti-vacuity: the converted boot-path module must still BE in the closure
+# (this guard is about what it pulls, not about whether it is reached), and
+# the stdlib-only replacement for the mode vocabulary must be what got there
+# in place of active_config. `chat_rag_events` is deliberately absent from
+# this list -- it is a Chat-MOUNT module, not a boot module, and has its own
+# test below.
+for expected in (
+    "tldw_chatbook.Library.library_local_rag_search_service",
+    "tldw_chatbook.RAG_Search.search_modes",
+):
+    assert expected in sys.modules, f"expected closure member missing: {expected}"
+
+print("APP_CLOSURE_OK")
+"""
+
+
+def test_app_import_does_not_execute_the_deferred_rag_packages(
+    tmp_path: Path,
+) -> None:
+    """`import tldw_chatbook.app` resolves none of the three packages.
+
+    The regression this pins measured 703 ``tldw_chatbook.*`` modules at app
+    import (Chunking 33 + RAG_Search.simplified 24 + Internal_Prompts 10 over
+    a 636 baseline).
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _APP_IMPORT_SNIPPET)
+    assert result.returncode == 0, (
+        "import tldw_chatbook.app must not execute the deferred RAG packages:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "APP_CLOSURE_OK" in result.stdout
+
+
+_CHAT_RAG_EVENTS_SNIPPET = _RESIDENT_HELPER + """
+from tldw_chatbook.Event_Handlers.Chat_Events import chat_rag_events
+
+loaded = resident()
+assert not loaded, (
+    f"importing chat_rag_events must not execute the RAG service tree: {loaded}"
+)
+
+# ...and the deferred probe must still RESOLVE when something asks. A guard
+# that only proves absence would be satisfied by deleting the feature.
+assert chat_rag_events._rag_services_available() is True, (
+    "the deferred RAG availability probe did not resolve"
+)
+assert "tldw_chatbook.RAG_Search.simplified" in sys.modules, (
+    "asking for RAG availability did not import the simplified package"
+)
+
+# The public module attribute keeps working (PEP 562 module __getattr__).
+assert chat_rag_events.RAG_SERVICES_AVAILABLE is True
+
+# ...and the real constructors it probes for are importable through it.
+from tldw_chatbook.RAG_Search.simplified import (  # noqa: E402
+    create_rag_service,
+    create_config_for_collection,
+)
+
+assert callable(create_rag_service) and callable(create_config_for_collection)
+print("CHAT_RAG_EVENTS_LAZY_OK")
+"""
+
+
+def test_chat_rag_events_import_is_lazy_but_the_probe_still_resolves(
+    tmp_path: Path,
+) -> None:
+    """The Chat-mount module must not execute the RAG tree -- and must still work.
+
+    ``chat_rag_events`` is imported while the default Chat screen mounts, on
+    the event loop, before the app is interactive. Its availability probe now
+    resolves on first ask. Both halves are asserted in one subprocess: the
+    import is cheap, and asking the question still returns ``True`` and
+    genuinely loads ``RAG_Search.simplified``.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _CHAT_RAG_EVENTS_SNIPPET)
+    assert result.returncode == 0, (
+        "chat_rag_events import/probe contract failed:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "CHAT_RAG_EVENTS_LAZY_OK" in result.stdout
+
+
+_SEARCH_MODES_SNIPPET = _RESIDENT_HELPER + """
+from tldw_chatbook.RAG_Search import search_modes
+
+loaded = resident()
+assert not loaded, f"search_modes must be import-cheap, pulled: {loaded}"
+
+assert search_modes.normalize_rag_search_mode("hybrid") == "hybrid"
+assert search_modes.normalize_rag_search_mode("nonsense") == "semantic"
+
+# One object, not a copy: active_config re-imports from here, so the
+# vocabulary the Library service normalizes against cannot drift from the
+# one the engine's own config validates against.
+from tldw_chatbook.RAG_Search.simplified import active_config  # noqa: E402
+from tldw_chatbook.Library import library_local_rag_search_service as lib  # noqa: E402
+
+assert (
+    active_config.normalize_rag_search_mode
+    is search_modes.normalize_rag_search_mode
+), "active_config holds a different normalize_rag_search_mode object"
+assert (
+    lib.normalize_rag_search_mode is search_modes.normalize_rag_search_mode
+), "the Library service holds a different normalize_rag_search_mode object"
+assert active_config._RAG_SEARCH_MODES is search_modes.RAG_SEARCH_MODES
+
+from tldw_chatbook.RAG_Search.simplified.search_service import (  # noqa: E402
+    normalize_rag_search_mode as search_service_normalize,
+)
+
+assert search_service_normalize is search_modes.normalize_rag_search_mode
+print("SEARCH_MODES_OK")
+"""
+
+
+_PROFILE_RAG_FROM_DEFERRED_STATE_SNIPPET = _RESIDENT_HELPER + """
+import asyncio
+from types import SimpleNamespace
+
+import tldw_chatbook.app  # noqa: F401
+
+assert not resident(), resident()
+
+# --- Leg 1: the Library profile-mode resolution PR #2049 shipped -----------
+# It must answer correctly WITHOUT the simplified stack -- that is the whole
+# point of the extraction, and a fix that merely moved the import would show
+# up here as a resident stack.
+from tldw_chatbook.Library import library_local_rag_search_service as lib  # noqa: E402
+
+
+def _runtime(mode):
+    return SimpleNamespace(
+        config=SimpleNamespace(search=SimpleNamespace(default_search_mode=mode))
+    )
+
+
+assert lib._resolve_profile_search_mode(_runtime("hybrid")) == "hybrid"
+assert lib._resolve_profile_search_mode(_runtime("plain")) == "plain"
+assert lib._resolve_profile_search_mode(_runtime("semantic")) == "semantic"
+assert lib._resolve_profile_search_mode(_runtime("nonsense")) == "semantic"
+assert lib._resolve_profile_search_mode(SimpleNamespace()) == "semantic"
+assert not resident(), f"profile-mode resolution pulled the stack: {resident()}"
+
+# --- Leg 2: the MCP profile-driven search PR #2049 shipped -----------------
+# Importing it on demand must WORK, not just be absent at boot.
+from tldw_chatbook.RAG_Search.simplified.search_service import (  # noqa: E402
+    SimplifiedRAGSearchService,
+)
+import tldw_chatbook.RAG_Search.simplified.search_service as search_service  # noqa: E402
+
+assert "tldw_chatbook.RAG_Search.simplified" in sys.modules
+assert any(m.startswith("tldw_chatbook.Chunking") for m in sys.modules), (
+    "the deferred stack did not actually load on demand"
+)
+
+
+class _StubRuntime:
+    def __init__(self):
+        self.calls = []
+
+    async def search(self, **kwargs):
+        self.calls.append(kwargs)
+        return [
+            SimpleNamespace(
+                id="media-1",
+                document="body",
+                score=0.5,
+                metadata={"title": "T", "media_type": "video"},
+            )
+        ]
+
+
+runtime = _StubRuntime()
+service = SimplifiedRAGSearchService(media_db=None)
+service.rag_service = runtime
+search_service.resolve_active_rag_search_mode = lambda: "hybrid"
+
+rows = asyncio.run(service.profile_search("credential", limit=3))
+
+assert [c["search_type"] for c in runtime.calls] == ["hybrid"], runtime.calls
+assert runtime.calls[0]["top_k"] == 3
+assert [r["id"] for r in rows] == ["media-1"], rows
+assert rows[0]["media_type"] == "video"
+print("PROFILE_RAG_FROM_DEFERRED_STATE_OK")
+"""
+
+
+def test_profile_driven_rag_still_works_from_the_deferred_boot_state(
+    tmp_path: Path,
+) -> None:
+    """PR #2049's features must still work once their imports are deferred.
+
+    Absence is not the deliverable -- a deleted feature would satisfy a
+    pure closure guard. This drives both legs of the MCP profile-driven RAG
+    search from exactly the state this task creates (app imported, nothing
+    RAG resolved): the Library profile-mode resolution answers correctly
+    without loading anything, and the MCP ``profile_search`` seam loads the
+    stack on demand and routes by the active mode.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _PROFILE_RAG_FROM_DEFERRED_STATE_SNIPPET)
+    assert result.returncode == 0, (
+        "profile-driven RAG failed from the deferred state:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "PROFILE_RAG_FROM_DEFERRED_STATE_OK" in result.stdout
+
+
+_MISSING_EXTRAS_SNIPPET = """
+import asyncio
+import sys
+from types import SimpleNamespace
+
+BLOCKED = "tldw_chatbook.RAG_Search.simplified"
+
+
+class _BlockSimplified:
+    \"\"\"Meta-path finder simulating an install without the RAG extras.\"\"\"
+
+    def find_spec(self, name, path=None, target=None):
+        if name == BLOCKED or name.startswith(BLOCKED + "."):
+            raise ImportError(f"simulated missing RAG dependency for {name}")
+        return None
+
+
+sys.meta_path.insert(0, _BlockSimplified())
+
+from loguru import logger
+
+warnings = []
+logger.add(lambda message: warnings.append(str(message)), level="WARNING")
+
+from tldw_chatbook.Event_Handlers.Chat_Events import chat_rag_events
+
+# The import itself must survive an install with no RAG extras...
+assert chat_rag_events._rag_services_available() is False
+assert chat_rag_events.RAG_SERVICES_AVAILABLE is False
+assert any("RAG services not available" in w for w in warnings), warnings
+
+# ...and the consumer degrades the way it always did: None, not a crash.
+service = asyncio.run(
+    chat_rag_events.get_or_initialize_rag_service(SimpleNamespace(config={}))
+)
+assert service is None, service
+
+# Cached: a second ask must not re-attempt the import (one warning, not two).
+assert chat_rag_events._rag_services_available() is False
+assert sum("RAG services not available" in w for w in warnings) == 1, warnings
+print("MISSING_EXTRAS_OK")
+"""
+
+
+def test_missing_rag_extras_degrade_at_first_use_exactly_as_they_did_at_import(
+    tmp_path: Path,
+) -> None:
+    """Moving an import moves its failure -- this pins where that failure lands.
+
+    With ``RAG_Search.simplified`` unimportable (the plain-install case), the
+    probe used to fail at ``chat_rag_events`` import time and set the flag
+    False. It now fails at the first ask. The observable contract is
+    unchanged: one warning, a ``False`` flag, and ``None`` from
+    ``get_or_initialize_rag_service`` -- never an exception escaping into the
+    Chat screen.
+
+    Runs in a subprocess with a meta-path blocker because ``sys.modules`` is
+    process-global: an earlier test that legitimately imported the RAG stack
+    would give this a false pass (the aiohttp precedent in
+    ``lessons-testing-evidence.md``).
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _MISSING_EXTRAS_SNIPPET)
+    assert result.returncode == 0, (
+        "missing-extras degradation contract failed:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "MISSING_EXTRAS_OK" in result.stdout
+
+
+def test_search_modes_is_import_cheap_and_single_sourced(tmp_path: Path) -> None:
+    """The extracted vocabulary must cost nothing and stay one object.
+
+    ``chunking_engine_version.py`` (TASK-21102) is the exemplar: a pure value
+    a boot-path module needs, lifted out of the heavy module that owned it,
+    and re-imported by that module so no second copy can drift. Both
+    properties are checked here, plus the two consumers that read it.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _SEARCH_MODES_SNIPPET)
+    assert result.returncode == 0, (
+        f"search_modes contract failed:\nstdout={result.stdout}\n"
+        f"stderr={result.stderr[-4000:]}"
+    )
+    assert "SEARCH_MODES_OK" in result.stdout

--- a/Tests/Performance/test_app_import_weight.py
+++ b/Tests/Performance/test_app_import_weight.py
@@ -118,6 +118,20 @@ ELIMINATED_MODULES = ("torch", "transformers")
 #   a perf assertion. A genuinely cold run (no .pyc anywhere, cold FS cache)
 #   was measured at 5.6s on the machine above, so a "tightened" time bound
 #   would buy noise-driven flakes, not signal.
+#
+# TASK-21731 re-measured on 2026-08-24, after this budget had caught its
+# first real regression: `tldw_chatbook.*` had reached 703 (the whole
+# Chunking engine + the RAG_Search.simplified tree + Internal_Prompts, all
+# pulled by one module-scope import in
+# `Library/library_local_rag_search_service.py`). Deferring it returned the
+# count to 637 -- the drift signal worked exactly as designed, and the
+# budget was NOT relaxed to accommodate the regression. The 637 is the 630
+# above plus unrelated growth since, plus the one-module stdlib-only
+# `RAG_Search/search_modes.py` that replaced the heavy import. Note what
+# this axis still cannot see: the same modules were also being imported
+# during the initial Chat screen mount, so removing them from the app
+# import alone left time-to-interactive unchanged -- that leg is guarded by
+# `Tests/Packaging/test_rag_boot_import_closure.py`.
 MAX_IMPORT_SECONDS = 8.0
 MAX_MODULE_COUNT = 2200
 MAX_TLDW_MODULE_COUNT = 660

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8144,3 +8144,48 @@ service's method KINDS first (`async def`, `async def ... yield`, plain `def`,
 plain generator), because the predicate is only as complete as the service it was
 written against. A plain sync generator has the mirror-image problem: routing it
 through a thread returns the generator without running any of it.
+---
+
+## An import-weight guard cannot see a cost that merely moved to screen mount (2026-08-24)
+
+**TASK-21731.** `import tldw_chatbook.app` had grown from 636 to 703 of this repo's
+own modules — the whole `Chunking` engine, the `RAG_Search.simplified` tree and
+`Internal_Prompts`, all in front of first paint. One module-scope import caused it
+(`Library/library_local_rag_search_service.py` reading `normalize_rag_search_mode`
+from `simplified.active_config`, a three-element frozenset lookup), and deferring
+that one import took the count straight back to 637 and turned two red guards green:
+`test_app_import_weight.py`'s own-module budget and
+`Tests/Packaging/test_chunking_import_closure.py`, **both of which had been failing
+on dev, so every branch inherited them red and the next regression would have been
+invisible**.
+
+That fix, on its own, bought the user nothing. A time-to-interactive probe (import →
+`TldwCli()` → `run_test()` → `_ui_ready`, censusing `sys.modules` at readiness)
+showed **Chunking 34, simplified 18, Internal_Prompts 10 still resident when the app
+became usable**: `Event_Handlers/Chat_Events/chat_rag_events.py` — imported during
+the *initial Chat screen mount*, on the event loop, via
+`UI/Console_Modules/retrieval.py` — ran a module-scope `try: from
+...RAG_Search.simplified import ...` availability probe. Timed with an import tracer,
+that single edge cost **50 ms** at mount. The eager boot import had merely been
+paying it early. Deferring the probe too (resolve on first ask, PEP 562
+`__getattr__` keeping the public flag readable) took residency at readiness to
+**Chunking 0, simplified 0** and the total from 984 to 928.
+
+**What to do.** `import tldw_chatbook.app` is a *budget*, not a boundary. Before
+claiming a deferral removed work, census `sys.modules` at `_ui_ready`, not after the
+import — and when the count does not drop, trace which module pulled it back in: the
+second importer is usually the default screen's mount chain, which every user walks
+anyway. This is the third recorded instance of the same shape (`__init__` is not the
+boundary, first paint is — TASK-21111; deferring at the CONSUMER can move the cost —
+TASK-21200); the instrument that settles it in one run is an import tracer that
+records the *importing module* and the *duration* of each first import, not a
+count.
+
+**Corollary on scope.** The bisect that filed this named three files as the cause
+(`MCP/server.py`, `MCP/tools.py`, `UI/MCP_Modules/mcp_inspector.py`). None of the
+three was on the boot path: `MCP/server.py` is in the closure but imports no RAG,
+`MCP/tools.py` (which *does* eagerly import `simplified.search_service`) is not in
+the closure at all, and `mcp_inspector.py` imports no RAG. A tracer that records
+`(importer, imported)` edges for the whole boot answered this in one run and disagreed
+with a plausible reading of the diff — run it before believing any reported chain,
+including one that comes with a bisect.

--- a/backlog/tasks/task-21731 - Boot-import-closure-regression-Chunking-RAG_Search-simplified-and-Internal_Prompts-are-eager-again.md
+++ b/backlog/tasks/task-21731 - Boot-import-closure-regression-Chunking-RAG_Search-simplified-and-Internal_Prompts-are-eager-again.md
@@ -1,0 +1,162 @@
+---
+id: TASK-21731
+title: >-
+  Boot import-closure regression - Chunking, the RAG_Search.simplified stack and Internal_Prompts are eager again
+status: Done
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - startup
+  - regression
+priority: high
+dependencies: []
+---
+
+## Description
+
+`import tldw_chatbook.app` executes 703 of this repo's own modules, up from 636. The 67
+added are the whole `Chunking` engine (33), the `RAG_Search.simplified` service stack (24)
+and `Internal_Prompts` (10) — none of which any user needs before first paint, including
+one who never opens a RAG surface.
+
+This undoes the guarantee TASK-21102 shipped ("app boot no longer executes the ~15k-LOC
+chunking engine") and it is invisible: the two guards that exist to catch exactly this —
+`Tests/Performance/test_app_import_weight.py::test_app_import_own_module_count_stays_at_the_post_diet_size`
+and `Tests/Packaging/test_chunking_import_closure.py` — are both red on dev, so every
+branch inherits a failing guard and the next boot-weight regression would land unseen.
+
+Context: this belongs to the holistic performance review recorded in
+`Docs/Design/2026-08-22-holistic-perf-review.md` (finding 21102 is the guarantee being
+restored).
+
+## Acceptance Criteria
+
+- [x] `import tldw_chatbook.app` resolves zero `tldw_chatbook.Chunking*`, zero
+      `tldw_chatbook.Internal_Prompts*` and zero `tldw_chatbook.RAG_Search.simplified*`
+      modules.
+- [x] `Tests/Performance/test_app_import_weight.py` passes **without** relaxing
+      `MAX_TLDW_MODULE_COUNT` (it stays at 660).
+- [x] `Tests/Packaging/test_chunking_import_closure.py` passes again.
+- [x] The removed work is gone, not relocated: boot-to-first-screen-usable is not worse,
+      and no deferred import is moved into `on_mount` or a post-paint task.
+- [x] The MCP profile-driven RAG search shipped by PR #2049 still resolves and behaves
+      identically — the deferred seam is exercised by a test that calls it, not merely
+      asserted absent.
+- [x] A failure at first use of a deferred import surfaces through the same path it did
+      when the import was eager (documented walk, plus a test for the optional-dependency
+      case).
+- [x] Every new test fails against a deliberately broken implementation (mutation result
+      recorded per test).
+
+## Implementation Plan
+
+1. Reproduce the closure and time it in an isolated-config subprocess; bisect the chain
+   with an import tracer rather than trusting a reported chain.
+2. Break every eager edge into `RAG_Search.simplified` from the boot path, following the
+   house pattern established by TASK-21102 (pure constants/helpers move to a stdlib-only
+   module outside the heavy package; everything else defers to its use site).
+3. Re-measure the closure and wall time, arms interleaved, and measure time-to-interactive
+   to prove the work is not merely relocated.
+4. Walk the first-use failure modes of every deferred import and cover the reachable ones.
+5. Add closure guards; mutation-test each one.
+
+## Implementation Notes
+
+**Two edges, not one.** The reported chain named three MCP files; an import tracer
+recording `(importer, imported)` edges over the whole boot disagreed with all three
+(`MCP/server.py` is in the closure but imports no RAG; `MCP/tools.py` does eagerly
+import `simplified.search_service` but is **not** in the boot closure;
+`UI/MCP_Modules/mcp_inspector.py` imports no RAG at all). The real boot edge was a
+single line PR #2049 added to `Library/library_local_rag_search_service.py`:
+`from ...simplified.active_config import normalize_rag_search_mode`. That module is on
+the app's import path, and `active_config` pulls `simplified.rag_service` ->
+`chunking_service` -> the Chunking engine -> `Internal_Prompts`.
+
+Deferring that alone took the closure from **703 to 637** and turned both red guards
+green — and bought the user **nothing**. A time-to-interactive probe (import ->
+`TldwCli()` -> `run_test()` -> `_ui_ready`, censusing `sys.modules` at readiness)
+showed Chunking 33 / simplified 19 / Internal_Prompts 10 still resident when the app
+became usable: `Event_Handlers/Chat_Events/chat_rag_events.py`, imported during the
+**initial Chat screen mount** via `UI/Console_Modules/retrieval.py`, ran a module-scope
+`try: from ...RAG_Search.simplified import ...` availability probe — **50 ms** on the
+event loop, timed with the same tracer. The eager boot import had merely been paying it
+early.
+
+**What shipped.**
+
+1. `tldw_chatbook/RAG_Search/search_modes.py` — new, stdlib-only: `RAG_SEARCH_MODES` +
+   `normalize_rag_search_mode`, lifted out of `active_config`. Same shape as
+   `chunking_engine_version.py` (TASK-21102): `active_config` re-imports both names, so
+   there is one object in the process and no copy that can drift from the vocabulary
+   `SearchConfig.default_search_mode` validates against. The Library service imports it
+   at module scope, which keeps the existing monkeypatch seam
+   (`test_resolve_profile_search_mode_delegates_normalization`) working.
+2. `chat_rag_events` resolves its availability probe on first ask
+   (`_rag_services_available()`, cached), with a PEP 562 module `__getattr__` keeping
+   `chat_rag_events.RAG_SERVICES_AVAILABLE` readable for external callers. The module's
+   own consumer had to switch to the function — a bare global lookup does not consult a
+   module `__getattr__`.
+
+**First-use failure walk (all three deferrals).** The `search_modes` import cannot fail
+(stdlib only), and it strictly *removes* a boot failure mode: an `active_config` that
+failed to import used to take the app's import down with it. The `chat_rag_events`
+probe keeps its `except ImportError` verbatim, so a plain install without the
+`embeddings_rag` extra gets the identical observable outcome — one warning, a `False`
+flag, `None` from `get_or_initialize_rag_service` — just at first ask
+(pinned by `test_missing_rag_extras_degrade_at_first_use...`). A NON-`ImportError`
+raised by `simplified` used to abort the Chat-screen module import (a dead app); it now
+propagates out of `get_or_initialize_rag_service`, which has **zero production callers**
+— every live RAG path resolves through `ingestion_indexing.get_shared_rag_service`,
+whose own error handling is untouched.
+
+**Deliberately left eager, with reasons.** `Internal_Prompts` still loads at Chat-screen
+mount (10 modules, 2.6 ms) via `Agents/agent_service`, which reads
+`CATALOG["agents.subagent_system"].default` into a module constant; it leaves the boot
+closure but deferring the mount leg means restructuring that constant, for 2.6 ms.
+`UI/Screens/settings_rag_profile_adapter` imports `active_config`,
+`collection_fingerprint` and `collection_indexes` at module scope as documented
+monkeypatch seams, so the background screen pre-importer still warms the RAG stack
+~0.2 s after first paint on a daemon thread (pre-existing, both arms, finding 21113's
+territory). Neither is part of this regression.
+
+**Measured, arms interleaved twice (5 runs/arm/pass for import, 3 for TTI; machine under
+concurrent load, load average 8–16).**
+
+| | base `65386b917` | fixed |
+|---|---|---|
+| `import tldw_chatbook.app` own modules | 703 | **637** |
+| total `sys.modules` | 2123 | **1960** |
+| import wall, pass A / pass B (median) | 876.0 / 885.6 ms | **834.3 / 854.9 ms** |
+| time-to-interactive, pass A / pass B (median) | 2699.9 / 2778.1 ms | **2478.5 / 2650.9 ms** |
+| resident at `_ui_ready`: Chunking / simplified / Internal_Prompts | 33 / 19 / 10 | **0 / 0 / 10** |
+| total `tldw_chatbook.*` at `_ui_ready` | 984 | **928** |
+
+The last two rows are the point: the work is absent when the app becomes usable, not moved
+somewhere later in the boot.
+
+**Test A/B (identical command, both arms).** `Tests/RAG Tests/RAG_Search Tests/MCP
+Tests/Packaging Tests/Performance`: base **16 failed / 2527 passed / 18 skipped**, fixed
+**9 failed / 2534 passed / 18 skipped**. The 9 are byte-identical on both arms
+(`test_fts5_match_forms_shared`, `test_gateway_runtime_prompts`,
+`test_installed_distribution::…migrates_v35…[source|sdist]`, and five
+`test_rag_citation_provenance_benchmark` tests) — all pre-existing. The 7-failure
+difference is exactly this task's guards: the two that were red on dev
+(`test_app_import_own_module_count_stays_at_the_post_diet_size`,
+`test_chunking_import_closure::test_app_import_does_not_execute_chunking`) plus the 5 new
+ones, all red on base and green here.
+
+**Pre-existing preflight red, not mine.** `./scripts/preflight.sh` reports 4/5 green and
+one failure — the production diagnostic inventory, naming
+`RAG_Search/simplified/{enhanced_rag_service_v2,rag_service,search_service}.py`. The same
+three rows drift byte-identically on pristine `65386b917` (verified by restoring the base
+tree and re-running the check), so the pin went stale at PR #2049's merge. None of the
+three is touched here, so `--write` was deliberately NOT run.
+
+**Modified/added files.** `tldw_chatbook/RAG_Search/search_modes.py` (new),
+`tldw_chatbook/RAG_Search/simplified/active_config.py`,
+`tldw_chatbook/Library/library_local_rag_search_service.py`,
+`tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py`,
+`Tests/Packaging/test_rag_boot_import_closure.py` (new, 5 tests),
+`Tests/Performance/test_app_import_weight.py` (budget docstring only — the limit is
+unchanged at 660), `backlog/docs/lessons-testing-evidence.md`.

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -107,17 +107,69 @@ class _ScopeExistenceReadError(RuntimeError):
 _CURRENT_ACTIVE_SESSION = object()
 
 
-# Check if RAG dependencies are available
-try:
-    from ...RAG_Search.simplified import (
-        create_rag_service,  # noqa: F401
-        create_config_for_collection,  # noqa: F401
-    )
+# Are the RAG dependencies available? Resolved on FIRST ASK, not at import
+# (TASK-21731).
+#
+# This module is imported during the initial Chat screen mount (via
+# `UI/Console_Modules/retrieval.py`), on the event loop, before the app is
+# interactive. The probe below executes `RAG_Search.simplified` -- and with
+# it `chunking_service` -> the ~15k-LOC `Chunking` engine and
+# `Internal_Prompts` -- measured at 50 ms on a fast M-series box, paid by
+# every user on every launch including one who never runs a retrieval.
+#
+# Semantics preserved exactly: the same two names are imported, the same
+# `ImportError` is caught, the same warning is logged (once), and the same
+# boolean is cached for the process. What moves is WHEN: the first caller
+# that actually asks (`get_or_initialize_rag_service`) pays it, and a
+# missing optional dependency surfaces there -- as the same `None` return
+# and the same warning line -- instead of at import.
+_RAG_SERVICES_AVAILABLE: Optional[bool] = None
 
-    RAG_SERVICES_AVAILABLE = True
-except ImportError:
-    logger.warning("RAG services not available")
-    RAG_SERVICES_AVAILABLE = False
+
+def _rag_services_available() -> bool:
+    """Whether the simplified RAG service package can be imported.
+
+    Returns:
+        ``True`` when ``RAG_Search.simplified`` resolves its constructors,
+        ``False`` when it raises ``ImportError`` (missing RAG extras). The
+        answer is computed once and cached for the process.
+    """
+    global _RAG_SERVICES_AVAILABLE
+    if _RAG_SERVICES_AVAILABLE is None:
+        try:
+            from ...RAG_Search.simplified import (
+                create_rag_service,  # noqa: F401
+                create_config_for_collection,  # noqa: F401
+            )
+
+            _RAG_SERVICES_AVAILABLE = True
+        except ImportError:
+            logger.warning("RAG services not available")
+            _RAG_SERVICES_AVAILABLE = False
+    return _RAG_SERVICES_AVAILABLE
+
+
+def __getattr__(name: str) -> Any:
+    """Keep ``chat_rag_events.RAG_SERVICES_AVAILABLE`` readable (PEP 562).
+
+    The flag used to be a module constant. External readers still get the
+    same boolean; resolving it here means the import cost is paid by whoever
+    asks rather than by every importer of this module. Note that the
+    module's own functions must call ``_rag_services_available()`` -- a bare
+    global lookup does not consult this hook.
+
+    Args:
+        name: Attribute being resolved.
+
+    Returns:
+        The resolved attribute value.
+
+    Raises:
+        AttributeError: For any other name, as usual.
+    """
+    if name == "RAG_SERVICES_AVAILABLE":
+        return _rag_services_available()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 async def perform_plain_rag_search(
@@ -417,7 +469,7 @@ async def get_or_initialize_rag_service(app: "TldwCli") -> Optional[Any]:
     callers that need the WHY on failure should call
     ``resolve_semantic_rag_service`` directly.
     """
-    if not RAG_SERVICES_AVAILABLE:
+    if not _rag_services_available():
         return None
 
     # Profile preference from config (first construction only; the shared

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -33,7 +33,13 @@ from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_ROUTE_NOTES_KEY,
     LIBRARY_RAG_SERVICE_ERROR_SELECTOR,
 )
-from tldw_chatbook.RAG_Search.simplified.active_config import (
+# TASK-21731: read the mode vocabulary from the stdlib-only `search_modes`
+# module, NOT from `simplified.active_config` -- this module is on the app's
+# import path, and active_config drags the whole simplified service tree
+# (-> chunking_service -> the Chunking engine -> Internal_Prompts) with it.
+# active_config re-imports the same objects, so normalization stays single-
+# sourced. Guarded by `Tests/Packaging/test_rag_boot_import_closure.py`.
+from tldw_chatbook.RAG_Search.search_modes import (
     normalize_rag_search_mode,
 )
 

--- a/tldw_chatbook/RAG_Search/search_modes.py
+++ b/tldw_chatbook/RAG_Search/search_modes.py
@@ -1,0 +1,45 @@
+"""The RAG search-mode vocabulary and its normalizer (stdlib only).
+
+Split out of ``RAG_Search/simplified/active_config.py`` by TASK-21731 for the
+same reason ``tldw_chatbook/chunking_engine_version.py`` was split out of
+``Chunking/`` by TASK-21102: a boot-path module needed one pure helper, and
+importing the module that held it executed a service tree.
+
+``Library/library_local_rag_search_service.py`` is on the app's import path
+and calls ``normalize_rag_search_mode`` to read the active profile's mode.
+Importing it from ``active_config`` pulled ``simplified.rag_service`` ->
+``chunking_service`` -> the whole ``Chunking`` engine -> ``Internal_Prompts``:
+67 modules of this repo executed before first paint, for a function that
+compares a string against a three-element frozenset.
+
+``active_config`` re-imports both names from here, so there is exactly one
+``_RAG_SEARCH_MODES`` object and one ``normalize_rag_search_mode`` function in
+the process — no second copy that can drift from the vocabulary
+``SearchConfig.default_search_mode`` validates against.
+
+This module must stay import-cheap: **standard library only**, no
+``tldw_chatbook`` imports. Guarded by
+``Tests/Packaging/test_rag_boot_import_closure.py``.
+"""
+
+from __future__ import annotations
+
+#: The exact vocabulary ``SearchConfig.default_search_mode`` supports
+#: (``RAG_Search/simplified/config.py``). Anything else -- a hand-edited
+#: TOML, a future mode this build does not know -- normalizes to
+#: ``"semantic"``, the historical behavior.
+RAG_SEARCH_MODES = frozenset({"plain", "semantic", "hybrid"})
+
+
+def normalize_rag_search_mode(value: object) -> str:
+    """Return a supported exact search mode.
+
+    Args:
+        value: Candidate search mode.
+
+    Returns:
+        ``value`` when it is a supported mode; otherwise ``"semantic"``.
+    """
+    return (
+        value if isinstance(value, str) and value in RAG_SEARCH_MODES else "semantic"
+    )

--- a/tldw_chatbook/RAG_Search/simplified/active_config.py
+++ b/tldw_chatbook/RAG_Search/simplified/active_config.py
@@ -27,10 +27,15 @@ if TYPE_CHECKING:
     from ..config_profiles import ProfileConfig
 from ..ingestion_indexing import reset_shared_rag_service
 from ..reranker import RerankingConfig
+# TASK-21731: the mode vocabulary + its normalizer live in the stdlib-only
+# `RAG_Search/search_modes.py` so `Library/library_local_rag_search_service`
+# (on the app's import path) can read them without executing this module's
+# service tree. Re-imported here so both names stay single-sourced.
+from ..search_modes import RAG_SEARCH_MODES as _RAG_SEARCH_MODES
+from ..search_modes import normalize_rag_search_mode
 
 DEFAULT_PROFILE = "hybrid_basic"
 _IMPORTED_ID = "imported_settings"
-_RAG_SEARCH_MODES = frozenset({"plain", "semantic", "hybrid"})
 
 # Legacy TOML keys (task-495): non-index-determining query-time settings a
 # user may have hand-set under the deprecated [AppRAGSearchConfig.rag.search]
@@ -43,20 +48,6 @@ _RAG_SEARCH_MODES = frozenset({"plain", "semantic", "hybrid"})
 # SP1 adopts the legacy collection under.
 _LEGACY_SEARCH_KEYS = ("default_top_k", "score_threshold", "include_citations")
 _LEGACY_PROCESSOR_KEYS = ("enable_reranking", "reranker_model", "reranker_top_k")
-
-
-def normalize_rag_search_mode(value: object) -> str:
-    """Return a supported exact search mode.
-
-    Args:
-        value: Candidate search mode.
-
-    Returns:
-        ``value`` when it is a supported mode; otherwise ``"semantic"``.
-    """
-    return (
-        value if isinstance(value, str) and value in _RAG_SEARCH_MODES else "semantic"
-    )
 
 
 def _manager():


### PR DESCRIPTION
## Summary

`import tldw_chatbook.app` had grown to **703** in-package modules from 636 — the whole `Chunking`
engine, the `RAG_Search.simplified` stack and `Internal_Prompts`, all loaded before the app can
paint, for every user including one who never opens a RAG surface. Two guards that exist to catch
exactly this had been **red on dev, unnoticed**.

Bisected to the merge of PR #2049 (`codex/task-3500-mcp-profile-rag`): `d589c56c5` passes,
`1daa47f0a` fails.

## The obvious fix would have been worthless

I filed this with a chain through `MCP/server.py`, `MCP/tools.py` and `mcp_inspector.py`. **All
three were wrong**, and an import tracer recording `(importer, imported)` edges over the whole boot
found the real one: `MCP/server.py` imports no RAG; `MCP/tools.py` *does* eagerly import
`simplified.search_service` but **is not in the boot closure at all**; `mcp_inspector.py` imports
no RAG. The actual boot edge was a single line PR #2049 added to
`Library/library_local_rag_search_service.py` → `active_config` → `rag_service` →
`chunking_service` → the Chunking engine → `Internal_Prompts`.

And deferring **only** that would have looked like a complete fix while fixing almost nothing. It
takes the closure to 637 and turns both guards green — but a time-to-interactive probe showed
**Chunking 33 / simplified 19 / Internal_Prompts 10 still resident at `_ui_ready`**, because
`Event_Handlers/Chat_Events/chat_rag_events.py`, imported during the initial Chat-screen mount **on
the event loop**, runs a module-scope availability probe timed at **50 ms**. The eager boot import
had merely been paying that cost early. Both edges had to go.

## Measured (arms interleaved twice; machine under load, LA 8–16)

| | base `65386b917` | fixed |
|---|---|---|
| own modules at `import tldw_chatbook.app` | 703 | **637** |
| total `sys.modules` | 2123 | **1960** |
| import wall, pass A / B (median of 5) | 876.0 / 885.6 ms | **834.3 / 854.9 ms** |
| **time-to-interactive**, pass A / B (median of 3) | 2699.9 / 2778.1 ms | **2478.5 / 2650.9 ms** |
| **at `_ui_ready`: Chunking / simplified / Internal_Prompts** | 33 / 19 / 10 | **0 / 0 / 10** |
| total `tldw_chatbook.*` at `_ui_ready` | 984 | **928** |

*Provenance note*: the wall-time and TTI rows were measured against base `65386b917`. The branch
has since been rebased onto `6db0f9f14`, and the timing arms were **not** re-measured there. What
*was* re-confirmed on the rebased base is the load-bearing evidence — 637 own modules, Chunking 0,
simplified 0, Internal_Prompts 0, total 1960, identical to the pre-rebase figures — plus a
byte-identical production patch across the rebase and 109 passed / 0 failed on the guards. Treat
the millisecond deltas as measured-on-the-original-base rather than re-derived.

The last two rows are the gone-not-relocated proof: **56 modules absent when the app becomes
usable**, not merely absent from the import span. `MAX_TLDW_MODULE_COUNT` stays **660** — the guard
was not relaxed to accommodate the regression.

## First-use failure paths

Lazification is the change class that has broken this programme three times, so each moved import
was walked:

- `search_modes` is stdlib-only and cannot fail. It strictly **removes** a boot failure mode: an
  `active_config` that failed to import used to take the app's own import down with it.
- `chat_rag_events` keeps its `except ImportError` verbatim — a plain install without
  `embeddings_rag` gets the same single warning, the same `False` flag and the same `None` from
  `get_or_initialize_rag_service`, just at first ask. Pinned by a subprocess test with a meta-path
  blocker.
- A **non**-`ImportError` from `simplified` used to abort the Chat-screen module import (dead app);
  it now propagates out of `get_or_initialize_rag_service`, which has **zero production callers** —
  every live RAG path goes through `ingestion_indexing.get_shared_rag_service`, untouched.
- Left eager, with reasons stated: `Internal_Prompts` still loads at Chat mount (10 modules,
  2.6 ms) via `Agents/agent_service`'s module-scope `CATALOG[...]` constant, and
  `settings_rag_profile_adapter`'s RAG imports are documented monkeypatch seams.

## PR #2049's feature still works

`Tests/Packaging/test_rag_boot_import_closure.py` includes a test that drives **both legs of #2049's
feature from the deferred state**: Library profile-mode resolution answers correctly *without*
loading anything, then `SimplifiedRAGSearchService.profile_search` loads the stack on demand and
routes by the active mode. **All 465 of PR #2049's own tests pass.**

## Mutation: 7 arms, all red

Restore the `active_config` import · restore the eager probe · probe always False · `ImportError`
no longer caught · `active_config` re-declares the normalizer · `_resolve_profile_search_mode`
returns raw · `profile_search` ignores the active mode. `__pycache__` cleared each time.

## Verification

`Tests/RAG RAG_Search MCP Packaging Performance`, identical command both arms: base **16 failed /
2527 passed**, fixed **9 failed / 2534 passed**. The 9 are identical on both arms and pre-existing
(fts5 match forms, gateway runtime prompts, 2× installed-distribution v35 migrate, 5× rag-citation
benchmark). The 7-failure delta is exactly this task's guards. Preflight green after rebase; both
import guards pass.

## Also found

- **Two guards had been silently red on dev**: `test_app_import_own_module_count...` and
  `test_chunking_import_closure::test_app_import_does_not_execute_chunking`.
- **`MCP/tools.py:18` still eagerly imports `simplified.search_service`** — not on the boot path
  today, but a latent second entry point that would reintroduce this.
- A lesson is recorded: *an import-weight guard cannot see a cost that merely moved to screen
  mount*. Without the `_ui_ready` census, this fix would have measured as a complete success while
  leaving 62 of the 67 modules loading before the user could type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
