### PR TITLE
perf(library): gate the file-notes reconcile poll on screen visibility (TASK-22219)

### DIFF
--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from rich.cells import cell_len
 from textual.app import App, ComposeResult
+from textual.screen import ModalScreen, Screen
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -5875,3 +5876,98 @@ async def test_large_file_uses_labeled_excerpt_and_exports_exact_disk_bytes(
             "exact export did not create the destination",
         )
         assert (root / "exact-copy.md").read_bytes() == source.read_bytes()
+
+
+class _PollCoverModal(ModalScreen[None]):
+    """Modal cover for the TASK-22219 visibility-gate probes."""
+
+
+class _PollCoverScreen(Screen[None]):
+    """Plain pushed-screen cover for the TASK-22219 visibility-gate probes."""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cover_factory", (_PollCoverModal, _PollCoverScreen))
+async def test_poll_reconcile_pauses_while_covered_and_resumes_on_return(
+    tmp_path: Path,
+    cover_factory: type,
+) -> None:
+    """TASK-22219: the poll must not walk the notes root while covered.
+
+    Covers both cover shapes the live app stacks over Library: a pushed
+    ``ModalScreen`` (dialogs, command palette) and a pushed plain ``Screen``
+    (help panels). Textual 8.2.8's ``Screen.is_active`` is
+    ``app.screen is self`` -- true only for the top of the stack -- so both
+    covers must gate the timer fire, and popping the cover must let the very
+    next tick reconcile again (the resume path IS the still-ticking timer;
+    nothing needs re-arming).
+    """
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "open.md").write_text("body", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=None,
+        poll_interval=0.05,
+    )
+
+    reconcile_times: list[float] = []
+    real_reconcile = FileNotesService.reconcile
+
+    def counting_reconcile(service: FileNotesService, *args, **kwargs):
+        reconcile_times.append(perf_counter())
+        return real_reconcile(service, *args, **kwargs)
+
+    def poll_settled() -> bool:
+        worker = workspace._poll_worker
+        return worker is None or worker.is_finished
+
+    with patch.object(FileNotesService, "reconcile", counting_reconcile):
+        async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: workspace.initialized,
+                "scan did not finish",
+            )
+            visible_baseline = len(reconcile_times)
+            await _wait_until(
+                pilot,
+                lambda: len(reconcile_times) > visible_baseline,
+                "poll did not reconcile while the screen was active",
+            )
+
+            pilot.app.push_screen(cover_factory())
+            await pilot.pause()
+            assert not workspace.screen.is_active
+            # Let a fire admitted before the push settle, so the covered
+            # window below counts only timer fires made while covered.
+            await _wait_until(
+                pilot,
+                poll_settled,
+                "in-flight poll never settled after the cover was pushed",
+            )
+            await pilot.pause(0.1)
+
+            covered_baseline = len(reconcile_times)
+            await pilot.pause(0.6)  # 12 poll intervals under the cover
+            covered_fires = len(reconcile_times) - covered_baseline
+            assert covered_fires == 0, (
+                f"reconcile fired {covered_fires}x while covered by "
+                f"{cover_factory.__name__}"
+            )
+
+            resume_baseline = len(reconcile_times)
+            pilot.app.pop_screen()
+            resumed_at = perf_counter()
+            await pilot.pause()
+            assert workspace.screen.is_active
+            await _wait_until(
+                pilot,
+                lambda: len(reconcile_times) > resume_baseline,
+                "poll did not resume after the cover was popped",
+            )
+            resume_delay = reconcile_times[resume_baseline] - resumed_at
+            # The contract is "the next tick reconciles" (one 0.05s interval);
+            # the bound is generous only for CI scheduling slack.
+            assert resume_delay < 2.0, f"resume took {resume_delay:.3f}s"
+    await workspace.shutdown()

--- a/backlog/tasks/task-22219 - Gate-the-file-notes-filesystem-reconcile-on-screen-visibility.md
+++ b/backlog/tasks/task-22219 - Gate-the-file-notes-filesystem-reconcile-on-screen-visibility.md
@@ -1,20 +1,22 @@
 ---
 id: TASK-22219
-title: >-
-  Gate the file-notes filesystem reconcile on screen visibility
-status: To Do
-assignee: []
+title: Gate the file-notes filesystem reconcile on screen visibility
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
+updated_date: '2026-08-25 15:57'
 labels:
   - performance
   - library
   - notes
-priority: medium
 dependencies: []
+priority: medium
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
 and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22219).
 
@@ -23,9 +25,81 @@ Pre-existing. `Widgets/Library/library_file_notes_workspace.py:1453-1456` arms a
 walk/stat of the notes root — 40x/minute for the Library screen's lifetime once the File
 Notes surface has been opened, including while other screens or modals are on top (the
 only gates are `_active`/transitioning/in-flight; no `screen.is_active`).
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 No reconcile fires while the Library screen is not active or is covered (probe)
+- [x] #2 Polling resumes on return to the screen; a change-driven or backoff cadence is considered and the choice stated
+- [x] #3 Filesystem scan count per minute measured before/after in the covered state
+<!-- AC:END -->
 
-- [ ] No reconcile fires while the Library screen is not active or is covered (probe)
-- [ ] Polling resumes on return to the screen; a change-driven or backoff cadence is considered and the choice stated
-- [ ] Filesystem scan count per minute measured before/after in the covered state
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify Textual 8.2.8 Screen.is_active semantics against the installed source (top-of-stack only; False under a pushed modal and when off the stack)
+2. Red-first probes in Tests/UI/test_library_file_notes_workspace.py: (a) covered-by-modal -> zero reconcile fires over a multi-interval window; (b) covered-by-pushed-plain-screen -> zero fires; (c) resume -> reconcile fires within one interval of the cover being popped
+3. Implement: add 'not self.is_attached or not self.screen.is_active' to the _start_poll gate (precedent: UI/Navigation/main_navigation.py:469); timer keeps ticking, fire early-returns while covered, so every return path resumes on the next tick with no pause/resume bookkeeping
+4. Measure covered-state scans/min before/after at the production 1.5s cadence (scratch probe)
+5. Targeted file-notes suites + --collect-only sweep (tee'd), ./scripts/preflight.sh
+6. Mutation-test: remove the visibility gate -> covered probes red; force the gate to always skip -> resume probe red
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two-condition visibility gate added to `_start_poll`
+(`Widgets/Library/library_file_notes_workspace.py`): the 1.5 s timer fire now
+also early-returns on `not self.is_attached or not self.screen.is_active`,
+before any worker is spawned — so `to_thread(service.reconcile)` (the notes-root
+walk/stat) never runs while the workspace's screen is covered by a pushed
+modal/plain screen or is otherwise not top-of-stack. Precedent gate:
+`UI/Navigation/main_navigation.py` overflow tick.
+
+**Cadence decision (AC #2):** visibility gate + unchanged fixed 1.5 s cadence.
+Change-driven watching (FSEvents/watchdog) or a backoff schedule was considered
+and rejected: the finding's entire cost was the covered state, which the gate
+removes completely (40/min -> 0/min); a watcher adds an optional dependency and
+platform-specific failure modes, and backoff adds visible-state staleness — the
+owner's stability-over-cleverness ruling applies.
+
+**Resume semantics (AC #2):** the timer is never paused — each covered fire is a
+no-op costing a property check — so the resume path IS the still-ticking timer:
+the first tick after the screen is active again runs the catch-up reconcile,
+within one poll interval (measured 0.96 s after popping the cover at the
+production 1.5 s cadence). No pause/resume bookkeeping exists to miss a return
+path (screen resume and modal dismiss are both covered by the same re-admission).
+The tab-switch-away case needs no gate: `switch_screen` unmounts the Library
+screen, `on_unmount` stops the timer, and on return the remounted workspace's
+`_initialize` resuming path already performs an immediate `service.reconcile`
+catch-up before polling restarts.
+
+**Textual 8.2.8 semantics (verified in installed source):** `Screen.is_active`
+is `self.app.screen is self` (screen.py:557) where `App.screen` is
+`_screen_stack[-1]` (app.py:1627) — False both under a pushed modal AND for a
+plain pushed screen; `Screen.is_current` would wrongly stay True for background
+screens and was not used. `is_attached` (message_pump.py:270) guards the
+`self.screen` walk; `not self._active` stays first in the gate so a straggler
+fire during unmount never touches `self.screen`.
+
+**Measurements (AC #3, production 1.5 s cadence, covered by a modal):**
+before 10 reconcile fires / 15 s = 40.0/min; after 0 / 15 s = 0.0/min.
+
+**Probes/tests:** new parametrized
+`test_poll_reconcile_pauses_while_covered_and_resumes_on_return`
+(ModalScreen + plain Screen covers) in
+`Tests/UI/test_library_file_notes_workspace.py` — red-first against the old
+code (12x and 13x covered fires in 12 intervals), green after. Mutation
+results: gate removed -> both covered probes red (12x fires); visibility leg
+forced to never re-admit -> probe red at "poll did not reconcile while the
+screen was active". Targeted suites: workspace+git+git_push 336 passed /
+2 failed and journey+modal-dismissal+session-owner-lifecycle 211 passed /
+1 failed — all 3 failures proven pre-existing dev reds unrelated to this
+change (theme-contrast `high_contrast_yellow_black` 'Save failed' 3.33:1,
+reproduced with the gate Edit-reverted; and an AST pin on
+`LibraryScreen.on_unmount` broken by a dev-side `_library_conversation_
+reader_mounted_authority` assignment — file untouched here). Whole-tree
+`--collect-only`: 59,368 collected; 28 errors, all `No module named 'numpy'`
+optional-deps suites (numpy absent from this venv). `scripts/preflight.sh`
+fully green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -4828,8 +4828,18 @@ class LibraryFileNotesWorkspace(Vertical):
         self._apply_opened_document(reloaded)
 
     def _start_poll(self) -> None:
+        # TASK-22219: skip the filesystem walk while this widget's screen is
+        # not the top of the stack (covered by a modal/pushed screen, or the
+        # Library screen is otherwise inactive). The timer itself keeps
+        # ticking -- a no-op fire every interval costs nothing, and it IS the
+        # resume path: the first tick after the screen is active again runs
+        # the catch-up reconcile, so no pause/resume bookkeeping can rot.
+        # Same gate as UI/Navigation/main_navigation.py's overflow tick;
+        # Textual 8.2.8 `Screen.is_active` is `app.screen is self`.
         if (
             not self._active
+            or not self.is_attached
+            or not self.screen.is_active
             or self._root_transitioning
             or self._path_transitioning
             or self._service is None


### PR DESCRIPTION
From the 2026-08-24 holistic perf review (finding 22219). Once the File Notes surface is opened, a 1.5 s timer ran a filesystem walk/stat of the notes root 40×/min for the Library screen's lifetime — including under modals and other screens.

**Change:** one gate in `_start_poll`: `not self.is_attached or not self.screen.is_active` (ordered after `_active` so a straggler fire during unmount never touches `self.screen`). The timer keeps ticking — the no-op fire IS the resume path, so no pause/resume bookkeeping can rot; first tick after re-activation runs the catch-up reconcile. `is_active` semantics proven from installed Textual 8.2.8 source (`app.screen is self` — False under pushed modals AND pushed screens; the composer-blink `has_focus_within` mistake explicitly avoided, covered-by-modal asserted in the test). Switched-away tabs need no gate: unmount stops the timer; remount's `_initialize` already catch-up-reconciles.

**Measured:** covered by modal — **40.0 reconciles/min → 0.0**; resume fires 0.96 s after the cover pops (within one interval). Cadence deliberately unchanged (visibility gate removes 100% of the covered cost; watchers/backoff rejected under the stability ruling).

Controller-verified (gate diff read; parametrized modal+screen-cover probe green; mutations both directions red; 336+211 targeted green with 3 pre-existing dev reds baselined, incl. a contrast regression and a stale AST pin worth follow-up). Rebased cleanly; probe re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1