### PR TITLE
test: repair the stale doubles, the media migration fixture, and give blocked egress provenance (TASK-21531, 21592, 21594)

### DIFF
--- a/Tests/Media_DB/test_media_db_v2.py
+++ b/Tests/Media_DB/test_media_db_v2.py
@@ -29,6 +29,7 @@ from tldw_chatbook.DB.Client_Media_DB_v2 import (
     DatabaseError,
     MediaDatabase as Database,
 )
+from Tests.DB.historical_bootstrap_v6 import media_db_at_version
 #
 #######################################################################################################################
 #
@@ -581,23 +582,53 @@ class TestDatabaseCRUDAndSync:
         )
 
     def test_reading_progress_reopens_through_versioned_migration(self, temp_db_path):
-        first_db = Database(db_path=temp_db_path, client_id="schema_client")
-        media_id, _, _ = first_db.add_media_with_keywords(
-            title="Reading Progress Migration",
-            media_type="article",
-            content="Migration content for reading progress.",
-            keywords=["reading", "migration"],
-        )
-        first_db.close_connection()
+        # A genuinely historical v2 database, built by the real migration chain
+        # (base v1 + v1->v2), NOT by stamping "2" onto a current one. The old
+        # hand-degraded fixture had to be taught about every artifact each new
+        # migration added, and broke on the first one it had not been told about
+        # (v5->v6's chunk_engine_version). See TASK-21594.
+        with media_db_at_version(temp_db_path, 2, client_id="schema_client") as old_db:
+            assert get_schema_version(old_db) == 2
+            # The historical preconditions the migration under test depends on:
+            # neither local-only store exists yet at v2.
+            for absent_table in ("ReadingProgress", "MediaReadItLaterState"):
+                assert (
+                    old_db.execute_query(
+                        "SELECT 1 FROM sqlite_master "
+                        "WHERE type = 'table' AND name = ?",
+                        (absent_table,),
+                    ).fetchone()
+                    is None
+                ), f"{absent_table} already exists at v2"
 
-        conn = sqlite3.connect(temp_db_path)
-        try:
-            conn.execute("DROP TABLE IF EXISTS ReadingProgress")
-            conn.execute("ALTER TABLE Media DROP COLUMN transcription_provenance_json")
-            conn.execute("UPDATE schema_version SET version = 2")
-            conn.commit()
-        finally:
-            conn.close()
+            # Seeded with the historical v1/v2 Media column set. The shipped
+            # writer cannot be used here: add_media_with_keywords() targets the
+            # current schema and fails with "no such column:
+            # transcription_provenance_json" (added at v4->v5) against a real
+            # v2 database -- the same reason this fixture needs a bootstrap
+            # module rather than production code.
+            now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            with old_db.transaction():
+                cursor = old_db.execute_query(
+                    """
+                    INSERT INTO Media (
+                        title, type, content, content_hash, uuid,
+                        ingestion_date, last_modified, client_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        "Reading Progress Migration",
+                        "article",
+                        "Migration content for reading progress.",
+                        "hash-reading-progress-migration",
+                        "11111111-2222-3333-4444-555555555555",
+                        now,
+                        now,
+                        "schema_client",
+                    ),
+                )
+                media_id = cursor.lastrowid
+            assert media_id is not None
 
         reopened_db = Database(db_path=temp_db_path, client_id="schema_client")
         try:

--- a/Tests/Notes/test_notes_library_unit.py
+++ b/Tests/Notes/test_notes_library_unit.py
@@ -8,6 +8,7 @@ import tempfile
 from loguru import logger
 import sqlite3
 
+from tldw_chatbook.Chat.console_library_policy import ConsoleLibraryMigrationSeed
 from tldw_chatbook.DB.ChaChaNotes_DB import (
     CharactersRAGDBError as Actual_CharactersRAGDBError,
     ConflictError as Actual_ConflictError,
@@ -27,11 +28,26 @@ class TestNotesInteropService(unittest.TestCase):
         self.base_db_dir = Path(self.temp_dir_obj.name).resolve()
         self.api_client_id = "test_api_client_v1"
 
+        # autospec (not bare ``spec``) so the double enforces the *real*
+        # ``CharactersRAGDB.__init__`` signature at call time. A production
+        # signature change now raises a TypeError here instead of silently
+        # drifting away from the expected-call literal below (TASK-21531).
         self.mock_ragdb_class_patcher = patch(
-            CHARACHERS_RAGDB_CLASS_PATCH_TARGET, spec=True
+            CHARACHERS_RAGDB_CLASS_PATCH_TARGET, autospec=True
         )
         self.MockCharactersRAGDB_class = self.mock_ragdb_class_patcher.start()
         self.addCleanup(self.mock_ragdb_class_patcher.stop)
+
+        # The migration seed is loaded from config by production; pin it to a
+        # non-default sentinel so the constructor assertion proves the loaded
+        # value is forwarded, not that *some* seed object was passed.
+        self.migration_seed = ConsoleLibraryMigrationSeed(auto_retrieve_on_send=True)
+        self.mock_seed_loader_patcher = patch(
+            f"{NOTES_LIBRARY_MODULE_PATH}.load_console_library_migration_seed",
+            return_value=self.migration_seed,
+        )
+        self.mock_seed_loader = self.mock_seed_loader_patcher.start()
+        self.addCleanup(self.mock_seed_loader_patcher.stop)
 
         self.mock_notes_library_logger_patcher = patch(
             f"{NOTES_LIBRARY_MODULE_PATH}.logger", spec=True
@@ -98,10 +114,16 @@ class TestNotesInteropService(unittest.TestCase):
     def test_get_db_new_instance(self):
         user_id = "user1"
         db_instance = self.service._get_db(user_id)
-        # The new implementation creates a DB instance with the unified DB path and user_id as client_id
+        # The per-user instance points at the unified DB path, uses user_id as
+        # its client_id, and carries the config-loaded legacy migration seed
+        # (TASK-19900) so a reopened legacy DB migrates with the user's real
+        # pre-upgrade automatic-retrieval value.
         self.MockCharactersRAGDB_class.assert_called_once_with(
-            db_path=self.mock_global_db.db_path_str, client_id=user_id
+            db_path=self.mock_global_db.db_path_str,
+            client_id=user_id,
+            console_library_migration_seed=self.migration_seed,
         )
+        self.mock_seed_loader.assert_called_once_with()
         self.assertIs(db_instance, self.mock_db_instance)
 
     def test_get_db_cached_instance(self):

--- a/Tests/UI/test_library_notes_lasting_sync_flow.py
+++ b/Tests/UI/test_library_notes_lasting_sync_flow.py
@@ -9,6 +9,11 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Button
 
+from tldw_chatbook.Notes.notes_sync_models import (
+    NotesSyncAction,
+    NotesSyncActionKind,
+)
+from tldw_chatbook.Notes.notes_sync_reconciler import ReconciliationPlan
 from tldw_chatbook.Notes.notes_sync_runtime import (
     NotesSyncControlResult,
     NotesSyncRootRuntimeSnapshot,
@@ -24,6 +29,9 @@ from tldw_chatbook.Widgets.Library.library_notes_sync_roots_canvas import (
 )
 from tldw_chatbook.Widgets import Library as library_widgets
 from tldw_chatbook.app import TldwCli
+
+#: A runtime observation token is a 64-character opaque provenance handle.
+OBSERVATION_TOKEN = "b" * 64
 
 
 def test_production_screen_derives_lasting_route_from_the_app_runtime() -> None:
@@ -137,9 +145,26 @@ async def test_activation_result_routes_to_truthful_receipt_or_root_recovery(
     expected_copy: str,
 ) -> None:
     class _Runtime:
+        def __init__(self) -> None:
+            self.activation_calls: list[tuple[str, object]] = []
+
+        async def check_root(self, root_id: str) -> ReconciliationPlan:
+            return ReconciliationPlan(
+                root_id=root_id,
+                observation_token=OBSERVATION_TOKEN,
+                safe_actions=(
+                    NotesSyncAction("act-1", NotesSyncActionKind.UPDATE_NOTE, "bind-1"),
+                ),
+                attention=(),
+                skips=(),
+                managed_placement_effects=(),
+                deletion_groups=(),
+            )
+
         async def activate_root(
-            self, _root_id: str, _authorization: object
+            self, root_id: str, authorization: object
         ) -> NotesSyncControlResult:
+            self.activation_calls.append((root_id, authorization))
             return result
 
         def snapshot(self) -> NotesSyncRuntimeSnapshot:
@@ -157,12 +182,23 @@ async def test_activation_result_routes_to_truthful_receipt_or_root_recovery(
         def begin_selection(self) -> None:
             raise AssertionError("activation must not enter import")
 
+    runtime = _Runtime()
     controller = LibraryNotesSyncController(
-        runtime=_Runtime(),
+        runtime=runtime,
         import_controller=_Importer(),
     )
-    accepted = await controller.activate_root("root-1")
+    # Activation is only reachable from a current, activation-typed migration
+    # review that carries the runtime's own observation token; calling it from
+    # the default phase short-circuits on the provenance guard and never
+    # reaches the runtime (TASK-21531).
+    await controller.check_migration("root-1")
+    assert controller.snapshot.review.activation is True
+    accepted = await controller.activate_root("root-1", OBSERVATION_TOKEN)
 
+    # Both parameterisations must prove activation actually ran: a guard
+    # short-circuit also returns False, so `accepted` alone cannot distinguish
+    # the "failed" case from an activation that never happened.
+    assert runtime.activation_calls == [("root-1", OBSERVATION_TOKEN)]
     assert accepted is result.accepted
     assert controller.snapshot.phase == expected_phase
 

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -530,7 +530,7 @@ def fd_leak_sentinel() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def _huggingface_hub_is_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+def _huggingface_hub_is_offline(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Close the other half of the offline latch (TASK-21562).
 
     The bootstrap above sets ``HF_HUB_OFFLINE`` before anything imports
@@ -548,13 +548,35 @@ def _huggingface_hub_is_offline(monkeypatch: pytest.MonkeyPatch) -> None:
     ``monkeypatch.setattr`` rather than assignment, so a session that opted out
     per-test is restored -- the same reasoning as
     ``Tests/RAG_Eval/conftest.py``'s fixture, which does this for its own scope.
+
+    TASK-21592: the latch is also re-asserted at teardown. It is the single
+    condition standing between the suite and the failure class this fixture was
+    written for -- a real hub fetch, five blocked retries on a worker thread,
+    and teardown errors landing on unrelated passing tests. A test that turns
+    the latch back off (directly, or by reloading ``huggingface_hub.constants``)
+    would otherwise re-arm that class silently for everything that follows it in
+    the process.
+
+    Yields:
+        None. The offline latch is re-asserted at teardown.
     """
     if _hf_downloads_allowed():
+        yield
         return
     constants = sys.modules.get("huggingface_hub.constants")
-    if constants is None:
-        return
-    monkeypatch.setattr(constants, "HF_HUB_OFFLINE", True, raising=False)
+    if constants is not None:
+        monkeypatch.setattr(constants, "HF_HUB_OFFLINE", True, raising=False)
+    yield
+    # Looked up again rather than reusing `constants`: a test that imports the
+    # hub for the first time is exactly the case where setup found nothing and
+    # teardown is the only place the latch can be checked at all.
+    still_loaded = sys.modules.get("huggingface_hub.constants")
+    assert still_loaded is None or getattr(still_loaded, "HF_HUB_OFFLINE", False), (
+        "huggingface_hub's offline latch was turned off during this test; the "
+        "next test to reach the hub will make a real request, retry it five "
+        "times on a worker thread, and fail an unrelated later test at teardown "
+        "(TASK-21592). Set TLDW_TEST_ALLOW_HF_DOWNLOADS=1 to opt the session out."
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -625,18 +647,19 @@ def _no_network_io(request: pytest.FixtureRequest) -> Iterator[None]:
         )
     except ValueError as exc:
         pytest.fail(f"conflicting network markers: {exc}", pytrace=False)
-    network_guard.drain_blocked_attempts()
+    network_guard.drain_blocked_attempts()  # also clears the thread record
     network_guard.set_mode(mode)
     try:
         yield
     finally:
         network_guard.set_mode(network_guard.NetworkMode.BLOCKED)
+        # Threads first: draining the attempts clears both records.
+        threads = network_guard.drain_blocked_attempt_threads()
         attempts = network_guard.drain_blocked_attempts()
     if attempts:
-        detail = ", ".join(f"{call} -> {address}" for call, address in attempts)
         raise AssertionError(
             "test attempted network egress (blocked): "
-            + detail
+            + network_guard.describe_blocked_attempts(attempts, threads)
             + " — stub the client seam, use @pytest.mark.loopback_network for "
             "an owned numeric loopback listener, or use "
             "@pytest.mark.allow_network for unrestricted sockets."

--- a/Tests/network_guard.py
+++ b/Tests/network_guard.py
@@ -31,6 +31,11 @@ Design
   that), every blocked attempt is also **recorded**. The autouse fixture in
   ``Tests/conftest.py`` fails the test at teardown on a non-empty record, so
   the guard cannot be silently absorbed by the code under test.
+* That record is process-global and drained at *every* teardown, so an attempt
+  made by a thread outliving its test lands on an unrelated later test. Each
+  attempt therefore also records the **thread** that made it, and
+  ``describe_blocked_attempts`` says so in the failure message when it is not
+  the main thread (task-21592).
 
 Opting in
 ---------
@@ -48,6 +53,7 @@ from __future__ import annotations
 import ipaddress
 import socket
 import threading
+from collections.abc import Sequence
 from enum import Enum
 from typing import Any
 
@@ -55,6 +61,8 @@ __all__ = [
     "BlockedNetworkAccess",
     "NetworkMode",
     "blocked_attempts",
+    "describe_blocked_attempts",
+    "drain_blocked_attempt_threads",
     "drain_blocked_attempts",
     "install",
     "is_allowed",
@@ -87,6 +95,21 @@ class NetworkMode(str, Enum):
 #: ``(call, address)`` pairs recorded since the last drain. Consulted by the
 #: autouse fixture so a swallowed block still fails its test.
 _blocked_attempts: list[tuple[str, str]] = []
+
+#: Names of the threads that made the recorded attempts, in the same order and
+#: drained alongside them. Kept as a parallel list rather than a third tuple
+#: element so the published ``(call, address)`` shape stays unpacking-compatible
+#: for the tests that already consume it.
+#:
+#: TASK-21592: this record is process-global and the autouse fixture asserts it
+#: empty at EVERY test's teardown, so an attempt made by a thread that outlives
+#: the test that started it is charged to whichever unrelated test happens to
+#: be finishing. That is exactly how ``huggingface_hub``'s five-retry backoff
+#: produced 10-15 teardown errors on innocent, passing ``Tests/Library`` nodes
+#: whose ids varied run to run. The thread name is the one piece of provenance
+#: available at record time, and it is enough to tell "this test did it" from
+#: "something older did it".
+_blocked_attempt_threads: list[str] = []
 
 #: Egress is denied unless a test explicitly selects a narrower or wider mode.
 _mode = NetworkMode.BLOCKED
@@ -153,9 +176,67 @@ def blocked_attempts() -> tuple[tuple[str, str], ...]:
 
 
 def drain_blocked_attempts() -> tuple[tuple[str, str], ...]:
-    """Return the recorded blocked attempts and clear the record."""
+    """Return the recorded blocked attempts and clear the record.
+
+    Also clears the parallel thread-name record, so
+    ``drain_blocked_attempt_threads`` must be called *before* this if both are
+    wanted for the same batch.
+    """
     recorded = tuple(_blocked_attempts)
     _blocked_attempts.clear()
+    _blocked_attempt_threads.clear()
+    return recorded
+
+
+def describe_blocked_attempts(
+    attempts: Sequence[tuple[str, str]],
+    threads: Sequence[str] = (),
+) -> str:
+    """Describe recorded attempts, naming any thread that is not the main one.
+
+    A non-main thread means the attempt may have been made by a worker that
+    outlived the test that started it, in which case the test being failed is a
+    bystander (TASK-21592). Saying so in the message is the difference between
+    a diagnosable failure and an unattributable flake.
+
+    Args:
+        attempts: The drained ``(call, address)`` records.
+        threads: The thread names from
+            :func:`drain_blocked_attempt_threads`, positionally aligned with
+            ``attempts``. May be shorter or empty.
+
+    Returns:
+        A one-line description, empty when there are no attempts.
+    """
+    if not attempts:
+        return ""
+    padded = list(threads) + ["thread unknown"] * (len(attempts) - len(threads))
+    detail = ", ".join(
+        f"{call} -> {address} [{thread}]"
+        for (call, address), thread in zip(attempts, padded)
+    )
+    main = threading.main_thread().name
+    foreign = sorted({name for name in threads if name != main})
+    if not foreign:
+        return detail
+    return (
+        f"{detail} — NOTE: recorded on {', '.join(foreign)}, not {main}, so the "
+        "attempt may belong to an EARLIER test whose worker outlived it; this "
+        "record is process-global and is drained at every teardown (TASK-21592)"
+    )
+
+
+def drain_blocked_attempt_threads() -> tuple[str, ...]:
+    """Return the thread names behind the recorded attempts, and clear them.
+
+    Positionally aligned with :func:`blocked_attempts`. Read this first, then
+    :func:`drain_blocked_attempts`.
+
+    Returns:
+        One thread name per currently recorded attempt.
+    """
+    recorded = tuple(_blocked_attempt_threads)
+    _blocked_attempt_threads.clear()
     return recorded
 
 
@@ -178,6 +259,7 @@ def _deny(call: str, address: Any) -> BlockedNetworkAccess:
     """
     described = _describe(address)
     _blocked_attempts.append((call, described))
+    _blocked_attempt_threads.append(threading.current_thread().name)
     return BlockedNetworkAccess(
         f"network access blocked in tests: {call}({described}). "
         "Tests must not touch a live endpoint — stub the client seam, use "

--- a/Tests/test_network_guard.py
+++ b/Tests/test_network_guard.py
@@ -458,3 +458,63 @@ def test_denial_is_restored_after_a_loopback_only_test() -> None:
     with pytest.raises(network_guard.BlockedNetworkAccess):
         socket.create_connection(("127.0.0.1", 8080), timeout=1)
     _drain_expecting()
+
+
+# --- provenance: which thread made the attempt (TASK-21592) -----------------
+#
+# The blocked-attempt record is process-global and the autouse `_no_network_io`
+# fixture drains it at EVERY teardown. `huggingface_hub` retries a blocked
+# request five times with backoff on a worker thread, so on dev `f49956038`
+# running `Tests/App` with `Tests/Library` produced ten teardown errors on
+# `Tests/Library` nodes that had themselves passed, with the ids varying run to
+# run (10, then 3, 7, 3 on a reduced repro). Nothing in the message said the
+# attempt came from somewhere else. These pin the provenance that says so.
+
+
+def test_a_blocked_attempt_records_the_thread_that_made_it() -> None:
+    with pytest.raises(network_guard.BlockedNetworkAccess):
+        socket.create_connection(("192.0.2.1", 80), timeout=1)
+
+    threads = network_guard.drain_blocked_attempt_threads()
+    _drain_expecting()
+    assert threads == (threading.main_thread().name,)
+
+
+def test_an_attempt_from_a_worker_thread_names_that_worker() -> None:
+    def _trip_the_guard() -> None:
+        try:
+            socket.create_connection(("192.0.2.1", 80), timeout=1)
+        except network_guard.BlockedNetworkAccess:
+            pass
+
+    worker = threading.Thread(target=_trip_the_guard, name="outlives-its-test")
+    worker.start()
+    worker.join(timeout=10)
+    assert not worker.is_alive()
+
+    threads = network_guard.drain_blocked_attempt_threads()
+    attempts = _drain_expecting()
+    assert threads == ("outlives-its-test",)
+
+    message = network_guard.describe_blocked_attempts(attempts, threads)
+    assert "outlives-its-test" in message
+    assert "EARLIER test" in message
+
+
+def test_a_main_thread_attempt_is_not_blamed_on_an_earlier_test() -> None:
+    """The provenance note must not fire for the ordinary same-test case."""
+    message = network_guard.describe_blocked_attempts(
+        (("socket.create_connection", "192.0.2.1:80"),),
+        (threading.main_thread().name,),
+    )
+    assert "192.0.2.1:80" in message
+    assert "EARLIER test" not in message
+
+
+def test_draining_the_attempts_also_clears_their_thread_names() -> None:
+    """The two records must never drift out of alignment across tests."""
+    with pytest.raises(network_guard.BlockedNetworkAccess):
+        socket.create_connection(("192.0.2.1", 80), timeout=1)
+
+    _drain_expecting()
+    assert network_guard.drain_blocked_attempt_threads() == ()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8375,3 +8375,38 @@ readiness gates, mutate each gate independently. A green expected-empty test is
 not evidence for the named gate until making that gate permissive turns the test
 red. Fixtures crossing association and canonical-owner boundaries must state
 which ID space each value occupies.
+---
+
+## A process-global record drained at every teardown charges one test's background work to a bystander (TASK-21592, 2026-08-24)
+
+**TASK-21592, 2026-08-24.** The filing said `Tests/App` polluted `Tests/Library`:
+13-15 errors with node ids that varied run to run, zero when either directory
+ran alone. Reproduced on the filing's own base (`f49956038`): 10 errors together,
+0 for `Tests/Library` alone. Every one of the ten was a **teardown** error on a
+test that had itself **passed**, and every one read the same thing —
+`socket.create_connection -> huggingface.co:443`, with `huggingface_hub` logging
+`Retrying in 1s [Retry 1/5]`.
+
+Two globals in series produced it. `huggingface_hub.constants.HF_HUB_OFFLINE`
+was frozen `False` at import (nothing set it), so a Library test that built the
+default embedding model against an empty cache reached the real hub. Then
+`Tests/network_guard._blocked_attempts` — a module-level list drained and
+asserted empty at *every* test's teardown — collected the five retries, which
+run on a worker thread with 1/2/4/8/16s backoff and outlive the test that
+started them. So the attempts landed on tests B, C, D. The "zero when alone"
+result was not the absence of the fetch: it was too short a tail of subsequent
+tests for the retries to land on.
+
+The count and the ids therefore carried no information about the culprit. Nine
+of the ten node ids named innocent tests, and bisecting on them would have led
+nowhere.
+
+**What to do.** When a suite-wide guard keeps a process-global record and
+asserts it empty per test, record provenance with each entry — at minimum
+`threading.current_thread().name` — and say so in the failure message when it is
+not the main thread. Read the error *body* before the node ids: a batch of
+failures that all carry the same address and differ only in which test they
+landed on is one background actor, not N flaky tests. And check the plugin list
+before trusting an ordering claim: `-p no:randomly` is a no-op in this venv
+because `pytest-randomly` is not installed, so it neither proves nor disproves
+anything about order.

--- a/backlog/tasks/task-21531 - Four-dev-reds-from-test-doubles-that-production-outgrew.md
+++ b/backlog/tasks/task-21531 - Four-dev-reds-from-test-doubles-that-production-outgrew.md
@@ -3,7 +3,7 @@ id: TASK-21531
 title: >-
   Four dev reds from test doubles that production outgrew - Notes library and
   lasting-sync flow
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-23'
 labels:
@@ -22,10 +22,10 @@ programme's "stale test doubles production has outgrown" finding.
 
 ## Acceptance Criteria
 
-- [ ] `Tests/Notes/test_notes_library_unit.py::TestNotesInteropService::test_get_db_new_instance` and `::TestLibraryNotesInteropDelegates::test_get_db_new_instance` pass, with the double updated to the real constructor signature rather than the assertion relaxed
-- [ ] Both `Tests/UI/test_library_notes_lasting_sync_flow.py::test_activation_result_routes_to_truthful_receipt_or_root_recovery` parameterisations pass, with the `activate_root` double matching the production signature
-- [ ] Each repaired double is verified to still fail when the behaviour it guards is broken -- a double updated only far enough to stop raising is not a fix
-- [ ] A brief note records whether either double had drifted far enough that it was passing vacuously before the signature change
+- [x] `Tests/Notes/test_notes_library_unit.py::TestNotesInteropService::test_get_db_new_instance` and `::TestLibraryNotesInteropDelegates::test_get_db_new_instance` pass, with the double updated to the real constructor signature rather than the assertion relaxed
+- [x] Both `Tests/UI/test_library_notes_lasting_sync_flow.py::test_activation_result_routes_to_truthful_receipt_or_root_recovery` parameterisations pass, with the `activate_root` double matching the production signature
+- [x] Each repaired double is verified to still fail when the behaviour it guards is broken -- a double updated only far enough to stop raising is not a fix
+- [x] A brief note records whether either double had drifted far enough that it was passing vacuously before the signature change
 
 ## Evidence (verified first-hand on dev 022b67fc7, 2026-08-23)
 
@@ -41,3 +41,71 @@ Mechanisms: the Notes doubles' mock `CharactersRAGDB` signature was outgrown by 
 now-required positional argument.
 
 Surfaced by the TASK-21129 implementer while A/B-baselining its own reds against dev.
+
+## Implementation Plan
+
+1. Re-verify all four reds on the working base (`a71e62e4b`) before changing anything.
+2. Read the real production signatures, not the filing's summary of them.
+3. Repair each double so it tracks the real seam, and add the assertion that a
+   drifted-but-silent version would still be missing.
+4. Mutate the production behaviour each repaired test claims to guard and prove
+   it goes red.
+5. Record the vacuity findings.
+
+## Implementation Notes
+
+All four reds reproduced on `a71e62e4b`. One of the two filed mechanisms was
+wrong, which is itself the finding:
+
+**Notes doubles (as filed).** `_get_db` gained
+`console_library_migration_seed=load_console_library_migration_seed()` in
+TASK-19900 and the expected-call literal never followed. The patch already used
+`spec=True`, which is signature-aware for *assertion matching* but applies no
+call-time check, so the drift surfaced only as a mismatched expected call.
+Repair: `autospec=True` (call-time signature enforcement) plus a patched seed
+loader returning a **non-default** sentinel
+(`ConsoleLibraryMigrationSeed(auto_retrieve_on_send=True)`), so the assertion
+proves the *loaded* seed is forwarded rather than that some seed object was
+passed.
+
+**Sync-flow test (filing was wrong).** The `activate_root` *double* was fine —
+`_Runtime.activate_root(self, _root_id, _authorization)` already had both
+parameters. The `TypeError` came from the test's own call to **production**:
+`LibraryNotesSyncController.activate_root(root_id, observation_token)` gained a
+required `observation_token`. Adding an argument alone would not have fixed it:
+activation is now gated on a current, activation-typed migration review whose
+plan and review both carry the runtime's observation token, so the call would
+have short-circuited and left the phase at `review`. The test now drives
+`check_migration("root-1")` first, asserts `review.activation is True`, then
+activates with the runtime's own token.
+
+**Vacuity findings.**
+- Notes: *not* vacuous before the drift. `spec=True` supplies `_spec_signature`,
+  so the pre-drift expected call was genuinely matched; it went red exactly when
+  it should have.
+- Sync flow: the `result1` (`failed` → `roots`) parameterisation **was**
+  structurally vacuous on `accepted`. Proven: with
+  `result = await self._runtime.activate_root(...)` replaced by a fabricated
+  `NotesSyncControlResult(False, "failed", "review_changes")` and the new
+  runtime-call assertion removed, that parameterisation still passed — the
+  runtime was never called and the test could not tell. The new
+  `assert runtime.activation_calls == [("root-1", OBSERVATION_TOKEN)]` closes it.
+
+**Mutation results (each applied to production, then reverted).**
+
+| Mutation | Result |
+| --- | --- |
+| Drop `console_library_migration_seed=` from `Notes_Library._get_db` | 2 failed |
+| Hardcode `ConsoleLibraryMigrationSeed(auto_retrieve_on_send=False)` instead of loading it | 2 failed |
+| Pass an unknown kwarg (autospec signature check) | 2 failed (`TypeError`) |
+| `phase=... "roots" if recovery` → `"review"` | 1 failed (`result1`) |
+| Receipt line → `"No changes were applied."` | 1 failed (`result0`) |
+| Fabricate the activation result, never call the runtime | 2 failed (1 of which passed before the new assertion) |
+
+**Counts.** `Tests/Notes/test_notes_library_unit.py` 62 passed / 2 failed → 64
+passed. `Tests/UI/test_library_notes_lasting_sync_flow.py` 5 passed / 2 failed →
+7 passed. With `Tests/UI/Library_Modules/test_library_notes_sync_controller.py`:
+199 passed, 0 failed.
+
+**Files.** `Tests/Notes/test_notes_library_unit.py`,
+`Tests/UI/test_library_notes_lasting_sync_flow.py`. No production changes.

--- a/backlog/tasks/task-21592 - Tests-App pollutes Tests-Library in the same process - 13 to 15 errors.md
+++ b/backlog/tasks/task-21592 - Tests-App pollutes Tests-Library in the same process - 13 to 15 errors.md
@@ -2,7 +2,7 @@
 id: TASK-21592
 title: >-
   Tests App pollutes Tests Library in the same process   13 to 15 errors
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-23'
 labels:
@@ -20,10 +20,10 @@ branch happens to be running.
 
 ## Acceptance Criteria
 
-- [ ] The leaking state is identified by name (module-level singleton, patched global, app instance, or fixture scope) rather than worked around with ordering or `-p no:randomly`
-- [ ] `Tests/App` and `Tests/Library` run clean together in one process, repeatedly and under random ordering
-- [ ] A guard prevents the same class of leak from returning — e.g. an autouse fixture asserting the relevant global is unset at teardown
-- [ ] The error count is confirmed to be zero on several consecutive runs, since the symptom is nondeterministic
+- [x] The leaking state is identified by name (module-level singleton, patched global, app instance, or fixture scope) rather than worked around with ordering or `-p no:randomly`
+- [x] `Tests/App` and `Tests/Library` run clean together in one process, repeatedly and under random ordering
+- [x] A guard prevents the same class of leak from returning — e.g. an autouse fixture asserting the relevant global is unset at teardown
+- [x] The error count is confirmed to be zero on several consecutive runs, since the symptom is nondeterministic
 
 ## Evidence
 
@@ -32,3 +32,143 @@ the same class on pristine dev `f49956038`, with varying node ids; running its n
 those Library files gave 306 passed and 0 errors.
 
 Pre-existing and unrelated to that task's change.
+
+## Implementation Plan
+
+1. Recount on the working base before assuming the filing still holds.
+2. If it does not reproduce, reproduce it on the base it was filed against and
+   find what closed it.
+3. Read the errors themselves rather than their node ids, and name the state.
+4. Bisect the two directories down to the smallest reproduction available.
+5. Add the guard that is still missing, and mutation-verify it.
+6. Confirm zero errors over several runs and under a shuffled order.
+
+## Implementation Notes
+
+### Recount: the filed symptom is already closed on this base
+
+| Run | `Tests/App` + `Tests/Library` | `Tests/Library` alone |
+| --- | --- | --- |
+| dev `f49956038` (the filing's base) | 2581 passed, **10 errors** | 2403 passed, **0 errors** |
+| dev `a71e62e4b` (this base), App first | 2638 passed, 1 failed, **0 errors** | 2448 passed, 1 failed, 0 errors |
+| dev `a71e62e4b`, Library first | 2638 passed, 1 failed, **0 errors** | — |
+
+The cross-directory premise was real on `f49956038` and I reproduced it. The one
+failure on this base (`test_outcome_first_recipe_has_stable_blank_markdown_blocks_in_both_lanes`)
+also fails with `Tests/Library` alone, so it is not an isolation effect.
+
+It closed because **TASK-21562** (`f9128f9bc`) and **TASK-21562.1**
+(`d7e218276`) landed between the two bases. They set `HF_HUB_OFFLINE=1` in the
+pre-import bootstrap and patch `huggingface_hub.constants.HF_HUB_OFFLINE` from
+an autouse fixture. Every one of the ten errors was a live hub fetch.
+
+### The leaking state, by name
+
+Every error is a **teardown** error raised by the autouse `_no_network_io`
+fixture, and every one of them reads
+`socket.create_connection -> huggingface.co:443`, with
+`huggingface_hub` logging `Retrying in 1s [Retry 1/5]` for
+`sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json`.
+
+Two globals, in series:
+
+1. **`huggingface_hub.constants.HF_HUB_OFFLINE`** — frozen at that module's
+   import time. Nothing set it on `f49956038`, so a Library test that built the
+   default `all-MiniLM-L6-v2` embedding model against an empty cache directory
+   reached the real hub. This is the *enabling* condition, and it is the one
+   TASK-21562 closed.
+2. **`Tests/network_guard._blocked_attempts`** — a module-level, process-global
+   list, drained and asserted empty at **every** test's teardown. `huggingface_hub`
+   retries a blocked request five times with 1/2/4/8/16s backoff on a worker
+   thread that outlives the test that started it, so attempts made by test A are
+   drained at the teardown of tests B, C, D… This is the *misattribution*
+   mechanism: it is why the count is 10-15 rather than 1, why the node ids vary
+   run to run, and why every erroring node had itself passed. It is untouched by
+   TASK-21562 and is what this task adds a guard for.
+
+Running either directory alone leaves too short a tail of subsequent tests for
+the retries to land on — that, not the absence of the fetch, is why the alone
+runs report zero.
+
+### Bisection
+
+On `f49956038`, against four Library files
+(`export_roundtrip`, `export_scope`, `export_state`, `rag_scope`, 87 tests):
+
+| Combination | Errors |
+| --- | --- |
+| the four Library files alone | 0 |
+| + each of the other eight `Tests/App` files | 0 |
+| + `Tests/App/test_app_shutdown.py` | 6 |
+| + only `test_app_shutdown.py::test_mounting_the_real_app_under_test_arms_no_watchdog` | 3, 7, 3 (three runs) |
+
+That test is the only one in `Tests/App` that mounts the real `TldwCli`, and it
+does so with no config/HOME isolation fixture of its own.
+
+**Recorded rather than glossed:** I could not name what that mount leaves
+behind. The shared sandbox `config.toml` is byte-identical after it (diffed).
+No single Library file reproduces with it — the reduced repro needs the whole
+group, consistent with a retry tail that has to outlive several tests. And
+loading a no-op diagnostic plugin (a `pytest_runtest_protocol` wrapper plus a
+passthrough wrapper on `_deny`) suppressed the failure on three consecutive
+runs, which is a timing window, not a fix. The enabling condition is closed, so
+I stopped there rather than keep guessing at the trigger.
+
+### Guard added
+
+`Tests/network_guard.py` now records the **thread name** behind each blocked
+attempt (`_blocked_attempt_threads`, a parallel list so the published
+`(call, address)` shape stays unpacking-compatible for the seven files that
+already consume it), and `describe_blocked_attempts()` builds the failure
+message. When an attempt came from anything other than the main thread the
+message says so explicitly, so a bystander failure names its likely origin
+instead of reading as "this test did network I/O".
+
+`Tests/conftest.py`'s `_huggingface_hub_is_offline` became a yield fixture that
+**re-asserts the offline latch at teardown**. That latch is the single condition
+standing between the suite and this entire failure class; a test that turned it
+back off would otherwise re-arm it silently for everything after it. The check
+runs at teardown regardless of whether the module was loaded at setup — the
+first version returned early when `sys.modules` had no hub yet, and a probe test
+that imported the hub and set the constant to `False` passed clean. Fixed, then
+re-probed: it now errors with the intended message.
+
+### Mutation results
+
+| Mutation | Result |
+| --- | --- |
+| `_deny` stops recording the thread name | 2 failed |
+| `describe_blocked_attempts` never emits the provenance note | 1 failed |
+| `drain_blocked_attempts` stops clearing the thread record | 1 failed |
+| a test sets `constants.HF_HUB_OFFLINE = False` | 1 error, correct message |
+
+### Counts
+
+`Tests/test_network_guard.py` 19 passed / 1 skipped → 23 passed / 1 skipped
+(four new). `Tests/test_huggingface_offline.py` + `Tests/test_network_guard.py`:
+26 passed, 1 skipped.
+
+Four consecutive `Tests/App` + `Tests/Library` runs, three orderings, **zero
+errors in every one**:
+
+| Run | Tree | Order | Result |
+| --- | --- | --- | --- |
+| baseline | pristine `a71e62e4b` | App, Library | 2638 passed, 1 failed, 2 skipped, 0 errors |
+| baseline | pristine `a71e62e4b` | Library, App | 2638 passed, 1 failed, 2 skipped, 0 errors |
+| A | this branch | App, Library | 2638 passed, 1 failed, 2 skipped, 0 errors |
+| B | this branch | Library, App | 2638 passed, 1 failed, 2 skipped, 0 errors |
+| C | this branch | 80 files shuffled, seed 21592 | 2638 passed, 1 failed, 2 skipped, 0 errors |
+
+The single failure is identical on pristine dev and appears with `Tests/Library`
+alone, so it is not an isolation effect.
+
+`pytest-randomly` is **not installed** in this venv (`pytest-mock`, `-asyncio`,
+`-shard`, `-xdist`, `-json-report`, `-timeout`, `-metadata` are), so
+"random ordering" was done by shuffling the 80 test files with a recorded seed
+(21592) rather than by a plugin. Worth knowing: `-p no:randomly` is a no-op here
+and proves nothing about ordering.
+
+### Files
+
+`Tests/network_guard.py`, `Tests/conftest.py`, `Tests/test_network_guard.py`.
+No production changes.

--- a/backlog/tasks/task-21594 - Media DB migration test hand-stamps a version onto an already-current database.md
+++ b/backlog/tasks/task-21594 - Media DB migration test hand-stamps a version onto an already-current database.md
@@ -2,7 +2,7 @@
 id: TASK-21594
 title: >-
   Media DB migration test hand stamps a version onto an already current database
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-23'
 labels:
@@ -20,9 +20,9 @@ chunk_engine_version`. The test will break again on every future media migration
 
 ## Acceptance Criteria
 
-- [ ] The test builds its historical database with a real historical fixture rather than stamping a version number onto a current one
-- [ ] It is green, and remains green when a new media migration is added on top
-- [ ] The repair is verified not to have made the test vacuous — it must still fail if the reading-progress migration is broken
+- [x] The test builds its historical database with a real historical fixture rather than stamping a version number onto a current one
+- [x] It is green, and remains green when a new media migration is added on top
+- [x] The repair is verified not to have made the test vacuous — it must still fail if the reading-progress migration is broken
 
 ## Evidence (verified first-hand on dev 33ff5b754, 2026-08-23)
 
@@ -36,3 +36,59 @@ pytest Tests/Media_DB/test_media_db_v2.py -k reading_progress_reopens
 `Tests/DB/historical_bootstrap_v6.py` already exists and is the right tool. Same family as
 TASK-21441: the shipped writer can no longer construct historical schemas, so fixtures have to
 come from a bootstrap module rather than from production code.
+
+## Implementation Plan
+
+1. Reproduce the red on the working base before changing anything.
+2. Replace the hand-degraded fixture with `media_db_at_version(path, 2)` so the
+   real chain builds a genuinely v2-shaped database.
+3. Assert the historical preconditions the migration under test depends on.
+4. Mutate each migration the test claims to cover and prove it goes red.
+5. Prove durability by adding a throwaway v8→v9 migration and re-running.
+
+## Implementation Notes
+
+Reproduced on `a71e62e4b`: `Migration v5->v6 failed: duplicate column name:
+chunk_engine_version`. The old fixture built a current (v8) database, then
+hand-degraded it — `DROP TABLE ReadingProgress`, `ALTER TABLE Media DROP COLUMN
+transcription_provenance_json`, `UPDATE schema_version SET version = 2` — so it
+had to be taught about every artifact each new migration added, and broke on the
+first one nobody remembered to remove (v5→v6's `chunk_engine_version` on
+`UnvectorizedMediaChunks`).
+
+Rebuilt on `Tests/DB/historical_bootstrap_v6.media_db_at_version(path, 2)`,
+which patches `_CURRENT_SCHEMA_VERSION` and lets the production chain build a
+real v2 database. The test now asserts its historical preconditions explicitly
+(`schema_version == 2`; neither `ReadingProgress` nor `MediaReadItLaterState`
+exists yet) before reopening unpatched and replaying v2→v8.
+
+**One thing the bootstrap module could not supply.** Seeding had to be a raw
+historical `INSERT` into `Media` with the v1 column set:
+`add_media_with_keywords()` targets the current schema and fails against a real
+v2 database with `no such column: transcription_provenance_json` (added at
+v4→v5). This is the same "the shipped writer can no longer construct historical
+schemas" family the filing names — it applies to row writers, not only to schema
+builders.
+
+**Mutation results (each applied to production, then reverted).**
+
+| Mutation | Result |
+| --- | --- |
+| `_apply_migration_v2_to_v3` bumps the version without creating `ReadingProgress` | 1 failed (`no such table: ReadingProgress`) |
+| `_apply_migration_v3_to_v4` bumps the version without creating `MediaReadItLaterState` | 1 failed (`no such table: MediaReadItLaterState`) |
+
+Both prove the assertions still reach the migration under test, and that no
+open-time "ensure tables exist" path silently supplies either table on a
+migrating database.
+
+**Durability.** With a throwaway v8→v9 migration registered
+(`ALTER TABLE Media ADD COLUMN probe_future_column`) and
+`_CURRENT_SCHEMA_VERSION = 9`, the repaired test still passed — the failure mode
+the old fixture had is structurally gone, because nothing stamps a version any
+more. Reverted after the probe.
+
+**Counts.** `Tests/Media_DB/test_media_db_v2.py` 55 passed / 1 failed → 56
+passed. `Tests/Media_DB` + `Tests/DB` together: 1382 passed / 13 failed, all 13
+pre-existing ChaChaNotes sync-log/FTS reds unrelated to this change.
+
+**Files.** `Tests/Media_DB/test_media_db_v2.py`. No production changes.


### PR DESCRIPTION
## Summary

Three test-health findings from the performance burn-down. **No production changes** —
`git diff origin/dev -- tldw_chatbook/` is empty. Three separate commits.

The theme: while the baseline lies, every other fix ships without a trustworthy signal. Two of the
three filings turned out to be partly wrong, which is itself the point.

## TASK-21531 — four dev reds from doubles production outgrew

All four reproduced. **One of the two filed mechanisms was wrong.** The Notes half was as described
(`_get_db` gained `console_library_migration_seed` in TASK-19900). The sync-flow half was not: the
`activate_root` **double already had both parameters** — the `TypeError` came from the test's own
call to *production*, `LibraryNotesSyncController.activate_root(root_id, observation_token)`.

Adding an argument would not have fixed it either: activation is gated on a current,
activation-typed migration review carrying the runtime's token, so the call would have
short-circuited and left the phase at `review`. The test now drives `check_migration()` first.

**One parameterisation was passing vacuously** — proven by fabricating the activation result and
deleting the new assertion: it still passed, because a guard short-circuit also returns `False`.
Now closed with `assert runtime.activation_calls == [("root-1", OBSERVATION_TOKEN)]`. The Notes half
was *not* vacuous before the drift (`spec=True` supplies `_spec_signature`).

Doubles upgraded from `spec=True` to `autospec`, so an unknown kwarg now fails at call time.
**6 mutations, each reverted**: dropping the seed arg → 2 failed; hardcoding it → 2; unknown kwarg →
2; breaking recovery routing → 1; breaking receipt copy → 1; fabricating the activation result → 2.

## TASK-21592 — the symptom is already closed, and the filed cause was wrong

**Recount on this base: App + Library = 2638 passed, 0 errors.** It does reproduce on the base it was
filed against (`f49956038`: 10 errors together, 0 with Library alone) — **TASK-21562 closed it in
between** by setting `HF_HUB_OFFLINE`.

**It was never App state reaching Library state.** Every error was a *teardown* error on a test that
had **passed**, all reading `socket.create_connection -> huggingface.co:443` with `huggingface_hub`
logging `Retrying in 1s [Retry 1/5]`. Two globals in series:

1. `huggingface_hub.constants.HF_HUB_OFFLINE`, frozen `False` at import — the enabling condition.
2. `Tests/network_guard._blocked_attempts`, a process-global drained and asserted empty at *every*
   teardown — collecting retries made on a worker thread that **outlived the test that started
   them**. Hence 10–15 errors with varying node ids. "Zero when either runs alone" was too short a
   tail for the backoff to land on, not the absence of the fetch.

Bisected to a single trigger: `Tests/App/test_app_shutdown.py::test_mounting_the_real_app_under_test_arms_no_watchdog`
(3/7/3 errors over three reduced runs; 0 without it). **What that mount leaves behind could not be
identified, and is recorded as unknown rather than guessed** — the sandbox config is byte-identical
afterwards, no single Library file reproduces with it, and a no-op diagnostic plugin suppressed it
three runs running.

**Guard added**: each blocked attempt now records its thread, the failure message says so when it is
not the main thread, and the offline latch is re-asserted at teardown. The first version of that
assertion returned early when the hub was not yet imported — a probe that imported it and set the
constant `False` passed clean; fixed and re-probed.

**Four consecutive clean runs across three orderings** (App-first, Library-first, and 80 files
shuffled with a recorded seed) plus pristine dev: 2638 passed / 1 failed / **0 errors** each.

*Method note worth propagating*: **`pytest-randomly` is not installed in this environment**, so
`-p no:randomly` is a no-op and proves nothing about ordering. Ordering was varied by shuffling the
file list with a recorded seed instead.

## TASK-21594 — the media fixture

Reproduced as filed and rebuilt on `media_db_at_version(path, 2)` with the historical preconditions
asserted explicitly. **The bootstrap module was not enough**: seeding needed a raw historical
`INSERT` with the v1 column set, because `add_media_with_keywords()` fails against a real v2 DB with
`no such column: transcription_provenance_json`.

That is the same class as TASK-21441, one layer deeper: **the shipped writer can no longer construct
historical *rows*, not just historical schemas.**

Mutations: stripping the `ReadingProgress` creation from v2→v3, and the read-it-later creation from
v3→v4, each go red — so no open-time "ensure tables" path is quietly supplying them. Durability
proven by registering a throwaway v8→v9 migration.

## Verification

127 passed across the three repaired files after rebase. Remaining reds A/B-proven identical:
`Tests/DB` (13) + `Tests/Library/test_library_prompts_state.py` (1) = **14 failed / 234 passed on
both pristine `a71e62e4b` and this branch, same node ids**. Broader sweep over RAG_Eval + Chunking +
Notes + RAG: pristine 4 failed / 4920 passed vs branch 2 failed / **4922** passed — the only
difference is the two Notes tests fixed here. Preflight green.

## Out of scope

- `Tests/network_guard`'s setup-time drain **silently discards** attempts arriving between teardown
  and the next setup. Not the cause here, but it is a hole.
- `test_mounting_the_real_app_under_test_arms_no_watchdog` mounts the real `TldwCli` with **no
  config/HOME isolation fixture of its own** — the only such test in `Tests/App`, and the
  demonstrated trigger. Worth isolating regardless of the HF fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs three test-health issues without touching production: stale Notes doubles, a brittle media migration fixture, and missing provenance for blocked network egress. This stabilizes failing tests and makes teardown egress errors actionable instead of misattributed.

**Bug Fixes**
- Notes: upgrade mocks to `autospec` and forward a non-default `ConsoleLibraryMigrationSeed`, aligning `_get_db` with production and closing TASK-21531.
- Sync flow: drive `check_migration()` and pass the runtime’s observation token to `activate_root`, then assert the runtime was called, preventing vacuous passes (TASK-21531).
- Media DB: rebuild the v2 fixture via `media_db_at_version(..., 2)` and seed with a historical `INSERT`, avoiding hand-stamped schemas and staying durable across new migrations (TASK-21594).
- Network guard: record the thread for each blocked attempt and include it in failure messages, and re-assert `huggingface_hub`’s offline latch at teardown so tests can’t re-arm real network calls (TASK-21592).

<sup>Written for commit 661bf1e97f90e46e5a49a7b457be998af973de96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

