### PR TITLE
fix(citations): persist citation provenance for durable Console turns (TASK-22302)

### DIFF
--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -1309,6 +1309,74 @@ def test_terminal_selected_answer_citations_survive_restart(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_real_durable_fail_closed_finalizer_persists_the_body_once(
+    real_citation_stack_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TASK-22302 review: a finalizer that fails closed must not lose the answer.
+
+    `finalize()` returns None when the builder cannot seal -- a real, logged
+    outcome ("attempt_or_seal_failure"), and the supported way to fall back to
+    an ordinary message. On a DURABLE turn that combination is delicate, because
+    the dispatch checkpoint has already written the assistant row with EMPTY
+    content:
+
+    * the final body must still be flushed, or the durable row keeps '' while
+      the in-memory message reads complete; and
+    * the flush must be an UPDATE, because `create_message`'s existing-row
+      handling lives inside its `prepared_citation is not None` branch -- with
+      no citation it falls through to `add_message` and inserts against an id
+      that already exists.
+
+    So: one row, carrying the body, and no citation rows.
+    """
+    stack = real_citation_stack_factory("real-fail-closed")
+    builder, prompt_id = _real_captured_builder(stack.repository)
+
+    def unsealable(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("seal-sentinel")
+
+    monkeypatch.setattr(CitationTraceBuilder, "seal", unsealable, raising=False)
+    controller = _real_controller(stack, builder, prompt_id)
+
+    log_stream, handler_id = _capture_logs()
+    try:
+        result = await controller.submit_draft("question")
+    finally:
+        logger.remove(handler_id)
+
+    assistant = _real_assistant(stack.store)
+    assert result.accepted is True
+    assert assistant.content == _BODY_SENTINEL
+
+    persisted = stack.db.get_message_by_id(assistant.id)
+    assert persisted is not None
+    assert persisted["content"] == _BODY_SENTINEL, (
+        "the durable row kept the checkpoint's empty content -- the answer was "
+        f"lost on the fail-closed path: {persisted['content']!r}"
+    )
+
+    duplicates = stack.db.get_connection().execute(
+        "SELECT count(*) FROM messages WHERE id = ?", (assistant.id,)
+    ).fetchone()[0]
+    assert duplicates == 1, f"the terminal write duplicated the row ({duplicates})"
+
+    # Fail CLOSED: an ordinary message, with no citation provenance at all.
+    assert _citation_row_counts(stack.db)["rag_citation_traces"] == 0
+
+    # ...and the terminal write must COMPLETE, not be abandoned. Without the
+    # citation guard this path calls `create_message` against an id that already
+    # exists, which raises `ConflictError: Unique constraint violation` -- and
+    # `mark_message_complete` swallows it into this one log line. The body still
+    # looks right (the UPDATE above already landed), so nothing else here would
+    # notice.
+    assert "terminal_citation_persistence_abandoned" not in log_stream.getvalue(), (
+        "the terminal write was abandoned -- an exception was swallowed on the "
+        "fail-closed path"
+    )
+
+
+@pytest.mark.asyncio
 async def test_real_rollback_deterministic_unavailable_falls_back_without_trace_rows(
     real_citation_stack_factory,
 ) -> None:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1758,6 +1758,12 @@ class _DurablePostcommitContinuation:
     turn_context: ConsoleTurnExecutionContext
     prepared: _PreparedSendContinuation | None
     committed_context_epoch: int
+    #: TASK-22302: the durable turn commits in `_accept_durable_turn` and
+    #: publishes its live owners in `resume_durable_postcommit`; the terminal
+    #: citation finalizer has to survive that hand-off. It did not -- the
+    #: publish site passed a hard-coded None -- so no durable Console turn
+    #: persisted any citation provenance from `a26cdafd8` onward.
+    terminal_citation_finalizer: TerminalCitationFinalizer | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -5776,6 +5782,7 @@ class ConsoleChatController:
             turn_context=turn_context,
             prepared=prepared_continuation,
             committed_context_epoch=committed_context_epoch,
+            terminal_citation_finalizer=terminal_citation_finalizer,
         )
         with self.store.durable_preparation_lock:
             self.store.validate_durable_acceptance_fingerprint(fingerprint)
@@ -5853,7 +5860,7 @@ class ConsoleChatController:
             _user, assistant = self.store.publish_durable_turn_owners(
                 session_id,
                 commit,
-                terminal_citation_finalizer=None,
+                terminal_citation_finalizer=continuation.terminal_citation_finalizer,
                 defer_terminal_persistence=(
                     continuation.citation_repair_session is not None
                 ),

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -8180,15 +8180,18 @@ class ConsoleChatStore:
             self._bump_payload_revision(session_id)
             self._settle_failed_retry_context(message, provider_visible=True)
             try:
-                if (
-                    citation_write is not None
-                    and message.persisted_message_id is not None
-                ):
-                    # TASK-22302: the checkpoint wrote this row with empty
-                    # content, and `create_message`'s existing-row branch is an
-                    # idempotent-RETRY path that verifies rather than updates.
-                    # Flush the final body first so the row matches; the
-                    # citation write below then keys to it.
+                if message.persisted_message_id is not None:
+                    # TASK-22302: the dispatch checkpoint already wrote this row
+                    # with EMPTY content, so the final body must be flushed with
+                    # an UPDATE -- `create_message`'s existing-row handling lives
+                    # inside its `prepared_citation is not None` branch and
+                    # verifies rather than updates, so it cannot carry the body.
+                    #
+                    # This matters most on the FAIL-CLOSED path: `finalize()`
+                    # returns None when the builder cannot seal, leaving no
+                    # `citation_write` at all. Guarding this flush on one would
+                    # leave the durable row empty while the in-memory message
+                    # reads complete -- the answer lost, silently.
                     self._persist_existing_message(
                         message, preserve_provider_continuation=True
                     )

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4030,6 +4030,19 @@ class ConsoleChatStore:
         if assistant.role is not ConsoleMessageRole.ASSISTANT:
             raise RuntimeError("Committed assistant owner changed role.")
         assistant.persisted_message_id = commit.assistant_message_id
+        # TASK-22302: arm here, AFTER the durable id is assigned.
+        # `append_message` gates arming on its own `persist` flag, which is
+        # False on this path and correctly so -- the checkpoint already wrote
+        # the row. But "this call does not create the row" is not "this message
+        # has no durable row", and arming needs the latter.
+        if (
+            terminal_citation_finalizer is not None
+            and self._citation_persistence_ready()
+        ):
+            self._terminal_citation_finalizers[assistant.id] = (
+                terminal_citation_finalizer
+            )
+            self._terminal_persistence_deferred_ids.add(assistant.id)
         return user, assistant
 
     def publish_committed_identity(
@@ -8112,6 +8125,12 @@ class ConsoleChatStore:
             recovery is not None
             and recovery.assistant_message_id == message.id
             and recovery.in_flight
+            # TASK-22302: do not let this shortcut swallow a turn that still
+            # owes a terminal citation write -- `finalizer` is popped above, so
+            # returning here discards it. Scoped to an actual finalizer, not
+            # `terminal_persistence`, which is also true for a merely DEFERRED
+            # turn that has no citation to seal.
+            and finalizer is None
         ):
             message.status = "complete"
             self._bump_message_speech_revision(message.id)
@@ -8161,6 +8180,18 @@ class ConsoleChatStore:
             self._bump_payload_revision(session_id)
             self._settle_failed_retry_context(message, provider_visible=True)
             try:
+                if (
+                    citation_write is not None
+                    and message.persisted_message_id is not None
+                ):
+                    # TASK-22302: the checkpoint wrote this row with empty
+                    # content, and `create_message`'s existing-row branch is an
+                    # idempotent-RETRY path that verifies rather than updates.
+                    # Flush the final body first so the row matches; the
+                    # citation write below then keys to it.
+                    self._persist_existing_message(
+                        message, preserve_provider_continuation=True
+                    )
                 self._persist_new_message(
                     session_id=session_id,
                     message=message,


### PR DESCRIPTION
## Summary

Since `a26cdafd8` ("resume Library-gated sends"), a durable Console turn has
written **no citation provenance at all** — every `rag_citation_*` table empty
for an answer carrying citations.

Bisected:

| commit | result |
|---|---|
| `a26cdafd8~1` (`52571f925`) | **passes** |
| `a26cdafd8` | **fails** |
| `dev` before this PR | fails |

All six tables come back 0 where 1 is expected: `rag_citation_traces`,
`rag_message_trace_owners`, `rag_evidence_runs`, `rag_evidence_snapshots`,
`rag_trace_evidence_refs`, `rag_answer_attempt_payloads`.

## Four sequential blockers

Each is independently mutation-proven — reverting any one turns the real-stack
tests red.

**1. The finalizer never survived the durable hand-off.**
`_accept_durable_turn` takes `terminal_citation_finalizer` as a parameter and
used it exactly once more: it built a `_DurablePostcommitContinuation` with no
field for it, and `resume_durable_postcommit` then published the live owners
with a hard-coded `terminal_citation_finalizer=None`. The parameter was
accepted and dropped.

**2. Arming was gated on the wrong condition.**
`append_message` arms only when its own `persist` flag is true. On this path
`persist=False` is *correct* — the durable row already exists, written by the
dispatch checkpoint, so this append must not create a second one. But "this call
does not create the row" is not the same as "this message has no durable row",
and arming needs the latter.

**3. The in-flight dispatch shortcut discarded it.**
`mark_message_complete` pops the finalizer, then returns via the
dispatch-recovery branch — thirty lines above the code that would use it.

Scoped deliberately to an actual `finalizer`, **not** to `terminal_persistence`:
that is also true for a merely DEFERRED turn which has no citation to seal, and
skipping the shortcut for those turned one ordinary terminal write into two.
The first version of this fix did exactly that and broke 7 capability tests.

**4. The body then persisted as `''`.**
`create_message`'s existing-row branch is an idempotent-RETRY path: it verifies
and writes the citation but does not update content. Flushing the final body
first makes the row match, after which the citation write keys to it — **no
persistence API change required**, which matters because the alternative was
extending a transactional method.

## Why it hid for months

The one test that would have caught it was failing **earlier**, for an unrelated
reason, so it never reached the citation assertion: its stack pre-created a
conversation via `create_conversation(...)`, which writes no
`console_conversation_library_policy` row, so `commit_durable_turn` took its
"conversation exists" branch, found `policy_row is None`, and refused the turn.

That refusal was itself **silent** until TASK-22251 added
`Durable turn commit failed; turn refused (exception_type=...)` — which is
literally the line that surfaced this.

## Verification

Against current `dev`, same test set both sides:

| | `dev` | this branch |
|---|---|---|
| collected | 2105 | 2105 (delta **+0**) |
| failures | 101 | **97** |
| newly broken | — | **0** |

`test_console_terminal_citation_persistence`: **92/92**.
`./scripts/preflight.sh`: all five derived-artifact checks pass.

## A retraction worth recording

This fix was first shelved after an A/B reported 7 regressions. That comparison
was **confounded** — my branch carried #2104's test changes while the baseline
predated them, so it moved two variables at once. Re-run against `dev` with
#2104 merged, the identical fix breaks nothing. The tests it appeared to break
never call `mark_message_complete`, the only path this change touches, which is
what prompted the re-check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-22302: durable Console turns no longer lose citation provenance or the terminal answer body. The citation finalizer now survives the durable hand-off, arms at the correct point, and the final body is flushed even when the finalizer fails closed, so the durable row keeps the answer instead of the checkpoint's empty content.

**Bug Fixes**
- Carries the finalizer through `_DurablePostcommitContinuation` instead of dropping it at the publish site.
- Arms the finalizer in `_hydrate_durable_turn_owner_messages` after the durable id is assigned, since `append_message`'s `persist` flag is false on this path.
- The dispatch-recovery shortcut in `mark_message_complete` now only skips the citation write when no finalizer is pending, leaving deferred turns untouched.
- Flushes the final body whenever a durable row already exists, so a fail-closed finalizer leaves the answer in the row instead of empty content.
- Adds a real-stack regression test driving an unsealable builder: it asserts one row, the body persisted, and no citation rows.
- Running the same 2107 tests against `dev` drops failures from 101 to 97 with zero newly broken.

<sup>Written for commit 84f743be619d9e4c78a7907fd1027019086800fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

