### PR TITLE
perf: small-residue batch — five shipped, five dropped with evidence (TASK-21134)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1140,7 +1140,7 @@
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "966692f9721f5fab93a3",
+      "diagnostic_digest": "e7f921d3123db6cc2e22",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_rechunk_service.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/Library/test_library_media_content.py
+++ b/Tests/Library/test_library_media_content.py
@@ -295,3 +295,84 @@ async def test_active_query_sync_mounts_controls_and_markdown_placeholder() -> N
         assert active_input.placeholder == "Search content (raw text)…"
         assert app.query_one("#library-media-content-search-prev", Button)
         assert app.query_one("#library-media-content-search-next", Button)
+
+
+# ---------------------------------------------------------------------------
+# TASK-21134: a search refresh restyles, it does not resize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_refresh_does_not_arm_a_layout_pass(monkeypatch) -> None:
+    """``sync_search`` restyles the SAME characters, so no layout is needed.
+
+    ``build_raw_content_renderable`` only moves highlight spans around: it
+    never adds, removes or rewraps a line, so the Static's size cannot change
+    between match-nav clicks. The layout pass ``Static.update()`` arms by
+    default cost a measured 84.9 -> 57.7 ms of CPU per click on a 100 KB
+    document at 120x40 (10 Layout messages per 10 clicks -> 0).
+    """
+    body = LibraryMediaContentBody(
+        content="alpha needle\nbeta\ngamma needle\n",
+        is_markdown=False,
+        mode="raw",
+        query="",
+        match_index=0,
+        id="body",
+    )
+    app = BodyHarness(body)
+
+    async with app.run_test(size=(60, 12)):
+        raw_widget = body._raw_widget
+        assert raw_widget is not None
+
+        seen: list[bool] = []
+        real_update = Static.update
+
+        def recording_update(self, content="", *, layout: bool = True) -> None:
+            if self is raw_widget:
+                seen.append(layout)
+            real_update(self, content, layout=layout)
+
+        monkeypatch.setattr(Static, "update", recording_update)
+
+        body.sync_search("needle", 0)
+        body.sync_search("needle", 1)
+
+        assert seen == [False, False], f"search refresh armed a layout pass: {seen}"
+
+
+@pytest.mark.asyncio
+async def test_search_refresh_still_repaints_the_active_match() -> None:
+    """Skipping layout must not skip the repaint the highlight depends on."""
+    body = LibraryMediaContentBody(
+        content="alpha needle\nbeta\ngamma needle\n",
+        is_markdown=False,
+        mode="raw",
+        query="",
+        match_index=0,
+        id="body",
+    )
+    app = BodyHarness(body)
+
+    async with app.run_test(size=(60, 12)):
+        raw_widget = body._raw_widget
+        assert raw_widget is not None
+
+        body.sync_search("needle", 0)
+        first = raw_widget.renderable
+        assert isinstance(first, Text)
+        first_active = [
+            span for span in first.spans if "bold" in str(span.style)
+        ]
+
+        body.sync_search("needle", 1)
+        second = raw_widget.renderable
+        assert isinstance(second, Text)
+        second_active = [
+            span for span in second.spans if "bold" in str(span.style)
+        ]
+
+        assert first.plain == second.plain  # same characters: no relayout owed
+        assert first_active and second_active
+        assert first_active[0].start != second_active[0].start

--- a/Tests/Library/test_library_rechunk_service.py
+++ b/Tests/Library/test_library_rechunk_service.py
@@ -1166,3 +1166,133 @@ def test_rechunk_one_item_reindex_default_off_and_opt_in(media_db, monkeypatch):
     assert opt_in["status"] == "rechunked"
     assert calls == [{"media_id": media_id, "rag_service": rag, "indexing_db": None}]
     assert opt_in["reindexed"] == {"status": "reindexed"}
+
+
+# ---------------------------------------------------------------------------
+# TASK-21134: chunk rows go in as one statement, not one statement per chunk
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_rows_are_inserted_in_one_statement(media_db, monkeypatch):
+    """One executemany, not one execute per chunk.
+
+    ``Connection.execute`` builds a fresh Cursor per call, so the per-chunk
+    loop paid that construction once per chunk. Measured over 7 replacements
+    of the same document: 5,000 chunks 139.7 -> 116.2 ms, 500 chunks
+    10.55 -> 8.89 ms.
+    """
+    from tldw_chatbook.Library import library_rechunk_service as service
+
+    media_id, _, _ = media_db.add_media_with_keywords(
+        title="Batch", media_type="document", content="x" * 400, keywords=[]
+    )
+    chunks = [
+        {
+            "text": f"body {index}",
+            "start_char": index,
+            "end_char": index + 1,
+            "chunk_type": "text",
+            "metadata": {"index": index},
+        }
+        for index in range(40)
+    ]
+
+    inserts = {"execute": 0, "executemany": 0}
+    real_transaction = MediaDatabase.transaction
+
+    class _CountingConnection:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def execute(self, sql, *args, **kwargs):
+            if "INSERT INTO UnvectorizedMediaChunks" in sql:
+                inserts["execute"] += 1
+            return self._inner.execute(sql, *args, **kwargs)
+
+        def executemany(self, sql, seq, *args, **kwargs):
+            if "INSERT INTO UnvectorizedMediaChunks" in sql:
+                inserts["executemany"] += 1
+            return self._inner.executemany(sql, seq, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def counting_transaction(self, *args, **kwargs):
+        with real_transaction(self, *args, **kwargs) as conn:
+            yield _CountingConnection(conn)
+
+    monkeypatch.setattr(MediaDatabase, "transaction", counting_transaction)
+
+    service._replace_chunk_rows(
+        media_db, media_id, chunks, template_name="t", template_params="{}"
+    )
+
+    assert inserts == {"execute": 0, "executemany": 1}
+
+    monkeypatch.undo()
+    with media_db.transaction() as conn:
+        stored = conn.execute(
+            "SELECT chunk_index, chunk_text FROM UnvectorizedMediaChunks "
+            "WHERE media_id = ? ORDER BY chunk_index",
+            (media_id,),
+        ).fetchall()
+    assert [row["chunk_index"] for row in stored] == list(range(40))
+    assert [row["chunk_text"] for row in stored] == [f"body {i}" for i in range(40)]
+
+
+def test_an_invalid_chunk_is_skipped_and_leaves_its_index_gap(media_db):
+    """Batching must not renumber the survivors around a skipped chunk."""
+    from tldw_chatbook.Library import library_rechunk_service as service
+
+    media_id, _, _ = media_db.add_media_with_keywords(
+        title="Gap", media_type="document", content="x" * 400, keywords=[]
+    )
+
+    service._replace_chunk_rows(
+        media_db,
+        media_id,
+        [
+            {"text": "first"},
+            {"text": None},  # invalid: skipped
+            "not-a-dict",  # invalid: skipped
+            {"text": "fourth"},
+        ],
+        template_name=None,
+        template_params=None,
+    )
+
+    with media_db.transaction() as conn:
+        stored = conn.execute(
+            "SELECT chunk_index, chunk_text FROM UnvectorizedMediaChunks "
+            "WHERE media_id = ? ORDER BY chunk_index",
+            (media_id,),
+        ).fetchall()
+    assert [(row["chunk_index"], row["chunk_text"]) for row in stored] == [
+        (0, "first"),
+        (3, "fourth"),
+    ]
+
+
+def test_replacing_with_no_valid_chunks_still_clears_the_old_rows(media_db):
+    """The DELETE is unconditional; only the INSERT is skipped when empty."""
+    from tldw_chatbook.Library import library_rechunk_service as service
+
+    media_id, _, _ = media_db.add_media_with_keywords(
+        title="Empty", media_type="document", content="x" * 400, keywords=[]
+    )
+    service._replace_chunk_rows(
+        media_db, media_id, [{"text": "old"}], template_name=None, template_params=None
+    )
+    service._replace_chunk_rows(
+        media_db, media_id, [], template_name=None, template_params=None
+    )
+
+    with media_db.transaction() as conn:
+        remaining = conn.execute(
+            "SELECT count(*) AS n FROM UnvectorizedMediaChunks WHERE media_id = ?",
+            (media_id,),
+        ).fetchone()["n"]
+    assert remaining == 0

--- a/Tests/MCP/test_execution_log.py
+++ b/Tests/MCP/test_execution_log.py
@@ -307,3 +307,138 @@ def test_shared_writable_ancestor_is_rejected_without_creating_log(tmp_path):
         execution_log.append(_record("blocked"))
 
     assert not active.parent.exists()
+
+
+# ---------------------------------------------------------------------------
+# TASK-21134: the legacy scrub must not re-run on an unchanged generation
+# ---------------------------------------------------------------------------
+
+
+def _count_parses(monkeypatch) -> dict[str, int]:
+    """Count full-line JSON decodes inside the execution-log module."""
+    from tldw_chatbook.MCP import execution_log as module
+
+    counter = {"loads": 0}
+    real_loads = json.loads
+
+    def counting_loads(payload, *args, **kwargs):
+        counter["loads"] += 1
+        return real_loads(payload, *args, **kwargs)
+
+    monkeypatch.setattr(module.json, "loads", counting_loads)
+    return counter
+
+
+def test_steady_state_appends_do_not_reparse_the_whole_log(tmp_path, monkeypatch):
+    """A scrub already applied to bytes we wrote must not be applied again.
+
+    Before TASK-21134 each append re-read and re-parsed every line of both
+    generations: 499 json.loads and 4.6 ms of wall time per tool invocation at
+    the 500-record cap, purely to re-derive bytes identical to the ones the
+    previous append had just written.
+    """
+    execution_log = MCPExecutionLog(
+        tmp_path / "mcp_execution_log.jsonl", max_records_per_file=200
+    )
+    for index in range(60):
+        execution_log.append(_record(f"warm-{index}"))
+
+    counter = _count_parses(monkeypatch)
+    for index in range(5):
+        execution_log.append(_record(f"hot-{index}"))
+
+    assert counter["loads"] == 0, (
+        f"appends re-parsed the log {counter['loads']} times"
+    )
+
+
+def test_appends_after_a_rotation_do_not_reparse_either_generation(
+    tmp_path, monkeypatch
+):
+    """Both generations are cached, so a rotated file is scrubbed once."""
+    execution_log = MCPExecutionLog(
+        tmp_path / "mcp_execution_log.jsonl", max_records_per_file=20
+    )
+    for index in range(45):  # forces at least two rotations
+        execution_log.append(_record(f"warm-{index}"))
+    assert (tmp_path / "mcp_execution_log.jsonl.1").exists()
+
+    counter = _count_parses(monkeypatch)
+    for index in range(5):
+        execution_log.append(_record(f"hot-{index}"))
+
+    assert counter["loads"] == 0
+
+
+def test_a_generation_changed_behind_our_back_is_still_scrubbed(tmp_path):
+    """The cache is a staleness check, never a licence to trust stale bytes."""
+    private = "MCP-CACHE-LEGACY-SENTINEL-sk-not-a-real-key"
+    active = tmp_path / "mcp_execution_log.jsonl"
+    execution_log = MCPExecutionLog(active, max_records_per_file=200)
+    execution_log.append(_record("warm"))  # primes the cache
+
+    # Another writer (or an older build) appends a legacy payload row.
+    with active.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "tool_name": "old",
+                    "arguments": {"query": private},
+                    "result_excerpt": private,
+                }
+            )
+            + "\n"
+        )
+
+    execution_log.append(_record("after"))
+
+    raw = active.read_text(encoding="utf-8")
+    assert private not in raw
+    assert "result_excerpt" not in raw
+    assert [row["tool_name"] for row in execution_log.read_recent()] == [
+        "after",
+        "old",
+        "warm",
+    ]
+
+
+def test_a_byte_for_byte_same_size_replacement_misses_the_cache(tmp_path):
+    """Neither size nor mtime alone can decide staleness.
+
+    The replacement below is padded to the EXACT byte length of the file it
+    displaces AND has its mtime restored to the displaced file's (what an
+    mtime-preserving restore or ``rsync -t`` does), so a fingerprint built on
+    either field alone would report a hit and hand back the stale, unscrubbed
+    bytes. Only the inode tells these two files apart.
+    """
+    private = "MCP-REPLACED-SENTINEL-sk-not-a-real-key"
+    active = tmp_path / "mcp_execution_log.jsonl"
+    execution_log = MCPExecutionLog(active, max_records_per_file=200)
+    for index in range(4):
+        execution_log.append(_record(f"warm-{index}"))
+
+    original = active.stat()
+    target = original.st_size
+    legacy = {"tool_name": "old", "result_excerpt": private, "pad": ""}
+    padding = target - len((json.dumps(legacy) + "\n").encode("utf-8"))
+    assert padding >= 0, "widen the warm-up above"
+    legacy["pad"] = "x" * padding
+    line = json.dumps(legacy) + "\n"
+    assert len(line.encode("utf-8")) == target
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(line, encoding="utf-8")
+    replacement.replace(active)
+    os.utime(active, ns=(original.st_atime_ns, original.st_mtime_ns))
+    assert active.stat().st_size == original.st_size
+    assert active.stat().st_mtime_ns == original.st_mtime_ns
+    assert active.stat().st_ino != original.st_ino
+
+    execution_log.append(_record("after"))
+
+    raw = active.read_text(encoding="utf-8")
+    assert private not in raw
+    assert [row["tool_name"] for row in execution_log.read_recent()] == [
+        "after",
+        "old",
+    ]

--- a/Tests/MCP/test_execution_log.py
+++ b/Tests/MCP/test_execution_log.py
@@ -442,3 +442,47 @@ def test_a_byte_for_byte_same_size_replacement_misses_the_cache(tmp_path):
         "after",
         "old",
     ]
+
+
+def test_a_concurrent_append_is_not_pinned_by_the_cache(tmp_path, monkeypatch):
+    """Another writer landing inside our own append window must not be cached.
+
+    A second process can append between the bytes we compute and the stat we
+    fingerprint them with. Caching then would pin content already short of the
+    file, under a fingerprint claiming it is current.
+    """
+    from tldw_chatbook.MCP import execution_log as module
+
+    private = "MCP-CONCURRENT-SENTINEL-sk-not-a-real-key"
+    active = tmp_path / "mcp_execution_log.jsonl"
+    execution_log = MCPExecutionLog(active, max_records_per_file=200)
+    execution_log.append(_record("warm"))
+
+    real_identity = module.MCPExecutionLog._identity
+    seen = {"active_calls": 0}
+
+    def intruding_identity(path):
+        # One append makes two _identity calls on the active generation: the
+        # staleness check, then the one that fingerprints what we just wrote.
+        # The window this guards is between them, so intrude before the second.
+        if Path(path) == active:
+            seen["active_calls"] += 1
+            if seen["active_calls"] == 2:
+                with active.open("a", encoding="utf-8") as handle:
+                    handle.write(
+                        json.dumps({"tool_name": "other", "result_excerpt": private})
+                        + "\n"
+                    )
+        return real_identity(path)
+
+    monkeypatch.setattr(
+        module.MCPExecutionLog, "_identity", staticmethod(intruding_identity)
+    )
+    execution_log.append(_record("ours"))
+    monkeypatch.undo()
+
+    # The intruder's row must be visible and scrubbed, not overwritten by a
+    # stale cached copy of the log.
+    names = [row["tool_name"] for row in execution_log.read_recent()]
+    assert names == ["other", "ours", "warm"], names
+    assert private not in active.read_text(encoding="utf-8")

--- a/Tests/UI/test_console_setup_backdrop_repaint_cost.py
+++ b/Tests/UI/test_console_setup_backdrop_repaint_cost.py
@@ -1,0 +1,89 @@
+"""TASK-21134 item 1: the setup-modal snow must not burn a core while idle.
+
+The backdrop covers the whole Console screen, so every repaint re-composites
+every line of it. Measured on dev ``68c061984``: 15.8 ms of CPU per tick at
+5 Hz -- ~6-15% of a core (load-dependent), burnt continuously by every
+not-yet-configured user, against a 0.09% floor with the field frozen. Density
+and glyph count are irrelevant to that cost; only the repaint RATE and whether
+the repaint also arms a layout pass are.
+
+These tests pin the three mechanics of the fix. Each was mutation-checked
+against the pre-fix code.
+"""
+
+import random
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import Static
+
+# Harness apps load the consolidated widget CSS the real app loads
+# (TASK-15450); without it the widgets under test mount unstyled.
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+
+from tldw_chatbook.Widgets.Console import console_setup_modal as setup_modal
+from tldw_chatbook.Widgets.Console.console_setup_modal import ConsoleSetupBackdrop
+
+
+class BackdropHarness(ConsolidatedCSSApp):
+    def compose(self) -> ComposeResult:
+        yield ConsoleSetupBackdrop(rng=random.Random(21134))
+
+
+@pytest.mark.asyncio
+async def test_snow_tick_repaints_without_arming_a_layout_pass(monkeypatch):
+    """A tick cannot change the field's size, so it must not request layout."""
+    app = BackdropHarness()
+
+    async with app.run_test(size=(80, 24)):
+        backdrop = app.query_one(ConsoleSetupBackdrop)
+        assert backdrop.flake_count > 0
+
+        seen: list[bool] = []
+        real_update = Static.update
+
+        def recording_update(self, content="", *, layout: bool = True) -> None:
+            if self is backdrop:
+                seen.append(layout)
+            real_update(self, content, layout=layout)
+
+        monkeypatch.setattr(Static, "update", recording_update)
+
+        backdrop._tick()
+        assert seen == [False], f"tick armed a layout pass: {seen}"
+
+        # The resize path really does change the field's dimensions, so it
+        # keeps asking for layout.
+        seen.clear()
+        backdrop._resize_flake_field()
+        assert seen == [True], f"resize skipped its layout pass: {seen}"
+
+
+@pytest.mark.asyncio
+async def test_snow_field_is_not_parsed_as_console_markup():
+    """The field is spaces plus three glyphs -- markup parsing is pure waste."""
+    app = BackdropHarness()
+
+    async with app.run_test(size=(80, 24)):
+        backdrop = app.query_one(ConsoleSetupBackdrop)
+        assert backdrop._render_markup is False
+
+
+def test_snow_repaint_rate_is_capped_and_drift_speed_is_preserved():
+    """Interval and displacement are a matched pair, not independent knobs.
+
+    Halving the repaint rate only helps if the per-tick displacement grows to
+    match; otherwise the fix silently slows the snow down instead of making it
+    cheaper. Both halves are asserted so neither can be changed alone.
+    """
+    interval = setup_modal._SNOW_TICK_INTERVAL
+
+    # Repaint-rate ceiling: the whole-screen repaint may not run faster than
+    # 2.5 Hz. The pre-fix 0.2 s (5 Hz) fails here.
+    assert interval >= 0.4, f"snow repaints at {1 / interval:.1f} Hz"
+
+    # On-screen drift is unchanged from the original 5 Hz field: flakes still
+    # fall at 2.0-7.0 rows/s and wobble up to 2.0 columns/s.
+    assert setup_modal._SNOW_MIN_SPEED / interval == pytest.approx(2.0)
+    assert setup_modal._SNOW_MAX_SPEED / interval == pytest.approx(7.0)
+    assert setup_modal._SNOW_MAX_WOBBLE / interval == pytest.approx(2.0)

--- a/Tests/UI/test_trajectory_timeline_integration.py
+++ b/Tests/UI/test_trajectory_timeline_integration.py
@@ -538,3 +538,121 @@ def test_widget_clock_formats_local_time_like_ledger() -> None:
 
     assert strip_clock(_T0) == ledger_clock(_T0)
     assert strip_clock(_T0) == datetime.fromtimestamp(_T0).strftime("%H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# TASK-21134: one brush drag must not rebuild the ledger once per column
+# ---------------------------------------------------------------------------
+
+
+def _mouse(x: int, y: int = 1):
+    """A minimal left-button mouse event for the strip's own handlers."""
+    return type("_Mouse", (), {"button": 1, "x": x, "y": y})()
+
+
+@pytest.mark.asyncio
+async def test_one_drag_gesture_rebuilds_the_ledger_once() -> None:
+    """A drag emits at most one brush per repaint, not one per column.
+
+    A real terminal delivers mouse-moves faster than Textual repaints, so the
+    whole gesture below is posted without forcing a frame between moves.
+    Before this throttle that was 69 full ledger rebuilds for one gesture, at
+    a measured 5.93 ms each on a 600-row ledger -- roughly 0.4 s of
+    synchronous event-loop work while the button is still down.
+    """
+    from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
+
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await pilot.pause()
+
+        rebuilds = {"count": 0}
+        real_render = TrajectoryScreen._render_ledger
+
+        def counting_render(self):
+            rebuilds["count"] += 1
+            return real_render(self)
+
+        TrajectoryScreen._render_ledger = counting_render
+        try:
+            start = LANE_LABEL_WIDTH + 1
+            end = timeline.size.width - 2
+            assert end - start > 10, "strip too narrow to drag across"
+            timeline.on_mouse_down(_mouse(start))
+            for x in range(start, end):
+                timeline.on_mouse_move(_mouse(x))
+            timeline.on_mouse_up(_mouse(end - 1))
+            await pilot.pause()
+            await pilot.pause()
+        finally:
+            TrajectoryScreen._render_ledger = real_render
+
+        assert rebuilds["count"] == 1, (
+            f"a {end - start}-column drag rebuilt the ledger "
+            f"{rebuilds['count']} times"
+        )
+        # The throttle may not cost the gesture its result.
+        assert timeline.brush is not None
+        assert screen._filter_bar.state.time_range == timeline.brush
+
+
+@pytest.mark.asyncio
+async def test_a_drag_that_ends_where_it_paused_still_reaches_the_ledger() -> None:
+    """The coalesced emission must not be swallowed by the mouse-up.
+
+    ``on_mouse_up`` re-brushes from the final column. When that column is the
+    one the last coalesced move already reached, the range does not change and
+    the equality gate in ``_set_brush`` emits nothing -- so the pending
+    emission has to be issued by the mouse-up itself.
+    """
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await pilot.pause()
+
+        start = LANE_LABEL_WIDTH + 1
+        last = start + 8
+        timeline.on_mouse_down(_mouse(start))
+        for x in range(start, last + 1):
+            timeline.on_mouse_move(_mouse(x))
+        # Ends on exactly the column the last move reached.
+        timeline.on_mouse_up(_mouse(last))
+        await pilot.pause()
+
+        assert timeline.brush is not None
+        assert screen._filter_bar.state.time_range == timeline.brush
+
+
+@pytest.mark.asyncio
+async def test_a_drag_abandoned_without_a_mouse_up_still_reaches_the_ledger() -> None:
+    """A coalesced emission is self-draining -- no gesture can lose it."""
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await pilot.pause()
+
+        start = LANE_LABEL_WIDTH + 1
+        timeline.on_mouse_down(_mouse(start))
+        for x in range(start, start + 9):
+            timeline.on_mouse_move(_mouse(x))
+        # No mouse-up at all (capture lost, terminal dropped the release...).
+        await pilot.pause()
+        await pilot.pause()
+
+        assert timeline.brush is not None
+        assert screen._filter_bar.state.time_range == timeline.brush
+
+
+@pytest.mark.asyncio
+async def test_a_non_drag_brush_still_reaches_the_ledger_immediately() -> None:
+    """Only the drag path throttles; every other caller emits synchronously."""
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await pilot.pause()
+
+        timeline.brush_columns(LANE_LABEL_WIDTH, LANE_LABEL_WIDTH + 10)
+        # Asserted BEFORE any pause: nothing may be left coalescing, or the
+        # throttle has leaked out of the drag path and delayed every caller
+        # (live snapshot re-brush, keyboard range select) by a repaint.
+        assert timeline._brush_emit_pending is False
+
+        await pilot.pause()
+        assert screen._filter_bar.state.time_range == timeline.brush

--- a/backlog/tasks/task-21134 - Perf small-residue batch - setup-modal snow idle burn, casefold UDF, MCP log parses, executemany, connection closes, misc.md
+++ b/backlog/tasks/task-21134 - Perf small-residue batch - setup-modal snow idle burn, casefold UDF, MCP log parses, executemany, connection closes, misc.md
@@ -2,7 +2,7 @@
 id: TASK-21134
 title: >-
   Perf small-residue batch - setup-modal snow idle burn, casefold UDF, MCP log parses, executemany, connection closes, misc
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-22'
 labels:
@@ -41,5 +41,214 @@ verified on the pin; none warrants a task alone, together they are a real tax.
 
 ## Acceptance Criteria
 
-- [ ] Each numbered item is either fixed as described or explicitly declined with a reason in the task notes
-- [ ] No behavior change beyond the stated performance mechanics; touched areas keep their existing tests green
+- [x] Each numbered item is either fixed as described or explicitly declined with a reason in the task notes
+- [x] No behavior change beyond the stated performance mechanics; touched areas keep their existing tests green
+
+## Implementation Plan
+
+1. Re-verify every item against dev `68c061984` before touching it. Five of seven findings
+   re-verified for wave 7 needed correcting, and this filing predates three further
+   corrections, so treat each item's cost claim as a hypothesis.
+2. Measure each item on its own, before and after, with a load-independent metric where
+   wall-clock is noisy (this box drifts >2x between identical windows).
+3. Ship each item as its own commit so any one can be reverted independently.
+4. Every new test must be proven to fail against a deliberately broken implementation.
+5. Walk quit/unmount and the error path for each shipped item.
+6. Drop, with evidence, any item whose cost does not reproduce or whose prescribed fix
+   makes things worse.
+
+## Implementation Notes
+
+Five items shipped, five dropped with evidence. Every measurement below is first-hand on
+dev `68c061984` with an isolated config/HOME; each shipped item is one commit.
+
+### Shipped
+
+**Item 1 - setup-modal snow (commit 1).** Reproduced exactly: with no provider configured
+the Console setup modal blocks, its full-screen snow backdrop ticks at 5 Hz, and the screen
+receives **75 Layout + 75 Update messages per 15 s** - the review's own census, to the
+message. CPU 6.2% of a core on a quiet box, 13-15% on a loaded one (the review recorded
+9.9%); the configured state measured 1.32% and reduced-motion 0.06%. Attribution: the
+backdrop covers the whole screen, so every repaint re-composites every line
+(`_compositor._render_chops`, 569 Strips per tick); density and glyph count are irrelevant
+to that cost, only the repaint rate is. Deterministic per-tick cost: **15.8 ms**.
+Fix: tick repaints with `layout=False` (a tick cannot resize the field), the backdrop is
+`markup=False` (the field is spaces plus three glyphs), and the interval goes 0.2 s -> 0.4 s
+with the per-tick displacement doubled so the flakes still drift at 2.0-7.0 rows/s.
+Interleaved A/B in one process, two rounds: **6.20/6.22% -> 2.60/2.81% of a core, Layout
+messages 59 -> 1 per 12 s window.**
+Declined half of the filing's prescription: defaulting `reduce_motion` to true on low-core
+machines. That setting is shared with the splash screen, so flipping its default would
+silently disable splash animation too, and it would make a visual default depend on
+hardware; the rate cut banks the same order of saving for every user.
+*User-visible:* the snow updates 2.5 times a second instead of 5, so it falls in slightly
+larger steps at the same speed. `[appearance] reduce_motion` still freezes it entirely.
+*Quit/error walk:* timer lifecycle, `pause_snow`/`resume_snow` and the reduced-motion path
+are untouched; `markup` is a `setdefault` so an explicit caller still wins; `layout=False`
+introduces no new failure mode.
+
+**Item 3 - MCP execution log (commit 2).** Reproduced, with one correction to the filing:
+it is two full-file *reads* per append but only ONE full parse until the first rotation
+(the rotated generation does not exist yet); after a rotation it really is two. Cost at the
+500-record cap: **499 json.loads + 500 json.dumps + 2 reads, 4.599 ms per tool invocation**,
+purely to re-derive bytes identical to those the previous append wrote.
+Fix: each generation this instance sanitizes is remembered under an identity fingerprint
+(device, inode, size, mtime_ns); a matching fingerprint returns the cached bytes, and
+`append` refreshes the entry from the bytes it just wrote. Every other outcome - a change by
+another process, a replaced or removed path, a symlink in the leaf, any stat failure - is a
+cache MISS that falls through to `_read_bytes` and its private-path guards exactly as
+before. **499 -> 0 loads, 500 -> 1 dumps, 2 -> 1 reads, 4.599 -> 0.315 ms (14.6x).**
+Post-rotation (700 records): 0 reads, 0 loads.
+Declined: removing the fsync-on-close. This is a security audit log, the fsync is what makes
+a recorded invocation survive a crash, and `open_private_text_append` is shared.
+*Quit/error walk:* no new failure mode - the fingerprint is consulted before the guarded
+read and never replaces it; a stat failure of any kind is a miss, not a decision.
+
+**Item 4 - re-chunk executemany (commit 3).** Reproduced and modest.
+**50 chunks 1.03 -> 0.84 ms; 500 chunks 10.55 -> 8.89 ms; 5,000 chunks 139.73 -> 116.20 ms
+(-17%).** The profile says why there is no more to take: what remains is SQLite's own work
+(executemany 72 ms, the DELETE 31 ms, commit 13 ms at 5,000 rows) plus 15 ms of uuid4.
+The parameter list is now built before the transaction opens, `chunk_index` still comes from
+the enumerate index (a skipped chunk leaves the same gap), and the DELETE stays
+unconditional.
+*Quit/error walk:* a malformed chunk now fails before a transaction is opened rather than
+inside one - strictly fewer partial states; the outer transaction on the auto path is
+unaffected.
+
+**Item 7 - media-viewer match-nav (commit 4).** Reproduced, and the cheap half of the fix
+was worth more than the prescribed half. `sync_search` repainted with `Static.update()`,
+whose `layout` defaults to True - but a search refresh restyles the SAME characters, so the
+size cannot change. Mounted harness at 120x40 over a 100 KB document, interleaved A/B,
+10 clicks per arm, two rounds: **Layout messages 10 -> 0, 84.75/85.18 -> 57.50/57.84 ms CPU
+per click (-32%).**
+Declined the filing's own prescription ("cache the match list, restyle two lines"): the
+match list is 6-10% of the renderable build (0.02 ms of 0.28 ms at 10 KB, 3.46 ms of
+34.23 ms at 1 MB), so caching it buys a tenth of what the one-keyword layout fix already
+banked, and restyling from cached spans is a real refactor of the highlight machinery for a
+click cost that is 0.28-3.5 ms at realistic media sizes.
+*User-visible:* nothing - the highlight moves exactly as before, without a screen relayout.
+*Quit/error walk:* `sync_search` is synchronous and unchanged apart from the keyword.
+
+**Item 8 - trajectory brush drag (commit 5).** Reproduced, with a correction: it is not
+literally per mouse-move. `_set_brush` is equality-gated on the exact time range and the
+range is quantized by column, so it is once per column crossed - but a full-width drag
+crosses ~70 columns, so the count is the same order. Measured with the gesture delivered as
+a burst (a real terminal delivers moves faster than Textual repaints): **69 full ledger
+rebuilds per gesture -> 1**, at a measured 5.93 ms per rebuild on a 600-row ledger (0.19 ms
+at 8 rows) - about 0.4 s of synchronous event-loop work while the button is still down. With
+a repaint forced between every move (the worst case for any throttle) it stays at one
+rebuild per move, which is exactly the "once per frame" the filing asked for.
+Only the drag path throttles; `apply_brush`, keyboard range selection and `clear_range` still
+emit synchronously, so a live snapshot re-brush is not delayed.
+*Quit/error walk:* the one hazard here is a debounce that loses state at the end. It cannot:
+`on_mouse_up` issues the pending emission itself when the final column matches the last
+coalesced one (the equality gate would otherwise emit nothing), a drag abandoned without a
+mouse-up drains on the next repaint, and `_flush_brush_emit` is a no-op once unmounted. All
+three are tested.
+
+### Dropped, with evidence
+
+**Item 2 - `unicode_casefold` UDF. Does not reproduce as a cost, and half the filing is
+wrong.** `EXPLAIN QUERY PLAN` with `sqlite_stat1` absent (the repo rule from TASK-21126)
+confirms `SCAN subscriptions` + `USE TEMP B-TREE FOR ORDER BY`. But the UDF is called
+**n+2 times, not 2n**: SQLite hoists the deterministic `unicode_casefold(?)` constant, and
+the ORDER BY evaluates it only for rows that survived the WHERE (52 calls for a 50-row
+table). The filed "WHERE **and** ORDER BY" doubling does not happen. Cost per agent-tool
+resolution: **0.034 ms at 50 sources, 0.147 ms at 500, 1.274 ms at 5,000** (miss, i.e. all
+three legs: 0.085 / 0.352 / 3.074 ms). Sub-millisecond at any realistic watchlist size, once
+per LLM tool call. Fixing it properly needs a normalized indexed column, i.e. a schema
+change, which this does not justify.
+
+**Item 5 - GC-leaked `with conn:`. The leak is real; the prescribed fix makes the operation
+slower.** Excluded per the brief: `Writing_Interop` (TASK-21125), `Research_Interop`
+(TASK-21127), `Notifications/event_state_repository.py` (TASK-21131). Of what remained,
+`Widgets/Tamagotchi/tamagotchi_storage.py` has no production importer at all (see item 10),
+leaving `Sync_Interop/sync_state_repository.py`.
+The leak reproduces and is worse than "style": 50 consecutive `get_latest_mirror_report`
+calls left **34 of the 50 connections still open** (live `sqlite3.Connection` objects
+2 -> 36) - refcounting does not reclaim them because they land in a reference cycle. An
+explicit close in a `_transactional_connection` helper across all 26 sites took that to
+**0 -> 0** and kept `Tests/Sync_Interop` green at 301 passed.
+It was reverted anyway, because it costs more than it saves. Interleaved A/B, 200 reads per
+arm, two rounds: **128.2/111.5 ms (leaking) -> 160.4/185.0 ms (closing)**. Cause, proven by
+a third arm: with one anchor connection held open for the run the two arms converge
+(129.5/129.1 vs 125.5/126.3 ms). **The leaked handles were acting as WAL anchors** - closing
+properly makes every close a last-connection close, which pays a WAL checkpoint and
+WAL/shm teardown. The change that wins on both axes is a held connection (the same query on
+one measured **0.002 ms against 0.619 ms**, i.e. ~310x), which is exactly the TASK-21125 /
+TASK-21127 shape and needs a task of its own, not a line in a residue batch. Recommend
+filing that; the leak is bounded (the generational GC reclaims it at ~33 live handles) and
+is not an fd-exhaustion risk.
+
+**Item 6 - `EnhancedStatusWidget` recompose. False positive: the widget is never
+instantiated.** `EnhancedStatusWidget(` appears nowhere in the repository outside its own
+class statement - not in production, not in tests. Its only would-be consumer,
+`Event_Handlers/ingest_status_helper.py`, has **zero importers** (its sole other mention is
+a row in the diagnostic inventory). The recompose-per-status-message costs nothing during
+ingest because nothing mounts it. Dead code, not a hot path; retiring it is a deletion, not
+a perf change.
+
+**Item 9 - `CAPABILITY_REGISTRY`. Both halves are too small to justify their risk.**
+1,324 rows (the filing said 1,323), 62% server-only - both confirmed.
+`validate_registry_completeness()` costs **0.030 ms**, once per process. Moving it to tests
+would trade a production invariant for 30 microseconds. `_build_capability_registry` is
+**1.41 ms of a 7.65 ms module import**, so lazy-building the server partition could save
+~0.9 ms of a 0.825 s warm boot (~0.1%) - in exchange for turning a plain dict that is used
+with `in`, `[]`, `.get()` and `.values()` (including `PolicyEngine(CAPABILITY_REGISTRY)` at
+app.py:5882) into a lazy mapping.
+
+**Item 10 - dormant sqlite owners. One no longer reproduces; the other three cost zero.**
+The Kanban boot connect **was already fixed by TASK-21105**: `LocalKanbanService.__init__`
+now resolves the path only and defers its 24 DDL statements to the first `connect()`
+(file-backed; `:memory:` stays eager). The other three are confirmed dormant *in production*
+and therefore cost nothing at runtime: `Sync_Interop/notes_mirror.py` is reached only via
+`notes_m1_flow.py`, whose only importer is `Tests/Sync_Interop/test_notes_m1_flow.py`;
+`Widgets/Tamagotchi/tamagotchi_storage.py` has no importer outside its own package except
+four test modules; `Third_Party/aider/repomap.py` is imported only by
+`Coding/code_mapper.py`, which has **zero importers of its own**. Retiring them is a
+dead-code deletion whose blast radius is live gate tests (the private-sqlite inventory, the
+CSS consolidation ratchet, the pragma census) - a task with its own review surface, not a
+line in a perf batch.
+
+### Test and preflight evidence
+
+Matched A/B against a detached worktree at pristine dev `68c061984`, same command, same
+interpreter, three groups:
+
+| group | pristine dev | this branch |
+|---|---|---|
+| `Tests/MCP` + `Tests/Sync_Interop` + private-sqlite inventory + pragma census | 1 failed, 1450 passed | 1 failed, **1454** passed |
+| re-chunk + media-content + reduced-motion + background-effects (+ the new backdrop file) | 48 passed | **56** passed |
+| the eight trajectory / trace suites | 201 passed | **205** passed |
+| `Tests/UI/test_widget_css_consolidation.py` (the CSS cliff guard) | 33 passed | 33 passed |
+| `Tests/UI/test_library_shell.py` (indirect consumer of the media body) | 12 failed, 716 passed | 12 failed, 716 passed -- identical set |
+
+Two reds, both identical in both arms and therefore pre-existing on dev:
+`Tests/MCP/test_gateway_runtime_prompts.py::test_real_keyword_search_failure_stays_private_through_prompt_gateway`,
+and the twelve `Tests/UI/test_library_shell.py` failures (compared as sets, not counts).
+
+`./scripts/preflight.sh` is green. Its diagnostic-inventory check was **already red on
+pristine dev**: the pin carries three stale `RAG_Search/simplified/*` rows left by the merged
+TASK-3500 RAG work one commit before this base. All four rows (those three plus this
+branch's own, a pure re-indent of an existing `logger.warning` in
+`library_rechunk_service.py`) were reviewed statement-by-statement with `--statements` and
+the review is recorded in the regen commit rather than absorbed silently.
+
+### Follow-up worth filing
+
+`SyncStateRepository` should be converted to a held connection (thread-local, with the
+liveness ping `AgentRuns_DB` already uses). Evidence in the item-5 note above: the current
+open-per-operation shape leaks ~33 live connections under load AND costs 0.619 ms per read
+against 0.002 ms on a held one, and the minimal "just close it" fix trades the leak for a
+per-close WAL checkpoint.
+
+### Files
+
+Modified: `tldw_chatbook/Widgets/Console/console_setup_modal.py`,
+`tldw_chatbook/MCP/execution_log.py`, `tldw_chatbook/Library/library_rechunk_service.py`,
+`tldw_chatbook/Widgets/Library/library_media_content.py`,
+`tldw_chatbook/UI/Widgets/trajectory_timeline.py`.
+Added: `Tests/UI/test_console_setup_backdrop_repaint_cost.py`. Extended:
+`Tests/MCP/test_execution_log.py`, `Tests/Library/test_library_rechunk_service.py`,
+`Tests/Library/test_library_media_content.py`,
+`Tests/UI/test_trajectory_timeline_integration.py`.

--- a/tldw_chatbook/Library/library_rechunk_service.py
+++ b/tldw_chatbook/Library/library_rechunk_service.py
@@ -258,49 +258,59 @@ def _replace_chunk_rows(
     """
     created = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
     client_id = getattr(media_db, "client_id", "local")
+    # TASK-21134: built as one parameter list and inserted with executemany.
+    # ``Connection.execute`` builds a fresh Cursor per call, so the old
+    # per-chunk loop paid that construction 5,000 times for a 5,000-chunk
+    # document. ``chunk_index`` still comes from the enumerate index, so a
+    # skipped invalid chunk leaves the same gap in the sequence it always did.
+    rows: List[tuple] = []
+    for index, chunk in enumerate(chunks):
+        if not isinstance(chunk, dict) or chunk.get("text") is None:
+            logger.warning(
+                f"Skipping invalid chunk index {index} for media_id {media_id}"
+            )
+            continue
+        rows.append(
+            (
+                media_id,
+                chunk["text"],
+                index,
+                chunk.get("start_char"),
+                chunk.get("end_char"),
+                chunk.get("chunk_type"),
+                created,
+                created,
+                False,
+                json.dumps(chunk.get("metadata"))
+                if isinstance(chunk.get("metadata"), dict)
+                else None,
+                template_name,
+                template_params,
+                # task-13 (spec §10.2): the stamp IS the point -- these
+                # rows leave the "legacy" report population.
+                ENGINE_VERSION,
+                media_db._generate_uuid(),
+                created,
+                1,
+                client_id,
+                0,
+                None,
+                None,
+            )
+        )
     with media_db.transaction() as conn:
         conn.execute(
             "DELETE FROM UnvectorizedMediaChunks WHERE media_id = ?", (media_id,)
         )
-        for index, chunk in enumerate(chunks):
-            if not isinstance(chunk, dict) or chunk.get("text") is None:
-                logger.warning(
-                    f"Skipping invalid chunk index {index} for media_id {media_id}"
-                )
-                continue
-            conn.execute(
+        if rows:
+            conn.executemany(
                 "INSERT INTO UnvectorizedMediaChunks (media_id, chunk_text, "
                 "chunk_index, start_char, end_char, chunk_type, creation_date, "
                 "last_modified_orig, is_processed, metadata, chunking_template, "
                 "chunking_params, chunk_engine_version, uuid, last_modified, "
                 "version, client_id, deleted, prev_version, merge_parent_uuid) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    media_id,
-                    chunk["text"],
-                    index,
-                    chunk.get("start_char"),
-                    chunk.get("end_char"),
-                    chunk.get("chunk_type"),
-                    created,
-                    created,
-                    False,
-                    json.dumps(chunk.get("metadata"))
-                    if isinstance(chunk.get("metadata"), dict)
-                    else None,
-                    template_name,
-                    template_params,
-                    # task-13 (spec §10.2): the stamp IS the point -- these
-                    # rows leave the "legacy" report population.
-                    ENGINE_VERSION,
-                    media_db._generate_uuid(),
-                    created,
-                    1,
-                    client_id,
-                    0,
-                    None,
-                    None,
-                ),
+                rows,
             )
 
 

--- a/tldw_chatbook/MCP/execution_log.py
+++ b/tldw_chatbook/MCP/execution_log.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -155,6 +156,10 @@ class MCPExecutionLog:
             raise ValueError("max_records_per_file must be positive")
         self.max_records_per_file = max_records_per_file
         self._lock = threading.RLock()
+        #: TASK-21134: identity fingerprint -> sanitized bytes, for each
+        #: generation this instance has already scrubbed. See
+        #: ``_migrate_generation``.
+        self._migrated: dict[str, tuple[tuple[int, ...], bytes]] = {}
 
     def append(self, record: ExecutionRecord) -> None:
         """Append one record, rotating generations at the size cap.
@@ -188,12 +193,20 @@ class MCPExecutionLog:
                     encoded_line,
                     application_owned_directory=self.path.parent,
                 )
+                # Both generations were just written from bytes that are
+                # already sanitized; re-deriving them on the next append
+                # would reproduce them exactly (TASK-21134).
+                self._remember_migration(rotated, active_payload or b"")
+                self._remember_migration(self.path, encoded_line)
                 return
             with open_private_text_append(
                 self.path,
                 application_owned_directory=self.path.parent,
             ) as handle:
                 handle.write(encoded_line.decode("utf-8"))
+            self._remember_migration(
+                self.path, (active_payload or b"") + encoded_line
+            )
 
     def read_recent(self, limit: int = 200) -> list[dict[str, Any]]:
         """Return recent records, newest first, across both generations.
@@ -344,11 +357,55 @@ class MCPExecutionLog:
             "result_size": result_size,
         }
 
+    @staticmethod
+    def _identity(path: Path) -> tuple[int, ...] | None:
+        """Fingerprint a generation file, or ``None`` if it cannot be read.
+
+        ``lstat`` deliberately: a symlink in the leaf's place reports the
+        link's own inode, which can never match the fingerprint of the
+        regular file this instance last wrote, so a swapped path is a cache
+        MISS and falls through to the guarded read. ``None`` (missing, or any
+        other stat failure) is also a miss, never a decision -- every failure
+        mode is handed to ``_read_bytes`` and its private-path guards to
+        classify, exactly as before this cache existed. The fingerprint
+        decides staleness only.
+        """
+        try:
+            stat = os.lstat(path)
+        except OSError:
+            return None
+        return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+
+    def _remember_migration(self, path: Path, sanitized: bytes) -> None:
+        identity = self._identity(path)
+        if identity is None:
+            self._migrated.pop(str(path), None)
+            return
+        self._migrated[str(path)] = (identity, sanitized)
+
     def _migrate_generation(self, path: Path) -> bytes | None:
-        """Scrub legacy payload rows and torn lines before further use."""
+        """Scrub legacy payload rows and torn lines before further use.
+
+        The scrub is idempotent, so re-running it on a file this instance
+        already sanitized and has not seen change is pure waste. TASK-21134
+        measured that waste at one full-file parse + re-serialize per tool
+        invocation -- 4.6 ms at the 500-record cap, on every MCP tool call,
+        purely to re-derive bytes identical to what the previous call wrote.
+        A cached identity fingerprint (device/inode/size/mtime) skips it. Any
+        change by another process, or a replaced path, misses the cache and
+        takes the full scrub exactly as before.
+        """
+
+        cached = self._migrated.get(str(path))
+        if cached is not None:
+            identity = self._identity(path)
+            if identity is not None and identity == cached[0]:
+                return cached[1]
+            self._migrated.pop(str(path), None)
 
         raw = self._read_bytes(path)
         if raw is None:
+            self._migrated.pop(str(path), None)
             return None
         rows: list[dict[str, Any]] = []
         for line in raw.decode("utf-8", errors="replace").splitlines():
@@ -367,4 +424,5 @@ class MCPExecutionLog:
                 sanitized,
                 application_owned_directory=self.path.parent,
             )
+        self._remember_migration(path, sanitized)
         return sanitized

--- a/tldw_chatbook/MCP/execution_log.py
+++ b/tldw_chatbook/MCP/execution_log.py
@@ -377,8 +377,16 @@ class MCPExecutionLog:
         return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
     def _remember_migration(self, path: Path, sanitized: bytes) -> None:
+        """Record ``sanitized`` as this generation's content, if it still is.
+
+        The size check is the multi-process window: another writer can append
+        between our read (or our own append) and this stat, and caching then
+        would pin bytes that are already short of the file while the
+        fingerprint says they are current. A mismatch simply means no cache
+        entry, i.e. the next call re-reads exactly as it did before.
+        """
         identity = self._identity(path)
-        if identity is None:
+        if identity is None or identity[2] != len(sanitized):
             self._migrated.pop(str(path), None)
             return
         self._migrated[str(path)] = (identity, sanitized)

--- a/tldw_chatbook/UI/Widgets/trajectory_timeline.py
+++ b/tldw_chatbook/UI/Widgets/trajectory_timeline.py
@@ -411,6 +411,9 @@ class TrajectoryTimeline(Widget):
         self._range_anchor: str | None = None
         self._drag_x: int | None = None
         self._drag_moved = False
+        #: TASK-21134: set while a mid-drag brush emission is coalescing.
+        #: See ``_set_brush``.
+        self._brush_emit_pending = False
 
     # -- state --------------------------------------------------------------
 
@@ -654,8 +657,38 @@ class TrajectoryTimeline(Widget):
             return
         self._brush = brush
         self.refresh()
-        if emit:
-            self.post_message(self.TrajectoryBrushChanged(brush))
+        if not emit:
+            return
+        if self._drag_x is not None:
+            # TASK-21134: mid-drag, coalesce to at most one emission per
+            # repaint. The visual brush above still follows the mouse on every
+            # move; what is throttled is the message, and the host rebuilds its
+            # whole ledger DataTable for each one. Measured on a burst-
+            # delivered 70-column drag (a real terminal delivers moves faster
+            # than Textual repaints): 69 full ledger rebuilds for one gesture,
+            # at 5.93 ms each on a 600-row ledger -- ~0.4 s of synchronous
+            # event-loop work while the user is still holding the button down.
+            # ``on_mouse_up`` always emits the final range, so the ledger can
+            # never end a gesture showing a range the strip is not painting.
+            self._schedule_brush_emit()
+            return
+        self.post_message(self.TrajectoryBrushChanged(brush))
+
+    def _schedule_brush_emit(self) -> None:
+        """Queue one coalesced mid-drag brush emission."""
+        if self._brush_emit_pending:
+            return
+        self._brush_emit_pending = True
+        self.call_after_refresh(self._flush_brush_emit)
+
+    def _flush_brush_emit(self) -> None:
+        """Emit the brush the drag has reached, if one is still pending."""
+        if not self._brush_emit_pending:
+            return
+        self._brush_emit_pending = False
+        if not self.is_mounted:
+            return
+        self.post_message(self.TrajectoryBrushChanged(self._brush))
 
     def clear_range(self, *, emit: bool = True) -> bool:
         """Clear an active brush/keyboard anchor; return whether state changed."""
@@ -751,7 +784,18 @@ class TrajectoryTimeline(Widget):
             else:
                 self.clear_range()
         else:
+            # TASK-21134: ``_drag_x`` is already None above, so this final
+            # ``brush_columns`` emits synchronously -- but only if it actually
+            # moves the range. When the gesture ends on the same column the
+            # last coalesced move reached, it does not, so the pending emission
+            # is issued here instead of a repaint later. Exactly one message
+            # either way, and the ledger always ends the gesture on the range
+            # the strip is painting.
+            self._brush_emit_pending = False
+            settled = self._brush
             self.brush_columns(start_x, event.x)
+            if self._brush == settled:
+                self.post_message(self.TrajectoryBrushChanged(self._brush))
 
     def on_mouse_scroll_up(self, event: MouseEvent) -> None:
         width = self._plot_width()

--- a/tldw_chatbook/UI/Widgets/trajectory_timeline.py
+++ b/tldw_chatbook/UI/Widgets/trajectory_timeline.py
@@ -790,11 +790,13 @@ class TrajectoryTimeline(Widget):
             # last coalesced move reached, it does not, so the pending emission
             # is issued here instead of a repaint later. Exactly one message
             # either way, and the ledger always ends the gesture on the range
-            # the strip is painting.
-            self._brush_emit_pending = False
+            # the strip is painting. Gated on there actually being one pending:
+            # a drag over a strip with no time domain never brushed anything,
+            # and must stay silent exactly as it did before.
+            pending, self._brush_emit_pending = self._brush_emit_pending, False
             settled = self._brush
             self.brush_columns(start_x, event.x)
-            if self._brush == settled:
+            if pending and self._brush == settled:
                 self.post_message(self.TrajectoryBrushChanged(self._brush))
 
     def on_mouse_scroll_up(self, event: MouseEvent) -> None:

--- a/tldw_chatbook/Widgets/Console/console_setup_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_setup_modal.py
@@ -62,16 +62,26 @@ _TYPING_LOCKED_HINT = (
     "Typing is locked until setup finishes — press Enter to continue setup."
 )
 
-# Snow tuning: modest density (~1 flake per 30-50 cells), gentle tick cadence
-# (0.15-0.25s), varied fall speed + a little horizontal wobble so the field
-# doesn't look mechanical. Mirrors the composer cursor-blink timer discipline:
-# created paused on mount, resumed only while blocking.
-_SNOW_TICK_INTERVAL = 0.2
+# Snow tuning: modest density (~1 flake per 30-50 cells), gentle tick cadence,
+# varied fall speed + a little horizontal wobble so the field doesn't look
+# mechanical. Mirrors the composer cursor-blink timer discipline: created
+# paused on mount, resumed only while blocking.
+#
+# TASK-21134: the cadence was 0.2 s (5 Hz) and cost a measured 15.8 ms of CPU
+# per tick -- ~7.9% of a core, burnt at idle by every not-yet-configured user,
+# against a 0.1% floor with the field frozen. The tick is expensive because the
+# backdrop covers the whole screen, so every repaint re-composites every line
+# of it; density and glyph count are irrelevant to that cost, only the repaint
+# RATE is. Halving the rate to 0.4 s and doubling the per-tick displacement
+# keeps the flakes drifting at the same cells-per-second (2-7 rows/s) for half
+# the CPU. Displacement and interval are therefore a matched pair: changing one
+# without the other changes how fast the snow appears to fall.
+_SNOW_TICK_INTERVAL = 0.4
 _SNOW_FLAKE_GLYPHS = ("·", "•", "*")  # ·, •, *
 _SNOW_DENSITY_CELLS = 40
-_SNOW_MIN_SPEED = 0.4
-_SNOW_MAX_SPEED = 1.4
-_SNOW_MAX_WOBBLE = 0.4
+_SNOW_MIN_SPEED = 0.8
+_SNOW_MAX_SPEED = 2.8
+_SNOW_MAX_WOBBLE = 0.8
 
 
 @dataclass
@@ -123,6 +133,11 @@ class ConsoleSetupBackdrop(Static):
         kwargs.setdefault("id", CONSOLE_SETUP_MODAL_BACKDROP_ID)
         classes = kwargs.pop("classes", "")
         kwargs["classes"] = f"console-setup-modal-backdrop-snow {classes}".strip()
+        # TASK-21134: the field is only spaces and the three flake glyphs, none
+        # of which is markup. Parsing it as console markup on every repaint is
+        # pure waste, and a glyph set that grew a "[" would otherwise silently
+        # become a markup tag.
+        kwargs.setdefault("markup", False)
         super().__init__(**kwargs)
         self._rng = rng if rng is not None else random.Random()
         #: TASK-2154.10 (AC-04): when True the flake field renders one static
@@ -239,19 +254,30 @@ class ConsoleSetupBackdrop(Static):
                 # field doesn't look like it's raining in vertical lines.
                 flake.y = 0.0
                 flake.x = self._rng.uniform(0, max(width - 1, 0))
-        self._render_flakes()
+        self._render_flakes(layout=False)
 
-    def _render_flakes(self) -> None:
+    def _render_flakes(self, *, layout: bool = True) -> None:
+        """Repaint the flake field.
+
+        Args:
+            layout: Whether the repaint may also change the widget's size.
+                A tick passes ``False``: the field is always exactly
+                ``_field_height`` lines of ``_field_width`` columns, so a tick
+                cannot resize it, and arming a layout pass 2.5 times a second
+                for a decoration made the Console's idle screen re-layout
+                (TASK-21134). The resize path keeps ``True`` -- there the
+                field's dimensions really did just change.
+        """
         width, height = self._field_width, self._field_height
         if width <= 0 or height <= 0:
-            self.update("")
+            self.update("", layout=layout)
             return
         rows = [[" "] * width for _ in range(height)]
         for flake in self._flakes:
             fx, fy = int(flake.x), int(flake.y)
             if 0 <= fx < width and 0 <= fy < height:
                 rows[fy][fx] = flake.glyph
-        self.update("\n".join("".join(row) for row in rows))
+        self.update("\n".join("".join(row) for row in rows), layout=layout)
 
 
 def _coerce_card_state(value: object) -> ConsoleSetupCardState:

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -122,8 +122,15 @@ class LibraryMediaContentBody(VerticalScroll):
         self._query = query
         self._match_index = match_index
         if self._raw_widget is not None:
+            # TASK-21134: ``layout=False`` -- a search refresh restyles the
+            # SAME characters (``build_raw_content_renderable`` only moves
+            # highlight spans around; it never adds, removes or rewraps a
+            # line), so the widget's size cannot change and the layout pass
+            # Static.update() arms by default was pure waste on every
+            # match-nav click and every keystroke in the search box.
             self._raw_widget.update(
-                build_raw_content_renderable(self.content, query, match_index)
+                build_raw_content_renderable(self.content, query, match_index),
+                layout=False,
             )
 
     async def _ensure_mode_mounted(self, mode: str) -> None:


### PR DESCRIPTION
## Summary

The small-residue batch from the 2026-08-22 review — items too small to warrant a task each, which
together are a real tax. **Five shipped, five dropped with evidence.** One commit per item, so any
single one can be reverted independently.

Dropping an item after measuring it is the point of a batch like this, not a shortfall: two of the
five drops were the filing being wrong, and one was a fix that measured *worse*.

## Shipped

**1 — Setup-modal snow.** Reproduced the review's census exactly: **75 Layout + 75 Update messages
per 15 s** at 5 Hz. Attribution corrected — the backdrop covers the whole screen, so every repaint
re-composites every line (569 Strips/tick); *density is irrelevant, only rate is*. CPU 6.2% of a
core quiet, 13–15% loaded (review said 9.9%), against 1.32% configured and 0.06% with
reduced-motion. Fix: repaint with `layout=False`, `markup=False`, and interval 0.2 → 0.4 s with
displacement doubled so drift stays 2.0–7.0 rows/s. **Interleaved A/B, 2 rounds: 6.20/6.22% →
2.60/2.81% of a core; Layout 59 → 1 per 12 s.** *A user sees* snow updating 2.5×/s instead of 5, at
the same fall speed with slightly larger steps.
*Declined* the low-core `reduce_motion` default — that setting is shared with the splash screen, so
flipping it would silently disable splash animation too.

**3 — MCP execution log.** Correction: two full-file *reads* but only **one** parse until the first
rotation. At the 500-record cap: **499 loads / 500 dumps / 2 reads / 4.599 ms per tool invocation →
0 / 1 / 1 / 0.315 ms (14.6×)**; post-rotation, zero reads. Identity fingerprint (dev, ino, size,
mtime_ns); every other outcome is a cache **miss** falling through to the guarded read.
*Declined* the fsync removal — it is a security audit log and the helper is shared.

**4 — Re-chunk `executemany`.** 50 chunks 1.03 → 0.84 ms; 5,000 chunks **139.73 → 116.20 ms (−17%)**.
Modest, and the profile shows why nothing more is available at the Python layer: SQLite's own
executemany is 72 ms, the DELETE 31 ms, commit 13 ms, `uuid4` 15 ms.

**7 — Media-viewer match-nav.** A second instance of the `Static.update()` default: `sync_search`
restyles the same characters but laid out anyway. **Layout messages 10 → 0; 84.75/85.18 → 57.50/57.84
ms CPU per click (−32%)** on a 100 KB document at 120×40. *Declined* the filing's own prescription
(cache the match list) — it is 6–10% of the build.

**8 — Trajectory brush drag.** Correction: the rebuild fires once per **column crossed**, not per
mouse-move. A burst-delivered 70-column drag: **69 ledger rebuilds → 1**, at 5.93 ms each on a
600-row ledger — roughly 0.4 s of loop work per gesture. Only the drag path throttles; mouse-up
issues the pending emission itself, and a domain-less drag stays silent (found in self-review).

## Dropped, each with the measurement that retired it

- **2 — casefold UDF.** The UDF runs **n+2 times, not 2n**: SQLite hoists the deterministic
  constant, and ORDER BY only sees surviving rows. The filed WHERE-and-ORDER-BY doubling does not
  happen. 0.034 / 0.147 / 1.274 ms at 50 / 500 / 5,000 sources. Plan checked with `sqlite_stat1`
  **absent**, per the rule TASK-21126 established.
- **5 — GC-leaked `with conn:`.** Only `sync_state_repository` remained after the sibling tasks. The
  leak is real (**2 → 36 live connections over 50 reads**), and the close was implemented and tested
  (301 passed) — then **reverted**, because 200 reads went **128/112 ms → 160/185 ms**. A third arm
  proved why: the leaked handles were acting as **WAL anchors**, and with one anchor held the arms
  converge. The fix that wins on both axes is a held connection (0.002 vs 0.619 ms/read), filed as a
  follow-up rather than smuggled into a residue batch.
- **6 — `EnhancedStatusWidget`.** Never instantiated anywhere; its only would-be consumer has zero
  importers.
- **9 — `CAPABILITY_REGISTRY`.** 1,324 rows, 62% server-only confirmed — but validation is
  **0.030 ms** once per process, and the build is 1.41 ms of a 7.65 ms import.
- **10 — Dormant owners.** The Kanban boot connect was **already fixed by TASK-21105**; the other
  three are confirmed dormant and cost zero at runtime.

## Mutation

19 mutations across the five shipped items — 4 / 5 / 3 / 2 / 5 — **all red**, all restored green.

## Verification

Matched A/B against a detached worktree at pristine dev:

| group | dev | branch |
|---|---|---|
| MCP + Sync_Interop + private-sqlite + pragma | 1 failed, 1450 passed | 1 failed, **1454** |
| rechunk + media-content + reduced-motion + bg-effects | 48 passed | **56** |
| 8 trajectory/trace suites | 201 passed | **205** |
| `test_library_shell.py` | 12 failed, 716 passed | 12 failed, 716 — identical set |

After rebase: `Tests/MCP` + rechunk = **1110 passed, 1 failed**, that one
(`test_real_keyword_search_failure_stays_private_through_prompt_gateway`) re-confirmed failing on
pristine dev `ecf331be8`. Preflight green — the single inventory row moved lines only, and
`--statements` reports "statement text is unchanged, NO review needed".

## Out of scope

- `SyncStateRepository` needs the held-connection conversion (evidence above).
- `EnhancedStatusWidget` + `ingest_status_helper.py`, `Sync_Interop/notes_mirror.py`,
  `Widgets/Tamagotchi/`, `Coding/code_mapper.py` + `Third_Party/aider/repomap.py` are all dead in
  production — a deletion task whose blast radius is its live gate tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts idle CPU, append latency, and UI thrash by shipping five small perf fixes for TASK-21134. No schema or API changes; user-visible change is setup snow updates at 2.5 Hz (from 5 Hz) at the same fall speed.

- Setup modal snow: ticks at 0.4 s and repaints with `layout=False`, `markup=False` (was 0.2 s, layout default, markup parsed). Same drift speed via doubled per-tick displacement; idle CPU drops substantially. File: `tldw_chatbook/Widgets/Console/console_setup_modal.py`.
- MCP execution log: stop re-scrubbing unchanged generations on every append. Cache sanitized bytes per generation keyed by (dev, ino, size, mtime_ns); miss falls back to guarded read; handles rotations, symlinks, and concurrent appends. Fsync unchanged. File: `tldw_chatbook/MCP/execution_log.py`.
- Re-chunk service: replace per-chunk `execute` with one `executemany`. Keeps unconditional DELETE; skips invalid chunks without renumbering survivors; inserting none still clears old rows. File: `tldw_chatbook/Library/library_rechunk_service.py`.
- Media viewer search: `Static.update(..., layout=False)` on match-nav; previously armed layout on every refresh. File: `tldw_chatbook/Widgets/Library/library_media_content.py`.
- Trajectory timeline: coalesce mid-drag brush emissions to one per repaint; mouse-up flush ensures no loss; non-drag callers remain synchronous; domain-less drags stay silent. File: `tldw_chatbook/UI/Widgets/trajectory_timeline.py`.

**Review notes**
- Focus on the execution-log cache correctness: identity fingerprinting via `lstat`, size check before caching, and miss paths still using the private-file guards.
- Verify timeline coalescing cannot drop the final range and does not throttle non-drag paths.
- Confirm rechunking preserves index gaps and clears rows when no valid chunks exist.
- Tests added for each change under `Tests/...`; diagnostic inventory digest updated. No migrations or config changes required.

<sup>Written for commit d230866a49c2823d574d9d497cb38ca7bf9a24c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

