### PR TITLE
fix(tests): repair the stale Console send harness and prove send works (TASK-21590)

### DIFF
--- a/Tests/UI/app_factory.py
+++ b/Tests/UI/app_factory.py
@@ -124,6 +124,46 @@ def build_test_app_config(
     return config
 
 
+def attach_chachanotes_db(app, *, client_id: str = "test-client"):
+    """Give a factory-built app the durable ChaChaNotes DB a real send needs.
+
+    TASK-21590. `_build_test_app` patches `get_chachanotes_db_lazy` to `None`,
+    so a factory app boots with `chachanotes_db = None`. `ConsoleRuntime.
+    ensure_chat_store` then builds the Console store with `persistence=None` --
+    and since TASK-19900.3's review-fix commit `56db75386` a durable Console
+    turn (any non-ephemeral manual or queued send) *fails closed* unless the
+    persistence adapter exposes a callable ``commit_durable_turn``, which a
+    `None` adapter cannot. That refusal returns a bare `ConsoleSubmitResult`
+    instead of going through `_block`, so it writes no system row and raises no
+    toast: 26 mounted send tests kept pressing Send and asserting against a
+    transcript production had silently refused to write.
+
+    ``:memory:`` is load-bearing, not a shortcut. `ConsoleRuntime.
+    ensure_agent_bridge` deliberately refuses to build an agent bridge for a
+    `:memory:` DB ("an in-memory harness still builds neither"), so this
+    restores exactly the precondition the send path lost -- a durable-capable
+    persistence adapter -- without also switching the caller onto the agent
+    loop, which a file-backed DB does and which these tests were never written
+    against. A test that is *about* the agent runtime must attach a
+    file-backed DB itself.
+
+    Attach BEFORE mounting: the store is built lazily on first use and caches
+    its persistence adapter.
+
+    Args:
+        app: A `_build_test_app` product, not yet mounted.
+        client_id: Client id recorded on the DB's rows.
+
+    Returns:
+        The `CharactersRAGDB` now assigned to ``app.chachanotes_db``.
+    """
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+    db = CharactersRAGDB(":memory:", client_id)
+    app.chachanotes_db = db
+    return db
+
+
 def drain_created_dirs() -> int:
     """Remove every user-data dir created since the last drain.
 

--- a/Tests/UI/conftest.py
+++ b/Tests/UI/conftest.py
@@ -119,6 +119,46 @@ def _disable_model_catalog_refresh(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _no_tiktoken_bpe_download(monkeypatch):
+    """Keep UI token counting off tiktoken's BPE download seam (TASK-21590).
+
+    Incident: repairing the Console send harness let 16 mounted send tests
+    reach `ConsoleProviderGateway.prepare_chat_request` for the first time —
+    `prepare_provider_request` → `_account_categories` → `_count_wire` →
+    `count_console_messages_tokens` → `token_counter.estimate_tokens` →
+    `count_tokens_tiktoken` → `get_tiktoken_encoding`. On a cold cache
+    `tiktoken.get_encoding` fetches its BPE blobs from
+    ``openaipublic.blob.core.windows.net`` over HTTPS, so the egress guard
+    recorded six blocked connects per test and failed each one at teardown.
+    The tests themselves passed; only the guard saw it. The old, broken
+    harness never got past the durable-acceptance gate, so it never reached
+    this seam at all — which is why the failure is invisible on dev.
+
+    ``get_tiktoken_encoding`` is the single chokepoint: every tiktoken use in
+    the Console send path funnels through it (`console_cost_tracker` and
+    `console_session_settings` only reach tiktoken via
+    ``count_tokens_messages``), and it resolves as a module global at call
+    time, so patching it here covers callers that imported
+    ``count_tokens_tiktoken``/``estimate_tokens`` by name.
+
+    Returning ``None`` drives the already-tested no-tokenizer branch
+    (`count_tokens_tiktoken`'s character estimate) — which is what a default
+    install actually does, since tiktoken is not a base dependency
+    (task-2526). No test's LOGICAL coverage changes, only its network access,
+    and the result stops depending on whether this machine happens to have a
+    warm ``$TMPDIR/data-gym-cache`` (which the HOME sandbox does not
+    redirect). A test that needs the real encoding monkeypatches it back
+    within its own scope, exactly as with `_disable_model_catalog_refresh`
+    above.
+    """
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Utils.token_counter.get_tiktoken_encoding",
+        lambda _model: None,
+    )
+
+
 @pytest_asyncio.fixture
 async def mock_app_config():
     """Provide a standard mock app configuration for tests."""

--- a/Tests/UI/test_console_composer_cursor.py
+++ b/Tests/UI/test_console_composer_cursor.py
@@ -14,6 +14,7 @@ from textual.widgets import Static
 
 from Tests.UI.test_console_native_chat_flow import (
     CapturingGateway,
+    _build_console_send_test_app,
     _configure_native_ready_console,
     _wait_for_text,
 )
@@ -463,7 +464,9 @@ async def test_console_composer_ctrl_w_deletes_word_left_of_caret():
 @pytest.mark.asyncio
 async def test_console_composer_shift_enter_inserts_newline_enter_still_sends():
     gateway = CapturingGateway()
-    app = _build_test_app()
+    # TASK-21590: this is the one test in this module that drives a real send,
+    # so it needs the durable persistence the shipping app always has.
+    app = _build_console_send_test_app()
     _configure_native_ready_console(app)
     app.console_provider_gateway_factory = lambda: gateway
     host = ConsoleHarness(app)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -21,6 +21,7 @@ from textual.pilot import OutOfBounds
 from textual.widgets import Button, Checkbox, Input, Static, TextArea
 
 from Tests.fixtures.required_doubles import exploding_double
+from Tests.UI.app_factory import attach_chachanotes_db
 from Tests.UI.background_signals import wait_for_background_signal, wait_for_signal
 from Tests.UI.console_controller_stubs import stub_image_controller
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
@@ -51,6 +52,9 @@ from tldw_chatbook.Chat.console_chat_models import (
 )
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from tldw_chatbook.Chat.console_image_view import IMAGE_CACHE_MAX_ENTRIES
+from tldw_chatbook.Chat.console_library_destination import (
+    resolve_console_destination,
+)
 from tldw_chatbook.Chat.console_provider_gateway import (
     AuxiliaryCompletionResult,
     ConsoleProviderGateway,
@@ -104,6 +108,30 @@ _ASYNC_SETTLE_TIMEOUT = 10.0
 
 def test_checking_citations_is_an_active_console_run_status():
     assert ConsoleRunStatus.CHECKING_CITATIONS in CONSOLE_ACTIVE_RUN_STATUSES
+
+
+def _build_console_send_test_app(*args, **kwargs):
+    """Build a factory app that can actually complete a Console send.
+
+    TASK-21590. `_build_test_app` boots with ``chachanotes_db = None``, so the
+    Console store is built with ``persistence=None``. Since TASK-19900.3's
+    review-fix commit `56db75386` a durable turn (any non-ephemeral manual or
+    queued send -- i.e. the flow every real user takes) *fails closed* unless
+    the persistence adapter exposes a callable ``commit_durable_turn``, and a
+    ``None`` adapter cannot. The refusal returns a bare `ConsoleSubmitResult`
+    rather than going through `_block`, so it writes no system row and raises
+    no toast: 26 tests in this module kept pressing Send and asserting against
+    a transcript the production gate had silently refused to write.
+
+    The shipping app always has this DB (`ConsoleRuntime.ensure_chat_store`
+    builds a real `ChatPersistenceService` from it), so every test here that
+    drives a real send builds its app through this helper instead. Use
+    `_build_test_app` directly for tests that are *about* the db-less shape.
+    See `attach_chachanotes_db` for why the attached DB is `:memory:`.
+    """
+    app = _build_test_app(*args, **kwargs)
+    attach_chachanotes_db(app)
+    return app
 
 
 def _configure_openai_missing_api_key(app) -> None:
@@ -290,8 +318,20 @@ def test_console_workspace_conversation_search_selection_refresh_invalidates_tok
 
 
 class _ReadyResolutionGateway:
+    """Stand-in for `ConsoleProviderGateway` that always resolves ready.
+
+    TASK-21590: a ready resolution must carry the typed
+    `ConsoleResolvedDestination` that `a26cdafd8` made mandatory --
+    `ConsoleChatController._resolved_destination_for_context` raises
+    `ValueError` without it and the send is blocked with "Provider destination
+    is incomplete." This double omitted it, and every mounted send test built
+    on it stopped reaching the provider. The destination is derived through the
+    production classifier the real gateway uses (`resolve_console_destination`)
+    rather than hand-built, so the double cannot silently drift from it again.
+    """
+
     async def resolve_for_send(self, selection):
-        return SimpleNamespace(
+        resolution = SimpleNamespace(
             provider=selection.provider,
             base_url=selection.base_url or "",
             model=selection.explicit_model
@@ -300,6 +340,8 @@ class _ReadyResolutionGateway:
             ready=True,
             visible_copy="",
         )
+        resolution.resolved_destination = resolve_console_destination(resolution)
+        return resolution
 
 
 class _PromptImprovementGateway:
@@ -1370,32 +1412,14 @@ class CapturingGateway(_ReadyResolutionGateway):
             yield chunk
 
 
-class WorkspaceLinkingPersistence:
-    def __init__(self, registry_service) -> None:
-        self.registry_service = registry_service
-        self.conversation_count = 0
-        self.message_count = 0
-
-    def create_conversation(self, **kwargs):
-        self.conversation_count += 1
-        conversation_id = f"persisted-conversation-{self.conversation_count}"
-        workspace_id = kwargs.get("workspace_id")
-        if kwargs.get("scope_type") == "workspace" and workspace_id:
-            self.registry_service.link_membership(
-                workspace_id,
-                item_type="conversation",
-                item_id=conversation_id,
-                role="workspace-thread",
-                title=kwargs.get("conversation_title") or "Chat 1",
-            )
-        return conversation_id
-
-    def create_message(self, **kwargs):
-        self.message_count += 1
-        return f"persisted-message-{self.message_count}"
-
-    def update_message_content(self, **kwargs):
-        return True
+# TASK-21590 removed `WorkspaceLinkingPersistence`, a three-method hand-rolled
+# persistence double that three send tests installed over the store's real
+# adapter. It predates durable turn acceptance and never grew a
+# `commit_durable_turn`, so production refused every send made through it --
+# silently, because that refusal does not go through `_block`. Its whole job
+# (linking a persisted conversation into the workspace registry) is what the
+# real `ChatPersistenceService` already does through the same registry, so the
+# three tests now assert against production's own linking.
 
 
 class StaticConversationTreeService:
@@ -2278,7 +2302,7 @@ def _select_llamacpp_console(console: ChatScreen) -> None:
 async def test_console_native_generic_provider_send_renders_completed_message(
     monkeypatch,
 ):
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.app_config["chat_defaults"] = {"provider": "openai", "model": "gpt-4.1"}
     app.app_config["api_settings"] = {}
     captured_kwargs = []
@@ -2328,7 +2352,7 @@ async def test_console_native_generic_provider_send_renders_completed_message(
 
 @pytest.mark.asyncio
 async def test_console_native_send_button_click_dispatches_message(monkeypatch):
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.app_config["chat_defaults"] = {"provider": "openai", "model": "gpt-4.1"}
     app.app_config["api_settings"] = {}
     captured_kwargs = []
@@ -2368,7 +2392,7 @@ async def test_console_native_send_button_click_dispatches_message(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_console_successful_send_does_not_leave_empty_send_tooltip(monkeypatch):
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.app_config["chat_defaults"] = {"provider": "openai", "model": "gpt-4.1"}
     app.app_config["api_settings"] = {"openai": {"api_key": DUMMY_OPENAI_API_KEY}}
 
@@ -2505,7 +2529,7 @@ async def test_console_setup_blocked_send_is_unreachable_behind_modal():
 
 @pytest.mark.asyncio
 async def test_console_native_blocked_send_preserves_composer_text_and_shows_recovery():
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = BlockedGateway
@@ -2799,7 +2823,7 @@ def test_console_session_settings_base_url_wins_over_llamacpp_fallback(monkeypat
 @pytest.mark.asyncio
 async def test_console_stop_interrupts_stream_and_keeps_partial_message_visible():
     gateway = WaitingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -2831,7 +2855,7 @@ async def test_console_stop_interrupts_stream_and_keeps_partial_message_visible(
 @pytest.mark.asyncio
 async def test_console_collapsed_stop_interrupts_real_run_without_expanding():
     gateway = WaitingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     _configure_native_ready_console(app, model="test-model")
     app.console_provider_gateway_factory = lambda: gateway
     host = ConsoleHarness(app)
@@ -2873,7 +2897,7 @@ async def test_console_collapsed_stop_interrupts_real_run_without_expanding():
 @pytest.mark.asyncio
 async def test_console_collapsed_stop_stale_action_warns_without_expanding():
     gateway = WaitingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     _configure_native_ready_console(app, model="test-model")
     app.console_provider_gateway_factory = lambda: gateway
     notifications: list[tuple[str, dict]] = []
@@ -2908,7 +2932,7 @@ async def test_console_collapsed_stop_stale_action_warns_without_expanding():
 @pytest.mark.asyncio
 async def test_console_composer_stop_is_subdued_when_idle():
     gateway = WaitingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -2963,7 +2987,7 @@ async def test_console_composer_stop_is_subdued_when_idle():
 @pytest.mark.asyncio
 async def test_console_duplicate_send_during_stream_does_not_break_stop_control():
     gateway = WaitingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -3020,7 +3044,7 @@ async def test_console_duplicate_send_during_stream_does_not_break_stop_control(
 @pytest.mark.asyncio
 async def test_console_streaming_chunks_render_after_slow_provider_validation():
     gateway = DelayedWaitingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -3087,7 +3111,7 @@ async def test_console_send_echoes_user_message_before_transcript_poll(monkeypat
     "not sent". The poll is disabled here so the echo has to stand on its own.
     """
     gateway = _HoldingStreamGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -3124,7 +3148,7 @@ async def test_console_send_echoes_user_message_before_transcript_poll(monkeypat
 async def test_console_collapsed_paste_sends_full_payload_not_visible_token():
     long_text = "x" * 80
     gateway = CapturingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -3151,7 +3175,7 @@ async def test_console_collapsed_paste_sends_full_payload_not_visible_token():
 @pytest.mark.asyncio
 async def test_console_native_send_preserves_expanded_payload_whitespace():
     gateway = CapturingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -3173,7 +3197,7 @@ async def test_console_native_send_preserves_expanded_payload_whitespace():
 @pytest.mark.asyncio
 async def test_console_configured_model_reaches_gateway_when_ui_model_is_unset():
     gateway = SelectionCapturingGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     # `chat_defaults.provider` (read by `_effective_console_provider_model`
     # at session-creation time), not `_console_control_provider` set after
     # mount: the active session's settings -- and so its provider -- are
@@ -3210,7 +3234,7 @@ async def test_console_configured_model_reaches_gateway_when_ui_model_is_unset()
 @pytest.mark.asyncio
 async def test_console_native_send_clears_composer_after_acceptance_and_updates_store():
     """Verify accepted sends clear the composer and render compact transcript text."""
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -3248,7 +3272,7 @@ async def test_console_native_send_clears_composer_after_acceptance_and_updates_
 @pytest.mark.asyncio
 async def test_console_chat_lifecycle_state_survives_screen_recreation_return():
     """Verify Console chat tabs, transcript, and draft restore after recreation."""
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -3312,7 +3336,7 @@ async def test_console_chat_lifecycle_state_survives_screen_recreation_return():
 
 @pytest.mark.asyncio
 async def test_console_send_refreshes_workspace_conversation_rail_after_persistence():
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -3326,8 +3350,12 @@ async def test_console_send_refreshes_workspace_conversation_rail_after_persiste
         row_texts = _console_workspace_conversation_texts(console)
         assert any("Chat 1" in text for text in row_texts)
         assert len(console.query("#console-workspace-empty-conversations")) == 0
-        store = console._ensure_console_chat_store()
-        store.persistence = WorkspaceLinkingPersistence(app.workspace_registry_service)
+        # TASK-21590: the hand-rolled WorkspaceLinkingPersistence double that
+        # used to be installed here predates durable turn acceptance and has no
+        # `commit_durable_turn`, so production refused the send outright. The
+        # real `ChatPersistenceService` the store already built links workspace
+        # membership through this same registry, so the double is both stale and
+        # redundant -- assert against production's own linking instead.
         _select_llamacpp_console(console)
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
         composer.load_draft("hello")
@@ -3363,7 +3391,7 @@ async def test_console_send_refreshes_workspace_conversation_rail_after_persiste
 
 @pytest.mark.asyncio
 async def test_console_send_after_workspace_switch_persists_to_selected_workspace():
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -3380,7 +3408,12 @@ async def test_console_send_after_workspace_switch_persists_to_selected_workspac
         await _wait_for_selector(console, pilot, "#console-native-composer")
         await _wait_for_selector(console, pilot, "#console-change-workspace")
         store = console._ensure_console_chat_store()
-        store.persistence = WorkspaceLinkingPersistence(service)
+        # TASK-21590: the hand-rolled WorkspaceLinkingPersistence double that
+        # used to be installed here predates durable turn acceptance and has no
+        # `commit_durable_turn`, so production refused the send outright. The
+        # real `ChatPersistenceService` the store already built links workspace
+        # membership through this same registry, so the double is both stale and
+        # redundant -- assert against production's own linking instead.
         _select_llamacpp_console(console)
         first_session = store.ensure_session()
         store.replace_session_settings(
@@ -3599,7 +3632,7 @@ async def test_console_tab_switch_aligns_active_workspace_context():
 
 @pytest.mark.asyncio
 async def test_console_unsupported_provider_block_renders_one_normalized_system_message():
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     host = ConsoleHarness(app)
 
     async with host.run_test(size=(160, 48)) as pilot:
@@ -4299,7 +4332,7 @@ async def test_console_accepted_send_records_first_send_flag():
     # Reuse the ready-provider send harness from
     # test_console_send_refreshes_workspace_conversation_rail_after_persistence:
     # same fixtures/gateway stub, then assert the persisted global flag.
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -4310,8 +4343,12 @@ async def test_console_accepted_send_records_first_send_flag():
     async with host.run_test(size=(160, 48)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
-        store = console._ensure_console_chat_store()
-        store.persistence = WorkspaceLinkingPersistence(app.workspace_registry_service)
+        # TASK-21590: the hand-rolled WorkspaceLinkingPersistence double that
+        # used to be installed here predates durable turn acceptance and has no
+        # `commit_durable_turn`, so production refused the send outright. The
+        # real `ChatPersistenceService` the store already built links workspace
+        # membership through this same registry, so the double is both stale and
+        # redundant -- assert against production's own linking instead.
         _select_llamacpp_console(console)
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
         composer.load_draft("hello")
@@ -4326,7 +4363,7 @@ async def test_console_accepted_send_records_first_send_flag():
 @pytest.mark.asyncio
 async def test_console_failed_send_does_not_record_first_send_flag():
     """A FAILED first send must not set the one-time onboarding flag (task-182d)."""
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: FailThenRecoverGateway()
@@ -5673,7 +5710,7 @@ async def test_console_selected_message_edit_action_opens_modal_and_saves_conten
 
 @pytest.mark.asyncio
 async def test_console_edit_resend_clears_replaced_descendant_original_attempt():
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -6359,7 +6396,7 @@ async def test_console_save_as_media_failure_notifies_without_crashing():
 @pytest.mark.asyncio
 async def test_console_failed_stream_renders_inline_retry_and_recovers():
     gateway = FailThenRecoverGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway
@@ -6404,7 +6441,7 @@ async def test_console_failed_stream_renders_inline_retry_and_recovers():
 
 @pytest.mark.asyncio
 async def test_console_continue_action_streams_new_message_from_selected_turn():
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -6450,7 +6487,7 @@ async def test_console_continue_action_streams_new_message_from_selected_turn():
 
 @pytest.mark.asyncio
 async def test_console_regenerate_action_streams_selected_variant():
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: CapturingGateway(
@@ -11463,7 +11500,7 @@ async def test_console_save_as_savers_confirm_at_success_severity():
 async def test_console_retry_accepted_fires_success_toast():
     """Retrying a failed response confirms at success severity (FB-07)."""
     gateway = FailThenRecoverGateway()
-    app = _build_test_app()
+    app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
     app.console_provider_gateway_factory = lambda: gateway

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8189,3 +8189,68 @@ the closure at all, and `mcp_inspector.py` imports no RAG. A tracer that records
 `(importer, imported)` edges for the whole boot answered this in one run and disagreed
 with a plausible reading of the diff — run it before believing any reported chain,
 including one that comes with a bisect.
+## A production gate that fails closed on a capability the test double lacks is invisible — the symptom is "nothing happened" (TASK-21590, 2026-08-24)
+
+**What happened.** `Tests/UI/test_console_native_chat_flow.py` was 26 red on dev and had
+been for a day. Every failure looked identical and told you nothing: press Send, wait,
+`AssertionError: Text not found: 'generic provider response'` with a screen dump showing
+`No messages yet.` and the draft still sitting in the composer. No exception, no system row,
+no toast — pressing Send simply did nothing.
+
+The cause was a fail-closed gate meeting a double that had never needed the capability it
+now demands. TASK-19900.3's `56db75386` changed the durable-turn gate from
+
+```python
+if persistence is not None and persistence.db is not None and ... and not callable(durable_commit):
+    return self._block(session.id, "Durable turn acceptance is unavailable; ...")
+```
+
+to
+
+```python
+if durable_turn and not callable(durable_commit):
+    return ConsoleSubmitResult(False, False, "Durable turn acceptance is unavailable; ...")
+```
+
+Two independent changes in one hunk. The first made `persistence=None` — which every
+`_build_test_app` app has, since the factory patches `get_chachanotes_db_lazy` to `None` —
+count as a durable turn that cannot commit. The second dropped `_block()`, which was the
+only thing that put the refusal on screen. So the gate went from "refuses loudly in a
+configuration tests never hit" to "refuses silently in the configuration every mounted
+Console test hits". The commit's own report says plainly: *"No full repository sweep was
+run."*
+
+Repairing that surfaced **two more stale doubles underneath it**, both hidden by the first
+refusal firing earlier in the same function: a fake gateway whose ready resolution had no
+`resolved_destination` (mandatory since `a26cdafd8`), and a hand-rolled three-method
+persistence double with no `commit_durable_turn`. Three layers of the same defect class, and
+you only ever see the outermost one.
+
+**What to do.**
+
+1. **Trace before you read the tests.** The failure text named the assertion, not the cause.
+   Wrapping the real seams in order — button handler → `ConsolePromptQueueUIController.
+   dispatch` → `ConsoleChatController.run_prompt_chain` — printed
+   `ConsoleSubmitResult(accepted=False, visible_copy='Durable turn acceptance is unavailable;
+   the provider was not called.', provider_started=False)` on the first try. `git log -S` on
+   that copy then named the commit in seconds. Reading 11,587 lines of test file first would
+   have found nothing, because nothing in the test was wrong.
+2. **A fail-closed gate must fail *visibly*.** If a refusal returns a bare result instead of
+   going through the path that writes a system row, it is indistinguishable from a dead
+   button — for the suite *and* for a user in the degraded state the gate exists to catch.
+   When you harden a gate, check what the user sees when it fires.
+3. **Expect the double to be the stale half, and expect more than one.** After fixing the
+   first, re-run and read the *new* failure text rather than assuming you are done: each
+   repair moves the failure one gate further down.
+4. **Prefer the harness shape production already names.** `ConsoleRuntime.ensure_agent_bridge`
+   explicitly returns `None` for a `:memory:` DB ("an in-memory harness still builds
+   neither"). Attaching a *file-backed* ChaChaNotes DB fixed the durable gate but also
+   switched 26 tests onto the agent loop, because `[console] agent_runtime` defaults on and
+   the bridge keys off a real `db_path`. `:memory:` restored exactly the lost precondition
+   and nothing else. When production distinguishes a harness case, use that case.
+5. **A red test may be the only honest thing in the file.** Two of the 26 stayed red after
+   the harness was correct, and a live run of the real app confirmed why: Send really is
+   disabled for the whole of every Console run, showing a greyed-out button labelled "Queue"
+   whose tooltip says to wait. Two shipped contracts disagree (ADR-046 vs the durable-owner
+   submission block, each with its own test asserting the opposite). That is an owner
+   decision, not a test edit — filed as TASK-22000 and left red.

--- a/backlog/tasks/task-21590 - Console-send is broadly red on dev - 26 failures in test-console-native-chat-flow.md
+++ b/backlog/tasks/task-21590 - Console-send is broadly red on dev - 26 failures in test-console-native-chat-flow.md
@@ -138,3 +138,51 @@ and reverted by hand; `git diff -- tldw_chatbook/` is empty.
 * `backlog/docs/lessons-testing-evidence.md` — the fail-closed-double lesson
 
 No production code changed.
+
+## Follow-up: the repair unblocked a real egress seam (2026-08-24)
+
+Review caught that the repaired tests were attempting live network egress: 16 teardown
+errors from `Tests/conftest.py`'s `_no_network_io` guard (task-15111), each recording
+`socket.connect -> 57.150.97.129:443` (an `openaipublic.blob.core.windows.net` address).
+The tests themselves passed; only the guard saw it, and because the errors attach to
+*passing* tests that still fail early on dev, a naive A/B baseline shows nothing.
+
+**Seam.** Not `chat_api_call`. Tracing the guard's `_deny` with a stack dump gave one
+distinct stack (the six connects are tiktoken's own retries):
+
+```
+_submit_console_native_draft -> run_prompt_chain -> submit_draft -> _accept_durable_turn
+  -> resume_durable_postcommit -> _run_durable_postcommit_effect
+  -> _stream_assistant_response -> _apply_conversation_memory_preflight
+  -> ConsoleProviderGateway.prepare_chat_request -> prepare_provider_request
+  -> _account_categories -> _count_wire -> count_console_messages_tokens
+  -> token_counter.estimate_tokens -> count_tokens_tiktoken -> get_tiktoken_encoding
+```
+
+`tiktoken.get_encoding` downloads its BPE blobs on a cold cache. The old harness never
+got past the durable-acceptance gate, so it never reached `prepare_chat_request` at all —
+the repair is what exposed the seam.
+
+**Fix.** A `_no_tiktoken_bpe_download` autouse fixture in `Tests/UI/conftest.py`, sibling
+to the existing `_disable_model_catalog_refresh` (task-16198, added for the same guard,
+same shape). It patches the single chokepoint `token_counter.get_tiktoken_encoding` to
+return `None`, which drives the already-tested no-tokenizer branch — the branch a default
+install takes anyway, since tiktoken is not a base dependency (task-2526). No
+`allow_network`, no `loopback_network`, no socket patching, and no narrowing of the
+dispatch under test: the send still runs the whole real path, it just counts tokens by
+character estimate. `Tests/UI` scope keeps `Tests/Chunking` (which legitimately needs a
+real tokenizer and skips when it is uncached) untouched.
+
+**Counts after the fix:** `test_console_native_chat_flow.py` + `test_console_composer_cursor.py`
+= **2 failed, 326 passed, 0 errors** (was 2 failed, 326 passed, **16 errors**). The 2
+failures are the unchanged TASK-22000 pair.
+
+**Mutation kills are unchanged:** M2 (force `durable_commit = None`) still kills 22/25,
+M3 (make `_resolved_destination_for_context` always raise) still kills 23/25, union
+survivors = none, so 25/25. Stubbing the tokenizer did not weaken what the tests exercise.
+
+**Wider cluster:** the 20 adjacent Console UI modules re-run at 26 failed / 600 passed
+with **0 blocked-egress attempts and 0 teardown errors** — the same 26 failures in the
+same 13 modules as before this change. Those tests still stop at the durable gate, so
+they never reached the tokenizer; the fixture pre-empts the seam for whenever they are
+repaired.

--- a/backlog/tasks/task-21590 - Console-send is broadly red on dev - 26 failures in test-console-native-chat-flow.md
+++ b/backlog/tasks/task-21590 - Console-send is broadly red on dev - 26 failures in test-console-native-chat-flow.md
@@ -24,11 +24,11 @@ a single-line control fails the same way — so it is not shift+enter specific.
 
 ## Acceptance Criteria
 
-- [ ] A determination is recorded, with evidence, of whether Console send is genuinely broken in the shipped app or only in the test harness
-- [ ] If the app is broken, the send path is fixed and a test pins the behaviour that regressed
-- [ ] If the harness is stale, the harness is repaired so the tests exercise the real send path again — not deleted, and not relaxed until they pass
-- [ ] `Tests/UI/test_console_native_chat_flow.py` is green on dev
-- [ ] The fix is verified by mutation: breaking send makes these tests fail again
+- [x] A determination is recorded, with evidence, of whether Console send is genuinely broken in the shipped app or only in the test harness
+- [x] If the app is broken, the send path is fixed and a test pins the behaviour that regressed
+- [x] If the harness is stale, the harness is repaired so the tests exercise the real send path again — not deleted, and not relaxed until they pass
+- [ ] `Tests/UI/test_console_native_chat_flow.py` is green on dev — **24 of 26 repaired; 2 deliberately left red, see Implementation Notes and TASK-22000**
+- [x] The fix is verified by mutation: breaking send makes these tests fail again
 
 ## Evidence (verified first-hand on dev 33ff5b754, 2026-08-23)
 
@@ -40,3 +40,101 @@ pytest Tests/UI/test_console_native_chat_flow.py -q -p no:randomly
 Surfaced by the TASK-21501/21123 implementer, which classified rather than waved through the
 composer-suite reds it inherited: 9 of its 12 composer-suite failures trace to this same root
 cause. Independently reproduced here before filing.
+
+## Implementation Plan
+
+1. Trace one representative failure through the real send path (button press -> screen
+   handler -> prompt-queue dispatch -> controller) instead of reading the tests first, and
+   record the exact refusal.
+2. Identify the commit that introduced the refusal (`git log -S` on the refusal copy, then an
+   A/B of that commit's production tree against the unchanged test file).
+3. Answer the only question that matters live: boot the REAL `TldwCli` headless under an
+   isolated HOME/XDG/`TLDW_CONFIG_PATH` sandbox with only the network boundary stubbed, press
+   Enter in the real composer, and record whether the provider is called and the draft clears.
+4. Repair whichever side is wrong. If the harness: restore the production precondition the
+   factory app is missing, do not delete/xfail/relax any test.
+5. Mutation-check every repaired test: break the production gate and confirm each goes red.
+6. Re-run the file and the related composer suite; run `./scripts/preflight.sh`.
+
+## Implementation Notes
+
+**Console send is not broken for real users.** A headless Pilot run of the real `TldwCli`
+(no `_build_test_app` stubs) under an isolated `HOME`/`XDG_*`/`TLDW_CONFIG_PATH` sandbox, with
+only `chat_api_call` stubbed, sends normally: `store.persistence = ChatPersistenceService`,
+`commit_durable_turn` callable, one provider call, draft cleared, transcript
+`user 'hello' [complete] / assistant 'LIVE-PROBE-REPLY-OK' [complete]`, run state COMPLETED. A
+second live probe confirmed a second send in the same session also works. The 26 failures were
+**stale test doubles**, in two layers, plus one genuine product conflict.
+
+### Root cause 1 — the factory app has no ChaChaNotes DB, and a durable turn now fails closed
+
+`56db75386` ("fix(console): harden durable turn ownership", 2026-08-23) rewrote TASK-19900.3's
+durable-acceptance gate. Before it, the gate required `persistence is not None and
+persistence.db is not None` and refused through `_block()`. After it, the gate is
+`durable_turn and not callable(durable_commit)` and returns a **bare `ConsoleSubmitResult`**.
+Two consequences: a `persistence=None` store (which `_build_test_app` always produces, because
+it patches `get_chachanotes_db_lazy` to `None`) is now treated as a durable turn that cannot
+commit; and the refusal writes no system row and raises no toast, so the symptom is literally
+"pressing Send does nothing". A/B with the test file unchanged: `56db75386^` → 1 passed,
+`56db75386` → 1 failed.
+
+Repair: `Tests/UI/app_factory.py` gains `attach_chachanotes_db(app)`, and the 26 send tests
+build through a local `_build_console_send_test_app()`. The DB is **`:memory:` on purpose** —
+`ConsoleRuntime.ensure_agent_bridge` refuses to build an agent bridge for a `:memory:` DB, so
+this restores exactly the precondition the send path lost without also flipping 26 tests onto
+the agent loop (which a file-backed DB does, since `[console] agent_runtime` defaults on).
+
+### Root cause 2 — two stale doubles the first refusal was hiding
+
+* `_ReadyResolutionGateway` returned a ready resolution with no `resolved_destination`.
+  `a26cdafd8` made that typed destination mandatory, so `_finalize_turn_execution_context`
+  raised and the send was blocked with "Provider destination is incomplete." The stub now
+  derives it through the production classifier (`resolve_console_destination`) so it cannot
+  drift again.
+* `WorkspaceLinkingPersistence`, a three-method hand-rolled persistence double three tests
+  installed over the store's real adapter, has no `commit_durable_turn` and hit the same
+  silent refusal. Its only job — linking a persisted conversation into the workspace registry
+  — is what the real `ChatPersistenceService` already does through the same registry, so the
+  double is deleted and those tests now assert against production's own linking.
+
+### The 2 tests left red are correct, and pin a real regression (TASK-22000)
+
+`test_console_composer_stop_is_subdued_when_idle` and
+`test_console_duplicate_send_during_stream_does_not_break_stop_control` assert ADR-046 /
+TASK-14808 / TASK-15121: an accepted live turn re-labels Send to "Queue" and admits a FIFO
+follow-up rather than blocking. Verified live on the real app mid-run: `send.label = 'Queue'`,
+`send.disabled = True`, `console-send-blocked` set, tooltip "Wait for the active Console run to
+finish before sending", `dispatch_recovery_blocks_submission = True` for a
+`DISPATCH_STARTED` owner whose own state says `runtime_active=True, recovery_needed=False`.
+Introduced by `2c7fcd200`. This is **not** harness staleness — but neither is it mine to flip:
+`Tests/Chat/test_console_dispatch_recovery_fix_round1.py::test_healthy_durable_owner_is_not_
+recovery_before_checkpoint_transition` asserts `blocks_submission is True` for exactly that
+healthy live owner, so the durable-turn programme pinned the opposite contract on purpose.
+Two shipped contracts disagree and an owner must choose; filed as TASK-22000. Relaxing either
+side here is the "green suite that proves nothing" this task exists to prevent.
+
+### Counts
+
+| | before | after |
+|---|---|---|
+| `Tests/UI/test_console_native_chat_flow.py` | 26 failed, 271 passed | 2 failed, 295 passed |
+| `Tests/UI/test_console_composer_cursor.py` | 1 failed, 28 passed | 0 failed, 29 passed |
+
+### Mutation evidence (every repaired test killed by at least one production mutation)
+
+* **M1** — delete `self._launch_chain(...)` in `ConsolePromptQueueUIController._stage_normal_chain`: **21 of 25 killed**. Survivors: the three retry/continue/regenerate action tests (different entry point) and one block-path test.
+* **M2** — force `durable_commit = None` (restores this task's regression): **22 of 25 killed**. Survivors: the same three action tests, which use non-manual origins the durable gate does not cover.
+* **M3** — make `_resolved_destination_for_context` always raise: **23 of 25 killed**. Survivors: the two block-path tests, which refuse before the provider is resolved — both killed by M2.
+
+Union of M2 and M3 = **25 of 25**. No repaired test passes vacuously. All mutations were applied
+and reverted by hand; `git diff -- tldw_chatbook/` is empty.
+
+### Files
+
+* `Tests/UI/app_factory.py` — new `attach_chachanotes_db`
+* `Tests/UI/test_console_native_chat_flow.py` — `_build_console_send_test_app`, 26 call sites, `_ReadyResolutionGateway` destination, `WorkspaceLinkingPersistence` removed
+* `Tests/UI/test_console_composer_cursor.py` — the one send-driving test in that module
+* `backlog/tasks/task-22000 - ...` — the ADR-046 queue conflict
+* `backlog/docs/lessons-testing-evidence.md` — the fail-closed-double lesson
+
+No production code changed.

--- a/backlog/tasks/task-22000 - Console-Send-is-disabled-during-a-live-run-so-the-ADR-046-queue-is-unreachable.md
+++ b/backlog/tasks/task-22000 - Console-Send-is-disabled-during-a-live-run-so-the-ADR-046-queue-is-unreachable.md
@@ -1,0 +1,74 @@
+---
+id: TASK-22000
+title: >-
+  Console Send is disabled during a live run so the ADR-046 queue is unreachable
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - console
+  - regression
+  - owner-decision
+priority: high
+---
+## Description
+
+Two shipped contracts now disagree about what Send does while a Console turn is running,
+and the losing one is the user-visible half.
+
+ADR-046 / TASK-14808 / TASK-15121 established that an accepted live turn does **not** block
+Send: the button re-labels to "Queue" and admits the draft as a FIFO follow-up turn. The
+whole queue subsystem is still wired and still renders ("Queue 0/10 · Draining", a queue
+region, a 10-entry cap, queue-full copy).
+
+TASK-19900.3's durable-turn work then added `ConsoleChatStore.dispatch_recovery_blocks_
+submission`, which `ChatScreen` folds into `send_blocked`. It returns True for a
+`DISPATCH_STARTED` recovery owner — including the app's own healthy, in-flight run, whose
+state is explicitly published as `runtime_active=True, recovery_needed=False`. The result is
+that Send is disabled for the whole duration of every non-ephemeral turn.
+
+The user sees a button labelled **"Queue"** that is greyed out and whose tooltip says
+**"Wait for the active Console run to finish before sending."** The label promises the
+feature; the state denies it. Whichever behaviour is intended, the two cannot both be.
+
+This needs an owner decision, not a unilateral fix: `Tests/Chat/test_console_dispatch_
+recovery_fix_round1.py::test_healthy_durable_owner_is_not_recovery_before_checkpoint_
+transition` deliberately asserts `dispatch_recovery_blocks_submission(...) is True` for a
+healthy live owner, so the durable-turn programme pinned the new behaviour on purpose. Two
+tests in `Tests/UI/test_console_native_chat_flow.py` pin the ADR-046 behaviour just as
+deliberately. One of the two sets is now wrong.
+
+## Evidence (live, real `TldwCli`, isolated sandbox, 2026-08-24, dev `d589c56c5`)
+
+A headless Pilot run of the real app with only `chat_api_call` stubbed (slow, 6 s), sampled
+mid-run:
+
+```
+run_state: ConsoleRunStatus.STREAMING
+send.disabled = True
+send.label = 'Queue'
+send has console-send-blocked = True
+send.tooltip = 'Wait for the active Console run to finish before sending.'
+dispatch_recovery_blocks_submission = True
+dispatch_recovery kind = ConsoleDispatchRecoveryKind.DISPATCH_STARTED
+[with draft] send.disabled = True     # typing a follow-up does not re-enable it
+```
+
+Sequential sends are fine: after the run completes the recovery owner clears
+(`dispatch_recovery_for_session -> None`, `blocks_submission -> False`) and a second message
+sends normally. Only the *concurrent* queue affordance is dead.
+
+Introduced by `2c7fcd200` "fix(console): enforce dispatch recovery ownership" (2026-08-23),
+the commit that added `dispatch_recovery_blocks_submission` and wired it into
+`ChatScreen`'s `send_blocked`.
+
+Surfaced by TASK-21590, which repaired the stale Console send harness; these two tests were
+the last of that file's 26 failures and are the only two that are **not** harness staleness.
+
+## Acceptance Criteria
+
+- [ ] An owner decision is recorded on whether a live durable turn admits a queued follow-up (ADR-046) or blocks Send
+- [ ] Send's label, disabled state, and tooltip agree with that decision — no "Queue" label on a button that refuses to queue
+- [ ] Whichever contract loses has its pinning tests updated in the same change, with the decision cited
+- [ ] `Tests/UI/test_console_native_chat_flow.py::test_console_composer_stop_is_subdued_when_idle` and `::test_console_duplicate_send_during_stream_does_not_break_stop_control` are green without weakening what they assert about the Stop control
+- [ ] The chosen behaviour is verified live, not only under pytest

--- a/backlog/tasks/task-22030 - A failed ChaChaNotes open makes Console Send silently do nothing.md
+++ b/backlog/tasks/task-22030 - A failed ChaChaNotes open makes Console Send silently do nothing.md
@@ -1,0 +1,68 @@
+---
+id: TASK-22030
+title: >-
+  A failed ChaChaNotes open makes Console Send silently do nothing
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - bug
+  - console
+  - error-handling
+priority: high
+---
+
+## Description
+
+If a user's ChaChaNotes database fails to open, pressing Send in the Console now does **nothing
+at all** — no message, no system row in the transcript, no toast, no user-visible log. The draft
+stays in the composer and the app looks like it ignored the keypress.
+
+The refusal itself is arguably correct — a durable turn that cannot be committed should not be
+started. What is wrong is that it is **invisible**. The user has no way to learn that their
+database is broken, and the most likely reading of the symptom is "the app is broken".
+
+## Acceptance Criteria
+
+- [ ] With an unopenable ChaChaNotes database, pressing Send produces a visible, legible explanation of why the message was not sent and what to do about it
+- [ ] The explanation names the real cause (the database could not be opened) rather than a generic failure
+- [ ] The draft is preserved so the user does not lose what they typed
+- [ ] An ephemeral/temporary conversation still sends in this state, since it needs no durable commit
+- [ ] A test drives the degraded path end to end and asserts the user-visible surface, not just the return value — the current gate returns a correct-looking result object while showing the user nothing
+- [ ] The test fails if the refusal is made silent again
+
+## Evidence (verified on dev, 2026-08-24)
+
+Introduced by `56db75386` ("fix(console): harden durable turn ownership", 2026-08-23), a
+review-fix on TASK-19900.3. The hunk replaced this:
+
+```python
+if (
+    self.store.persistence is not None
+    and getattr(self.store.persistence, "db", None) is not None
+    and not session.ephemeral
+    and origin in {ConsoleSubmissionOrigin.MANUAL, ConsoleSubmissionOrigin.QUEUED}
+    and not callable(durable_commit)
+):
+    return self._block(session.id, ...)
+```
+
+with this:
+
+```python
+if durable_turn and not callable(durable_commit):
+    return ConsoleSubmitResult(False, False, session_id=session.id, ...)
+```
+
+Two changes compound. The `persistence is not None and persistence.db is not None` precondition
+is gone, so a session with no working persistence now qualifies as "a durable turn that cannot
+commit" instead of being exempt. And `_block(...)` — which writes a system row and raises a toast
+— became a bare `ConsoleSubmitResult`, so the refusal has no user-visible surface at all.
+
+**Users with a working database are unaffected**: `durable_commit` is callable, the gate does not
+fire, and send works. This was confirmed by a live headless Pilot run of the real app with an
+isolated profile: one provider call, draft cleared, transcript complete, run state COMPLETED.
+
+Found while repairing the stale Console send test harness (TASK-21590). The harness had been
+masking this: every factory-built test app has `persistence=None`, so the doubles hid the
+behaviour change behind 26 unrelated-looking test failures.


### PR DESCRIPTION
## The question this had to answer first

`Tests/UI/test_console_native_chat_flow.py` was **26 failed / 271 passed on pristine dev**, across
generic-provider send, the retry/regenerate/continue family and the first-send-flag pair — the
Console's core send path. So before touching a single test: **is send broken for real users?**

**No.** A headless Pilot run of the real `TldwCli` (not `_build_test_app`) under an isolated
`HOME`/`XDG_*`/`TLDW_CONFIG_PATH` sandbox, with only `chat_api_call` stubbed, sends normally —
`persistence = ChatPersistenceService`, `commit_durable_turn` callable, one provider call, draft
cleared, transcript `user 'hello' [complete] / assistant [complete]`, run state COMPLETED. A second
send in the same session also works.

`git diff origin/dev -- tldw_chatbook/` on this branch is **empty**. Tests only.

## What was wrong: stale doubles in three layers — hiding two real regressions

Bisected to `56db75386` ("harden durable turn ownership", a review-fix on TASK-19900.3), **not**
the commit that introduced the gate. A/B with the test file unchanged: `56db75386^` → 1 passed,
`56db75386` → 1 failed.

Repairs, none of which delete, xfail, or relax anything:

- `Tests/UI/app_factory.py` — new `attach_chachanotes_db(app)`. **`:memory:` is load-bearing**:
  `ConsoleRuntime.ensure_agent_bridge` refuses a bridge for an in-memory DB, so this restores the
  lost precondition without flipping 26 tests onto the agent loop. A file-backed DB does exactly
  that (`[console] agent_runtime` defaults on) — tried, and the tests visibly changed subject.
- `test_console_native_chat_flow.py` — `_build_console_send_test_app()` at the 26 send sites;
  `_ReadyResolutionGateway` now derives the `resolved_destination` that `a26cdafd8` made mandatory
  **through the production classifier**, so it cannot drift again; `WorkspaceLinkingPersistence`, a
  hand-rolled double with no `commit_durable_turn`, deleted in favour of the real service.

| | before | after |
|---|---|---|
| `test_console_native_chat_flow.py` | 26 failed, 271 passed | **2 failed, 295 passed** |
| `test_console_composer_cursor.py` | 1 failed, 28 passed | **0 failed, 29 passed** |
| both files, after rebase | — | **2 failed, 326 passed, 0 errors** |

## Mutation: no repaired test passes vacuously

- **M2** force `durable_commit = None` (restores the regression): **22/25 killed**; survivors are
  the 3 retry/continue/regenerate tests, whose origins the gate does not cover.
- **M3** make `_resolved_destination_for_context` always raise: **23/25 killed**; survivors are the
  2 block-path tests — both killed by M2.
- **Union M2∪M3 = 25/25.**

## A defect found in the repair, during review

The first version made 16 tests attempt **live network egress** — six
`socket.connect -> 57.150.97.129:443` each, caught by `_no_network_io` at teardown. The repair had
taken those tests from failing early to running the real send path far enough to reach a client the
broken harness never got to.

**This is invisible to a naive A/B**: the errors attach to tests that now *pass*, and on dev the
same tests fail early, so a baseline comparison shows nothing.

Traced by wrapping `network_guard._deny` with a stack dump — all six connects share one stack, and
the seam is **not** `chat_api_call` but tiktoken's BPE blob download via token accounting:
`prepare_chat_request → prepare_provider_request → _account_categories → _count_wire →
count_console_messages_tokens → estimate_tokens → count_tokens_tiktoken → get_tiktoken_encoding`.

Fixed with `_no_tiktoken_bpe_download` in `Tests/UI/conftest.py`, patching the single chokepoint to
return `None` — an **already-tested fallback branch**, since tiktoken is not a base dependency
(task-2526) and a default install takes the character estimate anyway. No `allow_network`, no
`loopback_network`, no socket patching. It also removes a machine dependency: `$TMPDIR/data-gym-cache`
is not redirected by the HOME sandbox, so results previously varied with whether the box had a warm
cache. **Mutation kills re-verified after the stub and unchanged at 25/25**, so it did not weaken
what the tests exercise.

## The 2 remaining failures are correct — real regression, filed as TASK-22000

`test_console_composer_stop_is_subdued_when_idle` and
`test_console_duplicate_send_during_stream_does_not_break_stop_control` pin ADR-046/TASK-14808:
a live turn should re-label Send to "Queue" and admit a follow-up. Live on the real app mid-run:
`send.label='Queue'`, `send.disabled=True`, tooltip *"Wait for the active Console run to finish"*.
**Users cannot queue a follow-up during a run, behind a button that says they can.** Introduced by
`2c7fcd200`.

Deliberately not fixed here: `Tests/Chat/test_console_dispatch_recovery_fix_round1.py` asserts
`blocks_submission is True` for exactly that healthy live owner. Two shipped contracts disagree,
each with its own deliberate test — an owner decision, not a test edit.

## Also filed: TASK-22030 (high)

The same `56db75386` hunk dropped the `persistence is not None and persistence.db is not None`
precondition **and** replaced `_block(...)` (which writes a system row and a toast) with a bare
`ConsoleSubmitResult`. So if a user's ChaChaNotes DB fails to open, **Send silently does nothing** —
no message, no row, no toast. The refusal is defensible; its invisibility is not.

## Out of scope

The cluster is wider: 20 adjacent Console UI modules show **26 failures across 13 modules** with the
same fingerprint. This branch introduces none of them and adds no egress attempts there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the Console send test harness so end-to-end sends run in tests and confirms the shipped app’s send path works. Previously, test apps had no durable DB so sends failed silently; tests now attach an in-memory ChaChaNotes DB and align doubles with production resolution, fixing 24 of 26 failures.

- Adds `attach_chachanotes_db(app)` and `_build_console_send_test_app()` to restore the durable persistence precondition using a `:memory:` DB (avoids agent runtime side effects).
- Updates `_ReadyResolutionGateway` to derive `resolved_destination` via `resolve_console_destination`; removes the stale `WorkspaceLinkingPersistence` in favor of the real `ChatPersistenceService`.
- Adds an autouse fixture to stop `tiktoken` BPE downloads by returning `None` from `get_tiktoken_encoding` (tests use the existing character-count fallback; no network egress).
- Test counts: native chat flow 26 failed/271 passed → 2 failed/295 passed; composer cursor 1 failed/28 passed → 0 failed/29 passed. Mutations to durable-commit and destination resolution kill all repaired tests.
- No production code changed.

**Open items**
- Two remaining failures are correct and pin a real behavior conflict: Send is disabled during a live run, making the ADR-046 “Queue” path unreachable (TASK-22000).
- Separate defect: a failed ChaChaNotes open makes Send do nothing and shows no message (TASK-22030).

<sup>Written for commit 1ac76f8d4291845b0a7e0c97190d6a6eb2ff48e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

