### PR TITLE
perf(library): stop rebuilding the Reader document body per traversal keystroke (TASK-22207)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -541,3 +541,10 @@ update only the affected canvas region instead of rebuilding the whole
 screen. One visible refinement: opening the Prompts/Skills Import… row
 parks the caret in its path field, and Cancel returns focus to the Import…
 button.)*
+
+*Verified against fix/task-22207-perf (dev @ 983aa5878) — 2026-08-25
+(TASK-22207, performance — no workflow changes: arrow-keying through Browse
+Media's Items list no longer rebuilds the Reader's document body per
+keystroke; the "Loading preview…" banner paints and clears in place, and
+only the row you settle on renders its document, once. Behavior of the
+settle delay, Read/Analysis/Highlights/Info modes, and Find is unchanged.)*

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -417,9 +417,16 @@ async def test_pending_banner_names_selected_b_and_loaded_a():
         _, backing_b, title_b = _row_identity(row_b)
         row_b.press()
         await _wait_for_detail_call(service, backing_b)
+        # task-22207: the banner is now a persistent display-gated widget,
+        # so presence alone is vacuous -- wait for it to be PAINTED.
         await _wait_for_condition(
             pilot,
-            lambda: bool(screen.query("#library-media-viewer-loading")),
+            lambda: (
+                bool(screen.query("#library-media-viewer-loading"))
+                and screen.query_one(
+                    "#library-media-viewer-loading", Static
+                ).display
+            ),
             message="Reader never painted its pending banner.",
         )
 

--- a/Tests/UI/test_library_media_reader_traversal_t22207.py
+++ b/Tests/UI/test_library_media_reader_traversal_t22207.py
@@ -1,0 +1,388 @@
+"""TASK-22207: focus traversal must not rebuild the Reader document body.
+
+The permanent Media Reader opens on FOCUS (PR #2064), so arrow-keying the
+Items list drives ``_select_library_media_reader_row`` per keystroke. The
+settle timer debounces only the DB fetch -- before this task, each
+keystroke's ``_sync_library_media_viewer_or_recompose()`` fell through the
+``unchanged`` comparison on the just-flipped loading flag and rebuilt the
+FULL document body (a fresh ``LibraryMediaContentBody``; in rendered mode a
+fresh ``Markdown`` parse of the document being LEFT) purely to paint the
+"Loading..." banner, and the settle then rebuilt it a second time.
+
+These probes count ``LibraryMediaContentBody`` constructions (and
+``Markdown`` constructions) on the mounted harness: pass-through rows must
+build ZERO bodies; only the settled row builds one, once. The loading
+banner is asserted to paint IN PLACE (display-gated persistent ``Static``,
+same body widget identity) rather than via recompose.
+
+No wall-clock thresholds are asserted (the 15457 probe rule); the 1 MB
+fixture test prints its per-keystroke timings for the task record and pins
+the build count, which is what actually guarantees "no per-keystroke
+parse".
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from statistics import median
+from time import perf_counter
+from unittest.mock import patch
+
+import pytest
+from textual.widgets import Button, Markdown, Static
+
+from Tests.UI.test_library_media_reader_flow import (
+    ControlledDetailMediaService,
+    _flow_app,
+    _row_identity,
+    _wait_for_detail_call,
+)
+from Tests.UI.test_library_media_side_by_side import (
+    WIDE_SIZE,
+    _open_media_list,
+)
+from Tests.UI.test_library_shell import (
+    LibraryProductionCSSHarness,
+    _wait_for_condition,
+    _wait_for_selector,
+)
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_ROW_BROWSE_CONVERSATIONS,
+)
+from tldw_chatbook.Widgets.Library.library_media_content import (
+    LibraryMediaContentBody,
+)
+
+
+@contextmanager
+def _count_body_builds():
+    """Count document-body and Markdown constructions inside the block.
+
+    Wraps the two ``__init__``s via ``patch.object`` -- neither is an
+    ``@on``-decorated handler, so class-level patching is dispatch-safe
+    (the lessons-textual trap applies to message handlers only).
+    """
+    counts = {"body": 0, "markdown": 0}
+    body_init = LibraryMediaContentBody.__init__
+    markdown_init = Markdown.__init__
+
+    def counting_body(self, *args, **kwargs):
+        counts["body"] += 1
+        return body_init(self, *args, **kwargs)
+
+    def counting_markdown(self, *args, **kwargs):
+        counts["markdown"] += 1
+        return markdown_init(self, *args, **kwargs)
+
+    with (
+        patch.object(LibraryMediaContentBody, "__init__", counting_body),
+        patch.object(Markdown, "__init__", counting_markdown),
+    ):
+        yield counts
+
+
+def _loading_banner_displayed(screen) -> bool:
+    """True when the Reader's pending banner is mounted AND painted."""
+    banners = screen.query("#library-media-viewer-loading")
+    return bool(banners) and banners.first().display
+
+
+async def _load_row(screen, pilot, service: ControlledDetailMediaService, index: int):
+    """Press row ``index`` and settle its detail; return its identity."""
+    row = screen.query_one(f"#library-media-row-{index}", Button)
+    canonical_id, backing_id, title = _row_identity(row)
+    row.press()
+    await _wait_for_detail_call(service, backing_id)
+    service.release(backing_id)
+    await _wait_for_condition(
+        pilot,
+        lambda: screen._library_media_reader_session.loaded_id == canonical_id,
+        message=f"Row {index} never settled its detail.",
+    )
+    return canonical_id, backing_id, title
+
+
+def _release_everything(service: ControlledDetailMediaService) -> None:
+    for media_id in tuple(service.detail_release):
+        service.release(media_id)
+
+
+@pytest.mark.asyncio
+async def test_focus_traversal_builds_zero_bodies_for_pass_through_rows():
+    """10-row focus traversal: 0 body builds pass-through, 1 for the settled row."""
+    app, service = _flow_app()
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row(screen, pilot, service, 0)
+
+        final_id, final_backing_id, _ = _row_identity(
+            screen.query_one("#library-media-row-10", Button)
+        )
+        screen.query_one("#library-media-row-0", Button).focus()
+        await pilot.pause()
+        with _count_body_builds() as counts:
+            for _ in range(10):
+                await pilot.press("down")
+            pass_through_builds = counts["body"]
+            await _wait_for_detail_call(service, final_backing_id)
+            _release_everything(service)
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_reader_session.loaded_id == final_id,
+                message="The final traversal row never settled.",
+            )
+            await pilot.pause()
+
+        assert pass_through_builds == 0, (
+            "Pass-through focus rows rebuilt the document body "
+            f"{pass_through_builds} time(s); traversal must build zero."
+        )
+        assert counts["body"] == 1, (
+            f"Expected exactly one settled-row body build, saw {counts['body']}."
+        )
+
+
+@pytest.mark.asyncio
+async def test_loading_banner_paints_in_place_without_body_rebuild():
+    """The pending banner shows and hides without recomposing the body."""
+    app, service = _flow_app()
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        _, _, title_a = await _load_row(screen, pilot, service, 0)
+        body_before = screen.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        )
+
+        row_b = screen.query_one("#library-media-row-1", Button)
+        canonical_b, backing_b, title_b = _row_identity(row_b)
+        screen.query_one("#library-media-row-0", Button).focus()
+        await pilot.pause()
+        with _count_body_builds() as counts:
+            await pilot.press("down")
+            await _wait_for_condition(
+                pilot,
+                lambda: _loading_banner_displayed(screen),
+                message="The pending banner never painted on focus.",
+            )
+            assert counts["body"] == 0, (
+                "Painting the loading banner rebuilt the document body "
+                f"({counts['body']} build(s)); it must patch in place."
+            )
+            assert (
+                screen.query_one(
+                    "#library-media-viewer-content", LibraryMediaContentBody
+                )
+                is body_before
+            ), "The body widget was replaced just to show the loading banner."
+            banner_copy = str(
+                screen.query_one("#library-media-viewer-loading", Static).content
+            )
+            assert title_b in banner_copy
+            assert title_a in banner_copy
+
+            await _wait_for_detail_call(service, backing_b)
+            service.release(backing_b)
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_reader_session.loaded_id
+                == canonical_b,
+                message="Row B never settled.",
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: not _loading_banner_displayed(screen),
+                message="The banner stayed painted after the settle.",
+            )
+        assert counts["body"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_one_megabyte_markdown_document_is_not_reparsed_per_keystroke():
+    """Traversing past a loaded ~1 MB rendered document builds no bodies.
+
+    The build-count assertion is the guarantee; the printed per-keystroke
+    timings are task-record evidence only (no wall-clock threshold -- the
+    15457 probe rule).
+    """
+    app, service = _flow_app(count=12)
+    big_markdown = "# Big document\n\n" + (
+        "A paragraph of steady reading material that pads the document "
+        "toward one megabyte of markdown body text.\n\n" * 10000
+    )
+    assert len(big_markdown) > 1_000_000
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        # Rows sort by recency, so resolve which item row 0 actually shows
+        # and hand THAT one the 1 MB markdown body before it is fetched.
+        _, backing_id_0, _ = _row_identity(
+            screen.query_one("#library-media-row-0", Button)
+        )
+        source = next(
+            item
+            for item in service.media_items
+            if item["id"] == f"media-{backing_id_0}"
+        )
+        source["type"] = "markdown"
+        source["content"] = big_markdown
+        await _load_row(screen, pilot, service, 0)
+        assert screen._library_media_content_mode == "rendered"
+        assert screen.query_one("#library-media-viewer-content-markdown", Markdown)
+
+        final_id, final_backing_id, _ = _row_identity(
+            screen.query_one("#library-media-row-6", Button)
+        )
+        screen.query_one("#library-media-row-0", Button).focus()
+        await pilot.pause()
+        per_keystroke_ms: list[float] = []
+        with _count_body_builds() as counts:
+            for _ in range(6):
+                started = perf_counter()
+                await pilot.press("down")
+                per_keystroke_ms.append((perf_counter() - started) * 1000.0)
+            traversal_builds = counts["body"]
+            traversal_parses = counts["markdown"]
+            # Print BEFORE the settle wait so the red-first run still
+            # records the per-keystroke numbers when the settle drowns in
+            # the parse backlog it is red about.
+            print(
+                "TASK-22207 1MB traversal per-keystroke: "
+                f"median={median(per_keystroke_ms):.3f}ms samples="
+                + ",".join(f"{sample:.3f}" for sample in per_keystroke_ms)
+            )
+            await _wait_for_detail_call(service, final_backing_id)
+            _release_everything(service)
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_reader_session.loaded_id == final_id,
+                # Generous deadline: the PRE-fix tree queues a fresh 1 MB
+                # Markdown parse per keystroke, and the settle has to drain
+                # that backlog first -- the red run must still reach the
+                # timing printout below to record the before numbers.
+                timeout=180.0,
+                message="The settled row never loaded past the 1 MB document.",
+            )
+            await pilot.pause()
+
+        assert traversal_builds == 0, (
+            f"Traversing past a 1 MB document rebuilt its body "
+            f"{traversal_builds} time(s)."
+        )
+        assert traversal_parses == 0, (
+            f"Traversing past a 1 MB document re-parsed Markdown "
+            f"{traversal_parses} time(s)."
+        )
+        assert counts["body"] == 1
+
+
+@pytest.mark.asyncio
+async def test_settle_after_route_change_leaves_media_surface_alone():
+    """A detail resolving after the route moved paints nothing anywhere."""
+    app, service = _flow_app()
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row(screen, pilot, service, 0)
+        screen.query_one("#library-media-row-0", Button).focus()
+        await pilot.pause()
+        await pilot.press("down")
+
+        screen.query_one("#library-row-browse-conversations", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+
+        with _count_body_builds() as counts:
+            _release_everything(service)
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.pause()
+        assert counts["body"] == 0, (
+            "A settle landing after the route changed rebuilt a media body."
+        )
+        assert screen.query("#library-conversations-canvas")
+        assert not screen.query("#library-media-viewer")
+
+
+@pytest.mark.asyncio
+async def test_stale_failure_after_selection_moved_on_paints_no_error():
+    """A stale fetch failing never paints an error or a body for a dead row."""
+    app, service = _flow_app()
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row(screen, pilot, service, 0)
+        canonical_b, backing_b, title_b = _row_identity(
+            screen.query_one("#library-media-row-1", Button)
+        )
+        canonical_c, backing_c, title_c = _row_identity(
+            screen.query_one("#library-media-row-2", Button)
+        )
+        screen._select_library_media_reader_row(canonical_b, title_b, immediate=True)
+        await _wait_for_detail_call(service, backing_b)
+        screen._select_library_media_reader_row(canonical_c, title_c, immediate=True)
+        await _wait_for_detail_call(service, backing_c)
+
+        with _count_body_builds() as counts:
+            service.release(backing_b, RuntimeError("stale failure"))
+            await pilot.pause()
+            await pilot.pause()
+            assert screen._library_media_reader_session.error is None
+            assert not screen.query("#library-media-viewer-error")
+            assert counts["body"] == 0
+
+            service.release(backing_c)
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_reader_session.loaded_id
+                == canonical_c,
+                message="Row C never settled after the stale failure.",
+            )
+            await pilot.pause()
+        assert screen._library_media_reader_session.error is None
+        assert counts["body"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fast_alternating_focus_settles_identical_content_without_rebuild():
+    """A -> B -> A -> B -> A alternation re-settles A with zero body rebuilds."""
+    app, service = _flow_app()
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        canonical_a, backing_a, _ = await _load_row(screen, pilot, service, 0)
+        screen.query_one("#library-media-row-0", Button).focus()
+        await pilot.pause()
+
+        with _count_body_builds() as counts:
+            for key in ("down", "up", "down", "up"):
+                await pilot.press(key)
+            _release_everything(service)
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_media_reader_session.loaded_id == canonical_a
+                    and screen._library_media_reader_session.pending_request is None
+                ),
+                message="Alternating focus never re-settled row A.",
+            )
+            await pilot.pause()
+
+        # The re-fetched detail is a NEW dict with identical values; the
+        # display-state comparison must be structural, so the identical
+        # document is NOT rebuilt and no stale body wins.
+        assert counts["body"] == 0, (
+            f"Re-settling identical content rebuilt the body {counts['body']} "
+            "time(s); the unchanged comparison must be structural."
+        )
+        assert len(screen.query("#library-media-viewer-content")) == 1
+        assert not _loading_banner_displayed(screen)
+        assert screen._library_media_reader_session.error is None

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8472,3 +8472,29 @@ the calls converge on one function from many sites, **share at the converged
 function (here: an opt-in, asyncio-task-scoped cache consulted inside the
 build itself), not by threading state through each caller** — the callers you
 did not know about are exactly the ones a threading fix misses.
+
+---
+
+## A programmatic `.focus()` is not the user's keystroke — Library focus semantics gate on the INPUT that moved focus
+
+**TASK-22207, 2026-08-25.** The red-first probe for "arrow-keying the Media
+Items list must not rebuild the Reader body" drove the traversal with
+`row.focus()` + `pilot.pause()` — and the Reader silently ignored every one
+of them: no selection, no pending request, and the settled-row wait died on
+"Detail call did not start". Nothing was broken. `LibraryScreen.
+on_descendant_focus` deliberately treats a focus change as user intent only
+when a real input event could own it: `on_resize` arms
+`_library_notes_resize_settling` (True from the mount resize onward in a
+Pilot harness), and only real input handlers (`on_key`, `on_mouse_down`,
+wheel) clear it via `_mark_library_notes_user_interaction()`. A programmatic
+`.focus()` fires `DescendantFocus` without any of those, so the screen
+classifies it as resize/restore noise — exactly as designed, to stop
+background recomposes from yanking focus.
+
+**What to do.** In a mounted-screen test, drive the gesture, not the state:
+`await pilot.press("down")` (which routes through `on_key`, clears the
+suppression, and moves row focus via `_move_library_list_row_focus`) is the
+traversal; `row.focus()` is only the framework's half of it. If a
+focus-driven behavior mysteriously does not fire in a Pilot harness, check
+which interaction-intent flags the screen consults before dispatching —
+and prefer the input event that a user would actually produce.

--- a/backlog/tasks/task-22207 - Library-media-reader-do-not-rebuild-the-document-body-per-traversal-keystroke.md
+++ b/backlog/tasks/task-22207 - Library-media-reader-do-not-rebuild-the-document-body-per-traversal-keystroke.md
@@ -2,9 +2,11 @@
 id: TASK-22207
 title: >-
   Library media reader: do not rebuild the document body per traversal keystroke
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
+updated_date: '2026-08-25'
 labels:
   - performance
   - library
@@ -34,7 +36,150 @@ While Find is open, each rebuild adds 3 more O(document) match scans
 
 ## Acceptance Criteria
 
-- [ ] Traversing N rows performs zero document-body rebuilds for pass-through rows; only the settled row renders, once (probe counts `LibraryMediaContentBody` constructions per 10-row traversal)
-- [ ] Showing the loading placeholder does not require recomposing the document body
-- [ ] A 1 MB document can be traversed past with no per-keystroke parse (measured)
-- [ ] Reader behavior (settle, modes, search) unchanged; existing reader tests green
+- [x] Traversing N rows performs zero document-body rebuilds for pass-through rows; only the settled row renders, once (probe counts `LibraryMediaContentBody` constructions per 10-row traversal)
+- [x] Showing the loading placeholder does not require recomposing the document body
+- [x] A 1 MB document can be traversed past with no per-keystroke parse (measured)
+- [x] Reader behavior (settle, modes, search) unchanged; existing reader tests green
+
+## Implementation Plan
+
+1. Baseline: teed runs of the reader suites (`test_library_media_reader_flow.py`,
+   `test_library_media_reader_shell.py`, `test_library_per_click_recompose_t21116.py`,
+   `test_library_recompose_ratchet.py`, `test_library_media_side_by_side.py`, the
+   media-loading shell test) at branch base `983aa5878`.
+2. Red-first probe file `Tests/UI/test_library_media_reader_traversal_t22207.py`:
+   count `LibraryMediaContentBody` constructions (and `Markdown` builds) across a
+   scripted 10-row focus traversal on the mounted harness with a gated detail
+   service; assert 0 for pass-through rows and exactly 1 for the settled row.
+   Confirm RED on the unmodified tree.
+3. Fix, viewer side (`Widgets/Library/library_media_viewer.py`): make the loading
+   placeholder a persistent, display-gated widget (compose always yields
+   `#library-media-viewer-loading` when a media item is rendered, hidden unless
+   loading; the empty-reader `#library-media-reader-empty` keeps its dual copy) and
+   add `sync_loading_state(loading=..., message=...)` that patches copy + display in
+   place. Display-gating (not mount/unmount) is deliberate: an async mount seam here
+   is the TASK-21116 M3 DuplicateIds race class.
+4. Fix, screen side (`UI/Screens/library_screen.py::_sync_library_media_viewer_state`):
+   remove `loading`/`loading_message` from the recompose-deciding `unchanged`
+   comparison (it then compares only real compose identity: display state built from
+   the loaded detail, sub-state flags, highlights, search, mode, preview identity);
+   on the unchanged path, patch the loading placeholder in place via
+   `sync_loading_state`. Loading transitions alone no longer recompose the body;
+   detail/settle transitions still recompose exactly once.
+5. Evidence: per-keystroke traversal cost before/after with a ~1 MB markdown
+   document fixture (rendered mode), plus the probe counts.
+6. Mutation test: Edit-restore the loading-inclusive comparison, confirm the probes
+   go red, restore the fix (Edit-based, never `git checkout`).
+7. Failure/teardown paths: settle firing after the route changed; a fetch failing
+   after the selection moved on; fast alternating focus between two rows (existing
+   generation fences at `_library_media_preview_request_is_current` /
+   `_matches_pending` are the pattern; assert no stale body wins and no
+   DuplicateIds).
+8. Targeted suites + `--collect-only` sweep + ratchet census (must stay ≤ 97) +
+   `./scripts/preflight.sh`; tee everything and read counts from the tee.
+
+## Implementation Notes
+
+Two small changes at the mechanism, no new async seams, no windowing:
+
+1. **`Widgets/Library/library_media_viewer.py`** — the pending banner
+   (`#library-media-viewer-loading`) is now a PERSISTENT, display-gated child
+   (composed once whenever a media item renders, hidden unless loading) and a
+   new `sync_loading_state(loading=..., message=...)` patches its copy and
+   visibility (or the empty-reader placeholder's copy) in place. Display-gating
+   rather than mount/unmount is deliberate: an async mount seam on this surface
+   is the TASK-21116 M3 `DuplicateIds` race class.
+2. **`UI/Screens/library_screen.py::_sync_library_media_viewer_state`** —
+   `loading`/`loading_message` are removed from the recompose-deciding
+   `unchanged` comparison (every traversal keystroke flips the pending flag
+   BEFORE this runs, so the old comparison always fell through to
+   `viewer.refresh(recompose=True)`, re-parsing the document being LEFT to
+   paint "Loading…"). The comparison now covers only real compose identity
+   (viewer display state from the loaded detail, sub-state flags, highlights,
+   search, mode, error, preview identity); the unchanged path calls
+   `viewer.sync_loading_state`. Settle/detail transitions still recompose,
+   exactly once.
+
+### Evidence (all counts read from teed logs in `test-logs/`, gitignored)
+
+- **Red-first** (`probe-red-first-2.txt`, unmodified tree): 10-row arrow-key
+  traversal = **10 body builds** for pass-through rows; painting the banner =
+  1 build; A↔B alternation = 5 builds; a deferred loading recompose landed in
+  the stale-failure window (1 build).
+- **After** (`probe-green-final.txt` / `final-green-verification.txt`): the
+  same traversal = **0 pass-through builds, exactly 1 settled-row build**; the
+  banner paints and clears with the SAME `LibraryMediaContentBody` widget
+  identity and 0 builds; alternation re-settles identical content with 0
+  builds (the re-fetched detail is a new dict — the display-state comparison
+  is structural, so no stale body ever wins).
+- **1 MB markdown fixture** (rendered mode, real `pilot.press("down")`
+  keystrokes): pre-fix **median 16,889.688 ms per keystroke** (samples
+  16,049–18,183 ms — a fresh 1 MB `Markdown` parse per keystroke; the settle
+  then could not drain the parse backlog within 180 s; `probe-red-1mb-3.txt`).
+  Post-fix **median 400.793 ms**, **0 body builds / 0 Markdown parses** during
+  traversal, settle clean (`probe-green-1mb.txt`). Attribution probe
+  (`test-logs/attribution-probe-no-banner-update.py`): with the banner patch
+  fully suppressed the median is statistically identical (477 ms), so the
+  in-place patch adds no measurable cost; the residual per-keystroke cost is
+  the already-filed 22208/22210 work (preview projection, per-step progress
+  write), not this seam. No wall-clock threshold is asserted (15457 rule).
+- **Mutation test** (`mutation-red.txt`): Edit-restored the loading-inclusive
+  comparison and removed the in-place patch → the three probes went red on the
+  exact symptoms (10 / 1 / 6 builds); Edit-restored the fix (never
+  `git checkout` over uncommitted work).
+- **Failure/teardown paths** (probe file): a settle firing after the route
+  changed paints nothing anywhere (0 builds, conversations canvas intact); a
+  stale fetch failing after the selection moved on paints no error and no body
+  (existing `_matches_pending`/generation fences — no new fence needed); fast
+  alternating focus ends with one `#library-media-viewer-content` node, banner
+  hidden, 0 builds.
+- **Ratchet**: census at tip = **97** (pin 97); no whole-screen recompose
+  statements added or removed. The viewer-scoped `viewer.refresh
+  (recompose=True)` on the changed path is not in the census (by design).
+- **Suites** (this branch, base `983aa5878`): probe file 6/6; reader flow +
+  reader shell + ratchet + side-by-side **74 passed / 0 failed**;
+  media-adjacent (content-search debounce, prompt search, scroll keys, image
+  preview, trash, multiselect) **120 passed / 0 failed**; per-click t21116 +
+  screen navigation **132 passed / 7 failed** — the 7 are byte-identical to
+  the base run (`baseline-perclick-ratchet-sbs.txt`); canvas-sync trio
+  **23 passed / 8 failed**, byte-identical to base (`base-canvas-sync.txt`);
+  `test_library_shell.py -k media` **80 passed / 35 failed**, and every one
+  of the 35 FAILED names reproduces at base (chunked node-id re-run,
+  `base-media-failed-chunk{1,2}.txt`; sorted-set diff empty). Zero new reds
+  anywhere.
+- **Sweep**: `--collect-only` = **58,542 tests collected, 28 errors** — all 28
+  are optional-dependency modules (numpy/audio/TTS/Confluence), none touching
+  Library/UI or any changed file. `./scripts/preflight.sh` fully green
+  (CSS bundle, path census, diagnostic inventory, task ids, table allowlist).
+
+### Behavior notes
+
+- One deliberate test retarget: `test_pending_banner_names_selected_b_and_
+  loaded_a` waited on the banner's DOM PRESENCE, which is vacuous now that the
+  banner is persistent — it now waits for the banner to be DISPLAYED.
+- `Docs/User_Guide/library.md` got a "Verified against" stamp (no workflow
+  changes; precedent: the TASK-21116 stamp).
+- Lesson recorded in `backlog/docs/lessons-testing-evidence.md`: a
+  programmatic `.focus()` is not the user's keystroke — `on_resize` arms
+  `_library_notes_resize_settling` from the mount resize onward and only real
+  input events clear it, so a Pilot probe must drive `pilot.press("down")`,
+  not `row.focus()` (cost a debug cycle here).
+
+### Pre-existing findings, NOT fixed here (verified, not this task's scope)
+
+1. **Traversal-failure error paint gap**: with an older document rendered,
+   traversing to a row whose CURRENT fetch fails settles `session.error` but
+   never mounts `#library-media-viewer-error`/Retry —
+   `_recompose_library_media_detail_if_unrendered` early-returns because the
+   old detail is still "rendered identity". Reproduced IDENTICALLY at base
+   `983aa5878` (scratch probe; error paints only when no detail was rendered,
+   the case the existing retry test covers).
+2. **Dev-base harness staleness**: 7 reds in
+   `test_library_per_click_recompose_t21116.py`, 8 in the canvas-sync trio,
+   and the 35 media-scoped shell reds all reproduce at base — the dominant
+   signature is the harness boot recipe expecting `#library-rail-explore-all`,
+   which no longer mounts on this dev base (post-#2064 reader-shell boot).
+3. `test_library_shell_media_viewer_shows_loading_before_detail_loads` is red
+   at base: a fresh press with `detail=None` renders
+   `#library-media-reader-empty` (the empty branch returns before the banner),
+   yet the test asserts `#library-media-viewer-loading` exists.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -34419,6 +34419,22 @@ class LibraryScreen(BaseAppScreen):
             preview_available,
             preview_source,
         ) = self._library_media_image_preview_projection()
+        loading = (
+            self._library_media_reader_session.pending_request is not None
+            and self._library_media_reader_session.error is None
+        )
+        loading_message = (
+            self._library_media_reader_session.pending_banner or "Loading media…"
+        )
+        # task-22207: ``loading``/``loading_message`` are deliberately NOT
+        # part of this comparison. Every traversal keystroke flips the
+        # pending flag before this runs, so including it made the test
+        # always fall through to a full viewer recompose -- re-parsing the
+        # document being LEFT purely to paint "Loading…". The comparison
+        # now covers only real compose identity (display state built from
+        # the loaded detail, sub-state flags, highlights, search, mode,
+        # preview identity); the loading placeholder is patched in place on
+        # the unchanged path via ``viewer.sync_loading_state``.
         unchanged = (
             viewer.viewer == viewer_state
             and viewer.editing == self._library_media_editing
@@ -34428,14 +34444,8 @@ class LibraryScreen(BaseAppScreen):
             and viewer.content_query == self._library_media_content_query
             and viewer.content_match_index == self._library_media_content_match_index
             and viewer.content_mode == self._library_media_content_mode
-            and viewer.loading
-            == (
-                self._library_media_reader_session.pending_request is not None
-                and self._library_media_reader_session.error is None
-            )
-            and viewer.loading_message
-            == (self._library_media_reader_session.pending_banner or "Loading media…")
-            and viewer.error_message == (self._library_media_reader_session.error or "")
+            and viewer.error_message
+            == (self._library_media_reader_session.error or "")
             and viewer.reader_mode == self._library_media_reader_session.mode
             and viewer.more_open == self._library_media_reader_session.more_open
             and viewer.external_detail
@@ -34447,7 +34457,9 @@ class LibraryScreen(BaseAppScreen):
             and viewer.image_preview_hidden == preview_hidden
             and viewer.image_preview_available == preview_available
         )
-        if not unchanged:
+        if unchanged:
+            viewer.sync_loading_state(loading=loading, message=loading_message)
+        else:
             viewer.viewer = viewer_state
             viewer.editing = self._library_media_editing
             viewer.confirming_delete = self._library_media_confirming_delete
@@ -34456,13 +34468,8 @@ class LibraryScreen(BaseAppScreen):
             viewer.content_query = self._library_media_content_query
             viewer.content_match_index = self._library_media_content_match_index
             viewer.content_mode = self._library_media_content_mode
-            viewer.loading = (
-                self._library_media_reader_session.pending_request is not None
-                and self._library_media_reader_session.error is None
-            )
-            viewer.loading_message = (
-                self._library_media_reader_session.pending_banner or "Loading media…"
-            )
+            viewer.loading = loading
+            viewer.loading_message = loading_message
             viewer.error_message = self._library_media_reader_session.error or ""
             viewer.reader_mode = self._library_media_reader_session.mode
             viewer.more_open = self._library_media_reader_session.more_open

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -8,6 +8,7 @@ from rich.color import Color
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches, QueryError
 from textual.widget import Widget
 from textual.widgets import Button, Collapsible, Input, Static, TextArea
 
@@ -162,13 +163,20 @@ class LibraryMediaViewer(Vertical):
                 markup=False,
             )
             return
-        if self.loading:
-            yield Static(
-                self.loading_message,
-                id="library-media-viewer-loading",
-                classes="destination-purpose",
-                markup=False,
-            )
+        # task-22207: the pending banner is a PERSISTENT, display-gated
+        # widget rather than a conditional child. Traversal keystrokes flip
+        # only the loading state, and rebuilding the whole viewer (with a
+        # fresh full-document body) just to add/remove this one Static was
+        # the dominant per-keystroke cost. ``sync_loading_state`` patches
+        # its copy and visibility in place.
+        banner = Static(
+            self.loading_message,
+            id="library-media-viewer-loading",
+            classes="destination-purpose",
+            markup=False,
+        )
+        banner.display = self.loading
+        yield banner
         yield Static(
             "Server item · not in local Media list"
             if self.external_detail
@@ -373,6 +381,50 @@ class LibraryMediaViewer(Vertical):
             )
             raw_button.set_class(raw_selected, "-selected")
             yield raw_button
+
+    def sync_loading_state(self, *, loading: bool, message: str) -> None:
+        """Patch the mounted loading placeholder without rebuilding the body.
+
+        task-22207: a traversal keystroke flips only the pending-request
+        state; recomposing the viewer for that re-parses the full document
+        being LEFT purely to paint "Loading…". This patches the persistent
+        banner (or the empty-reader placeholder) in place instead.
+        Display-gating a widget composed once -- rather than mounting and
+        unmounting it here -- is deliberate: an async mount seam on this
+        surface is the TASK-21116 M3 ``DuplicateIds`` race class.
+
+        Args:
+            loading: Whether a detail request is pending without error.
+            message: Banner copy for the pending request.
+
+        Returns:
+            None.
+        """
+        self.loading = loading
+        self.loading_message = message
+        if not self.viewer.media_id:
+            try:
+                empty = self.query_one("#library-media-reader-empty", Static)
+            except (NoMatches, QueryError):
+                # Not composed yet -- compose() reads the attributes above.
+                return
+            copy = (
+                "Loading media…"
+                if loading
+                else "Select a media item to read it here."
+            )
+            if str(empty.content) != copy:
+                empty.update(copy)
+            return
+        try:
+            banner = self.query_one("#library-media-viewer-loading", Static)
+        except (NoMatches, QueryError):
+            # Not composed yet -- compose() reads the attributes above.
+            return
+        if loading and str(banner.content) != message:
+            banner.update(message)
+        if banner.display != loading:
+            banner.display = loading
 
     def sync_query_state(
         self, *, query: str, matches: tuple[int, ...], match_index: int


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22207). The media reader (PR #2064) opens on focus and recomposed the FULL document body per traversal keystroke — measured **16.9 s median per keystroke on a 1 MB markdown doc** (the settle debounces only the DB fetch, and the `unchanged` test compared a just-flipped pending flag, so it always fell through to a recompose that re-parsed the document being LEFT, just to paint a loading banner).

**Change:** the loading banner is a persistent display-gated child patched in place (`sync_loading_state`; mount/unmount deliberately avoided — the TASK-21116 DuplicateIds race class); `loading`/`loading_message` leave the unchanged-compare (every other field stays; `error_message` kept). Pass-through rows: **0 body builds, 0 Markdown parses**; settled row: exactly 1. **16.9 s → 400 ms median per keystroke (~42×)**; residual attributed by A/B to findings 22208/22210.

**Adversarial review: SHIP, zero blockers.** Removed-fields table proven per-field (each removed field's only-this-changes case covered by a live test; M2-M4 reviewer mutations all red); the current-fetch-failure error-paint gap proven byte-identical at base and head (pre-existing, finding recorded); no mismatched-chrome frame constructible (all chrome inputs remain in the compare); banner truthfulness probed under rapid A↔B alternation with slow fetches + stale-completion fences; perf independently reproduced (400.2 ms). 35 media-shell + 7 per-click + 8 canvas-sync dev reds baselined byte-identical at base.

Rebased over #2085's reader-shell refactor (one semantic conflict in the exact compare hunk, resolved to this change's field set); probes + ratchet (97==pin) re-run green post-rebase; preflight green. User Guide stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1