### PR TITLE
perf(ui): stop the splash and Persona Buddy animations relaying out the screen every frame (TASK-21595)

### DIFF
--- a/Tests/Architecture/test_timer_path_static_update_inventory.py
+++ b/Tests/Architecture/test_timer_path_static_update_inventory.py
@@ -1,0 +1,834 @@
+"""Census: no timer-path ``.update(`` may default to ``layout=True`` unnoticed.
+
+``Static.update`` is ``update(content="", *, layout: bool = True)`` and ends in
+``self.refresh(layout=layout)``. **The default lays out.** A repaint on a clock
+therefore arms a whole ``Screen._refresh_layout`` / ``Compositor.reflow`` on
+every tick unless the caller opts out. Three instances have been found the hard
+way:
+
+* TASK-21692 -- the Console composer cursor blink: 396 ``Widget.arrange`` calls
+  per 6 ticks, ~1.9 whole-screen reflows/second on an *idle* focused composer,
+  in a method whose own docstring said it must not do that.
+* TASK-21134 item 7 -- the media-viewer match-nav: 10 layout messages -> 0.
+* TASK-21595 (this census) -- ``SplashScreen._update_animation`` at 10-100 fps
+  during startup, and ``PersonaBuddyWidget._paint_frame`` at the pet's frame
+  rate.
+
+Three instances is a pattern, so this module rebuilds the census on every run
+instead of trusting a one-off sweep. It walks the package AST, collects every
+*repeating* clock root, follows the intra-package call graph from each, and
+requires that every ``.update(`` call it can reach is **classified**: either the
+call passes ``layout=`` explicitly, or it carries an entry in
+``CLASSIFIED_SITES`` saying why it does not need to.
+
+Adding a new timer-path repaint therefore fails this test until its author says
+which of the two it is. That is the whole point -- the cost is invisible to
+every other test, because nothing else counts layout operations.
+
+Runtime evidence for the two sites this census fixed (measured layout-pass
+counts against a measured idle floor, plus geometry-equivalence A/Bs) lives in
+``Tests/UI/test_timer_path_layout_cost.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+REPO_ROOT = PACKAGE_ROOT.parent
+
+#: How deep to follow the call graph out from a clock root. Six hops covers the
+#: real chains (``_poll_transcript`` -> ... -> a leaf widget's ``sync_*``)
+#: without the graph degenerating into "everything".
+MAX_CALL_DEPTH = 6
+
+#: Textual's own repeating-clock constructors. ``set_timer`` is a one-shot, so
+#: it only counts as a clock when the callback re-arms *itself* -- an interval
+#: spelled as a chain of one-shots, which is how the Persona Buddy frame timer
+#: and several Console ticks are written.
+REPEATING_CLOCK = "set_interval"
+ONE_SHOT_CLOCK = "set_timer"
+
+
+# ---------------------------------------------------------------------------
+# classification
+# ---------------------------------------------------------------------------
+#
+# Key: (path relative to the repo root, enclosing `Class.method`, receiver
+#       expression as written).
+# Value: why this call does not need `layout=False`.
+#
+# Four kinds of reason appear, and the distinction matters:
+#
+#   NOT-A-WIDGET  -- `dict.update` / `set.update`, which shares its name with
+#                    `Static.update` and is indistinguishable in the AST.
+#   NEEDS-LAYOUT  -- the rendered size genuinely depends on the content (a
+#                    `height: auto` box, or a `width: auto` strip), so skipping
+#                    the layout pass would leave stale geometry on screen. This
+#                    is a real behaviour change, not an optimisation.
+#   NOT-PER-TICK  -- the tick reaches the call only through an equality gate or
+#                    a branch a tick cannot take, so it is not a per-tick cost.
+#   UNREACHABLE   -- the module has no importer anywhere in the repo.
+#
+CLASSIFIED_SITES: dict[tuple[str, str, str], str] = {
+    # -- tldw_chatbook/UI/Console_Modules/prompt_queue.py
+    (
+        "tldw_chatbook/UI/Console_Modules/prompt_queue.py",
+        "ConsolePromptQueueRegion.sync_presentation",
+        "preview",
+    ): "NEEDS-LAYOUT: queue preview grows with the queued prompt.",
+    (
+        "tldw_chatbook/UI/Console_Modules/prompt_queue.py",
+        "ConsolePromptQueueRegion.sync_presentation",
+        "summary",
+    ): "NEEDS-LAYOUT: queue summary is height:auto.",
+    # -- tldw_chatbook/UI/Console_Modules/workspace.py
+    (
+        "tldw_chatbook/UI/Console_Modules/workspace.py",
+        "ConsoleWorkspaceController.apply_workspace_membership_snapshot",
+        "owner_by_conversation",
+    ): "NOT-A-WIDGET: local dict merge, not a Static.",
+    (
+        "tldw_chatbook/UI/Console_Modules/workspace.py",
+        "ConsoleWorkspaceController.apply_workspace_membership_snapshot",
+        "self._canonical_owner_observations",
+    ): "NOT-A-WIDGET: dict of owner observations, not a Static.",
+    # -- tldw_chatbook/UI/Research_Window.py
+    (
+        "tldw_chatbook/UI/Research_Window.py",
+        "ResearchWindow._update_detail",
+        "self.query_one('#research-run-detail', Static)",
+    ): (
+        "NEEDS-LAYOUT: run detail is a height:auto block that grows with "
+        "events."
+    ),
+    # -- tldw_chatbook/UI/Screens/chat_screen.py
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._prune_console_rail_preferences",
+        "live",
+    ): "NOT-A-WIDGET: set of live rail preference keys, not a Static.",
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_agent_section",
+        "fleet_summary",
+    ): (
+        "NEEDS-LAYOUT: height:auto summary whose line count tracks the "
+        "fleet size."
+    ),
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_agent_section",
+        "self.query_one('#console-agent-section-status', Static)",
+    ): "NEEDS-LAYOUT: height:auto agent status line.",
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_agent_section",
+        "self.query_one('#console-agent-section-steps', Static)",
+    ): "NEEDS-LAYOUT: height:auto agent steps line.",
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_mode_bar",
+        "mode_bar",
+    ): (
+        "NEEDS-LAYOUT: the mode bar's chip row wraps, so its height is "
+        "content-driven."
+    ),
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_rail_system_line",
+        "system_line",
+    ): (
+        "NOT-PER-TICK: equality-gated on _console_rail_system_line_last "
+        "(TASK-251), so the 0.2 s tick does not repaint it."
+    ),
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_settings_summary",
+        "recovery",
+    ): (
+        "NEEDS-LAYOUT: the readiness row is display-toggled on the same "
+        "path."
+    ),
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_settings_summary",
+        "self.query_one('#console-model-section-max-tokens .console-model-section-value', Static)",
+    ): (
+        "NEEDS-LAYOUT: as above -- shares the wrapped .console-model- "
+        "section-value rule."
+    ),
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_settings_summary",
+        "self.query_one('#console-model-section-model .console-model-section-value', Static)",
+    ): "NEEDS-LAYOUT: as above -- wrapped value, auto height capped at 3.",
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_settings_summary",
+        "self.query_one('#console-model-section-provider .console-model-section-value', Static)",
+    ): (
+        "NEEDS-LAYOUT: .console-model-section-value is text-wrap:wrap with "
+        "max-height:3, so the painted row count changes with the model "
+        "name."
+    ),
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_console_settings_summary",
+        "self.query_one('#console-model-section-temperature .console-model-section-value', Static)",
+    ): (
+        "NEEDS-LAYOUT: as above -- shares the wrapped .console-model- "
+        "section-value rule."
+    ),
+    (
+        "tldw_chatbook/UI/Screens/chat_screen.py",
+        "ChatScreen._sync_native_console_transcript",
+        "self._console_image_preparing",
+    ): "NOT-A-WIDGET: set of in-flight image ids, not a Static.",
+    # -- tldw_chatbook/UI/Screens/trajectory_screen.py
+    (
+        "tldw_chatbook/UI/Screens/trajectory_screen.py",
+        "TrajectoryScreen._refresh_state",
+        "self.query_one('#trajectory-state', Static)",
+    ): (
+        "NEEDS-LAYOUT: #trajectory-state is height:auto with max-height:4, "
+        "so the state copy really does change its row count."
+    ),
+    # -- tldw_chatbook/UI/Screens/video_player_screen.py
+    (
+        "tldw_chatbook/UI/Screens/video_player_screen.py",
+        "VideoPlayerScreen._refresh_status",
+        "self.query_one('#video-player-status', Static)",
+    ): (
+        "NOT-PER-TICK: #video-player-status is height:1, but the status "
+        "timer only runs while a video is actually playing and the line "
+        "changes on every tick anyway (position advances), so the repaint "
+        "is real work rather than idle burn. Left alone to avoid a "
+        "behaviour change for a gain that is one coalesced layout pass per "
+        "second."
+    ),
+    # -- tldw_chatbook/Widgets/Console/console_composer_bar.py
+    (
+        "tldw_chatbook/Widgets/Console/console_composer_bar.py",
+        "ConsoleComposerBar._refresh_visible_draft",
+        "self.query_one('#console-command-visible-text', Static)",
+    ): (
+        "NEEDS-LAYOUT: _refresh_visible_draft is the draft-mutation path "
+        "and must recompute the composer height. TASK-21692 split the blink "
+        "tick off into _render_visible_draft_only, which passes "
+        "layout=False."
+    ),
+    (
+        "tldw_chatbook/Widgets/Console/console_composer_bar.py",
+        "ConsoleComposerBar._sync_collapsed_presentation",
+        "status",
+    ): "NEEDS-LAYOUT: collapsed-composer status line is height:auto.",
+    (
+        "tldw_chatbook/Widgets/Console/console_composer_bar.py",
+        "ConsoleComposerBar._sync_send_disabled_reason",
+        "strip",
+    ): (
+        "NEEDS-LAYOUT: the Send disabled-reason strip is width:auto and the "
+        "same call toggles display/width/height inline -- the layout pass "
+        "is the point, not an accident."
+    ),
+    (
+        "tldw_chatbook/Widgets/Console/console_composer_bar.py",
+        "ConsoleComposerBar.set_pending_attachment_label",
+        "indicator",
+    ): (
+        "NEEDS-LAYOUT: attachment indicator is width:auto and display- "
+        "toggled."
+    ),
+    (
+        "tldw_chatbook/Widgets/Console/console_composer_bar.py",
+        "ConsoleComposerBar.set_voice_status",
+        "chip",
+    ): (
+        "NEEDS-LAYOUT: the voice chip's width is computed and assigned "
+        "inline on the same path (styles.width / display), so its box "
+        "changes with the content it is being handed."
+    ),
+    # -- tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
+    (
+        "tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py",
+        "ConsolePromptQueueModal._apply_snapshot",
+        "state",
+    ): "NEEDS-LAYOUT: modal state block is height:auto.",
+    # -- tldw_chatbook/Widgets/Console/console_session_surface.py
+    (
+        "tldw_chatbook/Widgets/Console/console_session_surface.py",
+        "ConsoleSessionSurface.set_session_title",
+        "header",
+    ): (
+        "NEEDS-LAYOUT: session title width is auto and tracks the title "
+        "text."
+    ),
+    (
+        "tldw_chatbook/Widgets/Console/console_session_surface.py",
+        "ConsoleSessionSurface.show_fleet_coachmark",
+        "content",
+    ): (
+        "NEEDS-LAYOUT: the fleet coachmark is a display-toggled auto-sized "
+        "callout."
+    ),
+    (
+        "tldw_chatbook/Widgets/Console/console_session_surface.py",
+        "ConsoleSessionSurface.sync_inline_guidance",
+        "title",
+    ): "NEEDS-LAYOUT: inline guidance is height:auto and display-toggled.",
+    # -- tldw_chatbook/Widgets/Console/console_status_chips.py
+    (
+        "tldw_chatbook/Widgets/Console/console_status_chips.py",
+        "ConsoleStatusChips.sync_cost_state",
+        "chip",
+    ): (
+        "NEEDS-LAYOUT: chips are width:auto -- the label length IS the "
+        "width."
+    ),
+    (
+        "tldw_chatbook/Widgets/Console/console_status_chips.py",
+        "ConsoleStatusChips.sync_run_chip",
+        "chip",
+    ): (
+        "NEEDS-LAYOUT: chips are width:auto -- the label length IS the "
+        "width."
+    ),
+    # -- tldw_chatbook/Widgets/Console/console_transcript.py
+    (
+        "tldw_chatbook/Widgets/Console/console_transcript.py",
+        "ConsoleTranscript.sync_jump_indicator",
+        "pill",
+    ): "NEEDS-LAYOUT: the jump pill is width:auto and display-toggled.",
+    # -- tldw_chatbook/Widgets/Console/console_video_preview.py
+    (
+        "tldw_chatbook/Widgets/Console/console_video_preview.py",
+        "ConsoleVideoPreview._update_frame",
+        "frame",
+    ): (
+        "NEEDS-LAYOUT: .console-video-preview-frame is height:auto and the "
+        "Pixels renderable's row count varies with the scaled image (and "
+        "with the poster-text fallback), so the box really does resize per "
+        "frame."
+    ),
+    # -- tldw_chatbook/Widgets/Console/console_workspace_context.py
+    (
+        "tldw_chatbook/Widgets/Console/console_workspace_context.py",
+        "ConsoleWorkspaceContextTray._update_workspace_tree_selection_context",
+        "context",
+    ): "NEEDS-LAYOUT: the context tray line count tracks the selection.",
+    # -- tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._apply_opened_document",
+        "self.query_one('#file-notes-breadcrumb', Static)",
+    ): (
+        "NEEDS-LAYOUT: the breadcrumb wraps, so its row count tracks the "
+        "path."
+    ),
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._dismiss_reload_confirmation",
+        "self.query_one('#file-notes-reload-confirm-copy', Static)",
+    ): (
+        "NEEDS-LAYOUT: the reload-confirm callout is display-toggled and "
+        "auto-sized."
+    ),
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._render_session_git_label",
+        "authority",
+    ): (
+        "NEEDS-LAYOUT: the authority line is width:auto and display- "
+        "toggled."
+    ),
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._set_action_status",
+        "self.query_one('#file-notes-action-status', Static)",
+    ): "NEEDS-LAYOUT: height:auto action status line.",
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._set_save_state",
+        "self.query_one('#file-notes-authority', Static)",
+    ): "NEEDS-LAYOUT: width:auto authority chip.",
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._set_save_state",
+        "status",
+    ): (
+        "NEEDS-LAYOUT: the save/preview status lines are height:auto and "
+        "display-toggled; the poll is a 1.5 s worker-backed reconcile, not "
+        "an animation clock."
+    ),
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._sync_large_file_preview",
+        "status",
+    ): (
+        "NEEDS-LAYOUT: the save/preview status lines are height:auto and "
+        "display-toggled; the poll is a 1.5 s worker-backed reconcile, not "
+        "an animation clock."
+    ),
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._update_controls",
+        "self.query_one('#file-notes-action-status', Static)",
+    ): "NEEDS-LAYOUT: height:auto action status line.",
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._update_controls",
+        "self.query_one('#file-notes-path-label', Static)",
+    ): (
+        "NEEDS-LAYOUT: the path label wraps, so its row count tracks the "
+        "path."
+    ),
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._update_root_surface",
+        "authority",
+    ): (
+        "NEEDS-LAYOUT: the authority line is width:auto and display- "
+        "toggled."
+    ),
+    (
+        "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",
+        "LibraryFileNotesWorkspace._update_root_surface",
+        "status",
+    ): (
+        "NEEDS-LAYOUT: the save/preview status lines are height:auto and "
+        "display-toggled; the poll is a 1.5 s worker-backed reconcile, not "
+        "an animation clock."
+    ),
+    # -- tldw_chatbook/Widgets/audio_troubleshooting_dialog.py
+    (
+        "tldw_chatbook/Widgets/audio_troubleshooting_dialog.py",
+        "AudioTroubleshootingDialog._update_level_meter",
+        "level_text",
+    ): (
+        "NEEDS-LAYOUT: 'Level: N%' is width:auto and its length changes "
+        "with the digit count; the tick also only runs during an explicit "
+        "user-started mic test, not at idle."
+    ),
+    (
+        "tldw_chatbook/Widgets/audio_troubleshooting_dialog.py",
+        "AudioTroubleshootingDialog._update_level_meter",
+        "meter",
+    ): (
+        "NOT-A-WIDGET: ProgressBar.update(progress=...) has no layout "
+        "kwarg."
+    ),
+    # -- tldw_chatbook/Widgets/detailed_progress.py
+    (
+        "tldw_chatbook/Widgets/detailed_progress.py",
+        "DetailedProgressBar._update_metrics",
+        "self.query_one('#elapsed-time', Static)",
+    ): (
+        "UNREACHABLE: Widgets/detailed_progress.py has no importer (prod or "
+        "tests)."
+    ),
+    (
+        "tldw_chatbook/Widgets/detailed_progress.py",
+        "DetailedProgressBar._update_metrics",
+        "self.query_one('#memory-usage', Static)",
+    ): (
+        "UNREACHABLE: Widgets/detailed_progress.py has no importer (prod or "
+        "tests)."
+    ),
+    (
+        "tldw_chatbook/Widgets/detailed_progress.py",
+        "DetailedProgressBar._update_metrics",
+        "self.query_one('#remaining-time', Static)",
+    ): (
+        "UNREACHABLE: Widgets/detailed_progress.py has no importer (prod or "
+        "tests)."
+    ),
+    (
+        "tldw_chatbook/Widgets/detailed_progress.py",
+        "DetailedProgressBar._update_metrics",
+        "self.query_one('#speed-metric', Static)",
+    ): (
+        "UNREACHABLE: Widgets/detailed_progress.py has no importer (prod or "
+        "tests)."
+    ),
+    # -- tldw_chatbook/Widgets/loading_states.py
+    (
+        "tldw_chatbook/Widgets/loading_states.py",
+        "InlineLoader._update_dots",
+        "self",
+    ): (
+        "UNREACHABLE: Widgets/loading_states.py has no importer (prod or "
+        "tests)."
+    ),
+    # -- tldw_chatbook/Widgets/splash_screen.py
+    (
+        "tldw_chatbook/Widgets/splash_screen.py",
+        "SplashScreen._display_static_fallback",
+        "display",
+    ): (
+        "NOT-PER-TICK: _display_static_fallback runs once, on the error "
+        "edge that also stops the animation timer. The per-frame repaint in "
+        "_update_animation passes layout=False (TASK-21595)."
+    ),
+    (
+        "tldw_chatbook/Widgets/splash_screen.py",
+        "SplashScreen._update_animation",
+        "self.effect_handler",
+    ): (
+        "NOT-A-WIDGET: the effect handler's own frame producer, not a "
+        "Static."
+    ),
+    # -- tldw_chatbook/Widgets/status_dashboard.py
+    (
+        "tldw_chatbook/Widgets/status_dashboard.py",
+        "StatusDashboard._update_time_display",
+        "time_display",
+    ): (
+        "UNREACHABLE: Widgets/status_dashboard.py has no importer (prod or "
+        "tests)."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# census machinery
+# ---------------------------------------------------------------------------
+
+
+class _Module:
+    __slots__ = ("path", "tree", "dotted", "classes", "methods", "funcs", "enclosing")
+
+    def __init__(self, path: Path, tree: ast.Module, dotted: str) -> None:
+        self.path = path
+        self.tree = tree
+        self.dotted = dotted
+        self.classes: dict[str, ast.ClassDef] = {}
+        self.methods: dict[tuple[str, str], ast.AST] = {}
+        self.funcs: dict[str, ast.AST] = {}
+        self.enclosing: dict[ast.AST, tuple[str | None, str | None]] = {}
+
+
+def _callee(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def _callback_names(arg: ast.AST) -> list[str]:
+    """Method/function names a timer callback argument can refer to."""
+    names: list[str] = []
+    if isinstance(arg, ast.Attribute):
+        names.append(arg.attr)
+    elif isinstance(arg, ast.Name):
+        names.append(arg.id)
+    elif isinstance(arg, ast.Lambda):
+        names.extend(_callee(n) for n in ast.walk(arg) if isinstance(n, ast.Call))
+    elif isinstance(arg, ast.Call) and _callee(arg) == "partial" and arg.args:
+        names.extend(_callback_names(arg.args[0]))
+    return [name for name in names if name]
+
+
+def _index_enclosing(tree: ast.Module) -> dict[ast.AST, tuple[str | None, str | None]]:
+    out: dict[ast.AST, tuple[str | None, str | None]] = {}
+
+    def walk(node: ast.AST, cls: str | None, fn: str | None) -> None:
+        for child in ast.iter_child_nodes(node):
+            child_cls, child_fn = cls, fn
+            if isinstance(child, ast.ClassDef):
+                child_cls, child_fn = child.name, None
+            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                child_fn = child.name
+            out[child] = (child_cls, child_fn)
+            walk(child, child_cls, child_fn)
+
+    walk(tree, None, None)
+    return out
+
+
+@lru_cache(maxsize=1)
+def _load_package() -> dict[str, _Module]:
+    modules: dict[str, _Module] = {}
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover
+            continue
+        dotted = ".".join(path.relative_to(REPO_ROOT).with_suffix("").parts)
+        module = _Module(path, tree, dotted)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                module.classes[node.name] = node
+                for sub in ast.walk(node):
+                    if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        module.methods[(node.name, sub.name)] = sub
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                module.funcs[node.name] = node
+        module.enclosing = _index_enclosing(tree)
+        modules[dotted] = module
+    return modules
+
+
+class _CallGraph:
+    def __init__(self, modules: dict[str, _Module]) -> None:
+        self.modules = modules
+        self.by_method: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        self.bases: dict[tuple[str, str], list[str]] = {}
+        for dotted, module in modules.items():
+            for cls, method in module.methods:
+                self.by_method[method].append((dotted, cls))
+            for cls, node in module.classes.items():
+                names = []
+                for base in node.bases:
+                    if isinstance(base, ast.Name):
+                        names.append(base.id)
+                    elif isinstance(base, ast.Attribute):
+                        names.append(base.attr)
+                self.bases[(dotted, cls)] = names
+
+    def resolve(self, dotted: str, cls: str | None, name: str):
+        module = self.modules.get(dotted)
+        if module is None:
+            return None
+        if cls and (cls, name) in module.methods:
+            return (dotted, cls, name, module.methods[(cls, name)])
+        for base in self.bases.get((dotted, cls or ""), []):
+            if (base, name) in module.methods:
+                return (dotted, base, name, module.methods[(base, name)])
+        if name in module.funcs:
+            return (dotted, None, name, module.funcs[name])
+        return None
+
+    def reachable(self, dotted: str, cls: str | None, name: str) -> Iterator[tuple]:
+        start = self.resolve(dotted, cls, name)
+        if start is None:
+            return
+        seen: set[tuple[str, str | None, str]] = set()
+        frontier = [(start, 1)]
+        while frontier:
+            nxt = []
+            for (mod, klass, meth, node), depth in frontier:
+                key = (mod, klass, meth)
+                if key in seen:
+                    continue
+                seen.add(key)
+                yield (mod, klass, meth, node)
+                if depth >= MAX_CALL_DEPTH:
+                    continue
+                for call in (n for n in ast.walk(node) if isinstance(n, ast.Call)):
+                    callee = _callee(call)
+                    if not callee:
+                        continue
+                    target = self.resolve(mod, klass, callee)
+                    if target is None:
+                        candidates = self.by_method.get(callee, [])
+                        if len(candidates) == 1:
+                            target = self.resolve(
+                                candidates[0][0], candidates[0][1], callee
+                            )
+                    if target and (target[0], target[1], target[2]) not in seen:
+                        nxt.append((target, depth + 1))
+            frontier = nxt
+
+
+def _clock_roots(modules: dict[str, _Module]) -> list[tuple[str, str, str | None, str]]:
+    """Every *repeating* clock in the package.
+
+    Returns ``(kind, module, class, callback_name)``. Two kinds:
+    ``set_interval`` (a real repeating timer) and ``rearming-set_timer`` (a
+    method that schedules itself again -- an interval written as a chain of
+    one-shots, which is how the Persona Buddy frame clock is spelled).
+    """
+    roots: list[tuple[str, str, str | None, str]] = []
+    for dotted, module in modules.items():
+        for node in ast.walk(module.tree):
+            if isinstance(node, ast.Call) and _callee(node) == REPEATING_CLOCK:
+                cls, _fn = module.enclosing.get(node, (None, None))
+                names = _callback_names(node.args[1]) if len(node.args) > 1 else []
+                for keyword in node.keywords:
+                    if keyword.arg == "callback":
+                        names.extend(_callback_names(keyword.value))
+                for name in names:
+                    roots.append((REPEATING_CLOCK, dotted, cls, name))
+        for (cls, method), node in module.methods.items():
+            for call in (n for n in ast.walk(node) if isinstance(n, ast.Call)):
+                if _callee(call) != ONE_SHOT_CLOCK:
+                    continue
+                names = _callback_names(call.args[1]) if len(call.args) > 1 else []
+                for keyword in call.keywords:
+                    if keyword.arg == "callback":
+                        names.extend(_callback_names(keyword.value))
+                if method in names:
+                    roots.append((f"rearming-{ONE_SHOT_CLOCK}", dotted, cls, method))
+    return roots
+
+
+def _receiver(call: ast.Call) -> str | None:
+    if not isinstance(call.func, ast.Attribute):
+        return None
+    try:
+        return ast.unparse(call.func.value)
+    except Exception:  # pragma: no cover
+        return None
+
+
+def census() -> dict[tuple[str, str, str], dict]:
+    """Every ``.update(`` reachable from a repeating clock.
+
+    Keyed ``(file, enclosing Class.method, receiver expression)``. The
+    enclosing function is part of the key on purpose: a first draft keyed only
+    ``(file, receiver)`` and the un-fixed ``SplashScreen._update_animation``
+    site SURVIVED its mutation, because ``_display_static_fallback`` in the
+    same module writes to a local also named ``display`` and its allowlist
+    entry covered both.
+    """
+    modules = _load_package()
+    graph = _CallGraph(modules)
+    found: dict[tuple[str, str, str], dict] = {}
+    for kind, dotted, cls, callback in _clock_roots(modules):
+        for mod, klass, meth, node in graph.reachable(dotted, cls, callback):
+            module = modules[mod]
+            rel = str(module.path.relative_to(REPO_ROOT))
+            for call in (n for n in ast.walk(node) if isinstance(n, ast.Call)):
+                if _callee(call) != "update":
+                    continue
+                receiver = _receiver(call)
+                if receiver is None:
+                    continue
+                explicit = any(kw.arg == "layout" for kw in call.keywords)
+                record = found.setdefault(
+                    (rel, f"{klass}.{meth}", receiver),
+                    {"lines": set(), "explicit": True, "roots": set()},
+                )
+                record["lines"].add(call.lineno)
+                record["explicit"] = record["explicit"] and explicit
+                record["roots"].add(f"[{kind}] {dotted.split('.')[-1]}:{cls}.{callback}")
+    return found
+
+
+@pytest.fixture(scope="module")
+def timer_path_census() -> dict[tuple[str, str, str], dict]:
+    return census()
+
+
+# ---------------------------------------------------------------------------
+# the guard
+# ---------------------------------------------------------------------------
+
+
+def test_census_actually_finds_the_known_clock_roots() -> None:
+    """The census must be proven to see, or the guard below passes vacuously.
+
+    A silently-broken AST walker that returns nothing would make every other
+    assertion in this module green. This pins the floor and names three roots
+    that must be found: an app-wide interval, the animation clock TASK-21595
+    fixed, and the self-rearming one-shot chain that the naive
+    "grep for set_interval" version of this census would miss entirely.
+    """
+    modules = _load_package()
+    roots = _clock_roots(modules)
+    assert len(roots) >= 30, f"census collapsed to {len(roots)} clock roots"
+
+    flattened = {(dotted.split(".")[-1], cls, name) for _kind, dotted, cls, name in roots}
+    assert ("splash_screen", "SplashScreen", "_update_animation") in flattened
+    assert (
+        "console_composer_bar",
+        "ConsoleComposerBar",
+        "_toggle_cursor_blink",
+    ) in flattened, "the TASK-21692 blink clock disappeared from the census"
+
+    rearming = {r for r in roots if r[0].startswith("rearming-")}
+    assert rearming, (
+        "no self-rearming set_timer found -- an interval spelled as a chain of "
+        "one-shots is exactly the shape a set_interval-only sweep misses"
+    )
+
+
+def test_no_timer_path_update_defaults_to_layout_true(timer_path_census) -> None:
+    """Every clock-reachable ``.update(`` is classified.
+
+    Either the call passes ``layout=`` explicitly, or ``CLASSIFIED_SITES`` says
+    why it does not have to. A new repaint on a timer lands here unclassified
+    and fails, which is the only signal this cost ever gets -- no other test in
+    the suite counts layout operations.
+    """
+    unclassified = sorted(
+        (path, qualname, receiver, sorted(rec["lines"]), sorted(rec["roots"]))
+        for (path, qualname, receiver), rec in timer_path_census.items()
+        if not rec["explicit"] and (path, qualname, receiver) not in CLASSIFIED_SITES
+    )
+    assert not unclassified, (
+        "These `.update(` calls are reachable from a repeating clock and do not "
+        "pass `layout=`. Static.update defaults to layout=True, so each of "
+        "these arms a whole screen reflow per tick.\n\n"
+        "Fix by either passing `layout=False` (only where the rendered size "
+        "genuinely cannot change -- prove it with a geometry-equivalence A/B, "
+        "see Tests/UI/test_timer_path_layout_cost.py), or by adding an entry to "
+        "CLASSIFIED_SITES saying why it does not need to.\n\n"
+        + "\n".join(
+            f"  {path}:{lines} in {qualname} recv={receiver!r}\n"
+            f"      via {roots[:2]}"
+            for path, qualname, receiver, lines, roots in unclassified
+        )
+    )
+
+
+def test_classified_sites_are_not_stale(timer_path_census) -> None:
+    """Every classification still names a real ``.update(`` call.
+
+    A refactor that deletes or renames one of these should retire its entry
+    rather than leave folklore behind. Deliberately lenient about
+    *reachability* (a call chain moving around is not a finding), strict about
+    the call still existing.
+    """
+    stale: list[str] = []
+    for (rel, qualname, receiver), reason in sorted(CLASSIFIED_SITES.items()):
+        path = REPO_ROOT / rel
+        if not path.exists():
+            stale.append(f"  {rel}: file no longer exists ({reason})")
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover
+            continue
+        enclosing = _index_enclosing(tree)
+        live = {
+            (
+                "{}.{}".format(*enclosing.get(node, (None, None))),
+                _receiver(node),
+            )
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and _callee(node) == "update"
+        }
+        if (qualname, receiver) not in live:
+            stale.append(
+                f"  {rel}: no `.update(` on {receiver!r} in {qualname} any more "
+                f"({reason})"
+            )
+    assert not stale, "Stale CLASSIFIED_SITES entries:\n" + "\n".join(stale)
+
+
+def test_every_classification_states_a_kind() -> None:
+    """Reasons must carry one of the four kinds, not just prose.
+
+    A reason that does not say *which* kind of exemption it is claiming cannot
+    be reviewed, and "documented" would degrade into "mentioned".
+    """
+    kinds = ("NOT-A-WIDGET:", "NEEDS-LAYOUT:", "NOT-PER-TICK:", "UNREACHABLE:")
+    bad = [
+        f"  {rel} / {qualname} / {receiver}: {reason}"
+        for (rel, qualname, receiver), reason in sorted(CLASSIFIED_SITES.items())
+        if not reason.startswith(kinds)
+    ]
+    assert not bad, (
+        f"Classifications must start with one of {kinds}:\n" + "\n".join(bad)
+    )

--- a/Tests/UI/test_timer_path_layout_cost.py
+++ b/Tests/UI/test_timer_path_layout_cost.py
@@ -1,0 +1,514 @@
+"""Layout cost of repeating-clock repaints (TASK-21595).
+
+``Static.update(content)`` ends in ``self.refresh(layout=layout)`` with
+``layout: bool = True``, so a repaint on a timer arms a whole
+``Screen._refresh_layout`` / ``Compositor.reflow`` every tick unless the caller
+opts out. TASK-21692 (Console composer cursor blink) and TASK-21134 item 7
+(media-viewer match-nav) each found one instance; this module covers the two
+animation-rate instances the TASK-21595 census turned up:
+
+* ``SplashScreen._update_animation`` -- 10-100 fps during startup.
+* ``PersonaBuddyWidget._paint_frame`` -- the pet's own frame clock, >= 10 fps
+  for as long as an animated buddy is on screen.
+
+Two kinds of assertion per site:
+
+1. **Cost** -- driven ticks must add no screen layout passes over a *measured*
+   idle floor (not a bare ``== 0``, which an unrelated timer could turn into a
+   flake), plus a paint assertion so a repaint that stopped happening cannot
+   score zero and pass.
+2. **Geometry equivalence** -- painting a given content with ``layout=False``
+   must land the *same* geometry that painting it with ``layout=True`` does.
+   That is an A/B against the real layout engine, not an inspection of the
+   stylesheet; per TASK-21692, asserting ``outer_size`` alone is not enough, so
+   the witness also carries the container size, the region, every sibling's
+   region, and the painted per-row cell widths.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import pytest
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.geometry import Size
+from textual.widget import Widget
+from textual.widgets import Static
+
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddySnapshot
+from tldw_chatbook.Persona_Buddy.preferences import PersonaBuddyPreferences
+from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+    PersonaBuddyWidget,
+)
+from tldw_chatbook.Widgets.splash_screen import SplashScreen
+
+VIEWPORT = (120, 40)
+
+
+# --------------------------------------------------------------------------
+# measurement helpers
+# --------------------------------------------------------------------------
+
+
+class _LayoutCounter:
+    """Count real layout work performed by the screen.
+
+    Counts ``Screen._refresh_layout`` (the call that reflows the whole
+    compositor) and ``Compositor.reflow``, rather than asserting on the
+    arguments a caller passed to ``refresh`` -- the claim under test is about
+    work performed, not about how it was requested.
+    """
+
+    def __init__(self, screen) -> None:
+        self._screen = screen
+        self.layout = 0
+        self.reflow = 0
+        self.seconds = 0.0
+        self._undo: list[Callable[[], None]] = []
+
+    def __enter__(self) -> "_LayoutCounter":
+        screen = self._screen
+        real_layout = screen._refresh_layout
+        compositor = screen._compositor
+        real_reflow = compositor.reflow
+
+        def counting_layout(*args, **kwargs):
+            self.layout += 1
+            started = time.perf_counter()
+            try:
+                return real_layout(*args, **kwargs)
+            finally:
+                self.seconds += time.perf_counter() - started
+
+        def counting_reflow(*args, **kwargs):
+            self.reflow += 1
+            return real_reflow(*args, **kwargs)
+
+        screen._refresh_layout = counting_layout
+        compositor.reflow = counting_reflow
+        self._undo = [
+            lambda: delattr(screen, "_refresh_layout"),
+            lambda: delattr(compositor, "reflow"),
+        ]
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        for undo in self._undo:
+            undo()
+        return False
+
+    def __repr__(self) -> str:  # pragma: no cover - only on failure
+        return (
+            f"layout={self.layout} reflow={self.reflow} "
+            f"ms={self.seconds * 1000:.2f}"
+        )
+
+
+async def _settle(pilot) -> None:
+    """Let every scheduled layout/refresh message drain."""
+    await pilot.pause()
+    await pilot.pause()
+
+
+async def count_layout_passes(
+    pilot, screen, rounds: int, tick: Callable[[], None] | None
+) -> _LayoutCounter:
+    """Drive ``rounds`` settles, calling ``tick`` before each when given."""
+    with _LayoutCounter(screen) as counter:
+        for _ in range(rounds):
+            if tick is not None:
+                tick()
+            await _settle(pilot)
+    return counter
+
+
+def _strips(widget: Widget):
+    try:
+        return widget.render_lines(widget.region.reset_offset)
+    except Exception:  # pragma: no cover - unmounted / zero-size
+        return []
+
+
+def _painted_rows(widget: Widget) -> list[int]:
+    """Per-row painted cell widths for ``widget``, from the real compositor."""
+    return [strip.cell_length for strip in _strips(widget)]
+
+
+def _painted_text(widget: Widget) -> str:
+    """What the compositor actually paints, used to prove a repaint landed."""
+    return "\n".join(strip.text for strip in _strips(widget))
+
+
+def _witness(widget: Widget, witnesses: Sequence[Widget]) -> tuple:
+    """Everything about the layout that a repaint must not be able to move."""
+    return (
+        widget.outer_size,
+        widget.container_size,
+        widget.content_size,
+        widget.region,
+        widget.scrollable_content_region,
+        tuple(w.region for w in witnesses),
+        tuple(w.outer_size for w in witnesses),
+        tuple(_painted_rows(widget)),
+    )
+
+
+# A content that is deliberately unlike every probe shape, used to wipe the
+# geometry the forced-layout arm produced. Without it the ``layout=False`` arm
+# would inherit the correct geometry from the arm before it and the test would
+# pass vacuously.
+_SCRUB = Text("\n".join("scrub" * 40 for _ in range(30)))
+
+
+async def assert_geometry_is_content_independent(
+    pilot,
+    target: Static,
+    contents: dict[str, Any],
+    witnesses: Sequence[Widget],
+) -> None:
+    """Painting with ``layout=False`` must land the same geometry as with True.
+
+    For each content: paint it with a forced layout and record the witness,
+    scrub the geometry with a deliberately different shape (also with a forced
+    layout), then paint the same content with ``layout=False`` and record
+    again. Equal witnesses mean the layout pass was doing no work *for this
+    widget's box* -- which is exactly the claim ``layout=False`` makes.
+    """
+    failures: list[str] = []
+    for name, content in contents.items():
+        target.update(content, layout=True)
+        await _settle(pilot)
+        with_layout = _witness(target, witnesses)
+        painted_with_layout = _painted_text(target)
+
+        target.update(_SCRUB, layout=True)
+        await _settle(pilot)
+        painted_scrub = _painted_text(target)
+
+        target.update(content, layout=False)
+        await _settle(pilot)
+        without_layout = _witness(target, witnesses)
+        painted_without_layout = _painted_text(target)
+
+        if with_layout != without_layout:
+            failures.append(
+                f"{name!r}: layout=False geometry differs\n"
+                f"    layout=True  -> {with_layout}\n"
+                f"    layout=False -> {without_layout}"
+            )
+        # Sanity 1: the scrub has to actually displace the content, otherwise
+        # the `layout=False` arm inherits the first arm's state and the
+        # equality above is vacuous.
+        if painted_scrub == painted_with_layout:
+            failures.append(
+                f"{name!r}: the scrub painted the same thing as the content -- "
+                "this comparison is not discriminating"
+            )
+        # Sanity 2: the `layout=False` write has to reach the surface. A
+        # `Static.update` that silently no-op'd would satisfy the geometry
+        # equality trivially.
+        if painted_without_layout != painted_with_layout:
+            failures.append(
+                f"{name!r}: layout=False painted different content than "
+                f"layout=True -- the repaint half is broken"
+            )
+    assert not failures, "\n".join(failures)
+
+
+# --------------------------------------------------------------------------
+# SplashScreen -- the animation frame repaint
+# --------------------------------------------------------------------------
+
+
+class _SplashHost(ConsolidatedCSSApp):
+    """Production stylesheet stack.
+
+    A bare ``App`` loads none of it, and even the app bundle alone is not
+    enough for every widget: ``#persona-buddy-frame`` (below) has **zero**
+    rules in ``tldw_cli_modular.tcss`` -- its geometry lives in the generated
+    ``widget_defaults_self.tcss``, which only ``ConsolidatedCSSApp`` registers.
+    A first draft of this module used the app bundle alone and a mutation that
+    made the buddy frame content-sized SURVIVED, because the widget was
+    mounting unstyled. Geometry conclusions need the whole stack.
+    """
+
+    CSS_PATH = BUNDLED_STYLESHEET
+
+    def __init__(self, card: str) -> None:
+        super().__init__()
+        self._card = card
+
+    def compose(self) -> ComposeResult:
+        yield SplashScreen(
+            card_name=self._card,
+            duration=0.0,
+            show_progress=True,
+            skip_on_keypress=False,
+        )
+
+
+# One card per rendering shape the effect registry produces: a full-viewport
+# character field, a glitch overlay of the static art, and a sparse starfield.
+SPLASH_CARDS = ("matrix", "glitch", "starfield")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("card", SPLASH_CARDS)
+async def test_splash_animation_tick_arms_no_layout_pass(card: str) -> None:
+    """An animation frame costs no more layout work than an idle settle.
+
+    TASK-21595. The shipped cards run ``animation_speed`` between 0.01 s and
+    0.1 s, so before the fix this was 10-100 whole-screen layout passes per
+    second for the entire splash, during startup.
+    """
+    host = _SplashHost(card)
+    async with host.run_test(size=VIEWPORT) as pilot:
+        await pilot.pause()
+        splash = host.query_one(SplashScreen)
+        display = splash.query_one("#splash-display", Static)
+        assert splash.effect_handler is not None, f"{card} did not start an effect"
+        # Own the clock: the free-running timer must not add uncounted ticks
+        # in the middle of a measurement.
+        assert splash.animation_timer is not None
+        splash.animation_timer.pause()
+        await _settle(pilot)
+
+        rounds = 6
+        idle = await count_layout_passes(pilot, host.screen, rounds, None)
+        ticking = await count_layout_passes(
+            pilot, host.screen, rounds, splash._update_animation
+        )
+
+        assert ticking.layout <= idle.layout, (
+            f"{card}: {rounds} animation ticks cost "
+            f"{ticking.layout - idle.layout} extra screen layout passes "
+            f"(idle floor {idle.layout}); ticking={ticking!r} idle={idle!r}"
+        )
+        assert ticking.reflow <= idle.reflow, (
+            f"{card}: {rounds} animation ticks cost "
+            f"{ticking.reflow - idle.reflow} extra compositor reflows "
+            f"(idle floor {idle.reflow})"
+        )
+
+        # The tick must still REPAINT -- an animation that stopped advancing
+        # would also score zero layout passes.
+        before = display.render_lines(display.region.reset_offset)
+        moved = False
+        for _ in range(12):
+            splash._update_animation()
+            await _settle(pilot)
+            if display.render_lines(display.region.reset_offset) != before:
+                moved = True
+                break
+        assert moved, f"{card}: the animation stopped painting new frames"
+
+
+@pytest.mark.asyncio
+async def test_splash_display_geometry_is_content_independent() -> None:
+    """``#splash-display`` cannot be sized by its content, so skipping the
+    layout pass cannot change where anything lands.
+
+    Both sheets that select it pin ``width: 100%; height: 100%``
+    (``features/_splash.tcss``, ``components/_settings_splash_theme.tcss``),
+    and the progress bar and progress label share the splash's vertical
+    budget -- so they are carried as witnesses too.
+    """
+    host = _SplashHost("matrix")
+    async with host.run_test(size=VIEWPORT) as pilot:
+        await pilot.pause()
+        splash = host.query_one(SplashScreen)
+        display = splash.query_one("#splash-display", Static)
+        if splash.animation_timer is not None:
+            splash.animation_timer.pause()
+        await _settle(pilot)
+
+        width = display.size.width
+        height = display.size.height
+        assert width > 0 and height > 0
+        witnesses = [splash, *splash.children]
+
+        await assert_geometry_is_content_independent(
+            pilot,
+            display,
+            {
+                "empty": "",
+                "one-row": "frame",
+                "exactly-viewport-width": "x" * width,
+                "one-past-viewport-width": "x" * (width + 1),
+                "full-field": "\n".join("." * width for _ in range(height)),
+                "taller-than-viewport": "\n".join(
+                    "." * width for _ in range(height * 2)
+                ),
+                "cjk-double-width": "漢" * width,
+                "rich-text": Text("\n".join("styled" for _ in range(height))),
+            },
+            witnesses,
+        )
+
+
+# --------------------------------------------------------------------------
+# PersonaBuddyWidget -- the pet frame repaint
+# --------------------------------------------------------------------------
+
+
+class _StubBuddyController:
+    """Minimal stand-in carrying the real preferences dataclass.
+
+    ``_paint_frame`` reads widget state (classes, ``_snapshot``,
+    ``_accepted_render``) rather than the controller; the controller is only
+    consulted by ``refresh_from_controller``, which is equality-gated by
+    ``_painted_authority`` and therefore is not the tick that repaints. The
+    frame clock (``advance_frame``) calls ``_paint_frame`` directly, and that
+    is the path measured here.
+    """
+
+    def __init__(self) -> None:
+        self._preferences = PersonaBuddyPreferences(enabled=True)
+        self._snapshot = PersonaBuddySnapshot(
+            generation=1, selection=None, state="idle", enabled=True
+        )
+
+    def snapshot(self) -> PersonaBuddySnapshot:
+        return self._snapshot
+
+    def current_preferences(self) -> PersonaBuddyPreferences:
+        return self._preferences
+
+
+class _BuddyHost(ConsolidatedCSSApp):
+    CSS_PATH = BUNDLED_STYLESHEET
+
+    def compose(self) -> ComposeResult:
+        yield PersonaBuddyWidget(
+            controller=_StubBuddyController(),
+            view_generation=1,
+            reconcile=lambda: None,
+            is_current=lambda _widget: True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_persona_buddy_frame_tick_arms_no_layout_pass() -> None:
+    """A pet frame repaint costs no more layout work than an idle settle.
+
+    TASK-21595. ``advance_frame`` re-arms itself at the visual's own frame
+    duration (>= 10 fps by default), and unlike ``refresh_from_controller`` it
+    is not equality-gated -- advancing the frame index is the point -- so every
+    frame armed a full screen layout pass while a buddy was visible.
+    """
+    host = _BuddyHost()
+    async with host.run_test(size=VIEWPORT) as pilot:
+        await pilot.pause()
+        buddy = host.query_one(PersonaBuddyWidget)
+        buddy._stop_frame_timer()
+        if buddy._poll_timer is not None:
+            buddy._poll_timer.pause()
+        await _settle(pilot)
+
+        rounds = 6
+        idle = await count_layout_passes(pilot, host.screen, rounds, None)
+        ticking = await count_layout_passes(
+            pilot, host.screen, rounds, buddy._paint_frame
+        )
+
+        assert ticking.layout <= idle.layout, (
+            f"{rounds} pet frame repaints cost {ticking.layout - idle.layout} "
+            f"extra screen layout passes (idle floor {idle.layout}); "
+            f"ticking={ticking!r} idle={idle!r}"
+        )
+
+        # The repaint must still reach the surface -- a `_paint_frame` that
+        # silently stopped writing would also score zero layout passes.
+        target = buddy.query_one("#persona-buddy-frame", Static)
+        target.update("stale", layout=False)
+        await _settle(pilot)
+        buddy._paint_frame()
+        await _settle(pilot)
+        assert "stale" not in str(target.renderable), (
+            "_paint_frame no longer repaints the frame surface"
+        )
+
+
+@pytest.mark.asyncio
+async def test_persona_buddy_frame_geometry_is_content_independent() -> None:
+    """``#persona-buddy-frame`` is pinned 100%/100% on its own layer, so no
+    frame content can resize it -- empty, alert copy, or a multi-row pet."""
+    host = _BuddyHost()
+    async with host.run_test(size=VIEWPORT) as pilot:
+        await pilot.pause()
+        buddy = host.query_one(PersonaBuddyWidget)
+        buddy._stop_frame_timer()
+        if buddy._poll_timer is not None:
+            buddy._poll_timer.pause()
+        await _settle(pilot)
+
+        target = buddy.query_one("#persona-buddy-frame", Static)
+        width = max(target.size.width, 1)
+        height = max(target.size.height, 1)
+        witnesses = [buddy, *buddy.children]
+
+        await assert_geometry_is_content_independent(
+            pilot,
+            target,
+            {
+                "empty": "",
+                "alert-copy": "Persona unavailable",
+                "one-row-at-width": "x" * width,
+                "one-past-width": "x" * (width + 1),
+                "full-box": "\n".join("." * width for _ in range(height)),
+                "taller-than-box": "\n".join(
+                    "." * width for _ in range(height * 3)
+                ),
+                "cjk-double-width": "漢" * width,
+                "rich-text": Text("\n".join("pet" for _ in range(height))),
+            },
+            witnesses,
+        )
+
+
+# --------------------------------------------------------------------------
+# the probe itself must be able to fail
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_geometry_equivalence_probe_catches_a_content_sized_widget() -> None:
+    """A control: on a ``height: auto`` widget the probe must go red.
+
+    Without this, a probe that silently measured nothing would make every
+    ``layout=False`` above look justified. The splash display is pinned; this
+    mounts an intentionally content-sized sibling and shows the same helper
+    rejects it.
+    """
+
+    class _AutoHost(App):
+        CSS = """
+        #auto-sized { width: auto; height: auto; }
+        #below { height: 3; }
+        """
+
+        def compose(self) -> ComposeResult:
+            yield Static("seed", id="auto-sized")
+            yield Static("below", id="below")
+
+    host = _AutoHost()
+    async with host.run_test(size=VIEWPORT) as pilot:
+        await pilot.pause()
+        target = host.query_one("#auto-sized", Static)
+        below = host.query_one("#below", Static)
+
+        with pytest.raises(AssertionError):
+            await assert_geometry_is_content_independent(
+                pilot,
+                target,
+                {
+                    "one-row": "x",
+                    "three-rows": "a\nb\nc",
+                },
+                [below],
+            )
+        assert isinstance(target.outer_size, Size)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -135,6 +135,20 @@ results. Loading the bundled stylesheet in the mounted shape matrix made the
 failure deterministic; sharing the mosaic grid calculation made graphics and
 mosaic settle to the same exact cell box.
 
+**Recurred, TASK-21595, 2026-08-25 — and this time the app bundle itself was
+not enough.** A geometry A/B for `PersonaBuddyWidget` used a plain `App` with
+`CSS_PATH = css/tldw_cli_modular.tcss`, i.e. the whole app bundle. The test
+passed, and so did the mutation that made the widget content-sized. The
+bundle contains **zero** `#persona-buddy-frame` rules: consolidated widget CSS
+(TASK-15450) lives in the generated `widget_defaults_{self,scoped}.tcss`, which
+the app registers via `_get_default_css` and only
+`Tests.UI.consolidated_css.ConsolidatedCSSApp` reproduces. The widget was
+mounting unstyled, so the probe was measuring nothing at all. **"I loaded the
+app bundle" is not the same as "I loaded what production loads"** — for any
+widget whose CSS was consolidated, inherit `ConsolidatedCSSApp`. The tell was
+the surviving mutant, not the failing test: a green geometry assertion under a
+harness that cannot see the rule looks identical to a correct one.
+
 ---
 
 ## An exact live-test gate must be the first gate that can skip the test

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -142,6 +142,35 @@ note that `content` is also the cheapest way to read back what was last painted,
 which is how that repaint skips a no-op write without a shadow copy that every
 other writer would have to remember to invalidate.
 
+**Recurred twice more, so it is now a guarded census — TASK-21595, 2026-08-25.**
+After TASK-21692 (the composer blink: 396 `Widget.arrange` per 6 ticks on an
+*idle* composer) and TASK-21134 item 7 (media-viewer match-nav), a package-wide
+AST census of every repeating-clock root found two more: `SplashScreen.
+_update_animation`, repainting a full-viewport `Static` at the shipped cards'
+0.01–0.1 s `animation_speed` — **10–100 whole-screen reflows per second during
+startup** — and `PersonaBuddyWidget._paint_frame` at the pet's own frame rate.
+Both measured 20 → 0 `_refresh_layout` / `reflow` / `arrange` per 20 ticks.
+`Tests/Architecture/test_timer_path_static_update_inventory.py` now rebuilds
+that census on every run and fails any clock-reachable `.update(` that neither
+passes `layout=` nor carries a stated exemption. Two things that census taught:
+
+1. **Grepping `set_interval` is not a census.** One of the two clocks is a
+   `set_timer` callback that re-arms *itself* — an interval spelled as a chain
+   of one-shots. Enumerate roots structurally (including the self-rearming
+   one-shot), then walk the call graph; the repaint is usually four to six hops
+   from the timer, in a different module.
+2. **`layout=False` is only sound where the box cannot be content-sized, and the
+   pin may not be in the stylesheet.** The Persona Buddy frame's real pin is
+   `frame.styles.width/height = "100%"` assigned *inline* by `_apply_geometry`,
+   which beats every sheet — so mutating its CSS to `auto` (even rebuilding the
+   generated bundle) left the geometry test green, a surviving mutant that was a
+   finding about the test. Prove the claim with an A/B against the layout engine
+   instead of reading CSS: paint the content with `layout=True` and record the
+   geometry, *scrub* with a deliberately different shape (without the scrub the
+   second arm inherits the first arm's geometry and passes vacuously), then
+   paint the same content with `layout=False` and compare — carrying sibling
+   regions and painted per-row cell widths, not just `outer_size`.
+
 ---
 
 ## `set_timer(0.0)` never fires — silently

--- a/backlog/tasks/task-21595 - Sweep timer and tick paths for Static-update calls that lay out by default.md
+++ b/backlog/tasks/task-21595 - Sweep timer and tick paths for Static-update calls that lay out by default.md
@@ -2,9 +2,10 @@
 id: TASK-21595
 title: >-
   Sweep timer and tick paths for Static update calls that lay out by default
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-23'
+updated_date: '2026-08-25'
 labels:
   - performance
   - ui
@@ -24,11 +25,11 @@ carries the same default.
 
 ## Acceptance Criteria
 
-- [ ] Every `.update(` call reachable from a `set_interval`, `set_timer`, animation or high-frequency watcher is enumerated
-- [ ] Each is either given `layout=False` with a stated reason the rendered size cannot change, or documented as legitimately needing layout
-- [ ] Each `layout=False` is justified by a geometry-equivalence check across the states the path can produce — not by inspection; TASK-21501's mutation showed `outer_size` alone is insufficient, since painted rows changed 1 → 2 while `outer_size` stayed constant
-- [ ] Layout-pass counts are measured before and after against a measured idle floor, not asserted as zero
-- [ ] A lint or guard test prevents a new timer-path `.update(` from defaulting to `layout=True`
+- [x] Every `.update(` call reachable from a `set_interval`, `set_timer`, animation or high-frequency watcher is enumerated
+- [x] Each is either given `layout=False` with a stated reason the rendered size cannot change, or documented as legitimately needing layout
+- [x] Each `layout=False` is justified by a geometry-equivalence check across the states the path can produce — not by inspection; TASK-21501's mutation showed `outer_size` alone is insufficient, since painted rows changed 1 → 2 while `outer_size` stayed constant
+- [x] Layout-pass counts are measured before and after against a measured idle floor, not asserted as zero
+- [x] A lint or guard test prevents a new timer-path `.update(` from defaulting to `layout=True`
 
 ## Evidence
 
@@ -40,3 +41,196 @@ From TASK-21501, measured with counters around `Screen._refresh_layout`, `Compos
 | `Screen._refresh_layout` | 6 | 0 |
 | `Widget.arrange` calls | 396 | 0 |
 | time in `_refresh_layout` | 3.1-6.5 ms/tick | 0 |
+
+## Implementation Plan
+
+1. Build a *census*, not a grep: parse the whole package with `ast`, collect every
+   repeating-clock root (`set_interval`, plus `set_timer` callbacks that re-arm
+   themselves), follow the intra-package call graph out from each, and collect every
+   reachable `.update(` that does not pass `layout=`.
+2. Prove the census can see: assert it finds the known roots (including the TASK-21692
+   blink clock and at least one self-rearming one-shot) before trusting a green run.
+3. Classify every site found. Fix only where the rendered size provably cannot change;
+   document the rest with a stated kind of exemption.
+4. Justify each `layout=False` by a geometry-equivalence A/B against the real layout
+   engine (paint X with `layout=True`, scrub, paint X with `layout=False`, compare),
+   not by reading the stylesheet.
+5. Measure layout-pass counts before/after against a measured idle floor, arms
+   interleaved in one process.
+6. Ship the census as a guard test so a new timer-path `.update(` cannot default to
+   `layout=True` unnoticed.
+7. Mutation-test every new assertion.
+
+## Implementation Notes
+
+**Result: two material sites, both animation-rate, both fixed. 52 further sites
+enumerated and classified; none of them wanted fixing.**
+
+### The census
+
+`Tests/Architecture/test_timer_path_static_update_inventory.py` rebuilds the census on
+every run. It parses all 1,889 package modules, finds **35 repeating-clock roots** — 32
+`set_interval` call sites plus 3 `set_timer` callbacks that re-arm *themselves* (an
+interval spelled as a chain of one-shots; a `set_interval`-only sweep misses these, and
+one of the two bugs found lives behind exactly that shape) — walks the call graph six
+hops out from each, and collects every reachable `.update(` call. That yields **54
+candidate sites** across 20 modules.
+
+The census was checked for blindness against the timer callbacks it found *no* sites in
+(`console_setup_modal._tick`, `console_background_effect._advance_frame`,
+`main_navigation._update_overflow_hints`, `base_tamagotchi`): each was read, and each
+genuinely repaints via `refresh(layout=False)`, a change-signature gate, or a reactive.
+
+### Fixed (2)
+
+| site | clock | before | after |
+|---|---|---|---|
+| `SplashScreen._update_animation` | `set_interval(animation_speed)`, 0.01–0.1 s across the shipped cards (**10–100 fps**) | 20 `_refresh_layout`, 20 `Compositor.reflow`, 40 `Widget.arrange` per 20 ticks | 0 / 0 / 0 |
+| `PersonaBuddyWidget._paint_frame` | self-rearming `advance_frame` at the visual's frame duration (>= 10 fps), plus the 0.1 s poll | 20 / 20 / 20 per 20 ticks | 0 / 0 / 0 |
+
+Measured under `ConsolidatedCSSApp` at 120x40, 20 ticks x 6 **interleaved** repeats in one
+process (medians), idle floor 0 in both arms:
+
+| | splash before | splash after | buddy before | buddy after |
+|---|---|---|---|---|
+| `Screen._refresh_layout` | 20 | **0** | 20 | **0** |
+| `Compositor.reflow` | 20 | **0** | 20 | **0** |
+| `Widget.arrange` | 40 | **0** | 20 | **0** |
+| time inside `_refresh_layout` | 49.2 ms | **0** | 12.7 ms | **0** |
+| process CPU over the window | 102.6 ms | 95.6 ms | 30.5 ms | 25.4 ms |
+
+The work is gone, not deferred: the measurement window includes two event-loop settles
+per tick, so relocated layout would still have been counted.
+
+At the splash's shipped cadence that is 10–100 whole-screen reflows per second removed
+from **startup**, the one moment the app is already contended (module imports, DB opens).
+
+### Why `layout=False` is safe at each — proven, not inspected
+
+Both surfaces are container-pinned, so content cannot size them:
+
+* `#splash-display` is `width: 100%; height: 100%` in both sheets that select it
+  (`features/_splash.tcss`, `components/_settings_splash_theme.tcss`).
+* `#persona-buddy-frame` is pinned twice over — `BUNDLED_CSS` says `100%/100%`, and
+  `_apply_geometry` *also* assigns `frame.styles.width/height = "100%"` **inline**, which
+  beats every sheet.
+
+TASK-21692 showed that reading the stylesheet is not enough (there, painted rows changed
+1 -> 2 while `outer_size` stayed constant). So each is pinned by a geometry-equivalence
+**A/B against the real layout engine** instead
+(`Tests/UI/test_timer_path_layout_cost.py::assert_geometry_is_content_independent`): for
+each content shape, paint it with `layout=True` and record a witness, *scrub* the widget
+with a deliberately different shape (without which the `layout=False` arm would inherit
+the first arm's geometry and pass vacuously), then paint the same content with
+`layout=False` and compare. The witness carries `outer_size`, `container_size`,
+`content_size`, `region`, `scrollable_content_region`, every sibling's region and size,
+and the painted per-row cell widths. Eight content shapes each: empty, one row, exactly
+at the box width, one past it, a full box, **taller than the box**, CJK double-width, and
+a Rich `Text`.
+
+### Classified, not fixed (52)
+
+Every remaining site carries an entry in `CLASSIFIED_SITES` with one of four stated
+kinds, and the guard rejects a reason that does not name its kind:
+
+* **NEEDS-LAYOUT (39)** — the box really is content-sized, so `layout=False` would leave
+  stale geometry on screen. That is a behaviour change, not an optimisation. Examples:
+  `.console-video-preview-frame` is `height: auto` and the `Pixels` row count tracks the
+  scaled image; the Console status chips and the Send disabled-reason strip are
+  `width: auto` (the label length *is* the width) and assign `styles.width`/`display` on
+  the same call; `.console-model-section-value` is `text-wrap: wrap` with `max-height: 3`.
+* **NOT-A-WIDGET (6)** — `dict.update` / `set.update` / `ProgressBar.update(progress=)`,
+  which are syntactically indistinguishable from `Static.update` in an AST.
+* **NOT-PER-TICK (3)** — reached only through an equality gate, so the tick does not
+  repaint (e.g. `_sync_console_rail_system_line`, gated on
+  `_console_rail_system_line_last` since TASK-251; `_display_static_fallback`, which runs
+  on the error edge that also stops the animation timer).
+* **UNREACHABLE (6)** — `Widgets/loading_states.py`, `Widgets/status_dashboard.py` and
+  `Widgets/detailed_progress.py` have **no importer anywhere in the repo**, production or
+  tests. Their timer repaints cost nothing because nothing mounts them. Not retired here;
+  noted as an out-of-scope finding.
+
+Two Console tick paths that looked like candidates are *already* handled and show up in
+the census as explicit: the TASK-21692 blink (`_render_visible_draft_only`) and the
+setup-modal snow field (`_render_flakes(layout=False)`, TASK-21134).
+
+### The guard
+
+Four tests. The load-bearing one asserts every clock-reachable `.update(` is classified —
+either it passes `layout=` explicitly, or `CLASSIFIED_SITES` says why it need not. A new
+timer-path repaint lands there unclassified and fails, which is the only signal this cost
+ever gets: nothing else in the suite counts layout operations. The other three keep the
+guard honest — the census must still find its known roots (a silently-broken AST walker
+would make everything else green), classifications must still name a real call, and a
+reason must state its kind rather than being prose.
+
+### Mutation results (every new assertion, per test)
+
+| mutation | expected red | result |
+|---|---|---|
+| splash `layout=False` removed | cost test | RED: "matrix: 6 animation ticks cost 6 extra screen layout passes (idle floor 0)" (x3 cards) |
+| buddy `layout=False` removed (all 4 calls) | cost test | RED: "6 pet frame repaints cost 6 extra screen layout passes (idle floor 0)" |
+| `_update_animation` stops painting | cost test's paint half | RED: "the animation stopped painting new frames" (x3) |
+| `_paint_frame` returns early | cost test's paint half | RED: "_paint_frame no longer repaints the frame surface" |
+| `#splash-display` forced `height: auto` | geometry A/B | RED on all 8 shapes |
+| buddy inline pin -> `auto` | geometry A/B | RED on all 8 shapes |
+| splash `layout=False` removed | census guard | RED, names `SplashScreen._update_animation:437` |
+| buddy `layout=False` removed | census guard | RED, names `PersonaBuddyWidget._paint_frame:[757,762,769,771]` |
+| `_clock_roots` returns `[]` | census-can-see test | RED: "census collapsed to 0 clock roots" |
+| fabricated allowlist entry | staleness test | RED, names the fabricated key |
+| reason without a kind prefix | kinds test | RED, names the entry |
+
+**Two mutants survived first and were findings about the tests, not passes:**
+
+1. The buddy geometry A/B survived making `#persona-buddy-frame` content-sized, because
+   the harness was a plain `App` with `CSS_PATH = tldw_cli_modular.tcss` — and that
+   bundle contains **zero** `persona-buddy-frame` rules; they live in the generated
+   `widget_defaults_self.tcss`, which only `ConsolidatedCSSApp` registers. The widget was
+   mounting unstyled, so the test was measuring nothing. Both harnesses now inherit
+   `ConsolidatedCSSApp`. (Even then the CSS mutation still survived — the *real* pin is
+   the inline `frame.styles.height = "100%"` in `_apply_geometry`, which is what the
+   mutation finally had to target.)
+2. The census guard survived removing the splash fix, because its key was
+   `(file, receiver)` and `_display_static_fallback` writes to a local also named
+   `display` — one allowlist entry was covering two distinct call sites. The key is now
+   `(file, enclosing Class.method, receiver)`.
+
+### Not touched
+
+No timer lifecycle changed anywhere — both edits add one keyword argument to a
+`Static.update` call. Creation, pause/resume, `stop()`, `on_unmount` and quit paths are
+byte-identical, so there is no shutdown surface to walk.
+
+### Test counts
+
+* New: `Tests/UI/test_timer_path_layout_cost.py` **7 passed**;
+  `Tests/Architecture/test_timer_path_static_update_inventory.py` **4 passed**.
+* Touched-module regression: `Tests/Persona_Buddy/`, `Tests/Persona_Visual/`, and the
+  five splash/startup suites — **754 passed**.
+* `Tests/UI/test_persona_buddy_widget.py`, `test_persona_buddy_app_mount.py`,
+  `test_library_file_notes_workspace.py` — **229 passed, 2 failed**. Both failures are
+  `test_high_stakes_file_notes_states_are_legible_in_shipped_themes[size0/size1]` in a
+  module this branch does not touch; reproduced identically on pristine dev `7f38cb6ef`
+  in a separate worktree (`'Save failed' paints at 3.33:1, below 4.5:1`,
+  `assert 3.3290074521434456 >= 4.5`).
+* `./scripts/preflight.sh` green (all five checks).
+
+### Out-of-scope findings
+
+* `Widgets/loading_states.py`, `Widgets/status_dashboard.py`,
+  `Widgets/detailed_progress.py`, `Widgets/activity_log.py` have no importer anywhere in
+  the repo — four dead widget modules, each carrying its own `set_interval`. Candidates
+  for retirement.
+* `ConsoleVideoPreview._update_progress` repaints a `height: 1` progress line once per
+  decoded video frame from `_show_frame`. It is a worker-driven path rather than a timer,
+  so it is outside this census's definition, and its layout request coalesces with
+  `_update_frame`'s (which legitimately lays out) in the same loop turn — so the gain
+  would be nil. Noted rather than changed.
+
+### Modified / added files
+
+* `tldw_chatbook/Widgets/splash_screen.py`
+* `tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py`
+* `Tests/Architecture/test_timer_path_static_update_inventory.py` (new)
+* `Tests/UI/test_timer_path_layout_cost.py` (new)
+* `backlog/docs/lessons-textual.md`

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -731,26 +731,44 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         return accepted
 
     def _paint_frame(self) -> None:
+        """Repaint the pet frame surface.
+
+        TASK-21595: every ``update`` here passes ``layout=False``. This runs on
+        two clocks -- the 0.1 s snapshot poll (``refresh_from_controller``) and
+        the self-rearming ``advance_frame`` timer, which ticks at the visual's
+        own frame duration -- so with ``Static.update``'s ``layout=True``
+        default a visible buddy armed a full screen layout pass at >= 10 Hz
+        forever. The frame's box cannot be sized by its content:
+        ``_apply_geometry`` sets ``frame.styles.width/height = "100%"``
+        *inline* -- which beats every sheet -- and ``BUNDLED_CSS`` says the
+        same, so the box is container-driven and no frame (empty, alert copy,
+        or a multi-row pet renderable) can resize it. The class toggles below
+        are colour-only (``persona-buddy-alert`` sets ``color``/``text-style``).
+        ``Tests/UI/test_timer_path_layout_cost.py`` pins the geometry
+        equivalence as an A/B against the real layout engine rather than by
+        inspection; mutating that inline pin to ``auto`` turns it red on all
+        eight content shapes.
+        """
         if not self.is_attached:
             return
         target = self.query_one("#persona-buddy-frame", Static)
         if self.has_class("persona-buddy-compact"):
             target.set_class(False, "persona-buddy-alert")
-            target.update("")
+            target.update("", layout=False)
             return
         alert = _ACTIONABLE_ALERTS.get(getattr(self._snapshot, "state", None))
         target.set_class(alert is not None, "persona-buddy-alert")
         if alert is not None:
-            target.update(alert)
+            target.update(alert, layout=False)
             return
         accepted = self._accepted_render_for_paint()
         visual = accepted.visual if accepted is not None else None
         frames = getattr(visual, "frames", ()) if visual is not None else ()
         if frames:
             self.frame_index = min(self.frame_index, len(frames) - 1)
-            target.update(frames[self.frame_index].renderable)
+            target.update(frames[self.frame_index].renderable, layout=False)
             return
-        target.update("")
+        target.update("", layout=False)
 
     def _sync_compact_state(self, collapsed: bool) -> None:
         compact = self._compact_presentation_for_geometry(

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -407,7 +407,22 @@ class SplashScreen(Container):
         return 80, 24
 
     def _update_animation(self) -> None:
-        """Update animation frame."""
+        """Update animation frame.
+
+        TASK-21595: the repaint passes ``layout=False``. ``Static.update``
+        defaults to ``layout=True``, so every animation frame used to arm a
+        full ``Screen._refresh_layout`` / ``Compositor.reflow``; at the
+        ``animation_speed`` values the shipped cards use (0.01-0.1 s, i.e.
+        10-100 fps) that is 10-100 whole-screen layout passes per second
+        during startup, the one moment the app is already contended.
+
+        Skipping layout is sound because ``#splash-display`` cannot be sized
+        by its content: both stylesheets that select it pin it to
+        ``width: 100%; height: 100%`` (``css/features/_splash.tcss`` and
+        ``css/components/_settings_splash_theme.tcss``), so its box is
+        entirely container-driven. ``Tests/UI/test_timer_path_layout_cost.py``
+        pins that as a geometry-equivalence A/B rather than by inspection.
+        """
         # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
         if not self.is_attached or not self.screen.is_active:
             return
@@ -419,7 +434,7 @@ class SplashScreen(Container):
                 if frame_content:
                     # Update display
                     display = self.query_one("#splash-display", Static)
-                    display.update(frame_content)
+                    display.update(frame_content, layout=False)
 
                 self.current_frame += 1
             except Exception as e:


### PR DESCRIPTION
## Summary

Textual's `Static.update` is `update(content="", *, layout: bool = True)` — **layout defaults to
True**. Two instances of the resulting cost had already been found and fixed (TASK-21692's blink
tick, TASK-21134's match-nav). This is the systematic sweep. **Two more found, and the bigger one
runs during startup.**

## The census is rebuilt on every run, not a one-off sweep

`Tests/Architecture/test_timer_path_static_update_inventory.py` `ast`-parses all **1,889 package
modules**, collects every *repeating*-clock root, walks the intra-package call graph 6 hops out, and
collects every reachable `.update(`.

**35 roots: 32 `set_interval` sites + 3 `set_timer` callbacks that re-arm themselves** — an interval
spelled as a chain of one-shots. That shape matters: **one of the two bugs lives behind it, and a
`set_interval` grep misses it entirely.** 54 candidate sites across 20 modules.

The census was checked for blindness against the timer callbacks it found *zero* sites in — each
genuinely repaints via `refresh(layout=False)`, a change-signature gate, or a reactive.

## Two sites fixed, both animation-rate

| site | clock | 20 ticks, idle floor 0 |
|---|---|---|
| `SplashScreen._update_animation` | `set_interval(animation_speed)` — **0.01–0.1 s, i.e. 10–100 fps** across shipped cards | `_refresh_layout` 20→0, `reflow` 20→0, `arrange` 40→0, **49.2 ms → 0** |
| `PersonaBuddyWidget._paint_frame` | self-rearming `advance_frame` at the pet's frame rate (≥10 fps), not equality-gated | 20→0, 20→0, 20→0, **12.7 ms → 0** |

The splash one is the headline: **10–100 whole-screen reflows per second during startup** — the
moment the app is already most contended, and precisely the window TASK-21110 and TASK-21731 were
buying back. Measured under `ConsolidatedCSSApp` at 120×40, 20 ticks × 6 **interleaved** repeats in
one process, with two event-loop settles per tick inside the window, so the work is gone rather than
deferred.

## Geometry equivalence proved against the real layout engine

Not inspection. For each site: paint content X with `layout=True` and record a witness; **scrub with
a deliberately different shape** — without that step the second arm inherits the first's geometry and
passes vacuously; repaint X with `layout=False`; compare. The witness carries `outer_size`,
`container_size`, `content_size`, `region`, `scrollable_content_region`, every sibling's region and
size, and painted per-row cell widths. Eight shapes each, including one taller than the box.

That breadth is deliberate: TASK-21692's mutation showed painted rows changing **1 → 2 while
`outer_size` stayed constant**, so a witness built on `outer_size` alone would pass a broken change.

## The other 52, each classified with a stated kind

**39 NEEDS-LAYOUT** — content-sized boxes, `width:auto` chips where the label length *is* the width,
`height:auto` boxes; `layout=False` there would be a behaviour change, not an optimisation.
**6 NOT-A-WIDGET** (`dict`/`set`/`ProgressBar.update`, indistinguishable in an AST) · **6
UNREACHABLE** · **3 NOT-PER-TICK**. The guard rejects a classification that doesn't name its kind.

## Mutation: 11 arms, all caught — two survived first, and both were findings about the tests

1. **The buddy geometry A/B was mounting the widget unstyled.** The harness used `CSS_PATH =
   tldw_cli_modular.tcss`, and that bundle contains **zero** `#persona-buddy-frame` rules — they live
   in a generated sheet only `ConsolidatedCSSApp` registers. Even after fixing the harness the CSS
   mutation still survived, because the *real* pin is an inline `frame.styles.height = "100%"` from
   `_apply_geometry` — which is what the mutation finally had to target.
2. **The census guard's `(file, receiver)` key collapsed two distinct call sites** in
   `splash_screen.py`, so removing the splash fix passed. Re-keyed to
   `(file, Class.method, receiver)`.

## Verification

New: **7 passed** (runtime cost/geometry) + **4 passed** (census). Touched-module regression: **754
passed**. Wider set: 229 passed / 2 failed — both in a module this branch does not touch and
**reproduced identically on pristine dev `7f38cb6ef`** in a separate worktree. Preflight green.

No timer lifecycle changed anywhere — both edits add one keyword argument — so there is no shutdown
surface to walk.

## Out of scope

- **`Widgets/loading_states.py`, `status_dashboard.py`, `detailed_progress.py`, `activity_log.py`
  have no importer anywhere in the repo**, production or tests — four dead widget modules, each
  carrying its own `set_interval`. Retirement candidates.
- `ConsoleVideoPreview._update_progress` repaints a `height: 1` line once per decoded video frame
  from a worker (not a timer, so outside this census); its layout request coalesces with
  `_update_frame`'s legitimate one, so the gain would be nil. Noted, not changed.

Lessons recorded: grepping `set_interval` is not a census; the geometry pin may be inline rather than
in the sheet; and *"I loaded the app bundle" ≠ "I loaded what production loads"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
