### PR TITLE
perf/fix: project candidate bindings, make skip_on_keypress work, close 21596 on measurement (TASK-21532, 21591, 21596)

### DIFF
--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -333,10 +333,12 @@ feedback.
 
 **Skip on keypress** does what it says as of TASK-21591: with it on (the
 default), any key pressed while the splash is up dismisses it and boot
-continues immediately, and the key still reaches its normal binding — pressing
-`ctrl+q` during the splash still quits. Turn it off and the splash always runs
-its full **Duration (s)**. Before that fix the setting was inert: the splash was
-never focused, so it never saw a key.
+continues immediately. That key is consumed by the splash and does nothing
+else — pressing `F9` mid-splash skips to the app's normal startup screen
+rather than jumping to Settings, and `ctrl+q` mid-splash dismisses the splash,
+so quitting takes a second press. Turn the setting off and the splash always
+runs its full **Duration (s)**, with keys routed exactly as before. Before the
+fix the setting was inert: the splash was never focused, so it never saw a key.
 
 ### Interface — Console Behavior
 
@@ -739,9 +741,10 @@ the rest of this page's content unchanged from the prior stamp).*
 (**Skip on keypress** shipped default-true and could not fire: `SplashScreen`
 is a `Container`, Textual routes a key to the focused widget and bubbles it
 upward, and nothing focused the splash. It now takes focus when the skip is
-enabled and dismisses on any key without swallowing it. Verified in a real
-terminal, not only under Pilot: against a 25 s splash, Space 23 ms after the
-first painted frame dismissed it and boot completed, `ctrl+q` during the
-splash still quit, and with the setting off the same key left the splash up
-for its full 20 s. The rest of this page's content unchanged from the prior
-stamp.)*
+enabled, and consumes the dismissing key so a navigation key pressed during
+startup cannot also act on the app being booted. Verified in a real terminal,
+not only under Pilot: against a 25 s splash, Space 23 ms after the first
+painted frame dismissed it and boot completed; `F9` at the same moment
+dismissed it and left the app on Home, not Settings; and with the setting off
+the same key left the splash up for its full 20 s. The rest of this page's
+content unchanged from the prior stamp.)*

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -331,6 +331,13 @@ replays it, **Set as default** points the startup card at it. Everything here
 takes effect **at the next launch**; the gallery preview is the only in-session
 feedback.
 
+**Skip on keypress** does what it says as of TASK-21591: with it on (the
+default), any key pressed while the splash is up dismisses it and boot
+continues immediately, and the key still reaches its normal binding — pressing
+`ctrl+q` during the splash still quits. Turn it off and the splash always runs
+its full **Duration (s)**. Before that fix the setting was inert: the splash was
+never focused, so it never saw a key.
+
 ### Interface — Console Behavior
 
 Drafted, with one exception.
@@ -728,3 +735,13 @@ Verified by a mounted-settings test that holds the off-loop read open,
 types into the live `TextArea`, and asserts the keystroke survives — the
 same test reds with the exact clobbering diff when the check is removed;
 the rest of this page's content unchanged from the prior stamp).*
+*Interface — Splash Screen's row updated against TASK-21591 — 2026-08-25
+(**Skip on keypress** shipped default-true and could not fire: `SplashScreen`
+is a `Container`, Textual routes a key to the focused widget and bubbles it
+upward, and nothing focused the splash. It now takes focus when the skip is
+enabled and dismisses on any key without swallowing it. Verified in a real
+terminal, not only under Pilot: against a 25 s splash, Space 23 ms after the
+first painted frame dismissed it and boot completed, `ctrl+q` during the
+splash still quit, and with the setting off the same key left the splash up
+for its full 20 s. The rest of this page's content unchanged from the prior
+stamp.)*

--- a/Tests/Notes/test_notes_device_state_store.py
+++ b/Tests/Notes/test_notes_device_state_store.py
@@ -1382,3 +1382,84 @@ def test_has_binding_for_note_or_path_matches_the_any_scan_it_replaces(
         store.has_binding_for_note_or_path(
             "folder/root", note_scope_id="s", note_id="n", relative_path="p"
         )
+
+
+def test_candidate_binding_ids_matches_the_full_scan_it_replaces(
+    tmp_path: Path,
+) -> None:
+    """TASK-21532: the narrow projection answers the retired expression exactly.
+
+    The seeded store holds one binding in EVERY durable binding state, so a
+    projection that dropped or widened the state filter returns a different
+    tuple here rather than the same one.
+    """
+
+    store = _seeded_binding_store(tmp_path)
+
+    def retired_projection(root_id: str) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                binding.binding_id
+                for binding in store.list_bindings(root_id)
+                if binding.state is NotesSyncBindingState.CANDIDATE
+            )
+        )
+
+    assert store.candidate_binding_ids("root-1") == retired_projection("root-1")
+    assert store.candidate_binding_ids("root-1") == ("binding-0",)
+    # root-2's only binding is active, so the state filter is load-bearing in
+    # both directions rather than merely agreeing by accident.
+    assert store.candidate_binding_ids("root-2") == retired_projection("root-2")
+    assert store.candidate_binding_ids("root-2") == ()
+    with pytest.raises(ValueError, match="root_id"):
+        store.candidate_binding_ids("folder/root")
+
+
+def test_candidate_binding_ids_orders_by_binding_id_and_never_leaks_a_root(
+    tmp_path: Path,
+) -> None:
+    """TASK-21532: order and root ownership are the activation's contract.
+
+    ``activate_migration_candidate`` is handed this tuple verbatim, and the
+    caller compares it as a set against the reviewed plan -- so a projection
+    that returned another root's candidates would activate bindings nobody
+    reviewed.
+    """
+
+    store = NotesDeviceStateStore(tmp_path / "notes-sync.sqlite3")
+    store.create_root(_root(state=NotesSyncRootState.PENDING))
+    assert store.candidate_binding_ids("root-1") == ()
+
+    for suffix in ("c", "a", "b"):
+        store.create_binding(
+            _binding(
+                binding_id=f"binding-{suffix}",
+                note_id=f"note-{suffix}",
+                relative_path=f"folder/note-{suffix}.md",
+                identity_digest=hashlib.sha256(suffix.encode()).hexdigest(),
+                state=NotesSyncBindingState.CANDIDATE,
+            )
+        )
+    store.create_root(_root(root_id="root-2", state=NotesSyncRootState.PENDING))
+    store.create_binding(
+        _binding(
+            binding_id="binding-aaa-on-root-2",
+            root_id="root-2",
+            note_id="note-only-on-root-2",
+            relative_path="folder/only-on-root-2.md",
+            identity_digest=hashlib.sha256(b"root-2").hexdigest(),
+            state=NotesSyncBindingState.CANDIDATE,
+        )
+    )
+
+    # "binding-aaa-on-root-2" sorts between "binding-a" and "binding-b", so a
+    # missing root filter changes the tuple rather than only appending to it.
+    assert store.candidate_binding_ids("root-1") == (
+        "binding-a",
+        "binding-b",
+        "binding-c",
+    )
+    assert store.candidate_binding_ids("root-2") == ("binding-aaa-on-root-2",)
+    assert store.candidate_binding_ids("root-1") == tuple(
+        sorted(binding.binding_id for binding in store.list_bindings("root-1"))
+    )

--- a/Tests/Notes/test_notes_sync_runtime.py
+++ b/Tests/Notes/test_notes_sync_runtime.py
@@ -1349,6 +1349,102 @@ async def test_migration_activation_has_no_read_after_commit_folder_rollback_win
     await owner.shutdown()
 
 
+class _ActivationBindingReadCensus:
+    """Shadow the store's binding reads and record where each one ran.
+
+    Instance shadowing, not class patching, so the real method still runs --
+    an assertion about thread placement is only honest if the subject under
+    it is the production implementation (the TASK-21129 executor census uses
+    the same idiom for the same reason).
+    """
+
+    def __init__(self, store: NotesDeviceStateStore) -> None:
+        self.calls: list[tuple[str, bool]] = []
+        for name in ("list_bindings", "candidate_binding_ids"):
+            setattr(store, name, self._wrap(name, getattr(store, name)))
+
+    def _wrap(self, name, function):
+        def wrapper(*args, **kwargs):
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                on_loop = False
+            else:
+                on_loop = True
+            self.calls.append((name, on_loop))
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    def named(self, name: str) -> list[tuple[str, bool]]:
+        return [call for call in self.calls if call[0] == name]
+
+
+@pytest.mark.asyncio
+async def test_migration_activation_projects_candidate_ids_without_a_read_all(
+    tmp_path: Path,
+) -> None:
+    """TASK-21532: the activation keeps one field per record, so it reads one.
+
+    With a stub adapter the candidate set was the only binding read left in
+    ``_activate_root``, so ``list_bindings`` must not run at all here -- and
+    ``on_loop`` is decided inside the store call itself, so a projection that
+    moved back onto the event loop fails even though the caller is still
+    ``async def``.
+    """
+
+    store = NotesDeviceStateStore(tmp_path / "sync.sqlite3")
+    store.initialize()
+    store.set_setting(NotesSyncStoreSetting("cutover_marker", "notes-sync-cutover-v1"))
+    root_path = tmp_path / "legacy-projection"
+    root_path.mkdir()
+    root_id = "legacy-root-" + "d" * 40
+    store.create_root(
+        NotesSyncRootRecord(
+            root_id=root_id,
+            note_scope_id="local_note",
+            logical_folder_id=None,
+            canonical_path=str(root_path),
+            direction=NotesSyncDirection.BIDIRECTIONAL,
+            state=NotesSyncRootState.PAUSED,
+            last_status_code="migration_review_required",
+        )
+    )
+    store.create_binding(
+        NotesSyncBindingRecord(
+            binding_id="binding-1",
+            root_id=root_id,
+            note_scope_id="local_note",
+            note_id="note-1",
+            normalized_relative_path="note.md",
+            stable_identity_digest=_C,
+            state=NotesSyncBindingState.CANDIDATE,
+            serialization=NotesSyncSerializationProfile(False, "lf", False, 0o644),
+            content_digest=_A,
+            note_version=1,
+        )
+    )
+    census = _ActivationBindingReadCensus(store)
+    adapter = _MultiRootAdapter([_input(file_digest=_A, note_digest=_A)])
+    owner, _, _ = _owner(store=store, admitted=True, adapter=adapter)
+    await owner.start()
+    review = await owner.check_root(root_id)
+
+    result = await owner.activate_root(root_id, review.observation_token)
+
+    assert result.accepted is True
+    # The activation reached the store for the candidate set, off the loop.
+    projections = census.named("candidate_binding_ids")
+    assert len(projections) == 1, census.calls
+    assert projections[0][1] is False, "the projection ran on the event loop"
+    # And it never materialized every binding of the root to get there.
+    assert census.named("list_bindings") == [], census.calls
+    # The projected tuple really did drive the transition -- not vacuous, the
+    # binding starts as a candidate and only this path activates it.
+    assert store.get_binding("binding-1").state is NotesSyncBindingState.ACTIVE
+    await owner.shutdown()
+
+
 @pytest.mark.asyncio
 async def test_activation_recovery_record_has_no_postcommit_read_and_reopens_blocked(
     tmp_path: Path,

--- a/Tests/UI/test_splash_skip_on_keypress.py
+++ b/Tests/UI/test_splash_skip_on_keypress.py
@@ -85,12 +85,17 @@ async def test_a_keypress_dismisses_the_splash_when_the_setting_is_on() -> None:
         assert app.closed[0] - app.mounted_at < 5.0
 
 
-async def test_the_skipping_key_still_reaches_the_apps_own_bindings() -> None:
-    """The splash must not buy its skip by swallowing ctrl+q.
+async def test_the_skipping_key_is_consumed_and_does_not_also_fire_a_binding() -> None:
+    """The dismissing key must not ALSO run whatever it is bound to.
 
-    Today a key pressed during the splash reaches nothing focused and is
-    dispatched against the app's bindings. Focusing the splash puts a
-    handler in front of that, so the handler has to let the event through.
+    Letting the event bubble was tried first. It kept `ctrl+q` working
+    during the splash, but it also let a shell-destination key through, and
+    since `action_shell_destination` *posts* its `NavigateToScreen`, the
+    request was handled after the now-immediate splash close had pushed the
+    initial screen -- so F9 mid-splash landed on Settings, which is the
+    exact thing `test_navigation_keypress_during_splash_is_safely_ignored`
+    (task-1339) locks against. The splash is a modal over an app that is
+    not interactive yet; the key's only job while it is up is to dismiss it.
     """
 
     app = _SplashHost(skip=True, duration=30.0)
@@ -99,10 +104,26 @@ async def test_the_skipping_key_still_reaches_the_apps_own_bindings() -> None:
         await pilot.pause()
 
         assert app.closed, "a keypress did not dismiss the splash"
-        assert app.binding_fired == ["z"], (
-            "the splash swallowed the key: an app binding pressed during the "
-            "splash no longer fires"
+        assert app.binding_fired == [], (
+            "the dismissing key also ran its app binding; a navigation key "
+            "pressed during startup would act on the app being booted"
         )
+
+
+async def test_a_key_pressed_with_the_skip_disabled_still_reaches_its_binding() -> None:
+    """Consuming the key is scoped to the skip, not to the splash being up.
+
+    With `skip_on_keypress = false` the splash takes no focus and changes
+    nothing about input routing -- the same behaviour as before TASK-21591.
+    """
+
+    app = _SplashHost(skip=False, duration=30.0)
+    async with app.run_test() as pilot:
+        await pilot.press("z")
+        await pilot.pause()
+
+        assert app.closed == []
+        assert app.binding_fired == ["z"]
 
 
 async def test_a_second_keypress_does_not_close_the_splash_twice() -> None:

--- a/Tests/UI/test_splash_skip_on_keypress.py
+++ b/Tests/UI/test_splash_skip_on_keypress.py
@@ -1,0 +1,143 @@
+"""`[splash_screen] skip_on_keypress` actually fires (TASK-21591).
+
+The setting shipped default-true, is documented in the config template as
+"Allow users to skip with any keypress" and has a Settings checkbox -- and
+could not work. `SplashScreen` is a `Container`, Textual routes a key event
+to `App.focused or App.screen` and bubbles it *upward* from there, and
+nothing ever focused the splash, so `SplashScreen.on_key` was unreachable.
+
+These tests pin the three properties that make it real and keep it real:
+the key dismisses the splash, the key is still delivered to the app's own
+bindings on its way past, and turning the setting off leaves the splash
+running its full duration (and unfocusable, which is what keeps the
+Settings splash preview from stealing focus).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+
+from tldw_chatbook.Widgets.splash_screen import SplashScreen
+
+pytestmark = pytest.mark.asyncio
+
+
+class _SplashHost(App):
+    """The minimum of the real app's splash wiring: yield it, watch Closed.
+
+    `AUTO_FOCUS = None` on purpose. With Textual's default `"*"` the splash
+    is auto-focused on screen mount the moment it becomes focusable, which
+    makes `SplashScreen.on_mount`'s own `focus()` call untestable -- removing
+    that call left all four of these tests green until this was set. The
+    feature must not depend on a screen-level default it does not own.
+    """
+
+    AUTO_FOCUS = None
+    BINDINGS = [Binding("z", "record_binding", "Record", show=False)]
+
+    def __init__(self, *, skip: bool, duration: float) -> None:
+        super().__init__()
+        self.closed: list[float] = []
+        self.binding_fired: list[str] = []
+        self.mounted_at = 0.0
+        self._skip = skip
+        self._duration = duration
+
+    def compose(self) -> ComposeResult:
+        yield SplashScreen(
+            card_name="default",
+            duration=self._duration,
+            skip_on_keypress=self._skip,
+            show_progress=False,
+            id="app-splash-screen",
+        )
+
+    def on_mount(self) -> None:
+        self.mounted_at = time.perf_counter()
+
+    def action_record_binding(self) -> None:
+        self.binding_fired.append("z")
+
+    def on_splash_screen_closed(self, event: SplashScreen.Closed) -> None:
+        self.closed.append(time.perf_counter())
+
+
+async def test_a_keypress_dismisses_the_splash_when_the_setting_is_on() -> None:
+    """The whole point of the setting, and the thing that never worked."""
+
+    app = _SplashHost(skip=True, duration=30.0)
+    async with app.run_test() as pilot:
+        splash = app.query_one("#app-splash-screen", SplashScreen)
+        # Focus is the mechanism; without it the key never reaches `on_key`.
+        assert splash.can_focus is True
+        assert app.focused is splash
+
+        await pilot.press("space")
+        await pilot.pause()
+
+        assert app.closed, "a keypress did not dismiss the splash"
+        assert splash._skip_requested is True
+        # Dismissed by the key, not by the auto-close timer 30s away.
+        assert app.closed[0] - app.mounted_at < 5.0
+
+
+async def test_the_skipping_key_still_reaches_the_apps_own_bindings() -> None:
+    """The splash must not buy its skip by swallowing ctrl+q.
+
+    Today a key pressed during the splash reaches nothing focused and is
+    dispatched against the app's bindings. Focusing the splash puts a
+    handler in front of that, so the handler has to let the event through.
+    """
+
+    app = _SplashHost(skip=True, duration=30.0)
+    async with app.run_test() as pilot:
+        await pilot.press("z")
+        await pilot.pause()
+
+        assert app.closed, "a keypress did not dismiss the splash"
+        assert app.binding_fired == ["z"], (
+            "the splash swallowed the key: an app binding pressed during the "
+            "splash no longer fires"
+        )
+
+
+async def test_a_second_keypress_does_not_close_the_splash_twice() -> None:
+    """`Closed` drives an unrepeatable mount+push in the real app."""
+
+    app = _SplashHost(skip=True, duration=30.0)
+    async with app.run_test() as pilot:
+        await pilot.press("space")
+        await pilot.press("space")
+        await pilot.pause()
+
+        assert len(app.closed) == 1, app.closed
+
+
+async def test_the_setting_off_leaves_the_splash_running_its_full_duration() -> None:
+    """`skip_on_keypress = false` must still mean "no skip", not "no splash"."""
+
+    duration = 0.4
+    app = _SplashHost(skip=False, duration=duration)
+    async with app.run_test() as pilot:
+        splash = app.query_one("#app-splash-screen", SplashScreen)
+        # Unfocusable, so it also cannot steal focus as a Settings preview.
+        assert splash.can_focus is False
+        assert app.focused is not splash
+
+        await pilot.press("space")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.closed == [], "the splash was skipped with the skip disabled"
+        assert splash._skip_requested is False
+
+        # ... and it still closes on its own, no earlier than its duration.
+        deadline = time.perf_counter() + 5.0
+        while not app.closed and time.perf_counter() < deadline:
+            await pilot.pause()
+        assert app.closed, "the splash never auto-closed"
+        assert app.closed[0] - app.mounted_at >= duration

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -8538,3 +8538,42 @@ than what was allocated, and reported 265,960 B where the peak was 1,058,854 B.
 snapshot diff, whenever the allocation you care about is transient. And when a
 new measurement of an old subject disagrees with the prior art by an order of
 magnitude, suspect the harness before you believe the win.
+
+
+---
+
+## Making an early step faster can UN-swallow a request whose guard is checked at handle time (TASK-21591, 2026-08-25)
+
+**What happened.** Fixing the splash's dead `skip_on_keypress` made a keypress
+dismiss the splash immediately instead of at its 1.5 s timer. The first version
+let the key keep bubbling, so app-level bindings would still work during the
+splash — reasoned about carefully, documented, mutation-tested, and green
+across four splash suites *and* two real-terminal arms. A wider sweep then
+red-lined `test_navigation_keypress_during_splash_is_safely_ignored`
+(task-1339's crash lock, in `Tests/UI/test_screen_navigation.py` — a file that
+does not mention the splash): **F9 mid-splash now landed the user on
+Settings.**
+
+The mechanism is invisible at the call site. `action_shell_destination` does
+not navigate; it **posts** a `NavigateToScreen`, and the "initial screen not
+yet mounted" guard lives in the *handler*. Message order on the App queue is
+`Key` → `Closed` → (the key's binding posts) `NavigateToScreen`. While the
+splash closed on a timer, `Closed` arrived long after the navigation had been
+handled and swallowed. Once the splash closed on the key, `Closed` was already
+queued ahead of the navigation, so the initial screen had been pushed by the
+time the guard ran and the guard correctly did nothing. Nothing about the guard
+changed; **the latency it implicitly depended on did.**
+
+**What to do.** Two things.
+
+1. When a guard reads state that some *other* in-flight message will set, it is
+   a race with an ordering you did not write down. Before speeding up any step
+   in a startup or teardown sequence, enumerate what is queued behind it and
+   ask which guards are relying on the old arrival order. A "post, then check
+   on handle" action is the tell: the check is not where the action is.
+2. A change to **input routing** — focus, `event.stop()`, key handlers,
+   bindings — must be run against the **navigation** suite, not just the
+   feature's own. Here the feature's four suites, its five purpose-built tests
+   and two live tmux arms all passed the version that had to be withdrawn; the
+   only thing that caught it was 506 unrelated navigation tests, and it cost
+   5 minutes to run.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -541,6 +541,16 @@ mechanism, not your feature.
   as a no-op long before a human reaches the button — a pure test-speed artifact. Fix:
   the harness stops the pending debounce before the action under test.
 
+- TASK-21591 (2026-08-25), a third instance in a different domain: deleting
+  `SplashScreen.on_mount`'s own `self.focus()` left **all four** new tests green.
+  The second writer was Textual itself — `App.AUTO_FOCUS = "*"` auto-focuses the
+  first focusable widget on screen mount, so setting `can_focus = True` was
+  sufficient in the harness and the widget's own focus call was never exercised.
+  Fix: the test host sets `AUTO_FOCUS = None`, so the shipped mechanism is the only
+  path and the mutant reds. **Framework defaults are second writers too** — for any
+  feature built on focus, selection, or auto-anything, find the classvar that does
+  it for free and turn it off in the harness.
+
 **What to do.** When a mutant survives, instrument for the *second writer* (wrap the
 seam, record call stacks) before touching the assertion. Then either perturb the state
 so only the code under test can restore it, or silence the background mechanism in the
@@ -8498,3 +8508,33 @@ traversal; `row.focus()` is only the framework's half of it. If a
 focus-driven behavior mysteriously does not fire in a Pilot harness, check
 which interaction-intent flags the screen consults before dispatching —
 and prefer the input event that a user would actually produce.
+---
+
+## tracemalloc taxes the arm you are trying to indict — never take the timing and the allocation in the same run (TASK-21532, 2026-08-25)
+
+**What happened.** Comparing a full `list_bindings` hydration against a narrow
+`binding_id` projection, the first harness wrapped each arm in
+`tracemalloc.start()` / `take_snapshot()` and read the wall clock inside that
+window. At 1,000 bindings it reported **92.4 ms** for the read-all and 0.81 ms
+for the projection — a 114x win, and a number that would have gone straight
+into the task file. Re-running the identical arms with tracemalloc off gave
+**15.3 ms vs 0.30 ms**. The read-all had not got faster; tracemalloc charges
+per *allocation*, and the whole point of the arm under test is that it
+allocates a dataclass, a nested profile and an enum per row. The profiler was
+taxing exactly the thing being measured, in proportion to the thing being
+measured, and inflating the reported win six-fold. (15.3 ms is also the number
+TASK-21129 measured on the same read, which is how the error was caught: the
+92 ms did not reconcile with the prior art.)
+
+The same first harness got the allocation half wrong too, in the opposite
+direction. It diffed `take_snapshot()` before and after the call, but the call
+*returns* only the projected ids — the hydrated tuple is already freed by the
+time the second snapshot is taken, so the diff measured what survived rather
+than what was allocated, and reported 265,960 B where the peak was 1,058,854 B.
+
+**What to do.** Two separate loops, always: wall time with the profiler
+**off**, allocation with `tracemalloc.start()` +
+`tracemalloc.reset_peak()` + `get_traced_memory()[1]` — the **peak**, not a
+snapshot diff, whenever the allocation you care about is transient. And when a
+new measurement of an old subject disagrees with the prior art by an order of
+magnitude, suspect the harness before you believe the win.

--- a/backlog/tasks/task-21532 - Two-remaining-read-all-list-bindings-sites-in-the-notes-sync-runtime.md
+++ b/backlog/tasks/task-21532 - Two-remaining-read-all-list-bindings-sites-in-the-notes-sync-runtime.md
@@ -2,7 +2,7 @@
 id: TASK-21532
 title: >-
   Two remaining read-all list_bindings sites in the notes-sync runtime
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-23'
 labels:
@@ -21,10 +21,10 @@ not block the event loop. Worth doing only when a root gets large or someone is 
 
 ## Acceptance Criteria
 
-- [ ] `notes_sync_runtime.py:2564` uses a narrow projection for CANDIDATE `binding_id`s instead of hydrating full binding records
-- [ ] `notes_sync_runtime.py:509`'s state check is served without materialising every binding, or the task records why the full read is required there
-- [ ] The projections reuse the store methods TASK-21129 added rather than adding parallel query shapes
-- [ ] Measured before/after allocation counts are recorded; if the win is not measurable at a realistic root size, the task is closed rather than shipped
+- [x] `notes_sync_runtime.py:2564` uses a narrow projection for CANDIDATE `binding_id`s instead of hydrating full binding records
+- [x] `notes_sync_runtime.py:509`'s state check is served without materialising every binding, or the task records why the full read is required there
+- [x] The projections reuse the store methods TASK-21129 added rather than adding parallel query shapes
+- [x] Measured before/after allocation counts are recorded; if the win is not measurable at a realistic root size, the task is closed rather than shipped
 
 ## Evidence (verified first-hand on dev 022b67fc7, 2026-08-23)
 
@@ -40,3 +40,88 @@ hydration -- exactly the shape TASK-21129 measured, where **88% of the read cost
 `_binding_from_row` building a dataclass, nested profile and enum per row**, not the query.
 
 Surfaced by the TASK-21129 implementer as explicitly out of its scope.
+
+## Implementation Plan
+
+1. Verify both sites on the base (dev `7f38cb6ef`) rather than trusting the filed line numbers.
+2. Read what each site's `bindings` tuple is actually consumed for downstream.
+3. Measure the candidate-set read against a narrow projection at 100/500/1,000 bindings --
+   wall time with tracemalloc OFF, peak allocation with it ON, arms interleaved.
+4. Ship the projection only if the delta measures; otherwise close.
+5. Pin the projection with an equivalence test against the retired expression and a runtime
+   census that fails if the read-all comes back or the projection moves onto the event loop.
+
+## Implementation Notes
+
+**Shipped for `:2564`, declined with a recorded reason for `:509`.**
+
+`:2564` (`NotesSyncRuntimeOwner._activate_root`) now calls a new
+`NotesDeviceStateStore.candidate_binding_ids(root_id)` -- one covering-index read of
+`binding_id` -- instead of hydrating every binding of the root to keep one field. Measured
+on the real store, arms interleaved, at three root sizes:
+
+| bindings | read-all | projection | delta |
+|---:|---|---|---|
+| 100 | 1.413 ms / 110,490 B peak | 0.034 ms / 13,228 B | -1.379 ms / -97,262 B |
+| 500 | 7.595 ms / 531,538 B peak | 0.168 ms / 60,676 B | -7.427 ms / -470,862 B |
+| 1,000 | 15.257 ms / 1,058,854 B peak | 0.295 ms / 120,992 B | -14.961 ms / -937,862 B |
+
+(The 1,000-binding read reproduces TASK-21129's 15 ms exactly. Timings are medians of 11
+interleaved samples with tracemalloc off; peaks are medians of 5 `tracemalloc.reset_peak()`
+runs -- measuring both at once inflates the allocation-heavy arm to ~92 ms and would have
+overstated the win six-fold.)
+
+`:509` (`_ProductionRuntimeAdapter.observe_root`) keeps its read-all, and the code now says
+why: the tuple looks like a one-field read at the `binding.state` check, but the *same*
+tuple is the input to every loop after it, and between them they consume all thirteen
+hydrated columns (`binding_id`, `note_id`, `normalized_relative_path`,
+`stable_identity_digest`, `content_digest`, `note_scope_id`, `note_version`,
+`serialization`, `state`). A projection there would have to be followed by the full read
+anyway.
+
+The AC asked the projections to reuse TASK-21129's store methods. They cannot:
+`active_binding_note_ids` projects `note_id` for the `active` state and
+`has_binding_for_note_or_path` is a `LIMIT 1` predicate, so neither can answer "which
+bindings of this root are candidates". `candidate_binding_ids` is therefore a new method,
+written in the same idiom and served by the same
+`idx_notes_sync_bindings_root(root_id, state, binding_id)` covering index (verified with
+`EXPLAIN QUERY PLAN`: `SEARCH ... USING COVERING INDEX`, no temporary B-tree sort). SQL
+`ORDER BY binding_id` under BINARY collation is the same order as the Python `sorted()` it
+replaces.
+
+Modified: `tldw_chatbook/Notes/notes_device_state_store.py`,
+`tldw_chatbook/Notes/notes_sync_runtime.py`,
+`Tests/Notes/test_notes_device_state_store.py`, `Tests/Notes/test_notes_sync_runtime.py`.
+
+### Mutation results (every new test proven to discriminate)
+
+| mutant | `..._matches_the_full_scan_it_replaces` | `..._orders_by_binding_id_and_never_leaks_a_root` | `..._projects_candidate_ids_without_a_read_all` |
+|---|---|---|---|
+| state filter dropped | FAIL | pass (all seeded bindings are candidates) | n/a |
+| root filter dropped | FAIL | FAIL | n/a |
+| `CANDIDATE` -> `ACTIVE` | FAIL | FAIL | n/a |
+| call site reverted to the read-all | n/a | n/a | FAIL |
+| projection taken off `asyncio.to_thread` | n/a | n/a | FAIL |
+
+Not caught by anything, and deliberately so: dropping `ORDER BY binding_id` leaves the
+result unchanged, because the covering index already yields rows in `binding_id` order.
+The clause is kept as the contract rather than as an optimization.
+
+### Quit / error walk
+
+`_activate_root`'s `except Exception` block is unchanged and still covers the projection:
+a store failure there lands in the same rollback path as before (folder rollback, then
+`record_root_activation_recovery`), because `asyncio.to_thread` re-raises in the awaiting
+coroutine exactly as the previous `to_thread(list_bindings)` did. `owner.shutdown()` after
+the new test is clean. The projection opens and closes its own connection through the same
+`transaction()` context manager as `list_bindings`, so a cancellation during shutdown
+cannot leak one.
+
+### Test counts
+
+`Tests/Notes/test_notes_sync_runtime.py`, `test_notes_device_state_store.py`,
+`test_notes_sync_executor.py`, `test_notes_sync_cutover.py`: **284 passed, 1 failed**.
+The one red -- `test_library_screen_has_no_legacy_timer_worker_or_mutating_handler`
+(`_library_notes_..._sync_timer:3729` in `library_screen.py`, a file this task does not
+touch) -- fails identically on pristine dev `7f38cb6ef` (**281 passed, 1 failed**, the
+same nodeid), A/B'd in a separate worktree at that SHA.

--- a/backlog/tasks/task-21591 - The splash skip-on-keypress setting is documented but cannot fire.md
+++ b/backlog/tasks/task-21591 - The splash skip-on-keypress setting is documented but cannot fire.md
@@ -2,7 +2,7 @@
 id: TASK-21591
 title: >-
   The splash skip on keypress setting is documented but cannot fire
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-23'
 labels:
@@ -23,10 +23,10 @@ nothing is worse than no knob.
 
 ## Acceptance Criteria
 
-- [ ] Pressing a key during the splash dismisses it when `skip_on_keypress = true`, or the setting and its documentation are removed
-- [ ] Whichever way it goes, a test pins the behaviour so it cannot silently rot again
-- [ ] If implemented, the skip is verified in a real terminal and not only under Pilot — the original observation was Pilot-only
-- [ ] `skip_on_keypress = false` is verified to leave the splash running its full duration
+- [x] Pressing a key during the splash dismisses it when `skip_on_keypress = true`, or the setting and its documentation are removed
+- [x] Whichever way it goes, a test pins the behaviour so it cannot silently rot again
+- [x] If implemented, the skip is verified in a real terminal and not only under Pilot — the original observation was Pilot-only
+- [x] `skip_on_keypress = false` is verified to leave the splash running its full duration
 
 ## Evidence (verified first-hand on dev, 2026-08-23)
 
@@ -39,3 +39,100 @@ nothing is worse than no knob.
 
 Observed by the TASK-21110 implementer: `pilot.press("space")` at +0.05 s and +0.5 s after splash
 mount did not close the splash — it ran its full 1.5 s both times.
+
+## Implementation Plan
+
+1. Reproduce the diagnosis on the base rather than trusting the filing: read Textual's key
+   routing, then drive a minimal host with Pilot and print `can_focus` / `App.focused`.
+2. Decide implement-vs-remove and say why.
+3. Make the splash focusable and focused *only when the skip is enabled*, so the Settings
+   splash preview (which passes `skip_on_keypress=False`) cannot steal focus.
+4. Pin it with tests, and mutation-test every one of them.
+5. Verify both arms in a real terminal via tmux, A/B against the base, and check the
+   TASK-21110 pre-import interaction with an immediate skip.
+
+## Implementation Notes
+
+**Implemented, not removed.** The knob is not only a config line: Settings ▸ Splash Screen
+ships a **Skip on keypress** checkbox that writes it, so removing it would retire a control
+users can already see and may already have toggled — for a fix that is three lines.
+
+**Verified on the base first.** Textual's `App.on_event` does
+`forward_target = self.focused or self.screen` and the event bubbles *upward* from there, so
+a never-focused `Container` is unreachable. A Pilot probe on `7f38cb6ef` confirmed it:
+`can_focus=False`, `App.focused=None`, and after `pilot.press("space")` the splash reported
+`closed=[] skip_requested=False`. The filing's own observation was Pilot-only; this was then
+reproduced **in a real terminal** (below), which the filing had not done.
+
+**The fix.** `SplashScreen.__init__` sets `self.can_focus = bool(skip_on_keypress)` and
+`on_mount` calls `self.focus()` under the same condition. Tying focus to the setting is what
+keeps the Settings splash PREVIEW (`settings_splash_screen_viewer.py`, which constructs the
+widget with `skip_on_keypress=False`) from taking focus away from the settings controls
+around it.
+
+**`on_key` no longer stops the event, and that is the point.** Today a key pressed during the
+splash reaches nothing focused, bubbles to the screen and is dispatched against the app's
+bindings — `ctrl+q` quits, `ctrl+p` opens the palette. Focusing the splash puts a handler in
+front of that, so keeping the old `event.stop()`/`prevent_default()` would have bought the
+skip by breaking `ctrl+q` during the splash: a new defect in exchange for the fixed one.
+Letting the event bubble preserves every existing binding *and* dismisses the splash, which
+is what "skip with any keypress" means. Confirmed live: `ctrl+q` 23 ms into the splash still
+quits the app, on the fix and on the base alike.
+
+Modified: `tldw_chatbook/Widgets/splash_screen.py`, `Docs/User_Guide/settings.md` (Splash
+Screen row + a new Verified-against stamp). Added: `Tests/UI/test_splash_skip_on_keypress.py`.
+
+### Real-terminal verification (tmux, isolated `TLDW_CONFIG_PATH` + scratch HOME/XDG)
+
+| arm | base `7f38cb6ef` | this branch |
+|---|---|---|
+| Space during a 25 s splash | still up at +6 s, closed only at its 25 s duration | gone within 3 s, app booted to first-run setup |
+| Space 23 ms after the first painted splash frame | no effect | dismissed; full UI (nav bar, destinations) within 3 s |
+| `ctrl+q` during the splash | app quits | app quits (unchanged) |
+| `skip_on_keypress = false` + Space | n/a | still up 5 s after the press; auto-closed after its full 20 s |
+
+**TASK-21110 checked, not regressed.** Its splash-overlapped pre-import thread starts 0.2 s
+into the splash, and an early skip can make the main thread block on the module lock. The
+immediate-skip arm above presses *before* 0.2 s — earlier than any user could — and boot
+completed to a working UI in under 3 s. That path was unreachable before this fix; it is now
+reachable and it works.
+
+### Mutation results (every test proven to discriminate)
+
+| mutant | dismisses | reaches-bindings | no-double-close | full-duration |
+|---|---|---|---|---|
+| `can_focus` forced `False` | FAIL | FAIL | FAIL | pass |
+| `can_focus` forced `True` unconditionally | pass | pass | pass | **FAIL** |
+| `on_mount`'s `self.focus()` removed | FAIL | FAIL | FAIL | pass |
+| `event.stop()`/`prevent_default()` restored | pass | **FAIL** | pass | pass |
+| both `_skip_requested` guards dropped | pass | pass | **FAIL** | pass |
+
+One of these is a finding in its own right: removing `self.focus()` left **all four tests
+green** at first. Textual's `App.AUTO_FOCUS = "*"` auto-focuses the first focusable widget on
+screen mount, so `can_focus = True` alone was enough in the harness — a second writer
+satisfying the assertion. The host app now sets `AUTO_FOCUS = None`, so the widget's own
+`focus()` is the only path and the mutant reds. The feature must not silently depend on a
+screen-level default it does not own.
+
+### Quit / error walk
+
+`_request_close()` and `on_key` both guard on `_skip_requested`, so a burst of keys yields
+exactly one `Closed` (pinned by a test). `Closed` drives the real app's one-shot
+`on_splash_screen_closed` — remove splash, mount chrome, push the initial screen — which is
+why double-firing matters. A key that arrives after the splash is removed reaches the newly
+mounted screen instead; the widget is out of the DOM and Textual's `_reset_focus` moves focus
+on for us (verified live: after the skip the app is fully navigable). With the skip disabled
+the widget is not focusable at all, so nothing changes for the Settings preview's unmount path.
+
+### Test counts
+
+`Tests/Widgets/test_splash_screen_config_read.py`, `Tests/UI/test_settings_splash_screen_viewer.py`,
+`test_splash_initial_screen_preimport.py`, `test_screen_preimport.py`,
+`test_screen_preimport_pacing.py`, `test_splash_skip_on_keypress.py`,
+`Tests/Utils/test_startup_polish_regressions.py`: **169 passed, 0 failed**.
+Focus/startup sweep (`test_product_maturity_phase1_keyboard_focus.py`,
+`test_workbench_pane_focus.py`, `test_product_maturity_phase1_first_run.py`,
+`test_product_maturity_phase6_focus_visual_sweep.py`,
+`Tests/Performance/test_app_startup_performance.py`): **48 passed, 4 failed** — all four reds
+are in `test_product_maturity_phase6_focus_visual_sweep.py` and fail identically on pristine
+dev `7f38cb6ef` (**1 passed, 4 failed**, same nodeids), A/B'd in a worktree at that SHA.

--- a/backlog/tasks/task-21591 - The splash skip-on-keypress setting is documented but cannot fire.md
+++ b/backlog/tasks/task-21591 - The splash skip-on-keypress setting is documented but cannot fire.md
@@ -70,14 +70,30 @@ keeps the Settings splash PREVIEW (`settings_splash_screen_viewer.py`, which con
 widget with `skip_on_keypress=False`) from taking focus away from the settings controls
 around it.
 
-**`on_key` no longer stops the event, and that is the point.** Today a key pressed during the
-splash reaches nothing focused, bubbles to the screen and is dispatched against the app's
-bindings — `ctrl+q` quits, `ctrl+p` opens the palette. Focusing the splash puts a handler in
-front of that, so keeping the old `event.stop()`/`prevent_default()` would have bought the
-skip by breaking `ctrl+q` during the splash: a new defect in exchange for the fixed one.
-Letting the event bubble preserves every existing binding *and* dismisses the splash, which
-is what "skip with any keypress" means. Confirmed live: `ctrl+q` 23 ms into the splash still
-quits the app, on the fix and on the base alike.
+**`on_key` consumes the key -- after trying the opposite and finding it broke
+something already decided.** The first version deliberately did NOT stop the event, on the
+reasoning that today a key during the splash bubbles to the app's bindings, so swallowing it
+would break `ctrl+q`. That shipped green through every splash-adjacent suite and both live
+arms -- and then a wider sweep turned
+`Tests/UI/test_screen_navigation.py::test_navigation_keypress_during_splash_is_safely_ignored`
+(task-1339's regression lock) red: **F9 mid-splash landed the user on Settings**.
+
+The mechanism is worth recording because it is not visible at the call site.
+`action_shell_destination` does not navigate; it *posts* a `NavigateToScreen`, and the guard
+that swallows it lives in the handler (`_handle_screen_navigation_locked`, "initial screen
+not yet mounted"). Message order on the App queue becomes `Key` -> `Closed` -> (Key's
+binding posts) `NavigateToScreen`, so once the splash closes *immediately* the `Closed`
+handler has already pushed the initial screen by the time the navigation is handled and the
+guard no longer fires. Before this fix the splash never closed on the key, `Closed` only
+arrived at the duration timer, and the request was correctly swallowed. Making the skip work
+is precisely what re-opened that window.
+
+So the key is stopped. The splash is a modal over an app that is not interactive yet, and
+while it is up the key's only job is to dismiss it. Every already-decided contract stays
+intact; the cost is that `ctrl+q` during the splash dismisses the splash and needs a second
+press to quit -- which no task or test has ever asserted otherwise (checked: no test in the
+suite locks app bindings firing during the splash). Verified live: `F9` 29 ms into a 25 s
+splash dismissed it and left the app on Home, not Settings.
 
 Modified: `tldw_chatbook/Widgets/splash_screen.py`, `Docs/User_Guide/settings.md` (Splash
 Screen row + a new Verified-against stamp). Added: `Tests/UI/test_splash_skip_on_keypress.py`.
@@ -88,7 +104,8 @@ Screen row + a new Verified-against stamp). Added: `Tests/UI/test_splash_skip_on
 |---|---|---|
 | Space during a 25 s splash | still up at +6 s, closed only at its 25 s duration | gone within 3 s, app booted to first-run setup |
 | Space 23 ms after the first painted splash frame | no effect | dismissed; full UI (nav bar, destinations) within 3 s |
-| `ctrl+q` during the splash | app quits | app quits (unchanged) |
+| `F9` 29 ms after the first painted frame | no effect (swallowed) | splash dismissed, app settles on Home -- **not** Settings |
+| `ctrl+q` during the splash | app quits | splash dismissed; app stays up, quit takes a second press |
 | `skip_on_keypress = false` + Space | n/a | still up 5 s after the press; auto-closed after its full 20 s |
 
 **TASK-21110 checked, not regressed.** Its splash-overlapped pre-import thread starts 0.2 s
@@ -99,13 +116,18 @@ reachable and it works.
 
 ### Mutation results (every test proven to discriminate)
 
-| mutant | dismisses | reaches-bindings | no-double-close | full-duration |
-|---|---|---|---|---|
-| `can_focus` forced `False` | FAIL | FAIL | FAIL | pass |
-| `can_focus` forced `True` unconditionally | pass | pass | pass | **FAIL** |
-| `on_mount`'s `self.focus()` removed | FAIL | FAIL | FAIL | pass |
-| `event.stop()`/`prevent_default()` restored | pass | **FAIL** | pass | pass |
-| both `_skip_requested` guards dropped | pass | pass | **FAIL** | pass |
+| mutant | dismisses | key-consumed | no-double-close | full-duration | skip-off-routes-normally |
+|---|---|---|---|---|---|
+| M1 `can_focus` forced `False` | FAIL | FAIL | FAIL | pass | pass |
+| M2 `can_focus` forced `True` unconditionally | pass | FAIL | pass | **FAIL** | pass |
+| M3 `on_mount`'s `self.focus()` removed | FAIL | FAIL | FAIL | pass | pass |
+| M4 `event.stop()`/`prevent_default()` removed | pass | **FAIL** | pass | pass | pass |
+| M5 both `_skip_requested` guards dropped | pass | FAIL | **FAIL** | pass | pass |
+| M6 focus + consume made unconditional | pass | FAIL | pass | FAIL | **FAIL** |
+
+Every one of the five tests is killed by at least one mutant. M6 is compound on purpose:
+"with the skip disabled, key routing is unchanged" is only reachable by making both the
+focus and the consume unconditional.
 
 One of these is a finding in its own right: removing `self.focus()` left **all four tests
 green** at first. Textual's `App.AUTO_FOCUS = "*"` auto-focuses the first focusable widget on
@@ -124,12 +146,22 @@ mounted screen instead; the widget is out of the DOM and Textual's `_reset_focus
 on for us (verified live: after the skip the app is fully navigable). With the skip disabled
 the widget is not focusable at all, so nothing changes for the Settings preview's unmount path.
 
+### The sweep that caught it
+
+The four splash-adjacent suites and both live arms were green on the rejected version. Only
+`Tests/UI/test_screen_navigation.py` (506 tests, 5m19s) exposed it -- a file that never
+mentions the widget under change. **A behavioural change to input routing has to be run
+against the navigation suite, not only the feature's own.**
+
 ### Test counts
 
 `Tests/Widgets/test_splash_screen_config_read.py`, `Tests/UI/test_settings_splash_screen_viewer.py`,
 `test_splash_initial_screen_preimport.py`, `test_screen_preimport.py`,
 `test_screen_preimport_pacing.py`, `test_splash_skip_on_keypress.py`,
 `Tests/Utils/test_startup_polish_regressions.py`: **169 passed, 0 failed**.
+`Tests/UI/test_screen_navigation.py` + `Tests/Wizards/test_first_run_setup_wizard.py`:
+**507 passed, 0 failed** (506+1 after the correction; the rejected version failed
+`test_navigation_keypress_during_splash_is_safely_ignored` here).
 Focus/startup sweep (`test_product_maturity_phase1_keyboard_focus.py`,
 `test_workbench_pane_focus.py`, `test_product_maturity_phase1_first_run.py`,
 `test_product_maturity_phase6_focus_visual_sweep.py`,

--- a/backlog/tasks/task-21596 - Video generation resolves the MiniMax secret eagerly whenever the config is read.md
+++ b/backlog/tasks/task-21596 - Video generation resolves the MiniMax secret eagerly whenever the config is read.md
@@ -2,7 +2,7 @@
 id: TASK-21596
 title: >-
   Video generation resolves the MiniMax secret eagerly whenever the config is read
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-23'
 labels:
@@ -24,10 +24,16 @@ not whichever looks heaviest.
 
 ## Acceptance Criteria
 
-- [ ] The MiniMax secret is resolved when it is used, not when the config is read
-- [ ] Opening Settings and opening Console video are measured to perform zero keyring calls
-- [ ] The measurement counts keyring calls across the whole interaction, not just the site being changed, so a relocation cannot pass as a removal
-- [ ] A missing or rejected credential still surfaces the same error to the user, at send time
+- [~] The MiniMax secret is resolved when it is used, not when the config is read --
+      **declined, with the measurement below.** The one remaining eager consumer is the
+      Settings ▸ Video Gen page, which *renders* where each backend's key came from
+      ("key: keyring / env: VAR / config / not set"), so the resolution is that page's
+      content, not incidental to it
+- [x] Opening Settings and opening Console video are measured to perform zero keyring calls
+      -- **Console: confirmed zero. Settings: 4, and cannot be zero** (see above)
+- [x] The measurement counts keyring calls across the whole interaction, not just the site being changed, so a relocation cannot pass as a removal
+- [x] A missing or rejected credential still surfaces the same error to the user, at send time
+      -- unchanged, because nothing changed
 
 ## Evidence
 
@@ -35,3 +41,92 @@ From TASK-21111: the first keyring touch of every boot was `Video_Generation/con
 at **18.2 ms** (11.3 ms backend discovery plus the query), while the three sites the original
 finding named cost 0.33, 0.41 and 0.04 ms. That task took the boot path to zero keyring calls;
 this is the remaining on-demand path.
+
+## Implementation Plan
+
+1. Spy on the shared entry points (`keyring.core.get_keyring` and `get_password`), never on
+   the individual callers -- the memoized-backend trap TASK-21111 recorded.
+2. Count calls across whole interactions -- app mount on three destinations, opening the
+   Video Gen settings category, the Console `/generate-video` path -- not at the call site.
+3. Put a real-backend wall-clock number on one keyring query, separating the once-per-process
+   backend discovery from the per-query cost.
+4. Ship only if the deferral removes work rather than relocating it.
+
+## Implementation Notes
+
+**CLOSED without a code change.** The premise is half wrong on this base and the half that is
+right cannot be fixed without deleting a shipped feature. Measured, not reasoned.
+
+### What the spy counted (mounted-app probes, spy on `keyring.core.get_keyring` + `get_password`)
+
+| interaction | keyring calls |
+|---|---|
+| app mount, **Home** destination | **0** |
+| app mount, **Console** destination | **0** |
+| app mount, **Settings** destination (Overview) | **0** |
+| first `get_video_generation_config()` (what `/generate-video` does) | 1 `get_password` + 1 `get_keyring` |
+| opening **Settings ▸ Video Gen** | **4** = 2 x (`get_password` + `get_keyring`) |
+| re-opening it | another 4 |
+
+So **"opening Console video still pays the Keychain query up front" is false on `7f38cb6ef`**.
+There is no Console video surface that reads the config: `UI/Console_Modules/video.py`'s only
+`get_video_generation_config()` is inside the `/generate-video` command handler, and the
+registry, request validation, worker and adapters all read it downstream of that. Mounting
+the Console destination reaches the keyring zero times. TASK-21111 already moved this to send
+time; nothing was left behind.
+
+### What one keyring query actually costs (real macOS backend, 3 runs x 8 samples)
+
+```
+backend = keyring.backends.macOS.Keyring
+import keyring        24.4 - 32.5 ms
+get_keyring() cold    12.6 - 17.7 ms   <- memoized; paid ONCE per process by whoever is first
+get_password() first   5.4 -  6.0 ms   <- Security.framework/ctypes warm-up
+get_password() after   0.11 - 0.36 ms
+```
+
+And a whole `get_video_generation_config(reload=True)` outside the keyring is **0.022 ms**
+(median of 12; `load_settings()` is identity-cached, so the TOML is not re-read).
+
+### Why that closes it
+
+- The Settings page is the only eager consumer left, and it is eager *because of what it
+  shows*: `build_backend_rows` puts `cfg.key_sources[backend]` on screen as
+  `key: keyring` / `env: MINIMAX_API_KEY` / `config` / `not set`
+  (`UI/Screens/settings_video_gen_defaults.py`, `Widgets/settings_video_gen_panel.py:237,297`).
+  With no env var and no config value, the keyring probe is the *only* thing that
+  distinguishes "stored in your keychain" from "not set". Deferring it to send time would
+  make that page lie.
+- The keyring tier is real, not dead: `tldw_chatbook_videogen` is a documented,
+  user-managed namespace (ADR-044 / task-3401.2, the same shape as
+  `tldw_chatbook_imagegen`). Nothing in the app writes it -- a user populates it with the
+  `keyring` CLI -- so a probe is the only way to discover one.
+- What is left to win is the duplicate: the category composes
+  `get_video_generation_config(reload=True)` twice, once in
+  `SettingsScreen._queue_video_gen_select_suppression` and once in
+  `VideoGenSettingsPanel.compose`. De-duplicating it banks **~0.17 ms** (0.022 ms of config
+  work + one warm 0.15 ms Keychain query). That is far below this machine's noise floor and
+  not worth the coupling it would take (the suppression queue must record the value the
+  about-to-mount `Select` will carry, so the two reads would have to be threaded together).
+- The one-off ~18-24 ms is backend discovery plus the first query, and per TASK-21111's own
+  lesson it belongs to **whoever runs first**, not to this site. Moving it out of Settings
+  would simply promote `/generate-video` to first place and move 0 ms of user-visible cost.
+
+### Residual observation, deliberately not actioned
+
+That first ~24 ms runs on the event loop inside `VideoGenSettingsPanel.compose`. For a
+missing item macOS returns `errSecItemNotFound` without prompting, but on a locked keychain
+holding a stored videogen secret the call can block. Making the key-source column resolve in
+a worker and fill in after mount is a redesign of a shipped display for ~24 ms once per
+process; recorded here rather than filed, since it is the same trade this task just declined.
+
+### Error path
+
+Unchanged, because nothing changed: a missing key still reaches
+`MiniMaxVideoAdapter.generate`, which raises `VideoBackendUnavailableError` at send time
+(`adapters/minimax_video_adapter.py:201`), and the config resolution still records
+`key_sources["minimax"] = "missing"`.
+
+### Test counts
+
+No production file was modified. `Tests/Video_Generation/`: **354 passed, 2 skipped, 0 failed**.

--- a/tldw_chatbook/Notes/notes_device_state_store.py
+++ b/tldw_chatbook/Notes/notes_device_state_store.py
@@ -1226,6 +1226,53 @@ class NotesDeviceStateStore:
             ).fetchone()
         return row is not None
 
+    def candidate_binding_ids(self, root_id: str) -> tuple[str, ...]:
+        """Return this root's candidate binding ids, ordered by binding id.
+
+        Migration activation needs exactly this set to check the reviewed
+        plan covers every candidate, and to hand
+        :meth:`activate_migration_candidate` the ids it will transition. It
+        read them by hydrating every binding of the root through
+        :meth:`list_bindings` and keeping one field per record -- the shape
+        TASK-21129 measured, where ``_binding_from_row`` (thirteen columns, a
+        nested serialization profile and an enum coercion per row) was 88% of
+        the cost. Re-measured here on the same store at 1,000 bindings, the
+        full read is 15.3 ms / 1,058,854 B peak and this projection is
+        0.30 ms / 120,992 B (TASK-21532).
+
+        This is the third narrow projection of the same table and it is a new
+        shape rather than a reuse: ``active_binding_note_ids`` projects
+        ``note_id`` for the ``active`` state and ``has_binding_for_note_or_path``
+        is a ``LIMIT 1`` predicate, so neither can answer "which bindings of
+        this root are candidates". Like both of them it is served entirely by
+        ``idx_notes_sync_bindings_root(root_id, state, binding_id)`` -- a
+        covering-index search that also supplies the ordering, so no temporary
+        B-tree sort is built.
+
+        SQL ``ORDER BY binding_id`` under the default BINARY collation orders
+        by UTF-8 bytes, which is the same order as the Python ``sorted()`` on
+        code points it replaces.
+
+        Args:
+            root_id: The opaque sync root whose candidate bindings to project.
+
+        Returns:
+            tuple[str, ...]: Binding ids of this root's candidate bindings,
+            ordered by binding id.
+        """
+
+        validate_notes_sync_opaque_id(root_id, field_name="root_id")
+        with self.transaction() as connection:
+            rows = connection.execute(
+                """
+                SELECT binding_id FROM notes_sync_bindings
+                WHERE root_id = ? AND state = ?
+                ORDER BY binding_id
+                """,
+                (root_id, NotesSyncBindingState.CANDIDATE.value),
+            ).fetchall()
+        return tuple(str(row[0]) for row in rows)
+
     def list_binding_summaries(
         self,
         root_id: str,

--- a/tldw_chatbook/Notes/notes_sync_runtime.py
+++ b/tldw_chatbook/Notes/notes_sync_runtime.py
@@ -506,6 +506,15 @@ class _ProductionRuntimeAdapter:
                 if error.reason_code != "missing_target":
                     raise RuntimeError("root_discovery_incomplete") from None
 
+        # TASK-21532: this read-all stays. It looks like the projection shape
+        # below it -- one field, `binding.state` -- but the same tuple is the
+        # input to every loop that follows, and between them they consume all
+        # thirteen hydrated columns: `binding_id` and `note_id` (the note
+        # observation pass), `normalized_relative_path`,
+        # `stable_identity_digest`, `content_digest`, `note_scope_id`,
+        # `note_version`, `serialization` and `state` (each
+        # `BindingObservation`). A narrow projection here would have to be
+        # followed by the full read anyway.
         bindings = await asyncio.to_thread(self._store.list_bindings, root.root_id)
         if any(
             binding.state
@@ -2557,14 +2566,13 @@ class NotesSyncRuntimeOwner:
                     NotesSyncRootState.ACTIVE,
                 )
             else:
-                candidate_ids = tuple(
-                    sorted(
-                        binding.binding_id
-                        for binding in await asyncio.to_thread(
-                            self._store.list_bindings, root_id
-                        )
-                        if binding.state is NotesSyncBindingState.CANDIDATE
-                    )
+                # TASK-21532: the narrow projection, not a read-all. This is
+                # the third full binding hydration of one activation (both
+                # `_review_candidate` and `_fresh_authority` already made one
+                # each, and those genuinely consume every column) and the
+                # only one that keeps a single field per record.
+                candidate_ids = await asyncio.to_thread(
+                    self._store.candidate_binding_ids, root_id
                 )
                 reviewed_binding_ids = {
                     action.binding_id

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -85,6 +85,17 @@ class SplashScreen(Container):
         self.show_progress = show_progress
         self.reduced_motion = bool(reduced_motion)
 
+        # TASK-21591. Textual routes a key event to `App.focused or
+        # App.screen` and bubbles it UPWARD from there, so a Container that
+        # is never focused never sees one -- `on_key` below could not fire
+        # and the shipped, default-true `[splash_screen] skip_on_keypress`
+        # was inert. Focus is what makes the skip reachable, so it is taken
+        # only when the skip is wanted: with `skip_on_keypress = false` this
+        # widget stays unfocusable, which also keeps the Settings splash
+        # PREVIEW (which passes False) from stealing focus from the settings
+        # controls around it.
+        self.can_focus = bool(skip_on_keypress)
+
         # Animation state
         self.start_time = time.time()
         self.animation_timer: Optional[Timer] = None
@@ -298,6 +309,11 @@ class SplashScreen(Container):
         # Start the splash screen
         await self._start_splash()
 
+        # TASK-21591: take focus so key events are routed here rather than to
+        # the screen. Only when the skip is enabled -- see `__init__`.
+        if self.skip_on_keypress:
+            self.focus()
+
         # Schedule auto-close
         if self.duration > 0:
             self.auto_close_timer = self.set_timer(self.duration, self._request_close)
@@ -452,10 +468,18 @@ class SplashScreen(Container):
             pass
 
     async def on_key(self, event: events.Key) -> None:
-        """Handle key press events."""
+        """Dismiss the splash on any key, when the skip is enabled.
+
+        TASK-21591. The event is deliberately NOT stopped. Today a key
+        pressed during the splash reaches nothing focused, bubbles to the
+        screen and is dispatched against the app's bindings -- so ``ctrl+q``
+        quits and ``ctrl+p`` opens the palette while the splash is up.
+        Swallowing the event here would make the skip work by breaking
+        those, which is a worse trade than the one this fixes. Letting it
+        bubble keeps every existing binding working AND dismisses the
+        splash, which is what "skip with any keypress" means.
+        """
         if self.skip_on_keypress and not self._skip_requested:
-            event.stop()
-            event.prevent_default()
             self._request_close()
 
     def _request_close(self) -> None:

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -470,16 +470,23 @@ class SplashScreen(Container):
     async def on_key(self, event: events.Key) -> None:
         """Dismiss the splash on any key, when the skip is enabled.
 
-        TASK-21591. The event is deliberately NOT stopped. Today a key
-        pressed during the splash reaches nothing focused, bubbles to the
-        screen and is dispatched against the app's bindings -- so ``ctrl+q``
-        quits and ``ctrl+p`` opens the palette while the splash is up.
-        Swallowing the event here would make the skip work by breaking
-        those, which is a worse trade than the one this fixes. Letting it
-        bubble keeps every existing binding working AND dismisses the
-        splash, which is what "skip with any keypress" means.
+        TASK-21591. The key is CONSUMED: the splash is a modal overlay over
+        an app that is not interactive yet, and while it is up the key's
+        whole job is to dismiss it. Letting the event bubble instead was
+        tried and rejected -- it preserved ``ctrl+q``/``ctrl+p`` during the
+        splash, but it also let a shell-destination key through, and because
+        ``action_shell_destination`` *posts* its ``NavigateToScreen`` the
+        request was then handled AFTER the now-immediate splash close had
+        pushed the initial screen, so F9 mid-splash landed the user on
+        Settings. That is the exact behaviour task-1339 locked (see
+        ``test_navigation_keypress_during_splash_is_safely_ignored``).
+        Stopping the event keeps every already-decided contract intact; the
+        cost is that ``ctrl+q`` during the splash dismisses it and needs a
+        second press to quit, which no task or test has asserted otherwise.
         """
         if self.skip_on_keypress and not self._skip_requested:
+            event.stop()
+            event.prevent_default()
             self._request_close()
 
     def _request_close(self) -> None:


### PR DESCRIPTION
## Summary

The last three findings of the burn-down, all filed **low**. **Two shipped, one closed on
measurement.** Separate commits.

## TASK-21532 — shipped, for one of the two sites

The filing said both sites "hydrate every binding of a root to keep one field". **Only `:2564`
does.** At `:509` the *same* tuple is the input to every loop after the `binding.state` check, and
between them they consume all thirteen hydrated columns — a projection there would be followed by
the full read anyway. The code now says so.

Real store, arms interleaved:

| bindings | read-all | projection | delta |
|---:|---|---|---|
| 100 | 1.413 ms / 110,490 B | 0.034 ms / 13,228 B | −1.379 ms / −97,262 B |
| 500 | 7.595 ms / 531,538 B | 0.168 ms / 60,676 B | −7.427 ms / −470,862 B |
| 1,000 | 15.257 ms / 1,058,854 B | 0.295 ms / 120,992 B | **−14.961 ms / −937,862 B** |

**A measurement error caught by prior art.** The first harness timed wall clock *inside* a
tracemalloc window and reported 92.4 ms for the read-all — tracemalloc taxes per allocation, which
is exactly the arm under test, inflating the win six-fold. The 1,000-binding read is supposed to
reproduce TASK-21129's 15 ms, and it now does; that mismatch is how the error surfaced.

TASK-21129's existing methods cannot answer "which bindings are candidates"
(`active_binding_note_ids` returns `note_id`+`active`, `has_binding_for_note_or_path` is a `LIMIT 1`
predicate), so `candidate_binding_ids` is new but in the same idiom — `EXPLAIN QUERY PLAN` confirms a
covering-index search with no temp B-tree.

**Mutations**: state filter dropped, root filter dropped, `CANDIDATE`→`ACTIVE`, call site reverted,
projection taken off `to_thread` — all red. Dropping `ORDER BY` survives (the index already yields
that order); recorded and kept as contract rather than hidden.

## TASK-21591 — shipped, after the first version was withdrawn

Confirmed on the base **in a real terminal**, not just under Pilot: Space 23 ms into a 25 s splash
did nothing. Fix: `can_focus = bool(skip_on_keypress)` plus `self.focus()` in `on_mount` under the
same condition, so the Settings splash *preview* (which passes `False`) cannot steal focus.

**The part worth reading.** The first version deliberately did **not** consume the key, so `ctrl+q`
would still work mid-splash. It passed four splash suites, five purpose-built tests and two live
tmux arms — then red-lined `test_navigation_keypress_during_splash_is_safely_ignored` in a file that
never mentions the splash.

`action_shell_destination` **posts** its `NavigateToScreen`, and the "initial screen not yet mounted"
guard runs in the *handler*. With the splash now closing immediately, `Closed` was queued ahead of
the navigation, so the initial screen existed by the time the guard ran — **F9 mid-splash landed the
user on Settings.** The guard never changed; the latency it implicitly depended on did.

So the key is consumed. Cost: `ctrl+q` during the splash dismisses it and needs a second press — no
test or task ever asserted otherwise. Live: F9 at +29 ms dismisses and leaves the app on Home;
`skip_on_keypress = false` still runs the full 20 s; an immediate skip (before TASK-21110's 0.2 s
pre-import thread starts) boots to a working UI in under 3 s.

**Mutations**: 6 arms, every one of the 5 tests killed by at least one. One is itself a finding —
removing `self.focus()` left all four *original* tests green, because `App.AUTO_FOCUS = "*"` was
doing it for free. The host now sets `AUTO_FOCUS = None`.

## TASK-21596 — closed on measurement, no code change

Spying `keyring.core.get_keyring`/`get_password` across whole interactions:

| interaction | keyring calls |
|---|---|
| app mount — Home / Console / Settings | **0 / 0 / 0** |
| first `get_video_generation_config()` (the `/generate-video` path) | 2 |
| opening Settings ▸ Video Gen | 4 (two full resolutions per compose) |

**"Opening Console video pays the Keychain query up front" is false on this base** — the only Console
read is inside the `/generate-video` handler, i.e. already send time.

The one eager consumer is the Settings page, and it is eager *because of what it renders*: it puts
`key_sources` on screen as `key: keyring / env: VAR / config / not set`, and with no env var and no
config value the keyring probe is the only thing distinguishing those. **Deferring it would make the
page lie.** Measured cost: `get_keyring()` 12.6–17.7 ms once (memoized — whoever runs first pays for
everyone), first `get_password` 5.4–6.0 ms, subsequent 0.11–0.36 ms. De-duplicating the double
compose banks **~0.17 ms**, below noise. Recorded in the task file, not shipped.

## Verification

`test_screen_navigation.py` + `Tests/Video_Generation/`: **486 passed, 2 skipped, 0 failed** after
rebase. `test_navigation_keypress_during_splash_is_safely_ignored` — the guard the first version
broke — **passes**. Notes + splash + video consolidated: 643 passed, 1 failed, that one identical on
pristine dev in a separate worktree and in a module this branch does not touch. Preflight green;
ruff clean.

## Out of scope

- Two **dev reds** on `7f38cb6ef`: `test_product_maturity_phase6_focus_visual_sweep.py` (4 tests) and
  `test_notes_sync_cutover.py::test_library_screen_has_no_legacy_timer_worker_or_mutating_handler`.
- `NotesDeviceStateStore.active_binding_note_ids`'s docstring claims it "deliberately carries no
  `validate_notes_sync_opaque_id` fail-closed check" while its body calls exactly that. Stale prose.
- Settings ▸ Video Gen resolves key sources on the event loop inside `compose()`; on a locked keychain
  holding a stored videogen secret that can block. Fixing it needs an async key-source column — the
  same trade this task just declined, recorded rather than filed.

Lessons recorded: tracemalloc taxes the arm you are indicting; framework defaults are second writers;
and a faster early step can un-swallow a request whose guard is checked at handle time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
