### PR TITLE
docs(perf): close out the 2026-08-22 performance burn-down

### DIFF
--- a/Docs/Design/2026-08-22-holistic-perf-review.md
+++ b/Docs/Design/2026-08-22-holistic-perf-review.md
@@ -506,6 +506,84 @@ silently edited.
 
 ---
 
+## Final outcome (2026-08-24)
+
+**30 of 35 findings shipped, across 40 PRs.** Five remain open, and four of those are recommended
+for closure rather than work — see below.
+
+### What the burn-down actually bought
+
+The wins that a user on the constrained hardware this review targets would notice, largest first:
+
+| finding | measure | before | after |
+|---|---|---|---|
+| 21730 (found mid-burn-down) | boot closure / time-to-interactive | 703 modules · 2699 ms | **637 · 2478 ms** |
+| 21130 | TTS v3→v4 migration peak memory | 966.9 MiB | **88.0 MiB** |
+| 21110 | first boot after upgrade, splash close → usable | 2.103 s | **1.128 s** |
+| 21127 | Research: connection opens / loop-side DB time | 1741 · 877 ms | **3 · 29 ms** |
+| 21131 | Notifications feed + mark_presented | 15.39 ms | **0.899 ms** |
+| 21129 | notes-sync per action @1k bindings; worst loop stall | 149.6 ms · 1495 ms | **2.96 ms · 2.40 ms** |
+| 21126 | Library legacy-chunk census (200k rows) | 118.8 ms | **23.4 ms** |
+| 21692 | composer blink tick | 396 `Widget.arrange`/6 ticks | **0** |
+| 21111 | app construction; keyring calls at boot | 77.0 ms · 4 | **60.9 ms · 0** |
+| 21134 item 1 | setup-modal snow idle burn | 6.2% of a core | **2.7%** |
+
+Two changes fixed correctness, not speed: 21131 took concurrent event recording from **9 of 12
+`IntegrityError`s to zero**, and 21127's `BEGIN IMMEDIATE` conversion eliminated a lost-update race
+(40 writes reporting success while the version advanced 11 times).
+
+### The dominant lesson: a finding tells you where to look, not what to do
+
+**Five of seven re-verified findings needed correcting before dispatch, and then nearly every
+implementer corrected its brief again during implementation.** Recorded here because the pattern
+matters more than any single number:
+
+- **21126** — the prescribed index would have shipped **dead**. It measured 112 → 3.4 ms only
+  because the probe had run `ANALYZE`; no media database in the wild has `sqlite_stat1`, and with
+  stats absent it was 118.8 vs 120.2 ms. The shipped index leads with a *redundant* column so the
+  no-stats planner will pick it at all.
+- **21130** — the cited call site is one real upgrades never take.
+- **21111** — the three named keyring sites bank **0 ms**; `keyring.get_keyring()` memoizes, so
+  whoever runs first pays for everyone.
+- **21129** — "no index on `root_id`" was false; **88%** of the read was dataclass hydration.
+- **21134 item 5** — the "close the leaked connections" fix measured **worse** (128 → 160 ms),
+  because the leaked handles were acting as WAL anchors.
+- **21134 item 2** — the casefold UDF runs n+2 times, not the filed 2n.
+- **21731** — the filed import chain was wrong on all three files; and deferring only the real edge
+  would have turned both guards green while leaving 62 of 67 modules loading before first paint.
+- **21113** — "a short sleep bounds GIL contention to one module" is impossible with one thread.
+
+### Guard hygiene, which turned out to matter as much as the fixes
+
+Three guards were found **silently red on dev**: the boot-closure weight guard, the chunking-closure
+guard, and the derived-artifacts gate (twice, from stale diagnostic-inventory pins — which blocks
+*every* PR in the repo, not just the offender's). A guard nobody runs protects nothing;
+`MAX_TLDW_MODULE_COUNT` was deliberately **not** raised to accommodate the regression it caught.
+
+### Still open
+
+- **21123** — the import half shipped (PIL off the post-paint loop). The architectural relocation is
+  deferred: `super().recompose()` removes every child, so an app-level owner reacting only to
+  screen-change events would silently lose the Buddy. **Owner decision.**
+- **21107 · 21109 · 21120 · 21132 — recommended for closure, each with the measurement that
+  retired it.** 21107 is ~19 ms and its prescribed fix cannot compile (the spec table stores schema
+  classes as runtime values, and a test already allowlists the import as deliberate). 21109 is
+  sub-millisecond in practice, and deferring it would let the default `session` sweep delete a video
+  published that session. 21120 is mis-stated on all three legs, and its one real cost already
+  shipped as 21692. 21132's recursion walks *upward*, so it is empty for the default profile and
+  already off-loop; the "fix" is a query inversion, not a filter.
+
+### Filed during the burn-down, not part of the original 35
+
+`21441` (v48 broke self-migration; 15 tests red) · `21531` (four dev reds from stale doubles) ·
+`21532` · `21590` (**Console send had 26 red tests and no working baseline** — send itself proved
+healthy) · `21591` (`skip_on_keypress` cannot fire) · `21592` · `21593` · `21594` · `21595` ·
+`21596` · `21700` (**RAG cache-hit log writes the user's search query to a persistent sink**) ·
+`21731` · `22000` (**users cannot queue a follow-up during a run, behind a button that says they
+can**) · `22030` (**a failed DB open makes Send silently do nothing**).
+
+---
+
 ## Verified clean — do not re-fix
 
 - **All 13 audited 2026-08-11 fix families are structurally intact** (checked one by one):

--- a/backlog/tasks/task-21107 - Kanban_Interop defeats tldw_api's lazy facade - 76 pydantic models forced at every boot.md
+++ b/backlog/tasks/task-21107 - Kanban_Interop defeats tldw_api's lazy facade - 76 pydantic models forced at every boot.md
@@ -53,3 +53,13 @@ pattern already exists — `local_kanban_service.py:336,430,558` do function-loc
 `from ..tldw_api import Kanban...`. This also requires updating the allowlist test. That is a
 larger and riskier change than the original filing implies; treat it as such, and if it does not
 justify ~19 ms for a feature with no UI consumers, close this instead.
+
+## Closure recommendation (2026-08-24, burn-down close-out)
+
+**Recommend closing without work.** ~19 ms warm, not ~44 ms, and the prescribed fix cannot compile: KANBAN_OPERATION_SPECS stores the schema classes as runtime values, two siblings read that dict at module scope, and Tests/Utils/test_tldw_api_schema_deferral.py already allowlists the import as "a genuine module-scope need, not an oversight". A real fix means a lazy spec table plus editing that allowlist test -- a larger, riskier change than ~19 ms for a feature with no UI consumers justifies.
+
+Left open rather than closed unilaterally: retiring a filed finding is the owner's call. The
+evidence above is what a re-verification pass measured against dev before dispatch; if it is
+accepted, close this as "retired on evidence" rather than "won't fix", because the mechanism was
+real and only the cost or the prescribed fix was wrong.
+

--- a/backlog/tasks/task-21109 - Generated-video store retention runs in __init__ behind a 5s interprocess lease - move it to deferred startup.md
+++ b/backlog/tasks/task-21109 - Generated-video store retention runs in __init__ behind a 5s interprocess lease - move it to deferred startup.md
@@ -55,3 +55,13 @@ prior-session video marker can briefly resolve to a file that is about to vanish
 **Revised severity: low, bordering on not-worth-doing.** If something here is worth shipping, it
 is the smaller honest win — stop creating `.generated_videos.capacity.lock` in every profile's
 data dir at every boot for users who have never generated a video.
+
+## Closure recommendation (2026-08-24, burn-down close-out)
+
+**Recommend closing without work.** Sub-millisecond in practice: for a user with no videos the whole pass is one mkdir, one lock-file create, one flock, one failed scandir. The 5 s stall needs a second instance mid-save, and boot already catches VideoStoreBusyError. Worse, the prescribed deferral is unsafe -- the default retention mode is "session", which deletes everything, so moving the pass past first paint opens a window where a video published this session is wiped.
+
+Left open rather than closed unilaterally: retiring a filed finding is the owner's call. The
+evidence above is what a re-verification pass measured against dev before dispatch; if it is
+accepted, close this as "retired on evidence" rather than "won't fix", because the mechanism was
+real and only the cost or the prescribed fix was wrong.
+

--- a/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
+++ b/backlog/tasks/task-21120 - Composer per-keystroke residue - half-gated reason strip, hidden-input mirror, ghost history scan.md
@@ -59,3 +59,13 @@ Blink interval is 0.53 s, not 0.5, and the timer is paused unless the composer i
 arms a full layout pass ~2x/second while merely focused and idle. Filed separately as TASK-21692.
 
 **Action**: rewrite this task down to the ghost-scan cap, or close it and keep only 21692.
+
+## Closure recommendation (2026-08-24, burn-down close-out)
+
+**Recommend closing without work.** Mis-stated on all three legs. Leg 1's gate claim is false (there is no ARIA announcement) and the ungated part folds into a layout pass already armed on the same keystroke. Leg 2's prescribed "skip unchanged text" can never fire while typing. Only the ghost-scan cap survives, and the real cost found in this file -- the blink tick arming a full reflow ~2x/second -- already shipped as TASK-21692.
+
+Left open rather than closed unilaterally: retiring a filed finding is the owner's call. The
+evidence above is what a re-verification pass measured against dev before dispatch; if it is
+accepted, close this as "retired on evidence" rather than "won't fix", because the mechanism was
+real and only the cost or the prescribed fix was wrong.
+

--- a/backlog/tasks/task-21132 - Note-folder managed-membership CTE anchors on the whole closure instead of the requested subtrees.md
+++ b/backlog/tasks/task-21132 - Note-folder managed-membership CTE anchors on the whole closure instead of the requested subtrees.md
@@ -56,3 +56,13 @@ managed membership under a deleted ancestor.
 
 **Recommendation**: cancel, or downgrade to a "clean this up when someone is next in this file"
 note. This is a correctness-of-shape improvement, not a performance fix.
+
+## Closure recommendation (2026-08-24, burn-down close-out)
+
+**Recommend closing without work.** Effectively free for the default user. The recursion walks UPWARD, so it is bounded by managed folders x tree depth, not by the folder tree; with no sync owners the anchor is empty and served by a partial index. It is already off the event loop via asyncio.to_thread. The rewrite is a query INVERSION, not a filter, and equivalence hinges on a quirk (deleted parents enter the result set but cannot recurse) that a naive downward rewrite would not reproduce.
+
+Left open rather than closed unilaterally: retiring a filed finding is the owner's call. The
+evidence above is what a re-verification pass measured against dev before dispatch; if it is
+accepted, close this as "retired on evidence" rather than "won't fix", because the mechanism was
+real and only the cost or the prescribed fix was wrong.
+


### PR DESCRIPTION
## Summary

Closes out the 2026-08-22 holistic performance review. Documents only.

**30 of 35 findings shipped, across 40 PRs.** This adds a "Final outcome" section to the evidence
doc and annotates the four remaining findings with the measurement that retired each one.

## What it buys the user

Largest first, on the constrained hardware the review targeted:

| finding | measure | before | after |
|---|---|---|---|
| 21731 | boot closure · time-to-interactive | 703 modules · 2699 ms | **637 · 2478 ms** |
| 21130 | TTS v3→v4 migration peak memory | 966.9 MiB | **88.0 MiB** |
| 21110 | first boot after upgrade, splash → usable | 2.103 s | **1.128 s** |
| 21127 | Research: opens · loop-side DB time | 1741 · 877 ms | **3 · 29 ms** |
| 21131 | Notifications feed + mark_presented | 15.39 ms | **0.899 ms** |
| 21129 | notes-sync per action @1k · worst loop stall | 149.6 ms · 1495 ms | **2.96 ms · 2.40 ms** |
| 21126 | Library census (200k rows) | 118.8 ms | **23.4 ms** |
| 21692 | composer blink tick | 396 `Widget.arrange` / 6 ticks | **0** |
| 21111 | app construction · keyring calls at boot | 77.0 ms · 4 | **60.9 ms · 0** |

Two of these fixed **correctness**, not speed: 21131 took concurrent event recording from 9-of-12
`IntegrityError`s to zero, and 21127's `BEGIN IMMEDIATE` conversion eliminated a lost-update race
where 40 writes reported success while the version advanced 11 times.

## The lesson worth keeping

**A finding tells you where to look, not what to do.** Five of seven re-verified findings needed
correcting *before* dispatch, and nearly every implementer corrected its brief again *during*
implementation. Two prescribed fixes would have been actively wrong:

- **21126's index would have shipped dead.** It measured 112 → 3.4 ms only because the probe had run
  `ANALYZE`. No media database in the wild has `sqlite_stat1`; with stats absent it was 118.8 vs
  120.2 ms. The shipped index leads with a *redundant* column so the no-stats planner picks it at
  all.
- **21134's "close the leaked connections" measured slower** (128 → 160 ms) — the leaked handles were
  acting as WAL anchors. Implemented, tested at 301 passed, then reverted.

Plus: 21130's cited call site is one real upgrades never take; 21111's three named keyring sites bank
0 ms because the backend memoizes; 21129's "missing index" exists and 88% of the read was dataclass
hydration; and my own 21731 import chain was wrong on all three files.

## Guard hygiene turned out to matter as much as the fixes

Three guards were found **silently red on dev**: the boot-closure weight guard, the chunking-closure
guard, and the derived-artifacts gate — twice, from stale diagnostic-inventory pins, which blocks
*every* PR in the repo rather than just the offender's. `MAX_TLDW_MODULE_COUNT` was deliberately not
raised to accommodate the regression it caught.

## Four findings recommended for closure — annotated in place, left open

Retiring a filed finding is an owner call, so these are annotated rather than closed:

- **21107** — ~19 ms, and the prescribed fix cannot compile: the spec table stores schema classes as
  runtime values, and a test already allowlists the import as deliberate.
- **21109** — sub-millisecond in practice, and the prescribed deferral would let the default
  `session` sweep delete a video published that session.
- **21120** — mis-stated on all three legs; its one real cost already shipped as 21692.
- **21132** — the recursion walks *upward*, so it is empty for the default profile and already
  off-loop; the "fix" is a query inversion, not a filter.

**21123** stays open on its merits: the import half shipped, but the architectural relocation would
break the enabled case, because `super().recompose()` removes every child and an app-level owner
reacting only to screen-change events would silently lose the Buddy.

## Filed during the burn-down, not part of the original 35

Fifteen new findings, including four that are not performance issues at all and matter more:
**21590** (Console send had 26 red tests and no working baseline — send itself proved healthy),
**22030** (a failed DB open makes Send silently do nothing), **22000** (users cannot queue a
follow-up during a run, behind a button that says they can), and **21700** (the RAG cache-hit log
writes the user's search query into a persistent sink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes out the 2026-08-22 performance burn-down docs with measured outcomes and closure recommendations. No runtime changes; this records what shipped (30/35 findings across 40 PRs), what improved for users, and which findings remain for owner decision.

- Adds a “Final outcome” section with the key before/after measurements, including two correctness fixes.
- Documents guard hygiene issues (three guards were red on dev) and the deliberate choice to not raise `MAX_TLDW_MODULE_COUNT`.
- Annotates tasks `21107`, `21109`, `21120`, and `21132` with closure recommendations; leaves `21123` open for the owner to decide.
- Lists new findings filed during the burn-down for tracking.
- No code paths changed and no migrations required. Review is docs-only: skim the new “Final outcome” section and the four annotated task files. Owners: decide on closing the four recommended findings and `21123`.

<sup>Written for commit 8d317fa365bcb08ab227a0d809521d3d6b0fdaf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

