### PR TITLE
chore: address all 60 review comments from the performance burn-down PRs

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1426,8 +1426,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "aaf302aa82116351a352",
+      "call_count": 2,
+      "diagnostic_digest": "b052e42b0107e06fda5e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notifications/event_state_repository.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3736,8 +3736,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 355,
-      "diagnostic_digest": "e87128a113e9ac3ef45e",
+      "call_count": 357,
+      "diagnostic_digest": "7a7c5b5361c2705abc5d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3976,6 +3976,6 @@
     "owner_files": 538,
     "persistent_sink_files": 8,
     "task_492_calls": 1241,
-    "task_494_calls": 7354
+    "task_494_calls": 7357
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1426,8 +1426,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "aaf302aa82116351a352",
+      "call_count": 2,
+      "diagnostic_digest": "b052e42b0107e06fda5e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notifications/event_state_repository.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3976,6 +3976,6 @@
     "owner_files": 538,
     "persistent_sink_files": 8,
     "task_492_calls": 1241,
-    "task_494_calls": 7354
+    "task_494_calls": 7355
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1426,8 +1426,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 2,
-      "diagnostic_digest": "b052e42b0107e06fda5e",
+      "call_count": 1,
+      "diagnostic_digest": "aaf302aa82116351a352",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notifications/event_state_repository.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3976,6 +3976,6 @@
     "owner_files": 538,
     "persistent_sink_files": 8,
     "task_492_calls": 1241,
-    "task_494_calls": 7355
+    "task_494_calls": 7354
   }
 }

--- a/Tests/Architecture/test_timer_path_static_update_inventory.py
+++ b/Tests/Architecture/test_timer_path_static_update_inventory.py
@@ -717,6 +717,16 @@ def census() -> dict[tuple[str, str, str], dict]:
 
 @pytest.fixture(scope="module")
 def timer_path_census() -> dict[tuple[str, str, str], dict]:
+    """Build the census once for the whole module.
+
+    Module-scoped because :func:`census` parses every file in the package
+    (1,889 modules at the time of writing) and every test below asks the same
+    question of the same answer.
+
+    Returns:
+        The mapping :func:`census` returns -- see its docstring for the key
+        and the per-site record.
+    """
     return census()
 
 

--- a/Tests/Chat/test_console_send_gate_queue_race.py
+++ b/Tests/Chat/test_console_send_gate_queue_race.py
@@ -22,6 +22,7 @@ real interleavings rather than reasoning about them:
 from __future__ import annotations
 
 import asyncio
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -120,40 +121,93 @@ async def test_queued_follow_up_cannot_be_admitted_while_the_durable_commit_runs
     gateway.hold = False
     controller.provider_gateway = gateway
     create_conversation = persistence.create_conversation
-    observed: list[tuple[bool, bool, bool, QueueMutationStatus, int]] = []
 
-    def observe_inside_the_open_transaction(**kwargs: Any):
-        # `commit_durable_turn` creates the conversation inside its own
-        # `BEGIN IMMEDIATE`, so this runs with the durable turn half-written.
-        snapshot = controller.prompt_queue_registry.snapshot("session-1")
-        activity = controller.activity_for("session-1")
-        admitted = controller.queue_prompt(
-            "session-1",
-            text="follow-up offered mid-commit",
-            expected_revision=snapshot.revision,
-        )
-        observed.append(
-            (
-                db.get_connection().in_transaction,
-                activity.accepted_live_turn,
-                store.dispatch_recovery_blocks_submission("session-1"),
-                admitted.status,
-                snapshot.total_count,
-            )
-        )
+    commit_is_open = threading.Event()
+    draft_was_offered = threading.Event()
+    # Sampled on the COMMIT's thread; the offer is made on the event loop.
+    transaction_open: list[bool] = []
+    offered_inside_the_window: list[bool] = []
+    observed: list[tuple[bool, bool, QueueMutationStatus, int]] = []
+
+    def hold_the_open_transaction(**kwargs: Any):
+        # Worker thread. `commit_durable_turn` creates the conversation
+        # inside its own `BEGIN IMMEDIATE`, so the durable turn is
+        # half-written here -- and since TASK-22205 (#2091) that whole
+        # transaction runs under `asyncio.to_thread`, off the event loop.
+        # `get_connection()` is thread-local, so the open transaction can
+        # only be observed HERE; the loop thread holds a different
+        # connection that is not in a transaction at all.
+        transaction_open.append(db.get_connection().in_transaction)
+        commit_is_open.set()
+        # Hold the write transaction open across the whole offer. Bounded,
+        # so a broken observer fails an assertion instead of hanging the
+        # run; whether the offer landed inside the window is recorded
+        # rather than assumed.
+        offered_inside_the_window.append(draft_was_offered.wait(timeout=10))
+        transaction_open.append(db.get_connection().in_transaction)
         return create_conversation(**kwargs)
 
     monkeypatch.setattr(
-        persistence, "create_conversation", observe_inside_the_open_transaction
+        persistence, "create_conversation", hold_the_open_transaction
     )
 
+    async def offer_a_draft_while_the_commit_is_open() -> None:
+        """Press Send from the thread a real user's Send runs on.
+
+        Before #2091 the commit occupied the event loop, so the only way to
+        interleave with it was to reach into the queue from inside the
+        transaction -- which happened to be the same thread. That is now
+        both unfaithful and impossible: the queue registry asserts its
+        owner thread (`_assert_owner_thread`, added 2026-08-23), and no
+        user submission ever originates on a persistence worker thread.
+        Since #2091 the loop is FREE while the commit runs, so this
+        interleaving is one a user can now actually produce -- the race got
+        more reachable, not less.
+        """
+        try:
+            if not await asyncio.to_thread(commit_is_open.wait, 10):
+                return
+            snapshot = controller.prompt_queue_registry.snapshot("session-1")
+            activity = controller.activity_for("session-1")
+            admitted = controller.queue_prompt(
+                "session-1",
+                text="follow-up offered mid-commit",
+                expected_revision=snapshot.revision,
+            )
+            observed.append(
+                (
+                    activity.accepted_live_turn,
+                    store.dispatch_recovery_blocks_submission("session-1"),
+                    admitted.status,
+                    snapshot.total_count,
+                )
+            )
+        finally:
+            draft_was_offered.set()
+
+    observer = asyncio.create_task(offer_a_draft_while_the_commit_is_open())
     result = await controller.run_prompt_chain("first", session_id="session-1")
+    # Deliberately longer than both inner waits combined. A tighter bound
+    # cancels the observer mid-wait and reports `CancelledError` instead of
+    # the assertion that names what actually went wrong -- which is how a
+    # staging failure gets mistaken for a flake.
+    await asyncio.wait_for(observer, timeout=30)
 
     assert result.accepted is True
-    # The hook fired exactly once, genuinely inside the commit transaction.
+    # POSITIVE proof that the race was actually staged, asserted before
+    # anything about its outcome. Without these three, a turn refused early
+    # -- for any unrelated reason -- leaves `observed` empty and every
+    # "nothing bad happened" assertion below passes vacuously. That is not
+    # hypothetical: between #2088 and #2091 this test went red for exactly
+    # that shape, and a careless repair would have made it green and blind.
+    assert transaction_open == [True, True], (
+        "the commit transaction was not open across the whole offer"
+    )
+    assert offered_inside_the_window == [True], (
+        "the draft was not offered before the commit hold timed out"
+    )
     assert len(observed) == 1
-    in_transaction, accepted_live, blocks, status, queued_before = observed[0]
-    assert in_transaction is True
+    accepted_live, blocks, status, queued_before = observed[0]
     # Nothing is accepted yet, so there is no chain and no owner at all --
     # admission cannot happen, and there is nothing to block submission with.
     assert accepted_live is False

--- a/Tests/DB/test_chachanotes_bare_open_self_migration.py
+++ b/Tests/DB/test_chachanotes_bare_open_self_migration.py
@@ -294,14 +294,18 @@ def test_a_failure_inside_the_v48_step_rewinds_the_whole_chain(tmp_path: Path):
     assert _raw_version(db_path) == CURRENT
 
 
+#: The child signals "I am inside the step" by CREATING A FILE rather than by
+#: printing, so the parent's wait is an existence poll with a real deadline
+#: instead of a `readline()` that cannot honour one. See the loop below.
 _STALL_CHILD = """
-import sys, time
+import os, sys, time
 sys.path.insert(0, {repo!r})
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
 
 def stalled(self, cursor):
-    print("inside-the-v48-transaction", flush=True)
+    fd = os.open({marker!r}, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.close(fd)
     time.sleep(600)
 
 
@@ -321,11 +325,23 @@ def test_a_sigkill_inside_the_v48_transaction_cannot_brick_the_database(
     read-only connection first (still v47, table not visible), because a
     partial apply that was ALREADY visible would be the brick this asserts
     against.
+
+    The wait for "the child got there" polls for a marker FILE, the shape
+    `test_chachanotes_v47_messages_fts_backfill.py` uses. The obvious
+    `child.stdout.readline()` inside a deadline loop cannot honour the
+    deadline -- it blocks until a newline or EOF -- so the exact regression
+    this test guards (a step that wedges before it is reached) would hang
+    the run instead of failing it. Measured: a child that neither prints nor
+    exits leaves that loop still blocked 8s after a 2s deadline. For the
+    same reason the pipes are only ever read once the child has EXITED; a
+    `child.stderr.read()` built into an assertion message is a second
+    unbounded wait, on a process that is sleeping by design.
     """
     source = tmp_path / "source.db"
     _seed_historical(source, 47, ["k1", "k2", "k3"])
     killed = tmp_path / "killed.db"
     control = tmp_path / "control.db"
+    marker_path = tmp_path / "inside-the-v48-transaction"
     shutil.copy2(source, killed)
     shutil.copy2(source, control)
     before = _content_hash(killed)
@@ -334,7 +350,9 @@ def test_a_sigkill_inside_the_v48_transaction_cannot_brick_the_database(
         [
             sys.executable,
             "-c",
-            _STALL_CHILD.format(repo=str(REPO_ROOT), path=str(killed)),
+            _STALL_CHILD.format(
+                repo=str(REPO_ROOT), path=str(killed), marker=str(marker_path)
+            ),
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -342,15 +360,21 @@ def test_a_sigkill_inside_the_v48_transaction_cannot_brick_the_database(
     )
     try:
         deadline = time.monotonic() + 60.0
-        marker = ""
+        entered = False
         while time.monotonic() < deadline:
-            marker = child.stdout.readline()
-            if marker or child.poll() is not None:
+            entered = marker_path.exists()
+            if entered or child.poll() is not None:
                 break
-        assert "inside-the-v48-transaction" in marker, (
-            f"child never entered the step (marker={marker!r} "
-            f"stderr={child.stderr.read()!r})"
-        )
+            time.sleep(0.02)
+        if not entered:
+            # Make the pipes safe to read before quoting them.
+            if child.poll() is None:
+                child.kill()
+                child.wait(timeout=60)
+            raise AssertionError(
+                "child never entered the step "
+                f"(stdout={child.stdout.read()!r} stderr={child.stderr.read()!r})"
+            )
         # The transaction is genuinely OPEN at kill time, not merely entered
         # and already rolled back: no second writer can take the lock. Without
         # this witness the assertions below would also pass against a child

--- a/Tests/DB/test_check_index_plan_pins.py
+++ b/Tests/DB/test_check_index_plan_pins.py
@@ -1,0 +1,350 @@
+"""Cover ``scripts/check_index_plan_pins.py`` -- the index query-plan guard.
+
+The checker is wired into ``scripts/preflight.sh`` and the required CI job,
+which exercises exactly one path: the current tree, passing. That says
+nothing about what it does with a missing row, a stale row, a malformed
+census, or -- the one that matters -- a row recorded ``plan-pinned`` whose
+"evidence" is a test asserting the planner does **not** choose the index.
+
+That last case was real. The first version of ``plan_pinning_files``
+accepted any ``idx_...`` token anywhere in a qualifying file, so measured
+against the shipped tree it reported ``idx_media_deleted`` and
+``idx_keywords_deleted`` as plan-pinned; both are named in
+``Tests/DB/test_media_db_schema_v9.py`` only by a ``#`` comment quoting the
+pre-fix plan and by ``assert "..." not in plan``. Flipping either census
+row to ``plan-pinned`` would have passed CI on evidence of the opposite of
+what the status claims. ``test_a_negative_assertion_is_not_a_pin`` and
+``test_the_real_tree_does_not_pin_an_index_it_asserts_is_absent`` are the
+two halves of that regression: one synthetic, one against the real files.
+
+**Naming discipline for this file.** It contains ``EXPLAIN QUERY PLAN`` and
+``sqlite_stat1``, so the checker treats it as a qualifying file like any
+other -- the first draft of these tests used real index names in its
+fixtures and duly made itself pin ``idx_media_deleted``, which is the
+defect under test. Every synthetic index here is therefore ``idx_zz_*``,
+and a real index name may appear only in a docstring, a comment, or the
+member side of a ``not in``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_index_plan_pins.py"
+
+PLAN_HEADER = '''
+"""A qualifying test module: it runs EXPLAIN QUERY PLAN with no stats."""
+
+def _plan(conn, sql):
+    assert conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE name='sqlite_stat1'"
+    ).fetchone() is None
+    return " | ".join(r[0] for r in conn.execute("EXPLAIN QUERY PLAN " + sql))
+'''
+
+
+@pytest.fixture()
+def checker() -> ModuleType:
+    """Load the script as a module (it is not importable by name)."""
+    spec = importlib.util.spec_from_file_location("_check_index_plan_pins", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, checker: ModuleType, monkeypatch: pytest.MonkeyPatch):
+    """Point the checker at a throwaway repository layout.
+
+    Returns a helper that writes a DB source file, a test file and a census
+    and then runs ``main()``, so each test states a whole scenario.
+    """
+    db_dir = tmp_path / "tldw_chatbook" / "DB"
+    tests_dir = tmp_path / "Tests"
+    db_dir.mkdir(parents=True)
+    tests_dir.mkdir(parents=True)
+    census = tmp_path / "index_plan_pin_census.tsv"
+
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "DB_DIR", db_dir)
+    monkeypatch.setattr(checker, "TESTS_DIR", tests_dir)
+    monkeypatch.setattr(checker, "CENSUS", census)
+
+    class Repo:
+        module = checker
+        root = tmp_path
+        db = db_dir
+        tests = tests_dir
+        census_path = census
+
+        @staticmethod
+        def write_db(name: str, body: str) -> None:
+            (db_dir / name).write_text(body, encoding="utf-8")
+
+        @staticmethod
+        def write_test(name: str, body: str) -> None:
+            (tests_dir / name).write_text(body, encoding="utf-8")
+
+        @staticmethod
+        def write_census(*rows: str) -> None:
+            census.write_text(
+                "# a census\n" + "\n".join(rows) + "\n", encoding="utf-8"
+            )
+
+    return Repo
+
+
+# ---------------------------------------------------------------------------
+# declared_indexes: what counts as a declaration
+# ---------------------------------------------------------------------------
+def test_a_sql_comment_inside_a_schema_string_is_not_an_index(repo):
+    """The first draft of this checker reported an index named ``for``."""
+    repo.write_db(
+        "Schema_DB.py",
+        'SCHEMA = """\n'
+        "-- Create index for feedback queries\n"
+        "CREATE INDEX idx_zz_feedback ON messages(feedback);\n"
+        '"""\n',
+    )
+    assert set(repo.module.declared_indexes()) == {"idx_zz_feedback"}
+
+
+def test_a_python_comment_naming_a_rejected_shape_is_not_a_declaration(repo):
+    """``_ACTIVE_MEDIA_INDEX_MIGRATION_SQL`` carries exactly this comment."""
+    repo.write_db(
+        "Media_DB.py",
+        "# Measured and REJECTED: CREATE INDEX idx_zz_rejected ON Media(x)\n"
+        'MIGRATION = "CREATE INDEX idx_zz_recent ON Media(deleted, id)"\n',
+    )
+    assert set(repo.module.declared_indexes()) == {"idx_zz_recent"}
+
+
+def test_a_sql_file_declares_its_indexes(repo):
+    repo.write_db("step.sql", "CREATE UNIQUE INDEX IF NOT EXISTS uq_thing ON t(a);")
+    declared = repo.module.declared_indexes()
+    assert set(declared) == {"uq_thing"}
+    assert declared["uq_thing"] == {"tldw_chatbook/DB/step.sql"}
+
+
+# ---------------------------------------------------------------------------
+# read_census: malformed input is a hard stop, not a silent skip
+# ---------------------------------------------------------------------------
+def test_a_missing_census_file_exits_nonzero(repo):
+    with pytest.raises(SystemExit) as exc:
+        repo.module.read_census()
+    assert exc.value.code == 1
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "idx_zz_lonely",  # no status column
+        "idx_zz_bad\tprobably-fine",  # status outside the vocabulary
+    ],
+)
+def test_a_malformed_census_row_exits_nonzero(repo, row):
+    repo.write_census(row)
+    with pytest.raises(SystemExit) as exc:
+        repo.module.read_census()
+    assert exc.value.code == 1
+
+
+def test_a_duplicated_census_row_exits_nonzero(repo):
+    repo.write_census("idx_zz_a\tpre-convention\tone", "idx_zz_a\tplan-pinned\ttwo")
+    with pytest.raises(SystemExit) as exc:
+        repo.module.read_census()
+    assert exc.value.code == 1
+
+
+def test_comments_and_blank_lines_are_skipped_and_notes_are_optional(repo):
+    repo.census_path.write_text(
+        "# header\n\nidx_zz_a\tpre-convention\n   \nidx_zz_b\tplan-pinned\twhy\n",
+        encoding="utf-8",
+    )
+    assert repo.module.read_census() == {
+        "idx_zz_a": ("pre-convention", ""),
+        "idx_zz_b": ("plan-pinned", "why"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# plan_pinning_files: only POSITIVE evidence is a pin
+# ---------------------------------------------------------------------------
+def test_a_positive_plan_assertion_is_a_pin(repo):
+    repo.write_test(
+        "test_good.py",
+        PLAN_HEADER
+        + '\nNAME = "idx_zz_recent"\n'
+        "def test_plan(conn):\n"
+        "    assert NAME in _plan(conn, 'SELECT 1')\n",
+    )
+    assert repo.module.plan_pinning_files()["idx_zz_recent"] == {
+        "Tests/test_good.py"
+    }
+
+
+def test_a_negative_assertion_is_not_a_pin(repo):
+    """The reported defect, in its smallest form.
+
+    ``assert "idx_x" not in plan`` is evidence the planner does NOT choose
+    ``idx_x``. The first version read it as a pin.
+    """
+    repo.write_test(
+        "test_negative.py",
+        PLAN_HEADER
+        + "\ndef test_plan(conn):\n"
+        "    plan = _plan(conn, 'SELECT 1')\n"
+        "    assert 'idx_zz_absent' not in plan\n",
+    )
+    assert "idx_zz_absent" not in repo.module.plan_pinning_files()
+
+
+def test_a_comment_only_mention_is_not_a_pin(repo):
+    repo.write_test(
+        "test_comment.py",
+        PLAN_HEADER
+        + "\ndef test_plan(conn):\n"
+        "    # The pre-fix plan was: SEARCH ... USING INDEX idx_zz_absent\n"
+        "    assert _plan(conn, 'SELECT 1')\n",
+    )
+    assert "idx_zz_absent" not in repo.module.plan_pinning_files()
+
+
+def test_a_docstring_only_mention_is_not_a_pin(repo):
+    repo.write_test(
+        "test_docstring.py",
+        PLAN_HEADER
+        + "\ndef test_plan(conn):\n"
+        '    """Explains why idx_zz_absent was the old plan."""\n'
+        "    assert _plan(conn, 'SELECT 1')\n",
+    )
+    assert "idx_zz_absent" not in repo.module.plan_pinning_files()
+
+
+def test_a_file_that_asserts_both_ways_still_pins_the_positive_name(repo):
+    """One negative mention must not disqualify a genuinely pinned index."""
+    repo.write_test(
+        "test_both.py",
+        PLAN_HEADER
+        + "\ndef test_plan(conn):\n"
+        "    plan = _plan(conn, 'SELECT 1')\n"
+        "    assert 'idx_zz_recent' in plan\n"
+        "    assert 'idx_zz_recent' not in 'something else'\n",
+    )
+    assert "idx_zz_recent" in repo.module.plan_pinning_files()
+
+
+@pytest.mark.parametrize("drop", ["EXPLAIN QUERY PLAN", "sqlite_stat1"])
+def test_a_file_missing_either_half_of_the_evidence_pins_nothing(repo, drop):
+    """A plan captured after ANALYZE is not the plan production runs."""
+    repo.write_test(
+        "test_half.py",
+        (PLAN_HEADER + '\nNAME = "idx_zz_recent"\n').replace(drop, "XXX"),
+    )
+    assert repo.module.plan_pinning_files() == {}
+
+
+# ---------------------------------------------------------------------------
+# main(): the three failure classes and the clean run
+# ---------------------------------------------------------------------------
+def _declare(repo, *names: str) -> None:
+    repo.write_db(
+        "Schema_DB.py",
+        "\n".join(f'S{i} = "CREATE INDEX {n} ON t(a)"' for i, n in enumerate(names))
+        + "\n",
+    )
+
+
+def test_a_clean_tree_exits_zero(repo, capsys):
+    _declare(repo, "idx_zz_a")
+    repo.write_census("idx_zz_a\tpre-convention\tno plan captured")
+    assert repo.module.main() == 0
+    assert "check_index_plan_pins: OK" in capsys.readouterr().out
+
+
+def test_a_declared_index_absent_from_the_census_fails(repo, capsys):
+    _declare(repo, "idx_zz_a", "idx_zz_new")
+    repo.write_census("idx_zz_a\tpre-convention\tno plan captured")
+    assert repo.module.main() == 1
+    out = capsys.readouterr().out
+    assert "idx_zz_new" in out and "plan-pinned" in out and "pre-convention" in out
+
+
+def test_a_census_row_for_an_index_nothing_creates_fails(repo, capsys):
+    _declare(repo, "idx_zz_a")
+    repo.write_census(
+        "idx_zz_a\tpre-convention\tno plan captured", "idx_zz_gone\tpre-convention\tstale"
+    )
+    assert repo.module.main() == 1
+    assert "idx_zz_gone" in capsys.readouterr().out
+
+
+def test_a_plan_pinned_row_with_no_pinning_test_fails(repo, capsys):
+    _declare(repo, "idx_zz_a")
+    repo.write_census("idx_zz_a\tplan-pinned\tTests/test_nothing.py")
+    assert repo.module.main() == 1
+    assert "idx_zz_a" in capsys.readouterr().out
+
+
+def test_a_plan_pinned_row_backed_only_by_a_negative_assertion_fails(repo, capsys):
+    """The whole point: the guard must reject evidence of the opposite.
+
+    Before the fix this returned 0 -- the census could claim ``plan-pinned``
+    while the only test naming the index proved the planner ignores it.
+    """
+    _declare(repo, "idx_zz_absent")
+    repo.write_test(
+        "test_negative.py",
+        PLAN_HEADER
+        + "\ndef test_plan(conn):\n"
+        "    plan = _plan(conn, 'SELECT 1')\n"
+        "    # pre-fix this was SEARCH ... USING INDEX idx_zz_absent\n"
+        "    assert 'idx_zz_absent' not in plan\n",
+    )
+    repo.write_census("idx_zz_absent\tplan-pinned\tTests/test_negative.py")
+    assert repo.module.main() == 1
+    assert "idx_zz_absent" in capsys.readouterr().out
+
+
+def test_a_plan_pinned_row_backed_by_a_real_pin_passes(repo):
+    _declare(repo, "idx_zz_recent")
+    repo.write_test(
+        "test_real.py",
+        PLAN_HEADER
+        + '\nNAME = "idx_zz_recent"\n'
+        "def test_plan(conn):\n"
+        "    assert NAME in _plan(conn, 'SELECT 1')\n",
+    )
+    repo.write_census("idx_zz_recent\tplan-pinned\tTests/test_real.py")
+    assert repo.module.main() == 0
+
+
+# ---------------------------------------------------------------------------
+# ...and the same claim against the real tree, not only a synthetic one
+# ---------------------------------------------------------------------------
+def test_the_real_tree_does_not_pin_an_index_it_asserts_is_absent(checker):
+    """Measured on the shipped files, so a revert is caught here too.
+
+    ``Tests/DB/test_media_db_schema_v9.py`` qualifies (it runs EXPLAIN QUERY
+    PLAN and asserts ``sqlite_stat1`` is absent) and names both of these,
+    every time in a comment, a docstring, or a ``not in`` assertion.
+    """
+    pins = checker.plan_pinning_files()
+    assert "idx_media_deleted" not in pins
+    assert "idx_keywords_deleted" not in pins
+    # ...while every index the census really does record as plan-pinned is
+    # still backed by a file, or the shipped checker would be failing CI.
+    census = checker.read_census()
+    declared = checker.declared_indexes()
+    pinned = {
+        name
+        for name, (status, _note) in census.items()
+        if status == checker.PLAN_PINNED and name in declared
+    }
+    assert pinned, "the census records no plan-pinned index; this test is vacuous"
+    assert pinned <= set(pins), sorted(pinned - set(pins))

--- a/Tests/DB/test_media_db_schema_v9.py
+++ b/Tests/DB/test_media_db_schema_v9.py
@@ -34,6 +34,7 @@ plan that no user's database produces.
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 
 import pytest
 
@@ -553,23 +554,25 @@ def test_bare_keyword_match_equals_the_lower_spelling_for_every_bindable_value(
     ``k.strip().lower()`` first. `typed` here is exactly what that
     expression yields.
     """
-    conn = sqlite3.connect(":memory:")
-    conn.execute(
-        "CREATE TABLE Keywords (id INTEGER PRIMARY KEY AUTOINCREMENT, "
-        "keyword TEXT NOT NULL UNIQUE COLLATE NOCASE, deleted BOOLEAN NOT NULL "
-        "DEFAULT 0)"
-    )
-    conn.execute("INSERT INTO Keywords (keyword) VALUES (?)", (stored,))
-    conn.commit()
-    assert typed == typed.strip().lower(), "the fixture must bind what the caller binds"
-    lowered = conn.execute(
-        "SELECT id FROM Keywords WHERE deleted = 0 AND LOWER(keyword) IN (?)", (typed,)
-    ).fetchall()
-    bare = conn.execute(
-        "SELECT id FROM Keywords WHERE deleted = 0 AND keyword IN (?)", (typed,)
-    ).fetchall()
-    assert [tuple(r) for r in bare] == [tuple(r) for r in lowered]
-    conn.close()
+    with closing(sqlite3.connect(":memory:")) as conn:
+        conn.execute(
+            "CREATE TABLE Keywords (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "keyword TEXT NOT NULL UNIQUE COLLATE NOCASE, deleted BOOLEAN NOT NULL "
+            "DEFAULT 0)"
+        )
+        conn.execute("INSERT INTO Keywords (keyword) VALUES (?)", (stored,))
+        conn.commit()
+        assert typed == typed.strip().lower(), (
+            "the fixture must bind what the caller binds"
+        )
+        lowered = conn.execute(
+            "SELECT id FROM Keywords WHERE deleted = 0 AND LOWER(keyword) IN (?)",
+            (typed,),
+        ).fetchall()
+        bare = conn.execute(
+            "SELECT id FROM Keywords WHERE deleted = 0 AND keyword IN (?)", (typed,)
+        ).fetchall()
+        assert [tuple(r) for r in bare] == [tuple(r) for r in lowered]
 
 
 def test_must_have_keywords_returns_the_same_media_as_before(fresh_db):

--- a/Tests/Library/test_library_ingest_jobs_restore.py
+++ b/Tests/Library/test_library_ingest_jobs_restore.py
@@ -159,6 +159,45 @@ class _RestoreHost(app_module.LibraryIngestQueueMixin):
         return callback(*args)
 
 
+def test_a_job_submitted_during_the_restore_window_reaches_the_store(tmp_path):
+    """The window's live job must survive the NEXT restart, not just this one.
+
+    It was submitted while the registry was store-less, so its own
+    ``_persist`` was a no-op. Nothing else re-offers it, so before the fix it
+    never reached disk -- and because both sessions allocate from
+    ``ingest-job-1`` upward, the persisted row it collided with stayed and
+    was restored in its place on the next launch.
+    """
+    store = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    seeder = LibraryIngestJobRegistry()
+    seeder.attach_store(store)
+    seeder.submit(source_path="/persisted-1.pdf")
+    seeder.submit(source_path="/persisted-2.pdf")
+    store.close()
+
+    store2 = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    plan = plan_restore(
+        store2.all_jobs(), max_persisted=500, now_iso="2026-08-23T00:00:00+00:00"
+    )
+    live = LibraryIngestJobRegistry()
+    raced = live.submit(source_path="/submitted-during-startup.pdf")
+    assert raced.job_id == "ingest-job-1"  # the collision this window creates
+
+    _RestoreHost(live)._apply_ingest_job_restore(store2, plan)
+    store2.close()
+
+    # Restart: the live job is on disk under its own id, and the stale row it
+    # collided with is gone rather than shadowing it.
+    store3 = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    persisted = {row["job_id"]: row["source_path"] for row in store3.all_jobs()}
+    assert persisted["ingest-job-1"] == "/submitted-during-startup.pdf"
+    assert "/persisted-1.pdf" not in persisted.values()
+
+    reg = _restore(store3, now_iso="2026-08-23T00:00:00+00:00")
+    assert "/submitted-during-startup.pdf" in {j.source_path for j in reg.jobs()}
+    store3.close()
+
+
 def test_a_failed_restore_closes_the_store_it_opened(tmp_path, monkeypatch):
     """A failure after the store opened must not leak its SQLite connection.
 

--- a/Tests/Library/test_library_ingest_jobs_restore.py
+++ b/Tests/Library/test_library_ingest_jobs_restore.py
@@ -1,3 +1,7 @@
+import sqlite3
+
+import tldw_chatbook.DB.Library_Ingest_Jobs_DB as jobs_db_module
+import tldw_chatbook.app as app_module
 from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
 from tldw_chatbook.Library.library_ingest_jobs import (
     LibraryIngestJobRegistry,
@@ -130,3 +134,61 @@ def test_merge_restored_keeps_a_job_submitted_during_the_restore_window(tmp_path
     # No future allocation can collide with a restored id either.
     assert live.submit(source_path="/next.pdf").job_id == "ingest-job-3"
     store2.close()
+
+
+# --------------------------------------------------------------------------
+# the app-side seam: `_apply_ingest_job_restore` / `_restore_ingest_jobs_off_thread`
+# --------------------------------------------------------------------------
+
+
+class _RestoreHost(app_module.LibraryIngestQueueMixin):
+    """The mixin's restore seam without booting a Textual app.
+
+    ``LibraryIngestQueueMixin`` is only ever mixed into an ``App``
+    (``TldwCli`` in production, ``_LibraryIngestCanvasHarness`` in
+    ``Tests/UI/test_library_shell.py``); the two restore methods exercised
+    here touch nothing from that base but ``call_from_thread``.
+    """
+
+    def __init__(self, registry: LibraryIngestJobRegistry) -> None:
+        self.library_ingest_jobs = registry
+        self._ingest_shutdown = False
+        self._library_ingest_jobs_store = None
+
+    def call_from_thread(self, callback, *args):
+        return callback(*args)
+
+
+def test_a_failed_restore_closes_the_store_it_opened(tmp_path, monkeypatch):
+    """A failure after the store opened must not leak its SQLite connection.
+
+    ``LibraryIngestJobsDB`` opens its connection in the constructor, and the
+    failure path leaves the registry store-less, so nothing else can ever
+    close it.
+    """
+    closed: list[str] = []
+
+    class _ExplodingStore:
+        def __init__(self, path, *args, **kwargs):
+            self.path = path
+
+        def all_jobs(self):
+            raise sqlite3.DatabaseError("file is not a database")
+
+        def close(self):
+            closed.append("closed")
+
+    monkeypatch.setattr(jobs_db_module, "LibraryIngestJobsDB", _ExplodingStore)
+    monkeypatch.setattr(
+        app_module,
+        "get_library_ingest_jobs_db_path",
+        lambda: tmp_path / "jobs.db",
+    )
+
+    registry = LibraryIngestJobRegistry()
+    host = _RestoreHost(registry)
+    host._restore_ingest_jobs_off_thread()  # never raises
+
+    assert closed == ["closed"]
+    assert list(registry.jobs()) == []
+    assert host._library_ingest_jobs_store is None

--- a/Tests/Notifications/test_event_state_repository_connections.py
+++ b/Tests/Notifications/test_event_state_repository_connections.py
@@ -488,3 +488,50 @@ def test_mark_presented_for_an_unknown_event_leaves_the_store_usable(repo):
         repo, limit=20, mark_presented=True, **_FEED_SCOPE
     )
     assert feed["total"] == 1
+
+
+def test_a_failing_close_is_recorded_rather_than_discarded(repo, monkeypatch):
+    """A swallowed `conn.close()` error left an untracked handle to debug.
+
+    Best-effort teardown is deliberate -- the entry is already out of `_held`
+    and re-closing a handle whose close raised would keep a broken connection
+    reachable. What must not happen is losing the fact that it happened.
+    """
+    repo.record_event_and_advance_processed_cursor(_event(0))
+
+    recorded: list[tuple] = []
+    monkeypatch.setattr(
+        esr_module.logger, "debug", lambda *args, **kwargs: recorded.append(args)
+    )
+
+    class _RefusesToClose:
+        """`sqlite3.Connection.close` is read-only, so stand in for the handle."""
+
+        def close(self):
+            # A real sqlite3 message can carry the database path; use one.
+            raise sqlite3.OperationalError("unable to close /private/db.sqlite")
+
+    held = list(repo._held.values())
+    assert held, "no held connection to close, so the assertion would be vacuous"
+    real_conns = []
+    for entry in held:
+        real_conns.append(entry.conn)
+        entry.conn = _RefusesToClose()
+
+    try:
+        repo.close()
+    finally:
+        for conn in real_conns:
+            conn.close()
+
+    rendered = " ".join(str(part) for call in recorded for part in call)
+    assert "close failed" in rendered, (
+        f"a failing close was discarded silently: {recorded}"
+    )
+    assert "OperationalError" in rendered, (
+        f"the failure type was not recorded: {recorded}"
+    )
+    # Type name ONLY: a sqlite3 message can carry the database path.
+    assert "/private/db.sqlite" not in rendered, (
+        f"the close diagnostic leaked the database path: {recorded}"
+    )

--- a/Tests/RAG/test_reranker_import_order.py
+++ b/Tests/RAG/test_reranker_import_order.py
@@ -1,0 +1,126 @@
+"""Import-order regression guard for the reranker <-> simplified cycle.
+
+The second edge of the cycle `Tests/RAG/test_config_profiles_import_order.py`
+guards, found by a review of PR2075 and reproduced here before anything was
+changed:
+
+    import tldw_chatbook.RAG_Search.reranker
+      -> reranker imports `.simplified.vector_store`
+      -> which executes `simplified/__init__`
+      -> which eagerly imports `enhanced_rag_service_v2`
+      -> which imported `create_reranker_from_config` from the STILL
+         partially-initialized `reranker` module
+      => ImportError: cannot import name 'create_reranker_from_config' from
+         partially initialized module
+
+Same shape as TASK-21160, opposite direction, and latent for the same reason:
+the eager `RAG_Search/__init__` used to front-load `simplified` in the safe
+order until TASK-21102 made that facade lazy. A test module that imported
+`reranker` first therefore could not be collected on its own, and full-suite
+import order masked it.
+
+Fixed by deferring the import to first use in `enhanced_rag_service_v2`,
+keeping `create_reranker_from_config` a module-level name because it is a
+monkeypatch seam (see `Tests/RAG_Search/test_reranker_construction.py`).
+
+Each test runs in a fresh subprocess so this file's own import order cannot
+mask a regression.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fresh_import(statement: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", statement],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+        timeout=120,
+    )
+
+
+def test_reranker_first_import_succeeds():
+    """The order that could not be collected: reranker before simplified."""
+    result = _fresh_import(
+        "from tldw_chatbook.RAG_Search import reranker as r; "
+        "from tldw_chatbook.RAG_Search.reranker import PointwiseReranker; "
+        "assert callable(r.create_reranker_from_config)"
+    )
+    assert result.returncode == 0, (
+        "reranker-first import failed -- the reranker<->simplified cycle is "
+        f"back:\n{result.stderr[-2000:]}"
+    )
+
+
+def test_simplified_first_import_still_succeeds():
+    """The historically-safe order must keep working after the deferral."""
+    result = _fresh_import(
+        "import tldw_chatbook.RAG_Search.simplified as s; "
+        "from tldw_chatbook.RAG_Search import reranker as r; "
+        "assert s.EnhancedRAGServiceV2 is not None; "
+        "assert callable(r.create_reranker_from_config)"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+
+
+def test_reranker_is_not_on_the_eager_simplified_import_graph():
+    """Behavioural edge census, self-maintaining where a static one is not.
+
+    A static sweep for module-level `..reranker` imports under `simplified/`
+    would flag `active_config.py`, which is NOT executed by
+    `simplified/__init__` and so cannot close the cycle. Asserting on the
+    loaded-module set instead catches any new eager back-edge from any
+    module the package actually executes, and stays quiet about the lazy ones.
+    """
+    result = _fresh_import(
+        "import sys; import tldw_chatbook.RAG_Search.simplified; "
+        "print('reranker' if 'tldw_chatbook.RAG_Search.reranker' in sys.modules "
+        "else 'clean')"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert result.stdout.strip().endswith("clean"), (
+        "importing `simplified` pulled in `RAG_Search.reranker` eagerly, which "
+        "re-creates the cycle for a reranker-first import order"
+    )
+
+
+def test_v2_keeps_create_reranker_from_config_as_a_patchable_module_attribute():
+    """The deferral must not break the construction-failure monkeypatch seam.
+
+    `Tests/RAG_Search/test_reranker_construction.py` replaces
+    `enhanced_rag_service_v2.create_reranker_from_config` eight times. A
+    module-accessor deferral (the shape used for `config_profiles`) would have
+    removed the name those tests patch, so the wrapper keeps it.
+    """
+    result = _fresh_import(
+        "from tldw_chatbook.RAG_Search.simplified import enhanced_rag_service_v2 as v2; "
+        "assert callable(v2.create_reranker_from_config); "
+        "sentinel = object(); "
+        "v2.create_reranker_from_config = lambda config: sentinel; "
+        "assert v2.create_reranker_from_config(None) is sentinel; "
+        "print('patchable')"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert result.stdout.strip().endswith("patchable")
+
+
+def test_deferred_wrapper_actually_builds_a_reranker():
+    """The wrapper must delegate, not just exist.
+
+    A wrapper that returned None would satisfy every assertion above while
+    silently disabling reranking, so build a real one through it.
+    """
+    result = _fresh_import(
+        "from tldw_chatbook.RAG_Search.simplified import enhanced_rag_service_v2 as v2; "
+        "from tldw_chatbook.RAG_Search.reranker import RerankingConfig, PointwiseReranker; "
+        "built = v2.create_reranker_from_config(RerankingConfig(strategy='pointwise')); "
+        "assert isinstance(built, PointwiseReranker), type(built); "
+        "print('built')"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert result.stdout.strip().endswith("built")

--- a/Tests/RAG_Search/test_rag_diagnostic_privacy.py
+++ b/Tests/RAG_Search/test_rag_diagnostic_privacy.py
@@ -332,9 +332,18 @@ def _interpolated_expressions(node: ast.Call) -> list[ast.AST]:
     for sub in ast.walk(node):
         if isinstance(sub, ast.FormattedValue):
             expressions.append(sub.value)
-    # loguru brace style and %-style both put the values in trailing args, and
-    # `extra=` keywords are rendered by some handlers too.
-    expressions.extend(node.args[1:])
+    # The FIRST argument is the message body, not just a format string, so it
+    # is scanned like any other. `logger.error(query)` and `logger.info(
+    # query[:50])` render the whole value -- the second is precisely the
+    # truncation shape TASK-21700 was filed for, merely passed positionally
+    # instead of interpolated, and an `args[1:]` scan let both through. A
+    # literal format string is harmless here because it contains no `ast.Name`
+    # at all; verified on the whole tree, this scans 0 -> 0 findings, so the
+    # widening costs no false positive.
+    #
+    # loguru brace style and %-style put the remaining values in trailing args,
+    # and `extra=` keywords are rendered by some handlers too.
+    expressions.extend(node.args)
     expressions.extend(keyword.value for keyword in node.keywords)
     return expressions
 
@@ -458,6 +467,22 @@ def test_census_detects_the_shape_it_exists_to_catch() -> None:
         ("logger.info('q=%s', query)", {"query"}),
         ("logger.info('q={}', response)", {"response"}),
         ("logger.debug(f'{query.strip()}')", {"query"}),
+        # The message argument itself. loguru renders `args[0]` as the body,
+        # so these leak exactly as hard as the f-string forms above -- and an
+        # `args[1:]` scan passed every one of them.
+        ("logger.error(query)", {"query"}),
+        ("logger.warning(response)", {"response"}),
+        ("logger.exception(text)", {"text"}),
+        # ...including the precise truncation shape TASK-21700 was filed for,
+        # merely passed positionally instead of interpolated.
+        ("logger.info(query[:50])", {"query"}),
+        ("logger.debug('prefix ' + query)", {"query"}),
+        # `logger.log` takes the level first, so the body is args[1]; both
+        # positions must be scanned for this to be caught.
+        ("logger.log('INFO', query)", {"query"}),
+        # A literal format string stays harmless: it contains no name at all.
+        ("logger.info('Cache hit for query')", set()),
+        ("logger.info('q=%s', len(query))", set()),
     ],
 )
 def test_census_classifier_boundaries(source: str, expected: set[str]) -> None:

--- a/Tests/Research/test_research_scope_service.py
+++ b/Tests/Research/test_research_scope_service.py
@@ -611,3 +611,103 @@ async def test_backend_exceptions_survive_the_offload(tmp_path):
     with pytest.raises(ValueError, match="research run not found"):
         await scope.get_bundle("no-such-run", mode="local")
     service.close()
+
+
+def _record_event_read_threads(monkeypatch):
+    """Record the thread each `list_run_events` read actually executes on.
+
+    `_record_db_threads` above hooks `_connect`, which a HELD connection only
+    reaches once per thread -- too coarse to tell where a later read ran.
+    """
+    seen: list[str] = []
+    real_list = LocalResearchService.list_run_events
+
+    def _recording(self, *args, **kwargs):
+        seen.append(threading.current_thread().name)
+        return real_list(self, *args, **kwargs)
+
+    monkeypatch.setattr(LocalResearchService, "list_run_events", _recording)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_local_stream_run_events_reads_off_the_event_loop(tmp_path, monkeypatch):
+    """The async-generator path must honour the same no-SQLite-on-the-loop rule.
+
+    `_ThreadOffloadedBackend` passes async generators through unwrapped, which
+    is right for the server backend but left `LocalResearchService.
+    stream_run_events` -- an `async def ... yield` whose body is a blocking
+    `list_run_events` call -- executing SQLite on the loop thread every time
+    the Research window's 2 s poll consumed it.
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    scope = ResearchScopeService(local_service=service, server_service=None)
+    run = await scope.create_run(mode="local", query="streamed off the loop")
+    for index in range(25):
+        service.record_run_event(run["id"], f"event-{index}", {"index": index})
+
+    loop_thread = threading.current_thread().name
+    seen = _record_event_read_threads(monkeypatch)
+    events = [event async for event in scope.stream_run_events(run["id"], mode="local")]
+
+    assert events, "the stream yielded nothing, so the thread assertion is vacuous"
+    assert seen, "no event read was observed at all"
+    assert loop_thread not in seen, f"SQLite ran on the event loop thread: {seen}"
+    assert all(name.startswith("research-backend") for name in seen), seen
+    service.close()
+
+
+@pytest.mark.asyncio
+async def test_local_stream_run_events_output_is_unchanged_by_the_offload(tmp_path):
+    """Taking the offloaded reader must yield exactly what the generator did.
+
+    `LocalResearchService.stream_run_events` is a snapshot loop over
+    `list_run_events`, so the two are required to agree item for item --
+    including under `after_id`, which is the argument the poll advances.
+    """
+    service = LocalResearchService(tmp_path / "research.db")
+    scope = ResearchScopeService(local_service=service, server_service=None)
+    run = await scope.create_run(mode="local", query="identical output")
+    for index in range(25):
+        service.record_run_event(run["id"], f"event-{index}", {"index": index})
+
+    direct = [event async for event in service.stream_run_events(run["id"])]
+    routed = [event async for event in scope.stream_run_events(run["id"], mode="local")]
+    assert routed == direct
+    assert len(routed) > 1, "too few events to distinguish a truncation bug"
+
+    tail_direct = [event async for event in service.stream_run_events(run["id"], after_id=10)]
+    tail_routed = [
+        event
+        async for event in scope.stream_run_events(run["id"], mode="local", after_id=10)
+    ]
+    assert tail_routed == tail_direct
+    assert len(tail_routed) < len(routed), "after_id was ignored"
+    service.close()
+
+
+@pytest.mark.asyncio
+async def test_async_backend_stream_is_still_consumed_as_a_generator():
+    """The server backend keeps its real streaming path -- no reader swap.
+
+    The offloaded-reader preference is gated on a SYNCHRONOUS `list_run_events`.
+    An async backend has none to prefer, so its `stream_run_events` must still
+    be the method that runs, and must still be iterated lazily.
+    """
+
+    class AsyncStreamingBackend:
+        def __init__(self):
+            self.streamed = 0
+
+        async def stream_run_events(self, run_id, *, after_id=0):
+            for index in range(3):
+                self.streamed += 1
+                yield {"id": index + 1, "run_id": run_id, "event": f"e{index}"}
+
+    backend = AsyncStreamingBackend()
+    scope = ResearchScopeService(local_service=None, server_service=backend)
+
+    events = [event async for event in scope.stream_run_events("r1", mode="server")]
+
+    assert backend.streamed == 3, "the async generator was not the method used"
+    assert [event["event"] for event in events] == ["e0", "e1", "e2"]

--- a/Tests/TTS/test_profile_reference_storage.py
+++ b/Tests/TTS/test_profile_reference_storage.py
@@ -1278,6 +1278,10 @@ profile_schema.open_profile_store(Path({path!r}))
 """
 
 
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX SIGKILL: signal.SIGKILL does not exist on Windows",
+)
 def test_v3_to_v4_migration_survives_sigkill_mid_transaction(tmp_path: Path) -> None:
     """A real SIGKILL inside the climb must leave v3, then re-enter cleanly.
 

--- a/Tests/UI/conftest.py
+++ b/Tests/UI/conftest.py
@@ -142,21 +142,52 @@ def _no_tiktoken_bpe_download(monkeypatch):
     time, so patching it here covers callers that imported
     ``count_tokens_tiktoken``/``estimate_tokens`` by name.
 
-    Returning ``None`` drives the already-tested no-tokenizer branch
-    (`count_tokens_tiktoken`'s character estimate) — which is what a default
-    install actually does, since tiktoken is not a base dependency
-    (task-2526). No test's LOGICAL coverage changes, only its network access,
-    and the result stops depending on whether this machine happens to have a
-    warm ``$TMPDIR/data-gym-cache`` (which the HOME sandbox does not
-    redirect). A test that needs the real encoding monkeypatches it back
-    within its own scope, exactly as with `_disable_model_catalog_refresh`
-    above.
-    """
+    ``TIKTOKEN_AVAILABLE`` is what selects the tier, and it is forced off
+    here rather than only stubbing the encoding, because those are NOT the
+    same accounting. With the flag left True, `estimate_tokens` still enters
+    `count_tokens_tiktoken`, whose no-encoding fallback is a bare
+    ``int(len(text) * 0.25)``: no CJK weighting, no headroom, and no
+    non-empty floor. Measured against `gpt-4`/`openai` on this venv:
 
+    ==========================  ====  =============  ==============
+    text                        real  encoding=None  tiktoken off
+    ==========================  ====  =============  ==============
+    ``"hi"``                       1              0               1
+    a repeated ASCII sentence     31             33              40
+    repeated CJK                  50             17              84
+    ==========================  ====  =============  ==============
+
+    The middle column is a tier no install runs, it undercounts CJK by ~3x
+    against the real tokenizer, and it re-introduces the zero-for-short-text
+    truncation that `_chars_estimate`'s ``max(1, ...)`` exists to prevent.
+    The right-hand column IS what a default install does, since tiktoken is
+    not a base dependency (task-2526). The encoding stub stays as a second
+    line of defence for anything that calls it directly.
+
+    `_ESTIMATE_CACHE` is cleared on both sides of the test: it is
+    process-global and keyed by ``(model, provider, len, hash(text))`` with
+    no tokenizer identity in the key, so without this a value computed under
+    the real tokenizer elsewhere in the session is served here (and one
+    computed here leaks the other way). pytest-randomly shuffles the run
+    order, so "Tests/Chat happens to run first" is not a defence.
+
+    No test's LOGICAL coverage changes, only its network access, and the
+    result stops depending on whether this machine happens to have a warm
+    ``$TMPDIR/data-gym-cache`` (which the HOME sandbox does not redirect) or
+    on what estimated the same string earlier in the session. A test that
+    needs the real encoding monkeypatches it back within its own scope,
+    exactly as with `_disable_model_catalog_refresh` above.
+    """
+    from tldw_chatbook.Utils import token_counter
+
+    monkeypatch.setattr(token_counter, "TIKTOKEN_AVAILABLE", False)
     monkeypatch.setattr(
         "tldw_chatbook.Utils.token_counter.get_tiktoken_encoding",
         lambda _model: None,
     )
+    token_counter.clear_estimate_cache()
+    yield
+    token_counter.clear_estimate_cache()
 
 
 @pytest_asyncio.fixture

--- a/Tests/UI/test_console_changed_files_scope_memo.py
+++ b/Tests/UI/test_console_changed_files_scope_memo.py
@@ -28,6 +28,8 @@ would drown the counter this probe exists to read.
 
 from __future__ import annotations
 
+import gc
+import weakref
 from types import SimpleNamespace
 
 import pytest
@@ -594,6 +596,55 @@ def test_restore_state_is_not_served_the_pre_restore_answer():
     )
 
     assert store.newest_change_review_run_id("restored-1") is None
+
+
+def test_restore_state_releases_the_replaced_transcript():
+    """The memo must not keep the PRE-restore view alive after a replacement.
+
+    Correctness never needed a hook here (the memo pins the old list, so a
+    rebuilt view cannot reuse its identity and the signature always misses),
+    which is why the slot was left alone. Retention is the live problem: the
+    slot holds a strong reference to the replaced session's whole view list,
+    and the "a later query evicts it" argument fails exactly when no later
+    query comes -- changed-files guard off, or the screen simply stops
+    asking. Then a whole replaced transcript, `image_data` bytes included,
+    stays reachable for the life of the store.
+
+    Observed rather than asserted white-box: a `weakref` to a message the
+    pre-restore view held, which is only collectable once nothing pins that
+    list. Deliberately a USER message, not the TOOL marker --
+    `_tool_markers_by_session` is NOT cleared by `restore_state` (TASK-21311)
+    and would keep a marker alive on its own account, hiding the subject.
+    """
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
+
+    store = ConsoleChatStore()
+    session = store.create_session(session_id="pinned-1")
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="ask")
+    # Arm the memo. The answer is `None` (no marker) -- the common case, and
+    # the one the memo exists to make free -- but the slot is filled either
+    # way, so it is pinning the view list from here on.
+    assert store.newest_change_review_run_id(session.id) is None
+    view = store._messages_by_session[session.id]
+    assert len(view) == 1
+    replaced_message = weakref.ref(view[0])
+    del view
+
+    store.restore_state(
+        sessions=[ConsoleChatSession(id="pinned-2", title="Replacement")],
+        messages_by_session={},
+        active_session_id="pinned-2",
+    )
+    gc.collect()
+
+    assert store._newest_change_review_memo is None, (
+        "restore_state left the memo pinning the replaced session's view"
+    )
+    assert replaced_message() is None, (
+        "a message from the replaced state is still reachable after restore"
+    )
+    # The replacement still answers correctly from a cold slot.
+    assert store.newest_change_review_run_id("pinned-2") is None
 
 
 def test_screen_scope_tolerates_a_store_without_the_active_session():

--- a/Tests/UI/test_splash_initial_screen_preimport.py
+++ b/Tests/UI/test_splash_initial_screen_preimport.py
@@ -498,3 +498,45 @@ async def test_no_overlap_thread_when_the_splash_is_disabled(monkeypatch):
         )
         assert type(app.screen).__name__ == "ChatScreen"
         await pilot.pause(0.2)
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    ["_schedule_initial_screen_preimport", "_schedule_screen_preimport"],
+)
+def test_a_thread_that_refuses_to_start_degrades_instead_of_raising(
+    monkeypatch, schedule
+):
+    """A refused `Thread.start()` must not escape the splash-path callback.
+
+    Both schedulers run from a timer / deferred-startup callback during boot,
+    where an exception is an unhandled error in a Textual timer task rather
+    than something a caller can catch. Under thread exhaustion (or a start
+    during interpreter shutdown) the right outcome is losing a speculative
+    warm-up: every module involved is imported normally on first navigation
+    anyway. Recording the handle only after a successful start also leaves the
+    once-guard able to try again rather than latching on a thread that never
+    ran.
+    """
+    monkeypatch.setenv("TLDW_SCREEN_PREIMPORT", "1")
+    app = _arm(_build_test_app())
+    monkeypatch.setattr(
+        app,
+        "_preimport_screens",
+        lambda routes: pytest.fail("the thread never started"),
+    )
+    monkeypatch.setattr(
+        app,
+        "_preimport_heavy_screens",
+        lambda: pytest.fail("the thread never started"),
+    )
+
+    def _refuse_to_start(self):
+        raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(threading.Thread, "start", _refuse_to_start)
+
+    getattr(app, schedule)()  # must not raise
+
+    assert app._initial_screen_preimport_thread is None
+    assert app._screen_preimport_thread is None

--- a/Tests/UI/test_ui_token_accounting_seam.py
+++ b/Tests/UI/test_ui_token_accounting_seam.py
@@ -1,0 +1,89 @@
+"""The UI suite's token accounting is the no-tokenizer tier, deterministically.
+
+``Tests/UI/conftest.py``'s autouse ``_no_tiktoken_bpe_download`` fixture exists
+to keep mounted Console tests off tiktoken's BPE download seam (TASK-21590).
+Stubbing ``get_tiktoken_encoding`` alone does that, but it also puts the whole
+suite on an accounting no install runs: ``estimate_tokens`` still enters
+``count_tokens_tiktoken``, whose no-encoding fallback is a bare
+``int(len(text) * 0.25)`` -- no CJK weighting, no headroom, no non-empty floor.
+
+These tests pin the two properties that distinguish the intended tier from that
+fallback, so the fixture cannot quietly drift back to it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Utils import token_counter
+
+from Tests.UI import conftest as ui_conftest
+
+
+def test_the_ui_suite_runs_the_no_tokenizer_tier() -> None:
+    """The tier flag itself, not just the encoding, must be off."""
+    assert token_counter.TIKTOKEN_AVAILABLE is False
+    assert token_counter.get_tiktoken_encoding("gpt-4") is None
+
+
+def test_non_empty_text_never_estimates_to_zero_tokens() -> None:
+    """``int(len(text) * 0.25)`` returns 0 for "hi"; the real tier returns 1.
+
+    ``_chars_estimate`` carries an explicit ``max(1, ...)`` for exactly this
+    case -- a UI suite budgeting a short message at zero tokens is measuring
+    something no user has.
+    """
+    assert token_counter.estimate_tokens("hi", "gpt-4", "openai") == 1
+
+
+def test_cjk_is_weighted_rather_than_counted_as_quarter_tokens() -> None:
+    """The conservative floor must stay above the flat 0.25/char fallback.
+
+    Repeated CJK measured 84 on the chars tier against 17 on the fallback and
+    50 on the real tokenizer, so the fallback undercounts the tokenizer ~3x
+    while the chars tier stays above it -- which is the direction a budget
+    guard has to err in.
+    """
+    text = "这是一个测试。" * 10
+    flat_fallback = int(len(text) * 0.25)
+
+    estimate = token_counter.estimate_tokens(text, "gpt-4", "openai")
+
+    assert estimate > flat_fallback
+
+
+def test_the_fixture_clears_a_foreign_tier_estimate_on_both_sides(
+    monkeypatch,
+) -> None:
+    """A value cached under a different tokenizer must not be served here.
+
+    ``_ESTIMATE_CACHE`` is process-global and its key is ``(model, provider,
+    len, hash(text))`` -- no tokenizer identity -- so an entry computed under
+    the real tiktoken elsewhere in the session would be returned verbatim
+    here, and one computed here would leak the other way. pytest-randomly
+    shuffles the run order, so "Tests/Chat happens to run first" is not a
+    defence.
+
+    The fixture's own body is driven directly rather than relying on it having
+    run for this test: an assertion about "the cache is empty at test start"
+    cannot tell the setup clear from the teardown clear of the *previous*
+    test, and would survive removing either.
+    """
+    fixture_body = ui_conftest._no_tiktoken_bpe_download._get_wrapped_function()
+    text = "cache-tier-witness " * 4
+    key = ("gpt-4", "openai", len(text), hash(text))
+
+    token_counter._ESTIMATE_CACHE[key] = 999_999
+    generator = fixture_body(monkeypatch)
+    next(generator)
+    after_setup = dict(token_counter._ESTIMATE_CACHE)
+    served = token_counter.estimate_tokens(text, "gpt-4", "openai")
+
+    token_counter._ESTIMATE_CACHE[key] = 999_999
+    with pytest.raises(StopIteration):
+        next(generator)
+    after_teardown = dict(token_counter._ESTIMATE_CACHE)
+
+    assert key not in after_setup
+    assert served != 999_999
+    assert key not in after_teardown

--- a/Tests/Utils/test_private_persistent_artifacts.py
+++ b/Tests/Utils/test_private_persistent_artifacts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import stat
+from pathlib import Path
 
 import pytest
 
@@ -86,3 +87,50 @@ def test_atomic_private_write_reports_unverified_windows_posture(
     assert result.status is PrivatePathStatus.UNVERIFIED_PLATFORM
     assert result.verified_private is False
     assert target.read_bytes() == b"private"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX append branch")
+def test_private_append_writes_one_lf_byte_per_line(tmp_path):
+    """The file's SIZE must equal the bytes the caller wrote.
+
+    ``MCPExecutionLog`` caches a generation's sanitized bytes keyed on
+    ``st_size`` (TASK-21134), so any newline translation between "what the
+    caller encoded" and "what landed on disk" silently evicts that cache on
+    every append and re-parses the whole log.
+    """
+    target = tmp_path / "events.jsonl"
+    encoded = b'{"a":1}\n{"b":2}\n'
+
+    with open_private_text_append(target) as stream:
+        stream.write(encoded.decode("utf-8"))
+
+    assert target.read_bytes() == encoded
+    assert target.stat().st_size == len(encoded)
+
+
+def test_private_append_stream_pins_lf_on_the_windows_branch(tmp_path, monkeypatch):
+    """The unverified-platform branch must not inherit ``os.linesep``.
+
+    ``Path.open("a")`` defaults to ``newline=None``, which translates every
+    ``\\n`` written into ``os.linesep`` -- ``\\r\\n`` on Windows. That cannot be
+    reproduced on POSIX (the translation target is a build-time constant, not
+    ``os.linesep`` at runtime), so this pins the one thing that decides it:
+    the keyword the branch passes.
+    """
+    recorded = {}
+    real_open = Path.open
+
+    def _recording_open(self, *args, **kwargs):
+        recorded.update(kwargs)
+        recorded["mode"] = args[0] if args else kwargs.get("mode")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(private_paths, "_posix_guards_available", lambda: False)
+    monkeypatch.setattr(private_paths, "_WINDOWS_PLATFORM", True)
+    monkeypatch.setattr(Path, "open", _recording_open)
+
+    stream = private_paths.open_private_text_append_stream(tmp_path / "events.jsonl")
+    stream.close()
+
+    assert recorded["mode"] == "a"
+    assert recorded["newline"] == "\n"

--- a/Tests/network_guard.py
+++ b/Tests/network_guard.py
@@ -111,6 +111,17 @@ _blocked_attempts: list[tuple[str, str]] = []
 #: "something older did it".
 _blocked_attempt_threads: list[str] = []
 
+#: Held across BOTH appends in ``_deny`` and across every read/drain of the two
+#: lists. Each ``list.append`` is individually atomic under the GIL, but the
+#: pair is not: two threads denying at once could interleave as
+#: append(attempt A) / append(attempt B) / append(thread B) / append(thread A),
+#: leaving the provenance record positionally swapped -- and provenance is the
+#: whole point of the second list (TASK-21592). Worker-thread egress is the
+#: case it was added for, so concurrent ``_deny`` is the expected operating
+#: condition, not an exotic one. The drains take it too, so a teardown cannot
+#: snapshot one list either side of a concurrent append.
+_blocked_attempt_lock = threading.Lock()
+
 #: Egress is denied unless a test explicitly selects a narrower or wider mode.
 _mode = NetworkMode.BLOCKED
 
@@ -172,7 +183,8 @@ def set_allowed(allowed: bool) -> None:
 
 def blocked_attempts() -> tuple[tuple[str, str], ...]:
     """Return the blocked egress attempts recorded so far."""
-    return tuple(_blocked_attempts)
+    with _blocked_attempt_lock:
+        return tuple(_blocked_attempts)
 
 
 def drain_blocked_attempts() -> tuple[tuple[str, str], ...]:
@@ -182,9 +194,10 @@ def drain_blocked_attempts() -> tuple[tuple[str, str], ...]:
     ``drain_blocked_attempt_threads`` must be called *before* this if both are
     wanted for the same batch.
     """
-    recorded = tuple(_blocked_attempts)
-    _blocked_attempts.clear()
-    _blocked_attempt_threads.clear()
+    with _blocked_attempt_lock:
+        recorded = tuple(_blocked_attempts)
+        _blocked_attempts.clear()
+        _blocked_attempt_threads.clear()
     return recorded
 
 
@@ -235,8 +248,9 @@ def drain_blocked_attempt_threads() -> tuple[str, ...]:
     Returns:
         One thread name per currently recorded attempt.
     """
-    recorded = tuple(_blocked_attempt_threads)
-    _blocked_attempt_threads.clear()
+    with _blocked_attempt_lock:
+        recorded = tuple(_blocked_attempt_threads)
+        _blocked_attempt_threads.clear()
     return recorded
 
 
@@ -258,8 +272,9 @@ def _deny(call: str, address: Any) -> BlockedNetworkAccess:
         The ``BlockedNetworkAccess`` the caller should raise.
     """
     described = _describe(address)
-    _blocked_attempts.append((call, described))
-    _blocked_attempt_threads.append(threading.current_thread().name)
+    with _blocked_attempt_lock:
+        _blocked_attempts.append((call, described))
+        _blocked_attempt_threads.append(threading.current_thread().name)
     return BlockedNetworkAccess(
         f"network access blocked in tests: {call}({described}). "
         "Tests must not touch a live endpoint — stub the client seam, use "

--- a/Tests/test_network_guard.py
+++ b/Tests/test_network_guard.py
@@ -518,3 +518,67 @@ def test_draining_the_attempts_also_clears_their_thread_names() -> None:
 
     _drain_expecting()
     assert network_guard.drain_blocked_attempt_threads() == ()
+
+
+def test_concurrent_denials_keep_each_attempt_with_its_own_thread_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two threads recording at once must not swap each other's provenance.
+
+    ``_deny`` appends to two parallel lists. Each ``append`` is atomic under
+    the GIL, but the PAIR is not, so an interleave can leave the thread names
+    positionally swapped -- and the whole reason the second list exists
+    (TASK-21592) is to say which thread made the attempt, so a swap points the
+    next debugger at an innocent thread.
+
+    The interleave is forced, not raced: the hook below runs inside the first
+    ``_deny``, between its two appends, and starts a second denier there. If
+    nothing serializes the pair, that second denier completes inside the
+    window and the records interleave every time; if it is serialized, it
+    cannot start until the window closes, so the wait times out and the
+    ordering holds.
+    """
+    network_guard.drain_blocked_attempt_threads()
+    network_guard.drain_blocked_attempts()
+
+    main_name = threading.current_thread().name
+    worker_finished = threading.Event()
+    real_current_thread = threading.current_thread
+    hooked = threading.Event()
+    workers: list[threading.Thread] = []
+
+    def _second_denier() -> None:
+        network_guard._deny("socket.create_connection", ("192.0.2.9", 443))
+        worker_finished.set()
+
+    def _hooked_current_thread() -> threading.Thread:
+        current = real_current_thread()
+        if current.name == main_name and not hooked.is_set():
+            hooked.set()
+            worker = threading.Thread(
+                target=_second_denier,
+                name="guard-provenance-race",
+            )
+            workers.append(worker)
+            worker.start()
+            # Returns early only if the second denial got all the way through
+            # while this one was mid-pair.
+            worker_finished.wait(0.5)
+        return current
+
+    monkeypatch.setattr(threading, "current_thread", _hooked_current_thread)
+    network_guard._deny("socket.create_connection", ("192.0.2.8", 80))
+    monkeypatch.undo()
+
+    for worker in workers:
+        worker.join(timeout=5.0)
+        assert not worker.is_alive()
+
+    threads = network_guard.drain_blocked_attempt_threads()
+    attempts = network_guard.drain_blocked_attempts()
+
+    assert hooked.is_set(), "the interleave hook never ran"
+    assert len(attempts) == len(threads) == 2
+    provenance = dict(zip((address for _call, address in attempts), threads))
+    assert provenance["192.0.2.8:80"] == main_name
+    assert provenance["192.0.2.9:443"] == "guard-provenance-race"

--- a/backlog/tasks/task-22557 - Console-native-chat-flow-suite-has-regressed-from-2-reds-to-9.md
+++ b/backlog/tasks/task-22557 - Console-native-chat-flow-suite-has-regressed-from-2-reds-to-9.md
@@ -1,0 +1,77 @@
+---
+id: TASK-22557
+title: >-
+  Console native chat flow suite has regressed from 2 reds to 9
+status: To Do
+assignee: []
+created_date: '2026-08-26'
+labels:
+  - console
+  - tests
+  - regression
+priority: high
+dependencies: []
+---
+
+## Description
+
+`Tests/UI/test_console_native_chat_flow.py` is the behavioural suite for the Console send
+surface — dispatch, streaming render, model resolution, workspace conversation resume, and
+collapsed-layout state. TASK-21590 repaired this file's harness and left it at **2 known
+reds**. It is now at **9**, so the surface it covers has regressed further since that repair
+and nothing caught it: no CI job has produced a verdict for the UI shards, and the reds do
+not announce themselves in any gate a PR author sees.
+
+This is filed as a diagnosis-first task rather than a fix: nine failures across five distinct
+behaviours are unlikely to share one cause, and the first job is to partition them. Found
+incidentally while triaging Qodo review comments on merged PRs (chore/qodo-console); the
+triage itself changed nothing in this file.
+
+## Evidence
+
+Measured with `.venv/bin/python -m pytest ... -p no:randomly -q`, cwd = a worktree at
+dev `732105c2d`, `tldw_chatbook.__file__` asserted to resolve inside that worktree.
+
+Whole-file run (with `Tests/UI/test_console_setup_backdrop_repaint_cost.py`):
+**302 collected, 293 passed, 9 failed, 0 errors** in 314 s.
+
+The nine failing node ids:
+
+```
+Tests/UI/test_console_native_chat_flow.py::test_improvement_disclosure_is_pinned_and_drift_before_click_is_blocked[selection]
+Tests/UI/test_console_native_chat_flow.py::test_improvement_disclosure_is_pinned_and_drift_before_click_is_blocked[config_endpoint]
+Tests/UI/test_console_native_chat_flow.py::test_console_native_generic_provider_send_renders_completed_message
+Tests/UI/test_console_native_chat_flow.py::test_console_native_send_button_click_dispatches_message
+Tests/UI/test_console_native_chat_flow.py::test_console_successful_send_does_not_leave_empty_send_tooltip
+Tests/UI/test_console_native_chat_flow.py::test_console_configured_model_reaches_gateway_when_ui_model_is_unset
+Tests/UI/test_console_native_chat_flow.py::test_console_workspace_conversation_row_resumes_persisted_conversation
+Tests/UI/test_console_native_chat_flow.py::test_console_workspace_conversation_resume_uses_real_local_services
+Tests/UI/test_console_native_chat_flow.py::test_console_collapsed_layout_follows_cross_workspace_tab_state
+```
+
+**A/B control.** The nine were re-run after swapping `tldw_chatbook/Chat/console_chat_store.py`
+to its `732105c2d` blob (identical command, identical selection), to rule out the branch's own
+edits: **the same 9 node ids failed, none more, none fewer** — `9 failed in 34.06 s`. The
+working tree was then restored and diff-verified byte-identical. So these are dev reds, not
+artefacts of the branch that observed them.
+
+Per `lessons-testing-evidence.md` ("Compare failure *sets* from identical commands, never
+counts"), the comparison above is of sets, not counts.
+
+## Acceptance Criteria
+
+- [ ] Each of the nine node ids is partitioned into: production regression, stale test double,
+      or harness/environment artefact — with the evidence for the call, not an assertion
+- [ ] For every one classified as a production regression, the user-visible defect is stated
+      in product terms (what a user does, what they see instead)
+- [ ] Any test found to be pinning a defect is corrected rather than deleted or relaxed, and
+      the production behaviour it was pinning is filed or fixed
+- [ ] The file runs green, or every remaining red has a filed task id recorded in this task
+- [ ] The delta from TASK-21590's 2 known reds to 9 is explained: which merges introduced
+      which failures (`git log` bisection over the suspect commits is acceptable evidence)
+- [ ] No `:memory:`-to-file-backed flips in `Tests/UI/app_factory.py`'s `attach_chachanotes_db`
+      (TASK-21590: `:memory:` is load-bearing — a file-backed DB moves these tests onto the
+      agent loop and changes their subject)
+- [ ] Teardown errors are checked explicitly, not inferred from a green summary line
+      (TASK-21590: 16 tests reached tiktoken's BPE download while *passing*; the current
+      302-item run reports 0 errors, so that is the baseline to hold)

--- a/scripts/check_index_plan_pins.py
+++ b/scripts/check_index_plan_pins.py
@@ -141,7 +141,13 @@ def _sql_texts(path: Path) -> list[str]:
 
 
 def declared_indexes() -> dict[str, set[str]]:
-    """Map index name -> the source files that declare it."""
+    """Find every index the schema sources under ``DB/`` create.
+
+    Returns:
+        Index name -> the repository-relative source paths whose SQL
+        declares it. A name created by more than one file (a fresh-schema
+        string and a migration step, typically) maps to both.
+    """
     found: dict[str, set[str]] = {}
     sources: list[tuple[Path, list[str]]] = []
     for py in sorted(DB_DIR.rglob("*.py")):
@@ -158,7 +164,22 @@ def declared_indexes() -> dict[str, set[str]]:
 
 
 def read_census() -> dict[str, tuple[str, str]]:
-    """Map index name -> (status, note). Raises SystemExit on a malformed row."""
+    """Parse ``index_plan_pin_census.tsv``.
+
+    Blank lines and ``#`` comments are skipped; the note column is optional.
+
+    Returns:
+        Index name -> ``(status, note)``, where status is one of
+        ``VALID_STATUSES`` and note is ``""`` when the row omits it.
+
+    Raises:
+        SystemExit: With code 1, after printing the offending line, when the
+            census file is missing, a row has fewer than two TAB-separated
+            columns, a row's status is outside ``VALID_STATUSES``, or an
+            index name appears twice. Malformed input is a hard stop rather
+            than a skipped row: a census that silently drops what it cannot
+            parse is a guard that reports success for rows nobody read.
+    """
     if not CENSUS.exists():
         print(f"FAIL: census file missing: {CENSUS.relative_to(REPO_ROOT)}")
         raise SystemExit(1)
@@ -280,6 +301,16 @@ def plan_pinning_files() -> dict[str, set[str]]:
 
 
 def main() -> int:
+    """Check the census against the tree and report every discrepancy.
+
+    Three failure classes are reported together rather than short-circuiting
+    on the first: an index created but absent from the census, a census row
+    naming an index nothing creates any more, and a row recorded
+    ``plan-pinned`` that no test file positively pins.
+
+    Returns:
+        0 when the census covers the tree exactly, 1 otherwise.
+    """
     declared = declared_indexes()
     census = read_census()
     pins = plan_pinning_files()

--- a/scripts/check_index_plan_pins.py
+++ b/scripts/check_index_plan_pins.py
@@ -63,6 +63,16 @@ WHAT THIS CANNOT SEE, measured rather than assumed:
   real pin looks like: assert the index name IS in the plan, assert
   ``TEMP B-TREE`` is NOT, and keep a negative control proving the shape you
   rejected is still not chosen.
+
+  What it *does* now refuse to read as evidence is a mention that says the
+  opposite. The first version accepted any ``idx_...`` token anywhere in a
+  qualifying file, and measured against the tree that admitted two indexes
+  the file only ever asserts are **absent** from a plan --
+  ``idx_media_deleted`` and ``idx_keywords_deleted``, both named solely by
+  a ``#`` comment quoting the pre-fix plan and by ``assert "..." not in
+  plan``. Either census row could have been flipped to ``plan-pinned`` and
+  passed CI on evidence that the planner does not choose the index. See
+  ``_plan_evidence_strings``.
 * Indexes created outside ``DB/`` (e.g. a vector store's own schema).
 
 Usage:  python scripts/check_index_plan_pins.py
@@ -175,23 +185,97 @@ def read_census() -> dict[str, tuple[str, str]]:
     return rows
 
 
+def _plan_evidence_strings(tree: ast.AST) -> list[str]:
+    """String literals in a test module that can carry POSITIVE plan evidence.
+
+    Two kinds of occurrence are dropped, because both are a claim that an
+    index is *not* what the planner uses:
+
+    * **docstrings and ``#`` comments** -- prose *about* an index, not an
+      assertion *on* one. ``test_media_db_schema_v9.py`` names
+      ``idx_media_deleted`` in a docstring and in two comments quoting the
+      pre-fix plan it replaced;
+    * the **member operand of a ``not in`` comparison** --
+      ``assert "idx_media_deleted" not in plan`` is evidence the planner
+      does NOT choose it, and counting it as a pin inverts the guard.
+
+    A name survives if it appears even once outside those positions, so a
+    file that asserts an index IS in one plan and is NOT in another still
+    pins it.
+
+    Args:
+        tree: The parsed module.
+
+    Returns:
+        Every qualifying string literal, in no particular order.
+    """
+    docstrings: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            continue
+        body = node.body
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            docstrings.add(id(body[0].value))
+
+    negated: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        operands = [node.left, *node.comparators]
+        for offset, operator in enumerate(node.ops):
+            member = operands[offset]
+            if isinstance(operator, ast.NotIn) and isinstance(member, ast.Constant):
+                negated.add(id(member))
+
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+        and id(node) not in negated
+    ]
+
+
 def plan_pinning_files() -> dict[str, set[str]]:
-    """Map index name -> test files that plan-pin it, with stats absent."""
+    """Find the test files that plan-pin each index, with stats absent.
+
+    A file qualifies only if it contains both ``EXPLAIN QUERY PLAN`` and a
+    ``sqlite_stat1`` mention; within a qualifying file an index counts as
+    pinned only where ``_plan_evidence_strings`` admits the name.
+
+    Returns:
+        Index name -> the repository-relative test files that pin it. Names
+        that no qualifying file mentions positively are simply absent.
+    """
     pins: dict[str, set[str]] = {}
     if not TESTS_DIR.exists():
         return pins
     for path in sorted(TESTS_DIR.rglob("test_*.py")):
         try:
-            text = path.read_text(encoding="utf-8")
+            source = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if _PLAN_CALL not in text or _NO_STATS not in text:
+        if _PLAN_CALL not in source or _NO_STATS not in source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
             continue
         rel = str(path.relative_to(REPO_ROOT))
-        for name in set(_CREATE_INDEX.findall(_strip_sql_comments(text))) | set(
-            re.findall(r"\bidx_[A-Za-z0-9_]+\b", text)
-        ):
-            pins.setdefault(name, set()).add(rel)
+        for text in _plan_evidence_strings(tree):
+            stripped = _strip_sql_comments(text)
+            for name in set(_CREATE_INDEX.findall(stripped)) | set(
+                re.findall(r"\bidx_[A-Za-z0-9_]+\b", text)
+            ):
+                pins.setdefault(name, set()).add(rel)
     return pins
 
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1782,6 +1782,22 @@ class ConsoleChatStore:
         second manual turn, and a queued follow-up is only *submitted* from
         ``_drain_waiting``, which runs after the previous turn reaches a
         terminal status -- by which point settlement has popped this owner.
+
+        Args:
+            session_id: Native Console session id. ``None`` -- and equally an
+                empty string or any non-``str`` -- means "no session to have
+                an owner", which ``dispatch_recovery_for_session`` answers
+                with ``None``, so the gate is open. Callers on a screen with
+                no active session therefore need no guard of their own.
+
+        Returns:
+            ``True`` only when that session has a recovery owner the user is
+            currently being shown a card for AND its kind is one of the five
+            unresolved source-local kinds above. ``False`` for no owner, for
+            a healthy in-flight owner (``recovery_needed=False``), and for
+            the three kinds outside that set (``REMOTE_ACCEPTED``,
+            ``REMOTE_DISPATCH_STARTED``, ``CONTINUATION``) -- i.e. the send
+            is admitted.
         """
 
         recovery = self.dispatch_recovery_for_presentation(session_id)

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4502,6 +4502,18 @@ class ConsoleChatStore:
                 )
         self._sessions.clear()
         self._messages_by_session.clear()
+        # Retention, not correctness: the memo holds a strong reference to the
+        # PRE-restore view list, so clearing `_messages_by_session` does not
+        # release it. Correctness was always safe (the memo pins that list, so
+        # a rebuilt view can never reuse its identity), but nothing evicts the
+        # slot until some later `newest_change_review_run_id` call overwrites
+        # it -- and that call never comes when the changed-files guard is off
+        # or the screen stops querying, leaving a replaced session's entire
+        # transcript (every `ConsoleChatMessage`, image bytes included) alive
+        # for the rest of the store's life. Same reasoning as
+        # `_drop_newest_change_review_memo`; unconditional here because
+        # restore_state replaces every session, not one.
+        self._newest_change_review_memo = None
         self._message_session_index.clear()
         self._pending_persistence_message_ids.clear()
         self._terminal_citation_finalizers.clear()
@@ -5345,8 +5357,11 @@ class ConsoleChatStore:
         (and therefore every ``ConsoleChatMessage`` in it) for an unbounded
         time when the closed session was the active one and nothing queries
         again. Dropping a memo can only cost a recompute, so that is hygiene,
-        not an invalidation protocol; ``restore_state`` needs no such hook
-        because the next query re-derives against a new list anyway.
+        not an invalidation protocol. ``restore_state`` clears the slot for
+        the same RETENTION reason (Qodo review, 2026-08-26): its correctness
+        never needed a hook -- the next query re-derives against a new list --
+        but until that query happens the slot keeps the whole REPLACED
+        transcript alive, and after a state replacement it may never happen.
 
         Args:
             session_id: Native Console session id.

--- a/tldw_chatbook/DB/migrations/README.md
+++ b/tldw_chatbook/DB/migrations/README.md
@@ -4,6 +4,27 @@
 methods in the matching `DB/*.py` module. Filenames are
 `<db>_v<from>_to_v<to>_<what>.sql`.
 
+## Which schemas live here (and which do not)
+
+Two of the eight versioned schemas do: `chachanotes` (`ChaChaNotes_DB.py`) and
+`workspaces` (`Workspace_DB.py`). The other six — media
+(`Client_Media_DB_v2.py`), agent runs, prompts, library ingest jobs, library
+collections, subscriptions — keep each step as a module-level SQL constant and
+run it from their own migration method. No `media_*.sql` has ever existed here.
+
+That is a scope statement, not a backlog item, and it is written down because
+reviewers keep reading "add `<db>_v<n>_to_v<n+1>.sql`" as repo-wide and filing
+the media DB's inline steps as a violation (twice on TASK-21126 and
+TASK-21593). What the rules below actually require of *every* schema is the
+behaviour: one guarded transaction per step, re-enterable, rewinding the
+version stamp on failure. `Client_Media_DB_v2._apply_migration_v8_to_v9` meets
+it through `self.transaction()` + `_execute_transactional_script`, and
+`Tests/DB/test_media_db_schema_v9.py::test_failed_v8_to_v9_rolls_back_and_
+leaves_a_working_v8_db` proves the rollback. Moving one media step into this
+directory would leave that module split across two conventions and buy
+nothing; moving all of them is a separate change, and would have to carry the
+packaging derivation in step 3 with it.
+
 ## Adding a migration
 
 1. Bump `_CURRENT_SCHEMA_VERSION` in the owning DB module.

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -663,6 +663,17 @@ class LibraryIngestJobRegistry:
         the likely case, and two entries sharing a ``job_id`` would make
         every id-keyed mutation ambiguous. ``_next_id`` takes the maximum so
         no future allocation can collide either.
+
+        Unlike the restored jobs -- already in the store by definition -- the
+        live ones are written through here when a store is attached. They
+        were submitted while the registry was still store-less, so their own
+        ``submit`` reached a ``_persist`` that was a no-op, and nothing else
+        ever re-offers them: without this they were silently absent from the
+        store, gone after the next launch, and any stale persisted row that
+        shared their id was restored in their place. Attach the store BEFORE
+        calling this (see ``TldwCli._apply_ingest_job_restore``); with none
+        attached the write-through is a no-op and the pure/in-memory contract
+        is unchanged.
         """
         live = self._jobs
         if not live:
@@ -678,6 +689,8 @@ class LibraryIngestJobRegistry:
         )
         self._jobs = restored + live
         self._next_id = max(next_id, self._next_id)
+        for job in live:
+            self._persist(job)
         self._notify_listeners()
 
     # -- listeners -----------------------------------------------------

--- a/tldw_chatbook/Notes/notes_device_state_store.py
+++ b/tldw_chatbook/Notes/notes_device_state_store.py
@@ -1143,11 +1143,9 @@ class NotesDeviceStateStore:
         ``idx_notes_sync_bindings_root(root_id, state, binding_id)``, which
         also supplies the ordering, so no temporary B-tree sort is built.
 
-        This is a private projection for owner-side reconciliation, not a
-        public summary: it deliberately carries no
-        :func:`validate_notes_sync_opaque_id` fail-closed check, exactly like
-        the :meth:`list_bindings` read it replaces. ``list_binding_summaries``
-        keeps that contract because it feeds surfaces outside this owner.
+        Both identifiers carry the same :func:`validate_notes_sync_opaque_id`
+        fail-closed check as the :meth:`list_bindings` read this replaces, so
+        narrowing the projection did not narrow the input contract.
 
         Args:
             root_id: The opaque sync root whose active bindings to project.
@@ -1157,6 +1155,10 @@ class NotesDeviceStateStore:
         Returns:
             tuple[str, ...]: Note ids of the matching active bindings, ordered
             by binding id.
+
+        Raises:
+            ValueError: If ``root_id`` -- or ``exclude_binding_id``, when
+                given -- is not a bounded opaque identifier.
         """
 
         validate_notes_sync_opaque_id(root_id, field_name="root_id")
@@ -1210,6 +1212,10 @@ class NotesDeviceStateStore:
         Returns:
             bool: True when some binding of this root, in any state, already
             claims that note identity or that relative path.
+
+        Raises:
+            ValueError: If ``root_id`` is not a bounded opaque identifier. The
+                three search terms above are deliberately exempt.
         """
 
         validate_notes_sync_opaque_id(root_id, field_name="root_id")

--- a/tldw_chatbook/Notifications/event_state_repository.py
+++ b/tldw_chatbook/Notifications/event_state_repository.py
@@ -256,10 +256,7 @@ class EventStateRepository(BaseDB):
             try:
                 entry.conn.execute("SELECT 1")
             except (sqlite3.ProgrammingError, sqlite3.OperationalError):
-                try:
-                    entry.conn.close()
-                except Exception:  # noqa: BLE001 - already unusable
-                    pass
+                self._close_quietly(entry.conn)
                 with self._held_lock:
                     if self._held.get(key) is entry:
                         del self._held[key]
@@ -371,10 +368,36 @@ class EventStateRepository(BaseDB):
                 # that no longer exist.
                 self._schema_ready = False
         for conn in closable:
-            try:
-                conn.close()
-            except Exception:  # noqa: BLE001 - best-effort teardown
-                pass
+            self._close_quietly(conn)
+
+    @staticmethod
+    def _close_quietly(conn: sqlite3.Connection) -> None:
+        """Close ``conn``, recording a failure instead of discarding it.
+
+        Best-effort by design -- the entry is already out of ``_held`` and a
+        re-close of a handle whose first close raised would keep a broken
+        connection reachable, which is worse than dropping it. What was
+        missing is the record: a swallowed close error left an untracked
+        handle with nothing to debug from. TASK-21131 already lost time to
+        exactly that (a cross-thread ``close()`` was raising and being
+        swallowed, which kept a wrong test green until the cause was found at
+        the mechanism), and both sibling stores --
+        ``Research_Interop.local_research_service`` and
+        ``Writing_Interop.local_writing_service`` -- log this case.
+
+        Type name only, matching those siblings: a sqlite3 message can carry
+        the database path, and this store's teardown is not a place to emit
+        one.
+
+        Args:
+            conn: The connection to close.
+        """
+        try:
+            conn.close()
+        except Exception as exc:  # noqa: BLE001 - best-effort teardown
+            logger.debug(
+                "Event state connection close failed: {}", type(exc).__name__
+            )
 
     def _initialize_schema(self) -> None:
         # Raw connection: runs under _ensure_schema's lock (TASK-21105), so

--- a/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
+++ b/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
@@ -22,7 +22,6 @@ from .rag_service import MetadataAllowlist
 from .config import RAGConfig
 from .data_models import IndexingResult
 from .vector_store import SearchResult, SearchResultWithCitations
-from ..reranker import create_reranker_from_config
 from ..parallel_processor import (
     create_embedding_processor,
     create_chunking_processor,
@@ -47,6 +46,7 @@ if TYPE_CHECKING:
         ProfileType,
         ConfigProfileManager,
     )
+    from ..reranker import BaseReranker, RerankingConfig
 
 
 def _config_profiles():
@@ -54,6 +54,34 @@ def _config_profiles():
     from .. import config_profiles
 
     return config_profiles
+
+
+def create_reranker_from_config(config: "RerankingConfig") -> "BaseReranker":
+    """Build a reranker, importing ``..reranker`` at first use.
+
+    The second edge of the same cycle ``_config_profiles()`` above defers, and
+    it fails in the opposite direction: ``reranker`` imports
+    ``.simplified.vector_store``, which executes ``simplified/__init__``, which
+    executes THIS module -- so a ``reranker``-FIRST import order reached the
+    old module-level ``from ..reranker import create_reranker_from_config``
+    while ``reranker`` was still partially initialized and raised ImportError.
+
+    Deliberately a same-named module-level wrapper rather than the
+    module-accessor shape used for ``config_profiles``: this name is a
+    monkeypatch seam. ``Tests/RAG_Search/test_reranker_construction.py``
+    replaces ``enhanced_rag_service_v2.create_reranker_from_config`` eight
+    times to drive construction-failure paths, and the two call sites below
+    resolve it as a module global, so patching keeps working unchanged.
+
+    Args:
+        config: The reranking configuration to construct from.
+
+    Returns:
+        The reranker instance ``reranker.create_reranker_from_config`` builds.
+    """
+    from ..reranker import create_reranker_from_config as _create
+
+    return _create(config)
 
 
 def _tag_first_result(

--- a/tldw_chatbook/Research_Interop/research_scope_service.py
+++ b/tldw_chatbook/Research_Interop/research_scope_service.py
@@ -139,6 +139,23 @@ class _ThreadOffloadedBackend:
     def __init__(self, backend: Any) -> None:
         self._backend = backend
 
+    def offloads(self, name: str) -> bool:
+        """Report whether ``name`` will be dispatched to the backend thread.
+
+        A pass-through (already-async) attribute runs its body wherever the
+        caller awaits it -- for an async *generator* over a synchronous
+        backend, that is the event loop. Callers that can choose between two
+        equivalent backend readers use this to prefer the offloaded one.
+
+        Args:
+            name: Backend attribute name to classify.
+
+        Returns:
+            True when calling ``name`` runs on the shared backend thread.
+        """
+        attribute = getattr(self._backend, name, None)
+        return callable(attribute) and not _is_async_callable(attribute)
+
     def __getattr__(self, name: str) -> Any:
         attribute = getattr(self._backend, name)
         if not callable(attribute) or _is_async_callable(attribute):
@@ -693,11 +710,32 @@ class ResearchScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._action_id("runs", "observe", normalized_mode))
         service = self._service_for_mode(normalized_mode)
-        method = getattr(service, "stream_run_events", None)
-        if method is None:
-            method = getattr(service, "observe_run_events", None)
-        if method is None:
+        # TASK-21127 left this one path on the loop. `_ThreadOffloadedBackend`
+        # passes async generators through unwrapped -- correct for the server
+        # backend, but `LocalResearchService.stream_run_events` is an
+        # `async def ... yield` whose whole body is
+        # `for event in self.list_run_events(...)`, a blocking SQLite read. So
+        # iterating the LOCAL stream executed the read on the event loop
+        # (measured: `research-backend_0` for `observe_run_events` vs
+        # `MainThread` here), on the Research window's 2 s refresh poll.
+        #
+        # A backend that exposes a SYNCHRONOUS `list_run_events` has no real
+        # streaming to offer -- its generator is a snapshot loop over exactly
+        # that call -- so take the offloaded reader instead and yield the same
+        # items. This adds no thread and no transaction: it selects a method
+        # the wrapper already dispatches to the one backend thread, which is
+        # what `observe_run_events` above has always done for this backend.
+        # A backend whose reader is async (the server) is untouched.
+        if isinstance(service, _ThreadOffloadedBackend) and service.offloads(
+            "list_run_events"
+        ):
             method = getattr(service, "list_run_events")
+        else:
+            method = getattr(service, "stream_run_events", None)
+            if method is None:
+                method = getattr(service, "observe_run_events", None)
+            if method is None:
+                method = getattr(service, "list_run_events")
         result = method(run_id, after_id=after_id)
         if inspect.isasyncgen(result):
             async for item in result:

--- a/tldw_chatbook/Utils/db_status_manager.py
+++ b/tldw_chatbook/Utils/db_status_manager.py
@@ -21,7 +21,12 @@ if TYPE_CHECKING:
 
 
 class DBStatusManager:
-    """Manages database size telemetry and footer token-count updates."""
+    """Manages database size telemetry.
+
+    Footer token-count updates used to live here too; task-21133 retired
+    that half after task-17653 removed its whole consumer surface (see the
+    module docstring).
+    """
 
     def __init__(self, app: "App"):
         """

--- a/tldw_chatbook/Utils/private_paths.py
+++ b/tldw_chatbook/Utils/private_paths.py
@@ -845,7 +845,21 @@ def open_private_text_append_stream(
     encoding: str = "utf-8",
     errors: str | None = None,
 ) -> TextIO:
-    """Return a pinned private text stream opened for append."""
+    """Return a pinned private text stream opened for append.
+
+    Every stream this returns writes ``\\n`` as a single LF byte on every
+    platform (``newline="\\n"``). The default (``newline=None``) translates
+    each ``\\n`` a caller writes into ``os.linesep``, which on Windows is
+    ``\\r\\n`` -- so a caller that encodes a line, writes it as text, and then
+    reasons about the file's SIZE (or diffs the file against the bytes it
+    just wrote) is wrong by one byte per line there. ``MCPExecutionLog``
+    does exactly that: it caches a generation's sanitized bytes keyed on
+    ``st_size``, so under CRLF translation the cache was dropped on every
+    append and the whole log was re-parsed and rewritten each time -- the
+    exact per-tool-call cost TASK-21134's cache removed on POSIX. These are
+    line-oriented JSONL/log files, so LF is also the shape every reader here
+    already assumes.
+    """
 
     selected = lexical_path(path)
     _prepare_application_owned_parent(selected, application_owned_directory)
@@ -853,7 +867,9 @@ def open_private_text_append_stream(
     if not _posix_guards_available():
         if _WINDOWS_PLATFORM:
             selected.parent.mkdir(parents=True, exist_ok=True)
-            return selected.open("a", encoding=encoding, errors=errors)
+            return selected.open(
+                "a", encoding=encoding, errors=errors, newline="\n"
+            )
         raise PrivatePathError(
             PrivatePathResult(
                 selected,
@@ -920,6 +936,11 @@ def open_private_text_append_stream(
             "a",
             encoding=encoding,
             errors=errors,
+            # Same LF contract as the Windows branch above. A no-op on this
+            # platform (``os.linesep`` is already LF), stated so the two
+            # branches cannot drift apart on the one property callers of
+            # this helper reason about in bytes.
+            newline="\n",
             closefd=True,
         )
         file_fd = -1

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2769,6 +2769,12 @@ class LibraryIngestQueueMixin:
         from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
         from tldw_chatbook.Library.library_ingest_jobs import plan_restore
 
+        # Bound before the `try` so the failure path can tell "never opened"
+        # from "opened, then a later step failed" -- the second case owns a
+        # live SQLite connection (the store opens one in its constructor, via
+        # `_initialize_schema`) that nothing else will ever close, because the
+        # registry is left store-less.
+        store = None
         try:
             # `LibraryIngestJobsDB` opens with `check_same_thread=False`, so
             # the connection this thread creates stays usable from the UI
@@ -2793,6 +2799,13 @@ class LibraryIngestQueueMixin:
             logger.opt(exception=True).warning(
                 "Failed to restore persisted ingest job history; starting empty."
             )
+            if store is not None:
+                try:
+                    store.close()
+                except Exception:
+                    logger.opt(exception=True).debug(
+                        "Ingest job store close after failed restore failed."
+                    )
             return
 
         try:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -14317,8 +14317,9 @@ class TldwCli(
             name="tldw-initial-screen-preimport",
             daemon=True,
         )
+        if not self._start_preimport_thread(thread):
+            return
         self._initial_screen_preimport_thread = thread
-        thread.start()
 
     def _schedule_screen_preimport(self) -> None:
         """Start the background screen-module pre-importer, at most once."""
@@ -14333,8 +14334,41 @@ class TldwCli(
             name="tldw-screen-preimport",
             daemon=True,
         )
+        if not self._start_preimport_thread(thread):
+            return
         self._screen_preimport_thread = thread
-        thread.start()
+
+    def _start_preimport_thread(self, thread: threading.Thread) -> bool:
+        """Start a pre-import thread; report whether it is running.
+
+        Args:
+            thread: The unstarted daemon thread to run.
+
+        Returns:
+            ``True`` when the thread started. ``False`` when the interpreter
+            refused to spawn it -- thread exhaustion, or a start during
+            interpreter shutdown -- in which case the caller must NOT record a
+            handle.
+
+        Both callers run from the splash-path timer/deferred-startup callback,
+        not a request/response path, so a ``RuntimeError`` out of ``start()``
+        would surface as an unhandled exception in a Textual timer task during
+        boot. Losing a speculative warm-up is the correct outcome there: every
+        module this would have pre-imported is still imported normally on
+        first navigation. Recording the handle only after a successful start
+        also keeps the once-guard honest -- a failed attempt leaves ``None``,
+        so a later call can try again.
+        """
+        try:
+            thread.start()
+        except RuntimeError as exc:
+            self.loguru_logger.debug(
+                "Screen pre-import thread could not start (name={}, error_type={})",
+                thread.name,
+                type(exc).__name__,
+            )
+            return False
+        return True
 
     def _schedule_tts_initialization(self) -> None:
         if self._tts_handler is not None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2836,13 +2836,22 @@ class LibraryIngestQueueMixin:
         store attach stay here even though the I/O moved. Uses
         ``merge_restored`` rather than ``restore`` so a job submitted in the
         few milliseconds between ``on_mount`` and this callback survives.
+
+        The store is attached BEFORE the merge, not after: a job submitted in
+        that window was submitted while the registry was store-less, so its
+        own ``_persist`` was a no-op, and nothing later re-offers it. With
+        the store attached first, ``merge_restored`` writes those live jobs
+        through -- which also replaces any persisted row that happens to
+        share their id (both sessions allocate from ``ingest-job-1`` upward,
+        so a collision in this window is the likely case, and the stale row
+        would otherwise be restored in the live job's place next launch).
         """
         if getattr(self, "_ingest_shutdown", False):
             store.close()
             return
         self._library_ingest_jobs_store = store
-        self.library_ingest_jobs.merge_restored(plan.jobs, plan.next_id)
         self.library_ingest_jobs.attach_store(store)
+        self.library_ingest_jobs.merge_restored(plan.jobs, plan.next_id)
 
     def _expand_library_ingest_source(self, source_path: str) -> list[str] | None:
         """Expand a directory source into the files it contains.


### PR DESCRIPTION
## Summary

Addresses **every inline review comment left on the 27 merged PRs** of the 2026-08-22 performance
burn-down — 60 comments from Qodo, none of which were triaged at the time, because those PRs merged
as soon as their required gate went green.

**Outcome: 23 real (fixed), 34 false positives (refused with evidence), 2 already fixed, 1 out of
scope.** Four areas worked in parallel, combined here into one branch.

I would rather have 60 accurate verdicts than 60 changes. **Every refusal below is backed by a
measurement or a citation, not an opinion**, and each is recorded in the commit that covers it.

## The findings that mattered

**Data loss in the ingest-job restore (High).** Jobs submitted during the off-thread restore window
never reached disk — confirmed end to end, including the likely case where a *colliding persisted
row* is restored in its place at next launch. The store is now attached before the merge and live
jobs are written through. Mutation: attaching after the merge, or dropping the write-through, each
fail with `assert '/persisted-1.pdf' == '/submitted-during-startup.pdf'`. This is a defect in
TASK-21111's own work; the poisoned-store check that shipped with it proved the app *came up*, which
is a strictly weaker property than *no submission is lost*.

**An index-plan guard that counted negative evidence as positive (High).** `check_index_plan_pins.py`
reported 7 indexes as plan-pinned when only 5 are: `idx_media_deleted` and `idx_keywords_deleted`
qualified purely from a `#` comment quoting the pre-fix plan and from
`assert "…" not in plan` — *evidence the planner does not choose them*. A census row could have been
flipped to `plan-pinned` and passed CI on the exact inverse of what it claims. Names are now
harvested via `ast` from string literals only, excluding docstrings and the member operand of a
`not in`. Restoring the raw-text scan reds 5 of 22 new tests. **This is a defect in TASK-21593,
shipped and verified by me two days ago — I checked the checker ran, never that its answer was
arrived at honestly.**

**A production import cycle that the comment wanted papered over.** Qodo said "reorder the test's
imports". `import tldw_chatbook.RAG_Search.reranker` in a fresh interpreter **raises ImportError** on
dev — reranker → `simplified/__init__` → `enhanced_rag_service_v2` → back into partially-initialised
`reranker`. Verified before and after. Fixed at the cycle edge, deliberately not with the
module-accessor shape, because that name is a monkeypatch seam a sibling test replaces 8 times.

**Windows CRLF silently defeating a cache (High).** `open_private_text_append_stream`'s Windows
branch used `newline=None`, so TASK-21134's execution-log cache was evicted on every append **and**
`_migrate_generation` rewrote the whole file every time (LF sanitized never equals CRLF raw). Fixed
centrally at the helper, so `Logging_Config`, `config.py` and `notes_sync_coordinator` inherit the
same LF contract.

**A test tokenizer stub that undercounted and was machine-dependent.** Measured: `"hi"` → real
**1**, stub **0**; CJK → real 50, stub 17, tiktoken-off 84. The stub reinstated exactly the
zero-for-short-text truncation that `max(1, …)` exists to prevent, and *which tier ran depended on
whether the machine had tiktoken installed*. Now forces the no-tokenizer tier deterministically,
with `_ESTIMATE_CACHE` cleared on both sides of every test (its key carries no tokenizer identity).
Another defect in my own TASK-21590 work.

**The ADR-046 race proof had been dead for days.**
`test_queued_follow_up_cannot_be_admitted_while_the_durable_commit_runs` — one of three tests
justifying the TASK-22000 gate narrowing — has failed since #2091 moved the durable commit off the
event loop, dying on `QueueThreadViolation` before its assertion ran. **No production change was
needed**: `ConsolePromptQueueCoordinator.activity()` already catches that and falls back to a
snapshot cache, so only the test's raw registry calls tripped the contract.

The rework is *more* faithful than the original: before #2091 the commit occupied the loop, so a user
physically could not press Send during it; now the loop is free, so **the race got more reachable**,
and the test stages the interleaving a real user can produce. Its pass-by-accident guard is the
evidence worth reading — with the observation suppressed and the positive guards removed, the test
**passes green and blind**, because every "nothing bad was seen" assertion is satisfied by a race
that never happened.

Also real: a leaked store connection on restore failure; an unhandled `thread.start()` failure that
latched the once-guard on a thread that never ran; an unsynchronised parallel provenance record in
the egress guard; a `restore_state` retention leak pinning a replaced transcript (image bytes
included) for the store's life; an async generator running its read on `MainThread` instead of the
backend thread; a SIGKILL test unguarded on Windows; and several genuine documentation defects.

## Why 34 comments were refused

Grouped, with the evidence:

- **"Add Google-style docstrings / type hints"** (12 comments). Census: of **45,811** test functions
  only **235 (0.5%)** use `Args:`/`Returns:`; **8,290 of 12,491** documented production functions with
  a non-`None` return have no `Returns:`. Complying would make the patched functions the anomaly. Two
  were also *wrong*: `Returns:` is the incorrect Google section for a `@contextmanager` generator.
- **"Fix import ordering / blank lines"** (5). **No `[tool.ruff]`, `[tool.isort]`, flake8, black or
  pylint config exists anywhere in the repo, no pre-commit config, and no workflow runs a linter.**
  The stated harm — "failing lint checks across the repo" — cannot occur. 51 sibling files use the
  grouping being objected to.
- **"Parameterise / validate this SQL identifier"** (4). Each interpolates a module-level string
  literal. SQLite cannot parameterise identifiers, and in one case the prescribed
  `validate_column_name` **fails closed** for tables absent from `VALID_COLUMNS` — "complying" would
  mean widening a production security allowlist to satisfy a test.
- **"Close these leaked connections"**. This is the change TASK-21134 already measured and
  **reverted**: 128.2/111.5 ms → 160.4/185.0 ms, with a third arm proving the handles were WAL
  anchors. The premise was also measured false — 200 sequential calls fan out to **one** worker
  thread, not the pool size.
- **"Reads should use `transaction()`"**. All sites are SELECT-only; `transaction()` issues
  `BEGIN IMMEDIATE`, so complying would take a **write lock for every read** on a 3-second-TTL feed,
  and it is non-reentrant on the held connection.
- **"Paginate this query"**. The caller requires exact whole-set equality against a re-derived set;
  a page cannot answer that, and the method already cut its predecessor's footprint 13 columns/row
  → 1.
- **"Wrapper-created timers evade the census"**. Measured: the census *does* record that root, and
  starting the walk directly at the named callback reaches 3 methods and **0** `.update(` sites — the
  prescribed fix banks nothing. The real residual is filed instead (see below).

## Verification

**2,683 passed / 1 failed** across `Tests/DB`, `Tests/Notifications`, `Tests/Research`, `Tests/RAG`,
the send-gate race, the changed-files memo and the boot-closure guard. That one failure is
A/B-proven identical on pristine dev. Per-area runs: DB **1,950 passed**; services **3,615 passed**
plus a RAG A/B showing identical failure sets and +13 passed; Console **492 passed, 0 errors**
(teardown checked explicitly, not inferred); app **277 passed** plus a 2,772-passed ingest sweep.

**The 660-module boot-closure limit was not touched.** Preflight green, all six checks. The
diagnostic inventory was re-pinned only after reviewing each added row with `--statements` — three
rows, carrying exception type names, a module-owned thread name and a literal.

Every mutation is reported in the commits; several agents discarded their own first mutation attempt
when it failed the *setup* rather than the property, which is not evidence.

## Filed, not fixed here

- **TASK-22557** — `Tests/UI/test_console_native_chat_flow.py` has regressed from the 2 known reds
  TASK-21590 left to **9**, across five distinct behaviours. Filed diagnosis-first with all nine node
  ids and an A/B control.
- **Timer-path census: an unresolvable clock root is silent.** Of 36 roots, 2 resolve to nothing and
  nothing notices, and the call graph cannot cross constructor-injected callables — which is how the
  whole `UI/Console_Modules` family is wired. Suggested shape: make an unresolvable root **fail**
  the census; teaching it injection seams is a separate job that may surface production changes.
- **SIGKILL portability sweep** — four more unguarded `os.kill(..., SIGKILL)` sites collected by the
  Windows nightly. One sweep, not four drive-bys.
- **If the Google-docstring rule is meant to bind, it needs a linter, not hand-patches.** Five of
  this batch's comments were that rule; one lint rule would settle the class permanently.
- `is_async_callable` naming/capability divergence; a duplicate test basename masked only by
  `--import-mode=importlib`; and several pre-existing dev reds, listed per area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses every inline review comment from the 27 merged performance burn-down PRs: 23 real fixes, 34 refusals backed by measurements or citations, 2 already fixed, 1 out of scope. The suite is at 2,683 passing with the single failure A/B-proven identical on pristine dev.

**Fixes**

- Fixes data loss in the ingest-job restore: jobs submitted during the off-thread restore window were never persisted, and a colliding persisted row was restored in their place at next launch.
- Fixes `scripts/check_index_plan_pins.py`, which counted `#` comments and `assert "..." not in plan` as positive evidence and reported 7 plan-pinned indexes where only 5 exist.
- Breaks the `reranker <-> simplified` import cycle that raised `ImportError` when `reranker` was imported first in a fresh interpreter.
- Pins LF on private text appends so Windows CRLF no longer evicts the `MCPExecutionLog` cache on every append.
- Puts the UI test suite on the deterministic no-tokenizer tier; the old stub undercounted tokens and made behavior depend on whether the machine had tiktoken installed.
- Reworks the ADR-046 race proof that had been dead since the durable commit moved off the event loop; the new test stages the off-loop interleaving a real user can produce.
- Also fixes a store connection leak on restore failure, an unhandled `thread.start()` failure, an unsynchronized provenance record in the network guard, a `restore_state` retention leak, an async generator reading on the event loop, and an unguarded SIGKILL test on Windows.

**Refusals and filed items**

- Refuses 34 comments with repo-wide evidence: docstring and type-hint requests that 99.5% of sibling test functions don't follow, import-ordering nits where no linter config exists, SQL identifier parameterization SQLite can't do, connection-close and transaction changes already reverted for measured performance, and a pagination request incompatible with the caller's whole-set equality.
- Files TASK-22557 for the console native chat flow suite regressing from 2 to 9 dev reds; the A/B control confirms the same 9 fail on pristine dev.

<sup>Written for commit 7b4018b92da87d3cdc2a3f9874c70d9971c90710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

