### PR TITLE
fix(console): restore the ADR-046 queue and make a failed DB open visible on Send (TASK-22000, TASK-22030)

### DIFF
--- a/Docs/User_Guide/console/chat-basics.md
+++ b/Docs/User_Guide/console/chat-basics.md
@@ -326,4 +326,8 @@ Transcript:
 Composer geometry, history recall, and ghost text re-verified against
 dev @ b6036515e — 2026-08-18 (task-17662: keys checked against the
 composer's key handling; geometry against the bottom-stack programme's
-painted probes).*
+painted probes). The Send→Queue behaviour described above was re-verified
+live against dev @ a71e62e4b — 2026-08-24 (TASK-22000: the page was
+correct and the app was not; mid-run the button now reads **Queue**, is
+enabled with a draft, and admits a FIFO follow-up that drains after the
+current turn).*

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -243,8 +243,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 49,
-      "diagnostic_digest": "00c188fa6c46fd077ba5",
+      "call_count": 51,
+      "diagnostic_digest": "4a06156c02dffecef8e0",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -3968,7 +3968,7 @@
   "summary": {
     "owner_files": 537,
     "persistent_sink_files": 8,
-    "task_492_calls": 1238,
+    "task_492_calls": 1240,
     "task_494_calls": 7334
   }
 }

--- a/Tests/Chat/test_console_dispatch_recovery_fix_round1.py
+++ b/Tests/Chat/test_console_dispatch_recovery_fix_round1.py
@@ -212,6 +212,25 @@ async def test_healthy_durable_owner_is_not_recovery_before_checkpoint_transitio
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The pre-transition owner is live truth, never a user-visible recovery.
+
+    TASK-22000 (owner decision, 2026-08-24): this test originally also pinned
+    ``dispatch_recovery_blocks_submission(...) is True`` for this exact
+    healthy window. That half is now wrong -- it disabled Send for the whole
+    duration of every live turn, which contradicts ADR-046 / TASK-14808 /
+    TASK-15121 (an accepted live turn re-labels Send to "Queue" and admits the
+    draft as a FIFO follow-up). What this test is *named* for is unchanged and
+    still pinned below: the owner published before the checkpoint transition
+    is runtime truth (``runtime_active=True, recovery_needed=False``) and must
+    never surface as a recovery card. The genuine blocking contract this file
+    protects lives in
+    ``test_restored_source_owner_refuses_fresh_submit_before_echo_or_acceptance``
+    and ``_assert_original_owner_rolled_back`` -- both unhealthy owners, both
+    still refused -- plus
+    ``test_unhealthy_recovery_owner_still_blocks_submission_and_a_queued_turn``
+    in ``Tests/Chat/test_console_send_gate_queue_race.py``.
+    """
+
     _db, store, controller, _gateway = _controller(tmp_path)
     observed: list[tuple[object, bool, bool, bool]] = []
     publish = store.publish_durable_turn_owners
@@ -235,7 +254,7 @@ async def test_healthy_durable_owner_is_not_recovery_before_checkpoint_transitio
     result = await controller.submit_draft("healthy durable", session_id="session-1")
 
     assert result.accepted is True
-    assert observed == [(None, True, True, False)]
+    assert observed == [(None, False, True, False)]
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_first_send_atomicity.py
+++ b/Tests/Chat/test_console_first_send_atomicity.py
@@ -9,7 +9,10 @@ import pytest
 
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
-from tldw_chatbook.Chat.console_chat_models import ConsoleRunStatus
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunStatus,
+)
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_dispatch_checkpoint import (
     ConsoleDispatchCheckpointState,
@@ -117,7 +120,17 @@ async def test_real_durable_adapter_without_atomic_method_fails_closed(
     )
 
     assert result.accepted is False
-    assert "durable turn acceptance is unavailable" in result.visible_copy.lower()
+    # TASK-22030: the refusal is right; its old shape (a bare result, no run
+    # state, no row, no toast) was not. Assert the user-visible surface, not
+    # just the return value.
+    assert "not sent" in result.visible_copy.lower()
+    assert result.should_clear_draft is False
+    run_state = controller.run_state_for("session-1")
+    assert run_state.status is ConsoleRunStatus.BLOCKED
+    assert run_state.visible_copy == result.visible_copy
+    rows = store.messages_for_session("session-1")
+    assert [row.role for row in rows] == [ConsoleMessageRole.SYSTEM]
+    assert rows[0].content == result.visible_copy
     assert gateway.calls == 0
     assert store.sessions()[0].persisted_conversation_id is None
     assert (

--- a/Tests/Chat/test_console_send_gate_queue_race.py
+++ b/Tests/Chat/test_console_send_gate_queue_race.py
@@ -1,0 +1,360 @@
+"""TASK-22000: the restored ADR-046 queue cannot race a durable commit.
+
+The owner decided that a *healthy* in-flight durable turn must not block Send
+(ADR-046 / TASK-14808: the button re-labels to "Queue" and admits the draft as
+a FIFO follow-up). TASK-19900.3's ``dispatch_recovery_blocks_submission``
+previously refused for the app's own live run, so the queue was unreachable.
+
+Narrowing that predicate is only safe if a queued follow-up genuinely cannot
+overlap the first turn's durable commit -- two durable owners in one
+conversation are refused at the SQLite level ("active dispatch checkpoint"),
+so an overlap would surface as a raw ``RuntimeError``. These tests drive the
+real interleavings rather than reasoning about them:
+
+* admission attempted *while the commit transaction is open* (refused: there
+  is no chain to admit into until the turn is accepted);
+* admission accepted mid-stream, then drained (strictly after the first turn
+  settles, never alongside it -- at most one checkpoint row exists at a time);
+* admission accepted mid-run whose owner then becomes genuinely unhealthy
+  (still refused, with a visible reason and the entry returned to the queue).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from Tests.Chat.test_console_dispatch_recovery import (
+    _acceptance,
+    _database,
+    _insert,
+    _restored_store,
+)
+from Tests.Chat.test_console_first_send_atomicity import _controller
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunState,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.Chat.console_dispatch_checkpoint import (
+    ConsoleEgressClass,
+    ConsoleResolvedDestination,
+)
+from tldw_chatbook.Chat.console_prompt_queue import (
+    PromptQueueMode,
+    PromptQueuePauseReason,
+    QueueMutationStatus,
+)
+from tldw_chatbook.Chat.console_prompt_queue_coordinator import _PromptChain
+
+
+class _HoldingGateway:
+    """Stream one chunk, then hold the turn open until explicitly released."""
+
+    def __init__(self, db) -> None:
+        self.db = db
+        self.calls = 0
+        self.prompts: list[str] = []
+        self.checkpoint_counts: list[int] = []
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.hold = True
+
+    async def resolve_for_send(self, _selection: object) -> object:
+        return SimpleNamespace(
+            ready=True,
+            provider="llama_cpp",
+            model="test-model",
+            base_url="http://127.0.0.1:9099",
+            visible_copy="",
+            resolved_destination=ConsoleResolvedDestination(
+                provider="llama_cpp",
+                model="test-model",
+                endpoint_identity="http://127.0.0.1:9099",
+                egress_class=ConsoleEgressClass.ON_DEVICE,
+            ),
+        )
+
+    async def stream_chat(
+        self, _resolution: object, messages: list[dict[str, Any]], **_kwargs: Any
+    ):
+        self.calls += 1
+        self.prompts.append(str(messages[-1].get("content", "")))
+        self.checkpoint_counts.append(_checkpoint_rows(self.db))
+        self.started.set()
+        yield "done"
+        if self.hold:
+            await self.release.wait()
+
+
+def _checkpoint_rows(db) -> int:
+    return int(
+        db.get_connection()
+        .execute("SELECT COUNT(*) FROM console_dispatch_checkpoints")
+        .fetchone()[0]
+    )
+
+
+def _message_rows(db) -> int:
+    return int(
+        db.get_connection().execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_follow_up_cannot_be_admitted_while_the_durable_commit_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A draft offered mid-commit is refused admission, not silently queued."""
+
+    db, store, controller, _gateway = _controller(tmp_path)
+    persistence = store.persistence
+    assert persistence is not None
+    gateway = _HoldingGateway(db)
+    gateway.hold = False
+    controller.provider_gateway = gateway
+    create_conversation = persistence.create_conversation
+    observed: list[tuple[bool, bool, bool, QueueMutationStatus, int]] = []
+
+    def observe_inside_the_open_transaction(**kwargs: Any):
+        # `commit_durable_turn` creates the conversation inside its own
+        # `BEGIN IMMEDIATE`, so this runs with the durable turn half-written.
+        snapshot = controller.prompt_queue_registry.snapshot("session-1")
+        activity = controller.activity_for("session-1")
+        admitted = controller.queue_prompt(
+            "session-1",
+            text="follow-up offered mid-commit",
+            expected_revision=snapshot.revision,
+        )
+        observed.append(
+            (
+                db.get_connection().in_transaction,
+                activity.accepted_live_turn,
+                store.dispatch_recovery_blocks_submission("session-1"),
+                admitted.status,
+                snapshot.total_count,
+            )
+        )
+        return create_conversation(**kwargs)
+
+    monkeypatch.setattr(
+        persistence, "create_conversation", observe_inside_the_open_transaction
+    )
+
+    result = await controller.run_prompt_chain("first", session_id="session-1")
+
+    assert result.accepted is True
+    # The hook fired exactly once, genuinely inside the commit transaction.
+    assert len(observed) == 1
+    in_transaction, accepted_live, blocks, status, queued_before = observed[0]
+    assert in_transaction is True
+    # Nothing is accepted yet, so there is no chain and no owner at all --
+    # admission cannot happen, and there is nothing to block submission with.
+    assert accepted_live is False
+    assert blocks is False
+    assert status is QueueMutationStatus.REROUTE_NORMAL_SEND
+    assert queued_before == 0
+    # The rejected mid-commit draft left no entry behind.
+    assert controller.prompt_queue_registry.snapshot("session-1").total_count == 0
+    assert gateway.calls == 1
+    assert _checkpoint_rows(db) == 0
+    assert _message_rows(db) == 2
+
+
+@pytest.mark.asyncio
+async def test_healthy_live_owner_admits_a_queued_follow_up_drained_strictly_after(
+    tmp_path: Path,
+) -> None:
+    """The ADR-046 queue works, and never holds two durable owners at once."""
+
+    db, store, controller, _gateway = _controller(tmp_path)
+    gateway = _HoldingGateway(db)
+    controller.provider_gateway = gateway
+
+    task = asyncio.create_task(
+        controller.run_prompt_chain("first", session_id="session-1")
+    )
+    await asyncio.wait_for(gateway.started.wait(), timeout=5)
+
+    # A healthy in-flight durable owner exists...
+    recovery = store.dispatch_recovery_for_session("session-1")
+    assert recovery is not None
+    assert recovery.runtime_active is True
+    assert recovery.recovery_needed is False
+    # ...and, per the TASK-22000 owner decision, does NOT block submission or
+    # surface as a recovery card.
+    assert store.dispatch_recovery_blocks_submission("session-1") is False
+    assert store.dispatch_recovery_for_presentation("session-1") is None
+    # A *manual* second turn is still refused -- by the live run, not by the
+    # recovery owner. The distinction is the whole point: the queue is the
+    # affordance for a follow-up, and it is now reachable.
+    refusal = controller.send_refusal_copy("session-1")
+    assert refusal
+    assert "pending response" not in refusal.lower()
+    assert _checkpoint_rows(db) == 1
+
+    snapshot = controller.prompt_queue_registry.snapshot("session-1")
+    admitted = controller.queue_prompt(
+        "session-1", text="second", expected_revision=snapshot.revision
+    )
+    assert admitted.status is QueueMutationStatus.APPLIED
+    # Admission is a memory-only registry write: the follow-up has NOT been
+    # submitted, and the first turn still owns the only checkpoint row.
+    assert gateway.calls == 1
+    assert _checkpoint_rows(db) == 1
+
+    gateway.hold = False
+    gateway.release.set()
+    result = await asyncio.wait_for(task, timeout=10)
+
+    assert result.accepted is True
+    assert gateway.calls == 2
+    assert gateway.prompts == ["first", "second"]
+    # The decisive evidence: at each provider entry exactly one durable owner
+    # existed, so the queued turn never overlapped the first turn's commit.
+    assert gateway.checkpoint_counts == [1, 1]
+    assert _checkpoint_rows(db) == 0
+    assert _message_rows(db) == 4
+    users = [
+        message.content
+        for message in store.messages_for_session("session-1")
+        if message.role is ConsoleMessageRole.USER
+    ]
+    assert users == ["first", "second"]
+    assert controller.prompt_queue_registry.snapshot("session-1").total_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_recovery_owner_still_blocks_submission_and_a_queued_turn(
+    tmp_path: Path,
+) -> None:
+    """The block TASK-19900.3 actually needed survives the narrowing."""
+
+    db, conversation_id, repository = _database(tmp_path / "unhealthy.sqlite")
+    _insert(db, repository, _acceptance(conversation_id))
+    store, session_id = _restored_store(db, conversation_id)
+    gateway = _HoldingGateway(db)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        base_url="http://127.0.0.1:9099",
+        agent_runtime_enabled=False,
+    )
+
+    recovery = store.dispatch_recovery_for_session(session_id)
+    assert recovery is not None
+    assert recovery.recovery_needed is True
+    assert store.dispatch_recovery_blocks_submission(session_id) is True
+    assert store.dispatch_recovery_for_presentation(session_id) is recovery
+    assert "pending response" in (
+        controller.send_refusal_copy(session_id) or ""
+    ).lower()
+
+    manual = await controller.submit_draft("manual retry", session_id=session_id)
+    assert manual.accepted is False
+    assert "pending response" in manual.visible_copy.lower()
+
+    # And the same refusal reaches a genuinely coordinator-authorized QUEUED
+    # send, driven through the real drain rather than a hand-built origin.
+    coordinator = controller.prompt_queue_coordinator
+    registry = coordinator.registry
+    begun = registry.begin_chain(session_id, context_epoch=0, expected_revision=0)
+    entry = registry.admit(
+        session_id,
+        text="queued retry",
+        expected_revision=begun.snapshot.revision,
+    )
+    assert entry.entry_id is not None
+    coordinator._chains[session_id] = _PromptChain()
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.COMPLETED), session_id=session_id
+    )
+    queued_results: list[Any] = []
+    submit_queued = coordinator._submit_queued
+
+    async def capture(text: str, **kwargs: Any):
+        result = await submit_queued(text, **kwargs)
+        queued_results.append(result)
+        return result
+
+    coordinator._submit_queued = capture
+
+    await coordinator._drain_waiting(session_id, ConsoleRunStatus.COMPLETED)
+
+    assert len(queued_results) == 1
+    assert queued_results[0].accepted is False
+    assert "pending response" in queued_results[0].visible_copy.lower()
+    snapshot = registry.snapshot(session_id)
+    assert [item.entry_id for item in snapshot.entries] == [entry.entry_id]
+    assert snapshot.mode is PromptQueueMode.PAUSED
+    assert snapshot.pause_reason is PromptQueuePauseReason.DISPATCH_REFUSED
+
+    assert gateway.calls == 0
+    assert _checkpoint_rows(db) == 1
+    assert _message_rows(db) == 2
+
+
+@pytest.mark.asyncio
+async def test_follow_up_admitted_mid_run_is_refused_when_the_owner_turns_unhealthy(
+    tmp_path: Path,
+) -> None:
+    """A drain that meets a failed settlement refuses visibly and keeps the entry."""
+
+    db, store, controller, _gateway = _controller(tmp_path)
+    gateway = _HoldingGateway(db)
+    controller.provider_gateway = gateway
+
+    task = asyncio.create_task(
+        controller.run_prompt_chain("first", session_id="session-1")
+    )
+    await asyncio.wait_for(gateway.started.wait(), timeout=5)
+
+    snapshot = controller.prompt_queue_registry.snapshot("session-1")
+    admitted = controller.queue_prompt(
+        "session-1", text="second", expected_revision=snapshot.revision
+    )
+    assert admitted.status is QueueMutationStatus.APPLIED
+
+    # Break terminal settlement AFTER the follow-up is already queued, so the
+    # first turn's owner is left genuinely unhealthy with work behind it.
+    db.get_connection().execute(
+        "CREATE TRIGGER task22000_block_settlement "
+        "BEFORE DELETE ON console_dispatch_checkpoints "
+        "BEGIN SELECT RAISE(ABORT, 'task22000 settlement failure'); END"
+    )
+    db.get_connection().commit()
+
+    gateway.hold = False
+    gateway.release.set()
+    await asyncio.wait_for(task, timeout=10)
+
+    recovery = store.dispatch_recovery_for_session("session-1")
+    assert recovery is not None
+    assert recovery.recovery_needed is True
+    assert store.dispatch_recovery_blocks_submission("session-1") is True
+    # The queued follow-up never reached the provider, and it is still queued.
+    assert gateway.calls == 1
+    queue = controller.prompt_queue_registry.snapshot("session-1")
+    assert queue.total_count == 1
+    assert queue.mode is PromptQueueMode.PAUSED
+    assert queue.pause_reason is not PromptQueuePauseReason.MANUAL
+    assert _checkpoint_rows(db) == 1
+
+    # Forcing the drain anyway is refused by the narrowed gate, visibly, and
+    # the entry is returned to the head rather than consumed.
+    await controller.prompt_queue_coordinator.resume_and_drain("session-1")
+
+    assert gateway.calls == 1
+    queue = controller.prompt_queue_registry.snapshot("session-1")
+    assert queue.total_count == 1
+    assert queue.mode is PromptQueueMode.PAUSED
+    assert queue.pause_reason is PromptQueuePauseReason.DISPATCH_REFUSED
+    assert _checkpoint_rows(db) == 1

--- a/Tests/UI/test_console_degraded_database_send.py
+++ b/Tests/UI/test_console_degraded_database_send.py
@@ -1,0 +1,185 @@
+"""TASK-22030: a refused send must be visible, never silent.
+
+If the ChaChaNotes database cannot be opened, `TldwCli.__init__` leaves
+``chachanotes_db = None`` and ``ConsoleRuntime.ensure_chat_store`` builds the
+Console store with ``persistence=None``. Since `56db75386` a durable turn
+(every non-ephemeral manual or queued send) fails closed there -- correctly --
+but the refusal was returned as a bare ``ConsoleSubmitResult``: no run state,
+no transcript row, no toast. Pressing Send did *nothing at all*.
+
+These tests drive the mounted Console against exactly that state and assert
+the surfaces a user can actually see, not the return value.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.app_factory import attach_chachanotes_db
+from Tests.UI.test_console_native_chat_flow import (
+    WaitingGateway,
+    _ASYNC_SETTLE_TIMEOUT,
+    _select_llamacpp_console,
+    _wait_for_text,
+)
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+
+def _degraded_app(notifications: list[tuple[str, dict]]):
+    """Build a Console app whose ChaChaNotes database could not be opened."""
+
+    app = _build_test_app()
+    # `_build_test_app` already patches `get_chachanotes_db_lazy` to None, so
+    # this is the production post-failure shape verbatim -- no double.
+    assert getattr(app, "chachanotes_db", None) is None
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+    app.notify = lambda message, **kwargs: notifications.append((message, kwargs))
+    return app
+
+
+@pytest.mark.asyncio
+async def test_unopenable_database_refuses_send_visibly_and_keeps_the_draft():
+    notifications: list[tuple[str, dict]] = []
+    gateway = WaitingGateway()
+    app = _degraded_app(notifications)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello")
+
+        console.query_one("#console-send-message", Button).press()
+        await pilot.pause()
+        await pilot.pause(0.2)
+
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        assert session_id is not None
+
+        # 1. A transcript row the user can read, naming the real cause.
+        rows = [
+            message
+            for message in controller.store.messages_for_session(session_id)
+            if message.role is ConsoleMessageRole.SYSTEM
+        ]
+        assert len(rows) == 1, [row.content for row in rows]
+        copy = rows[0].content
+        assert "not sent" in copy.lower()
+        assert "database could not be opened" in copy.lower()
+        assert "temporary chat" in copy.lower()
+
+        # 2. A toast carrying the same explanation.
+        assert notifications, "the refusal raised no toast at all"
+        assert any(
+            "database could not be opened" in message.lower()
+            for message, _kwargs in notifications
+        ), notifications
+
+        # 3. A blocked run state, so the control bar is not left reading idle.
+        assert (
+            controller.run_state_for(session_id).status is ConsoleRunStatus.BLOCKED
+        )
+
+        # 4. The draft the user typed is still there.
+        assert composer.draft_text() == "hello"
+
+        # 5. Nothing reached the provider.
+        assert gateway.started.is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_unopenable_database_still_sends_a_temporary_conversation():
+    """A temporary chat needs no durable commit, so it must keep working."""
+
+    notifications: list[tuple[str, dict]] = []
+    gateway = WaitingGateway()
+    app = _degraded_app(notifications)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+        store = console._ensure_console_chat_store()
+        settings = store.sessions()[0].settings
+        temporary = store.create_session(
+            title="Temp chat", settings=settings, ephemeral=True, activate=True
+        )
+        await pilot.pause()
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello from a temporary chat")
+        console.query_one("#console-send-message", Button).press()
+        await asyncio.wait_for(gateway.started.wait(), timeout=_ASYNC_SETTLE_TIMEOUT)
+        await _wait_for_text(console, pilot, "partial")
+
+        assert temporary.ephemeral is True
+        roles = [
+            message.role for message in store.messages_for_session(temporary.id)
+        ]
+        assert ConsoleMessageRole.USER in roles
+        assert ConsoleMessageRole.SYSTEM not in roles
+        assert not any(
+            "database could not be opened" in message.lower()
+            for message, _kwargs in notifications
+        ), notifications
+
+        gateway.release.set()
+        await _wait_for_text(console, pilot, "partial done")
+
+
+@pytest.mark.asyncio
+async def test_working_database_is_unaffected_by_the_degraded_path():
+    """Control arm: with a usable database the refusal never fires."""
+
+    notifications: list[tuple[str, dict]] = []
+    gateway = WaitingGateway()
+    app = _degraded_app(notifications)
+    attach_chachanotes_db(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello")
+
+        console.query_one("#console-send-message", Button).press()
+        await asyncio.wait_for(gateway.started.wait(), timeout=_ASYNC_SETTLE_TIMEOUT)
+        await _wait_for_text(console, pilot, "partial")
+
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        assert session_id is not None
+        assert not [
+            message
+            for message in controller.store.messages_for_session(session_id)
+            if message.role is ConsoleMessageRole.SYSTEM
+        ]
+        assert not any(
+            "database could not be opened" in message.lower()
+            for message, _kwargs in notifications
+        ), notifications
+        assert composer.draft_text() == ""
+
+        gateway.release.set()
+        await _wait_for_text(console, pilot, "partial done")

--- a/backlog/tasks/task-22000 - Console-Send-is-disabled-during-a-live-run-so-the-ADR-046-queue-is-unreachable.md
+++ b/backlog/tasks/task-22000 - Console-Send-is-disabled-during-a-live-run-so-the-ADR-046-queue-is-unreachable.md
@@ -2,7 +2,7 @@
 id: TASK-22000
 title: >-
   Console Send is disabled during a live run so the ADR-046 queue is unreachable
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-24'
 labels:
@@ -67,8 +67,131 @@ the last of that file's 26 failures and are the only two that are **not** harnes
 
 ## Acceptance Criteria
 
-- [ ] An owner decision is recorded on whether a live durable turn admits a queued follow-up (ADR-046) or blocks Send
-- [ ] Send's label, disabled state, and tooltip agree with that decision — no "Queue" label on a button that refuses to queue
-- [ ] Whichever contract loses has its pinning tests updated in the same change, with the decision cited
-- [ ] `Tests/UI/test_console_native_chat_flow.py::test_console_composer_stop_is_subdued_when_idle` and `::test_console_duplicate_send_during_stream_does_not_break_stop_control` are green without weakening what they assert about the Stop control
-- [ ] The chosen behaviour is verified live, not only under pytest
+- [x] An owner decision is recorded on whether a live durable turn admits a queued follow-up (ADR-046) or blocks Send
+- [x] Send's label, disabled state, and tooltip agree with that decision — no "Queue" label on a button that refuses to queue
+- [x] Whichever contract loses has its pinning tests updated in the same change, with the decision cited
+- [x] `Tests/UI/test_console_native_chat_flow.py::test_console_composer_stop_is_subdued_when_idle` and `::test_console_duplicate_send_during_stream_does_not_break_stop_control` are green without weakening what they assert about the Stop control
+- [x] The chosen behaviour is verified live, not only under pytest
+
+## Owner decision (2026-08-24)
+
+**Restore the ADR-046 queue.** A healthy in-flight durable turn does not block
+Send: the button re-labels to "Queue" and admits the draft as a FIFO follow-up.
+The block stays for a genuinely *unhealthy* recovery owner, which is what
+TASK-19900.3 actually needed it for.
+
+## Implementation Plan
+
+1. Re-derive the mechanism on the current dev rather than trusting the filing.
+2. Establish what the block was guarding, and prove FIFO queueing cannot race a
+   durable commit — including the mid-commit and unhealthy-owner interleavings.
+3. Narrow the blocking predicate to unresolved owners only.
+4. Update the round1 pinning assertion, citing the decision, and confirm what it
+   genuinely protected is still pinned somewhere.
+5. Verify live (real `TldwCli`, isolated sandbox), A/B against pristine dev.
+6. Mutation-check every new/changed assertion.
+
+## Implementation Notes
+
+`ConsoleChatStore.dispatch_recovery_blocks_submission` now reads the
+**presentation** owner (`dispatch_recovery_for_presentation`) instead of the raw
+one, so it fires only when `recovery_needed` is True. Nothing invisible can
+refuse a send any more — if the user is not being shown a recovery card, the
+gate does not exist. Every state the block was genuinely added for carries
+`recovery_needed=True` and is untouched:
+
+* a checkpoint restored from a previous app run (`_hydrate_dispatch_recovery`
+  stores an owner only when it needs recovery), which would otherwise hit the
+  repository's "active dispatch checkpoint" refusal on the next send;
+* a live owner whose terminal settlement failed
+  (`mark_dispatch_recovery_needed` /
+  `_restore_dispatch_recovery_after_settlement_failure`) — its run state is
+  `BLOCKED`, which `is_send_allowed` **permits**, so this gate is the only thing
+  between the user and a raw `RuntimeError` from a second durable owner;
+* `QUARANTINED` ownership that could not be read at all.
+
+**The filing was half right — narrowing the predicate alone does not fix it.**
+`2c7fcd200` made two changes to `ChatScreen._sync_console_composer_action_state`,
+not one: it added the recovery predicate *and* changed the active-session line
+from an assignment (`send_blocked = not queue_presentation.send_enabled`, the
+ADR-046 shape where the queue projection is the sole authority) to an `or` that
+folds the raw run state back in. Since `not is_send_allowed` is exactly the
+VALIDATING/STREAMING/CHECKING_CITATIONS/RETRYING set that
+`derive_prompt_queue_presentation` already reads as `occupies_slot`, the only
+state that `or` could change was the one ADR-046 exists for. Both halves are
+fixed here; each was mutation-proven to be independently load-bearing.
+
+**Proving the queue cannot race a durable commit** (new
+`Tests/Chat/test_console_send_gate_queue_race.py`, real SQLite):
+
+* Admission requires `activity.accepted_live_turn`, which is set only by
+  `turn_accepted`/`acknowledge_durable_acceptance` — i.e. strictly *after*
+  `commit_durable_turn` returns. A test hooks `create_conversation` (which runs
+  inside `commit_durable_turn`'s own `BEGIN IMMEDIATE`; the assertion
+  `in_transaction is True` proves the window is real) and offers a follow-up
+  there: it is refused `REROUTE_NORMAL_SEND`, leaving no entry behind.
+* Admission is a memory-only registry write; a queued entry is *submitted* only
+  from `_drain_waiting`, which runs after the previous turn reaches a terminal
+  status, by which point settlement has already popped the owner. A test admits
+  mid-stream and asserts the provider saw exactly one checkpoint row at each
+  entry (`checkpoint_counts == [1, 1]`), FIFO order, and zero rows at the end.
+* A follow-up admitted mid-run whose owner then turns unhealthy (settlement
+  failure) is refused: the queue pauses, and forcing `resume_and_drain` returns
+  the entry to the head with `DISPATCH_REFUSED` rather than consuming it.
+
+`test_healthy_durable_owner_is_not_recovery_before_checkpoint_transition`'s
+`blocks_submission is True` assertion is now `False`, with the decision cited in
+the test's docstring. What it is *named* for (the pre-transition owner is
+runtime truth, never a recovery card) is unchanged and still pinned.
+
+### Live verification (real `TldwCli`, headless Pilot, isolated `HOME`/`XDG_*`/`TLDW_CONFIG_PATH` + scratch `[paths] data_dir`)
+
+Mid-run, sampled while STREAMING:
+
+| | pristine dev `a71e62e4b` | this branch |
+|---|---|---|
+| `send.label` | `Queue` | `Queue` |
+| `send.disabled` (with a draft) | **True** | **False** |
+| `send.tooltip` | "Wait for the active Console run to finish before sending." | "Send the active Console session draft." |
+| `console-send-blocked` | True | False |
+| `blocks_submission` | True | False |
+| recovery owner | `DISPATCH_STARTED`, `runtime_active=True`, `recovery_needed=False` | same |
+
+After pressing Queue: admitted (`queue_count=1`), draft cleared, and the drain
+produced `['first live prompt', 'queued live follow-up']` in FIFO order with the
+queue empty and the run COMPLETED. The real profile's `config.toml` and
+ChaChaNotes DB were byte-identical before and after every run.
+
+Note on the dev arm: the probe drove admission through
+`handle_console_send_message` (the Enter path, which deliberately bypasses the
+disabled button), so dev still queued — the defect was that the **button** was
+dead and the **tooltip lied**, which is exactly what the table shows.
+
+### Mutation results
+
+| mutation | tests that caught it |
+|---|---|
+| predicate reads the raw owner again (pre-fix) | `test_healthy_live_owner_admits_a_queued_follow_up_drained_strictly_after`, `test_healthy_durable_owner_is_not_recovery_before_checkpoint_transition`, both ADR-046 UI tests |
+| predicate always returns `False` (over-narrowed) | `test_unhealthy_recovery_owner_still_blocks_submission_and_a_queued_turn`, `test_follow_up_admitted_mid_run_is_refused_when_the_owner_turns_unhealthy`, `test_restored_source_owner_refuses_fresh_submit_before_echo_or_acceptance`, `test_continuation_row_read_failure_remains_blocking_until_exact_reread` |
+| composer gate re-folds `send_blocked or …` | both ADR-046 UI tests |
+| registry admits before a chain exists | `test_queued_follow_up_cannot_be_admitted_while_the_durable_commit_runs` |
+
+Every mutation was applied and reverted in place (no `git checkout`), and the
+full set is green again afterwards.
+
+### Shutdown / error walk
+
+* Quit with a queued follow-up pending: the real confirmation reads
+  `Live agent runs: 1 / Sessions with queued prompts: 1 / Unsent queued
+  prompts: 1`, and `ConsoleRuntime.dispose()` completes cleanly.
+* A queued turn whose predecessor fails: pinned by
+  `test_failed_accepted_queued_turn_pauses_remaining_without_requeueing_it`
+  (green) and by the new settlement-failure test above.
+
+### Modified or added files
+
+* `tldw_chatbook/Chat/console_chat_store.py` — narrowed predicate.
+* `tldw_chatbook/UI/Screens/chat_screen.py` — composer gate defers to the queue
+  projection for an active session.
+* `Tests/Chat/test_console_dispatch_recovery_fix_round1.py` — updated pin.
+* `Tests/Chat/test_console_send_gate_queue_race.py` — new (4 tests).

--- a/backlog/tasks/task-22030 - A failed ChaChaNotes open makes Console Send silently do nothing.md
+++ b/backlog/tasks/task-22030 - A failed ChaChaNotes open makes Console Send silently do nothing.md
@@ -2,7 +2,7 @@
 id: TASK-22030
 title: >-
   A failed ChaChaNotes open makes Console Send silently do nothing
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-24'
 labels:
@@ -24,12 +24,99 @@ database is broken, and the most likely reading of the symptom is "the app is br
 
 ## Acceptance Criteria
 
-- [ ] With an unopenable ChaChaNotes database, pressing Send produces a visible, legible explanation of why the message was not sent and what to do about it
-- [ ] The explanation names the real cause (the database could not be opened) rather than a generic failure
-- [ ] The draft is preserved so the user does not lose what they typed
-- [ ] An ephemeral/temporary conversation still sends in this state, since it needs no durable commit
-- [ ] A test drives the degraded path end to end and asserts the user-visible surface, not just the return value — the current gate returns a correct-looking result object while showing the user nothing
-- [ ] The test fails if the refusal is made silent again
+- [x] With an unopenable ChaChaNotes database, pressing Send produces a visible, legible explanation of why the message was not sent and what to do about it
+- [x] The explanation names the real cause (the database could not be opened) rather than a generic failure
+- [x] The draft is preserved so the user does not lose what they typed
+- [x] An ephemeral/temporary conversation still sends in this state, since it needs no durable commit
+- [x] A test drives the degraded path end to end and asserts the user-visible surface, not just the return value — the current gate returns a correct-looking result object while showing the user nothing
+- [x] The test fails if the refusal is made silent again
+
+## Implementation Plan
+
+1. Confirm the mechanism on the current dev: `chachanotes_db = None` →
+   `persistence=None` → `durable_commit` is not callable → bare result.
+2. Restore a user-visible refusal (run state + transcript row + toast) with copy
+   that names the database, keeping the fail-closed behaviour.
+3. Keep the ephemeral exemption exactly as-is.
+4. Drive the degraded path end to end in a mounted test and live, asserting the
+   user-visible surfaces.
+5. Mutation-check each surface independently.
+
+## Implementation Notes
+
+The refusal is kept (a turn that cannot be committed must not reach the
+provider) and made loud. The bare `ConsoleSubmitResult` is replaced by
+`ConsoleChatController._block_undurable_turn`, which routes through the existing
+`_block` (blocked run state + SYSTEM transcript row) and adds an error toast via
+a new defensive `_notify_app` helper (mirrors `_notify_detached_approval`: an
+app double whose `notify` takes the message alone, or no app at all, must not
+turn a refusal into an exception on the send path).
+
+The copy distinguishes the two causes rather than emitting one generic string.
+With no usable adapter (`persistence is None` or `persistence.db is None` — the
+precondition `56db75386` dropped, now used to *choose the wording* instead of to
+skip the gate):
+
+> Not sent: your conversation database could not be opened, so this message
+> could not be saved. Restart Chatbook, and check the app log for the database
+> error if it keeps happening. Your draft was kept; a temporary chat still
+> sends.
+
+A persistence adapter that exists but cannot commit durable turns gets the
+neutral variant. `should_clear_draft` stays `False`, so the draft survives.
+`durable_turn` still exempts ephemeral sessions, so a temporary chat sends
+normally in this state.
+
+### Live verification (real `TldwCli`, genuinely unopenable database)
+
+Driven through real config: `[database] chachanotes_db_path` points at a
+**directory**, so `sqlite3.connect` fails and `app.__init__` records
+`chachanotes_db = None` exactly as it does after a real failed open. Confirmed
+in-run: `app.chachanotes_db: None`, `store.persistence: None`.
+
+| observation | pristine dev `a71e62e4b` | this branch |
+|---|---|---|
+| transcript rows after Send | `[]` | one SYSTEM row naming the database |
+| run state | `IDLE` | `BLOCKED` (same copy) |
+| toasts (`app._notifications`) | `[]` | 1, severity `error` |
+| composer draft | preserved | preserved |
+| provider calls | 0 | 0 |
+| temporary conversation | sends | sends |
+
+Pressing Send on dev was *completely* silent — no row, no state change, no
+toast — which is the defect verbatim. The real profile's `config.toml` and
+ChaChaNotes DB were byte-identical before and after every run.
+
+### Mutation results
+
+| mutation | tests that caught it |
+|---|---|
+| revert to the bare `ConsoleSubmitResult` | `test_unopenable_database_refuses_send_visibly_and_keeps_the_draft`, `test_real_durable_adapter_without_atomic_method_fails_closed` |
+| keep the transcript row, drop only the toast | `test_unopenable_database_refuses_send_visibly_and_keeps_the_draft` |
+| collapse both causes into the generic copy | `test_unopenable_database_refuses_send_visibly_and_keeps_the_draft` |
+| `should_clear_draft=True` on the refusal | `test_unopenable_database_refuses_send_visibly_and_keeps_the_draft`, `test_real_durable_adapter_without_atomic_method_fails_closed` |
+| `durable_turn` no longer exempts ephemeral | `test_unopenable_database_still_sends_a_temporary_conversation` |
+
+Every mutation was applied and reverted in place (no `git checkout`), and the
+full set is green again afterwards.
+
+### Shutdown / error walk
+
+Degraded-database quit: `has_loss_risk` is False (nothing was sent), the quit
+confirmation is not raised, and `ConsoleRuntime.dispose()` completes cleanly
+with `persistence=None`.
+
+### Modified or added files
+
+* `tldw_chatbook/Chat/console_chat_controller.py` — `_block_undurable_turn`,
+  `_notify_app`, and the gate now calling them.
+* `Tests/UI/test_console_degraded_database_send.py` — new (3 tests: degraded
+  refusal surface, temporary-conversation exemption, working-DB control arm).
+* `Tests/Chat/test_console_first_send_atomicity.py` — the existing fail-closed
+  test now asserts the user-visible surface rather than only `visible_copy`.
+* `Docs/security/production-diagnostic-inventory.json` — regenerated for the two
+  new content-free `logger.debug` calls in `_notify_app` (both reviewed with
+  `--statements`; neither interpolates user content, secrets, paths, or URLs).
 
 ## Evidence (verified on dev, 2026-08-24)
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -4771,11 +4771,11 @@ class ConsoleChatController:
             in {ConsoleSubmissionOrigin.MANUAL, ConsoleSubmissionOrigin.QUEUED}
         )
         if durable_turn and not callable(durable_commit):
-            return ConsoleSubmitResult(
-                False,
-                False,
-                "Durable turn acceptance is unavailable; the provider was not called.",
-                session_id=session.id,
+            # TASK-22030: a refusal the user cannot see is indistinguishable
+            # from a broken app. `_block_undurable_turn` writes the run state,
+            # the transcript row, and the toast that `56db75386` dropped.
+            return self._block_undurable_turn(
+                session.id,
                 origin=origin,
                 queue_entry_id=queue_entry_id,
             )
@@ -12347,6 +12347,74 @@ class ConsoleChatController:
             accepted=False,
             should_clear_draft=False,
             visible_copy=visible_copy,
+        )
+
+    def _notify_app(self, message: str, *, severity: str = "warning") -> None:
+        """Raise one best-effort toast through the app, never raising.
+
+        Mirrors ``_notify_detached_approval``'s defensive shape: an app double
+        whose ``notify`` takes the message alone, or no app at all, must not
+        turn a refusal into an exception on the send path.
+        """
+
+        app = self.app
+        notify = getattr(app, "notify", None) if app is not None else None
+        if not callable(notify):
+            return
+        try:
+            notify(message, severity=severity)
+        except TypeError:
+            try:
+                notify(message)
+            except Exception:  # noqa: BLE001 -- surfacing is best-effort
+                logger.debug("Console send refusal notice could not be delivered")
+        except Exception as exc:  # noqa: BLE001 -- surfacing is best-effort
+            logger.debug(
+                "Console send refusal notice raised (exception_type={})",
+                type(exc).__name__,
+            )
+
+    def _block_undurable_turn(
+        self,
+        session_id: str,
+        *,
+        origin: ConsoleSubmissionOrigin,
+        queue_entry_id: str | None,
+    ) -> ConsoleSubmitResult:
+        """Refuse a durable turn nothing can commit -- visibly (TASK-22030).
+
+        `56db75386` turned this refusal into a bare ``ConsoleSubmitResult``:
+        no run state, no transcript row, no toast. With an unopenable
+        ChaChaNotes database that made Send do *nothing at all* -- the draft
+        stayed put and the app looked like it had ignored the keypress, which
+        reads as "the app is broken" rather than "your database is broken".
+
+        The refusal itself is correct and stays (a turn that cannot be
+        committed must not reach the provider), but it now names its real
+        cause, keeps the draft, and points at the one thing that still works.
+        """
+
+        persistence = self.store.persistence
+        if persistence is None or getattr(persistence, "db", None) is None:
+            visible_copy = (
+                "Not sent: your conversation database could not be opened, so "
+                "this message could not be saved. Restart Chatbook, and check "
+                "the app log for the database error if it keeps happening. "
+                "Your draft was kept; a temporary chat still sends."
+            )
+        else:
+            visible_copy = (
+                "Not sent: this conversation cannot be saved right now, so the "
+                "message was not sent to the provider. Your draft was kept; a "
+                "temporary chat still sends."
+            )
+        blocked = self._block(session_id, visible_copy)
+        self._notify_app(visible_copy, severity="error")
+        return replace(
+            blocked,
+            session_id=session_id,
+            origin=origin,
+            queue_entry_id=queue_entry_id,
         )
 
     async def _capture_rag_context(

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1748,9 +1748,43 @@ class ConsoleChatStore:
         return recovery
 
     def dispatch_recovery_blocks_submission(self, session_id: str | None) -> bool:
-        """Return whether one source-local owner owns the next response slot."""
+        """Return whether one UNRESOLVED source-local owner blocks the next send.
 
-        recovery = self.dispatch_recovery_for_session(session_id)
+        TASK-22000 (owner decision, 2026-08-24): this reads the *presentation*
+        owner, not the raw one. Only an owner the user is actually being shown
+        a recovery card for can refuse a send -- a healthy in-flight run
+        (``runtime_active=True, recovery_needed=False``) never does.
+
+        The original TASK-19900.3 predicate keyed on ``kind`` alone, so the
+        app's own live durable turn refused submission for its whole duration.
+        ADR-046 / TASK-14808 say the opposite: an accepted live turn re-labels
+        Send to "Queue" and admits the draft as a FIFO follow-up. The user got
+        a button labelled "Queue" that was greyed out. Reading the presentation
+        owner makes the two agree by construction: nothing invisible refuses.
+
+        What the gate was actually guarding is untouched, because every one of
+        those states carries ``recovery_needed=True``:
+
+        * a checkpoint restored from a previous app run
+          (``_hydrate_dispatch_recovery`` stores an owner only when it needs
+          recovery), which would otherwise hit the repository's
+          "active dispatch checkpoint" refusal on the next send;
+        * a live owner whose terminal settlement failed
+          (``mark_dispatch_recovery_needed`` /
+          ``_restore_dispatch_recovery_after_settlement_failure``) -- note its
+          run state is ``BLOCKED``, which ``is_send_allowed`` *permits*, so
+          this gate is the only thing standing between the user and a raw
+          ``RuntimeError`` from a second durable owner;
+        * ``QUARANTINED`` ownership that could not be read at all.
+
+        A healthy in-flight owner needs no gate here: its run state is
+        VALIDATING/STREAMING, so ``_active_run_rejection`` already refuses a
+        second manual turn, and a queued follow-up is only *submitted* from
+        ``_drain_waiting``, which runs after the previous turn reaches a
+        terminal status -- by which point settlement has popped this owner.
+        """
+
+        recovery = self.dispatch_recovery_for_presentation(session_id)
         return recovery is not None and recovery.kind in {
             ConsoleDispatchRecoveryKind.ACCEPTED,
             ConsoleDispatchRecoveryKind.DISPATCH_STARTED,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -17756,9 +17756,27 @@ class ChatScreen(BaseAppScreen):
                     active_id,
                     composer_collapsed=composer.collapsed,
                 )
+                # TASK-22000 (owner decision, 2026-08-24): for a session with
+                # a live queue projection the PRESENTATION is the authority on
+                # whether Send accepts a draft -- not the raw run state. That
+                # was ADR-046's original shape (an assignment here, not an
+                # `or`); `2c7fcd200` folded `send_blocked` back in with `or`
+                # alongside the new recovery predicate, and since
+                # `not is_send_allowed` is exactly the VALIDATING/STREAMING/
+                # CHECKING_CITATIONS/RETRYING set that `derive_prompt_queue_
+                # presentation` already reads as `occupies_slot`, the only
+                # thing that `or` could still change was the one state ADR-046
+                # exists for: an ACCEPTED live turn, which must read "Queue"
+                # and admit a FIFO follow-up. It rendered as a greyed-out
+                # button labelled "Queue" for the whole duration of every run.
+                #
+                # Nothing is lost by deferring: before acceptance the same
+                # projection returns "Preparing..." with `send_enabled=False`,
+                # so an unaccepted live run still refuses. The recovery
+                # predicate stays in the `or` and still refuses for a genuinely
+                # unresolved owner (see `dispatch_recovery_blocks_submission`).
                 send_blocked = (
-                    send_blocked
-                    or not queue_presentation.send_enabled
+                    not queue_presentation.send_enabled
                     or controller.store.dispatch_recovery_blocks_submission(active_id)
                 )
                 try:


### PR DESCRIPTION
## Summary

Two fixes in the Console send gate, both introduced by the same durable-turn work. Separate commits.

> **Provenance note:** the implementing agent completed both commits but hit a session limit before
> writing its report, so the verification below is **mine**, run independently against this branch —
> not a relayed summary.

## 1. TASK-22000 — restore the ADR-046 queue (owner decision)

Two shipped contracts disagreed. ADR-046 / TASK-14808 say a live turn re-labels Send to **"Queue"**
and admits the draft as a FIFO follow-up; TASK-19900.3's `dispatch_recovery_blocks_submission`
returned True for a `DISPATCH_STARTED` owner — **including the app's own healthy in-flight run**
(`runtime_active=True, recovery_needed=False`). Users saw a button labelled "Queue" that was greyed
out and told them to wait.

**The owner decided to restore the queue.** The fix reads the **presentation** owner rather than the
raw one, so only an owner the user is actually being shown a recovery card for can refuse a send.
The principle, from the new docstring: *nothing invisible refuses.*

Critically, **what the gate was actually guarding is untouched**, because every one of those states
carries `recovery_needed=True` — and the implementation enumerated them rather than assuming:

- a checkpoint restored from a previous app run, which would otherwise hit the repository's "active
  dispatch checkpoint" refusal on the next send;
- a live owner whose terminal settlement failed — note its run state is `BLOCKED`, which
  `is_send_allowed` **permits**, so this gate is the only thing between the user and a raw
  `RuntimeError` from a second durable owner;
- `QUARANTINED` ownership that could not be read at all.

`Tests/Chat/test_console_dispatch_recovery_fix_round1.py` — which deliberately pinned the blocking
behaviour — is updated in this change, citing TASK-22000. A new 360-line
`test_console_send_gate_queue_race.py` covers the race I asked to be retired before narrowing the
predicate.

## 2. TASK-22030 — a failed database open silently swallowed Send

`56db75386` dropped the `persistence is not None and persistence.db is not None` precondition **and**
replaced `_block(...)` with a bare `ConsoleSubmitResult`. So with an unopenable ChaChaNotes DB,
pressing Send did nothing at all: no run state, no transcript row, no toast.

Now routed through `_block_undurable_turn`, which restores the run state, the transcript row and the
toast that commit dropped. Ephemeral conversations still send, since they need no durable commit.
New `Tests/UI/test_console_degraded_database_send.py` drives the degraded path end to end and asserts
the **user-visible surface**, not the return value.

## Verification (mine, independent)

**The two ADR-046 tests now pass.** A/B of `Tests/UI/test_console_native_chat_flow.py`, branch vs
pristine dev, comparing sorted failure sets:

- **on branch but not on dev: none** — zero regressions
- **on dev but not on branch: exactly two** — `test_console_composer_stop_is_subdued_when_idle` and
  `test_console_duplicate_send_during_stream_does_not_break_stop_control`

dev 11 failed / branch 9 failed, and the 9 are a strict subset of dev's — they belong to the wider
Console cluster TASK-21590 documented, not to this change.

`test_console_send_gate_queue_race.py` + `test_console_dispatch_recovery_fix_round1.py`: **16
passed**. `test_console_degraded_database_send.py` + `test_console_first_send_atomicity.py`: **17
passed**. Preflight green.

**Egress check**: zero teardown errors and zero blocked-egress attempts in
`test_console_native_chat_flow.py` — the trap that bit TASK-21590's first attempt, where a repair
made tests reach a live endpoint and was invisible to a naive A/B because the errors attach to tests
that *pass*.

Also updated: `Docs/User_Guide/console/chat-basics.md`, per the repo rule that a screen's UI change
updates its guide page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores ADR-046: during a healthy in-flight durable turn, Send relabels to Queue and admits a FIFO follow-up; only unresolved recovery owners block submission (TASK-22000). Also makes an unopenable ChaChaNotes database visible on Send: the app now refuses clearly with a blocked state, a system row, and an error toast, while temporary chats still send (TASK-22030).

- Only the presentation (unresolved) recovery owner can block; nothing invisible refuses.
- The composer defers to the prompt queue projection so Queue is enabled during an accepted live turn.
- Admission during an open durable commit is refused; queued items drain only after settlement.
- When durable persistence is unavailable, refuse visibly, keep the draft, and don’t call the provider.
- Ephemeral sessions bypass durability and continue to send normally.

<sup>Written for commit 7db3cacfe03ef6afc3933df4dae7e238169759ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

