### PR TITLE
fix(db): let ChaChaNotes migrate itself again after v48 (TASK-21441)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -621,8 +621,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 359,
-      "diagnostic_digest": "57b427ee7f33cc3f7a9b",
+      "call_count": 360,
+      "diagnostic_digest": "9adf81dc4aab6a5fe01f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3969,6 +3969,6 @@
     "owner_files": 537,
     "persistent_sink_files": 8,
     "task_492_calls": 1238,
-    "task_494_calls": 7331
+    "task_494_calls": 7332
   }
 }

--- a/Tests/ChaChaNotesDB/historical_bootstrap.py
+++ b/Tests/ChaChaNotesDB/historical_bootstrap.py
@@ -57,7 +57,15 @@ def open_current_chachanotes_from_legacy(
     client_id: str,
     auto_retrieve_on_send: bool = False,
 ) -> CharactersRAGDB:
-    """Open a pre-v45 fixture with the explicit sanitized migration seed."""
+    """Open a legacy fixture with an EXPLICIT sanitized migration seed.
+
+    A bare ``CharactersRAGDB(path, client_id=...)`` also upgrades a legacy
+    fixture (task-21441 made the seed optional; ``Tests/DB/
+    test_chachanotes_bare_open_self_migration.py`` is the guard). Use this
+    helper only when the fixture's assertions depend on the seeded
+    automatic-retrieval value; otherwise the bare open is the more honest
+    fixture, because it is what a non-TUI consumer actually does.
+    """
     return CharactersRAGDB(
         str(db_path),
         client_id=client_id,
@@ -89,8 +97,10 @@ def chachanotes_db_at_version(
         version: The historical schema version to stop the chain at. Must be
             within ``[MINIMUM_BOOTSTRAP_VERSION, _CURRENT_SCHEMA_VERSION]``.
         client_id: Client id for the bootstrap connection.
-        console_library_migration_seed: Sanitized seed for a historical chain
-            that traverses the v44-to-v45 migration.
+        console_library_migration_seed: Optional sanitized seed for a
+            historical chain that traverses the v47-to-v48 migration. Omit it
+            unless the fixture asserts on the seeded automatic-retrieval
+            value; the step defaults to off (task-21441).
 
     Yields:
         The open ``CharactersRAGDB`` instance, recorded at ``version``.

--- a/Tests/DB/test_chachanotes_bare_open_self_migration.py
+++ b/Tests/DB/test_chachanotes_bare_open_self_migration.py
@@ -1,0 +1,480 @@
+"""A ChaChaNotes database upgrades itself, from any caller (task-21441).
+
+The incident, not the rule. Schema v48 made the v47->v48 step raise
+``SchemaError: Console library migration seed is required for v47 upgrade.``
+unless the constructor had been handed a ``ConsoleLibraryMigrationSeed``, with
+a fresh database exempted -- so the requirement bit exactly the upgrade case.
+Every production construction site threads the seed, so the TUI was insulated
+and no user saw an outage; sixteen tests were red, and the one that named the
+mechanism honestly was ``Tests/Packaging/test_installed_distribution.py``,
+which installs the wheel into an empty tree and opens a v35 database the way a
+non-TUI consumer would. A migration step that requires caller-supplied data
+turns "open the database" into "open the database from inside one
+application", and nothing outside that application can upgrade a profile.
+
+The seed is now optional and defaults to automatic retrieval OFF -- the same
+value ``config.load_console_library_migration_seed`` yields for a missing key
+and the same value the fresh-database path has always written. This module is
+the guard that a future step cannot quietly reintroduce the requirement:
+``test_a_bare_open_migrates...`` fails the moment any step in the chain needs
+something the constructor did not get.
+
+Evidence style follows ``test_chachanotes_v47_messages_fts_backfill.py``: the
+interrupt is a real SIGKILL inside the migration transaction, the equivalence
+claims are content HASHES over every table rather than row counts, and the
+post-conditions are absolute rather than before/after snapshots.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+from contextlib import closing
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from Tests.ChaChaNotesDB.historical_bootstrap import chachanotes_db_at_version
+from tldw_chatbook.Chat.console_library_policy import ConsoleLibraryMigrationSeed
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, SchemaError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_NAME = CharactersRAGDB._SCHEMA_NAME
+CURRENT = CharactersRAGDB._CURRENT_SCHEMA_VERSION
+
+#: The only value the v47->v48 step generates that two identical runs cannot
+#: agree on: `console_conversation_library_policy.updated_at` defaults to
+#: CURRENT_TIMESTAMP. Masked in the content hash, and separately asserted to be
+#: a real timestamp so masking cannot hide an empty column.
+_VOLATILE = {("console_conversation_library_policy", "updated_at")}
+
+
+def _raw_version(db_path: Path) -> int:
+    """Read the stamped version WITHOUT the class that would migrate it."""
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as probe:
+        return probe.execute(
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (SCHEMA_NAME,),
+        ).fetchone()[0]
+
+
+def _raw_table_names(db_path: Path) -> set[str]:
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as probe:
+        return {
+            row[0]
+            for row in probe.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+
+
+def _content_hash(db_path: Path) -> str:
+    """Hash the whole database: its schema text and every row of every table.
+
+    Row order is normalized by sorting, so this is a content identity, not a
+    storage-layout one -- two runs that produce the same rows agree even if
+    SQLite laid the pages out differently.
+    """
+    digest = hashlib.sha256()
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as probe:
+        schema = sorted(
+            probe.execute(
+                "SELECT type, name, tbl_name, COALESCE(sql, '') FROM sqlite_master"
+            ).fetchall()
+        )
+        for entry in schema:
+            digest.update(repr(entry).encode("utf-8"))
+        tables = sorted(
+            row[0]
+            for row in probe.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        )
+        for table in tables:
+            columns = [
+                row[1] for row in probe.execute(f'PRAGMA table_info("{table}")')
+            ]
+            rows = probe.execute(f'SELECT * FROM "{table}"').fetchall()
+            masked = sorted(
+                repr(
+                    tuple(
+                        "<volatile>" if (table, column) in _VOLATILE else value
+                        for column, value in zip(columns, row)
+                    )
+                )
+                for row in rows
+            )
+            digest.update(repr((table, columns, masked)).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _integrity_is_clean(db_path: Path) -> bool:
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as probe:
+        return probe.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+
+
+def _policy_rows(db_path: Path) -> list[tuple]:
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as probe:
+        return probe.execute(
+            "SELECT conversation_id, auto_retrieve_on_send, assistant_library_access,"
+            " policy_revision, updated_at"
+            " FROM console_conversation_library_policy ORDER BY conversation_id"
+        ).fetchall()
+
+
+def _trigger_sql(db_path: Path, name: str) -> str:
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as probe:
+        row = probe.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+            (name,),
+        ).fetchone()
+    assert row is not None, f"trigger {name} is missing"
+    return " ".join(row[0].lower().split())
+
+
+def _seed_historical(db_path: Path, version: int, titles: list[str]) -> list[str]:
+    """Build a genuine ``version``-shaped database with ``titles`` conversations."""
+    with chachanotes_db_at_version(db_path, version, client_id="t21441-seed") as db:
+        conversation_ids = [
+            db.add_conversation({"title": title, "character_id": 1})
+            for title in titles
+        ]
+        for index, conversation_id in enumerate(conversation_ids):
+            db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "user",
+                    "content": f"body-{index:03d}",
+                }
+            )
+    return conversation_ids
+
+
+# ---------------------------------------------------------------------------
+# AC #1 / AC #6 -- the database upgrades itself
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("start_version", [45, 47])
+def test_a_bare_open_migrates_an_existing_database_to_current(
+    tmp_path: Path, start_version: int
+):
+    """The regression guard: no constructor argument beyond a client id.
+
+    Both entry points are covered because the requirement had two halves that
+    fired on different databases: a pre-flight check keyed on entering at
+    exactly v47, and the step's own check, which is what a v35/v45 database
+    walking the whole chain actually hit.
+    """
+    db_path = tmp_path / "chachanotes.db"
+    conversation_ids = _seed_historical(db_path, start_version, ["a", "b", "c"])
+    assert _raw_version(db_path) == start_version
+
+    upgraded = CharactersRAGDB(db_path, client_id="t21441-bare")
+    try:
+        assert upgraded.get_message_by_id is not None  # instance is usable
+    finally:
+        upgraded.close_connection()
+
+    assert _raw_version(db_path) == CURRENT
+    assert _integrity_is_clean(db_path)
+    assert [row[0] for row in _policy_rows(db_path)] == sorted(conversation_ids)
+    # Never / Allowed, the fail-safe default: no automatic retrieval.
+    assert {(row[1], row[2], row[3]) for row in _policy_rows(db_path)} == {(0, 1, 1)}
+    assert all(row[4] for row in _policy_rows(db_path))
+
+
+def test_the_v47_and_v48_index_guarantees_survive_an_unseeded_upgrade(
+    tmp_path: Path,
+):
+    """task-21100's membership guards and task-21128's UPDATE OF scope.
+
+    Both are load-bearing and both live downstream of the step this task
+    changed, so an unseeded upgrade has to land them exactly as a seeded one
+    does.
+    """
+    db_path = tmp_path / "chachanotes.db"
+    _seed_historical(db_path, 45, ["guarded"])
+    CharactersRAGDB(db_path, client_id="t21441-guards").close_connection()
+
+    messages_au = _trigger_sql(db_path, "messages_au")
+    assert "after update of content, deleted on messages" in messages_au
+    assert "messages_fts_docsize" in messages_au
+    assert "old.deleted = 0" in messages_au
+    assert "new.deleted = 0" in messages_au
+    assert "messages_fts_docsize" in _trigger_sql(db_path, "messages_ad")
+
+
+def test_an_unseeded_upgrade_is_content_identical_to_an_explicit_false_seed(
+    tmp_path: Path,
+):
+    """The default is not a different outcome -- it is the same outcome.
+
+    One fixture, copied, so every byte written before the migration is shared;
+    the only value two runs cannot agree on is the CURRENT_TIMESTAMP default,
+    which the hash masks and the previous test asserts non-empty.
+    """
+    source = tmp_path / "source.db"
+    _seed_historical(source, 45, ["x", "y"])
+    unseeded = tmp_path / "unseeded.db"
+    seeded = tmp_path / "seeded.db"
+    shutil.copy2(source, unseeded)
+    shutil.copy2(source, seeded)
+
+    CharactersRAGDB(unseeded, client_id="t21441-cmp").close_connection()
+    CharactersRAGDB(
+        seeded,
+        client_id="t21441-cmp",
+        console_library_migration_seed=ConsoleLibraryMigrationSeed(
+            auto_retrieve_on_send=False
+        ),
+    ).close_connection()
+
+    assert _content_hash(unseeded) == _content_hash(seeded)
+
+
+def test_a_true_seed_still_carries_the_legacy_value(tmp_path: Path):
+    """The seed is optional, not ignored: the boot path still wins."""
+    db_path = tmp_path / "chachanotes.db"
+    _seed_historical(db_path, 45, ["kept"])
+    CharactersRAGDB(
+        db_path,
+        client_id="t21441-true",
+        console_library_migration_seed=ConsoleLibraryMigrationSeed(
+            auto_retrieve_on_send=True
+        ),
+    ).close_connection()
+
+    assert {row[1] for row in _policy_rows(db_path)} == {1}
+
+
+def test_a_wrong_typed_seed_is_still_rejected(tmp_path: Path):
+    """An absent value defaults; a caller defect does not."""
+    db_path = tmp_path / "chachanotes.db"
+    _seed_historical(db_path, 45, ["bad"])
+    with pytest.raises(SchemaError, match="ConsoleLibraryMigrationSeed"):
+        CharactersRAGDB(
+            db_path,
+            client_id="t21441-bad",
+            console_library_migration_seed={"auto_retrieve_on_send": True},
+        )
+    assert _raw_version(db_path) == 45
+    assert "console_conversation_library_policy" not in _raw_table_names(db_path)
+
+
+# ---------------------------------------------------------------------------
+# migration correctness: atomic, re-enterable, interrupt-safe
+# ---------------------------------------------------------------------------
+def test_a_failure_inside_the_v48_step_rewinds_the_whole_chain(tmp_path: Path):
+    """Deterministic atomicity: the chain is one transaction, not eight."""
+    db_path = tmp_path / "chachanotes.db"
+    _seed_historical(db_path, 45, ["rewind"])
+    before = _content_hash(db_path)
+
+    with patch.object(
+        CharactersRAGDB,
+        "_seed_console_library_policy_rows",
+        side_effect=sqlite3.OperationalError("injected"),
+    ):
+        with pytest.raises(SchemaError):
+            CharactersRAGDB(db_path, client_id="t21441-fail")
+
+    assert _raw_version(db_path) == 45
+    assert "console_conversation_library_policy" not in _raw_table_names(db_path)
+    assert _content_hash(db_path) == before
+    assert _integrity_is_clean(db_path)
+
+    # ...and it is re-enterable: a plain retry still converges.
+    CharactersRAGDB(db_path, client_id="t21441-retry").close_connection()
+    assert _raw_version(db_path) == CURRENT
+
+
+_STALL_CHILD = """
+import sys, time
+sys.path.insert(0, {repo!r})
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def stalled(self, cursor):
+    print("inside-the-v48-transaction", flush=True)
+    time.sleep(600)
+
+
+CharactersRAGDB._update_console_library_policy_schema_version = stalled
+CharactersRAGDB({path!r}, client_id="t21441-killed")
+"""
+
+
+def test_a_sigkill_inside_the_v48_transaction_cannot_brick_the_database(
+    tmp_path: Path,
+):
+    """Real kill at the worst moment, not a simulated one.
+
+    The child stalls in the last statement of the step -- the guarded version
+    bump -- so the DDL has run and the policy rows are inserted when SIGKILL
+    lands, with nothing committed. The parent proves that state through a
+    read-only connection first (still v47, table not visible), because a
+    partial apply that was ALREADY visible would be the brick this asserts
+    against.
+    """
+    source = tmp_path / "source.db"
+    _seed_historical(source, 47, ["k1", "k2", "k3"])
+    killed = tmp_path / "killed.db"
+    control = tmp_path / "control.db"
+    shutil.copy2(source, killed)
+    shutil.copy2(source, control)
+    before = _content_hash(killed)
+
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            _STALL_CHILD.format(repo=str(REPO_ROOT), path=str(killed)),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 60.0
+        marker = ""
+        while time.monotonic() < deadline:
+            marker = child.stdout.readline()
+            if marker or child.poll() is not None:
+                break
+        assert "inside-the-v48-transaction" in marker, (
+            f"child never entered the step (marker={marker!r} "
+            f"stderr={child.stderr.read()!r})"
+        )
+        # The transaction is genuinely OPEN at kill time, not merely entered
+        # and already rolled back: no second writer can take the lock. Without
+        # this witness the assertions below would also pass against a child
+        # that never started the step.
+        with closing(sqlite3.connect(killed, timeout=0.2, isolation_level=None)) as other:
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                other.execute("BEGIN IMMEDIATE")
+        # Uncommitted work must be invisible to every other reader.
+        assert _raw_version(killed) == 47
+        assert "console_conversation_library_policy" not in _raw_table_names(killed)
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=60)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=60)
+
+    # Nothing survived the kill, and the file is not damaged.
+    assert _raw_version(killed) == 47
+    assert "console_conversation_library_policy" not in _raw_table_names(killed)
+    assert _integrity_is_clean(killed)
+    assert _content_hash(killed) == before
+
+    # Re-entering converges on exactly the uninterrupted result.
+    CharactersRAGDB(killed, client_id="t21441-recovered").close_connection()
+    CharactersRAGDB(control, client_id="t21441-control").close_connection()
+    assert _raw_version(killed) == CURRENT
+    assert _integrity_is_clean(killed)
+    assert _content_hash(killed) == _content_hash(control)
+
+
+def test_reopening_an_upgraded_database_changes_nothing(tmp_path: Path):
+    """Re-enterability at the top: an at-version open is a no-op."""
+    db_path = tmp_path / "chachanotes.db"
+    _seed_historical(db_path, 45, ["stable"])
+    CharactersRAGDB(db_path, client_id="t21441-first").close_connection()
+    once = _content_hash(db_path)
+    CharactersRAGDB(db_path, client_id="t21441-second").close_connection()
+    assert _content_hash(db_path) == once
+
+
+# ---------------------------------------------------------------------------
+# AC #2 -- the shipped writer populates the schema it is opened against
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("version", [45, 47, CURRENT])
+def test_the_shipped_writer_populates_the_schema_it_is_given(
+    tmp_path: Path, version: int
+):
+    """`add_message` builds its INSERT from the table, not from the newest one."""
+    db_path = tmp_path / "chachanotes.db"
+    with chachanotes_db_at_version(db_path, version, client_id="t21441-writer") as db:
+        conversation_id = db.add_conversation({"title": "w", "character_id": 1})
+        message_id = db.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": "historical body",
+            }
+        )
+        row = db.execute_query(
+            "SELECT content, role, version, deleted FROM messages WHERE id = ?",
+            (message_id,),
+        ).fetchone()
+        assert (row["content"], row["role"], row["version"], row["deleted"]) == (
+            "historical body",
+            "user",
+            1,
+            0,
+        )
+        columns = db._messages_table_columns()
+    # The column the fixture is meant to be missing is genuinely missing --
+    # otherwise this test would pass without exercising anything.
+    assert ("assistant_generation_state" in columns) == (version >= 48)
+
+
+def test_the_writer_refuses_to_drop_a_value_the_schema_cannot_hold(tmp_path: Path):
+    """The omission is lossless or it raises; it is never a silent drop.
+
+    This is what keeps a schema-adaptive writer from masking an incompletely
+    migrated database: every column newer than the base schema is nullable, so
+    a genuine defect arrives as a non-None value with nowhere to go.
+    """
+    db_path = tmp_path / "chachanotes.db"
+    with chachanotes_db_at_version(db_path, 47, client_id="t21441-loss") as db:
+        conversation_id = db.add_conversation({"title": "loss", "character_id": 1})
+        with pytest.raises(SchemaError, match="assistant_generation_state"):
+            db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "assistant",
+                    "content": "body",
+                    "assistant_generation_state": "complete",
+                }
+            )
+        assert (
+            db.execute_query(
+                "SELECT COUNT(*) AS n FROM messages WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()["n"]
+            == 0
+        )
+
+
+def test_the_writer_still_names_every_current_column(tmp_path: Path):
+    """At the current version nothing is dropped -- the adaptive path is inert.
+
+    Pinned as a statement, not a round trip, so a future column that the
+    writer stops naming is visible here rather than only in whatever feature
+    test happens to read it back.
+    """
+    db = CharactersRAGDB(tmp_path / "chachanotes.db", client_id="t21441-current")
+    try:
+        query, params = db._messages_insert_statement(
+            (("id", "x"), ("assistant_generation_state", None), ("content", "c"))
+        )
+        assert "assistant_generation_state" in query
+        assert params == ("x", None, "c")
+        assert db._messages_table_columns() >= {
+            "id",
+            "conversation_id",
+            "content",
+            "role",
+            "provider_continuation_json",
+            "assistant_generation_state",
+        }
+    finally:
+        db.close_connection()

--- a/Tests/DB/test_chachanotes_console_library_migration_seed_openers.py
+++ b/Tests/DB/test_chachanotes_console_library_migration_seed_openers.py
@@ -53,7 +53,14 @@ def _db_version(path: Path) -> int:
 
 
 def test_every_production_characters_rag_db_opener_passes_explicit_seed() -> None:
-    """Catch an opener that could bypass the config-layer seed sanitization."""
+    """Catch an opener that could bypass the config-layer seed sanitization.
+
+    Still load-bearing after task-21441 made the seed optional, and arguably
+    more so: an absent seed now DEFAULTS (to automatic retrieval off) instead
+    of raising, so a production opener that stopped passing one would silently
+    discard a user's `chat_defaults.rag_auto_retrieve_on_send = true` on
+    upgrade instead of failing loudly. This static sweep is what catches that.
+    """
 
     calls = _production_characters_rag_db_calls()
     assert calls
@@ -89,33 +96,79 @@ def test_current_database_accepts_no_console_library_migration_seed(tmp_path: Pa
     reopened.close_connection()
 
 
-@pytest.mark.parametrize("migration_seed", [None, object()])
-def test_v47_upgrade_rejects_missing_or_invalid_seed_before_ddl(
+def _v47_database(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    migration_seed: object,
-) -> None:
-    """A legacy v47 database must not start the v48 migration without a typed seed."""
+    *,
+    conversation_title: str | None = None,
+) -> tuple[Path, str | None]:
+    """Build a genuine v47 database, optionally holding one conversation."""
 
     path = tmp_path / "v47.sqlite"
+    conversation_id: str | None = None
     with monkeypatch.context() as v47_patch:
         v47_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 47)
         seeded = CharactersRAGDB(path, client_id="v47-seed")
+        if conversation_title is not None:
+            conversation_id = seeded.add_conversation(
+                {"title": conversation_title, "character_id": 1}
+            )
         seeded.close_connection()
     assert _db_version(path) == 47
+    return path, conversation_id
+
+
+def test_v47_upgrade_rejects_a_wrong_typed_seed_before_ddl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller defect still stops the migration before it touches the DDL."""
+
+    path, _ = _v47_database(tmp_path, monkeypatch)
     before = _schema_snapshot(path)
 
     with monkeypatch.context() as target_patch:
         target_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 48)
         with pytest.raises(
             SchemaError,
-            match="Console library migration seed is required for v47 upgrade",
+            match="must be a ConsoleLibraryMigrationSeed",
         ):
             CharactersRAGDB(
                 path,
                 client_id="v48-upgrade",
-                console_library_migration_seed=migration_seed,  # type: ignore[arg-type]
+                console_library_migration_seed=object(),  # type: ignore[arg-type]
             )
 
     assert _db_version(path) == 47
     assert _schema_snapshot(path) == before
+
+
+def test_v47_upgrade_without_a_seed_migrates_with_retrieval_off(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The inverted half of this test, and the reason task-21441 exists.
+
+    This case used to raise, which is what stopped a ChaChaNotes database from
+    being upgradable by anything but the TUI. An absent seed now defaults to
+    the config layer's own default -- automatic retrieval off -- so the
+    migration completes and the policy it writes is the fail-safe one.
+    """
+
+    path, conversation_id = _v47_database(
+        tmp_path, monkeypatch, conversation_title="legacy"
+    )
+
+    with monkeypatch.context() as target_patch:
+        target_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 48)
+        upgraded = CharactersRAGDB(path, client_id="v48-upgrade")
+        upgraded.close_connection()
+
+    assert _db_version(path) == 48
+    with sqlite3.connect(path) as connection:
+        policy = connection.execute(
+            "SELECT auto_retrieve_on_send, assistant_library_access"
+            " FROM console_conversation_library_policy WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+    assert policy == (0, 1)

--- a/Tests/DB/test_chachanotes_console_library_policy_migration.py
+++ b/Tests/DB/test_chachanotes_console_library_policy_migration.py
@@ -420,26 +420,68 @@ def test_initializer_begins_immediate_before_its_first_version_read(
     db.close_connection()
 
 
-@pytest.mark.parametrize("migration_seed", [None, object()])
-def test_v47_missing_or_invalid_seed_leaves_schema_unchanged(
+def test_v47_invalid_seed_leaves_schema_unchanged(
     tmp_path: Path,
     v47_template: Path,
-    migration_seed: object,
 ) -> None:
-    path = tmp_path / "missing-seed.sqlite"
+    """A wrong-typed seed is a caller defect and still stops before the DDL.
+
+    The ``None`` half of this parametrization inverted in task-21441 -- see
+    ``test_v47_absent_seed_migrates_with_retrieval_off`` below. Absent is a
+    legitimate state with a defined default; malformed is not.
+    """
+    path = tmp_path / "invalid-seed.sqlite"
     _copy_template(v47_template, path)
     before = _schema_snapshot(path)
 
-    with pytest.raises(SchemaError, match="migration seed is required"):
+    with pytest.raises(SchemaError, match="must be a ConsoleLibraryMigrationSeed"):
         CharactersRAGDB(
             path,
             client_id="invalid-seed",
-            console_library_migration_seed=migration_seed,  # type: ignore[arg-type]
+            console_library_migration_seed=object(),  # type: ignore[arg-type]
         )
 
     with sqlite3.connect(path) as connection:
         assert _version(connection) == 47
     assert _schema_snapshot(path) == before
+
+
+def test_v47_absent_seed_migrates_with_retrieval_off(
+    tmp_path: Path,
+    v47_template: Path,
+) -> None:
+    """No seed is not a failure: the step defaults, and the default is safe.
+
+    This case used to raise ``SchemaError`` and is the whole reason
+    ``CharactersRAGDB`` could not migrate itself (task-21441). The result must
+    be indistinguishable from an explicit ``auto_retrieve_on_send=False``,
+    including for the soft-deleted conversation the template carries.
+    """
+    absent = tmp_path / "absent-seed.sqlite"
+    explicit = tmp_path / "explicit-false-seed.sqlite"
+    _copy_template(v47_template, absent)
+    _copy_template(v47_template, explicit)
+
+    CharactersRAGDB(absent, client_id="absent-seed").close_connection()
+    CharactersRAGDB(
+        explicit,
+        client_id="explicit-seed",
+        console_library_migration_seed=FALSE_SEED,
+    ).close_connection()
+
+    for path in (absent, explicit):
+        with sqlite3.connect(path) as connection:
+            assert _version(connection) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+            assert sorted(
+                connection.execute(
+                    "SELECT conversation_id, auto_retrieve_on_send,"
+                    " assistant_library_access"
+                    " FROM console_conversation_library_policy"
+                ).fetchall()
+            ) == [
+                ("active-conversation", 0, 1),
+                ("deleted-conversation", 0, 1),
+            ]
 
 
 @pytest.mark.parametrize("failure_index", range(12))

--- a/Tests/DB/test_chachanotes_sync_log_retention.py
+++ b/Tests/DB/test_chachanotes_sync_log_retention.py
@@ -54,6 +54,22 @@ def _needle() -> str:
     return "zqx" + uuid.uuid4().hex[:12]
 
 
+def _chat_envelope_payload_hash(content: str, role: str) -> str:
+    """Hash of the chat envelope payload for a message with no private parts.
+
+    The chat envelope's clear payload is exactly three keys, and
+    `assistant_generation_state` is present even when it is None -- the one
+    optional key (`provider_continuation_json`) is the one production omits.
+    """
+    return canonical_payload_hash(
+        {
+            "assistant_generation_state": None,
+            "content": content,
+            "role": role,
+        }
+    )
+
+
 def _sync_log_hits(db: CharactersRAGDB, needle: str) -> list[dict]:
     """Every sync_log row whose payload still carries `needle`, whatever entity."""
     return [
@@ -255,6 +271,15 @@ def test_retention_does_not_break_the_committed_intent_readers(db: CharactersRAG
     `read_committed_chat_sync_intent` returns None, so a retention rule that
     pruned the frontier would turn every continuation checkpoint into a hard
     error while silently disabling Sync v2.
+
+    The envelope payload is built through `_chat_envelope_payload` rather than
+    inline: this test hand-rolled `{"content": ..., "role": ...}` and went red
+    the moment v48 added `assistant_generation_state` to the envelope contract,
+    reporting a retention defect that did not exist (task-21441). The helper
+    states the contract once, in the same shape production states it -- see
+    `Sync_Interop/envelope_builder.build_chat_message_upsert` and
+    `envelope_applier`'s `allowed_keys` -- so the next envelope key breaks it
+    in one place with a readable diff.
     """
     conversation_id = db.add_conversation({"title": "intents", "character_id": 1})
     message_id = db.add_message(
@@ -270,15 +295,15 @@ def test_retention_does_not_break_the_committed_intent_readers(db: CharactersRAG
     record = db.read_committed_chat_sync_intent(
         message_id=message_id,
         message_version=3,
-        payload_hash=canonical_payload_hash({"content": "third", "role": row["role"]}),
+        payload_hash=_chat_envelope_payload_hash("third", row["role"]),
     )
 
     assert record is not None
     assert record.content == "third"
     # The base hash comes from the version below the frontier; that row is
     # exactly what the retention rule keeps for live messages.
-    assert record.base_payload_hash == canonical_payload_hash(
-        {"content": "second", "role": row["role"]}
+    assert record.base_payload_hash == _chat_envelope_payload_hash(
+        "second", row["role"]
     )
 
     # And a restore-time reconcile still sees the conversation's intents.

--- a/backlog/decisions/079-console-library-conversation-authority.md
+++ b/backlog/decisions/079-console-library-conversation-authority.md
@@ -38,7 +38,8 @@ Every production opener supplies the v44→v45 migration one sanitized effective
 legacy automatic-retrieval boolean. The database module does not read config.
 The migration-capable initializer acquires `BEGIN IMMEDIATE` before its first
 schema-version read rather than trying to upgrade a deferred outer transaction;
-inside that transaction it requires the seed, creates the policy table plus a
+inside that transaction it applies the seed (defaulting it when absent, per the
+amendment in the trade-offs below), creates the policy table plus a
 dedicated `console_dispatch_checkpoints` table/index, inserts final policy rows
 for active and soft-deleted conversations present in the migration transaction,
 adds nullable `messages.assistant_generation_state`, and advances the version.
@@ -57,8 +58,9 @@ data. The automatic-send task consumes this compatibility seam rather than
 introducing it later.
 Those policy rows use the seeded automatic value and
 assistant Allowed to preserve the previously always-advertised built-in Library
-provider. Missing seed or failure rolls the whole migration back rather than
-guessing. Conversations inserted later cannot be swept into a backfill because
+provider. A malformed seed or a failure rolls the whole migration back rather
+than guessing; an ABSENT seed defaults to automatic retrieval off (amended by
+TASK-21441 -- see the trade-offs below). Conversations inserted later cannot be swept into a backfill because
 there is no later initializer.
 
 An app/store-owned coordinator publishes every committed CAS result to all
@@ -341,8 +343,19 @@ accepted ADR-003, ADR-030, ADR-032, ADR-066, or ADR-067 in place.
 
 ### Accepted trade-offs
 
-- The main conversation database gains a device-local policy table and a required
-  sanitized migration seed for v44→v45; production database openers must pass it.
+- The main conversation database gains a device-local policy table and a
+  sanitized migration seed for the policy step; production database openers
+  must pass it. **Amended by TASK-21441:** the seed is no longer *required*.
+  Making it mandatory meant `CharactersRAGDB` could not upgrade a pre-existing
+  database at all unless the caller could read the user's configuration, which
+  is a property only the TUI has -- an installed distribution's non-TUI
+  consumer could not open the database, and the packaging migration test caught
+  it. An absent seed now defaults to automatic retrieval off, which is both
+  `config.load_console_library_migration_seed`'s own fallback for a missing key
+  and what a fresh database has always received, so the trade-off's intent
+  (deterministic, config-read-free migration; no guessing) is preserved while
+  the database stays self-migrating. A wrong-typed seed still rolls the whole
+  migration back rather than guessing.
 - Existing conversations are intentionally backfilled to Allowed and their
   current automatic default, so privacy-tight defaults apply prospectively
   rather than silently changing established behavior.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8410,3 +8410,42 @@ landed on is one background actor, not N flaky tests. And check the plugin list
 before trusting an ordering claim: `-p no:randomly` is a no-op in this venv
 because `pytest-randomly` is not installed, so it neither proves nor disproves
 anything about order.
+## Three green tests pinned the requirement; the red one was the only test that opened the database like a stranger (TASK-21441, 2026-08-24)
+
+**TASK-21441, 2026-08-24.** Schema v48 made `_migrate_from_v47_to_v48` raise
+unless the constructor was handed a `ConsoleLibraryMigrationSeed`, exempting a
+*fresh* database — so `CharactersRAGDB` could no longer upgrade an existing one
+without the caller supplying data only the TUI knows how to build. Three tests
+covered that behaviour and all three were **green**, because each asserted the
+requirement rather than the property the requirement destroyed:
+`test_v47_missing_or_invalid_seed_leaves_schema_unchanged[None]`,
+`test_v47_upgrade_rejects_missing_or_invalid_seed_before_ddl[None]`, and
+`test_fresh_database_accepts_no_console_library_migration_seed` (which passes
+either way — a fresh database was the exempted case). ADR-079 even listed
+"a required sanitized migration seed" as an accepted trade-off.
+
+The test that told the truth was
+`Tests/Packaging/test_installed_distribution.py::test_installed_distribution_migrates_v35_database_to_current`,
+which installs the wheel into an empty tree and opens a v35 database from a
+child process with nothing but a path and a client id. It is the only test in
+the repo that opens the database the way a stranger would, and it was red.
+
+**What to do.** A test that asserts *your API raises* is not evidence the
+requirement is correct; it is a transcript of the decision. When a change adds
+a precondition to a component, ask which test exercises that component **from
+outside every convenience the change assumed** — an installed artifact, a
+child process, a caller with no access to app config — and check it is not the
+one that just went red. If the only red test is the one with the fewest
+privileges, the defect is in the precondition, not the test. Fixing it by
+teaching that test to supply the argument deletes the repo's last witness.
+
+**Corollary for fixtures.** The same release broke `add_message` for pre-v48
+schemas by naming the newest column list unconditionally, which stopped
+`Tests/ChaChaNotesDB/historical_bootstrap.py` from seeding historical fixtures
+with production code — the doctrine task-16840 established precisely because
+hand-rolled fixture SQL had been silently wrong. When a schema addition makes
+the production writer unusable against an older schema, the pressure is to go
+back to hand-rolled SQL in the test. Resist it: that trades a loud failure for
+a silent one. (Writing that hand-rolled INSERT is also harder than it looks —
+the first attempt at one in this task died on a `NOT NULL` column the writer
+fills for you.)

--- a/backlog/tasks/task-21441 - Restore-the-historical-fixture-and-self-migration-surface-broken-by-schema-v48.md
+++ b/backlog/tasks/task-21441 - Restore-the-historical-fixture-and-self-migration-surface-broken-by-schema-v48.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-21441
 title: Restore the historical-fixture and self-migration surface broken by schema v48
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-24 04:32'
 labels:
@@ -21,13 +21,33 @@ Schema v48 made two changes that, together, mean the shipped ChaChaNotes writer 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A pre-v47 database can be upgraded by opening CharactersRAGDB without the caller supplying a ConsoleLibraryMigrationSeed, or the requirement is documented as an intentional API contract with a migration note and a defaulting path for non-TUI callers
-- [ ] #2 The shipped message writer can populate a pre-v48 messages table, so historical fixtures can once again be built with production code rather than hand-rolled SQL
-- [ ] #3 Tests/Packaging/test_installed_distribution.py::test_installed_distribution_migrates_v35_database_to_current passes for both source and sdist
-- [ ] #4 The 14 reds in Tests/DB and the actor-pack migration red in Tests/ChaChaNotesDB are green, with each fix addressing the mechanism rather than re-pinning the assertion around it
-- [ ] #5 test_schema_version_is_47's stale pin is updated in a way that does not require editing on every future schema bump
-- [ ] #6 A regression test proves a bare CharactersRAGDB open of an existing older database still migrates, so the next migration step cannot silently reintroduce a caller-supplied-data requirement
+- [x] #1 A pre-v47 database can be upgraded by opening CharactersRAGDB without the caller supplying a ConsoleLibraryMigrationSeed, or the requirement is documented as an intentional API contract with a migration note and a defaulting path for non-TUI callers
+- [x] #2 The shipped message writer can populate a pre-v48 messages table, so historical fixtures can once again be built with production code rather than hand-rolled SQL
+- [x] #3 Tests/Packaging/test_installed_distribution.py::test_installed_distribution_migrates_v35_database_to_current passes for both source and sdist
+- [x] #4 The 14 reds in Tests/DB and the actor-pack migration red in Tests/ChaChaNotesDB are green, with each fix addressing the mechanism rather than re-pinning the assertion around it
+- [x] #5 test_schema_version_is_47's stale pin is updated in a way that does not require editing on every future schema bump
+- [x] #6 A regression test proves a bare CharactersRAGDB open of an existing older database still migrates, so the next migration step cannot silently reintroduce a caller-supplied-data requirement
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Re-measure every red on the implementation base (`a71e62e4b`), not on the
+   filing's base, and record the per-test failing MECHANISM rather than the count.
+2. Direction: **restore self-migration**. Make `console_library_migration_seed`
+   genuinely optional in `_migrate_from_v47_to_v48`, defaulting to the same
+   `auto_retrieve_on_send = 0` the fresh-database path already uses; keep a
+   wrong-typed seed a hard error; warn when defaulting on an existing database.
+   Delete the now-dead duplicate pre-flight check in `_initialize_schema`.
+3. Make `add_message` write the column set the OPEN database actually has, so a
+   historical fixture is built by production code; raise rather than silently
+   drop when a caller supplies a value for a column the schema lacks.
+4. Prove the migration is still atomic, re-enterable, interrupt-safe, and that
+   the unseeded result is byte-identical to the seeded-False result (content
+   hash, not row count) with `PRAGMA integrity_check` clean.
+5. Repair the one stale test double (`sync_log` retention's hand-built envelope
+   hash predates v48's `assistant_generation_state` envelope key).
+6. Document the defaulting contract in `DB/migrations/README.md` and the
+   constructor docstring; mutation-test every new assertion.
 
 ## Evidence (measured first-hand on pristine dev `b3a7cf97b`, 2026-08-23)
 
@@ -76,3 +96,75 @@ from inside one application. That is the part worth fixing, beyond the red tests
 Surfaced while renumbering TASK-21128 from v48 to v49 after a schema-version collision.
 Every red listed here reproduces on pristine dev with no burn-down changes applied; the
 21128 branch actually *fixes* one of them. Filed against v48, not 21128.
+
+## Implementation Notes
+
+Restored self-migration rather than documenting the requirement as a contract.
+
+**Direction, and why.** The seed carries one boolean, and
+`config.load_console_library_migration_seed` already yields `False` for a
+missing or non-boolean `chat_defaults.rag_auto_retrieve_on_send` -- the same
+value the step's own `fresh_without_seed` branch has always written. So the
+requirement was not protecting an invariant; it was protecting nothing, at the
+cost of the DB class being able to upgrade itself. Defaulting is also fail-safe
+in the direction `console_library_policy` itself defines (absent authority is
+Never/Blocked, never permission): the worst case for an unseeded upgrade is a
+user re-enabling automatic retrieval, against a current worst case of the
+database refusing to open at all. `_migrate_from_v47_to_v48` now defaults an
+absent seed, logs a warning when it does so for an existing database, and still
+raises for a wrong-typed one -- absent is a legitimate state, malformed is a
+caller defect. The duplicate pre-flight check in `_initialize_schema` is gone;
+being keyed on entering at exactly v47, it never even fired for the v35 case it
+was meant to guard. The packaging canary passes untouched.
+
+**Writer.** `add_message` built its INSERT from the newest schema's column list
+-- an assertion about a schema it never checked -- so v48's
+`messages.assistant_generation_state` made the shipped writer unable to populate
+a pre-v48 `messages` table, which is exactly how `Tests/ChaChaNotesDB/
+historical_bootstrap.py` builds migration fixtures. It now derives the column
+list from `PRAGMA table_info(messages)` (read once per instance) and drops an
+absent column **only when its value is None** -- the `NULL` it would have
+received anyway -- raising otherwise, so the adaptive path cannot mask an
+incompletely migrated database. This is per-schema, not per-column: the next
+nullable `messages` column needs no fixture work. `create_assistant_continuation`
+deliberately keeps its fixed list; that data has nowhere to go in an old schema.
+
+**Trade-off accepted:** one `PRAGMA table_info` per `CharactersRAGDB` instance.
+
+**Stale doubles repaired, not re-pinned.** Three tests pinned the old contract
+and were changed deliberately: the `None` halves of
+`test_v47_missing_or_invalid_seed_leaves_schema_unchanged` and
+`test_v47_upgrade_rejects_missing_or_invalid_seed_before_ddl` INVERT (absent
+seed now migrates, with the resulting policy asserted equal to an explicit
+`False` seed); their wrong-type halves survive. `test_retention_does_not_break_
+the_committed_intent_readers` hand-rolled `{"content", "role"}` and went red
+when v48 added `assistant_generation_state` to the envelope contract -- it now
+builds the payload through one helper that states the contract once.
+`test_every_production_characters_rag_db_opener_passes_explicit_seed` stays and
+matters more, since a production opener that stopped passing a seed would now
+default silently instead of raising.
+
+**Evidence.** Baseline on `a71e62e4b`: 13 failed / 1303 passed / 1 skipped in
+`Tests/DB`, 1 failed / 404 passed in `Tests/ChaChaNotesDB` (+ the policy
+migration file), 2 failed in the packaging migrate test. After: 0 failed / 1710
+passed / 1 skipped across `Tests/DB` + `Tests/ChaChaNotesDB`, and 2 passed
+`[source]` + `[sdist]`. Migration correctness is proven by a real SIGKILL inside
+the v48 transaction (child stalls in the guarded version bump; the parent first
+witnesses the open write lock, then proves nothing is visible, kills, and shows
+the file still at v47 with an unchanged content hash and a clean
+`PRAGMA integrity_check`), by a deterministic mid-step failure that rewinds the
+whole chain, and by content HASHES over every table -- unseeded vs explicit
+`False`, and post-kill vs uninterrupted -- rather than row counts. Twelve
+mutations of the implementation were each confirmed to turn the new assertions
+red. AC #5 needed no work: task-21128 already replaced that literal with
+`_CURRENT_SCHEMA_VERSION` and moved the one exact pin to the newest step's own
+file; verified on this base.
+
+**Modified or added files.** `tldw_chatbook/DB/ChaChaNotes_DB.py`,
+`tldw_chatbook/DB/migrations/README.md`,
+`Docs/security/production-diagnostic-inventory.json` (one row, the new warning),
+`Tests/ChaChaNotesDB/historical_bootstrap.py`,
+`Tests/DB/test_chachanotes_console_library_policy_migration.py`,
+`Tests/DB/test_chachanotes_console_library_migration_seed_openers.py`,
+`Tests/DB/test_chachanotes_sync_log_retention.py`, and the new
+`Tests/DB/test_chachanotes_bare_open_self_migration.py`.

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -3100,8 +3100,16 @@ UPDATE db_schema_version
             client_id: A unique identifier for this client instance. Used for
                        tracking changes in the sync log and records. Must not be empty.
             check_integrity_on_startup: Whether to run integrity check on startup.
-            console_library_migration_seed: Sanitized legacy library policy needed
-                only when migrating a pre-existing v44 database.
+            console_library_migration_seed: Sanitized legacy Console Library
+                automatic-retrieval value carried into the v47->v48 policy
+                seed. OPTIONAL: an absent seed defaults to automatic retrieval
+                OFF for every pre-existing conversation, which is both the
+                config layer's own default and the fresh-database behaviour, so
+                any caller can migrate a database without it (task-21441). Pass
+                it when the caller can read the user's configuration -- the
+                boot path does -- so a user who had automatic retrieval on keeps
+                it. A value that is not a ``ConsoleLibraryMigrationSeed``
+                raises rather than defaulting.
 
         Raises:
             ValueError: If `client_id` is empty or None.
@@ -3124,6 +3132,8 @@ UPDATE db_schema_version
             raise ValueError("Client ID cannot be empty or None.")
         self.client_id = client_id
         self.console_library_migration_seed = console_library_migration_seed
+        #: Lazily-read `messages` column set (see `_messages_table_columns`).
+        self._messages_columns_cache: frozenset[str] | None = None
 
         logger.info(
             f"Initializing CharactersRAGDB for path: {self.db_path_str} [Client ID: {self.client_id}]"
@@ -6396,16 +6406,38 @@ UPDATE db_schema_version
 
         Existing conversations, including soft-deleted rows, receive the one
         sanitized legacy automatic-retrieval value supplied by the config
-        layer and assistant Library access Allowed. A fresh database may enter
-        this step without a seed because it has no legacy conversations.
+        layer and assistant Library access Allowed.
+
+        The seed is OPTIONAL (task-21441). As shipped, this step raised unless
+        the constructor was handed a ``ConsoleLibraryMigrationSeed``, with a
+        fresh database exempted -- so it bit exactly the upgrade case and the
+        class could no longer migrate itself. Every production construction
+        site threads the seed, so the TUI was insulated; nothing else was, and
+        ``Tests/Packaging/test_installed_distribution.py``'s bare open of a v35
+        database inside an installed wheel is the canary that caught it. A
+        migration that requires caller-supplied data makes "open the database"
+        mean "only from inside one application".
+
+        The default is not invented here: the seed's whole content is one
+        boolean, and ``config.load_console_library_migration_seed`` already
+        yields ``False`` for a missing or non-boolean
+        ``chat_defaults.rag_auto_retrieve_on_send``, which is also what the
+        fresh-database path has always written. Defaulting is fail-safe in the
+        direction ``console_library_policy`` itself defines -- absent authority
+        is Never/Blocked, never permission -- so the worst case for an unseeded
+        upgrade is that a user who had automatic retrieval on re-enables it,
+        against a current worst case of the database refusing to open at all.
+        A seed of the WRONG TYPE is still a hard error: that is a caller
+        defect, not an absent value.
 
         Args:
             conn: The active connection, inside ``_initialize_schema``'s
                 outer immediate transaction.
 
         Raises:
-            SchemaError: If the entry version or seed is invalid, the migration
-                file cannot be applied, or the guarded version update fails.
+            SchemaError: If the entry version is wrong, a supplied seed is not
+                a ``ConsoleLibraryMigrationSeed``, the migration file cannot be
+                applied, or the guarded version update fails.
         """
         self._require_migration_entry_version(conn, 47, "V47→V48")
         from tldw_chatbook.Chat.console_library_policy import (
@@ -6413,12 +6445,16 @@ UPDATE db_schema_version
         )
 
         seed = self.console_library_migration_seed
-        fresh_without_seed = (
-            seed is None and getattr(self, "_schema_initial_version", None) == 0
-        )
-        if not isinstance(seed, ConsoleLibraryMigrationSeed) and not fresh_without_seed:
+        if seed is not None and not isinstance(seed, ConsoleLibraryMigrationSeed):
             raise SchemaError(
-                "Console library migration seed is required for v47 upgrade."
+                "Console library migration seed must be a "
+                "ConsoleLibraryMigrationSeed for the v47 upgrade."
+            )
+        if seed is None and getattr(self, "_schema_initial_version", None) != 0:
+            logger.warning(
+                f"[{self._SCHEMA_NAME} V47→V48] No Console Library migration seed "
+                "supplied for an existing database; seeding every conversation "
+                "with automatic retrieval OFF (the config-layer default)."
             )
         auto_retrieve_on_send = (
             int(seed.auto_retrieve_on_send)
@@ -6679,18 +6715,14 @@ UPDATE db_schema_version
                     f"Checking DB schema '{self._SCHEMA_NAME}'. Current version: {current_db_version}. Code supports: {target_version}"
                 )
 
-                if current_db_version == 47 and target_version > 47:
-                    from tldw_chatbook.Chat.console_library_policy import (
-                        ConsoleLibraryMigrationSeed,
-                    )
-
-                    if not isinstance(
-                        self.console_library_migration_seed,
-                        ConsoleLibraryMigrationSeed,
-                    ):
-                        raise SchemaError(
-                            "Console library migration seed is required for v47 upgrade."
-                        )
+                # (task-21441) A pre-flight seed check lived here. It duplicated
+                # `_migrate_from_v47_to_v48`'s own requirement and, being keyed
+                # on `current_db_version == 47`, only fired for a database that
+                # entered at exactly v47 -- a v35 database walked the whole
+                # chain and died at the step itself. Both are gone: the step now
+                # defaults an absent seed. Any FUTURE step that wants
+                # caller-supplied data belongs in the step, not here, and should
+                # read this method's docstring first.
 
                 if current_db_version == target_version:
                     self._ensure_notes_fts_update_trigger_handles_undelete(conn)
@@ -10712,6 +10744,80 @@ UPDATE db_schema_version
             raise
 
     # --- Message Methods ---
+    def _messages_table_columns(self) -> frozenset[str]:
+        """Return the column names the OPEN ``messages`` table actually has.
+
+        Read once per instance with ``PRAGMA table_info``. A database's column
+        set cannot change under an open instance: ``_initialize_schema`` runs
+        to completion in ``__init__`` before any writer, and the historical
+        fixture bootstrap builds each version behind its own instance.
+        """
+        cached = getattr(self, "_messages_columns_cache", None)
+        if cached is None:
+            cached = frozenset(
+                row["name"]
+                for row in self.get_connection().execute("PRAGMA table_info(messages)")
+            )
+            self._messages_columns_cache = cached
+        return cached
+
+    def _messages_insert_statement(
+        self,
+        fields: tuple[tuple[str, Any], ...],
+    ) -> tuple[str, tuple[Any, ...]]:
+        """Build the ``messages`` INSERT for the schema this database has.
+
+        The general-purpose message writer names the column set of the NEWEST
+        schema. That is an assertion about a schema it never checks, and it
+        broke the repo's fixture doctrine when v48 added
+        ``assistant_generation_state``: ``Tests/ChaChaNotesDB/
+        historical_bootstrap.py`` builds a genuinely historical database by
+        replaying the real migration chain to an older version, and the
+        production writer could no longer populate it -- pushing migration
+        fixtures back to the hand-rolled SQL that task-16840 retired for being
+        silently wrong (task-21441). This recurs on EVERY future ``messages``
+        column, so the repair is per-schema rather than per-column: no version
+        ledger, no per-bump maintenance.
+
+        A column absent from the table is dropped only when its value is
+        ``None`` -- exactly the ``NULL`` the column would have received, so the
+        omission is provably lossless. Anything else raises, which is what
+        keeps this from masking an incompletely-migrated or corrupt database:
+        the newest columns are all nullable, so a genuine defect surfaces as a
+        non-``None`` value with nowhere to go.
+
+        Args:
+            fields: Ordered ``(column, value)`` pairs for one message row.
+
+        Returns:
+            The parameterized INSERT and its bound parameters.
+
+        Raises:
+            SchemaError: If a column carrying data is absent from the table.
+        """
+        available = self._messages_table_columns()
+        dropped_with_data = [
+            column
+            for column, value in fields
+            if column not in available and value is not None
+        ]
+        if dropped_with_data:
+            raise SchemaError(
+                f"Cannot write messages column(s) {sorted(dropped_with_data)}: "
+                f"absent from the '{self._SCHEMA_NAME}' messages table."
+            )
+        # Interpolating the column list is safe by construction, not by
+        # escaping: `written` is a SUBSET of `fields`, whose names are a fixed
+        # literal in the calling writer. No caller-supplied string reaches the
+        # SQL text; every VALUE stays bound.
+        written = [(column, value) for column, value in fields if column in available]
+        columns = ", ".join(column for column, _ in written)
+        placeholders = ", ".join("?" for _ in written)
+        return (
+            f"INSERT INTO messages ({columns}) VALUES ({placeholders})",
+            tuple(value for _, value in written),
+        )
+
     def add_message(self, msg_data: Dict[str, Any]) -> Optional[str]:
         """
         Adds a new message to a conversation, optionally with image data.
@@ -10819,33 +10925,33 @@ UPDATE db_schema_version
         now = self._get_current_utc_timestamp_iso()
         timestamp = msg_data.get("timestamp") or now
 
-        query = """
-                INSERT INTO messages (id, conversation_id, parent_message_id, sender, content,
-                                      image_data, image_mime_type,
-                                      timestamp, ranking, last_modified, client_id, version, deleted, role,
-                                      usage_json, metadata_json, provider_continuation_json,
-                                      assistant_generation_state)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?, ?)
-                """
-        params = (
-            msg_id,
-            msg_data["conversation_id"],
-            msg_data.get("parent_message_id"),
-            msg_data["sender"],
-            msg_data.get("content", ""),  # Default to empty string if no text content
-            msg_data.get("image_data"),
-            msg_data.get("image_mime_type"),
-            timestamp,
-            msg_data.get("ranking"),
-            now,
-            client_id,
-            role,
-            msg_data.get("usage_json"),
-            msg_data.get("metadata_json"),
-            provider_continuation_json,
-            normalized_generation_state.value
-            if normalized_generation_state is not None
-            else None,
+        query, params = self._messages_insert_statement(
+            (
+                ("id", msg_id),
+                ("conversation_id", msg_data["conversation_id"]),
+                ("parent_message_id", msg_data.get("parent_message_id")),
+                ("sender", msg_data["sender"]),
+                # Default to empty string if no text content
+                ("content", msg_data.get("content", "")),
+                ("image_data", msg_data.get("image_data")),
+                ("image_mime_type", msg_data.get("image_mime_type")),
+                ("timestamp", timestamp),
+                ("ranking", msg_data.get("ranking")),
+                ("last_modified", now),
+                ("client_id", client_id),
+                ("version", 1),
+                ("deleted", 0),
+                ("role", role),
+                ("usage_json", msg_data.get("usage_json")),
+                ("metadata_json", msg_data.get("metadata_json")),
+                ("provider_continuation_json", provider_continuation_json),
+                (
+                    "assistant_generation_state",
+                    normalized_generation_state.value
+                    if normalized_generation_state is not None
+                    else None,
+                ),
+            )
         )
         try:
             # IMMEDIATE (task-21100 review): every hot `messages` writer reserves the

--- a/tldw_chatbook/DB/migrations/README.md
+++ b/tldw_chatbook/DB/migrations/README.md
@@ -32,6 +32,62 @@ methods in the matching `DB/*.py` module. Filenames are
    `EXPECTED_CHACHANOTES_INDEXES` in `Tests/ChaChaNotesDB/test_index_census.py`.**
 6. Run `./scripts/preflight.sh`. It checks 4 and reports exactly what to paste.
 
+## A migration step may not require caller-supplied data (TASK-21441)
+
+A step gets one connection and whatever is already in the database. It may
+**not** make the upgrade conditional on an argument the constructor was
+handed, because that turns "open the database" into "open the database from
+inside the one application that knows how to build the argument".
+
+v47→v48 did exactly that: it raised `SchemaError: Console library migration
+seed is required for v47 upgrade.` unless the caller passed a
+`ConsoleLibraryMigrationSeed`, exempting only a *fresh* database — so the
+requirement bit precisely the upgrade case, and `CharactersRAGDB` stopped
+being able to migrate itself. All twelve production construction sites thread
+the seed, so the TUI never broke and no user saw an outage. Sixteen tests were
+red, and the one that named the mechanism was
+`Tests/Packaging/test_installed_distribution.py::test_installed_distribution_
+migrates_v35_database_to_current`, which installs the wheel into an empty tree
+and opens a v35 database the way any non-TUI consumer would. **That test is
+the canary for this rule: if it ever goes red on a seed/argument requirement,
+fix the step, not the test.**
+
+If a step wants a value the caller can supply:
+
+* give it a **default the step can justify from the schema or the config
+  layer's own default**, and apply that default when the argument is absent
+  (v47→v48 defaults automatic retrieval to off, which is both
+  `config.load_console_library_migration_seed`'s fallback and what the
+  fresh-database path has always written);
+* prefer defaults that **fail safe** — an absent value must never grant more
+  access than it withholds;
+* still reject a **wrong-typed** argument. Absent is a legitimate state;
+  malformed is a caller defect.
+
+`Tests/DB/test_chachanotes_bare_open_self_migration.py` pins this: it opens a
+genuinely historical database with nothing but a client id, and goes red the
+moment any step in the chain needs something else.
+
+## The writer writes the schema it is opened against (TASK-21441)
+
+`CharactersRAGDB.add_message` used to name the newest schema's column list
+unconditionally, which is an assertion about a schema it never checked. When
+v48 added `messages.assistant_generation_state`, the shipped writer could no
+longer populate a pre-v48 `messages` table — and that is how the repo builds
+migration fixtures: `Tests/ChaChaNotesDB/historical_bootstrap.py` replays the
+real migration chain to an older version and then seeds it with production
+code, precisely so fixtures cannot drift from the schema (task-16840 retired
+the hand-maintained rollback registry that could, and was, silently wrong).
+
+`add_message` now builds its INSERT from `PRAGMA table_info(messages)`, read
+once per instance, and drops a column the table lacks **only when its value is
+`None`** — the `NULL` it would have received anyway. Anything else raises, so
+the adaptive path cannot mask an incompletely migrated database. Adding a
+nullable `messages` column therefore needs no fixture work. A writer for a
+feature that *requires* the new column (e.g. `create_assistant_continuation`)
+keeps its fixed column list and should: that data has nowhere to go in an
+older schema.
+
 ## The table-allowlist trap (TASK-20971)
 
 `VALID_TABLES` is a hand-maintained allowlist keyed by database. It is not


### PR DESCRIPTION
## Summary

Schema v48 left the ChaChaNotes DB unable to migrate itself: upgrading an *existing* database
raised unless the **caller** supplied a `ConsoleLibraryMigrationSeed`, and the shipped writer could
no longer populate a pre-v48 `messages` table. **Direction chosen: restore self-migration.**

## Why optional rather than a documented contract

The seed's entire content is **one boolean**, and `config.load_console_library_migration_seed`
**already returns `False`** for a missing or non-boolean `chat_defaults.rag_auto_retrieve_on_send`.
The migration's own `fresh_without_seed` branch already wrote `0`. So *"no seed"* and *"seed built
from a default config"* were always the same value — **the requirement protected nothing**, at the
cost of the class being unable to migrate itself.

Defaulting is fail-safe in the direction the module itself defines: `console_library_policy`'s safe
snapshot is Never/Blocked, "absent authority is never permission". The worst case for an unseeded
upgrade is a user re-enabling automatic retrieval; the current worst case is **the database not
opening**. A wrong-typed seed still raises — absent is a legitimate state, malformed is a caller
defect.

**The packaging test was not touched.** It passes on its merits, both `[source]` and `[sdist]`.

Also removed: a duplicate pre-flight check in `_initialize_schema` keyed on
`current_db_version == 47`, which **never fired for the v35 case it was meant to guard** — a v35
database walked the whole chain and died at the step.

## The writer half

`add_message` now builds its INSERT from `PRAGMA table_info(messages)` (read once per instance),
dropping an absent column **only when its value is `None`** — the `NULL` it would have received —
and **raising otherwise**, so the adaptive path cannot mask an incompletely migrated database.
Per-schema, not per-column: no version ledger, no per-bump fixture work.
`create_assistant_continuation` deliberately keeps its fixed list.

## Re-measured on this base — the filing's numbers were stale

| surface | before | after |
|---|---|---|
| `Tests/DB` | **13** failed / 1303 passed | **0 failed** |
| `Tests/ChaChaNotesDB` + policy migration | **1** failed / 404 passed | **0 failed** |
| packaging `-k migrates` | **2** failed | **2 passed** |
| combined, after rebase | — | **1767 passed, 1 skipped, 0 failed** |

The filing said 14 in `Tests/DB`; the extra one had already been fixed by task-21128 — which is also
why AC #5 needed no work. And the mechanism split was **not** what the filing claimed: **12 of the
13 reds were the writer, only 1 the seed.**

## Migration correctness

- **Atomicity** — injected `OperationalError` mid-step: version back at 45, policy table absent,
  whole-database content hash unchanged, `integrity_check` ok, plain retry converges.
- **Interrupt** — real SIGKILL inside the v48 transaction. Before killing, the parent **witnesses the
  open write lock** (a second `BEGIN IMMEDIATE` raises `database is locked`), so the test cannot pass
  against a child that never started. After: still v47, table absent, integrity ok, hash unchanged.
- **Byte-identity** — content hashes over `sqlite_master` plus every row of every table, from one
  copied fixture: unseeded == explicitly-`False`-seeded, and post-kill-resumed == uninterrupted.
  (Only a `CURRENT_TIMESTAMP` default is masked, and separately asserted non-empty.)
- **Prior guarantees intact** — a new test pins that an *unseeded* upgrade still lands TASK-21100's
  `messages_fts_docsize` membership guards and TASK-21128's `AFTER UPDATE OF content, deleted` scope.
- No migration step added; `_CURRENT_SCHEMA_VERSION` stays 49; no version claimed.

## Mutation: 12/12 red

Seed-required-again · default flips retrieval ON · seed ignored · wrong-typed seed accepted · writer
silently drops data · writer back to fixed newest columns · writer drops a newest column at current
version · v48 commits its DDL early · v49 trigger scope widened · at-version open mutates the file ·
envelope drops the null generation state · policy seed blocks assistant access. Every restore
verified clean.

## Three contract-pinning tests inverted deliberately

They asserted the *requirement itself*, and were **green while the packaging canary was red** — which
is the whole shape of this bug. The `None` halves of two now assert the migration completes with a
policy equal to an explicit `False` seed; their wrong-type halves survive.
`test_every_production_characters_rag_db_opener_passes_explicit_seed` stays and **matters more now**
— a production opener that stopped passing one would default silently instead of raising. ADR-079's
accepted trade-off is amended in place.

One of the reds was itself a **stale double**: a hand-rolled `{"content", "role"}` sync-log hash
predating v48's `assistant_generation_state` envelope key. Production is consistent across
builder/applier/reader and both store call sites, so the test now builds its payload through one
helper.

## Out of scope

- **Three more v48 stale doubles are red on dev**, same family, outside these ACs: two
  `test_get_db_new_instance` cases (**being fixed in the TASK-21531 branch**) and
  `Tests/Character_Chat/test_character_persona_scope_service.py::test_app_wires_character_persona_services`,
  which **nothing currently fixes**.
- **`Tests/Chat` cannot be run to completion on this machine** — a full run hits the 300 s session
  timeout, and xdist stalled at 98% with two `node down` under contention from ~11 concurrent pytest
  processes belonging to other sessions. Substituted a targeted A/B over the 13 message-persistence
  files: **14 failed / 585 passed on both trees, same 14 IDs**, all pre-existing.

Preflight green; the one added inventory row interpolates only `self._SCHEMA_NAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores ChaChaNotes DB self‑migration after v48 blocked upgrades by requiring a `ConsoleLibraryMigrationSeed`. The seed is now optional (defaults to auto‑retrieve OFF), and the writer adapts to the `messages` table it opens; wrong‑typed seeds still error.

**Bug Fixes**
- Bare opens of v35/v45/v47 upgrade to current; defaulting the seed on existing DBs logs a warning.
- Removed the duplicate v47 pre‑flight seed check in `_initialize_schema`.
- `add_message` builds its INSERT from `PRAGMA table_info(messages)` and raises if a non‑NULL value targets a missing column.
- Added a regression suite for self‑migration, atomicity, re‑enterability, and SIGKILL interrupt safety; packaging migration tests pass for source and `sdist`.
- Repaired stale test doubles and moved envelope payload hashing to a single helper; documented the “no caller‑data in migrations” rule in `DB/migrations/README.md` and amended ADR‑079.

**Migration**
- No schema version change; no manual steps required.
- Production openers should keep passing a typed seed to preserve user defaults; absent seeds default to auto‑retrieve OFF and emit a warning.
- Writers against older schemas may now raise when given non‑NULL values for columns that don’t exist.

Addresses TASK-21441.

<sup>Written for commit d9d57c46e126d74e4cf57941fc9d96ff9a42ad38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

