### PR TITLE
fix(console): closing a chat mid-turn is not an error (TASK-22587)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -243,8 +243,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 52,
-      "diagnostic_digest": "9470774591ce409dfb1a",
+      "call_count": 55,
+      "diagnostic_digest": "7572789e67be8299bff3",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -3968,7 +3968,7 @@
   "summary": {
     "owner_files": 537,
     "persistent_sink_files": 8,
-    "task_492_calls": 1241,
+    "task_492_calls": 1244,
     "task_494_calls": 7360
   }
 }

--- a/Tests/Chat/test_console_close_during_durable_postcommit.py
+++ b/Tests/Chat/test_console_close_during_durable_postcommit.py
@@ -1,0 +1,225 @@
+"""Closing a Console session mid-turn is not an error (TASK-22587).
+
+Closing a session retires its durable preparation. An effect still in flight
+then finds its fingerprint gone, and `_require_durable_fingerprint_locked`
+raised `RuntimeError("Durable postcommit fingerprint changed.")` out of the
+RELEASE path -- the one place whose whole job is to clean up after a failure.
+Worse, that raise REPLACED the exception that sent us down the release path, so
+the real cause was lost and the user saw a fingerprint message instead.
+
+The guard's intent is right: an effect must not commit against a retired
+preparation. What was missing is a defined outcome for "the preparation was
+retired underneath me" (ordinary: the user closed a chat) as distinct from
+"the fingerprint changed unexpectedly" (a bug). Those shared one raise.
+
+`retire_durable_acceptance` leaves a tombstone carrying the SAME fingerprint,
+so the two are decidable rather than guessed -- which is what
+`_durable_retired_locked` reads.
+
+The negative control below is the point of this file: narrowing a safety guard
+is only safe if the guard still fires for the case it was written for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.Chat.test_console_durable_turn_acceptance import _ready_store
+from Tests.console_provider_doubles import provider_resolution
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleDurableAcceptanceRetired
+
+EFFECT = "checkpoint_transition"
+
+
+def _claimed_effect(tmp_path, *, claim: bool = True):
+    """A committed durable turn, with one postcommit effect optionally claimed.
+
+    The controller-level tests pass ``claim=False`` because
+    ``_run_durable_postcommit_effect`` claims the effect itself; pre-claiming
+    would make it refuse with "already in flight" before reaching the path
+    under test.
+    """
+
+    db, _service, store, _preparation, acceptance = _ready_store(tmp_path)
+    commit = store.commit_durable_turn(acceptance)
+    prep = acceptance.preparation_id
+    fingerprint = store.durable_acceptance_fingerprint_for(prep)
+    assert fingerprint is not None, "harness precondition: a fingerprint exists"
+
+    store.begin_durable_postcommit_effects(
+        preparation_id=prep,
+        session_id="session-1",
+        assistant_message_id=commit.assistant_message_id,
+        fingerprint=fingerprint,
+    )
+    if claim:
+        assert store.claim_durable_postcommit_effect(
+            prep, EFFECT, fingerprint=fingerprint
+        ), "harness precondition: the effect must be claimable"
+    return store, prep, fingerprint
+
+
+def test_releasing_a_claim_after_the_session_closed_does_not_raise(tmp_path) -> None:
+    """AC1/AC2: the release path survives the user closing the chat."""
+
+    store, prep, fingerprint = _claimed_effect(tmp_path)
+
+    store.close_session("session-1")
+
+    store.abandon_durable_postcommit_effect(prep, EFFECT, fingerprint=fingerprint)
+
+
+def test_retirement_has_already_released_the_in_flight_claim(tmp_path) -> None:
+    """Why the no-op is safe rather than merely quiet.
+
+    `retire_durable_acceptance` drops every in-flight key for the preparation,
+    so by the time the release path runs there is nothing left to release. If
+    that ever stops being true, a silent `return` would start leaking claims --
+    so it is asserted here rather than assumed.
+    """
+
+    store, prep, fingerprint = _claimed_effect(tmp_path)
+    assert (prep, EFFECT) in store._durable_effects_in_flight
+
+    store.close_session("session-1")
+
+    assert (prep, EFFECT) not in store._durable_effects_in_flight
+
+
+def test_a_changed_fingerprint_still_raises(tmp_path) -> None:
+    """NEGATIVE CONTROL: the guard still fires for the case it was written for.
+
+    A preparation that was never retired, asked about with a fingerprint that
+    does not match, must still raise the generic error -- and must NOT be
+    reported as a retirement.
+    """
+
+    store, prep, fingerprint = _claimed_effect(tmp_path)
+    from dataclasses import replace
+
+    wrong = replace(fingerprint, assistant_message_id="wrong-assistant")
+
+    with pytest.raises(RuntimeError, match="fingerprint changed") as caught:
+        store.abandon_durable_postcommit_effect(prep, EFFECT, fingerprint=wrong)
+    assert not isinstance(caught.value, ConsoleDurableAcceptanceRetired), (
+        "an unexpected fingerprint change was misreported as an ordinary "
+        "session close, which is exactly the conflation this task removed"
+    )
+
+
+def test_a_retired_preparation_reports_retirement_not_a_changed_fingerprint(
+    tmp_path,
+) -> None:
+    """The two causes are now distinguishable by type, not by string."""
+
+    store, prep, fingerprint = _claimed_effect(tmp_path)
+    store.close_session("session-1")
+
+    with pytest.raises(ConsoleDurableAcceptanceRetired):
+        store.complete_durable_postcommit_effect(
+            prep, EFFECT, fingerprint=fingerprint
+        )
+
+
+class _Gateway:
+    """Minimal ready gateway; no send is performed in these tests."""
+
+    async def resolve_for_send(self, selection):
+        return provider_resolution()
+
+    async def stream_chat(self, resolution, messages, **kwargs):
+        yield "reply"
+
+
+def _controller_over(store):
+    return ConsoleChatController(
+        store=store,
+        provider_gateway=_Gateway(),
+        provider="llama_cpp",
+        model="test-model",
+        agent_runtime_enabled=False,
+    )
+
+
+class _ClosedTheChat(RuntimeError):
+    """The distinctive failure a real effect would raise."""
+
+
+@pytest.mark.asyncio
+async def test_an_effect_that_fails_while_the_chat_closes_reports_its_own_cause(
+    tmp_path,
+) -> None:
+    """End-to-end shape of the original bug, on the realistic path.
+
+    Before the fix the release path raised "Durable postcommit fingerprint
+    changed." from inside `except BaseException:`, REPLACING the failure that
+    sent us there. Note this passes on the store fix alone -- it does not
+    exercise the controller's release guard, which
+    `test_a_failing_release_never_replaces_the_original_failure` covers.
+    """
+
+    store, prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+    controller = _controller_over(store)
+
+    def effect():
+        store.close_session("session-1")
+        raise _ClosedTheChat("the real cause")
+
+    with pytest.raises(_ClosedTheChat, match="the real cause"):
+        await controller._run_durable_postcommit_effect(
+            prep, EFFECT, effect, fingerprint=fingerprint
+        )
+
+
+@pytest.mark.asyncio
+async def test_closing_the_chat_during_a_successful_effect_does_not_raise(
+    tmp_path,
+) -> None:
+    """AC1/AC3: close-during-collection on a DURABLE session is not an error.
+
+    The effect's work succeeded; the session simply went away before it could
+    be recorded. There is no ledger left to write to, and that is fine.
+    """
+
+    store, prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+    controller = _controller_over(store)
+
+    def effect():
+        store.close_session("session-1")
+        return "done"
+
+    result = await controller._run_durable_postcommit_effect(
+        prep, EFFECT, effect, fingerprint=fingerprint
+    )
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_release_never_replaces_the_original_failure(
+    tmp_path,
+) -> None:
+    """The release guard itself, pinned independently of WHY release fails.
+
+    The store fix means retirement no longer makes `abandon` raise, so the
+    realistic path above cannot exercise this. The invariant is still worth
+    holding: code running inside `except BaseException:` must never turn one
+    failure into a different, less informative one. Forcing `abandon` to raise
+    is the only way to test that, and this test goes red without the guard.
+    """
+
+    store, prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+    controller = _controller_over(store)
+
+    def exploding_release(*_args, **_kwargs):
+        raise ValueError("bookkeeping blew up")
+
+    store.abandon_durable_postcommit_effect = exploding_release
+
+    def effect():
+        raise _ClosedTheChat("the real cause")
+
+    with pytest.raises(_ClosedTheChat, match="the real cause"):
+        await controller._run_durable_postcommit_effect(
+            prep, EFFECT, effect, fingerprint=fingerprint
+        )

--- a/Tests/Chat/test_console_close_during_durable_postcommit.py
+++ b/Tests/Chat/test_console_close_during_durable_postcommit.py
@@ -396,3 +396,74 @@ def test_completed_effects_survive_the_close_that_retired_them(tmp_path) -> None
     store.close_session("session-1")
 
     assert EFFECT in store.durable_completed_effects_for(prep, fingerprint=fingerprint)
+
+
+def test_retirement_proof_survives_a_flood_of_unrelated_closes(tmp_path) -> None:
+    """Qodo finding #4 on #2123: eviction must not lose retirement proof.
+
+    Tombstones are FIFO-evicted past `DURABLE_TOMBSTONE_CAP`. A plain eviction
+    could reclaim the tombstone of a preparation whose postcommit sequence was
+    still running -- and that tombstone is the only proof its retirement was an
+    ordinary close rather than a mutation. Losing it put the generic
+    fingerprint-change error back on the in-flight effect, which made
+    correctness depend on unrelated session-close volume.
+    """
+
+    from dataclasses import replace
+
+    store, prep, fingerprint = _claimed_effect(tmp_path)
+    store.close_session("session-1")
+    assert store._durable_retired_locked(prep, fingerprint), (
+        "harness precondition: the close left retirement proof"
+    )
+
+    # Far more unrelated retirements than the cap allows.
+    for index in range(store.DURABLE_TOMBSTONE_CAP * 2):
+        other_id = f"unrelated-{index}"
+        other_fp = replace(fingerprint, assistant_message_id=other_id)
+        store._durable_fingerprint_by_preparation[other_id] = other_fp
+        store.retire_durable_acceptance(other_id, other_fp)
+
+    assert store._durable_retired_locked(prep, fingerprint), (
+        "the in-flight preparation's retirement proof was evicted, so its "
+        "effect would see a fingerprint-change error instead of an ordinary "
+        "close -- correctness must not depend on unrelated close volume"
+    )
+
+
+def test_protecting_tombstones_still_honours_the_cap(tmp_path) -> None:
+    """The protection must not turn a bounded cache into a leak.
+
+    A pinned entry is skipped, oldest-first -- but if everything is pinned the
+    oldest is evicted anyway. Without that fallback, an unreleased protection
+    would let the tombstone map grow without limit.
+    """
+
+    from dataclasses import replace
+
+    store, prep, fingerprint = _claimed_effect(tmp_path)
+    store.close_session("session-1")
+
+    for index in range(store.DURABLE_TOMBSTONE_CAP * 2):
+        other_id = f"pinned-{index}"
+        other_fp = replace(fingerprint, assistant_message_id=other_id)
+        store._durable_fingerprint_by_preparation[other_id] = other_fp
+        # Pin every single one, which is the pathological case.
+        store._durable_active_postcommit.add(other_id)
+        store.retire_durable_acceptance(other_id, other_fp)
+
+    assert len(store._durable_tombstones) <= store.DURABLE_TOMBSTONE_CAP, (
+        f"tombstones grew past the cap ({len(store._durable_tombstones)} > "
+        f"{store.DURABLE_TOMBSTONE_CAP}) -- protection became a leak"
+    )
+
+
+def test_releasing_activity_lets_the_tombstone_be_evicted_again(tmp_path) -> None:
+    """Protection is scoped to the sequence, not permanent."""
+
+    store, prep, _fingerprint = _claimed_effect(tmp_path)
+    assert prep in store._durable_active_postcommit
+
+    store.release_durable_postcommit_activity(prep)
+
+    assert prep not in store._durable_active_postcommit

--- a/Tests/Chat/test_console_close_during_durable_postcommit.py
+++ b/Tests/Chat/test_console_close_during_durable_postcommit.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import pytest
 
 from Tests.Chat.test_console_durable_turn_acceptance import _ready_store
+from Tests.Chat.test_console_first_send_atomicity import _controller
 from Tests.console_provider_doubles import provider_resolution
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_store import ConsoleDurableAcceptanceRetired
@@ -223,3 +224,175 @@ async def test_a_failing_release_never_replaces_the_original_failure(
         await controller._run_durable_postcommit_effect(
             prep, EFFECT, effect, fingerprint=fingerprint
         )
+
+
+# ---------------------------------------------------------------------------
+# The REAL path.
+#
+# Everything above drives `_run_durable_postcommit_effect` directly, which is
+# not how a send reaches it. Qodo's review of #2123 made the point precisely:
+# suppressing retirement inside one effect only moves the raise to the NEXT
+# fingerprint-validated effect, or to the unconditional `retire` that ends the
+# sequence -- and a helper-only test cannot see either. These drive
+# `resume_durable_postcommit`, the enclosing orchestration real sends use.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resume_after_the_chat_was_closed_does_not_raise(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC1 on the path production actually takes.
+
+    A postcommit step fails, leaving a continuation to resume. The user closes
+    the chat before it resumes -- so the whole sequence now runs against a
+    retired preparation.
+    """
+
+    _db, store, controller, _gateway = _controller(tmp_path)
+    original = store.publish_durable_turn_identity
+    calls = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("injected identity publication")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(store, "publish_durable_turn_identity", fail_once)
+    first = await controller.submit_draft(
+        "draft the user abandoned", session_id="session-1"
+    )
+    assert first.accepted is True, "harness precondition: the turn was accepted"
+    assert first.preparation_id in controller._durable_postcommit_continuations
+
+    store.close_session("session-1")
+
+    resumed = await controller.resume_durable_postcommit(first.preparation_id)
+    assert resumed is not None
+
+
+@pytest.mark.asyncio
+async def test_resume_after_close_leaves_no_dangling_continuation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Closing must not strand the continuation the resume was meant to clear.
+
+    Without this, "does not raise" could be satisfied by bailing out early and
+    leaking the very state the sequence exists to release.
+    """
+
+    _db, store, controller, _gateway = _controller(tmp_path)
+    original = store.publish_durable_turn_identity
+    calls = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("injected identity publication")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(store, "publish_durable_turn_identity", fail_once)
+    first = await controller.submit_draft("another draft", session_id="session-1")
+    assert first.accepted is True
+
+    store.close_session("session-1")
+    await controller.resume_durable_postcommit(first.preparation_id)
+
+    assert store.durable_content_retention_count() == 0, (
+        "closing the chat left content-bearing durable state behind"
+    )
+
+
+@pytest.mark.asyncio
+async def test_closing_midway_through_the_effect_sequence_does_not_raise(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Close DURING the sequence -- Qodo's finding #2 on #2123.
+
+    Closing before the resume is caught by the early lookup. Closing while the
+    sequence runs is the harder case: the effect that notices retirement
+    completes benignly, and then the NEXT fingerprint-validated effect raises.
+    Suppressing retirement per-effect only moved the raise one effect along, so
+    this is the test that distinguishes the two.
+
+    The close happens inside effect #1 of eight, leaving the remaining seven to
+    cope with a preparation that no longer exists.
+    """
+
+    _db, store, controller, _gateway = _controller(tmp_path)
+    original = store.publish_durable_turn_identity
+    calls = 0
+
+    def fail_then_close(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            # Leaves a continuation for `resume_durable_postcommit` to pick up.
+            raise RuntimeError("injected identity publication")
+        # Second call is effect #1 of the resumed sequence: the user closes the
+        # chat right here, mid-flight.
+        result = original(*args, **kwargs)
+        store.close_session("session-1")
+        return result
+
+    monkeypatch.setattr(store, "publish_durable_turn_identity", fail_then_close)
+    first = await controller.submit_draft("mid-sequence draft", session_id="session-1")
+    assert first.accepted is True, "harness precondition: the turn was accepted"
+
+    resumed = await controller.resume_durable_postcommit(first.preparation_id)
+    assert resumed is not None
+    assert calls == 2, "harness precondition: the resume re-ran the first effect"
+
+
+def test_retiring_an_already_retired_acceptance_is_a_no_op(tmp_path) -> None:
+    """The sequence's own tail retire, after close already retired.
+
+    Qodo's finding #2 on #2123 named this directly: the postcommit sequence
+    ends with an unconditional `retire_durable_acceptance`, and closing the
+    chat has already performed one. Retiring the SAME acceptance twice is a
+    no-op -- the tombstone proves it is the same one -- where it used to raise
+    "Durable acceptance fingerprint changed."
+    """
+
+    store, prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+    store.close_session("session-1")
+
+    store.retire_durable_acceptance(prep, fingerprint)
+
+
+def test_a_different_acceptance_on_a_retired_id_still_raises(tmp_path) -> None:
+    """NEGATIVE CONTROL for the idempotent retire.
+
+    Idempotency must key on THIS acceptance, not merely on the preparation id
+    having a tombstone -- otherwise a genuinely different acceptance would be
+    silently accepted as an already-done retirement.
+    """
+
+    from dataclasses import replace
+
+    store, prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+    store.close_session("session-1")
+    other = replace(fingerprint, assistant_message_id="a-different-turn")
+
+    with pytest.raises(RuntimeError, match="fingerprint changed"):
+        store.retire_durable_acceptance(prep, other)
+
+
+def test_completed_effects_survive_the_close_that_retired_them(tmp_path) -> None:
+    """Recovery must still be able to tell whether the provider had started.
+
+    The failure handler asks which effects completed, and it asks AFTER a
+    failure -- by which point the user may have closed the chat. Reading the
+    live ledger raised there; the tombstone retains `completed` precisely so
+    the answer survives, which is what keeps `provider_started` correct.
+    """
+
+    store, prep, fingerprint = _claimed_effect(tmp_path)
+    store.complete_durable_postcommit_effect(prep, EFFECT, fingerprint=fingerprint)
+
+    store.close_session("session-1")
+
+    assert EFFECT in store.durable_completed_effects_for(prep, fingerprint=fingerprint)

--- a/backlog/tasks/task-22587 - Closing-a-session-during-a-durable-postcommit-raises.md
+++ b/backlog/tasks/task-22587 - Closing-a-session-during-a-durable-postcommit-raises.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-22587
 title: Closing a session during a durable postcommit raises
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: ''
-updated_date: '2026-08-26 20:48'
+updated_date: '2026-08-26 21:11'
 labels:
   - console
   - durable-turns
@@ -41,10 +41,10 @@ durable turn is in flight takes the same path.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Closing a session during an in-flight durable turn does not raise
-- [ ] #2 The in-flight effect is released (or deliberately abandoned) without an
+- [x] #1 Closing a session during an in-flight durable turn does not raise
+- [x] #2 The in-flight effect is released (or deliberately abandoned) without an
       unhandled exception
-- [ ] #3 A test covers close-during-collection on a DURABLE session
+- [x] #3 A test covers close-during-collection on a DURABLE session
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -61,20 +61,19 @@ durable turn is in flight takes the same path.
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-The fingerprint guard is correct in intent — an effect must not commit against a
-retired preparation. What is missing is a defined outcome for "the preparation
-was retired underneath me", distinct from "the fingerprint changed
-unexpectedly". A retired preparation is an ordinary consequence of the user
-closing a chat; a *changed* one is a bug. Those two currently share a raise.
+Reproduced at store level first: claim a postcommit effect, close the session, release the claim -> RuntimeError('Durable postcommit fingerprint changed.').
 
-Related: TASK-22301 (converting that module's assertions to row queries needs
-durable sessions, so this blocks it).
+The bug was worse than filed. That raise comes out of the RELEASE path, which runs inside `except BaseException:`, so it REPLACED the exception that sent us there -- a genuine failure during a turn the user happened to close was reported as a fingerprint message.
 
-## Renumbering provenance
+Fix rests on a fact already in the code rather than a guess: retire_durable_acceptance leaves a tombstone carrying the SAME fingerprint, so 'retired' is decidable from 'changed'. New `_durable_retired_locked` reads it; retirement raises the distinct `ConsoleDurableAcceptanceRetired`; a real mismatch still raises the generic RuntimeError (pinned by a negative-control test, since narrowing a guard is only safe if it still fires for its original case).
 
-Filed as task-22303; renumbered to task-22587 under the 2026-08-21 owner rule
-(TASK-19601) after a same-id collision with
-`task-22303 - Restore-priced-Console-cost-chip-harness-readiness`, which
-arrived first and keeps the id. No dependencies or doc references pointed at the
-old number.
+Release-after-retirement is a no-op. Safe rather than merely quiet: retirement has already dropped every in-flight key for the preparation, so there is nothing left to release -- asserted in a test so the no-op cannot silently start leaking claims if that stops holding.
+
+Controller: the release call can no longer replace the original failure, and retirement during a SUCCESSFUL effect is a non-event (work done, no ledger left to record it in).
+
+MUTATION TESTING CAUGHT A TEST THAT COULD NOT FAIL -- mine. The first 'not masked by the release path' test passed with the controller guard removed, because the store fix already stops abandon from raising there. Split into one honest end-to-end test (which documents what it does NOT cover) and one that forces abandon to raise and does go red without the guard. That also made a '# pragma: no cover' I had written false, so it was removed. All 4 changes are now individually mutation-proven.
+
+Verification: A/B of Tests/Chat against merge-base 65cf855371 -- 0 newly broken, +7 collected, 111 failures both sides. Preflight green; the +2 diagnostics were reviewed before regenerating (internal effect names only, exception TYPE not message, per TASK-22251).
+
+Files: tldw_chatbook/Chat/console_chat_store.py, tldw_chatbook/Chat/console_chat_controller.py, Tests/Chat/test_console_close_during_durable_postcommit.py (new), Docs/security/production-diagnostic-inventory.json
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-22587 - Closing-a-session-during-a-durable-postcommit-raises.md
+++ b/backlog/tasks/task-22587 - Closing-a-session-during-a-durable-postcommit-raises.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: ''
-updated_date: '2026-08-26 21:11'
+updated_date: '2026-08-26 21:42'
 labels:
   - console
   - durable-turns
@@ -61,19 +61,33 @@ durable turn is in flight takes the same path.
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Reproduced at store level first: claim a postcommit effect, close the session, release the claim -> RuntimeError('Durable postcommit fingerprint changed.').
+--- ROUND 2 (Qodo review of PR #2123) ---
 
-The bug was worse than filed. That raise comes out of the RELEASE path, which runs inside `except BaseException:`, so it REPLACED the exception that sent us there -- a genuine failure during a turn the user happened to close was reported as a fingerprint message.
+Both findings were real and both were verified empirically before fixing. The
+diagnosis: round 1 fixed the HELPER, not the ORCHESTRATION. Suppressing
+retirement inside one effect only moved the raise to the next
+fingerprint-validated effect, or to the unconditional retire ending the sequence.
 
-Fix rests on a fact already in the code rather than a guess: retire_durable_acceptance leaves a tombstone carrying the SAME fingerprint, so 'retired' is decidable from 'changed'. New `_durable_retired_locked` reads it; retirement raises the distinct `ConsoleDurableAcceptanceRetired`; a real mismatch still raises the generic RuntimeError (pinned by a negative-control test, since narrowing a guard is only safe if it still fires for its original case).
+Retirement is now terminal-benign for the whole orchestration:
+1. the early durable_postcommit_effects_for lookup is guarded -- it sits BEFORE
+   the try block, so guarding only the sequence left it raising (this is what
+   actually fires first);
+2. a sequence-level except arm covering all 8 effects;
+3. retire_durable_acceptance is idempotent for the SAME acceptance (keyed on the
+   tombstone fingerprint, with a negative control proving a different acceptance
+   on a retired id still raises);
+4. new durable_completed_effects_for reads completed names from ledger OR
+   tombstone, so the failure handler's provider_started question survives a
+   close instead of raising inside the handler.
+Both paths share _postcommit_stopped_by_close, which runs the normal cleanup
+tail minus the owner-changed check.
 
-Release-after-retirement is a no-op. Safe rather than merely quiet: retirement has already dropped every in-flight key for the preparation, so there is nothing left to release -- asserted in a test so the no-op cannot silently start leaking claims if that stops holding.
+MUTATION TESTING CAUGHT UNPROVEN CODE A SECOND TIME: after the round-2 fix,
+3 of the changes stayed GREEN under mutation, because every test closed the chat
+BEFORE resume and the early guard short-circuited the rest. Added a mid-sequence
+close (inside effect #1 of 8) plus store-level tests; all 8 mutations now go red.
 
-Controller: the release call can no longer replace the original failure, and retirement during a SUCCESSFUL effect is a non-event (work done, no ledger left to record it in).
-
-MUTATION TESTING CAUGHT A TEST THAT COULD NOT FAIL -- mine. The first 'not masked by the release path' test passed with the controller guard removed, because the store fix already stops abandon from raising there. Split into one honest end-to-end test (which documents what it does NOT cover) and one that forces abandon to raise and does go red without the guard. That also made a '# pragma: no cover' I had written false, so it was removed. All 4 changes are now individually mutation-proven.
-
-Verification: A/B of Tests/Chat against merge-base 65cf855371 -- 0 newly broken, +7 collected, 111 failures both sides. Preflight green; the +2 diagnostics were reviewed before regenerating (internal effect names only, exception TYPE not message, per TASK-22251).
-
-Files: tldw_chatbook/Chat/console_chat_store.py, tldw_chatbook/Chat/console_chat_controller.py, Tests/Chat/test_console_close_during_durable_postcommit.py (new), Docs/security/production-diagnostic-inventory.json
+Round-2 verification: 13 tests; A/B of Tests/Chat vs merge-base 65cf855371 ->
+collected 7682->7695 (+13), failures 111->111, 0 newly broken; preflight green
+(+1 diagnostic, a constant string with no interpolation).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-22587 - Closing-a-session-during-a-durable-postcommit-raises.md
+++ b/backlog/tasks/task-22587 - Closing-a-session-during-a-durable-postcommit-raises.md
@@ -1,15 +1,21 @@
 ---
-id: task-22587
+id: TASK-22587
 title: Closing a session during a durable postcommit raises
-status: To Do
+status: In Progress
+assignee:
+  - '@claude'
+created_date: ''
+updated_date: '2026-08-26 20:48'
 labels:
   - console
   - durable-turns
+dependencies: []
 priority: medium
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Closing a Console session while a durable turn is still collecting raises
 `RuntimeError: Durable postcommit fingerprint changed.` out of the effect
 release path.
@@ -31,16 +37,30 @@ ephemeral sessions throughout.
 The conversion was reverted rather than worked around, so this is currently
 latent in tests but reachable in production: any user closing a chat while a
 durable turn is in flight takes the same path.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] Closing a session during an in-flight durable turn does not raise
-- [ ] The in-flight effect is released (or deliberately abandoned) without an
+<!-- AC:BEGIN -->
+- [ ] #1 Closing a session during an in-flight durable turn does not raise
+- [ ] #2 The in-flight effect is released (or deliberately abandoned) without an
       unhandled exception
-- [ ] A test covers close-during-collection on a DURABLE session
+- [ ] #3 A test covers close-during-collection on a DURABLE session
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce at store level: claim an effect, retire the preparation, release the claim -> RuntimeError (DONE: confirmed on dev)
+2. Distinguish the two causes the guard currently conflates. retire_durable_acceptance already leaves a tombstone carrying the SAME fingerprint, so 'retired' is decidable: tombstone present AND fingerprint matches = ordinary retirement; anything else = genuine mismatch.
+3. Add a distinct exception type for retirement so callers can handle it without string-matching, and keep the existing RuntimeError for a real fingerprint change.
+4. Make the RELEASE path tolerate retirement: abandon_durable_postcommit_effect on a retired preparation is a no-op, not a raise. There is nothing left to protect.
+5. Fix the masking bug in _run_durable_postcommit_effect: its 'except BaseException: abandon(); raise' arm currently loses the ORIGINAL exception when abandon raises.
+6. Mutation-prove each behaviour change, then A/B the Chat/Console test set against the merge-base.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 The fingerprint guard is correct in intent — an effect must not commit against a
 retired preparation. What is missing is a defined outcome for "the preparation
 was retired underneath me", distinct from "the fingerprint changed
@@ -50,7 +70,6 @@ closing a chat; a *changed* one is a bug. Those two currently share a raise.
 Related: TASK-22301 (converting that module's assertions to row queries needs
 durable sessions, so this blocks it).
 
-
 ## Renumbering provenance
 
 Filed as task-22303; renumbered to task-22587 under the 2026-08-21 owner rule
@@ -58,3 +77,4 @@ Filed as task-22303; renumbered to task-22587 under the 2026-08-21 owner rule
 `task-22303 - Restore-priced-Console-cost-chip-harness-readiness`, which
 arrived first and keeps the id. No dependencies or doc references pointed at the
 old number.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -5853,6 +5853,43 @@ class ConsoleChatController:
             )
         return await self.resume_durable_postcommit(preparation.preparation_id)
 
+    def _postcommit_stopped_by_close(
+        self,
+        *,
+        preparation_id: str,
+        session_id: str,
+        commit: Any,
+        continuation: Any,
+    ) -> ConsoleSubmitResult:
+        """Terminal benign outcome when the chat closed mid-postcommit.
+
+        TASK-22587. Runs the same continuation cleanup the normal tail runs --
+        settle, drop the continuation, release prepared evidence -- but not the
+        owner-changed check (the owner is legitimately gone) and not `retire`
+        (closing already did it, and it is idempotent besides).
+        """
+
+        logger.debug("Durable postcommit sequence stopped: session closed")
+        self._settle_accepted_preparation(preparation_id)
+        with self.store.durable_preparation_lock:
+            current = self._durable_postcommit_continuations.pop(preparation_id, None)
+            if current is not None:
+                self._release_retired_prepared_evidence(current)
+        return ConsoleSubmitResult(
+            True,
+            True,
+            "",
+            session_id=session_id,
+            user_message_id=commit.user_message_id,
+            assistant_message_id=commit.assistant_message_id,
+            terminal_status=self.run_state_for(session_id).status,
+            origin=continuation.origin,
+            queue_entry_id=continuation.queue_entry_id,
+            committed_context_epoch=continuation.committed_context_epoch,
+            preparation_id=preparation_id,
+            provider_started=True,
+        )
+
     async def resume_durable_postcommit(
         self,
         preparation_id: str,
@@ -5883,10 +5920,21 @@ class ConsoleChatController:
         commit = continuation.commit
         fingerprint = continuation.fingerprint
         session_id = continuation.session_id
-        existing_effects = self.store.durable_postcommit_effects_for(
-            preparation_id,
-            fingerprint=fingerprint,
-        )
+        try:
+            existing_effects = self.store.durable_postcommit_effects_for(
+                preparation_id,
+                fingerprint=fingerprint,
+            )
+        except ConsoleDurableAcceptanceRetired:
+            # TASK-22587: the chat was closed before this resume began, so the
+            # whole sequence is moot. This lookup sits BEFORE the try block
+            # below, which is why guarding only the sequence was not enough.
+            return self._postcommit_stopped_by_close(
+                preparation_id=preparation_id,
+                session_id=session_id,
+                commit=commit,
+                continuation=continuation,
+            )
         if (
             existing_effects is not None
             and "checkpoint_transition" in existing_effects.completed
@@ -6148,6 +6196,17 @@ class ConsoleChatController:
                 ),
                 fingerprint=fingerprint,
             )
+        except ConsoleDurableAcceptanceRetired:
+            # TASK-22587: the user closed the chat mid-sequence. Every REMAINING
+            # effect validates against a preparation that no longer exists, so
+            # retirement is terminal-benign for the whole orchestration, not
+            # just the effect that noticed it first.
+            return self._postcommit_stopped_by_close(
+                preparation_id=preparation_id,
+                session_id=session_id,
+                commit=commit,
+                continuation=continuation,
+            )
         except ConsoleDispatchSettlementError:
             self._restore_dispatch_recovery_after_settlement_failure(
                 session_id,
@@ -6170,12 +6229,14 @@ class ConsoleChatController:
                 provider_started=True,
             )
         except BaseException:
-            state = self.store.durable_postcommit_effects_for(
+            # TASK-22587: this lookup runs inside the failure handler, so it
+            # must not raise -- a close mid-turn retires the ledger and the
+            # raise would REPLACE the failure being handled. The tombstone
+            # keeps `completed`, so the answer survives the close.
+            completed = self.store.durable_completed_effects_for(
                 preparation_id, fingerprint=fingerprint
             )
-            provider_started = bool(
-                state is not None and "checkpoint_transition" in state.completed
-            )
+            provider_started = "checkpoint_transition" in completed
             if self.store.dispatch_recovery_for_session(session_id) is None:
                 self.store.publish_durable_recovery_owner(
                     session_id,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -94,6 +94,7 @@ from tldw_chatbook.Chat.console_chat_store import (
     ConsoleChatSession,
     ConsoleChatStore,
     ConsoleDispatchSettlementError,
+    ConsoleDurableAcceptanceRetired,
     ConsoleDurableAcceptanceFingerprint,
     ConsoleDurableTurnCommit,
     TerminalCitationFinalizer,
@@ -5605,13 +5606,34 @@ class ConsoleChatController:
             if inspect.isawaitable(result):
                 result = await result
         except BaseException:
-            self.store.abandon_durable_postcommit_effect(
+            # TASK-22587: releasing the claim must never REPLACE the failure
+            # that sent us here. Bookkeeping is strictly less informative than
+            # the original exception, and this arm also runs for CancelledError.
+            try:
+                self.store.abandon_durable_postcommit_effect(
+                    preparation_id, effect_name, fingerprint=fingerprint
+                )
+            except Exception as release_exc:
+                logger.warning(
+                    "Durable postcommit effect release failed; keeping the "
+                    "original failure (effect={}, release_exception_type={})",
+                    effect_name,
+                    type(release_exc).__name__,
+                )
+            raise
+        try:
+            self.store.complete_durable_postcommit_effect(
                 preparation_id, effect_name, fingerprint=fingerprint
             )
-            raise
-        self.store.complete_durable_postcommit_effect(
-            preparation_id, effect_name, fingerprint=fingerprint
-        )
+        except ConsoleDurableAcceptanceRetired:
+            # TASK-22587: the session was closed while this effect ran. The
+            # work itself succeeded; there is simply no ledger left to record
+            # it in. Closing a chat is not an error.
+            logger.debug(
+                "Durable postcommit effect completed after retirement "
+                "(effect={})",
+                effect_name,
+            )
         return result
 
     def _durable_db_call_offloadable(self) -> bool:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -5870,6 +5870,7 @@ class ConsoleChatController:
         """
 
         logger.debug("Durable postcommit sequence stopped: session closed")
+        self.store.release_durable_postcommit_activity(preparation_id)
         self._settle_accepted_preparation(preparation_id)
         with self.store.durable_preparation_lock:
             current = self._durable_postcommit_continuations.pop(preparation_id, None)
@@ -6276,6 +6277,7 @@ class ConsoleChatController:
             self._durable_postcommit_continuations.pop(preparation_id, None)
             self._release_retired_prepared_evidence(current)
             self.store.retire_durable_acceptance(preparation_id, fingerprint)
+        self.store.release_durable_postcommit_activity(preparation_id)
         if not isinstance(stream_result, ConsoleSubmitResult):
             stream_result = ConsoleSubmitResult(True, True)
         return replace(

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -3793,6 +3793,30 @@ class ConsoleChatStore:
             self._require_durable_fingerprint_locked(preparation_id, fingerprint)
             return self._durable_effects_by_preparation.get(preparation_id)
 
+    def durable_completed_effects_for(
+        self,
+        preparation_id: str,
+        *,
+        fingerprint: ConsoleDurableAcceptanceFingerprint,
+    ) -> frozenset[str]:
+        """Return completed effect names from the live ledger OR a tombstone.
+
+        TASK-22587: recovery needs to know whether the checkpoint transition
+        ran, and it asks *after* a failure -- by which point the user may have
+        closed the chat and retired the preparation. Reading the ledger
+        directly raises there, which masked the original failure. The tombstone
+        retains `completed` for exactly this reason, so the answer survives a
+        close instead of becoming an exception.
+        """
+
+        with self._preparation_lock:
+            if self._durable_retired_locked(preparation_id, fingerprint):
+                tombstone = self._durable_tombstones.get(preparation_id)
+                return tombstone.completed if tombstone is not None else frozenset()
+            self._require_durable_fingerprint_locked(preparation_id, fingerprint)
+            effects = self._durable_effects_by_preparation.get(preparation_id)
+            return effects.completed if effects is not None else frozenset()
+
     def durable_turn_commit_for(
         self,
         preparation_id: str,
@@ -3902,6 +3926,12 @@ class ConsoleChatStore:
         with self._preparation_lock:
             current = self._durable_fingerprint_by_preparation.get(preparation_id)
             if current != fingerprint:
+                if self._durable_retired_locked(preparation_id, fingerprint):
+                    # TASK-22587: closing a chat retires the preparation, and
+                    # the postcommit sequence retires it again when it ends.
+                    # Retiring what is already retired is a no-op, not a bug --
+                    # the tombstone proves this is the SAME acceptance.
+                    return
                 raise RuntimeError("Durable acceptance fingerprint changed.")
             effects = self._durable_effects_by_preparation.get(preparation_id)
             completed = effects.completed if effects is not None else frozenset()

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -185,6 +185,21 @@ class ConsoleDispatchSettlementError(RuntimeError):
     """An owned dispatch terminal could not commit atomically."""
 
 
+class ConsoleDurableAcceptanceRetired(RuntimeError):
+    """The preparation was retired underneath an in-flight postcommit effect.
+
+    TASK-22587: closing a Console session retires its durable preparation, so
+    an effect still in flight finds its fingerprint gone. That is an ORDINARY
+    consequence of the user closing a chat, and it is not the same event as a
+    fingerprint that changed unexpectedly -- which is a bug, and which must
+    keep raising the bare ``RuntimeError`` the postcommit APIs already document.
+
+    Retirement is decidable rather than inferred: ``retire_durable_acceptance``
+    leaves a tombstone carrying the SAME fingerprint, so a matching tombstone
+    proves the preparation was retired rather than mutated.
+    """
+
+
 def _refuse_roleplay_projection_write(**_kwargs: object) -> bool:
     """Represent a missing durable projection seam in an immutable plan."""
     return False
@@ -3844,6 +3859,12 @@ class ConsoleChatStore:
         """Release a failed effect claim without recording completion."""
 
         with self._preparation_lock:
+            if self._durable_retired_locked(preparation_id, fingerprint):
+                # TASK-22587: `retire_durable_acceptance` already dropped every
+                # in-flight key for this preparation, so there is nothing left
+                # to release and nothing left to protect. Raising here would
+                # only mask the failure that sent us down the release path.
+                return
             self._require_durable_fingerprint_locked(preparation_id, fingerprint)
             self._durable_effects_in_flight.discard((preparation_id, effect_name))
 
@@ -3855,7 +3876,21 @@ class ConsoleChatStore:
         if not isinstance(fingerprint, ConsoleDurableAcceptanceFingerprint):
             raise TypeError("fingerprint must be ConsoleDurableAcceptanceFingerprint")
         if self._durable_fingerprint_by_preparation.get(preparation_id) != fingerprint:
+            if self._durable_retired_locked(preparation_id, fingerprint):
+                raise ConsoleDurableAcceptanceRetired(
+                    "Durable acceptance was retired."
+                )
             raise RuntimeError("Durable postcommit fingerprint changed.")
+
+    def _durable_retired_locked(
+        self,
+        preparation_id: str,
+        fingerprint: ConsoleDurableAcceptanceFingerprint,
+    ) -> bool:
+        """True when this exact preparation was retired, not mutated."""
+
+        tombstone = self._durable_tombstones.get(preparation_id)
+        return tombstone is not None and tombstone.fingerprint == fingerprint
 
     def retire_durable_acceptance(
         self,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -981,6 +981,11 @@ class ConsoleChatStore:
         self._durable_fingerprint_by_preparation: dict[
             str, ConsoleDurableAcceptanceFingerprint
         ] = {}
+        #: Preparations whose postcommit sequence has begun and has not yet
+        #: been released. Their tombstones are the ONLY proof that an
+        #: in-flight effect's preparation was retired rather than mutated,
+        #: so FIFO eviction must not reclaim them first (TASK-22587).
+        self._durable_active_postcommit: set[str] = set()
         self._durable_tombstones: OrderedDict[str, _ConsoleDurableTombstone] = (
             OrderedDict()
         )
@@ -3763,6 +3768,7 @@ class ConsoleChatStore:
         self._session_or_raise(session_id)
         with self._preparation_lock:
             self._require_durable_fingerprint_locked(preparation_id, fingerprint)
+            self._durable_active_postcommit.add(preparation_id)
             existing = self._durable_effects_by_preparation.get(preparation_id)
             if existing is not None:
                 if (
@@ -3949,8 +3955,46 @@ class ConsoleChatStore:
                 fingerprint=fingerprint,
                 completed=completed,
             )
-            while len(self._durable_tombstones) > self.DURABLE_TOMBSTONE_CAP:
+            self._evict_durable_tombstones_locked()
+
+    def _evict_durable_tombstones_locked(self) -> None:
+        """Hold the cap while preserving retirement proof still in use.
+
+        TASK-22587 (Qodo review of #2123): a plain FIFO `popitem` could reclaim
+        the tombstone of a preparation whose postcommit sequence was STILL
+        RUNNING, and that tombstone is the only proof its retirement was an
+        ordinary close rather than a mutation. Losing it put the generic
+        fingerprint-change error back on the in-flight effect -- making
+        correctness depend on unrelated session-close volume.
+
+        Protected entries are skipped, oldest-first, so the cap still holds:
+        if every entry is protected the oldest is evicted anyway, because a
+        bounded cache that can be pinned open without limit is a leak.
+        """
+
+        while len(self._durable_tombstones) > self.DURABLE_TOMBSTONE_CAP:
+            victim = next(
+                (
+                    key
+                    for key in self._durable_tombstones
+                    if key not in self._durable_active_postcommit
+                ),
+                None,
+            )
+            if victim is None:
                 self._durable_tombstones.popitem(last=False)
+                continue
+            self._durable_tombstones.pop(victim, None)
+
+    def release_durable_postcommit_activity(self, preparation_id: str) -> None:
+        """Allow this preparation's tombstone to be evicted again.
+
+        Called once the postcommit sequence is finished with the preparation,
+        by either the normal tail or the closed-session path (TASK-22587).
+        """
+
+        with self._preparation_lock:
+            self._durable_active_postcommit.discard(preparation_id)
 
     def discard_uncommitted_durable_preparation(self, preparation_id: str) -> None:
         """Forget staged content for an acceptance which never committed."""


### PR DESCRIPTION
## Summary

Closing a Console session while a durable turn is still collecting raised
`RuntimeError: Durable postcommit fingerprint changed.`

Reproduced at store level on clean `dev` before anything was changed: claim a
postcommit effect, close the session, release the claim.

## The bug was worse than filed

That raise comes out of the **release** path — the one whose entire job is to
clean up after a failure — and that path runs inside `except BaseException:`:

```python
except BaseException:
    self.store.abandon_durable_postcommit_effect(...)   # raised
    raise                                              # never reached
```

So it **replaced** the exception that sent us there. A genuine failure during a
turn the user happened to close was reported as a fingerprint message.

## Fix

The guard's intent is right: an effect must not commit against a retired
preparation. What was missing is a defined outcome for *"the preparation was
retired underneath me"* — an ordinary consequence of closing a chat — as
distinct from *"the fingerprint changed unexpectedly"*, which is a bug. Those
shared one raise.

The two are **decidable, not guessed**: `retire_durable_acceptance` already
leaves a tombstone carrying the *same* fingerprint. A matching tombstone proves
retirement rather than mutation, which is what the new `_durable_retired_locked`
reads. Retirement raises the distinct `ConsoleDurableAcceptanceRetired`; a real
mismatch still raises the generic `RuntimeError`.

Releasing a claim after retirement is a **no-op**, and that is safe rather than
merely quiet: `retire_durable_acceptance` has already dropped every in-flight
key for the preparation, so there is nothing left to release. A test asserts
that precondition, so the no-op cannot silently start leaking claims if it ever
stops holding.

Controller: the release call can no longer replace the original failure, and
retirement during a **successful** effect is a non-event — the work is done,
there is simply no ledger left to record it in.

## Mutation testing caught a test of mine that could not fail

Four mutations, one per behaviour change. **M3 stayed green**: the first
"not masked by the release path" test passed with the controller guard removed,
because the store fix already stops `abandon` from raising on that path. It
never tested what its name claimed.

Split into two: one honest end-to-end test whose docstring says what it does
*not* cover, and one that forces `abandon` to raise — which does go red without
the guard. That also made a `# pragma: no cover` I had written false, so it is
gone. All four changes are now individually mutation-proven.

The negative control is the load-bearing test here: narrowing a safety guard is
only safe if the guard still fires for the case it was written for.

## Verification

A/B of `Tests/Chat` against merge-base `65cf855371`, baseline tree verified with
`git diff --quiet` before the control ran:

| | merge-base `65cf855371` | this branch |
|---|---|---|
| collected | 7682 | 7689 (**+7**, the new tests) |
| failures | 111 | **111** |
| newly broken | — | **0** |

`./scripts/preflight.sh` green. The inventory reported +2 diagnostics in
`console_chat_controller.py`; both were reviewed before regenerating — they
interpolate internal effect names only (all 10 are string literals at the call
sites) and the exception **type**, never its message, per the TASK-22251
precedent that exists because those messages carry conversation and workspace
identifiers.

## Unblocks

TASK-22301 — converting `test_console_local_citation_boundary` to row
assertions needs durable sessions, which is what tripped this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes closing a Console chat mid-turn so it no longer raises `RuntimeError: Durable postcommit fingerprint changed.` The release path raised from inside `except BaseException:`, replacing the failure that sent it there and hiding the real cause. A retired preparation is now a defined, ordinary outcome of the user closing a chat.

**Bug Fixes**
- Retirement is detected via a tombstone carrying the same fingerprint, so it's never confused with a genuine mismatch.
- Retirement raises a distinct `ConsoleDurableAcceptanceRetired`; a real fingerprint change still raises the generic `RuntimeError`.
- Releasing a claim after retirement is a no-op, and a test pins the precondition so the no-op can't silently leak claims.
- Retirement is terminal-benign for the whole postcommit sequence: the resume lookup, in-flight effects, the sequence's final retire, and the recovery handler's completed-effects read all survive a close without raising or leaking state.
- Preparations with a running sequence pin their tombstone against FIFO eviction, so unrelated close volume can't turn the close back into the fingerprint error.
- The controller no longer lets bookkeeping replace the original failure, and retirement during a successful effect just leaves the work unrecorded.
- Unblocks TASK-22301, which needs durable sessions.

<sup>Written for commit 49ffcd6fa686c8f59faed4c4212d182242b89f41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

