### PR TITLE
fix(change-review): distinguish repeated-root windows

### DIFF
--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -17,12 +17,14 @@ from textual.app import App
 from textual.containers import Vertical
 from textual.widgets import Button, Input, Select, Static, Tree
 
+from Tests.UI.test_console_narrow_layout import _compositor_text
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.UI.Screens.change_review_screen import (
     AgentRunsChangeReviewProvider,
     ChangeReviewDiffPane,
     ChangeReviewScreen,
     _hunk_containing_line,
+    _window_labels,
 )
 from tldw_chatbook.Widgets.glyph_fallback import resolve_glyph
 from tldw_chatbook.Workspaces.change_tracking import ShadowRepoService
@@ -54,6 +56,76 @@ def _record_turn(db, tracker, root, run_id: str, mutate) -> None:
             untracked_oversize=rec.untracked_oversize,
             nested_repos=rec.nested_repos,
         )
+
+
+def _same_root_window_provider(tmp_path, kinds: tuple[str, ...]):
+    """Build real consecutive snapshot windows over one root and path."""
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "shared.txt").write_text("seed\n")
+
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    conv = "conv-1"
+    run_id = db.create_run(conversation_id=conv, agent_kind="primary")
+    markers = ("ALPHA_ONLY_MARKER", "BRAVO_ONLY_MARKER")
+
+    for kind, marker in zip(kinds, markers):
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "shared.txt").write_text(f"{marker}\n")
+        for rec in tracker.end_turn(handle):
+            db.record_change_snapshot(
+                run_id=run_id,
+                root=rec.root,
+                baseline_sha=rec.baseline_sha,
+                end_sha=rec.end_sha,
+                files_changed=rec.files_changed,
+                adds=rec.adds,
+                dels=rec.dels,
+                tracking_error=rec.tracking_error,
+                untracked_oversize=rec.untracked_oversize,
+                nested_repos=rec.nested_repos,
+                kind=kind,
+            )
+
+    rows = db.change_snapshots_for_run_review(run_id)
+    assert len(rows) == len(kinds), (
+        f"fixture must produce one row per window, got {rows}"
+    )
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id=conv
+    )
+    return provider, root, run_id, tuple(int(row["id"]) for row in rows)
+
+
+@pytest.fixture()
+def same_root_windows_fixture(tmp_path):
+    from tldw_chatbook.Chat.console_agent_bridge import (
+        CHANGE_KIND_SUBAGENT_POST_TURN,
+        CHANGE_KIND_TURN,
+    )
+
+    return _same_root_window_provider(
+        tmp_path,
+        (CHANGE_KIND_TURN, CHANGE_KIND_SUBAGENT_POST_TURN),
+    )
+
+
+def test_same_root_window_label_taxonomy_is_complete_and_stable(tmp_path):
+    root = str(tmp_path / "root")
+    rows = [
+        {"root": root, "kind": "turn"},
+        {"root": root, "kind": "turn_concurrent_subagent"},
+        {"root": root, "kind": "subagent_post_turn"},
+    ]
+
+    assert [_window_labels(rows)[id(row)] for row in rows] == [
+        "Turn",
+        "Turn with sub-agent overlap",
+        "Sub-agent after turn",
+    ]
 
 
 @pytest.fixture()
@@ -996,71 +1068,143 @@ async def test_unknown_initial_path_falls_back_to_the_first_leaf(review_fixture)
 
 
 @pytest.mark.asyncio
-async def test_initial_snapshot_id_disambiguates_two_windows_on_same_path(tmp_path):
-    """TASK-18060 Task 3 (review-rail spec §2/§3): a run's ``change_snapshots``
-    can hold rows from TWO windows -- the turn's own window and its
-    surviving sub-agents' post-turn window -- and both can cover the SAME
-    path with DIFFERENT diff content (same fixture shape as
-    ``test_console_turn_file_card.py``'s
-    ``test_real_provider_two_windows_on_same_root_no_duplicates_own_diffs``).
-    Path-only selection is ambiguous here -- it can only ever reach the
-    FIRST-recorded window's leaf. ``initial_snapshot_id`` must pick the
-    leaf whose OWN row id matches, reaching either window on demand.
-    """
-    from tldw_chatbook.Chat.console_agent_bridge import (
-        CHANGE_KIND_SUBAGENT_POST_TURN,
-        CHANGE_KIND_TURN,
+async def test_same_root_windows_have_visible_source_labels_and_honest_counts(
+    same_root_windows_fixture,
+):
+    """Removing the window prefix makes two painted rows look identical."""
+    provider, _root, run_id, _window_ids = same_root_windows_fixture
+    turn = provider.turn_for_run(run_id)
+    assert turn is not None
+    assert "2 file changes +2 −2" in turn.label
+
+    app = _Harness(provider, initial_run_id=run_id)
+    async with app.run_test(size=(80, 24)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        labels = await _wait_for(
+            pilot,
+            lambda: (lambda values: values if len(values) == 2 else None)(
+                [
+                    label
+                    for label in _tree_labels(
+                        screen.query_one("#change-review-tree", Tree)
+                    )
+                    if "shared.txt" in label
+                ]
+            ),
+            "both same-root window labels",
+        )
+        assert any(label.startswith("Turn · shared.txt") for label in labels), labels
+        assert any(
+            label.startswith("Sub-agent after turn · shared.txt") for label in labels
+        ), labels
+        assert str(screen.query_one("#change-review-totals", Static).renderable) == (
+            "2 file changes  +2 −2"
+        )
+        painted = _compositor_text(app.export_screenshot(simplify=True))
+        assert "Turn · shared.txt" in painted
+        assert "Sub-agent after turn · shared.txt" in painted
+
+
+@pytest.mark.asyncio
+async def test_unknown_same_root_window_kinds_receive_numbered_labels(tmp_path):
+    """Future or malformed duplicate kinds must never collapse visually."""
+    provider, _root, run_id, _window_ids = _same_root_window_provider(
+        tmp_path, ("future_kind", "future_kind")
     )
+    app = _Harness(provider, initial_run_id=run_id)
+    async with app.run_test(size=(80, 24)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        labels = await _wait_for(
+            pilot,
+            lambda: (lambda values: values if len(values) == 2 else None)(
+                [
+                    label
+                    for label in _tree_labels(
+                        screen.query_one("#change-review-tree", Tree)
+                    )
+                    if "shared.txt" in label
+                ]
+            ),
+            "both unknown-kind window labels",
+        )
+        assert any(
+            label.startswith("Change window 1 · shared.txt") for label in labels
+        ), labels
+        assert any(
+            label.startswith("Change window 2 · shared.txt") for label in labels
+        ), labels
 
-    root = tmp_path / "root"
-    root.mkdir()
-    (root / "shared.txt").write_text("seed\n")
 
+@pytest.mark.asyncio
+async def test_ordinary_multi_root_labels_remain_unchanged(tmp_path):
+    """Distinct roots keep the existing path/stats/root label ordering."""
+    root_a = tmp_path / "alpha"
+    root_b = tmp_path / "beta"
+    root_a.mkdir()
+    root_b.mkdir()
     service = ShadowRepoService(data_dir=tmp_path / "appdata")
     tracker = ChangeTurnTracker(service=service)
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
-    conv = "conv-1"
-    run_id = db.create_run(conversation_id=conv, agent_kind="primary")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
 
-    def _record_window(kind: str, mutate) -> None:
-        handle = tracker.begin_turn([root])
-        handle.await_baseline()
-        mutate()
-        for rec in tracker.end_turn(handle):
-            db.record_change_snapshot(
-                run_id=run_id,
-                root=rec.root,
-                baseline_sha=rec.baseline_sha,
-                end_sha=rec.end_sha,
-                files_changed=rec.files_changed,
-                adds=rec.adds,
-                dels=rec.dels,
-                tracking_error=rec.tracking_error,
-                untracked_oversize=rec.untracked_oversize,
-                nested_repos=rec.nested_repos,
-                kind=kind,
-            )
-
-    # Window 1: the turn's own window -- recorded FIRST.
-    _record_window(
-        CHANGE_KIND_TURN,
-        lambda: (root / "shared.txt").write_text("ALPHA_ONLY_MARKER\n"),
-    )
-    # Window 2: the post-turn window -- same run, same root, same path,
-    # recorded SECOND -- its baseline is window 1's end state.
-    _record_window(
-        CHANGE_KIND_SUBAGENT_POST_TURN,
-        lambda: (root / "shared.txt").write_text("BRAVO_ONLY_MARKER\n"),
-    )
-
-    rows = db.change_snapshots_for_run_review(run_id)
-    assert len(rows) == 2, f"fixture must produce exactly two windows, got {rows}"
-    window1_id, window2_id = int(rows[0]["id"]), int(rows[1]["id"])
-    assert window1_id != window2_id
+    handle = tracker.begin_turn([root_a, root_b])
+    handle.await_baseline()
+    (root_a / "alpha.txt").write_text("alpha\n")
+    (root_b / "beta.txt").write_text("beta\n")
+    for rec in tracker.end_turn(handle):
+        db.record_change_snapshot(
+            run_id=run_id,
+            root=rec.root,
+            baseline_sha=rec.baseline_sha,
+            end_sha=rec.end_sha,
+            files_changed=rec.files_changed,
+            adds=rec.adds,
+            dels=rec.dels,
+        )
 
     provider = AgentRunsChangeReviewProvider(
-        db=db, service=service, conversation_id=conv
+        db=db, service=service, conversation_id="conv-1"
     )
+    app = _Harness(provider, initial_run_id=run_id)
+    async with app.run_test(size=(120, 32)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        labels = await _wait_for(
+            pilot,
+            lambda: (lambda values: values if len(values) == 2 else None)(
+                [
+                    label
+                    for label in _tree_labels(
+                        screen.query_one("#change-review-tree", Tree)
+                    )
+                    if ".txt" in label
+                ]
+            ),
+            "both multi-root labels",
+        )
+        assert "alpha.txt  +1 −0  · alpha" in labels
+        assert "beta.txt  +1 −0  · beta" in labels
+
+
+@pytest.mark.asyncio
+async def test_initial_snapshot_id_disambiguates_two_windows_on_same_path(
+    same_root_windows_fixture,
+):
+    """A snapshot id selects the matching same-path window's own diff."""
+    provider, _root, run_id, window_ids = same_root_windows_fixture
+    window1_id, window2_id = window_ids
+    assert window1_id != window2_id
 
     async def _opened_diff(snapshot_id: int) -> str:
         app = _Harness(
@@ -1072,34 +1216,78 @@ async def test_initial_snapshot_id_disambiguates_two_windows_on_same_path(tmp_pa
         async with app.run_test(size=(160, 48)) as pilot:
             screen = await _wait_for(
                 pilot,
-                lambda: app.screen
-                if isinstance(app.screen, ChangeReviewScreen)
-                else None,
+                lambda: (
+                    app.screen if isinstance(app.screen, ChangeReviewScreen) else None
+                ),
                 "review screen",
             )
-            await _wait_for(
-                pilot, lambda: screen._leaves or None, "leaves loaded"
-            )
-            assert len(screen._leaves) == 2, (
-                "both windows' leaves for shared.txt must both be present"
-            )
-            text = await _wait_for(
+            await _wait_for(pilot, lambda: screen._leaves or None, "leaves loaded")
+            assert len(screen._leaves) == 2
+            return await _wait_for(
                 pilot,
                 lambda: (
-                    lambda t: t
-                    if ("ALPHA_ONLY_MARKER" in t or "BRAVO_ONLY_MARKER" in t)
-                    else None
+                    lambda text: (
+                        text
+                        if (
+                            "ALPHA_ONLY_MARKER" in text
+                            or "BRAVO_ONLY_MARKER" in text
+                        )
+                        else None
+                    )
                 )(screen.diff_pane_text()),
                 "a window's diff rendered",
             )
-            return text
 
     window1_diff = await _opened_diff(window1_id)
-    assert "ALPHA_ONLY_MARKER" in window1_diff, window1_diff
-    assert "BRAVO_ONLY_MARKER" not in window1_diff, window1_diff
+    assert "ALPHA_ONLY_MARKER" in window1_diff
+    assert "BRAVO_ONLY_MARKER" not in window1_diff
 
     window2_diff = await _opened_diff(window2_id)
-    assert "BRAVO_ONLY_MARKER" in window2_diff, window2_diff
+    assert "BRAVO_ONLY_MARKER" in window2_diff
+
+
+@pytest.mark.asyncio
+async def test_undo_all_refuses_same_root_windows_before_preflight(
+    same_root_windows_fixture, monkeypatch
+):
+    """Removing the guard starts an order-sensitive whole-turn revert."""
+    provider, root, run_id, _window_ids = same_root_windows_fixture
+    preflight_calls: list[tuple[int, tuple[str, ...]]] = []
+    original_preflight = provider.preflight_revert
+
+    def record_preflight(row, paths):
+        preflight_calls.append((int(row["id"]), tuple(paths)))
+        return original_preflight(row, paths)
+
+    monkeypatch.setattr(provider, "preflight_revert", record_preflight)
+    app = _Harness(provider, initial_run_id=run_id)
+    notices: list[tuple[str, str | None]] = []
+    app.notify = lambda message, **kwargs: notices.append(
+        (str(message), kwargs.get("severity"))
+    )
+
+    async with app.run_test(size=(120, 32)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        await _wait_for(pilot, lambda: screen._leaves or None, "turn files")
+        screen.action_undo_all()
+        await pilot.pause(0.2)
+
+        assert app.screen is screen, "ambiguous Undo All opened a confirm modal"
+        assert preflight_calls == [], (
+            "same-root windows reached order-sensitive revert preflight"
+        )
+        assert (root / "shared.txt").read_text() == "BRAVO_ONLY_MARKER\n"
+        assert notices == [
+            (
+                "This turn has multiple change windows for the same workspace. "
+                "Revert files individually from one labeled window at a time.",
+                "warning",
+            )
+        ]
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-15670 - Change-review-lists-one-root-twice-under-a-single-turn-entry.md
+++ b/backlog/tasks/task-15670 - Change-review-lists-one-root-twice-under-a-single-turn-entry.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15670
-title: 'Change review lists one root twice under a single turn entry'
-status: To Do
-assignee: []
+title: Change review lists one root twice under a single turn entry
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-11 21:30'
+updated_date: '2026-08-27 00:48'
 labels:
   - console
   - change-review
@@ -20,7 +22,35 @@ priority: medium
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A run holding both a turn window and a survivor window lists each root once, or labels the two entries so the repetition is explained
-- [ ] #2 multi_root labelling still behaves as it does today
-- [ ] #3 The provider's existing tests still pass and a new one fails when the duplicate reappears
+- [x] #1 A run holding multiple change windows for the same canonical root gives every affected file row a concise, distinct, visible window label; the normal turn and survivor labels explain when and by whom the change happened, and unknown or repeated kinds remain distinguishable
+- [x] #2 Ordinary single-window and multi-root file labels still behave as they do today
+- [x] #3 Review-wide **Undo All** refuses a same-root multi-window run before preflight or mutation and tells the user to revert one labeled window at a time; per-file revert remains available
+- [x] #4 Affected turn-selector and tree totals describe summed entries as file changes rather than implying they are unique files
+- [x] #5 The provider's existing tests pass, and production-shaped regressions cover same-root windows, narrow rendering, multi-root preservation, and the no-mutation refusal
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: This is a bounded Review-screen clarity and safety correction under accepted ADR-089; it changes no storage, ownership, runtime boundary, or cross-module contract.
+
+1. Add failing real-provider and mounted-screen regressions for distinct same-root window labels, narrow visibility, honest counts, ordinary multi-root preservation, and Review-wide Undo All refusal before provider work.
+2. Add the smallest Review-screen row-classification and label presentation needed to distinguish repeated-root windows, with a stable fallback for unexpected kinds.
+3. Reuse the same canonical-root comparison to refuse ambiguous whole-turn revert while preserving focused per-file revert.
+4. Run the focused provider/screen tests, scoped static checks, and diff hygiene checks; self-review the exact branch diff against ADR-089 and this task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented explicit provenance and safe recovery for repeated-root change windows in the full Change Review screen.
+
+- Kept every snapshot window and prefixed affected rows with stable turn, overlap, survivor, or numbered fallback labels that remain visible in the narrow tree.
+- Changed only repeated-root aggregates to say `file change(s)`; ordinary single-window and multi-root labels retain their existing copy and ordering.
+- Refused Review-wide **Undo All** before provider preflight or mutation when one canonical root has multiple windows, with explicit guidance to use the labeled per-file reverts.
+- Added real tracker/database/provider regressions for all persisted label kinds, unknown-kind fallbacks, 80-column rendering, snapshot-specific diff selection, ordinary multi-root preservation, and no-mutation refusal.
+- ADR required: no. Accepted ADR-089 already owns this Review-screen safety boundary; no storage or cross-module contract changed.
+- Verification: all 58 Change Review tests passed; the 6 focused new/affected tests, Ruff, Python compilation, and diff checks passed. The adjacent 12-test card suite has a pre-existing order-sensitive timeout in its final mounted retry test: the exact timeout reproduced unchanged on `origin/dev`, while that test passes alone.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -160,6 +160,68 @@ _GROUPS: tuple[tuple[str, str], ...] = (
 )
 _OTHER_GROUP = "Other"
 
+#: A repeated-root turn has order-sensitive snapshot windows. The compact
+#: card already uses this wording when it routes the user here; Review adds
+#: the recovery because its whole-turn shortcut must not replay those rows.
+MULTI_WINDOW_UNDO_REFUSAL = (
+    "This turn has multiple change windows for the same workspace. "
+    "Revert files individually from one labeled window at a time."
+)
+
+#: User-facing provenance for the three persisted window kinds. Keep this
+#: local to Review: importing the Console bridge for three storage literals
+#: would invert the display/runtime dependency.
+_WINDOW_KIND_LABELS = {
+    "turn": "Turn",
+    "turn_concurrent_subagent": "Turn with sub-agent overlap",
+    "subagent_post_turn": "Sub-agent after turn",
+}
+
+
+def _snapshot_root_key(row: dict) -> str:
+    """Return the card-compatible comparison key for a snapshot root."""
+    root = str(row.get("root") or "")
+    return os.path.normcase(os.path.normpath(root)) if root else ""
+
+
+def _window_labels(rows: "Sequence[dict]") -> dict[int, str]:
+    """Label rows only where one canonical root owns multiple windows.
+
+    Known kinds use concise provenance. Repeated or unknown kinds gain a
+    stable ordinal so every affected row remains distinguishable.
+
+    Args:
+        rows: One run's snapshot rows in storage order.
+
+    Returns:
+        Row-object identities mapped to their visible window labels.
+    """
+    by_root: dict[str, list[dict]] = {}
+    for row in rows:
+        by_root.setdefault(_snapshot_root_key(row), []).append(row)
+
+    labels: dict[int, str] = {}
+    for root_rows in by_root.values():
+        if len(root_rows) < 2:
+            continue
+        base_labels = [
+            _WINDOW_KIND_LABELS.get(str(row.get("kind") or ""), "Change window")
+            for row in root_rows
+        ]
+        totals = {base: base_labels.count(base) for base in set(base_labels)}
+        seen: dict[str, int] = {}
+        for row, base in zip(root_rows, base_labels):
+            seen[base] = seen.get(base, 0) + 1
+            labels[id(row)] = f"{base} {seen[base]}" if totals[base] > 1 else base
+    return labels
+
+
+def _file_count_noun(count: int, *, repeated_root: bool) -> str:
+    """Name an aggregate without calling repeated paths unique files."""
+    if repeated_root:
+        return "file change" if count == 1 else "file changes"
+    return "files"
+
 
 @dataclass(frozen=True)
 class ReviewTurn:
@@ -337,9 +399,14 @@ class AgentRunsChangeReviewProvider:
         adds = sum(int(r["adds"] or 0) for r in rows)
         dels = sum(int(r["dels"] or 0) for r in rows)
         stamp = str(rows[0].get("created_at", ""))[:19].replace("T", " ")
+        repeated_root = bool(_window_labels(rows))
         return ReviewTurn(
             run_id=run_id,
-            label=f"{stamp} · {files} files +{adds} −{dels}",
+            label=(
+                f"{stamp} · {files} "
+                f"{_file_count_noun(files, repeated_root=repeated_root)} "
+                f"+{adds} −{dels}"
+            ),
             rows=tuple(rows),
         )
 
@@ -1839,6 +1906,7 @@ class ChangeReviewScreen(Screen):
         self._diff_cache_error = None
         self._active_turn = turn
         multi_root = len(turn.rows) > 1
+        window_labels = _window_labels(turn.rows)
         tree = self.query_one("#change-review-tree", Tree)
         tree.clear()
         tree.root.expand()
@@ -1917,7 +1985,13 @@ class ChangeReviewScreen(Screen):
                 return True
             return change.path not in touched
 
-        self._populate_tree(tree, grouped, multi_root, _badged)
+        self._populate_tree(
+            tree,
+            grouped,
+            multi_root,
+            _badged,
+            window_labels=window_labels,
+        )
 
         self._turn_banner_lines = banners
         # A turn view carries no current-mode per-root failures.
@@ -1930,7 +2004,8 @@ class ChangeReviewScreen(Screen):
         totals = self.query_one("#change-review-totals", Static)
         adds = sum(int(r["adds"] or 0) for r in turn.rows)
         dels = sum(int(r["dels"] or 0) for r in turn.rows)
-        totals.update(f"{len(self._leaves)} files  +{adds} −{dels}")
+        noun = _file_count_noun(len(self._leaves), repeated_root=bool(window_labels))
+        totals.update(f"{len(self._leaves)} {noun}  +{adds} −{dels}")
 
         # TASK-18060 Task 3: the initials are constructor state consumed
         # exactly ONCE -- cleared here, UNCONDITIONALLY, so a later turn
@@ -1972,6 +2047,8 @@ class ChangeReviewScreen(Screen):
         grouped: "dict[str, list[tuple[dict, ChangedFile]]]",
         multi_root: bool,
         badge: "Callable[[dict, ChangedFile], bool]",
+        *,
+        window_labels: "dict[int, str] | None" = None,
     ) -> None:
         """Fill the changed-file tree and ``self._leaves`` from ``grouped``.
 
@@ -1987,7 +2064,10 @@ class ChangeReviewScreen(Screen):
             badge: Per-leaf "changed outside direct file tools" predicate
                 (TASK-1978). Always False in `current` mode -- provenance
                 is a property of a recorded run, not of the working tree.
+            window_labels: Optional visible provenance for repeated-root
+                snapshot rows. Current mode and ordinary turns pass none.
         """
+        labels_by_row = window_labels or {}
         known = {code for code, _label in _GROUPS}
         for code, label in _GROUPS:
             entries = grouped.get(code, [])
@@ -1999,7 +2079,11 @@ class ChangeReviewScreen(Screen):
                 # selection can load the diff (j/k was the only loader).
                 branch.add_leaf(
                     self._leaf_label(
-                        row, change, multi_root, badge=badge(row, change)
+                        row,
+                        change,
+                        multi_root,
+                        badge=badge(row, change),
+                        window_label=labels_by_row.get(id(row)),
                     ),
                     data=len(self._leaves),
                 )
@@ -2017,7 +2101,11 @@ class ChangeReviewScreen(Screen):
                 # selection can load the diff (j/k was the only loader).
                 branch.add_leaf(
                     self._leaf_label(
-                        row, change, multi_root, badge=badge(row, change)
+                        row,
+                        change,
+                        multi_root,
+                        badge=badge(row, change),
+                        window_label=labels_by_row.get(id(row)),
                     ),
                     data=len(self._leaves),
                 )
@@ -3170,6 +3258,7 @@ class ChangeReviewScreen(Screen):
         change: ChangedFile,
         multi_root: bool,
         badge: bool = False,
+        window_label: str | None = None,
     ) -> Text:
         """Build one leaf label as a PLAIN rich Text.
 
@@ -3189,7 +3278,12 @@ class ChangeReviewScreen(Screen):
             from pathlib import Path as _P
 
             parts.append(f"· {_P(str(row['root'])).name}")
-        label = Text("  ".join(parts))
+        label = Text()
+        if window_label:
+            # Provenance leads because the tree is fixed at 46 columns: a
+            # trailing qualifier disappears first for realistic long paths.
+            label.append(f"{window_label} · ")
+        label.append("  ".join(parts))
         if badge:
             # TASK-1978: exact spec copy — 'outside direct file tools',
             # never 'not by the agent' (script writes are agent work too,
@@ -3895,7 +3989,7 @@ class ChangeReviewScreen(Screen):
         self._confirm_and_revert(row, [change.path], f"Revert {change.path}?")
 
     def action_undo_all(self) -> None:
-        """Revert every file in the active turn, per root (confirmed)."""
+        """Revert every unambiguous file in the active turn (confirmed)."""
         # TASK-16801 arc B (spec §4.1): same gate as `action_revert_file`,
         # and it must come BEFORE the `_active_turn is None` check below --
         # current mode holds no active turn, so without this the key would
@@ -3904,6 +3998,9 @@ class ChangeReviewScreen(Screen):
             self.notify(CURRENT_MODE_REVERT_REFUSAL, severity="warning")
             return
         if self._active_turn is None or not self._leaves:
+            return
+        if _window_labels(self._active_turn.rows):
+            self.notify(MULTI_WINDOW_UNDO_REFUSAL, severity="warning")
             return
         by_row: dict[int, tuple[dict, list[str]]] = {}
         for row, change in self._leaves:


### PR DESCRIPTION
## Summary

- preserve every same-root snapshot window while giving its file rows visible turn, overlap, survivor, or numbered fallback provenance
- describe repeated-root aggregates as file changes without altering ordinary single-window or multi-root labels
- refuse Review-wide Undo All before preflight or mutation for ambiguous same-root windows and direct users to labeled per-file reverts
- add production-shaped tracker, database, provider, narrow-rendering, and no-mutation regressions

## Verification

- `pytest -q Tests/UI/test_change_review_screen.py` — 58 passed
- focused six new/affected tests — 6 passed
- `ruff check tldw_chatbook/UI/Screens/change_review_screen.py Tests/UI/test_change_review_screen.py`
- `python -m py_compile tldw_chatbook/UI/Screens/change_review_screen.py Tests/UI/test_change_review_screen.py`
- `git diff --check`

## Baseline note

The adjacent 12-test Console card Undo All file has an order-sensitive timeout in its final mounted retry test: 11 tests pass, and the same final timeout reproduces on detached, unmodified `origin/dev`; the exact test passes alone. This PR does not modify the card path.

## Task and architecture

- TASK-15670
- ADR required: no; accepted ADR-089 already owns this Review-screen safety boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-15670: change review no longer lists one root twice under a single turn entry as indistinguishable rows. Repeated-root snapshot windows now get visible provenance labels, and Review-wide Undo All refuses ambiguous same-root runs before preflight or mutation.

**Bug Fixes**
- Same-root snapshot rows get a concise window label (Turn, Turn with sub-agent overlap, Sub-agent after turn, or a numbered fallback) that stays visible in the narrow tree.
- Repeated-root totals say `file changes` instead of `files` so counts don't imply unique files.
- Review-wide Undo All now refuses before any preflight or mutation when one canonical root has multiple windows, directing the user to per-file reverts from one labeled window at a time.
- Ordinary single-window and multi-root labels are unchanged.

<sup>Written for commit 0a128fdc7760f005449b083ebf17454b27df0255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

