### PR TITLE
One flag, one meaning, and two holes in the offline guard (TASK-21562.1)

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -99,7 +99,20 @@ if os.environ.get("TLDW_TEST_REAL_KEYRING") != "1":
 #
 # `TLDW_TEST_ALLOW_HF_DOWNLOADS=1` opts out, for a test that genuinely needs a
 # live fetch.
-if os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS") != "1":
+# Truthy, not `== "1"`. `Tests/RAG_Search/conftest.py` already reads this same
+# flag as `.strip().lower() in {"1","true","yes","on"}`, so an exact-match test
+# here meant `TLDW_TEST_ALLOW_HF_DOWNLOADS=true` opted out there and stayed
+# offline here -- one flag, two answers (TASK-21562.1).
+_HF_DOWNLOAD_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _hf_downloads_allowed() -> bool:
+    """Whether this session opted into real HuggingFace downloads."""
+    raw = os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS", "")
+    return raw.strip().lower() in _HF_DOWNLOAD_TRUTHY
+
+
+if not _hf_downloads_allowed():
     os.environ["HF_HUB_OFFLINE"] = "1"
 
 import pytest  # noqa: E402
@@ -536,7 +549,7 @@ def _huggingface_hub_is_offline(monkeypatch: pytest.MonkeyPatch) -> None:
     per-test is restored -- the same reasoning as
     ``Tests/RAG_Eval/conftest.py``'s fixture, which does this for its own scope.
     """
-    if os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS") == "1":
+    if _hf_downloads_allowed():
         return
     constants = sys.modules.get("huggingface_hub.constants")
     if constants is None:

--- a/Tests/test_huggingface_offline.py
+++ b/Tests/test_huggingface_offline.py
@@ -29,8 +29,12 @@ OPT_OUT = "TLDW_TEST_ALLOW_HF_DOWNLOADS"
 #: developer who asked for live fetches should not get a red suite for it. They
 #: skip rather than `return`, so the opt-out is visible in the run's summary
 #: instead of looking like three tests that passed while asserting nothing.
+#: Matches the root conftest and `Tests/RAG_Search/conftest.py`: this flag is
+#: truthy, not exactly "1" (TASK-21562.1).
+_TRUTHY = {"1", "true", "yes", "on"}
+
 pytestmark = pytest.mark.skipif(
-    os.environ.get(OPT_OUT) == "1",
+    os.environ.get(OPT_OUT, "").strip().lower() in _TRUTHY,
     reason=f"{OPT_OUT}=1: this session deliberately permits model downloads",
 )
 
@@ -55,10 +59,16 @@ def test_huggingface_hub_actually_reports_itself_offline() -> None:
     version, that should be a loud failure telling us to re-check how offline
     mode is decided, not a silently skipped assertion.
     """
-    from huggingface_hub import constants, is_offline_mode
+    hub = pytest.importorskip(
+        "huggingface_hub",
+        reason=(
+            "huggingface_hub is not installed, so nothing can reach the hub and "
+            "there is no offline latch to check"
+        ),
+    )
 
-    assert constants.HF_HUB_OFFLINE is True
-    assert is_offline_mode() is True
+    assert hub.constants.HF_HUB_OFFLINE is True
+    assert hub.is_offline_mode() is True
 
 
 def test_the_autouse_fixture_covers_an_already_imported_module() -> None:
@@ -68,10 +78,15 @@ def test_the_autouse_fixture_covers_an_already_imported_module() -> None:
     fixture's `sys.modules` lookup succeeds. Ordering makes this cheap: nothing
     here imports the hub stack on its own account.
     """
-    constants = sys.modules.get("huggingface_hub.constants")
-    assert constants is not None, (
-        "the previous test imported huggingface_hub, so it must be in sys.modules "
-        "-- if it is not, these tests were reordered and this one no longer "
-        "checks the already-imported path it exists for"
+    # Import it here rather than relying on a previous test having done so.
+    # The original leaned on declaration order and returned early when the
+    # lookup missed -- so running this test alone, or reordering the file,
+    # silently checked nothing (TASK-21562.1).
+    pytest.importorskip(
+        "huggingface_hub",
+        reason="huggingface_hub is not installed; the fixture has nothing to patch",
     )
+
+    constants = sys.modules.get("huggingface_hub.constants")
+    assert constants is not None, "importorskip above must have populated sys.modules"
     assert constants.HF_HUB_OFFLINE is True

--- a/backlog/tasks/task-21562.1 - One-flag-two-answers-and-two-weaknesses-in-the-offline-guard.md
+++ b/backlog/tasks/task-21562.1 - One-flag-two-answers-and-two-weaknesses-in-the-offline-guard.md
@@ -1,0 +1,68 @@
+---
+id: TASK-21562.1
+title: 'One flag, two answers, and two weaknesses in the offline guard'
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-08-24 18:09'
+labels:
+  - testing
+  - test-integrity
+dependencies: []
+parent_task_id: TASK-21562
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Review findings on the change that forbade model downloads during tests. All three are
+genuine, and the parent change was merged before they were read — recorded here rather than
+quietly folded in.
+
+The opt-out flag is read two different ways. One suite treats it as a truthy word, accepting
+the usual spellings; the root bootstrap compared it against a single literal. Setting it to
+anything other than that literal opted out in one place and not the other, which is worse
+than either behaviour on its own: the run is partly offline, and the reason is invisible.
+
+The guard's own tests import the hub client directly. Where that client is not installed —
+which is the only situation in which the guard is unnecessary — the tests fail on the import
+rather than skipping.
+
+And one of them depended on a sibling test having run first to populate the module table.
+Alone, or after a reordering, its lookup missed and the test returned without checking
+anything. The dependency was written into its docstring rather than removed, which is the
+wrong side of a choice: a test that silently checks nothing when run alone is not a guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The opt-out flag means the same thing everywhere it is read
+- [x] #2 The guard's tests skip rather than error where the hub client is absent
+- [x] #3 No test in the file depends on another having run first
+- [x] #4 Each fix is demonstrated, including that the flag's alternative spellings now take effect
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**AC#1.** `Tests/RAG_Search/conftest.py` reads `TLDW_TEST_ALLOW_HF_DOWNLOADS` as
+`.strip().lower() in {"1","true","yes","on"}`. The root bootstrap used `== "1"`, so
+`TLDW_TEST_ALLOW_HF_DOWNLOADS=true` opted out there and stayed offline here. Both root sites
+now share one `_hf_downloads_allowed()` helper using the same truthy set.
+
+Demonstrated: with `=true`, the guard tests now report **3 skipped** (opted out). On `dev`
+before this change, the same command reports **3 passed** — the flag was ignored. `=1`
+continues to work.
+
+**AC#2.** `pytest.importorskip("huggingface_hub", reason=...)` replaces the direct import. The
+original carried a comment arguing against a `try/except` so a future API move would fail
+loudly — that reasoning covers version drift, not absence, and conflated the two. Where the
+client is not installed nothing can reach the hub and there is no latch to check.
+
+**AC#3.** The third test relied on the second having imported the client, and returned early
+when the lookup missed — so alone it checked nothing while reporting success. It now imports
+for itself. Verified passing standalone.
+
+Modified: `Tests/conftest.py`, `Tests/test_huggingface_offline.py`.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Three review findings on #2046. **All three are genuine, and I merged that PR before reading
them** — this clears the debt rather than folding it in quietly.

## 1. One flag, two answers

`Tests/RAG_Search/conftest.py` already reads `TLDW_TEST_ALLOW_HF_DOWNLOADS` as
`.strip().lower() in {"1","true","yes","on"}`. The root bootstrap compared it to `"1"`.

So `TLDW_TEST_ALLOW_HF_DOWNLOADS=true` opted out in one place and stayed offline in the
other — a partly-offline run, with no visible reason why. Both root sites now share one
`_hf_downloads_allowed()` helper using the same truthy set.

| `TLDW_TEST_ALLOW_HF_DOWNLOADS=true` | result |
|---|---|
| on `dev` today | **3 passed** — flag ignored, stayed offline |
| with this change | **3 skipped** — opt-out honoured |

`=1` continues to work.

I initially doubted this one, on the grounds that the flag was introduced by #2046 so nothing
else could be reading it. That was wrong — `Tests/RAG_Search/conftest.py` reads it, and calls
it "the general escape hatch". Worth checking before dismissing.

## 2. Direct import where the client may be absent

The guard's tests imported `huggingface_hub` directly, so in a minimal install — **the one
case where the guard is unnecessary** — they error on the import instead of skipping.

The original carried a comment arguing against a `try/except` so a future API move would fail
loudly. That reasoning covers version *drift*, not *absence*, and I conflated the two. Now
`pytest.importorskip` with a reason.

## 3. A test that checked nothing when run alone

The third test relied on the second having imported the client, and returned early when the
`sys.modules` lookup missed — so run in isolation it checked nothing and reported success.

I had written that ordering dependency into its docstring rather than removing it. That was
the wrong side of the choice: a test that silently checks nothing when run alone is not a
guard. It now imports for itself, and passes standalone.

## Verification

`Tests/test_huggingface_offline.py`: 3 passed; 3 skipped with `=true`; 3 skipped with `=1`;
the previously order-dependent test passes on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `TLDW_TEST_ALLOW_HF_DOWNLOADS` semantics and fixes two gaps in the Hugging Face offline guard so test behavior is consistent. Previously, `true/yes/on` opted out in `Tests/RAG_Search` but were ignored in the root bootstrap; now both treat the flag as truthy. Addresses TASK-21562.1.

- Both root sites use a shared `_hf_downloads_allowed()` with `{"1","true","yes","on"}` (case-insensitive). With `TLDW_TEST_ALLOW_HF_DOWNLOADS=true`, the guard tests now skip (opt-out honored); `=1` still works.
- Tests use `pytest.importorskip("huggingface_hub", ...)` to skip when `huggingface_hub` is not installed, avoiding import errors on minimal installs.
- The order-dependent test now imports the hub itself, so it validates correctly in isolation.

<sup>Written for commit d7e218276865239b7e34e298bb6a616e47be121f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

