### PR TITLE
perf(console): one transcript copy per avatar tick — share the expression snapshot (TASK-22204)

### DIFF
--- a/Tests/Chat/test_console_expression_state.py
+++ b/Tests/Chat/test_console_expression_state.py
@@ -186,6 +186,52 @@ def test_complete_message_returns_final_immutable_history_identity_only():
     )
 
 
+def test_prefetched_snapshot_bypasses_the_store_fetch():
+    """TASK-22204: a passed ``messages`` snapshot must never re-consult the store."""
+
+    class ExplodingStore:
+        def messages_for_session(self, session_id):
+            raise AssertionError("the shared snapshot must not be re-fetched")
+
+    snapshot = [_Msg(_FakeRole.ASSISTANT, "streaming")]
+
+    selection = resolve_console_expression_selection(
+        ExplodingStore(), "s1", react_enabled=True, messages=snapshot
+    )
+    assert selection.state == "speaking"
+    assert selection.source == "operational"
+    assert (
+        resolve_console_expression_state(
+            ExplodingStore(), "s1", react_enabled=True, messages=snapshot
+        )
+        == "speaking"
+    )
+
+
+def test_prefetched_snapshot_matches_store_fetch_for_every_status():
+    """The snapshot path resolves identically to the fetch path (TASK-22204)."""
+
+    for status in ("pending", "streaming", "complete", "stopped", "failed"):
+        messages = [_Msg(_FakeRole.USER, "complete"), _Msg(_FakeRole.ASSISTANT, status)]
+        store = _FakeStore({"s1": messages})
+        fetched = resolve_console_expression_selection(store, "s1", react_enabled=True)
+        shared = resolve_console_expression_selection(
+            store, "s1", react_enabled=True, messages=messages
+        )
+        assert shared == fetched
+
+
+def test_react_disabled_pins_idle_even_with_a_snapshot():
+    snapshot = [_Msg(_FakeRole.ASSISTANT, "streaming")]
+    store = _FakeStore({})
+    assert (
+        resolve_console_expression_state(
+            store, "s1", react_enabled=False, messages=snapshot
+        )
+        == "idle"
+    )
+
+
 def test_react_config_helper_defaults_true():
     assert resolve_react_character_expressions({}) is True
     cfg = {"chat": {"images": {"react_character_expressions": False}}}

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -1168,7 +1168,10 @@ async def test_decode_completion_live_fences_every_avatar_request_input(
     original_store = controller.store
     state = {"value": "thinking"}
 
-    def expression_state(store, _session_id, *, react_enabled):
+    def expression_state(store, _session_id, *, react_enabled, messages=None):
+        # `messages` mirrors the TASK-22204 shared-snapshot kwarg the
+        # production caller now passes; this stub keys off the store/flag
+        # like before and ignores the snapshot.
         if not react_enabled:
             return "idle"
         if store is not original_store:

--- a/Tests/UI/test_console_character_avatar_copy_budget.py
+++ b/Tests/UI/test_console_character_avatar_copy_budget.py
@@ -16,6 +16,8 @@ edges, mirroring ``Tests/UI/test_console_character_controller.py``.
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from types import SimpleNamespace
 from typing import Any
 
@@ -95,6 +97,7 @@ def _avatar_controller(
     is_mounted=lambda: True,
     actor_scope_accessor=None,
     resolve_visual_identity=None,
+    app_config_accessor=lambda: {},
 ) -> ConsoleCharacterController:
     """Real controller wired for the avatar paint path with recording edges."""
 
@@ -123,7 +126,7 @@ def _avatar_controller(
         painted.append(spec)
 
     dependencies: dict[str, Any] = {
-        "app_config_accessor": lambda: {},
+        "app_config_accessor": app_config_accessor,
         "chat_store_accessor": lambda: store,
         "active_native_session_accessor": lambda: None,
         "current_conversation_id_accessor": lambda: None,
@@ -231,6 +234,56 @@ async def test_mid_teardown_tick_never_paints_and_never_raises() -> None:
     await controller._refresh_active_character_avatar_if_scope_changed()
 
     assert painted == []
+
+
+@pytest.mark.asyncio
+async def test_paint_in_flight_when_avatar_hidden_never_applies() -> None:
+    """A paint racing a hide toggle must drop (review probe, TASK-22204).
+
+    The avatar-hidden early return in `_refresh_avatar_request` never
+    rebuilds `_latest_built_request`, so ONLY its explicit baseline clear
+    fences a paint that was already resolving when the avatar was hidden.
+    Deleting that clear lets the stale paint apply a spec (and repaint the
+    DOM edge) while `show_character_avatar` is off -- this test reds then.
+    """
+
+    store, session_id = _streaming_store()
+    config = {"chat": {"images": {"show_character_avatar": True}}}
+    painted: list[dict | None] = []
+    started = threading.Event()
+    release = threading.Event()
+    first = {"blocked": False}
+    resolution = _operational_resolution()
+
+    def blocking_resolve(_scope, _state, _manual):
+        if not first["blocked"]:
+            first["blocked"] = True
+            started.set()
+            assert release.wait(timeout=5)
+        return resolution
+
+    controller = _avatar_controller(
+        store,
+        session_id,
+        painted=painted,
+        resolve_visual_identity=blocking_resolve,
+        app_config_accessor=lambda: config,
+    )
+
+    stale = asyncio.create_task(
+        controller._refresh_active_character_avatar_if_scope_changed(force=True)
+    )
+    assert await asyncio.to_thread(started.wait, 5)
+    # The user hides the avatar while that paint is still resolving; the
+    # next tick observes hidden, clears state, and takes the early return.
+    config["chat"]["images"]["show_character_avatar"] = False
+    await controller._refresh_active_character_avatar_if_scope_changed()
+    assert controller._active_character_avatar is None
+    release.set()
+    await stale
+
+    assert painted == []
+    assert controller._active_character_avatar is None
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_character_avatar_copy_budget.py
+++ b/Tests/UI/test_console_character_avatar_copy_budget.py
@@ -1,0 +1,251 @@
+"""TASK-22204: transcript-copy budget for the Console avatar tick.
+
+PR #2020 (streaming emotes) made `_current_request` resolve the expression
+state twice and made `_request_is_current` re-enter `_current_request`, so a
+repainting 0.2 s tick paid 4-12 whole-transcript `dataclasses.replace` copy
+passes through `store.messages_for_session`. These probes pin the budget: a
+full paint tick pays exactly ONE `messages_for_session` copy, and the
+race-fence checks pay ZERO. Reintroducing an unshared second resolution (the
+22204 mutation) turns the first probe red.
+
+The harness drives the real ``ConsoleCharacterController`` and the real
+``ConsoleChatStore`` (streaming assistant message included, so the
+idle/operational double-resolution gate is exercised) with plain late-bound
+edges, mirroring ``Tests/UI/test_console_character_controller.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
+
+
+async def _noop_async(*_args: object, **_kwargs: object) -> None:
+    return None
+
+
+class _FakeImageCache:
+    """Minimal stand-in for the console image cache used by the paint path."""
+
+    def prepare(self, _key: str, _image_bytes: bytes) -> bool:
+        return True
+
+    def get_pil(self, _key: str) -> object:
+        return object()
+
+
+def _operational_resolution() -> SimpleNamespace:
+    """One resolvable expression identity for the operational paint path."""
+
+    return SimpleNamespace(
+        image_bytes=b"fake-png-bytes",
+        asset_id=11,
+        resolved_expression_key="speaking",
+        resolution_source="pack_operational",
+        cache_identity=(
+            "actor_kind=character",
+            "actor_id=7",
+            "expression=speaking",
+        ),
+    )
+
+
+def _count_transcript_copies(store: ConsoleChatStore) -> dict[str, int]:
+    """Shadow ``messages_for_session`` on the instance with a call counter."""
+
+    counter = {"copies": 0}
+    original = store.messages_for_session
+
+    def counting(session_id: str):
+        counter["copies"] += 1
+        return original(session_id)
+
+    store.messages_for_session = counting  # type: ignore[method-assign]
+    return counter
+
+
+def _streaming_store() -> tuple[ConsoleChatStore, str]:
+    """Real store with a user turn and a still-streaming assistant message."""
+
+    store = ConsoleChatStore()
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="hello"
+    )
+    message = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    store.append_stream_chunk(message.id, "streamed prose")
+    return store, session.id
+
+
+def _avatar_controller(
+    store: ConsoleChatStore | None,
+    session_id: str | None,
+    *,
+    painted: list[dict | None],
+    fence_results: list[bool] | None = None,
+    is_mounted=lambda: True,
+    actor_scope_accessor=None,
+    resolve_visual_identity=None,
+) -> ConsoleCharacterController:
+    """Real controller wired for the avatar paint path with recording edges."""
+
+    if actor_scope_accessor is None:
+        scope = (session_id, "character", "7") if session_id else None
+        actor_scope_accessor = lambda: scope  # noqa: E731
+    if resolve_visual_identity is None:
+        resolution = _operational_resolution()
+        resolve_visual_identity = (  # noqa: E731
+            lambda _scope, _state, _manual: resolution
+        )
+
+    async def render(
+        *,
+        spec: dict | None,
+        name: str | None,
+        manual_label: str | None,
+        is_current,
+    ) -> None:
+        # Mirror the real screen edge: it consults the fence before mutating
+        # the DOM. Under pre-22204 code every one of these re-entered
+        # `_current_request` and paid 2 more transcript copies.
+        alive = is_current()
+        if fence_results is not None:
+            fence_results.append(alive)
+        painted.append(spec)
+
+    dependencies: dict[str, Any] = {
+        "app_config_accessor": lambda: {},
+        "chat_store_accessor": lambda: store,
+        "active_native_session_accessor": lambda: None,
+        "current_conversation_id_accessor": lambda: None,
+        "character_db_accessor": lambda: None,
+        "ensure_chat_store": ConsoleChatStore,
+        "provider_readiness_config_accessor": lambda: {},
+        "default_session_settings": lambda: ConsoleSessionSettings(),
+        "swap_session_character": lambda *_args, **_kwargs: False,
+        "sync_temporary_chip": lambda: None,
+        "sync_native_chat_ui": _noop_async,
+        "notify": lambda *_args, **_kwargs: None,
+        "actor_scope_accessor": actor_scope_accessor,
+        "manual_reaction_key": lambda _scope: None,
+        "resolve_visual_identity": resolve_visual_identity,
+        "resolve_historical_visual_identity": lambda *_args: None,
+        "ensure_console_image_view": lambda: (None, _FakeImageCache()),
+        "console_image_default_mode": lambda: "pixels",
+        "is_mounted": is_mounted,
+        "render_character_avatar": render,
+    }
+    return ConsoleCharacterController(**dependencies)
+
+
+@pytest.mark.asyncio
+async def test_streaming_repaint_tick_pays_exactly_one_transcript_copy() -> None:
+    """A full paint tick (build + every fence check) copies the transcript once."""
+
+    store, session_id = _streaming_store()
+    painted: list[dict | None] = []
+    fence_results: list[bool] = []
+    controller = _avatar_controller(
+        store, session_id, painted=painted, fence_results=fence_results
+    )
+    counter = _count_transcript_copies(store)
+
+    await controller._refresh_active_character_avatar_if_scope_changed()
+
+    # The paint genuinely happened (operational "speaking" for a streaming
+    # assistant message) and the fence agreed it was current -- so every
+    # fence site on the paint path really ran before the count is read.
+    assert fence_results == [True]
+    assert len(painted) == 1
+    assert painted[0] is not None
+    assert painted[0]["state"] == "speaking"
+    assert counter["copies"] == 1
+
+
+@pytest.mark.asyncio
+async def test_steady_state_tick_pays_at_most_one_transcript_copy() -> None:
+    """An unchanged follow-up tick (request-key dedupe) stays within budget."""
+
+    store, session_id = _streaming_store()
+    painted: list[dict | None] = []
+    controller = _avatar_controller(store, session_id, painted=painted)
+    await controller._refresh_active_character_avatar_if_scope_changed()
+    counter = _count_transcript_copies(store)
+
+    await controller._refresh_active_character_avatar_if_scope_changed()
+
+    assert len(painted) == 1  # deduped: no second paint
+    assert counter["copies"] <= 1
+
+
+@pytest.mark.asyncio
+async def test_zero_message_session_tick_is_idle_and_within_budget() -> None:
+    """A session with no messages resolves idle in at most one copy."""
+
+    store = ConsoleChatStore()
+    session = store.ensure_session(title="Empty")
+    painted: list[dict | None] = []
+    controller = _avatar_controller(store, session.id, painted=painted)
+    counter = _count_transcript_copies(store)
+
+    await controller._refresh_active_character_avatar_if_scope_changed()
+
+    assert len(painted) == 1
+    assert painted[0] is not None
+    assert painted[0]["state"] == "idle"
+    assert counter["copies"] <= 1
+
+
+@pytest.mark.asyncio
+async def test_mid_teardown_tick_never_paints_and_never_raises() -> None:
+    """Unmounting during off-thread resolution drops the paint, fail-soft."""
+
+    store, session_id = _streaming_store()
+    painted: list[dict | None] = []
+    mounted = {"value": True}
+    resolution = _operational_resolution()
+
+    def resolve_and_unmount(_scope, _state, _manual):
+        # Runs inside asyncio.to_thread during the refresh: the screen goes
+        # away while the expression is being resolved.
+        mounted["value"] = False
+        return resolution
+
+    controller = _avatar_controller(
+        store,
+        session_id,
+        painted=painted,
+        is_mounted=lambda: mounted["value"],
+        resolve_visual_identity=resolve_and_unmount,
+    )
+
+    await controller._refresh_active_character_avatar_if_scope_changed()
+
+    assert painted == []
+
+
+@pytest.mark.asyncio
+async def test_storeless_teardown_tick_is_a_safe_noop() -> None:
+    """A tick after the store handle is gone neither copies nor raises."""
+
+    painted: list[dict | None] = []
+    controller = _avatar_controller(
+        None,
+        None,
+        painted=painted,
+        is_mounted=lambda: False,
+        actor_scope_accessor=lambda: None,
+    )
+
+    await controller._refresh_active_character_avatar_if_scope_changed()
+
+    assert painted == []

--- a/backlog/tasks/task-22204 - Resolve-the-Console-expression-state-once-per-tick-and-stop-re-copying-the-transcript.md
+++ b/backlog/tasks/task-22204 - Resolve-the-Console-expression-state-once-per-tick-and-stop-re-copying-the-transcript.md
@@ -2,8 +2,10 @@
 id: TASK-22204
 title: >-
   Resolve the Console expression state once per tick and stop re-copying the transcript
-status: To Do
-assignee: []
+status: Done
+updated_date: '2026-08-24'
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
 labels:
   - performance
@@ -35,7 +37,128 @@ for the avatar path.
 
 ## Acceptance Criteria
 
-- [ ] One `messages_for_session` copy at most per avatar refresh per tick (reuse `selection.state`; make `_request_is_current` compare against the already-built request) — proven by a call-count probe during a simulated streaming tick
-- [ ] Emote/idle/operational selection behavior unchanged (existing expression tests green)
-- [ ] Stretch (may split to a follow-up): a single shared per-tick transcript snapshot consumed by the avatar, guidance, and cost-chip paths, with the seam documented
-- [ ] Per-tick copy count during streaming measured before/after
+- [x] One `messages_for_session` copy at most per avatar refresh per tick (shared snapshot through both resolutions; `_request_is_current` compares against the already-built request) — proven by a call-count probe during a simulated streaming tick (`Tests/UI/test_console_character_avatar_copy_budget.py`)
+- [x] Emote/idle/operational selection behavior unchanged (existing expression tests green — 218 passed across the avatar/emote/expression files; one test stub's signature widened to accept the new kwarg, its assertions untouched)
+- [x] Stretch — DECLINED for this task via this AC's own split-to-follow-up escape hatch: a shared per-tick snapshot across avatar/guidance/cost-chip crosses three controllers with different staleness contracts and needs its own invalidation design; reason recorded in Implementation Notes, direction stays documented under finding 22204 in `Docs/Design/2026-08-24-holistic-perf-review.md`
+- [x] Per-tick copy count during streaming measured before/after (300-message session: repaint tick 8.0 → 1.0 copies, median 7.17 ms → 0.93 ms; steady tick 2.0 → 1.0 copies, 1.80 ms → 0.85 ms)
+
+## Implementation Plan
+
+1. Semantics first: establish why `_current_request` re-runs
+   `resolve_console_expression_state` after
+   `resolve_console_expression_selection` for idle/operational sources.
+   Finding (git `7bd039077`, PR #2020): pre-#2020 the method called only
+   `resolve_console_expression_state`; #2020 added the selection call and kept
+   the legacy call gated to idle/operational — over one message snapshot the
+   two are provably identical for those sources (the explicit params only
+   change the streaming+matching branch, which yields source `explicit`, and
+   mood-label completes yield `historical`; both are excluded by the gate).
+   The retained call is (a) a defensive legacy fallback and (b) the
+   monkeypatch seam eight existing avatar tests drive states through — so it
+   must SURVIVE, not be deleted.
+2. Add a keyword-only `messages=None` pre-fetched-snapshot parameter to both
+   resolvers in `Chat/console_expression_state.py`;
+   `resolve_console_expression_state` forwards it. `None` keeps today's
+   fetch-and-fail-soft behavior byte-for-byte.
+3. `_current_request` fetches `store.messages_for_session(...)` exactly once
+   (same guards the resolver uses: react on, store and session present;
+   exception → empty snapshot, which resolves idle exactly like today's
+   except-path) and passes that one snapshot to BOTH resolver calls.
+4. Fence: store the last-built request on the controller
+   (`_latest_built_request`, written by `_current_request`); change
+   `_request_is_current` to compare against it instead of re-entering
+   `_current_request`. Freshness is tick-bound (the 0.2 s sync tick rebuilds
+   it). The avatar-hidden early return in `_refresh_avatar_request` clears it
+   so paints in flight across a visibility toggle still drop; `_is_mounted`
+   stays in the fence for teardown.
+5. Red-first probe: new `Tests/UI/test_console_character_avatar_copy_budget.py`
+   drives the real `ConsoleCharacterController` + real `ConsoleChatStore`
+   (streaming assistant message) through one full paint tick with
+   `messages_for_session` wrapped by a counter; assert exactly 1 copy per
+   tick (red on current code: 10+), plus zero-message and mid-teardown
+   failure paths, plus a resolver-snapshot unit test in
+   `Tests/Chat/test_console_expression_state.py`.
+6. Measure per-tick copies and wall time before/after with a 300-message
+   synthetic session (scratch harness, both numbers into Implementation
+   Notes).
+7. Adapt the one strict-signature test stub
+   (`test_decode_completion_live_fences_every_avatar_request_input`) to accept
+   the new kwarg; run the avatar/expression/emote-adjacent test files +
+   `--collect-only` sweep + `./scripts/preflight.sh`, tee everything.
+8. Mutation test: reintroduce an unshared second resolution and confirm the
+   probe reds; revert.
+
+## Implementation Notes
+
+Restored the pin's one-transcript-copy-per-tick budget for the Console avatar
+path without changing what any tick resolves.
+
+**Why the double call existed (the semantics question).** Pre-#2020,
+`_current_request` called only `resolve_console_expression_state`. PR #2020
+(`7bd039077`) added `resolve_console_expression_selection` for explicit/
+historical emotes and KEPT the legacy call gated to idle/operational sources.
+Over one message snapshot the two are provably identical for those sources:
+the explicit parameters only alter the streaming-and-matching branch (which
+returns source `explicit`), and a mood-labelled complete returns `historical`
+— both excluded by the gate; every other path is byte-identical code. The
+retained call's real value is (a) a defensive fallback and (b) the seam eight
+avatar tests monkeypatch (`character.resolve_console_expression_state`) to
+drive operational states without message fixtures. So it was PRESERVED, not
+deleted: both resolvers now accept a keyword-only pre-fetched `messages`
+snapshot, `_current_request` fetches once and passes it to both calls, and a
+monkeypatched state resolver still overrides the state exactly as before.
+
+**Fence.** `_request_is_current` no longer re-enters `_current_request` (2
+copies per check); it compares against `_latest_built_request`, which every
+build writes. Freshness is tick-bound: the 0.2 s sync tick rebuilds it each
+pass, so a world change fences an in-flight paint at the next rebuild — at
+most one tick later, and immediately for forced refreshes (the existing
+stale-paint race tests, which insert a rebuild between mutation and release,
+pass unchanged for every context-change parametrization). The avatar-hidden
+early return and `_invalidate_actor` clear the baseline so in-flight paints
+drop across a visibility toggle or actor invalidation; `_is_mounted()` stays
+in the fence for teardown.
+
+**Persistence-timing check (read-that-writes).** `messages_for_session`
+folds stream buffers and may persist a newly materialized pending row.
+Verified idempotent: `_fold_stream_buffer_without_persistence` no-ops when
+`_stream_materialized_counts` already matches the buffer, and
+`_persist_pending_message_if_ready` no-ops once `_persist_new_message`
+discards the id from `_pending_persistence_message_ids`. Within one
+synchronous tick the 2nd–14th calls were therefore pure copies; dropping them
+moves nothing observable — the one remaining call per tick still folds and
+persists at the same tick boundary.
+
+**Measured (300-message synthetic session, 200 ticks, real store + real
+controller).** Repaint tick: 8.0 → 1.0 copies/tick, median 7.17 ms → 0.93 ms.
+Steady (deduped) tick: 2.0 → 1.0 copies, median 1.80 ms → 0.85 ms. Cold
+full-paint tick in the probe: 14 copies before, exactly 1 after.
+
+**Mutation-tested.** Reintroducing an unshared second resolution reds the
+probe (2 copies, 3 tests fail); making the fence re-entrant again also reds
+it (7 copies, 2 tests fail). Restores verified byte-identical to the commit.
+
+**Stretch AC declined** (allowed by its own wording): a shared per-tick
+transcript snapshot for avatar + guidance + cost-chip spans three consumers
+in different controllers with different staleness contracts (the control-bar
+comment at `chat_screen.py` explicitly withdrew one-tuple-per-tick reuse for
+the rail-visibility half after PR #660 caught a staleness regression). That
+seam needs its own invalidation design and review; bolting it on here
+inflates risk for a task whose finding is the avatar path. Direction remains
+documented under finding 22204 in the holistic perf review.
+
+**Files.** `tldw_chatbook/Chat/console_expression_state.py` (snapshot
+parameter on both resolvers), `tldw_chatbook/UI/Console_Modules/character.py`
+(shared snapshot; non-re-entrant fence; baseline clears),
+`Tests/UI/test_console_character_avatar_copy_budget.py` (new probes: budget,
+steady-state, zero-message, mid-teardown, storeless teardown),
+`Tests/Chat/test_console_expression_state.py` (snapshot-path unit tests),
+`Tests/UI/test_console_character_avatar.py` (one stub signature widened).
+
+**Not mine, found on the way:**
+`Tests/Chat/test_console_chat_controller.py::test_provider_switch_ignores_
+unrelated_completed_continuation_history` errors at TEARDOWN on any machine
+without a cached tiktoken `o200k_base` encoding — `token_counter.
+get_tiktoken_encoding` tries to download it and the network guard blocks the
+egress (same class as the CI blocked-HF-egress finding). Reproduced
+byte-for-byte on base `983aa5878` with this task's files reverted.

--- a/tldw_chatbook/Chat/console_expression_state.py
+++ b/tldw_chatbook/Chat/console_expression_state.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 
@@ -50,6 +51,7 @@ def resolve_console_expression_selection(
     react_enabled: bool,
     explicit_message_id: str | None = None,
     explicit_state: str | None = None,
+    messages: Sequence[Any] | None = None,
 ) -> ConsoleExpressionSelection:
     """Return the operational, live-explicit, or final historical selection.
 
@@ -59,6 +61,12 @@ def resolve_console_expression_selection(
         react_enabled: Whether automatic character reactions are enabled.
         explicit_message_id: Streaming message associated with an explicit event.
         explicit_state: Most recent normalized explicit state for that message.
+        messages: Optional pre-fetched transcript snapshot for
+            ``active_session_id``. When provided, the store is not consulted:
+            ``messages_for_session`` replace-copies every message per call, so
+            a caller resolving more than once per tick fetches one snapshot
+            and shares it (TASK-22204). ``None`` keeps the fetch-and-fail-soft
+            behavior.
 
     Returns:
         The precedence-resolved selection before manual display overrides.
@@ -67,10 +75,11 @@ def resolve_console_expression_selection(
     idle = ConsoleExpressionSelection("idle", "idle")
     if not react_enabled or active_session_id is None or store is None:
         return idle
-    try:
-        messages = store.messages_for_session(active_session_id)
-    except Exception:
-        return idle
+    if messages is None:
+        try:
+            messages = store.messages_for_session(active_session_id)
+        except Exception:
+            return idle
     for message in reversed(messages):
         if getattr(message, "role", None) is not ConsoleMessageRole.ASSISTANT:
             continue
@@ -115,11 +124,24 @@ def resolve_console_expression_state(
     active_session_id,
     *,
     react_enabled: bool,
+    messages: Sequence[Any] | None = None,
 ) -> str:
-    """Return the legacy state string for callers without live-event context."""
+    """Return the legacy state string for callers without live-event context.
+
+    Args:
+        store: Console chat store that owns the session messages.
+        active_session_id: Session whose latest assistant message controls state.
+        react_enabled: Whether automatic character reactions are enabled.
+        messages: Optional pre-fetched transcript snapshot, forwarded to
+            :func:`resolve_console_expression_selection` (TASK-22204).
+
+    Returns:
+        The resolved expression state string.
+    """
 
     return resolve_console_expression_selection(
         store,
         active_session_id,
         react_enabled=react_enabled,
+        messages=messages,
     ).state

--- a/tldw_chatbook/UI/Console_Modules/character.py
+++ b/tldw_chatbook/UI/Console_Modules/character.py
@@ -9,7 +9,7 @@ framework worker/modal edges and final Textual mutation remain named callbacks.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import replace
 from functools import partial
 from typing import Any, Literal
@@ -114,6 +114,10 @@ class ConsoleCharacterController:
         self._active_character_avatar_name: str | None = None
         self._last_console_avatar_scope: Any | None = None
         self._last_console_avatar_request_key: Any | None = None
+        # TASK-22204: the most recently BUILT avatar request; the staleness
+        # fence compares against it instead of re-deriving the world (see
+        # `_request_is_current`).
+        self._latest_built_request: AvatarRequest | None = None
         self._console_expression_spec_cache: dict[tuple[str, ...], dict] = {}
         self._character_emote_cursor_by_session: dict[str, int] = {}
         self._character_emote_explicit_by_session: dict[str, tuple[str, str]] = {}
@@ -281,17 +285,38 @@ class ConsoleCharacterController:
         explicit_message_id, explicit_state = (
             self._character_emote_explicit_by_session.get(session_id, (None, None))
         )
+        # TASK-22204: fetch the transcript snapshot ONCE and share it across
+        # both resolutions below. `messages_for_session` replace-copies every
+        # message (after folding live stream buffers), and this method runs on
+        # the 0.2 s sync tick; the pre-22204 shape re-fetched it here twice
+        # and again inside every `_request_is_current` fence check. The empty
+        # snapshot on failure resolves idle exactly like the resolver's own
+        # fetch-and-fail-soft path.
+        messages: Sequence[Any] = ()
+        if react and store is not None and session_id is not None:
+            try:
+                messages = store.messages_for_session(session_id)
+            except Exception:
+                messages = ()
         selection = resolve_console_expression_selection(
             store,
             session_id,
             react_enabled=react,
             explicit_message_id=explicit_message_id,
             explicit_state=explicit_state,
+            messages=messages,
         )
         state = selection.state
         if selection.source in {"idle", "operational"}:
+            # Retained from PR #2020: for non-explicit, non-historical sources
+            # the legacy resolver still owns the state string (this call is
+            # also the seam the avatar tests monkeypatch to drive states). It
+            # now reuses the snapshot instead of re-copying the transcript --
+            # over one snapshot the two resolutions are provably identical for
+            # these sources, because the explicit parameters only alter the
+            # streaming+matching branch (source "explicit").
             state = resolve_console_expression_state(
-                store, session_id, react_enabled=react
+                store, session_id, react_enabled=react, messages=messages
             )
         manual = self._manual_reaction_key(actor) if actor else None
         source: AvatarRequestSource = selection.source
@@ -302,7 +327,7 @@ class ConsoleCharacterController:
             source = "manual"
             history_identity = None
             message_id = None
-        return (
+        request: AvatarRequest = (
             actor,
             state,
             manual,
@@ -315,6 +340,8 @@ class ConsoleCharacterController:
             message_id,
             history_identity,
         )
+        self._latest_built_request = request
+        return request
 
     async def _consume_character_emote_events(self) -> bool:
         """Advance the active feed and paint each eligible live beat in order."""
@@ -351,9 +378,25 @@ class ConsoleCharacterController:
         return painted
 
     def _request_is_current(self, request: AvatarRequest) -> bool:
-        return self._current_request() == request and self._is_mounted()
+        """Race fence: is ``request`` still the newest built avatar request?
+
+        TASK-22204: compares against the most recently built request instead
+        of re-entering `_current_request` (which re-copied the whole
+        transcript per check -- 4-6 copies per repainting 0.2 s tick).
+        Freshness is tick-bound: the sync tick rebuilds
+        `_latest_built_request` on every pass, so an in-flight paint made
+        stale by a world change is fenced by the first rebuild that observes
+        it (at most one tick later, immediately for every forced refresh).
+        The mounted check keeps teardown paints out unchanged.
+        """
+        return request == self._latest_built_request and self._is_mounted()
 
     def _invalidate_actor(self, actor_kind: str, actor_id: str) -> None:
+        # TASK-22204: the actor's cached identities are no longer
+        # trustworthy, so neither is any paint still in flight -- drop the
+        # fence baseline; the forced refresh that always follows this call
+        # rebuilds it and repaints fresh.
+        self._latest_built_request = None
         actor_tokens = (f"actor_kind={actor_kind}", f"actor_id={actor_id}")
 
         def belongs_to_actor(identity: tuple[str, ...]) -> bool:
@@ -440,6 +483,10 @@ class ConsoleCharacterController:
             self._active_character_avatar_name = None
             self._last_console_avatar_scope = None
             self._last_console_avatar_request_key = None
+            # TASK-22204: this early return never rebuilds the request, so
+            # drop the fence baseline explicitly -- any paint still in flight
+            # from before the avatar was hidden must fail its fence check.
+            self._latest_built_request = None
             return
 
         request = self._current_request()


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22204). PR #2020's streaming-emote wiring made the default-ON avatar path copy the whole transcript 2-14× per 0.2 s run tick (double expression resolution + a re-entrant staleness fence). 

**Change:** both resolvers in `Chat/console_expression_state.py` accept a pre-fetched `messages` snapshot; `_current_request` fetches once and shares it; `_request_is_current` compares against the stored `_latest_built_request` instead of re-resolving (with fence clears on avatar-hide and actor-invalidate). The second resolver call is preserved — it is the monkeypatch seam eight avatar tests drive — just fed the shared snapshot.

**Measured** (300-msg session, 200 ticks, real store+controller): repaint tick **8.0 → 1.0 copies** (median 7.17 → 0.93 ms); steady tick 2.0 → 1.0; cold full paint 14 → 1.

**Adversarial review: SHIP**, with one review commit: mutation-testing found the avatar-hidden fence clear was load-bearing and uncovered (a paint blocked in the resolver could apply while hidden — probe-proven), so the review added the missing race test (red under the mutation). Equivalence of the shared-snapshot resolution was verified by exhaustive enumeration (0 mismatches for idle/operational); the one behavioral delta vs old code is snapshot-coherence where old code could produce incoherent mid-tick hybrids. Persistence timing proven identical (1 effective fold+persist per tick, both shapes). The known residual — a ≤1-build visual transient when the world changes between build and apply with no later rebuild — is documented in the fence docstring and converges on the next tick.

Stretch AC (one shared snapshot across avatar/guidance/cost-chip) declined with reasons in the task notes; the direction stays filed under finding 22204.

Tests: targeted 137 passed (review scope) / 218 passed (implementer scope); controller file 194/194 + 1 pre-existing tiktoken-download teardown error (reproduced on base); preflight all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts Console avatar transcript copies from 2–14 per 0.2 s tick to exactly one by resolving from a shared snapshot and comparing paints to the last built request. Old behavior double-resolved and re-fetched in the fence; new behavior shares one fetch per tick and fences with a cached baseline, reducing repaint time without changing selection semantics.

**Refactors**
- Adds an optional `messages` snapshot kwarg to both resolvers; omission preserves existing behavior.
- `_current_request` fetches the transcript once and passes it to both resolver calls.
- `_request_is_current` compares against `_latest_built_request` instead of re-deriving state; the baseline is cleared on avatar hide and actor invalidate.
- Meets TASK-22204’s budget of one `messages_for_session` copy per tick; new tests pin the copy budget and the hidden-avatar fence.

<sup>Written for commit 1071880ec4c1f1e4a8bf27a9228557b4ee2d18d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

