### PR TITLE
perf(boot): keep PIL off the warm boot path — lazy import in visual_identity (TASK-22217)

### DIFF
--- a/Tests/Character_Chat/test_visual_identity_pil_lazy.py
+++ b/Tests/Character_Chat/test_visual_identity_pil_lazy.py
@@ -1,0 +1,140 @@
+"""Census guard: the warm-boot seeding chain must not import PIL.
+
+TASK-22217: every boot runs ``seed_builtin_content`` ->
+``ensure_builtin_samira`` (``config.py`` -> ``Character_Chat/
+visual_identity.py``). The preflight exits early on warm boots, but a
+module-level ``from PIL import Image, UnidentifiedImageError`` in
+``visual_identity.py`` made every boot pay the ~80-module PIL import
+before the preflight could run. PIL belongs only to the code paths that
+actually decode image bytes (fresh-profile seeding, pack validation).
+
+The guard runs the REAL chain twice, each in a clean interpreter against
+one scratch profile:
+
+* Phase 1 (fresh profile): ``seed_builtin_content`` on an empty DB. This
+  is the real image-work path -- PIL is expected and allowed. The phase
+  asserts the Samira card AND pack were actually created, so phase 2
+  cannot silently measure a half-seeded (non-terminal) profile.
+* Phase 2 (warm boot): a new interpreter opens the same DB and runs
+  ``seed_builtin_content`` again. The chain must import
+  ``visual_identity`` (proving the census exercises the real import
+  chain, not a stub) while loading no ``PIL*`` module at all.
+
+Scope note (honest census): this guard covers the seeding chain only.
+At ``_ui_ready`` in a full app boot PIL is still present via
+chat_screen's own pre-first-paint import chains -- finding 22213 in
+``Docs/Design/2026-08-24-holistic-perf-review.md``, not this task's
+scope -- so a whole-process census at ``_ui_ready`` cannot pass today
+and would not isolate a regression in this chain if it could.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PHASE_1_FRESH_SEED = """
+import sys
+from pathlib import Path
+
+from tldw_chatbook.config import seed_builtin_content
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+db = CharactersRAGDB(db_path=Path(sys.argv[1]), client_id="test-pil-lazy-seed")
+try:
+    seed_builtin_content(db)
+
+    from tldw_chatbook.Character_Chat.visual_identity import (
+        _find_builtin_samira_card,
+        _find_builtin_samira_pack,
+    )
+
+    assert _find_builtin_samira_card(db) is not None, "fresh seed created no card"
+    assert _find_builtin_samira_pack(db) is not None, "fresh seed created no pack"
+finally:
+    db.close_connection()
+print("SEEDED")
+"""
+
+_PHASE_2_WARM_CENSUS = """
+import sys
+from pathlib import Path
+
+preloaded = sorted(n for n in sys.modules if n == "PIL" or n.startswith("PIL."))
+assert not preloaded, f"PIL preloaded before the chain ran: {preloaded[:5]}"
+
+from tldw_chatbook.config import seed_builtin_content
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+db = CharactersRAGDB(db_path=Path(sys.argv[1]), client_id="test-pil-lazy-warm")
+try:
+    seed_builtin_content(db)
+
+    assert "tldw_chatbook.Character_Chat.visual_identity" in sys.modules, (
+        "the seeding chain never imported visual_identity -- "
+        "this census is not measuring the real chain"
+    )
+    from tldw_chatbook.Character_Chat.visual_identity import _samira_seed_preflight
+
+    assert _samira_seed_preflight(db)["terminal"] is True, (
+        "profile is not terminal after the warm pass -- phase 1 half-seeded"
+    )
+    offenders = sorted(n for n in sys.modules if n == "PIL" or n.startswith("PIL."))
+    assert not offenders, (
+        "warm-boot seeding chain imported PIL (module-level import back in "
+        f"visual_identity.py, or the profile was not terminal): {offenders[:5]}"
+    )
+finally:
+    db.close_connection()
+print("WARM-NO-PIL")
+"""
+
+
+def _isolated_env(tmp_path: Path) -> dict[str, str]:
+    home = tmp_path / "home"
+    data = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    for directory in (home, data, config_dir):
+        directory.mkdir(mode=0o700, exist_ok=True)
+    env = dict(os.environ)
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "XDG_DATA_HOME": str(data),
+            "XDG_CONFIG_HOME": str(config_dir),
+            "TLDW_CONFIG_PATH": str(config_dir / "config.toml"),
+            "TLDW_TEST_MODE": "1",
+        }
+    )
+    return env
+
+
+def _run_phase(script: str, db_path: Path, env: dict[str, str], marker: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(db_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    assert result.returncode == 0, (
+        f"phase failed (rc={result.returncode}):\n{result.stderr[-4000:]}"
+    )
+    assert marker in result.stdout, (
+        f"phase produced no {marker!r} marker:\n{result.stdout[-2000:]}"
+    )
+
+
+@pytest.mark.integration
+def test_warm_seeding_chain_loads_no_pil(tmp_path: Path) -> None:
+    env = _isolated_env(tmp_path)
+    db_path = tmp_path / "profile" / "chachanotes.db"
+    db_path.parent.mkdir(mode=0o700)
+
+    _run_phase(_PHASE_1_FRESH_SEED, db_path, env, "SEEDED")
+    _run_phase(_PHASE_2_WARM_CENSUS, db_path, env, "WARM-NO-PIL")

--- a/backlog/tasks/task-22217 - Keep-PIL-off-the-warm-boot-path-lazy-import-in-visual_identity.md
+++ b/backlog/tasks/task-22217 - Keep-PIL-off-the-warm-boot-path-lazy-import-in-visual_identity.md
@@ -2,8 +2,9 @@
 id: TASK-22217
 title: >-
   Keep PIL off the warm boot path: lazy import in visual_identity
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
 labels:
   - performance
@@ -29,6 +30,93 @@ closure) via the construct-time gap the guards cannot see; PIL was confirmed pre
 
 ## Acceptance Criteria
 
-- [ ] A warm boot with seeding already terminal loads no PIL (census `sys.modules` at `_ui_ready` under a default profile)
-- [ ] Fresh-profile seeding still works end to end (Samira card + pack created)
-- [ ] PIL imports move inside the code paths that actually do image work in `visual_identity.py`
+- [x] A warm boot with seeding already terminal loads no PIL **through the seeding
+  chain**: the real `seed_builtin_content` -> `ensure_builtin_samira` chain imports
+  `visual_identity` with zero `PIL*` modules in `sys.modules` (subprocess census,
+  `Tests/Character_Chat/test_visual_identity_pil_lazy.py`). **Corrected from the
+  original whole-process wording** ("census at `_ui_ready` under a default
+  profile"): measured on a real headless warm boot, PIL is STILL present at
+  `_ui_ready` (16 modules) via `UI/Console_Modules/character_avatar_layout.py:7`
+  reached from `Chat/console_image_view.py:21` -- chat/Console pre-first-paint
+  chains, which are finding 22213's scope, not this task's. A whole-process
+  census cannot pass until 22213 lands, and would not isolate a regression in
+  THIS chain even if it could; the committed guard therefore scopes to the
+  seeding chain. (Warm-boot PIL footprint still dropped 72 -> 16 modules,
+  because the seeding chain no longer triggers `Image.open`'s full plugin
+  registry.)
+- [x] Fresh-profile seeding still works end to end (Samira card + pack created)
+- [x] PIL imports move inside the code paths that actually do image work in `visual_identity.py`
+
+## Implementation Plan
+
+1. Census every PIL-name use in `visual_identity.py` (Image, UnidentifiedImageError,
+   annotations, except clauses) and every module importing PIL names FROM
+   visual_identity. Confirm the file has `from __future__ import annotations`.
+2. Red-first census test (`Tests/Character_Chat/test_visual_identity_pil_lazy.py`):
+   two clean subprocesses against one scratch profile DB. Phase 1 runs the REAL
+   `seed_builtin_content` chain on a fresh DB (seeds Samira; PIL allowed) and
+   asserts the pack exists. Phase 2, a clean interpreter against the now-terminal
+   DB, runs the REAL `seed_builtin_content` -> `ensure_builtin_samira` chain and
+   asserts `tldw_chatbook.Character_Chat.visual_identity` is in `sys.modules`
+   while no `PIL*` module is. Red today (module-level import at line 24).
+3. Fix: drop the module-level `from PIL import Image, UnidentifiedImageError`;
+   import it function-locally at the single function that does image work
+   (`_inspect_image_bytes`, which contains ALL runtime uses incl. the except
+   tuple). The `Image.Image` annotation on `_image_duration_ms` stays a string
+   under `from __future__ import annotations`. Missing-PIL still surfaces as the
+   same ImportError, now at first image work instead of module import; both are
+   contained by `seed_builtin_content`'s `except Exception` on the boot path.
+4. Verify the whole-boot claim with a real headless boot (subprocess, isolated
+   scratch profile, boot twice, census PIL at `_ui_ready` on the warm boot).
+   Finding 22213 says chat_screen's own chains load PIL pre-first-paint; if that
+   holds, scope the committed guard to the seeding chain and correct AC 1
+   honestly, citing 22213.
+5. Fresh-profile e2e: run the existing lifecycle tests that exercise the real
+   image path (`Tests/Character_Chat/test_visual_identity_lifecycle.py`, assets,
+   contract, resolution, preflight suites).
+6. Targeted tests + `--collect-only` sweep (tee everything); `./scripts/preflight.sh`.
+7. Mutation test: Edit-restore the module-level PIL import -> census test must
+   go red; Edit-revert.
+8. Tick ACs (with honest corrections), Implementation Notes, status Done, commit,
+   push.
+
+## Implementation Notes
+
+The warm-boot seeding chain no longer imports PIL. `visual_identity.py`'s
+module-level `from PIL import Image, UnidentifiedImageError` moved inside
+`_inspect_image_bytes` -- the census of the whole 3,489-line file found that
+EVERY runtime PIL use (the `Image.DecompressionBombWarning` filter, `Image.open`,
+and the except tuple catching `UnidentifiedImageError`/`DecompressionBombError`/
+`DecompressionBombWarning`) already lives inside that one function, so one
+function-local import covers them all. The only other reference, the
+`Image.Image` annotation on `_image_duration_ms`, stays a string under the
+file's `from __future__ import annotations`; a `TYPE_CHECKING`-guarded
+`from PIL import Image` keeps it resolvable for type checkers and ruff. No
+module imports PIL names FROM `visual_identity` (grepped package + Tests), so
+nothing else changes. Missing Pillow (a hard dep, so hypothetical) still
+surfaces as the same ImportError, now at first image work instead of module
+import; on the boot path both are contained by `seed_builtin_content`'s
+`except Exception`.
+
+- New guard: `Tests/Character_Chat/test_visual_identity_pil_lazy.py` -- two
+  clean subprocesses on one scratch profile: phase 1 runs the REAL
+  `seed_builtin_content` fresh seed (asserts card + pack, so phase 2 cannot
+  measure a half-seeded profile); phase 2 reruns the real chain warm and
+  asserts `visual_identity` imported with zero `PIL*` modules. Red before the
+  fix (caught `['PIL', 'PIL.ExifTags', 'PIL.Image', ...]`), green after;
+  mutation-verified (re-adding a module-level PIL import turns it red).
+- AC 1 corrected to the seeding-chain scope, with first-hand measurement:
+  real headless warm boot to `_ui_ready` still holds 16 PIL modules via
+  `character_avatar_layout.py:7` <- `console_image_view.py:21` (finding 22213,
+  out of scope here); fresh boot holds 72. See the review doc, finding 22217.
+- Verification: red-first census; 1,198 passed across Tests/Character_Chat +
+  Tests/Actor_Packs + vendor-pin (1 pre-existing unrelated red,
+  `test_character_persona_scope_service.py::test_app_wires_character_persona_services`,
+  fails identically with the module-level import restored -- an Actor_Packs
+  Mock-wiring failure, and its solo-run collection hits the 22223 circular
+  import); 311 passed across the seven Tests/UI visual-identity suites;
+  full `--collect-only` 59,176 collected (28 errors, all missing optional
+  deps: numpy/audio/TTS/transcription/Confluence); `./scripts/preflight.sh`
+  all green; ruff clean on both changed files.
+- Files: `tldw_chatbook/Character_Chat/visual_identity.py`,
+  `Tests/Character_Chat/test_visual_identity_pil_lazy.py`, this task file.

--- a/tldw_chatbook/Character_Chat/visual_identity.py
+++ b/tldw_chatbook/Character_Chat/visual_identity.py
@@ -17,11 +17,13 @@ from dataclasses import dataclass, field
 from importlib import resources
 from io import BytesIO
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from loguru import logger
-from PIL import Image, UnidentifiedImageError
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 from tldw_chatbook.config import get_user_data_dir
 from tldw_chatbook.Utils.path_validation import validate_path
@@ -1858,6 +1860,17 @@ def _inspect_image_bytes(
     *,
     decoded_pixels_before: int = 0,
 ) -> tuple[str, tuple[int, int], int, bool, int | None, int]:
+    # TASK-22217: PIL stays off the warm boot path. This module is imported on
+    # EVERY boot via seed_builtin_content -> ensure_builtin_samira, whose
+    # preflight exits early once seeding is terminal -- so the ~80-module PIL
+    # import belongs here, at the single function that decodes image bytes,
+    # not at module scope. All runtime PIL uses (including the except tuple
+    # below) live inside this function; `Image.Image` in an annotation stays a
+    # string under `from __future__ import annotations`. A missing Pillow
+    # still surfaces as the same ImportError as the old module-level import,
+    # now raised at first image work instead of at module import.
+    from PIL import Image, UnidentifiedImageError
+
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("error", Image.DecompressionBombWarning)


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22217). Every boot paid the ~80-module PIL import through `seed_builtin_content → ensure_builtin_samira → visual_identity.py`'s module-level `from PIL import ...` — before the seeding preflight could early-exit, undermining the TASK-21103/21200 closure guards via the construct-time gap they cannot see.

**Change:** the module-level PIL import moves function-local into `_inspect_image_bytes` — the census showed all 7 runtime PIL references (including the except tuple) live inside that one function; the single annotation stays resolvable via a TYPE_CHECKING import under `from __future__ import annotations`. Missing-Pillow behavior unchanged (same ImportError, now at first image work, still contained by `seed_builtin_content`'s except). Warm-boot PIL fan-out dropped 72 → 16 modules (the residual 16 are chat_screen's own chains — finding 22213, explicitly out of scope; AC honestly corrected to the seeding-chain census, guard committed: `visual_identity` imports with zero `PIL*` modules through the REAL seeding chain, two-phase subprocess probe).

Controller-verified (diff read line-by-line; census test + 190 visual-identity suite tests + fresh-profile seeding green; mutation — restoring the module-level import — reds the guard). Side-find recorded: the 22223 config↔Library layering issue is a live circular import breaking solo test collection (raises that task's priority).

Tests: census guard 1/1; visual-identity suites 190 passed; implementer's broader run 1,198 + 311 passed; preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1