### PR TITLE
perf(boot): stagger the boot worker fleet — worst keypress 876 → 467 ms on a post-upgrade boot (TASK-22215)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1846,8 +1846,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 3,
-      "diagnostic_digest": "769552c703844018c3aa",
+      "call_count": 5,
+      "diagnostic_digest": "f450151dc969ffd3b19d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/fts_backfill.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3736,8 +3736,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 350,
-      "diagnostic_digest": "a425ecab6ea6dbf0cba8",
+      "call_count": 355,
+      "diagnostic_digest": "e87128a113e9ac3ef45e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3976,6 +3976,6 @@
     "owner_files": 538,
     "persistent_sink_files": 8,
     "task_492_calls": 1241,
-    "task_494_calls": 7347
+    "task_494_calls": 7354
   }
 }

--- a/Tests/App/test_boot_worker_stagger_policy.py
+++ b/Tests/App/test_boot_worker_stagger_policy.py
@@ -1,0 +1,280 @@
+"""Boot worker stagger/priority policy (TASK-22215).
+
+TASK-22222's census pins WHICH workers may start during boot; this pins WHEN
+and HOW MANY AT ONCE. The properties under test:
+
+* the staggered fleet starts in the declared order, prefetches (which a
+  surface can otherwise pay for inline, on the event loop) ahead of the
+  resumable FTS backfills that nothing waits on;
+* at most ``MAX_CONCURRENT_STAGGERED_BOOT_WORKERS`` run at a time, and each
+  completion admits the next -- including the completion of a worker that
+  never started (so a failing starter cannot strand the queue);
+* the FTS backfills no longer ride ``on_mount`` ahead of first paint: on a
+  real mounted app every staggered body observes ``_ui_ready`` already True;
+* a quit inside the staggered window closes the gate rather than starting
+  more work, and nothing pending is lost (each member is either re-run by the
+  surface that gates on it or resumes from a frontier in its own database).
+
+Each policy row is also cross-checked against the census allowlist, so a
+worker cannot be staggered under one identity and censused under another.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Performance.test_boot_worker_census import ALLOWED_BOOT_WORKERS
+from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.Utils.boot_worker_policy import (
+    BOOT_WORKER_KEY_BY_IDENTITY,
+    BOOT_WORKER_POLICY,
+    MAX_CONCURRENT_STAGGERED_BOOT_WORKERS,
+    STAGGERED_BOOT_WORKER_KEYS,
+    BootWorkerTier,
+    StaggeredBootWorkerGate,
+)
+
+
+# --------------------------------------------------------------------------
+# The policy itself
+# --------------------------------------------------------------------------
+
+
+def test_every_policy_row_is_on_the_boot_worker_census_allowlist():
+    """A staggered worker must be the same worker the census pins.
+
+    Guards the drift that would make both files individually green and
+    jointly meaningless: a rename on one side only.
+    """
+    unknown = {
+        (spec.name, spec.group)
+        for spec in BOOT_WORKER_POLICY
+        if (spec.name, spec.group) not in ALLOWED_BOOT_WORKERS
+    }
+    assert not unknown, (
+        f"boot worker policy rows missing from the TASK-22222 census "
+        f"allowlist: {sorted(unknown)}"
+    )
+
+
+def test_staggered_order_runs_prefetches_before_the_resumable_backfills():
+    """Order is the whole policy -- pin it literally.
+
+    The two actor-pack workers are prefetches for surfaces that gate on the
+    same once-lock, so a late start means the surface pays the work on the
+    event loop. The two FTS backfills have nothing waiting on them and the
+    ChaChaNotes one can run for tens of seconds on a first post-upgrade boot,
+    so it must never hold a slot ahead of a prefetch.
+    """
+    assert STAGGERED_BOOT_WORKER_KEYS == (
+        "actor_pack_recovery",
+        "actor_pack_staging_sweep",
+        "chachanotes_fts_backfill",
+        "subscriptions_fts_backfill",
+    )
+
+
+def test_the_two_fts_backfills_are_staggered_not_immediate():
+    """Neither whole-table re-tokenization may ride the pre-first-paint tier."""
+    tiers = {
+        spec.key: spec.tier
+        for spec in BOOT_WORKER_POLICY
+        if spec.key.endswith("_fts_backfill")
+    }
+    assert tiers == {
+        "chachanotes_fts_backfill": BootWorkerTier.STAGGERED,
+        "subscriptions_fts_backfill": BootWorkerTier.STAGGERED,
+    }
+
+
+def test_the_concurrency_cap_is_below_the_staggered_fleet_size():
+    """A cap that admits everything is not a cap."""
+    assert 1 <= MAX_CONCURRENT_STAGGERED_BOOT_WORKERS < len(STAGGERED_BOOT_WORKER_KEYS)
+
+
+def test_every_policy_row_records_what_it_unblocks():
+    """The starvation check a reorder has to pass is a required field."""
+    assert all(spec.unblocks.strip() for spec in BOOT_WORKER_POLICY)
+
+
+# --------------------------------------------------------------------------
+# The admission gate
+# --------------------------------------------------------------------------
+
+
+def test_gate_admits_only_up_to_the_cap():
+    gate = StaggeredBootWorkerGate(("a", "b", "c", "d"), limit=2)
+    assert gate.admit() == ("a", "b")
+    assert gate.admit() == ()
+    assert gate.in_flight == ("a", "b")
+    assert gate.pending == ("c", "d")
+
+
+def test_completion_admits_the_next_worker_in_policy_order():
+    gate = StaggeredBootWorkerGate(("a", "b", "c", "d"), limit=2)
+    gate.admit()
+    assert gate.complete("a") is True
+    assert gate.admit() == ("c",)
+    assert gate.complete("b") is True
+    assert gate.admit() == ("d",)
+    assert gate.complete("c") and gate.complete("d")
+    assert gate.is_drained
+
+
+def test_completing_an_unknown_or_repeated_key_releases_nothing():
+    """The same terminal transition reaches the gate from two call sites."""
+    gate = StaggeredBootWorkerGate(("a", "b"), limit=1)
+    gate.admit()
+    assert gate.complete("a") is True
+    assert gate.complete("a") is False
+    assert gate.complete("nonsense") is False
+    assert gate.admit() == ("b",)
+
+
+def test_closing_the_gate_drops_pending_and_never_admits_again():
+    gate = StaggeredBootWorkerGate(("a", "b", "c"), limit=1)
+    gate.admit()
+    assert gate.close() == ("b", "c")
+    assert gate.admit() == ()
+    assert gate.pending == ()
+    assert gate.is_closed
+
+
+def test_gate_rejects_a_zero_limit_and_duplicate_keys():
+    with pytest.raises(ValueError):
+        StaggeredBootWorkerGate(("a",), limit=0)
+    with pytest.raises(ValueError):
+        StaggeredBootWorkerGate(("a", "a"), limit=2)
+
+
+# --------------------------------------------------------------------------
+# The app wiring
+# --------------------------------------------------------------------------
+
+
+def test_app_can_start_every_staggered_key():
+    """Every policy key resolves to a real starter on the app."""
+    app = _build_test_app()
+    starters = app.boot_worker_starters()
+    assert set(starters) == set(STAGGERED_BOOT_WORKER_KEYS)
+    assert all(callable(starter) for starter in starters.values())
+
+
+def _fake_worker(spec_key: str) -> SimpleNamespace:
+    """A stand-in for the Textual worker a starter would return."""
+    from tldw_chatbook.Utils.boot_worker_policy import BOOT_WORKER_POLICY
+
+    spec = next(row for row in BOOT_WORKER_POLICY if row.key == spec_key)
+    return SimpleNamespace(
+        name=spec.name, group=spec.group, is_finished=False, is_cancelled=False
+    )
+
+
+def test_deferred_startup_starts_the_cap_then_advances_on_completion():
+    """The app starts up to the cap, then one more per terminal transition."""
+    cap = MAX_CONCURRENT_STAGGERED_BOOT_WORKERS
+    app = _build_test_app()
+    started: list[str] = []
+    workers: dict[str, SimpleNamespace] = {}
+
+    def record(key: str):
+        started.append(key)
+        workers[key] = _fake_worker(key)
+        return workers[key]
+
+    app._start_boot_worker = record
+
+    app._start_staggered_boot_workers()
+    assert started == list(STAGGERED_BOOT_WORKER_KEYS[:cap])
+
+    # Completing the oldest in-flight worker admits exactly one more, in
+    # policy order, until the whole fleet has run.
+    for index in range(len(STAGGERED_BOOT_WORKER_KEYS) - cap):
+        app._release_boot_worker_slot(workers[STAGGERED_BOOT_WORKER_KEYS[index]])
+        assert started == list(STAGGERED_BOOT_WORKER_KEYS[: cap + index + 1])
+
+    assert started == list(STAGGERED_BOOT_WORKER_KEYS)
+
+
+def test_a_starter_that_starts_nothing_still_advances_the_queue():
+    """A skipped or failing start must not hold its slot forever."""
+    app = _build_test_app()
+    started: list[str] = []
+
+    def record(key: str):
+        started.append(key)
+        if key == STAGGERED_BOOT_WORKER_KEYS[0]:
+            raise RuntimeError("starter blew up")
+        return None  # every other starter declines to start anything
+
+    app._start_boot_worker = record
+
+    app._start_staggered_boot_workers()
+    assert started == list(STAGGERED_BOOT_WORKER_KEYS)
+
+
+def test_shutdown_closes_the_gate_instead_of_starting_more_work():
+    """A quit inside the staggered window starts nothing further."""
+    app = _build_test_app()
+    started: list[str] = []
+    app._start_boot_worker = lambda key: (started.append(key), _fake_worker(key))[1]
+
+    cap = MAX_CONCURRENT_STAGGERED_BOOT_WORKERS
+    app._start_staggered_boot_workers()
+    assert started == list(STAGGERED_BOOT_WORKER_KEYS[:cap])
+
+    app._shutting_down = True
+    app._release_boot_worker_slot(_fake_worker(STAGGERED_BOOT_WORKER_KEYS[0]))
+
+    assert started == list(STAGGERED_BOOT_WORKER_KEYS[:cap])
+    assert app._boot_worker_gate.is_closed
+    assert app._boot_worker_gate.pending == ()
+
+
+def test_the_worker_identity_map_covers_the_whole_policy():
+    """`Worker.StateChanged` is mapped back onto the row that owns the slot."""
+    assert set(BOOT_WORKER_KEY_BY_IDENTITY.values()) == {
+        spec.key for spec in BOOT_WORKER_POLICY
+    }
+
+
+@pytest.mark.asyncio
+async def test_every_staggered_body_runs_after_the_ui_is_ready():
+    """On a real mounted app, no staggered body runs before first paint.
+
+    Red on the pre-fix tree: both FTS backfills were started from
+    ``on_mount``, so they observed ``_ui_ready`` False. Also the
+    anti-starvation pin -- all four must actually run, not merely be queued.
+    """
+    app = _build_test_app()
+    observed: dict[str, bool] = {}
+    done = threading.Event()
+
+    def recorder(key: str):
+        def body() -> None:
+            observed[key] = bool(getattr(app, "_ui_ready", False))
+            if len(observed) == len(STAGGERED_BOOT_WORKER_KEYS):
+                done.set()
+
+        return body
+
+    app.ensure_actor_pack_recovery = recorder("actor_pack_recovery")
+    app.ensure_actor_pack_staging_sweep = recorder("actor_pack_staging_sweep")
+    app._backfill_chachanotes_messages_fts = recorder("chachanotes_fts_backfill")
+    app._backfill_subscription_items_fts = recorder("subscriptions_fts_backfill")
+
+    async with app.run_test() as pilot:
+        for _ in range(120):
+            if done.is_set():
+                break
+            await pilot.pause(0.05)
+
+    assert set(observed) == set(STAGGERED_BOOT_WORKER_KEYS), (
+        f"staggered boot workers that never ran: "
+        f"{sorted(set(STAGGERED_BOOT_WORKER_KEYS) - set(observed))}"
+    )
+    early = sorted(key for key, ready in observed.items() if not ready)
+    assert not early, f"staggered boot workers that ran before _ui_ready: {early}"

--- a/Tests/Performance/test_boot_worker_census.py
+++ b/Tests/Performance/test_boot_worker_census.py
@@ -17,9 +17,15 @@ it -- the eighth worker arrives in review, not silently. The allowlist is
 deliberately the superset of everything legitimately observed (fresh-boot
 one-offs and stall-triggered threads included), because the guard's job is
 to catch NEW UNREVIEWED members, not to flake on members that only
-sometimes run. TASK-22215 (stagger/priority policy for this fleet) should
-treat this allowlist as the inventory it reorders; staggering itself is out
-of scope here.
+sometimes run. TASK-22215 (stagger/priority policy for this fleet) took
+this allowlist as the inventory it reorders; staggering itself stays out of
+scope here. That policy now lives in ``tldw_chatbook/Utils/boot_worker_
+policy.py`` and ``Tests/App/test_boot_worker_stagger_policy.py`` cross-checks
+every policy row against the allowlist below, so the two cannot drift: WHICH
+workers may start is pinned here, WHEN and HOW MANY AT ONCE is pinned there.
+No allowlist row changed for that task -- the four staggered members kept
+their (name, group) identity and merely moved from ``on_mount`` to the
+post-``_ui_ready`` tier, which is still inside this census's settle window.
 
 Raising/extending: when this fails, the message prints the unlisted
 starters. Name the feature that added each, decide whether it must really

--- a/Tests/Subscriptions/test_fts_backfill.py
+++ b/Tests/Subscriptions/test_fts_backfill.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tldw_chatbook.DB.fts_backfill_pacing import ABORT_POLL_SECONDS
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Subscriptions.fts_backfill import backfill_subscription_items_fts
 
@@ -86,3 +87,110 @@ def test_wired_backfill_on_already_fully_indexed_db_is_a_noop(db):
     _insert_legacy_item(db, source_id, "https://a.example/1", "Item", "alpha content")
 
     assert backfill_subscription_items_fts(db) == 0
+
+
+# --------------------------------------------------------------------------
+# TASK-22215 pacing: this backfill is one of the boot-time thread workers, so
+# it must yield the write lock to foreground watchlists writes and must not
+# make a quit wait out its pauses. (The ChaChaNotes sibling got this in
+# TASK-22200; the primitives are now shared.)
+# --------------------------------------------------------------------------
+
+
+def _legacy_backlog(db, count: int) -> None:
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/f"
+    )
+    _drop_ai_trigger(db)
+    for index in range(count):
+        _insert_legacy_item(
+            db,
+            source_id,
+            f"https://a.example/{index}",
+            f"Item {index}",
+            "retrieval quality rubric",
+        )
+
+
+def test_backfill_sleeps_the_configured_pause_between_chunks(db):
+    """Chunks no longer convoy: each one that did work is followed by a gap."""
+    _legacy_backlog(db, 12)
+    recorded: list[float] = []
+
+    total = backfill_subscription_items_fts(
+        db, chunk_size=5, pause_seconds=0.25, sleep=recorded.append
+    )
+
+    assert total == 12
+    # Three chunks index rows (5, 5, 2); the fourth finds nothing and must
+    # not pause -- an up-to-date database stays a single free scan.
+    assert recorded == [0.25, 0.25, 0.25]
+
+
+def test_the_no_op_boot_probe_never_sleeps(db):
+    """Every boot runs this against a database with nothing left to index."""
+    _legacy_backlog(db, 3)
+    assert backfill_subscription_items_fts(db, pause_seconds=0.0) == 3
+
+    recorded: list[float] = []
+    assert (
+        backfill_subscription_items_fts(db, pause_seconds=5.0, sleep=recorded.append)
+        == 0
+    )
+    assert recorded == []
+
+
+def test_abort_between_chunks_leaves_the_resumable_frontier(db):
+    """A cancelled worker stops early; the next run finishes the job."""
+    _legacy_backlog(db, 10)
+    chunks_done = 0
+    original = SubscriptionsDB.backfill_items_fts
+
+    def counting(self, *args, **kwargs):
+        nonlocal chunks_done
+        result = original(self, *args, **kwargs)
+        chunks_done += 1
+        return result
+
+    with pytest.MonkeyPatch.context() as patcher:
+        patcher.setattr(SubscriptionsDB, "backfill_items_fts", counting)
+        total = backfill_subscription_items_fts(
+            db,
+            chunk_size=4,
+            pause_seconds=0.0,
+            should_abort=lambda: chunks_done >= 1,
+        )
+
+    assert total == 4
+    assert (
+        db.conn.execute(
+            "SELECT COUNT(*) FROM subscription_items_fts_docsize"
+        ).fetchone()[0]
+        == 4
+    )
+    # The frontier lives in the database, so a fresh run finishes the job.
+    assert backfill_subscription_items_fts(db, chunk_size=4, pause_seconds=0.0) == 6
+
+
+def test_abort_cuts_an_in_flight_pause_at_the_poll_slice(db):
+    """Shutdown waits one slice, not a whole pause (a flag cannot cut sleep)."""
+    _legacy_backlog(db, 8)
+    recorded: list[float] = []
+    aborted = {"flag": False}
+
+    def sliced_sleep(seconds: float) -> None:
+        recorded.append(seconds)
+        if len(recorded) >= 3:
+            aborted["flag"] = True  # "shutdown" arrives mid-pause
+
+    total = backfill_subscription_items_fts(
+        db,
+        chunk_size=4,
+        pause_seconds=5.0,
+        should_abort=lambda: aborted["flag"],
+        sleep=sliced_sleep,
+    )
+
+    assert total == 4
+    assert recorded == [ABORT_POLL_SECONDS] * 3
+    assert sum(recorded) < 5.0

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -687,8 +687,24 @@ def test_actor_pack_recovery_precedes_character_persona_surfaces():
         "recovery is back on the construction path (task-21106 regression)"
     )
 
+    # TASK-22215 moved the deferred-startup kick behind the boot-worker
+    # stagger policy: `_schedule_deferred_startup_work` opens the gate, the
+    # policy names the row, and the app's starter table calls the gate's
+    # `ensure_actor_pack_recovery`. Recovery is still FIRST in that order --
+    # it is a prefetch for a surface that would otherwise run SQLite recovery
+    # on the event loop -- and the behavioral proof that it actually runs
+    # after first paint lives in Tests/UI/test_actor_pack_recovery_seam.py
+    # and Tests/App/test_boot_worker_stagger_policy.py.
+    from tldw_chatbook.Utils.boot_worker_policy import STAGGERED_BOOT_WORKER_KEYS
+
     deferred = inspect.getsource(TldwCli._schedule_deferred_startup_work)
-    assert "ensure_actor_pack_recovery" in deferred, deferred
+    assert "_start_staggered_boot_workers" in deferred, deferred
+    assert STAGGERED_BOOT_WORKER_KEYS[0] == "actor_pack_recovery", (
+        f"recovery must stay first in the staggered boot order; observed "
+        f"{STAGGERED_BOOT_WORKER_KEYS!r}"
+    )
+    starters = inspect.getsource(TldwCli.boot_worker_starters)
+    assert "ensure_actor_pack_recovery" in starters, starters
 
     personas_load = inspect.getsource(PersonasScreen._load_after_mount)
     assert "ensure_actor_pack_recovery" in personas_load, personas_load

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1249,6 +1249,29 @@ asymmetrically toward failure.
 
 ---
 
+## The A/A control also tells you WHICH metric to report, not just how big a diff must be
+
+**TASK-22215, 2026-08-26.** Measuring input latency during the first 5 s after mount
+(before/after the boot-worker stagger, simulated post-upgrade profile, n=8 per arm,
+interleaved in both orders), the headline that jumped out was the median keypress:
+**before 90.5-92.6 ms, after 71.9-72.8 ms in three of four runs** — a tidy -22%. The A/A
+control (identical tree, two labels, same shape) killed it: its four runs measured 72.7,
+89.5, 77.8, 72.0 ms. The metric is **bimodal**, and both modes appear with the code held
+constant, so any single pair of runs can "show" a 20 ms median win or none at all.
+
+What survived on the same data was the metric whose RANGES separated: worst single
+keypress **625-876 ms before vs 395-467 ms after**, with the A/A control's 426-476 ms
+sitting inside the after range, and mean 111-124 vs 99-109 ms. p95, loop-heartbeat excess
+and time-to-ready were washes, and the warm-boot shape was a wash on everything.
+
+**What to do.** Run the A/A control with the SAME repeat count as the arms, and read its
+per-run spread, not only its aggregate: a metric whose A/A runs are multi-modal cannot
+carry a claim at that n no matter how clean the A/B looks, while a metric whose A/A range
+is narrow and disjoint from one arm can. Report the ones that separate, say "wash" for
+the rest, and never quote a median that the control also produced.
+
+---
+
 ## A crash mid-transfer proves nothing durable if the checkpoint is never written mid-transfer
 
 **TASK-595 Task 10, 2026-07-31.** Asked to write a real-subprocess, SIGKILL-based test

--- a/backlog/tasks/task-22215 - Stagger-the-boot-time-background-worker-fleet.md
+++ b/backlog/tasks/task-22215 - Stagger-the-boot-time-background-worker-fleet.md
@@ -1,19 +1,21 @@
 ---
 id: TASK-22215
-title: >-
-  Stagger the boot-time background worker fleet
-status: To Do
-assignee: []
+title: Stagger the boot-time background worker fleet
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-24'
+updated_date: '2026-08-26 10:10'
 labels:
   - performance
   - startup
-priority: medium
 dependencies: []
+priority: medium
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Source: holistic performance review of dev `a71e62e4b` (2026-08-24). Evidence, measurements,
 and full file:line cites: `Docs/Design/2026-08-24-holistic-perf-review.md` (finding 22215).
 
@@ -23,9 +25,141 @@ CPU-bound import/tokenize threads plus the Textual pump share one interpreter du
 first seconds after mount — worst on the first post-upgrade boot when 22200's backfill
 runs to completion alongside the pre-importer. Each worker is individually justified; the
 aggregate is what the user feels.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Boot workers are census'd (a test pins the set, so an eighth is a reviewed decision) and started with an explicit priority/stagger policy
+- [x] #2 Input latency during the first 5 s after mount measured before/after on a warm boot and on a simulated first-post-upgrade boot
+- [x] #3 Backfills yield to foreground work (coordinate with TASK-22200)
+<!-- AC:END -->
 
-- [ ] Boot workers are census'd (a test pins the set, so an eighth is a reviewed decision) and started with an explicit priority/stagger policy
-- [ ] Input latency during the first 5 s after mount measured before/after on a warm boot and on a simulated first-post-upgrade boot
-- [ ] Backfills yield to foreground work (coordinate with TASK-22200)
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Enumerate the boot fleet from the 22222 census: for each worker, what user-visible surface waits on it (starvation check before any reorder).
+2. Add a pure policy module (Utils/boot_worker_policy.py): ordered specs (key/name/group/tier/unblocks) + a concurrency-capped admission gate. Red-first policy test.
+3. Wire app.py: the two FTS backfills leave on_mount (pre-first-paint) for the staggered tier; actor-pack recovery + staging sweep join it; admission released from on_worker_state_changed with a reconcile watchdog so a lost event cannot strand a pending worker; nothing admitted once _shutting_down.
+4. AC3: re-verify 22200's ChaChaNotes pacing (already done, do not duplicate); close the remaining gap on the subscriptions FTS backfill (no pacing, no abort poll today).
+5. Measure AC2: headless Pilot boot, loop-side heartbeat + synthetic keypress latency for the first 5 s, warm boot AND simulated first-post-upgrade boot (seeded history with messages_fts cleared). A/A control first, arms interleaved in both orders.
+6. Targeted tests + --collect-only sweep, preflight, mutation test (break the order/cap -> policy test reds), teardown walk (quit inside the staggered window).
+7. Census stays green or is updated deliberately with the reason recorded.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped: an explicit boot-worker start policy (`Utils/boot_worker_policy.py`) with a
+serial admission gate, the two FTS backfills moved off `on_mount` (they used to start
+before first paint), and the subscriptions backfill given the pacing its ChaChaNotes
+sibling already had. Measured: a real win on the post-upgrade boot shape, an honest wash
+on the warm one.
+
+### What each boot worker unblocks (the starvation check, done before any reorder)
+
+| worker (name, group) | tier | what waits on it |
+|---|---|---|
+| `run`, `scheduling` | immediate | overdue reminders / scheduled watchlist checks. Coroutine worker that spends its life awaiting; must stay on the app's one loop (the watchlists in-flight guard is lock-free on that). |
+| `restore_ingest_jobs`, `ingest_restore` | immediate | the Library ingest job history. Until it lands the registry is EMPTY — a wrong answer, not a slow one. |
+| `deferred_actor_pack_recovery` | staggered #1 | nothing hard: Personas' first library read and `create_persona` gate on the coordinator's own once-lock. The worker is the prefetch that keeps that gate off the event loop. |
+| `deferred_actor_pack_staging_sweep` | staggered #2 | nothing hard: `inspect_archive` gates on the same once-lock. Prefetch of a filesystem walk. |
+| `_backfill_chachanotes_messages_fts` | staggered #3 | nothing. Search fills in progressively; frontier is `messages_fts_docsize` in the DB. Longest member on a post-upgrade boot. |
+| `_backfill_subscription_items_fts` | staggered #4 | nothing. Same shape against `subscription_items_fts_docsize`. |
+
+Deliberately NOT gated: the screen pre-importer (a daemon thread, already proportionally
+paced by TASK-22214, and the thing that protects the first click to Library/Settings —
+queueing it behind a minutes-long backfill would trade away its whole purpose), and
+`on_mount`'s await-shaped research/scheduler coroutine workers.
+
+### The policy
+
+Order = the table above. Cap = **1** (`MAX_CONCURRENT_STAGGERED_BOOT_WORKERS`), so the
+order IS the schedule. The first cut used 2 and was wrong for a specific reason worth
+recording: with two slots the short prefetches finish immediately and then BOTH
+whole-table re-tokenizations are admitted — the exact worst shape the finding is about.
+Admission advances on `Worker.StateChanged` (the app-wide hook already sees every
+transition); a slow `set_interval` reconcile is the backstop for a terminal transition
+that never arrives, and it stops itself once the gate drains. `_shutting_down` closes the
+gate, so a completion landing mid-teardown cannot start a fresh thread worker.
+
+### AC #2 — measured (headless Pilot boot; loop-side 20 ms heartbeat + `pilot.press` every 100 ms for 5 s from `_ui_ready`; fresh copy of a seeded 30k-message / 20k-item profile per run; arms interleaved in BOTH orders; A/A control at the same n)
+
+Post-upgrade shape (both FTS indexes emptied, i.e. the v45->v46 window), n=8/arm:
+
+| metric | before | after | A/A control (n=4) |
+|---|---|---|---|
+| worst keypress | **625-876 ms** | **395-467 ms** | 426-476 ms |
+| mean keypress | **111-124 ms** | **99-109 ms** | 101-104 ms |
+| median keypress | 73-93 ms | 72-92 ms | 72-90 ms (bimodal) |
+| p95 keypress | 125-169 ms | 125-183 ms | 136-177 ms |
+| loop excess stall, 5 s | 566-613 ms | 570-625 ms | 566-658 ms |
+| time to `_ui_ready` | 1.39-1.52 s | 1.36-1.49 s | — |
+
+Worst-keypress and mean ranges are disjoint between arms AND the control sits inside the
+after range, so those two carry the claim. **The median does not**: the A/A control
+produced both modes with the code held constant, which is what stopped a "-22% median"
+headline from being written (lesson filed in `lessons-testing-evidence.md`). p95, loop
+stall and time-to-ready are washes.
+
+Warm boot (same profile, indexes complete): **wash on every metric** (median 71-72 both
+arms, worst 389-434 before vs 425-452 after against an A/A of 416-458, stall 544-616 vs
+559-616). Expected — with nothing to backfill the fleet is four cheap calls in both arms,
+and on an M-series the loop is not starved either way (the TASK-21113/22214 precedent).
+
+Anti-vacuity, read off the profile at the end of each window: both arms indexed ~21k
+messages during the 5 s, so a live backfill really was competing in both. The mechanism
+of the win is visible in the same numbers: `subscription_items` indexed during the window
+= **20000 before** (the second re-tokenization ran concurrently) vs **0 after** (queued
+behind the first). A 25 s run confirms deferral is not abandonment: 30000/20000 rows
+indexed, gate fully drained.
+
+### AC #3 — 22200 re-verified, its gap closed
+
+The ChaChaNotes backfill's pacing was already correct and is untouched (its 9 pacing
+tests stay green): inter-chunk pause, lock-queue backoff, abort-sliced sleeps, worker
+`is_cancelled` wired through. The **subscriptions** backfill had none of it — a
+back-to-back chunk loop on `subscriptions.db`, where every watchlist ingest/status/
+briefing write is also `BEGIN IMMEDIATE`, and no cancellation poll at all. It now shares
+the primitives (extracted verbatim into `DB/fts_backfill_pacing.py`) and `app.py` hands it
+the worker's cancellation flag. Its lock-retry schedule was deliberately NOT copied —
+sizing a retry loop without a measurement is the clever-and-unstable half of the owner's
+ruling.
+
+### Teardown walk (quit inside the staggered window)
+
+Quit with the ChaChaNotes backfill in flight and the subscriptions one pending:
+`on_shutdown_request` returned in 1 ms, the gate closed, the pending worker never started,
+the interrupted run left 4000 rows indexed (consistent, resumable), and the next boot
+finished both (30000/20000) and drained the gate.
+
+### Census
+
+`Tests/Performance/test_boot_worker_census.py` stays green with **no allowlist change**:
+all four staggered members keep their (name, group) identity and merely move to the
+post-`_ui_ready` tier, still inside the census's settle window. Its docstring now names
+the policy module, and the new policy test cross-checks every policy row against the
+allowlist so the two files cannot drift.
+
+### Mutation tests (all restored)
+
+1. cap 1 -> 4: `test_the_concurrency_cap_is_below_the_staggered_fleet_size` red.
+2. app ignores the policy cap: `test_deferred_startup_starts_the_cap_then_advances_on_completion` + `test_shutdown_closes_the_gate_instead_of_starting_more_work` red.
+3. staggered order reversed: `test_staggered_order_runs_prefetches_before_the_resumable_backfills` red.
+4. subscriptions pacing off: `test_backfill_sleeps_the_configured_pause_between_chunks` + `test_abort_cuts_an_in_flight_pause_at_the_poll_slice` red.
+Plus the born-red evidence for the tier move: before the change,
+`test_every_staggered_body_runs_after_the_ui_is_ready` failed with *"staggered boot
+workers that ran before _ui_ready: ['chachanotes_fts_backfill',
+'subscriptions_fts_backfill']"*.
+
+### Files
+
+Added `tldw_chatbook/Utils/boot_worker_policy.py`, `tldw_chatbook/DB/fts_backfill_pacing.py`,
+`Tests/App/test_boot_worker_stagger_policy.py`. Modified `tldw_chatbook/app.py`,
+`tldw_chatbook/Subscriptions/fts_backfill.py`, `tldw_chatbook/DB/chachanotes_fts_backfill.py`
+(pacing primitives re-exported from the shared module; semantics unchanged),
+`Tests/Subscriptions/test_fts_backfill.py`, `Tests/UI/test_console_runtime_ownership.py`
+(its `getsource` pin followed the recovery kick to the new seam),
+`Tests/Performance/test_boot_worker_census.py` (docstring), `backlog/docs/lessons-testing-evidence.md`,
+`Docs/security/production-diagnostic-inventory.json` (7 added log lines, each reviewed:
+policy keys and row counts only — no user content, secrets, paths or URLs).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/chachanotes_fts_backfill.py
+++ b/tldw_chatbook/DB/chachanotes_fts_backfill.py
@@ -46,19 +46,22 @@ from typing import Callable, Optional, TYPE_CHECKING
 
 from loguru import logger
 
+from .fts_backfill_pacing import (
+    # Re-exported, not dead: this module is the documented home of the pacing
+    # contract, and TASK-22200's tests import the slice size from here.
+    ABORT_POLL_SECONDS as _ABORT_POLL_SECONDS,  # noqa: F401
+    INTER_CHUNK_PAUSE_SECONDS,
+    interruptible_sleep as _interruptible_sleep,
+)
+
 if TYPE_CHECKING:
     from .ChaChaNotes_DB import CharactersRAGDB
 
-#: Pause between chunks. Chosen against measurement, not taste: a default
-#: 500-row chunk of typical chat text holds the write lock for single-digit
-#: milliseconds, so 0.1 s caps the backfill's lock duty cycle at a few
-#: percent while still finishing a 100k-message history in tens of seconds
-#: of added wall time (background thread; nobody is waiting on it).
-INTER_CHUNK_PAUSE_SECONDS = 0.1
-
-#: Slice size for abort-checked sleeps. Also the worst-case extra shutdown
-#: latency a sleeping backfill adds once the worker is cancelled.
-_ABORT_POLL_SECONDS = 0.05
+# TASK-22215 moved the two pacing primitives above into
+# `DB/fts_backfill_pacing.py` so the subscription_items backfill (task-688)
+# could adopt the same rules instead of a second copy of them. Names, values
+# and semantics are unchanged; they are re-exported here because this module
+# is where TASK-22200 built and documented them.
 
 #: Escalating waits before retrying a chunk that lost the lock queue. Each
 #: failed attempt already sat out the connection's 15 s busy handler, so
@@ -99,33 +102,6 @@ def _is_lock_queue_timeout(exc: BaseException) -> bool:
                 return True
         current = current.__cause__ or current.__context__
     return False
-
-
-def _interruptible_sleep(
-    seconds: float,
-    should_abort: Optional[Callable[[], bool]],
-    sleep: Callable[[float], None],
-) -> bool:
-    """Sleep ``seconds``, abort-checked. Returns True if aborted.
-
-    Without ``should_abort`` this is a single ``sleep`` call (keeps injected
-    recorders 1:1 with pauses in tests). With it, the wait is sliced into
-    ``_ABORT_POLL_SECONDS`` steps so a cancelled worker stops within one
-    slice instead of finishing the whole pause.
-    """
-    if seconds <= 0:
-        return bool(should_abort and should_abort())
-    if should_abort is None:
-        sleep(seconds)
-        return False
-    remaining = seconds
-    while remaining > 0:
-        if should_abort():
-            return True
-        step = min(_ABORT_POLL_SECONDS, remaining)
-        sleep(step)
-        remaining -= step
-    return should_abort()
 
 
 def backfill_chachanotes_messages_fts(

--- a/tldw_chatbook/DB/fts_backfill_pacing.py
+++ b/tldw_chatbook/DB/fts_backfill_pacing.py
@@ -1,0 +1,78 @@
+"""Pacing primitives shared by the background FTS backfills.
+
+Extracted in TASK-22215 from ``DB/chachanotes_fts_backfill.py``, where
+TASK-22200 first built them, so the *other* boot-time backfill
+(``Subscriptions/fts_backfill.py``, task-688) yields to foreground work by the
+same rules rather than by a second, drifting copy of them.
+
+Both drivers have the same shape: a resumable loop of ``BEGIN IMMEDIATE``
+chunks whose frontier lives in the database, running on a boot-time thread
+worker that nothing waits on. Two properties matter and both live here:
+
+* **Yield between chunks.** Back-to-back chunks convoy against every
+  foreground UI write (also ``BEGIN IMMEDIATE``), so a foreground writer waits
+  out chunk after chunk. A pause after each chunk that did work bounds the
+  backfill's share of the write lock to a few percent and lets a foreground
+  writer take it inside the gap.
+* **Abort-checked waits.** A cancel that only sets a flag cannot cut a plain
+  ``time.sleep``, so shutdown would wait out every remaining pause. Waits are
+  sliced at :data:`ABORT_POLL_SECONDS` and re-check the caller's abort flag
+  between slices; stopping is always safe because the frontier is in the
+  database, not in the loop.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+__all__ = [
+    "INTER_CHUNK_PAUSE_SECONDS",
+    "ABORT_POLL_SECONDS",
+    "interruptible_sleep",
+]
+
+#: Pause between chunks. Chosen against measurement, not taste (TASK-22200): a
+#: default 500-row chunk of typical chat text holds the write lock for
+#: single-digit milliseconds, so 0.1 s caps the backfill's lock duty cycle at a
+#: few percent while still finishing a 100k-row history in tens of seconds of
+#: added wall time (background thread; nobody is waiting on it).
+INTER_CHUNK_PAUSE_SECONDS = 0.1
+
+#: Slice size for abort-checked sleeps. Also the worst-case extra shutdown
+#: latency a sleeping backfill adds once its worker is cancelled.
+ABORT_POLL_SECONDS = 0.05
+
+
+def interruptible_sleep(
+    seconds: float,
+    should_abort: Optional[Callable[[], bool]],
+    sleep: Callable[[float], None],
+) -> bool:
+    """Sleep ``seconds``, abort-checked. Returns True if aborted.
+
+    Without ``should_abort`` this is a single ``sleep`` call (keeps injected
+    recorders 1:1 with pauses in tests). With it, the wait is sliced into
+    :data:`ABORT_POLL_SECONDS` steps so a cancelled worker stops within one
+    slice instead of finishing the whole pause.
+
+    Args:
+        seconds: How long to wait; ``<= 0`` only polls the abort flag.
+        should_abort: Optional predicate polled between slices.
+        sleep: The sleep implementation (injected by tests).
+
+    Returns:
+        True if ``should_abort`` asked to stop, False otherwise.
+    """
+    if seconds <= 0:
+        return bool(should_abort and should_abort())
+    if should_abort is None:
+        sleep(seconds)
+        return False
+    remaining = seconds
+    while remaining > 0:
+        if should_abort():
+            return True
+        step = min(ABORT_POLL_SECONDS, remaining)
+        sleep(step)
+        remaining -= step
+    return should_abort()

--- a/tldw_chatbook/Subscriptions/fts_backfill.py
+++ b/tldw_chatbook/Subscriptions/fts_backfill.py
@@ -12,12 +12,35 @@ fix -- it just drives ``backfill_items_fts`` to completion. ``app.py`` wires
 it into a ``run_worker(thread=True)`` call at startup so a large backlog
 never blocks app boot or screen mount; see
 ``TldwCli._backfill_subscription_items_fts``.
+
+Pacing (TASK-22215, closing the half of TASK-22200's "backfills yield to
+foreground work" that its ChaChaNotes sibling did not cover): this loop also
+ran its chunks back to back, so on a profile with a large pre-index backlog it
+held ``subscriptions.db``'s write lock essentially continuously while the app
+was already serving screens -- and every watchlist ingest write, item status
+change and briefing write is also ``BEGIN IMMEDIATE`` on that database. It now
+sleeps :data:`~tldw_chatbook.DB.fts_backfill_pacing.INTER_CHUNK_PAUSE_SECONDS`
+after every chunk that indexed rows, and the wait is abort-sliced so a
+cancelled worker (app quit) stops within one slice instead of waiting out the
+pause. Stopping early is safe for the same reason a crash is: the frontier is
+``subscription_items_fts_docsize`` membership in the database itself.
+
+Deliberately NOT copied from the ChaChaNotes driver: its lock-queue retry
+schedule. That exists because chat writes race the messages backfill
+constantly; here a chunk that loses the queue after the connection's own busy
+timeout is rare enough that the existing fail-and-resume-next-boot contract is
+still the honest behavior, and inventing a retry loop without a measurement to
+size it would be the "clever, unstable" half of the owner's ruling.
 """
 
 from __future__ import annotations
 
+import time
+from typing import Callable, Optional
+
 from loguru import logger
 
+from ..DB.fts_backfill_pacing import INTER_CHUNK_PAUSE_SECONDS, interruptible_sleep
 from ..DB.Subscriptions_DB import SubscriptionsDB
 
 
@@ -39,7 +62,14 @@ class FTSBackfillError(RuntimeError):
         self.rows_indexed = rows_indexed
 
 
-def backfill_subscription_items_fts(db: SubscriptionsDB, chunk_size: int = 500) -> int:
+def backfill_subscription_items_fts(
+    db: SubscriptionsDB,
+    chunk_size: int = 500,
+    *,
+    pause_seconds: float = INTER_CHUNK_PAUSE_SECONDS,
+    should_abort: Optional[Callable[[], bool]] = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int:
     """Index every pre-existing ``subscription_items`` row missing from FTS.
 
     ``SubscriptionsDB.backfill_items_fts`` indexes at most ``chunk_size`` rows
@@ -56,10 +86,19 @@ def backfill_subscription_items_fts(db: SubscriptionsDB, chunk_size: int = 500) 
     Args:
         db: The ``SubscriptionsDB`` instance to backfill.
         chunk_size: Rows to index per underlying ``backfill_items_fts`` call.
+        pause_seconds: Yield this long after every chunk that indexed rows, so
+            foreground writers can take the write lock in the gap. ``0``
+            restores the old back-to-back loop (tests, one-shot scripts).
+        should_abort: Polled between chunks and inside every pause; when it
+            returns True the run stops and returns what it indexed so far. The
+            app passes the Textual worker's ``is_cancelled``, so quitting does
+            not wait out a pause.
+        sleep: Sleep implementation, injected by tests.
 
     Returns:
         Total number of rows indexed by this call (``0`` if there was
-        nothing left to index).
+        nothing left to index, or if the run was aborted before its first
+        chunk).
 
     Raises:
         FTSBackfillError: If the underlying ``backfill_items_fts`` call
@@ -70,6 +109,13 @@ def backfill_subscription_items_fts(db: SubscriptionsDB, chunk_size: int = 500) 
     """
     total = 0
     while True:
+        if should_abort is not None and should_abort():
+            logger.debug(
+                "Subscription items FTS backfill aborted after {} row(s); "
+                "the remaining frontier resumes on the next run.",
+                total,
+            )
+            return total
         try:
             indexed = db.backfill_items_fts(chunk_size=chunk_size)
         except Exception as exc:
@@ -83,6 +129,15 @@ def backfill_subscription_items_fts(db: SubscriptionsDB, chunk_size: int = 500) 
             indexed,
             total,
         )
+        # Only a chunk that did work pays the pause: the every-boot no-op
+        # probe (one indexed scan finding nothing) must stay free.
+        if interruptible_sleep(pause_seconds, should_abort, sleep):
+            logger.debug(
+                "Subscription items FTS backfill aborted mid-pause after {} "
+                "row(s); the remaining frontier resumes on the next run.",
+                total,
+            )
+            return total
 
     if total:
         logger.info(

--- a/tldw_chatbook/Utils/boot_worker_policy.py
+++ b/tldw_chatbook/Utils/boot_worker_policy.py
@@ -1,0 +1,369 @@
+"""Explicit start policy for the boot-time background worker fleet (TASK-22215).
+
+The 2026-08-24 holistic perf review counted the boot-time concurrent worker
+fleet growing 4 -> 7. Each member was individually justified; the aggregate is
+what the user feels, because under the GIL those threads plus the Textual
+message pump share one interpreter during the first seconds after mount --
+worst on the first post-upgrade boot, when the ChaChaNotes FTS backfill runs to
+completion alongside the screen pre-importer.
+
+``Tests/Performance/test_boot_worker_census.py`` (TASK-22222) pins *which*
+workers may start during boot. This module is the other half: *when* and *how
+many at once*. It is deliberately pure -- specs, an order, a cap, and an
+admission gate with no Textual, no app and no I/O -- so the policy can be
+asserted directly and ``app.py`` is left holding only the wiring.
+
+What the policy actually decides
+--------------------------------
+
+Two tiers:
+
+``IMMEDIATE``
+    Started during ``on_mount``, before first paint, because something a user
+    can reach at once is degraded until they finish (or because they are
+    long-lived loops that spend their life awaiting and cost the interpreter
+    nothing).
+
+``STAGGERED``
+    Started after ``_ui_ready``, in the declared order, at most
+    :data:`MAX_CONCURRENT_STAGGERED_BOOT_WORKERS` at a time; each completion
+    admits the next. Every member here is either a *prefetch* for a surface
+    that re-runs the same work itself behind a once-gate, or a resumable
+    background rebuild that no surface waits on. That is the property that
+    makes delaying one safe, and it is recorded per row in ``unblocks``.
+
+The honest lever is ORDER and CONCURRENCY, not more sleeping: a sleep cannot
+subdivide one ``import_module`` or one ``BEGIN IMMEDIATE`` chunk (TASK-21113,
+TASK-22214). Pacing *within* a worker is that worker's own business -- see
+``DB/chachanotes_fts_backfill.py`` (TASK-22200) and the screen pre-importer's
+proportional yield (``app.py``'s ``SCREEN_PREIMPORT_*``).
+
+Deliberately NOT gated here
+---------------------------
+
+* The screen pre-importer. It is a daemon thread, not a Textual worker; it
+  already paces itself proportionally to each import's cost (TASK-22214), and
+  it protects the FIRST click to Library/Settings -- queueing it behind a
+  minutes-long FTS backfill would trade away the exact thing it exists for.
+* ``on_mount``'s coroutine workers (the scheduler loop and the research
+  startup reconciles). They are await-shaped: their thread time is bounded
+  ``asyncio.to_thread`` hops, and the scheduler loop is time-sensitive.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+__all__ = [
+    "BootWorkerSpec",
+    "BootWorkerTier",
+    "BOOT_WORKER_POLICY",
+    "IMMEDIATE_BOOT_WORKERS",
+    "STAGGERED_BOOT_WORKERS",
+    "STAGGERED_BOOT_WORKER_KEYS",
+    "MAX_CONCURRENT_STAGGERED_BOOT_WORKERS",
+    "BOOT_WORKER_KEY_BY_IDENTITY",
+    "StaggeredBootWorkerGate",
+]
+
+
+class BootWorkerTier(str, Enum):
+    """When a boot worker is allowed to start."""
+
+    #: Started in ``on_mount``, before first paint.
+    IMMEDIATE = "immediate"
+    #: Started after ``_ui_ready``, in policy order, under the concurrency cap.
+    STAGGERED = "staggered"
+
+
+@dataclass(frozen=True)
+class BootWorkerSpec:
+    """One boot worker's start policy.
+
+    Attributes:
+        key: Stable policy identifier, used by ``app.py``'s starter table and
+            by the admission gate. Independent of the worker's Textual name so
+            a rename cannot silently detach a row from its policy.
+        name: The Textual worker ``name`` -- must match the (name, group) pair
+            censused by ``Tests/Performance/test_boot_worker_census.py``.
+        group: The Textual worker ``group``.
+        tier: :class:`BootWorkerTier`.
+        unblocks: The user-visible surface that is degraded until this worker
+            finishes, or the explicit statement that nothing waits on it. This
+            is the starvation check a reorder has to pass, so it is a required
+            field rather than a comment.
+    """
+
+    key: str
+    name: str
+    group: str
+    tier: BootWorkerTier
+    unblocks: str
+
+    def __post_init__(self) -> None:
+        if not self.key or not self.name or not self.group:
+            raise ValueError("boot worker specs need a key, a name and a group")
+        if not self.unblocks:
+            raise ValueError(
+                f"boot worker {self.key!r} must record what it unblocks -- a "
+                "reorder cannot be reviewed without it"
+            )
+
+
+#: The fleet, in start order. Staggered rows are admitted top-down.
+#:
+#: Priority reasoning, recorded because it is the reviewable part:
+#:
+#: 1. ``actor_pack_recovery`` and ``actor_pack_staging_sweep`` are prefetches
+#:    for surfaces that gate on the SAME once-lock (Personas' first library
+#:    read / ``create_persona``; the importer's ``inspect_archive``). If the
+#:    worker has not run, the surface runs the work itself -- on the event
+#:    loop. They are short one-shots, so they go first: finishing them frees
+#:    the slots quickly and removes the inline-cost risk.
+#: 2. The two FTS backfills go last, and behind each other (the cap is 1, so
+#:    the order IS the schedule). Nothing waits on either -- search fills in
+#:    progressively and both are resumable across kills -- and on a first
+#:    post-upgrade boot the ChaChaNotes one can run for tens of seconds, so it
+#:    is exactly the member that must not sit in front of a worker a surface
+#:    can block on.
+BOOT_WORKER_POLICY: tuple[BootWorkerSpec, ...] = (
+    # -- IMMEDIATE: before first paint --
+    BootWorkerSpec(
+        key="scheduler_loop",
+        name="run",
+        group="scheduling",
+        tier=BootWorkerTier.IMMEDIATE,
+        unblocks=(
+            "Reminders and scheduled watchlist checks that are already overdue "
+            "at launch. A coroutine worker that spends its life awaiting, so "
+            "starting it early costs the interpreter nothing; it must also stay "
+            "on the app's one event loop (the watchlists in-flight guard is "
+            "lock-free on that invariant)."
+        ),
+    ),
+    BootWorkerSpec(
+        key="ingest_restore",
+        name="restore_ingest_jobs",
+        group="ingest_restore",
+        tier=BootWorkerTier.IMMEDIATE,
+        unblocks=(
+            "The Library ingest job history. Until it lands the in-memory "
+            "registry is empty, so a user opening Library ingest sees no "
+            "history at all -- a wrong answer, not a slow one. Bounded work "
+            "against one small store."
+        ),
+    ),
+    # -- STAGGERED: after `_ui_ready`, capped, in this order --
+    BootWorkerSpec(
+        key="actor_pack_recovery",
+        name="deferred_actor_pack_recovery",
+        group="actor_pack_recovery",
+        tier=BootWorkerTier.STAGGERED,
+        unblocks=(
+            "Nothing hard: the Personas screen's first library read and every "
+            "create_persona gate on the coordinator's own once-lock. This "
+            "worker is the prefetch that keeps that gate from running SQLite "
+            "recovery on the event loop -- so it is first among the staggered."
+        ),
+    ),
+    BootWorkerSpec(
+        key="actor_pack_staging_sweep",
+        name="deferred_actor_pack_staging_sweep",
+        group="actor_pack_staging_sweep",
+        tier=BootWorkerTier.STAGGERED,
+        unblocks=(
+            "Nothing hard: ActorPackImportService.inspect_archive gates on the "
+            "same once-lock, so a first import sweeps for itself. Prefetch of a "
+            "filesystem walk, second for the same reason as recovery."
+        ),
+    ),
+    BootWorkerSpec(
+        key="chachanotes_fts_backfill",
+        name="_backfill_chachanotes_messages_fts",
+        group="chachanotes-fts-backfill",
+        tier=BootWorkerTier.STAGGERED,
+        unblocks=(
+            "Nothing. Message-content search over pre-upgrade history fills in "
+            "progressively and the frontier lives in the database "
+            "(messages_fts_docsize), so a run that never starts, is cut short "
+            "or is cancelled simply resumes next boot. The longest-running "
+            "member of the fleet on a first post-upgrade boot."
+        ),
+    ),
+    BootWorkerSpec(
+        key="subscriptions_fts_backfill",
+        name="_backfill_subscription_items_fts",
+        group="subscriptions-fts-backfill",
+        tier=BootWorkerTier.STAGGERED,
+        unblocks=(
+            "Nothing. Search over subscription items scraped before the FTS "
+            "index existed; resumable exactly like the ChaChaNotes backfill "
+            "(subscription_items_fts_docsize). Last, so it runs behind that "
+            "one rather than beside it -- two whole-table re-tokenizations at "
+            "once is the shape this policy exists to prevent."
+        ),
+    ),
+)
+
+#: How many staggered boot workers may run at once. One: the fleet is strictly
+#: serial in policy order, which is the whole point of the finding -- the
+#: aggregate, not any individual member, is what the user feels.
+#:
+#: Why not two (the first cut). With a cap of two and this order, the two
+#: prefetches finish quickly and then BOTH FTS backfills are admitted -- so
+#: the worst shape in the fleet, two whole-table re-tokenizations running at
+#: once, is exactly what the cap would still permit. Serializing costs the
+#: prefetches nothing measurable (they are ahead of the backfills, and their
+#: own durations are milliseconds on a healthy profile), and nothing else in
+#: the tier has a waiter.
+#:
+#: What still runs alongside: the screen pre-importer's daemon thread, the
+#: immediate tier, and the event loop itself. This cap bounds the staggered
+#: fleet, not the process.
+MAX_CONCURRENT_STAGGERED_BOOT_WORKERS = 1
+
+IMMEDIATE_BOOT_WORKERS: tuple[BootWorkerSpec, ...] = tuple(
+    spec for spec in BOOT_WORKER_POLICY if spec.tier is BootWorkerTier.IMMEDIATE
+)
+
+STAGGERED_BOOT_WORKERS: tuple[BootWorkerSpec, ...] = tuple(
+    spec for spec in BOOT_WORKER_POLICY if spec.tier is BootWorkerTier.STAGGERED
+)
+
+STAGGERED_BOOT_WORKER_KEYS: tuple[str, ...] = tuple(
+    spec.key for spec in STAGGERED_BOOT_WORKERS
+)
+
+#: (worker name, worker group) -> policy key, for mapping a Textual
+#: ``Worker.StateChanged`` back onto the row that owns its slot.
+BOOT_WORKER_KEY_BY_IDENTITY: dict[tuple[str, str], str] = {
+    (spec.name, spec.group): spec.key for spec in BOOT_WORKER_POLICY
+}
+
+if len({spec.key for spec in BOOT_WORKER_POLICY}) != len(BOOT_WORKER_POLICY):
+    raise RuntimeError("duplicate key in BOOT_WORKER_POLICY")
+if len(BOOT_WORKER_KEY_BY_IDENTITY) != len(BOOT_WORKER_POLICY):
+    raise RuntimeError("duplicate (name, group) in BOOT_WORKER_POLICY")
+
+
+class StaggeredBootWorkerGate:
+    """Admits staggered boot workers in policy order, ``limit`` at a time.
+
+    Pure bookkeeping: it never starts anything. The caller starts whatever
+    :meth:`admit` hands back and calls :meth:`complete` when that worker
+    reaches a terminal state (or failed to start at all), which frees the slot
+    and lets the next admission through.
+
+    Not thread-safe by design: every call site is the Textual event loop
+    (deferred-startup scheduling, the ``Worker.StateChanged`` hook, and the
+    reconcile timer), and adding a lock would invite off-loop use.
+    """
+
+    def __init__(self, keys: Iterable[str], limit: int) -> None:
+        """Build a gate over ``keys`` in order.
+
+        Args:
+            keys: Policy keys, in admission order.
+            limit: Maximum simultaneously in-flight workers (>= 1).
+
+        Raises:
+            ValueError: If ``limit`` < 1 or ``keys`` contains duplicates.
+        """
+        if limit < 1:
+            raise ValueError("a boot worker gate needs room for at least one worker")
+        ordered = list(keys)
+        if len(set(ordered)) != len(ordered):
+            raise ValueError(f"duplicate boot worker key in {ordered!r}")
+        self._pending: deque[str] = deque(ordered)
+        self._in_flight: list[str] = []
+        self._limit = limit
+        self._closed = False
+
+    @property
+    def limit(self) -> int:
+        """Maximum simultaneously in-flight workers."""
+        return self._limit
+
+    @property
+    def pending(self) -> tuple[str, ...]:
+        """Keys not yet admitted, in admission order."""
+        return tuple(self._pending)
+
+    @property
+    def in_flight(self) -> tuple[str, ...]:
+        """Keys admitted and not yet completed."""
+        return tuple(self._in_flight)
+
+    @property
+    def is_closed(self) -> bool:
+        """Whether the gate has been closed (shutdown); nothing more admits."""
+        return self._closed
+
+    @property
+    def is_drained(self) -> bool:
+        """Whether nothing is pending and nothing is in flight."""
+        return not self._pending and not self._in_flight
+
+    def admit(self) -> tuple[str, ...]:
+        """Take as many keys as the cap allows, marking them in flight.
+
+        Returns:
+            The keys the caller must now start, in policy order. Empty when
+            the gate is closed, drained, or already at its cap.
+        """
+        if self._closed:
+            return ()
+        admitted: list[str] = []
+        while self._pending and len(self._in_flight) < self._limit:
+            key = self._pending.popleft()
+            self._in_flight.append(key)
+            admitted.append(key)
+        return tuple(admitted)
+
+    def complete(self, key: str) -> bool:
+        """Release ``key``'s slot.
+
+        Args:
+            key: A previously admitted key. Unknown or already-completed keys
+                are ignored -- the same terminal transition can reach the gate
+                from both the worker hook and the reconcile timer.
+
+        Returns:
+            True if a slot was actually released.
+        """
+        if key not in self._in_flight:
+            return False
+        self._in_flight.remove(key)
+        return True
+
+    def close(self) -> tuple[str, ...]:
+        """Stop admitting (shutdown) and drop whatever never started.
+
+        Returns:
+            The keys that were still pending, in order -- for the caller's log.
+            Their work is not lost: every staggered member is either re-run by
+            the surface that gates on it or resumes from a frontier in its own
+            database on the next boot.
+        """
+        self._closed = True
+        dropped = tuple(self._pending)
+        self._pending.clear()
+        return dropped
+
+
+def describe_policy(specs: Sequence[BootWorkerSpec] = BOOT_WORKER_POLICY) -> str:
+    """Render the policy as a readable table (diagnostics, docs, review).
+
+    Args:
+        specs: Rows to render; defaults to the whole policy.
+
+    Returns:
+        One line per row: tier, key, (name, group).
+    """
+    return "\n".join(
+        f"{spec.tier.value:<10} {spec.key:<28} ({spec.name}, {spec.group})"
+        for spec in specs
+    )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -305,6 +305,12 @@ from tldw_chatbook.Utils.app_shutdown import (
     register_running_app,
     unregister_running_app,
 )
+from tldw_chatbook.Utils.boot_worker_policy import (
+    BOOT_WORKER_KEY_BY_IDENTITY,
+    MAX_CONCURRENT_STAGGERED_BOOT_WORKERS,
+    STAGGERED_BOOT_WORKER_KEYS,
+    StaggeredBootWorkerGate,
+)
 from tldw_chatbook.Utils.ui_responsiveness import UIResponsivenessMonitor
 from tldw_chatbook.Utils.db_status_manager import DBStatusManager
 from tldw_chatbook.Utils.persistent_diagnostics import persist_event
@@ -735,6 +741,16 @@ DEFERRED_MEDIA_CLEANUP_DELAY_SECONDS = 5.0
 # (the wait ends the moment the last worker finishes) while still bounding a
 # thread worker that will not notice cancellation at all.
 WORKER_CANCELLATION_GRACE_SECONDS = 3.0
+
+# TASK-22215: how often the staggered boot fleet reconciles its admission
+# slots against the workers actually holding them. This is a BACKSTOP for a
+# terminal transition that never reaches `on_worker_state_changed`, not the
+# primary mechanism -- so it is deliberately slow (it costs one dict walk over
+# at most `MAX_CONCURRENT_STAGGERED_BOOT_WORKERS` entries) and stops itself the
+# moment the gate drains. Without it, one lost event would strand every
+# remaining member of the fleet for the whole session: exactly the failure a
+# stagger policy must not introduce.
+BOOT_WORKER_RECONCILE_INTERVAL_SECONDS = 2.0
 
 # task-15472: after first paint, warm the lazy screen-module import cache from
 # a background thread so the FIRST click to each tab doesn't pay for a
@@ -7061,6 +7077,14 @@ class TldwCli(
         self._shutting_down = False  # Track if app is shutting down
         self._quit_in_progress = False
 
+        # TASK-22215: staggered boot-worker fleet state. The gate is built at
+        # `_ui_ready` (`_start_staggered_boot_workers`); until then there is
+        # deliberately nothing to admit, because every member of the fleet is
+        # post-first-paint work by policy.
+        self._boot_worker_gate: StaggeredBootWorkerGate | None = None
+        self._boot_worker_handles: dict[str, Worker] = {}
+        self._boot_worker_reconcile_timer: Optional[Timer] = None
+
         # --- Assign DB instances for event handlers ---
         if self.prompts_service_initialized:
             # Get the database instance using the get_db_instance() function
@@ -9529,7 +9553,22 @@ class TldwCli(
         hop scheduled onto that thread gets a fresh connection instead of a
         closed one. It is not safe to "improve" this into a close of the
         instance itself.
+
+        TASK-22215: the driver paces itself between chunks (the TASK-22200
+        treatment, now shared) and this worker hands it the Textual worker's
+        cancellation flag -- pacing makes the run longer, and a thread worker
+        that never polls ``is_cancelled`` would make shutdown wait out every
+        remaining pause. Stopping is safe: the resume frontier lives in the
+        database.
         """
+        from textual.worker import NoActiveWorker, get_current_worker
+
+        try:
+            worker = get_current_worker()
+        except NoActiveWorker:
+            worker = None  # direct calls in tests/harnesses run un-cancellable
+        should_abort = (lambda: worker.is_cancelled) if worker is not None else None
+
         db = None
         db_path = get_subscriptions_db_path()
         try:
@@ -9537,7 +9576,7 @@ class TldwCli(
             if db is None:
                 # Only a harness that skipped service wiring gets here.
                 db = SubscriptionsDB(db_path, CLI_APP_CLIENT_ID)
-            backfill_subscription_items_fts(db)
+            backfill_subscription_items_fts(db, should_abort=should_abort)
         except FTSBackfillError as exc:
             logger.opt(exception=True).error(
                 "Subscription items FTS backfill failed for database {} "
@@ -12476,28 +12515,12 @@ class TldwCli(
             group="scheduling",
         )
 
-        # task-688: index subscription_items rows scraped before the FTS5
-        # index existed, so search covers a user's whole back catalogue
-        # without any action on their part. thread=True because this does
-        # blocking sqlite work; never blocks startup or screen mount since
-        # run_worker only schedules it.
-        self.run_worker(
-            self._backfill_subscription_items_fts,
-            thread=True,
-            exclusive=True,
-            group="subscriptions-fts-backfill",
-        )
-
-        # task-21100: reinsert the messages the v45->v46 FTS reset no longer
-        # indexes inline, so an upgraded profile's chat history becomes fully
-        # searchable again without ever blocking boot on the index rewrite.
-        # thread=True for the same reason as the subscriptions backfill above.
-        self.run_worker(
-            self._backfill_chachanotes_messages_fts,
-            thread=True,
-            exclusive=True,
-            group="chachanotes-fts-backfill",
-        )
+        # TASK-22215: the two FTS backfills (task-688 subscription_items,
+        # task-21100 messages) used to start HERE, before first paint, next
+        # to the scheduler. They are whole-table re-tokenizations that
+        # nothing waits on and that resume from a frontier in their own
+        # database, so they belong in the staggered tier -- see
+        # `Utils/boot_worker_policy.py` and `_start_staggered_boot_workers`.
 
     def _init_model_catalog_disk_store(self) -> "ModelCatalogDiskStore | None":
         """Build the disk-backed model catalog cache for startup (ADR-020).
@@ -13464,33 +13487,12 @@ class TldwCli(
     def _schedule_deferred_startup_work(self) -> None:
         """Start nonessential services after the first interactive UI frame."""
 
-        # task-21106: Actor Pack crash recovery moved here from __init__ —
-        # synchronous SQLite has no place on the construction path. A thread
-        # worker (not a coroutine) because recovery does blocking DB I/O; the
-        # coordinator's own once-guard makes every later surface-side call
-        # (Personas mount, create_persona) a cached no-op.
-        self.run_worker(
-            self.ensure_actor_pack_recovery,
-            name="deferred_actor_pack_recovery",
-            group="actor_pack_recovery",
-            thread=True,
-            exclusive=True,
-            exit_on_error=False,
-        )
-        # task-22216: the Actor Pack staging crash-sweep moved here from
-        # ActorPackImportService.__init__ (reached from __init__ via
-        # _wire_character_persona_services) — synchronous filesystem I/O
-        # has no place on the construction path. The service's once-gate
-        # also fires at the entry of inspect_archive, so whichever comes
-        # first sweeps and the other is a cached no-op.
-        self.run_worker(
-            self.ensure_actor_pack_staging_sweep,
-            name="deferred_actor_pack_staging_sweep",
-            group="actor_pack_staging_sweep",
-            thread=True,
-            exclusive=True,
-            exit_on_error=False,
-        )
+        # TASK-22215: the boot-time thread fleet starts here, under the
+        # explicit order/concurrency policy in `Utils/boot_worker_policy.py`,
+        # rather than all at once (and rather than partly from `on_mount`,
+        # ahead of first paint, which is where the two FTS backfills used to
+        # start).
+        self._start_staggered_boot_workers()
         self.set_timer(
             DEFERRED_DB_SIZE_UPDATE_DELAY_SECONDS,
             self._schedule_footer_status_updates,
@@ -13529,6 +13531,252 @@ class TldwCli(
                 name="deferred_legacy_citation_migration",
             )
         self._schedule_launch_wake()
+
+    # ------------------------------------------------------------------
+    # TASK-22215: the staggered boot-worker fleet
+    # ------------------------------------------------------------------
+
+    def boot_worker_starters(self) -> dict[str, Callable[[], Optional[Worker]]]:
+        """The start callables for every staggered boot worker, by policy key.
+
+        One table, so the policy (``Utils/boot_worker_policy.py``) and the
+        code that starts the fleet cannot drift apart: a key with no starter
+        -- or a starter with no key -- is a test failure, not a worker that
+        silently never runs.
+
+        Returns:
+            Policy key -> zero-argument callable returning the started
+            ``Worker`` (or ``None`` when there was nothing to start).
+        """
+
+        def start_actor_pack_recovery() -> Worker:
+            # task-21106: Actor Pack crash recovery, moved out of __init__ --
+            # synchronous SQLite has no place on the construction path. A
+            # thread worker (not a coroutine) because recovery does blocking
+            # DB I/O; the coordinator's own once-guard makes every later
+            # surface-side call (Personas mount, create_persona) a cached
+            # no-op -- which is also why this may be staggered at all.
+            return self.run_worker(
+                self.ensure_actor_pack_recovery,
+                name="deferred_actor_pack_recovery",
+                group="actor_pack_recovery",
+                thread=True,
+                exclusive=True,
+                exit_on_error=False,
+            )
+
+        def start_actor_pack_staging_sweep() -> Worker:
+            # task-22216: the Actor Pack staging crash-sweep, moved out of
+            # ActorPackImportService.__init__ (synchronous filesystem I/O on
+            # the construction path). The service's once-gate also fires at
+            # the entry of inspect_archive, so whichever comes first sweeps
+            # and the other is a cached no-op.
+            return self.run_worker(
+                self.ensure_actor_pack_staging_sweep,
+                name="deferred_actor_pack_staging_sweep",
+                group="actor_pack_staging_sweep",
+                thread=True,
+                exclusive=True,
+                exit_on_error=False,
+            )
+
+        def start_chachanotes_fts_backfill() -> Worker:
+            # task-21100: reinsert the messages the v45->v46 FTS reset no
+            # longer indexes inline, so an upgraded profile's chat history
+            # becomes fully searchable again. thread=True: blocking sqlite.
+            # The name is explicit so the (name, group) identity the boot
+            # census pins cannot drift with a method rename.
+            return self.run_worker(
+                self._backfill_chachanotes_messages_fts,
+                name="_backfill_chachanotes_messages_fts",
+                group="chachanotes-fts-backfill",
+                thread=True,
+                exclusive=True,
+            )
+
+        def start_subscriptions_fts_backfill() -> Worker:
+            # task-688: index subscription_items rows scraped before the FTS5
+            # index existed, so search covers a user's whole back catalogue
+            # without any action on their part.
+            return self.run_worker(
+                self._backfill_subscription_items_fts,
+                name="_backfill_subscription_items_fts",
+                group="subscriptions-fts-backfill",
+                thread=True,
+                exclusive=True,
+            )
+
+        return {
+            "actor_pack_recovery": start_actor_pack_recovery,
+            "actor_pack_staging_sweep": start_actor_pack_staging_sweep,
+            "chachanotes_fts_backfill": start_chachanotes_fts_backfill,
+            "subscriptions_fts_backfill": start_subscriptions_fts_backfill,
+        }
+
+    def _start_boot_worker(self, key: str) -> Optional[Worker]:
+        """Start one staggered boot worker.
+
+        Args:
+            key: A key from ``STAGGERED_BOOT_WORKER_KEYS``.
+
+        Returns:
+            The started worker, or None if the key has no starter (which is a
+            wiring bug the policy test catches, not a runtime failure).
+        """
+        starter = self.boot_worker_starters().get(key)
+        if starter is None:
+            self.loguru_logger.warning(
+                f"No starter registered for staggered boot worker {key!r}"
+            )
+            return None
+        return starter()
+
+    def _start_staggered_boot_workers(self) -> None:
+        """Open the admission gate for the post-readiness boot fleet.
+
+        Called once, from ``_schedule_deferred_startup_work`` (the last
+        statement of ``_post_mount_setup``, i.e. after ``_ui_ready``).
+        """
+        if getattr(self, "_shutting_down", False):
+            return
+        self._boot_worker_gate = StaggeredBootWorkerGate(
+            STAGGERED_BOOT_WORKER_KEYS,
+            MAX_CONCURRENT_STAGGERED_BOOT_WORKERS,
+        )
+        self._boot_worker_handles = {}
+        self._admit_staggered_boot_workers()
+
+    def _admit_staggered_boot_workers(self) -> None:
+        """Start whatever the gate admits, then arm the reconcile timer.
+
+        Loops because a starter that raises (or declines to start anything)
+        frees its slot immediately -- the queue must advance past it in the
+        same pass rather than waiting for a completion that will never come.
+        """
+        gate = getattr(self, "_boot_worker_gate", None)
+        if gate is None:
+            return
+        if getattr(self, "_shutting_down", False):
+            self._close_boot_worker_gate("shutdown")
+            return
+        while True:
+            admitted = gate.admit()
+            if not admitted:
+                break
+            for key in admitted:
+                worker: Optional[Worker] = None
+                try:
+                    worker = self._start_boot_worker(key)
+                except Exception:
+                    self.loguru_logger.opt(exception=True).warning(
+                        f"Staggered boot worker {key!r} failed to start"
+                    )
+                if worker is None:
+                    # Nothing is in flight for this key, so no terminal
+                    # transition will ever arrive: release the slot now.
+                    gate.complete(key)
+                    continue
+                self._boot_worker_handles[key] = worker
+        self._arm_boot_worker_reconcile()
+
+    def _release_boot_worker_slot(self, worker: Any) -> None:
+        """Free the slot a finished boot worker held and admit the next.
+
+        Args:
+            worker: The worker whose state just went terminal. Anything that
+                is not a policy member is ignored, so this is safe to call
+                from the app-wide ``Worker.StateChanged`` hook.
+        """
+        gate = getattr(self, "_boot_worker_gate", None)
+        if gate is None:
+            return
+        key = BOOT_WORKER_KEY_BY_IDENTITY.get(
+            (getattr(worker, "name", ""), getattr(worker, "group", ""))
+        )
+        if key is None or not gate.complete(key):
+            return
+        self._boot_worker_handles.pop(key, None)
+        self._admit_staggered_boot_workers()
+
+    def _arm_boot_worker_reconcile(self) -> None:
+        """Keep a slow reconcile running while the fleet is outstanding.
+
+        The gate advances on ``Worker.StateChanged``. This is the backstop
+        for the one thing that hook cannot cover: a terminal transition that
+        never reaches the handler (a worker whose message is dropped during a
+        screen swap, a duck-typed worker). Without it a lost event would
+        strand every remaining member of the fleet for the whole session --
+        the failure mode a stagger policy must not introduce. It stops itself
+        as soon as the gate is drained.
+        """
+        if getattr(self, "_boot_worker_reconcile_timer", None) is not None:
+            return
+        gate = getattr(self, "_boot_worker_gate", None)
+        if gate is None or gate.is_drained or gate.is_closed:
+            return
+        try:
+            self._boot_worker_reconcile_timer = self.set_interval(
+                BOOT_WORKER_RECONCILE_INTERVAL_SECONDS,
+                self._reconcile_boot_worker_slots,
+            )
+        except Exception:  # noqa: BLE001 -- boot never dies on a backstop
+            self.loguru_logger.opt(exception=True).debug(
+                "Could not arm the staggered boot worker reconcile"
+            )
+
+    def _reconcile_boot_worker_slots(self) -> None:
+        """Release slots held by workers that already finished, then advance."""
+        gate = getattr(self, "_boot_worker_gate", None)
+        if gate is None:
+            self._stop_boot_worker_reconcile()
+            return
+        released = False
+        for key, worker in list(self._boot_worker_handles.items()):
+            finished = bool(getattr(worker, "is_finished", False)) or bool(
+                getattr(worker, "is_cancelled", False)
+            )
+            if not finished:
+                continue
+            self._boot_worker_handles.pop(key, None)
+            released = gate.complete(key) or released
+        if released:
+            self._admit_staggered_boot_workers()
+        if gate.is_drained or gate.is_closed:
+            self._stop_boot_worker_reconcile()
+
+    def _stop_boot_worker_reconcile(self) -> None:
+        """Stop the reconcile timer if one is running."""
+        timer = getattr(self, "_boot_worker_reconcile_timer", None)
+        if timer is None:
+            return
+        self._boot_worker_reconcile_timer = None
+        try:
+            timer.stop()
+        except Exception:  # noqa: BLE001 -- teardown must not raise
+            pass
+
+    def _close_boot_worker_gate(self, reason: str) -> None:
+        """Stop admitting staggered boot workers (quit/shutdown).
+
+        Whatever never started is not lost: each staggered member is either
+        re-run by the surface that gates on it (the actor-pack pair) or
+        resumes from a frontier in its own database on the next boot (both
+        FTS backfills). Workers already in flight are cancelled by the normal
+        shutdown path, not here.
+
+        Args:
+            reason: Logged, so a quit-time drop is explainable.
+        """
+        self._stop_boot_worker_reconcile()
+        gate = getattr(self, "_boot_worker_gate", None)
+        if gate is None or gate.is_closed:
+            return
+        dropped = gate.close()
+        if dropped:
+            self.loguru_logger.debug(
+                f"Staggered boot workers not started before {reason}: "
+                f"{', '.join(dropped)} (each resumes or re-runs on demand)"
+            )
 
     def _schedule_launch_wake(self) -> None:
         """Deliver a supervisor wake this install already owed at launch.
@@ -14161,6 +14409,11 @@ class TldwCli(
 
         # Set shutdown flag to prevent new operations
         self._shutting_down = True
+
+        # TASK-22215: stop admitting staggered boot workers before cancelling
+        # the live ones, so a completion arriving mid-teardown cannot start a
+        # fresh thread worker behind the cancel sweep.
+        self._close_boot_worker_gate("shutdown request")
 
         # Cancel all active workers first
         await self._cancel_and_settle_workers("shutdown request")
@@ -14991,6 +15244,24 @@ class TldwCli(
             f"(Group: {worker_group}, State: {event.state})"
         )
 
+        # TASK-22215. The same "one hook sees every transition" property the
+        # diagnostics below rely on is what advances the staggered boot fleet:
+        # a terminal state frees that worker's admission slot and lets the next
+        # member start. Non-members return immediately (one dict lookup), and
+        # the whole thing is best-effort -- a boot stagger must never be able
+        # to break the app-wide worker hook.
+        if event.state in (
+            WorkerState.SUCCESS,
+            WorkerState.ERROR,
+            WorkerState.CANCELLED,
+        ):
+            try:
+                self._release_boot_worker_slot(event.worker)
+            except Exception:
+                self.loguru_logger.opt(exception=True).debug(
+                    "Staggered boot worker slot release failed"
+                )
+
         # TASK-1240. One hook already sees every worker transition, so failures
         # are recorded without touching any of the 398 run_worker call sites.
         # Only ERROR persists: a start or success event here would emit a line
@@ -15308,6 +15579,10 @@ class TldwCli(
             return
 
         self._shutting_down = True
+        # TASK-22215: the user has approved the quit -- nothing further from
+        # the staggered boot fleet may start (idempotent with the same call in
+        # `on_shutdown_request`, which the quit path reaches later).
+        self._close_boot_worker_gate("quit")
         await self._run_approved_quit_cleanup()
 
     async def _run_approved_quit_cleanup(self) -> None:


### PR DESCRIPTION
The final task of the 2026-08-24 holistic perf review's 29-task burn-down. Boot-time concurrent workers had grown 4 → 7 during the review window; under the GIL those CPU-bound threads share one interpreter with the message pump during the first seconds after mount — worst on the first post-upgrade boot, when the FTS backfill runs alongside the pre-importer.

**Starvation check before any reorder** — what each worker actually unblocks:
- **immediate**: `scheduling` (overdue reminders + watchlist checks) and `restore_ingest_jobs` (an empty ingest registry is a *wrong* answer, not a slow one).
- **staggered**: actor-pack recovery and staging sweep (nothing hard waits, but a late start means the Personas surface runs SQLite recovery **on the event loop** — so they lead the staggered order), then the two FTS backfills (nothing waits; progressive, frontier in the DB).
- **not gated**, with reasons recorded: the pre-importer (already paced by TASK-22214, and it protects the first Library/Settings click) and `on_mount`'s coroutine workers.

**Policy**: both FTS backfills leave `on_mount` — they were starting *before first paint* — for the staggered tier. **Cap = 1**, and the first cut of 2 was wrong for a concrete reason: the short prefetches finish instantly, after which *both* whole-table re-tokenizations get admitted — precisely the shape this finding is about. Admission advances on the app-wide `Worker.StateChanged` hook with a slow `set_interval` reconcile as backstop; `_shutting_down` closes the gate.

**Measured** (simulated first-post-upgrade boot: 30k messages + 20k items, both indexes emptied; n=8/arm, interleaved both orders, A/A control at the same n):

| metric | before | after | A/A control |
|---|---|---|---|
| worst keypress | **625–876 ms** | **395–467 ms** | 426–476 ms |
| mean keypress | 111–124 ms | 99–109 ms | 101–104 ms |
| median / p95 / loop stall / time-to-ready | — | wash | — |

Warm boot is a **wash on every metric** (M-series loop isn't starved either way — the 21113/22214 precedent). **The median is reported as a wash deliberately**: the A/A control reproduced both modes of a bimodal distribution, which would have supported a tidy but false "−22% median" headline. Recorded as a new lesson. Anti-vacuity: both arms indexed ~21k messages inside the window; the mechanism shows as `subscription_items` indexed 20000 → 0 (queued, not run).

**AC 3 — TASK-22200 verified, and its gap closed**: the ChaChaNotes driver's pacing was already correct and is untouched. The **subscriptions** backfill had none of it — back-to-back chunks against `subscriptions.db`, where every watchlist write is also `BEGIN IMMEDIATE`, and no cancellation poll. Both backfills now share extracted pacing/abort-slicing primitives.

Verification: policy tests + census **17 passed** (census unchanged and green 3× — members keep their (name, group) and only change tier); final targeted run 1219 passed / 6 skipped; Architecture 325 passed; preflight green (7 added log statements read before regenerating the inventory — policy keys and row counts only). Mutations: cap→4, app ignoring the cap, order reversed, subscriptions pacing off — each reds its intended test; born-red evidence captured for the tier move. Teardown: quit with a backfill in flight + one pending → shutdown returned in 1 ms, pending never started, 4000 rows consistent, next boot drained to completion (deferral ≠ abandonment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhSbV3dj8ijoMwDRTAJFx1
