### PR TITLE
perf(chat): conversation resume O(N²)→O(N) — one narrow query, iterative build, batched image hydration (TASK-22206)

### DIFF
--- a/Tests/Chat/test_chat_conversation_service.py
+++ b/Tests/Chat/test_chat_conversation_service.py
@@ -31,6 +31,10 @@ class FakeDB:
     child_messages: dict[tuple[str, tuple[str, ...], str], list[dict[str, Any]]] = (
         field(default_factory=dict)
     )
+    tree_rows: dict[tuple[str, str], list[dict[str, Any]]] = field(
+        default_factory=dict
+    )
+    images_by_message_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     latest_message: dict[str, dict[str, Any] | None] = field(default_factory=dict)
     messages_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     messages_by_conversation: dict[tuple[str, int, int, str], list[dict[str, Any]]] = (
@@ -210,6 +214,32 @@ class FakeDB:
         return self.child_messages.get(
             (conversation_id, tuple(parent_ids), order_by_timestamp), []
         )
+
+    def get_message_tree_rows_for_conversation(
+        self,
+        conversation_id,
+        order_by_timestamp="ASC",
+        include_deleted_conversation=False,
+    ):
+        self.calls.append(
+            (
+                "get_message_tree_rows_for_conversation",
+                (conversation_id,),
+                {
+                    "order_by_timestamp": order_by_timestamp,
+                    "include_deleted_conversation": include_deleted_conversation,
+                },
+            )
+        )
+        return self.tree_rows.get((conversation_id, order_by_timestamp), [])
+
+    def get_message_images_by_ids(self, message_ids):
+        self.calls.append(("get_message_images_by_ids", (tuple(message_ids),), {}))
+        return {
+            message_id: dict(self.images_by_message_id[message_id])
+            for message_id in message_ids
+            if message_id in self.images_by_message_id
+        }
 
     def get_message_by_id(self, message_id):
         self.calls.append(("get_message_by_id", (message_id,), {}))
@@ -1018,9 +1048,11 @@ def test_get_conversation_tree_wraps_root_and_child_rows():
                 "version": 1,
             }
         },
-        root_counts={"conv-1": 2},
-        root_messages={
-            ("conv-1", 50, 0, "ASC"): [
+        # TASK-22206: the tree is assembled from ONE conversation-scoped
+        # fetch (timestamp order, roots and children interleaved) instead of
+        # the old per-parent query fan-out.
+        tree_rows={
+            ("conv-1", "ASC"): [
                 {
                     "id": "msg-root-1",
                     "conversation_id": "conv-1",
@@ -1047,14 +1079,6 @@ def test_get_conversation_tree_wraps_root_and_child_rows():
                     "is_selected_variant": None,
                     "total_variants": None,
                 },
-            ]
-        },
-        child_messages={
-            (
-                "conv-1",
-                ("msg-root-1",),
-                "ASC",
-            ): [
                 {
                     "id": "msg-child-1",
                     "conversation_id": "conv-1",
@@ -1067,7 +1091,7 @@ def test_get_conversation_tree_wraps_root_and_child_rows():
                     "variant_number": 2,
                     "is_selected_variant": 1,
                     "total_variants": 2,
-                }
+                },
             ]
         },
     )

--- a/Tests/Chat/test_chat_conversation_service_tree_build.py
+++ b/Tests/Chat/test_chat_conversation_service_tree_build.py
@@ -1,0 +1,506 @@
+"""TASK-22206: the conversation-tree build must be O(N), iterative, BLOB-lazy.
+
+The pre-22206 ``ChatConversationService._build_message_tree`` recursed once per
+message and issued one ``get_messages_for_conversation_by_parent_ids`` call per
+node; with ``sqlite_stat1`` absent every one of those calls post-filtered a full
+``idx_msgs_conv_ts`` scan, hydrating every ``image_data`` BLOB N times, and the
+recursion depth equalled the conversation length (RecursionError at ~980-message
+linear chains -- the default recursion limit is 1000).
+
+These tests pin the replacement:
+
+* ``test_2000_message_linear_chain_resumes_without_recursion_error`` -- red
+  before the fix (RecursionError in both the service build and the resume
+  flattener) -- drives the full resume tree path at 2x the old breaking depth.
+* ``test_new_build_matches_legacy_recursive_build_on_branched_fixture`` -- the
+  legacy recursive algorithm is ported verbatim below as the oracle and both
+  builds run against the same real SQLite file; output must be identical
+  (sibling order, parenthood, roots, deep branch, image bytes, pagination,
+  depth-cap truncation, DESC ordering).
+* ``test_tree_build_query_count_is_independent_of_message_count`` -- red before
+  the fix (the statement count grew linearly with N) -- a
+  ``set_trace_callback`` probe asserts O(1) statements per
+  ``get_conversation_tree`` and that image hydration is exactly one extra
+  batched statement, present only when the conversation actually has images.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+import pytest
+
+from tldw_chatbook.Chat.chat_conversation_service import (
+    ChatConversationService,
+    normalize_message_row,
+)
+from tldw_chatbook.Chat.console_conversation_hydration import (
+    console_messages_from_conversation_tree,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path):
+    database = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test-client")
+    try:
+        yield database
+    finally:
+        database.close_connection()
+
+
+def _ts(index: int) -> str:
+    """Strictly increasing, lexicographically ordered timestamps."""
+    return f"2026-01-01T00:00:00.{index:06d}Z"
+
+
+def _add_message(
+    db: CharactersRAGDB,
+    conversation_id: str,
+    *,
+    index: int,
+    parent_message_id: str | None,
+    content: str | None = None,
+    sender: str | None = None,
+    image_data: bytes | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "conversation_id": conversation_id,
+        "sender": sender or ("user" if index % 2 == 0 else "assistant"),
+        "content": content if content is not None else f"message {index}",
+        "parent_message_id": parent_message_id,
+        "timestamp": _ts(index),
+    }
+    if image_data is not None:
+        payload["image_data"] = image_data
+        payload["image_mime_type"] = "image/png"
+    message_id = db.add_message(payload)
+    assert message_id is not None
+    return message_id
+
+
+def _add_linear_chain(
+    db: CharactersRAGDB, conversation_id: str, count: int
+) -> list[str]:
+    ids: list[str] = []
+    parent: str | None = None
+    with db.transaction():  # one commit for the whole fixture
+        for index in range(count):
+            parent = _add_message(
+                db, conversation_id, index=index, parent_message_id=parent
+            )
+            ids.append(parent)
+    return ids
+
+
+def _build_branched_fixture(db: CharactersRAGDB, conversation_id: str) -> dict[str, str]:
+    """Two roots; root one carries siblings, an image, and a deep branch.
+
+    root1                      root2
+      +- a (image)
+      |    +- a1
+      |    +- a2
+      |         +- deep0 .. deep9   (10-deep chain)
+      +- b
+    """
+    ids: dict[str, str] = {}
+    with db.transaction():
+        ids["root1"] = _add_message(
+            db, conversation_id, index=0, parent_message_id=None, content="root one"
+        )
+        ids["a"] = _add_message(
+            db,
+            conversation_id,
+            index=1,
+            parent_message_id=ids["root1"],
+            content="branch a",
+            image_data=b"\x89PNG-fake-bytes-a",
+        )
+        ids["b"] = _add_message(
+            db,
+            conversation_id,
+            index=2,
+            parent_message_id=ids["root1"],
+            content="branch b",
+        )
+        ids["a1"] = _add_message(
+            db, conversation_id, index=3, parent_message_id=ids["a"], content="a1"
+        )
+        ids["a2"] = _add_message(
+            db, conversation_id, index=4, parent_message_id=ids["a"], content="a2"
+        )
+        parent = ids["a2"]
+        for depth in range(10):
+            parent = _add_message(
+                db,
+                conversation_id,
+                index=5 + depth,
+                parent_message_id=parent,
+                content=f"deep {depth}",
+            )
+            ids[f"deep{depth}"] = parent
+        ids["root2"] = _add_message(
+            db, conversation_id, index=50, parent_message_id=None, content="root two"
+        )
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# the legacy algorithm, ported verbatim as the equivalence oracle
+# ---------------------------------------------------------------------------
+
+
+def _legacy_build_message_tree(
+    db: Any,
+    conversation_id: str,
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    order_by_timestamp: str,
+    depth_cap: int,
+    depth: int,
+    seen_message_ids: set[str],
+) -> list[dict[str, Any]]:
+    """The pre-TASK-22206 recursive one-query-per-node build, verbatim."""
+    nodes: list[dict[str, Any]] = []
+    for row in rows:
+        message_id = row.get("id")
+        normalized_row = normalize_message_row(row)
+        if normalized_row is None:
+            continue
+        if message_id is not None and message_id in seen_message_ids:
+            normalized_row["children"] = []
+            normalized_row["truncated"] = True
+            nodes.append(normalized_row)
+            continue
+
+        next_seen = set(seen_message_ids)
+        if message_id is not None:
+            next_seen.add(message_id)
+
+        if depth >= depth_cap:
+            normalized_row["children"] = []
+            normalized_row["truncated"] = True
+            nodes.append(normalized_row)
+            continue
+
+        child_rows = db.get_messages_for_conversation_by_parent_ids(
+            conversation_id,
+            [message_id] if message_id is not None else [],
+            order_by_timestamp=order_by_timestamp,
+            include_deleted_conversation=False,
+        )
+        normalized_row["children"] = _legacy_build_message_tree(
+            db,
+            conversation_id,
+            child_rows,
+            order_by_timestamp=order_by_timestamp,
+            depth_cap=depth_cap,
+            depth=depth + 1,
+            seen_message_ids=next_seen,
+        )
+        normalized_row["truncated"] = False
+        nodes.append(normalized_row)
+    return nodes
+
+
+def _legacy_get_conversation_tree(
+    service: ChatConversationService,
+    conversation_id: str,
+    *,
+    root_limit: int = 50,
+    root_offset: int = 0,
+    order_by_timestamp: str = "ASC",
+    depth_cap: int = 50,
+) -> dict[str, Any]:
+    """The pre-TASK-22206 ``get_conversation_tree``, verbatim."""
+    conversation = service.get_conversation_metadata(conversation_id)
+    if conversation is None:
+        return {
+            "conversation": None,
+            "root_threads": [],
+            "pagination": {
+                "limit": root_limit,
+                "offset": root_offset,
+                "total_root_threads": 0,
+                "has_more": False,
+            },
+            "depth_cap": depth_cap,
+        }
+
+    total_root_threads = service.db.count_root_messages_for_conversation(
+        conversation_id,
+        include_deleted_conversation=False,
+    )
+    root_rows = service.db.get_root_messages_for_conversation(
+        conversation_id,
+        limit=root_limit,
+        offset=root_offset,
+        order_by_timestamp=order_by_timestamp,
+        include_deleted_conversation=False,
+    )
+    root_threads = _legacy_build_message_tree(
+        service.db,
+        conversation_id,
+        root_rows,
+        order_by_timestamp=order_by_timestamp,
+        depth_cap=depth_cap,
+        depth=1,
+        seen_message_ids=set(),
+    )
+
+    return {
+        "conversation": conversation,
+        "root_threads": root_threads,
+        "pagination": {
+            "limit": root_limit,
+            "offset": root_offset,
+            "total_root_threads": total_root_threads,
+            "has_more": root_offset + len(root_rows) < total_root_threads,
+        },
+        "depth_cap": depth_cap,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) 2000-message linear chain resumes without RecursionError
+# ---------------------------------------------------------------------------
+
+
+def test_2000_message_linear_chain_resumes_without_recursion_error(db):
+    conversation_id = db.add_conversation({"title": "long chain"})
+    assert conversation_id is not None
+    message_ids = _add_linear_chain(db, conversation_id, 2000)
+    service = ChatConversationService(db)
+
+    # The exact caps the resume path uses (load_console_conversation_tree).
+    tree = service.get_conversation_tree(
+        conversation_id, root_limit=10_000, depth_cap=10_000
+    )
+    messages = console_messages_from_conversation_tree(tree, db=db)
+
+    assert len(messages) == 2000
+    assert messages[0].persisted_message_id == message_ids[0]
+    assert messages[0].parent_message_id is None
+    assert messages[-1].persisted_message_id == message_ids[-1]
+    assert messages[-1].parent_message_id == message_ids[-2]
+    assert messages[-1].content == "message 1999"
+    assert tree["pagination"]["total_root_threads"] == 1
+
+
+# ---------------------------------------------------------------------------
+# (b) the new build is byte-identical to the legacy recursive build
+# ---------------------------------------------------------------------------
+
+
+def test_new_build_matches_legacy_recursive_build_on_branched_fixture(db):
+    conversation_id = db.add_conversation({"title": "branched"})
+    assert conversation_id is not None
+    ids = _build_branched_fixture(db, conversation_id)
+    service = ChatConversationService(db)
+
+    new_tree = service.get_conversation_tree(conversation_id)
+    legacy_tree = _legacy_get_conversation_tree(service, conversation_id)
+    assert new_tree == legacy_tree
+
+    # Structural spot-checks so the equality above cannot silently pass on
+    # two identically-empty trees.
+    roots = new_tree["root_threads"]
+    assert [node["id"] for node in roots] == [ids["root1"], ids["root2"]]
+    root1_children = roots[0]["children"]
+    assert [node["id"] for node in root1_children] == [ids["a"], ids["b"]]
+    assert root1_children[0]["image_data"] == b"\x89PNG-fake-bytes-a"
+    assert root1_children[0]["image_mime_type"] == "image/png"
+    assert root1_children[1]["image_data"] is None
+    a_children = root1_children[0]["children"]
+    assert [node["id"] for node in a_children] == [ids["a1"], ids["a2"]]
+    node = a_children[1]
+    for depth in range(10):
+        assert len(node["children"]) == 1
+        node = node["children"][0]
+        assert node["id"] == ids[f"deep{depth}"]
+        assert node["parent_message_id"] == (
+            ids["a2"] if depth == 0 else ids[f"deep{depth - 1}"]
+        )
+    assert node["children"] == []
+    assert node["truncated"] is False
+    assert new_tree["pagination"]["total_root_threads"] == 2
+
+
+def test_new_build_matches_legacy_for_desc_pagination_and_depth_cap(db):
+    conversation_id = db.add_conversation({"title": "branched variants"})
+    assert conversation_id is not None
+    _build_branched_fixture(db, conversation_id)
+    service = ChatConversationService(db)
+
+    for kwargs in (
+        {"order_by_timestamp": "DESC"},
+        {"root_limit": 1, "root_offset": 1},
+        {"root_limit": 1, "root_offset": 0},
+        {"depth_cap": 3},
+        {"depth_cap": 1},
+        {"order_by_timestamp": "DESC", "depth_cap": 4, "root_limit": 1},
+    ):
+        new_tree = service.get_conversation_tree(conversation_id, **kwargs)
+        legacy_tree = _legacy_get_conversation_tree(
+            service, conversation_id, **kwargs
+        )
+        assert new_tree == legacy_tree, f"diverged for {kwargs}"
+
+    # The depth-capped shape itself (not just parity): nodes at the cap are
+    # truncated with no children.
+    capped = service.get_conversation_tree(conversation_id, depth_cap=2)
+    root1 = capped["root_threads"][0]
+    assert root1["truncated"] is False
+    for child in root1["children"]:
+        assert child["truncated"] is True
+        assert child["children"] == []
+
+
+def test_missing_conversation_shape_is_unchanged(db):
+    service = ChatConversationService(db)
+    tree = service.get_conversation_tree("no-such-conversation")
+    assert tree == {
+        "conversation": None,
+        "root_threads": [],
+        "pagination": {
+            "limit": 50,
+            "offset": 0,
+            "total_root_threads": 0,
+            "has_more": False,
+        },
+        "depth_cap": 50,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (c) O(1) statements per tree build; image hydration lazy and batched
+# ---------------------------------------------------------------------------
+
+
+def _trace_statements(db: CharactersRAGDB, fn):
+    connection = db.get_connection()
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
+    try:
+        result = fn()
+    finally:
+        connection.set_trace_callback(None)
+    return result, statements
+
+
+def _message_selects(statements: list[str]) -> list[str]:
+    return [
+        statement
+        for statement in statements
+        if "FROM messages" in statement and statement.lstrip().upper().startswith(
+            "SELECT"
+        )
+    ]
+
+
+def test_tree_build_query_count_is_independent_of_message_count(db):
+    service = ChatConversationService(db)
+
+    small_id = db.add_conversation({"title": "small"})
+    large_id = db.add_conversation({"title": "large"})
+    assert small_id is not None and large_id is not None
+    _add_linear_chain(db, small_id, 40)
+    _add_linear_chain(db, large_id, 120)
+
+    small_tree, small_statements = _trace_statements(
+        db,
+        lambda: service.get_conversation_tree(
+            small_id, root_limit=10_000, depth_cap=10_000
+        ),
+    )
+    large_tree, large_statements = _trace_statements(
+        db,
+        lambda: service.get_conversation_tree(
+            large_id, root_limit=10_000, depth_cap=10_000
+        ),
+    )
+
+    def _count_nodes(tree):
+        count = 0
+        stack = list(tree["root_threads"])
+        while stack:
+            node = stack.pop()
+            count += 1
+            stack.extend(node["children"])
+        return count
+
+    assert _count_nodes(small_tree) == 40
+    assert _count_nodes(large_tree) == 120
+    assert len(small_statements) == len(large_statements), (
+        "statement count grew with conversation size: "
+        f"{len(small_statements)} @40 msgs vs {len(large_statements)} @120 msgs"
+    )
+    assert len(_message_selects(large_statements)) <= 2, (
+        "expected O(1) message reads per tree build, got: "
+        + "\n".join(_message_selects(large_statements))
+    )
+
+
+def test_image_blobs_are_hydrated_lazily_in_one_batched_statement(db):
+    service = ChatConversationService(db)
+
+    plain_id = db.add_conversation({"title": "no images"})
+    imaged_id = db.add_conversation({"title": "images"})
+    assert plain_id is not None and imaged_id is not None
+    _add_linear_chain(db, plain_id, 30)
+    with db.transaction():
+        parent = None
+        for index in range(30):
+            parent = _add_message(
+                db,
+                imaged_id,
+                index=index,
+                parent_message_id=parent,
+                image_data=(b"\x00" * 64 if index in (3, 17) else None),
+            )
+
+    def _image_fetches(statements: list[str]) -> list[str]:
+        # A statement that hydrates the BLOB selects the image_data COLUMN;
+        # the tree read only derives the has_image flag from it.
+        return [
+            statement
+            for statement in _message_selects(statements)
+            if "image_data" in statement and "has_image" not in statement
+        ]
+
+    plain_tree, plain_statements = _trace_statements(
+        db, lambda: service.get_conversation_tree(plain_id, root_limit=10_000)
+    )
+    imaged_tree, imaged_statements = _trace_statements(
+        db, lambda: service.get_conversation_tree(imaged_id, root_limit=10_000)
+    )
+
+    assert _image_fetches(plain_statements) == [], (
+        "an imageless conversation must not read BLOB columns at all"
+    )
+    assert len(_image_fetches(imaged_statements)) == 1, (
+        "image hydration must be one batched statement, got: "
+        + "\n".join(_image_fetches(imaged_statements))
+    )
+
+    def _nodes_with_images(tree):
+        found = []
+        stack = list(tree["root_threads"])
+        while stack:
+            node = stack.pop()
+            if node["image_data"] is not None:
+                found.append(node)
+            stack.extend(node["children"])
+        return found
+
+    assert _nodes_with_images(plain_tree) == []
+    imaged_nodes = _nodes_with_images(imaged_tree)
+    assert len(imaged_nodes) == 2
+    for node in imaged_nodes:
+        assert node["image_data"] == b"\x00" * 64
+        assert node["image_mime_type"] == "image/png"

--- a/backlog/tasks/task-22206 - Conversation-resume-replace-the-O(N-squared)-per-node-message-tree-build.md
+++ b/backlog/tasks/task-22206 - Conversation-resume-replace-the-O(N-squared)-per-node-message-tree-build.md
@@ -157,7 +157,12 @@ on the loop via `chat_conversation_scope_service`. On-loop cost is now linear
 and small: 5.2 ms @600, 21.0 ms @2000 with a 1 KB blob on every message
 (32.1 ms including the flatten) — under the repo's 100 ms worker threshold up
 to roughly 6,000+ messages. The old build exceeded that threshold at ~600
-messages.
+messages. Image-HEAVY bound (adversarial review, temp-file DB): 100 messages
+each carrying a 1 MB blob — 100 MB of position-0 images, well past any
+realistic resume — builds in 41.4 ms median (legacy inline hydration of the
+same fixture: 31.6 ms), still under the worker threshold; total BLOB bytes
+read are unchanged from legacy (the same has_image rows, read once, batched)
+so blob volume cannot regress the loop relative to the old build.
 
 **Tests** (`Tests/Chat/test_chat_conversation_service_tree_build.py`, all
 red-first where the defect allowed):
@@ -198,4 +203,9 @@ passes but its teardown reds on attempted tiktoken-encoding download (network
 guard); `test_console_workspace_dead_rows.py::test_failed_resume_marks_row_broken_with_honest_single_toast`
 (ghost row never renders); 11 `test_console_native_chat_flow.py` failures
 (incl. two resume tests failing on drifted inspector copy — the resume itself
-succeeds there).
+succeeds there). Adversarial review added: `Tests/UI/test_console_launch_wake.py`
+fails 7/11 in this environment at the same first-`submit_draft`
+"Provider destination is incomplete" seeding step — re-baselined at 983aa5878
+in a clean merge-base worktree (import path verified pointing at the
+baseline): the identical 7 tests fail there, so pre-existing, not from this
+change.

--- a/backlog/tasks/task-22206 - Conversation-resume-replace-the-O(N-squared)-per-node-message-tree-build.md
+++ b/backlog/tasks/task-22206 - Conversation-resume-replace-the-O(N-squared)-per-node-message-tree-build.md
@@ -2,8 +2,9 @@
 id: TASK-22206
 title: >-
   Conversation resume: replace the O(N-squared) per-node message-tree build
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
 labels:
   - performance
@@ -31,7 +32,170 @@ a ~980-message linear conversation raises RecursionError on resume.
 
 ## Acceptance Criteria
 
-- [ ] Resume performs O(N) total work: either one conversation-scoped query with in-memory tree assembly, or a per-parent query shape proven by EXPLAIN QUERY PLAN with sqlite_stat1 ABSENT to use `idx_msgs_parent`
-- [ ] BLOB columns are not hydrated during tree construction
-- [ ] A 2000-message linear conversation resumes without RecursionError (iterative build or explicit bound with a graceful path)
-- [ ] Resume time measured before/after at 600+ messages; the walk runs off the event loop or its on-loop time is bounded and stated
+- [x] Resume performs O(N) total work: either one conversation-scoped query with in-memory tree assembly, or a per-parent query shape proven by EXPLAIN QUERY PLAN with sqlite_stat1 ABSENT to use `idx_msgs_parent`
+- [x] BLOB columns are not hydrated during tree construction
+- [x] A 2000-message linear conversation resumes without RecursionError (iterative build or explicit bound with a graceful path)
+- [x] Resume time measured before/after at 600+ messages; the walk runs off the event loop or its on-loop time is bounded and stated
+
+## Implementation Plan
+
+1. Caller census (done before writing code): `get_messages_for_conversation_by_parent_ids`
+   is called in production ONLY by `_build_message_tree`; direct DB-level tests
+   (`test_chat_conversation_parity.py`, `test_provider_continuation.py`) call it and are
+   left untouched — the DB method's semantics do not change. The tree's only production
+   consumers are `console_conversation_hydration.console_messages_from_conversation_tree`
+   (reads content/image_data/usage_json/metadata_json/provider_continuation_json/
+   assistant_generation_state/id/role/sender/children) and the scope/server services
+   (pass-through). `image_data` IS consumed on resume (position-0 legacy attachment), so
+   the tree contract keeps carrying it — it just must not be hydrated N times during the
+   build.
+2. New narrow DB read `get_message_tree_rows_for_conversation(conversation_id, *,
+   order_by_timestamp, include_deleted_conversation=False)`: ONE conversation-scoped
+   query, all columns the old per-parent query selected EXCEPT the `image_data` BLOB,
+   plus `(m.image_data IS NOT NULL) AS has_image`, ordered by `m.timestamp`. EXPLAIN
+   QUERY PLAN recorded on a schema-only scratch DB with `sqlite_stat1` ABSENT (repo rule
+   from TASK-21126) — must drive off `idx_msgs_conv_ts (conversation_id, timestamp)`
+   with no post-filter scan and no temp B-tree.
+3. New batched BLOB fetch `get_message_images_by_ids(message_ids)` (chunked IN(...) at
+   500 ids, mirroring `get_attachments_for_messages`) used AFTER the build, once, only
+   for nodes whose row said `has_image` — zero BLOB reads for imageless conversations.
+4. Rewrite `ChatConversationService.get_conversation_tree`/`_build_message_tree` to:
+   fetch once, partition rows into a children-by-parent map preserving SQL order
+   (per-parent order == the old per-parent query's timestamp order), page roots in
+   memory (offset/limit slice of the parent-IS-NULL rows), assemble iteratively with an
+   explicit stack — preserving depth_cap truncation (`depth >= depth_cap` ⇒
+   `children=[]`, `truncated=True`), the seen-id cycle guard (re-encounter ⇒ truncated),
+   the normalize-None row-drop (drops its subtree), and id-None rows getting
+   `children=[]`. `total_root_threads` computed from the same fetched rows (identical
+   predicate to the old COUNT query).
+5. The resume path recurses once more in `console_messages_from_conversation_tree._walk`
+   (depth == chain length ⇒ same RecursionError at ~1000): convert that walk to an
+   explicit stack too, preserving pre-order.
+6. Red-first tests (Tests/Chat/test_chat_conversation_service_tree_perf.py):
+   (a) 2000-message linear chain through `get_conversation_tree` +
+   `console_messages_from_conversation_tree` — red today with RecursionError;
+   (b) equivalence: new build output == the OLD recursive algorithm (ported verbatim
+   into the test as the reference oracle, running against the same real DB) on a
+   branched fixture — siblings order, parents, roots, deep branch, images;
+   (c) query-count probe via `sqlite3` trace callback: O(1) queries per
+   `get_conversation_tree` regardless of N (and that adding an image adds exactly one
+   batched query, not N).
+7. Update the FakeDB in `Tests/Chat/test_chat_conversation_service.py` to serve the new
+   one-shot read so `test_get_conversation_tree_wraps_root_and_child_rows` exercises the
+   new seam.
+8. Measure resume-build time before/after at 600 and 2000 messages (temp-file DB, 1 KB
+   blobs); decide inline-vs-worker from the measured number (AC allows "bounded and
+   stated").
+9. Mutation test: reintroduce a per-node query into the build, confirm probe (c) reds.
+10. Targeted suites + `--collect-only` sweep, tee everything; `./scripts/preflight.sh`;
+    notes, ACs, Done; commit + push (no PR).
+
+## Implementation Notes
+
+The resume tree build is now ONE conversation-scoped, BLOB-free query plus an
+in-memory iterative assembly, and the resume flattener no longer recurses.
+Measured on a temp-file DB, linear chain, **1 KB image blob on every message**
+(median of repeats; `.taskwork/bench_output.txt` methodology mirrors the
+review's):
+
+| N | before (legacy recursive build) | after (new build) | after (build + resume flatten) |
+|---|---|---|---|
+| 600 | 110.2 ms | **5.2 ms** (21x) | 9.0 ms |
+| 2000 | **RecursionError** at the production recursion limit; 1892.4 ms with the limit raised to 50k | **21.0 ms** (90x) | 32.1 ms |
+
+**Core changes**
+
+- `DB/ChaChaNotes_DB.py`: new `get_message_tree_rows_for_conversation` — one
+  query, all live rows of the conversation, the same columns as the old
+  per-parent query EXCEPT `image_data`, which becomes a
+  `(m.image_data IS NOT NULL) AS has_image` flag; ordered by `m.timestamp` so
+  a stable partition reproduces each parent's child order. New
+  `get_message_images_by_ids` — batched (500-id chunks, mirroring
+  `get_attachments_for_messages`) fetch of the position-0 image columns for
+  exactly the ids that need them. `get_messages_for_conversation_by_parent_ids`
+  is UNCHANGED (its remaining callers are direct DB-level tests; production no
+  longer calls it).
+- `Chat/chat_conversation_service.py`: `get_conversation_tree` fetches once,
+  partitions rows into a children-by-parent map, pages roots in memory
+  (`total_root_threads` computed from the same fetch — identical predicate to
+  the old COUNT query), and `_build_message_tree` assembles the nested nodes
+  with an explicit stack: no recursion, no per-node queries, no per-node
+  `set(seen)` copies (the visited set is global; it differs from the old
+  per-path copy only on inputs a real DB cannot produce — a duplicated primary
+  key). Depth-cap truncation, the seen-id truncation flag, normalize-rejected
+  row subtree drops, id-less rows, and SQL LIMIT/OFFSET edge semantics
+  (negative limit = unbounded, negative offset = 0) are all preserved.
+  `_hydrate_tree_images` then fills `image_data` once, batched, only for
+  `has_image` rows — an imageless conversation performs ZERO BLOB reads
+  (trace-probe-asserted).
+- `Chat/console_conversation_hydration.py`:
+  `console_messages_from_conversation_tree`'s per-node recursive `_walk` was
+  the SECOND RecursionError in the same resume (depth == chain length);
+  it is now an explicit pre-order stack. Fixing only the service build would
+  have left the 2000-message resume red — the red-first test drives the full
+  path and caught it.
+
+**EXPLAIN QUERY PLAN** (schema-only scratch DB, `sqlite_stat1` ABSENT —
+`.taskwork/explain_probe.py`; repo rule from TASK-21126):
+
+```
+-- get_message_tree_rows_for_conversation (ASC and DESC identical) --
+SEARCH c USING INDEX sqlite_autoindex_conversations_1 (id=?)
+SEARCH m USING INDEX idx_msgs_conv_ts (conversation_id=?)
+-- get_message_images_by_ids (IN chunk) --
+SEARCH messages USING INDEX sqlite_autoindex_messages_1 (id=?)
+```
+
+One index-driven range scan over exactly the conversation's rows, no temp
+B-tree in either direction, PK point lookups for images. (The legacy
+per-parent query showed the same `idx_msgs_conv_ts (conversation_id=?)`
+search — i.e. a full-conversation scan with post-filter — PER NODE, which is
+what made the old walk O(N^2).)
+
+**Event-loop decision (AC 4, "bounded and stated")**: the build stays inline
+on the loop via `chat_conversation_scope_service`. On-loop cost is now linear
+and small: 5.2 ms @600, 21.0 ms @2000 with a 1 KB blob on every message
+(32.1 ms including the flatten) — under the repo's 100 ms worker threshold up
+to roughly 6,000+ messages. The old build exceeded that threshold at ~600
+messages.
+
+**Tests** (`Tests/Chat/test_chat_conversation_service_tree_build.py`, all
+red-first where the defect allowed):
+
+- 2000-message linear chain through `get_conversation_tree` +
+  `console_messages_from_conversation_tree` — was `RecursionError`, now green.
+- Equivalence: the legacy recursive algorithm is ported verbatim into the test
+  as the oracle; new output must equal it exactly against the same real SQLite
+  file — branched fixture (two roots, siblings, image, 10-deep branch), plus
+  DESC / root pagination / depth-cap variants, plus structural spot-checks so
+  equality cannot pass on two empty trees.
+- Query-count probes (`sqlite3` trace callback): statement count identical
+  @40 vs @120 messages (was 45 vs 125 — linear); image hydration is exactly one
+  batched statement, present only when the conversation has images.
+- `Tests/Chat/test_chat_conversation_service.py` FakeDB updated to serve the
+  new one-shot read (`tree_rows`/`images_by_message_id`); the wraps-root-and-
+  child-rows assertions are unchanged.
+
+**Mutation test**: reintroducing a per-node
+`get_messages_for_conversation_by_parent_ids` call inside the new build turned
+both probes red (44 vs 124 statements; BLOB probe red) — then the mutation was
+reverted (Edit-based restore). Verified green after restore.
+
+**Verification**: 188 passed / 0 failed across the affected suites
+(conversation service + tree build + hydration + scope/server service + video
+message + generation store + ChaChaNotes parity + provider continuation +
+resume-active-path + launch wake; `.taskwork/final_run.txt`). Whole-suite
+`--collect-only`: 58,548 collected; the 28 collection errors are all
+pre-existing optional-dependency modules (numpy/audio/TTS/transcription/web-
+scraping), none in touched areas. `./scripts/preflight.sh` all green.
+
+**Pre-existing failures encountered (baselined at merge-base 983aa5878 with
+the same venv — identical failures there, NOT introduced by this task)**:
+6 integration e2e tests (`test_console_branching_e2e` etc.) fail at the FIRST
+`submit_draft` with "Provider destination is incomplete";
+`test_console_chat_controller.py::test_provider_switch_ignores_unrelated_completed_continuation_history`
+passes but its teardown reds on attempted tiktoken-encoding download (network
+guard); `test_console_workspace_dead_rows.py::test_failed_resume_marks_row_broken_with_honest_single_toast`
+(ghost row never renders); 11 `test_console_native_chat_flow.py` failures
+(incl. two resume tests failing on drifted inspector copy — the resume itself
+succeeds there).

--- a/tldw_chatbook/Chat/chat_conversation_service.py
+++ b/tldw_chatbook/Chat/chat_conversation_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, cast
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CONVERSATION_SCOPE_ALL
 
@@ -942,25 +942,43 @@ class ChatConversationService:
                 "depth_cap": depth_cap,
             }
 
-        total_root_threads = self.db.count_root_messages_for_conversation(
+        # TASK-22206: ONE conversation-scoped query (no BLOB hydration),
+        # then a purely in-memory, iterative tree assembly. The old shape
+        # issued one get_messages_for_conversation_by_parent_ids call per
+        # node -- each a full-conversation scan under the production query
+        # plan (sqlite_stat1 absent) -- and recursed once per message.
+        rows = self.db.get_message_tree_rows_for_conversation(
             conversation_id,
-            include_deleted_conversation=False,
-        )
-        root_rows = self.db.get_root_messages_for_conversation(
-            conversation_id,
-            limit=root_limit,
-            offset=root_offset,
             order_by_timestamp=order_by_timestamp,
             include_deleted_conversation=False,
         )
-        root_threads = self._build_message_tree(
-            conversation_id,
-            root_rows,
-            order_by_timestamp=order_by_timestamp,
+        children_by_parent: dict[Any, list[Mapping[str, Any]]] = {}
+        root_rows: list[Mapping[str, Any]] = []
+        for row in rows:
+            parent_id = row.get("parent_message_id")
+            if parent_id is None:
+                root_rows.append(row)
+            else:
+                children_by_parent.setdefault(parent_id, []).append(row)
+        # Same predicate the old COUNT query used, computed from the same
+        # fetch (conversation-scoped, live rows, live conversation).
+        total_root_threads = len(root_rows)
+        # Replicate SQL LIMIT/OFFSET semantics for non-positive inputs:
+        # a negative OFFSET is 0, a negative LIMIT means "no limit".
+        effective_offset = max(0, root_offset)
+        if root_limit < 0:
+            paged_root_rows = root_rows[effective_offset:]
+        else:
+            paged_root_rows = root_rows[
+                effective_offset : effective_offset + root_limit
+            ]
+
+        root_threads, image_pending = self._build_message_tree(
+            paged_root_rows,
+            children_by_parent,
             depth_cap=depth_cap,
-            depth=1,
-            seen_message_ids=set(),
         )
+        self._hydrate_tree_images(image_pending)
 
         return {
             "conversation": conversation,
@@ -969,7 +987,7 @@ class ChatConversationService:
                 "limit": root_limit,
                 "offset": root_offset,
                 "total_root_threads": total_root_threads,
-                "has_more": root_offset + len(root_rows) < total_root_threads,
+                "has_more": root_offset + len(paged_root_rows) < total_root_threads,
             },
             "depth_cap": depth_cap,
         }
@@ -1135,50 +1153,98 @@ class ChatConversationService:
 
     def _build_message_tree(
         self,
-        conversation_id: str,
-        rows: Iterable[Mapping[str, Any]],
+        paged_root_rows: Sequence[Mapping[str, Any]],
+        children_by_parent: Mapping[Any, Sequence[Mapping[str, Any]]],
         *,
-        order_by_timestamp: str,
         depth_cap: int,
-        depth: int,
-        seen_message_ids: set[str],
-    ) -> list[dict[str, Any]]:
-        nodes: list[dict[str, Any]] = []
-        for row in rows:
+    ) -> tuple[list[dict[str, Any]], list[tuple[Any, dict[str, Any]]]]:
+        """Assemble nested tree nodes iteratively from one row fetch.
+
+        TASK-22206: replaces the recursive one-query-per-node walk (O(N^2)
+        row scans, RecursionError at ~1000-deep linear conversations).
+        Semantics preserved exactly: per-parent child order is the fetch's
+        timestamp order (a stable partition of one ``ORDER BY m.timestamp``
+        result); a node at ``depth >= depth_cap`` or whose id was already
+        visited keeps ``children=[]`` with ``truncated=True``; a row
+        ``normalize_message_row`` rejects is dropped along with its subtree;
+        a row without an id gets no children. The visited set is global
+        rather than the old per-path copy -- the two differ only on inputs a
+        real DB cannot produce (a duplicated primary key), and the global
+        set is what makes the walk O(N).
+
+        BLOB columns are never touched here: rows carry ``has_image`` and
+        image-bearing nodes are returned for one batched hydration pass
+        (``_hydrate_tree_images``).
+
+        Args:
+            paged_root_rows: The page of root rows, in fetch order.
+            children_by_parent: All non-root rows, bucketed by
+                ``parent_message_id``, each bucket in fetch order.
+            depth_cap: Maximum depth; roots are depth 1.
+
+        Returns:
+            The nested root nodes, and ``(message_id, node)`` pairs for
+            every node whose row carries an image.
+        """
+        roots: list[dict[str, Any]] = []
+        image_pending: list[tuple[Any, dict[str, Any]]] = []
+        seen_message_ids: set[Any] = set()
+        # (row, depth, parent's children list); explicit stack keeps
+        # arbitrary-depth conversations off the Python recursion limit.
+        stack: list[tuple[Mapping[str, Any], int, list[dict[str, Any]]]] = [
+            (row, 1, roots) for row in reversed(paged_root_rows)
+        ]
+        while stack:
+            row, depth, siblings = stack.pop()
             message_id = row.get("id")
             normalized_row = normalize_message_row(row)
             if normalized_row is None:
                 continue
+            if message_id is not None and row.get("has_image"):
+                image_pending.append((message_id, normalized_row))
             if message_id is not None and message_id in seen_message_ids:
                 normalized_row["children"] = []
                 normalized_row["truncated"] = True
-                nodes.append(normalized_row)
+                siblings.append(normalized_row)
                 continue
-
-            next_seen = set(seen_message_ids)
             if message_id is not None:
-                next_seen.add(message_id)
-
+                seen_message_ids.add(message_id)
             if depth >= depth_cap:
                 normalized_row["children"] = []
                 normalized_row["truncated"] = True
-                nodes.append(normalized_row)
+                siblings.append(normalized_row)
                 continue
-
-            child_rows = self.db.get_messages_for_conversation_by_parent_ids(
-                conversation_id,
-                [message_id] if message_id is not None else [],
-                order_by_timestamp=order_by_timestamp,
-                include_deleted_conversation=False,
-            )
-            normalized_row["children"] = self._build_message_tree(
-                conversation_id,
-                child_rows,
-                order_by_timestamp=order_by_timestamp,
-                depth_cap=depth_cap,
-                depth=depth + 1,
-                seen_message_ids=next_seen,
-            )
+            children: list[dict[str, Any]] = []
+            normalized_row["children"] = children
             normalized_row["truncated"] = False
-            nodes.append(normalized_row)
-        return nodes
+            siblings.append(normalized_row)
+            if message_id is not None:
+                for child_row in reversed(children_by_parent.get(message_id, ())):
+                    stack.append((child_row, depth + 1, children))
+        return roots, image_pending
+
+    def _hydrate_tree_images(
+        self, image_pending: Sequence[tuple[Any, dict[str, Any]]]
+    ) -> None:
+        """Fill image BLOBs into built tree nodes, one batched fetch.
+
+        TASK-22206: nodes leave ``_build_message_tree`` with
+        ``image_data=None``; the actual BLOBs are read here, once, only for
+        the messages that have one. A conversation without images performs
+        zero BLOB reads. Skipped silently for DB objects (test fakes) that
+        do not expose the batched fetch -- their rows carry ``image_data``
+        inline and ``normalize_message_row`` already passed it through.
+        """
+        if not image_pending:
+            return
+        fetcher = getattr(self.db, "get_message_images_by_ids", None)
+        if not callable(fetcher):
+            return
+        images = fetcher([message_id for message_id, _node in image_pending])
+        for message_id, node in image_pending:
+            image_row = images.get(message_id)
+            if image_row is None:
+                # Deleted between the two reads; the node keeps image_data
+                # None, matching a snapshot taken a moment later.
+                continue
+            node["image_data"] = image_row.get("image_data")

--- a/tldw_chatbook/Chat/console_conversation_hydration.py
+++ b/tldw_chatbook/Chat/console_conversation_hydration.py
@@ -169,9 +169,22 @@ def console_messages_from_conversation_tree(
     """
     messages: list[ConsoleChatMessage] = []
 
-    def _walk(node: Any, parent_persisted_id: str | None) -> None:
-        if not isinstance(node, dict):
-            return
+    # TASK-22206: an explicit stack, not recursion -- a linear conversation's
+    # tree is as deep as it is long, and the old per-node recursion raised
+    # RecursionError on resume at ~1000 messages. Children are pushed in
+    # reverse so pop order preserves the original pre-order. The visited
+    # guard turns a (malformed) self-referential mapping into a skip instead
+    # of a hang; a well-formed tree never revisits a node.
+    stack: list[tuple[Any, str | None]] = []
+    root_threads = tree.get("root_threads")
+    if isinstance(root_threads, list):
+        stack = [(root, None) for root in reversed(root_threads)]
+    visited_node_ids: set[int] = set()
+    while stack:
+        node, parent_persisted_id = stack.pop()
+        if not isinstance(node, dict) or id(node) in visited_node_ids:
+            continue
+        visited_node_ids.add(id(node))
         content = str(node.get("content") or "")
         raw_image = node.get("image_data")
         image_data = (
@@ -243,13 +256,9 @@ def console_messages_from_conversation_tree(
         child_parent_id = node_persisted_id if kept else parent_persisted_id
         children = node.get("children")
         if isinstance(children, list):
-            for child in children:
-                _walk(child, child_parent_id)
+            for child in reversed(children):
+                stack.append((child, child_parent_id))
 
-    root_threads = tree.get("root_threads")
-    if isinstance(root_threads, list):
-        for root in root_threads:
-            _walk(root, None)
     _batch_fetch_resume_attachments(db, messages)
     return messages
 

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -9715,6 +9715,102 @@ UPDATE db_schema_version
         cursor = self.execute_query(query, tuple([conversation_id, *parent_ids]))
         return [dict(row) for row in cursor.fetchall()]
 
+    def get_message_tree_rows_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        order_by_timestamp: str = "ASC",
+        include_deleted_conversation: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Fetch every live message row of one conversation, without BLOBs.
+
+        TASK-22206: the single conversation-scoped read backing
+        ``ChatConversationService.get_conversation_tree``'s in-memory tree
+        assembly (which replaced a one-query-per-node recursive walk).
+        Selects the same columns as
+        ``get_messages_for_conversation_by_parent_ids`` EXCEPT the
+        ``image_data`` BLOB, which is replaced by a ``has_image`` flag so
+        callers can batch-hydrate images lazily via
+        ``get_message_images_by_ids``. Ordered by ``m.timestamp`` so the
+        query is driven by ``idx_msgs_conv_ts (conversation_id, timestamp)``
+        with no post-sort (plan verified with ``sqlite_stat1`` absent, the
+        production shape) and a stable partition of the result reproduces
+        each parent's child order.
+
+        Args:
+            conversation_id: The conversation UUID.
+            order_by_timestamp: 'ASC' or 'DESC'.
+            include_deleted_conversation: Include rows whose parent
+                conversation is soft-deleted.
+
+        Returns:
+            All non-deleted message rows of the conversation, in timestamp
+            order, each with ``has_image`` (0/1) instead of ``image_data``.
+
+        Raises:
+            InputError: If ``order_by_timestamp`` is not 'ASC'/'DESC'.
+        """
+        if order_by_timestamp.upper() not in ["ASC", "DESC"]:
+            raise InputError("order_by_timestamp must be 'ASC' or 'DESC'.")
+        query = f"""
+            SELECT m.id, m.conversation_id, m.parent_message_id, m.sender, m.content,
+                   (m.image_data IS NOT NULL) AS has_image, m.image_mime_type,
+                   m.timestamp, m.ranking, m.last_modified,
+                   m.version, m.client_id, m.deleted, m.feedback, m.role,
+                   m.variant_of, m.variant_number, m.is_selected_variant, m.total_variants,
+                   m.usage_json, m.metadata_json, m.provider_continuation_json,
+                   m.assistant_generation_state
+            FROM messages m
+            JOIN conversations c ON m.conversation_id = c.id
+            WHERE m.conversation_id = ?
+              AND m.deleted = 0
+            ORDER BY m.timestamp {order_by_timestamp}
+        """
+        if not include_deleted_conversation:
+            query = query.replace(
+                "ORDER BY", "AND c.deleted = 0\n            ORDER BY", 1
+            )
+        cursor = self.execute_query(query, (conversation_id,))
+        return [dict(row) for row in cursor.fetchall()]
+
+    def get_message_images_by_ids(
+        self, message_ids: Sequence[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Batch-fetch the legacy position-0 image columns for messages.
+
+        TASK-22206 companion to ``get_message_tree_rows_for_conversation``:
+        the tree read carries only a ``has_image`` flag; callers hydrate the
+        actual BLOBs here, once, for exactly the ids that need them. Chunked
+        at 500 ids per statement (mirrors ``get_attachments_for_messages``).
+
+        Args:
+            message_ids: Message UUIDs to fetch image columns for.
+
+        Returns:
+            Mapping of message id to ``{"image_data", "image_mime_type"}``;
+            ids with no stored image are absent.
+        """
+        ids = [str(m) for m in message_ids if m]
+        if not ids:
+            return {}
+        result: Dict[str, Dict[str, Any]] = {}
+        with self.transaction() as cursor:
+            for start in range(0, len(ids), 500):
+                chunk = ids[start : start + 500]
+                placeholders = ",".join("?" for _ in chunk)
+                cursor.execute(
+                    "SELECT id, image_data, image_mime_type FROM messages"
+                    f" WHERE id IN ({placeholders})"
+                    " AND image_data IS NOT NULL",
+                    chunk,
+                )
+                for row in cursor.fetchall():
+                    result[row["id"]] = {
+                        "image_data": row["image_data"],
+                        "image_mime_type": row["image_mime_type"],
+                    }
+        return result
+
     def update_conversation(
         self, conversation_id: str, update_data: Dict[str, Any], expected_version: int
     ) -> Optional[bool]:


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22206). Conversation-tree resume recursed once per message, each recursion re-scanning the whole conversation with BLOB hydration (measured O(N²): 110 ms @600 msgs) and raising RecursionError on ~980-message linear chains.

**Change:** one conversation-scoped narrow query (`get_message_tree_rows_for_conversation` — same columns minus `image_data`, which becomes `has_image`), children-by-parent partition, explicit-stack build (no recursion, no per-node queries, no per-node set copies), roots paged in memory with an identical count predicate; images hydrated once post-build, batched 500 ids (`get_message_images_by_ids`), only for has_image rows. The resume flattener `_walk` was a SECOND hidden per-message recursion — also converted to an explicit stack. Legacy DB method untouched (remaining callers are DB-level tests).

**Measured:** 110.2 → 5.2 ms @600 (21×); RecursionError → 21.0 ms @2000 (90× vs legacy at a raised limit). EXPLAIN with `sqlite_stat1` ABSENT: single `idx_msgs_conv_ts` search, no temp B-tree. Stays inline on the loop with the bound stated (≤100 ms up to ~6,000 msgs; image-heavy case measured 41.4 ms @100×1 MB — legacy read the same bytes).

**Adversarial review: SHIP.** Tie-order parity proven against the VERBATIM base modules on equal-timestamp siblings/roots across 16 parameterizations (a case the implementer's fixture missed), ASC+DESC, with and without ANALYZE stats; pagination/count identity proven incl. degenerate limits; cycle/self-parent/dangling/cross-conversation-parent corruption probed to parity (terminates, corrupt rows dropped in both); depth-cap boundary parity; 501-image chunking + delete-between-fetch-and-hydrate probed. Mutations: per-node-query reintroduction and partition-breaking both red; the seen-guard is unreachable on real-DB input in BOTH implementations (documented, informational). 7 `test_console_launch_wake.py` reds baselined identical at merge-base (pre-existing seeding class).

Tests: new file 6/6; affected suites 188 passed; review's broader re-run 336 passed / 7 pre-existing; preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up conversation resume by replacing the per-node recursive tree build with a single O(N) pass and lazy, batched image hydration. This removes the ~1000-message RecursionError while keeping ordering, pagination, and depth-cap behavior the same.

**Refactors**
- Adds `get_message_tree_rows_for_conversation` to read all non-BLOB rows once in timestamp order.
- Builds the tree iteratively from a children-by-parent partition; roots are paged in memory.
- Hydrates images post-build via `get_message_images_by_ids` (500-id batches); imageless conversations perform no BLOB reads.
- Replaces the recursive resume flattener with an explicit stack.
- Preserves sibling order, seen-id guard, normalize drops, and count semantics.
- Observed: ~110 ms → ~5 ms @600 msgs; RecursionError → ~21 ms @2000; statement count is O(1).

<sup>Written for commit 975d1cfe087c54c48cf04645050796b56df7c171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

