### PR TITLE
perf(console): zero registry SQL on the run tick; one workspace build per tick (TASK-22201)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2379,7 +2379,7 @@
     },
     {
       "call_count": 32,
-      "diagnostic_digest": "4e9caa034220e212f9e4",
+      "diagnostic_digest": "2336c4e1042eef6ce2f4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/workspace.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/UI/test_console_run_tick_workspace_reads.py
+++ b/Tests/UI/test_console_run_tick_workspace_reads.py
@@ -1,0 +1,357 @@
+"""The Console 5 Hz run tick must not touch the Workspace DB.
+
+TASK-22201. The holistic perf review (Docs/Design/2026-08-24-holistic-perf-review.md,
+finding 22201) measured that PR #2034 reintroduced the TASK-21118 hot-path shape on
+the run tick: ``_sync_native_console_chat_ui`` builds
+``_build_console_workspace_context_state()`` three times per 0.2 s tick, each build
+reaching ``_console_browser_workspace_records()`` twice (browser labels + the new
+``workspace_tree_projection``), and each of those calls ran
+``ensure_default_workspace()`` (SELECT + bindings probe + occasional DELETE write
+transaction) plus ``list_workspaces()`` — synchronous SQLite on the event loop,
+roughly 45 extra statements/second while a reply streams — plus the O(materialized
+rows) merge/canonical-owner/overlay pipeline twice per build.
+
+These tests replicate the review's counter probe as a permanent gate, the same
+shape as ``test_console_keystroke_workspace_reads.py`` (TASK-21118):
+
+* zero registry-service reads AND zero WorkspaceDB round-trips AND zero traced SQL
+  statements across settled run ticks;
+* a control proving the counters still see real registry traffic;
+* the staleness guard: a registry mutation performed directly on the service (no
+  Console seam) must be reflected by the very next tick;
+* the row merge / canonical-owner / overlay pipeline runs at most once per state
+  build, and a settled tick builds the workspace context state at most once.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from Tests.UI.test_console_dictation import _mounted_console, _ready_host
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+APP_SIZE = (140, 42)
+
+#: Enough ticks that per-tick work cannot hide in warmup noise; at the real
+#: cadence this window is one second of streaming.
+SETTLED_TICKS = 5
+
+
+async def _settled_console(host, pilot):
+    """Mount the ready Console and let its own sync passes settle.
+
+    The mount's first passes may legitimately read the registry to warm the
+    generation-keyed memos; one explicit tick afterwards guarantees the memo
+    is warm before a counter window opens.
+    """
+    console = await _mounted_console(host, pilot)
+    for _ in range(3):
+        await pilot.pause()
+    await console._sync_native_console_chat_ui()
+    for _ in range(2):
+        await pilot.pause()
+    return console
+
+
+class _WorkspaceReadCounter:
+    """Count registry-service reads, WorkspaceDB round-trips, and statements.
+
+    Patches at the class so every instance-bound call the app makes is
+    counted, and counts THREE layers: the display-read service methods, the
+    ``WorkspaceDB.connection`` / ``WorkspaceDB.transaction`` context
+    factories, and — via ``sqlite3``'s own trace callback installed on every
+    connection those factories yield — the literal SQL statements executed
+    (the review's probe recipe). Restored on exit, including the trace
+    callbacks.
+    """
+
+    _READ_METHODS = (
+        "ensure_default_workspace",
+        "get_active_workspace",
+        "list_workspaces",
+        "list_runtime_bindings",
+        "list_workspace_memberships",
+    )
+
+    def __init__(self) -> None:
+        self.read_calls: dict[str, int] = {name: 0 for name in self._READ_METHODS}
+        self.db_connections = 0
+        self.db_transactions = 0
+        self.statements: list[str] = []
+        self._original_reads = {
+            name: getattr(LocalWorkspaceRegistryService, name)
+            for name in self._READ_METHODS
+        }
+        self._original_connection = WorkspaceDB.connection
+        self._original_transaction = WorkspaceDB.transaction
+        self._traced_connections: list = []
+
+    def __enter__(self) -> "_WorkspaceReadCounter":
+        counter = self
+
+        def _counting_read(name, original):
+            def wrapper(service, *args, **kwargs):
+                counter.read_calls[name] += 1
+                return original(service, *args, **kwargs)
+
+            return wrapper
+
+        for name, original in self._original_reads.items():
+            setattr(
+                LocalWorkspaceRegistryService, name, _counting_read(name, original)
+            )
+
+        original_connection = self._original_connection
+        original_transaction = self._original_transaction
+
+        def _trace(statement: str) -> None:
+            counter.statements.append(statement)
+
+        def _tracing_context(original, attr):
+            from contextlib import contextmanager
+
+            @contextmanager
+            def wrapper(db):
+                setattr(counter, attr, getattr(counter, attr) + 1)
+                with original(db) as conn:
+                    conn.set_trace_callback(_trace)
+                    if conn not in counter._traced_connections:
+                        counter._traced_connections.append(conn)
+                    try:
+                        yield conn
+                    finally:
+                        conn.set_trace_callback(None)
+
+            return wrapper
+
+        WorkspaceDB.connection = _tracing_context(
+            original_connection, "db_connections"
+        )
+        WorkspaceDB.transaction = _tracing_context(
+            original_transaction, "db_transactions"
+        )
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        for name, original in self._original_reads.items():
+            setattr(LocalWorkspaceRegistryService, name, original)
+        WorkspaceDB.connection = self._original_connection
+        WorkspaceDB.transaction = self._original_transaction
+        for conn in self._traced_connections:
+            try:
+                conn.set_trace_callback(None)
+            except Exception:
+                pass
+
+    @property
+    def registry_reads(self) -> int:
+        return sum(self.read_calls.values())
+
+    @property
+    def db_round_trips(self) -> int:
+        return self.db_connections + self.db_transactions
+
+
+# ---------------------------------------------------------------------------
+# 1. Settled run ticks: zero Workspace-DB work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settled_run_ticks_do_zero_workspace_registry_sql():
+    """The review's probe, as a gate: settled ticks -> 0 registry SQL.
+
+    On the pre-fix code each tick counts ~6 ``ensure_default_workspace`` +
+    ~6 ``list_workspaces`` + 3 x (``get_active_workspace`` +
+    ``list_runtime_bindings`` + ``list_workspaces`` +
+    ``list_workspace_memberships``) and their SQLite statements.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _settled_console(host, pilot)
+
+        with _WorkspaceReadCounter() as counter:
+            started = time.perf_counter()
+            for _ in range(SETTLED_TICKS):
+                await console._sync_native_console_chat_ui()
+                await pilot.pause()
+            elapsed = time.perf_counter() - started
+
+        # Measurement metric for the task record; the assertions carry the gate.
+        print(
+            f"\n[t22201] {SETTLED_TICKS} settled ticks: "
+            f"{elapsed * 1000.0:.1f} ms wall, "
+            f"reads={counter.read_calls}, "
+            f"round_trips={counter.db_round_trips}, "
+            f"statements={len(counter.statements)}"
+        )
+        assert counter.read_calls["ensure_default_workspace"] == 0
+        assert counter.registry_reads == 0
+        assert counter.db_round_trips == 0
+        assert counter.statements == []
+
+
+@pytest.mark.asyncio
+async def test_the_counter_still_sees_real_registry_traffic():
+    """Control: "zero" above must not be satisfiable by an unwired counter."""
+    app, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        await _settled_console(host, pilot)
+        registry = app.workspace_registry_service
+        assert registry is not None
+
+        with _WorkspaceReadCounter() as counter:
+            active = registry.get_active_workspace()
+            listed = registry.list_workspaces()
+            registry.ensure_default_workspace()
+
+        assert active is not None
+        assert listed
+        assert counter.read_calls["get_active_workspace"] >= 1
+        assert counter.read_calls["list_workspaces"] >= 1
+        assert counter.read_calls["ensure_default_workspace"] == 1
+        assert counter.db_round_trips >= 3
+        assert any("workspace_records" in s for s in counter.statements)
+
+
+# ---------------------------------------------------------------------------
+# 2. The memo must not go stale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registry_mutation_reflects_in_the_next_tick():
+    """A mutation with no Console seam must reach the next tick's state.
+
+    The create/rename/set-active trio is performed directly on the registry
+    service — the way Settings or Library do it — so only the memo's own
+    ``mutation_generation`` revalidation can keep the Console truthful.
+    """
+    app, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _settled_console(host, pilot)
+        registry = app.workspace_registry_service
+        assert registry is not None
+        controller = console._workspace
+
+        before_records = controller._console_browser_workspace_records()
+        assert all(
+            record.workspace_id != "workspace-gamma" for record in before_records
+        )
+
+        registry.create_workspace(workspace_id="workspace-gamma", name="Gamma")
+        registry.set_active_workspace("workspace-gamma")
+
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        after_records = controller._console_browser_workspace_records()
+        assert any(
+            record.workspace_id == "workspace-gamma" for record in after_records
+        )
+        context = controller._current_console_workspace_context()
+        assert context.active_workspace_id == "workspace-gamma"
+        state = controller._build_console_workspace_context_state()
+        assert state.active_workspace_id == "workspace-gamma"
+        assert state.workspace_name == "Gamma"
+
+        registry.rename_workspace("workspace-gamma", "Gamma Renamed")
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+        renamed = controller._build_console_workspace_context_state()
+        assert renamed.workspace_name == "Gamma Renamed"
+
+
+# ---------------------------------------------------------------------------
+# 3. The row pipeline runs once per build; a settled tick builds once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_row_pipeline_runs_once_per_state_build():
+    """canonical-owner + overlay must each run once for a no-query build."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _settled_console(host, pilot)
+        controller = console._workspace
+
+        calls = {"canonical": 0, "overlay": 0}
+        original_canonical = controller._rows_with_latest_canonical_owner
+        original_overlay = controller._overlay_current_console_browser_markers
+
+        def counting_canonical(rows):
+            calls["canonical"] += 1
+            return original_canonical(rows)
+
+        def counting_overlay(rows, current_conversation_id=None):
+            calls["overlay"] += 1
+            return original_overlay(rows, current_conversation_id)
+
+        controller._rows_with_latest_canonical_owner = counting_canonical
+        controller._overlay_current_console_browser_markers = counting_overlay
+        try:
+            controller._build_console_workspace_context_state()
+        finally:
+            del controller._rows_with_latest_canonical_owner
+            del controller._overlay_current_console_browser_markers
+
+        assert calls["canonical"] == 1, calls
+        assert calls["overlay"] == 1, calls
+
+
+@pytest.mark.asyncio
+async def test_settled_tick_builds_workspace_state_once(monkeypatch):
+    """One settled tick must pay for the context build at most once.
+
+    Counted at the uncached seam (``build_console_workspace_state`` as
+    imported by the workspace controller module) rather than the memoized
+    front method, which the tick legitimately CALLS several times -- the
+    stack probe that motivated the tick scope measured six calls per tick
+    (rail states x2, workspace push, control bar + agent section inspector
+    legs, settings summary).
+    """
+    from tldw_chatbook.UI.Console_Modules import workspace as workspace_module
+
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _settled_console(host, pilot)
+
+        builds = {"count": 0}
+        original_build = workspace_module.build_console_workspace_state
+
+        def counting_build(**kwargs):
+            builds["count"] += 1
+            return original_build(**kwargs)
+
+        monkeypatch.setattr(
+            workspace_module, "build_console_workspace_state", counting_build
+        )
+        await console._sync_native_console_chat_ui()
+
+        assert builds["count"] <= 1, builds
+
+
+@pytest.mark.asyncio
+async def test_tick_scope_rebuilds_when_registry_changes_mid_scope():
+    """Inputs changing inside one tick scope must rebuild, not reuse."""
+    app, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _settled_console(host, pilot)
+        registry = app.workspace_registry_service
+        assert registry is not None
+        controller = console._workspace
+
+        with controller.tick_workspace_build_scope():
+            first = controller._build_console_workspace_context_state()
+            again = controller._build_console_workspace_context_state()
+            assert again is first
+
+            registry.create_workspace(workspace_id="workspace-delta", name="Delta")
+            registry.set_active_workspace("workspace-delta")
+
+            refreshed = controller._build_console_workspace_context_state()
+            assert refreshed is not first
+            assert refreshed.active_workspace_id == "workspace-delta"

--- a/Tests/UI/test_console_run_tick_workspace_reads.py
+++ b/Tests/UI/test_console_run_tick_workspace_reads.py
@@ -355,3 +355,164 @@ async def test_tick_scope_rebuilds_when_registry_changes_mid_scope():
             refreshed = controller._build_console_workspace_context_state()
             assert refreshed is not first
             assert refreshed.active_workspace_id == "workspace-delta"
+
+
+@pytest.mark.asyncio
+async def test_tick_scope_rebuilds_when_session_is_created_mid_scope():
+    """The PR #660 letter, store half: a session created mid-tick rebuilds.
+
+    ``_sync_console_native_session_tabs`` can create a session between the
+    tick's builds; the fingerprint's store-sessions component is the ONLY
+    thing keeping the later reads fresh. Adversarial review (TASK-22201)
+    proved a mutant with that component deleted passed every prior test:
+    the registry mid-scope test above cannot see it (a session create
+    touches no registry table), and a create was masked one layer deeper
+    still by the per-session queued-counts token changing length. The
+    activation test below pins the fully-masked case.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _settled_console(host, pilot)
+        controller = console._workspace
+        store = console._console_chat_store
+        assert store is not None
+
+        with controller.tick_workspace_build_scope():
+            first = controller._build_console_workspace_context_state()
+            assert controller._build_console_workspace_context_state() is first
+
+            session = store.create_session(
+                title="Mid-tick session", activate=True
+            )
+
+            refreshed = controller._build_console_workspace_context_state()
+            assert refreshed is not first, (
+                "session created mid-scope was served from the stale cache"
+            )
+            refreshed_ids = {
+                str(row.conversation_id) for row in refreshed.conversation_rows
+            }
+            assert f"native:{session.id}" in refreshed_ids
+
+
+@pytest.mark.asyncio
+async def test_tick_scope_rebuilds_when_session_is_activated_mid_scope():
+    """Activating a DIFFERENT session mid-scope must rebuild, not reuse.
+
+    The narrowest #660 shape: activation changes no session-row fields and
+    no queued counts, so only the fingerprint's ``active_session_id``
+    component can catch it — the exact component the review's escaping
+    mutant had deleted.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _settled_console(host, pilot)
+        controller = console._workspace
+        store = console._console_chat_store
+        assert store is not None
+        extra = store.create_session(title="Background session", activate=False)
+        # Settle the out-of-scope create so only the activation is mid-scope.
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        with controller.tick_workspace_build_scope():
+            first = controller._build_console_workspace_context_state()
+            assert controller._build_console_workspace_context_state() is first
+
+            store.switch_session(extra.id)
+
+            refreshed = controller._build_console_workspace_context_state()
+            assert refreshed is not first, (
+                "session activation mid-scope was served from the stale cache"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. Prepared-union projection equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_prepared_union_projection_matches_self_contained_projection():
+    """The build's prepared-union tree == the standalone projection's tree.
+
+    TASK-22201 replaced the tree projection's own merge/canonical/overlay
+    pass with the state build's already-processed union, partitioned back
+    out by display identity. This pins the equivalence on the divergence
+    candidates adversarial review probed: a page-attempt row sharing
+    display identity with a browser row (the browser copy must win), and
+    an attempt row whose canonical owner moved (the filter must drop it
+    from both paths).
+    """
+    from types import SimpleNamespace
+
+    from Tests.UI.test_console_workspace_controller import (
+        _browser_row,
+        _workspace_controller,
+    )
+    from tldw_chatbook.UI.Console_Modules.workspace import PageAttemptState
+
+    registry = SimpleNamespace(
+        list_workspaces=lambda: (
+            SimpleNamespace(workspace_id="workspace-7", name="Seven", archived=False),
+            SimpleNamespace(workspace_id="workspace-8", name="Eight", archived=False),
+        ),
+    )
+    controller = _workspace_controller(
+        app_instance=SimpleNamespace(workspace_registry_service=registry)
+    )
+    browser_rows = (
+        _browser_row("shared", "Shared (browser copy)"),
+        _browser_row("browser-only", "Browser only"),
+    )
+    controller._workspace_page_attempts["workspace-7"] = PageAttemptState(
+        rows=(
+            _browser_row("shared", "Shared (attempt copy)"),
+            _browser_row("attempt-only", "Attempt only"),
+            _browser_row("moved-away", "Moved away"),
+        )
+    )
+    controller._canonical_owner_observations["moved-away"] = "workspace-8"
+
+    # Standalone path (prepared_rows omitted): the self-contained pipeline.
+    standalone = controller.workspace_tree_projection(browser_rows)
+
+    # Prepared path: the build's exact union recipe, handed to the projection.
+    controller._prune_stale_workspace_page_attempts()
+    union = controller._merge_console_browser_rows(
+        browser_rows,
+        *(
+            attempt.rows
+            for attempt in controller._workspace_page_attempts.values()
+        ),
+    )
+    union = controller._rows_with_latest_canonical_owner(union)
+    union = controller._overlay_current_console_browser_markers(union)
+    prepared = controller.workspace_tree_projection(
+        browser_rows, prepared_rows=union
+    )
+
+    assert prepared == standalone
+    # The seeded shapes actually exercised the interesting paths.
+    seven = next(node for node in prepared if node.workspace_id == "workspace-7")
+    ids = [row.conversation_id for row in seven.conversations]
+    assert "shared" in ids and "attempt-only" in ids
+    assert "moved-away" not in ids
+    shared_titles = [
+        row.title for row in seven.conversations if row.conversation_id == "shared"
+    ]
+    assert shared_titles == ["Shared (browser copy)"]
+
+    # Partitioning the union back out by display identity must equal the
+    # base pipeline over the browser rows alone.
+    base_rows = controller._merge_console_browser_rows(browser_rows)
+    identities = {
+        controller._console_browser_display_identity(row) for row in base_rows
+    }
+    base_rows = controller._rows_with_latest_canonical_owner(base_rows)
+    base_rows = controller._overlay_current_console_browser_markers(base_rows)
+    partition = tuple(
+        row
+        for row in union
+        if controller._console_browser_display_identity(row) in identities
+    )
+    assert partition == base_rows

--- a/Tests/Workspaces/test_workspace_registry_service.py
+++ b/Tests/Workspaces/test_workspace_registry_service.py
@@ -894,7 +894,57 @@ def test_mutation_generation_is_stable_across_pure_reads(tmp_path: Path) -> None
     service.get_active_workspace()
     service.get_workspace(DEFAULT_WORKSPACE_ID)
     service.list_workspaces()
+    service.list_runtime_bindings(DEFAULT_WORKSPACE_ID)
+    service.list_workspace_memberships(DEFAULT_WORKSPACE_ID)
     # ensure with an active workspace already resting on Default and no
     # stale bindings changes nothing -- and must therefore bump nothing.
     service.ensure_default_workspace()
+    assert service.mutation_generation == generation
+
+
+def test_mutation_generation_bumps_on_binding_and_membership_mutators(
+    tmp_path: Path,
+) -> None:
+    """Binding and membership mutators must advance `mutation_generation`.
+
+    TASK-22201 widened the generation contract to the Console context
+    build's whole display read set: the run tick serves
+    `list_runtime_bindings` / `list_workspace_memberships` from a
+    generation-keyed view, so a binding or membership write that forgot to
+    bump would leave the Console rail's runtime/handoff rows STALE until
+    the next unrelated workspace mutation.
+    """
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+
+    generation = service.mutation_generation
+    service.save_runtime_binding(
+        WorkspaceRuntimeBinding(
+            workspace_id="ws-a",
+            binding_id="binding-1",
+            binding_kind=RuntimeBindingKind.GIT_WORKTREE,
+            label="Repo",
+            locator="/tmp/repo",
+            status=RuntimeBindingStatus.INSPECT_ONLY,
+            metadata={"branch": "dev"},
+        )
+    )
+    assert service.mutation_generation > generation
+
+    generation = service.mutation_generation
+    service.link_membership(
+        "ws-a",
+        item_type="conversation",
+        item_id="conversation-1",
+        title="Linked conversation",
+    )
+    assert service.mutation_generation > generation
+
+    generation = service.mutation_generation
+    service.remove_runtime_binding("binding-1")
+    assert service.mutation_generation > generation
+
+    generation = service.mutation_generation
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.remove_runtime_binding("binding-1")  # already gone
     assert service.mutation_generation == generation

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8449,3 +8449,26 @@ back to hand-rolled SQL in the test. Resist it: that trades a loud failure for
 a silent one. (Writing that hand-rolled INSERT is also harder than it looks —
 the first attempt at one in this task died on a `NOT NULL` column the writer
 fills for you.)
+
+## Count the calls with a stack probe before wiring a shared-state fix at the call sites you know about (TASK-22201, 2026-08-25)
+
+The perf review said the Console run tick builds
+`_build_console_workspace_context_state()` **three** times (two rail-state
+legs + the workspace-context push), so the first fix threaded one prebuilt
+state through exactly those three call sites. The build-once gate test then
+failed with `count == 6`: a stack-capturing probe showed the other three
+builds arriving through call chains the review never named — the inspector
+rows leg (`_selected_console_conversation_inspector_rows`) builds the
+workspace state inside BOTH rail-state calls, the control bar's own inspector
+build, and the agent section's payload lambda. Parameter-threading at the
+named sites would have shipped "fixed" while leaving 4 of 6 builds in place —
+and only the gate asserting on the COUNT, not on the three known sites,
+caught it.
+
+Two rules. **Measure the call multiplicity with a stack probe (wrap the
+function, record `traceback.extract_stack`) before designing the fix** — a
+finding's count is a lower bound from the paths its author traced. And when
+the calls converge on one function from many sites, **share at the converged
+function (here: an opt-in, asyncio-task-scoped cache consulted inside the
+build itself), not by threading state through each caller** — the callers you
+did not know about are exactly the ones a threading fix misses.

--- a/backlog/tasks/task-22201 - Take-workspace-registry-reads-and-the-doubled-row-pipeline-off-the-Console-run-tick.md
+++ b/backlog/tasks/task-22201 - Take-workspace-registry-reads-and-the-doubled-row-pipeline-off-the-Console-run-tick.md
@@ -2,8 +2,8 @@
 id: TASK-22201
 title: >-
   Take workspace registry reads and the doubled row pipeline off the Console run tick
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-08-24'
 labels:
   - performance
@@ -38,7 +38,164 @@ clean (memo at `workspace.py:2726-2826` intact — verified live: 19 keys = 0 SQ
 
 ## Acceptance Criteria
 
-- [ ] A run tick with unchanged registry state performs zero workspace-registry SQL (memoize `_console_browser_workspace_records` on the existing `mutation_generation`, the TASK-21118 pattern) — proven by the sqlite trace-callback probe from the review
-- [ ] The row merge / canonical-owner / overlay pipeline runs at most once per state build, and the build runs at most once per tick unless its inputs changed
-- [ ] `ensure_default_workspace()` (a write-capable repair) is not called from any display/build path — only from mutation paths
-- [ ] Per-tick build cost during streaming is measured before/after; tree/browser behavior is unchanged when the registry actually changes (existing tests green)
+- [x] A run tick with unchanged registry state performs zero workspace-registry SQL (memoize `_console_browser_workspace_records` on the existing `mutation_generation`, the TASK-21118 pattern) — proven by the sqlite trace-callback probe from the review
+- [x] The row merge / canonical-owner / overlay pipeline runs at most once per state build, and the build runs at most once per tick unless its inputs changed
+- [x] `ensure_default_workspace()` (a write-capable repair) is not called from any display/build path — only from mutation paths
+- [x] Per-tick build cost during streaming is measured before/after; tree/browser behavior is unchanged when the registry actually changes (existing tests green)
+
+## Implementation Plan
+
+1. Baseline measurement on the pristine worktree: a mounted-console probe (the
+   TASK-21118 `_WorkspaceReadCounter` shape — `WorkspaceDB.connection`/`transaction`
+   round-trips + registry read-method counts + `set_trace_callback` statement counts)
+   across 50 direct `_sync_native_console_chat_ui()` ticks, plus wall-time and
+   build/pipeline invocation counts.
+2. Registry read memo, the TASK-21118 pattern extended: a generation-keyed
+   read-through view over the app's `LocalWorkspaceRegistryService` serving the four
+   display reads the Console context build performs (`get_active_workspace`,
+   `list_workspaces`, `list_runtime_bindings`, `list_workspace_memberships`), cached
+   on (service identity, `mutation_generation`), never caching on doubles without a
+   real int generation and never caching a raised read.
+   `_console_browser_workspace_records` is served from the same view's
+   `list_workspaces` cache; `build_console_workspace_state` receives the view.
+   ADR-028's from-disk binding-status recompute keeps running per build (only the
+   SQL is cached).
+3. Generation completeness for THIS memo's read set: today only workspace-record
+   mutators bump. Add `_bump_mutation_generation()` to `save_runtime_binding`
+   (covers `add_folder_binding`/`set_folder_binding_access`),
+   `remove_runtime_binding`, `_delete_default_runtime_bindings` (on actual delete),
+   and `link_membership`; update the property's contract docstring.
+   `set_workspace_scope`/`set_change_review_enabled` write tables outside this read
+   set and stay as-is.
+4. `ensure_default_workspace` off the display path: delete the call from
+   `_console_browser_workspace_records`. Repair ownership stays with the existing
+   mutation/startup seams: app wiring (`app.py` `_wire_workspace_registry_services`),
+   `archive_workspace`, `set_active_workspace`'s switch-to-Default repair, and
+   `_set_active_workspace_for_console_session`'s global branch — the display path
+   was never the only invoker.
+5. Row pipeline once per build: `_with_console_conversation_browser_state` prepares
+   ONE merged union (browser rows + workspace page-attempt rows), runs
+   canonical-owner + overlay once over it, partitions the browser subset back out by
+   display identity, and hands the prepared union to
+   `workspace_tree_projection(rows, prepared_rows=...)`, which skips its own
+   merge/canonical/overlay on the no-query path (the query path keeps its
+   settled-lane pipeline — a different, small input set).
+6. Build at most once per tick: a per-tick build cache object created at the top of
+   `_sync_native_console_chat_ui`, revalidated at each of the three consumption
+   points against a cheap volatile-input fingerprint (registry generation, current
+   conversation id, store session tuples + active session id, run status, queued
+   counts, canonical-membership revision, persisted-cache token, browser/lane
+   queries); any fingerprint component failure or non-int generation means rebuild.
+   Never consulted outside the tick, so every push path that builds after a
+   mutation stays live. `_current_console_rail_state` and
+   `_sync_console_workspace_context` accept an optional prebuilt state.
+7. AC probes (red-first where feasible): new `Tests/UI/test_console_run_tick_workspace_reads.py`
+   — (a) N settled ticks = 0 registry reads + 0 WorkspaceDB round-trips (+ trace-callback
+   statement count 0); (b) counter-control test; (c) registry mutation (create/rename/
+   set-active/binding change) followed by one tick refreshes browser records/tree; (d)
+   pipeline runs ≤ once per build; (e) steady tick builds the state once.
+8. Mutation tests: skip a generation bump → invalidation test reds; remove the memo →
+   0-SQL probe reds.
+9. Failure paths: registry write fails mid-transaction (generation NOT bumped on the
+   raise paths — memo keeps serving the last committed truth, matching the DB);
+   teardown-scoped except in `_sync_native_console_chat_ui` unchanged (the tick cache
+   is a local, dies with the coroutine).
+10. Targeted suites + `--collect-only` sweep, tee'd; `./scripts/preflight.sh`;
+    re-measure per-tick cost; notes + Done.
+
+## Implementation Notes
+
+Three mechanisms, each the smallest one that closes its half of the finding:
+
+1. **Generation-keyed display-read view** (`_ConsoleRegistryDisplayReads`,
+   `UI/Console_Modules/workspace.py`): a read-through stand-in for the registry
+   service serving the context build's four display reads
+   (`get_active_workspace`, `list_workspaces`, `list_runtime_bindings`,
+   `list_workspace_memberships`) from a cache revalidated against
+   (service identity, `mutation_generation`) — the TASK-21118 memo pattern,
+   extended. Raised reads are never cached; doubles without a real int
+   generation stay live; ADR-028's from-disk binding-status recompute still
+   runs per build (only the SQL is cached).
+   `_console_browser_workspace_records` and `build_console_workspace_state`
+   both read through it. **Generation contract widened** to cover the view's
+   read set: `save_runtime_binding` (routes `add_folder_binding` /
+   `set_folder_binding_access`), `remove_runtime_binding`,
+   `_delete_default_runtime_bindings` (on actual delete), and
+   `link_membership` now bump (`Workspaces/registry_service.py`);
+   `set_workspace_scope`/`set_change_review_enabled` write tables outside the
+   read set and deliberately do not.
+2. **`ensure_default_workspace` off the display path**: removed from
+   `_console_browser_workspace_records`. The repair's owners were already the
+   mutation/startup seams — app wiring (`app.py`
+   `_wire_workspace_registry_services`), `archive_workspace`,
+   `set_active_workspace`'s switch-to-Default repair,
+   `_set_active_workspace_for_console_session`'s global branch — the display
+   path was never the only invoker, so nothing new had to take ownership.
+3. **One pipeline pass + one build per tick**:
+   `_with_console_conversation_browser_state` now merges browser + surviving
+   page-attempt rows into ONE union, runs canonical-owner + overlay once, and
+   partitions the browser subset back out by display identity (both passes are
+   per-row, so this is exactly equivalent — see inline comment);
+   `workspace_tree_projection(prepared_rows=...)` consumes the prepared union
+   on the no-query path (stale page attempts are pruned BEFORE the union via
+   the hoisted `_prune_stale_workspace_page_attempts`). The tick's builds are
+   shared through `tick_workspace_build_scope` + `ConsoleTickWorkspaceBuilds`
+   (task-15452's opt-in scope shape, plus asyncio-task identity): only the
+   tick coroutine's own task reads the cache, each read revalidates a
+   volatile-input fingerprint (registry generation, conversation id, store
+   sessions/active, run status, queued counts, membership revision,
+   persisted-cache token, lane generations, page-attempt shape), so the
+   PR #660 freshness ruling is kept by mechanism — a session created mid-tick
+   rebuilds — while interleaving handlers/workers always build live.
+
+**A finding correction**: the review said 3 builds/tick; a stack probe measured
+SIX (the inspector rows leg builds workspace state inside both rail-state
+calls, the control bar, and the agent section). Explicitly threading state
+through the three named call sites — the first implementation — left 4 of 6
+builds; the task-scoped share catches all of them.
+
+**Measured** (mounted-console harness, `Tests/UI/test_console_run_tick_workspace_reads.py`):
+- Registry SQL, 5 settled ticks: **400 round-trips / 400 traced statements →
+  0 / 0** (per tick: 16× ensure + 24× get_active + 24× list_workspaces +
+  8× bindings + 8× memberships → all zero).
+- Context builds per settled tick: **6 → 1** (gated at the
+  `build_console_workspace_state` seam).
+- 50-tick wall time (same venv, base worktree at `983aa5878` vs this branch):
+  14.8–17.0 ms/tick → 13.0–14.3 ms/tick. Modest in this near-empty sandbox
+  registry — the point of the fix is the eliminated event-loop SQL (incl. the
+  occasional DELETE write txn) under real, contended databases (the 22200
+  post-upgrade window), not sandbox wall time.
+
+**Mutation-tested**: skipping the `rename_workspace` bump reds
+`test_registry_mutation_reflects_in_the_next_tick`; deleting the view's cache
+reds the 0-SQL probe (35 round-trips reappear); freezing the fingerprint reds
+`test_tick_scope_rebuilds_when_registry_changes_mid_scope`.
+
+**Failure paths walked**: every new bump sits after its transaction commits, so
+a failed write rolls back AND leaves the generation unchanged — the memo keeps
+serving the still-true pre-write state; raised reads are never cached, so a
+persistently failing DB degrades per-build exactly as before. The tick scope's
+`finally` clears the shared cache even when teardown kills the tick mid-await
+(the scope sits inside the tick's teardown-scoped try), and the cache is
+per-tick, so nothing outlives the coroutine.
+
+**Tests**: new gate `Tests/UI/test_console_run_tick_workspace_reads.py`
+(6 tests: 0-SQL probe w/ trace callback, counter control, mutation refresh,
+pipeline once per build, one build per tick, mid-scope rebuild) + 1 new
+registry-suite test for the binding/membership bumps + widened pure-reads
+stability test. Targeted runs: Tests/Workspaces + workspace/rail/tray/tick UI
+suites — 439 + 140 + 203 + 48 + 47 passed; `--collect-only` sweep of
+Tests/UI + Tests/Workspaces: 16118 collected, 0 errors; preflight green after
+regenerating the diagnostic inventory (reviewed: 1 removed debug — the deleted
+ensure-repair log — and 1 added constant-string debug, no interpolation).
+**12 pre-existing dev reds** in adjacent suites were each baselined RED on the
+pristine pin `983aa5878` (test_console_new_workspace ×2, fleet-wake ×3,
+session-settings ×2, stream-scrollback ×1, agent-rail ×1,
+staged-evidence-strip ×3) — not caused by and not fixed by this change.
+
+**Files**: `tldw_chatbook/UI/Console_Modules/workspace.py`,
+`tldw_chatbook/UI/Screens/chat_screen.py`,
+`tldw_chatbook/Workspaces/registry_service.py`,
+`Tests/UI/test_console_run_tick_workspace_reads.py` (new),
+`Tests/Workspaces/test_workspace_registry_service.py`,
+`Docs/security/production-diagnostic-inventory.json` (regenerated).

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -18,6 +18,7 @@ DOM or reach through sibling controllers.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from functools import partial
 from typing import Any, Optional, TYPE_CHECKING
@@ -174,6 +175,177 @@ def _normalized_console_workspace_id(workspace_id: str | None) -> str:
     if not normalized or normalized == CONSOLE_GLOBAL_WORKSPACE_ID:
         return DEFAULT_WORKSPACE_ID
     return normalized
+
+
+class _ConsoleRegistryDisplayReads:
+    """Generation-keyed read-through view over the workspace registry.
+
+    TASK-22201 (extending the TASK-21118 memo pattern): the Console run tick
+    rebuilt its workspace context state up to six times per 0.2 s (see
+    :class:`ConsoleTickWorkspaceBuilds`), and each build performed the
+    registry's whole display read set as synchronous SQLite on the event
+    loop -- measured at ~80 WorkspaceDB round-trips per settled tick. Every one of those reads is a pure function of registry
+    tables that ``mutation_generation`` versions, so this view serves them
+    from a cache revalidated against (service identity, generation) and every
+    registry mutation anywhere in the app -- create, rename, archive,
+    set-active, binding and membership writes -- invalidates it on the very
+    next read.
+
+    Contract details:
+
+    * Only the four display reads are intercepted (``get_active_workspace``,
+      ``list_workspaces``, ``list_runtime_bindings``,
+      ``list_workspace_memberships``); every other attribute delegates to the
+      wrapped service, so this object can stand in for it inside
+      ``build_console_workspace_state``.
+    * A raised read is never cached -- callers keep their existing degraded
+      paths, and the next read retries live.
+    * Doubles without a real ``int`` generation are never cached (a
+      MagicMock's auto-attribute compares equal to itself forever and would
+      freeze the view -- the TASK-21118 lesson), so reduced test doubles stay
+      on live reads.
+    * ADR-028 is preserved by construction: only the SQL is cached.
+      ``display_state._safe_runtime_bindings`` still recomputes filesystem
+      binding status straight from disk on every build.
+    """
+
+    __slots__ = ("_service", "_generation", "_cache")
+
+    def __init__(self, service: Any) -> None:
+        self._service = service
+        self._generation: int | None = None
+        self._cache: dict[tuple, Any] = {}
+
+    @property
+    def service(self) -> Any:
+        """The wrapped registry service (identity checks by the owner)."""
+        return self._service
+
+    def _cacheable(self) -> bool:
+        """Revalidate the cache against the service's mutation generation."""
+        generation = getattr(self._service, "mutation_generation", None)
+        if isinstance(generation, bool) or not isinstance(generation, int):
+            self._cache.clear()
+            self._generation = None
+            return False
+        if generation != self._generation:
+            self._cache.clear()
+            self._generation = generation
+        return True
+
+    def _read(self, key: tuple, method_name: str, *args: Any) -> Any:
+        cacheable = self._cacheable()
+        if cacheable and key in self._cache:
+            return self._cache[key]
+        value = getattr(self._service, method_name)(*args)
+        if cacheable:
+            self._cache[key] = value
+        return value
+
+    def get_active_workspace(self) -> Any:
+        return self._read(("active",), "get_active_workspace")
+
+    def list_workspaces(self, *, include_archived: bool = False) -> Any:
+        if include_archived:
+            # Rare (Settings archive lists); not worth a cache slot.
+            return self._service.list_workspaces(include_archived=True)
+        return self._read(("workspaces",), "list_workspaces")
+
+    def list_runtime_bindings(self, workspace_id: str) -> Any:
+        return self._read(
+            ("bindings", str(workspace_id)), "list_runtime_bindings", workspace_id
+        )
+
+    def list_workspace_memberships(self, workspace_id: str) -> Any:
+        return self._read(
+            ("memberships", str(workspace_id)),
+            "list_workspace_memberships",
+            workspace_id,
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        # Private names never delegate: with ``__slots__`` a not-yet-bound
+        # ``_service`` would otherwise recurse straight back through here.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._service, name)
+
+
+class ConsoleTickWorkspaceBuilds:
+    """One run tick's shared workspace-context build (TASK-22201).
+
+    ``_sync_native_console_chat_ui`` used to build
+    ``_build_console_workspace_context_state()`` SIX times per 0.2 s tick
+    (measured with a stack probe): the two rail-state legs, the
+    workspace-context push, the control bar's and the agent section's
+    inspector legs, and the settings summary's rail read. This object is
+    created fresh for ONE tick by ``tick_workspace_build_scope`` and serves
+    every build the tick's own task performs; each read revalidates the
+    controller's volatile-input fingerprint, so:
+
+    * a settled tick pays for exactly one build;
+    * the PR #660 freshness ruling holds -- a session created/activated by
+      ``_sync_console_native_session_tabs`` mid-tick changes the store
+      fingerprint, and the workspace-context push and the visibility check
+      rebuild rather than reuse the pre-await snapshot;
+    * a ``None`` fingerprint (reduced doubles, any component failure) means
+      every read builds live, exactly the pre-cache behavior.
+
+    Task-scoped and never shared across ticks: ``accepts_current_task``
+    admits only the coroutine task that opened the scope, so workers,
+    message handlers, and search settles interleaving during the tick's
+    awaits keep building live -- a mutation followed by a push can never be
+    masked. Inputs outside the fingerprint changing DURING one tick are
+    repainted by the next tick, at most 0.2 s later -- the same cadence
+    every other tick-driven surface repaints at.
+    """
+
+    __slots__ = ("_controller", "_task", "_fingerprint", "_state", "_building")
+
+    def __init__(self, controller: "ConsoleWorkspaceController") -> None:
+        self._controller = controller
+        try:
+            self._task = asyncio.current_task()
+        except RuntimeError:
+            self._task = None
+        self._fingerprint: tuple | None = None
+        self._state: Any = None
+        self._building = False
+
+    def accepts_current_task(self) -> bool:
+        """Whether the calling context is the tick task that owns this cache.
+
+        Also False while the shared build itself is running (re-entrancy
+        guard) and when the scope was opened outside any asyncio task.
+        """
+        if self._building or self._task is None:
+            return False
+        try:
+            return asyncio.current_task() is self._task
+        except RuntimeError:
+            return False
+
+    def state(self) -> Any:
+        """Return the current context state, rebuilding when inputs changed."""
+        controller = self._controller
+        fingerprint = controller._console_workspace_build_fingerprint()
+        if (
+            self._state is not None
+            and fingerprint is not None
+            and fingerprint == self._fingerprint
+        ):
+            return self._state
+        self._building = True
+        try:
+            state = controller._build_console_workspace_context_state()
+        finally:
+            self._building = False
+        # Recomputed AFTER the build: building advances canonical-owner
+        # bookkeeping some fingerprint components include, and the stored
+        # token must describe the state actually cached.
+        self._fingerprint = controller._console_workspace_build_fingerprint()
+        self._state = state
+        return state
 
 
 class ConsoleWorkspaceController:
@@ -1522,11 +1694,13 @@ class ConsoleWorkspaceController:
         )
         attempt.membership_unknown = True
 
-    def workspace_tree_projection(
-        self,
-        rows: Iterable[ConsoleConversationBrowserInputRow] = (),
-    ) -> tuple[WorkspaceTreeWorkspace, ...]:
-        """Return the current immutable named-workspace projection."""
+    def _prune_stale_workspace_page_attempts(self) -> tuple[WorkspaceRecord, ...]:
+        """Drop page attempts for workspaces gone from the registry.
+
+        Returns:
+            Live named-workspace records (non-archived, excluding the
+            built-in Default), the set the workspace tree renders.
+        """
         all_records = tuple(
             record
             for record in self._console_browser_workspace_records()
@@ -1542,6 +1716,27 @@ class ConsoleWorkspaceController:
         for workspace_id in tuple(self._workspace_page_attempts):
             if workspace_id not in workspace_ids:
                 self._workspace_page_attempts.pop(workspace_id, None)
+        return records
+
+    def workspace_tree_projection(
+        self,
+        rows: Iterable[ConsoleConversationBrowserInputRow] = (),
+        *,
+        prepared_rows: tuple[ConsoleConversationBrowserInputRow, ...] | None = None,
+    ) -> tuple[WorkspaceTreeWorkspace, ...]:
+        """Return the current immutable named-workspace projection.
+
+        Args:
+            rows: Browser input rows to merge with the page-attempt rows on
+                the no-query path.
+            prepared_rows: The state build's already merged + canonical-owner
+                + overlay processed union of browser and page-attempt rows
+                (TASK-22201). When provided and no tree query is active, the
+                merge/canonical/overlay pipeline is NOT re-run here -- the
+                build already ran it once over the identical input set.
+                Standalone callers omit it and keep the self-contained path.
+        """
+        records = self._prune_stale_workspace_page_attempts()
         workspace_lane = self._workspace_tree_search
         projection_query = (
             workspace_lane.settled_query
@@ -1554,13 +1749,17 @@ class ConsoleWorkspaceController:
                 if workspace_lane.error
                 else workspace_lane.rows
             )
+            source_rows = self._rows_with_latest_canonical_owner(source_rows)
+            source_rows = self._overlay_current_console_browser_markers(source_rows)
+        elif prepared_rows is not None:
+            source_rows = prepared_rows
         else:
             source_rows = self._merge_console_browser_rows(
                 rows,
                 *(attempt.rows for attempt in self._workspace_page_attempts.values()),
             )
-        source_rows = self._rows_with_latest_canonical_owner(source_rows)
-        source_rows = self._overlay_current_console_browser_markers(source_rows)
+            source_rows = self._rows_with_latest_canonical_owner(source_rows)
+            source_rows = self._overlay_current_console_browser_markers(source_rows)
         return build_workspace_tree_state(
             workspaces=(
                 (str(record.workspace_id), str(record.name or record.workspace_id))
@@ -2673,9 +2872,32 @@ class ConsoleWorkspaceController:
                 workspace_labels=canonical_labels,
                 canonical_rows=canonical_rows,
             )
-        rows = self._rows_with_latest_canonical_owner(rows)
-        rows = self._overlay_current_console_browser_markers(
-            rows, current_conversation_id
+        # TASK-22201: ONE canonical-owner + overlay pass per build. The
+        # browser rows and the workspace tree's no-query source (browser
+        # rows + surviving page-attempt rows) used to run this pipeline
+        # separately -- twice per build, up to six times per run tick. Both
+        # passes are per-row (the canonical filter and every overlay marker
+        # depend only on the row itself plus controller/store state), so one
+        # pass over the merged union, partitioned back out by display
+        # identity, is exactly equivalent. Stale page attempts are pruned
+        # FIRST -- the projection used to do that before its own merge, and
+        # a just-deleted workspace's rows must not ride in via the union.
+        self._prune_stale_workspace_page_attempts()
+        browser_identities = {
+            self._console_browser_display_identity(row) for row in rows
+        }
+        union_rows = self._merge_console_browser_rows(
+            rows,
+            *(attempt.rows for attempt in self._workspace_page_attempts.values()),
+        )
+        union_rows = self._rows_with_latest_canonical_owner(union_rows)
+        union_rows = self._overlay_current_console_browser_markers(
+            union_rows, current_conversation_id
+        )
+        rows = tuple(
+            row
+            for row in union_rows
+            if self._console_browser_display_identity(row) in browser_identities
         )
         if not projection_query.strip() and not self._flat_conversation_search.error:
             ordinary_rows = tuple(
@@ -2705,7 +2927,9 @@ class ConsoleWorkspaceController:
             state,
             conversation_browser=browser,
             conversation_section=legacy_state.conversation_section,
-            workspace_tree=self.workspace_tree_projection(rows),
+            workspace_tree=self.workspace_tree_projection(
+                rows, prepared_rows=union_rows
+            ),
             workspace_query=self._workspace_tree_search.query,
             workspace_loading=self._workspace_tree_search.request_key is not None,
             workspace_error=str(self._workspace_tree_search.error or ""),
@@ -3792,12 +4016,49 @@ class ConsoleWorkspaceController:
 
     # -- Workspace context state / grouped conversation rows -----------------
 
+    #: The open run tick's shared build cache, or ``None`` outside a tick
+    #: (TASK-22201). A CLASS attribute default, matching the screen's memo
+    #: conventions, so hand-built fixtures that skip ``__init__`` still
+    #: read a defined value.
+    _console_tick_builds: "ConsoleTickWorkspaceBuilds | None" = None
+
+    @contextmanager
+    def tick_workspace_build_scope(self):
+        """Share ONE fingerprint-validated context build across a run tick.
+
+        Opened by ``_sync_native_console_chat_ui`` around its sync body
+        (TASK-22201): every ``_build_console_workspace_context_state`` call
+        the tick's own asyncio task performs -- directly or through the
+        inspector/control-bar/agent-section legs -- is served from one
+        :class:`ConsoleTickWorkspaceBuilds` cache. Deliberately opt-in and
+        scoped, like the screen's ``_console_derivation_scope``
+        (task-15452): outside a ``with`` block, and for any OTHER task
+        interleaving during the tick's awaits, every build is live exactly
+        as before. Re-entrant (an inner scope keeps the outer cache) and
+        always torn down, so a raising tick cannot leave a stale build
+        cached for the next one.
+        """
+        if getattr(self, "_console_tick_builds", None) is not None:
+            yield
+            return
+        self._console_tick_builds = ConsoleTickWorkspaceBuilds(self)
+        try:
+            yield
+        finally:
+            self._console_tick_builds = None
+
     def _build_console_workspace_context_state(self) -> ConsoleWorkspaceContextState:
+        builds = getattr(self, "_console_tick_builds", None)
+        if builds is not None and builds.accepts_current_task():
+            return builds.state()
         current_conversation = self._current_console_conversation_id()
+        # The generation-keyed display-read view stands in for the raw
+        # service (TASK-22201): the builder's read set (active workspace,
+        # workspaces, runtime bindings, memberships) is served without SQL
+        # while the registry is unchanged. ADR-028's from-disk binding
+        # status recompute still runs per build inside the builder.
         state = build_console_workspace_state(
-            registry_service=getattr(
-                self.app_instance, "workspace_registry_service", None
-            ),
+            registry_service=self._console_registry_reads_view(),
             current_conversation=current_conversation,
             conversations=(),
             server_adapter_state=getattr(
@@ -3816,6 +4077,111 @@ class ConsoleWorkspaceController:
             state,
             current_conversation_id=current_conversation,
         )
+
+    def _console_workspace_build_fingerprint(self) -> tuple | None:
+        """Cheap change token over the context build's volatile inputs.
+
+        Serves the run tick's build cache (TASK-22201): identical
+        fingerprints between two reads WITHIN ONE TICK mean the cached
+        build may be reused. Covered inputs -- registry identity +
+        ``mutation_generation``, current conversation, store sessions
+        (identity, title, timestamps, persistence, workspace) + active
+        session, run status + per-session queued counts, canonical
+        membership revision, persisted-rows cache token, both search
+        lanes' generations/queries/errors, and the page-attempt shape --
+        are exactly the ones the PR #660 / task-280 freshness rulings care
+        about across the tick's awaits (session create/activate/persist).
+        Deliberately NOT exhaustive: long-tail inputs (stars, unseen
+        markers, collapse preferences) change only through paths that
+        rebuild and push OUTSIDE the tick cache's lifetime, so a miss is
+        bounded by one 0.2 s tick. Returns ``None`` (never reuse) when the
+        registry lacks a real ``int`` generation or any component read
+        fails.
+        """
+        try:
+            registry_service = getattr(
+                self.app_instance, "workspace_registry_service", None
+            )
+            generation = getattr(registry_service, "mutation_generation", None)
+            if registry_service is not None and (
+                isinstance(generation, bool) or not isinstance(generation, int)
+            ):
+                return None
+            store = self._console_chat_store
+            controller = self._console_chat_controller
+            sessions_token: tuple = ()
+            active_session_id = None
+            queued_token: tuple = ()
+            if store is not None:
+                active_session_id = store.active_session_id
+                sessions = tuple(store.sessions())
+                sessions_token = tuple(
+                    (
+                        session.id,
+                        str(session.title or ""),
+                        str(session.updated_at or ""),
+                        str(session.persisted_conversation_id or ""),
+                        str(session.workspace_id or ""),
+                    )
+                    for session in sessions
+                )
+                if controller is not None:
+                    queued_token = tuple(
+                        controller.activity_for(session.id).queued_count
+                        for session in sessions
+                    )
+            run_status = (
+                controller.run_state.status if controller is not None else None
+            )
+            flat_lane = self._flat_conversation_search
+            workspace_lane = self._workspace_tree_search
+            attempts_token = tuple(
+                (
+                    workspace_id,
+                    attempt.generation,
+                    len(attempt.rows),
+                    attempt.loading,
+                    attempt.error,
+                    attempt.next_cursor,
+                    attempt.retry_cursor,
+                    attempt.membership_unknown,
+                )
+                for workspace_id, attempt in self._workspace_page_attempts.items()
+            )
+            return (
+                id(registry_service),
+                generation,
+                self._current_console_conversation_id(),
+                active_session_id,
+                sessions_token,
+                queued_token,
+                run_status,
+                self._canonical_membership_revision,
+                self._console_persisted_rows_cache_token,
+                self._console_conversation_browser_query,
+                (
+                    flat_lane.generation,
+                    flat_lane.query,
+                    flat_lane.error,
+                    flat_lane.settled_query,
+                    flat_lane.request_key,
+                ),
+                (
+                    workspace_lane.generation,
+                    workspace_lane.query,
+                    workspace_lane.error,
+                    workspace_lane.settled_query,
+                    workspace_lane.request_key,
+                ),
+                attempts_token,
+                getattr(self.app_instance, "workspace_server_adapter_state", None),
+                getattr(self.app_instance, "workspace_acp_handoff_state", None),
+            )
+        except Exception:
+            logger.debug(
+                "Console workspace build fingerprint unavailable; building live"
+            )
+            return None
 
     @staticmethod
     def _console_workspace_row_key(row: ConsoleWorkspaceConversationRow) -> str:
@@ -3862,20 +4228,48 @@ class ConsoleWorkspaceController:
                 "Unable to activate Console workspace for browser row",
             )
 
-    def _console_browser_workspace_records(self) -> tuple[WorkspaceRecord, ...]:
-        """Return all local workspace records visible to the Console browser."""
+    #: Generation-keyed display-read view over the app's registry service,
+    #: or ``None`` before the first read (TASK-22201). A CLASS attribute
+    #: default, matching the screen's memo conventions, so hand-built
+    #: fixtures that skip ``__init__`` still read a defined value.
+    _console_registry_display_reads: "_ConsoleRegistryDisplayReads | None" = None
+
+    def _console_registry_reads_view(self) -> "_ConsoleRegistryDisplayReads | None":
+        """Return the display-read view bound to the CURRENT service instance.
+
+        Rebound (dropping its cache) whenever the app swaps its registry
+        service, mirroring the identity check in the TASK-21118 memo.
+        """
         service = getattr(self.app_instance, "workspace_registry_service", None)
         if service is None:
+            return None
+        view = getattr(self, "_console_registry_display_reads", None)
+        if view is None or view.service is not service:
+            view = _ConsoleRegistryDisplayReads(service)
+            self._console_registry_display_reads = view
+        return view
+
+    def _console_browser_workspace_records(self) -> tuple[WorkspaceRecord, ...]:
+        """Return all local workspace records visible to the Console browser.
+
+        Served from the generation-keyed display-read view (TASK-22201):
+        the run tick reaches this method many times per 0.2 s (browser
+        labels, the workspace tree projection, page-row labels), and each
+        call used to run ``ensure_default_workspace()`` -- a write-capable
+        REPAIR (SELECT + bindings probe + occasional DELETE transaction) --
+        plus ``list_workspaces()``, synchronously on the event loop. The
+        repair does not belong on a display path and was never this path's
+        responsibility alone: boot wiring (``app.py``
+        ``_wire_workspace_registry_services``), ``archive_workspace``,
+        ``set_active_workspace``'s switch-to-Default repair, and
+        ``_set_active_workspace_for_console_session``'s global branch all
+        keep the registry resting on an active workspace. Display reads a
+        degraded registry as degraded and repairs nothing.
+        """
+        view = self._console_registry_reads_view()
+        if view is None:
             return ()
-        ensure_default = getattr(service, "ensure_default_workspace", None)
-        if callable(ensure_default):
-            try:
-                ensure_default()
-            except Exception:
-                logger.opt(exception=True).debug(
-                    "Unable to ensure default workspace for Console browser"
-                )
-        list_workspaces = getattr(service, "list_workspaces", None)
+        list_workspaces = getattr(view, "list_workspaces", None)
         if not callable(list_workspaces):
             return ()
         try:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10931,7 +10931,12 @@ class ChatScreen(BaseAppScreen):
         available_columns: int | None = None,
         inspector_state: ConsoleInspectorState | None = None,
     ) -> ConsoleRailState:
-        """Build the current effective rail state from mounted Console context."""
+        """Build the current effective rail state from mounted Console context.
+
+        Inside a run tick's `tick_workspace_build_scope` (TASK-22201) the
+        workspace-context build below is served from the tick's shared,
+        fingerprint-validated build; every other caller builds live.
+        """
         resolved_available_columns = (
             available_columns
             if available_columns is not None
@@ -15203,18 +15208,32 @@ class ChatScreen(BaseAppScreen):
             # fresh post-await state (PR #660 review caught the reuse as a
             # staleness regression — the one-tuple-per-tick dedupe is
             # withdrawn for the visibility half).
-            rail_state = self._current_console_rail_state()
-            self._sync_console_control_bar(rail_state)
-            self._sync_console_settings_summary()
-            self._sync_console_mode_bar()
-            await self._sync_console_native_session_tabs()
-            self._dispatch_active_console_roleplay_refresh()
-            self._sync_console_workspace_context()
-            project_instruction_ui.sync_project_instruction_status_for_screen(self)
-            await self._sync_native_console_transcript()
-            self._sync_console_rail_visibility_if_changed(
-                self._current_console_rail_state()
-            )
+            #
+            # TASK-22201: the workspace-context builds of one tick (the rail
+            # states here, the workspace-context push, the control bar's and
+            # agent section's inspector legs — six per tick, measured) share
+            # ONE fingerprint-validated build through this scope. The PR
+            # #660 ruling is kept by MECHANISM rather than by always
+            # rebuilding: a session created/activated across the awaits
+            # changes the store fingerprint and the later reads rebuild,
+            # while a settled tick pays for one build. Task-scoped: only
+            # THIS coroutine's task reads the cache — workers and handlers
+            # interleaving during the awaits keep building live.
+            with self._workspace.tick_workspace_build_scope():
+                rail_state = self._current_console_rail_state()
+                self._sync_console_control_bar(rail_state)
+                self._sync_console_settings_summary()
+                self._sync_console_mode_bar()
+                await self._sync_console_native_session_tabs()
+                self._dispatch_active_console_roleplay_refresh()
+                self._sync_console_workspace_context()
+                project_instruction_ui.sync_project_instruction_status_for_screen(
+                    self
+                )
+                await self._sync_native_console_transcript()
+                self._sync_console_rail_visibility_if_changed(
+                    self._current_console_rail_state()
+                )
             self._dispatch_console_rail_preference_prune()
         except Exception:
             # Teardown-scoped ONLY. A tick that was mid-flight when the

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -271,18 +271,30 @@ class LocalWorkspaceRegistryService:
 
     @property
     def mutation_generation(self) -> int:
-        """Monotonic count of workspace-record mutations (TASK-21118).
+        """Monotonic count of registry display-read mutations (TASK-21118).
 
         Bumped by every mutator that can change what a workspace-record
         read (``get_active_workspace``, ``get_workspace``,
         ``list_workspaces``) returns: create, rename, archive, unarchive,
         set-active, clear-active, and the built-in Default restore.
         ``ensure_default_workspace`` bumps through those same legs when
-        (and only when) it actually changed something.
+        (and only when) it actually changed something. TASK-22201 widened
+        the contract to the Console context build's whole display read set:
+        runtime-binding mutators (``save_runtime_binding`` — which
+        ``add_folder_binding`` and ``set_folder_binding_access`` route
+        through — ``remove_runtime_binding``, and the Default stale-binding
+        repair) and ``link_membership`` now bump too, so
+        ``list_runtime_bindings`` / ``list_workspace_memberships`` results
+        are also safe to cache against this value.
+        ``set_workspace_scope`` / ``set_change_review_enabled`` write
+        tables outside that read set and deliberately do not bump.
 
         This is the invalidation subscription point for read caches: the
         Console keystroke path memoizes its active-workspace resolution
-        against this value instead of re-reading SQLite ~1.25x per key.
+        against this value instead of re-reading SQLite ~1.25x per key,
+        and the Console run tick serves its registry display reads from a
+        generation-keyed view instead of ~80 SQLite round-trips per 0.2 s
+        tick (TASK-22201).
         Every UI seam that changes the active workspace (Console switcher,
         browser-row open, session switch, Settings "Set active", Library's
         create modal, archive flows) funnels through these mutators on the
@@ -733,6 +745,11 @@ class LocalWorkspaceRegistryService:
                 )
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        # Membership rows feed the Console context build's display reads,
+        # so generation-keyed caches (TASK-22201) must revalidate. INSERT OR
+        # IGNORE may have been a no-op; the occasional spurious bump merely
+        # costs one re-read.
+        self._bump_mutation_generation()
         try:
             with self.db.connection() as conn:
                 row = conn.execute(
@@ -2008,6 +2025,7 @@ class LocalWorkspaceRegistryService:
                 )
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        self._bump_mutation_generation()
         stored = self.get_runtime_binding(safe_binding.binding_id)
         if stored is None:
             raise WorkspaceRegistryServiceError("Runtime binding save failed.")
@@ -2116,6 +2134,7 @@ class LocalWorkspaceRegistryService:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         if cursor.rowcount == 0:
             raise BindingNotFound(safe_binding_id)
+        self._bump_mutation_generation()
 
     def set_folder_binding_access(
         self, binding_id: str, *, allow_write: bool
@@ -2525,6 +2544,9 @@ class LocalWorkspaceRegistryService:
                 )
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        # A binding row changed, so generation-keyed display-read caches
+        # (TASK-22201) must revalidate; only reached when rows were deleted.
+        self._bump_mutation_generation()
 
     def _restore_default_workspace(self) -> None:
         """Restore the built-in Default workspace when it is the only safe active fallback."""


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22201). PR #2034's workspace tree reintroduced the TASK-21118 defect class on the 5 Hz run tick: ~45 synchronous registry queries/second on the event loop while streaming (incl. `ensure_default_workspace`'s write-capable repair), plus the O(all-conversations) row pipeline run twice per build, six builds per tick.

**Change (three mechanisms):** (1) `_ConsoleRegistryDisplayReads` — a generation-keyed read-through view over the four registry display reads, keyed on `mutation_generation` (contract widened: binding/membership mutators now bump; every bump sits after commit); never caches raised reads. (2) The row pipeline runs once per build on a merged union, partitioned back by display identity; stale-attempt pruning hoisted before the union. (3) `tick_workspace_build_scope` — an asyncio-task-scoped shared build revalidated by a volatile-input fingerprint; the tick body runs inside it. `ensure_default_workspace` is off all display paths (repair ownership audited: boot wiring, archive, activation paths — the display path was never the sole invoker).

**Measured:** registry SQL over 5 settled ticks **400 → 0**; context builds per tick **6 → 1** (the filing undercounted at 3 — corrected, lesson recorded); 50-tick wall 14.8-17.0 → 13.0-14.3 ms/tick in a near-empty sandbox registry (the eliminated on-loop SQL under contended real DBs is the point — see TASK-22200's window).

**Adversarial review: SHIP** after one review commit: mutation-testing found the fingerprint's store components (sessions token + active session) could be deleted with the entire 161-test surface green — the exact PR #660 mid-tick freshness scenario invisible — so the review added two gate tests that kill the mutant. Full fingerprint-coverage inventory in the review record; uncovered long-tail inputs (stars/fleet-unseen/collapse prefs/subagent counts) are a documented ≤1-tick staleness class. No-bump exemptions verified against a complete SQL-write inventory; bump-after-commit verified at every site; failure path = degrade-per-build exactly as base; the scope's `finally` clears the cache (mutation-pinned).

Tests: gate file 9/9 (6 implementer + 3 review); 439+140+203+48+47 targeted green except baselined pre-existing reds (reproduced on pristine base); preflight green (inventory row change re-audited: constant-string debug only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates synchronous Workspace registry SQL on the 5 Hz Console run tick and reduces six workspace‑context builds per tick to one while preserving mid‑tick freshness. Old behavior: ~80 event‑loop SQL calls per tick and the merge/canonical/overlay pipeline ran twice per build; new behavior: zero registry SQL on settled ticks and one build per tick; `ensure_default_workspace()` no longer runs on display paths.

**Refactors**
- Serve `get_active_workspace`, `list_workspaces`, `list_runtime_bindings`, and `list_workspace_memberships` via a generation‑keyed read‑through view; never caches raised reads.
- Widen `mutation_generation` to bump on runtime‑binding saves/removes/default‑binding cleanup and `link_membership`; bumps occur after commit.
- Remove `ensure_default_workspace()` from `_console_browser_workspace_records`; repairs remain in boot and mutation seams.
- Run the merge/canonical‑owner/overlay pipeline once over a merged union and pass prepared rows to `workspace_tree_projection`.
- Share one build per tick with `tick_workspace_build_scope`, revalidated by a volatile‑input fingerprint; other tasks and out‑of‑scope callers still build live.

<sup>Written for commit 49a8d5ab0fd1f3694f978c2df6eda4185561d50c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

