### PR TITLE
docs(console): plan Ctrl+K activity switcher views

### DIFF
--- a/.impeccable/critique/2026-08-24T04-08-30Z__console-session-switcher-activity-views-design-md.md
+++ b/.impeccable/critique/2026-08-24T04-08-30Z__console-session-switcher-activity-views-design-md.md
@@ -1,0 +1,159 @@
+---
+target: TASK-21351 Ctrl+K activity views design
+total_score: 23
+max_score: 40
+na_heuristics: []
+p0_count: 0
+p1_count: 4
+timestamp: 2026-08-24T04-08-30Z
+slug: console-session-switcher-activity-views-design-md
+---
+# TASK-21351 Ctrl+K Activity Views Critique
+
+## Design Health Score
+
+| # | Heuristic | Score | Key issue |
+|---|---|---:|---|
+| 1 | Visibility of system status | 3 | Sync, stale, unavailable, gap, and result-change states are named; accepted live-update/focus behavior is incomplete. |
+| 2 | Match with the real world | 2 | `Switch Session` can open standalone workflow runs, and `Finished unseen` is system vocabulary. |
+| 3 | User control and freedom | 2 | Esc and explicit modes help, but terminal acknowledgement has no undo and History is reset every invocation. |
+| 4 | Consistency and standards | 2 | Strong keyboard conventions, but a session picker also acts as a cross-destination work inbox. |
+| 5 | Error prevention | 3 | Explicit targets and version guards are strong; stale async-search activation is not explicitly prevented. |
+| 6 | Recognition rather than recall | 2 | Controls are visible, but destination, authority, state, and metadata compete in one subtitle. |
+| 7 | Flexibility and efficiency | 3 | Keyboard, pointer, search, and paging are covered; historical search adds a recurring F3 step. |
+| 8 | Aesthetic and minimalist design | 2 | Geometry is bounded, but five groups and many subtitle tokens exceed the two-row budget. |
+| 9 | Error recognition and recovery | 2 | Failures are non-destructive, but `Waiting for you` can lead to a read-only destination. |
+| 10 | Help and documentation | 2 | Key hints exist; cross-destination behavior and unavailable recovery are not taught. |
+| **Total** | | **23/40** | **Acceptable; significant UX correction remains.** |
+
+## Design Specificity Verdict
+
+The systems design is strongly Chatbook-specific: lifecycle/activity separation,
+local/server authority, FLEET outcomes, exact Workflows handoff, and fail-closed
+degradation match the local-first control-room product. The visible modal is
+under-authored by comparison. Its name, row grammar, destination cues, focus
+behavior under live updates, and recovery experience are not yet as precise as
+the distributed persistence design beneath it.
+
+The deterministic detector scanned the Markdown target once and returned zero
+rules/findings. That is not evidence that the interaction design is clean; the
+detector has no implemented markup/widget tree to inspect. No browser overlay
+was created because the target is a future-design document, not a rendered UI.
+Line-numbered incumbent source and tests were used as the mechanical fallback.
+
+## Overall Impression
+
+The spec is unusually rigorous about data loss and authority, but its biggest
+opportunity is to choose a narrower product identity and ship local value before
+building a distributed activity subsystem. The highest-risk UX moment is an
+urgent `Waiting for you` row that leaves Console for a Workflows card where the
+user cannot perform the action being requested.
+
+## What's Working
+
+1. Activity membership comes from user consequence rather than overloading
+   lifecycle, recency, or open state.
+2. Explicit activation targets and authority/version checks prevent server IDs
+   from falling through local conversation-resume paths.
+3. Keyboard, degraded-state, migration, replay, and acknowledgement race
+   contracts are substantially more concrete than the incumbent switcher.
+
+## Priority Issues
+
+### P1 — The session switcher silently becomes a universal work inbox
+
+The `Switch Session` heading and existing Ctrl+K muscle memory promise a
+conversation/session destination, while standalone workflow rows navigate to
+Workflows. Choose one identity. Preferred v1: keep Ctrl+K conversation-scoped,
+hydrate correlated activity onto conversation rows, and defer standalone runs.
+If universal navigation is intentional, rename it `Jump to Work`, change the
+placeholder, and make `Opens Console` / `Opens Workflows` non-truncatable.
+
+### P1 — `Waiting for you` can lead somewhere the user cannot act
+
+The highest-priority group includes approval, human input, paused, failed, and
+stuck runs, while the minimal Workflows card explicitly excludes approval,
+retry, pause, inputs, outputs, and details. Only label a row `Waiting for you`
+when its destination provides a concrete next action. Otherwise use honest
+read-only attention copy with owner/problem/impact/recovery instructions. Do not
+acknowledge failures merely because a skeletal card painted; use explicit
+`Mark seen` or ensure meaningful diagnostic detail is visible first.
+
+### P1 — V1 is a distributed activity subsystem disguised as a modal change
+
+The spec adds multiple local receipt/mark states, polling, a server inbox,
+global event cursors, reset/gap recovery, reconciliation, metadata hydration,
+capability bundling, and cross-repository migrations. Phase it:
+
+1. Local Active/History from open sessions, controller state, and AgentRunsDB.
+2. Correlated server status after Workflows has useful exact-run detail.
+3. Standalone server workflows and lossless server activity feed as a separate
+   server-activity task/ADR.
+
+Use one versioned local activity-receipt seam for ordinary and survivor outcomes.
+Keep the coarse FLEET mark as compatibility state instead of turning generic
+conversation marks into an epoch/cause ledger.
+
+### P1 — Async search and live regrouping can activate the wrong row
+
+The spec discards late search responses, but Enter from search activates the top
+matching rendered row without requiring it to match the current query and result
+generation. The incumbent modal rebuilds positional buttons, so reordering can
+also move focus onto another subject. Require immutable entry payloads keyed by
+stable subject ID; Enter may activate only a result committed for the current
+modal/query/mode/authority/result generation. While the current query is pending,
+Enter waits or reports `Searching…`. Keyed reconciliation preserves the focused
+subject, with an announced deterministic fallback if it disappears.
+
+### P2 — History and row presentation add recurring friction
+
+Every invocation resetting to Active makes existing historical lookup require
+F3 after an empty search. Let typed search widen to History when Active has zero
+matches, while keeping Active as the default browse mode. Specify the exact
+two-row grammar and truncation order. Attention, source/authority, destination,
+and stale/error state must never truncate; lifecycle, workspace, and recency are
+the first omissions. Add width behavior, literal selected-mode text, and page
+location such as `51–100 of 243`.
+
+## Cognitive Load
+
+Five of eight checks fail: single focus, chunking, hierarchy, minimal choices,
+and progressive disclosure. Five Active groups plus a metadata-rich two-row row
+shape ask the user to process too many concepts at once. Consider three urgency
+groups (`Needs attention`, `Working`, `New results`) and express Current/Open as
+badges rather than separate sections.
+
+## Persona Red Flags
+
+- **Alex, power user:** History gains a repeated F3 tax; page resets and five
+  groups weaken the type-and-Enter switcher idiom.
+- **Sam, keyboard/accessibility user:** selected mode is not defined as literal
+  announced text; dynamic regrouping lacks a focus/announcement contract; the
+  subtitle can truncate critical authority or destination information.
+- **Riley, stress tester:** background mutation can race activation; fallback
+  workflow labels can be ambiguous across servers; corrupt-inbox recovery does
+  not name an exact user action.
+- **Solo builder/operator:** local value is held behind a cross-repository event
+  feed, and an urgent read-only destination violates inspectable control.
+
+## Minor Observations
+
+- `Finished unseen` is internal language; `New results` is clearer.
+- The placeholder becomes inaccurate if workflow runs are searchable.
+- F3 conflicts with ADR-031's blanket single-letter screen-action wording; the
+  ADR or modal-scoped exception must be clarified before implementation.
+- Current History persistence is offset-based and has no result generation;
+  keyset/generation behavior is a real new service contract, not widget work.
+- The spec should name how a stable ordinary outcome ID reaches the existing
+  in-memory `_unvisited_outcomes` transition seam.
+- The design defines a height ceiling but no narrow-width degradation contract.
+
+## Questions to Consider
+
+1. Is Ctrl+K fundamentally a conversation switcher or a universal work inbox?
+2. Can a row honestly say `Waiting for you` when Chatbook cannot provide the
+   action at its destination?
+3. What user value requires the signed global cursor before local Active/History
+   ships?
+4. If only three row tokens survive at 72 columns, which three must never
+   disappear?

--- a/Docs/superpowers/plans/2026-08-23-task-21351-console-session-switcher-activity-views.md
+++ b/Docs/superpowers/plans/2026-08-23-task-21351-console-session-switcher-activity-views.md
@@ -1,0 +1,849 @@
+# TASK-21351 Console Session-Switcher Activity Views Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the local Phase 1 `Ctrl+K` Active/History switcher with durable per-outcome acknowledgement, exact destination activation, and a production-verified 35-row modal.
+
+**Architecture:** `AgentRunsDB` v15 owns safe local activity receipts; one app-lifetime service coordinates those receipts with the legacy FLEET badge. The switcher consumes a pure canonical Active projection immediately and loads bounded persisted History pages asynchronously. Activation carries an immutable target and frozen receipt ID/status evidence into an always-mounted destination notice, which acknowledges only after visible paint or explicit `Mark seen`.
+
+**Tech Stack:** Python 3.11+, SQLite, Textual 8.x, Rich `Text`, pytest/pytest-asyncio, existing Console runtime and conversation services. No new dependency.
+
+---
+
+## Scope and dependency gate
+
+This plan implements only the approved local Phase 1 in
+`Docs/superpowers/specs/2026-08-23-console-session-switcher-activity-views-design.md`.
+Do not add server workflow correlation, polling, authority caches, or a universal
+work inbox. TASK-20937.6 must be complete before final terminal-parity closeout;
+implementation may begin only from a branch containing the completed TASK-20937
+changes. TASK-21351 remains In Progress as the approved design/umbrella owner.
+At that gate, create one atomic Phase 1 child through Backlog.md with parent
+TASK-21351 and dependency TASK-20937, copy all Phase 1 implementation acceptance
+criteria into it, and link this plan, the approved spec, and ADR-085. Put that
+child In Progress while the parent remains In Progress, and execute these tasks
+under the child. Complete the child's criteria/notes/Done transition first;
+complete the parent's criteria/notes/Done transition only after the child and
+all parent-level evidence are complete. Do not mint the child early: task IDs
+are provisional until re-swept against current remote refs and worktrees.
+
+ADR required: yes
+ADR path: `backlog/decisions/085-console-activity-receipts-and-switcher-ownership.md`
+Reason: ADR-085 owns durable local acknowledgement, the derived FLEET badge,
+canonical switcher identity/targets, and the modal-scoped F3 exception to ADR-031.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `tldw_chatbook/DB/AgentRuns_DB.py` | v15 optional receipt capability, idempotent revision/supersession, exact acknowledgement, unseen reads/counts, atomic orphan repair. |
+| `tldw_chatbook/Chat/console_activity_receipts.py` | App-lifetime receipt/mark coordinator, safe status mapping, degraded-state signal, in-memory unseen snapshot. |
+| `tldw_chatbook/Chat/console_runtime.py` | Construct and retain exactly one receipt service next to the one AgentRunsDB instance; own stable profile authority and runtime authority token. |
+| `tldw_chatbook/Chat/console_agent_bridge.py` | Add stable `FleetDrained.drain_id` for null-run survivor identity. |
+| `tldw_chatbook/Chat/console_fleet_attention.py` | Publish only post-turn survivors through the receipt service; keep toast/handoff behavior. |
+| `tldw_chatbook/Chat/console_fleet_wake.py` | Route wake-delivery badge reconciliation through the receipt coordinator. |
+| `tldw_chatbook/Chat/console_launch_wake.py` | Route unresolvable launch-wake cleanup through the receipt coordinator. |
+| `tldw_chatbook/Chat/console_prompt_queue_coordinator.py` | Give each queue chain one stable logical-outcome ID and pass it to the terminal callback. |
+| `tldw_chatbook/Chat/console_chat_controller.py` | Route direct/queue outcomes through one non-throwing helper while retaining compatibility markers/toasts. |
+| `tldw_chatbook/Chat/console_switcher_state.py` | Pure subject aggregation, activity grouping, sorting, display tokens, History calendar grouping, immutable activation payloads. |
+| `tldw_chatbook/UI/Console_Modules/workspace.py` | Build immediate Active snapshot and bounded local History loader without altering rail state. |
+| `tldw_chatbook/Widgets/Console/console_session_switcher_modal.py` | 35-row Active/History modal, async generation guards, paging, stable focus, keyboard/pointer contract. |
+| `tldw_chatbook/Widgets/Console/console_activity_outcome_notice.py` | Compact receipt-keyed success/failure notice and explicit `Mark seen` action. |
+| `tldw_chatbook/Widgets/Console/console_session_surface.py` | Always mount and display-manage the outcome notice at the destination. |
+| `tldw_chatbook/UI/Screens/chat_screen.py` | Open Ctrl+K immediately from Active snapshot and pass the History loader. |
+| `tldw_chatbook/UI/Console_Modules/session.py` | Dispatch explicit targets and coordinate post-paint acknowledgement. |
+| `tldw_chatbook/UI/Console_Modules/wiring.py` | Inject coordinator-owned FLEET read/clear seams instead of legacy direct helpers. |
+| `Docs/User_Guide/console/sessions-tabs-workspaces.md` | Explain Active/History, acknowledgement, keys, and degradation. |
+
+Do not create a generic notification framework, repository-wide pagination
+abstraction, or new CSS dependency. Keep component CSS with the two Console
+widgets unless a production-bundle rule demonstrably overrides it; if bundled
+TCSS changes become necessary, regenerate it with the repository CSS builder.
+
+### Task 1: Add AgentRunsDB v15 activity receipts
+
+**Files:**
+- Modify: `tldw_chatbook/DB/AgentRuns_DB.py`
+- Modify: `Tests/DB/test_agent_runs_db.py`
+
+- [ ] **Step 1: Write fresh-v15 and genuine v14 migration tests**
+
+Add tests that construct the current inline pre-v14 fixture/v14 shape, assert
+`console_activity_receipts` is absent, open `AgentRunsDB`, and assert the full
+table/index/check-constraint shape plus `MAX(schema_version) == 15`. Reopen the
+same file and verify existing agent definitions/change notes remain unchanged.
+
+Also inject failure at only the v15 receipt DDL boundary and prove core
+`AgentRunsDB` construction and existing run/definition/note reads still succeed
+with `receipt_capability_available is False`. Core schema/migration failures
+must still raise.
+
+- [ ] **Step 2: Run the migration tests and confirm RED**
+
+Run:
+
+```bash
+pytest Tests/DB/test_agent_runs_db.py -k 'activity_receipt or pre_v15 or receipt_capability' -q
+```
+
+Expected: FAIL because schema v15 and receipt operations do not exist.
+
+- [ ] **Step 3: Add the guarded additive schema**
+
+Use the incumbent idempotent `CREATE TABLE IF NOT EXISTS` mechanism, but isolate
+only the optional v15 receipt DDL/version-row work in a named savepoint. On a
+receipt-specific DDL failure, roll back that savepoint, leave versions 1-14 and
+all core tables usable, set an instance capability flag false, and continue.
+Never catch or downgrade failures from the core schema/versions 1-14. On a
+successful receipt savepoint, bump the constant/version row together:
+
+```sql
+CREATE TABLE IF NOT EXISTS console_activity_receipts (
+    activity_id TEXT PRIMARY KEY,
+    origin TEXT NOT NULL CHECK(origin IN ('ordinary', 'fleet_survivor')),
+    logical_outcome_id TEXT NOT NULL,
+    transition_revision INTEGER NOT NULL CHECK(transition_revision > 0),
+    session_id TEXT,
+    conversation_id TEXT,
+    run_id TEXT,
+    assistant_message_id TEXT,
+    status TEXT NOT NULL CHECK(status IN
+        ('done', 'failed', 'stuck', 'stopped', 'cancelled')),
+    created_at TEXT NOT NULL,
+    acknowledged_at TEXT,
+    superseded_at TEXT,
+    CHECK(session_id IS NOT NULL OR conversation_id IS NOT NULL),
+    UNIQUE(origin, logical_outcome_id, transition_revision)
+);
+CREATE INDEX IF NOT EXISTS idx_console_activity_receipts_unseen
+    ON console_activity_receipts(conversation_id, created_at)
+    WHERE acknowledged_at IS NULL AND superseded_at IS NULL;
+```
+
+Set `_CURRENT_SCHEMA_VERSION = 15` and append version 15 only after receipt DDL
+succeeds. Receipt operations check the capability and raise one focused
+`ConsoleActivityReceiptsUnavailable` error; callers can degrade without
+misreporting the core database as corrupt. Never add quarantine/delete/rebuild
+behavior.
+
+- [ ] **Step 4: Write RED repository-operation tests**
+
+Cover:
+
+- identical `(origin, logical_outcome_id, status)` restamp returns the same ID;
+- `failed → done` and `done → failed → done` create revisions 1/2 and 1/2/3;
+- only the latest unsuperseded revision appears unseen;
+- acknowledging exact IDs cannot acknowledge a newer revision;
+- mixed-success/failure acknowledgement updates only supplied IDs;
+- unseen survivor count excludes ordinary, acknowledged, and superseded rows.
+
+- [ ] **Step 5: Implement the minimum transaction-local operations**
+
+Add one private insert/update helper that accepts an existing SQLite connection
+so orphan reconciliation can share its transaction, plus public wrappers:
+
+```python
+def publish_console_activity(self, *, origin: str, logical_outcome_id: str,
+                             status: str, session_id: str | None,
+                             conversation_id: str | None,
+                             run_id: str | None = None,
+                             assistant_message_id: str | None = None) -> tuple[str, bool]: ...
+
+def list_unseen_console_activity(self) -> tuple[dict, ...]: ...
+def acknowledge_console_activity(self, activity_ids: Sequence[str]) -> int: ...
+def count_unseen_fleet_activity(self, conversation_id: str) -> int: ...
+```
+
+Generate deterministic IDs with stdlib `uuid.uuid5` from origin, logical ID,
+revision, and status. Parameterize every query and validate enum/destination
+fields before entering SQLite.
+
+- [ ] **Step 6: Make orphan repair atomic with receipt publication**
+
+Inside `reconcile_orphaned_runs`, select `conversation_id` with each orphan and,
+in the existing transaction, insert `fleet-run:<run_id>` / `failed` before changing
+`running → error`. Let any receipt failure roll back the entire repair; register
+`_swept_paths` only after commit. If the optional receipt capability is absent,
+the constructor's existing reconciliation guard logs the exception and leaves
+the orphan `running` for a later retry; core DB construction and bridge use still
+succeed. Do not backfill already-terminal rows.
+
+- [ ] **Step 7: Run the complete AgentRunsDB suite**
+
+Run:
+
+```bash
+pytest Tests/DB/test_agent_runs_db.py -q
+```
+
+Expected: PASS, including existing definitions/change-note and schema-version
+tests.
+
+- [ ] **Step 8: Commit the database boundary**
+
+```bash
+git add tldw_chatbook/DB/AgentRuns_DB.py Tests/DB/test_agent_runs_db.py
+git commit -m "feat(console): persist activity receipts"
+```
+
+### Task 2: Coordinate receipts, FLEET marks, and producer identities
+
+**Files:**
+- Create: `tldw_chatbook/Chat/console_activity_receipts.py`
+- Create: `Tests/Chat/test_console_activity_receipts.py`
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+- Modify: `tldw_chatbook/Chat/console_fleet_attention.py`
+- Modify: `tldw_chatbook/Chat/console_fleet_wake.py`
+- Modify: `tldw_chatbook/Chat/console_launch_wake.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `Tests/Chat/test_fleet_attention.py`
+- Modify: `Tests/Chat/test_console_fleet_wake.py`
+- Modify: `Tests/UI/test_console_launch_wake.py`
+- Modify: `Tests/UI/test_console_runtime_ownership.py`
+
+- [ ] **Step 1: Write RED service and forced-interleaving tests**
+
+Use a real temporary AgentRunsDB and a recording marks service. Cover exact
+status mapping, duplicate drain delivery, null-run children in two drain events,
+unknown-status degradation, mark-write failure, and an event-gated interleaving
+where acknowledgement attempts to clear the badge while a new survivor publishes.
+The final invariant is: an unseen survivor receipt implies the coarse badge is
+set after reconciliation. Cover optional receipt capability unavailable and a
+post-migration read error: both expose a content-free degraded state and empty
+receipt cache without breaking bridge construction, open-session switching, or
+History. Cover cold hydration, concurrent-call coalescing, publication and
+acknowledgement serialization during hydration, successful degraded-state retry,
+and runtime disposal before the hydration callback. The runtime-ownership test
+must exercise the real
+`ConsoleRuntime.ensure_agent_bridge` construction seam. Task 4's production-path
+UI test must later prove Active still shows open sessions and History still
+returns bounded rows while the receipt service is degraded.
+
+- [ ] **Step 2: Add the focused app-lifetime service**
+
+Implement one class with no generic repository abstraction:
+
+```python
+class ConsoleActivityReceiptService:
+    def __init__(self, runs_db: AgentRunsDB, marks: Any | None) -> None:
+        self._db = runs_db
+        self._marks = marks
+        self._lock = threading.RLock()
+        self._degraded = False
+
+    def publish_ordinary(...): ...
+    def publish_fleet_drain(self, event: FleetDrained) -> tuple[str, ...]: ...
+    def acknowledge(self, activity_ids: Sequence[str]) -> int: ...
+    def unseen_snapshot(self) -> tuple[ConsoleActivityReceipt, ...]: ...
+    def hydrate_from_storage(self) -> int: ...
+    def hydration_state(self) -> Literal["cold", "loading", "ready", "degraded"]: ...
+    def reconcile_fleet_marks(self) -> None: ...
+```
+
+The lock spans receipt write/ack, unseen survivor count, and badge set/clear.
+Catch and log only content-free exception type/context on live publication;
+set `degraded=True` and never raise into execution. Keep database exceptions
+observable from the explicit orphan-reconciliation path. Maintain an immutable
+in-memory unseen snapshot and monotonically increasing projection generation;
+the switcher read path never queries SQLite synchronously. When AgentRunsDB
+reports the optional receipt capability unavailable, initialize directly in
+degraded mode with an empty cache; do not suppress unrelated core DB errors.
+
+`hydrate_from_storage` is the single restart-hydration owner. The caller runs it
+off the event loop; inside the service it acquires the same lock as publication
+and acknowledgement, transitions `cold/degraded → loading`, reads the durable
+unseen rows, replaces the immutable cache, reconciles FLEET marks, increments
+the projection generation, and commits `ready`. A read failure atomically
+publishes `degraded` without clearing the last valid cache. A later invocation
+is an explicit retry; concurrent calls coalesce behind the service state/lock.
+
+- [ ] **Step 3: Give every FLEET drain stable identity**
+
+Add `drain_id: str = field(default_factory=lambda: str(uuid.uuid4()))` to
+`FleetDrained`. Preserve explicit construction in tests. For survivors, use
+`fleet-run:<run_id>` when present and `fleet-drain:<drain_id>:<ordinal>`
+otherwise. Filter `settled_after_turn is True`, map `done/error/cancelled` to
+`done/failed/cancelled`, and fail closed on anything else.
+
+- [ ] **Step 4: Construct the service once in ConsoleRuntime**
+
+Create it immediately after the one `AgentRunsDB` instance, store it cold on
+`ConsoleRuntime`, and pass it to bridge/controller consumers. Construction does
+no receipt read or badge reconciliation and does not construct a second
+AgentRunsDB against the same path. Add
+`ConsoleRuntime.ensure_activity_hydration()`: it owns the one in-flight off-loop
+hydration call, coalesces concurrent callers, allows a later retry only from
+`degraded`, and invalidates completion after runtime disposal. Hydration is the
+sole initial receipt-load and FLEET-badge reconciliation path.
+
+Define the stable profile authority as the normalized resolved string form of
+the durable `chachanotes_db.db_path`. Add a fresh opaque
+`ConsoleRuntime.authority_token` at runtime construction. Subject keys use only
+the stable profile authority; async jobs capture both the authority and token,
+then compare them with the current runtime before commit. Do not reuse the
+existing dispose counter `ConsoleRuntime.generation` as a profile token.
+
+- [ ] **Step 5: Route FLEET attention through the service**
+
+Replace direct mark writes in `ConsoleFleetAttentionConsumer` with
+`publish_fleet_drain(event)`. Keep the incumbent app-loop toast and deep-link
+fanout, using only successfully mapped survivor statuses. Inject a DB failure
+and assert the consumer still announces/returns without raising.
+
+- [ ] **Step 6: Route every legacy FLEET mark mutation through the coordinator**
+
+Replace the direct set/clear helpers reached from `console_fleet_wake.py`,
+`console_launch_wake.py`, and `UI/Console_Modules/wiring.py` with coordinator
+methods. Wake delivery and visible-session acknowledgement may request
+reconciliation, but the coordinator clears `FLEET_UNSEEN` only after its locked
+unseen-survivor count is zero. Unresolvable ephemeral launch cleanup explicitly
+does not acknowledge receipts: it preserves the receipt and coarse mark, and the
+Active projection exposes a receipt-keyed `Session unavailable` notice with an
+explicit `Mark seen` action. That action acknowledges only its frozen receipt
+IDs. When receipt storage is degraded, keep the coarse mark rather than risk
+hiding unseen work.
+Retain the exported legacy helpers as thin compatibility delegates only if tests
+or out-of-cluster callers still require them—no production path may mutate the
+mark outside the coordinator. Add forced-interleaving tests for all three paths.
+
+- [ ] **Step 7: Run focused service/FLEET tests**
+
+Run:
+
+```bash
+pytest Tests/Chat/test_console_activity_receipts.py Tests/Chat/test_fleet_attention.py Tests/Chat/test_console_fleet_wake.py Tests/UI/test_console_launch_wake.py Tests/UI/test_console_runtime_ownership.py -q
+```
+
+Expected: PASS; the forced interleaving must fail if the shared lock is removed.
+
+- [ ] **Step 8: Commit the service boundary**
+
+```bash
+git add tldw_chatbook/Chat/console_activity_receipts.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_fleet_attention.py tldw_chatbook/Chat/console_fleet_wake.py tldw_chatbook/Chat/console_launch_wake.py tldw_chatbook/UI/Console_Modules/wiring.py Tests/Chat/test_console_activity_receipts.py Tests/Chat/test_fleet_attention.py Tests/Chat/test_console_fleet_wake.py Tests/UI/test_console_launch_wake.py Tests/UI/test_console_runtime_ownership.py
+git commit -m "feat(console): coordinate activity receipts"
+```
+
+### Task 3: Publish ordinary direct and queue-chain outcomes
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_prompt_queue_coordinator.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `Tests/Chat/test_console_prompt_queue_coordinator.py`
+- Modify: `Tests/Chat/test_console_chat_controller.py`
+- Modify: `Tests/Chat/test_console_activity_receipts.py`
+
+- [ ] **Step 1: Write RED logical-identity and failure-isolation tests**
+
+Cover one direct completed turn, one direct failed turn, a defensive same-status
+restamp, a corrected terminal status, one multi-entry queue chain, and injected
+receipt-write failure on direct and queue terminal seams. Assert incumbent run
+state, cleanup, marker, toast, and wake retry still occur exactly as before.
+
+- [ ] **Step 2: Add one restart-stable queue-chain ID**
+
+Do not use `conversation_context_epoch` or `PromptQueueSnapshot.expected_context_epoch`:
+both are process-local fences. Give `_PromptChain` a
+`logical_outcome_id: str | None` derived from the most recently accepted durable
+dispatch checkpoint's `preparation_id`, for example
+`queue-chain:<preparation-id>`. Thread `preparation_id` into the manual
+`turn_accepted` call, reuse the already-present argument in
+`acknowledge_durable_acceptance`, and set the same value from
+`hydrate_dispatch_recovery`. Each later accepted queued turn replaces the chain
+value, so the one terminal receipt is keyed by the durable final accepted turn;
+a crash replay of that checkpoint reconstructs the identical ID. Change
+`on_chain_terminal` to receive `(session_id, status, logical_outcome_id)`.
+
+Fail closed when a terminal chain has no durable preparation identity: preserve
+the incumbent terminal behavior but publish no receipt and expose degradation.
+Add tests proving process-local epoch reuse cannot collide, the same recovered
+checkpoint produces the same ID after coordinator reconstruction, and two later
+accepted checkpoints produce different terminal IDs.
+
+- [ ] **Step 3: Route terminal publication through one controller helper**
+
+Add a non-throwing helper called by both `_set_run_state` and
+`_publish_queue_chain_terminal`:
+
+```python
+def _publish_inactive_outcome(
+    self, *, session_id: str, status: ConsoleRunStatus,
+    logical_outcome_id: str, assistant_message_id: str | None = None,
+) -> None: ...
+```
+
+Map `COMPLETED → done`, `FAILED → failed`, and a genuine inactive terminal
+`STOPPED → stopped`; publish only when `terminal_notification_eligible` and the
+session is not active. `BLOCKED` remains live Waiting for you and creates no
+receipt. Thread the owning assistant message/turn ID through terminal call sites;
+do not infer identity from title, timestamp, or current positional state.
+
+- [ ] **Step 4: Keep compatibility state derived but behaviorally intact**
+
+After successful publication, update `_unvisited_outcomes` for incumbent tab/rail
+badges. On publication failure, preserve its current marker/toast behavior and
+surface the receipt service's degraded flag. `mark_session_visited` may clear the
+in-memory compatibility marker but must not acknowledge durable receipts without
+captured receipt IDs.
+
+- [ ] **Step 5: Run controller and queue tests**
+
+Run:
+
+```bash
+pytest Tests/Chat/test_console_prompt_queue_coordinator.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_activity_receipts.py -q
+```
+
+Expected: PASS; the multi-entry chain produces one logical outcome receipt.
+
+- [ ] **Step 6: Commit producer wiring**
+
+```bash
+git add tldw_chatbook/Chat/console_prompt_queue_coordinator.py tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_prompt_queue_coordinator.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_activity_receipts.py
+git commit -m "feat(console): publish inactive outcomes"
+```
+
+### Task 4: Build canonical Active and bounded History projections
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_switcher_state.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/workspace.py`
+- Modify: `Tests/Chat/test_console_switcher_state.py`
+- Create: `Tests/UI/test_console_activity_switcher.py`
+
+- [ ] **Step 1: Write RED pure aggregation tests**
+
+Test canonical keys, duplicate native sessions, current-session preference,
+activity-time/session-ID tie breaks, unbound drafts, lifecycle independence,
+all five groups, existing-star ordering without star-created membership, mixed
+local contributions, `+N`, unavailable-session
+aggregation/group/search/order, mixed done+failed notice precedence, more than
+50 unavailable notices across pages, exact contribution ties resolved by stable
+contribution key, and a same-target done+failed+shell reduction with exact
+group/state/time/captured IDs/`+N`. Cover malformed timestamps, literal
+markup/emoji/CJK/RTL, and
+group/star/time/title/key ordering. Add pure History bucket
+tests for `Today`, `Yesterday`, `Previous 7 days`, and `Older` using an injected
+local timezone and clock. Pin midnight boundaries, a DST transition, future
+timestamps (`Today`), and missing/invalid timestamps (`Older`).
+
+- [ ] **Step 2: Replace nullable activation inference with explicit payloads**
+
+Use small frozen types in `console_switcher_state.py`:
+
+```python
+class SwitcherMode(Enum):
+    ACTIVE = "active"
+    HISTORY = "history"
+
+class ActivityGroup(Enum):
+    WAITING_FOR_YOU = "waiting_for_you"
+    WORKING = "working"
+    NEW_RESULTS = "new_results"
+    CURRENT = "current"
+    OTHER_OPEN = "other_open"
+
+class SwitcherTargetKind(Enum):
+    NATIVE_SESSION = "console_native_session"
+    PERSISTED_CONVERSATION = "console_persisted_conversation"
+
+@dataclass(frozen=True)
+class CapturedReceipt:
+    activity_id: str
+    status: str
+
+@dataclass(frozen=True)
+class ConsoleSwitcherTarget:
+    kind: SwitcherTargetKind
+    profile_authority: str
+    authority_token: str
+    session_id: str | None
+    conversation_id: str | None
+    scope_type: str | None
+    workspace_id: str | None
+    receipts: tuple[CapturedReceipt, ...] = ()
+
+@dataclass(frozen=True)
+class UnavailableSessionNotice:
+    stable_result_key: str
+    profile_authority: str
+    session_id: str
+    group: ActivityGroup
+    latest_at: datetime | None
+    receipts: tuple[CapturedReceipt, ...]
+
+ConsoleSwitcherActiveResult = ConsoleSwitcherEntry | UnavailableSessionNotice
+```
+
+`ConsoleSwitcherEntry` exposes `stable_result_key` equal to its canonical
+subject key; `UnavailableSessionNotice` exposes the documented unavailable key.
+Widget maps, focus retention, page relocation, and immutable payload lookup use
+that common result key for both union variants.
+
+Validate the required fields in `__post_init__`. Buttons and callbacks carry
+this target directly; no handler decides a kind from whichever field is non-null.
+The target's profile authority and runtime token are the immutable choice
+evidence Task 6 revalidates. Validate captured receipt statuses against the local
+receipt enum so activation never needs to consult mutable current receipt state
+to decide acknowledgement.
+
+`UnavailableSessionNotice` is not a `ConsoleSwitcherTarget`. Aggregate effective
+session-only receipts by `unavailable-session:<profile>:<session_id>`; map
+`done` and `cancelled` to New results and failed/stuck/stopped to Waiting for
+you; for mixed receipts choose the highest-priority group, then primary status
+by latest receipt time, `stuck > failed > stopped > cancelled > done`, and
+activity ID. Render primary status plus `+N`; index every unique safe status for
+search. Mark notices unstarred and sort all records by
+group/star/time/title/key; also search literal `Session unavailable` and exact
+session ID. Its sole
+selectable control is receipt-keyed `Mark seen` for the frozen IDs. Count and
+page these notices with subject results, keeping every result page at no more
+than 50 mounted result rows.
+
+- [ ] **Step 3: Implement the pure Active projection**
+
+Merge subjects by `conversation:<profile>:<conversation_id>` or
+`session:<profile>:<session_id>`. Deduplicate raw sources by
+`receipt:<activity-id>`, `controller:<target-key>:<state>`, or
+`shell:<session-id>`. Reduce each exact activation target by highest-priority
+group, then latest valid time, the spec's fixed state rank, and source key.
+Carry the winning time/state, every sorted effective receipt ID for that target,
+and distinct raw-source multiplicity. Rank reduced targets by group/time,
+local actionable/executing then receipt then shell precedence, and finally
+`native:<session-id>` or `conversation:<conversation-id>` target key; an idle
+shell reduces under its native target key. `+N` is total distinct raw sources in
+the subject minus one. Capture only receipt ID/status pairs represented by the chosen local
+destination. Emit the separately normalized unavailable-session notices after
+subject aggregation, using the same deterministic group/page ordering and no
+activation fallback.
+
+- [ ] **Step 4: Split immediate Active from lazy History in workspace.py**
+
+Add the new APIs:
+
+```python
+def console_session_switcher_active_entries(self) -> tuple[ConsoleSwitcherActiveResult, ...]: ...
+
+async def load_console_session_switcher_history(
+    self, *, query: str, offset: int, limit: int,
+) -> ConsoleSwitcherHistoryPage: ...
+```
+
+Retain `console_session_switcher_rows()` as a compatibility adapter with its
+incumbent return contract until Task 5 migrates `ChatScreen` and the modal in the
+same commit. Task 4 must therefore remain independently runnable and must not
+change current Ctrl+K behavior.
+
+The Active call reads open sessions, controller state, and the receipt service's
+in-memory snapshot only. The History loader runs existing flat-conversation and
+existing `LocalChatConversationService.list_conversations(scope_type="all")`
+call off the event loop and returns at most 50 entries plus total/range metadata.
+Resolve workspace labels from the existing registry cache after the bounded
+page returns. It must not perform the incumbent full membership scan and must
+not mutate or reuse the Context rail's search/page lanes.
+
+Apply the pure calendar bucketer after each bounded page returns. Parse stored
+timestamps as aware instants, convert to the captured local `ZoneInfo`, compare
+local dates against the captured clock, and preserve the fixed section order.
+Future instants are `Today`; missing or invalid values are `Older`.
+
+- [ ] **Step 5: Prove immediate projection and rail isolation**
+
+In the workspace/projection test, block the History loader with an event, call
+`console_session_switcher_active_entries()`, and assert it returns and filters
+open/live rows before History is released. Do not press Ctrl+K or assert the new
+modal before Task 5 migrates its caller. Snapshot Context/Inspector projection
+owners before/after and assert they are unchanged. When the receipt cache has
+not warmed yet, call
+`ConsoleRuntime.ensure_activity_hydration()` directly without awaiting its
+off-loop storage work; completion verifies the current runtime authority token
+and requests Active reconciliation through the projection-generation guard.
+Concurrent calls coalesce, a later call retries only `degraded`, and runtime
+disposal invalidates the callback. Inject a post-migration receipt read
+failure and assert open-session Active rows and bounded History search still
+work while the local-activity-unavailable status is visible.
+
+- [ ] **Step 6: Run projection/service tests**
+
+Run:
+
+```bash
+pytest Tests/Chat/test_console_switcher_state.py Tests/UI/test_console_activity_switcher.py -q
+```
+
+Expected: PASS with immediate Active projection, bounded off-loop History, and
+no Context/Inspector projection mutation.
+
+- [ ] **Step 7: Commit projection and paging**
+
+```bash
+git add tldw_chatbook/Chat/console_switcher_state.py tldw_chatbook/UI/Console_Modules/workspace.py Tests/Chat/test_console_switcher_state.py Tests/UI/test_console_activity_switcher.py
+git commit -m "feat(console): project active switcher rows"
+```
+
+### Task 5: Replace the eager modal with Active/History interaction
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_session_switcher_modal.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/workspace.py`
+- Modify: `Tests/UI/test_console_activity_switcher.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+
+- [ ] **Step 1: Write RED modal interaction and geometry tests**
+
+Under `Tests.UI.consolidated_css.ConsolidatedCSSApp`, cover Active-on-open,
+search focus, automatic zero-match History widening, F3 query retention, F2
+focused-native-only behavior, immutable button payloads, Cancel/Esc, pointer
+parity, page actions, stable focus across live reorder, and deterministic focus
+fallback when any result variant disappears. In the production-path case, block History,
+press Ctrl+K, and prove Active paints and filters before History is released.
+When the top search result is unavailable, assert the first Enter only focuses
+its `Mark seen` action and a second Enter performs the explicit acknowledgement.
+
+Add async barriers proving:
+
+- Enter while a query is pending cannot activate an old row;
+- a late query/page/profile/modal generation cannot replace current state; and
+- closing during a load produces no remount or callback.
+
+- [ ] **Step 2: Implement the bounded modal structure**
+
+Compose heading, literal selected-mode controls (`Active (N) — selected |
+History` or `Active (N) | History — selected`), search, grouped result scroll,
+the persistent one-row `#console-switcher-status`, status/page actions, truthful
+hints, and visible Cancel. The status line renders exact selection ordinal/title
+or mode/loading/error copy; forced live-reconciliation focus fallback also uses
+the existing app notification channel with identical text. Cap the complete
+modal at 35 rows and mount at most 50 result rows total. Conversation subjects
+use selectable two-row buttons; unavailable notices use two-row receipt-keyed
+`Mark seen` actions. Store a mapping from stable widget ID to the frozen union
+payload; conversation variants carry a target and notice variants carry the
+explicit receipt action. Never derive behavior from index. Bounded
+mode/page/Cancel controls sit
+outside the 50-row result count.
+Session-only receipts whose ephemeral target vanished render as non-subject
+`Session unavailable` notices with receipt-keyed `Mark seen` actions; they never
+activate or fall back to another row.
+
+- [ ] **Step 3: Implement generation-gated local async work**
+
+Capture modal instance, mode, query generation, stable profile authority,
+`ConsoleRuntime.authority_token`, Active projection generation, and page request.
+Commit only if every captured value still matches the current runtime and the
+modal is mounted. Changing query/mode resets page one; blank Active never calls
+History. No mode action performs network I/O.
+
+Migrate `ChatScreen.action_open_console_session_switcher` in this same task: it
+opens from the immediate Active snapshot, calls
+`ConsoleRuntime.ensure_activity_hydration()` without awaiting it, passes the
+lazy History loader, and stops awaiting the compatibility
+`console_session_switcher_rows()` adapter. Remove that compatibility adapter in
+this task only after the caller and modal migration are covered together.
+
+- [ ] **Step 4: Implement exact keyboard/pointer behavior**
+
+Add modal-scoped F3, Up/Down without wrap, Up-first-to-search, Enter on a focused
+conversation row or current-query top conversation result, F2 only on a focused renameable native row,
+Tab/Shift+Tab visual order, Esc safe dismissal, and always-visible Cancel.
+If search submission's top result is an unavailable notice, move focus to its
+`Mark seen` action and update status without acknowledging; only a subsequent
+Enter on that focused action or a pointer click acknowledges.
+Keep footer/hints exactly aligned with implemented actions.
+
+- [ ] **Step 5: Assert painted rows, not only styles**
+
+At widths 52, 72, and 120 and heights 20/35/50, inspect compositor text and
+visible-widget containment. Assert state/destination tokens survive, omission
+order is lifecycle/workspace/recency, labels never wrap past two rows, Cancel is
+visible/reachable, selected mode and selection status are literal text, forced
+focus fallback emits the same notification copy, and total modal height is
+`<= 35`.
+
+- [ ] **Step 6: Run modal and incumbent draft-integrity suites**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_activity_switcher.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_switch_draft_integrity.py -q
+```
+
+Expected: PASS; update the old F2-fallback test to assert the approved no-op.
+
+- [ ] **Step 7: Commit the modal**
+
+```bash
+git add tldw_chatbook/Widgets/Console/console_session_switcher_modal.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Console_Modules/workspace.py Tests/UI/test_console_activity_switcher.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_switch_draft_integrity.py
+git commit -m "feat(console): add active and history switcher modes"
+```
+
+### Task 6: Add exact destination notices and acknowledgement
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/Console/console_activity_outcome_notice.py`
+- Create: `Tests/UI/test_console_activity_outcome_notice.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_session_surface.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `Tests/UI/test_console_activity_switcher.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+
+- [ ] **Step 1: Write RED notice and activation tests**
+
+Drive the real `_apply_console_switcher_choice` route for native session and
+persisted conversation targets. Cover success, mixed success/failure, failure,
+new receipt during navigation, missing destination, profile change, dismissal,
+receipt-service failure, switch-away before post-refresh, notice replacement,
+notice hide, and notice remount. Assert no unrelated session fallback and no
+acknowledgement from a stale presentation callback.
+
+- [ ] **Step 2: Always mount a compact destination notice**
+
+Add `ConsoleActivityOutcomeNotice` between task cards and transcript. Keep it
+mounted with `display: none` when inactive so hot updates never require a
+structural recompose. Its state contains literal-safe status/copy and the frozen
+`CapturedReceipt` evidence selected in the modal, including whether `Mark seen`
+is required, plus a monotonically increasing presentation generation. Showing,
+replacing, hiding, or unmounting the notice increments that generation. Give the
+button ordinary Tab/Enter and pointer behavior; add no global binding.
+
+- [ ] **Step 3: Dispatch only explicit activation targets**
+
+In `_apply_console_switcher_choice`, match `target.kind` and call only the named
+native-session or persisted-conversation path. Revalidate captured stable profile
+authority, runtime authority token, and destination identity. Navigation failure
+leaves every receipt unacknowledged and shows existing honest recovery copy.
+
+- [ ] **Step 4: Acknowledge only after visible paint**
+
+After activation and `_sync_native_console_chat_ui()`, show the receipt-keyed
+notice, capture destination identity, exact receipt IDs, and notice presentation
+generation, then use the mounted notice's `call_after_refresh` confirmation. On
+that confirmation, first revalidate the same destination is still selected and
+the same notice is mounted, displayed, and current at the captured generation;
+otherwise return without acknowledgement. A valid callback acknowledges only
+IDs whose frozen captured status is `done`. For
+`failed/stuck/stopped/cancelled`, acknowledge only from the notice button. If a
+captured ID is superseded or a newer revision exists, the service's exact-ID
+update cannot hide the newer row. Never re-read current receipt status to decide
+which captured outcomes auto-acknowledge.
+
+- [ ] **Step 5: Prove the paint boundary and focus safety**
+
+Hold `call_after_refresh`, assert successful receipts remain unseen, release it,
+assert the notice text is in the compositor, then assert acknowledgement. Verify
+switch-away, replacement, hide, and remount each invalidate the captured
+presentation generation and leave receipts unseen. Verify
+the activation settle does not steal focus or reorder text typed immediately in
+the composer; retain the existing draft-integrity test as a reachable guard.
+
+- [ ] **Step 6: Run outcome and production-path tests**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_activity_outcome_notice.py Tests/UI/test_console_activity_switcher.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_switch_draft_integrity.py -q
+```
+
+Expected: PASS, including mixed receipts and new-arrival race.
+
+- [ ] **Step 7: Commit acknowledgement UX**
+
+```bash
+git add tldw_chatbook/Widgets/Console/console_activity_outcome_notice.py tldw_chatbook/Widgets/Console/console_session_surface.py tldw_chatbook/UI/Console_Modules/session.py Tests/UI/test_console_activity_outcome_notice.py Tests/UI/test_console_activity_switcher.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_switch_draft_integrity.py
+git commit -m "feat(console): acknowledge visible activity outcomes"
+```
+
+### Task 7: Documentation, performance, and final evidence
+
+**Files:**
+- Modify: `Docs/User_Guide/console/sessions-tabs-workspaces.md`
+- Create: `Docs/superpowers/qa/task-21351-console-switcher-activity/README.md`
+- Modify: `backlog/tasks/task-21351 - Add-activity-views-to-CtrlK-session-switcher.md`
+- Modify: the resolved Phase 1 child task file created at the dependency gate
+
+When the child is created, replace this descriptive file-list entry and the
+Step 9 placeholder with its exact `backlog/tasks/...md` path before beginning
+implementation; do not leave an unresolved child path in the executable plan.
+
+- [ ] **Step 1: Update the user guide**
+
+Document Active groups, History and automatic widening, F3/F2/arrow/Enter/Esc,
+successful auto-ack versus `Mark seen`, the 35-row/scroll behavior, and the
+local-activity-unavailable degradation that leaves History usable.
+
+- [ ] **Step 2: Run focused lint and format checks**
+
+Run Ruff against only changed Python files, then the repository formatter/check
+appropriate to the branch. Do not mass-format unrelated code.
+
+- [ ] **Step 3: Run all reachable automated suites**
+
+At minimum:
+
+```bash
+pytest Tests/DB/test_agent_runs_db.py Tests/Chat/test_console_activity_receipts.py Tests/Chat/test_fleet_attention.py Tests/Chat/test_console_fleet_wake.py Tests/Chat/test_console_prompt_queue_coordinator.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_switcher_state.py Tests/UI/test_console_launch_wake.py Tests/UI/test_console_runtime_ownership.py Tests/UI/test_console_activity_switcher.py Tests/UI/test_console_activity_outcome_notice.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_switch_draft_integrity.py -q
+```
+
+Then run the full test suite before PR closeout. Compare any failure set against
+the identical command on untouched current `dev`; counts alone are insufficient.
+
+- [ ] **Step 4: Measure bounded work**
+
+Record median/p95 modal open, Active filter, zero-match widening, F3 toggle,
+History page, and one receipt-cache refresh at small/representative/stress data
+sizes. Record mounted selectable widgets and database rows materialized. Do not
+claim a speed improvement without measured evidence.
+
+- [ ] **Step 5: Verify the real user path**
+
+Launch with an isolated profile and ensure this worktree wins import ordering.
+Drive: background success → Ctrl+K → Enter → visible notice → auto-ack; background
+failure → Ctrl+K → Enter → visible notice → `Mark seen`; History search and page;
+F2 no-fallback; Cancel/Esc; immediate typing after activation. Capture compositor
+or SVG evidence, not style values alone.
+
+- [ ] **Step 6: Record equal-cell terminal parity**
+
+After TASK-20937.6 is complete, capture the same rows/columns in iTerm2 and
+Windows Terminal. Confirm complete modal `<= 35` rows, two-row results, visible
+Cancel/page actions, identical search/mode behavior, and no rail ownership
+regression. Missing Windows Terminal access blocks closeout.
+
+- [ ] **Step 7: Self-review and request code review**
+
+Review the diff against every TASK-21351 criterion, ADR-085, ADR-031, and the
+approved spec. Use `superpowers:requesting-code-review`; resolve correctness
+findings before final verification.
+
+- [ ] **Step 8: Complete task hygiene only after every gate passes**
+
+Check every child acceptance criterion, add concise child Implementation Notes
+naming approach/tradeoffs/files/evidence, state whether a lessons entry was
+warranted, and set the child Done through Backlog CLI. Then check the umbrella
+TASK-21351 criteria, add its roll-up Implementation Notes, and set the parent
+Done only after the child and all parent-level evidence are complete. Re-read
+both tasks afterward because the CLI can replace free-form sections.
+
+- [ ] **Step 9: Commit documentation and closeout evidence**
+
+```bash
+git add Docs/User_Guide/console/sessions-tabs-workspaces.md Docs/superpowers/qa/task-21351-console-switcher-activity/README.md 'backlog/tasks/task-21351 - Add-activity-views-to-CtrlK-session-switcher.md' '<resolved Phase 1 child task path>'
+git commit -m "docs(console): verify activity switcher"
+```
+
+## Final verification checklist
+
+- [ ] TASK-20937 and TASK-20937.6 are Done on the branch baseline.
+- [ ] ADR-085 remains Accepted and matches the implementation.
+- [ ] No Phase 2 server integration entered the diff.
+- [ ] `git diff --check` is clean.
+- [ ] Focused DB/Chat/Workspace/UI suites pass.
+- [ ] Full pytest and scoped static checks pass or have an identical documented
+  current-dev failure set.
+- [ ] Production-stylesheet compositor evidence proves geometry and visible copy.
+- [ ] Real Ctrl+K activation proves the receipt-to-visible-notice boundary.
+- [ ] Equal-cell iTerm2/Windows Terminal evidence is recorded.
+- [ ] The implementation child is complete with criteria/notes/Done before the
+  umbrella TASK-21351 criteria/notes/Done transition.
+- [ ] ADR-085 is re-swept against `origin/dev` and open PRs; any collision is
+  renumbered across the file, header, task, spec, and plan before merge.

--- a/Docs/superpowers/specs/2026-08-23-console-session-switcher-activity-views-design.md
+++ b/Docs/superpowers/specs/2026-08-23-console-session-switcher-activity-views-design.md
@@ -1,0 +1,1012 @@
+# Console Session Switcher Activity Views Design
+
+**Date:** 2026-08-23
+**Status:** Approved by independent specification review and user; implementation gated by TASK-20937
+**Task:** TASK-21351
+**Surface:** Console `Ctrl+K` session switcher
+
+## Goal
+
+Make `Ctrl+K` a fast, conversation-scoped way to find work that is happening
+now, needs attention, or was recently completed while preserving complete
+historical conversation search.
+
+The switcher distinguishes conversation lifecycle, execution activity, open
+state, and recency. A resolved, backlog, or non-viable conversation remains in
+`Active` while associated work is running or requires action. The first release
+ships from local state and is not blocked by a new server activity subsystem.
+
+## Approved product decisions
+
+### Ctrl+K remains conversation-scoped
+
+Every selectable subject is a Console session or a persisted conversation.
+Correlated workflow status may decorate a conversation in a later phase, and a
+correlated workflow may become that conversation row's explicit activation
+destination. Standalone workflow runs do not appear in this switcher.
+
+`Switch Session` remains honest: Enter never selects an uncorrelated server run.
+A future universal work inbox or `Jump to Work` surface is separate work.
+
+### Delivery is phased
+
+1. **Local Active/History** ships first using open sessions, controller state,
+   `AgentRunsDB`, and one durable local activity-receipt seam.
+2. **Correlated server activity** follows as an independently deployable
+   integration after Workflows can open a useful exact correlated run.
+3. **Standalone workflows and a lossless global server activity feed** are
+   deferred to separate future design/task work and are not acceptance criteria
+   for TASK-21351.
+
+The local phase must be useful and releasable without the server phase.
+
+### Acknowledgement depends on consequence
+
+- Successful `done`/`succeeded` results are acknowledged automatically only
+  after the exact destination has visibly loaded the selected result.
+- Failed, error, stuck, stopped, or cancelled results require an explicit
+  `Mark seen` action at the destination.
+- Approval, human-input, paused, queued, and running states are not terminal and
+  are never acknowledged by opening them.
+- A newer result arriving during navigation remains unseen.
+
+This avoids silently dismissing a problem merely because a detail card painted.
+
+## Scope
+
+### Phase 1 — TASK-21351 local release
+
+This specification requires:
+
+- `Active` and `History` modes in the Console `Ctrl+K` modal;
+- conversation-scoped normalized rows and explicit activation targets;
+- local open/current/running/approval/paused/terminal-unseen state;
+- durable local receipts for ordinary inactive-session and FLEET survivor
+  outcomes;
+- automatic acknowledgement of successful outcomes after destination paint,
+  with one manual exception: a vanished session-only destination clears only
+  through its receipt-keyed `Session unavailable` / `Mark seen` action;
+- complete persisted-conversation History search;
+- deterministic ordering, bounded paging, safe async search, and stable focus;
+- a 35-total-row modal ceiling; and
+- iTerm2/Windows Terminal parity evidence inherited from TASK-20937.6.
+
+### Phase 2 — correlated server integration
+
+The later integration adds only:
+
+- explicit workflow-run `conversation_id` correlation;
+- cached background synchronization of correlated workflow activity;
+- per-run activity versions and per-device acknowledgements;
+- an exact correlated-run Workflows destination with useful status, recovery,
+  and `Mark seen`; and
+- local-only degradation when the server capability is absent.
+
+Phase 2 does not add general remote conversation browsing or standalone workflow
+rows to Ctrl+K.
+
+### Out of scope
+
+- a general notification center or universal work inbox;
+- standalone or uncorrelated workflow runs in Ctrl+K;
+- a lossless global workflow event feed, signed cursor, retention-gap recovery,
+  or deletion-event history;
+- cross-device acknowledgement synchronization;
+- remote conversation editing;
+- workflow inputs, outputs, artifacts, prompts, messages, or tool details in the
+  switcher projection;
+- approval/retry/pause implementation beyond the destination's existing or
+  separately scoped controls; and
+- changes to the Console Context rail ownership model.
+
+## Evidence and incumbent seams
+
+The current switcher:
+
+- mounts at most 20 two-row buttons;
+- sorts the selected row before recency;
+- receives an eagerly assembled mixed tuple;
+- waits for persisted rows before opening;
+- identifies result widgets positionally;
+- uses offset-based conversation pagination;
+- has no mode, authority, activity, or typed activation target; and
+- lets F2 fall back to an unrelated first native session.
+
+Local activity signals already exist but are fragmented:
+
+- open native sessions and unsaved drafts;
+- controller run and approval state;
+- `AgentRunsDB` statuses;
+- in-memory `_unvisited_outcomes` for ordinary inactive-session completion;
+- durable `FLEET_UNSEEN` conversation marks; and
+- `FleetDrained.children`, which carries exact survivor run, session, message,
+  and terminal-status identity.
+
+The local design consolidates terminal presentation state without replacing
+execution storage. `wake_delivered_at` remains supervisor-delivery state and is
+never reused as user-seen state.
+
+## Active membership and ordering
+
+Conversation lifecycle (`in-progress`, `resolved`, `backlog`, `non-viable`) is
+independent from execution activity. Lifecycle never suppresses an otherwise
+eligible Active row.
+
+Active groups are ordered:
+
+1. **Waiting for you**
+2. **Working**
+3. **New results**
+4. **Current**
+5. **Other open**
+
+Only nonempty headings render.
+
+| Effective state | Group | Notes |
+| --- | --- | --- |
+| approval or human input required | Waiting for you | Destination must name the action or honest recovery path. |
+| failed / error / stuck / stopped, unseen | Waiting for you | Requires explicit `Mark seen`. |
+| paused | Waiting for you | Opening does not clear it. |
+| running | Working | Local first; correlated server in Phase 2. |
+| queued | Working | Correlated server in Phase 2. |
+| done / succeeded, unseen | New results | Auto-acknowledged only after exact visible load. |
+| cancelled, unseen | New results | Copy says cancelled; requires explicit `Mark seen`. |
+| superseded | Excluded | Retracted/replaced work is not an outcome. |
+| current conversation | Current | Only when no higher state applies. |
+| other open idle session | Other open | Only when no higher state applies. |
+| terminal acknowledged | Excluded | Conversation remains available in History. |
+
+Rows sort by:
+
+1. group priority;
+2. existing conversation starred state, starred first;
+3. latest relevant activity time, descending;
+4. case-folded title; and
+5. stable subject key.
+
+Persisted conversation subjects read the incumbent conversation-star property;
+unbound sessions and unavailable-session notices are unstarred. Star affects
+ordering only and never creates Active membership.
+
+Malformed/missing timestamps sort after valid timestamps inside their group and
+still use deterministic title/key tie-breakers.
+
+## History behavior
+
+History contains every conversation in the existing Chatbook persisted source,
+including conversations also present in Active. Unsaved drafts are Active-only.
+General server conversation browsing is not added.
+
+History headings are:
+
+- `Today`
+- `Yesterday`
+- `Previous 7 days`
+- `Older`
+
+Aware timestamps convert to the application's local display timezone before
+calendar grouping. `zoneinfo` supplies DST behavior. Invalid/missing timestamps
+fall under `Older`; future timestamps group under `Today` and may carry a safe
+clock-skew diagnostic outside user content logs.
+
+### Search widening
+
+Every modal opens in Active. A blank query shows only Active rows.
+
+For a nonblank query:
+
+1. Active search completes first.
+2. When it has one or more matches, only those matches render.
+3. When it has zero matches, the same query automatically searches History and
+   renders `No active matches — showing History` followed by History matches.
+4. F3 still toggles full History browsing and retains the query for the life of
+   the modal.
+
+Closing the modal discards its query and mode. This preserves activity-first
+browsing without adding an F3 tax to ordinary historical lookup.
+
+## Normalized local projection
+
+The modal consumes presentation records; it does not read controller/database
+schemas directly. Each selectable conversation subject row contains:
+
+- stable subject key and local profile authority;
+- title and optional workspace label;
+- existing conversation starred state (false for unbound sessions);
+- native session ID and/or persisted conversation ID;
+- explicit activation target carrying the stable profile authority and opaque
+  runtime authority token captured when the row was built;
+- effective activity state and group;
+- lifecycle state when known;
+- latest relevant timestamp;
+- current/open flags;
+- zero or more immutable local activity receipt ID/status pairs;
+- run multiplicity; and
+- literal-safe display tokens.
+
+The projection stores no prompt, message, response, tool arguments/results,
+hidden reasoning, artifact content, model output, or credentials.
+
+An unresolvable session-only receipt uses a separate frozen
+`UnavailableSessionNotice` record, not a conversation subject or activation
+target. It contains only:
+
+- stable key `unavailable-session:<profile-authority>:<native-session-id>`;
+- profile authority and the unavailable native session ID;
+- effective group/state and latest receipt timestamp;
+- the frozen effective receipt ID/status pairs; and
+- literal-safe `Session unavailable` / `Mark seen` copy.
+
+All effective receipts for the same unavailable session aggregate into one
+notice. `done` and `cancelled` notices rank in New results; failed, stuck, and
+stopped notices rank in Waiting for you. They are unstarred and use the same
+group/star/time/title/key comparator as conversation subjects. For mixed
+receipts, the highest-priority group wins. Within that group, primary display
+status uses latest receipt time, then `stuck > failed > stopped > cancelled >
+done`, then activity ID. The second line renders the primary status plus `+N`,
+and search indexes every unique safe status. They also match `session
+unavailable` or exact session ID. The notice's `Mark seen` control
+is its only selectable action and acknowledges only its frozen receipt IDs.
+Unavailable notices participate in the Active count and the same bounded paging
+as conversation subjects, so any number remains scroll/search reachable without
+exceeding the result-page mount bound.
+
+### Canonical subject aggregation
+
+Aggregation is conversation-first within one local profile authority:
+
+- when a persisted conversation ID exists, the subject key is
+  `conversation:<profile-authority>:<conversation-id>`;
+- every open native session bound to that conversation merges into that one
+  subject; and
+- an unsaved/unbound draft uses
+  `session:<profile-authority>:<native-session-id>` and never merges by title or
+  workspace label.
+
+When multiple native sessions represent one persisted conversation, the
+deterministic local session is the current session when present, otherwise the
+session with the latest valid activity time, then lexicographically smallest
+session ID. A receipt naming a still-open exact session retains that destination;
+otherwise it resumes the persisted conversation.
+
+Each raw contribution has a stable source key: `receipt:<activity-id>` for a
+receipt, `controller:<target-key>:<state>` for the current controller signal,
+and `shell:<session-id>` for current/open shell state. Duplicate source keys
+collapse.
+
+Raw contributions sharing the same explicit activation target reduce to one
+target contribution as follows:
+
+1. effective group is the highest-priority nonempty group represented;
+2. only raw contributions in that group compete for primary display state;
+3. primary display state uses latest valid timestamp, then the fixed state rank
+   `human-input/approval > stuck > failed/error > stopped > paused > running >
+   queued > cancelled > done/succeeded > current > other-open`, then source key;
+4. latest relevant timestamp is the winning primary contribution's timestamp;
+5. captured receipt IDs include every effective receipt for that exact target,
+   deduplicated and sorted by activity ID; and
+6. target multiplicity is the number of distinct raw source keys.
+
+Each merged subject then ranks these reduced target contributions by approved
+group, latest relevant timestamp descending, destination precedence, and a final
+stable target contribution key:
+
+1. an actionable or executing native Console session;
+2. a correlated workflow run;
+3. a local terminal receipt; and
+4. the current/open idle Console shell.
+
+Target contribution keys are explicit identity, never title:
+`native:<session-id>` for native targets and
+`conversation:<conversation-id>` for persisted targets. An idle shell for a
+native target reduces under that target's `native:` key; `shell:` is only its
+raw source key. A future Phase 2 contract may add an authority-qualified
+workflow run/version target key. Lexicographically smallest target key wins an
+otherwise exact tie.
+
+The highest-ranked target contribution supplies the row's primary state and
+explicit activation target. `+N` is total distinct raw source keys across the
+subject minus the one primary display contribution, so same-target aggregation
+retains deterministic multiplicity. Enter acts only on
+that captured primary target: a local destination captures only its represented
+receipt IDs, while a Workflows destination captures only its run ID and visible
+activity version. Other contributions remain unseen/active.
+
+Phase 2 activity may join only a persisted local conversation subject whose
+canonical conversation ID and configured server authority match the correlated
+run. A correlated run with no such local subject is excluded from Ctrl+K; the
+switcher never manufactures a server-only conversation row.
+
+### Explicit activation targets
+
+Phase 1 target kinds are:
+
+- `console_native_session`; and
+- `console_persisted_conversation` through the explicitly named local adapter.
+
+Phase 2 may add `correlated_workflow_run`, always carrying conversation ID,
+server authority, run ID, and captured activity version. Nullable-field inference
+in the button handler is forbidden.
+
+## Unified local activity receipts
+
+The profile-local `AgentRunsDB` owns one additive `console_activity_receipts`
+table for both ordinary inactive-session outcomes and FLEET survivor outcomes.
+
+Each receipt has immutable identity/payload fields and mutable lifecycle
+timestamps:
+
+- `activity_id` primary key;
+- origin: `ordinary` or `fleet_survivor`;
+- stable logical-outcome identity and positive transition revision;
+- nullable Console session ID;
+- nullable persisted conversation ID;
+- nullable AgentRunsDB run ID;
+- nullable assistant-message ID when the producing turn has one;
+- safe terminal status (`done`, `failed`, `stuck`, `stopped`, `cancelled`);
+- created timestamp;
+- nullable acknowledged timestamp; and
+- nullable superseded timestamp.
+
+Storage enforces that at least one destination identity—Console session ID or
+persisted conversation ID—is present. A receipt may therefore survive a restart
+even when only the durable conversation identity remains.
+
+There is no separate ordinary-outcome version ledger and no FLEET causal-epoch
+table.
+
+### Stable receipt identity
+
+- Every producer supplies a stable logical-outcome identity. Ordinary direct
+  turns namespace the durable assistant-message/turn identity; queue chains
+  namespace the most recent accepted durable dispatch checkpoint's
+  `preparation_id`. Each accepted queued turn replaces that identity, so the
+  terminal receipt is keyed by the final accepted turn; recovery reconstructs
+  the same identity from that checkpoint. Process-local context epochs are
+  never receipt identity. FLEET survivors use the identities below.
+- `activity_id` is deterministic from origin, logical-outcome identity,
+  transition revision, and safe terminal status. The publication transaction
+  reads the latest revision: restamping the same effective status is a no-op;
+  changing status supersedes that receipt and inserts revision `N+1` atomically.
+  A uniqueness constraint over `(origin, logical_outcome_id, revision)` makes
+  retries idempotent at the storage boundary rather than relying on a toast
+  guard or an in-memory cache.
+- A survivor with a run ID uses a namespaced run identity.
+- `FleetDrained` gains one stable `drain_id` generated when the bridge constructs
+  the event. A survivor without a run ID uses a deterministic namespaced identity
+  from that drain ID and its stable child ordinal.
+- Duplicate insertion is idempotent by `activity_id`.
+- A later effective correction is a new revision. Superseding the prior receipt
+  is not acknowledgement, but removes that obsolete revision from Active.
+  Acknowledging an old ID cannot acknowledge the correction. A sequence such as
+  `done → failed → done` therefore produces revisions 1, 2, and 3 rather than
+  reusing the first `done` identity.
+
+The terminal transition seam writes the receipt before updating its in-memory
+compatibility cache. On restart, unseen rows repopulate the projection.
+Pre-migration terminal AgentRunsDB history is not imported, preventing an
+upgrade flood.
+
+### Ordinary producer contract
+
+One controller helper owns ordinary outcome publication and is called from both
+the direct run-state transition path and the queue-chain terminal callback. The
+helper takes the stable logical-outcome identity, destination identity, and the
+effective source transition; it performs the idempotent receipt insert before
+refreshing `_unvisited_outcomes` compatibility state.
+
+The exact mapping is:
+
+| Source transition | Receipt status | Rule |
+| --- | --- | --- |
+| `COMPLETED` | `done` | Publish only for an inactive, terminal-notification-eligible turn/chain. |
+| `FAILED` | `failed` | Publish only for an inactive, terminal-notification-eligible turn/chain. |
+| `STOPPED` | `stopped` | Publish only when an inactive turn/chain produces a genuine terminal stop outcome. |
+| `BLOCKED` | none | Remains live `Waiting for you`; it is not a terminal receipt. |
+| all other ordinary states | none | Execution/open-state projection remains authoritative. |
+
+Queue chains currently publish only `COMPLETED` and `FAILED`; adding a stopped
+chain transition must use the same helper. An effective correction to a
+different terminal status creates a new receipt revision, while restamping the
+same logical outcome and status does not.
+
+### Additive migration and crash reconciliation
+
+`AgentRunsDB` advances from schema v14 to v15 with an additive, guarded
+`console_activity_receipts` migration and the equivalent fresh-schema DDL.
+Migration failure fails closed for local activity; it never deletes, replaces,
+quarantines, or rebuilds `AgentRunsDB`, because that database also owns run
+definitions and change notes.
+
+The startup orphan reconciliation that changes an existing FLEET run from
+`running` to `error` also inserts its `failed` receipt in the same transaction.
+Its logical identity is namespaced from the run ID, its persisted conversation
+ID comes from `agent_runs`, and its Console session ID may be null. Only rows
+changed by post-v15 reconciliation produce these receipts. Existing terminal
+history is not backfilled.
+
+### FLEET producer contract
+
+`FleetDrained` is the sole live FLEET receipt producer. It considers only child
+records with `settled_after_turn=True`; children settled in-turn remain ordinary
+turn outcomes and must not be duplicated as survivor receipts. Safe mapping is:
+
+| `FleetDrained` child status | Receipt status |
+| --- | --- |
+| `done` | `done` |
+| `error` | `failed` |
+| `cancelled` | `cancelled` |
+
+An unknown status fails closed: it creates no receipt, emits only a content-free
+diagnostic/degraded-state signal, and cannot interrupt event fanout.
+
+### FLEET mark compatibility
+
+`console_activity_receipts` is the source of truth for switcher membership and
+acknowledgement. `FLEET_UNSEEN` remains a coarse compatibility badge for existing
+Console/wake surfaces; it does not provide per-run status or control Active.
+
+All receipt/mark writes route through one service that owns a new process-wide
+re-entrant lock. The lock spans the database receipt insert/acknowledgement,
+the unseen-survivor count, and the compatibility-mark set/clear/reconciliation
+as one ordered critical section:
+
+1. persist a survivor receipt;
+2. best-effort set the coarse FLEET mark;
+3. on acknowledgement, acknowledge exact receipt IDs first;
+4. clear the coarse mark only when no unseen survivor receipt remains; and
+5. reconcile marks from unseen survivor receipts on startup and after a failed
+   mark write.
+
+A crash can temporarily leave a false-positive coarse badge, but cannot hide an
+unseen receipt. Star/unstar storage and semantics are unchanged. Multiple app
+processes concurrently writing the same local profile remain outside the
+supported runtime model.
+
+### Publication failure isolation
+
+Receipt publication is best-effort presentation bookkeeping on the direct
+run-state, queue-chain, and live FLEET event paths. Each seam catches storage or
+mapping failures, preserves incumbent terminal state, cleanup, toast, and event
+fanout behavior, sets one content-free recoverable local-activity degraded-state
+signal, and never raises into execution settlement. A later successful refresh
+may clear that signal.
+
+Startup orphan reconciliation is the deliberate exception because status and
+receipt share one durable repair: a receipt failure rolls back the orphan status
+transition so the complete reconciliation can retry on the next startup.
+
+### Acknowledgement coordinator
+
+Activation captures exact receipt IDs.
+
+- After the exact Console session/conversation is selected, it paints a compact
+  outcome notice keyed to the captured receipt IDs/statuses. Only after that
+  notice is visible does the coordinator mark the captured `done` receipt IDs
+  acknowledged.
+- For `failed`, `stuck`, `stopped`, or `cancelled`, activation opens the exact
+  destination and presents a compact outcome notice with status, safe recovery
+  copy, and a focusable `Mark seen` action. Only that action acknowledges the
+  captured IDs.
+- An aggregate containing both successful and unsuccessful receipts auto-clears
+  only its captured successful subset; the unsuccessful subset remains behind
+  the explicit notice.
+- A newer receipt created during navigation remains unseen because its ID was
+  not captured.
+- Navigation failure, profile change, missing destination, or dismissal does
+  not acknowledge anything.
+- A terminal receipt whose unbound ephemeral session no longer exists remains
+  unseen. Active renders a receipt-keyed `Session unavailable` notice with a
+  separate `Mark seen` action; the unavailable notice is not a selectable
+  conversation subject and never falls back to another destination. This is
+  the only cleanup path for an unresolvable session-only receipt.
+
+Visible-paint acknowledgement is generation-fenced. Showing, replacing,
+hiding, or unmounting the outcome notice increments its presentation generation.
+The post-refresh callback captures the destination identity, exact receipt IDs,
+and presentation generation, then revalidates that the same destination is
+still selected and the same receipt-keyed notice is mounted, displayed, and
+current. Switching away or remounting before the callback therefore leaves the
+receipts unseen.
+
+The outcome notice uses button/Tab/Enter interaction and introduces no new
+protected or terminal-convention binding.
+
+## Modal interaction and layout
+
+### Structure
+
+The modal contains:
+
+1. `Switch Session` heading;
+2. one-row `Active (N) | History` mode controls;
+3. search input;
+4. grouped results/status;
+5. accurate key hints; and
+6. the existing pointer-accessible Cancel action.
+
+`N` is the number of aggregated Active conversation/session subjects plus
+unavailable-session notices before query filtering. It is not a run count.
+
+The entire modal—including border, padding, heading, modes, input, results,
+hints, and Cancel—uses at most **35 terminal rows**. Smaller terminals clamp to
+the safe viewport. Results own the remaining vertical scroll area.
+
+The modal also defines a width contract:
+
+- preferred width: incumbent width or wider when available;
+- minimum supported width: 52 cells inside the terminal-safe viewport;
+- below that width, lifecycle/workspace/recency tokens omit in that order;
+- title ellipsizes after required state/destination tokens receive space; and
+- no row horizontally scrolls.
+
+### Exact two-row grammar
+
+Each selectable result is exactly two terminal rows:
+
+1. literal-safe title;
+2. one non-wrapping token line.
+
+Token order is:
+
+`STATE · SOURCE/DESTINATION · WORKSPACE · LIFECYCLE · RECENCY · +N`
+
+Never truncate:
+
+- state/attention;
+- ambiguous source or authority;
+- activation destination when it is not Console; and
+- stale/error/unavailable state.
+
+First omissions are lifecycle, workspace, then recency. Multiplicity collapses
+to `+N`; the title receives remaining width. User-controlled text uses Rich
+`Text` or escaping and cannot introduce markup.
+
+Current/open are group headings in the approved v1 model, not extra subtitle
+badges. A later simplification may merge them only through a separately approved
+UX change.
+
+Mode controls use the literal grammar `Active (N) — selected | History` or
+`Active (N) | History — selected`, in addition to focus/background styling.
+State never relies on color alone. A persistent one-row
+`#console-switcher-status` line exposes `Selection: <ordinal> of <count> —
+<literal-safe title>` or a mode/loading/error message. When live reconciliation
+moves focus because a subject disappeared, the modal updates that line and
+calls the existing app notification channel with the same text. Compositor and
+notification-spy tests assert the exact copy; no unsupported terminal screen
+reader API is assumed.
+
+### Keyboard and pointer contract
+
+- `Ctrl+K`: open a new modal in Active with search focused.
+- `F3`: toggle Active/History and retain the query within the modal.
+- `Up`/`Down`: move through selectable rows without wrapping; Up from the first
+  result returns to search.
+- `Enter`: activate the focused conversation row. From search, Enter activates
+  the top current-query conversation result; when the top result is an
+  unavailable-session notice, it moves focus to that notice's explicit
+  `Mark seen` action and updates the status line without acknowledging. Only a
+  subsequent Enter on the focused `Mark seen` action (or its pointer click)
+  acknowledges the frozen IDs.
+- `F2`: rename only the focused renameable native session; no fallback.
+- `Tab`/`Shift+Tab`: follow visual order through modes, search, results/page
+  actions, and Cancel.
+- `Esc`: close without acknowledgement.
+
+Pointer activation matches keyboard activation. Group/status rows are not
+focusable. Modal-scoped F3 must be documented as an explicit ADR-031 exception
+or the ADR wording updated before implementation; footer hints advertise only
+implemented actions.
+
+### Safe asynchronous search and live updates
+
+Every search attempt captures:
+
+- modal instance ID;
+- mode;
+- exact query and query generation;
+- local profile/authority generation; and
+- Active projection generation when applicable.
+
+A result commits only when all captured values still match.
+
+Active results are the closed union of conversation `ConsoleSwitcherEntry` and
+`UnavailableSessionNotice`. Both expose `stable_result_key`; subject entries map
+their subject key to it, and unavailable notices use their documented
+unavailable-session key. Each result widget owns its immutable union payload
+keyed by that stable result key.
+Activation reads that payload, never a positional index or a freshly looked-up
+list entry.
+
+Enter from search acts only on a result committed for the current query and
+generation. A conversation result activates; an unavailable-session notice only
+receives focus as specified above. While the current query is pending, Enter
+waits for that attempt or shows non-destructive `Searching…`; it never activates
+an older rendered match or acknowledges an unavailable notice.
+
+Live Active reconciliation preserves focus by stable result key. If the focused
+result disappears, focus moves to the next row, then previous row, then search,
+and the change is reported through `#console-switcher-status` plus the existing
+app notification channel.
+Reordering never changes the target owned by an already focused button.
+
+The existing 200 ms debounce may remain. Mode changes supersede pending work.
+No network request occurs on modal open or F3.
+
+### Paging
+
+Both modes use pages of at most 50 result records. In Active that bound includes
+conversation subjects and unavailable-session notices. Page actions are bounded
+modal controls outside that result-record count and are explicit rows such as:
+
+- `Previous · 1–50 of 243`
+- `Next · 101–150 of 243`
+
+They are keyboard/pointer activatable and never accept F2.
+
+Active pages come from the already cached projection. When that projection
+changes materially, the modal recomputes the page containing the focused stable
+result key; it returns to page one only when that result no longer exists.
+
+History reuses the repository's bounded storage query with deterministic order
+and immutable conversation IDs. Offset pagination is acceptable for this
+ephemeral browsing surface: concurrent mutation may move an item between pages,
+but it cannot change an entry's activation target. The UI does not promise a
+frozen historical snapshot, and it does not add a repository-wide mutation
+generation solely for this modal.
+
+Changing query or mode resets to page one. Late pages cannot replace a newer
+query, mode, profile, or modal instance.
+
+## Nonbinding Phase 2 research notes
+
+This section records research constraints and one plausible future shape only.
+It is not an approved server contract, does not add TASK-21351 acceptance
+criteria, and grants no implementation authority. A separately created server
+task and ADR must revalidate or replace every schema, endpoint, authorization,
+polling, cache, and Workflows-handoff detail below before Phase 2 implementation.
+Nothing in this section may delay or enter the Phase 1 diff.
+
+### Server correlation and snapshot sequence
+
+`workflow_runs` adds:
+
+- nullable immutable `conversation_id` using the Chat API's canonical string;
+- monotonically increasing per-run `activity_version`;
+- server-managed `state_changed_at`; and
+- global monotonically increasing `activity_sequence` assigned on each
+  activity-relevant change.
+
+`session_id` keeps its existing workflow/ACP meaning. Existing runs are never
+heuristically correlated.
+
+One server database method owns effective status/reason transitions and, in one
+transaction, updates status/reason, increments activity version, assigns the
+next activity sequence, and writes state-change time. Run creation performs the
+same sequence assignment. Existing workflow-event logging may remain separate;
+the lossless event-feed refactor is deferred.
+
+Sequence allocation uses a durable one-row counter serialized inside that same
+transaction. SQLite relies on its serialized write transaction. Backends that
+permit concurrent writers lock the counter row until the run mutation commits
+or rolls back. The endpoint captures its upper bound by reading the committed
+counter through the same serialization boundary. Consequently, once it returns
+that bound, no transaction can later commit an activity sequence at or below
+it.
+
+### Correlated activity endpoint
+
+A user-scoped endpoint returns only workflow runs with an explicit visible
+conversation correlation. It:
+
+- enforces tenant/user authorization;
+- returns immutable `(server_instance_id, tenant_id, user_id)` authority;
+- orders/pages by `activity_sequence` then run ID;
+- accepts a validated nonnegative `after_sequence` and a fixed
+  `snapshot_upper_bound` after the first page;
+- caps pages at 200;
+- returns `snapshot_upper_bound`, `next_after_sequence`, and `has_more` on every
+  page;
+- selects only `after_sequence < activity_sequence <= snapshot_upper_bound`;
+- supports a complete current-nonterminal listing;
+- supports bounded reconciliation of cached run IDs;
+- returns only safe list metadata; and
+- never returns prompts, messages, inputs, outputs, errors bodies, artifacts, or
+  hidden reasoning.
+
+The sequence is continuation state, not an authorization token; endpoint scope
+is enforced independently. Arbitrary sequence values may skip or replay the
+caller's own results but cannot cross authority.
+
+First sync captures a committed upper bound, baselines old terminal runs,
+imports the complete current nonterminal set, then consumes later sequences.
+The client holds the upper bound fixed across all pages and advances its durable
+authority watermark only after `has_more=false`. A crash before completion
+replays the snapshot idempotently from the prior durable watermark. Run rows
+retain their latest activity sequence. Hard-deletion-before-sync and a lossless
+deletion/event history are explicitly deferred; known cached IDs are reconciled
+so revocation/deletion does not leak stale metadata.
+
+### Server authority and per-device acknowledgement
+
+The server provisions `server_instance_id` once during database/configuration
+initialization, stores it durably, and keeps it stable across restarts and URL
+changes. It is never derived from a URL or credential. Docs-info, correlated
+activity pages, and exact-run responses return the same identifier.
+
+An additive local `correlated_workflow_activity_cache` table keys every server
+row by configured target scope plus
+`(server_instance_id, tenant_id, user_id, run_id)`. It stores the latest safe
+snapshot metadata, `activity_version`, `activity_sequence`, and the highest
+locally acknowledged activity version. Acknowledgement is per device and
+local-only: successful post-paint confirmation or explicit `Mark seen` writes
+the exact version that was visible. If a newer version has already arrived,
+that newer version remains unseen. No server acknowledgement API is introduced.
+
+### Background cache and capability
+
+Ctrl+K reads only local/cached state. A single background sync per authority:
+
+- polls approximately every five seconds while correlated nonterminal work
+  exists and every thirty seconds otherwise;
+- uses jittered exponential backoff up to five minutes;
+- validates authority generation before commit; and
+- applies each page idempotently and advances the durable watermark atomically
+  only with the final page of a fully drained snapshot.
+
+`/api/v1/config/docs-info` advertises
+`hasCorrelatedWorkflowActivityV1=true` only when correlation columns, sequence
+assignment, the correlated endpoint, authority envelope, reconciliation, and
+exact-run fetch are all ready. Old/partial servers remain local-only without
+repeated endpoint probing.
+
+### Exact Workflows destination
+
+A correlated server-primary row carries an explicit Workflows handoff with
+authority, conversation ID, run ID, and captured activity version.
+
+Workflows:
+
+1. claims the handoff under the same authority generation;
+2. fetches the exact run;
+3. rejects authority/run mismatch or version regression;
+4. renders a selected-run card containing safe workflow label, status,
+   attention/recovery reason, state-change time, and activity version;
+5. provides the concrete existing action when available, otherwise honest
+   `Read-only here` recovery instructions naming where the action must occur;
+6. provides `Mark seen` for failed/stuck/cancelled terminal outcomes; and
+7. reports visible-load success after Textual's post-refresh confirmation.
+
+Successful terminal results auto-acknowledge the exact visible fetched version.
+Unsuccessful terminal results acknowledge only through `Mark seen`. Waiting,
+paused, queued, and running items remain Active after opening.
+
+## Failure and degradation
+
+- Local receipt storage failure does not prevent opening/switching; the modal
+  shows one recoverable local-activity status.
+- Receipt migration/read failure disables only local activity membership for
+  that profile, reports a recoverable status, and leaves open-session switching
+  and History available. The application never automatically deletes or
+  rebuilds `AgentRunsDB`.
+- Missing local conversations never redirect to another session.
+- Search/page failures preserve query and current safe results.
+- Profile change dismisses the modal and invalidates pending activation.
+- Server absence, old capability, auth loss, or offline state leaves Phase 1
+  fully operational.
+- Cached server rows show stale age; authority changes never reuse cached data.
+- Missing/revoked correlated runs remain unacknowledged until authoritative
+  reconciliation removes their cached metadata.
+
+## Security and privacy
+
+- Local receipts contain IDs/status/timestamps only.
+- Server endpoints enforce user/tenant scope independently from continuation
+  values.
+- Correlation is explicit and server-validated.
+- Source authority is part of every server key and activation target.
+- User titles/workspace labels are never interpreted as markup.
+- Activity diagnostics do not add conversation content, model output, workflow
+  payloads, or credentials.
+- Parameterized queries and existing validation helpers are required at every
+  storage/API boundary.
+
+## Performance requirements
+
+- Ctrl+K opens immediately from local/cached Active state; History loads lazily.
+- Modal open/F3 perform no network I/O.
+- Database/search work over 100 ms runs outside Textual's event loop.
+- At most 50 selectable result widgets plus bounded headings/page actions mount.
+- No transcript reconstruction or workflow detail fetch occurs while listing.
+- Poll attempts never overlap.
+- No new UI, paging, cursor, or virtualization dependency is added.
+
+Production-shaped benchmarks record modal open, Active filtering, automatic
+History widening, F3 toggle, History paging, and one background cache commit at
+representative/stress sizes before any speed claim.
+
+## Verification
+
+### Pure model tests
+
+- every local status maps to the approved group;
+- lifecycle never suppresses active execution/attention;
+- acknowledged terminal rows leave Active but remain in History;
+- ties use group/star/time/title/key deterministically;
+- superseded runs are excluded;
+- multiple receipts aggregate into one conversation row;
+- primary state and `+N` are deterministic;
+- exact same-group/time/destination contribution ties resolve by stable
+  contribution key;
+- a same-target done+failed+shell aggregate reduces to Waiting for you, chooses
+  the deterministic failure display state/time, captures both receipt IDs for
+  that target, and reports the exact raw-signal `+N`;
+- mixed unavailable done/failed receipts choose Waiting for you, render the
+  deterministic primary status plus `+N`, and remain searchable by both states;
+- malformed timestamps/metadata remain safe; and
+- literal markup, emoji, CJK, RTL, and mixed-width titles remain literal.
+
+### Local receipt tests
+
+- fresh v15 creation and guarded v14-to-v15 migration preserve existing run
+  definitions/change notes;
+- receipt migration/read failure fails closed without deleting or rebuilding
+  `AgentRunsDB`;
+- ordinary inactive completion/failure persists across restart;
+- identical terminal restamp creates no duplicate receipt;
+- `failed → done` and `done → failed → done` create monotonic revisions,
+  supersede obsolete receipts without acknowledging them, and expose only the
+  latest effective revision;
+- direct and queue-chain terminal seams publish through the same idempotent
+  helper with distinct stable logical-outcome identities;
+- post-v15 orphan reconciliation changes status and inserts its receipt in one
+  transaction, while pre-v15 terminal history is not backfilled;
+- later correction has a different immutable ID;
+- FLEET duplicate delivery is idempotent;
+- `FleetDrained` excludes in-turn children, maps survivor
+  `done/error/cancelled` to `done/failed/cancelled`, and fails closed for an
+  unknown status;
+- null-run survivor identities remain distinct within/across drain events;
+- cold restart hydration restores unseen receipts, concurrent calls coalesce,
+  degraded hydration can retry, and runtime disposal rejects a late commit;
+- success activation acknowledges only captured success IDs;
+- failed/stuck/stopped/cancelled remain until explicit `Mark seen`;
+- a receipt created during navigation remains unseen;
+- switch-away, notice replacement, hide, or remount before post-refresh leaves
+  every captured receipt unseen;
+- an unavailable ephemeral destination never falls back and clears only through
+  its receipt-keyed `Mark seen` action;
+- mark-write failure cannot hide an unseen survivor receipt;
+- a forced interleaving of receipt publication, acknowledgement, survivor
+  counting, and mark reconciliation cannot clear a badge while an unseen
+  survivor exists;
+- injected receipt-write failure cannot escape the direct, queue-chain, or live
+  FLEET settlement seam and preserves incumbent cleanup/toast/fanout behavior;
+- injected orphan-reconciliation receipt failure rolls back its status change
+  for retry;
+- startup reconciliation repairs false-positive/false-negative FLEET badges;
+- star/unstar behavior is unchanged; and
+- historical AgentRunsDB rows do not create upgrade floods.
+
+### Modal tests
+
+- every invocation starts Active with search focused;
+- open sessions for one persisted conversation merge under its canonical
+  conversation key; duplicate session selection is deterministic;
+- an unbound draft remains a distinct session subject;
+- blank Active query never loads History;
+- zero Active matches automatically show History matches for the same query;
+- F3 retains the query only for the modal lifetime;
+- Enter while search is pending cannot activate an old result;
+- a late query/page cannot replace a newer generation;
+- result activation uses immutable payload, not positional index;
+- live reorder preserves subject focus and activation identity;
+- disappearing focus follows/announces the deterministic fallback;
+- F2 never falls back to another session;
+- exact row grammar/truncation preserves required tokens at supported widths;
+- mode/state/focus and forced-focus-fallback status remain readable in
+  monochrome/ASCII fallback and use the exact literal/notification grammar;
+- total geometry never exceeds 35 rows and clamps on small terminals;
+- page rows show useful ranges and remain reachable; and
+- no network request occurs on modal open or F3.
+
+Production-shaped Textual tests load the bundled stylesheet and assert
+compositor text, containment, focus, hit testing, row height, truncation, and
+small-terminal scrolling. Equal-cell manual evidence is recorded in iTerm2 and
+Windows Terminal; TASK-20937.6 remains the owner of its prerequisite parity
+evidence.
+
+### Nonbinding future Phase 2 verification ideas
+
+These ideas are not TASK-21351 gates. A future server task and ADR must select,
+revise, and own them together with the corresponding contract.
+
+- fresh/historical SQLite and backend migrations;
+- durable `server_instance_id` survives restart and URL changes and matches
+  docs-info, activity-page, and exact-run responses;
+- exact schema target verification and fail-closed capability;
+- explicit correlation authorization and immutability;
+- sequence/version assignment is atomic with effective run-state changes;
+- interleaved writer transactions cannot commit a sequence at or below an
+  already returned snapshot upper bound;
+- unchanged writes do not advance sequence/version;
+- multi-page snapshots hold a fixed upper bound while concurrent later updates
+  wait for the next sync cycle;
+- a crash during paging replays idempotently and advances the durable watermark
+  only after the snapshot is fully drained;
+- correlated endpoint excludes standalone runs and other principals;
+- first-sync baseline does not flood old terminal history;
+- complete nonterminal and cached-ID reconciliation;
+- authority generation rejects late responses;
+- old/partial/offline servers remain local-only;
+- exact Workflows fetch rejects mismatches/regressions;
+- per-device acknowledgement records the exact visible activity version and
+  does not hide a newer cached version;
+- successful result auto-acks only after visible confirmation;
+- failed/stuck/cancelled result requires `Mark seen`; and
+- destination recovery copy is actionable or explicitly read-only.
+
+## Rollout and task boundaries
+
+1. Approve this revised written specification.
+2. Update TASK-21351 acceptance criteria to make the local release independently
+   complete and releasable.
+3. Complete TASK-20937 and its terminal-parity dependency.
+4. Keep TASK-21351 In Progress as the design/umbrella owner. Create one atomic
+   Chatbook child for the local projection, receipts, modal, and acknowledgement
+   notice; copy the Phase 1 implementation criteria, link the spec/plan/ADR, and
+   put the child In Progress only when adding its plan.
+5. Implement, verify, and merge the local child before starting server work.
+6. File a separate correlated-server companion task/ADR and Chatbook integration
+   child for Phase 2.
+7. Treat standalone workflows/lossless global activity feed as separate future
+   design work, not an implicit extension of TASK-21351.
+
+No uncreated future task ID is referenced. Task files receive concrete
+dependencies only after the companion tasks exist.
+
+## ADR decision
+
+ADR required: **yes**.
+
+- **Phase 1 Chatbook ADR:**
+  `backlog/decisions/085-console-activity-receipts-and-switcher-ownership.md`
+  records durable local activity-receipt ownership, canonical switcher targets,
+  and the relationship between receipts and the compatibility FLEET mark.
+- **Phase 2 server ADR:** workflow conversation correlation, activity sequence,
+  authority, and correlated snapshot contract.
+
+Phase 1 does not wait for the Phase 2 ADR. The standalone/lossless feed requires
+its own later design decision if pursued.
+
+## Rejected alternatives
+
+### Universal workflow rows in Ctrl+K
+
+Rejected for TASK-21351 because `Switch Session` must remain predictable and the
+current Workflows surface cannot provide a complete universal-work experience.
+
+### Server-first delivery
+
+Rejected because local state already delivers the core user value and should not
+wait for cross-repository schema/feed work.
+
+### Automatic acknowledgement of every terminal result
+
+Rejected because painting a failed/stuck/cancelled card does not prove the user
+understood or acted on the problem.
+
+### Three separate local acknowledgement systems
+
+Rejected in favor of one immutable activity-receipt table. FLEET marks remain a
+derived compatibility badge, and `wake_delivered_at` remains supervisor state.
+
+### Repository-wide History mutation generation
+
+Rejected for v1. Immutable activation payloads prevent wrong-target activation;
+an ephemeral History page need not promise a frozen snapshot.
+
+### Importing old terminal AgentRunsDB history as unseen
+
+Rejected because it would create an upgrade notification flood unrelated to the
+user's acknowledgement baseline.

--- a/backlog/decisions/085-console-activity-receipts-and-switcher-ownership.md
+++ b/backlog/decisions/085-console-activity-receipts-and-switcher-ownership.md
@@ -1,0 +1,159 @@
+# ADR-085: Console activity receipts and session-switcher ownership
+
+Status: Accepted
+Date: 2026-08-23
+Related Task: [TASK-21351](../tasks/task-21351%20-%20Add-activity-views-to-CtrlK-session-switcher.md)
+Related Spec: [Console session-switcher activity views design](../../Docs/superpowers/specs/2026-08-23-console-session-switcher-activity-views-design.md)
+Preserves: ADR-010, ADR-031, ADR-083
+
+## Decision
+
+Console `Ctrl+K` remains a conversation-scoped switcher. Every selectable
+subject is either an unbound native Console session or a persisted local
+conversation. Open sessions for one persisted conversation merge under that
+conversation's profile-local identity; titles and workspace labels never
+establish identity. Activity contributions determine the row's state and one
+explicit immutable activation target. Server-only and uncorrelated workflow
+runs do not appear.
+
+The first release is local and independently releasable. Active membership is
+the ordered union of action-required work, running work, unseen terminal
+outcomes, the current conversation, and other open sessions. History remains a
+separate bounded projection over every persisted local conversation. Console
+Context and Inspector rails remain consumers of their existing projections and
+do not read the switcher's normalized model.
+
+The profile-local `AgentRunsDB` owns additive v15
+`console_activity_receipts`. A receipt stores only safe identity, terminal
+status, timestamps, and destination fields. Stable logical-outcome identity
+plus a monotonic transition revision makes duplicate publication idempotent and
+effective correction explicit. Supersession removes an obsolete revision from
+Active without claiming the user saw it. Existing terminal history is not
+backfilled.
+
+One app-lifetime activity-receipt service coordinates receipt publication,
+acknowledgement, and the existing `FLEET_UNSEEN` compatibility mark under one
+process-wide re-entrant lock. Receipts are authoritative for switcher
+membership. The mark remains a derived coarse badge for incumbent Console/wake
+surfaces and is cleared only when no unseen FLEET survivor receipt remains.
+Starred marks remain unrelated.
+
+Direct-run, queue-chain, and live `FleetDrained` publication is non-throwing
+presentation bookkeeping: failure preserves execution settlement and exposes a
+content-free degraded-state signal. Startup orphan repair is different because
+it changes durable execution state; its `running → error` update and failed
+receipt insert commit in the same AgentRunsDB transaction or both roll back.
+Receipt DDL/read failure disables only the optional receipt capability: core
+AgentRunsDB construction, agent execution, open-session switching, and History
+remain available. Core schema failures are not downgraded. AgentRunsDB is never
+automatically deleted, quarantined, or rebuilt.
+
+Acknowledgement is consequence-aware and evidence-specific. A successful
+outcome is acknowledged only after the exact destination and receipt-keyed
+notice visibly paint. Failed, stuck, stopped, and cancelled outcomes require
+the notice's explicit `Mark seen` action. Activation captures exact receipt
+IDs and statuses as immutable evidence, so mutable current state cannot change
+consequence policy and a newer outcome cannot be cleared accidentally. The
+post-refresh acknowledgement callback is additionally fenced by destination
+identity and notice presentation generation. If an unbound ephemeral session
+has disappeared, its receipt remains unseen and Active shows a receipt-keyed
+`Session unavailable` notice; only that notice's explicit `Mark seen` action may
+clear it, and no alternate destination is inferred. This manual unavailable
+notice is the sole exception to successful outcomes' destination-paint rule.
+Unavailable-session notices are frozen, receipt-keyed non-target records. They
+aggregate by profile/session identity and share Active grouping, search, count,
+ordering, and the bounded result page with conversation subjects.
+The incumbent persisted-conversation star property participates only in Active
+ordering after group priority; it never creates membership. Unbound sessions
+and unavailable notices are unstarred.
+
+The app-lifetime receipt service also owns restart hydration. Construction
+leaves it cold and performs no receipt read or badge reconciliation. Ctrl+K paints
+open/live rows from memory immediately, while one runtime-owned off-loop
+hydration call serializes durable read/merge with publication and
+acknowledgement under the service lock. Hydration failure preserves the last
+valid cache, exposes degraded state, and can be retried without blocking
+History.
+
+The switcher owns bounded asynchronous History paging and validates modal,
+profile, mode, query, and generation before committing a result. Its complete
+geometry is capped at 35 terminal rows, result labels are exactly two rows, and
+Cancel is always pointer-accessible. F3 is a deliberate modal-scoped exception
+to ADR-031's general single-letter screen-action rule: it toggles the two
+switcher modes without inserting text into the focused search input, matches
+the incumbent F2 modal action vocabulary, and is advertised only while it is
+implemented and active. ADR-031's reserved globals, terminal-convention keys,
+truthful hints, and safe modal dismissal remain unchanged.
+
+Correlated server workflow activity, authority/version caches, exact Workflows
+handoff, and standalone workflow browsing are not owned by this ADR. They need
+a separate server contract, task, and ADR after the local release.
+
+## Context
+
+The incumbent switcher eagerly loads a mixed local tuple, mounts at most twenty
+results, sorts the selected row before recency, identifies widgets by position,
+and may resume any row carrying a conversation ID. It cannot distinguish open
+state, live work, unseen success, action-required failure, or historical
+recency. Ordinary terminal outcomes live only in controller memory, while
+post-turn FLEET attention has only a conversation-level mark. Neither is a
+restart-safe per-outcome acknowledgement model.
+
+`AgentRunsDB` already owns local agent-run identity and is profile-local, but it
+also stores durable user-authored agent definitions and change notes. That
+makes it the correct additive owner for activity receipts and makes destructive
+recovery unacceptable. The existing `FleetDrained` event carries survivor
+identity and settlement timing, and the controller owns both direct and queue
+terminal seams, so no new event bus or dependency is needed.
+
+The user approved a local-first release because it improves the common Console
+path without waiting for cross-repository workflow schema, authorization,
+sequence paging, or exact-run navigation. A universal inbox would also make
+the `Switch Session` title dishonest before Workflows can open a useful exact
+run.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Treat open, running, or recent as the sole meaning of Active | Each omits important work and conflates lifecycle with execution; the ranked union is explicit and deterministic. |
+| Reuse only `_unvisited_outcomes` | It is process memory, has no per-outcome identity, and cannot survive restart or safe concurrent acknowledgement. |
+| Extend only `FLEET_UNSEEN` | A conversation-level bit cannot identify status, revision, producer, or the exact evidence being acknowledged. |
+| Store receipts in a new database | Adds another lifecycle, migration, and failure boundary although AgentRunsDB already owns the durable run identities. |
+| Rebuild AgentRunsDB when receipts are corrupt | Risks deleting user-authored definitions and change notes to repair optional presentation state. |
+| Acknowledge every terminal result on activation | Merely painting a failed or cancelled result does not prove it was understood; non-success requires an explicit action. |
+| Load all History before opening | Makes Ctrl+K latency scale with the full corpus and repeats the incumbent eager-load problem. |
+| Add a virtualization or cursor dependency | Bounded native paging and at most fifty mounted rows satisfy the approved scale with less code and risk. |
+| Put standalone workflow runs in Ctrl+K | Violates conversation scope and cannot provide an honest session-switch destination. |
+| Use a printable letter for mode switching | Search owns printable keys while focused; F3 is unambiguous and local to this modal. |
+
+## Consequences
+
+- AgentRunsDB advances to v15 through guarded additive DDL and gains an optional
+  receipt capability; genuine v14, fresh-v15, and receipt-DDL degradation paths
+  require coverage.
+- One small service becomes the only writer that coordinates receipts with the
+  FLEET compatibility badge. Multiple app processes sharing one profile remain
+  unsupported.
+- Ordinary outcome producers must carry stable turn/queue-chain identity;
+  queue-chain identity comes from the final accepted durable dispatch
+  checkpoint rather than a process-local context epoch. `FleetDrained` gains
+  stable drain identity for null-run survivors.
+- The modal opens from cached local Active state and loads History lazily;
+  History may shift between pages under concurrent mutation, but immutable
+  activation identity prevents wrong-target activation.
+- The destination surface gains a compact receipt-keyed outcome notice with a
+  visible `Mark seen` action for non-success.
+- Production verification must load the real stylesheet hierarchy, inspect the
+  painted compositor, exercise the real Ctrl+K-to-destination route, and compare
+  equal row/column dimensions in iTerm2 and Windows Terminal.
+- Phase 2 server integration cannot silently enter this task; it needs a new
+  authority/version/sequence decision and independently releasable work.
+
+## Links
+
+- [Approved design](../../Docs/superpowers/specs/2026-08-23-console-session-switcher-activity-views-design.md)
+- [Implementation plan](../../Docs/superpowers/plans/2026-08-23-task-21351-console-session-switcher-activity-views.md)
+- [ADR-010: Console conversation-local marks](010-console-conversation-local-marks.md)
+- [ADR-031: TUI keybinding and footer-hint conventions](031-tui-keybinding-and-footer-hint-conventions.md)
+- [ADR-083: Console edge rails and workspace-owned conversation Tree](083-console-edge-rails-and-workspace-tree-ownership.md)

--- a/backlog/tasks/task-21351 - Add-activity-views-to-CtrlK-session-switcher.md
+++ b/backlog/tasks/task-21351 - Add-activity-views-to-CtrlK-session-switcher.md
@@ -1,32 +1,87 @@
 ---
 id: TASK-21351
 title: Add activity views to Ctrl+K session switcher
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-23 22:37'
+updated_date: '2026-08-24 05:04'
 labels: []
 dependencies:
   - TASK-20937
 references:
   - >-
     Docs/superpowers/specs/2026-08-22-console-edge-rails-workspace-tree-design.md#follow-up-ctrlk-active-conversation-view
+  - Docs/superpowers/specs/2026-08-23-console-session-switcher-activity-views-design.md
+  - Docs/superpowers/plans/2026-08-23-task-21351-console-session-switcher-activity-views.md
+  - backlog/decisions/085-console-activity-receipts-and-switcher-ownership.md
 priority: medium
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Help users quickly switch to conversations that are active now without losing historical-date browsing in the Console session switcher. Define and expose an explicit activity model before implementation so open tabs, running work, and recency are not conflated.
+Help users quickly switch to local Console conversations that are active now,
+need attention, or have unseen outcomes without losing complete historical
+conversation browsing. Deliver a local-first activity model whose durable
+acknowledgement state survives restart; correlated server workflows remain a
+separately releasable later phase.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The task defines whether active means an open tab, currently running work, recent activity, or a documented ranked combination.
-- [ ] #2 Ctrl+K lets users browse an activity-focused view and the existing historical-date view.
-- [ ] #3 Activity ordering and filtering are deterministic, keyboard accessible, and do not alter Console rail projections.
-- [ ] #4 Automated tests cover mixed active and historical conversations, ordering ties, and switching behavior.
+- [ ] #1 Ctrl+K opens immediately in an activity-focused view whose ordered groups are Waiting for you, Working, New results, Current, and Other open; conversation lifecycle never hides otherwise active execution or attention.
+- [ ] #2 Every selectable conversation result is one canonical local Console session or persisted conversation; duplicate open sessions merge deterministically, unbound drafts remain distinct, and activation uses an explicit immutable destination rather than nullable-field or positional inference. A vanished session-only outcome is instead a separately labeled, receipt-keyed Mark seen action with no inferred destination.
+- [ ] #3 History can browse and search every persisted local conversation, groups results by local calendar recency, pages bounded results, and remains available when local activity storage is degraded.
+- [ ] #4 A nonblank Active search widens to History only after zero Active matches; the documented Active/History toggle retains the modal-lifetime query, while closing resets mode and query.
+- [ ] #5 Ordinary inactive-session and post-turn FLEET outcomes persist as idempotent, revisioned receipts across restart; effective corrections supersede obsolete revisions, in-turn FLEET children do not duplicate ordinary outcomes, and pre-migration terminal history does not create an upgrade flood.
+- [ ] #6 Successful outcomes are acknowledged only after the exact destination and receipt-keyed notice visibly load, except that a vanished session-only destination can clear only through its receipt-keyed Session unavailable / Mark seen action; failed, stuck, stopped, and cancelled outcomes require an explicit Mark seen action, and newer outcomes arriving during navigation remain unseen.
+- [ ] #7 Activity and compatibility-mark publication is race-safe and never interrupts direct-run, queue-chain, or FLEET execution settlement; migration/read failure fails closed without deleting or rebuilding AgentRunsDB, while orphan reconciliation rolls status and receipt forward atomically or not at all.
+- [ ] #8 Ordering, focus retention, paging, async-result rejection, F2 rename scope, keyboard/pointer activation, literal-safe two-row labels, narrow-width omission, and the unconditional Cancel action are deterministic and accessible; the complete modal never exceeds 35 terminal rows.
+- [ ] #9 Opening Ctrl+K or changing local modes performs no network request, mounts at most 50 conversation/unavailable result rows plus bounded modal controls, does not reconstruct transcripts, and leaves Console Context/Inspector rail projections and ownership unchanged.
+- [ ] #10 Automated model, migration, producer, race, production-path activation, and production-stylesheet compositor tests cover the approved behavior; final evidence includes equal-cell iTerm2 and Windows Terminal parity after TASK-20937.6 is complete.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Record the Phase 1 receipt/projection ownership and modal-scoped F3
+   exception in ADR-085.
+2. Keep TASK-21351 In Progress as the approved design/umbrella owner. After
+   TASK-20937 is Done, create one atomic Phase 1 implementation child with
+   TASK-20937 as its dependency, copy all implementation acceptance criteria
+   into that child, and link the approved spec, plan, and ADR before changing
+   code. Put the child In Progress while the parent remains In Progress.
+3. Add AgentRunsDB v15 receipt persistence, revision/supersession operations,
+   and atomic orphan reconciliation with genuine v14-to-v15 coverage.
+4. Route ordinary direct, queue-chain, and post-turn FLEET outcomes through one
+   non-throwing activity-receipt service while retaining the FLEET mark only as
+   a compatibility badge.
+5. Build the canonical local Active projection and bounded persisted History
+   adapter without changing the Console rail projections.
+6. Replace the eager switcher with the 35-row Active/History modal, immutable
+   activation payloads, generation-gated async search/paging, stable focus, and
+   truthful keyboard/pointer controls.
+7. Add the destination outcome notice and receipt-specific acknowledgement
+   coordinator, then verify the production activation path and visible-paint
+   boundary.
+8. Run focused and reachable suites, production-stylesheet compositor checks,
+   performance measurements, and equal-cell terminal parity before closeout.
+9. Complete the child acceptance criteria, notes, and Done transition first;
+   then complete the parent acceptance criteria, notes, and Done transition
+   after the child and all parent-level evidence are complete.
+
+Detailed plan:
+`Docs/superpowers/plans/2026-08-23-task-21351-console-session-switcher-activity-views.md`.
+
+ADR required: yes
+ADR path: `backlog/decisions/085-console-activity-receipts-and-switcher-ownership.md`
+Reason: ADR-085 records durable acknowledgement ownership, the derived FLEET
+mark relationship, canonical switcher subjects/targets, and the deliberate
+modal-scoped F3 exception to ADR-031. Phase 2 server correlation requires its
+own later task and ADR.
 
 ## Renumbering provenance
 
-Two delayed Backlog CLI attempts assigned TASK-21201 and TASK-21202, both already claimed on remote branches at filing time. The duplicate TASK-21201 file was removed, and the surviving TASK-21202 follow-up moved to TASK-21351 before implementation or review references were created.
+Two delayed Backlog CLI attempts assigned TASK-21201 and TASK-21202, both
+already claimed on remote branches at filing time. The duplicate TASK-21201
+file was removed, and the surviving TASK-21202 follow-up moved to TASK-21351
+before implementation or review references were created.


### PR DESCRIPTION
## Summary\n\n- define Active and History lifecycle semantics for the Ctrl+K session switcher\n- record durable activity-receipt ownership and acknowledgement rules in ADR-085\n- add the approved implementation plan and update TASK-21351 scope and dependency gating\n\n## Verification\n\n- : 10 passed\n- backlog task-ID and Windows-path integrity check passed\n-  passed\n- independent specification review approved with no blockers\n\nImplementation remains gated on TASK-20937 / TASK-20937.6 terminal evidence closeout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the `Ctrl+K` session switcher’s Active and History views and adopts durable activity-receipt ownership and acknowledgement rules so the first release can ship locally with predictable behavior. No runtime behavior changes; this adds the approved spec, ADR-085, and an implementation plan, and updates `TASK-21351` scope and status.

**New Features**
- Phase 1 is local-only; receipts persist in `AgentRunsDB` v15.
- Activation targets are immutable; acknowledgement happens after visible paint or explicit Mark seen.
- Server-only or uncorrelated runs are excluded; sessions merge under conversation identity.
- The switcher modal is bounded to 35 rows with paged History.

**Dependencies**
- Implementation is gated on `TASK-20937` closeout.
- `TASK-21351` is moved to In Progress with linked plan/spec/ADR for execution.

<sup>Written for commit a445858c67f0dd31fc22d6c93b0e37a80b7385ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

