### PR TITLE
docs(backlog): file TASK-22617 settlement-failure citation finalizer

### DIFF
--- a/backlog/tasks/task-22617 - Settlement-failure-recovery-discards-the-citation-finalizer.md
+++ b/backlog/tasks/task-22617 - Settlement-failure-recovery-discards-the-citation-finalizer.md
@@ -1,0 +1,35 @@
+---
+id: TASK-22617
+title: Settlement-failure recovery discards the citation finalizer
+status: To Do
+assignee: []
+created_date: '2026-08-26 19:20'
+labels:
+  - console
+  - citations
+  - durable-turn
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-22302 fixed four sites where a durable turn's citation trace was never persisted. A fifth call site was found during that work and deliberately left out of scope, because it sits on a different path and may be intentional.
+
+`ConsoleChatController.resume_durable_postcommit` has an `except BaseException:` arm that publishes a recovery owner via `store.publish_durable_recovery_owner(...)` with `terminal_citation_finalizer=None` hard-coded (console_chat_controller.py:6126). The enclosing `continuation` object IS in scope there -- the very next argument reads `continuation.citation_repair_session` -- so the finalizer is available and discarded rather than unavailable.
+
+Two readings, and the task is to decide which is right:
+
+1. It is the same data-loss defect as TASK-22302. A turn whose settlement failed still has a committed assistant row, and its citation trace is dropped with no way to recover it.
+2. It is correct as written. This path reports "Delivery status is unknown", so arming a finalizer might persist a trace describing content that never reached the user -- provenance worse than absent.
+
+Reading 2 is plausible enough that this must not be 'fixed' by pattern-matching TASK-22302. Establish which it is with a test before changing anything.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The BaseException path in resume_durable_postcommit is reproduced in a test that observes whether a citation trace survives a settlement failure
+- [ ] #2 A decision is recorded, with evidence, on whether dropping the finalizer there is data loss or a deliberate guard against attributing unsent content
+- [ ] #3 If it is data loss: the finalizer is forwarded, and the fix is mutation-proven (revert it, watch the new test go red)
+- [ ] #4 If it is deliberate: the hard-coded None carries a comment naming the reason, so the next reader does not file this again
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

One backlog file. No product or test code changes.

Found while mutation-proving TASK-22302's fix (#2115) after rebasing it onto
current `dev`. A stray `sed` match exposed a **fifth** call site of the same
shape, which #2115 deliberately did not touch.

## The finding

`ConsoleChatController.resume_durable_postcommit` has an `except BaseException:`
arm that publishes a recovery owner with `terminal_citation_finalizer=None`
hard-coded (`console_chat_controller.py:6126`). The enclosing `continuation`
object **is** in scope there — the very next argument reads
`continuation.citation_repair_session` — so the finalizer is *discarded*,
not unavailable.

## Why this is filed rather than fixed

Two readings are both plausible, and pattern-matching TASK-22302 would beg the
question:

1. **Same data-loss defect.** A turn whose settlement failed still has a
   committed assistant row, and its citation trace is dropped unrecoverably.
2. **Correct as written.** That path reports *"Delivery status is unknown"*.
   Arming a finalizer could persist a trace describing content that never
   reached the user — provenance worse than absent.

Reading 2 is credible enough that this needs evidence, not a reflex. The ACs
require the question be settled **by test** either way, and — if it turns out
deliberate — require the hard-coded `None` to carry its reason as a comment so
the next reader does not re-file this.

## Verification

`./scripts/preflight.sh` green (includes the duplicate-task-id check). Task id
swept across all remotes and worktrees and leapfrogged past the CLI's `max+1`
assignment, which is the collision-prone case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backlog task, `TASK-22617`, documenting a potential fifth call site where `resume_durable_postcommit` discards the terminal citation finalizer on the `except BaseException:` path. No product or test code changes.

The task is filed, not fixed, because it may intentionally guard against attributing unsent content rather than being the same data-loss defect as `TASK-22302`; the acceptance criteria require settling that by test.

<sup>Written for commit b62079dcdc2c69062418df4a0723e1460bbfb137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

