### PR TITLE
test(citations): ephemeral sessions and legible misses — 69 failures to 40

### DIFF
--- a/Tests/Chat/test_console_local_citation_boundary.py
+++ b/Tests/Chat/test_console_local_citation_boundary.py
@@ -65,6 +65,28 @@ from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from Tests.console_provider_doubles import provider_resolution, with_destination
 
 
+def _first(matches, *, what: str):
+    """First match, or an assertion naming what never arrived.
+
+    A bare `next(<genexpr>)` raises StopIteration, which Python re-raises out of
+    a coroutine as `RuntimeError: coroutine raised StopIteration` -- naming
+    neither the missing item nor the turn that failed to produce it. 33 failures
+    in this module reported that way, hiding their real causes behind one
+    opaque message.
+
+    Args:
+        matches: Iterable of candidates.
+        what: Human-readable name of the thing expected, for the failure text.
+
+    Returns:
+        The first match.
+    """
+    value = next(iter(matches), None)
+    assert value is not None, f"no {what} was produced by the turn under test"
+    return value
+
+
+
 class _RequestBuilder:
     pass
 
@@ -499,8 +521,16 @@ def _recording_citation_store(
     persistence: _ReadyCitationPersistence | None = None,
 ) -> _RecordingCitationStore:
     store = _RecordingCitationStore(persistence=persistence)
-    session = store.ensure_session(
-        settings=ConsoleSessionSettings(provider="openai", model="repair-model")
+    # EPHEMERAL, for the same reason as `_persisted_store`: these doubles record
+    # `create_message` calls, which is the citation-write seam under test, and
+    # they carry `db = None`. A non-ephemeral MANUAL send is therefore refused
+    # twice over -- once because the adapter cannot `commit_durable_turn`, and
+    # again by TASK-22030's DB-open gate -- before any provider call. Both gates
+    # are guarded by `not session.ephemeral`, which is production's own carve-out
+    # for a chat that is not being saved.
+    session = store.create_session(
+        settings=ConsoleSessionSettings(provider="openai", model="repair-model"),
+        ephemeral=True,
     )
     session.project_instruction_state = (
         ProjectInstructionControlState.legacy_disabled()
@@ -550,11 +580,11 @@ def _capture_result(
 
 
 def _assistant(store: ConsoleChatStore):
-    return next(
+    return _first((
         message
         for message in store.messages_for_session(store.active_session_id)
         if message.role is ConsoleMessageRole.ASSISTANT
-    )
+    ), what="ASSISTANT message")
 
 
 # Task 3b rebase note: the controller's in-flight bookkeeping is now a
@@ -597,11 +627,11 @@ def _assert_no_terminal_state(store: ConsoleChatStore) -> None:
 
 
 def _final_user_content(messages) -> str:
-    return next(
+    return _first((
         message["content"]
         for message in reversed(messages)
         if message["role"] == ConsoleMessageRole.USER.value
-    )
+    ), what="message in the provider payload")
 
 
 @pytest.mark.asyncio
@@ -673,11 +703,11 @@ async def test_console_canonical_evidence_is_added_after_prompt_transforms_and_b
     result = await controller.submit_draft(ordinary_prompt)
 
     assert result.accepted is True
-    stored_user = next(
+    stored_user = _first((
         message
         for message in store.messages_for_session(store.active_session_id)
         if message.role is ConsoleMessageRole.USER
-    )
+    ), what="expected item")
     assert stored_user.content == ordinary_prompt
     provider_user = _final_user_content(gateway.messages_seen)
     assert provider_user == (
@@ -1764,7 +1794,8 @@ async def test_original_attempt_cache_cleans_up_and_is_never_reconstructed():
         content="First repaired [S1]",
     )
     second_session = store.create_session(
-        settings=ConsoleSessionSettings(provider="openai", model="repair-model")
+        settings=ConsoleSessionSettings(provider="openai", model="repair-model"),
+        ephemeral=True,
     )
     second = store.append_message(
         second_session.id,
@@ -2046,11 +2077,11 @@ async def test_citation_repair_direct_completed_initial_does_not_leak_into_lifec
         ((initial_body,), (replacement_body,)),
         persistence=persistence,
     )
-    initial_user = next(
+    initial_user = _first((
         message
         for message in store.messages_for_session(store.active_session_id)
         if message.role is ConsoleMessageRole.USER
-    )
+    ), what="expected item")
     initial_assistant = _assistant(store)
     assert initial_assistant.content == initial_body
     _assert_no_terminal_state(store)
@@ -2316,9 +2347,9 @@ async def test_citation_repair_agent_missing_placeholder_keeps_runtime_row_witho
             self.calls.append(kwargs)
             original_id = kwargs["assistant_message_id"]
             session_id = self.store.session_id_for_message(original_id)
-            session = next(
+            session = _first((
                 item for item in self.store.sessions() if item.id == session_id
-            )
+            ), what="session")
             retained = [
                 message
                 for message in self.store.messages_for_session(session_id)
@@ -2485,26 +2516,26 @@ def _assert_user_citation_repair_cancel(
         *expected_leading_system_messages,
         "Citation repair canceled by user.",
     ]
-    append_call = next(
+    append_call = _first((
         call
         for call in store.message_append_calls
         if call["role"] is ConsoleMessageRole.SYSTEM
         and call["content"] == "Citation repair canceled by user."
-    )
+    ), what="store message-append call")
     assert append_call["kwargs"]["persist"] is (persistence is not None)
 
     if persistence is not None:
-        assistant_write = next(
+        assistant_write = _first((
             call
             for call in persistence.create_calls
             if call["sender"] == ConsoleMessageRole.ASSISTANT.value
-        )
-        system_write = next(
+        ), what="persistence create CALL")
+        system_write = _first((
             call
             for call in persistence.create_calls
             if call["sender"] == ConsoleMessageRole.SYSTEM.value
             and call["content"] == "Citation repair canceled by user."
-        )
+        ), what="persistence create CALL")
         assert persistence.create_calls.index(
             assistant_write
         ) < persistence.create_calls.index(system_write)
@@ -2855,17 +2886,17 @@ async def test_citation_repair_cancel_row_persistence_failure_is_fail_soft(
     ]
     assert len(assistant_writes) == 1
     assert assistant_writes[0]["content"] == initial_body
-    cancel_attempt = next(
+    cancel_attempt = _first((
         call
         for call in persistence.create_attempts
         if call["sender"] == ConsoleMessageRole.SYSTEM.value
-    )
+    ), what="persistence create ATTEMPT")
     assert persistence.create_attempts.index(
-        next(
+        _first((
             call
             for call in persistence.create_attempts
             if call["sender"] == ConsoleMessageRole.ASSISTANT.value
-        )
+        ), what="persistence create ATTEMPT")
     ) < persistence.create_attempts.index(cancel_attempt)
     assert cancel_attempt["parent_message_id"] == assistant.persisted_message_id
 
@@ -3227,9 +3258,9 @@ async def test_agent_replaced_placeholder_does_not_transfer_finalizer():
         def run_reply(self, **kwargs):
             original_id = kwargs["assistant_message_id"]
             session_id = self.store.session_id_for_message(original_id)
-            session = next(
+            session = _first((
                 session for session in self.store.sessions() if session.id == session_id
-            )
+            ), what="session")
             retained = [
                 message
                 for message in self.store.messages_for_session(session_id)

--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -276,9 +276,14 @@ def real_citation_stack_factory(tmp_path: Path):
         session = store.ensure_session(
             settings=ConsoleSessionSettings(provider="llama_cpp")
         )
-        session.persisted_conversation_id = persistence.create_conversation(
-            runtime_backend="local"
-        )
+        # Deliberately NOT pre-created. `create_conversation` writes the
+        # conversation row but no `console_conversation_library_policy` row,
+        # and `commit_durable_turn` then takes its "conversation already
+        # exists" branch, finds `policy_row is None`, and refuses the turn
+        # with "Durable Console Library policy no longer matches acceptance."
+        # -- so the send produced a USER row and nothing else. Letting the
+        # first turn create the conversation writes the row and its policy in
+        # the same transaction, which is what production does.
         stack = _RealCitationStack(
             db_path=db_path,
             client_id=client_id,

--- a/backlog/tasks/task-22301 - Citation tests observe a persistence seam the durable path bypasses.md
+++ b/backlog/tasks/task-22301 - Citation tests observe a persistence seam the durable path bypasses.md
@@ -1,0 +1,54 @@
+---
+id: task-22301
+title: Citation tests observe a persistence seam the durable path bypasses
+status: To Do
+labels:
+  - tests
+  - console
+  - citations
+priority: medium
+---
+
+## Description
+
+29 tests in `Tests/Chat/test_console_local_citation_boundary.py` assert on
+persistence CALL COUNTS — `assert len(persistence.create_calls) == 1` and
+similar. They cannot pass as written, for two compounding reasons.
+
+**1. The session must be ephemeral for the send to happen at all.** The doubles
+(`_ReadyCitationPersistence`, `_RecordingCitationStore`) predate
+`commit_durable_turn` and carry `db = None`, so a non-ephemeral MANUAL send is
+refused twice: by the durable-turn gate (`56db75386`) and by the DB-open gate
+(`#2088` / TASK-22030). Both are guarded by `not session.ephemeral`. Making the
+sessions ephemeral is what took this file from 69 failures to 40 — but an
+ephemeral session deliberately does not persist, so call-count assertions see 0.
+
+**2. The seam itself may be obsolete.** `a26cdafd8`'s durable dispatch
+checkpoint writes its USER and assistant rows with raw SQL in
+`console_dispatch_repository.insert_with_messages`, bypassing `create_message`
+entirely. So even a durable-capable double might never see the calls these tests
+count.
+
+The tests' subject — that a sealed citation write reaches persistence exactly
+once, and that a failed repair writes nothing — is still worth testing. What is
+stale is *where* they watch for it.
+
+## Acceptance Criteria
+
+- [ ] The tests observe a seam the current durable path actually uses
+- [ ] Each still fails when its real invariant is broken (mutation-proven)
+- [ ] No test asserts a call count that an ephemeral session cannot produce
+- [ ] `test_console_local_citation_boundary` reports 0 failures
+
+## Implementation Notes
+
+Decide first WHICH seam is authoritative for a citation write now: the raw-SQL
+checkpoint, `create_message`, or the citation repository. Then move the
+assertions there — asserting on durable ROWS rather than on call counts would
+survive the next refactor of the write path, which counting calls did not.
+
+Do not "fix" these by adding `commit_durable_turn` to the doubles. The real
+method owns a transaction, creates the conversation, writes the Library policy
+and returns a checkpoint; hand-copying that into a fake is the
+fake-validates-the-mistake trap, and it is what these doubles already did with
+`create_message`.

--- a/backlog/tasks/task-22302 - Durable turns silently discard citation provenance.md
+++ b/backlog/tasks/task-22302 - Durable turns silently discard citation provenance.md
@@ -1,0 +1,160 @@
+---
+id: task-22302
+title: Durable turns silently discard citation provenance
+status: To Do
+labels:
+  - console
+  - citations
+  - data-loss
+  - regression
+priority: high
+---
+
+## Description
+
+Since `a26cdafd8` ("resume Library-gated sends"), a durable Console turn writes
+**no citation provenance at all**. Every citation table stays empty for an answer
+that carries citations.
+
+Bisected:
+
+| commit | result |
+|---|---|
+| `a26cdafd8~1` (`52571f925`) | **passes** |
+| `a26cdafd8` | **fails** |
+| current `dev` | fails |
+
+Reproduced by `Tests/Chat/test_console_terminal_citation_persistence.py::
+test_real_atomic_direct_controller_persists_exact_body_and_trace_on_restart`,
+which runs a real in-memory ChaChaNotes stack. All six tables report 0 where 1
+is expected:
+
+`rag_citation_traces`, `rag_message_trace_owners`, `rag_evidence_runs`,
+`rag_evidence_snapshots`, `rag_trace_evidence_refs`,
+`rag_answer_attempt_payloads`.
+
+## Mechanism
+
+`ConsoleChatStore.mark_message_complete` pops the terminal citation finalizer at
+`console_chat_store.py:8045`:
+
+```python
+finalizer = self._terminal_citation_finalizers.pop(message.id, None)
+```
+
+Then, at 8052, it takes the in-flight dispatch-recovery branch and **returns at
+8063**:
+
+```python
+if recovery is not None and recovery.assistant_message_id == message.id and recovery.in_flight:
+    ...
+    self._settle_owned_dispatch_terminal(message, "complete")
+    self._record_message_completed(session_id, message.id)
+    return self._snapshot(message)
+```
+
+The code that actually uses the finalizer — building `citation_write` and passing
+it to `_persist_new_message` — is at 8095, thirty lines below a return that now
+fires for every checkpointed turn. The finalizer is consumed and dropped.
+
+Confirming evidence: `_settle_owned_dispatch_terminal` contains zero citation
+handling, and `console_dispatch_repository.py` (which writes the checkpoint rows
+with raw SQL) contains zero occurrences of "citation". Citations only reach
+storage via `create_message(citation_write=...)` -> `CitationTraceRepository`,
+and a probe against a real stack confirms **`create_message` is never called** on
+the durable path.
+
+## Why it went unnoticed
+
+The one test that would have caught it was failing EARLIER, for an unrelated
+reason, so it never reached the citation assertion. Its stack pre-created the
+conversation with `create_conversation(...)`, which writes no
+`console_conversation_library_policy` row; `commit_durable_turn` then took its
+"conversation exists" branch, found `policy_row is None`, and refused the turn
+with "Durable Console Library policy no longer matches acceptance." The send
+produced a USER row and nothing else.
+
+That upstream refusal was itself silent until TASK-22251 added
+`Durable turn commit failed; turn refused (exception_type=...)`, which is what
+surfaced it.
+
+## Acceptance Criteria
+
+- [ ] A durable turn with citations writes its trace, owner, evidence and
+      attempt rows
+- [ ] The real-stack tests in `test_console_terminal_citation_persistence` pass
+- [ ] A test fails if the finalizer is dropped again (mutation-proven)
+- [ ] The fix is verified on a real ChaChaNotes stack, not a recording double
+
+## Implementation Notes
+
+The fix belongs in the dispatch-recovery branch: it must still honour the
+terminal citation finalizer before returning, or the branch must not swallow a
+turn that has one. Note the finalizer is popped BEFORE the branch decision, so
+simply reordering the pop is not enough — the branch has to carry the write.
+
+Do not fix this by reverting the checkpoint. The checkpoint is what makes a turn
+resumable; the defect is that its terminal path forgot one write.
+
+Related: TASK-22301 (the boundary tests' recording doubles observe
+`create_message`, which this same finding shows the durable path never calls).
+
+
+## Update — candidate fix identified, NOT landed
+
+Three sequential blockers were found and each was individually mutation-proven.
+Together they make the two real-stack tests pass and the whole
+`test_console_terminal_citation_persistence` file green (92/92). They are NOT
+committed, because in the full test composition the same change produces a
+DUPLICATE `create_message` call (`assert 2 == 1`, the same body written twice)
+in seven capability tests. That is reproducible — two identical runs failed the
+identical seven — so it is a real interaction, not xdist ordering.
+
+### Blocker 1 — the finalizer never survives the durable hand-off
+
+`_accept_durable_turn` takes `terminal_citation_finalizer` as a parameter
+(`console_chat_controller.py:5600`) and uses it exactly once more: it builds a
+`_DurablePostcommitContinuation` (5723) that has NO field for it, and
+`resume_durable_postcommit` then publishes the live owners with a hard-coded
+`terminal_citation_finalizer=None` (5820). Adding the field and forwarding it
+fixes this leg.
+
+### Blocker 2 — arming is gated on the wrong condition
+
+`append_message` arms only when its own `persist` flag is true. On this path
+`persist=False` is CORRECT — the durable row already exists, written by the
+dispatch checkpoint — but "this call does not create the row" is not the same as
+"this message has no durable row", and arming needs the latter.
+`_hydrate_durable_turn_owner_messages` assigns `persisted_message_id`
+immediately after the append, so arming there works.
+
+### Blocker 3 — the in-flight dispatch shortcut discards the finalizer
+
+`mark_message_complete` pops the finalizer (`console_chat_store.py:8045`) and
+then returns early via the dispatch-recovery branch (8052-8063), thirty lines
+above the code that would use it. Skipping that branch when a finalizer is owed
+reaches the citation write.
+
+### Blocker 4 — the body then persists as ''
+
+`create_message`'s existing-row branch is an idempotent-RETRY path: it verifies
+and writes the citation but deliberately does not update content. The checkpoint
+wrote `content=''`, so the answer persisted empty. Flushing the body first (via
+`_persist_existing_message`) makes the row match, after which the citation write
+keys to it — no persistence API change required.
+
+### Why it is not landed
+
+Narrowing both store-side changes to the citation path (skip the shortcut only
+when a `finalizer` is owed; flush content only when a `citation_write` will
+follow) fixed 7 regressions the first attempt caused, and the file went 92/92.
+But the full composition still shows the duplicate `create_message` in those
+seven capability tests, and it could not be reproduced in any smaller set
+(terminal file alone: 92/92; terminal + boundary: clean; terminal + 10 union
+files: clean). Each full-composition iteration costs ~25 minutes.
+
+A duplicate durable write is a worse defect than the one being fixed, so this
+needs the trigger identified before it can land. The likely suspect is the
+interaction between arming `_terminal_persistence_deferred_ids` and
+`mark_message_complete`'s `terminal_persistence` predicate, which then routes a
+turn to `_persist_new_message` whose row already exists.


### PR DESCRIPTION
## Summary

Takes `test_console_local_citation_boundary` from **69 failures to 40**, measured
against clean `dev` `36bf1bdf4` on the same 95 tests, with **zero newly broken**.
All 14 timeouts are gone.

For context on why this file matters: until #2102 it was **unmeasurable** — it
hung, and `timeout_method = "thread"` destroyed the pytest process, so no JUnit
was written and none of its failures were visible at all.

## Two causes

**The second store helper was never made ephemeral.** #2102 fixed
`_persisted_store`; `_recording_citation_store` still called `ensure_session()`,
which is why 30 tests kept failing with no assistant row.

Those tests were hitting a **second** gate. `#2088` (TASK-22030) added a DB-open
refusal — *"Not sent: your conversation database could not be opened"* — and the
citation doubles carry `db = None`, so a non-ephemeral MANUAL send is refused
twice over: once because the adapter cannot `commit_durable_turn`, again by the
DB-open check. Both are guarded by `not session.ephemeral`, which is
production's own carve-out for a chat that is not being saved.

The refusal copy promises *"a temporary chat still sends"*. I verified that
promise holds rather than assuming it — a copy guaranteeing something the gate
did not honour would have been a real product bug.

**11 bare `next(<genexpr>)` calls.** StopIteration escaping a coroutine is
re-raised as `RuntimeError: coroutine raised StopIteration`, naming neither the
missing item nor the turn that failed to produce it — 33 failures here reported
that way. Replaced with `_first(..., what=...)`.

That step is what found the DB-open gate: it fixed nothing by itself, but once
the message read *"no ASSISTANT message was produced by the turn under test"*,
one probe located the cause. The same sequence worked in
`test_console_agent_swap` earlier in this arc.

## The remaining 40 — filed, not patched

29 assert on persistence **call counts**, which an ephemeral session
legitimately does not make. Their `create_message` seam is also bypassed by the
durable checkpoint's raw-SQL writes in `insert_with_messages`, so even a
durable-capable double might never see those calls.

Filed as **TASK-22301**. It needs a decision about which seam is authoritative
for a citation write now — asserting on durable ROWS rather than call counts
would survive the next refactor of the write path, which counting calls did not.
Explicitly *not* fixed by adding `commit_durable_turn` to the doubles: the real
method owns a transaction, creates the conversation, writes the Library policy
and returns a checkpoint, and hand-copying that into a fake is the trap these
doubles already fell into with `create_message`.

## Verification

| | clean `dev` `36bf1bdf4` | this branch |
|---|---|---|
| collected | 95 | 95 |
| failures | 69 | **40** |
| fixed | — | **29** |
| newly broken | — | **0** |

`./scripts/preflight.sh` passes all five derived-artifact checks.
