### PR TITLE
perf(watchlists): hysteresis at responsive collapse boundaries (TASK-22211)

### DIFF
--- a/Tests/Watchlists/test_watchlists_layout_hysteresis_probe.py
+++ b/Tests/Watchlists/test_watchlists_layout_hysteresis_probe.py
@@ -1,0 +1,131 @@
+"""TASK-22211 screen-level probe: resize oscillation must not churn panes.
+
+`WatchlistsCollectionsScreen.on_resize` re-derives the effective layout per
+Textual Resize event. Without hysteresis, a +/-1-cell width oscillation at a
+collapse boundary re-runs a region factory and mounts/removes the whole pane
+body on every crossing (`watchlists_workbench.py`'s
+`_apply_effective_layout_request`). This probe counts region-body builds
+across such an oscillation at the management-mode RIGHT_RAIL boundary
+(108 = 44 centre + 2*5 grips + 24 + 30), driving the real `on_resize` ->
+`_recompute_effective_layout` -> `request_region_layout` -> mount/remove
+pipeline with only the width *measurement* stubbed. The screen opens on its
+default Read section (`active_section = "items"`), whose all-open
+requirement is 145 = 44 centre + 3*5 grips + 24 + 32 + 30; RIGHT_RAIL is
+the first collapse candidate below it.
+
+The conftest `isolate_test_environment` fixture patches
+`load_region_layout` to `RegionLayout()` (nothing collapsed), so the
+preferred layout here is all-open and every collapse below is responsive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_destination_shells import DestinationHarness
+from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
+    WatchlistsCollectionsScreen,
+)
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
+from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+    WatchlistsWorkbench,
+)
+
+pytestmark = pytest.mark.asyncio
+
+#: Read mode all-open requirement: RIGHT_RAIL collapses below this.
+READ_BOUNDARY_WIDTH = 145
+
+
+class _RegionBuildCounter:
+    """Count pane-body factory construction (same idiom as the cold-open
+    suite's counter: every mount of a region body passes through
+    `WatchlistsWorkbench._region_body`)."""
+
+    def __init__(self) -> None:
+        self.regions: list[Region] = []
+        self._original = WatchlistsWorkbench._region_body
+
+    def __enter__(self) -> "_RegionBuildCounter":
+        counter = self
+        original = self._original
+
+        def _counting_build(widget_self, region, content=None):
+            counter.regions.append(region)
+            return original(widget_self, region, content)
+
+        WatchlistsWorkbench._region_body = _counting_build
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        WatchlistsWorkbench._region_body = self._original
+
+
+async def _resize_to(screen, pilot, width_box, width: int) -> None:
+    width_box["value"] = width
+    screen.on_resize(None)
+    await pilot.pause(0.05)
+
+
+async def test_one_cell_resize_oscillation_at_the_boundary_causes_no_churn():
+    """+/-1-cell oscillation at the RIGHT_RAIL boundary: after the first
+    legitimate collapse, zero further factory builds and zero
+    mount/remove churn -- and a width that genuinely clears the boundary
+    by the hysteresis margin still re-expands the pane."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        assert isinstance(screen, WatchlistsCollectionsScreen)
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        assert workbench.read_mode is True, (
+            "probe assumes the default Read section (items)"
+        )
+        assert workbench._mounted_region_body(Region.RIGHT_RAIL) is not None, (
+            "all-open preferred layout at 180 columns must mount RIGHT_RAIL"
+        )
+
+        width_box = {"value": READ_BOUNDARY_WIDTH}
+        screen._available_layout_width = lambda: width_box["value"]
+
+        # Settle exactly at the boundary: everything still fits at 145.
+        await _resize_to(screen, pilot, width_box, READ_BOUNDARY_WIDTH)
+        assert workbench._mounted_region_body(Region.RIGHT_RAIL) is not None
+
+        with _RegionBuildCounter() as builds:
+            for _ in range(5):
+                await _resize_to(
+                    screen, pilot, width_box, READ_BOUNDARY_WIDTH - 1
+                )
+                await _resize_to(
+                    screen, pilot, width_box, READ_BOUNDARY_WIDTH
+                )
+
+            # The first 144 collapses the rail; every later +/-1 step must
+            # be absorbed: NO region body is ever rebuilt during the
+            # oscillation, and the rail stays collapsed (no re-mount at
+            # 145, which is inside the hysteresis band).
+            assert builds.regions == [], (
+                "a +/-1-cell oscillation must cause zero region-body "
+                f"rebuilds; got {builds.regions!r}"
+            )
+            assert workbench._mounted_region_body(Region.RIGHT_RAIL) is None, (
+                "RIGHT_RAIL must stay collapsed while the width oscillates "
+                "inside the hysteresis band"
+            )
+
+        # Convergence: clearing the boundary by the hysteresis width is a
+        # real expand and must still work (hysteresis never sticks a pane).
+        with _RegionBuildCounter() as reopen_builds:
+            await _resize_to(
+                screen, pilot, width_box, READ_BOUNDARY_WIDTH + 4
+            )
+            assert (
+                workbench._mounted_region_body(Region.RIGHT_RAIL) is not None
+            ), "clearing the boundary by the hysteresis width must re-expand"
+            assert reopen_builds.regions == [Region.RIGHT_RAIL]

--- a/Tests/Watchlists/test_watchlists_responsive_layout.py
+++ b/Tests/Watchlists/test_watchlists_responsive_layout.py
@@ -13,6 +13,7 @@ def resolve(
     read_mode: bool = True,
     article_focus: bool = False,
     priority_target: Region | None = None,
+    previous: RegionLayout | None = None,
 ) -> RegionLayout:
     return region_layout.resolve_effective_layout(
         preferred,
@@ -20,6 +21,7 @@ def resolve(
         read_mode=read_mode,
         article_focus=article_focus,
         priority_target=priority_target,
+        previous=previous,
     )
 
 
@@ -172,3 +174,173 @@ def test_resolver_discards_a_retired_reader_collapse_value():
     effective = resolve(preferred, 145)
     assert effective.collapsed == frozenset({Region.LEFT_RAIL})
     assert not effective.is_collapsed(Region.CONTENT)
+
+
+# --- Hysteresis at the collapse boundaries (TASK-22211) -------------------
+#
+# Boundary map (read mode, everything preferred open):
+#   145 = 44 (centre) + 3*5 (grips) + 24 + 32 + 30  -> RIGHT_RAIL collapses < 145
+#   115 = 145 - 30                                  -> LEFT_RAIL collapses < 115
+#    91 = 115 - 24                                  -> ITEMS collapses < 91
+# Management mode: 108 -> RIGHT_RAIL, 78 -> LEFT_RAIL.
+# A collapsed pane re-expands only once the width clears its boundary by
+# LAYOUT_HYSTERESIS_WIDTH (the Library reader precedent).
+
+
+def test_hysteresis_constant_matches_the_library_reader_precedent():
+    from tldw_chatbook.Library.library_media_reader_state import (
+        LAYOUT_HYSTERESIS_WIDTH as READER_HYSTERESIS,
+    )
+
+    assert region_layout.LAYOUT_HYSTERESIS_WIDTH == READER_HYSTERESIS == 4
+
+
+def test_one_cell_oscillation_at_the_read_inspector_boundary_is_stable():
+    preferred = RegionLayout()
+    layout = resolve(preferred, 145)
+    assert layout.collapsed == frozenset()
+    for _ in range(5):
+        layout = resolve(preferred, 144, previous=layout)
+        assert layout.collapsed == frozenset({Region.RIGHT_RAIL})
+        layout = resolve(preferred, 145, previous=layout)
+        assert layout.collapsed == frozenset({Region.RIGHT_RAIL})
+
+
+def test_expansion_requires_clearing_the_boundary_by_the_hysteresis_width():
+    preferred = RegionLayout()
+    collapsed = resolve(preferred, 144, previous=resolve(preferred, 145))
+    assert collapsed.collapsed == frozenset({Region.RIGHT_RAIL})
+
+    still_held = resolve(preferred, 148, previous=collapsed)
+    assert still_held.collapsed == frozenset({Region.RIGHT_RAIL})
+
+    reopened = resolve(preferred, 149, previous=collapsed)
+    assert reopened.collapsed == frozenset()
+
+    # The expand boundary is itself stable in both directions: once open,
+    # dropping one cell below it does not re-collapse (the bare threshold,
+    # 145, governs collapse).
+    assert resolve(preferred, 148, previous=reopened).collapsed == frozenset()
+
+
+def test_crossing_by_at_least_the_hysteresis_width_still_flips_both_ways():
+    preferred = RegionLayout()
+    open_layout = resolve(preferred, 149)
+    assert open_layout.collapsed == frozenset()
+
+    collapsed = resolve(preferred, 144, previous=open_layout)
+    assert collapsed.collapsed == frozenset({Region.RIGHT_RAIL})
+
+    reopened = resolve(preferred, 149, previous=collapsed)
+    assert reopened.collapsed == frozenset()
+
+
+def test_one_cell_oscillation_at_the_management_boundary_is_stable():
+    preferred = RegionLayout()
+    layout = resolve(preferred, 108, read_mode=False)
+    assert layout.collapsed == frozenset()
+    for _ in range(5):
+        layout = resolve(preferred, 107, read_mode=False, previous=layout)
+        assert layout.collapsed == frozenset({Region.RIGHT_RAIL})
+        layout = resolve(preferred, 108, read_mode=False, previous=layout)
+        assert layout.collapsed == frozenset({Region.RIGHT_RAIL})
+    assert resolve(preferred, 112, read_mode=False, previous=layout).collapsed == (
+        frozenset()
+    )
+
+
+def test_hysteresis_composes_per_region_when_two_boundaries_are_near():
+    preferred = RegionLayout()
+    prev = RegionLayout(
+        collapsed=frozenset({Region.RIGHT_RAIL, Region.LEFT_RAIL})
+    )
+
+    # LEFT_RAIL's expand boundary (115 + 4) is evaluated with RIGHT_RAIL's
+    # suppressed width already deducted -- per-region state, not one flag.
+    held = resolve(preferred, 118, previous=prev)
+    assert held.collapsed == frozenset({Region.RIGHT_RAIL, Region.LEFT_RAIL})
+
+    left_back = resolve(preferred, 119, previous=prev)
+    assert left_back.collapsed == frozenset({Region.RIGHT_RAIL})
+
+    # RIGHT_RAIL's own expand boundary is the all-open requirement + 4.
+    assert resolve(preferred, 148, previous=prev).collapsed == frozenset(
+        {Region.RIGHT_RAIL}
+    )
+    assert resolve(preferred, 149, previous=prev).collapsed == frozenset()
+
+
+def test_hysteresis_applies_to_the_priority_target_too():
+    preferred = RegionLayout()
+    prev = resolve(preferred, 88, priority_target=Region.RIGHT_RAIL)
+    assert prev.collapsed == frozenset(region_layout.COLLAPSIBLE_REGIONS)
+
+    # Protected target's own requirement once LEFT/ITEMS are collapsed:
+    # 44 + 15 + 30 = 89, so its expand boundary is 93.
+    held = resolve(preferred, 92, priority_target=Region.RIGHT_RAIL, previous=prev)
+    assert held.collapsed == frozenset(region_layout.COLLAPSIBLE_REGIONS)
+
+    reopened = resolve(
+        preferred, 93, priority_target=Region.RIGHT_RAIL, previous=prev
+    )
+    assert reopened.collapsed == frozenset({Region.LEFT_RAIL, Region.ITEMS})
+
+
+def test_article_focus_still_collapses_everything_regardless_of_previous():
+    preferred = RegionLayout()
+    effective = resolve(
+        preferred, 200, article_focus=True, previous=RegionLayout()
+    )
+    assert effective.collapsed == frozenset(region_layout.COLLAPSIBLE_REGIONS)
+
+
+def test_resolution_with_previous_reaches_a_fixed_point():
+    preferred = RegionLayout()
+    layout = resolve(preferred, 144, previous=resolve(preferred, 145))
+    assert resolve(preferred, 144, previous=layout) == layout
+    layout = resolve(preferred, 118, previous=layout)
+    assert resolve(preferred, 118, previous=layout) == layout
+
+
+@pytest.mark.parametrize("read_mode", [True, False])
+@pytest.mark.parametrize(
+    "previous_collapsed",
+    [
+        frozenset(),
+        frozenset({Region.RIGHT_RAIL}),
+        frozenset({Region.RIGHT_RAIL, Region.LEFT_RAIL}),
+        frozenset(region_layout.COLLAPSIBLE_REGIONS),
+    ],
+)
+def test_hysteresis_never_holds_a_pane_open_the_bare_resolver_collapses(
+    read_mode: bool,
+    previous_collapsed: frozenset[Region],
+):
+    """Overflow safety: hysteresis only ever suppresses expansion.
+
+    The resolved collapsed set with ``previous`` threaded is always a
+    superset of the bare resolution's, so ``required_width`` can never
+    exceed what the bare resolver already fit into ``width`` -- a pane is
+    never stuck open at a width where it cannot fit.
+    """
+    preferred = RegionLayout()
+    previous = RegionLayout(collapsed=previous_collapsed)
+    for width in range(0, 201):
+        bare = resolve(preferred, width, read_mode=read_mode)
+        with_hysteresis = resolve(
+            preferred, width, read_mode=read_mode, previous=previous
+        )
+        assert with_hysteresis.collapsed >= bare.collapsed
+
+
+def test_no_previous_state_resolves_exactly_as_before():
+    preferred = RegionLayout()
+    for width in (90, 91, 114, 115, 144, 145):
+        assert resolve(preferred, width) == resolve(
+            preferred, width, previous=None
+        )
+    # A far shrink with previous threaded still collapses everything the
+    # bare resolver would (convergence at genuinely narrow widths).
+    assert resolve(
+        preferred, 60, previous=resolve(preferred, 200)
+    ).collapsed == frozenset(region_layout.COLLAPSIBLE_REGIONS)

--- a/backlog/tasks/task-22211 - Watchlists-responsive-layout-needs-hysteresis-at-its-collapse-boundaries.md
+++ b/backlog/tasks/task-22211 - Watchlists-responsive-layout-needs-hysteresis-at-its-collapse-boundaries.md
@@ -2,8 +2,9 @@
 id: TASK-22211
 title: >-
   Watchlists responsive layout needs hysteresis at its collapse boundaries
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
 labels:
   - performance
@@ -32,6 +33,125 @@ user resize.
 
 ## Acceptance Criteria
 
-- [ ] Repeated +/-1-cell width changes at a collapse boundary cause no mount/remove churn (hysteresis test at the boundary, both directions)
-- [ ] The width source is not flappable by a scrollbar toggle, or a code-level guard absorbs sub-hysteresis changes (the repo rule: never trust a CSS-only guard)
-- [ ] Approach consistent with the Library reader's hysteresis precedent
+- [x] Repeated +/-1-cell width changes at a collapse boundary cause no mount/remove churn (hysteresis test at the boundary, both directions)
+- [x] The width source is not flappable by a scrollbar toggle, or a code-level guard absorbs sub-hysteresis changes (the repo rule: never trust a CSS-only guard)
+- [x] Approach consistent with the Library reader's hysteresis precedent
+
+## Implementation Plan
+
+1. Red-first pure-function tests on `resolve_effective_layout` (extend
+   `Tests/Watchlists/test_watchlists_responsive_layout.py`): a new
+   `previous: RegionLayout | None` keyword threads the previously resolved
+   effective layout; +/-1-cell oscillation at each collapse boundary (read
+   145/144, management 108/107, and the second read boundary 115/114) is
+   stable in both directions; expansion requires clearing the boundary by
+   `LAYOUT_HYSTERESIS_WIDTH = 4` (the Library reader precedent,
+   `Library/library_media_reader_state.py:16`); two boundaries near each
+   other compose per-region (RIGHT_RAIL stays collapsed while LEFT_RAIL's
+   own expand boundary is evaluated with the freed width accounted);
+   `previous=None` (first-ever resolve) is byte-identical to today's
+   behavior; hysteresis result's collapsed set is always a superset of the
+   bare resolve's (overflow safety: hysteresis can only suppress
+   *expansion*, never suppress a collapse, so `required_width <= width`
+   whenever the bare resolver achieves it — a pane is never held open at a
+   width where it cannot fit).
+2. Red-first screen-level probe (new
+   `Tests/Watchlists/test_watchlists_layout_hysteresis_probe.py`): count
+   RIGHT_RAIL factory invocations and region-body mount presence across a
+   +/-1-cell `on_resize` oscillation at the management boundary with the
+   width source stubbed; today each up-crossing re-mounts the pane (factory
+   churn), after the fix the count stays at zero once collapsed.
+3. Implement: `LAYOUT_HYSTERESIS_WIDTH = 4` and the `previous` parameter in
+   `UI/Watchlists_Modules/region_layout.py` — after the existing greedy
+   collapse loop, a pane that is open in the bare result but collapsed in
+   `previous` is kept collapsed unless `required_width +
+   LAYOUT_HYSTERESIS_WIDTH <= width`, iterating in the same priority order
+   and re-deducting each suppressed pane's minimum width so adjacent
+   boundaries compose. `article_focus` early-return unchanged.
+4. Thread state in the screen: `_recompute_effective_layout` gains a
+   `previous` parameter forwarded to the effective resolve only; `on_resize`
+   passes `self._effective_region_layout`. All other call sites (mount,
+   gestures, section switches, article focus, rollback) keep `previous=None`
+   so manual gestures and first resolves behave exactly as today.
+   Scrollbar-flap aggravator: the hysteresis IS the code-level guard — the
+   default vertical scrollbar is 2 cells < 4, so a scrollbar-induced width
+   delta at a boundary is absorbed on every resize-driven resolve (a
+   scrollbar toggle alone posts no Resize to the Screen, so it cannot
+   trigger a recompute by itself; the width it perturbs is only read at the
+   next resolve, where the guard applies).
+5. Verify persistence safety: only preferred layouts
+   (`self.region_layout`) reach `_schedule_layout_persist`; the hysteresis
+   only touches `_effective_region_layout`.
+6. Targeted suites (region layout, workbench, screen, cold-open, grips,
+   store) + `--collect-only` sweep, tee'd; `./scripts/preflight.sh`.
+7. Mutation test: remove the previous-state threading in `on_resize` (and
+   separately neuter the resolver's hysteresis block) → oscillation tests
+   must go red; restore via Edit.
+
+## Implementation Notes
+
+Matched the Library reader precedent exactly in shape and value:
+`LAYOUT_HYSTERESIS_WIDTH = 4` in `UI/Watchlists_Modules/region_layout.py`,
+and `resolve_effective_layout` gained a keyword-only
+`previous: RegionLayout | None = None`. After the existing greedy collapse
+pass, panes still open but collapsed in `previous` are re-collapsed unless
+`required_width + LAYOUT_HYSTERESIS_WIDTH <= width`, iterating in the same
+priority order (priority target last) and deducting each suppressed pane's
+minimum width before judging the next — so two nearby boundaries compose
+per region, not through one global flag. Hysteresis therefore only ever
+*suppresses expansion*: collapse still fires exactly at the bare
+threshold, the resolved collapsed set is provably a superset of the bare
+resolution's (parametrized sweep over widths 0–200 x 4 previous states x
+both modes), and no pane can be held open at a width where it cannot fit —
+no cap logic is needed because the overflow case is unreachable by
+construction.
+
+Threading: only `WatchlistsCollectionsScreen.on_resize` passes
+`previous=self._effective_region_layout` (via a new `previous` parameter
+on `_recompute_effective_layout`). First-ever resolves, manual gestures
+(`_toggle_preferred_region`, Article Focus), section switches, and
+rollback keep `previous=None` and byte-identical pre-change behavior —
+this also keeps a manual expand instantly honored inside the hysteresis
+band, and the resize path still applies hysteresis to the priority target
+so the just-expanded pane cannot flap during a drag.
+
+Scrollbar aggravator (AC#2, second disjunct): resolved with a code-level
+guard, not a width-source swap. `workbench.size.width` in Textual 8.2.8 is
+`content_region` (region minus border/padding, NOT minus own scrollbars),
+but it shrinks by 2 when the Screen (default `overflow-y: auto`) grows a
+vertical scrollbar. A scrollbar toggle posts Resize only to the resized
+widget (no bubbling), so it cannot trigger a recompute by itself; when the
+perturbed width IS next read, the resize path's hysteresis (4 > 2)
+absorbs the delta. Documented in `_available_layout_width`'s docstring and
+in the constant's comment (the 4 > scrollbar-width invariant).
+
+Persistence audited: `_schedule_layout_persist`/`save_region_layout` only
+ever receive *preferred* layouts (`_apply_layout`,
+`_toggle_preferred_region`, rollback); hysteresis touches only the
+transient `_effective_region_layout`, so saved preferences cannot be
+corrupted. Teardown: `on_resize` during unmount resolves at the 10_000
+sentinel where hysteresis is a no-op, unchanged from before.
+
+Evidence: red-first tests (pure suite failed on the missing parameter and,
+for the probe, on real churn — 5 full RIGHT_RAIL pane rebuilds across 5
++/-1-cell oscillation cycles at the Read boundary; 0 after). New tests: 10
+pure hysteresis tests in `Tests/Watchlists/test_watchlists_responsive_layout.py`
+(boundary stability both directions in both modes, expand-boundary
+clearance and its own stability, >= hysteresis crossings still flip,
+two-boundary composition, priority-target hysteresis, article focus,
+fixed point, superset sweep, previous=None equivalence) + screen probe
+`Tests/Watchlists/test_watchlists_layout_hysteresis_probe.py` (zero
+region-body rebuilds during oscillation, re-expand at boundary+4 works).
+Suites: `Tests/Watchlists/` 802 passed; the seven `Tests/UI/`
+watchlists files 262 passed + 1 pre-existing timing flake
+(`test_loader_results_landing_before_textual_flips_is_mounted_still_paint`,
+a 3s poll-budget precondition unrelated to layout: fails/passes on the
+same tree, passes at dev baseline and with this change on rerun, and no
+Resize fires in its scenario). Mutation-tested both halves: dropping the
+`on_resize` threading reds the probe (5 rebuilds return); neutering the
+resolver block reds 5 pure tests. `./scripts/preflight.sh` all green.
+
+Files: `tldw_chatbook/UI/Watchlists_Modules/region_layout.py`,
+`tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
+`Tests/Watchlists/test_watchlists_responsive_layout.py`,
+`Tests/Watchlists/test_watchlists_layout_hysteresis_probe.py`.

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1175,8 +1175,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._refresh_overview_data()
 
     def on_resize(self, _event: events.Resize) -> None:
-        """Re-derive responsive state without changing the preference."""
-        self._recompute_effective_layout()
+        """Re-derive responsive state without changing the preference.
+
+        Threads the current effective layout as ``previous`` so the
+        resolver's boundary hysteresis (TASK-22211) can absorb
+        sub-hysteresis width changes -- the +/-1-cell oscillation of a
+        drag-resize, and the 2-cell delta of an ancestor scrollbar
+        appearing or disappearing -- instead of mounting/removing a whole
+        pane per Resize event. Only this resize path threads state: manual
+        gestures and section switches still resolve fresh.
+        """
+        self._recompute_effective_layout(previous=self._effective_region_layout)
 
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
         """Apply a validated section/run deep link from shell navigation."""
@@ -3036,7 +3045,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
 
     def _available_layout_width(self) -> int:
-        """Best live width for the pure responsive resolver."""
+        """Best live width for the pure responsive resolver.
+
+        Scrollbar-toggle flap (TASK-22211): the preferred candidate,
+        ``workbench.size.width``, shrinks by the scrollbar width (2 cells)
+        when an ancestor grows a vertical scrollbar (the Screen defaults to
+        ``overflow-y: auto``), so a measurement taken across a scrollbar
+        toggle can differ by 2 with no user resize. That delta is absorbed
+        in CODE, not CSS: a scrollbar toggle posts no Resize to this
+        Screen (Textual posts Resize to the resized widget only, and it
+        does not bubble), so it cannot trigger a recompute by itself, and
+        every resize-driven recompute threads the previous effective
+        layout into the resolver whose `LAYOUT_HYSTERESIS_WIDTH` (4) is
+        deliberately wider than the scrollbar -- see `on_resize` and
+        `resolve_effective_layout`. Measuring the genuinely narrower width
+        when a scrollbar is really present remains correct; only the
+        sub-hysteresis flap is suppressed.
+        """
         if not self.is_mounted:
             return 10_000
         candidates: list[int] = []
@@ -3076,8 +3101,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         *,
         section: str | None = None,
         request_workbench: bool = True,
+        previous: RegionLayout | None = None,
     ) -> int | None:
-        """Resolve and push transient responsive/Article Focus state."""
+        """Resolve and push transient responsive/Article Focus state.
+
+        Args:
+            section: Section to resolve for; defaults to the active one.
+            request_workbench: Whether to push the result at the workbench.
+            previous: Previously resolved effective layout, threaded into
+                the resolver for boundary hysteresis (TASK-22211). Only the
+                resize path passes it: a Resize-driven recompute must not
+                flip a pane on a sub-hysteresis width change, while manual
+                gestures, section switches, and the first resolve keep
+                today's fresh (hysteresis-free) resolution.
+        """
         section = self.active_section if section is None else section
         read_mode = section == "items"
         width = self._available_layout_width()
@@ -3099,6 +3136,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             read_mode=read_mode,
             article_focus=self._article_focus_active,
             priority_target=self._responsive_priority_target,
+            previous=previous,
         )
         previous = self._effective_region_layout
         if (

--- a/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
@@ -66,6 +66,16 @@ PANE_MINIMUM_WIDTHS: dict[Region, int] = {
 #: Preferred comfort width for the permanent Reader or management canvas.
 CENTRE_COMFORT_WIDTH = 44
 
+#: Extra columns a responsively collapsed pane must clear before it
+#: re-expands (TASK-22211). Same value and role as the Library reader's
+#: `LAYOUT_HYSTERESIS_WIDTH` (`Library/library_media_reader_state.py`):
+#: collapse happens exactly at a pane's bare width boundary, but expansion
+#: waits until the width clears that boundary by this margin, so a +/-1-cell
+#: resize oscillation (or a 2-cell scrollbar toggle) at the boundary cannot
+#: mount/remove a whole pane per event. Must stay wider than the default
+#: vertical scrollbar (2 cells) for the scrollbar-toggle guard to hold.
+LAYOUT_HYSTERESIS_WIDTH = 4
+
 #: Default collapse order when Read becomes too narrow.
 READ_COLLAPSE_PRIORITY: tuple[Region, ...] = (
     Region.RIGHT_RAIL,
@@ -136,6 +146,7 @@ def resolve_effective_layout(
     read_mode: bool,
     article_focus: bool,
     priority_target: Region | None,
+    previous: RegionLayout | None = None,
 ) -> RegionLayout:
     """Derive mounted side-pane collapses without changing ``preferred``.
 
@@ -145,6 +156,16 @@ def resolve_effective_layout(
         read_mode: Whether Read's Feed Items pane is mounted.
         article_focus: Whether every mounted side pane is temporarily hidden.
         priority_target: An expanded mounted pane to collapse last, if any.
+        previous: The previously resolved effective layout, used for
+            hysteresis (TASK-22211, Library reader precedent). A pane that
+            ``previous`` holds collapsed only re-expands once ``width``
+            clears its bare boundary by `LAYOUT_HYSTERESIS_WIDTH`, so
+            sub-hysteresis width oscillation at a boundary is absorbed.
+            Hysteresis only ever suppresses *expansion* -- collapse still
+            happens exactly at the bare boundary, so the result never
+            requires more width than the bare resolution did. ``None``
+            (a first resolve, or a manual gesture that should re-resolve
+            fresh) behaves exactly as before the parameter existed.
 
     Returns:
         A new effective layout with no solo or restore state.
@@ -171,5 +192,21 @@ def resolve_effective_layout(
             break
         collapsed.add(region)
         required_width -= PANE_MINIMUM_WIDTHS[region]
+
+    if previous is not None:
+        # Hysteresis, per region, in the same collapse-priority order as
+        # the greedy pass: a pane the previous effective layout had
+        # collapsed stays collapsed unless the width clears the current
+        # requirement by the hysteresis margin. Each suppressed pane's
+        # minimum width is deducted before the next pane is judged, so two
+        # nearby boundaries compose (the later pane's expand boundary
+        # accounts for the earlier pane staying collapsed).
+        for region in candidates:
+            if region in collapsed or not previous.is_collapsed(region):
+                continue
+            if required_width + LAYOUT_HYSTERESIS_WIDTH <= width:
+                continue
+            collapsed.add(region)
+            required_width -= PANE_MINIMUM_WIDTHS[region]
 
     return RegionLayout(collapsed=frozenset(collapsed))


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22211). The Watchlists reader layout (PR #2063) applied bare width thresholds per Resize event — a ±1-cell oscillation at the ~145-column boundary mounted/removed a whole pane per event (the documented width-flap trap; the Library reader carries the fix, Watchlists did not).

**Change:** `resolve_effective_layout` gains `previous` + `LAYOUT_HYSTERESIS_WIDTH = 4` (the Library precedent, same name/value): a previously-collapsed pane re-expands only once width clears its boundary by the margin, iterated per region in collapse-priority order with each suppressed pane's minimum deducted (two nearby boundaries compose). Only `on_resize` threads `previous` — mount, manual gestures, section switches, Article Focus behave byte-identically. **Safety by construction:** hysteresis only ever suppresses expansion, so the resolved layout never requires more width than the bare resolution fit — no stuck-open pane possible (pinned by a 0-200-width × 4-previous-state × both-modes sweep). Scrollbar-flap guarded: hysteresis (4) > scrollbar (2), with the size.width semantics documented in code (one factual correction to the finding recorded: `content_region` excludes own scrollbars; ancestor-sensitivity only).

**Measured:** 5 ±1-cell oscillation cycles at the boundary — **5 full pane rebuilds → 0** (one legitimate collapse at first down-crossing; re-expand at boundary+4 with exactly 1 rebuild).

Controller-verified (resolver diff read line-by-line; 10 red-first pure tests + screen probe; both mutations red; 802 Watchlists tests + 262 UI-watchlists green with 1 pre-existing flake baselined both-ways). Rebased over #2086 cleanly; suites re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1