### PR TITLE
docs(perf): file the 2026-08-24 holistic performance review — 29 tasks (22200-22228) + evidence doc

### DIFF
--- a/Docs/Design/2026-08-24-holistic-perf-review.md
+++ b/Docs/Design/2026-08-24-holistic-perf-review.md
@@ -1,0 +1,288 @@
+# 2026-08-24 Holistic Performance Review — dev `a71e62e4b`
+
+Fourth full performance review (after 2026-07, the 2026-08-11 input-latency audit, and the
+2026-08-22 review whose burn-down closed 2026-08-24 with 30/35 findings shipped).
+Commissioned because users report the app "recently slowed down a bit … again".
+
+**Method.** Seven parallel read-only lanes against a pinned worktree
+`.worktrees/perf-review-2026-08-24` (dev `a71e62e4b`): Console chrome (#2034/#2053/#2029),
+streaming/run path (#2020/#2028/#2021/#2013), Library/Watchlists readers (#2064/#2063),
+data layer, boot-path accretion, timers/pollers census, and a fix-regression audit of all
+20 burn-down headline fixes. Plus live A/B probes against the PREVIOUS review's pin
+`35d4bf3a1` — two additional worktrees (`perf-probe-2026-08-24`, `perf-base-2026-08-24`),
+each with its own uv venv (`.[dev]`), isolated scratch profiles (own HOME/XDG/
+TLDW_CONFIG_PATH; `[first_run] setup_completed=true`, splash disabled, valid-shaped openai
+key so the Console is in the configured state, not the setup modal). 87 first-parent merges
+landed between the pins. Top claims were re-verified first-hand before filing (the standing
+lesson: a finding tells you where to look, not what to do — last review 5 of 7 filings
+needed correction before dispatch).
+
+Filed as TASK-22200 … TASK-22228 (29 tasks). Finding numbers below are task ids.
+
+---
+
+## The verdict in one paragraph
+
+The burn-down's fixes **held** — every one of the 20 headline mechanisms is present and
+load-bearing at tip (one exception: the CSS allowlist ratchet is RED, see 22212), and the
+live A/B proves the two biggest wins in the starkest way (19 keystrokes: **48 SQL
+statements at the pin → 0 at tip**; idle 4 s: **8 layout passes → 0**; fresh-profile first
+boot construct **4.70 s → 2.35 s**). The new slowdown is **new code**: (1) every user who
+upgraded across schema v46 gets a first session where an **unpaced whole-history FTS
+rebuild** contends with every UI write — the single most plausible mechanism behind the
+complaints; (2) the Console edge-rails redesign (#2034) and streaming emotes (#2020) made
+the **5 Hz run tick** expensive — registry SQL on the loop, tripled O(all-conversations)
+row pipelines, doubled-to-sextupled whole-transcript copies — the same defect *classes* the
+burn-down removed, reintroduced on a different trigger; (3) the Library media reader
+(#2064) rebuilds and re-parses the whole document **per traversal keystroke**; and (4) warm
+boot-to-ready **regressed ~11%** while every import guard stayed green, because the growth
+is on the legs the guards cannot see (Chat first-paint import leg, pre-importer payload,
+boot worker fleet, eagerly-parsed CSS bytes).
+
+---
+
+## Measured A/B (tip `a71e62e4b` vs pin `35d4bf3a1`, same machine, interleaved runs)
+
+| Metric | Pin 35d4bf3a1 | Tip a71e62e4b | Verdict |
+|---|---|---|---|
+| Warm `import tldw_chatbook.app` | 0.73 s | 0.64–0.88 s | equal (interleaved ×3) |
+| tldw modules in import closure | 748 (incl. PIL, bs4, keyring, 39 Chunking) | 638 (none of those) | burn-down wins HELD |
+| Warm `TldwCli()` construct | 58.5 ms | 63.5–105.7 ms | ~equal |
+| Fresh-profile first-boot construct | 4.70 s | 2.35 s | IMPROVED 2× |
+| Warm boot → `_ui_ready` (headless Pilot) | 1323 / 1331 / 1360 / 1368 ms | 1413 / 1435 / 1467 / 1473 / 1509 ms | **REGRESSED ~140 ms (~11%)** |
+| tldw modules at `_ui_ready` | 984 | 931 (−93 removed, +40 new) | net smaller, yet slower |
+| Widgets on Chat screen at ready | 460 | 469 | equal |
+| `chat_screen` module import (after app import) | 186–199 ms | 182–198 ms | equal |
+| 19 keystrokes into the focused Console composer: SQL statements | **48** | **0** | TASK-21118 verified live |
+| 19 keystrokes: screen layout passes | 24 | 21 | equal (~1/key) |
+| Idle 4 s: screen layout passes | 8 | 0 | TASK-21692 verified live |
+| First-visit switch Library / Artifacts / Personas / Watchlists | 665 / 387 / 1135 / 606 ms | 581 / 368 / 1159 / 589 ms | equal (Personas slowest, pre-existing) |
+
+TTI-regression attribution (honest state): NOT import time, NOT `chat_screen` import time,
+NOT widget count, NOT the parallel init tasks (~62 ms total on the pool, of which
+notes_service 53 ms). The identified contributors, each traced: the Chat first-paint import
+leg grew +11,638 LOC (22213); the model-catalog refresh moved onto the initial-screen push
+line (filed inside 22222's census scope; mechanism `app.py:12080`); boot-parsed CSS grew
++43 KB and `TieAwareStylesheet` arms full reparses during first mount (22222); boot workers
+went 4 → 7 (22215); PIL loads on every boot via the Samira seeding chain (22217 — traced
+live: `app.py:8784 _init_notes_service → get_chachanotes_db_lazy → seed_builtin_content →
+Character_Chat/visual_identity.py:24`). A residual remains unattributed; 22213's AC
+requires re-measuring with this review's interleaved method.
+
+**Correction recorded during the review** (the filing-points-at-the-wrong-thing class): the
+new `config.py:1802` import of `Library.library_media_reader_state` inside
+`_load_settings_uncached` initially looked like ~100 ms moved onto config load — but the
+Library package was already in the pin's import closure via `app.py:238`, so the
+incremental cost today is small. Filed honestly as a **layering** finding (22223), not a
+milliseconds finding.
+
+Guard status at tip, run first-hand in the probe venv:
+`Tests/Performance/test_app_import_weight.py` 5 passed (budget 660, measured 637–638);
+`Tests/App/test_boot_no_feature_db_files.py` passed;
+`Tests/UI/test_library_recompose_ratchet.py` 4 passed (census 97 == pin 97 — ZERO
+headroom, watch item);
+`Tests/UI/test_widget_css_consolidation.py::test_class_level_css_stays_within_the_allowlist`
+**FAILED on pristine tip** (22212).
+
+---
+
+## Findings by theme (task id = finding id)
+
+### A. The most plausible complaint mechanism: the post-upgrade window
+
+- **22200 (high)** — v46 truncates `messages_fts`; `DB/chachanotes_fts_backfill.py:82-97`
+  then re-tokenizes the ENTIRE history in back-to-back 500-row `BEGIN IMMEDIATE`
+  transactions with **no pacing between chunks** (verified — no sleep in the loop), while
+  every UI write is also `BEGIN IMMEDIATE` (15 s busy timeout) and chunk commits kill
+  concurrent DEFERRED read-then-write writers instantly (task-21100's own wave-1 lesson).
+  Every upgrading user's first session contends with a whole-history rebuild — concurrently
+  with the pre-importer, the subscriptions backfill, and actor-pack recovery.
+- **22215 (medium)** — boot worker fleet 4 → 7 since the pin; the aggregate GIL contention
+  at first interaction is what the user feels, worst on that same first-post-upgrade boot.
+
+### B. The Console run tick got heavy (PR #2034 + #2020) — the burn-down's defect classes on a new trigger
+
+- **22201 (high)** — 3 × `_build_console_workspace_context_state()` per 0.2 s tick
+  (`chat_screen.py:15206-15218`), each now reaching `ensure_default_workspace()` +
+  `list_workspaces()` twice (browser labels + the NEW `workspace_tree_projection`,
+  `workspace.py:2708→1525→3865-3887`; `registry_service.py:572-609`, `:1173-1203`): ~45
+  extra synchronous queries/second on the loop while streaming, plus the O(all-
+  conversations) canonical-owner/merge/overlay pipeline run twice per build × 3 builds.
+  The keystroke path is still clean (memo intact; A/B-proven above) — this is the same
+  shape on the tick trigger.
+- **22202 (high)** — `ConsoleWorkspaceTree.sync_projection` (new file) is an unconditional
+  O(rows) reconcile per push; one changed node blows Textual's whole tree line cache.
+- **22203 (high)** — every tree cursor move posts a context update whose unguarded
+  `Static.update()` arms a layout pass; boundary crossings trigger the full 7-section,
+  ~45-`query_one` rail allocation pipeline. One arrow key = up to 2 extra frames + a full
+  rail measure.
+- **22204 (high)** — streaming emotes doubled (to as much as 6×) the per-tick
+  whole-transcript `dataclasses.replace` copies via double expression resolution +
+  re-entrant `_request_is_current` (`character.py:284-295`, `:353-354`;
+  `console_expression_state.py:71`; `console_chat_store.py:5227-5234`). Default-ON
+  (`resolve_show_character_avatar` defaults True). The tick already pays ~3 other full
+  copies (native transcript, cost chip, guidance) — a shared per-tick snapshot is the
+  stretch direction.
+- **22221 (medium)** — avatar geometry: PIL LANCZOS resample on the UI thread per viewport
+  size; allocation reconcile gained three per-pass legs and clears tree hover every pass
+  (~5 Hz during runs).
+
+### C. Send/restore path (new dispatch-checkpoint machinery)
+
+- **22205 (high)** — per send, a ~10-statement `BEGIN IMMEDIATE` transaction (incl. FTS
+  triggers + full-content `sync_log` JSON = ~3× write amplification) runs synchronously on
+  the event loop before dispatch (`console_chat_controller.py:5635`;
+  `chat_persistence_service.py:384`; `console_dispatch_repository.py:103-262`), plus a
+  second pre-dispatch and a third at settle; every restore takes an IMMEDIATE (write)
+  transaction just to read recovery state. Unbounded (up to 15 s) under 22200's window.
+- **22206 (high)** — conversation resume is O(N²): per-node full-conversation scans with
+  BLOB hydration (plan verified with `sqlite_stat1` ABSENT — `idx_msgs_parent` exists but
+  is never chosen). **Measured: 89.8 ms @600 msgs vs 2.0 ms with the parent index forced
+  (45×, O(N))**. Also RecursionError at ~980-message linear conversations.
+- **22226 (low)** — create-path readbacks hydrate `image_data` up to 3× per persist.
+
+### D. Library media reader (#2064) + Watchlists reader (#2063)
+
+- **22207 (high)** — the reader now opens on FOCUS; each traversal keystroke synchronously
+  recomposes the full document body (fresh `Markdown(content)` parse on the loop), then the
+  settle recomposes a second time; the always-falls-through `unchanged` test at
+  `library_screen.py:33096-33100`; no windowing. The merge is otherwise net-NEGATIVE on
+  recompose count (245 → 237 sites; media-scoped whole-screen 27 → 21) — the regression is
+  the new trigger, not site count.
+- **22208 (medium)** — PIL mosaic preview built on the loop BEFORE the unchanged test and
+  discarded on the no-change path; every interaction copies the whole content string.
+- **22209 (medium)** — match navigation: 3–4 O(document) passes per Prev/Next click.
+- **22210 (medium)** — one un-deduplicated SQLite progress write per traversal step, no
+  exclusive worker.
+- **22211 (medium)** — Watchlists collapse boundaries have NO hysteresis (bare threshold at
+  `region_layout.py:132-175`; ±1 cell mounts/unmounts a whole pane; scrollbar-sensitive
+  width source). The Library reader carries the fix (`LAYOUT_HYSTERESIS_WIDTH = 4`);
+  Watchlists does not — the documented width-flap trap.
+- **22228 items 6–7 (low)** — six reader presses still whole-screen recompose; two layout
+  resolves per Resize event.
+
+### E. Boot: the import guards are green and the boot still got slower
+
+- **22213 (high)** — Chat first-paint import leg +11,638 LOC / +10 modules since the pin
+  (AST closure, not diff-grep): `chat_screen.py:51` module-level-imports the entire
+  TrajectoryScreen; `console_voice_input` (2,260 LOC) new on the leg; `Widgets/Console/
+  __init__.py` eagerly re-exports the new tree/speech/authority widgets; `Internal_Prompts`
+  (10 modules) still on the mount leg despite TASK-21731's title — its guard imports one
+  module, never `chat_screen`. PIL + keyring load pre-first-paint via chat_screen chains
+  (pre-existing).
+- **22214 (medium)** — pre-importer payload +99 modules / +74,524 LOC; the 0.10 s max-gap
+  cap makes the yield term a near-no-op (~92% GIL duty for a 1.2 s route); macOS falls back
+  to `os.cpu_count()` → unthrottled tier. (TASK-21113 history honored: a sleep cannot
+  subdivide `import_module` — the levers are payload, order, cap.)
+- **22216 (medium)** — PR #1998 put a synchronous staging sweep back into
+  `TldwCli.__init__` (`Actor_Packs/importer.py:216` from `app.py:7322`): a per-component
+  privacy walk from `/` + scandir + per-candidate O_NOFOLLOW opens, every boot — the
+  task-21106 class, invisible to the six-filename boot guard.
+- **22217 (medium)** — PIL re-enters EVERY boot via `seed_builtin_content` →
+  `visual_identity.py:24` module-level import; the seeding preflight exits early but the
+  import is paid first. PIL confirmed present at `_ui_ready` on tip.
+- **22222 (medium)** — the guard blind spots as a class: no census at `_ui_ready`, no CSS
+  byte budget (770,285 → 813,605 B; the 21115 ratchet FORCES new widget CSS into the
+  eagerly-parsed bundle with no size budget), no boot-thread census, construct-time runtime
+  imports invisible (`app.py:7273-7274` re-imports `Persona_Visual.*` — harmless today,
+  boundary crossed silently), no TTI tripwire; `TieAwareStylesheet` full-reparse count
+  uninstrumented.
+- **22223 (low)** — config load imports a feature package (layering; correction note above).
+
+### F. Idle/recurring (timer census: 42 sites, ZERO new timers since the pin)
+
+- **22218 (medium)** — composer caret blink at 1.89 Hz does 2 `query_one` + (with a draft)
+  a ≤1000-entry history scan + a full grapheme wrap of the ENTIRE draft per tick, and keeps
+  ticking under every modal (`has_focus_within` survives `push_screen`). The 21692 layout
+  half holds; the compute half was never addressed.
+- **22219 (medium)** — file-notes workspace: 1.5 s filesystem reconcile, 40×/min, no
+  `screen.is_active` gate — keeps scanning under modals and other screens.
+- **22220 (low)** — db-size stat burst (~15 syscalls) ON the loop every 120 s; Ollama
+  probe constructs a worker every 3 s just for the in-coroutine gate to drop it;
+  `InlineLoadingIndicator` tick never stopped after terminal states.
+- Dead-timer inventory: `Tamagotchi` and `DetailedProgress` (1 Hz psutil import per fire)
+  have NO production mount path — zero cost today, flagged so a future mount is a decision.
+
+### G. Data-layer hardening
+
+- **22224 (medium)** — `isolation_level=None` missing on held connections across ~8 stores
+  INCLUDING the template (`Library_Ingest_Jobs_DB.py`) and ChaChaNotes; mechanism verified
+  empirically: bare DML leaves an implicit DEFERRED txn that makes
+  `transaction(immediate=True)` silently BORROW — defeating the 21100 hardening the moment
+  one bare DML lands. Zero firing sites today (loaded gun, not a firing one).
+  `Notifications/event_state_repository.py` is the one store that gets it right.
+- **22225 (low)** — v48 seeds policy rows for deleted conversations.
+- **22227 (low)** — character emote pipeline constants (per-character UTF-16 encode loop;
+  16 regex passes per turn; O(assets²) snapshot projection).
+
+### H. Dev health
+
+- **22212 (high)** — the CSS allowlist ratchet is RED on pristine tip: PR #2053 (the tip
+  merge) shipped `ConsolePromptComparisonModal.DEFAULT_CSS` neither allowlisted nor
+  bundle-ridden. Every PR inherits the red. Otherwise the ratchet worked exactly as
+  designed across the window: 26 class-CSS blocks removed, 31 new blocks correctly rode the
+  bundle, ONE defector.
+
+---
+
+## Verified clean / regression audit (do NOT re-fix)
+
+All 20 burn-down headline fixes re-audited at tip; every mechanism present and
+load-bearing, with the hot path routed through it (workspace keystroke memo 21118;
+selection-dismissal registries 21119; transcript-copy guard 21121 — the one new bypass is
+22204's, which was already a bypass at the pin, just doubled; Inspector pure-scroll split
+21117; blink layout gate 21692; drag-selection 21114; Library canvas projections 21116
+(ratchet at exactly 97/97); lock-free config reads 21124; PIL/Chunking closure guards
+21103/21200/21102 (import-time); six lazy feature DBs 21105; notes-sync gate + backoff
+21112; splash overlap 21110 (delay 0.2 > 0; the `set_timer(0.0)` trap correctly branched);
+dead token timer 21133; device store 21101; bindings projections 21129; research store
+21127; event-state repo 21131 — the one store with `isolation_level=None` correct; import
+weight guard 21108 at 637/660). Streaming is O(1) per chunk with 5 Hz coalescing intact;
+markdown streaming append-only; reconciler move-guard intact; cost-chip gate intact;
+Persona Buddy paint gate holds and post-dates the chrome rewrite (merge order verified);
+auto-speak (#2028) is a pure ownership refactor; prompt workbench (#2053) is off the
+run/keystroke path (except 22228 item 5); per-chat sandbox (#2021) is well-bounded
+(3 syscalls once per session); subscriptions scheduler materially fixed (in-memory pop_due;
+DB via to_thread every ~30 min); no new store shipped DELETE/FULL journaling (32/32 sites
+NORMAL); connection creation centralized (one raw `sqlite3.connect` outside tests); both
+new indexes verified chosen with `sqlite_stat1` absent; v47/v49 migrations are O(1) DDL
+(v49 genuinely REDUCES per-update trigger work); no new `exclusive=True` with a falsy
+group; no `set_timer(0.0)`; no `run_worker` positional-arg misuse; the reactive-mutable
+inventory holds.
+
+---
+
+## Traps recorded (for the next review)
+
+- **Python `sorted()` order ≠ `comm`'s C-locale order.** The first module-set diff produced
+  false "tip-only" rows (`Text2SQL_Interop` etc. appeared new while present in both).
+  `LC_ALL=C sort` both files before `comm`. The corrected diff changed the boot story.
+- **Interleave A/B runs under identical load.** Tip-vs-base import first measured 1.4 s vs
+  0.82 s — pure contention noise from seven concurrently-running review agents; interleaved
+  re-runs showed tip equal-or-faster. Five interleaved TTI pairs were needed before the
+  ~140 ms delta was trustworthy.
+- **`python -c` from the wrong cwd resolves the MAIN checkout's package** even under the
+  probe venv (the documented editable-install trap, fired again). Assert
+  `tldw_chatbook.__file__` in every probe.
+- **The default focus target matters:** the first keystroke probe focused
+  `Input#compact-temperature` (first Input in walk order), not the composer — the composer
+  IS the default focus, so the right probe presses keys without touching focus.
+- **A "lazy import" comment is not a lazy import** if the enclosing function runs at module
+  import (`config.py:1802` — `load_settings()` executes at config import).
+- **Attribute before filing:** the Library-package-in-config-load finding shrank from
+  "~100 ms on config load" to a layering note once the base closure was checked — the
+  package was already there. Same class as wave-7's five corrected briefs.
+
+## Probe recipes (reusable)
+
+- SQL-per-interaction: wrap `sqlite3.connect` to `set_trace_callback` a global list BEFORE
+  importing the app; count statements inside the interaction window.
+- Layout passes: count `Screen._refresh_layout` calls via a subclass-safe wrapper.
+- Module censuses: `sys.modules` snapshots at import / construct / `_ui_ready`, diffed
+  between pins with `LC_ALL=C sort` + `comm`.
+- Import chains: a `builtins.__import__` wrapper capturing the first-import stack of target
+  modules (note: misses `importlib.import_module` callers — Actor_Packs needed the static
+  AST closure instead).
+- Worktrees left in place for the burn-down: `perf-review-2026-08-24` (pinned review tree),
+  `perf-probe-2026-08-24` + `perf-base-2026-08-24` (venvs installed, scratch profiles under
+  the session scratchpad are ephemeral — recreate per the Method section).

--- a/backlog/tasks/task-22200 - Pace-the-ChaChaNotes-messages_fts-backfill-and-yield-to-foreground-writes.md
+++ b/backlog/tasks/task-22200 - Pace-the-ChaChaNotes-messages_fts-backfill-and-yield-to-foreground-writes.md
@@ -1,0 +1,39 @@
+---
+id: TASK-22200
+title: >-
+  Pace the ChaChaNotes messages_fts backfill and yield to foreground writes
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - database
+  - console
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22200).
+
+`DB/chachanotes_fts_backfill.py:82-97` drives `backfill_messages_fts` in a tight loop with
+no sleep, yield, or time budget between chunks; every chunk is a `BEGIN IMMEDIATE`
+tokenize+write transaction on the shared CharactersRAGDB (`DB/ChaChaNotes_DB.py:16173`).
+Every UI write is also `BEGIN IMMEDIATE` (15 s busy timeout), and a chunk commit kills any
+concurrent DEFERRED read-then-write writer instantly (snapshot-upgrade SQLITE_BUSY bypasses
+busy_timeout — the recorded wave-1 lesson from task-21100's own review). On the first boot
+after upgrading across v46 the loop runs to completion over the user's entire message
+history, concurrently with the screen pre-importer, the subscriptions FTS backfill, and
+actor-pack recovery (boot workers went 4 -> 7 since `35d4bf3a1`). This is the single most
+plausible mechanism behind "the app recently got slower": every upgrading user gets a
+first session that contends with a whole-history rebuild. The backfill itself is the fix
+for a worse defect (the v46 inline freeze) — the residue is the unpaced contention window.
+
+## Acceptance Criteria
+
+- [ ] Inter-chunk pacing exists (sleep/yield and/or contention-aware backoff) and its effect is measured: a UI write issued mid-backfill completes within a stated bound in a probe that runs a concurrent writer against an in-flight backfill
+- [ ] Total backfill duration for a large history is measured before/after and reported in the notes (pacing may lengthen it — state the trade explicitly)
+- [ ] Resumability is preserved: killing the process mid-backfill still leaves a consistent, resumable index (existing state = messages_fts_docsize membership)
+- [ ] The every-boot no-op probe stays cheap (one indexed scan)

--- a/backlog/tasks/task-22201 - Take-workspace-registry-reads-and-the-doubled-row-pipeline-off-the-Console-run-tick.md
+++ b/backlog/tasks/task-22201 - Take-workspace-registry-reads-and-the-doubled-row-pipeline-off-the-Console-run-tick.md
@@ -1,0 +1,44 @@
+---
+id: TASK-22201
+title: >-
+  Take workspace registry reads and the doubled row pipeline off the Console run tick
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - console
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22201).
+
+PR #2034 (`a581f28e0`) reintroduced the exact hot-path shape TASK-21118 removed — on the
+run tick instead of the keystroke path. `_sync_native_console_chat_ui`
+(`UI/Screens/chat_screen.py:15206-15218`) builds `_build_console_workspace_context_state()`
+three times per 0.2 s tick (twice via `_current_console_rail_state()`, once via
+`_sync_console_workspace_context()`). Each build now reaches
+`_console_browser_workspace_records()` twice (pre-existing browser labels + the NEW
+`workspace_tree_projection(rows)` at `UI/Console_Modules/workspace.py:2708` -> `:1525-1535`
+-> `:3865-3887`), and each call runs `ensure_default_workspace()` (SELECT + bindings probe
++ occasional DELETE write txn, `Workspaces/registry_service.py:572-609`, `:1173-1203`) plus
+`list_workspaces()` — all synchronous on the event loop: roughly 45 extra queries/second
+while a reply streams. The same builds also run the whole-row-set canonical-owner
+reconciliation twice per build (`workspace.py:2628-2679` and again at `:1558-1563` inside
+the tree projection): merge across five row groups, membership dict rebuild,
+`_rows_with_latest_canonical_owner` + `_overlay_current_console_browser_markers` passes —
+O(all conversations), pure Python, x3 per tick. The `state_changed` guard at
+`chat_screen.py:11100` gates only the push, not the build. The keystroke path is still
+clean (memo at `workspace.py:2726-2826` intact — verified live: 19 keys = 0 SQL at tip vs
+48 at the pin).
+
+## Acceptance Criteria
+
+- [ ] A run tick with unchanged registry state performs zero workspace-registry SQL (memoize `_console_browser_workspace_records` on the existing `mutation_generation`, the TASK-21118 pattern) — proven by the sqlite trace-callback probe from the review
+- [ ] The row merge / canonical-owner / overlay pipeline runs at most once per state build, and the build runs at most once per tick unless its inputs changed
+- [ ] `ensure_default_workspace()` (a write-capable repair) is not called from any display/build path — only from mutation paths
+- [ ] Per-tick build cost during streaming is measured before/after; tree/browser behavior is unchanged when the registry actually changes (existing tests green)

--- a/backlog/tasks/task-22202 - Equality-guard-ConsoleWorkspaceTree.sync_projection-and-scope-its-invalidation.md
+++ b/backlog/tasks/task-22202 - Equality-guard-ConsoleWorkspaceTree.sync_projection-and-scope-its-invalidation.md
@@ -1,0 +1,34 @@
+---
+id: TASK-22202
+title: >-
+  Equality-guard ConsoleWorkspaceTree.sync_projection and scope its invalidation
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - console
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22202).
+
+`Widgets/Console/console_workspace_tree.py:313-467` (new in PR #2034): `sync_projection`
+is called on every workspace-context push with no projection-level equality guard. Each
+call rebuilds a `WorkspaceTreeNodeData` and a rich `Text` label for every workspace and
+conversation, materializes the full node set for `can_focus` (`:443-450`), and calls
+`get_node_at_line` twice plus `_update_tooltip()`. Any node change calls Textual's
+`Tree._invalidate()`, whose `self._updates += 1` is part of the line-render cache key — one
+changed node invalidates every cached tree line. During a run this fires at 5 Hz (the
+projection embeds `selected`/`run_marker`/`loading`, so it genuinely changes).
+
+## Acceptance Criteria
+
+- [ ] An unchanged projection results in zero node writes and zero tree invalidations (counted by a probe on `Tree._invalidate`)
+- [ ] A single-conversation change invalidates a bounded set of nodes, not the whole line cache, or the whole-cache cost is measured and accepted in the notes with numbers
+- [ ] `can_focus` derivation does not materialize the full node set per pass
+- [ ] Per-tick tree cost during streaming measured before/after

--- a/backlog/tasks/task-22203 - Stop-workspace-tree-cursor-moves-fanning-out-into-rail-wide-reconciles.md
+++ b/backlog/tasks/task-22203 - Stop-workspace-tree-cursor-moves-fanning-out-into-rail-wide-reconciles.md
@@ -1,0 +1,39 @@
+---
+id: TASK-22203
+title: >-
+  Stop workspace-tree cursor moves fanning out into rail-wide reconciles
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - console
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22203).
+
+New with PR #2034. `console_workspace_tree.py:945-948`: every cursor move (arrow key,
+click, sync) runs `_update_tooltip()` (per-move `get_node_at_line` + `cell_len` +
+`scrollable_content_region`) and posts `WorkspaceTreeContextChanged`. The rail handler
+(`UI/Console_Modules/left_rail.py:1992-2005`) calls
+`sync_workspace_tree_context` (`Widgets/Console/console_workspace_context.py:1359-1434`),
+which does an unguarded `context.update(copy)` — `Static.update` defaults to `layout=True`
+in Textual 8.2.8, so one screen layout pass is armed per cursor keypress — plus an
+unguarded tooltip assignment. When the cursor crosses a workspace<->conversation boundary
+(constant while arrowing), the action-row `display` flip triggers `styles.height = "auto"`
++ `refresh(layout=True)` + two deferred frames ending in
+`_reconcile_workspace_action_owners` (`:1448-1462`), which requests the full 7-section,
+~45-`query_one` rail allocation pipeline (`left_rail.py:916-1035`). One arrow key = up to
+2 extra frames + a full rail measure + >=2 layout passes.
+
+## Acceptance Criteria
+
+- [ ] An arrow-key move that does not cross the workspace/conversation boundary arms zero screen layout passes beyond the Tree's own repaint (probe on `Screen._refresh_layout`)
+- [ ] Context tray updates are equality-guarded (content and tooltip) before any `Static.update`/tooltip write
+- [ ] A boundary crossing performs at most one scoped reconcile, not the full rail allocation pipeline, or the full pipeline's per-press cost is measured and justified in the notes
+- [ ] Per-press layout-pass count measured before/after

--- a/backlog/tasks/task-22204 - Resolve-the-Console-expression-state-once-per-tick-and-stop-re-copying-the-transcript.md
+++ b/backlog/tasks/task-22204 - Resolve-the-Console-expression-state-once-per-tick-and-stop-re-copying-the-transcript.md
@@ -1,0 +1,41 @@
+---
+id: TASK-22204
+title: >-
+  Resolve the Console expression state once per tick and stop re-copying the transcript
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - console
+  - streaming
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22204).
+
+New with PR #2020 (streaming emotes), default-ON (`resolve_show_character_avatar` defaults
+True, `Chat/console_image_view.py:137-152`). `UI/Console_Modules/character.py:284-295`:
+`_current_request` calls `resolve_console_expression_selection` and then — whenever
+`selection.source` is `idle`/`operational`, the common case — re-runs
+`resolve_console_expression_state`, and `_request_is_current` (`:353-354`) re-enters
+`_current_request`. Every resolution funnels into
+`store.messages_for_session(...)` (`Chat/console_expression_state.py:71`), which
+materializes stream buffers and returns a `dataclasses.replace` copy of every message
+(`Chat/console_chat_store.py:5227-5234`). At the pin this was one copy per tick; now a
+repainting tick pays 4-6. The 0.2 s tick runs for the whole duration of a run, so this is
+10-30 whole-transcript copies per second while streaming. Context: the tick already pays
+~3 other full copies (native transcript, cost chip, setup-card guidance) — a shared
+per-tick snapshot seam would collapse all of them, but the minimum fix is restoring 1 copy
+for the avatar path.
+
+## Acceptance Criteria
+
+- [ ] One `messages_for_session` copy at most per avatar refresh per tick (reuse `selection.state`; make `_request_is_current` compare against the already-built request) — proven by a call-count probe during a simulated streaming tick
+- [ ] Emote/idle/operational selection behavior unchanged (existing expression tests green)
+- [ ] Stretch (may split to a follow-up): a single shared per-tick transcript snapshot consumed by the avatar, guidance, and cost-chip paths, with the seam documented
+- [ ] Per-tick copy count during streaming measured before/after

--- a/backlog/tasks/task-22205 - Move-the-per-send-durable-turn-commit-and-restore-reconcile-off-the-event-loop.md
+++ b/backlog/tasks/task-22205 - Move-the-per-send-durable-turn-commit-and-restore-reconcile-off-the-event-loop.md
@@ -1,0 +1,40 @@
+---
+id: TASK-22205
+title: >-
+  Move the per-send durable-turn commit and restore reconcile off the event loop
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - console
+  - database
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22205).
+
+New since the pin (console dispatch checkpoint work). Per send,
+`Chat/console_chat_controller.py:5635` runs `store.commit_durable_turn(acceptance)`
+synchronously on the event loop before the provider request goes out: one
+`BEGIN IMMEDIATE` transaction (`Chat/chat_persistence_service.py:384`) containing ~10
+statements including two message INSERTs (each firing the FTS trigger and a full-content
+`sync_log` JSON write — ~3x write amplification of the message text), an attachments
+`executemany`, and a readback (`Chat/console_dispatch_repository.py:103-262`). A second
+IMMEDIATE transaction runs at `:657` pre-dispatch and a third at settle
+(`console_chat_store.py:2141`). Separately, every conversation restore/switch runs
+`reconcile_for_session` (`console_dispatch_repository.py:324-345`) — an IMMEDIATE (write)
+transaction taken to read recovery state that usually writes nothing, plus a recursive
+active-path CTE, inline on the loop. Steady-state cost is tens of ms; under the 22200
+backfill window it is unbounded up to the 15 s busy timeout — on the event loop.
+
+## Acceptance Criteria
+
+- [ ] The durable-turn commit runs off the event loop (worker/`to_thread`) with its ordering guarantees preserved and the dispatch-checkpoint test suite green
+- [ ] `reconcile_for_session` takes a write transaction only when it actually has a write to make; the read path uses a read transaction
+- [ ] Send-to-dispatch latency measured before/after (steady state and with an artificial write-lock holder)
+- [ ] No new shutdown/error-path regressions: the review's standing rule — when you defer, walk the teardown and failure paths in real teardown order

--- a/backlog/tasks/task-22206 - Conversation-resume-replace-the-O(N-squared)-per-node-message-tree-build.md
+++ b/backlog/tasks/task-22206 - Conversation-resume-replace-the-O(N-squared)-per-node-message-tree-build.md
@@ -1,0 +1,37 @@
+---
+id: TASK-22206
+title: >-
+  Conversation resume: replace the O(N-squared) per-node message-tree build
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - chat
+  - database
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22206).
+
+`Chat/chat_conversation_service.py:1136-1184`: `_build_message_tree` recurses once per
+message and issues one `get_messages_for_conversation_by_parent_ids` per node
+(`DB/ChaChaNotes_DB.py:9684-9716`). With `sqlite_stat1` absent (no production DB has it)
+the plan uses `idx_msgs_conv_ts` and post-filters — every per-node call scans all N rows,
+hydrating `content` and the `image_data` BLOB. Python adds a per-node `set(seen)` copy.
+Measured in-memory with 1 KB blobs: 3.0 ms @100 msgs, 22.7 @300, 89.8 @600 (clean N^2);
+the same walk with `idx_msgs_parent` forced: 2.0 ms @600 — 45x, O(N). The walk is awaited
+inline on the loop (`UI/Console_Modules/workspace.py:3679`, `:3706`) on every saved-
+conversation resume/session restore. Also: recursion depth equals conversation length —
+a ~980-message linear conversation raises RecursionError on resume.
+
+## Acceptance Criteria
+
+- [ ] Resume performs O(N) total work: either one conversation-scoped query with in-memory tree assembly, or a per-parent query shape proven by EXPLAIN QUERY PLAN with sqlite_stat1 ABSENT to use `idx_msgs_parent`
+- [ ] BLOB columns are not hydrated during tree construction
+- [ ] A 2000-message linear conversation resumes without RecursionError (iterative build or explicit bound with a graceful path)
+- [ ] Resume time measured before/after at 600+ messages; the walk runs off the event loop or its on-loop time is bounded and stated

--- a/backlog/tasks/task-22207 - Library-media-reader-do-not-rebuild-the-document-body-per-traversal-keystroke.md
+++ b/backlog/tasks/task-22207 - Library-media-reader-do-not-rebuild-the-document-body-per-traversal-keystroke.md
@@ -1,0 +1,40 @@
+---
+id: TASK-22207
+title: >-
+  Library media reader: do not rebuild the document body per traversal keystroke
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - library
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22207).
+
+New with PR #2064. `UI/Screens/library_screen.py:7407-7419`: `on_descendant_focus` now
+opens the reader on focus, so arrow-keying through the Items list drives it per keystroke.
+`_select_library_media_reader_row` runs `_sync_library_media_viewer_or_recompose()`
+synchronously (`:12424`) — the 120 ms settle timer debounces only the DB fetch, not the
+recompose — and the `unchanged` test at `:33096-33100` compares `viewer.loading` against a
+freshly-flipped pending flag, so it always falls through to `viewer.refresh(recompose=True)`
+(`:33141`). Compose constructs a brand-new full-document body
+(`Widgets/Library/library_media_viewer.py:296-311`): in rendered mode a fresh
+`Markdown(content)` whose mount parses the whole document on the loop. The settle path
+then recomposes a second time. Net: 2 full-document rebuilds per settled selection, 1 per
+keystroke during fast traversal — and the wasted one re-parses the document being LEFT,
+purely to paint a "Loading..." placeholder. There is no windowing of the reader body.
+While Find is open, each rebuild adds 3 more O(document) match scans
+(`library_media_viewer.py:296`, `library_media_content.py:34`, `:155`).
+
+## Acceptance Criteria
+
+- [ ] Traversing N rows performs zero document-body rebuilds for pass-through rows; only the settled row renders, once (probe counts `LibraryMediaContentBody` constructions per 10-row traversal)
+- [ ] Showing the loading placeholder does not require recomposing the document body
+- [ ] A 1 MB document can be traversed past with no per-keystroke parse (measured)
+- [ ] Reader behavior (settle, modes, search) unchanged; existing reader tests green

--- a/backlog/tasks/task-22208 - Media-reader-no-change-syncs-stop-rebuilding-PIL-previews-and-copying-the-document.md
+++ b/backlog/tasks/task-22208 - Media-reader-no-change-syncs-stop-rebuilding-PIL-previews-and-copying-the-document.md
@@ -1,0 +1,36 @@
+---
+id: TASK-22208
+title: >-
+  Media reader no-change syncs: stop rebuilding PIL previews and copying the document
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - library
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22208).
+
+New with PR #2064. `_sync_library_media_viewer_state` computes the image-preview
+projection BEFORE its `unchanged` test (`library_screen.py:33079-33085` vs `:33110`), so
+every interaction — traversal step, mode switch, More toggle, Escape — synchronously runs
+`build_media_image_widget` (`Widgets/Library/library_media_image_preview.py:127-175`): a
+PIL LANCZOS resize plus a per-cell Python loop over the mosaic grid
+(`Utils/mosaic_render.py:216-240`), on the event loop, then discards the widget when
+nothing changed. Separately, every interaction rebuilds the full viewer display state:
+`build_library_media_viewer_state` copies the whole content string (`str(...).strip()` at
+`Library/library_media_viewer_state.py:305` — a trailing newline forces a full copy) and
+the `unchanged` compare memcmps it (`:33087`).
+
+## Acceptance Criteria
+
+- [ ] A no-change sync builds no preview widget and performs no O(document) string copies (probe)
+- [ ] Preview construction is memoized by source (and/or moved off the loop) with the memo's invalidation stated
+- [ ] The change test compares cheap identity (ids/revisions), falling back to content compare only when identity is inconclusive
+- [ ] Per-interaction cost measured before/after on an image-typed item

--- a/backlog/tasks/task-22209 - Media-reader-match-navigation-one-document-pass-per-click.md
+++ b/backlog/tasks/task-22209 - Media-reader-match-navigation-one-document-pass-per-click.md
@@ -1,0 +1,33 @@
+---
+id: TASK-22209
+title: >-
+  Media reader match-navigation: one document pass per click
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - library
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22209).
+
+Pre-existing, still live (the markdown re-parse half was fixed; this is the text half).
+Per Prev/Next click: `_advance_library_media_content_match`
+(`library_screen.py:33451-33484`) rebuilds the viewer state (full content copy), runs
+`find_content_matches` over the whole document, then `sync_match_index -> sync_search ->
+build_raw_content_renderable` runs a SECOND full `find_content_matches` plus a Rich `Text`
+rebuild with up to 3 appends per line over the entire document
+(`Widgets/Library/library_media_content.py:16-53`, `:112-134`). 3-4 O(document) passes per
+click; noticeable on multi-MB transcripts.
+
+## Acceptance Criteria
+
+- [ ] Match navigation performs at most one O(document) scan per click (match list cached keyed on content identity + query; the renderable patches highlight styles rather than rebuilding, or its rebuild is measured and accepted)
+- [ ] Measured before/after on a multi-MB document
+- [ ] TASK-21134's layout=False mitigation on the search refresh is preserved

--- a/backlog/tasks/task-22210 - Deduplicate-and-serialize-media-reading-progress-writes.md
+++ b/backlog/tasks/task-22210 - Deduplicate-and-serialize-media-reading-progress-writes.md
@@ -1,0 +1,31 @@
+---
+id: TASK-22210
+title: >-
+  Deduplicate and serialize media reading-progress writes
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - library
+  - database
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22210).
+
+New with PR #2064. `_capture_library_media_loaded_progress`
+(`library_screen.py:33239-33262`) fires an SQLite upsert worker on every traversal step
+and every mode switch, with no `exclusive=True` and no equality skip — holding an arrow
+key through 30 rows queues 30 concurrent `to_thread` writers contending for the same
+write lock.
+
+## Acceptance Criteria
+
+- [ ] An unchanged offset produces no write; identical consecutive captures are skipped
+- [ ] In-flight progress writes are superseded, not stacked (exclusive worker group or coalescing)
+- [ ] A 30-row traversal produces at most one settled write (probe)

--- a/backlog/tasks/task-22211 - Watchlists-responsive-layout-needs-hysteresis-at-its-collapse-boundaries.md
+++ b/backlog/tasks/task-22211 - Watchlists-responsive-layout-needs-hysteresis-at-its-collapse-boundaries.md
@@ -1,0 +1,37 @@
+---
+id: TASK-22211
+title: >-
+  Watchlists responsive layout needs hysteresis at its collapse boundaries
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - watchlists
+  - ux
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22211).
+
+New with PR #2063. `UI/Watchlists_Modules/region_layout.py:132-175`:
+`resolve_effective_layout` applies bare width thresholds with no `previous` state, and
+`on_resize` recomputes per Textual Resize event. Crossing 145 columns by ONE cell flips
+the right rail: region factory + mount/remove pair per flip
+(`watchlists_workbench.py:226-309`), repeated per Resize during a drag. This is the
+documented sub-2-cell width-flap trap; the Library media reader carries the fix
+(`LAYOUT_HYSTERESIS_WIDTH = 4`, `Library/library_media_reader_state.py:16`, `:341-355`)
+and Watchlists does not. Aggravator (medium confidence): `_available_layout_width` prefers
+`workbench.size.width` (`watchlists_collections_screen.py:2999`), which is
+scrollbar-sensitive — a scrollbar toggle at the boundary could flap the layout with no
+user resize.
+
+## Acceptance Criteria
+
+- [ ] Repeated +/-1-cell width changes at a collapse boundary cause no mount/remove churn (hysteresis test at the boundary, both directions)
+- [ ] The width source is not flappable by a scrollbar toggle, or a code-level guard absorbs sub-hysteresis changes (the repo rule: never trust a CSS-only guard)
+- [ ] Approach consistent with the Library reader's hysteresis precedent

--- a/backlog/tasks/task-22212 - Restore-the-CSS-allowlist-ratchet-to-green-bundle-ride-ConsolePromptComparisonModal.md
+++ b/backlog/tasks/task-22212 - Restore-the-CSS-allowlist-ratchet-to-green-bundle-ride-ConsolePromptComparisonModal.md
@@ -1,0 +1,35 @@
+---
+id: TASK-22212
+title: >-
+  Restore the CSS allowlist ratchet to green: bundle-ride ConsolePromptComparisonModal
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - css
+  - console
+  - dev-red
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22212).
+
+Dev is red at tip: `Tests/UI/test_widget_css_consolidation.py::
+test_class_level_css_stays_within_the_allowlist` FAILS on pristine `a71e62e4b` (run
+first-hand during this review). PR #2053 (the tip merge) added
+`Widgets/Console/console_prompt_comparison_modal.py:23` with a class-level `DEFAULT_CSS`
+that is neither in `_UNCONSOLIDATED_CSS_ALLOWLIST` nor bundle-ridden (0 hits in
+`css/*.tcss`; the sibling `ConsoleDispatchRecoveryRegion` from the same era is correctly
+bundled). Every PR inherits this red. The modal is imported at Console module scope
+(`chat_screen.py:523`), so first use also registers a new live stylesheet source — one
+step toward the LRUCache(64) parse-cache cliff the ratchet exists to prevent.
+
+## Acceptance Criteria
+
+- [ ] The consolidation suite is green on dev (modal CSS rides the bundle; no new allowlist entry)
+- [ ] `css/tldw_cli_modular.tcss` regenerated via `build_css.py`, both committed
+- [ ] First open of the compare-drafts modal registers no new stylesheet source (source-count probe or the suite's own check)

--- a/backlog/tasks/task-22213 - Put-the-Chat-first-paint-import-leg-on-a-diet-and-give-it-a-guard-that-can-see-it.md
+++ b/backlog/tasks/task-22213 - Put-the-Chat-first-paint-import-leg-on-a-diet-and-give-it-a-guard-that-can-see-it.md
@@ -1,0 +1,43 @@
+---
+id: TASK-22213
+title: >-
+  Put the Chat first-paint import leg on a diet and give it a guard that can see it
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - startup
+  - console
+priority: high
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22213).
+
+Measured this review: warm boot-to-`_ui_ready` regressed ~140 ms (~11%) vs pin
+`35d4bf3a1` (1323-1368 -> 1413-1509 ms, five interleaved runs) while the app IMPORT
+closure got smaller and every import guard stayed green — the growth is on the legs the
+guards cannot see. The Chat first-paint import leg grew +11,638 LOC / +10 modules since
+the pin. Named edges (lane 5's AST closure, not diff-grep):
+`UI/Screens/chat_screen.py:51` module-level-imports the entire TrajectoryScreen (~4,600
+LOC of trajectory work landed since the pin rides the Chat leg);
+`Chat/console_voice_input` (2,260 LOC) newly on the leg via `chat_screen.py:241`;
+`Widgets/Console/__init__.py` eagerly re-exports the new tree/speech/authority widgets;
+`Internal_Prompts` (10 modules) is still on the mount leg via
+`Chat/console_chat_controller.py:266` although TASK-21731's title claims otherwise — its
+guard (`Tests/Packaging/test_rag_boot_import_closure.py`) imports one module, never
+`chat_screen`. PIL and keyring also load pre-first-paint via chat_screen chains
+(pre-existing; `session.py:189 -> visual_identity.py:24`; `image.py:38 ->
+Image_Generation/config.py:15`).
+
+## Acceptance Criteria
+
+- [ ] `TrajectoryScreen` is not imported at chat_screen module level (screen-registry route or local import at the navigation seam)
+- [ ] `Internal_Prompts` is off the Chat mount leg, or kept with a measured, stated cost
+- [ ] The closure guard is extended to assert DEFERRED_PREFIXES absent after importing `UI.Screens.chat_screen` (closing the one-module blind spot)
+- [ ] chat_screen module import time and boot-to-`_ui_ready` measured before/after with the review's interleaved A/B method; the regression is at least halved or the residual is attributed
+- [ ] A `sys.modules` census at `_ui_ready` is pinned as a guard so mount-leg growth is visible in review (the import-weight guard's documented blind spot)

--- a/backlog/tasks/task-22214 - Budget-and-genuinely-pace-the-screen-pre-importer's-grown-payload.md
+++ b/backlog/tasks/task-22214 - Budget-and-genuinely-pace-the-screen-pre-importer's-grown-payload.md
@@ -1,0 +1,36 @@
+---
+id: TASK-22214
+title: >-
+  Budget and genuinely pace the screen pre-importer's grown payload
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - startup
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22214).
+
+The whole-registry pre-importer payload grew +99 modules / +74,524 LOC since the pin
+(568k -> 552k LOC compiled on a daemon thread; library_screen route 92,758 -> 135,933 LOC,
+settings 43,762 -> 72,963). Pacing (`app.py:12725-12731`) is
+`min(previous_cost * SCREEN_PREIMPORT_YIELD_RATIO, SCREEN_PREIMPORT_MAX_ROUTE_GAP_SECONDS)`
+with the cap at 0.10 s (`app.py:795-796`) — for a 1.2 s route compile that is ~92% GIL
+duty exactly while the user first touches the UI. `_usable_cpu_count` falls back to
+`os.cpu_count()` on macOS (no sched_getaffinity), so laptops take the unthrottled tier.
+Honest history: TASK-21113 shipped as a wash because a sleep cannot subdivide one
+`import_module` — the lever here is payload size, route order, and the gap CAP, not finer
+sleeping.
+
+## Acceptance Criteria
+
+- [ ] Pre-importer GIL duty cycle over the first 5 s after mount is measured (tip) and reduced, or the payload is trimmed per-route with the top growers listed and justified
+- [ ] The gap cap / yield ratio is retuned with measurements at both a high-core and a low-core tier, honestly reporting overlap if results wash (the 21113 precedent)
+- [ ] First-navigation latency to Library and Settings measured before/after (the pre-import exists to protect it — do not trade it away silently)
+- [ ] A payload budget (module count or LOC per route) is pinned so the next +30k LOC lands in review, not in users' laps

--- a/backlog/tasks/task-22215 - Stagger-the-boot-time-background-worker-fleet.md
+++ b/backlog/tasks/task-22215 - Stagger-the-boot-time-background-worker-fleet.md
@@ -1,0 +1,31 @@
+---
+id: TASK-22215
+title: >-
+  Stagger the boot-time background worker fleet
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - startup
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22215).
+
+Boot-time concurrent workers went 4 -> 7 since the pin (new: chachanotes-fts-backfill,
+the initial-screen pre-import thread, actor-pack recovery relocation). Under the GIL these
+CPU-bound import/tokenize threads plus the Textual pump share one interpreter during the
+first seconds after mount — worst on the first post-upgrade boot when 22200's backfill
+runs to completion alongside the pre-importer. Each worker is individually justified; the
+aggregate is what the user feels.
+
+## Acceptance Criteria
+
+- [ ] Boot workers are census'd (a test pins the set, so an eighth is a reviewed decision) and started with an explicit priority/stagger policy
+- [ ] Input latency during the first 5 s after mount measured before/after on a warm boot and on a simulated first-post-upgrade boot
+- [ ] Backfills yield to foreground work (coordinate with TASK-22200)

--- a/backlog/tasks/task-22216 - Move-the-actor-pack-staging-sweep-out-of-TldwCli.__init__.md
+++ b/backlog/tasks/task-22216 - Move-the-actor-pack-staging-sweep-out-of-TldwCli.__init__.md
@@ -1,0 +1,34 @@
+---
+id: TASK-22216
+title: >-
+  Move the actor-pack staging sweep out of TldwCli.__init__
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - startup
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22216).
+
+PR #1998 (`ac1037732`) put synchronous filesystem work back into construct — the class
+task-21106 removed: `app.py:7322` constructs `ActorPackImportService`, whose `__init__`
+ends with `self.sweep_staging()` (`Actor_Packs/importer.py:216`). The sweep runs
+`secure_private_directory(..., create=True)` — a per-component walk from `/` with
+`os.open`+`fstat` owner/mode checks (`Utils/private_paths.py:995-1030`) — then `os.scandir`
+over up to 32 staging candidates, each with lstat + two O_NOFOLLOW opens (`importer.py:
+218-255`, `:1313`), every boot, before the event loop exists. Small-medium warm; medium on
+network/FUSE homes or with residue. The boot-files guard cannot see it (it asserts six DB
+filenames, and this is a directory).
+
+## Acceptance Criteria
+
+- [ ] `TldwCli.__init__` performs no staging filesystem I/O (probe or guard asserts the sweep is not reached from construct)
+- [ ] The sweep runs on first import-feature use or a deferred worker; crash-recovery semantics preserved (staging residue still cleaned within the session)
+- [ ] The boot-time guard is extended to cover this class (construct-time filesystem side effects), with its blind spots stated

--- a/backlog/tasks/task-22217 - Keep-PIL-off-the-warm-boot-path-lazy-import-in-visual_identity.md
+++ b/backlog/tasks/task-22217 - Keep-PIL-off-the-warm-boot-path-lazy-import-in-visual_identity.md
@@ -1,0 +1,34 @@
+---
+id: TASK-22217
+title: >-
+  Keep PIL off the warm boot path: lazy import in visual_identity
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - startup
+  - personas
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22217).
+
+Traced live this review: every boot, `app.py:8784 _init_notes_service` ->
+`get_chachanotes_db_lazy()` -> `seed_builtin_content()` (`config.py:7231`) ->
+`Character_Chat/visual_identity.py:24` module-level `from PIL import Image, ...`.
+`ensure_builtin_samira` preflights and exits early on warm boots — but the PIL import
+(~80 modules) is paid before the preflight can run, on the init thread pool, every boot,
+in every profile. This undermines TASK-21103/21200 (which keep PIL out of the import
+closure) via the construct-time gap the guards cannot see; PIL was confirmed present at
+`_ui_ready` on tip.
+
+## Acceptance Criteria
+
+- [ ] A warm boot with seeding already terminal loads no PIL (census `sys.modules` at `_ui_ready` under a default profile)
+- [ ] Fresh-profile seeding still works end to end (Samira card + pack created)
+- [ ] PIL imports move inside the code paths that actually do image work in `visual_identity.py`

--- a/backlog/tasks/task-22218 - Composer-caret-blink-no-per-tick-draft-wrap,-history-scan,-or-under-modal-ticking.md
+++ b/backlog/tasks/task-22218 - Composer-caret-blink-no-per-tick-draft-wrap,-history-scan,-or-under-modal-ticking.md
@@ -1,0 +1,35 @@
+---
+id: TASK-22218
+title: >-
+  Composer caret blink: no per-tick draft wrap, history scan, or under-modal ticking
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22218).
+
+Pre-existing (the TASK-21692 layout fix holds — verified live, idle layouts 0 at tip vs 8
+at pin — but the per-tick COMPUTE remains). `Widgets/Console/console_composer_bar.py:
+2952-3003`: at 1.89 Hz while the composer has focus (the Console steady state), each blink
+fires 2 `query_one` + placeholder/draft render; with a non-empty draft it additionally
+runs `_ghost_suffix()` — a linear `startswith` scan over up to 1000 history entries
+(`Chat/prompt_history.py:261-264`) — and a grapheme-aware `cell_len` wrap of the ENTIRE
+draft (window sliced after the full wrap, `:2282-2296`): a pasted 20 KB draft is re-wrapped
+1.89x/s forever. The resume gate is `has_focus_within` (`:2993-2996`), which survives
+`push_screen` — every modal leaves the blink ticking and repainting underneath.
+
+## Acceptance Criteria
+
+- [ ] A blink tick with unchanged draft, width, and history performs no wrap and no history scan (memoized by those inputs; only the caret cell repaints)
+- [ ] The wrap, when it does run, is bounded to the visible window rather than the whole draft, or the whole-draft cost is measured and accepted
+- [ ] The blink pauses while the composer's screen is not the active screen (modal on top)
+- [ ] Tick cost with a 20 KB draft measured before/after

--- a/backlog/tasks/task-22219 - Gate-the-file-notes-filesystem-reconcile-on-screen-visibility.md
+++ b/backlog/tasks/task-22219 - Gate-the-file-notes-filesystem-reconcile-on-screen-visibility.md
@@ -1,0 +1,31 @@
+---
+id: TASK-22219
+title: >-
+  Gate the file-notes filesystem reconcile on screen visibility
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - library
+  - notes
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22219).
+
+Pre-existing. `Widgets/Library/library_file_notes_workspace.py:1453-1456` arms a 1.5 s
+`set_interval` (`pause=False`) whose fire runs `to_thread(service.reconcile)` — a
+walk/stat of the notes root — 40x/minute for the Library screen's lifetime once the File
+Notes surface has been opened, including while other screens or modals are on top (the
+only gates are `_active`/transitioning/in-flight; no `screen.is_active`).
+
+## Acceptance Criteria
+
+- [ ] No reconcile fires while the Library screen is not active or is covered (probe)
+- [ ] Polling resumes on return to the screen; a change-driven or backoff cadence is considered and the choice stated
+- [ ] Filesystem scan count per minute measured before/after in the covered state

--- a/backlog/tasks/task-22220 - Timer-hygiene-batch-db-size-stats-off-the-loop,-hoist-the-Ollama-gate,-stop-the-loading-indicator-tick.md
+++ b/backlog/tasks/task-22220 - Timer-hygiene-batch-db-size-stats-off-the-loop,-hoist-the-Ollama-gate,-stop-the-loading-indicator-tick.md
@@ -1,0 +1,37 @@
+---
+id: TASK-22220
+title: >-
+  Timer hygiene batch: db-size stats off the loop, hoist the Ollama gate, stop the loading-indicator tick
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - cleanup
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22220).
+
+Three small pre-existing recurring costs from the timer census (42-site table in the
+evidence doc):
+1. `Utils/db_status_manager.py:34-98` — every 120 s, ~15 stat/exists syscalls for
+   DB+WAL+SHM sizes run synchronously ON the event loop, plus an unconditional
+   `logger.info` triple; no gate, no change-skip.
+2. `UI/LLM_Management_Window.py:611`, `:740-756` — the 3 s Ollama probe constructs and
+   schedules a worker every tick even when the inside-the-coroutine `is_active` gate will
+   immediately drop it; hoist the gate into `_schedule_ollama_api_state`.
+3. `Widgets/loading_states.py:233-266` — `InlineLoadingIndicator` arms a 0.5 s tick on
+   mount, discards the handle, and `set_success`/`set_error`/`reset` never stop it: a
+   forever timer per mounted indicator.
+
+## Acceptance Criteria
+
+- [ ] DB-size collection runs off-loop (or is change-gated) and the periodic log line only fires on change
+- [ ] The Ollama tick creates no worker when the screen is inactive (gate hoisted to the scheduler)
+- [ ] The loading indicator's timer stops on terminal states and on reset-to-idle
+- [ ] Each item verified by a probe; no behavior change beyond the mechanics

--- a/backlog/tasks/task-22221 - Avatar-geometry-PIL-resample-off-the-loop;-trim-allocation-reconcile-legs.md
+++ b/backlog/tasks/task-22221 - Avatar-geometry-PIL-resample-off-the-loop;-trim-allocation-reconcile-legs.md
@@ -1,0 +1,35 @@
+---
+id: TASK-22221
+title: >-
+  Avatar geometry: PIL resample off the loop; trim allocation-reconcile legs
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22221).
+
+New with PR #2034. (a) `UI/Console_Modules/left_rail.py:1037-1094` +
+`Chat/console_image_view.py:103-107`: each distinct rail viewport size triggers
+`image.copy()` + LANCZOS `thumbnail` synchronously on the UI thread (drag-resize burst
+cost; the memo prevents steady-state cost). (b) `_run_allocation_reconcile` gained three
+per-pass legs since the pin (`left_rail.py:944-1035`): avatar geometry reconcile,
+`set_allocation(None)`+height reset across all 7 sections before every measurement pass,
+and `_measure_outer_content_height` iterating every outer child — plus
+`_refresh_workspace_tree_after_reflow` (`:1030`) clears the tree hover row on EVERY pass
+(~5 Hz during runs: hover flicker + 2 repaints + tooltip per tick).
+
+## Acceptance Criteria
+
+- [ ] The avatar resample runs off the loop with the existing memo and race fences intact
+- [ ] The allocation reconcile does not clear tree hover when the hover row is unaffected
+- [ ] Per-pass query/measure counts recorded before/after; reconcile passes converge in the same number of frames
+- [ ] Resize-drag cost measured before/after with a high-resolution character card

--- a/backlog/tasks/task-22222 - Boot-guards-for-what-the-import-guards-cannot-see.md
+++ b/backlog/tasks/task-22222 - Boot-guards-for-what-the-import-guards-cannot-see.md
@@ -1,0 +1,41 @@
+---
+id: TASK-22222
+title: >-
+  Boot guards for what the import guards cannot see
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - testing
+  - startup
+  - guard-efficacy
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22222).
+
+This review measured a real user-visible boot regression (+~11% to `_ui_ready`) with every
+import guard green, because all of them assert on `import tldw_chatbook.app`:
+- no census at `_ui_ready` (the mount leg grew invisibly; PIL present at ready);
+- no budget on boot-parsed CSS bytes (770,285 -> 813,605 B since the pin; the TASK-21115
+  ratchet design FORCES new widget CSS into the eagerly-parsed bundle with no size budget);
+- no census of boot-time worker threads (4 -> 7 unnoticed);
+- construct-time runtime imports are invisible (`app.py:7273-7274` re-imports
+  `Persona_Visual.*` at construct — harmless today, boundary crossed silently);
+- `Tests/App/test_boot_no_feature_db_files.py` is a fixed six-filename list (a seventh
+  store, or non-DB side effects like 22216's staging sweep, pass silently);
+- no wall-clock or structural TTI regression tripwire at all.
+Also: TieAwareStylesheet (`app.py:5893`, new since pin) arms full ~814 KB reparses during
+first mount when tie-breakers lower — instrument the count so the cost is visible.
+
+## Acceptance Criteria
+
+- [ ] A `sys.modules` census at `_ui_ready` is pinned (allowlist + budget), so mount-leg growth and construct-time imports land in review
+- [ ] Boot-parsed CSS bytes carry a budget with a stated raise procedure
+- [ ] Boot worker census pinned (see TASK-22215)
+- [ ] The boot-files guard's fixed-list blind spot is documented in the test and extended where cheap
+- [ ] TieAwareStylesheet reparse count during a cold boot is measured once and recorded (instrumentation may be temporary); each new guard documents its own blind spots

--- a/backlog/tasks/task-22223 - Config-load-must-not-import-feature-packages-(media-reader-normalizer-layering).md
+++ b/backlog/tasks/task-22223 - Config-load-must-not-import-feature-packages-(media-reader-normalizer-layering).md
@@ -1,0 +1,34 @@
+---
+id: TASK-22223
+title: >-
+  Config load must not import feature packages (media-reader normalizer layering)
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - architecture
+  - startup
+  - library
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22223).
+
+`config.py:1802` (added 2026-08-24, `455d8d061`) imports
+`Library.library_media_reader_state` inside `_load_settings_uncached`, whose comment
+claims the import is lazy — but `load_settings()` runs at config-module import
+(`config.py:7416`), so it fires on every boot inside the app import closure. Honest
+scoping from this review: the incremental cost TODAY is small (the Library package was
+already in the pin's import closure via `app.py:238`), so this is a layering finding, not
+a milliseconds finding — config load acquiring feature-package imports is the mechanism by
+which the next 100 ms lands silently.
+
+## Acceptance Criteria
+
+- [ ] Preference normalization happens without config.py importing the Library package (move the normalizer to a config-safe leaf module, or normalize at first read in the Library layer)
+- [ ] A comment or guard at the site prevents the next feature from repeating the pattern
+- [ ] No behavior change to media-reader preference handling

--- a/backlog/tasks/task-22224 - Add-isolation_level=None-to-held-connection-stores,-including-the-template.md
+++ b/backlog/tasks/task-22224 - Add-isolation_level=None-to-held-connection-stores,-including-the-template.md
@@ -1,0 +1,37 @@
+---
+id: TASK-22224
+title: >-
+  Add isolation_level=None to held-connection stores, including the template
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - database
+  - hardening
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22224).
+
+Latent but load-bearing (mechanism verified empirically this review on Python 3.12/SQLite
+3.49.1): without `isolation_level = None`, any bare DML on a held connection opens an
+implicit DEFERRED transaction; `TransactionContextManager` then BORROWS it
+(`ChaChaNotes_DB.py:18969-18978`) and `transaction(immediate=True)` silently degrades —
+defeating the task-21100 hardening (12 IMMEDIATE sites) the moment one bare DML lands.
+`ChaChaNotes_DB.py:3121-3141` never sets it; nor do `DB/Library_Ingest_Jobs_DB.py:48-60`
+(the store TEMPLATE others copy), `DB/Evals_DB.py:180-203`,
+`Widgets/Tamagotchi/tamagotchi_storage.py`, `Sync_Interop/sync_state_repository.py`,
+`Kanban_Interop/local_kanban_db.py`, `Scheduling/db/scheduled_tasks_db.py`,
+`Sync_Interop/notes_mirror.py`. `Notifications/event_state_repository.py:224` is the one
+store that gets it right. Currently zero firing call sites were found — this is a loaded
+gun, filed as hardening under the stability-over-quick-wins ruling.
+
+## Acceptance Criteria
+
+- [ ] All held-connection stores set `isolation_level = None` at open (or the exception is documented at the site)
+- [ ] A test reproduces the degradation mechanism (bare DML then `transaction(immediate=True)` must still BEGIN IMMEDIATE) and pins it repo-wide or at the template
+- [ ] The template file (`Library_Ingest_Jobs_DB.py`) carries the rule in its docstring so copies inherit it

--- a/backlog/tasks/task-22225 - v48-policy-seeding-skip-deleted-conversations.md
+++ b/backlog/tasks/task-22225 - v48-policy-seeding-skip-deleted-conversations.md
@@ -1,0 +1,30 @@
+---
+id: TASK-22225
+title: >-
+  v48 policy seeding: skip deleted conversations
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - database
+  - migration
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22225).
+
+`DB/ChaChaNotes_DB.py:5953-5970`: the v48 bump seeds
+`console_conversation_library_policy` with one row per conversation via
+`INSERT ... SELECT id FROM conversations` with no `WHERE deleted = 0` — O(all
+conversations ever) inserts inside the boot version-bump transaction, permanently storing
+rows for tombstoned conversations.
+
+## Acceptance Criteria
+
+- [ ] The seeding migration (current version at fix time) excludes deleted conversations; a fresh-migration test proves it
+- [ ] Existing over-seeded rows are cleaned or explicitly documented as inert
+- [ ] Migration remains self-contained (the TASK-21441 lesson)

--- a/backlog/tasks/task-22226 - Stop-re-hydrating-image_data-on-message-create-readbacks.md
+++ b/backlog/tasks/task-22226 - Stop-re-hydrating-image_data-on-message-create-readbacks.md
@@ -1,0 +1,29 @@
+---
+id: TASK-22226
+title: >-
+  Stop re-hydrating image_data on message-create readbacks
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - database
+  - chat
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22226).
+
+Pre-existing shape (the select list grew since the pin). `Chat/chat_persistence_service.py:
+1324-1382` re-reads the just-written message up to three times per create (feedback +
+citation paths), each via `get_message_by_id` (`DB/ChaChaNotes_DB.py:10965`) which
+hydrates the `image_data` BLOB — MBs copied per image message persist.
+
+## Acceptance Criteria
+
+- [ ] Create-path readbacks use a projection without BLOB columns, or reuse already-known values
+- [ ] Measured before/after on an image message persist
+- [ ] No change to what callers receive (shape-compatible)

--- a/backlog/tasks/task-22227 - Character-emote-pipeline-bound-the-per-chunk-and-per-send-constants.md
+++ b/backlog/tasks/task-22227 - Character-emote-pipeline-bound-the-per-chunk-and-per-send-constants.md
@@ -1,0 +1,36 @@
+---
+id: TASK-22227
+title: >-
+  Character emote pipeline: bound the per-chunk and per-send constants
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - chat
+  - personas
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22227).
+
+New with PR #2020, character sessions only (armed only when the assistant is a character).
+(a) `Character_Chat/emote_directives.py:251-263`, `:333-337`, `:434-438`: the streaming
+parser consumes per CHARACTER with a per-character `str.encode('utf-16-le')`
+(`:92-95`) and list append — O(len(chunk)) with a high constant (~16k encodes per reply)
+plus a clone + `safe_copy` per chunk. (b) `Chat/console_chat_store.py:7905-7947`:
+`detect_character_mood` runs 14 compiled regex passes + 2 more over the full reply at the
+terminal seam, on the loop. (c) `Chat/console_chat_controller.py:16091-16150`:
+`_build_character_emote_snapshot` is O(assets^2) in regex evaluations per send (~1600 for
+a 40-asset pack).
+
+## Acceptance Criteria
+
+- [ ] The parser publishes visible text in runs, not per character (or its per-chunk cost is measured and shown acceptable at 16k-char replies)
+- [ ] The snapshot projection is O(assets) (normalize each asset once)
+- [ ] Mood detection cost per turn is measured and bounded (or moved off-loop)
+- [ ] Emote semantics unchanged: existing directive/mood tests green

--- a/backlog/tasks/task-22228 - Console-and-reader-small-residue-batch-(press-scroll-recompose-leftovers).md
+++ b/backlog/tasks/task-22228 - Console-and-reader-small-residue-batch-(press-scroll-recompose-leftovers).md
@@ -1,0 +1,44 @@
+---
+id: TASK-22228
+title: >-
+  Console and reader small-residue batch (press/scroll/recompose leftovers)
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - performance
+  - cleanup
+priority: low
+dependencies: []
+---
+
+## Description
+
+Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
+and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22228).
+
+Verified small items that do not warrant tasks alone (each with cites in the evidence
+doc):
+1. `chat_screen.py:18953-18956` — `on_mouse_up` runs an id `query_one` on every Console
+   mouse-up before any cheap guard (same physical press 21119 cleaned; cheaper class).
+2. `left_rail.py:145-148`, `:1250-1267` — the left rail lacks the TASK-21117 pure-scroll
+   split the Inspector rail has (guarded, but 2 query_one + max_scroll_y per frame).
+3. `left_rail.py:561-585` — `_focusable_body_controls` does an uncached subtree
+   `query("*")` per focus change in the rail.
+4. `Workspaces/display_state.py:631-688` — 3+ stat/realpath syscalls per bound folder per
+   state build (deliberate ADR-028 posture; frequency drops with TASK-22201 — re-evaluate
+   a short-TTL cache for network mounts after it lands).
+5. `Widgets/Prompts/prompt_block_editor.py:818-888` — `_sync_footer` fires 3 unguarded
+   `Static.update()` (layout=True) + an unguarded tooltip write per keystroke while the
+   prompt workbench is open (partly PR #2053).
+6. `library_screen.py:32300`, `:32311`, `:32506-32521`, `:33599`, `:33611`, `:14316` — six
+   reader button presses still whole-screen recompose; the two delete-confirm presses
+   re-parse the document in Read mode.
+7. `library_screen.py:5741-5755` + `library_media_reader_shell.py:117-127` — two layout
+   resolves per Resize event (screen-level one fires even when Media is not active).
+
+## Acceptance Criteria
+
+- [ ] Each numbered item is fixed as described or explicitly declined with a reason in the notes
+- [ ] No behavior change beyond the stated mechanics; touched areas keep their tests green
+- [ ] Fixes verified by the cheap probe named in the evidence doc where one exists


### PR DESCRIPTION
Fourth full performance review, commissioned for renewed user reports that the app "recently slowed down". Seven read-only lanes against pinned dev `a71e62e4b` plus live A/B probes against the previous review's pin `35d4bf3a1` (isolated venvs + scratch profiles, interleaved runs). Files 29 tasks (TASK-22200…TASK-22228) and the evidence doc `Docs/Design/2026-08-24-holistic-perf-review.md`. No fixes implemented — burn-down not yet commissioned.

**Headlines**
- Every 2026-08-22 burn-down fix HELD and two were verified live in A/B (19 keystrokes: 48 SQL statements at the pin → 0 at tip; idle layout passes 8 → 0; fresh-profile first boot 4.70 → 2.35 s).
- The most plausible complaint mechanism: the v46 post-upgrade `messages_fts` rebuild runs unpaced back-to-back `BEGIN IMMEDIATE` chunks against every UI write for the whole first session after upgrade (22200).
- The Console 5 Hz run tick re-acquired the removed defect classes via #2034/#2020: registry SQL on the loop ×3 builds/tick, O(all-conversations) pipelines ×2 per build, whole-transcript copies doubled-to-sextupled, arrow-keys fanning into rail-wide reconciles (22201-22205, 22221).
- The Library media reader re-parses the whole document per traversal keystroke; Watchlists reader shipped without layout hysteresis (22207-22211).
- Warm boot→ready REGRESSED ~11% (measured, 5 interleaved pairs) while every import guard stayed green — the growth is on the legs the guards cannot see: Chat first-paint import leg +11.6k LOC, pre-importer payload +74.5k LOC at ~92% GIL duty, boot workers 4→7, boot-parsed CSS +43 KB, PIL back on every boot via the Samira seeding chain (22213-22217, 22222).
- Dev is RED at tip on the CSS allowlist ratchet — PR #2053 shipped an un-bundled `DEFAULT_CSS` (22212, verified by running the test).
- Conversation resume measured O(N²): 89.8 ms @600 messages vs 2.0 ms with the parent index forced, plan verified with `sqlite_stat1` absent (22206).

`./scripts/preflight.sh`: all checks green (task filenames made Windows-safe after its catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files the 2026-08-24 holistic performance review and adds 29 backlog tasks. This documents measured regressions and sets the burn-down; no code changes or fixes are included.

- Key findings to triage
  - Post-upgrade window: an unpaced `messages_fts` rebuild contends with UI writes in the first session (TASK-22200).
  - Console run tick: 5 Hz loop regained heavy registry SQL and O(all-conversations) pipelines from recent changes (22201-22205).
  - Conversation resume: O(N^2) tree build without `sqlite_stat1`; 600 messages measured at 89.8 ms vs 2.0 ms with parent index (22206).
  - Library/Watchlists: reader re-parses the document per traversal key; Watchlists lacks layout hysteresis (22207-22211).
  - Boot: warm boot-to-ready regressed ~11% due to mount-leg growth outside import guards; CSS bytes up, workers up, PIL loads on boot (22213-22217, 22222).
  - Dev health: CSS allowlist ratchet is red; an unbundled `DEFAULT_CSS` stylesheet must ride the bundle to restore green (22212).

- Notes for reviewers
  - Scope is docs/tasks only; behavior does not change.
  - The evidence doc includes A/B measurements, probes, and file:line cites for each task.
  - Immediate unblockers for the next PRs: pace the FTS backfill (22200) and restore the CSS ratchet to green (22212).

<sup>Written for commit 483fee387239ece8bb63ccf2880ebbc861aa4f82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

