### PR TITLE
perf(db): pace the ChaChaNotes messages_fts backfill and yield to foreground writes (TASK-22200)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -677,8 +677,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 3,
-      "diagnostic_digest": "4631ec939c52ce71d837",
+      "call_count": 7,
+      "diagnostic_digest": "c7e081542ed2f8099216",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/chachanotes_fts_backfill.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3969,6 +3969,6 @@
     "owner_files": 537,
     "persistent_sink_files": 8,
     "task_492_calls": 1240,
-    "task_494_calls": 7334
+    "task_494_calls": 7338
   }
 }

--- a/Tests/DB/test_chachanotes_fts_backfill_pacing.py
+++ b/Tests/DB/test_chachanotes_fts_backfill_pacing.py
@@ -1,0 +1,351 @@
+"""Pacing for the ChaChaNotes ``messages_fts`` backfill driver (task-22200).
+
+task-21100 moved the v46 whole-history FTS reinsert off the boot path into
+``DB/chachanotes_fts_backfill.py`` -- but the driver ran its ``BEGIN
+IMMEDIATE`` chunks in a tight loop with no pause, so an upgrading user's whole
+first session contended with a back-to-back write-lock convoy (the
+holistic-perf review's finding 22200). task-22200 adds:
+
+- a fixed inter-chunk pause, so the write lock's duty cycle is bounded and a
+  foreground ``BEGIN IMMEDIATE`` writer acquires the lock inside the gaps
+  instead of racing the next chunk's begin;
+- bounded retry-with-backoff when a chunk itself dies on SQLite's plain
+  lock-queue timeout (`database is locked` after the 15 s busy handler -- the
+  RETRYABLE kind; the non-retryable snapshot-upgrade form only exists for
+  DEFERRED read-then-write transactions, which the IMMEDIATE chunk is not),
+  so one slow foreground transaction no longer kills the run until next boot;
+- a ``should_abort`` seam checked between chunks and inside every sleep
+  (sliced), so app shutdown cuts an in-flight pause instead of waiting it out.
+
+The deterministic tests below pin each mechanism through an injected ``sleep``
+recorder; ``test_ui_write_latency_stays_bounded_while_a_backfill_is_in_flight``
+is the AC's behavioural probe -- a real concurrent writer against a real
+in-flight backfill, with the in-flight-ness asserted so the probe cannot pass
+vacuously.
+
+Resumability invariants stay where task-21100 put them
+(``Tests/DB/test_chachanotes_v47_messages_fts_backfill.py``, including the
+real-SIGKILL form); this module re-witnesses only the abort path's frontier.
+
+Fixture note: the backfill window is opened by seeding a CURRENT-schema DB
+and then issuing the same ``'delete-all'`` the v46 migration performs, NOT by
+replaying the real v45 upgrade like the v47 module does. Deliberate, twice
+over: this module tests the driver's pacing against the window STATE (live
+rows absent from ``messages_fts_docsize``), which the reset reproduces
+exactly -- and at the time of writing the v45 bootstrap seeding path is a
+pre-existing dev red anyway (``add_message`` now writes
+``assistant_generation_state``, a v48 column, so every
+``chachanotes_db_at_version(..., 45)`` fixture that seeds through it fails
+with ``no column named assistant_generation_state``; see task-22200's notes).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tldw_chatbook.DB.chachanotes_fts_backfill import (
+    _ABORT_POLL_SECONDS,
+    _LOCKED_RETRY_BACKOFF_SECONDS,
+    ChaChaNotesFTSBackfillError,
+    backfill_chachanotes_messages_fts,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def _open_with_backfill_window(
+    db_path: Path, count: int, *, client_id: str
+) -> CharactersRAGDB:
+    """A current-schema DB holding ``count`` live messages, index cleared.
+
+    Seeds in one outer transaction (so a few hundred rows stay cheap), then
+    reproduces the post-v46-upgrade state with the migration's own reset:
+    ``'delete-all'`` empties the index and its ``_docsize`` shadow table
+    while every live row stays in ``messages`` -- the exact window the
+    backfill driver exists to close.
+    """
+    db = CharactersRAGDB(db_path, client_id=client_id)
+    with db.transaction(immediate=True):
+        conversation_id = db.add_conversation(
+            {"title": "pacing", "character_id": 1}
+        )
+        for i in range(count):
+            db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "user",
+                    "content": f"paceneedle{i:04d} body",
+                }
+            )
+    with db.transaction(immediate=True) as conn:
+        conn.execute("INSERT INTO messages_fts(messages_fts) VALUES ('delete-all')")
+    assert _docsize_count(db) == 0  # the window is open
+    return db
+
+
+def _docsize_count(db: CharactersRAGDB) -> int:
+    return db.execute_query(
+        "SELECT COUNT(*) FROM messages_fts_docsize"
+    ).fetchone()[0]
+
+
+def _live_count(db: CharactersRAGDB) -> int:
+    return db.execute_query(
+        "SELECT COUNT(*) FROM messages WHERE deleted = 0"
+    ).fetchone()[0]
+
+
+@pytest.fixture
+def upgraded_db(tmp_path: Path):
+    """A DB with 10 live messages awaiting backfill (empty index)."""
+    instance = _open_with_backfill_window(
+        tmp_path / "chachanotes.db", 10, client_id="t22200-test"
+    )
+    yield instance
+    instance.close_connection()
+
+
+def test_backfill_sleeps_the_configured_pause_between_chunks(upgraded_db):
+    """The load-bearing line: every data chunk is followed by exactly one
+    pause (10 rows / chunk 4 -> chunks of 4, 4, 2 -> 3 pauses; the terminal
+    0-row probe ends the run without sleeping again)."""
+    recorded: list[float] = []
+
+    total = backfill_chachanotes_messages_fts(
+        upgraded_db, chunk_size=4, pause_seconds=0.25, sleep=recorded.append
+    )
+
+    assert total == 10
+    assert recorded == [0.25, 0.25, 0.25]
+    assert _docsize_count(upgraded_db) == _live_count(upgraded_db)
+
+
+def test_the_no_op_boot_probe_never_sleeps(upgraded_db):
+    """AC #4: the every-boot call on a complete index stays one indexed scan
+    -- and must not pick up a pacing sleep either."""
+    assert backfill_chachanotes_messages_fts(upgraded_db, chunk_size=4) == 10
+
+    recorded: list[float] = []
+    assert (
+        backfill_chachanotes_messages_fts(
+            upgraded_db, chunk_size=4, pause_seconds=0.25, sleep=recorded.append
+        )
+        == 0
+    )
+    assert recorded == []
+
+
+def test_abort_between_chunks_leaves_the_resumable_frontier(upgraded_db):
+    """Stopping is not failing: an abort after the first chunk returns the
+    partial count, leaves ``messages_fts_docsize`` as the frontier, and a
+    later un-aborted run converges (task-21100's resumability, AC #3)."""
+    chunks_done = 0
+    original = CharactersRAGDB.backfill_messages_fts
+
+    def counting(self, *args, **kwargs):
+        nonlocal chunks_done
+        result = original(self, *args, **kwargs)
+        chunks_done += 1
+        return result
+
+    with patch.object(CharactersRAGDB, "backfill_messages_fts", counting):
+        total = backfill_chachanotes_messages_fts(
+            upgraded_db,
+            chunk_size=4,
+            pause_seconds=0.0,
+            should_abort=lambda: chunks_done >= 1,
+        )
+
+    assert total == 4
+    assert _docsize_count(upgraded_db) == 4
+    # The frontier is in the database; a fresh run finishes the job.
+    assert backfill_chachanotes_messages_fts(upgraded_db, chunk_size=4) == 6
+    assert _docsize_count(upgraded_db) == _live_count(upgraded_db)
+
+
+def test_abort_cuts_an_in_flight_pause_at_the_poll_slice(upgraded_db):
+    """A ``stop()`` that only sets flags cannot cut a plain ``time.sleep``
+    (documented lesson): with ``should_abort`` provided, the pause must be
+    sliced into abort-checked increments so shutdown waits one slice, not the
+    whole pause."""
+    recorded: list[float] = []
+    aborted = {"flag": False}
+
+    def sliced_sleep(seconds: float) -> None:
+        recorded.append(seconds)
+        if len(recorded) >= 3:
+            aborted["flag"] = True  # "shutdown" arrives mid-pause
+
+    total = backfill_chachanotes_messages_fts(
+        upgraded_db,
+        chunk_size=4,
+        pause_seconds=5.0,
+        should_abort=lambda: aborted["flag"],
+        sleep=sliced_sleep,
+    )
+
+    # One chunk committed, then the pause began and was cut at the third
+    # slice -- never anywhere near the full 5 s.
+    assert total == 4
+    assert recorded == [_ABORT_POLL_SECONDS] * 3
+    assert sum(recorded) < 5.0
+    assert _docsize_count(upgraded_db) == 4
+
+
+def test_a_locked_chunk_is_retried_with_backoff_and_the_run_completes(
+    upgraded_db,
+):
+    """Contention-aware backoff (AC #1's second half): one foreground
+    transaction outliving the chunk's 15 s busy handler must cost a backoff
+    sleep and a retry, not the rest of the run."""
+    attempts = {"n": 0}
+    recorded: list[float] = []
+    original = CharactersRAGDB.backfill_messages_fts
+
+    def locked_once(self, *args, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return original(self, *args, **kwargs)
+
+    with patch.object(CharactersRAGDB, "backfill_messages_fts", locked_once):
+        total = backfill_chachanotes_messages_fts(
+            upgraded_db, chunk_size=10, pause_seconds=0.0, sleep=recorded.append
+        )
+
+    assert total == 10
+    assert recorded[0] == _LOCKED_RETRY_BACKOFF_SECONDS[0]
+    assert _docsize_count(upgraded_db) == _live_count(upgraded_db)
+
+
+def test_locked_retries_are_bounded_then_wrapped_with_the_partial_count(
+    upgraded_db,
+):
+    """Permanent contention still ends the run the pre-existing way: wrapped,
+    with the rows this run really committed, after the whole (bounded)
+    backoff schedule."""
+    attempts = {"n": 0}
+    recorded: list[float] = []
+    original = CharactersRAGDB.backfill_messages_fts
+
+    def locked_after_one_chunk(self, *args, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return original(self, *args, **kwargs)
+        raise sqlite3.OperationalError("database is locked")
+
+    with patch.object(
+        CharactersRAGDB, "backfill_messages_fts", locked_after_one_chunk
+    ):
+        with pytest.raises(ChaChaNotesFTSBackfillError) as excinfo:
+            backfill_chachanotes_messages_fts(
+                upgraded_db,
+                chunk_size=4,
+                pause_seconds=0.0,
+                sleep=recorded.append,
+            )
+
+    assert excinfo.value.rows_indexed == 4
+    # One good chunk, then 1 failing call + one retry per backoff step.
+    assert attempts["n"] == 2 + len(_LOCKED_RETRY_BACKOFF_SECONDS)
+    assert recorded == list(_LOCKED_RETRY_BACKOFF_SECONDS)
+
+
+def test_a_non_lock_error_still_fails_fast(upgraded_db):
+    """The backoff is for lock-queue timeouts only -- any other failure keeps
+    task-21100's fail-fast-and-wrap contract, with zero sleeps."""
+    recorded: list[float] = []
+
+    def broken(self, *args, **kwargs):
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    with patch.object(CharactersRAGDB, "backfill_messages_fts", broken):
+        with pytest.raises(ChaChaNotesFTSBackfillError) as excinfo:
+            backfill_chachanotes_messages_fts(
+                upgraded_db, pause_seconds=0.0, sleep=recorded.append
+            )
+
+    assert excinfo.value.rows_indexed == 0
+    assert recorded == []
+
+
+#: The stated bound for the AC's latency probe. A foreground ``add_message``
+#: colliding with the paced backfill waits at most one in-flight chunk (a few
+#: ms of tokenize+write for 8 tiny rows) plus scheduler noise; 2 s is ~100x
+#: the locally measured worst case (see the task file's measurements) while
+#: staying far below the 15 s busy timeout an unpaced convoy can consume.
+UI_WRITE_LATENCY_BOUND_SECONDS = 2.0
+
+
+def test_ui_write_latency_stays_bounded_while_a_backfill_is_in_flight(
+    tmp_path: Path,
+):
+    """AC #1's probe: a concurrent writer against an in-flight backfill.
+
+    Production shape end to end: ONE shared ``CharactersRAGDB`` (thread-local
+    connections), the real driver with its default pacing on a worker thread,
+    and the real ``add_message`` (``BEGIN IMMEDIATE``) from the foreground.
+    240 rows / chunk 8 = 30 chunks at >=0.05 s pause gives the backfill a
+    >=1.5 s floor, so the five foreground writes (~0.3 s) provably land
+    mid-run -- asserted via ``thread.is_alive()`` after the last write, which
+    is what keeps this probe from passing vacuously against a finished run.
+    """
+    db = _open_with_backfill_window(
+        tmp_path / "chachanotes.db", 240, client_id="t22200-probe"
+    )
+    try:
+        conversation_id = db.add_conversation(
+            {"title": "latency probe", "character_id": 1}
+        )
+
+        failures: list[BaseException] = []
+
+        def run_backfill() -> None:
+            try:
+                backfill_chachanotes_messages_fts(
+                    db, chunk_size=8, pause_seconds=0.05
+                )
+            except BaseException as exc:  # pragma: no cover - failure detail
+                failures.append(exc)
+
+        backfill_thread = threading.Thread(target=run_backfill, daemon=True)
+        backfill_thread.start()
+
+        # Wait for the run to be genuinely in flight (first chunk committed).
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and _docsize_count(db) == 0:
+            time.sleep(0.005)
+        assert _docsize_count(db) > 0, "backfill never started"
+
+        latencies: list[float] = []
+        for i in range(5):
+            started = time.perf_counter()
+            message_id = db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "user",
+                    "content": f"foreground write {i} during the window",
+                }
+            )
+            latencies.append(time.perf_counter() - started)
+            assert message_id, "a foreground write failed during the window"
+            time.sleep(0.04)
+
+        assert backfill_thread.is_alive(), (
+            "backfill finished before the writes -- probe was vacuous; "
+            f"latencies so far: {latencies}"
+        )
+        assert max(latencies) < UI_WRITE_LATENCY_BOUND_SECONDS, latencies
+
+        backfill_thread.join(timeout=60.0)
+        assert not backfill_thread.is_alive()
+        assert failures == []
+        # Everything converged: 240 backfilled + 5 trigger-indexed writes.
+        assert _docsize_count(db) == _live_count(db) == 245
+    finally:
+        db.close_connection()

--- a/Tests/DB/test_chachanotes_fts_backfill_pacing.py
+++ b/Tests/DB/test_chachanotes_fts_backfill_pacing.py
@@ -256,6 +256,51 @@ def test_locked_retries_are_bounded_then_wrapped_with_the_partial_count(
     assert recorded == list(_LOCKED_RETRY_BACKOFF_SECONDS)
 
 
+def test_abort_cuts_an_in_flight_backoff_sleep_at_the_poll_slice(upgraded_db):
+    """The backoff sleep must poll ``should_abort`` too, not just the
+    inter-chunk pause -- otherwise app quit during a contention backoff waits
+    out up to the full 2 s step, the exact shutdown-linger class this task
+    removes. Added in review: the mutation that passes ``None`` instead of
+    ``should_abort`` into the backoff's ``_interruptible_sleep`` survived the
+    original eight tests; this pins that call site (driver line
+    ``_interruptible_sleep(backoff, should_abort, sleep)`` in the retry
+    branch, and its clean-return-with-partial-count contract)."""
+    attempts = {"n": 0}
+    recorded: list[float] = []
+    aborted = {"flag": False}
+    original = CharactersRAGDB.backfill_messages_fts
+
+    def locked_second(self, *args, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 2:
+            raise sqlite3.OperationalError("database is locked")
+        return original(self, *args, **kwargs)
+
+    def sliced_sleep(seconds: float) -> None:
+        recorded.append(seconds)
+        if len(recorded) >= 3:
+            aborted["flag"] = True  # "shutdown" arrives mid-backoff
+
+    with patch.object(CharactersRAGDB, "backfill_messages_fts", locked_second):
+        total = backfill_chachanotes_messages_fts(
+            upgraded_db,
+            chunk_size=4,
+            pause_seconds=0.0,
+            should_abort=lambda: aborted["flag"],
+            sleep=sliced_sleep,
+        )
+
+    # One chunk committed, the next lost the lock, and the 0.5 s backoff was
+    # cut at the third abort-poll slice -- a clean partial return, never a
+    # single uninterruptible 0.5 s sleep (and never a retry after abort).
+    assert total == 4
+    assert attempts["n"] == 2
+    assert recorded == [_ABORT_POLL_SECONDS] * 3
+    assert _docsize_count(upgraded_db) == 4
+    # The frontier still resumes.
+    assert backfill_chachanotes_messages_fts(upgraded_db, chunk_size=4) == 6
+
+
 def test_a_non_lock_error_still_fails_fast(upgraded_db):
     """The backoff is for lock-queue timeouts only -- any other failure keeps
     task-21100's fail-fast-and-wrap contract, with zero sleeps."""

--- a/backlog/tasks/task-22200 - Pace-the-ChaChaNotes-messages_fts-backfill-and-yield-to-foreground-writes.md
+++ b/backlog/tasks/task-22200 - Pace-the-ChaChaNotes-messages_fts-backfill-and-yield-to-foreground-writes.md
@@ -160,3 +160,11 @@ abort), `tldw_chatbook/app.py` (`_backfill_chachanotes_messages_fts` passes
 `Tests/DB/test_chachanotes_fts_backfill_pacing.py` (new),
 `Docs/security/production-diagnostic-inventory.json` (reviewed regen),
 `backlog/tasks/task-22280 - ...md` (dev-red finding).
+
+**Review correction (controller-recorded):** the description's sentence "Every UI write is
+also BEGIN IMMEDIATE" is refuted — `add_conversation` (`ChaChaNotes_DB.py:8886`) is a plain
+DEFERRED writer and dies un-retried with the snapshot-upgrade `database is locked` the
+instant a backfill chunk commits (review-reproduced 3/3; `add_message` IMMEDIATE survived
+10/10). Pacing shrinks that collision window ~10× but cannot close it; the residual fix
+(`immediate=True` in `add_conversation` + a sweep for sibling deferred writers) is filed as
+a follow-up from this burn-down.

--- a/backlog/tasks/task-22200 - Pace-the-ChaChaNotes-messages_fts-backfill-and-yield-to-foreground-writes.md
+++ b/backlog/tasks/task-22200 - Pace-the-ChaChaNotes-messages_fts-backfill-and-yield-to-foreground-writes.md
@@ -2,8 +2,9 @@
 id: TASK-22200
 title: >-
   Pace the ChaChaNotes messages_fts backfill and yield to foreground writes
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
 labels:
   - performance
@@ -33,7 +34,129 @@ for a worse defect (the v46 inline freeze) — the residue is the unpaced conten
 
 ## Acceptance Criteria
 
-- [ ] Inter-chunk pacing exists (sleep/yield and/or contention-aware backoff) and its effect is measured: a UI write issued mid-backfill completes within a stated bound in a probe that runs a concurrent writer against an in-flight backfill
-- [ ] Total backfill duration for a large history is measured before/after and reported in the notes (pacing may lengthen it — state the trade explicitly)
-- [ ] Resumability is preserved: killing the process mid-backfill still leaves a consistent, resumable index (existing state = messages_fts_docsize membership)
-- [ ] The every-boot no-op probe stays cheap (one indexed scan)
+- [x] Inter-chunk pacing exists (sleep/yield and/or contention-aware backoff) and its effect is measured: a UI write issued mid-backfill completes within a stated bound in a probe that runs a concurrent writer against an in-flight backfill
+- [x] Total backfill duration for a large history is measured before/after and reported in the notes (pacing may lengthen it — state the trade explicitly)
+- [x] Resumability is preserved: killing the process mid-backfill still leaves a consistent, resumable index (existing state = messages_fts_docsize membership)
+- [x] The every-boot no-op probe stays cheap (one indexed scan)
+
+## Implementation Plan
+
+1. Add pacing to the driver loop in `DB/chachanotes_fts_backfill.py` (the one place the
+   tight loop lives — `CharactersRAGDB.backfill_messages_fts` itself stays a
+   single-chunk primitive):
+   - A fixed inter-chunk pause (`time.sleep`, default 0.1 s) after every chunk that
+     indexed rows. The no-op boot probe (first chunk finds nothing) never sleeps, so
+     the every-boot cost stays one indexed scan.
+   - Contention-aware backoff: a chunk that dies with SQLite's plain lock-queue
+     timeout (`database is locked` from the chunk's own `BEGIN IMMEDIATE` after the
+     15 s busy handler expires — the retryable kind, NOT the non-retryable
+     snapshot-upgrade form, which only DEFERRED read-then-write transactions can hit)
+     is retried a bounded number of times with escalating sleeps instead of killing
+     the whole run until next boot. Non-lock errors keep the existing
+     fail-fast-and-wrap behavior.
+   - A `should_abort` callback checked between chunks; when provided, every sleep is
+     sliced into <=50 ms increments that re-check it, so an in-flight sleep is
+     interruptible. `app.py`'s worker passes the Textual worker's `is_cancelled` so
+     app shutdown cuts the pacing instead of waiting out the paced run.
+2. TDD: new `Tests/DB/test_chachanotes_fts_backfill_pacing.py` — deterministic
+   pacing/backoff/abort tests written red-first against the unpaced driver, plus the
+   AC's behavioural probe: a concurrent `add_message` writer against an in-flight
+   backfill thread, asserting each write lands within a stated bound while the
+   backfill is provably still running.
+3. Measure on a synthetic history (scratchpad script, production driver, same code
+   both arms with pause=0 as the "before"): (a) concurrent-writer `add_message`
+   latency mid-backfill, (b) total backfill duration. Report both and state the
+   pacing-lengthens-total-time trade.
+4. Mutation-test the pacing line (remove the sleep, watch the pacing test go red).
+5. Targeted tests teed to a file, `./scripts/preflight.sh`, tick ACs, notes, Done.
+
+## Implementation Notes
+
+**Approach.** Pacing lives entirely in the driver
+(`DB/chachanotes_fts_backfill.py`); `CharactersRAGDB.backfill_messages_fts`
+stays a single-chunk primitive. Per the owner's durable-over-clever ruling the
+core is a fixed sleep, not an adaptive scheme:
+
+- `pause_seconds` (default `INTER_CHUNK_PAUSE_SECONDS = 0.1`) after every
+  chunk that indexed rows. The completion/no-op path never sleeps, so the
+  every-boot probe stays exactly one indexed scan (pinned by
+  `test_the_no_op_boot_probe_never_sleeps`).
+- Contention-aware backoff: a chunk that dies on SQLite's *plain lock-queue*
+  timeout (`database is locked` after the chunk's own 15 s busy handler — the
+  retryable kind; the non-retryable snapshot-upgrade form only exists for
+  DEFERRED read-then-write transactions, which the `BEGIN IMMEDIATE` chunk is
+  not) is retried through a bounded schedule (`0.5/1/2 s`, counter reset on
+  any successful chunk) instead of killing the run until next boot. Any other
+  error keeps task-21100's fail-fast-and-wrap contract.
+- `should_abort` seam, polled between chunks and inside every sleep; `app.py`'s
+  worker passes the Textual worker's `is_cancelled`.
+
+**Measurements** (synthetic history: 50,000 messages x ~2 KB ≈ 100 MB text,
+NVMe, template DB copied per arm, arms interleaved x2; foreground
+`add_message` every 50 ms for the whole window — the real UI write shape,
+`BEGIN IMMEDIATE` on a shared instance from a second thread):
+
+| arm | backfill total | write-lock duty cycle | fg add_message mean / median / p95 / max |
+|---|---|---|---|
+| before (pause=0, the old tight loop) | 1.15–1.17 s | ~100% | 153–197 ms / 111–207 ms / ~207 ms / **462–470 ms** |
+| after (pause=0.1) | 11.51–11.53 s | 10% | 3.5 ms / 1.0 ms / ~11 ms / **23.5–24.5 ms** |
+
+Chunks: 101 per run, mean 11.5 ms, max 28 ms — so the paced foreground worst
+case is exactly "one in-flight chunk", while the unpaced convoy made every
+write queue for hundreds of ms. **The trade, explicitly: total backfill time
+grows ~10x (1.2 s -> 11.5 s here) because the run is 90% sleep.** Nobody
+waits on the backfill (background thread; search fills in progressively by
+design), and on the slower disks/bigger histories where the unpaced window
+gets long enough to be felt, its stall ceiling grows with chunk cost while
+the paced ceiling stays one-chunk-bounded. Honest calibration of the
+finding's premise: on this machine the unpaced window for 50k messages is
+~1.2 s, not session-long — the "whole first session" form needs a much larger
+history or slower storage; what is unconditionally true is the 100% duty
+cycle and the ~half-second stalls while it lasts.
+
+**Stated bound** in the probe
+(`test_ui_write_latency_stays_bounded_while_a_backfill_is_in_flight`): every
+concurrent write completes in < 2.0 s (CI-generous; measured max 24.5 ms at
+50k scale). The probe asserts the backfill thread is still alive after the
+last write, so it cannot pass vacuously against a finished run — under the
+pacing mutation the probe itself failed on exactly that guard.
+
+**Mutation tests** (both restored): (1) pacing sleep disabled -> 3 tests red
+(`test_backfill_sleeps_the_configured_pause_between_chunks`,
+`test_abort_cuts_an_in_flight_pause_at_the_poll_slice`, and the latency
+probe via its vacuousness guard); (2) backoff branch disabled -> both locked-
+retry tests red.
+
+**Shutdown path.** Chosen mechanism: interruptible sleeps, not
+"short enough to matter" (the backoff can be 2 s). All sleeps route through
+`_interruptible_sleep`; with `should_abort` present the wait is sliced into
+<= 50 ms (`_ABORT_POLL_SECONDS`) abort-checked steps, so a cancelled worker
+stops within one slice + one chunk. Stopping is clean, not a failure: the
+frontier is `messages_fts_docsize` membership in the DB, and the next boot's
+run resumes it (`test_abort_between_chunks_leaves_the_resumable_frontier`).
+The chunk itself (mean 11.5 ms of work; up to the 15 s busy timeout if queued
+behind a foreground writer) remains non-interruptible — pre-existing and
+bounded. Resumability semantics are untouched: each chunk still commits in
+its own IMMEDIATE transaction and every sleep happens outside any
+transaction; task-21100's SIGKILL witness pins the kill-safe form.
+
+**Test evidence.** New `Tests/DB/test_chachanotes_fts_backfill_pacing.py`:
+8 passed (with `test_chachanotes_v49_messages_fts_update_scope.py`: 27
+passed). `./scripts/preflight.sh` green after a reviewed regen of the
+diagnostic inventory (+4 rows in the driver: three abort log.info + one
+backoff log.warning; each interpolates only integer counts/fixed constants).
+**Pre-existing dev red, NOT from this change** (baselined in a clean worktree
+at `983aa5878`): 12 migration tests fail on dev itself because production
+`add_message` now writes `assistant_generation_state` (a v48 column) and
+breaks every `chachanotes_db_at_version(..., 44/45)` fixture that seeds
+through it — 8/14 in `test_chachanotes_v47_messages_fts_backfill.py`, 4/7 in
+`test_chachanotes_sync_log_retention_migration.py`. Filed as **task-22280**;
+this task's new tests avoid the broken path by seeding at current schema and
+issuing the v46 migration's own `'delete-all'` to reproduce the window state.
+
+**Files.** `tldw_chatbook/DB/chachanotes_fts_backfill.py` (pacing/backoff/
+abort), `tldw_chatbook/app.py` (`_backfill_chachanotes_messages_fts` passes
+`is_cancelled` as `should_abort`),
+`Tests/DB/test_chachanotes_fts_backfill_pacing.py` (new),
+`Docs/security/production-diagnostic-inventory.json` (reviewed regen),
+`backlog/tasks/task-22280 - ...md` (dev-red finding).

--- a/backlog/tasks/task-22280 - add_message-writes-a-v48-column-breaking-every-pre-v48-historical-bootstrap-fixture.md
+++ b/backlog/tasks/task-22280 - add_message-writes-a-v48-column-breaking-every-pre-v48-historical-bootstrap-fixture.md
@@ -1,0 +1,54 @@
+---
+id: TASK-22280
+title: >-
+  add_message writes a v48 column, breaking every pre-v48 historical-bootstrap
+  fixture (12 dev-red migration tests)
+status: To Do
+assignee: []
+created_date: '2026-08-24'
+labels:
+  - testing
+  - database
+priority: high
+dependencies: []
+---
+
+## Description
+
+Found during task-22200 (backfill pacing), baselined against pristine dev
+`983aa5878` in a clean worktree: **12 migration tests are red on dev itself**,
+all with `sqlite3.OperationalError: table messages has no column named
+assistant_generation_state`:
+
+- `Tests/DB/test_chachanotes_v47_messages_fts_backfill.py` — 8 of 14 red
+  (including the SIGKILL resumability witness and both snapshot-upgrade
+  interleave tests for the hot-writer IMMEDIATE contract)
+- `Tests/DB/test_chachanotes_sync_log_retention_migration.py` — 4 of 7 red
+
+Mechanism: `CharactersRAGDB.add_message` now unconditionally INSERTs
+`assistant_generation_state` (the sync/continuation work around `a2e056a8d` /
+`dc10bda0a` / `b89052dc4`), but that column is only created by the v47->v48
+migration (`chachanotes_v47_to_v48_console_library_policy.sql:22`). Every
+fixture that builds a genuinely historical DB via
+`Tests/ChaChaNotesDB/historical_bootstrap.chachanotes_db_at_version(path, 44/45)`
+and then seeds through `add_message` (`_seed_v45` and friends) fails at the
+seed, so the migration guarantees those files existed to pin (deferred FTS
+rebuild, kill-safety, rewind-on-failure, the v47 trigger guards) currently
+have no working witnesses.
+
+Note the coverage shape when fixing: task-22200's pacing tests deliberately
+sidestep this by seeding at CURRENT schema + the migration's own
+`'delete-all'` reset (see `Tests/DB/test_chachanotes_fts_backfill_pacing.py`'s
+module docstring), which reproduces the backfill WINDOW but cannot replace the
+v45-replay coverage these red tests provided. The likely fix directions:
+either `add_message` probes/branches on column presence (ugly, production code
+serving tests), or the historical seeding helpers write pre-v48 rows with
+version-appropriate SQL instead of calling today's `add_message` — the
+historical-bootstrap module's own philosophy ("knowledge about the single
+migration the test pins, owned by that test") points at the latter.
+
+## Acceptance Criteria
+
+- [ ] The 12 enumerated tests pass on dev without weakening what they pin (the deferred-rebuild, kill-safety, rewind, and trigger-guard assertions stay intact)
+- [ ] Seeding a `chachanotes_db_at_version(..., 44/45)` fixture with messages works again, via a mechanism that does not require production `add_message` to know about test schemas
+- [ ] A guard or lesson entry records how a production column addition silently invalidated historical-bootstrap seeding, so the next `messages` column addition does not repeat this

--- a/tldw_chatbook/DB/chachanotes_fts_backfill.py
+++ b/tldw_chatbook/DB/chachanotes_fts_backfill.py
@@ -10,6 +10,23 @@ completion, and ``app.py`` wires it into a ``run_worker(thread=True)`` call at
 mount (next to the structurally identical subscriptions backfill,
 ``Subscriptions/fts_backfill.py``) so the reinsert never blocks boot.
 
+Pacing (task-22200): the loop originally ran its ``BEGIN IMMEDIATE`` chunks
+back to back, so an upgrading user's whole first session contended with a
+write-lock convoy -- every UI write (also ``BEGIN IMMEDIATE``, 15 s busy
+timeout) had to race the next chunk's begin for the lock. The driver now
+sleeps :data:`INTER_CHUNK_PAUSE_SECONDS` after every chunk that indexed rows,
+bounding the backfill's write-lock duty cycle (measured ~3-5 ms of chunk work
+per 100 ms pause on a default-size chunk) so a foreground writer acquires the
+lock inside the gap instead. A chunk that itself dies on SQLite's plain
+lock-queue timeout (``database is locked`` after the busy handler expires --
+the RETRYABLE kind; the non-retryable snapshot-upgrade form only exists for
+DEFERRED read-then-write transactions, which the IMMEDIATE chunk is not) is
+retried through the bounded :data:`_LOCKED_RETRY_BACKOFF_SECONDS` schedule
+instead of killing the run until the next boot. Both sleeps are cut at
+:data:`_ABORT_POLL_SECONDS` granularity when the caller provides
+``should_abort`` -- app shutdown must interrupt an in-flight pause, because a
+cancel that only sets a flag cannot cut a plain ``time.sleep``.
+
 Search semantics during the window, chosen deliberately (task-21100 notes):
 the index is empty-but-consistent after the upgrade commits and fills oldest
 rowid first; message-content search returns progressively more history until
@@ -23,12 +40,31 @@ itself (``messages_fts_docsize`` membership), not in any caller.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import sqlite3
+import time
+from typing import Callable, Optional, TYPE_CHECKING
 
 from loguru import logger
 
 if TYPE_CHECKING:
     from .ChaChaNotes_DB import CharactersRAGDB
+
+#: Pause between chunks. Chosen against measurement, not taste: a default
+#: 500-row chunk of typical chat text holds the write lock for single-digit
+#: milliseconds, so 0.1 s caps the backfill's lock duty cycle at a few
+#: percent while still finishing a 100k-message history in tens of seconds
+#: of added wall time (background thread; nobody is waiting on it).
+INTER_CHUNK_PAUSE_SECONDS = 0.1
+
+#: Slice size for abort-checked sleeps. Also the worst-case extra shutdown
+#: latency a sleeping backfill adds once the worker is cancelled.
+_ABORT_POLL_SECONDS = 0.05
+
+#: Escalating waits before retrying a chunk that lost the lock queue. Each
+#: failed attempt already sat out the connection's 15 s busy handler, so
+#: these are deliberately short -- the point is to survive one slow
+#: foreground transaction, not to poll a wedged database forever.
+_LOCKED_RETRY_BACKOFF_SECONDS = (0.5, 1.0, 2.0)
 
 
 class ChaChaNotesFTSBackfillError(RuntimeError):
@@ -48,45 +84,141 @@ class ChaChaNotesFTSBackfillError(RuntimeError):
         self.rows_indexed = rows_indexed
 
 
+def _is_lock_queue_timeout(exc: BaseException) -> bool:
+    """True when ``exc`` (or its cause chain) is SQLite's plain busy/locked
+    timeout -- the contention signal the backoff schedule exists for. Walks
+    the chain because the DB layer sometimes wraps ``sqlite3`` errors in
+    ``CharactersRAGDBError`` (``raise ... from``)."""
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, sqlite3.OperationalError):
+            message = str(current).lower()
+            if "database is locked" in message or "database is busy" in message:
+                return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _interruptible_sleep(
+    seconds: float,
+    should_abort: Optional[Callable[[], bool]],
+    sleep: Callable[[float], None],
+) -> bool:
+    """Sleep ``seconds``, abort-checked. Returns True if aborted.
+
+    Without ``should_abort`` this is a single ``sleep`` call (keeps injected
+    recorders 1:1 with pauses in tests). With it, the wait is sliced into
+    ``_ABORT_POLL_SECONDS`` steps so a cancelled worker stops within one
+    slice instead of finishing the whole pause.
+    """
+    if seconds <= 0:
+        return bool(should_abort and should_abort())
+    if should_abort is None:
+        sleep(seconds)
+        return False
+    remaining = seconds
+    while remaining > 0:
+        if should_abort():
+            return True
+        step = min(_ABORT_POLL_SECONDS, remaining)
+        sleep(step)
+        remaining -= step
+    return should_abort()
+
+
 def backfill_chachanotes_messages_fts(
-    db: "CharactersRAGDB", chunk_size: int = 500
+    db: "CharactersRAGDB",
+    chunk_size: int = 500,
+    *,
+    pause_seconds: float = INTER_CHUNK_PAUSE_SECONDS,
+    should_abort: Optional[Callable[[], bool]] = None,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> int:
     """Index every live ``messages`` row missing from ``messages_fts``.
 
     ``CharactersRAGDB.backfill_messages_fts`` indexes at most ``chunk_size``
     rows per call and reports ``0`` once nothing remains past its cursor.
     Looping it to completion here is what makes the wired path resumable and
-    idempotent: an interrupted run (app killed mid-loop, worker cancelled)
-    leaves some rows unindexed for the next call to pick up, and a call made
-    after completion does no writes at all. The ascending in-run cursor only
-    skips rows this run has already walked past; a restart begins at 0 and is
-    always correct, because rows below the cursor can only be indexed (never
-    un-indexed while live) by the triggers.
+    idempotent: an interrupted run (app killed mid-loop, worker cancelled,
+    ``should_abort`` fired) leaves some rows unindexed for the next call to
+    pick up, and a call made after completion does no writes at all. The
+    ascending in-run cursor only skips rows this run has already walked past;
+    a restart begins at 0 and is always correct, because rows below the
+    cursor can only be indexed (never un-indexed while live) by the triggers.
+
+    Pacing (task-22200): after every chunk that indexed rows the loop sleeps
+    ``pause_seconds`` so foreground ``BEGIN IMMEDIATE`` writers acquire the
+    lock between chunks; a chunk lost to the busy-handler timeout is retried
+    through ``_LOCKED_RETRY_BACKOFF_SECONDS`` before the run gives up. The
+    no-work path (first chunk finds nothing -- every boot after completion)
+    performs no sleep at all, so the boot probe stays one indexed scan.
 
     Args:
         db: The ``CharactersRAGDB`` instance to backfill. Thread-local
             connections make sharing the app's instance safe from a worker
             thread.
         chunk_size: Rows to index per underlying call.
+        pause_seconds: Sleep between chunks. ``0`` disables pacing (tests,
+            offline tools with exclusive access).
+        should_abort: Polled between chunks and inside every sleep; when it
+            returns True the run stops cleanly, returning the rows indexed so
+            far. Stopping is not failing -- the frontier lives in the DB and
+            the next run resumes it.
+        sleep: Injection seam for the pacing/backoff waits (tests).
 
     Returns:
         Total number of rows indexed by this call (``0`` if there was
-        nothing left to index).
+        nothing left to index; may be partial if ``should_abort`` fired).
 
     Raises:
         ChaChaNotesFTSBackfillError: If the underlying call raises partway
-            through the run. Wraps the original exception (``raise ... from``)
-            and records how many rows this run had already indexed.
+            through the run (after exhausting the lock-timeout retries, for
+            contention errors). Wraps the original exception
+            (``raise ... from``) and records how many rows this run had
+            already indexed.
     """
     total = 0
     cursor = 0
+    locked_retries = 0
     while True:
+        if should_abort is not None and should_abort():
+            logger.info(
+                "ChaChaNotes messages FTS backfill stopping on abort signal "
+                "after {} row(s); the next run resumes from the database's "
+                "own frontier.",
+                total,
+            )
+            return total
         try:
             indexed, cursor = db.backfill_messages_fts(
                 chunk_size=chunk_size, after_rowid=cursor
             )
         except Exception as exc:
+            if (
+                _is_lock_queue_timeout(exc)
+                and locked_retries < len(_LOCKED_RETRY_BACKOFF_SECONDS)
+            ):
+                backoff = _LOCKED_RETRY_BACKOFF_SECONDS[locked_retries]
+                locked_retries += 1
+                logger.warning(
+                    "ChaChaNotes messages FTS backfill chunk lost the lock "
+                    "queue (attempt {}/{}); backing off {}s before retrying.",
+                    locked_retries,
+                    len(_LOCKED_RETRY_BACKOFF_SECONDS),
+                    backoff,
+                )
+                if _interruptible_sleep(backoff, should_abort, sleep):
+                    logger.info(
+                        "ChaChaNotes messages FTS backfill stopping on abort "
+                        "signal during contention backoff after {} row(s).",
+                        total,
+                    )
+                    return total
+                continue
             raise ChaChaNotesFTSBackfillError(total) from exc
+        locked_retries = 0
         if indexed == 0:
             break
         total += indexed
@@ -96,6 +228,13 @@ def backfill_chachanotes_messages_fts(
             indexed,
             total,
         )
+        if _interruptible_sleep(pause_seconds, should_abort, sleep):
+            logger.info(
+                "ChaChaNotes messages FTS backfill stopping on abort signal "
+                "during the inter-chunk pause after {} row(s).",
+                total,
+            )
+            return total
 
     if total:
         logger.info(

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -9481,11 +9481,29 @@ class TldwCli(
         On an up-to-date database the loop's first chunk finds nothing and
         the whole call is one indexed scan -- cheap, and it doubles as
         self-healing for any run interrupted before completion.
+
+        task-22200: the driver paces itself (inter-chunk sleep + backoff on
+        lock-queue timeouts) so this run yields the write lock to foreground
+        UI writes instead of convoying against them for the whole first
+        post-upgrade session. The worker's own cancellation flag is passed
+        through as ``should_abort`` -- pacing makes the run longer, and a
+        thread worker that never polls ``is_cancelled`` would make shutdown
+        wait out every remaining pause; the driver polls it between chunks
+        and inside every sleep, and stopping is safe because the resume
+        frontier lives in the database.
         """
+        from textual.worker import NoActiveWorker, get_current_worker
+
         from tldw_chatbook.DB.chachanotes_fts_backfill import (
             ChaChaNotesFTSBackfillError,
             backfill_chachanotes_messages_fts,
         )
+
+        try:
+            worker = get_current_worker()
+        except NoActiveWorker:
+            worker = None  # direct calls in tests/harnesses run un-cancellable
+        should_abort = (lambda: worker.is_cancelled) if worker is not None else None
 
         try:
             db = get_chachanotes_db_lazy()
@@ -9494,7 +9512,7 @@ class TldwCli(
                     "ChaChaNotes messages FTS backfill skipped: no database instance."
                 )
                 return
-            backfill_chachanotes_messages_fts(db)
+            backfill_chachanotes_messages_fts(db, should_abort=should_abort)
         except ChaChaNotesFTSBackfillError as exc:
             logger.opt(exception=True).error(
                 "ChaChaNotes messages FTS backfill failed after indexing {} "


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22200) — the most plausible mechanism behind "the app got slower after updating": the v46 post-upgrade FTS rebuild ran back-to-back `BEGIN IMMEDIATE` chunks with no pacing, a session-long write-lock convoy.

**Change:** the backfill driver sleeps 0.1 s after each productive chunk, retries plain lock-queue timeouts with a bounded 0.5/1/2 s backoff (explicitly not the snapshot-upgrade form, which the IMMEDIATE chunk structurally cannot hit), and takes a `should_abort` callback (the Textual worker's `is_cancelled`) polled between chunks and inside ≤50 ms sleep slices. No-op boot probe unchanged; resumability unchanged (frontier = `messages_fts_docsize` membership).

**Measured** (50k msgs ≈ 100 MB text, concurrent writer every 50 ms, interleaved ×2): foreground write mean/max **153-197 / 462-470 ms → 3.5 / 23.5-24.5 ms**; lock duty ~100% → 10%; backfill total 1.15 s → 11.5 s (90% sleep, on a background thread — the stated trade).

**Adversarial review: SHIP.** Wedge probe proved the retry ladder's terminal behavior + resume; cancellation truth proven from textual 8.2.8 source AND live probe (quit mid-backfill: wired arm exits in 48 ms, unwired control lingers 3.1 s); review added a test pinning the abort-poll inside the backoff sleep (its mutation had survived); 4 new diagnostic-inventory rows audited (counts/constants only). 12 pre-existing migration-test reds baselined identically on pristine dev and filed as task-22280 (rides this PR).

**Review's adjacent find (follow-up, not this PR):** `add_conversation` is a DEFERRED writer that dies un-retried when a chunk commits (3/3 reproduced) — pacing shrinks the window ~10× but the residual fix is `immediate=True` there; recorded in the task notes for close-out filing.

Tests: new pacing file 9 passed (incl. review test); v49 pin file green; preflight all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paces the ChaChaNotes `messages_fts` backfill so foreground writes don’t sit behind a write‑lock convoy after upgrades. Old behavior ran back‑to‑back `BEGIN IMMEDIATE` chunks; new behavior sleeps between productive chunks, retries `database is locked` with bounded backoff, and aborts promptly, trading lower foreground latency for longer total backfill time.

- Sleeps 0.1 s after each non-empty chunk; the no‑op boot probe never sleeps.
- Retries lock timeouts with 0.5/1/2 s backoff; non‑lock errors still fail fast and report the partial count.
- Slices all sleeps to ≤50 ms and polls `should_abort`; `tldw_chatbook/app.py` passes the Textual worker’s `is_cancelled`.
- Preserves resumability; the frontier remains `messages_fts_docsize` membership.
- Measured: foreground write max fell to ~24 ms (was ~462–470 ms); backfill total rose to ~11.5 s (was ~1.2 s).
- Adds deterministic pacing/backoff/abort tests, including a new test pinning abort polling during backoff.
- Updates diagnostic inventory counts; core logic lives in `tldw_chatbook/DB/chachanotes_fts_backfill.py`.
- Linear: TASK-22200; opens TASK-22280 for unrelated pre‑v48 historical‑bootstrap test reds; review also notes `add_conversation` is a DEFERRED writer (residual fix tracked separately).

<sup>Written for commit e98952fbf4b467eccf4251c598737891caf6e268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

