### PR TITLE
test(library): repair Prompt baseline contracts (TASK-19602)

### DIFF
--- a/Tests/Library/test_library_prompts_state.py
+++ b/Tests/Library/test_library_prompts_state.py
@@ -1789,10 +1789,10 @@ def test_outcome_first_recipe_has_stable_blank_markdown_blocks_in_both_lanes():
     )
     assert tuple(block.id for block in first.lanes[1].blocks) == (
         "goal",
-        "success-criteria",
         "context-evidence",
         "constraints",
         "output",
+        "success-criteria",
         "stop-rules",
     )
     assert all(

--- a/Tests/UI/test_library_prompt_collections.py
+++ b/Tests/UI/test_library_prompt_collections.py
@@ -2114,7 +2114,14 @@ async def test_library_screen_collection_manager_selects_exact_browse_scope(tmp_
 
 @pytest.mark.asyncio
 async def test_real_library_screen_collection_manager_crosses_sqlite_page_100(tmp_path):
-    _db, service = _real_prompt_scope_service(tmp_path)
+    db, service = _real_prompt_scope_service(tmp_path)
+    db.add_prompt(
+        name="Collection paging prompt",
+        author="A",
+        details="Keeps the populated-list collection control mounted.",
+        system_prompt="System",
+        user_prompt="User",
+    )
     created = []
     for index in range(1, 108):
         created.append(
@@ -2299,10 +2306,27 @@ async def test_library_screen_manager_create_search_rename_and_explicit_all(tmp_
             ),
             message="renamed collection never became the active filter",
         )
-        await _wait_for_selector(screen, pilot, "#library-prompts-collection")
-        assert (
-            str(screen.query_one("#library-prompts-collection", Button).label)
-            == f"collection: {renamed_name}"
+        await _wait_for_selector(
+            screen, pilot, "#library-prompts-empty-collection-label"
+        )
+        assert len(screen.query("#library-prompts-collection")) == 0
+        assert renamed_name in str(
+            screen.query_one(
+                "#library-prompts-empty-collection-label", Static
+            ).renderable
+        )
+
+        screen.query_one("#library-prompts-empty-all-prompts", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_prompt_browse_controller.scope.collection_id is None
+                and screen._library_prompt_browse_controller.applied_result is not None
+                and screen._library_prompt_browse_controller.applied_result.scope.collection_id
+                is None
+                and len(screen.query("#library-prompts-collection")) == 1
+            ),
+            message="empty collection recovery did not restore All prompts",
         )
 
         screen.query_one("#library-prompts-collection", Button).press()
@@ -2326,14 +2350,11 @@ async def test_library_screen_manager_create_search_rename_and_explicit_all(tmp_
             lambda: _active_library_screen(host) is screen,
             message="filtered manager did not close",
         )
-        assert (
-            screen._library_prompt_browse_controller.scope.collection_id
-            == collection_id
-        )
+        assert screen._library_prompt_browse_controller.scope.collection_id is None
         await _wait_for_selector(screen, pilot, "#library-prompts-collection")
         assert (
             str(screen.query_one("#library-prompts-collection", Button).label)
-            == f"collection: {renamed_name}"
+            == "collection: All prompts"
         )
 
         screen.query_one("#library-prompts-collection", Button).press()

--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -3082,11 +3082,10 @@ async def test_library_prompt_canvas_receives_retained_pager_on_sync(size) -> No
         ]
     )
     app.prompt_scope_service = service
-    async with app.run_test(size=size) as pilot:
-        assert type(app) is TldwCli
-        assert app.CSS_PATH == TldwCli.CSS_PATH
-        screen = LibraryScreen(app)
-        await app.push_screen(screen)
+    host = LibraryProductionCSSHarness(app)
+    async with host.run_test(size=size) as pilot:
+        assert host.CSS_PATH == TldwCli.CSS_PATH
+        screen = _active_library_screen(host)
         try:
             await _wait_for_library_shell(screen, pilot)
             screen.query_one("#library-row-browse-prompts", Button).press()
@@ -3125,7 +3124,7 @@ async def test_library_prompt_canvas_receives_retained_pager_on_sync(size) -> No
             ):
                 widget = screen.query_one(selector)
                 assert pane.region.contains_region(widget.region), selector
-                assert widget in app.screen._compositor.visible_widgets, selector
+                assert widget in host.screen._compositor.visible_widgets, selector
             for selector in (
                 "#library-prompts-page-previous",
                 "#library-prompts-page-next",
@@ -3149,7 +3148,7 @@ async def test_library_prompt_canvas_receives_retained_pager_on_sync(size) -> No
                 lambda: all(
                     pane.region.contains_region(screen.query_one(selector).region)
                     and screen.query_one(selector)
-                    in app.screen._compositor.visible_widgets
+                    in host.screen._compositor.visible_widgets
                     for selector in (
                         "#library-prompts-header",
                         "#library-prompts-page-label",
@@ -3174,7 +3173,7 @@ async def test_library_prompt_canvas_receives_retained_pager_on_sync(size) -> No
             ):
                 widget = screen.query_one(selector)
                 assert pane.region.contains_region(widget.region), selector
-                assert widget in app.screen._compositor.visible_widgets, selector
+                assert widget in host.screen._compositor.visible_widgets, selector
             previous = screen.query_one("#library-prompts-page-previous", Button)
             next_page = screen.query_one("#library-prompts-page-next", Button)
             assert previous.disabled is True
@@ -3203,12 +3202,11 @@ async def test_library_prompt_pager_first_and_filter_failure_states(size) -> Non
         browse_failures=1,
     )
     app.prompt_scope_service = service
+    host = LibraryProductionCSSHarness(app)
 
-    async with app.run_test(size=size) as pilot:
-        assert type(app) is TldwCli
-        assert app.CSS_PATH == TldwCli.CSS_PATH
-        screen = LibraryScreen(app)
-        await app.push_screen(screen)
+    async with host.run_test(size=size) as pilot:
+        assert host.CSS_PATH == TldwCli.CSS_PATH
+        screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         screen.query_one("#library-row-browse-prompts", Button).press()
         await _wait_for_condition(
@@ -3241,7 +3239,7 @@ async def test_library_prompt_pager_first_and_filter_failure_states(size) -> Non
         ):
             widget = screen.query_one(selector)
             assert pane.region.contains_region(widget.region), selector
-            assert widget in app.screen._compositor.visible_widgets, selector
+            assert widget in host.screen._compositor.visible_widgets, selector
         for selector in (
             "#library-prompts-page-previous",
             "#library-prompts-page-next",
@@ -3297,7 +3295,7 @@ async def test_library_prompt_pager_first_and_filter_failure_states(size) -> Non
         ):
             widget = screen.query_one(selector)
             assert pane.region.contains_region(widget.region), selector
-            assert widget in app.screen._compositor.visible_widgets, selector
+            assert widget in host.screen._compositor.visible_widgets, selector
 
 
 @pytest.mark.asyncio
@@ -3317,9 +3315,9 @@ async def test_library_prompt_clamped_next_focuses_filter_when_both_pages_disabl
         ]
     )
 
-    async with app.run_test(size=(100, 30)) as pilot:
-        screen = LibraryScreen(app)
-        await app.push_screen(screen)
+    host = LibraryHarness(app)
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         screen.query_one("#library-row-browse-prompts", Button).press()
         await _wait_for_condition(
@@ -3370,9 +3368,9 @@ async def test_library_prompt_page_focus_survives_loading_recompose() -> None:
     )
     app.prompt_scope_service = service
 
-    async with app.run_test(size=(100, 30)) as pilot:
-        screen = LibraryScreen(app)
-        await app.push_screen(screen)
+    host = LibraryHarness(app)
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         screen.query_one("#library-row-browse-prompts", Button).press()
         await _wait_for_condition(
@@ -3430,11 +3428,10 @@ async def test_library_prompt_pager_geometry_pages_and_focus(size) -> None:
         ]
     )
 
-    async with app.run_test(size=size) as pilot:
-        assert type(app) is TldwCli
-        assert app.CSS_PATH == TldwCli.CSS_PATH
-        screen = LibraryScreen(app)
-        await app.push_screen(screen)
+    host = LibraryProductionCSSHarness(app)
+    async with host.run_test(size=size) as pilot:
+        assert host.CSS_PATH == TldwCli.CSS_PATH
+        screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         screen.query_one("#library-row-browse-prompts", Button).press()
         await _wait_for_selector(screen, pilot, "#library-prompt-row-26")
@@ -3467,7 +3464,7 @@ async def test_library_prompt_pager_geometry_pages_and_focus(size) -> None:
         )
         for widget in (canvas, rows, pager, status, previous, next_page):
             assert pane.region.contains_region(widget.region), widget.id
-            assert widget in app.screen._compositor.visible_widgets, widget.id
+            assert widget in host.screen._compositor.visible_widgets, widget.id
         assert rows.region.bottom <= pager.region.y
 
         pager_identity = pager
@@ -3478,7 +3475,7 @@ async def test_library_prompt_pager_geometry_pages_and_focus(size) -> None:
         await _wait_for_condition(
             pilot,
             lambda: rows.scroll_y > 0
-            and last_row in app.screen._compositor.visible_widgets,
+            and last_row in host.screen._compositor.visible_widgets,
             message="Prompt row 20 never became compositor-visible.",
         )
         assert screen.query_one("#library-prompts-pager") is pager_identity
@@ -4187,8 +4184,8 @@ def test_library_prompt_scope_restore_validates_query_page_offset_and_page_size(
 
 
 @pytest.mark.asyncio
-async def test_library_prompts_restored_create_row_list_dispatches_browse_once():
-    """A restored create-row/list state settles one exact browse request."""
+async def test_library_prompts_restored_create_row_list_stays_on_landing():
+    """A non-resumable create-row state does not bypass the Library landing."""
     app = _build_test_app()
     _wire_empty_non_prompt_services(app)
     service = _FakePromptScopeServiceWithList(
@@ -4207,23 +4204,12 @@ async def test_library_prompts_restored_create_row_list_dispatches_browse_once()
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
-        await _wait_for_selector(screen, pilot, "#library-prompt-row-5")
         await pilot.pause(0.1)
 
-        assert screen._library_selected_row_id == LIBRARY_ROW_CREATE_PROMPT
+        assert screen._library_selected_row_id == ""
         assert screen._library_prompts_view == "list"
-        assert screen._library_prompt_browse_controller.result.status == "ready"
-        assert service.browse_calls == [
-            {
-                "mode": "local",
-                "query": "",
-                "collection_id": None,
-                "sort_by": "last_modified",
-                "sort_order": "desc",
-                "page": 1,
-                "page_size": 20,
-            }
-        ]
+        assert len(screen.query("#library-hub-continue")) == 0
+        assert service.browse_calls == []
 
 
 @pytest.mark.asyncio
@@ -4269,8 +4255,13 @@ async def test_library_prompts_fresh_reentry_refetches_the_applied_scope_once():
 
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-hub-continue")
+        assert screen._library_selected_row_id == ""
+        screen.query_one("#library-hub-continue", Button).press()
         await _wait_for_prompt_browse_scope(screen, pilot, scope)
 
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_PROMPTS
         assert service.browse_calls == [
             {
                 "mode": "local",

--- a/backlog/tasks/task-19602 - PR-1893-library-first-run-power-user-workflows-re-broke-the-library-prompts-canvas-suite.md
+++ b/backlog/tasks/task-19602 - PR-1893-library-first-run-power-user-workflows-re-broke-the-library-prompts-canvas-suite.md
@@ -3,10 +3,11 @@ id: TASK-19602
 title: >-
   PR #1893 (library first-run/power-user workflows) re-broke the
   library-prompts-canvas suite
-status: In Progress
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-21'
-updated_date: '2026-08-21'
+updated_date: '2026-08-26 00:41'
 labels:
   - ci
   - library
@@ -50,11 +51,28 @@ clean-worktree reproduction is deterministic.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `test_library_prompts_canvas.py` is green on a clean dev checkout (full file, single run).
-- [ ] #2 The `app_config` AttributeError is resolved at the correct seam (production guard or harness provision — not a blind `getattr` swallow).
-- [ ] #3 The workspace-registry readiness path either does not gate the prompts canvas in a host without a registry, or the harness readies it; the decision is recorded in the PR.
-- [ ] #4 The TASK-18611 trio stays green (no regression of PR #1849's fix).
+- [x] #1 `test_library_prompts_canvas.py` is green on a clean dev checkout (full file, single run).
+- [x] #2 The `app_config` AttributeError is resolved at the correct seam (production guard or harness provision — not a blind `getattr` swallow).
+- [x] #3 The workspace-registry readiness path either does not gate the prompts canvas in a host without a registry, or the harness readies it; the decision is recorded in the PR.
+- [x] #4 The TASK-18611 trio stays green (no regression of PR #1849's fix).
+- [x] #5 Prompt Recipe block-order tests reflect the accepted outcome-first essential/optional ordering.
+- [x] #6 Collection-manager tests exercise the manager from populated or explicit empty-collection recovery states without contradicting the distilled empty-state contract.
+- [x] #7 Prompt re-entry tests reflect the explicit Library landing/Continue receipt contract and still prove exact one-request scope restoration.
+- [x] #8 Production-CSS pager geometry tests run in a deterministic single-Library-screen harness and remain green at both required terminal sizes.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the focused Library Prompt baseline on latest dev and classify every failure as product defect, stale contract, or harness race.
+2. Align stale Recipe, collection, Continue-landing, and production-CSS harness expectations with their accepted contracts; keep production behavior unchanged.
+3. Run the focused failures, the complete affected test files, and static checks; document exact evidence.
+4. Self-review the diff and update the task acceptance criteria and implementation notes.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a test-baseline repair implementing already accepted UI and persistence contracts; it introduces no architectural decision.
+<!-- SECTION:PLAN:END -->
 
 ## Notes
 
@@ -244,3 +262,12 @@ applied_scope_once -- dispatch/refetch counting; plus the known
 cross-suite order flakes (combined three-file runs surface them; CI
 shards files separately). File under TASK-18610's remainder or a new
 task.
+
+## Implementation Notes (2026-08-25 baseline closeout)
+
+- Aligned the Recipe test with the accepted outcome-first ordering: essential user blocks precede optional Success criteria.
+- Kept collection-manager coverage honest under the distilled empty-state contract by seeding the paging case and exercising the empty-collection “All prompts” recovery path before reopening the manager. The recovery wait now observes the applied browse scope, removing a requested/applied race.
+- Reframed saved Prompt re-entry around the explicit Library landing/Continue receipt contract: non-resumable create state stays on the landing page, while an authoritative applied Prompt scope continues and refetches exactly once.
+- Moved Prompt pager/focus integrations from the full `TldwCli` startup lifecycle to the single-Library production-CSS harness. This preserves the exact stylesheet and compositor assertions without allowing unrelated default-route/Console mounts to replace the screen under test.
+- Verification: the nine formerly failing parametrized cases pass together; the original eight-file baseline reached 682/683 with only the subsequently removed full-app routing race; the complete `test_library_prompts_canvas.py` file then passed 338/338; the four changed pager/focus cases passed 4/4; Ruff and `git diff --check` passed.
+- ADR check: no ADR required. The changes enforce existing Recipe, empty-state, Continue, and harness contracts and introduce no architecture or product behavior.


### PR DESCRIPTION
## Summary

- Align stale Recipe, empty-collection, and Continue expectations with the accepted Library contracts.
- Replace full-app Prompt pager/focus hosts with deterministic single-Library production-CSS harnesses.
- Close TASK-19602 without changing production behavior.

## Test plan

- `pytest Tests/UI/test_library_prompts_canvas.py -q` — 338 passed.
- Post-rebase focused changed cases — 13 passed.
- Ruff on the three changed test modules — passed.
- `git diff --check origin/dev...HEAD` — passed.