### PR TITLE
fix(ci,console): stop cancelling PR test runs; report hangs instead of killing them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,20 @@ on:
 # so its history stays complete.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # TASK-22250: cancel superseded PUSH runs, never a pull_request run.
+  #
+  # This suite is the slowest in the repo (12 UI shards + 6 core shards, ~35
+  # min each). Cancelling pull_request runs on every push to the branch meant
+  # an actively-worked PR effectively never produced a verdict: measured on
+  # #2078, each push cancelled the previous batch wholesale -- 20 checks killed
+  # at once -- and the cancellation timestamp of each batch matched the
+  # creation timestamp of the next. That is why `Tests` has reported nothing
+  # since 2026-06-26 while short workflows report fine.
+  #
+  # The exception proves it: `derived-artifacts.yml` already scopes
+  # cancellation to `push` only, and it is the one required check that
+  # consistently survives to report. This adopts that same rule.
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,15 @@ concurrency:
   # The exception proves it: `derived-artifacts.yml` already scopes
   # cancellation to `push` only, and it is the one required check that
   # consistently survives to report. This adopts that same rule.
+  #
+  # Scope, precisely: this protects a RUNNING pull_request batch. GitHub
+  # concurrency keeps one running plus one PENDING member per group, and a
+  # third arrival still replaces the pending one -- `cancel-in-progress`
+  # cannot prevent that. Only a per-run group (e.g. including `github.run_id`)
+  # would, and that would also stop superseding obsolete commits while
+  # multiplying queue pressure that is already the bottleneck here. Killing a
+  # QUEUED run costs nothing and yields the newer commit's verdict; killing a
+  # RUNNING batch throws away up to 35 minutes per shard for nothing.
   cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -243,8 +243,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 51,
-      "diagnostic_digest": "4a06156c02dffecef8e0",
+      "call_count": 52,
+      "diagnostic_digest": "9470774591ce409dfb1a",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -3968,7 +3968,7 @@
   "summary": {
     "owner_files": 537,
     "persistent_sink_files": 8,
-    "task_492_calls": 1240,
+    "task_492_calls": 1241,
     "task_494_calls": 7338
   }
 }

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -465,8 +465,21 @@ def test_the_test_summary_job_can_actually_fail() -> None:
     )
 
 
-def test_a_pull_request_run_is_never_cancelled_by_a_later_push() -> None:
-    """TASK-22250: superseding PR runs is why `Tests` never reports.
+def test_an_in_flight_pull_request_run_is_not_cancelled_mid_run() -> None:
+    """TASK-22250: superseding RUNNING PR runs is why `Tests` never reports.
+
+    Scope, stated precisely because the first version of this test overclaimed:
+    this guarantees only that a PR run already EXECUTING is not killed
+    mid-flight. GitHub concurrency keeps one running plus one *pending* member
+    per group, and a third arrival still replaces the pending one -- so a PR run
+    can be cancelled while queued, and `cancel-in-progress` cannot prevent that.
+    Making the group unique per run would, but it would also stop superseding
+    obsolete commits and multiply queue pressure that is already this repo's
+    bottleneck (runs observed queued 20+ minutes before starting).
+
+    Killing a queued run costs nothing and yields the newer commit's verdict,
+    which is what you want. Killing a RUNNING batch throws away up to 35 minutes
+    per shard and produces no verdict at all. Only the second is the defect.
 
     This is the slowest workflow in the repo -- 12 UI shards plus 6 core
     shards at roughly 35 minutes each. With `cancel-in-progress` applying to
@@ -492,8 +505,8 @@ def test_a_pull_request_run_is_never_cancelled_by_a_later_push() -> None:
     )
     assert "github.event_name == 'push'" in cancel_line, (
         "cancel-in-progress must be scoped to push events; cancelling a "
-        "pull_request run is what stopped this workflow reporting. Line: "
-        f"{cancel_line.strip()!r}"
+        "RUNNING pull_request run mid-flight is what stopped this workflow "
+        f"reporting. Line: {cancel_line.strip()!r}"
     )
     assert "github.ref != 'refs/heads/main'" in cancel_line, (
         f"main must never be cancelled. Line: {cancel_line.strip()!r}"

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -463,3 +463,38 @@ def test_the_test_summary_job_can_actually_fail() -> None:
         "the verdict must be the final step, after the PR comment is posted; "
         f"steps end with {step_names[-2:]}"
     )
+
+
+def test_a_pull_request_run_is_never_cancelled_by_a_later_push() -> None:
+    """TASK-22250: superseding PR runs is why `Tests` never reports.
+
+    This is the slowest workflow in the repo -- 12 UI shards plus 6 core
+    shards at roughly 35 minutes each. With `cancel-in-progress` applying to
+    `pull_request` events, every push to a branch killed the batch already
+    running for that branch's PR, so an actively-worked PR never produced a
+    verdict at all.
+
+    Measured on PR #2078: one push cancelled 20 checks at once (all 6 core
+    shards, all 12 UI shards, MCP min-Textual, an artifact-lease leg), and
+    each batch's cancellation timestamp matched the NEXT batch's creation
+    timestamp -- supersession, not an external agent.
+
+    `derived-artifacts.yml` already scopes cancellation to `push` only, and it
+    is the one required check that reliably survives to report. That is the
+    precedent this pins.
+
+    A push run may still be superseded: pushing again genuinely obsoletes the
+    previous commit's run. `main` is never cancelled either way.
+    """
+    concurrency = _workflow_text().split("concurrency:", 1)[1].split("permissions:", 1)[0]
+    cancel_line = next(
+        line for line in concurrency.splitlines() if "cancel-in-progress:" in line
+    )
+    assert "github.event_name == 'push'" in cancel_line, (
+        "cancel-in-progress must be scoped to push events; cancelling a "
+        "pull_request run is what stopped this workflow reporting. Line: "
+        f"{cancel_line.strip()!r}"
+    )
+    assert "github.ref != 'refs/heads/main'" in cancel_line, (
+        f"main must never be cancelled. Line: {cancel_line.strip()!r}"
+    )

--- a/Tests/Chat/test_console_durable_commit_diagnostics.py
+++ b/Tests/Chat/test_console_durable_commit_diagnostics.py
@@ -1,0 +1,125 @@
+"""A failed durable commit must say WHICH failure occurred (TASK-22251).
+
+`_submit_draft_inner` wraps `commit_durable_turn` in `except Exception:` and
+returns one generic sentence -- "Couldn't save the prepared turn. Retry or
+cancel." -- for every way that multi-step transaction can fail: conversation
+create, Library-policy write, workspace validation, checkpoint insert.
+
+The copy is fine. Discarding the exception is not. Two distinct causes were
+found behind that identical message while burning down Console tests
+("Workspace registry is required for workspace conversations" and "Unknown
+workspace: <id>"), and identifying each required adding a temporary `print`
+inside production. A failure nobody can attribute without editing the product
+is a diagnostic defect, not a user-experience one.
+
+These tests pin both halves: the type IS recorded, and the exception's message
+is NOT (it can carry conversation and workspace identifiers).
+"""
+
+from __future__ import annotations
+
+import pytest
+from loguru import logger as loguru_logger
+
+from Tests.console_provider_doubles import provider_resolution
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+class _Gateway:
+    """Ready provider that streams one chunk."""
+
+    async def resolve_for_send(self, selection):
+        return provider_resolution()
+
+    async def stream_chat(self, resolution, messages, **kwargs):
+        yield "reply"
+
+
+class _CapturedLines:
+    """Collect loguru records without disturbing the ambient sinks."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self._sink_id: int | None = None
+
+    def __enter__(self) -> "_CapturedLines":
+        self._sink_id = loguru_logger.add(
+            lambda message: self.lines.append(str(message)),
+            level="TRACE",
+            diagnose=False,
+        )
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        if self._sink_id is not None:
+            try:
+                loguru_logger.remove(self._sink_id)
+            except ValueError:
+                pass
+
+    def matching(self, needle: str) -> list[str]:
+        return [line for line in self.lines if needle in line]
+
+
+#: A value that must never be logged: it stands in for the conversation and
+#: workspace identifiers a real commit failure puts in its exception message.
+SECRET_IDENTIFIER = "ws-private-4f2a-identifier"
+
+
+class _ExplodingPersistence:
+    """Persistence whose durable commit fails with an identifying message."""
+
+    db = None
+
+    def commit_durable_turn(self, *args, **kwargs):
+        raise ValueError(f"Unknown workspace: {SECRET_IDENTIFIER}")
+
+
+def _controller_with_failing_commit():
+    store = ConsoleChatStore(persistence=_ExplodingPersistence())
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_Gateway(),
+        provider="llama_cpp",
+        model="test-model",
+        agent_runtime_enabled=False,
+    )
+    return controller, store
+
+
+@pytest.mark.asyncio
+async def test_a_failed_durable_commit_records_the_exception_type() -> None:
+    """The refusal is attributable from logs alone, with no product edit."""
+    controller, _store = _controller_with_failing_commit()
+
+    with _CapturedLines() as captured:
+        result = await controller.submit_draft("capital of Japan?")
+
+    assert result.accepted is False
+    assert "Couldn't save the prepared turn" in (result.visible_copy or "")
+
+    recorded = captured.matching("Durable turn commit failed")
+    assert recorded, (
+        "a swallowed durable-commit failure left no trace; the refusal is "
+        "unattributable without editing production. Lines seen: "
+        f"{[line[:90] for line in captured.lines][-5:]}"
+    )
+    assert any("ValueError" in line for line in recorded), (
+        f"the exception TYPE was not recorded: {[l[:120] for l in recorded]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_failure_log_does_not_leak_the_exception_message() -> None:
+    """Type only. A commit exception can name a conversation or workspace."""
+    controller, _store = _controller_with_failing_commit()
+
+    with _CapturedLines() as captured:
+        await controller.submit_draft("capital of Japan?")
+
+    leaked = [line for line in captured.lines if SECRET_IDENTIFIER in line]
+    assert not leaked, (
+        "the durable-commit failure log leaked the exception message, which "
+        f"carries caller identifiers: {[line[:140] for line in leaked]}"
+    )

--- a/Tests/Chat/test_console_local_citation_boundary.py
+++ b/Tests/Chat/test_console_local_citation_boundary.py
@@ -428,8 +428,16 @@ def _persisted_store(
     persistence: _ReadyCitationPersistence | None = None,
 ) -> ConsoleChatStore:
     store = ConsoleChatStore(persistence=persistence)
-    session = store.ensure_session(
-        settings=ConsoleSessionSettings(provider="llama_cpp")
+    # EPHEMERAL: these doubles record `create_message` calls, which is the
+    # citation-write seam under test. They predate `commit_durable_turn`, so a
+    # non-ephemeral MANUAL send is refused before any provider call -- and the
+    # tests then wait forever on an Event the refused turn never sets.
+    # `durable_turn = not session.ephemeral and origin in {MANUAL, QUEUED}`, so
+    # an ephemeral session keeps the send on the `create_message` path these
+    # doubles actually observe.
+    session = store.create_session(
+        settings=ConsoleSessionSettings(provider="llama_cpp"),
+        ephemeral=True,
     )
     session.project_instruction_state = (
         ProjectInstructionControlState.legacy_disabled()
@@ -1118,13 +1126,6 @@ async def test_direct_non_success_does_not_seal_and_clears_terminal_state(
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="TASK-22062: this test never completes -- its coroutine awaits "
-    "something that is never resolved. With timeout_method='thread' the "
-    "300s timeout destroys the whole pytest process rather than failing "
-    "the test, so leaving it in place deletes the results of every other "
-    "test sharing its worker."
-)
 async def test_direct_user_stop_does_not_seal_and_clears_terminal_state():
     builder, prompt_id = _citation_builder()
     persistence = _ReadyCitationPersistence()

--- a/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
+++ b/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
@@ -1,0 +1,105 @@
+---
+id: task-22250
+title: CI runs are swept by simultaneous burst cancellations
+status: In Progress
+labels:
+  - ci
+  - infrastructure
+priority: high
+---
+
+## Description
+
+Whole sets of CI checks are cancelled at the same instant, unrelated to the code
+under test. This is the reason `test.yml` has produced no verdict since
+2026-06-26, and it survives the sharding work: the shards themselves are fine,
+they simply never get to finish.
+
+Two observations from PR #2061 on 2026-08-24:
+
+**Before re-running** — two runs on head `4204db845` were both killed at
+20:33:2x despite wildly different durations (Derived Artifacts 4.7 min; GGUF
+source ubuntu 20.1 min). Identical kill time across unrelated workflows with
+unrelated runtimes is not a timeout and not a code failure.
+
+**After re-running** — head `de126e038` reached `Tests` executing for the first
+time under the new sharding (6 core shards + 12 UI shards), and **20 checks were
+cancelled simultaneously**: all 6 core shards, all 12 UI shards, MCP min-Textual,
+and one artifact-lease leg. The required check
+(`Derived artifacts reproduce from their sources`) survived and passed.
+
+Note this is NOT the `cancel-in-progress` concurrency rule: a push-triggered run
+on a stable ref was swept too, so a `cancel-in-progress` change alone would not
+fix it (this is why the proposed workflow edit was put on hold).
+
+## Acceptance Criteria
+
+- [ ] The agent performing the cancellations is identified (account concurrency
+      ceiling, manual queue clearing, or workflow configuration)
+- [ ] A PR's test workflows can run to completion without being swept
+- [ ] `Tests` produces a verdict on at least one PR
+
+## Implementation Notes
+
+Needs owner input: the cancellations originate outside the workflow files, so
+they cannot be diagnosed from the repository alone. Candidates worth checking in
+order — the account's concurrent-job ceiling (macOS runners are already scarce
+and one UI shard has been observed queueing ~90 min), someone clearing the
+Actions queue by hand, and org-level runner policy.
+
+Until this is resolved, "re-run the cancelled checks" is the only available
+mitigation, and it is not reliable: the second attempt on #2061 was swept more
+broadly than the first.
+
+
+## Update 2026-08-26 — cause identified and half fixed
+
+**The cancellations were `cancel-in-progress`, not an external agent.** My
+earlier note here argued the opposite, on the grounds that a push-triggered run
+on a stable ref was swept too. That reasoning was wrong: a later push to the same
+ref supersedes the earlier push run, same concurrency group. The Actions API
+shows each batch's cancellation timestamp matching the NEXT batch's creation
+timestamp.
+
+Fixed in PR #2102 by scoping `test.yml`'s cancellation to `push` events only,
+matching `derived-artifacts.yml` — which already did this and was, not
+coincidentally, the one required check that reliably survived to report.
+
+Confirmed empirically on #2102's own CI. Pushing `40c7f2d9` superseded
+`2f10322d`; on the superseded head, same push and same instant:
+
+| workflow | rule | outcome |
+|---|---|---|
+| Tests (fixed) | push-only | queued — survived |
+| Derived Artifacts | push-only | queued — survived |
+| Perf Guard | blanket | cancelled |
+| CSS Bundle Guard | blanket | cancelled |
+| Backlog Guard | blanket | cancelled |
+
+Scope, precisely: this protects a RUNNING batch. GitHub concurrency keeps one
+running plus one PENDING member per group, and a third arrival still replaces the
+pending one — observed on this PR. Only a per-run group would prevent that, at
+the cost of never superseding obsolete commits.
+
+## The other half: runner starvation — still open, owner input needed
+
+Cancellation was one cause of the missing verdicts. It is not the only one.
+
+Measured 2026-08-26 while #2102 waited: **8 runs queued repo-wide for 23–40
+minutes with ZERO in progress.** Nothing was cancelled and nothing was running.
+
+The repo is public and user-owned. GitHub Actions concurrency is billed and
+limited **per account, not per repository**, so runs here can be starved by other
+repositories or branches under the same account. That cannot be diagnosed from
+inside this repo.
+
+What the owner would need to check:
+- the account's concurrent-job ceiling and what is consuming it
+- whether other repositories under `rmusser01` are running Actions concurrently
+- any spending limit or billing state affecting Actions
+
+Note the interaction: with cancellation now scoped to push, a superseded PR run
+keeps its queue position and the newer run waits behind it, so under starvation
+both eventually run rather than one replacing the other. That is correct for
+getting verdicts but doubles runner demand for a branch under active work —
+which matters only while starvation persists.

--- a/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
+++ b/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
@@ -103,3 +103,50 @@ keeps its queue position and the newer run waits behind it, so under starvation
 both eventually run rather than one replacing the other. That is correct for
 getting verdicts but doubles runner demand for a branch under active work —
 which matters only while starvation persists.
+
+
+## Update 2026-08-26 (second) — there IS a second cancellation source
+
+The supersession finding above is correct but does not explain everything. A
+second, distinct mechanism is now documented, and it is the one the original
+title described.
+
+Measured on `fix/task-22251-findings` at head `d86e82800`, with **no newer
+commit** (local and remote both at that SHA):
+
+| workflow | timeout-minutes | job started | job cancelled | ran for |
+|---|---|---|---|---|
+| Perf Guard | 15 | 02:02:52 | 02:07:37 | 4m45s |
+| CSS Bundle Guard | none (default 360) | 02:02:51 | 02:07:38 | ~4m47s |
+| Backlog Guard | none (default 360) | 02:02:51 | 02:07:40 | ~4m49s |
+| TASK-2062.1 / .2 GGUF | — | 02:02:51 | 02:07:39-40 | ~4m48s |
+
+These were **running** jobs, killed within ~3 seconds of each other, roughly 5
+minutes in. Not supersession — nothing superseded them. Not `timeout-minutes` —
+one had 15 minutes, the others had the 6-hour default.
+
+The same shape appeared on an unrelated branch (`fix/setup-wizard-uat`, batch
+created 01:38:43): guards and GGUF cancelled, `Derived Artifacts` in progress,
+`Tests` queued. So it is systematic, not branch-specific.
+
+Also observed in the same window: 8 runs queued repo-wide for 23-40 minutes with
+**zero** in progress, then capacity returning.
+
+### What this needs from the owner
+
+The repo is public and user-owned; Actions concurrency and billing are
+**per-account**, so nothing inside this repository can identify the source.
+Worth checking, in order:
+
+- the account's concurrent-job ceiling, and what else under `rmusser01` consumes it
+- Actions spending limit / billing state (a hit limit can stop and cancel jobs)
+- whether any automation, bot, or another session calls the cancel-workflow API
+- GitHub's own status for the relevant runner pools during these windows
+
+### What is NOT the cause (ruled out with evidence)
+
+- `timeout-minutes` — one victim had 15 min, others the 6h default, all died at ~5 min
+- supersession by a later push — local and remote were the same SHA
+- the `cancel-in-progress` rule — `Derived Artifacts` and `Tests`, which are
+  push-scoped, were not hit in this burst while the blanket-rule ones were;
+  but note that is correlation observed once, not a mechanism

--- a/backlog/tasks/task-22300 - Rewind summarize guard test is order-dependent under xdist.md
+++ b/backlog/tasks/task-22300 - Rewind summarize guard test is order-dependent under xdist.md
@@ -1,0 +1,44 @@
+---
+id: task-22300
+title: Rewind summarize guard test is order-dependent under xdist
+status: To Do
+labels:
+  - tests
+  - flake
+priority: low
+---
+
+## Description
+
+`Tests/UI/test_console_rewind_restore.py::test_summarize_choice_guards_against_changed_active_session`
+passes or fails depending on what else runs alongside it, not on the code under
+test.
+
+Evidence — the same unmodified baseline commit produced both outcomes across two
+separate `-n 2` runs of the same file set:
+
+| run | tree under test | result |
+|---|---|---|
+| `newDevBase` | clean `dev` | FAIL |
+| `findBase` | clean `dev` | pass |
+
+In isolation it passes 5/5, and its own file passes 22/22. Only the parallel
+run flips it.
+
+This wasted real time twice. It was first dismissed as a flake on the strength
+of "passes in isolation" alone — which was wrong, it had a genuine cause then
+(a missing durable DB, fixed in #2078). It now flips on identical code, which
+is what actually establishes non-determinism.
+
+## Acceptance Criteria
+
+- [ ] The test produces the same result regardless of what runs beside it
+- [ ] The shared state or timing assumption behind the order-dependence is named
+- [ ] It passes 10/10 consecutive `-n 2` runs of its file set
+
+## Implementation Notes
+
+Do not "fix" this by re-running until green or by marking it flaky. "Passes in
+isolation" is not evidence of no cause; the evidence that matters is the same
+code producing different outcomes. Look for state shared across the worker —
+the active-session pointer this test guards is a plausible candidate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -565,8 +565,17 @@ addopts = "--ignore=STests --import-mode=importlib --durations=25 --durations-mi
 asyncio_mode = "auto"
 # Default timeout for all tests (in seconds)
 timeout = 300
-# Timeout method: thread (default) or signal
-timeout_method = "thread"
+# Timeout method: DELIBERATELY UNSET (TASK-22062). pytest-timeout picks
+# `signal` where SIGALRM exists (Linux, macOS) and falls back to `thread` on
+# Windows. The previous explicit `thread` was set on the belief -- recorded in
+# the comment it replaced -- that thread was the library default. It is not.
+#
+# It matters because `thread` cannot interrupt a blocked thread: when the
+# timeout fires it destroys the pytest process, so no JUnit is written, no test
+# is named as failing, and under xdist the worker dies and takes its queued
+# tests with it as setup errors. Measured on one real hang in
+# `test_console_local_citation_boundary`: with `thread` no JUnit file was
+# produced at all; with `signal` the same hang reported as exactly one failure.
 markers = [
     "unit: marks tests as unit tests",
     "integration: marks tests as integration tests",

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -5682,7 +5682,21 @@ class ConsoleChatController:
             commit = await self._run_durable_db_call(
                 self.store.commit_durable_turn, acceptance
             )
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 -- a failed commit is a retry, not a crash
+            # TASK-22251: the user-facing copy stays deliberately generic, but
+            # something must record WHICH failure occurred. `commit_durable_turn`
+            # is a multi-step transaction -- conversation create, Library-policy
+            # write, workspace validation, checkpoint insert -- and swallowing
+            # the exception collapsed every one of them into a single sentence.
+            # Two distinct causes ("Workspace registry is required for workspace
+            # conversations" and "Unknown workspace: <id>") were previously
+            # indistinguishable, and each needed a temporary print inside this
+            # method to identify. Type only, never the message: an exception
+            # string here can carry conversation or workspace identifiers.
+            logger.warning(
+                "Durable turn commit failed; turn refused (exception_type={})",
+                type(exc).__name__,
+            )
             return ConsoleSubmitResult(
                 False,
                 False,


### PR DESCRIPTION
## Summary

Three findings from the Console test burn-down, each fixed with its own evidence.
Two of them correct diagnoses I had recorded wrongly.

## TASK-22250 — `Tests` has produced no verdict since 2026-06-26

`cancel-in-progress` applied to `pull_request` events, so every push to a branch
killed the batch already running for that branch's PR. This is the repo's slowest
workflow — 12 UI shards plus 6 core shards at ~35 min each — so an actively-worked
PR never finished one.

Measured on #2078: a single push cancelled **20 checks at once**, and each batch's
cancellation timestamp matched the **next** batch's creation timestamp. That is
supersession, not an external agent.

**The exception proves it.** `derived-artifacts.yml` already scopes cancellation to
`push` only, and it is the one required check that reliably survives to report.
`test.yml` now adopts the same rule. Push runs may still be superseded — pushing
again genuinely obsoletes the previous commit's run — and `main` is never cancelled.

> **Correction.** I previously argued this was *not* `cancel-in-progress`, on the
> grounds that a push-triggered run on a stable ref was swept too. That reasoning
> was wrong: a later push to the same ref supersedes the earlier push run, same
> concurrency group. This fix sat unmade for a cycle because of it.

## TASK-22062 — a hanging test destroyed the whole run

`timeout_method = "thread"` was set explicitly, with a comment claiming thread is
the library default. It is not — pytest-timeout uses `signal` wherever SIGALRM
exists. It matters because `thread` **cannot interrupt a blocked thread**: when the
timeout fires the pytest process dies, so no JUnit is written, nothing is named as
failing, and under xdist the worker takes its queued tests with it as setup errors.

Measured on a real hang:

| method | JUnit written | outcome |
|---|---|---|
| `thread` (was set) | **no** — process destroyed | results silently lost |
| default (`signal` on Unix) | yes | 1 failure, named |

Removing the override is the minimal fix: Unix gets `signal`, Windows still gets
`thread` automatically, so there is no platform risk. There are **661 unbounded
`await <event>.wait()` calls** in `Tests/`, each of which was a potential run-killer.

> **Correction.** The task recorded this as a coroutine awaiting something never
> resolved — implying a product deadlock. It was not. `_ReadyCitationPersistence`
> predates `commit_durable_turn`, so the send was refused and the test waited
> forever on an Event the refused turn never set: the same stale-double class as
> the rest of the burn-down, with a failure mode that hangs instead of asserting.

Its store now creates an **ephemeral** session — production's own carve-out
(`durable_turn = not session.ephemeral and origin in {MANUAL, QUEUED}`) — which
keeps the send on the `create_message` seam those doubles observe.
`test_console_local_citation_boundary` was previously unmeasurable; it now reports
95 tests and went from **83 failures to 69**, none newly broken.

## TASK-22251 — an unattributable failure

A failed durable commit discarded its exception, collapsing every way that
multi-step transaction can fail — conversation create, Library-policy write,
workspace validation, checkpoint insert — into one sentence. Two distinct causes
hid behind it, and identifying each required adding a temporary `print` **inside
production**.

Now logged by **type only**: an exception message here can name a conversation or
workspace. Two tests pin both halves, each mutation-proven — removing the log turns
one red, logging the full exception turns the other red.

## Verification

A/B against clean `dev`, same file set both sides:

| | clean `dev` | this branch |
|---|---|---|
| collected | 2217 | 2220 (+3 new tests) |
| failures | 51 | 52 |
| newly broken | — | **0** |

The one apparent regression,
`test_console_rewind_restore::test_summarize_choice_guards_against_changed_active_session`,
is order-dependent under xdist and filed as TASK-22300. The evidence is that the
**same unmodified baseline commit** produced both outcomes across two runs
(`newDevBase` FAIL, `findBase` pass); it passes 5/5 in isolation and 22/22 in its
own file. Noting explicitly because I called this one a flake once before on weaker
evidence and was wrong then — "passes in isolation" shows non-determinism, not
absence of cause.

`./scripts/preflight.sh` passes all five derived-artifact checks. The diagnostic
inventory was regenerated only after reading the single added row as the tool
instructs: one `logger.warning` interpolating `type(exc).__name__` — no user
content, secret, path or URL.
