### PR TITLE
fix(rag): stop RAG diagnostics rendering the user's query and whole model replies (TASK-21700)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1546,7 +1546,7 @@
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "7f47baa2e9fbc15edbc1",
+      "diagnostic_digest": "52bf22e698d2575fdd14",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/reranker.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1644,7 +1644,7 @@
     },
     {
       "call_count": 68,
-      "diagnostic_digest": "4fdc85d5341fd96f8785",
+      "diagnostic_digest": "c4a90e6ef7b0d97fe7f8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/rag_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1658,7 +1658,7 @@
     },
     {
       "call_count": 19,
-      "diagnostic_digest": "ae73af1d1b8304ed2445",
+      "diagnostic_digest": "d1a1b4210d7c044970bd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/simple_cache.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/RAG_Search/test_rag_diagnostic_privacy.py
+++ b/Tests/RAG_Search/test_rag_diagnostic_privacy.py
@@ -1,0 +1,502 @@
+"""No RAG_Search diagnostic carries the user's words (TASK-21700).
+
+## What was found, and what the sink actually does
+
+`rag_service.py` logged `f"[{correlation_id}] Cache hit for query:
+'{query[:50]}...'"` at INFO. Search queries are user content, and the
+persistent diagnostic inventory exists to keep exactly that class of value out
+of persistent sinks.
+
+Measured on this branch before deciding anything, because the severity turns on
+it: **that record never reached the persistent file sink.** The shipped
+`PrivateRotatingFileHandler` carries `PersistentDiagnosticFilter`, which is
+default-DENY -- it admits a Chatbook record only when it carries the
+`_tldw_metadata_only_record` marker, and only `log_persistent_metadata` sets
+that. A loguru record crossing `_forward_loguru_to_standard` cannot carry it
+(that function rebuilds `extra` from scratch, deliberately: if the marker
+crossed the boundary, any code could `logger.bind(...)` its way past the
+schema). A probe that installed the real sink, emitted this exact statement
+from a real `RAG_Search.simplified` module through the real loguru bridge, and
+read the file back found the query absent and a control `persist_event` record
+present. The Logs screen's "Copy all"/"Copy visible" export reuses the same
+`PersistentDiagnosticFilter` object and replaces every non-metadata message
+body with `***REDACTED***`, so the clipboard route is closed too.
+
+So the fix-at-the-sink prior art this repo already has (ADR-029's admission
+boundary; `redact_log_line`'s home-path collapse for the in-app view) applies
+here and was *already applied*. The residual exposure was the live terminal and
+the in-app Logs view -- real, but narrower than "written to a file a user
+attaches to a bug report". These call sites were changed anyway, for a reason
+that stands on its own: the query text bought nothing. See
+`content_fingerprint`'s docstring -- a 50-character prefix loses the identity a
+maintainer reads the line for while keeping the words they must not read.
+
+## What this module pins
+
+* the two cache paths and the LLM reranker, exercised for real, emit no query
+  or response text -- and still emit a usable handle;
+* a census over the whole `RAG_Search` tree, so a future refactor cannot
+  reintroduce the shape anywhere in it.
+
+Deliberately NOT re-pinned here: the sink boundary itself, which
+`Tests/test_remaining_diagnostic_sentinel_matrix.py` already covers for the
+`rag_search` domain owner.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+from pathlib import Path
+from typing import Callable, Iterator, List
+
+import pytest
+from loguru import logger as loguru_logger
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call as real_chat_api_call
+from tldw_chatbook.RAG_Search import reranker as reranker_module
+from tldw_chatbook.RAG_Search.reranker import PointwiseReranker, RerankingConfig
+from tldw_chatbook.RAG_Search.simplified.simple_cache import SimpleRAGCache
+from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
+from tldw_chatbook.Utils.log_sanitizer import (
+    EMPTY_FINGERPRINT,
+    content_fingerprint,
+)
+
+
+#: A query no other code in the suite can produce, so its presence in a captured
+#: line is unambiguous. Long enough that a `[:50]` truncation would still leave
+#: a recognisable fragment -- the head is checked separately for that reason.
+SENTINEL_QUERY = (
+    "ZZ-T21700-PRIVATE-QUERY my divorce settlement and psychiatric records "
+    "for the deposition on the fourteenth"
+)
+SENTINEL_HEAD = SENTINEL_QUERY[:50]
+
+#: The per-transition cache lines. Deliberately NOT a bare "Cache" prefix:
+#: "Cache initialized" names no query and would drag an unrelated line into
+#: the debuggability assertion below.
+CACHE_EVENTS = (
+    "Cache miss",
+    "Cache hit",
+    "Cache expired",
+    "Cache entry expired",
+    "Cached results",
+)
+
+
+@pytest.fixture
+def captured_lines() -> Iterator[List[str]]:
+    """Collect every loguru message emitted during the test.
+
+    Adds a sink and removes only that sink id: a bare `logger.remove()` would
+    tear down the sink `tldw_chatbook/__init__.py` installs and leak that
+    teardown into unrelated tests.
+    """
+    lines: List[str] = []
+    sink_id = loguru_logger.add(
+        lambda message: lines.append(message.record["message"]),
+        level="TRACE",
+        format="{message}",
+        diagnose=False,
+    )
+    try:
+        yield lines
+    finally:
+        loguru_logger.remove(sink_id)
+
+
+def _assert_no_query_text(lines: List[str]) -> None:
+    joined = "\n".join(lines)
+    assert SENTINEL_QUERY not in joined, (
+        "a diagnostic carried the whole query:\n" + joined
+    )
+    assert SENTINEL_HEAD not in joined, (
+        "a diagnostic carried a truncated prefix of the query -- truncation is "
+        "not redaction:\n" + joined
+    )
+    # Belt and braces: any distinctive word from the query is a leak, even if
+    # some future rewording no longer contains the exact prefix.
+    for word in ("divorce", "psychiatric", "deposition"):
+        assert word not in joined, (
+            f"a diagnostic carried the query word {word!r}:\n" + joined
+        )
+
+
+# ---------------------------------------------------------------------------
+# The cache paths, run for real
+# ---------------------------------------------------------------------------
+
+
+def test_sync_cache_diagnostics_carry_a_handle_but_no_query_text(captured_lines):
+    """Miss, store, hit and expiry through the real synchronous cache."""
+    cache = SimpleRAGCache(max_size=4, ttl_seconds=3600, enabled=True)
+
+    assert cache.get(SENTINEL_QUERY, "semantic", 5) is None  # miss
+    cache.put(SENTINEL_QUERY, "semantic", 5, [], "context")  # store
+    assert cache.get(SENTINEL_QUERY, "semantic", 5) is not None  # hit
+
+    expired = SimpleRAGCache(max_size=4, ttl_seconds=0, enabled=True)
+    expired.put(SENTINEL_QUERY, "semantic", 5, [], "context")
+    assert expired.get(SENTINEL_QUERY, "semantic", 5) is None  # expired
+
+    _assert_no_query_text(captured_lines)
+    fingerprint = content_fingerprint(SENTINEL_QUERY)
+    # Debuggability is the other half of the contract: a line with the query
+    # stripped and nothing put in its place is a worse diagnostic, not a safer
+    # one. Every cache line that used to name the query must still identify it.
+    named = [line for line in captured_lines if line.startswith(CACHE_EVENTS)]
+    assert named, f"no cache diagnostics were emitted at all: {captured_lines}"
+    for line in named:
+        assert fingerprint in line, f"cache line lost its query handle: {line}"
+        assert "key=" in line, f"cache line lost its cache-key handle: {line}"
+
+
+def test_async_cache_diagnostics_carry_a_handle_but_no_query_text(captured_lines):
+    """The same four transitions through `get_async`/`put_async`."""
+
+    async def exercise() -> None:
+        cache = SimpleRAGCache(max_size=4, ttl_seconds=3600, enabled=True)
+        assert await cache.get_async(SENTINEL_QUERY, "hybrid", 5) is None
+        await cache.put_async(SENTINEL_QUERY, "hybrid", 5, [], "context")
+        assert await cache.get_async(SENTINEL_QUERY, "hybrid", 5) is not None
+
+        expired = SimpleRAGCache(max_size=4, ttl_seconds=0, enabled=True)
+        await expired.put_async(SENTINEL_QUERY, "hybrid", 5, [], "context")
+        assert await expired.get_async(SENTINEL_QUERY, "hybrid", 5) is None
+
+    asyncio.run(exercise())
+
+    _assert_no_query_text(captured_lines)
+    fingerprint = content_fingerprint(SENTINEL_QUERY)
+    named = [line for line in captured_lines if line.startswith(CACHE_EVENTS)]
+    assert named, f"no cache diagnostics were emitted at all: {captured_lines}"
+    for line in named:
+        assert fingerprint in line, f"cache line lost its query handle: {line}"
+
+
+# ---------------------------------------------------------------------------
+# The LLM reranker's parse-failure path, run for real
+# ---------------------------------------------------------------------------
+
+
+SENTINEL_RESPONSE = (
+    "I cannot score this. ZZ-T21700-MODEL-REPLY The document describes the "
+    "patient's diagnosis in detail, and the query asks about the settlement, "
+    "so scoring would require disclosing both."
+)
+
+
+def _install_fake_provider(monkeypatch, responder: Callable[[list], str]) -> None:
+    """Fake the reranker's single provider seam, BOUND to the real signature.
+
+    Copied in spirit from `test_reranker_degraded_paths.py`: binding against
+    `inspect.signature(chat_api_call)` and refusing positionals is what stops a
+    fake from agreeing with a mis-ordered call (TASK-17065).
+    """
+    signature = inspect.signature(real_chat_api_call)
+
+    def fake_chat_api_call(*args, **kwargs):
+        assert not args, f"reranker must call chat_api_call by keyword: {args!r}"
+        bound = signature.bind(*args, **kwargs)
+        return responder(bound.arguments["messages_payload"])
+
+    monkeypatch.setattr(reranker_module, "chat_api_call", fake_chat_api_call)
+
+
+@pytest.mark.asyncio
+async def test_reranker_parse_failure_reports_shape_not_model_reply(
+    monkeypatch, captured_lines
+):
+    """A malformed reranker reply must be diagnosed without being quoted.
+
+    The reply is user content by derivation: the scoring prompt hands the model
+    the user's query, the document title, and 500 characters of the document
+    body, so a non-JSON reply is usually prose about all three.
+    """
+    _install_fake_provider(monkeypatch, lambda _messages: SENTINEL_RESPONSE)
+    reranker = PointwiseReranker(
+        RerankingConfig(
+            strategy="pointwise", top_k_to_rerank=2, retry_on_failure=False
+        )
+    )
+    results = [
+        SearchResult(
+            id=f"doc-{i}",
+            score=0.9 - 0.1 * i,
+            document=f"body of document number {i}",
+            metadata={"doc_title": f"doc-{i}", "source_type": "media"},
+        )
+        for i in range(2)
+    ]
+
+    await reranker.rerank(SENTINEL_QUERY, results)
+
+    joined = "\n".join(captured_lines)
+    assert "ZZ-T21700-MODEL-REPLY" not in joined, (
+        "the model's reply was quoted into a diagnostic:\n" + joined
+    )
+    assert SENTINEL_RESPONSE[:200] not in joined
+    for word in ("diagnosis", "settlement", "patient"):
+        assert word not in joined, f"reply word {word!r} reached a diagnostic"
+
+    failures = [line for line in captured_lines if "Failed to parse" in line]
+    assert failures, f"the parse failure was not diagnosed at all: {captured_lines}"
+    for line in failures:
+        # The structural facts a maintainer reads this line for must survive.
+        assert "JSONDecodeError" in line, f"lost the failure type: {line}"
+        assert f"chars={len(SENTINEL_RESPONSE)}" in line, f"lost the length: {line}"
+        assert content_fingerprint(SENTINEL_RESPONSE) in line, (
+            f"lost the reply handle, so 'always the same bad body?' is now "
+            f"unanswerable: {line}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The census: the shape must not come back anywhere in RAG_Search
+# ---------------------------------------------------------------------------
+
+
+RAG_SEARCH_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook" / "RAG_Search"
+
+LOG_METHODS = frozenset(
+    {
+        "critical",
+        "debug",
+        "error",
+        "exception",
+        "info",
+        "log",
+        "success",
+        "trace",
+        "warning",
+    }
+)
+
+#: Local names whose VALUE is user content wherever they appear in this tree.
+#: Deliberately names only bare locals: `entry.document['id']` and
+#: `doc.get('id')` are identifiers, not bodies, and flagging them would make
+#: this census noise -- and a noisy census gets suppressed rather than read.
+CONTENT_NAMES = frozenset(
+    {
+        "query",
+        "response",
+        "text",
+        "content",
+        "document",
+        "chunk",
+        "chunk_text",
+        "prompt",
+        "body",
+        "snippet",
+    }
+)
+
+#: Calls that reduce user content to a scalar safe to log. A risky name is
+#: allowed only as a DIRECT argument of one of these.
+#:
+#: An ATTRIBUTE of a risky name still counts as a finding -- `response.text`,
+#: `response.content` and `choices[0].message.content` are precisely how model
+#: output escapes, and no attribute allowlist survives contact with the next
+#: provider SDK. The cost is a false positive on genuinely scalar attributes
+#: such as `response.status_code`; the escape hatch is to bind the scalar to a
+#: differently-named local first (`status = response.status_code`), which is
+#: what the line means anyway. Widening this set is not the fix.
+SAFE_WRAPPERS = frozenset({"len", "content_fingerprint", "type", "id", "bool"})
+
+
+def _logger_symbols(tree: ast.AST) -> set[str]:
+    symbols = {"logger", "logging", "loguru_logger"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in {"logging", "loguru"}:
+            for alias in node.names:
+                symbols.add(alias.asname or alias.name)
+    return symbols
+
+
+def _is_diagnostic(node: ast.Call, symbols: set[str]) -> bool:
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in LOG_METHODS:
+        return False
+    receiver = node.func.value
+    while isinstance(receiver, (ast.Call, ast.Attribute)):
+        receiver = receiver.func if isinstance(receiver, ast.Call) else receiver.value
+    return isinstance(receiver, ast.Name) and (
+        receiver.id in symbols or receiver.id.casefold().endswith("logger")
+    )
+
+
+def _interpolated_expressions(node: ast.Call) -> list[ast.AST]:
+    """Every expression whose VALUE is rendered into the emitted message."""
+    expressions: list[ast.AST] = []
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.FormattedValue):
+            expressions.append(sub.value)
+    # loguru brace style and %-style both put the values in trailing args, and
+    # `extra=` keywords are rendered by some handlers too.
+    expressions.extend(node.args[1:])
+    expressions.extend(keyword.value for keyword in node.keywords)
+    return expressions
+
+
+def _unsafe_content_names(expression: ast.AST) -> set[str]:
+    """Risky bare names in `expression` that are not inside a safe wrapper."""
+    safe: set[int] = set()
+    for sub in ast.walk(expression):
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name):
+            if sub.func.id in SAFE_WRAPPERS:
+                safe.update(id(arg) for arg in sub.args)
+    return {
+        sub.id
+        for sub in ast.walk(expression)
+        if isinstance(sub, ast.Name)
+        and sub.id in CONTENT_NAMES
+        and id(sub) not in safe
+    }
+
+
+def rag_search_content_interpolations() -> list[tuple[str, int, str, list[str]]]:
+    """Every RAG_Search diagnostic that renders user content verbatim.
+
+    Exposed as a function rather than inlined so a mutation check can call it
+    against a modified tree.
+    """
+    findings: list[tuple[str, int, str, list[str]]] = []
+    for path in sorted(RAG_SEARCH_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        symbols = _logger_symbols(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_diagnostic(node, symbols):
+                continue
+            names: set[str] = set()
+            for expression in _interpolated_expressions(node):
+                names |= _unsafe_content_names(expression)
+            if names:
+                findings.append(
+                    (
+                        path.as_posix(),
+                        node.lineno,
+                        " ".join((ast.get_source_segment(source, node) or "").split()),
+                        sorted(names),
+                    )
+                )
+    return findings
+
+
+def test_census_actually_scans_the_tree() -> None:
+    """A census that scanned nothing would pass vacuously.
+
+    `pytest "no tests ran"` has an exact analogue here: an empty finding list
+    is the PASS condition, so the scanner has to be shown to have work to do.
+    """
+    total = 0
+    for path in sorted(RAG_SEARCH_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        symbols = _logger_symbols(tree)
+        total += sum(
+            1
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and _is_diagnostic(node, symbols)
+        )
+    assert total > 300, f"the census found only {total} diagnostics; it is not scanning"
+
+
+def test_no_rag_search_diagnostic_interpolates_user_content() -> None:
+    """The regression guard. Every hit is a query/body/reply rendered verbatim.
+
+    To fix a failure: keep the diagnostic, drop the words. `len(value)` and
+    `content_fingerprint(value)` are both accepted, and between them they carry
+    what these lines are actually read for -- how big, and is it the same one
+    as last time.
+    """
+    findings = rag_search_content_interpolations()
+    assert not findings, "user content rendered into RAG_Search diagnostics:\n" + "\n".join(
+        f"  {path}:{line} {names}\n      {text}"
+        for path, line, text, names in findings
+    )
+
+
+def test_census_detects_the_shape_it_exists_to_catch() -> None:
+    """The census must fail on the exact statement TASK-21700 was filed for.
+
+    Without this, a scanner bug that matched nothing would leave the guard
+    green forever -- the failure mode of every census test.
+    """
+    module = ast.parse(
+        "from loguru import logger\n"
+        "def f(query, correlation_id):\n"
+        "    logger.info(f\"[{correlation_id}] Cache hit for query: "
+        "'{query[:50]}...'\")\n"
+    )
+    symbols = _logger_symbols(module)
+    calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call) and _is_diagnostic(node, symbols)
+    ]
+    assert len(calls) == 1
+    names: set[str] = set()
+    for expression in _interpolated_expressions(calls[0]):
+        names |= _unsafe_content_names(expression)
+    assert names == {"query"}
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # The accepted replacements must NOT be flagged, or the guard would
+        # push people back towards truncation.
+        ("logger.info(f'{content_fingerprint(query)}')", set()),
+        ("logger.info(f'{len(query)}')", set()),
+        ("logger.info(f'{len(query)} {content_fingerprint(query)}')", set()),
+        # ...and every way of rendering the value itself must be.
+        ("logger.info(f'{query}')", {"query"}),
+        ("logger.info(f'{query[:50]}')", {"query"}),
+        ("logger.info(f'{query!r}')", {"query"}),
+        ("logger.info('q=%s', query)", {"query"}),
+        ("logger.info('q={}', response)", {"response"}),
+        ("logger.debug(f'{query.strip()}')", {"query"}),
+    ],
+)
+def test_census_classifier_boundaries(source: str, expected: set[str]) -> None:
+    module = ast.parse("from loguru import logger\n" + source)
+    symbols = _logger_symbols(module)
+    call = next(
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call) and _is_diagnostic(node, symbols)
+    )
+    names: set[str] = set()
+    for expression in _interpolated_expressions(call):
+        names |= _unsafe_content_names(expression)
+    assert names == expected
+
+
+# ---------------------------------------------------------------------------
+# The replacement handle itself
+# ---------------------------------------------------------------------------
+
+
+def test_content_fingerprint_carries_no_plaintext_and_is_stable() -> None:
+    fingerprint = content_fingerprint(SENTINEL_QUERY)
+    assert fingerprint == content_fingerprint(SENTINEL_QUERY), "not stable"
+    assert len(fingerprint) == 12
+    assert all(char in "0123456789abcdef" for char in fingerprint)
+    for word in ("divorce", "psychiatric", "ZZ-T21700"):
+        assert word not in fingerprint
+    assert content_fingerprint("a") != content_fingerprint("b")
+    # A prefix collision is exactly the case truncation could not distinguish.
+    long_a = SENTINEL_HEAD + "alpha"
+    long_b = SENTINEL_HEAD + "bravo"
+    assert content_fingerprint(long_a) != content_fingerprint(long_b)
+
+
+def test_content_fingerprint_distinguishes_empty_from_a_real_value() -> None:
+    assert content_fingerprint("") == EMPTY_FINGERPRINT
+    assert content_fingerprint(None) == EMPTY_FINGERPRINT
+    assert content_fingerprint("x") != EMPTY_FINGERPRINT
+    # Non-strings must not raise: a diagnostic that crashes is worse than one
+    # that leaks, and these sites run inside `except` blocks.
+    assert content_fingerprint(12345) == content_fingerprint("12345")

--- a/backlog/tasks/task-21700 - RAG cache-hit log writes the user search query into a persistent sink.md
+++ b/backlog/tasks/task-21700 - RAG cache-hit log writes the user search query into a persistent sink.md
@@ -2,7 +2,7 @@
 id: TASK-21700
 title: >-
   RAG cache-hit log writes the user search query into a persistent sink
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-24'
 labels:
@@ -27,12 +27,12 @@ review.
 
 ## Acceptance Criteria
 
-- [ ] It is determined and recorded whether this statement actually reaches a persistent sink at the shipped default log level, or is filtered before it lands
-- [ ] If it does reach one, the query text is removed, hashed, or length-only — the diagnostic keeps its debugging value without carrying user content
-- [ ] The whole `RAG_Search` tree is swept for the same shape: any diagnostic interpolating a query, a document body, a chunk, or a filename
-- [ ] Anything found is fixed in the same pass, or filed with a reason it is safe
-- [ ] A test or census guard pins the outcome so a future refactor cannot reintroduce it
-- [ ] If the conclusion is that this is acceptable, that reasoning is written down — an unreviewed "it's fine" is what let it sit this long
+- [x] It is determined and recorded whether this statement actually reaches a persistent sink at the shipped default log level, or is filtered before it lands
+- [x] If it does reach one, the query text is removed, hashed, or length-only — the diagnostic keeps its debugging value without carrying user content
+- [x] The whole `RAG_Search` tree is swept for the same shape: any diagnostic interpolating a query, a document body, a chunk, or a filename
+- [x] Anything found is fixed in the same pass, or filed with a reason it is safe
+- [x] A test or census guard pins the outcome so a future refactor cannot reintroduce it
+- [x] If the conclusion is that this is acceptable, that reasoning is written down — an unreviewed "it's fine" is what let it sit this long
 
 ## Evidence (verified on dev 1daa47f0a, 2026-08-24)
 
@@ -50,3 +50,138 @@ with identical text, so the refactor moved it rather than introducing it.
 
 Note the truncation to 50 characters limits the volume but not the kind: a 50-character prefix of
 a search query is still the user's words.
+
+## Implementation Plan
+
+1. Re-confirm both cited statements on the branch base (line numbers drift).
+2. Establish the SINK reality empirically before deciding severity: install the
+   real `PrivateRotatingFileHandler`, emit this exact statement from a real
+   `RAG_Search.simplified` module through the real loguru bridge, read the file
+   back. Record the answer either way.
+3. Sweep the whole `RAG_Search` tree by AST, not grep, for diagnostics that
+   interpolate a query, a body, a chunk, a filename, or a path.
+4. Fix the user-content sites; keep debuggability (a handle, not silence).
+   Record the reason for every site left alone.
+5. Add a census guard in the spirit of the inventory checker, plus real
+   behavioural tests through the production seams.
+6. Review each drifted inventory row with `--statements` before `--write`.
+
+## Implementation Notes
+
+### AC#1 — does it reach a persistent sink? No. Measured, not assumed.
+
+The shipped `PrivateRotatingFileHandler` (`Logging_Config._configure_private_
+file_logging`) carries `PersistentDiagnosticFilter`, which is default-DENY: a
+Chatbook record is admitted only when it carries the
+`_tldw_metadata_only_record` marker, and only `log_persistent_metadata` sets
+that. A loguru record cannot carry it, because `_forward_loguru_to_standard`
+rebuilds `extra` from scratch — deliberately, so no caller can
+`logger.bind()` its way past the schema.
+
+Probed on this base with an isolated `HOME`/`TLDW_CONFIG_PATH`: the real sink
+installed at its default level (`file_log_level=INFO`), the cache-hit statement
+emitted from a real module under `tldw_chatbook/RAG_Search/simplified/`, plus a
+control `persist_event`. The log file contained the control record and
+**neither the query nor the phrase "Cache hit for query"**.
+
+The Logs screen's "Copy all"/"Copy visible" export reuses the same
+`PersistentDiagnosticFilter` object and replaces every non-metadata message
+body with `***REDACTED***`, so the clipboard route is closed too. The live
+in-app Logs view and the terminal do show the line (`redact_log_line` collapses
+home paths and secrets there, but a query is neither).
+
+**Blast radius that can be proven: the live terminal and the in-app Logs
+view.** Not a log file a user attaches to a bug report. The fix-at-the-sink
+prior art this repo already has (ADR-029's admission boundary; TASK-19555's
+`redact_log_line`) applies here and was *already applied* — that is why this
+was a defence-in-depth fix and not an incident.
+
+### AC#2/#3/#4 — the sweep, and what was changed
+
+Swept by AST over all 408 `RAG_Search` diagnostics. Twelve statements rendered
+user content; all twelve were fixed, and three of them were worse than the one
+filed:
+
+| site | level | was | now |
+|---|---|---|---|
+| `rag_service.py` cache hit | INFO | `query[:50]` | `query_fp` + `chars` |
+| `rag_service.py` FTS5 failure | ERROR | the **whole** query | `query_fp` + `chars` + `{e}` |
+| `simple_cache.py` ×8 | DEBUG | `query[:50]` | `query_fp` + the cache `key` |
+| `reranker.py` parse failure | ERROR | `response[:200]` | type + `{e}` + `chars` + `response_fp` |
+| `reranker.py` unexpected format | WARNING | the **whole** response dict | `keys=[...]` |
+
+The last row was found by the census after both greps had missed it (neither
+regex included "response"), and it dumped an entire provider response — the
+model's text about the user's query and 500 characters of their document — at
+WARNING, untruncated. `pointwise` is the DEFAULT reranking strategy, so this
+is live product code.
+
+The replacement handle is `Utils/log_sanitizer.content_fingerprint`. Its
+docstring states the guarantee precisely: it removes plaintext, it is **not**
+secrecy against someone who already holds the log. It is deliberately
+unsalted, because a per-run salt would destroy the across-restart correlation
+the handle exists to provide. Truncation was strictly worse than the
+replacement in both directions: it kept the words *and* lost the identity, since
+two long queries sharing a prefix printed identically.
+
+Left alone, with reasons:
+
+* **Paths** (`db_path`, `persist_directory`, `config_file`, `cache_dir`,
+  `path.name` in `config_profiles.py`) — the path IS the diagnostic ("database
+  not found at X"); hashing it destroys the line. They reach no persistent
+  sink, and the one route off the machine (the Logs export) already runs
+  `redact_user_paths`, which strips the account name — the identifying part.
+  This is the same fix-at-the-sink argument, already shipped.
+* **`{e}` in the FTS5 and reranker lines** — kept. The exception is the
+  diagnostic; the query never was. What reaches SQLite is `escaped_query`,
+  per-token quoted and pinned by `test_fts5_query_escaping.py`.
+* **Identifiers and counts** (`doc['id']`, `doc_id`, `chunk_id`, `len(texts)`,
+  `model_name`, `collection_name`, `profile_id`, `type(e).__name__`) — code-side
+  handles, not user words.
+* **No document or chunk BODY was found interpolated anywhere in the tree**;
+  every `doc`/`chunk`/`text` hit was a length or an id.
+
+### AC#5 — the guard
+
+`Tests/RAG_Search/test_rag_diagnostic_privacy.py` (17 tests):
+
+* a **census** over all of `RAG_Search`, allowing `len(value)` and
+  `content_fingerprint(value)` and rejecting every other rendering — it is what
+  found the `reranker.py` dump;
+* a vacuity guard (`test_census_actually_scans_the_tree`), because an empty
+  finding list is the PASS condition and a blinded scanner would pass forever;
+* classifier boundary cases, including the exact statement this task was filed
+  for;
+* **real behavioural** tests: the sync and async cache paths through
+  `SimpleRAGCache`, and the reranker parse-failure path through
+  `PointwiseReranker` with a signature-bound fake at the single provider seam.
+  Each asserts both halves — no user words, AND a usable handle still present,
+  so a future "fix" that just deletes the value fails too.
+
+Mutation-tested: 14 deliberate breaks, all detected (see PR notes).
+
+### Files
+
+`tldw_chatbook/Utils/log_sanitizer.py` (new `content_fingerprint`),
+`tldw_chatbook/RAG_Search/simplified/rag_service.py`,
+`tldw_chatbook/RAG_Search/simplified/simple_cache.py`,
+`tldw_chatbook/RAG_Search/reranker.py`,
+`Tests/RAG_Search/test_rag_diagnostic_privacy.py` (new),
+`Docs/security/production-diagnostic-inventory.json` (3 rows, all privacy
+improvements; counts unchanged at 12/68/19, no sink-topology change).
+
+### Out of scope, found on the way
+
+* The same census over the rest of `tldw_chatbook` reports 90 candidate sites.
+  The notable ones: `UI/Console_Modules/workspace.py` logs the Console
+  conversation-browser **search query** with `!r` at EXCEPTION level;
+  `UI/MediaWindow_v2.py` and `LLM_Calls/LLM_API_Calls.py` dump whole provider
+  responses/`response.text` at ERROR. (Many of the 90 are classifier false
+  positives on `response.status_code`.)
+* `reranker.py`'s parse-failure handler references `response` in an `except`
+  that can be reached before `response` is bound (`_call_llm` raising
+  `ValueError`), which would raise `NameError` inside the handler. Pre-existing;
+  untouched.
+* Importing `tldw_chatbook.RAG_Search.reranker` as the first RAG module raises
+  `ImportError` from a `reranker -> simplified/__init__ -> enhanced_rag_service_v2
+  -> reranker` cycle. All three edges exist at the base commit; pre-existing.

--- a/backlog/tasks/task-21700 - RAG diagnostics render the user search query and whole model replies.md
+++ b/backlog/tasks/task-21700 - RAG diagnostics render the user search query and whole model replies.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-21700
 title: >-
-  RAG cache-hit log writes the user search query into a persistent sink
+  RAG diagnostics render the user search query and whole model replies
 status: Done
 assignee: []
 created_date: '2026-08-24'
@@ -13,6 +13,15 @@ priority: medium
 ---
 
 ## Description
+
+> **Title corrected 2026-08-24.** This was filed as "…into a persistent sink". That framing was
+> **wrong**, and the implementation disproved it by measurement: the shipped
+> `PrivateRotatingFileHandler` carries a **default-deny** `PersistentDiagnosticFilter`, so none of
+> these statements reach the log file. The provable blast radius is the **live terminal and the
+> in-app Logs view**, not a file a user attaches to a bug report. The finding still stands — the
+> sweep found three sites *worse* than the one originally filed — but the severity is narrower than
+> the title claimed, and the title should not keep asserting something that was measured false.
+
 
 `RAG_Search/simplified/rag_service.py` logs a cache hit at INFO level with the first 50
 characters of the user's search query interpolated into the message. Search queries are user

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -44,6 +44,7 @@ except ImportError:
 from ..Chat.Chat_Functions import chat_api_call
 from ..Metrics.metrics_logger import log_counter, log_histogram, timeit
 from tldw_chatbook.Internal_Prompts import get_internal_prompt, safe_substitute
+from tldw_chatbook.Utils.log_sanitizer import content_fingerprint
 from .simplified.vector_store import SearchResult, SearchResultWithCitations
 
 
@@ -449,7 +450,18 @@ class BaseReranker(ABC):
                 elif "text" in response:
                     return response["text"]
                 else:
-                    logger.warning(f"Unexpected response format: {response}")
+                    # TASK-21700. This used to dump the whole provider
+                    # response dict, whose values are the model's text about
+                    # the user's query and documents. What the line is named
+                    # for -- "unexpected FORMAT" -- is answered by the keys
+                    # alone, and the keys are provider vocabulary, not user
+                    # content. Found by this task's census
+                    # (Tests/RAG_Search/test_rag_diagnostic_privacy.py), not
+                    # by the greps that preceded it.
+                    response_keys = sorted(str(key) for key in response)
+                    logger.warning(
+                        f"Unexpected reranker response format; keys={response_keys}"
+                    )
                     return str(response)
             else:
                 return str(response)
@@ -612,8 +624,23 @@ class PointwiseReranker(BaseReranker):
             )
 
         except (json.JSONDecodeError, ValueError, KeyError) as e:
+            # TASK-21700. This printed 200 characters of the model's reply at
+            # ERROR. That reply is user content by derivation: the prompt
+            # above hands the model the user's query, the document title, and
+            # 500 characters of the document body, and a malformed reply is
+            # usually prose *about* those. `{e}` is kept and given its type --
+            # a JSONDecodeError already names the character position and what
+            # it expected, which is the structural fact this line is read for.
+            # `chars` and `response_fp` add what the truncation used to imply
+            # but never actually showed: how long the reply was, and whether
+            # every failing result came back with the SAME bad body (one
+            # broken prompt template) or a different one each time (a flaky
+            # model).
             logger.error(
-                f"Failed to parse LLM response: {e}, Response: {response[:200]}"
+                f"Failed to parse LLM reranker response "
+                f"({type(e).__name__}: {e}); "
+                f"chars={len(response)}, "
+                f"response_fp={content_fingerprint(response)}"
             )
             # Return original score on parse error, unstamped: nothing
             # usable came back, so this row was not rescored (note-b).

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -53,6 +53,7 @@ from tldw_chatbook.Utils.fts5_match_forms import (
     is_fts5_stopword,
     quote_fts5_token,
 )
+from tldw_chatbook.Utils.log_sanitizer import content_fingerprint
 from tldw_chatbook.Metrics.metrics_logger import (
     log_counter,
     log_histogram,
@@ -1337,8 +1338,16 @@ class RAGService:
             if cached_result is not None:
                 results, context = cached_result
                 log_counter("rag_search_cache_hit", labels={"type": search_type})
+                # TASK-21700. The query used to be interpolated here as
+                # `query[:50]` -- the user's own words, at INFO, on every
+                # cached search. A cache hit returns immediately, so this is
+                # the ONLY line emitted for that search and it does need a
+                # handle for the query; the fingerprint is that handle, and it
+                # matches the one `SearchCache` prints for the same query, so
+                # a hit can still be traced from here into the cache module.
                 logger.info(
-                    f"[{correlation_id}] Cache hit for query: '{query[:50]}...'"
+                    f"[{correlation_id}] Cache hit for {search_type} query "
+                    f"(query_fp={content_fingerprint(query)}, chars={len(query)})"
                 )
                 return results
             log_counter("rag_search_cache_miss", labels={"type": search_type})
@@ -4199,7 +4208,21 @@ class RAGService:
                             }
                         )
             except Exception as e:
-                logger.error(f"FTS5 search failed for query '{query}': {e}")
+                # TASK-21700. This used to print the raw query in full, at
+                # ERROR -- the widest user-content interpolation in this tree.
+                # `{e}` is kept: what actually fails here is the database
+                # call, and the sqlite exception is the diagnostic. The query
+                # itself was never the diagnostic -- what reaches SQLite is
+                # `escaped_query`, per-token quoted by
+                # `_build_fts5_match_expression` and pinned by
+                # Tests/RAG_Search/test_fts5_query_escaping.py -- so the
+                # fingerprint and length carry what a maintainer reads this
+                # line for (is it always the same query? how long was it?).
+                logger.error(
+                    f"FTS5 search failed "
+                    f"(query_fp={content_fingerprint(query)}, "
+                    f"chars={len(query)}): {e}"
+                )
                 # Re-raise with more context
                 raise RuntimeError(f"Database search failed: {str(e)}") from e
 

--- a/tldw_chatbook/RAG_Search/simplified/simple_cache.py
+++ b/tldw_chatbook/RAG_Search/simplified/simple_cache.py
@@ -3,6 +3,15 @@ Simple cache implementation for the RAG service.
 
 This provides a lightweight caching solution for search results,
 replacing the complex cache service from the old implementation.
+
+Diagnostics here name a query by ``query_fp`` (a ``content_fingerprint``) and
+by ``key`` (this cache's own index), never by its text. TASK-21700: every
+cache diagnostic used to interpolate ``query[:50]`` -- the user's own words --
+and the prefix was strictly *less* useful than either handle, since two long
+queries sharing a prefix printed identically. ``key`` answers "did these two
+lines hit the same cache entry"; ``query_fp`` is stable across the whole
+RAG tree, so a hit logged in ``rag_service`` can be traced to the entry
+logged here.
 """
 
 import hashlib
@@ -33,6 +42,7 @@ from tldw_chatbook.Metrics.metrics_logger import (
     log_gauge,
     timeit,
 )
+from tldw_chatbook.Utils.log_sanitizer import content_fingerprint
 
 
 # The keyword leg's pre-TASK-15400 MATCH construction. A key built with
@@ -387,7 +397,9 @@ class SimpleRAGCache:
             if key not in self._cache:
                 self._misses += 1
                 log_counter("cache_miss", labels={"type": search_type})
-                logger.debug(f"Cache miss for query: '{query[:50]}...'")
+                logger.debug(
+                    f"Cache miss (query_fp={content_fingerprint(query)}, key={key})"
+                )
                 return None
 
             entry = self._cache[key]
@@ -402,7 +414,8 @@ class SimpleRAGCache:
                 log_counter("cache_expired", labels={"type": search_type})
                 log_histogram("cache_entry_expired_age_seconds", age)
                 logger.debug(
-                    f"Cache entry expired for query: '{query[:50]}...' (age: {age:.1f}s, ttl: {ttl}s)"
+                    f"Cache entry expired (query_fp={content_fingerprint(query)}, "
+                    f"key={key}, age: {age:.1f}s, ttl: {ttl}s)"
                 )
                 return None
 
@@ -424,7 +437,8 @@ class SimpleRAGCache:
             log_gauge("cache_hit_rate", hit_rate)
 
             logger.debug(
-                f"Cache hit for query: '{query[:50]}...' (age: {age:.1f}s, accesses: {entry.access_count})"
+                f"Cache hit (query_fp={content_fingerprint(query)}, key={key}, "
+                f"age: {age:.1f}s, accesses: {entry.access_count})"
             )
 
             return entry.value
@@ -543,7 +557,9 @@ class SimpleRAGCache:
             if key not in self._cache:
                 self._misses += 1
                 log_counter("cache_miss", labels={"type": search_type})
-                logger.debug(f"Cache miss for query: '{query[:50]}...'")
+                logger.debug(
+                    f"Cache miss (query_fp={content_fingerprint(query)}, key={key})"
+                )
                 return None
 
             entry = self._cache[key]
@@ -555,7 +571,9 @@ class SimpleRAGCache:
             if time.time() - entry.timestamp > ttl:
                 self._misses += 1
                 log_counter("cache_expired", labels={"type": search_type})
-                logger.debug(f"Cache expired for query: '{query[:50]}...'")
+                logger.debug(
+                    f"Cache expired (query_fp={content_fingerprint(query)}, key={key})"
+                )
                 del self._cache[key]
                 self._update_memory_sync()
                 return None
@@ -568,7 +586,9 @@ class SimpleRAGCache:
 
             self._hits += 1
             log_counter("cache_hit", labels={"type": search_type})
-            logger.debug(f"Cache hit for query: '{query[:50]}...'")
+            logger.debug(
+                f"Cache hit (query_fp={content_fingerprint(query)}, key={key})"
+            )
 
             # Check for corrupted entry (None value)
             if entry.value is None:
@@ -710,7 +730,9 @@ class SimpleRAGCache:
             log_histogram("cache_entry_size_mb", entry_memory / 1024 / 1024)
 
             logger.debug(
-                f"Cached results for query: '{query[:50]}...' ({len(results)} results, {entry_memory / 1024 / 1024:.1f}MB)"
+                f"Cached results (query_fp={content_fingerprint(query)}, "
+                f"key={key}, {len(results)} results, "
+                f"{entry_memory / 1024 / 1024:.1f}MB)"
             )
 
     def put(
@@ -843,7 +865,9 @@ class SimpleRAGCache:
             log_gauge("cache_memory_mb", self._current_memory_bytes / 1024 / 1024)
 
             logger.debug(
-                f"Cached results for query: '{query[:50]}...' ({len(results)} results, {entry_memory / 1024 / 1024:.1f}MB)"
+                f"Cached results (query_fp={content_fingerprint(query)}, "
+                f"key={key}, {len(results)} results, "
+                f"{entry_memory / 1024 / 1024:.1f}MB)"
             )
 
     async def clear_async(self) -> None:

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -5,6 +5,7 @@ This module provides functions to scrub API keys, passwords, and other
 sensitive information from log messages.
 """
 
+import hashlib
 import os
 import re
 from functools import lru_cache
@@ -15,6 +16,16 @@ from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
 
 
 REDACTION_MARKER = "***REDACTED***"
+#: Hex characters kept from a content fingerprint. Twelve gives ~2e-8 collision
+#: probability across a thousand distinct values in one debugging session --
+#: far beyond what a maintainer reading a log needs -- while staying short
+#: enough to scan by eye when correlating two lines.
+CONTENT_FINGERPRINT_CHARS = 12
+#: What ``content_fingerprint`` returns for an empty or missing value. A
+#: fingerprint of "" is a valid digest, and printing it would make "the user
+#: searched for nothing" indistinguishable from a real query at a glance;
+#: an explicit token keeps that difference visible.
+EMPTY_FINGERPRINT = "empty"
 #: Labels that name a secret in a LOG LINE but are not config keys, so they
 #: are deliberately not added to ``sensitive_config_keys`` (that predicate
 #: also drives config encryption and the Privacy & Security protected-field
@@ -350,6 +361,50 @@ def redact_user_paths(text: str) -> str:
     result = pattern.sub("~", text) if pattern is not None else text
     result = _HOME_ROOTS_POSIX.sub("~", result)
     return _HOME_ROOTS_WINDOWS.sub("~", result)
+
+
+def content_fingerprint(
+    value: object, *, chars: int = CONTENT_FINGERPRINT_CHARS
+) -> str:
+    """Return a stable, plaintext-free handle for a value too sensitive to log.
+
+    A search query, a prompt, or a model response is user content, so a
+    diagnostic must not carry its words. But the thing a maintainer actually
+    reads such a diagnostic *for* is identity -- "is this the same query that
+    failed a minute ago?", "did every result come back with the same malformed
+    body?" -- and identity survives hashing. Truncating the value instead (the
+    ``value[:50]`` idiom this function replaces, TASK-21700) keeps the words
+    and loses the identity: two different long queries that share a prefix
+    print identically, so the one property the line was read for is the one
+    truncation destroys.
+
+    Scope of the guarantee, stated plainly so it is not over-read: this
+    removes plaintext from the line. It is **not** a secrecy mechanism against
+    an adversary who already holds the log -- an unsalted digest of a short,
+    guessable string can be recovered by trying candidates. It is not salted
+    per process on purpose: a per-run salt would break exactly the
+    across-restart correlation the fingerprint exists to provide, and the
+    values it covers here never reach a persistent sink in the first place
+    (``PersistentDiagnosticFilter`` admits only schema-validated metadata
+    records). The honest claim is "a maintainer reading this log cannot read
+    the user's words", not "this value is protected".
+
+    Args:
+        value: Any value; non-strings are rendered with ``str`` first.
+        chars: Hex characters to keep. Defaults to
+            ``CONTENT_FINGERPRINT_CHARS``.
+
+    Returns:
+        A lowercase hex digest prefix, or ``EMPTY_FINGERPRINT`` when the value
+        is ``None`` or renders empty.
+    """
+    if value is None:
+        return EMPTY_FINGERPRINT
+    text = value if isinstance(value, str) else str(value)
+    if not text:
+        return EMPTY_FINGERPRINT
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+    return digest[: max(1, chars)]
 
 
 def redact_log_line(text: str, max_length: int = MAX_REDACTED_LINE_CHARS) -> str:


### PR DESCRIPTION
## Summary

RAG diagnostics rendered the user's search query, and in three places worse things — the whole
untruncated query, and the entire provider response. Twelve sites fixed, each keeping a usable
handle rather than going silent.

## First: the severity in the original filing was wrong, and this proves it

I filed this as *"writes the user's search query into a persistent sink"*. **That was measured
false**, so the task has been retitled.

The shipped `PrivateRotatingFileHandler` carries `PersistentDiagnosticFilter`, which is
**default-deny**: a Chatbook record is admitted only if it carries `_tldw_metadata_only_record`,
which only `log_persistent_metadata` sets — and a loguru record *cannot* carry it, because
`_forward_loguru_to_standard` rebuilds `extra` from scratch precisely so no caller can `bind()` past
the schema.

Probed rather than read: the real sink installed at its default level, a real module written under
`RAG_Search/simplified/`, the byte-identical statement emitted through the real loguru bridge, plus
a control `persist_event`, under an isolated `HOME`/`TLDW_CONFIG_PATH`. The file contained **only**
the two metadata records — `SENTINEL IN FILE: False`, `CACHE-HIT PHRASE IN FILE: False`,
`CONTROL EVENT IN FILE: True`.

**Provable blast radius: the live terminal and the in-app Logs view** — not a file a user attaches
to a bug report. The clipboard route is closed too: Logs "Copy all"/"Copy visible" reuses the same
filter object and replaces non-metadata bodies with `***REDACTED***`.

The repo's fix-at-the-sink prior art (ADR-029's admission filter, TASK-19555's `redact_log_line`)
**applies and was already applied**. This change is about the console-visible surface.

## The sweep mattered more than the filed line

408 diagnostics censused across `RAG_Search`; **12 rendered user content, and three were worse than
the one filed**:

| site | level | was rendering |
|---|---|---|
| `rag_service.py:1340` cache hit | INFO | `query[:50]` — the filed one |
| `rag_service.py:4202` FTS5 failure | ERROR | the **whole, untruncated** query |
| `simple_cache.py` ×8 | DEBUG | `query[:50]` |
| `reranker.py:615` parse failure | ERROR | `response[:200]` |
| `reranker.py:453` unexpected format | WARNING | the **entire provider response dict** |

The last is the worst and **both greps missed it** — it was found by the census, because neither
regex included "response". It dumped the model's text about the user's query plus 500 characters of
their document, untruncated, on `pointwise` — the **default** strategy.

## Fixed with a handle, not silence

New `Utils/log_sanitizer.content_fingerprint`, plus a length, the cache `key`, the exception, or the
response's keys. **Truncation was worse in both directions**: it keeps the user's words *and* loses
identity, since two long queries sharing a prefix print identically.

**Left alone, with reasons recorded** in the task file: paths (`db_path`, `persist_directory`,
`config_file`) — the path *is* the diagnostic, reaches no persistent sink, and the one route off the
machine already runs `redact_user_paths`, which strips the account name; `{e}` in both error lines —
the exception is the diagnostic, and what reaches SQLite is `escaped_query`, pinned by
`test_fts5_query_escaping.py`; ids and counts. **No document or chunk body was interpolated anywhere
in the tree** — every `doc`/`chunk`/`text` hit was a length or an id.

## Mutation: 14/14 detected

Reverting each fixed site reds. Deleting the handle entirely reds (the debuggability half is pinned,
not just the redaction half). Blinding the new census scanner three separate ways reds. A fingerprint
that returns plaintext, that collapses empty and non-empty, or that truncates instead of hashing —
all red.

One honest note: the first M8 spec was **wrong** (it removed one log method rather than all) and
showed green. The mutation was corrected, not the test.

## Verification

**1414 passed / 2 failed** across `Tests/RAG_Search`, `Tests/RAG`, log-sanitizer and the
diagnostic-boundary suites. Pristine dev `a71e62e4b` in a throwaway worktree: **1397 passed / 2
failed** — the *same two node ids*, A/B-proven pre-existing. +17 = exactly the new tests.
Preflight green.

Inventory: 3 rows, reviewed with `--statements --since` before writing. **Counts unchanged, no
sink-topology change, and all 12 replacements are privacy improvements** — every removed statement
rendered user content; every added one renders a digest, a length, a hash key, an exception type, or
dict keys.

## Out of scope, worth filing

- **The same census over the rest of `tldw_chatbook`: 90 candidates.** Notably
  `UI/Console_Modules/workspace.py:2224` logs the Console conversation-browser **search query** with
  `!r` at EXCEPTION, and `UI/MediaWindow_v2.py:1972` / `LLM_Calls/LLM_API_Calls.py:500` dump whole
  provider responses. Many of the 90 are classifier false positives on `response.status_code`.
- `reranker.py`'s parse handler references `response` in an `except` reachable **before `response` is
  bound**, so it raises `NameError` inside the handler. Pre-existing, untouched.
- Importing `tldw_chatbook.RAG_Search.reranker` first raises `ImportError` from a
  `reranker → simplified/__init__ → enhanced_rag_service_v2 → reranker` cycle. All three edges
  verified present at `a71e62e4b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops RAG diagnostics from rendering user queries and model replies by emitting stable fingerprints and lengths instead. Previously cache hits and some errors printed query prefixes or entire provider responses in live console and the in‑app Logs view; now logs use `query_fp`/`response_fp`, sizes, keys, and exception types instead. (TASK-21700)

- Bug Fixes
  - `tldw_chatbook/RAG_Search/simplified/rag_service.py`: cache-hit INFO now logs `query_fp` and `chars`, not `query[:50]`.
  - `tldw_chatbook/RAG_Search/simplified/rag_service.py`: FTS5 ERROR now logs `query_fp`, `chars`, and `{e}`, not the full query.
  - `tldw_chatbook/RAG_Search/simplified/simple_cache.py`: eight DEBUG lines now log `query_fp` and cache `key`, not `query[:50]`.
  - `tldw_chatbook/RAG_Search/reranker.py`: parse-failure ERROR now logs error type, `chars`, and `response_fp`, not `response[:200]`.
  - `tldw_chatbook/RAG_Search/reranker.py`: unexpected-format WARNING now logs `keys=[...]`, not the entire response dict.

- Refactors
  - Adds `content_fingerprint` to `tldw_chatbook/Utils/log_sanitizer.py` and uses it in RAG logging.
  - Adds `Tests/RAG_Search/test_rag_diagnostic_privacy.py` to pin “no user content in diagnostics” and keep usable handles.
  - Updates three rows in `Docs/security/production-diagnostic-inventory.json` (privacy-only changes; counts unchanged).

<sup>Written for commit 9eb680384b93d4930c50e4e5f45c069fd3a1db27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

