### PR TITLE
perf(console): per-send durable commit off the event loop; reconcile reads without the write lock (TASK-22205)

### DIFF
--- a/Tests/Chat/test_console_durable_commit_offload.py
+++ b/Tests/Chat/test_console_durable_commit_offload.py
@@ -1,0 +1,382 @@
+"""TASK-22205: the per-send durable commit must not block the event loop.
+
+Three probes:
+
+(a) event-loop-stall — a second connection holds ``BEGIN IMMEDIATE`` while a
+    send is submitted; the event loop must stay responsive (the commit waits
+    on a worker thread, not on the loop).
+(b) ordering — provider dispatch must not begin before the durable commit is
+    visible to an independent connection (committed, not dirty-read), and the
+    checkpoint must already be in ``dispatch_started``.
+(c) restore reconcile — a reconcile with nothing to write must not take the
+    SQLite write lock (no ``BEGIN IMMEDIATE`` in the connection trace); a
+    reconcile that DOES have a write to make still makes it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleDispatchRecoveryKind
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from Tests.Chat.test_console_durable_turn_acceptance import _ready_store
+from Tests.Chat.test_console_first_send_atomicity import (
+    _CheckpointObservingGateway,
+    _controller,
+)
+
+
+class _CommitVisibilityGateway(_CheckpointObservingGateway):
+    """Record, at first stream call, what an INDEPENDENT connection can see."""
+
+    def __init__(self, db: CharactersRAGDB, db_path: str) -> None:
+        super().__init__(db)
+        self.db_path = db_path
+        self.visible_at_stream: list[dict[str, Any]] = []
+
+    async def stream_chat(
+        self, resolution: object, messages: list[dict[str, Any]], **kwargs: Any
+    ):
+        fresh = sqlite3.connect(self.db_path)
+        try:
+            fresh.row_factory = sqlite3.Row
+            users = fresh.execute(
+                "SELECT content FROM messages WHERE role = 'user'"
+            ).fetchall()
+            checkpoints = fresh.execute(
+                "SELECT state FROM console_dispatch_checkpoints"
+            ).fetchall()
+        finally:
+            fresh.close()
+        self.visible_at_stream.append(
+            {
+                "user_contents": [row["content"] for row in users],
+                "checkpoint_states": [row["state"] for row in checkpoints],
+            }
+        )
+        async for chunk in super().stream_chat(resolution, messages, **kwargs):
+            yield chunk
+
+
+def _hold_write_lock(
+    db_path: str,
+    hold_seconds: float,
+    acquired: threading.Event,
+) -> None:
+    connection = sqlite3.connect(db_path, timeout=5)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        acquired.set()
+        time.sleep(hold_seconds)
+        connection.commit()
+    finally:
+        connection.close()
+
+
+async def test_send_does_not_stall_event_loop_while_write_lock_is_held(
+    tmp_path: Path,
+) -> None:
+    """Probe (a): loop stays responsive while the durable commit waits."""
+
+    db, store, controller, gateway = _controller(tmp_path)
+    db_path = str(tmp_path / "controller.sqlite")
+    hold_seconds = 2.0
+
+    acquired = threading.Event()
+    blocker = threading.Thread(
+        target=_hold_write_lock,
+        args=(db_path, hold_seconds, acquired),
+        daemon=True,
+    )
+    blocker.start()
+    assert acquired.wait(timeout=5)
+
+    stalls: list[float] = []
+    stop = asyncio.Event()
+
+    async def heartbeat() -> None:
+        last = time.monotonic()
+        while not stop.is_set():
+            await asyncio.sleep(0.01)
+            now = time.monotonic()
+            stalls.append(now - last)
+            last = now
+
+    monitor = asyncio.create_task(heartbeat())
+    # Let the heartbeat actually start ticking BEFORE the send: a task that
+    # has not reached its first ``await`` yet cannot observe a stall.
+    await asyncio.sleep(0.05)
+    assert stalls, "heartbeat must be running before the send starts"
+    started = time.monotonic()
+    result = await controller.submit_draft("stall probe", session_id="session-1")
+    elapsed = time.monotonic() - started
+    stop.set()
+    await monitor
+    blocker.join(timeout=5)
+
+    max_stall = max(stalls) if stalls else 0.0
+    # The send itself must have waited for the artificial lock holder --
+    # otherwise the probe proved nothing about contention.
+    assert elapsed >= hold_seconds * 0.5, (
+        f"send finished in {elapsed:.3f}s; the 2s lock holder never contended"
+    )
+    assert result.accepted is True
+    assert gateway.calls == 1
+    # The event loop must never have been blocked for a contention-scale
+    # interval: the commit waits on a worker thread, not on the loop.
+    assert max_stall < 0.5, (
+        f"event loop stalled {max_stall:.3f}s during the send "
+        f"(send took {elapsed:.3f}s under a {hold_seconds}s write-lock holder)"
+    )
+
+
+async def test_dispatch_begins_only_after_commit_is_durably_visible(
+    tmp_path: Path,
+) -> None:
+    """Probe (b): the provider stream starts only after the durable commit.
+
+    Visibility is checked from an INDEPENDENT connection, so only committed
+    data counts. This is the ordering barrier's regression guard: under the
+    mutation "dispatch no longer waits for the commit" it must fail.
+    """
+
+    db = CharactersRAGDB(tmp_path / "controller.sqlite", client_id="task14-test")
+    from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+    from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    store.create_session(session_id="session-1", title="Chat 1")
+    gateway = _CommitVisibilityGateway(db, str(tmp_path / "controller.sqlite"))
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+    )
+
+    result = await controller.submit_draft(
+        "ordering probe draft", session_id="session-1"
+    )
+
+    assert result.accepted is True
+    assert gateway.calls == 1
+    assert gateway.visible_at_stream == [
+        {
+            "user_contents": ["ordering probe draft"],
+            "checkpoint_states": ["dispatch_started"],
+        }
+    ]
+
+
+async def test_cancel_during_offloaded_commit_leaves_consistent_state(
+    tmp_path: Path,
+) -> None:
+    """Shutdown-path walk: cancelling a send mid-commit corrupts nothing.
+
+    ``asyncio.to_thread`` survives task cancellation, so the commit thread
+    runs its single transaction to completion. The DB must end atomically
+    consistent (the whole turn, or nothing), the provider must never have
+    been called, no unretrieved-exception noise may leak, and the restore
+    reconcile must recognize the committed checkpoint — the same
+    crash-window recovery the checkpoint machinery already owns.
+    """
+
+    import gc
+
+    db, store, controller, gateway = _controller(tmp_path)
+    db_path = str(tmp_path / "controller.sqlite")
+
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold() -> None:
+        connection = sqlite3.connect(db_path, timeout=5)
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            acquired.set()
+            release.wait(timeout=10)
+            connection.commit()
+        finally:
+            connection.close()
+
+    blocker = threading.Thread(target=hold, daemon=True)
+    blocker.start()
+    assert acquired.wait(timeout=5)
+
+    loop = asyncio.get_running_loop()
+    unhandled: list[dict[str, Any]] = []
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+    try:
+        task = asyncio.create_task(
+            controller.submit_draft("cancelled mid-commit", session_id="session-1")
+        )
+        # Wait until the durable commit is genuinely in flight (reservation
+        # registered; the worker thread is blocked on the held write lock)
+        # so the cancellation deterministically lands mid-commit.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not store._durable_commit_in_flight:
+            await asyncio.sleep(0.01)
+        assert store._durable_commit_in_flight, (
+            "the durable commit never started; the probe cancelled too early"
+        )
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        release.set()
+        blocker.join(timeout=5)
+        # Give the surviving commit thread time to finish its transaction.
+        fresh = sqlite3.connect(db_path, timeout=5)
+        fresh.row_factory = sqlite3.Row
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                checkpoints = fresh.execute(
+                    "SELECT COUNT(*) FROM console_dispatch_checkpoints"
+                ).fetchone()[0]
+                if checkpoints:
+                    break
+                await asyncio.sleep(0.05)
+            counts = {
+                table: fresh.execute(
+                    f"SELECT COUNT(*) FROM {table}"
+                ).fetchone()[0]
+                for table in (
+                    "conversations",
+                    "messages",
+                    "console_dispatch_checkpoints",
+                )
+            }
+        finally:
+            fresh.close()
+        del task
+        gc.collect()
+        await asyncio.sleep(0.05)
+    finally:
+        loop.set_exception_handler(None)
+
+    assert gateway.calls == 0, "dispatch must never precede a settled commit"
+    assert unhandled == [], f"cancellation leaked loop exceptions: {unhandled!r}"
+    # The surviving thread committed the whole turn atomically: the exact
+    # crash-window state (commit durable, dispatch never started).
+    assert counts["console_dispatch_checkpoints"] == 1
+    assert counts["conversations"] == 1
+    assert counts["messages"] == 2
+    repository = store.persistence.console_dispatch_repository
+    conversation_id = (
+        db.get_connection().execute("SELECT id FROM conversations").fetchone()["id"]
+    )
+    state = repository.reconcile_for_session(conversation_id)
+    assert state is not None, (
+        "restore reconcile must surface the committed-but-undispatched "
+        "turn as a recovery owner"
+    )
+    assert state.kind is not ConsoleDispatchRecoveryKind.QUARANTINED
+
+
+def _traced_statements(db: CharactersRAGDB) -> list[str]:
+    statements: list[str] = []
+    db.get_connection().set_trace_callback(statements.append)
+    return statements
+
+
+def test_clean_restore_reconcile_takes_no_write_lock(tmp_path: Path) -> None:
+    """Probe (c): a reconcile with nothing to write must use a read txn."""
+
+    db, service, store, _preparation, acceptance = _ready_store(tmp_path)
+    repository = service.console_dispatch_repository
+    commit = store.commit_durable_turn(acceptance)
+    conversation_id = commit.identity.conversation_id
+    # Settle the turn out-of-band so the checkpoint is gone and the restore
+    # is clean: terminal assistant + no checkpoint = nothing to reconcile.
+    with db.transaction(immediate=True) as cursor:
+        cursor.execute(
+            "UPDATE messages SET assistant_generation_state = 'complete', "
+            "content = 'done' WHERE id = ?",
+            (commit.assistant_message_id,),
+        )
+        cursor.execute(
+            "DELETE FROM console_dispatch_checkpoints WHERE assistant_message_id = ?",
+            (commit.assistant_message_id,),
+        )
+
+    statements = _traced_statements(db)
+    try:
+        state = repository.reconcile_for_session(conversation_id)
+    finally:
+        db.get_connection().set_trace_callback(None)
+
+    assert state is None
+    begins = [s for s in statements if s.strip().upper().startswith("BEGIN")]
+    assert begins, "reconcile must still read under a transaction"
+    assert not any("IMMEDIATE" in s.upper() for s in begins), (
+        f"clean restore reconcile took the write lock: {begins!r}"
+    )
+
+
+def test_valid_checkpoint_reconcile_takes_no_write_lock(tmp_path: Path) -> None:
+    """Probe (c) variant: a valid recovery owner is read, never written."""
+
+    db, service, store, _preparation, acceptance = _ready_store(tmp_path)
+    repository = service.console_dispatch_repository
+    commit = store.commit_durable_turn(acceptance)
+    conversation_id = commit.identity.conversation_id
+
+    statements = _traced_statements(db)
+    try:
+        state = repository.reconcile_for_session(conversation_id)
+    finally:
+        db.get_connection().set_trace_callback(None)
+
+    assert state is not None
+    assert state.kind is not ConsoleDispatchRecoveryKind.QUARANTINED
+    assert state.assistant_message_id == commit.assistant_message_id
+    begins = [s for s in statements if s.strip().upper().startswith("BEGIN")]
+    assert begins, "reconcile must still read under a transaction"
+    assert not any("IMMEDIATE" in s.upper() for s in begins), (
+        f"read-only reconcile took the write lock: {begins!r}"
+    )
+
+
+def test_terminal_checkpoint_reconcile_still_deletes_under_write_lock(
+    tmp_path: Path,
+) -> None:
+    """A reconcile that has a write to make still makes it (write txn)."""
+
+    db, service, store, _preparation, acceptance = _ready_store(tmp_path)
+    repository = service.console_dispatch_repository
+    commit = store.commit_durable_turn(acceptance)
+    conversation_id = commit.identity.conversation_id
+    # Terminal assistant state with a lingering checkpoint row: reconcile
+    # must delete the checkpoint -- a real write.
+    with db.transaction(immediate=True) as cursor:
+        cursor.execute(
+            "UPDATE messages SET assistant_generation_state = 'complete', "
+            "content = 'done' WHERE id = ?",
+            (commit.assistant_message_id,),
+        )
+
+    statements = _traced_statements(db)
+    try:
+        state = repository.reconcile_for_session(conversation_id)
+    finally:
+        db.get_connection().set_trace_callback(None)
+
+    assert state is None
+    assert any("IMMEDIATE" in s.upper() for s in statements), (
+        "the write pass must take the write lock up front (no deferred "
+        "read-then-write upgrade)"
+    )
+    remaining = (
+        db.get_connection()
+        .execute("SELECT COUNT(*) FROM console_dispatch_checkpoints")
+        .fetchone()[0]
+    )
+    assert remaining == 0

--- a/Tests/Chat/test_console_durable_turn_acceptance.py
+++ b/Tests/Chat/test_console_durable_turn_acceptance.py
@@ -367,8 +367,13 @@ def _install_failure(
             connection.commit()
 
         return cleanup_commit_fault
+    # TASK-22205: a permanent (not TEMP) trigger — controller-driven durable
+    # commits now run on a worker thread with their own thread-local
+    # connection, and a TEMP trigger is per-connection so it would never
+    # fire there. Permanent triggers fire on every connection, including
+    # this test thread's own direct-call path.
     connection.execute(
-        f"CREATE TEMP TRIGGER {trigger} BEFORE INSERT ON {table}{when} "
+        f"CREATE TRIGGER {trigger} BEFORE INSERT ON {table}{when} "
         "BEGIN SELECT RAISE(ABORT, 'task14 injected failure'); END"
     )
     return lambda: connection.execute(f"DROP TRIGGER {trigger}")

--- a/Tests/Chat/test_console_first_send_atomicity.py
+++ b/Tests/Chat/test_console_first_send_atomicity.py
@@ -186,8 +186,11 @@ async def test_precommit_failure_keeps_input_and_never_calls_provider(
     db, store, controller, gateway = _controller(tmp_path)
     session = store.sessions()[0]
     session.draft = "first durable prompt"
+    # TASK-22205: a permanent (not TEMP) trigger — the durable commit now
+    # runs on a worker thread with its own thread-local connection, and a
+    # TEMP trigger is per-connection so it would never fire there.
     db.get_connection().execute(
-        "CREATE TEMP TRIGGER task14_fail_checkpoint "
+        "CREATE TRIGGER task14_fail_checkpoint "
         "BEFORE INSERT ON console_dispatch_checkpoints "
         "BEGIN SELECT RAISE(ABORT, 'task14 injected failure'); END"
     )

--- a/backlog/tasks/task-22205 - Move-the-per-send-durable-turn-commit-and-restore-reconcile-off-the-event-loop.md
+++ b/backlog/tasks/task-22205 - Move-the-per-send-durable-turn-commit-and-restore-reconcile-off-the-event-loop.md
@@ -2,8 +2,8 @@
 id: TASK-22205
 title: >-
   Move the per-send durable-turn commit and restore reconcile off the event loop
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-08-24'
 labels:
   - performance
@@ -34,7 +34,135 @@ backfill window it is unbounded up to the 15 s busy timeout — on the event loo
 
 ## Acceptance Criteria
 
-- [ ] The durable-turn commit runs off the event loop (worker/`to_thread`) with its ordering guarantees preserved and the dispatch-checkpoint test suite green
-- [ ] `reconcile_for_session` takes a write transaction only when it actually has a write to make; the read path uses a read transaction
-- [ ] Send-to-dispatch latency measured before/after (steady state and with an artificial write-lock holder)
-- [ ] No new shutdown/error-path regressions: the review's standing rule — when you defer, walk the teardown and failure paths in real teardown order
+- [x] The durable-turn commit runs off the event loop (worker/`to_thread`) with its ordering guarantees preserved and the dispatch-checkpoint test suite green
+- [x] `reconcile_for_session` takes a write transaction only when it actually has a write to make; the read path uses a read transaction
+- [x] Send-to-dispatch latency measured before/after (steady state and with an artificial write-lock holder)
+- [x] No new shutdown/error-path regressions: the review's standing rule — when you defer, walk the teardown and failure paths in real teardown order
+
+## Implementation Plan
+
+1. Nesting census (done before any code): production callers of `store.commit_durable_turn`
+   are exactly one — `console_chat_controller._accept_durable_turn:5635`; the only caller of
+   `persistence.commit_durable_turn` is the store (`console_chat_store.py:3649`). Neither the
+   controller nor the store ever opens a `db.transaction()` themselves (zero `.transaction(`
+   hits in both files), so the persistence service's `BEGIN IMMEDIATE` at
+   `chat_persistence_service.py:384` is always the OUTERMOST manager-owned transaction on the
+   calling thread — nothing borrows an enclosing same-connection transaction on this path.
+   Moving the whole `store.commit_durable_turn` call to a worker thread moves the entire
+   outer transaction (and its internal borrowed nests, e.g. `create_conversation` →
+   `db.add_conversation`) to that one thread intact.
+2. Offload gate: follow the existing `chat_conversation_scope_service._is_memory_backed`
+   precedent — `asyncio.to_thread` only when `store.persistence.db` is not a `:memory:`
+   CharactersRAGDB (a memory DB is per-connection, so a worker thread would see an empty,
+   unmigrated database). Fakes without `.db` thread harmlessly.
+3. Red-first probes (new test module):
+   (a) event-loop-stall probe — second connection holds `BEGIN IMMEDIATE`, submit a send,
+       measure max event-loop stall (base: ~lock-hold duration; after: bounded small);
+   (b) ordering — provider dispatch must not begin before the durable commit is visible in
+       the DB (gateway records commit-visibility at first stream call);
+   (c) reconcile read path — sqlite trace on a clean restore shows no `BEGIN IMMEDIATE`.
+4. Implement:
+   - `_accept_durable_turn`: `commit = await` a small helper that runs
+     `self.store.commit_durable_turn(acceptance)` via `asyncio.to_thread` behind the memory
+     gate. Ordering guarantees: dispatch-after-commit holds because the coroutine only
+     resumes after the thread returns; per-session serialization holds because
+     `begin_preparation` is a single live slot per session and the prompt-queue dispatcher
+     refuses/queues while `preparing_before_acceptance`/`accepted_live_turn`; result
+     visibility holds because everything after the `await` sees the returned commit.
+   - `transition_checkpoint` (pre-dispatch `cas_state`, the second per-send IMMEDIATE
+     transaction, squarely inside send-to-dispatch latency): same offload via the async
+     effect callback (`_run_durable_postcommit_effect` already awaits awaitables).
+   - `ConsoleDispatchRepository.reconcile_for_session`: two-pass shape. Pass 1 is a
+     DEFERRED read transaction that never issues a write statement (parametrized
+     `allow_writes=False` returns a sentinel at the exact two write points: active
+     continuation precedence, terminal-state checkpoint delete). Only when pass 1 reports a
+     write does pass 2 open a fresh `BEGIN IMMEDIATE` and re-run the full logic from
+     scratch (re-reads inside the write txn; no deferred-upgrade — the wave-1
+     snapshot-upgrade lesson).
+5. Measure send-to-dispatch latency before/after, steady state and with a 2 s artificial
+   write-lock holder.
+6. Targeted suites: dispatch-checkpoint, durable-turn (acceptance + fix rounds 1-4),
+   dispatch recovery, controller, first-send atomicity, persistence; `--collect-only`
+   sweep; tee everything. `./scripts/preflight.sh`.
+7. Mutation test: remove the await barrier (dispatch no longer waits on the commit) → the
+   ordering probe must go red.
+8. Shutdown/failure walk: task cancelled while the commit thread runs → `to_thread`
+   survives cancellation, the transaction completes or rolls back atomically on the worker
+   thread, `except Exception` does not swallow `CancelledError`, and a post-cancel
+   committed checkpoint lands in the exact crash-recovery state restore reconcile already
+   handles. Off-loop commit failure re-raises the same exception object in the awaiting
+   coroutine → identical PERSISTENCE-pause + "Couldn't save the prepared turn." path.
+
+## Implementation Notes
+
+Both per-send pre-dispatch `BEGIN IMMEDIATE` transactions now run off the event loop, and
+the restore reconcile no longer takes the write lock just to read.
+
+**Controller** (`Chat/console_chat_controller.py`): new `_run_durable_db_call` helper runs a
+durable persistence call via `asyncio.to_thread`, gated by `_durable_db_call_offloadable`
+(the `_is_memory_backed` precedent: a `:memory:` CharactersRAGDB is per-connection, so
+memory-backed persistence stays inline; test fakes without `.db` thread harmlessly). Used
+at both per-send transaction sites: the `store.commit_durable_turn(acceptance)` call in
+`_accept_durable_turn`, and the pre-dispatch `repository.cas_state(...)` inside the
+`checkpoint_transition` postcommit effect (the effect runner already awaits awaitable
+callbacks). The `await` IS the ordering barrier — dispatch cannot precede the commit;
+per-session serialization is upstream (`begin_preparation` single live slot + the
+prompt-queue dispatcher refusing/queueing while a turn is preparing/accepted).
+
+**Repository** (`Chat/console_dispatch_repository.py`): `reconcile_for_session` is now
+two-pass. Pass 1 is a DEFERRED read transaction that never issues a write statement —
+`_reconcile_checkpoint_row(..., allow_writes=False)` returns a `_ReconcileWriteNeeded`
+sentinel at the exact two write points (active continuation precedence; terminal-state
+checkpoint delete). Only then does pass 2 open a fresh `BEGIN IMMEDIATE` and re-run the
+full logic from scratch inside the write lock — never an in-place deferred upgrade (the
+task-21100 wave-1 snapshot-upgrade lesson; also why 22200's chunk commits could kill a
+deferred read-then-write instantly).
+
+**Nesting census** (prerequisite): the only production caller of `store.commit_durable_turn`
+is `_accept_durable_turn`; the only caller of `persistence.commit_durable_turn` is the
+store; neither the controller nor the store opens `db.transaction()` themselves, so the
+persistence service's outer IMMEDIATE is always outermost on its thread — nothing borrowed
+an enclosing transaction, and the internal borrowed nests (`create_conversation` →
+`add_conversation`) move to the worker thread intact.
+
+**Tests**: new `Tests/Chat/test_console_durable_commit_offload.py` (6 tests: loop-stall
+probe, independent-connection ordering probe, cancellation/teardown walk, 3 reconcile
+lock-shape probes — the stall and two reconcile probes were red-first on base). Two
+existing injection mechanisms changed from `CREATE TEMP TRIGGER` to permanent
+`CREATE TRIGGER` (`test_console_first_send_atomicity.py`,
+`_install_failure` in `test_console_durable_turn_acceptance.py`): TEMP triggers are
+per-connection and the commit now runs on a worker-thread connection — behavioral
+assertions unchanged, and the direct-call (same-thread) tests fire them identically.
+
+**Measurements** (file DB, this machine): steady-state send-to-dispatch median 3.1 ms →
+3.5 ms (+0.4 ms thread-hop, negligible); with a 2 s write-lock holder the send correctly
+still takes ~2 s (durability requires the lock) but the **max event-loop stall drops
+2049 ms → 11 ms**. Clean-restore reconcile trace: `BEGIN IMMEDIATE` → plain `BEGIN`.
+
+**Mutation**: making the commit fire-and-forget behind a fabricated checkpoint (the
+"dispatch no longer waits" mutation at the store's `durable_commit` call) reds the
+ordering probe (provider never legitimately entered); reverted byte-identical.
+
+**Shutdown/failure walk**: cancellation mid-commit is exercised by
+`test_cancel_during_offloaded_commit_leaves_consistent_state` — the surviving thread
+commits atomically, no loop-exception-handler leakage, provider never called, and
+`reconcile_for_session` surfaces the committed-but-undispatched turn as a recovery owner
+(the pre-existing crash-window contract). Off-loop failures re-raise the original
+exception in the awaiting coroutine → the identical PERSISTENCE-pause path
+(`test_precommit_failure_keeps_input_and_never_calls_provider`, now via a worker-thread
+connection, still green).
+
+**Suite evidence**: targeted suites 571 passed (durable-turn acceptance + fix rounds 1-4,
+first-send atomicity, dispatch recovery + fix rounds 1-4, queue recovery, continuation
+handoff/review fixes, persistence service, controller, prompt-queue coordinator,
+automatic library preparation, offload probes); store suites + UI native chat flow: 650
+passed, 11 failed — **all 11 UI-flow failures reproduce identically at base `e94cd66b1`**
+(pre-existing dev reds, verified test-by-test in a clean baseline worktree; "no such
+table: conversations" memory-DB symptom, unrelated to this change). Collect-only sweep:
+23,546 collected, no errors. `./scripts/preflight.sh` all green.
+
+**Out of scope / residue**: the third per-send IMMEDIATE transaction — settle
+(`console_chat_store.py` `settle_dispatch_recovery` → `settle_with_assistant`) — still
+runs on the loop (post-response, not in send-to-dispatch latency; offloading it needs an
+async refactor of a sync store API). Same for `publish_durable_turn_owners`' persistence
+writes if any. Worth a follow-up if settle shows up in loop-stall traces.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -5531,6 +5531,48 @@ class ConsoleChatController:
         )
         return result
 
+    def _durable_db_call_offloadable(self) -> bool:
+        """True when a durable persistence call may run on a worker thread.
+
+        TASK-22205: the per-send ``BEGIN IMMEDIATE`` durable-turn commit and
+        the pre-dispatch checkpoint CAS used to run synchronously on the
+        event loop — tens of ms steady-state, up to the 15 s busy timeout
+        under write-lock contention (e.g. the messages_fts backfill window).
+        Follows the ``_is_memory_backed`` precedent in
+        ``chat_conversation_scope_service``: thread-local file-backed sqlite
+        connections are safe on ``asyncio.to_thread``, but a ``:memory:``
+        CharactersRAGDB is per-connection — a worker thread would see an
+        empty, unmigrated database — so memory-backed persistence stays
+        inline. A persistence fake with no ``.db`` threads harmlessly.
+        """
+
+        db = getattr(self.store.persistence, "db", None)
+        return not bool(getattr(db, "is_memory_db", False))
+
+    async def _run_durable_db_call(
+        self, call: Callable[..., Any], /, *args: Any
+    ) -> Any:
+        """Run one durable DB transaction off the event loop when safe.
+
+        The ``await`` is the ordering barrier: the coroutine resumes only
+        after the transaction durably exists (or raised), so provider
+        dispatch can never precede the commit, and every state transition
+        after the call still sees its result. Per-session serialization is
+        upstream: ``begin_preparation`` holds a single live slot per
+        session, and the prompt-queue dispatcher refuses/queues while a
+        turn is preparing or accepted. Exceptions cross ``to_thread``
+        unchanged, so the off-loop failure path is byte-identical to the
+        inline one. Task cancellation during the await leaves the thread
+        running to completion (``to_thread`` survives cancellation): the
+        transaction still commits or rolls back atomically on the worker
+        thread, which is exactly the crash-window state the restore
+        reconcile already recovers.
+        """
+
+        if self._durable_db_call_offloadable():
+            return await asyncio.to_thread(call, *args)
+        return call(*args)
+
     async def _accept_durable_turn(
         self,
         *,
@@ -5632,7 +5674,11 @@ class ConsoleChatController:
             contributions=contributions,
         )
         try:
-            commit = self.store.commit_durable_turn(acceptance)
+            # TASK-22205: the ~10-statement BEGIN IMMEDIATE turn commit runs
+            # off the event loop; the await is the dispatch-ordering barrier.
+            commit = await self._run_durable_db_call(
+                self.store.commit_durable_turn, acceptance
+            )
         except Exception:
             return ConsoleSubmitResult(
                 False,
@@ -5837,7 +5883,7 @@ class ConsoleChatController:
                     "Prepared turn changed before acceptance publication."
                 )
 
-        def transition_checkpoint() -> None:
+        async def transition_checkpoint() -> None:
             current_commit = self.store.durable_turn_commit_for(
                 preparation_id, fingerprint=fingerprint
             )
@@ -5848,7 +5894,16 @@ class ConsoleChatController:
             )
             if repository is None:
                 raise RuntimeError("Durable dispatch repository is unavailable.")
-            result = repository.cas_state(
+            # TASK-22205: the pre-dispatch checkpoint CAS is the second
+            # per-send BEGIN IMMEDIATE transaction; it runs off the event
+            # loop behind the same await barrier as the turn commit. The
+            # publication and preparation CAS below stay on the loop and
+            # re-validate their owners, so an interleaved discard/close
+            # during the await fails this effect exactly like a crash
+            # between CAS and provider entry (a state resume already
+            # recovers).
+            result = await self._run_durable_db_call(
+                repository.cas_state,
                 ConsoleDispatchTransition(
                     assistant_message_id=current_commit.assistant_message_id,
                     expected_state=ConsoleDispatchCheckpointState.ACCEPTED,
@@ -5861,7 +5916,7 @@ class ConsoleChatController:
                     ),
                     new_state=ConsoleDispatchCheckpointState.DISPATCH_STARTED,
                     new_attempt_id=current_commit.checkpoint.attempt_id,
-                )
+                ),
             )
             if result.status is not ConsoleDispatchResultStatus.COMMITTED:
                 raise RuntimeError("Durable dispatch checkpoint transition failed.")

--- a/tldw_chatbook/Chat/console_dispatch_repository.py
+++ b/tldw_chatbook/Chat/console_dispatch_repository.py
@@ -94,6 +94,13 @@ _ACTIVE_OWNER_SELECT = """
 _IDENTIFIER_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,199}\Z")
 
 
+class _ReconcileWriteNeeded:
+    """Sentinel: the read-only reconcile pass found write-requiring work."""
+
+
+_RECONCILE_WRITE_NEEDED = _ReconcileWriteNeeded()
+
+
 class ConsoleDispatchRepository:
     """Own accepted insert, recovery validation, CAS, settlement, and handoff."""
 
@@ -334,27 +341,26 @@ class ConsoleDispatchRepository:
         if type(conversation_id) is not str or not conversation_id.strip():
             return None
         try:
-            with self.db.transaction(immediate=True) as cursor:
-                rows = cursor.execute(
-                    _OWNER_SELECT + " WHERE checkpoint.conversation_id = ?",
-                    (conversation_id,),
-                ).fetchall()
-                if len(rows) > 1:
-                    return self._quarantined(
-                        conversation_id,
-                        "",
-                        "duplicate_active_path_owner",
-                    )
-                if rows:
-                    return self._reconcile_checkpoint_row(
-                        cursor,
-                        conversation_id,
-                        rows[0],
-                    )
-                return self._reconcile_checkpoint_free_owner(
-                    cursor,
-                    conversation_id,
+            # TASK-22205: most reconciles have nothing to write (no
+            # checkpoint at all, or a still-valid owner), so the first pass
+            # is a plain read transaction that never issues a write
+            # statement — it must not queue on the 15 s write-lock busy
+            # timeout just to read recovery state. Only when the read pass
+            # finds write-requiring work does a SECOND, fresh
+            # ``BEGIN IMMEDIATE`` transaction re-run the full logic from
+            # scratch (re-reading inside the write lock). The read pass
+            # never upgrades in place: a DEFERRED read-then-write hits
+            # SQLite's non-retryable snapshot-upgrade deadlock under
+            # concurrent writers (the recorded task-21100 wave-1 lesson).
+            outcome = self._reconcile_pass(conversation_id, allow_writes=False)
+            if not isinstance(outcome, _ReconcileWriteNeeded):
+                return outcome
+            outcome = self._reconcile_pass(conversation_id, allow_writes=True)
+            if isinstance(outcome, _ReconcileWriteNeeded):  # pragma: no cover
+                raise sqlite3.IntegrityError(
+                    "Reconcile write pass refused to write."
                 )
+            return outcome
         except sqlite3.Error:
             return self._quarantined(
                 conversation_id,
@@ -362,12 +368,45 @@ class ConsoleDispatchRepository:
                 "checkpoint_reconcile_error",
             )
 
+    def _reconcile_pass(
+        self,
+        conversation_id: str,
+        *,
+        allow_writes: bool,
+    ) -> "ConsoleDispatchRecoveryState | None | _ReconcileWriteNeeded":
+        """Run one reconcile pass; read passes may report write-needed."""
+
+        with self.db.transaction(immediate=allow_writes) as cursor:
+            rows = cursor.execute(
+                _OWNER_SELECT + " WHERE checkpoint.conversation_id = ?",
+                (conversation_id,),
+            ).fetchall()
+            if len(rows) > 1:
+                return self._quarantined(
+                    conversation_id,
+                    "",
+                    "duplicate_active_path_owner",
+                )
+            if rows:
+                return self._reconcile_checkpoint_row(
+                    cursor,
+                    conversation_id,
+                    rows[0],
+                    allow_writes=allow_writes,
+                )
+            return self._reconcile_checkpoint_free_owner(
+                cursor,
+                conversation_id,
+            )
+
     def _reconcile_checkpoint_row(
         self,
         cursor: sqlite3.Cursor,
         conversation_id: str,
         row: sqlite3.Row,
-    ) -> ConsoleDispatchRecoveryState | None:
+        *,
+        allow_writes: bool = True,
+    ) -> "ConsoleDispatchRecoveryState | None | _ReconcileWriteNeeded":
         assistant_id = str(row["assistant_message_id"] or "")
         if not self._valid_reconcile_pair(row):
             return self._quarantined(
@@ -393,6 +432,8 @@ class ConsoleDispatchRepository:
                     assistant_id,
                     "invalid_continuation",
                 )
+            if not allow_writes:
+                return _RECONCILE_WRITE_NEEDED
             next_version = int(row["current_assistant_version"]) + 1
             now = self.db._get_current_utc_timestamp_iso()
             updated = cursor.execute(
@@ -430,6 +471,8 @@ class ConsoleDispatchRepository:
 
         assistant_state = row["assistant_state"]
         if assistant_state in {"complete", "stopped", "failed", "discarded"}:
+            if not allow_writes:
+                return _RECONCILE_WRITE_NEEDED
             self._delete_exact_checkpoint(cursor, row)
             return None
         if (


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22205). Every send ran a ~10-statement `BEGIN IMMEDIATE` transaction synchronously on the event loop before dispatch (plus a pre-dispatch CAS and a write-locked read at every restore) — up to the 15 s busy timeout of loop stall under contention, e.g. during TASK-22200's post-upgrade backfill window.

**Change:** `_run_durable_db_call` (+ `:memory:`-inline gate) runs `commit_durable_turn` and the pre-dispatch checkpoint CAS via `asyncio.to_thread`; `reconcile_for_session` is two-pass — a DEFERRED read pass with write-point sentinels, and only when a write is needed a FRESH `BEGIN IMMEDIATE` re-runs the logic (never an in-place deferred upgrade, the snapshot-upgrade lesson).

**Measured:** max event-loop stall under a 2 s write-lock holder **2049 ms → 11 ms** (send correctly still waits for durability: 2043→2025 ms); steady send +0.4 ms thread hop; clean-restore reconcile now takes a read transaction (trace-proven).

**Adversarial review: SHIP.** Per-session ordering proven from the preparation-slot state machine (no path to a second preparation during the offloaded window; cited transitions); connection affinity clean (thread-local connections + depth, no per-connection functions, readbacks same-cursor, first loop readback strictly post-commit); loop-stall claim independently reproduced (11.3 ms); cancel-mid-commit + cancel-before-CAS probed to full recovery; interpreter-exit executor-drain verified empirically. Review's latent find (cancel-DURING-CAS ledger/DB divergence — no production trigger, recover-on-restart) + two coverage notes go to close-out filing. Test-injection TEMP triggers → permanent (worker-thread connections; per-test DBs, assertions unchanged).

Tests: 31 offload/atomicity/acceptance + 190 recovery-family + 571 targeted green; 14 + 11 pre-existing reds baselined node-identical at base; preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1