### PR TITLE
Extract Console review and selection workflow ownership

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2364,6 +2364,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 4,
+      "diagnostic_digest": "bf1a8f227f525815cf81",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Console_Modules/review_selection.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 16,
       "diagnostic_digest": "e044eabcb75ac5dceb06",
       "owner": "TASK-494",
@@ -2574,8 +2581,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 90,
-      "diagnostic_digest": "8667d02ba0e92b5d5f34",
+      "call_count": 86,
+      "diagnostic_digest": "8e52a60594b66423f235",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3973,7 +3980,7 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 538,
+    "owner_files": 539,
     "persistent_sink_files": 8,
     "task_492_calls": 1247,
     "task_494_calls": 7369

--- a/Docs/superpowers/plans/2026-08-27-task-3070-13-console-review-selection-controller.md
+++ b/Docs/superpowers/plans/2026-08-27-task-3070-13-console-review-selection-controller.md
@@ -12,9 +12,9 @@
 
 ## Global Constraints
 
-- Implementation base: `origin/dev` `ee8dc24115ba14cddef9de2b262e1cbf7bfa32ca`; if the executable drift gate finds a changed 7/3/6 family, stop and amend before continuing.
+- Implementation base: `origin/dev` `c6218918d1e70c1938f7e11df592d0c70ca60383`; if the executable drift gate finds a changed 7/3/6 family, stop and amend before continuing.
 - Exact ownership: seven moves, three complete delegates of at most five physical lines each, six screen stays.
-- Conservative screen reduction: at least 399 physical lines and seven direct methods; the trajectory adapter's additional removal is not counted toward this minimum.
+- Conservative screen reduction: at least 409 physical lines and seven unique direct method names; the trajectory adapter's additional removal is not counted toward this minimum.
 - No `ChatScreen` reference, DOM query, sibling-controller object, dependency container, dynamic facade, mixin, Git authority, SQL/schema ownership, stale screen re-export, or compatibility shadow state.
 - Preserve ADR-068 screen ownership of review-note modal/fetch/mutate/forced-reload flow.
 - Keep `TrajectoryScreen` lazily imported at presentation time; importing the controller module must not widen Chat first paint.
@@ -28,9 +28,9 @@
 
 - Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-3070-13-console-review-selection`
 - Planning branch: `codex/task-3070-13-console-review-selection`
-- Current screen: 17,599 physical lines / 539 direct methods.
-- Frozen current-base family: 16 methods / 840 lines = seven moves / three delegates / six stays.
-- Conservative final screen: no more than 17,200 physical lines / 532 direct methods.
+- Current screen: 17,624 physical lines / 539 unique direct method names (569 AST definitions including property getter/setter definitions).
+- Frozen current-base family: 16 methods / 850 lines = seven moves / three delegates / six stays.
+- Conservative final screen: no more than 17,215 physical lines / 532 unique direct method names; the existing 17,727/593 AST-definition ratchet is not raised.
 - Focused baseline: 111/115 pass. The four known failures are stale unit traversals in `Tests/UI/test_console_annotation_markers.py`; mounted annotation behavior is green and production must not be changed to satisfy those assertions.
 
 ADR required: no
@@ -122,16 +122,16 @@ Reason: this task applies the existing controller ownership rule in `DESIGN.md` 
   - the controller has no `query`, `query_one`, `focus`, `push_screen`, `ChatScreen`, `__getattr__`, `__getattribute__`, mixin base, SQL literal/execute call, Git subprocess, or stored sibling-controller accessor/object;
   - `build_console_controllers()` assigns `screen._review_selection` exactly once and is the sole production constructor;
   - the constructor has only named keyword-only callables and no `screen`, `app_instance`, dependency object, `*args`, or `**kwargs` escape hatch;
-  - `chat_screen.py` is at most 17,200 lines / 532 direct methods and the immutable ratchet is not raised.
+  - `chat_screen.py` is at most 17,215 lines / 532 unique direct method names and the immutable 17,727/593 AST-definition ratchet is not raised.
 
 - [ ] **Step 2: Add current-base arithmetic and durable rebase drift coverage**
 
-  Read the frozen `TASK_BASE` and live `origin/dev` sources with bounded `git show`. For the frozen base, assert 17,599/539, the 16 exact candidate names, 840 total lines, seven/three/six, 280 move lines, 426 stay lines, and conservative 399/7 removal. For live `origin/dev`, accept only one of two complete states:
+  Read the frozen `TASK_BASE` and live `origin/dev` sources with bounded `git show`. For the frozen base, assert 17,624/539 unique names, the 16 exact candidate names, 850 total lines, seven/three/six, 280 move lines, 426 stay lines, 144 delegate lines, and conservative 409/7 removal. For live `origin/dev`, accept only one of two complete states:
 
   ```python
   if MOVE_METHODS <= origin_screen_methods:
       assert exact_current_family(origin_screen) == reviewed_family
-      assert projected_counts(origin_screen) <= (17_200, 532)
+      assert projected_counts(origin_screen) <= (17_215, 532)
   else:
       assert final_owner_contract(origin_screen, origin_review_module)
   ```
@@ -202,6 +202,7 @@ Reason: this task applies the existing controller ownership rule in `DESIGN.md` 
           run_active_for_root: Callable[[str], bool],
           workspace_roots_accessor: Callable[[], tuple[str, ...] | None],
           agent_runs_db_accessor: Callable[[], Any | None],
+          capture_policy_bindings_accessor: Callable[[str, str], Any | None],
           native_messages_accessor: Callable[[], list[Any]],
           run_worker: Callable[..., Any],
           show_feedback_comment: Callable[[str, str], Awaitable[str | None]],
@@ -236,11 +237,12 @@ Reason: this task applies the existing controller ownership rule in `DESIGN.md` 
               conversation_id=launch.conversation_id,
               revision_provider=launch.revision_provider,
               snapshot_builder=launch.snapshot_builder,
+              capture_policy_bindings=launch.capture_policy_bindings,
           )
       )
   ```
 
-  `ConsoleTrajectoryLaunch` is a frozen, slotted dataclass defined in `review_selection.py` carrying `snapshot`, `screen_title`, `conversation_id`, `revision_provider`, and `snapshot_builder`. This is data, not a dependency container. The lazy import must stay inside `_present_console_trajectory`.
+  `ConsoleTrajectoryLaunch` is a frozen, slotted dataclass defined in `review_selection.py` carrying `snapshot`, `screen_title`, `conversation_id`, `revision_provider`, `snapshot_builder`, and `capture_policy_bindings`. This is data, not a dependency container. The lazy import must stay inside `_present_console_trajectory`, and the presenter passes `capture_policy_bindings=launch.capture_policy_bindings` to `TrajectoryScreen`.
 
   Construct `screen._review_selection` immediately before `_send_price`. Wire each fine-grained callable with a late-bound lambda that resolves the exact current operation/fact at call time. No callable may return `_agent`, `_prompt_queue`, `_session`, or `_console_chat_controller`; only the store/service object, scalar/tuple fact, or operation result may cross.
 
@@ -468,7 +470,7 @@ Reason: this task applies the existing controller ownership rule in `DESIGN.md` 
 
 **Interfaces:**
 
-- Consumes: current store/session metadata, agent-runs DB seam, `run_worker`, `marshal_to_ui`, `present_trajectory`, and existing store/repository read APIs.
+- Consumes: current store/session metadata, agent-runs DB seam, semantic-capture policy binding accessor, `run_worker`, `marshal_to_ui`, `present_trajectory`, and existing store/repository read APIs.
 - Produces: module function `_build_trajectory_snapshot`, `ConsoleTrajectoryLaunch`, `open_trajectory_view()`, and the final screen action delegate.
 
 - [ ] **Step 1: Retarget the trajectory helper tests RED-first**
@@ -505,7 +507,13 @@ Reason: this task applies the existing controller ownership rule in `DESIGN.md` 
       conversation_id: str
       revision_provider: Callable[[], int]
       snapshot_builder: Callable[[], TrajectorySnapshot]
+      capture_policy_bindings: Any | None
   ```
+
+  Resolve capture-policy bindings before launching with the current session id and
+  persisted conversation id. Wiring owns the late-bound call through
+  `build_capture_policy_bindings`; the controller receives only the resulting
+  binding data and never a Console chat controller.
 
 - [ ] **Step 4: Install the final action delegate and retarget patch handles**
 

--- a/Docs/superpowers/plans/2026-08-27-task-3070-13-console-review-selection-controller.md
+++ b/Docs/superpowers/plans/2026-08-27-task-3070-13-console-review-selection-controller.md
@@ -1,0 +1,789 @@
+# TASK-3070.13 Console Review and Selection Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the seven reviewed Console review/selection policy methods and the trajectory snapshot adapter out of `ChatScreen` into one explicit non-DOM `ConsoleReviewSelectionController`, while preserving the three Textual delegates, six screen-owned presentation/ADR-068 methods, persistence authority, privacy boundaries, and user-visible behavior.
+
+**Architecture:** `tldw_chatbook/UI/Console_Modules/review_selection.py` will own review provider/root policy, annotation discovery state, selection feedback and note policy, trajectory snapshot loading, and trajectory launch sequencing. The existing `build_console_controllers()` seam will construct `screen._review_selection` from fine-grained late-bound callables; `ChatScreen` will retain three complete five-line-or-shorter Textual delegates and three fail-loud `_ControllerState` descriptors with no shadow storage. Persistence remains in existing stores/repositories/DB services, Textual modal/screen construction remains in wiring or `ChatScreen`, and the feedback worker returns an immutable result before controller state is updated on the event-loop thread.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, pytest/pytest-asyncio, Ruff, stdlib AST source inspection, Backlog.md CLI, existing persistent-diagnostic inventory tooling.
+
+**Spec:** `Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md`
+
+## Global Constraints
+
+- Implementation base: `origin/dev` `ee8dc24115ba14cddef9de2b262e1cbf7bfa32ca`; if the executable drift gate finds a changed 7/3/6 family, stop and amend before continuing.
+- Exact ownership: seven moves, three complete delegates of at most five physical lines each, six screen stays.
+- Conservative screen reduction: at least 399 physical lines and seven direct methods; the trajectory adapter's additional removal is not counted toward this minimum.
+- No `ChatScreen` reference, DOM query, sibling-controller object, dependency container, dynamic facade, mixin, Git authority, SQL/schema ownership, stale screen re-export, or compatibility shadow state.
+- Preserve ADR-068 screen ownership of review-note modal/fetch/mutate/forced-reload flow.
+- Keep `TrajectoryScreen` lazily imported at presentation time; importing the controller module must not widen Chat first paint.
+- Never mutate `annotation_previews` from the blocking feedback-persistence thread.
+- Never add selected text, note content/title, prompt content, raw DB rows, or provider failures to logs/diagnostics.
+- Do not run a local full test suite. Use only the focused tests and gates named below; GitHub Actions remains the broad integration gate.
+
+---
+
+## Scope, baseline, and ADR check
+
+- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-3070-13-console-review-selection`
+- Planning branch: `codex/task-3070-13-console-review-selection`
+- Current screen: 17,599 physical lines / 539 direct methods.
+- Frozen current-base family: 16 methods / 840 lines = seven moves / three delegates / six stays.
+- Conservative final screen: no more than 17,200 physical lines / 532 direct methods.
+- Focused baseline: 111/115 pass. The four known failures are stale unit traversals in `Tests/UI/test_console_annotation_markers.py`; mounted annotation behavior is green and production must not be changed to satisfy those assertions.
+
+ADR required: no
+
+ADR path: `backlog/decisions/068-console-text-selection-and-annotations.md`
+
+Reason: this task applies the existing controller ownership rule in `DESIGN.md` section 7 and preserves ADR-068's explicit screen-owned review-note boundary. It changes no storage/schema, Git/database authority, service contract, security/privacy policy, dependency, or long-lived UX structure.
+
+## Task 0: Record the implementation plan before production changes
+
+**Files:**
+
+- Add: `Docs/superpowers/plans/2026-08-27-task-3070-13-console-review-selection-controller.md`
+- Modify: `backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md`
+
+**Interfaces:**
+
+- Consumes: the approved/hardened design spec and the task's five acceptance criteria.
+- Produces: a Backlog `## Implementation Plan` section that links this exact execution order and ADR decision.
+
+- [ ] **Step 1: Attach the plan to the In Progress Backlog task**
+
+  Run before changing production code:
+
+  ```bash
+  backlog task edit 3070.13 --plan "1. Freeze the exact current-base 7/3/6 boundary with RED architecture tests\n2. Establish ConsoleReviewSelectionController through build_console_controllers and fail-loud descriptors\n3. Move and characterize change-review and annotation policy\n4. Move selection-feedback and selection-note policy with an explicit worker/event-loop boundary\n5. Move trajectory loading/launch policy, install the three complete delegates, and retarget focused callers\n6. Prove five high-risk branches with bounded manual mutations\n7. Run focused behavior, architecture, static, privacy, diagnostic, backlog-ID, and diff gates\n8. Rebase on latest dev, revalidate drift, refresh task evidence, and complete delivery\n\nADR required: no\nADR path: backlog/decisions/068-console-text-selection-and-annotations.md\nReason: applies DESIGN.md section 7 while preserving ADR-068 review-note ownership and all existing durable authorities."
+  ```
+
+- [ ] **Step 2: Verify and commit the planning artifacts**
+
+  ```bash
+  backlog task 3070.13 --plain
+  git diff --check
+  git add "backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md" Docs/superpowers/plans/2026-08-27-task-3070-13-console-review-selection-controller.md
+  git commit -m "docs(console): plan review selection extraction"
+  ```
+
+## Task 1: Freeze the reviewed boundary with executable RED architecture tests
+
+**Files:**
+
+- Create: `Tests/Architecture/test_console_review_selection_controller_boundary.py`
+- Reference: `Tests/Architecture/test_console_wave6_closeout_inventory.py`
+- Reference: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Reference: `tldw_chatbook/UI/Console_Modules/wiring.py`
+
+**Interfaces:**
+
+- Consumes: the exact seven move names, three delegate names, six stay names, three state names, and current-base spans from the design spec.
+- Produces: `MOVE_METHODS`, `DELEGATE_METHODS`, `STAY_METHODS`, `TASK_BASE`, AST helpers, and a live `origin/dev` drift test used again after the final rebase.
+
+- [ ] **Step 1: Add path-first AST tests without importing the missing module**
+
+  Define the exact sets in the new architecture file:
+
+  ```python
+  MOVE_METHODS = frozenset({
+      "_console_change_review_provider",
+      "_console_change_review_workspace_roots",
+      "_console_selection_feedback_flow",
+      "_create_console_selection_note",
+      "_load_console_annotation_previews",
+      "_record_console_feedback_event",
+      "_sync_console_annotation_discovery",
+  })
+  DELEGATE_METHODS = frozenset({
+      "action_open_trajectory_view",
+      "on_console_selection_feedback_requested",
+      "on_console_selection_note_requested",
+  })
+  STAY_METHODS = frozenset({
+      "_console_change_review_run_id",
+      "_console_review_notes_flow",
+      "_console_selection_quote_requested",
+      "_dismiss_console_selection_menus_outside_transcript",
+      "_open_change_review",
+      "on_console_review_notes_requested",
+  })
+  ```
+
+  Assert the final contract:
+
+  - all seven move names are direct methods on `ConsoleReviewSelectionController` and absent from `ChatScreen`;
+  - all six stays remain direct `ChatScreen` methods and are absent from the controller;
+  - all three delegates retain their current Textual decorator/binding surfaces, call one `self._review_selection` entrypoint, contain no policy, and span at most five physical lines excluding decorators;
+  - `_build_trajectory_snapshot` is a module-level function in `review_selection.py`, absent from `chat_screen.py`, and the review module has no module-scope import of `trajectory_screen`;
+  - `ChatScreen` declares three `_ControllerState` descriptors pointing to `("_review_selection", "annotation_loaded_conversation")`, `("_review_selection", "annotation_previews")`, and `("_review_selection", "selection_feedback_inflight")` and has no instance assignment to the compatibility names;
+  - descriptor access before wiring raises `RuntimeError`;
+  - the controller has no `query`, `query_one`, `focus`, `push_screen`, `ChatScreen`, `__getattr__`, `__getattribute__`, mixin base, SQL literal/execute call, Git subprocess, or stored sibling-controller accessor/object;
+  - `build_console_controllers()` assigns `screen._review_selection` exactly once and is the sole production constructor;
+  - the constructor has only named keyword-only callables and no `screen`, `app_instance`, dependency object, `*args`, or `**kwargs` escape hatch;
+  - `chat_screen.py` is at most 17,200 lines / 532 direct methods and the immutable ratchet is not raised.
+
+- [ ] **Step 2: Add current-base arithmetic and durable rebase drift coverage**
+
+  Read the frozen `TASK_BASE` and live `origin/dev` sources with bounded `git show`. For the frozen base, assert 17,599/539, the 16 exact candidate names, 840 total lines, seven/three/six, 280 move lines, 426 stay lines, and conservative 399/7 removal. For live `origin/dev`, accept only one of two complete states:
+
+  ```python
+  if MOVE_METHODS <= origin_screen_methods:
+      assert exact_current_family(origin_screen) == reviewed_family
+      assert projected_counts(origin_screen) <= (17_200, 532)
+  else:
+      assert final_owner_contract(origin_screen, origin_review_module)
+  ```
+
+  Any partial family, span change, classification change, missing lazy-import guarantee, or higher projection fails and requires a written amendment.
+
+- [ ] **Step 3: Run the new test and observe RED**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/Architecture/test_console_review_selection_controller_boundary.py -q
+  ```
+
+  Expected: FAIL because `review_selection.py` and `ConsoleReviewSelectionController` do not exist and the seven methods/state still belong to `ChatScreen`.
+
+- [ ] **Step 4: Commit the RED contract**
+
+  ```bash
+  git add Tests/Architecture/test_console_review_selection_controller_boundary.py
+  git commit -m "test(console): freeze review selection boundary"
+  ```
+
+## Task 2: Establish the controller, state, and wiring seam
+
+**Files:**
+
+- Create: `tldw_chatbook/UI/Console_Modules/review_selection.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/UI/test_console_controller_wiring.py`
+- Modify: `Tests/Architecture/test_console_review_selection_controller_boundary.py`
+
+**Interfaces:**
+
+- Consumes: current screen/app/store services only through late-bound wiring lambdas.
+- Produces: `ConsoleReviewSelectionController`, `screen._review_selection`, three owner state fields, and these exact public controller entrypoints for retained framework callers: `request_selection_feedback(self, action: str, quote: str, anchor_message_id: str | None) -> None`, `request_selection_note(self, quote: str) -> None`, and `open_trajectory_view(self) -> None`.
+
+- [ ] **Step 1: Extend the wiring tests first**
+
+  Import `ConsoleReviewSelectionController`, add `("_review_selection", ConsoleReviewSelectionController)` to `_ALL_CONTROLLER_SLOTS` immediately before `_send_price`, and rename the count-specific test to seventeen. Add `test_review_selection_controller_is_late_bound_without_sibling_objects` that replaces each permitted screen target after construction, calls the stored seam, and observes the replacement.
+
+  The test must also assert initial owner state:
+
+  ```python
+  assert controller.annotation_loaded_conversation is None
+  assert controller.annotation_previews == {}
+  assert controller.selection_feedback_inflight is False
+  ```
+
+  Run and expect import/collection RED:
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_controller_wiring.py -q
+  ```
+
+- [ ] **Step 2: Add the smallest importable controller skeleton**
+
+  Create a non-Textual module with a documenting 7/3/6 ownership header and this constructor contract:
+
+  ```python
+  class ConsoleReviewSelectionController:
+      def __init__(
+          self,
+          *,
+          store_accessor: Callable[[], Any],
+          agent_conversation_id_accessor: Callable[[], str | None],
+          change_review_provider_accessor: Callable[[str], Any | None],
+          run_active_accessor: Callable[[], bool],
+          run_active_for_root: Callable[[str], bool],
+          workspace_roots_accessor: Callable[[], tuple[str, ...] | None],
+          agent_runs_db_accessor: Callable[[], Any | None],
+          native_messages_accessor: Callable[[], list[Any]],
+          run_worker: Callable[..., Any],
+          show_feedback_comment: Callable[[str, str], Awaitable[str | None]],
+          dispatch_prompt: Callable[[str], Awaitable[Any]],
+          marshal_to_ui: Callable[..., None],
+          present_trajectory: Callable[..., None],
+          notify: Callable[..., None],
+      ) -> None:
+          self.annotation_loaded_conversation: str | None = None
+          self.annotation_previews: dict[str, tuple[str, ...]] = {}
+          self.selection_feedback_inflight = False
+  ```
+
+  Store only these callables and state fields. Do not accept or cache a screen, app, Console chat controller, agent controller, prompt-queue controller, dependency dataclass, or generic callback mapping.
+
+- [ ] **Step 3: Add presentation helpers and construct through existing wiring**
+
+  In `wiring.py`, add two module-level presentation helpers:
+
+  ```python
+  async def _show_console_feedback_comment(screen: Any, action: str, quote: str) -> str | None:
+      return await screen.app.push_screen_wait(
+          ConsoleFeedbackCommentModal(action=action, quote=quote)
+      )
+
+  def _present_console_trajectory(screen: Any, launch: ConsoleTrajectoryLaunch) -> None:
+      from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
+      screen.app.push_screen(
+          TrajectoryScreen(
+              launch.snapshot,
+              screen_title=launch.screen_title,
+              conversation_id=launch.conversation_id,
+              revision_provider=launch.revision_provider,
+              snapshot_builder=launch.snapshot_builder,
+          )
+      )
+  ```
+
+  `ConsoleTrajectoryLaunch` is a frozen, slotted dataclass defined in `review_selection.py` carrying `snapshot`, `screen_title`, `conversation_id`, `revision_provider`, and `snapshot_builder`. This is data, not a dependency container. The lazy import must stay inside `_present_console_trajectory`.
+
+  Construct `screen._review_selection` immediately before `_send_price`. Wire each fine-grained callable with a late-bound lambda that resolves the exact current operation/fact at call time. No callable may return `_agent`, `_prompt_queue`, `_session`, or `_console_chat_controller`; only the store/service object, scalar/tuple fact, or operation result may cross.
+
+- [ ] **Step 4: Move the three mutable fields and install fail-loud compatibility**
+
+  Reuse the existing descriptor class:
+
+  ```python
+  _console_annotation_loaded_conversation = _ControllerState(
+      "_review_selection", "annotation_loaded_conversation"
+  )
+  _console_annotation_previews = _ControllerState(
+      "_review_selection", "annotation_previews"
+  )
+  _console_selection_feedback_inflight = _ControllerState(
+      "_review_selection", "selection_feedback_inflight"
+  )
+  ```
+
+  Remove the three `__init__` assignments. Preserve mutable-map identity: reads and writes both forward; no screen or descriptor shadow is permitted.
+
+- [ ] **Step 5: Run seam tests**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_controller_wiring.py Tests/Architecture/test_console_review_selection_controller_boundary.py -q
+  ```
+
+  Expected: wiring/state tests GREEN; architecture remains RED only for not-yet-moved methods, adapter, delegates, and final count.
+
+- [ ] **Step 6: Commit the seam**
+
+  ```bash
+  git add tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_controller_wiring.py Tests/Architecture/test_console_review_selection_controller_boundary.py
+  git commit -m "refactor(console): establish review selection controller seam"
+  ```
+
+## Task 3: Move change-review and annotation-discovery policy
+
+**Files:**
+
+- Create: `Tests/UI/test_console_review_selection_controller.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/review_selection.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/UI/test_change_review_opener_roots.py`
+- Modify: `Tests/UI/test_console_annotation_markers.py`
+
+**Interfaces:**
+
+- Consumes: `agent_conversation_id_accessor`, `change_review_provider_accessor`, live run probes, `workspace_roots_accessor`, `native_messages_accessor`, `run_worker`, and an explicit store argument for discovery.
+- Produces these exact moved controller signatures: `_console_change_review_provider(self) -> Any | None`, `_console_change_review_workspace_roots(self) -> tuple[str, ...] | None`, `_sync_console_annotation_discovery(self, store: Any) -> None`, and async `_load_console_annotation_previews(self, database: Any, store: Any, conversation_id: str) -> None`.
+
+- [ ] **Step 1: Write isolated RED tests with plain fakes**
+
+  Cover:
+
+  - missing/raising agent identity returns no change-review provider;
+  - a provider receives the live `run_active` and `run_active_for_root` callables, not captured boolean state;
+  - workspace roots return the exact tuple and degrade to `None` on missing/raised collaborators;
+  - missing persisted conversation clears loaded id/previews, same conversation dispatches no duplicate load, transition clears previews and dispatches one named worker;
+  - annotation DB read occurs off the event-loop thread;
+  - persisted annotation ids re-key to current native ids and preserve comment order;
+  - a stale conversation result and a load failure leave current state untouched and do not leak note content.
+
+  Use the exact node names `test_annotation_loader_discards_stale_conversation_result`, `test_annotation_loader_rekeys_on_event_loop_after_worker_read`, and `test_change_review_provider_uses_live_run_probes`, because Task 6 invokes them directly.
+
+  Run and observe RED on missing methods:
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py -q
+  ```
+
+- [ ] **Step 2: Move the four methods without screen delegates**
+
+  Preserve existing bodies and exception posture, replacing only ambient accesses with the constructor callables and owner state. The loader may update `annotation_previews` only after `await asyncio.to_thread(...)` resumes. Remove all four definitions from `ChatScreen`; do not leave same-name delegates.
+
+- [ ] **Step 3: Retarget production callers to the owner**
+
+  Update:
+
+  ```python
+  self._review_selection._sync_console_annotation_discovery(store)
+  transcript.set_change_review_provider_factory(
+      self._review_selection._console_change_review_provider
+  )
+  provider = self._review_selection._console_change_review_provider()
+  workspace_roots = self._review_selection._console_change_review_workspace_roots()
+  ```
+
+  In the screen-owned ADR-068 reload branch, set the compatibility descriptor as today, then await `self._review_selection._load_console_annotation_previews(...)`; retain the screen-owned transcript sync immediately afterward.
+
+- [ ] **Step 4: Retarget focused test seams only**
+
+  - Change direct `screen._sync_console_annotation_discovery(store)` calls to `screen._review_selection._sync_console_annotation_discovery(store)`.
+  - In `test_change_review_opener_roots.py`, patch or inspect the owning controller methods while keeping mounted `v`/opener expectations unchanged.
+  - Keep state assertions through the three fail-loud compatibility descriptors to prove read/write forwarding and map identity.
+
+- [ ] **Step 5: Run focused change-review/annotation tests**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py Tests/Architecture/test_console_review_selection_controller_boundary.py -q
+  ```
+
+  At this checkpoint, only the four previously documented nested-row assertions may remain red; no new failure is accepted.
+
+- [ ] **Step 6: Commit the coherent slice**
+
+  ```bash
+  git add tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py
+  git commit -m "refactor(console): move review annotation policy"
+  ```
+
+## Task 4: Move selection feedback and note policy with a safe thread boundary
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Console_Modules/review_selection.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/UI/test_console_review_selection_controller.py`
+- Modify: `Tests/UI/test_console_selection_end_to_end.py`
+- Modify: `Tests/UI/test_console_annotation_markers.py`
+
+**Interfaces:**
+
+- Consumes: `store_accessor`, `show_feedback_comment`, `dispatch_prompt`, `run_worker`, `notify`.
+- Produces the three remaining exact moved signatures plus event-free request entrypoints: `_record_console_feedback_event(self, store: Any | None, session_id: str | None, action: str, quote: str, comment: str, anchor_message_id: str | None) -> bool`, async `_console_selection_feedback_flow(self, action: str, quote: str, anchor_message_id: str | None = None) -> None`, and async `_create_console_selection_note(self, quote: str) -> None`.
+
+  `_record_console_feedback_event` returns `True` only when the comment annotation was created; it catches every persistence error and never mutates controller state.
+
+- [ ] **Step 1: Extend isolated RED coverage**
+
+  Add plain-fake tests for blank/duplicate request guards, cancel, exact message composition, no-anchor dispatch, non-fatal audit failure, annotation-only-for-nonempty-comment, audit-before-dispatch, `finally` guard release, note validation/title/provenance/date cap, missing DB, markup-safe success, and privacy-safe failure.
+
+  Add a thread-bound preview map:
+
+  ```python
+  class _EventLoopOnlyMap(dict):
+      def __init__(self, owner_thread: int) -> None:
+          super().__init__()
+          self.owner_thread = owner_thread
+      def __setitem__(self, key: str, value: tuple[str, ...]) -> None:
+          assert threading.get_ident() == self.owner_thread
+          super().__setitem__(key, value)
+  ```
+
+  Use it in `test_feedback_preview_map_changes_only_on_event_loop`; record the store write thread and assert it differs from the map mutation/event-loop thread.
+
+  Add exact mutation nodes named `test_feedback_audit_finishes_before_dispatch`, `test_feedback_guard_releases_after_dispatch_error`, and `test_note_write_failure_never_logs_selected_text`.
+
+- [ ] **Step 2: Move feedback policy and harden the worker boundary**
+
+  In the event-loop coroutine, capture the current store and session id with a non-fatal guarded lookup before `to_thread`. Then:
+
+  ```python
+  annotation_created = await asyncio.to_thread(
+      self._record_console_feedback_event,
+      store,
+      session_id,
+      action,
+      quote,
+      comment,
+      anchor_message_id,
+  )
+  if annotation_created and anchor_message_id:
+      existing = self.annotation_previews.get(anchor_message_id, ())
+      self.annotation_previews[anchor_message_id] = existing + (comment,)
+  await self._dispatch_prompt("\n".join(lines))
+  ```
+
+  The blocking helper owns only store writes and a boolean result. It must not call sibling-controller accessors, inspect the screen, or mutate `annotation_previews`. Preserve audit-before-send and non-fatal audit failure.
+
+- [ ] **Step 3: Move note policy and install the two complete Textual delegates**
+
+  Move `_create_console_selection_note` and the validation/provenance/privacy behavior to the controller. Add request entrypoints that validate blank input, arm/schedule the reviewed worker, and capture immutable event values.
+
+  Reduce the screen handlers to complete framework boundaries:
+
+  ```python
+  # Import the long Textual message names with these local type aliases so
+  # Ruff formatting cannot expand either delegate past the five-line ceiling.
+  FeedbackRequested = ConsoleSelectionFeedbackRequested
+  NoteRequested = ConsoleSelectionNoteRequested
+
+  @on(ConsoleSelectionFeedbackRequested)
+  def on_console_selection_feedback_requested(self, event: FeedbackRequested) -> None:
+      event.stop()
+      self._review_selection.request_selection_feedback(
+          event.action, event.quote, event.anchor_message_id
+      )
+
+  @on(ConsoleSelectionNoteRequested)
+  def on_console_selection_note_requested(self, event: NoteRequested) -> None:
+      event.stop()
+      self._review_selection.request_selection_note(event.quote)
+  ```
+
+  Keep the shown short type aliases and format each definition to at most five physical lines excluding decorators; do not move policy back onto the screen to satisfy formatting.
+
+- [ ] **Step 4: Run focused feedback/note regressions**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_annotation_markers.py Tests/Architecture/test_console_review_selection_controller_boundary.py -q
+  ```
+
+  Expected: all feedback/note/controller nodes GREEN; only documented stale nested-marker assertions may remain red.
+
+- [ ] **Step 5: Commit the persistence/threading slice**
+
+  ```bash
+  git add tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_review_selection_controller.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_annotation_markers.py
+  git commit -m "refactor(console): move selection feedback policy"
+  ```
+
+## Task 5: Move trajectory ownership, finish delegates, and repair focused ownership handles
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Console_Modules/review_selection.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/UI/test_console_review_selection_controller.py`
+- Modify: `Tests/UI/test_trajectory_live.py`
+- Modify: `Tests/UI/test_console_turn_undo_all.py`
+- Modify: `Tests/UI/test_console_annotation_markers.py`
+- Modify: `Tests/Architecture/test_console_review_selection_controller_boundary.py`
+
+**Interfaces:**
+
+- Consumes: current store/session metadata, agent-runs DB seam, `run_worker`, `marshal_to_ui`, `present_trajectory`, and existing store/repository read APIs.
+- Produces: module function `_build_trajectory_snapshot`, `ConsoleTrajectoryLaunch`, `open_trajectory_view()`, and the final screen action delegate.
+
+- [ ] **Step 1: Retarget the trajectory helper tests RED-first**
+
+  Change only the helper import:
+
+  ```python
+  from tldw_chatbook.UI.Console_Modules.review_selection import (
+      _build_trajectory_snapshot,
+  )
+  ```
+
+  Keep `TrajectoryScreen` imports and behavioral assertions where presentation tests need them. Run the helper nodes and observe RED until the adapter moves:
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_trajectory_live.py -q -k "build_trajectory_snapshot or snapshot_builder"
+  ```
+
+- [ ] **Step 2: Move the adapter unchanged and keep projection purity**
+
+  Move `_build_trajectory_snapshot` from `chat_screen.py` to `review_selection.py` with its existing store/repository calls, `capture_failed` diagnostics, paging, citation verification, and `derive_trajectory` inputs unchanged. Move `ProviderUsage`/`derive_trajectory` imports with it; keep `ActiveCitationTraceState` in `chat_screen.py` if its independent citation-count path still uses it. Do not move service reads into `Chat/trajectory.py`.
+
+- [ ] **Step 3: Implement trajectory launch sequencing on the controller**
+
+  `open_trajectory_view()` resolves the current persisted conversation/title and current agent-runs DB, emits the same two notifications, builds off-thread, marshals back through `marshal_to_ui`, and passes a `ConsoleTrajectoryLaunch` to the presenter. Preserve `thread=True`, `exclusive=True`, and group `"trajectory-launch"`.
+
+  The launch dataclass carries live callbacks:
+
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class ConsoleTrajectoryLaunch:
+      snapshot: TrajectorySnapshot
+      screen_title: str
+      conversation_id: str
+      revision_provider: Callable[[], int]
+      snapshot_builder: Callable[[], TrajectorySnapshot]
+  ```
+
+- [ ] **Step 4: Install the final action delegate and retarget patch handles**
+
+  Replace `ChatScreen.action_open_trajectory_view` with:
+
+  ```python
+  def action_open_trajectory_view(self) -> None:
+      """Open Trace for the active Console conversation (``y``)."""
+      self._review_selection.open_trajectory_view()
+  ```
+
+  In `test_console_turn_undo_all.py`, retarget the two monkeypatches from `screen._console_change_review_provider` to `screen._review_selection._console_change_review_provider`. Do not add a callable compatibility facade. Retarget any remaining direct moved-method test call similarly.
+
+- [ ] **Step 5: Correct the four stale nested-marker assertions without production changes**
+
+  Add one test-only recursive row helper:
+
+  ```python
+  def _all_rows(transcript: ConsoleTranscript) -> list[Any]:
+      rows: list[Any] = []
+      def visit(row: Any) -> None:
+          rows.append(row)
+          for nested in row.nested_rows:
+              visit(nested)
+      for row in transcript._transcript_rows():
+          visit(row)
+      return rows
+  ```
+
+  Use it only where the four stale assertions currently search top-level rows for `kind == "annotations"`. Keep the same marker count/content expectations; do not alter transcript grouping/rendering.
+
+- [ ] **Step 6: Run the complete focused behavior/ownership suite**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_turn_undo_all.py Tests/UI/test_trajectory_live.py Tests/UI/test_console_controller_wiring.py Tests/Architecture/test_console_review_selection_controller_boundary.py Tests/Architecture/test_console_wave6_closeout_inventory.py -q
+  ```
+
+  Expected: GREEN. This is the focused suite; do not add other repository paths merely to increase the count.
+
+- [ ] **Step 7: Commit the completed extraction checkpoint**
+
+  ```bash
+  git add tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_review_selection_controller.py Tests/UI/test_trajectory_live.py Tests/UI/test_console_turn_undo_all.py Tests/UI/test_console_annotation_markers.py Tests/Architecture/test_console_review_selection_controller_boundary.py
+  git commit -m "refactor(console): complete review selection ownership"
+  ```
+
+## Task 6: Prove high-risk tests with bounded manual mutations
+
+**Files:**
+
+- Temporarily modify, then restore with `apply_patch`: `tldw_chatbook/UI/Console_Modules/review_selection.py`
+- Test: `Tests/UI/test_console_review_selection_controller.py`
+
+**Interfaces:**
+
+- Consumes: a clean committed extraction checkpoint.
+- Produces: five observed RED/GREEN pairs with no mutation residue.
+
+For every mutation: make one semantic edit with `apply_patch`, run only the named node and observe RED, restore the exact inverse with `apply_patch`, rerun GREEN, then require `git diff --exit-code`. Never use `git checkout`, `git reset`, a mutation dependency, or an unbounded test sweep.
+
+- [ ] **Mutation 1: stale annotation result rejection**
+
+  Temporarily remove/invert the `annotation_loaded_conversation` comparison before loader state replacement.
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py::test_annotation_loader_discards_stale_conversation_result -q
+  ```
+
+  Expected mutated result: RED because a prior conversation paints its preview map. Restore and expect GREEN.
+
+- [ ] **Mutation 2: feedback inflight release**
+
+  Temporarily move `selection_feedback_inflight = False` out of the flow's `finally` block.
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py::test_feedback_guard_releases_after_dispatch_error -q
+  ```
+
+  Expected mutated result: RED because an exception latches the feature. Restore and expect GREEN.
+
+- [ ] **Mutation 3: audit-before-dispatch ordering**
+
+  Temporarily dispatch the composed prompt before awaiting feedback persistence.
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py::test_feedback_audit_finishes_before_dispatch -q
+  ```
+
+  Expected mutated result: RED on observed call order. Restore and expect GREEN.
+
+- [ ] **Mutation 4: event-loop-only preview mutation**
+
+  Temporarily move the `annotation_previews` assignment back inside `_record_console_feedback_event`.
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py::test_feedback_preview_map_changes_only_on_event_loop -q
+  ```
+
+  Expected mutated result: RED from `_EventLoopOnlyMap` on the worker thread. Restore and expect GREEN.
+
+- [ ] **Mutation 5: selection-note privacy logging**
+
+  Temporarily include `title` or `quote` in the note write-failure log.
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py::test_note_write_failure_never_logs_selected_text -q
+  ```
+
+  Expected mutated result: RED because the sentinel selected text appears in captured logs. Restore and expect GREEN.
+
+- [ ] **Step 6: Confirm exact restoration**
+
+  ```bash
+  git diff --exit-code
+  git status --short
+  ```
+
+  Retain the five RED/GREEN outcomes in the active evidence for final Implementation Notes; commit no mutation.
+
+## Task 7: Run targeted static, privacy, diagnostic, and repository gates
+
+**Files:**
+
+- Modify only if reviewed statement ownership requires it: `Docs/security/production-diagnostic-inventory.json`
+- Test: `Tests/Architecture/test_persistent_diagnostic_inventory.py`
+- Test: `Tests/CI/test_backlog_task_id_uniqueness.py`
+
+**Interfaces:**
+
+- Consumes: the clean extraction checkpoint and exact modified Python paths.
+- Produces: focused Ruff/format/compile, privacy, diagnostic, task-ID, count, and diff evidence.
+
+- [ ] **Step 1: Run targeted Ruff, format, compile, and diff checks**
+
+  ```bash
+  ../../.venv/bin/python -m ruff check tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Architecture/test_console_review_selection_controller_boundary.py Tests/UI/test_console_controller_wiring.py Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_turn_undo_all.py Tests/UI/test_trajectory_live.py
+  ../../.venv/bin/python -m ruff format --check tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Architecture/test_console_review_selection_controller_boundary.py Tests/UI/test_console_controller_wiring.py Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_turn_undo_all.py Tests/UI/test_trajectory_live.py
+  ../../.venv/bin/python -c 'from pathlib import Path; paths = ["tldw_chatbook/UI/Console_Modules/review_selection.py", "tldw_chatbook/UI/Console_Modules/wiring.py", "tldw_chatbook/UI/Screens/chat_screen.py"]; [compile(Path(path).read_bytes(), path, "exec") for path in paths]'
+  git diff --check
+  ```
+
+- [ ] **Step 2: Run exact architecture/count/privacy gates**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/Architecture/test_console_review_selection_controller_boundary.py Tests/Architecture/test_console_wave6_closeout_inventory.py Tests/Architecture/test_persistent_diagnostic_inventory.py Tests/CI/test_backlog_task_id_uniqueness.py -q
+  rg -n "logger\.|log\.|notify\(|quote|comment|title|api[_ -]?key|provider.*error" tldw_chatbook/UI/Console_Modules/review_selection.py
+  ```
+
+  Manually verify each log/notification preserves the reviewed privacy boundary. The selected quote/comment/title may appear only in intended user-visible content or persistence arguments, never new diagnostics.
+
+- [ ] **Step 3: Validate and reconcile persistent diagnostics only if needed**
+
+  First run the non-write checker:
+
+  ```bash
+  ../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+  ```
+
+  If it reports moved statement ownership, inspect the exact source pair against the inventory base:
+
+  ```bash
+  git log -1 --format=%H -- Docs/security/production-diagnostic-inventory.json
+  ../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py --statements tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Console_Modules/review_selection.py --since <inventory-base-sha>
+  ```
+
+  Only after confirming metadata relocation with no widened payload, regenerate through the supported writer and rerun:
+
+  ```bash
+  ../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py --write
+  ../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+  ```
+
+- [ ] **Step 4: Run repository task hygiene and no-placeholder scans**
+
+  ```bash
+  ../../.venv/bin/python scripts/check_backlog_task_ids.py
+  ../../.venv/bin/python -c 'from pathlib import Path; p = [Path("Docs/superpowers/plans/2026-08-27-task-3070-13-console-review-selection-controller.md"), Path("backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md")]; needles = [bytes.fromhex(value).decode() for value in ("544244", "544f444f", "696d706c656d656e74206c61746572", "66696c6c20696e2064657461696c73")]; hits = [(str(path), needle) for path in p for needle in needles if needle in path.read_text()]; assert not hits, hits'
+  ```
+
+  Expected: task-ID checker GREEN and placeholder scan empty.
+
+- [ ] **Step 5: Commit diagnostic inventory relocation only if present**
+
+  ```bash
+  git add Docs/security/production-diagnostic-inventory.json
+  git commit -m "docs(security): relocate review selection diagnostics"
+  ```
+
+  Skip this commit when the inventory is unchanged.
+
+## Task 8: Rebase, revalidate, record evidence, and deliver
+
+**Files:**
+
+- Modify: `backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md`
+- Modify only for a real reusable incident: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-backlog-hygiene.md`
+
+**Interfaces:**
+
+- Consumes: clean focused-green branch, five mutation proofs, and latest `origin/dev`.
+- Produces: post-rebase evidence, checked acceptance criteria, Implementation Notes, Done task status, and PR-ready branch.
+
+- [ ] **Step 1: Self-review before rebase**
+
+  ```bash
+  git diff --stat origin/dev...HEAD
+  git diff --check origin/dev...HEAD
+  git diff origin/dev...HEAD -- tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py
+  ```
+
+  Verify no behavior redesign, new durable authority, sibling-controller object, broad screen facade, stale re-export, shadow state, eager trajectory import, privacy widening, ratchet increase, or unrelated edit entered the branch.
+
+- [ ] **Step 2: Rebase onto latest dev with a clean tree**
+
+  ```bash
+  git status --short
+  git fetch origin dev
+  git rebase origin/dev
+  ```
+
+  If the rebase changes the reviewed family or makes the architecture drift test red, stop and amend the spec/task rather than absorbing the change.
+
+- [ ] **Step 3: Run the executable live-base drift gate first**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/Architecture/test_console_review_selection_controller_boundary.py::test_origin_dev_review_selection_family_still_matches_review -q
+  ```
+
+  Expected: GREEN in either complete pre-extraction or complete post-extraction state; partial/unrecognized state is a blocker.
+
+- [ ] **Step 4: Rerun final focused evidence after rebase**
+
+  ```bash
+  ../../.venv/bin/python -m pytest Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_turn_undo_all.py Tests/UI/test_trajectory_live.py Tests/UI/test_console_controller_wiring.py Tests/Architecture/test_console_review_selection_controller_boundary.py Tests/Architecture/test_console_wave6_closeout_inventory.py -q
+  ../../.venv/bin/python -m ruff check tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Architecture/test_console_review_selection_controller_boundary.py Tests/UI/test_console_controller_wiring.py Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_turn_undo_all.py Tests/UI/test_trajectory_live.py
+  ../../.venv/bin/python -m ruff format --check tldw_chatbook/UI/Console_Modules/review_selection.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Architecture/test_console_review_selection_controller_boundary.py Tests/UI/test_console_controller_wiring.py Tests/UI/test_console_review_selection_controller.py Tests/UI/test_change_review_opener_roots.py Tests/UI/test_console_annotation_markers.py Tests/UI/test_console_selection_end_to_end.py Tests/UI/test_console_turn_undo_all.py Tests/UI/test_trajectory_live.py
+  ../../.venv/bin/python -c 'from pathlib import Path; paths = ["tldw_chatbook/UI/Console_Modules/review_selection.py", "tldw_chatbook/UI/Console_Modules/wiring.py", "tldw_chatbook/UI/Screens/chat_screen.py"]; [compile(Path(path).read_bytes(), path, "exec") for path in paths]'
+  ../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+  ../../.venv/bin/python scripts/check_backlog_task_ids.py
+  git diff --check
+  ```
+
+  Expected: all targeted gates GREEN. Do not run a local full suite.
+
+- [ ] **Step 5: Record post-rebase implementation evidence**
+
+  Use Backlog.md CLI to check all five acceptance criteria and add concise `## Implementation Notes` covering:
+
+  - the final one-owner extraction and exact 7/3/6 boundary;
+  - final `ChatScreen` line/direct-method counts and conservative reduction;
+  - named fine-grained wiring and three fail-loud descriptors;
+  - preserved ADR-068 screen-owned review-note flow and existing Git/database authority;
+  - worker-thread persistence versus event-loop preview mutation evidence;
+  - focused pytest/Ruff/format/compile/privacy/diagnostic/task-ID/diff results;
+  - all five mutation RED/GREEN outcomes;
+  - ADR required: no, ADR-068 path/reason, plan deviations, and whether a real lessons entry was warranted.
+
+  Do not mark Done until every Definition-of-Done item is satisfied.
+
+- [ ] **Step 6: Commit task evidence and complete the Backlog task**
+
+  ```bash
+  git add "backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md"
+  git commit -m "docs(backlog): record review selection evidence"
+  backlog task edit 3070.13 -s Done
+  git add "backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md"
+  git commit -m "docs(backlog): complete TASK-3070.13"
+  ```
+
+  Add a lessons file to the first commit only if implementation surfaced a genuinely reusable incident; do not invent one.
+
+- [ ] **Step 7: PR and merge handoff**
+
+  Push normally, or use `--force-with-lease` only if rebase rewrote the remote branch. Open/update the PR, wait for Qodo, inspect every top-level and inline review comment, verify each finding against current code, implement only technically valid minimal fixes, reply in original inline threads when applicable, rerun only affected focused tests plus required gates, and merge only when review is fully addressed, latest dev is included, required GitHub Actions are green, and GitHub permits the merge.
+
+## Plan self-review
+
+- Spec coverage: Tasks 1-5 map every goal, non-goal, ownership rule, state contract, runtime flow, compatibility retarget, and verification requirement to an executable step.
+- Placeholder scan: the plan contains no implementation placeholder; `<inventory-base-sha>` is an explicit runtime value obtained by the immediately preceding command, not missing design work.
+- Type consistency: the controller constructor, seven moved method signatures, three event-free entrypoints, `ConsoleTrajectoryLaunch`, descriptor targets, and caller spellings are consistent across all tasks.
+- Scope check: this remains one atomic controller extraction/PR; change review, annotations, feedback, notes, and trajectory are one current screen ownership family and share state/wiring/verification boundaries.

--- a/Docs/superpowers/specs/2026-08-23-console-decomposition-wave6-closeout-amendment.md
+++ b/Docs/superpowers/specs/2026-08-23-console-decomposition-wave6-closeout-amendment.md
@@ -53,6 +53,23 @@ Each extraction starts from the latest `dev` only after its predecessor merges. 
 later rebase that invalidates either exact family or the conservative projection stops
 that child for amendment; it never rewrites the evidence or raises a budget.
 
+### TASK-3070.13 current-base amendment (2026-08-27)
+
+TASK-3070.12 and an independent per-turn changed-files simplification merged before
+TASK-3070.13 began. On the resulting `dev` base `ee8dc24115`, ten methods from the
+historical 26-method review/selection inventory no longer exist. Reintroducing those
+deleted paths would be a regression, while pretending the frozen inventory still
+matched the implementation would violate the stop-and-amend rule above.
+
+The approved task-specific design at
+`2026-08-27-task-3070-13-console-review-selection-controller-design.md` therefore
+supersedes only TASK-3070.13's current implementation boundary. The immutable
+amendment evidence remains historical source-of-truth. The surviving family is 16
+methods and 840 physical lines: seven moves, three framework delegates, and six
+screen stays. With 426 stay lines and a maximum 15 delegate lines, TASK-3070.13 must
+remove at least 399 lines and seven direct methods. This revised extraction still
+reduces both current screen counts and never raises either Wave 6 ratchet.
+
 ## Ownership Boundary
 
 Both new owners follow `DESIGN.md` section 7:

--- a/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
+++ b/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
@@ -1,0 +1,375 @@
+# TASK-3070.13 Console Review and Selection Controller Design
+
+**Status:** design direction approved by the owner 2026-08-26; written amendment
+prepared for final review 2026-08-27
+
+**Task:** `TASK-3070.13 - Extract Console review and selection workflow ownership`
+
+**Depends on:** TASK-3070.12 and the approved
+`2026-08-23-console-decomposition-wave6-closeout-amendment.md`
+
+## Context and Amendment Trigger
+
+The Wave 6 closeout amendment characterized a 26-method, 1,114-line
+review/selection family at its historical base. It also required a later child to
+stop and amend rather than silently reclassify the family if a rebase invalidated
+that exact inventory.
+
+That condition now applies. TASK-3070.12 merged, and an independent per-turn
+changed-files simplification removed these ten historical methods before
+TASK-3070.13 began:
+
+- `_build_console_changed_files_state`
+- `_console_changed_files_scope`
+- `_console_changed_files_section_enabled`
+- `_dispatch_console_changed_files_worker`
+- `_land_console_changed_files`
+- `_land_console_changed_files_empty`
+- `_on_console_change_review_dismissed`
+- `_sync_console_changed_files_if_scope_changed`
+- `_sync_console_changed_files_section`
+- `handle_console_changed_files_selected`
+
+Recreating deleted changed-files coordination would restore obsolete behavior.
+Marking the task superseded would leave seven surviving policy methods on
+`ChatScreen` and fail the parent task's ownership objective. This design amends only
+the current implementation boundary for TASK-3070.13; the original inventory and
+arithmetic remain immutable historical evidence.
+
+The exact implementation base is `origin/dev` `ee8dc24115`. At that revision,
+`ChatScreen` is 17,599 physical lines with 539 direct methods. The surviving coherent
+family is 16 methods and 840 physical lines.
+
+The focused pre-change baseline is 111 passing tests out of 115. The four failures
+are pre-existing stale unit assertions in `test_console_annotation_markers.py`:
+assistant-turn grouping now nests annotation rows inside the top-level
+`assistant-turn` row, while those assertions still search only top-level rows. The
+mounted annotation, persistence, feedback, note, review-note, trajectory, and
+architecture coverage passes. This task may correct those four test traversals but
+must not change product behavior to satisfy them.
+
+## Goals
+
+1. Give the seven surviving policy methods one explicit, non-DOM owner.
+2. Preserve the three Textual event/action boundaries as complete delegates of at
+   most five physical lines each.
+3. Retain the six exact DOM, modal, composer, dismissal, and ADR-068 review-note
+   methods on `ChatScreen`.
+4. Move annotation preview/load identity and selection-feedback exclusion state to
+   the new owner without mirrored state or stale compatibility behavior.
+5. Preserve Git, run-store, note, annotation, prompt-queue, privacy, cancellation,
+   and user-visible behavior.
+6. Remove at least 399 physical `ChatScreen` lines and seven direct methods without
+   raising a ratchet.
+
+## Non-goals
+
+- Reintroducing the deleted changed-files section or its worker/state machinery.
+- Redesigning change review, annotations, review notes, feedback copy, note format,
+  selection UX, trajectory presentation, or persistence schemas.
+- Moving Git, database, run-store, prompt-queue, or transcript rendering authority.
+- Moving ADR-068's review-note fetch, optimistic edit/delete wrappers, modal, or
+  forced inline preview reload out of `ChatScreen`.
+- Moving composer quote insertion, selection-menu dismissal, or change-review screen
+  presentation out of `ChatScreen`.
+- Adding a mixin, dynamic method facade, ambient screen reference, sibling-controller
+  reference, or shadow compatibility state.
+- Running a local full test suite. Required GitHub Actions remain the broad
+  integration gate.
+
+## Current-Base Method Inventory
+
+Physical spans are measured from the exact implementation base. The classification
+is exhaustive and binding for this task.
+
+| Method | Lines | Classification | Reason |
+|---|---:|---|---|
+| `_console_change_review_provider` | 35 | move | collaborator and run-state policy; no DOM |
+| `_console_change_review_run_id` | 35 | stay | reads the mounted transcript before store fallback |
+| `_console_change_review_workspace_roots` | 27 | move | execution-context policy; no DOM |
+| `_console_review_notes_flow` | 217 | stay | explicit ADR-068 screen-owned modal/fetch/mutate/reload flow |
+| `_console_selection_feedback_flow` | 44 | move | modal-result sequencing, audit ordering, and prompt dispatch |
+| `_console_selection_quote_requested` | 24 | stay | Textual event plus composer DOM insertion |
+| `_create_console_selection_note` | 52 | move | validation, provenance, persistence, and privacy policy |
+| `_dismiss_console_selection_menus_outside_transcript` | 64 | stay | screen DOM ancestry and presentation cleanup |
+| `_load_console_annotation_previews` | 28 | move | off-thread load, stale-conversation guard, and re-keying policy |
+| `_open_change_review` | 55 | stay | constructs and pushes the presentation screen |
+| `_record_console_feedback_event` | 60 | move | durable audit/annotation policy and immediate preview update |
+| `_sync_console_annotation_discovery` | 34 | move | conversation transition and worker-dispatch policy |
+| `action_open_trajectory_view` | 62 | delegate | Textual binding must remain on the screen |
+| `on_console_review_notes_requested` | 31 | stay | ADR-068 event ownership and inflight contract |
+| `on_console_selection_feedback_requested` | 48 | delegate | Textual `@on` boundary must remain on the screen |
+| `on_console_selection_note_requested` | 24 | delegate | Textual `@on` boundary must remain on the screen |
+| **Total** | **840** | **7 move / 3 delegate / 6 stay** | |
+
+The seven move methods contain 280 lines. The six stays contain 426 lines. Capping
+each complete delegate at five lines leaves at most 441 screen lines from this
+family, so the minimum net removal is 399 lines and seven direct methods. The
+conservative post-extraction screen is therefore at most 17,200 lines and 532 direct
+methods. Actual results may be smaller; the projection is not a new ratchet.
+
+## Considered Approaches
+
+### 1. Dedicated `ConsoleReviewSelectionController` (chosen)
+
+Create `tldw_chatbook/UI/Console_Modules/review_selection.py`, construct one
+controller through the existing `build_console_controllers()` seam, and install it as
+`screen._review_selection`. Move the seven policy methods and the controller-side
+implementations behind the three delegates.
+
+This creates one inspectable owner, follows `DESIGN.md` section 7, preserves the
+framework boundary, and supports direct tests with plain fakes.
+
+### 2. Close TASK-3070.13 as superseded
+
+This correctly avoids restoring deleted changed-files code but leaves seven policy
+methods and their mutable state on `ChatScreen`. It does not satisfy the parent
+ownership acceptance criterion and is rejected.
+
+### 3. Recreate the historical 26-method family
+
+This would regress the independently simplified per-turn review path solely to make
+old inventory arithmetic match. It is rejected.
+
+### 4. Mixin or broad screen delegates
+
+A mixin preserves ambient access to all screen state. Delegating every moved method
+preserves direct-method inventory and dual navigation paths. Both hide rather than
+improve ownership and are rejected.
+
+## Ownership and Module Boundary
+
+`ConsoleReviewSelectionController` owns:
+
+- change-review provider construction and live workspace-root resolution;
+- annotation discovery transitions, background loading, stale-result rejection, and
+  native-message re-keying;
+- selection-feedback mutual exclusion, comment result handling, message composition,
+  durable audit ordering, annotation sidecar writes, and prompt-queue dispatch;
+- selection-note validation, title/provenance derivation, off-thread persistence,
+  privacy-safe failure logging, and notification policy;
+- trajectory snapshot orchestration and background build sequencing.
+
+The controller does not query the DOM, focus widgets, construct or push Textual
+screens/modals, reference `ChatScreen`, or hold sibling-controller objects. External
+work is expressed through named, late-bound callables installed in
+`UI/Console_Modules/wiring.py`.
+
+`ChatScreen` retains exactly:
+
+- `_console_change_review_run_id`;
+- `_console_review_notes_flow`;
+- `_console_selection_quote_requested`;
+- `_dismiss_console_selection_menus_outside_transcript`;
+- `_open_change_review`;
+- `on_console_review_notes_requested`.
+
+It also retains the three binding methods as complete delegates:
+
+- `action_open_trajectory_view`;
+- `on_console_selection_feedback_requested`;
+- `on_console_selection_note_requested`.
+
+Each delegate may stop its event where applicable and invoke one controller entrypoint.
+It contains no validation, inflight, worker, persistence, modal-result, or dispatch
+policy and spans at most five physical source lines.
+
+## Construction and Dependencies
+
+`build_console_controllers()` remains the single construction API and adds
+`screen._review_selection`. Its docstring and controller count are updated; no second
+wiring path is introduced.
+
+Named callables cover these capabilities:
+
+- current/ensured Console chat controller and store;
+- current/ensured agent bridge and current run state;
+- native Console messages;
+- worker scheduling and UI-thread callback marshaling;
+- prompt-queue dispatch;
+- feedback-comment modal wait;
+- trajectory-screen presentation;
+- native transcript synchronization;
+- user notifications.
+
+The presentation callbacks may close over the screen in wiring, but the controller
+does not retain or discover the screen. The trajectory presenter owns lazy
+`TrajectoryScreen` import/construction and `app.push_screen`; the controller owns
+only the snapshot inputs, worker sequencing, and handoff. The feedback-modal callback
+similarly owns Textual modal construction/wait while returning only the comment
+result to the controller.
+
+Sibling behavior is reached through purpose-named callables, never by passing
+`screen._agent`, `screen._prompt_queue`, or another controller object.
+
+## State and Compatibility
+
+The controller is the sole owner of:
+
+- `annotation_loaded_conversation: str | None`;
+- `annotation_previews: dict[str, tuple[str, ...]]`;
+- `selection_feedback_inflight: bool`.
+
+`ChatScreen` keeps temporary private compatibility names
+`_console_annotation_loaded_conversation`, `_console_annotation_previews`, and
+`_console_selection_feedback_inflight` as fail-loud read/write descriptors:
+
+- reads and writes forward to `screen._review_selection`;
+- access before controller wiring raises an actionable `RuntimeError`;
+- no descriptor or screen instance stores a shadow copy;
+- mutable-map identity is preserved so existing in-place preview updates and focused
+  tests continue to observe the controller-owned map.
+
+`_console_review_notes_inflight` remains screen-owned. The review-note flow may call
+the controller's annotation loader during its forced reload, but it continues to own
+the modal, database-bound edit/delete wrappers, conversation-current guard, and
+post-change transcript refresh required by ADR-068.
+
+## Runtime Flows
+
+### Annotation discovery and reload
+
+The existing transcript sync path calls the controller directly with the active
+store. The controller compares the persisted conversation id with its loaded id,
+clears previews on transitions, and schedules one named worker. The loader performs
+the database read off-thread, rejects a result after a conversation switch, maps
+persisted ids back to native message ids, and replaces the preview map.
+
+The screen-owned review-note flow continues to force an inline reload while idle by
+awaiting the controller loader, then synchronizing the transcript. This preserves the
+live-verification fix recorded in ADR-068.
+
+### Selection feedback
+
+The Textual handler stops the event and passes action, quote, and anchor id to the
+controller. The controller rejects blank or duplicate in-flight requests, arms its
+guard, and schedules the existing non-exclusive worker flow. The flow waits through
+the named modal callback, composes identical feedback text, records audit and optional
+annotation off-thread before dispatch, sends through the named prompt-queue callable,
+and releases the guard on every exit.
+
+Audit failure remains non-fatal. Comment annotations update the controller-owned
+preview map immediately. Raw selected text never enters new logs or diagnostic fields.
+
+### Selection note
+
+The Textual handler stops the event and delegates the quote. The controller rejects
+blank input, schedules a worker, validates the bounded untrusted text, derives the
+same title and provenance content, writes through the existing database off-thread,
+and emits markup-safe confirmation. Failure logging continues to expose title length
+only, never selected content.
+
+### Change review
+
+Existing callers request provider and workspace roots directly from the controller.
+The provider still joins on the same agent conversation id and receives live
+run-active callbacks. Workspace roots still derive from the active turn execution
+context and degrade to `None` on missing collaborators or exceptions.
+
+`_open_change_review` and `_console_change_review_run_id` remain screen-owned. They
+retain transcript-first run-id resolution, lazy `ChangeReviewScreen` import,
+constructor arguments, notification, and `push_screen` presentation.
+
+### Trajectory view
+
+The Textual action delegates to the controller. The controller resolves the current
+persisted conversation, title, run database, and snapshot builder; emits the same
+empty-state/building notifications; and builds off-thread. The named UI-thread and
+presentation callbacks push the same live-tail `TrajectoryScreen`. No controller DOM
+or Textual screen dependency is introduced.
+
+## Error Handling and Privacy
+
+The extraction preserves the existing degrade posture:
+
+- missing change-review collaborators return `None` rather than raising;
+- annotation load failures warn without logging note bodies;
+- feedback audit failure never prevents feedback dispatch;
+- selection-note failures never log selected text or derived title;
+- stale annotation loads never paint previews from a prior conversation;
+- every feedback exit releases mutual exclusion;
+- UI callbacks remain marshaled through the existing app boundary.
+
+No API key, prompt body, quote, note content, raw database row, or provider failure is
+added to diagnostics, notifications, or logs.
+
+## Verification Strategy
+
+Implementation follows red-green-refactor and uses focused local gates only.
+
+### RED-first ownership tests
+
+Add a source-inspected architecture suite proving:
+
+- all seven exact move methods are absent from `ChatScreen` and owned by
+  `ConsoleReviewSelectionController`;
+- the six exact stays remain on `ChatScreen`;
+- the three exact delegates retain their binding/action surfaces, contain only the
+  allowed handoff, and fit the five-line ceiling;
+- the controller has no Textual DOM queries, screen reference, mixin, dynamic facade,
+  sibling-controller object, Git authority, or database implementation;
+- wiring is the sole constructor and supplies the reviewed named dependencies;
+- compatibility descriptors are read/write, fail loudly before wiring, and store no
+  shadow state;
+- the current-base family spans and conservative 399-line / seven-method removal are
+  met without a ratchet increase.
+
+### Isolated controller tests
+
+Use plain fakes to cover:
+
+- change-review provider/root success and graceful degradation;
+- annotation transition clearing, stale-load rejection, native-id re-keying, and load
+  failure behavior;
+- feedback blank/duplicate guards, cancel, dispatch composition, audit-before-send,
+  annotation preview update, and `finally` release;
+- note validation, provenance/title caps, off-thread persistence, markup-safe success,
+  and privacy-safe failure;
+- trajectory missing-conversation behavior and worker-to-presentation handoff.
+
+### Mounted and repository regression tests
+
+Retarget focused tests only where ownership or patch handles move. Correct the four
+stale annotation-marker assertions to inspect the nested assistant-turn rows while
+keeping their product expectations unchanged. Run the related annotation, selection,
+change-review opener, trajectory, turn-undo, controller-wiring, and architecture
+suites. Do not run a local full suite.
+
+Use bounded manual mutation checks after a checkpoint commit for the highest-risk
+policy branches: stale annotation result rejection, feedback inflight release,
+audit-before-dispatch ordering, and selection-note privacy logging. Each temporary
+semantic edit must make its exact focused node fail, then be restored with
+`apply_patch` and rerun green. The implementation plan will name the precise edits and
+commands.
+
+Run targeted Ruff check/format on modified Python, isolated compile on modified
+production modules, diagnostic inventory generation/validation, backlog task-ID
+validation, `git diff --check`, and the Wave 6/current-boundary architecture gates.
+Review the final diff for behavior drift, accidental authority transfer, privacy
+widening, or unrelated changes.
+
+## Delivery Sequence
+
+1. Freeze the current 7/3/6 boundary and state/wiring contracts with RED tests.
+2. Add the controller, state descriptors, and plain-fake tests.
+3. Move annotation, change-review, feedback, note, and trajectory policy in coherent
+   slices, keeping focused tests green after each slice.
+4. Install the three complete delegates and retarget direct call sites/patch handles.
+5. Correct the four stale nested-marker unit traversals without production changes.
+6. Run focused behavioral, mutation, architecture, static, privacy, diagnostic,
+   backlog-ID, and diff gates.
+7. Record task evidence and rebase on the latest `origin/dev`. If that rebase changes
+   the reviewed 16-method family, invalidates 7/3/6 ownership, or breaks the
+   conservative reduction, stop and amend again before delivery.
+
+## ADR Check
+
+ADR required: no.
+
+ADR path: `backlog/decisions/068-console-text-selection-and-annotations.md`.
+
+Reason: this task applies the accepted screen/controller ownership rule in
+`DESIGN.md` section 7 and preserves ADR-068's explicit screen ownership for review
+note fetching, optimistic edit/delete wrappers, modal presentation, and forced inline
+reload. It changes neither storage/schema, Git or database authority, service
+contracts, security/privacy policy, dependency/tooling, nor long-lived UX structure.

--- a/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
+++ b/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
@@ -205,7 +205,6 @@ Named callables cover these capabilities:
 - prompt-queue dispatch;
 - feedback-comment modal wait;
 - trajectory-screen presentation;
-- native transcript synchronization;
 - user notifications.
 
 The presentation callbacks may close over the screen in wiring, but the controller

--- a/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
+++ b/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
@@ -1,7 +1,8 @@
 # TASK-3070.13 Console Review and Selection Controller Design
 
 **Status:** design direction approved by the owner 2026-08-26; written amendment
-reviewed and hardened 2026-08-27 before implementation planning
+reviewed and hardened 2026-08-27, then revalidated against latest dev before
+implementation
 
 **Task:** `TASK-3070.13 - Extract Console review and selection workflow ownership`
 
@@ -36,9 +37,16 @@ Marking the task superseded would leave seven surviving policy methods on
 the current implementation boundary for TASK-3070.13; the original inventory and
 arithmetic remain immutable historical evidence.
 
-The exact implementation base is `origin/dev` `ee8dc24115`. At that revision,
-`ChatScreen` is 17,599 physical lines with 539 direct methods. The surviving coherent
-family is 16 methods and 840 physical lines.
+The exact implementation base is `origin/dev` `c6218918d1`. At that revision,
+`ChatScreen` is 17,624 physical lines with 539 unique direct method names (569 AST
+definitions when property getter/setter definitions are counted separately). The
+surviving coherent family is 16 methods and 850 physical lines.
+
+The base moved once after the first review: TASK-2126 added semantic-capture policy
+bindings to `action_open_trajectory_view`, increasing that retained delegate from 62
+to 72 lines while leaving the seven move methods, six stays, and their behavior
+unchanged. This amendment incorporates that current behavior instead of extracting
+from the stale `ee8dc24115` body.
 
 The focused pre-change baseline is 111 passing tests out of 115. The four failures
 are pre-existing stale unit assertions in `test_console_annotation_markers.py`:
@@ -59,7 +67,7 @@ must not change product behavior to satisfy them.
    the new owner without mirrored state or stale compatibility behavior.
 5. Preserve Git, run-store, note, annotation, prompt-queue, privacy, cancellation,
    and user-visible behavior.
-6. Remove at least 399 physical `ChatScreen` lines and seven direct methods without
+6. Remove at least 409 physical `ChatScreen` lines and seven direct methods without
    raising a ratchet.
 7. Keep persistence work off the event loop without mutating controller/UI state from
    the persistence worker thread.
@@ -98,17 +106,19 @@ is exhaustive and binding for this task.
 | `_open_change_review` | 55 | stay | constructs and pushes the presentation screen |
 | `_record_console_feedback_event` | 60 | move | durable audit/annotation policy and immediate preview update |
 | `_sync_console_annotation_discovery` | 34 | move | conversation transition and worker-dispatch policy |
-| `action_open_trajectory_view` | 62 | delegate | Textual binding must remain on the screen |
+| `action_open_trajectory_view` | 72 | delegate | Textual binding must remain on the screen |
 | `on_console_review_notes_requested` | 31 | stay | ADR-068 event ownership and inflight contract |
 | `on_console_selection_feedback_requested` | 48 | delegate | Textual `@on` boundary must remain on the screen |
 | `on_console_selection_note_requested` | 24 | delegate | Textual `@on` boundary must remain on the screen |
-| **Total** | **840** | **7 move / 3 delegate / 6 stay** | |
+| **Total** | **850** | **7 move / 3 delegate / 6 stay** | |
 
-The seven move methods contain 280 lines. The six stays contain 426 lines. Capping
-each complete delegate at five lines leaves at most 441 screen lines from this
-family, so the minimum net removal is 399 lines and seven direct methods. The
-conservative post-extraction screen is therefore at most 17,200 lines and 532 direct
-methods. Actual results may be smaller; the projection is not a new ratchet.
+The seven move methods contain 280 lines. The six stays contain 426 lines. The three
+delegates now contain 144 lines. Capping each complete delegate at five lines leaves
+at most 441 screen lines from this family, so the minimum net removal is 409 lines and
+seven unique direct method names. The conservative post-extraction screen is therefore
+at most 17,215 lines and 532 unique direct method names. Actual results may be smaller;
+the projection is not a new ratchet, whose existing AST-definition budget remains
+unchanged.
 
 ## Considered Approaches
 
@@ -200,6 +210,7 @@ Named callables cover these capabilities:
 - active agent-conversation identity, change-review provider resolution, live
   run-active probes, and current turn workspace roots;
 - the current agent-runs database read seam;
+- semantic-capture policy bindings for the active session/conversation;
 - native Console messages;
 - worker scheduling and UI-thread callback marshaling;
 - prompt-queue dispatch;
@@ -303,9 +314,10 @@ constructor arguments, notification, and `push_screen` presentation.
 ### Trajectory view
 
 The Textual action delegates to the controller. The controller resolves the current
-persisted conversation, title, run database, and snapshot builder; emits the same
-empty-state/building notifications; and builds off-thread. The named UI-thread and
-presentation callbacks push the same live-tail `TrajectoryScreen`. No controller DOM
+persisted conversation, title, run database, semantic-capture policy bindings, and
+snapshot builder; emits the same empty-state/building notifications; and builds
+off-thread. The named UI-thread and presentation callbacks push the same live-tail
+`TrajectoryScreen`, including the current capture-policy bindings. No controller DOM
 or Textual screen dependency is introduced. The presentation callback keeps the
 `TrajectoryScreen` import lazy, so importing `review_selection.py` does not widen the
 Chat first-paint import leg.
@@ -346,11 +358,11 @@ Add a source-inspected architecture suite proving:
   dependencies, and exposes no sibling-controller object accessor;
 - compatibility descriptors are read/write, fail loudly before wiring, and store no
   shadow state;
-- the current-base family spans and conservative 399-line / seven-method removal are
+- the current-base family spans and conservative 409-line / seven-method removal are
   met without a ratchet increase.
 
 Moving the module-level trajectory adapter removes additional `chat_screen.py` lines,
-but those lines are intentionally excluded from the frozen 399-line family arithmetic.
+but those lines are intentionally excluded from the frozen 409-line family arithmetic.
 The guaranteed reduction therefore remains conservative and directly comparable with
 the approved inventory.
 

--- a/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
+++ b/Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
@@ -1,7 +1,7 @@
 # TASK-3070.13 Console Review and Selection Controller Design
 
 **Status:** design direction approved by the owner 2026-08-26; written amendment
-prepared for final review 2026-08-27
+reviewed and hardened 2026-08-27 before implementation planning
 
 **Task:** `TASK-3070.13 - Extract Console review and selection workflow ownership`
 
@@ -61,6 +61,8 @@ must not change product behavior to satisfy them.
    and user-visible behavior.
 6. Remove at least 399 physical `ChatScreen` lines and seven direct methods without
    raising a ratchet.
+7. Keep persistence work off the event loop without mutating controller/UI state from
+   the persistence worker thread.
 
 ## Non-goals
 
@@ -150,10 +152,22 @@ improve ownership and are rejected.
   privacy-safe failure logging, and notification policy;
 - trajectory snapshot orchestration and background build sequencing.
 
+The existing module-level `_build_trajectory_snapshot` adapter moves unchanged from
+`chat_screen.py` into `review_selection.py` with this owner. Leaving it behind would
+force the new controller to import `chat_screen` (an import cycle through `wiring.py`)
+or require a hidden screen dependency. It remains a service-read adapter over the
+existing store/repositories; the pure `Chat/trajectory.py` projection stays
+stdlib-only and query-free. `test_trajectory_live.py` retargets its helper import to
+the owning module rather than preserving a stale `chat_screen` re-export.
+
 The controller does not query the DOM, focus widgets, construct or push Textual
 screens/modals, reference `ChatScreen`, or hold sibling-controller objects. External
 work is expressed through named, late-bound callables installed in
 `UI/Console_Modules/wiring.py`.
+
+The review module does not instantiate databases, issue SQL, mutate schema, or acquire
+Git authority. Its trajectory adapter and controller invoke the existing store,
+repository, and database service APIs supplied through the reviewed seams.
 
 `ChatScreen` retains exactly:
 
@@ -182,8 +196,10 @@ wiring path is introduced.
 
 Named callables cover these capabilities:
 
-- current/ensured Console chat controller and store;
-- current/ensured agent bridge and current run state;
+- the current Console store and persisted session metadata;
+- active agent-conversation identity, change-review provider resolution, live
+  run-active probes, and current turn workspace roots;
+- the current agent-runs database read seam;
 - native Console messages;
 - worker scheduling and UI-thread callback marshaling;
 - prompt-queue dispatch;
@@ -199,8 +215,12 @@ only the snapshot inputs, worker sequencing, and handoff. The feedback-modal cal
 similarly owns Textual modal construction/wait while returning only the comment
 result to the controller.
 
-Sibling behavior is reached through purpose-named callables, never by passing
-`screen._agent`, `screen._prompt_queue`, or another controller object.
+No constructor dependency returns a sibling controller object. Wiring may call
+through `screen._agent`, `screen._prompt_queue`, or the Console chat controller at
+invocation time, but it exposes only the exact operation or immutable fact the review
+controller needs. Existing store, bridge-provider, repository, and database service
+objects may cross their named accessors for one operation; they are not controller
+objects and are not cached across sessions.
 
 ## State and Compatibility
 
@@ -219,6 +239,9 @@ The controller is the sole owner of:
 - no descriptor or screen instance stores a shadow copy;
 - mutable-map identity is preserved so existing in-place preview updates and focused
   tests continue to observe the controller-owned map.
+
+The implementation reuses `chat_screen.py`'s existing `_ControllerState` descriptor;
+it does not introduce a second compatibility abstraction.
 
 `_console_review_notes_inflight` remains screen-owned. The review-note flow may call
 the controller's annotation loader during its forced reload, but it continues to own
@@ -248,6 +271,14 @@ the named modal callback, composes identical feedback text, records audit and op
 annotation off-thread before dispatch, sends through the named prompt-queue callable,
 and releases the guard on every exit.
 
+Before entering `asyncio.to_thread`, the event-loop path captures the current store
+and session id. The blocking persistence helper returns whether it created an
+annotation (and any identifier needed for the decision); it never mutates
+`annotation_previews`. After the await resumes on the event loop, the controller
+updates the preview map and then dispatches the feedback. This preserves
+audit-before-send and immediate-marker behavior while removing the current cross-thread
+map mutation and avoiding sibling-controller access from the worker.
+
 Audit failure remains non-fatal. Comment annotations update the controller-owned
 preview map immediately. Raw selected text never enters new logs or diagnostic fields.
 
@@ -276,7 +307,9 @@ The Textual action delegates to the controller. The controller resolves the curr
 persisted conversation, title, run database, and snapshot builder; emits the same
 empty-state/building notifications; and builds off-thread. The named UI-thread and
 presentation callbacks push the same live-tail `TrajectoryScreen`. No controller DOM
-or Textual screen dependency is introduced.
+or Textual screen dependency is introduced. The presentation callback keeps the
+`TrajectoryScreen` import lazy, so importing `review_selection.py` does not widen the
+Chat first-paint import leg.
 
 ## Error Handling and Privacy
 
@@ -303,16 +336,24 @@ Add a source-inspected architecture suite proving:
 
 - all seven exact move methods are absent from `ChatScreen` and owned by
   `ConsoleReviewSelectionController`;
+- `_build_trajectory_snapshot` is absent from `chat_screen.py`, owned by the review
+  module, and does not pull `trajectory_screen` onto the first-paint import leg;
 - the six exact stays remain on `ChatScreen`;
 - the three exact delegates retain their binding/action surfaces, contain only the
   allowed handoff, and fit the five-line ceiling;
 - the controller has no Textual DOM queries, screen reference, mixin, dynamic facade,
   sibling-controller object, Git authority, or database implementation;
-- wiring is the sole constructor and supplies the reviewed named dependencies;
+- wiring is the sole constructor, supplies the reviewed fine-grained named
+  dependencies, and exposes no sibling-controller object accessor;
 - compatibility descriptors are read/write, fail loudly before wiring, and store no
   shadow state;
 - the current-base family spans and conservative 399-line / seven-method removal are
   met without a ratchet increase.
+
+Moving the module-level trajectory adapter removes additional `chat_screen.py` lines,
+but those lines are intentionally excluded from the frozen 399-line family arithmetic.
+The guaranteed reduction therefore remains conservative and directly comparable with
+the approved inventory.
 
 ### Isolated controller tests
 
@@ -322,7 +363,7 @@ Use plain fakes to cover:
 - annotation transition clearing, stale-load rejection, native-id re-keying, and load
   failure behavior;
 - feedback blank/duplicate guards, cancel, dispatch composition, audit-before-send,
-  annotation preview update, and `finally` release;
+  event-loop annotation preview update, and `finally` release;
 - note validation, provenance/title caps, off-thread persistence, markup-safe success,
   and privacy-safe failure;
 - trajectory missing-conversation behavior and worker-to-presentation handoff.
@@ -335,10 +376,17 @@ keeping their product expectations unchanged. Run the related annotation, select
 change-review opener, trajectory, turn-undo, controller-wiring, and architecture
 suites. Do not run a local full suite.
 
+Explicit compatibility updates include the trajectory helper import in
+`test_trajectory_live.py`, direct annotation-discovery calls, and the two turn-undo
+tests that currently monkeypatch `_console_change_review_provider` on the screen.
+They retarget the owning controller seam; no callable screen facade or stale module
+re-export is added. A thread-bound preview-map fake proves persistence happens on a
+worker while the map mutation happens only after control returns to the event loop.
+
 Use bounded manual mutation checks after a checkpoint commit for the highest-risk
 policy branches: stale annotation result rejection, feedback inflight release,
-audit-before-dispatch ordering, and selection-note privacy logging. Each temporary
-semantic edit must make its exact focused node fail, then be restored with
+audit-before-dispatch ordering/UI-thread preview update, and selection-note privacy
+logging. Each temporary semantic edit must make its exact focused node fail, then be restored with
 `apply_patch` and rerun green. The implementation plan will name the precise edits and
 commands.
 
@@ -352,8 +400,9 @@ widening, or unrelated changes.
 
 1. Freeze the current 7/3/6 boundary and state/wiring contracts with RED tests.
 2. Add the controller, state descriptors, and plain-fake tests.
-3. Move annotation, change-review, feedback, note, and trajectory policy in coherent
-   slices, keeping focused tests green after each slice.
+3. Move the trajectory snapshot adapter plus annotation, change-review, feedback,
+   note, and trajectory policy in coherent slices, keeping focused tests green after
+   each slice.
 4. Install the three complete delegates and retarget direct call sites/patch handles.
 5. Correct the four stale nested-marker unit traversals without production changes.
 6. Run focused behavioral, mutation, architecture, static, privacy, diagnostic,

--- a/Tests/Architecture/test_console_review_selection_controller_boundary.py
+++ b/Tests/Architecture/test_console_review_selection_controller_boundary.py
@@ -1,0 +1,562 @@
+"""Source-inspected ownership contract for Console review and selection policy."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_SCREEN_PATH = REPO_ROOT / "tldw_chatbook/UI/Screens/chat_screen.py"
+REVIEW_PATH = REPO_ROOT / "tldw_chatbook/UI/Console_Modules/review_selection.py"
+WIRING_PATH = REPO_ROOT / "tldw_chatbook/UI/Console_Modules/wiring.py"
+RATCHET_PATH = REPO_ROOT / "Tests/Architecture/test_screen_size_ratchet.py"
+SCREEN_RELATIVE_PATH = "tldw_chatbook/UI/Screens/chat_screen.py"
+REVIEW_RELATIVE_PATH = "tldw_chatbook/UI/Console_Modules/review_selection.py"
+TASK_BASE = "c6218918d1e70c1938f7e11df592d0c70ca60383"
+GIT_TIMEOUT_SECONDS = 10
+TASK_BASE_COUNTS = (17_624, 539)
+FAMILY_LINES = 850
+MOVE_LINES = 280
+STAY_LINES = 426
+MINIMUM_LINE_REDUCTION = 409
+MINIMUM_METHOD_REDUCTION = 7
+PROJECTED_LINE_CEILING = 17_215
+PROJECTED_METHOD_CEILING = 532
+MAX_DELEGATE_LINES = 5
+
+MOVE_METHODS = frozenset(
+    {
+        "_console_change_review_provider",
+        "_console_change_review_workspace_roots",
+        "_console_selection_feedback_flow",
+        "_create_console_selection_note",
+        "_load_console_annotation_previews",
+        "_record_console_feedback_event",
+        "_sync_console_annotation_discovery",
+    }
+)
+DELEGATE_METHODS = frozenset(
+    {
+        "action_open_trajectory_view",
+        "on_console_selection_feedback_requested",
+        "on_console_selection_note_requested",
+    }
+)
+STAY_METHODS = frozenset(
+    {
+        "_console_change_review_run_id",
+        "_console_review_notes_flow",
+        "_console_selection_quote_requested",
+        "_dismiss_console_selection_menus_outside_transcript",
+        "_open_change_review",
+        "on_console_review_notes_requested",
+    }
+)
+FAMILY_METHODS = MOVE_METHODS | DELEGATE_METHODS | STAY_METHODS
+STATE_SLOTS = {
+    "_console_annotation_loaded_conversation": (
+        "_review_selection",
+        "annotation_loaded_conversation",
+    ),
+    "_console_annotation_previews": ("_review_selection", "annotation_previews"),
+    "_console_selection_feedback_inflight": (
+        "_review_selection",
+        "selection_feedback_inflight",
+    ),
+}
+CONTROLLER_DEPENDENCIES = frozenset(
+    {
+        "store_accessor",
+        "agent_conversation_id_accessor",
+        "change_review_provider_accessor",
+        "run_active_accessor",
+        "run_active_for_root",
+        "workspace_roots_accessor",
+        "agent_runs_db_accessor",
+        "capture_policy_bindings_accessor",
+        "native_messages_accessor",
+        "run_worker",
+        "show_feedback_comment",
+        "dispatch_prompt",
+        "marshal_to_ui",
+        "present_trajectory",
+        "notify",
+    }
+)
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _tree(path: Path) -> ast.Module:
+    """Parse a required source file."""
+    assert path.is_file(), f"required production module is missing: {path}"
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _class_node(path: Path, class_name: str) -> ast.ClassDef:
+    """Return one top-level class by exact name."""
+    classes = [
+        node
+        for node in _tree(path).body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    ]
+    assert len(classes) == 1
+    return classes[0]
+
+
+def _class_from_source(source: str, class_name: str) -> ast.ClassDef:
+    """Return one top-level class from source text."""
+    classes = [
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    ]
+    assert len(classes) == 1
+    return classes[0]
+
+
+def _method_nodes(owner: ast.ClassDef) -> list[FunctionNode]:
+    """Return every direct method, retaining duplicates."""
+    return [
+        node
+        for node in owner.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+
+
+def _methods(owner: ast.ClassDef) -> dict[str, FunctionNode]:
+    """Return direct methods by name."""
+    return {node.name: node for node in _method_nodes(owner)}
+
+
+def _method_counts(owner: ast.ClassDef) -> Counter[str]:
+    """Count every direct method definition."""
+    return Counter(node.name for node in _method_nodes(owner))
+
+
+def _span(node: FunctionNode) -> int:
+    """Return physical definition span without decorators."""
+    return node.end_lineno - node.lineno + 1
+
+
+def _counts(source: str) -> tuple[int, int]:
+    """Return physical source lines and unique direct ChatScreen method names."""
+    owner = _class_from_source(source, "ChatScreen")
+    return len(source.splitlines()), len(_methods(owner))
+
+
+def _source_at_revision(revision: str, relative_path: str) -> str:
+    """Read a repository file at one revision with a bounded subprocess."""
+    return subprocess.run(
+        ["git", "show", f"{revision}:{relative_path}"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=GIT_TIMEOUT_SECONDS,
+    ).stdout
+
+
+def _optional_source_at_revision(revision: str, relative_path: str) -> str | None:
+    """Read an optional revision path, distinguishing absence from Git failure."""
+    try:
+        return _source_at_revision(revision, relative_path)
+    except subprocess.CalledProcessError as error:
+        if "does not exist" in error.stderr or "exists on disk, but not in" in error.stderr:
+            return None
+        raise
+
+
+def _call_name(call: ast.Call) -> str | None:
+    """Return a call's terminal name."""
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _class_bindings(
+    owner: ast.ClassDef, names: set[str]
+) -> dict[str, list[ast.expr | None]]:
+    """Return class-body assignment values for exact names."""
+    found = {name: [] for name in names}
+    for node in owner.body:
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets, value = [node.target], node.value
+        else:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id in found:
+                found[target.id].append(value)
+    return found
+
+
+def _state_bindings(owner: ast.ClassDef) -> dict[str, tuple[str, str]]:
+    """Return exact compatibility descriptor targets."""
+    bindings = _class_bindings(owner, set(STATE_SLOTS))
+    assert all(len(values) == 1 for values in bindings.values())
+    result: dict[str, tuple[str, str]] = {}
+    for name, (value,) in bindings.items():
+        assert isinstance(value, ast.Call)
+        assert _call_name(value) == "_ControllerState"
+        assert len(value.args) == 2
+        assert all(isinstance(argument, ast.Constant) for argument in value.args)
+        result[name] = tuple(argument.value for argument in value.args)  # type: ignore[misc]
+    return result
+
+
+def _self_writes(owner: ast.ClassDef, names: set[str]) -> set[str]:
+    """Return named self attributes assigned by direct screen methods."""
+    found: set[str] = set()
+    for method in _method_nodes(owner):
+        for node in ast.walk(method):
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+                targets = [node.target]
+            else:
+                continue
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                    and target.attr in names
+                ):
+                    found.add(target.attr)
+    return found
+
+
+def _descriptor_type() -> type:
+    """Execute only the shared descriptor class for runtime forwarding tests."""
+    screen_tree = _tree(CHAT_SCREEN_PATH)
+    descriptor = next(
+        node
+        for node in screen_tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "_ControllerState"
+    )
+    namespace: dict[str, object] = {"__builtins__": __builtins__}
+    module = ast.Module(body=[descriptor], type_ignores=[])
+    exec(
+        compile(ast.fix_missing_locations(module), str(CHAT_SCREEN_PATH), "exec"),
+        namespace,
+    )
+    descriptor_type = namespace["_ControllerState"]
+    assert isinstance(descriptor_type, type)
+    return descriptor_type
+
+
+def _assert_descriptor_runtime() -> None:
+    """Prove unwired access is loud and wired access has no shadow storage."""
+    descriptor_type = _descriptor_type()
+
+    class Host:
+        pass
+
+    for name, (owner_name, state_name) in STATE_SLOTS.items():
+        setattr(Host, name, descriptor_type(owner_name, state_name))
+    host = Host()
+    for name in STATE_SLOTS:
+        with pytest.raises(RuntimeError, match="controller not wired"):
+            getattr(host, name)
+        with pytest.raises(RuntimeError, match="controller not wired"):
+            setattr(host, name, object())
+        assert name not in vars(host)
+
+    class Review:
+        annotation_loaded_conversation = None
+        annotation_previews: dict[str, tuple[str, ...]] = {}
+        selection_feedback_inflight = False
+
+    review = Review()
+    host._review_selection = review
+    preview_map = {"m1": ("note",)}
+    host._console_annotation_loaded_conversation = "conversation"
+    host._console_annotation_previews = preview_map
+    host._console_selection_feedback_inflight = True
+    assert review.annotation_loaded_conversation == "conversation"
+    assert review.annotation_previews is preview_map
+    assert review.selection_feedback_inflight is True
+    assert not (set(vars(host)) & set(STATE_SLOTS))
+
+
+def _binding_actions(owner: ast.ClassDef) -> set[str]:
+    """Return Textual action names declared in direct BINDINGS assignments."""
+    return {
+        call.args[1].value
+        for assignment in owner.body
+        if isinstance(assignment, (ast.Assign, ast.AnnAssign))
+        if assignment.value is not None
+        for call in ast.walk(assignment.value)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Name)
+        and call.func.id == "Binding"
+        and len(call.args) >= 2
+        and isinstance(call.args[1], ast.Constant)
+        and isinstance(call.args[1].value, str)
+    }
+
+
+def _review_calls(method: FunctionNode) -> list[ast.Call]:
+    """Return calls rooted directly at self._review_selection."""
+    calls: list[ast.Call] = []
+    for node in ast.walk(method):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        root = node.func.value
+        if (
+            isinstance(root, ast.Attribute)
+            and isinstance(root.value, ast.Name)
+            and root.value.id == "self"
+            and root.attr == "_review_selection"
+        ):
+            calls.append(node)
+    return calls
+
+
+def _assert_final_ownership(screen_source: str, review_source: str) -> None:
+    """Assert final method ownership in an arbitrary complete revision."""
+    screen = _class_from_source(screen_source, "ChatScreen")
+    controller = _class_from_source(review_source, "ConsoleReviewSelectionController")
+    screen_counts = _method_counts(screen)
+    controller_counts = _method_counts(controller)
+    assert all(controller_counts[name] == 1 for name in MOVE_METHODS)
+    assert all(screen_counts[name] == 0 for name in MOVE_METHODS)
+    assert all(screen_counts[name] == 1 for name in STAY_METHODS | DELEGATE_METHODS)
+    assert all(controller_counts[name] == 0 for name in STAY_METHODS | DELEGATE_METHODS)
+
+
+@pytest.mark.unit
+def test_review_selection_controller_path_and_exact_method_ownership() -> None:
+    """The dedicated controller owns seven methods and the six stays do not move."""
+    controller = _class_node(REVIEW_PATH, "ConsoleReviewSelectionController")
+    screen = _class_node(CHAT_SCREEN_PATH, "ChatScreen")
+    screen_counts = _method_counts(screen)
+    controller_counts = _method_counts(controller)
+
+    assert all(controller_counts[name] == 1 for name in MOVE_METHODS)
+    assert all(screen_counts[name] == 0 for name in MOVE_METHODS)
+    assert all(screen_counts[name] == 1 for name in STAY_METHODS)
+    assert all(controller_counts[name] == 0 for name in STAY_METHODS)
+    assert all(screen_counts[name] == 1 for name in DELEGATE_METHODS)
+    assert all(controller_counts[name] == 0 for name in DELEGATE_METHODS)
+
+
+@pytest.mark.unit
+def test_review_selection_delegates_are_complete_and_bounded() -> None:
+    """Framework bindings stop their event when needed and perform one handoff."""
+    screen = _class_node(CHAT_SCREEN_PATH, "ChatScreen")
+    methods = _methods(screen)
+    assert "open_trajectory_view" in _binding_actions(screen)
+    assert {
+        name: tuple(ast.unparse(item) for item in methods[name].decorator_list)
+        for name in DELEGATE_METHODS - {"action_open_trajectory_view"}
+    } == {
+        "on_console_selection_feedback_requested": (
+            "on(ConsoleSelectionFeedbackRequested)",
+        ),
+        "on_console_selection_note_requested": ("on(ConsoleSelectionNoteRequested)",),
+    }
+    for name in DELEGATE_METHODS:
+        method = methods[name]
+        assert _span(method) <= MAX_DELEGATE_LINES, (name, _span(method))
+        assert len(_review_calls(method)) == 1
+        assert not any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"run_worker", "to_thread", "dispatch"}
+            for node in ast.walk(method)
+        )
+
+
+@pytest.mark.unit
+def test_trajectory_adapter_moves_without_eager_screen_import() -> None:
+    """Trajectory service reads move with the owner while presentation stays lazy."""
+    screen_tree = _tree(CHAT_SCREEN_PATH)
+    review_tree = _tree(REVIEW_PATH)
+    assert not any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_build_trajectory_snapshot"
+        for node in screen_tree.body
+    )
+    helpers = [
+        node
+        for node in review_tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_build_trajectory_snapshot"
+    ]
+    assert len(helpers) == 1
+    assert not any(
+        isinstance(node, (ast.Import, ast.ImportFrom))
+        and "trajectory_screen" in ast.unparse(node)
+        for node in review_tree.body
+    )
+
+
+@pytest.mark.unit
+def test_review_selection_module_has_no_dom_sibling_or_authority_bypass() -> None:
+    """The owner cannot recover ambient screen, sibling, Git, SQL, or DOM authority."""
+    tree = _tree(REVIEW_PATH)
+    controller = _class_node(REVIEW_PATH, "ConsoleReviewSelectionController")
+    assert not controller.bases
+    source = REVIEW_PATH.read_text(encoding="utf-8")
+    assert "ChatScreen" not in source
+    assert "trajectory_screen" not in source
+    assert "subprocess" not in source
+    assert ".execute(" not in source
+    assert not any(
+        isinstance(node, ast.ImportFrom)
+        and node.module is not None
+        and node.module.startswith("textual")
+        for node in tree.body
+    )
+    forbidden = {
+        "__getattr__",
+        "__getattribute__",
+        "query",
+        "query_one",
+        "focus",
+        "push_screen",
+        "_agent",
+        "_prompt_queue",
+        "_session",
+        "_console_chat_controller",
+    }
+    assert not {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr in forbidden
+    }
+
+
+@pytest.mark.unit
+def test_review_selection_state_uses_fail_loud_descriptors_without_shadowing() -> None:
+    """Compatibility state is read/write, fail-loud, and owned only once."""
+    screen = _class_node(CHAT_SCREEN_PATH, "ChatScreen")
+    assert _state_bindings(screen) == STATE_SLOTS
+    assert not _self_writes(screen, set(STATE_SLOTS))
+    _assert_descriptor_runtime()
+
+
+@pytest.mark.unit
+def test_build_console_controllers_is_the_single_explicit_constructor() -> None:
+    """Wiring constructs one controller from exact keyword-only callables."""
+    wiring_tree = _tree(WIRING_PATH)
+    builder = next(
+        node
+        for node in wiring_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_console_controllers"
+    )
+    assignments = [
+        node
+        for node in ast.walk(builder)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "screen"
+            and target.attr == "_review_selection"
+            for target in node.targets
+        )
+    ]
+    assert len(assignments) == 1
+    constructor = assignments[0].value
+    assert isinstance(constructor, ast.Call)
+    assert _call_name(constructor) == "ConsoleReviewSelectionController"
+    assert not constructor.args
+    assert all(keyword.arg is not None for keyword in constructor.keywords)
+    assert {keyword.arg for keyword in constructor.keywords} == CONTROLLER_DEPENDENCIES
+
+    controller = _class_node(REVIEW_PATH, "ConsoleReviewSelectionController")
+    initializer = _methods(controller)["__init__"]
+    assert [argument.arg for argument in initializer.args.args] == ["self"]
+    assert initializer.args.vararg is None
+    assert initializer.args.kwarg is None
+    dependencies = {argument.arg: argument for argument in initializer.args.kwonlyargs}
+    assert set(dependencies) == CONTROLLER_DEPENDENCIES
+    assert not any("controller" in name or "screen" in name for name in dependencies)
+    assert all(
+        argument.annotation is not None
+        and "Callable" in ast.unparse(argument.annotation)
+        for argument in dependencies.values()
+    )
+
+    constructors: list[Path] = []
+    for path in sorted((REPO_ROOT / "tldw_chatbook").rglob("*.py")):
+        if "ConsoleReviewSelectionController" not in path.read_text(encoding="utf-8"):
+            continue
+        for node in ast.walk(_tree(path)):
+            if isinstance(node, ast.Call) and _call_name(node) == (
+                "ConsoleReviewSelectionController"
+            ):
+                constructors.append(path)
+    assert constructors == [WIRING_PATH]
+
+
+@pytest.mark.unit
+def test_chat_screen_remains_within_reviewed_projection_without_ratchet_raise() -> None:
+    """The extraction earns the conservative screen reduction itself."""
+    source = CHAT_SCREEN_PATH.read_text(encoding="utf-8")
+    assert _counts(source) <= (PROJECTED_LINE_CEILING, PROJECTED_METHOD_CEILING)
+    ratchet_tree = ast.parse(RATCHET_PATH.read_text(encoding="utf-8"))
+    assignment = next(
+        node
+        for node in ratchet_tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "_BUDGETS"
+    )
+    assert assignment.value is not None
+    budgets = ast.literal_eval(assignment.value)
+    assert budgets[SCREEN_RELATIVE_PATH] == ("ChatScreen", 17_727, 593)
+
+
+@pytest.mark.unit
+def test_frozen_task_base_family_and_projection_match_review() -> None:
+    """The written 7/3/6 arithmetic remains reproducible at the exact base."""
+    source = _source_at_revision(TASK_BASE, SCREEN_RELATIVE_PATH)
+    owner = _class_from_source(source, "ChatScreen")
+    methods = _methods(owner)
+    assert _counts(source) == TASK_BASE_COUNTS
+    assert all(_method_counts(owner)[name] == 1 for name in FAMILY_METHODS)
+    assert sum(_span(methods[name]) for name in FAMILY_METHODS) == FAMILY_LINES
+    assert sum(_span(methods[name]) for name in MOVE_METHODS) == MOVE_LINES
+    assert sum(_span(methods[name]) for name in STAY_METHODS) == STAY_LINES
+    residue = STAY_LINES + len(DELEGATE_METHODS) * MAX_DELEGATE_LINES
+    assert FAMILY_LINES - residue == MINIMUM_LINE_REDUCTION
+    assert len(MOVE_METHODS) == MINIMUM_METHOD_REDUCTION
+    assert (
+        TASK_BASE_COUNTS[0] - MINIMUM_LINE_REDUCTION,
+        TASK_BASE_COUNTS[1] - MINIMUM_METHOD_REDUCTION,
+    ) == (PROJECTED_LINE_CEILING, PROJECTED_METHOD_CEILING)
+
+
+@pytest.mark.unit
+def test_origin_dev_review_selection_family_still_matches_review() -> None:
+    """Latest dev is a complete reviewed pre- or post-extraction state."""
+    screen_source = _source_at_revision("origin/dev", SCREEN_RELATIVE_PATH)
+    review_source = _optional_source_at_revision("origin/dev", REVIEW_RELATIVE_PATH)
+    screen = _class_from_source(screen_source, "ChatScreen")
+    counts = _method_counts(screen)
+    if all(counts[name] == 1 for name in MOVE_METHODS):
+        methods = _methods(screen)
+        assert all(counts[name] == 1 for name in FAMILY_METHODS)
+        assert sum(_span(methods[name]) for name in FAMILY_METHODS) == FAMILY_LINES
+        assert sum(_span(methods[name]) for name in MOVE_METHODS) == MOVE_LINES
+        assert sum(_span(methods[name]) for name in STAY_METHODS) == STAY_LINES
+        projected = (
+            _counts(screen_source)[0] - MINIMUM_LINE_REDUCTION,
+            _counts(screen_source)[1] - MINIMUM_METHOD_REDUCTION,
+        )
+        assert projected <= (PROJECTED_LINE_CEILING, PROJECTED_METHOD_CEILING)
+        return
+    assert review_source is not None
+    _assert_final_ownership(screen_source, review_source)

--- a/Tests/Architecture/test_console_review_selection_controller_boundary.py
+++ b/Tests/Architecture/test_console_review_selection_controller_boundary.py
@@ -167,7 +167,10 @@ def _optional_source_at_revision(revision: str, relative_path: str) -> str | Non
     try:
         return _source_at_revision(revision, relative_path)
     except subprocess.CalledProcessError as error:
-        if "does not exist" in error.stderr or "exists on disk, but not in" in error.stderr:
+        if (
+            "does not exist" in error.stderr
+            or "exists on disk, but not in" in error.stderr
+        ):
             return None
         raise
 
@@ -453,7 +456,8 @@ def test_build_console_controllers_is_the_single_explicit_constructor() -> None:
     builder = next(
         node
         for node in wiring_tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == "build_console_controllers"
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "build_console_controllers"
     )
     assignments = [
         node

--- a/Tests/UI/test_console_annotation_markers.py
+++ b/Tests/UI/test_console_annotation_markers.py
@@ -34,12 +34,26 @@ def _message(message_id: str, role=ConsoleMessageRole.ASSISTANT) -> ConsoleChatM
     return ConsoleChatMessage(role=role, content="body", id=message_id)
 
 
+def _all_rows(transcript: ConsoleTranscript) -> list[object]:
+    """Return top-level and recursively nested transcript rows."""
+    rows: list[object] = []
+
+    def visit(row: object) -> None:
+        rows.append(row)
+        for nested in row.nested_rows:  # type: ignore[attr-defined]
+            visit(nested)
+
+    for row in transcript._transcript_rows():
+        visit(row)
+    return rows
+
+
 def test_annotated_message_gains_a_marker_row() -> None:
     transcript = ConsoleTranscript()
     transcript.set_messages([_message("m1"), _message("m2")])
     transcript.set_annotation_previews({"m1": ("tighten error paths",)})
 
-    rows = [row for row in transcript._transcript_rows() if row.kind == "annotations"]
+    rows = [row for row in _all_rows(transcript) if row.kind == "annotations"]
     assert [row.message.id for row in rows] == ["m1"]
     rendered = str(rows[0].renderable)
     assert "tighten error paths" in rendered
@@ -50,7 +64,7 @@ def test_marker_row_lists_every_note_in_order() -> None:
     transcript.set_messages([_message("m1")])
     transcript.set_annotation_previews({"m1": ("first pass", "second pass")})
 
-    (row,) = [r for r in transcript._transcript_rows() if r.kind == "annotations"]
+    (row,) = [r for r in _all_rows(transcript) if r.kind == "annotations"]
     rendered = str(row.renderable)
     assert rendered.index("first pass") < rendered.index("second pass")
 
@@ -76,9 +90,9 @@ def test_marker_signature_changes_when_notes_change() -> None:
     transcript = ConsoleTranscript()
     transcript.set_messages([_message("m1")])
     transcript.set_annotation_previews({"m1": ("v1",)})
-    (before,) = [r for r in transcript._transcript_rows() if r.kind == "annotations"]
+    (before,) = [r for r in _all_rows(transcript) if r.kind == "annotations"]
     transcript.set_annotation_previews({"m1": ("v1", "v2")})
-    (after,) = [r for r in transcript._transcript_rows() if r.kind == "annotations"]
+    (after,) = [r for r in _all_rows(transcript) if r.kind == "annotations"]
     assert before.signature != after.signature
 
 
@@ -87,7 +101,7 @@ def test_marker_widget_is_a_static_keyed_to_the_message() -> None:
     transcript.set_messages([_message("m1")])
     transcript.set_annotation_previews({"m1": ("note",)})
 
-    (row,) = [r for r in transcript._transcript_rows() if r.kind == "annotations"]
+    (row,) = [r for r in _all_rows(transcript) if r.kind == "annotations"]
     widget = transcript._build_row_widget(row, track=False)
     assert widget.id == "console-annotations-m1"
     assert widget.has_class("console-transcript-annotations")
@@ -170,7 +184,7 @@ async def test_restore_rekeys_persisted_annotations_to_native_ids(tmp_path):
                 comment="from a previous run",
             )
 
-            screen._sync_console_annotation_discovery(store)
+            screen._review_selection._sync_console_annotation_discovery(store)
             for _ in range(50):
                 await pilot.pause()
                 if screen._console_annotation_previews:
@@ -234,9 +248,7 @@ async def test_marker_click_requests_notes_not_message_toggle():
         await pilot.click("#console-annotations-m1")
         await pilot.pause()
 
-        assert [
-            event.anchor_message_id for event in app.review_notes_events
-        ] == ["m1"]
+        assert [event.anchor_message_id for event in app.review_notes_events] == ["m1"]
         assert transcript.selected_message_id == "m1"
 
 
@@ -255,9 +267,7 @@ async def test_n_on_selected_noted_message_requests_notes():
         await pilot.press("n")
         await pilot.pause()
 
-        assert [
-            event.anchor_message_id for event in app.review_notes_events
-        ] == ["m1"]
+        assert [event.anchor_message_id for event in app.review_notes_events] == ["m1"]
 
 
 @pytest.mark.asyncio
@@ -393,7 +403,9 @@ async def test_edit_then_delete_round_trip_pins_the_sidecar_row(tmp_path):
             snapshots: dict[str, object] = {}
 
             async def _resolver(modal) -> bool:
-                snapshots["edit_ok"] = await modal._on_edit(annotation_id, "edited comment")
+                snapshots["edit_ok"] = await modal._on_edit(
+                    annotation_id, "edited comment"
+                )
                 snapshots["after_edit_annotations"] = db.get_transcript_annotations(
                     conversation_id
                 )
@@ -425,8 +437,14 @@ async def test_edit_then_delete_round_trip_pins_the_sidecar_row(tmp_path):
             edited = after_edit[0]
             assert edited["comment"] == "edited comment"
             assert edited["updated_at"] != original["updated_at"]
-            for key in ("annotation_id", "conversation_id", "row_key", "message_id",
-                        "quote_text", "created_at"):
+            for key in (
+                "annotation_id",
+                "conversation_id",
+                "row_key",
+                "message_id",
+                "quote_text",
+                "created_at",
+            ):
                 assert edited[key] == original[key], key
 
             # Sidecar row is byte-identical after the edit.
@@ -475,11 +493,9 @@ async def test_delete_of_last_note_removes_the_marker_after_forced_reload(tmp_pa
                 comment="only note",
             )
 
-            screen._sync_console_annotation_discovery(store)
+            screen._review_selection._sync_console_annotation_discovery(store)
             await _wait_until(pilot, lambda: bool(screen._console_annotation_previews))
-            assert screen._console_annotation_previews == {
-                assistant.id: ("only note",)
-            }
+            assert screen._console_annotation_previews == {assistant.id: ("only note",)}
 
             async def _resolver(modal) -> bool:
                 assert await modal._on_delete(annotation_id) is True

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -52,6 +52,11 @@ from tldw_chatbook.UI.Console_Modules.prompt_queue import (
 )
 from tldw_chatbook.UI.Console_Modules.prompts import ConsolePromptsController
 from tldw_chatbook.UI.Console_Modules.realtime import ConsoleRealtimeController
+from tldw_chatbook.UI.Console_Modules.review_selection import (
+    ConsoleReviewSelectionController,
+)
+from tldw_chatbook.UI.Console_Modules import wiring as wiring_module
+from tldw_chatbook.Chat.console_chat_models import FEEDBACK_ACTIVE_RUN_STATUSES
 from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
 from tldw_chatbook.UI.Console_Modules.send_price import ConsoleSendPriceController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
@@ -88,6 +93,7 @@ _ALL_CONTROLLER_SLOTS: list[tuple[str, type]] = [
     ("_prompts", ConsolePromptsController),
     ("_agent", ConsoleAgentController),
     ("_prompt_queue", ConsolePromptQueueUIController),
+    ("_review_selection", ConsoleReviewSelectionController),
     ("_send_price", ConsoleSendPriceController),
 ]
 
@@ -119,7 +125,7 @@ def test_all_six_controllers_are_constructed_with_the_right_classes():
         )
 
 
-def test_all_sixteen_controllers_are_constructed_with_the_right_classes() -> None:
+def test_all_seventeen_controllers_are_constructed_with_the_right_classes() -> None:
     screen = _unmounted_console()
     names = [attr for attr, _ in _ALL_CONTROLLER_SLOTS]
     observed = [key for key in vars(screen) if key in set(names)]
@@ -131,6 +137,75 @@ def test_all_sixteen_controllers_are_constructed_with_the_right_classes() -> Non
             f"{attr} is {type(controller).__name__}, expected {cls.__name__}"
         )
     assert observed == names, f"controller build order changed: {observed}"
+
+
+def test_review_selection_controller_is_late_bound_without_sibling_objects(
+    monkeypatch,
+) -> None:
+    screen = _unmounted_console()
+    controller = screen._review_selection
+
+    assert controller.annotation_loaded_conversation is None
+    assert controller.annotation_previews == {}
+    assert controller.selection_feedback_inflight is False
+
+    store = object()
+    conversation_id = "conversation"
+    provider = object()
+    roots = object()
+    runs_db = object()
+    bindings = object()
+    native_messages = object()
+    screen._ensure_console_chat_store = lambda: store
+    active_status = next(iter(FEEDBACK_ACTIVE_RUN_STATUSES))
+    chat_controller = SimpleNamespace(
+        store=SimpleNamespace(active_session_id="session"),
+        run_state=SimpleNamespace(status=active_status),
+        _agent_conversation_id=lambda session_id: (conversation_id, session_id),
+        run_active_for_workspace=lambda root: ("active", root),
+        resolve_turn_execution_context=lambda session_id: SimpleNamespace(
+            workspace_roots=(roots, session_id)
+        ),
+    )
+    screen._console_chat_controller = chat_controller
+    screen._ensure_console_chat_controller = lambda: chat_controller
+    screen._ensure_console_agent_bridge = lambda: SimpleNamespace(
+        runs_db=runs_db,
+        change_review_provider=lambda value: (provider, value),
+    )
+    screen._console_runtime = lambda: SimpleNamespace(chat_controller=chat_controller)
+    monkeypatch.setattr(
+        wiring_module,
+        "build_capture_policy_bindings",
+        lambda controller, session_id, conv_id: (
+            bindings,
+            controller,
+            session_id,
+            conv_id,
+        ),
+    )
+    screen._native_console_messages = lambda: native_messages
+
+    assert controller._store_accessor() is store
+    assert controller._agent_conversation_id_accessor() == (
+        conversation_id,
+        "session",
+    )
+    assert controller._change_review_provider_accessor("conversation") == (
+        provider,
+        "conversation",
+    )
+    assert controller._run_active_accessor() is True
+    assert controller._run_active_for_root("root") == ("active", "root")
+    assert controller._workspace_roots_accessor() == (roots, "session")
+    assert controller._agent_runs_db_accessor() is runs_db
+    assert controller._capture_policy_bindings_accessor("session", "conversation") == (
+        bindings,
+        chat_controller,
+        "session",
+        "conversation",
+    )
+    assert controller._native_messages_accessor() is native_messages
 
 
 def test_send_price_controller_is_constructed_with_late_bound_screen_edges() -> None:

--- a/Tests/UI/test_console_review_selection_controller.py
+++ b/Tests/UI/test_console_review_selection_controller.py
@@ -1,0 +1,247 @@
+"""Focused policy tests for the Console review/selection owner."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
+import threading
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.UI.Console_Modules import review_selection as review_module
+from tldw_chatbook.UI.Console_Modules.review_selection import (
+    ConsoleReviewSelectionController,
+)
+
+
+class _EventLoopOnlyMap(dict[str, tuple[str, ...]]):
+    """Reject mutation from any thread except the creating event-loop thread."""
+
+    def __init__(self, owner_thread: int) -> None:
+        super().__init__()
+        self.owner_thread = owner_thread
+
+    def __setitem__(self, key: str, value: tuple[str, ...]) -> None:
+        assert threading.get_ident() == self.owner_thread
+        super().__setitem__(key, value)
+
+
+async def _no_comment(_action: str, _quote: str) -> str | None:
+    return None
+
+
+async def _no_dispatch(_text: str) -> None:
+    return None
+
+
+def _controller(
+    *,
+    store_accessor: Callable[[], Any] = lambda: None,
+    agent_conversation_id_accessor: Callable[[], str | None] = lambda: None,
+    change_review_provider_accessor: Callable[[str], Any | None] = lambda _id: None,
+    run_active_accessor: Callable[[], bool] = lambda: False,
+    run_active_for_root: Callable[[str], bool] = lambda _root: False,
+    workspace_roots_accessor: Callable[[], tuple[str, ...] | None] = lambda: None,
+    agent_runs_db_accessor: Callable[[], Any | None] = lambda: None,
+    capture_policy_bindings_accessor: Callable[
+        [str, str], Any | None
+    ] = lambda _session, _conversation: None,
+    native_messages_accessor: Callable[[], list[Any]] = lambda: [],
+    run_worker: Callable[..., Any] = lambda *_args, **_kwargs: None,
+    show_feedback_comment: Callable[[str, str], Awaitable[str | None]] = _no_comment,
+    dispatch_prompt: Callable[[str], Awaitable[Any]] = _no_dispatch,
+    notify: Callable[..., None] = lambda *_args, **_kwargs: None,
+) -> ConsoleReviewSelectionController:
+    return ConsoleReviewSelectionController(
+        store_accessor=store_accessor,
+        agent_conversation_id_accessor=agent_conversation_id_accessor,
+        change_review_provider_accessor=change_review_provider_accessor,
+        run_active_accessor=run_active_accessor,
+        run_active_for_root=run_active_for_root,
+        workspace_roots_accessor=workspace_roots_accessor,
+        agent_runs_db_accessor=agent_runs_db_accessor,
+        capture_policy_bindings_accessor=capture_policy_bindings_accessor,
+        native_messages_accessor=native_messages_accessor,
+        run_worker=run_worker,
+        show_feedback_comment=show_feedback_comment,
+        dispatch_prompt=dispatch_prompt,
+        marshal_to_ui=lambda *_args: None,
+        present_trajectory=lambda *_args: None,
+        notify=notify,
+    )
+
+
+def test_change_review_provider_uses_live_run_probes() -> None:
+    provider = SimpleNamespace()
+    active = False
+    roots: set[str] = set()
+    controller = _controller(
+        agent_conversation_id_accessor=lambda: "conversation-1",
+        change_review_provider_accessor=lambda _conversation_id: provider,
+        run_active_accessor=lambda: active,
+        run_active_for_root=lambda root: root in roots,
+    )
+
+    assert controller._console_change_review_provider() is provider
+    assert provider.run_active() is False
+    active = True
+    roots.add("/workspace")
+    assert provider.run_active() is True
+    assert provider.run_active_for_root("/workspace") is True
+
+
+@pytest.mark.asyncio
+async def test_annotation_loader_discards_stale_conversation_result() -> None:
+    database = SimpleNamespace(
+        get_transcript_annotations=lambda _conversation_id: [
+            {"message_id": "persisted-1", "comment": "stale"}
+        ]
+    )
+    message = SimpleNamespace(id="native-1", persisted_message_id="persisted-1")
+    controller = _controller(native_messages_accessor=lambda: [message])
+    controller.annotation_loaded_conversation = "conversation-2"
+    controller.annotation_previews = {"native-current": ("keep",)}
+
+    await controller._load_console_annotation_previews(
+        database, object(), "conversation-1"
+    )
+
+    assert controller.annotation_previews == {"native-current": ("keep",)}
+
+
+@pytest.mark.asyncio
+async def test_annotation_loader_rekeys_on_event_loop_after_worker_read() -> None:
+    event_loop_thread = threading.get_ident()
+    read_threads: list[int] = []
+
+    def read(_conversation_id: str) -> list[dict[str, str]]:
+        read_threads.append(threading.get_ident())
+        return [{"message_id": "persisted-1", "comment": "note"}]
+
+    message = SimpleNamespace(id="native-1", persisted_message_id="persisted-1")
+    controller = _controller(native_messages_accessor=lambda: [message])
+    controller.annotation_loaded_conversation = "conversation-1"
+
+    await controller._load_console_annotation_previews(
+        SimpleNamespace(get_transcript_annotations=read),
+        object(),
+        "conversation-1",
+    )
+
+    assert read_threads and read_threads[0] != event_loop_thread
+    assert controller.annotation_previews == {"native-1": ("note",)}
+
+
+@pytest.mark.asyncio
+async def test_feedback_audit_finishes_before_dispatch() -> None:
+    order: list[str] = []
+
+    class _Store:
+        active_session_id = "session-1"
+
+        def record_feedback_event(self, *_args: Any, **_kwargs: Any) -> None:
+            order.append("audit")
+
+        def record_feedback_annotation(self, *_args: Any, **_kwargs: Any) -> str:
+            return "annotation-1"
+
+    async def show(_action: str, _quote: str) -> str:
+        return "comment"
+
+    async def dispatch(_text: str) -> None:
+        order.append("dispatch")
+
+    controller = _controller(
+        store_accessor=_Store,
+        show_feedback_comment=show,
+        dispatch_prompt=dispatch,
+    )
+    controller.selection_feedback_inflight = True
+
+    await controller._console_selection_feedback_flow(
+        "comment", "selected", "message-1"
+    )
+
+    assert order == ["audit", "dispatch"]
+
+
+@pytest.mark.asyncio
+async def test_feedback_guard_releases_after_dispatch_error() -> None:
+    async def show(_action: str, _quote: str) -> str:
+        return ""
+
+    async def dispatch(_text: str) -> None:
+        raise RuntimeError("dispatch failed")
+
+    controller = _controller(
+        show_feedback_comment=show,
+        dispatch_prompt=dispatch,
+    )
+    controller.selection_feedback_inflight = True
+
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        await controller._console_selection_feedback_flow("lgm", "selected")
+
+    assert controller.selection_feedback_inflight is False
+
+
+@pytest.mark.asyncio
+async def test_feedback_preview_map_changes_only_on_event_loop() -> None:
+    event_loop_thread = threading.get_ident()
+    write_threads: list[int] = []
+
+    class _Store:
+        active_session_id = "session-1"
+
+        def record_feedback_event(self, *_args: Any, **_kwargs: Any) -> None:
+            write_threads.append(threading.get_ident())
+
+        def record_feedback_annotation(self, *_args: Any, **_kwargs: Any) -> str:
+            write_threads.append(threading.get_ident())
+            return "annotation-1"
+
+    async def show(_action: str, _quote: str) -> str:
+        return "comment"
+
+    controller = _controller(
+        store_accessor=_Store,
+        show_feedback_comment=show,
+    )
+    controller.annotation_previews = _EventLoopOnlyMap(event_loop_thread)
+
+    await controller._console_selection_feedback_flow(
+        "comment", "selected", "message-1"
+    )
+
+    assert write_threads and all(
+        thread != event_loop_thread for thread in write_threads
+    )
+    assert controller.annotation_previews == {"message-1": ("comment",)}
+
+
+@pytest.mark.asyncio
+async def test_note_write_failure_never_logs_selected_text(monkeypatch) -> None:
+    selected = "SECRET transcript selection"
+    logged: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def fail_write(_title: str, _content: str) -> None:
+        raise RuntimeError("write failed")
+
+    store = SimpleNamespace(
+        active_session_id="session-1",
+        _sessions={"session-1": SimpleNamespace(title="Console")},
+        persistence=SimpleNamespace(db=SimpleNamespace(add_note=fail_write)),
+    )
+    monkeypatch.setattr(
+        review_module.logger,
+        "warning",
+        lambda *args, **kwargs: logged.append((args, kwargs)),
+    )
+    controller = _controller(store_accessor=lambda: store)
+
+    await controller._create_console_selection_note(selected)
+
+    rendered = repr(logged)
+    assert selected not in rendered
+    assert "SECRET" not in rendered

--- a/Tests/UI/test_console_review_selection_controller.py
+++ b/Tests/UI/test_console_review_selection_controller.py
@@ -13,6 +13,7 @@ from tldw_chatbook.UI.Console_Modules import review_selection as review_module
 from tldw_chatbook.UI.Console_Modules.review_selection import (
     ConsoleReviewSelectionController,
 )
+from tldw_chatbook.Widgets.Console.console_selection import SELECTION_QUOTE_CAP
 
 
 class _EventLoopOnlyMap(dict[str, tuple[str, ...]]):
@@ -89,6 +90,34 @@ def test_change_review_provider_uses_live_run_probes() -> None:
     roots.add("/workspace")
     assert provider.run_active() is True
     assert provider.run_active_for_root("/workspace") is True
+
+
+@pytest.mark.parametrize(
+    ("action", "quote", "anchor_message_id"),
+    [
+        ("unsupported", "selected", "message-1"),
+        ("comment", 42, "message-1"),
+        ("comment", "x" * (SELECTION_QUOTE_CAP + 1), "message-1"),
+        ("comment", "selected", "m" * 256),
+    ],
+)
+def test_feedback_request_rejects_invalid_boundary_values(
+    action: str, quote: object, anchor_message_id: str
+) -> None:
+    scheduled: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    notifications: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    controller = _controller(
+        run_worker=lambda *args, **kwargs: scheduled.append((args, kwargs)),
+        notify=lambda *args, **kwargs: notifications.append((args, kwargs)),
+    )
+
+    controller.request_selection_feedback(action, quote, anchor_message_id)  # type: ignore[arg-type]
+
+    assert scheduled == []
+    assert controller.selection_feedback_inflight is False
+    assert notifications == [
+        (("Selection feedback is invalid or too large.",), {"severity": "warning"})
+    ]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_selection_end_to_end.py
+++ b/Tests/UI/test_console_selection_end_to_end.py
@@ -765,7 +765,8 @@ async def test_run_gating_parametrized(run_status: str, expect_armed: bool):
             is not expect_armed
         )
         assert (
-            menu.query_one("#console-selection-lgm", Button).disabled is not expect_armed
+            menu.query_one("#console-selection-lgm", Button).disabled
+            is not expect_armed
         )
         assert not menu.query_one("#console-selection-comment", Button).disabled
         if expect_armed:
@@ -1091,8 +1092,15 @@ async def test_drag_release_click_never_wipes_selection_for_menu_actions():
 
     def raw(event_cls, x, y, button=0):
         return event_cls(
-            widget=None, x=x, y=y, delta_x=0, delta_y=0, button=button,
-            shift=False, meta=False, ctrl=False,
+            widget=None,
+            x=x,
+            y=y,
+            delta_x=0,
+            delta_y=0,
+            button=button,
+            shift=False,
+            meta=False,
+            ctrl=False,
         )
 
     async def drag_menu_and_click_ask(pilot) -> bool:
@@ -1122,7 +1130,9 @@ async def test_drag_release_click_never_wipes_selection_for_menu_actions():
         pilot.app.post_message(raw(MouseUp, cx, cy, button=1))
         await pilot.pause()
         await pilot.pause()
-        modals = [s for s in pilot.app.screen_stack if isinstance(s, ConsoleSideChatModal)]
+        modals = [
+            s for s in pilot.app.screen_stack if isinstance(s, ConsoleSideChatModal)
+        ]
         return bool(modals) and bool(sel_at_click)
 
     async with make_console_pilot(size=(80, 32)) as pilot:
@@ -1133,13 +1143,15 @@ async def test_drag_release_click_never_wipes_selection_for_menu_actions():
             ConsoleMessageRole,
         )
 
-        transcript.set_messages([
-            ConsoleChatMessage(
-                role=ConsoleMessageRole.ASSISTANT,
-                content="first selection text",
-                id="mm0",
-            )
-        ])
+        transcript.set_messages(
+            [
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content="first selection text",
+                    id="mm0",
+                )
+            ]
+        )
         await transcript.refresh_messages()
         await pilot.pause(0.4)
 
@@ -1148,13 +1160,15 @@ async def test_drag_release_click_never_wipes_selection_for_menu_actions():
         await pilot.press("escape")
         await pilot.pause(0.3)
 
-        transcript.set_messages([
-            ConsoleChatMessage(
-                role=ConsoleMessageRole.ASSISTANT,
-                content="second selection text",
-                id="mm0",
-            )
-        ])
+        transcript.set_messages(
+            [
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content="second selection text",
+                    id="mm0",
+                )
+            ]
+        )
         await transcript.refresh_messages()
         await pilot.pause(0.4)
         row = screen.query_one("#console-message-mm0")

--- a/Tests/UI/test_console_turn_undo_all.py
+++ b/Tests/UI/test_console_turn_undo_all.py
@@ -506,7 +506,11 @@ async def test_mounted_duplicate_root_undo_refuses_inline_and_routes_to_review(
         session = store.create_session(session_id="conv-ambiguous-undo")
         session.persisted_conversation_id = session.id
         screen._ensure_console_chat_controller()
-        monkeypatch.setattr(screen, "_console_change_review_provider", lambda: provider)
+        monkeypatch.setattr(
+            screen._review_selection,
+            "_console_change_review_provider",
+            lambda: provider,
+        )
         review_calls: list[str] = []
         monkeypatch.setattr(
             screen,
@@ -579,7 +583,11 @@ async def test_mounted_partial_and_provider_failures_name_problem_and_allow_retr
         session = store.create_session(session_id="conv-partial-undo")
         session.persisted_conversation_id = session.id
         screen._ensure_console_chat_controller()
-        monkeypatch.setattr(screen, "_console_change_review_provider", lambda: provider)
+        monkeypatch.setattr(
+            screen._review_selection,
+            "_console_change_review_provider",
+            lambda: provider,
+        )
         store.append_message(
             session.id,
             role=ConsoleMessageRole.TOOL,

--- a/Tests/UI/test_trajectory_live.py
+++ b/Tests/UI/test_trajectory_live.py
@@ -36,11 +36,12 @@ from tldw_chatbook.Chat.console_context_repository import (
 )
 from tldw_chatbook.Chat.trajectory import derive_trajectory
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, TrajectoryRowWrite
-from tldw_chatbook.UI.Screens.chat_screen import (
-    CONSOLE_WORKBENCH_SHORTCUTS,
-    ChatScreen,
+from tldw_chatbook.UI.Console_Modules.review_selection import (
+    ConsoleReviewSelectionController,
     _build_trajectory_snapshot,
 )
+from tldw_chatbook.UI.Console_Modules.wiring import _present_console_trajectory
+from tldw_chatbook.UI.Screens.chat_screen import CONSOLE_WORKBENCH_SHORTCUTS, ChatScreen
 from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
 
 # ---------------------------------------------------------------------------
@@ -655,6 +656,25 @@ async def test_trajectory_launch_action_presents_screen():
         # Console view and require every decomposed controller.
         instance._console_runtime_ref = SimpleNamespace(chat_store=_Store())
         instance.notify = lambda *args, **kwargs: None  # not under test
+        instance._review_selection = ConsoleReviewSelectionController(
+            store_accessor=lambda: instance._console_runtime_ref.chat_store,
+            agent_conversation_id_accessor=lambda: None,
+            change_review_provider_accessor=lambda _conversation_id: None,
+            run_active_accessor=lambda: False,
+            run_active_for_root=lambda _root: False,
+            workspace_roots_accessor=lambda: None,
+            agent_runs_db_accessor=lambda: None,
+            capture_policy_bindings_accessor=lambda _session_id, _conv_id: None,
+            native_messages_accessor=lambda: [],
+            run_worker=lambda *args, **kwargs: instance.run_worker(*args, **kwargs),
+            show_feedback_comment=lambda _action, _quote: None,  # type: ignore[arg-type]
+            dispatch_prompt=lambda _text: None,  # type: ignore[arg-type]
+            marshal_to_ui=lambda callback, *args: app.call_from_thread(callback, *args),
+            present_trajectory=lambda launch: _present_console_trajectory(
+                instance, launch
+            ),
+            notify=instance.notify,
+        )
 
         ChatScreen.action_open_trajectory_view(instance)
         # build() runs on a real worker thread; present() is marshaled back

--- a/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
+++ b/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
@@ -1,31 +1,39 @@
 ---
 id: TASK-3070.13
 title: Extract Console review and selection workflow ownership
-status: To Do
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-24 01:01'
+updated_date: '2026-08-27 04:05'
 labels:
   - console
   - architecture-gate
 dependencies:
   - TASK-3070.12
+references:
+  - >-
+    Docs/superpowers/specs/2026-08-23-console-decomposition-wave6-closeout-amendment.md
+  - >-
+    Docs/superpowers/specs/2026-08-27-task-3070-13-console-review-selection-controller-design.md
 parent_task_id: TASK-3070
 priority: high
-references:
-  - Docs/superpowers/specs/2026-08-23-console-decomposition-wave6-closeout-amendment.md
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Move the characterized change-review, changed-files, annotation, feedback, note, quote, and trajectory policy out of ChatScreen behind one explicit owner while preserving exact screen-owned presentation stays, ADR-068 review-note ownership, Git authority, persistence, privacy, and user-visible behavior.
+Move the seven surviving change-review, annotation, feedback, selection-note, and
+trajectory policy methods out of `ChatScreen` behind one explicit owner. Preserve
+the three Textual delegates, six reviewed screen-owned presentation/ADR-068 stays,
+existing Git and database authorities, privacy boundaries, and user-visible behavior.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The reviewed review/selection move set has one non-DOM workflow owner; exact presentation and ADR-068 review-note stays remain screen-owned and the four retained event/action delegates preserve their Textual bindings within the five-line ceiling
-- [ ] #2 Changed-files review, annotation, feedback, selection note/quote, trajectory, dismissal, and screen-owned review-note fetch/reload behavior remains unchanged
-- [ ] #3 Isolated controller and focused mounted product tests plus architecture, static, privacy, and diagnostic gates pass
-- [ ] #4 The extraction reduces ChatScreen lines and direct methods without increasing a ratchet budget
+- [ ] #1 The current-base seven-method move set has one non-DOM workflow owner; the three retained Textual event/action delegates are complete within the five-line ceiling and the six exact presentation/ADR-068 stays remain screen-owned
+- [ ] #2 Change-review provider/root resolution, annotation discovery, feedback audit/dispatch, selection-note creation, and trajectory orchestration remain unchanged; screen-owned quote insertion, change-review presentation, selection dismissal, and review-note fetch/mutate/forced-reload behavior also remain unchanged
+- [ ] #3 Annotation preview/load identity and selection-feedback exclusion state live only on the new owner, with fail-loud read/write compatibility proxies and no shadow copies; existing services retain Git, run-store, note, and annotation authority
+- [ ] #4 Isolated controller and focused mounted product tests plus architecture, static, privacy, diagnostic, backlog-ID, and diff gates pass without a local full-suite run
+- [ ] #5 The extraction removes at least seven direct `ChatScreen` methods and 399 physical lines without increasing a ratchet budget
 <!-- AC:END -->

--- a/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
+++ b/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
@@ -91,6 +91,11 @@ Reason: applies DESIGN.md section 7 while preserving ADR-068 review-note ownersh
   contract, and live-base architecture test were amended before extraction.
   Four stale nested-row assertions in existing annotation tests were corrected
   without changing production behavior. No new lessons entry was warranted.
+- Qodo follow-up: added a strict Pydantic boundary that reuses the shared text
+  validator for selection feedback, rejecting unsupported actions, malformed or
+  oversized quotes, and invalid anchor IDs before any worker is scheduled. Added
+  the requested Google-style constructor and public-method argument documentation;
+  the boundary regression covered four malformed cases with RED/GREEN evidence.
 - ADR required: no. Existing ADR:
   `backlog/decisions/068-console-text-selection-and-annotations.md`; the change
   applies its ownership boundary without changing durable authority or policy.

--- a/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
+++ b/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
@@ -33,7 +33,7 @@ existing Git and database authorities, privacy boundaries, and user-visible beha
 <!-- AC:BEGIN -->
 - [ ] #1 The current-base seven-method move set has one non-DOM workflow owner; the three retained Textual event/action delegates are complete within the five-line ceiling and the six exact presentation/ADR-068 stays remain screen-owned
 - [ ] #2 Change-review provider/root resolution, annotation discovery, feedback audit/dispatch, selection-note creation, and trajectory orchestration remain unchanged; screen-owned quote insertion, change-review presentation, selection dismissal, and review-note fetch/mutate/forced-reload behavior also remain unchanged
-- [ ] #3 Annotation preview/load identity and selection-feedback exclusion state live only on the new owner, with fail-loud read/write compatibility proxies and no shadow copies; existing services retain Git, run-store, note, and annotation authority
+- [ ] #3 Annotation preview/load identity and selection-feedback exclusion state live only on the new owner, with fail-loud read/write compatibility proxies, no shadow copies, no sibling-controller object dependency, and no annotation preview mutation from a persistence worker thread; existing services retain Git, run-store, note, and annotation authority
 - [ ] #4 Isolated controller and focused mounted product tests plus architecture, static, privacy, diagnostic, backlog-ID, and diff gates pass without a local full-suite run
 - [ ] #5 The extraction removes at least seven direct `ChatScreen` methods and 399 physical lines without increasing a ratchet budget
 <!-- AC:END -->

--- a/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
+++ b/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-3070.13
 title: Extract Console review and selection workflow ownership
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-24 01:01'
-updated_date: '2026-08-27 04:20'
+updated_date: '2026-08-27 04:57'
 labels:
   - console
   - architecture-gate
@@ -57,6 +57,7 @@ Reason: applies DESIGN.md section 7 while preserving ADR-068 review-note ownersh
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 - Added `ConsoleReviewSelectionController` as the single non-DOM owner for the
   reviewed seven-method family. `ChatScreen` retains exactly three complete
   Textual delegates and the six reviewed presentation/ADR-068 methods.
@@ -93,3 +94,4 @@ Reason: applies DESIGN.md section 7 while preserving ADR-068 review-note ownersh
 - ADR required: no. Existing ADR:
   `backlog/decisions/068-console-text-selection-and-annotations.md`; the change
   applies its ownership boundary without changing durable authority or policy.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
+++ b/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
@@ -31,11 +31,11 @@ existing Git and database authorities, privacy boundaries, and user-visible beha
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The current-base seven-method move set has one non-DOM workflow owner; the three retained Textual event/action delegates are complete within the five-line ceiling and the six exact presentation/ADR-068 stays remain screen-owned
-- [ ] #2 Change-review provider/root resolution, annotation discovery, feedback audit/dispatch, selection-note creation, and trajectory orchestration remain unchanged; screen-owned quote insertion, change-review presentation, selection dismissal, and review-note fetch/mutate/forced-reload behavior also remain unchanged
-- [ ] #3 Annotation preview/load identity and selection-feedback exclusion state live only on the new owner, with fail-loud read/write compatibility proxies, no shadow copies, no sibling-controller object dependency, and no annotation preview mutation from a persistence worker thread; existing services retain Git, run-store, note, and annotation authority
-- [ ] #4 Isolated controller and focused mounted product tests plus architecture, static, privacy, diagnostic, backlog-ID, and diff gates pass without a local full-suite run
-- [ ] #5 The extraction removes at least seven direct `ChatScreen` methods and 409 physical lines without increasing a ratchet budget
+- [x] #1 The current-base seven-method move set has one non-DOM workflow owner; the three retained Textual event/action delegates are complete within the five-line ceiling and the six exact presentation/ADR-068 stays remain screen-owned
+- [x] #2 Change-review provider/root resolution, annotation discovery, feedback audit/dispatch, selection-note creation, and trajectory orchestration remain unchanged; screen-owned quote insertion, change-review presentation, selection dismissal, and review-note fetch/mutate/forced-reload behavior also remain unchanged
+- [x] #3 Annotation preview/load identity and selection-feedback exclusion state live only on the new owner, with fail-loud read/write compatibility proxies, no shadow copies, no sibling-controller object dependency, and no annotation preview mutation from a persistence worker thread; existing services retain Git, run-store, note, and annotation authority
+- [x] #4 Isolated controller and focused mounted product tests plus architecture, static, privacy, diagnostic, backlog-ID, and diff gates pass without a local full-suite run
+- [x] #5 The extraction removes at least seven direct `ChatScreen` methods and 409 physical lines without increasing a ratchet budget
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,3 +54,42 @@ ADR required: no
 ADR path: backlog/decisions/068-console-text-selection-and-annotations.md
 Reason: applies DESIGN.md section 7 while preserving ADR-068 review-note ownership and all existing durable authorities.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+- Added `ConsoleReviewSelectionController` as the single non-DOM owner for the
+  reviewed seven-method family. `ChatScreen` retains exactly three complete
+  Textual delegates and the six reviewed presentation/ADR-068 methods.
+- Wired the controller once through `build_console_controllers` with 15 named,
+  late-bound callable dependencies. Three fail-loud `_ControllerState`
+  descriptors preserve compatibility without screen shadow state or sibling
+  controller object dependencies.
+- Preserved existing Git, run-store, note, annotation, and ADR-068 review-note
+  authorities. Feedback and note persistence run off-thread; annotation preview
+  maps are changed only after control returns to the event loop. Persistent
+  diagnostic inventory changes are exact ownership relocation: four unchanged
+  statement digests moved from `chat_screen.py` to `review_selection.py`.
+- Final current-base measurements are 16,968 physical `ChatScreen` lines and 532
+  unique direct methods. The screen diff is 31 insertions and 687 deletions, a
+  net 656-line reduction, with seven direct methods removed and no ratchet
+  increase. This exceeds the conservative 409-line acceptance floor.
+- Focused verification passed: 160 targeted UI/controller/wiring/architecture
+  tests, targeted Ruff and Ruff format, compile, live-base drift, persistent
+  diagnostic inventory, backlog-ID uniqueness across 2,665 task files, privacy
+  review, placeholder scan, and diff checks. No local full-suite run was made.
+  Two unrelated persistent-diagnostic ledger assertions fail identically on the
+  untouched `origin/dev` base (`library_screen.py` and
+  `watchlists_collections_screen.py`); the task-owned inventory checker and
+  relocation assertion pass.
+- Five bounded mutations each produced the intended RED and returned GREEN after
+  exact restoration: stale-conversation acceptance, missing in-flight guard
+  release, dispatch-before-audit ordering, worker-thread preview mutation, and
+  selected-text diagnostic leakage. No mutation was committed.
+- Plan deviation: upstream TASK-2126 added capture-policy bindings and grew the
+  reviewed trajectory action before implementation. The spec, task floor, wiring
+  contract, and live-base architecture test were amended before extraction.
+  Four stale nested-row assertions in existing annotation tests were corrected
+  without changing production behavior. No new lessons entry was warranted.
+- ADR required: no. Existing ADR:
+  `backlog/decisions/068-console-text-selection-and-annotations.md`; the change
+  applies its ownership boundary without changing durable authority or policy.

--- a/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
+++ b/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
@@ -35,7 +35,7 @@ existing Git and database authorities, privacy boundaries, and user-visible beha
 - [ ] #2 Change-review provider/root resolution, annotation discovery, feedback audit/dispatch, selection-note creation, and trajectory orchestration remain unchanged; screen-owned quote insertion, change-review presentation, selection dismissal, and review-note fetch/mutate/forced-reload behavior also remain unchanged
 - [ ] #3 Annotation preview/load identity and selection-feedback exclusion state live only on the new owner, with fail-loud read/write compatibility proxies, no shadow copies, no sibling-controller object dependency, and no annotation preview mutation from a persistence worker thread; existing services retain Git, run-store, note, and annotation authority
 - [ ] #4 Isolated controller and focused mounted product tests plus architecture, static, privacy, diagnostic, backlog-ID, and diff gates pass without a local full-suite run
-- [ ] #5 The extraction removes at least seven direct `ChatScreen` methods and 399 physical lines without increasing a ratchet budget
+- [ ] #5 The extraction removes at least seven direct `ChatScreen` methods and 409 physical lines without increasing a ratchet budget
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
+++ b/backlog/tasks/task-3070.13 - Extract-Console-review-and-selection-workflow-ownership.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-24 01:01'
-updated_date: '2026-08-27 04:05'
+updated_date: '2026-08-27 04:20'
 labels:
   - console
   - architecture-gate
@@ -37,3 +37,20 @@ existing Git and database authorities, privacy boundaries, and user-visible beha
 - [ ] #4 Isolated controller and focused mounted product tests plus architecture, static, privacy, diagnostic, backlog-ID, and diff gates pass without a local full-suite run
 - [ ] #5 The extraction removes at least seven direct `ChatScreen` methods and 399 physical lines without increasing a ratchet budget
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Freeze the exact current-base 7/3/6 boundary with RED architecture tests
+2. Establish ConsoleReviewSelectionController through build_console_controllers and fail-loud descriptors
+3. Move and characterize change-review and annotation policy
+4. Move selection-feedback and selection-note policy with an explicit worker/event-loop boundary
+5. Move trajectory loading/launch policy, install the three complete delegates, and retarget focused callers
+6. Prove five high-risk branches with bounded manual mutations
+7. Run focused behavior, architecture, static, privacy, diagnostic, backlog-ID, and diff gates
+8. Rebase on latest dev, revalidate drift, refresh task evidence, and complete delivery
+
+ADR required: no
+ADR path: backlog/decisions/068-console-text-selection-and-annotations.md
+Reason: applies DESIGN.md section 7 while preserving ADR-068 review-note ownership and all existing durable authorities.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/Console_Modules/review_selection.py
+++ b/tldw_chatbook/UI/Console_Modules/review_selection.py
@@ -1,0 +1,556 @@
+"""Console review, selection-feedback, annotation, and trajectory policy.
+
+TASK-3070.13 moves seven policy methods out of the screen class while the three
+Textual event/action boundaries remain small screen delegates and six
+presentation/DOM methods remain on the screen. Services keep persistence,
+Git, note, and annotation authority; this owner only sequences them through
+explicit late-bound callables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+from rich.markup import escape as escape_markup
+
+from tldw_chatbook.Chat.citation_trace_repository import ActiveCitationTraceState
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.Chat.trajectory import TrajectorySnapshot, derive_trajectory
+
+
+_FEEDBACK_MESSAGE_HEADERS = {
+    "request-changes": "[Request changes]",
+    "lgm": "[LGTM]",
+    "comment": "[Comment]",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleTrajectoryLaunch:
+    """Presentation data for one lazily opened trajectory view."""
+
+    snapshot: TrajectorySnapshot
+    screen_title: str
+    conversation_id: str
+    revision_provider: Callable[[], int]
+    snapshot_builder: Callable[[], TrajectorySnapshot]
+    capture_policy_bindings: Any | None
+
+
+def _build_trajectory_snapshot(
+    store: Any,
+    conversation_id: str,
+    *,
+    agent_runs_db: Any | None = None,
+) -> TrajectorySnapshot:
+    """Assemble the ``derive_trajectory`` inputs for one conversation."""
+    messages: list[Any] = []
+    traj_rows: list[Any] = []
+    variant_sets: list[Any] = []
+    compaction_records: list[Any] = []
+    agent_runs: list[Any] = []
+    agent_steps: list[Any] = []
+    retrieval_runs: list[Any] = []
+    diagnostic_events: list[Any] = []
+    active_leaf: str | None = None
+
+    def capture_failed(
+        source: str, error: Exception, *, message_id: str | None = None
+    ) -> None:
+        logger.opt(exception=error).error(
+            "Trace source read failed: source={} conversation_id={}",
+            source,
+            conversation_id,
+        )
+        diagnostic_events.append(
+            {
+                "event_id": (
+                    f"capture-failed:{source}:{conversation_id}"
+                    f"{f':{message_id}' if message_id else ''}"
+                ),
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+                "event_kind": "capture_failed",
+                "status": "capture_failed",
+                "summary": f"{source} capture failed",
+                "field_states": {
+                    "source": "capture_failed",
+                    **({"message_id": "observed"} if message_id else {}),
+                },
+                "sensitivity": "diagnostic",
+            }
+        )
+
+    persistence = getattr(store, "persistence", None)
+    db = getattr(persistence, "db", None)
+    if db is not None:
+        try:
+            messages = list(
+                db.get_messages_for_conversation(
+                    conversation_id,
+                    limit=1_000_000,
+                    include_image_data=False,
+                )
+            )
+        except Exception as error:  # noqa: BLE001 - launch degrades, never fails
+            capture_failed("messages", error)
+            messages = []
+        try:
+            traj_rows = list(db.get_trajectory_rows(conversation_id))
+        except Exception as error:  # noqa: BLE001
+            capture_failed("trajectory", error)
+            traj_rows = []
+        try:
+            active_leaf = db.get_conversation_active_leaf(conversation_id)
+        except Exception as error:  # noqa: BLE001
+            capture_failed("active_leaf", error)
+            active_leaf = None
+    usage_by_id: dict[str, ProviderUsage] = {}
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        usage = ProviderUsage.from_json(message.get("usage_json"))
+        if usage is not None:
+            usage_by_id[str(message.get("id"))] = usage
+    try:
+        variant_sets = list(store.variant_sets_for_conversation(conversation_id))
+    except Exception as error:  # noqa: BLE001
+        capture_failed("variants", error)
+        variant_sets = []
+    context_repository = getattr(persistence, "context_repository", None)
+    if context_repository is not None:
+        try:
+            offset = 0
+            while True:
+                page = list(
+                    context_repository.list_auxiliary_attempts(
+                        conversation_id, limit=500, offset=offset
+                    )
+                )
+                compaction_records.extend(
+                    {**record, "trace_lifecycle": True}
+                    if isinstance(record, Mapping)
+                    else record
+                    for record in page
+                )
+                if len(page) < 500:
+                    break
+                offset += len(page)
+        except Exception as error:  # noqa: BLE001
+            capture_failed("context", error)
+    turn_by_message: dict[str, str] = {}
+    for trajectory_row in traj_rows:
+        if isinstance(trajectory_row, Mapping):
+            row_message_id = trajectory_row.get("message_id")
+            row_turn_id = trajectory_row.get("turn_id")
+        else:
+            row_message_id = getattr(trajectory_row, "message_id", None)
+            row_turn_id = getattr(trajectory_row, "turn_id", None)
+        if row_message_id and row_turn_id:
+            turn_by_message[str(row_message_id)] = str(row_turn_id)
+    if agent_runs_db is not None:
+        try:
+            raw_runs = agent_runs_db.list_runs(conversation_id)
+            for raw_run in raw_runs:
+                try:
+                    run = dict(raw_run) if isinstance(raw_run, Mapping) else {}
+                    run_id = str(run.get("id") or "")
+                    if not run_id:
+                        continue
+                    assistant_message_id = str(run.get("assistant_message_id") or "")
+                    if assistant_message_id in turn_by_message:
+                        run["turn_id"] = turn_by_message[assistant_message_id]
+                    steps = list(run.get("steps", ()) or ())
+                    converted_steps = [
+                        {
+                            **step,
+                            "run_id": run_id,
+                            "conversation_id": conversation_id,
+                            "turn_id": run.get("turn_id"),
+                        }
+                        for step in steps
+                        if isinstance(step, Mapping)
+                    ]
+                    agent_runs.append(run)
+                    agent_steps.extend(converted_steps)
+                except Exception as error:  # noqa: BLE001
+                    capture_failed("agent", error)
+        except Exception as error:  # noqa: BLE001
+            capture_failed("agent", error)
+    citation_repository = getattr(persistence, "citation_repository", None)
+    if citation_repository is not None:
+        assistant_ids = [
+            str(message.get("id") or "")
+            for message in messages
+            if isinstance(message, Mapping)
+            and str(message.get("sender") or "").lower() == "assistant"
+            and message.get("id")
+        ]
+        try:
+            candidates = citation_repository.active_owner_candidate_message_ids(
+                assistant_ids
+            )
+        except Exception as error:  # noqa: BLE001
+            capture_failed("retrieval_candidates", error)
+            candidates = set()
+        for message in messages:
+            if not isinstance(message, Mapping):
+                continue
+            message_id = str(message.get("id") or "")
+            if (
+                not message_id
+                or str(message.get("sender") or "").lower() != "assistant"
+                or message_id not in candidates
+            ):
+                continue
+            try:
+                result = citation_repository.get_active_trace_for_current_message(
+                    message_id,
+                    str(message.get("content") or ""),
+                )
+                if (
+                    result.state is not ActiveCitationTraceState.ACTIVE
+                    or result.summary is None
+                    or not citation_repository.verify_active_trace_result(result)
+                ):
+                    continue
+                for run in result.summary.trace.evidence_runs:
+                    row = run.model_dump(mode="python")
+                    retrieval_runs.append(
+                        {
+                            **row,
+                            "conversation_id": conversation_id,
+                            "message_id": message_id,
+                            "turn_id": turn_by_message.get(message_id),
+                            "field_states": {"payload": "omitted"},
+                            "sensitivity": "retrieval_metadata",
+                            "trace_lifecycle": True,
+                        }
+                    )
+            except Exception as error:  # noqa: BLE001
+                capture_failed("retrieval", error, message_id=message_id)
+    return derive_trajectory(
+        messages,
+        usage_by_id,
+        traj_rows,
+        variant_sets,
+        compaction_records,
+        active_leaf_message_id=active_leaf,
+        agent_runs=agent_runs,
+        agent_steps=agent_steps,
+        retrieval_runs=retrieval_runs,
+        diagnostic_events=diagnostic_events,
+    )
+
+
+class ConsoleReviewSelectionController:
+    """Own Console review/selection policy without DOM or sibling authority."""
+
+    def __init__(
+        self,
+        *,
+        store_accessor: Callable[[], Any],
+        agent_conversation_id_accessor: Callable[[], str | None],
+        change_review_provider_accessor: Callable[[str], Any | None],
+        run_active_accessor: Callable[[], bool],
+        run_active_for_root: Callable[[str], bool],
+        workspace_roots_accessor: Callable[[], tuple[str, ...] | None],
+        agent_runs_db_accessor: Callable[[], Any | None],
+        capture_policy_bindings_accessor: Callable[[str, str], Any | None],
+        native_messages_accessor: Callable[[], list[Any]],
+        run_worker: Callable[..., Any],
+        show_feedback_comment: Callable[[str, str], Awaitable[str | None]],
+        dispatch_prompt: Callable[[str], Awaitable[Any]],
+        marshal_to_ui: Callable[..., None],
+        present_trajectory: Callable[..., None],
+        notify: Callable[..., None],
+    ) -> None:
+        self._store_accessor = store_accessor
+        self._agent_conversation_id_accessor = agent_conversation_id_accessor
+        self._change_review_provider_accessor = change_review_provider_accessor
+        self._run_active_accessor = run_active_accessor
+        self._run_active_for_root = run_active_for_root
+        self._workspace_roots_accessor = workspace_roots_accessor
+        self._agent_runs_db_accessor = agent_runs_db_accessor
+        self._capture_policy_bindings_accessor = capture_policy_bindings_accessor
+        self._native_messages_accessor = native_messages_accessor
+        self._run_worker = run_worker
+        self._show_feedback_comment = show_feedback_comment
+        self._dispatch_prompt = dispatch_prompt
+        self._marshal_to_ui = marshal_to_ui
+        self._present_trajectory = present_trajectory
+        self._notify = notify
+        self.annotation_loaded_conversation: str | None = None
+        self.annotation_previews: dict[str, tuple[str, ...]] = {}
+        self.selection_feedback_inflight = False
+
+    def _console_change_review_provider(self) -> Any | None:
+        """Return the live provider recipe, degrading on missing collaborators."""
+        try:
+            conversation_id = self._agent_conversation_id_accessor()
+            if not conversation_id:
+                return None
+            provider = self._change_review_provider_accessor(conversation_id)
+        except Exception:  # noqa: BLE001 -- opener must degrade, not raise
+            return None
+        if provider is None:
+            return None
+        provider.run_active = self._run_active_accessor
+        provider.run_active_for_root = self._run_active_for_root
+        return provider
+
+    def _console_change_review_workspace_roots(self) -> tuple[str, ...] | None:
+        """Return the current turn workspace roots, or ``None`` on failure."""
+        try:
+            return self._workspace_roots_accessor()
+        except Exception:  # noqa: BLE001 -- opener must degrade, not raise
+            return None
+
+    def _sync_console_annotation_discovery(self, store: Any) -> None:
+        """Load persisted annotations when the active conversation changes."""
+        session = getattr(store, "_sessions", {}).get(
+            getattr(store, "active_session_id", None)
+        )
+        conversation_id = getattr(session, "persisted_conversation_id", None)
+        if not conversation_id:
+            if self.annotation_loaded_conversation is not None:
+                self.annotation_loaded_conversation = None
+                self.annotation_previews = {}
+            return
+        conversation_id = str(conversation_id)
+        if conversation_id == self.annotation_loaded_conversation:
+            return
+        self.annotation_loaded_conversation = conversation_id
+        self.annotation_previews = {}
+        database = getattr(getattr(store, "persistence", None), "db", None)
+        if database is None:
+            return
+        self._run_worker(
+            self._load_console_annotation_previews(database, store, conversation_id),
+            exclusive=True,
+            group="console-annotation-previews",
+            exit_on_error=False,
+        )
+
+    async def _load_console_annotation_previews(
+        self, database: Any, store: Any, conversation_id: str
+    ) -> None:
+        """Read annotations off-thread and re-key them on the event loop."""
+        try:
+            rows = await asyncio.to_thread(
+                database.get_transcript_annotations, conversation_id
+            )
+        except Exception:
+            logger.warning(
+                f"Console annotations: load failed for {conversation_id!r}",
+                exc_info=True,
+            )
+            return
+        if self.annotation_loaded_conversation != conversation_id:
+            return
+        native_by_persisted = {
+            message.persisted_message_id: message.id
+            for message in self._native_messages_accessor()
+            if message.persisted_message_id is not None
+        }
+        previews: dict[str, tuple[str, ...]] = {}
+        for row in rows:
+            native_id = native_by_persisted.get(row.get("message_id"))
+            if native_id is None:
+                continue
+            previews[native_id] = previews.get(native_id, ()) + (row["comment"],)
+        self.annotation_previews = previews
+
+    def request_selection_note(self, quote: str) -> None:
+        """Schedule selection-note creation for non-blank input."""
+        if not quote.strip():
+            return
+        self._run_worker(
+            self._create_console_selection_note(quote),
+            group="console-selection-note",
+            exit_on_error=False,
+        )
+
+    async def _create_console_selection_note(self, quote: str) -> None:
+        """Derive note provenance and persist it off-thread."""
+        from tldw_chatbook.Utils.input_validation import validate_text_input
+        from tldw_chatbook.Widgets.Console.console_selection import (
+            SELECTION_QUOTE_CAP,
+        )
+
+        if not validate_text_input(
+            quote, max_length=SELECTION_QUOTE_CAP + 64, allow_html=True
+        ):
+            self._notify(
+                "Selection is too large to save as a note.", severity="warning"
+            )
+            return
+        first_line = quote.strip().splitlines()[0]
+        title = first_line if len(first_line) <= 48 else first_line[:47] + "…"
+        try:
+            store = self._store_accessor()
+            database = (
+                getattr(store.persistence, "db", None) if store.persistence else None
+            )
+            if database is None:
+                self._notify(
+                    "Notes are unavailable (no notes database).",
+                    severity="warning",
+                )
+                return
+            session = getattr(store, "_sessions", {}).get(store.active_session_id)
+            session_title = str(getattr(session, "title", "") or "Console")
+            stamp = datetime.now().strftime("%Y-%m-%d")
+            content = f"{quote}\n\n— Console selection, {session_title}, {stamp}"
+            await asyncio.to_thread(database.add_note, title, content)
+        except Exception:
+            logger.warning(
+                f"Console selection note: write failed (title length {len(title)})",
+                exc_info=True,
+            )
+            self._notify("Could not create the note.", severity="warning")
+            return
+        self._notify(f"Note created: {escape_markup(title)}")
+
+    def request_selection_feedback(
+        self, action: str, quote: str, anchor_message_id: str | None
+    ) -> None:
+        """Schedule one feedback flow for a non-blank transcript selection."""
+        if not quote.strip() or self.selection_feedback_inflight:
+            return
+        self.selection_feedback_inflight = True
+        self._run_worker(
+            self._console_selection_feedback_flow(action, quote, anchor_message_id),
+            group="console-selection-feedback",
+        )
+
+    def _record_console_feedback_event(
+        self,
+        store: Any | None,
+        session_id: str | None,
+        action: str,
+        quote: str,
+        comment: str,
+        anchor_message_id: str | None,
+    ) -> bool:
+        """Write feedback persistence and report whether an annotation was made."""
+        if store is None or not session_id or not anchor_message_id:
+            return False
+        try:
+            store.record_feedback_event(
+                session_id,
+                anchor_message_id=anchor_message_id,
+                action=action,
+                quote=quote,
+                comment=comment or None,
+            )
+            if action != "comment" or not comment:
+                return False
+            return bool(
+                store.record_feedback_annotation(
+                    session_id,
+                    anchor_message_id=anchor_message_id,
+                    quote=quote,
+                    comment=comment,
+                )
+            )
+        except Exception:
+            logger.warning(
+                "Console selection feedback: audit record failed for anchor "
+                f"{anchor_message_id!r}; the feedback itself was dispatched.",
+                exc_info=True,
+            )
+            return False
+
+    async def _console_selection_feedback_flow(
+        self, action: str, quote: str, anchor_message_id: str | None = None
+    ) -> None:
+        """Collect a comment, persist its audit, and dispatch exact feedback."""
+        try:
+            comment = await self._show_feedback_comment(action, quote)
+            if comment is None:
+                return
+            lines = [_FEEDBACK_MESSAGE_HEADERS.get(action, "[Comment]")]
+            lines.extend(
+                f"> {line}" if line.strip() else ">" for line in quote.splitlines()
+            )
+            if comment:
+                lines.append(comment)
+            try:
+                store = self._store_accessor()
+                session_id = getattr(store, "active_session_id", None)
+            except Exception:  # noqa: BLE001 -- audit loss cannot cost feedback
+                store = None
+                session_id = None
+            annotation_created = await asyncio.to_thread(
+                self._record_console_feedback_event,
+                store,
+                session_id,
+                action,
+                quote,
+                comment,
+                anchor_message_id,
+            )
+            if annotation_created and anchor_message_id:
+                existing = self.annotation_previews.get(anchor_message_id, ())
+                self.annotation_previews[anchor_message_id] = existing + (comment,)
+            await self._dispatch_prompt("\n".join(lines))
+        finally:
+            self.selection_feedback_inflight = False
+
+    def open_trajectory_view(self) -> None:
+        """Build and present a trace for the active persisted conversation."""
+        store = self._store_accessor()
+        session = getattr(store, "_sessions", {}).get(
+            getattr(store, "active_session_id", None)
+        )
+        conversation_id = getattr(session, "persisted_conversation_id", None)
+        if not conversation_id:
+            self._notify("The active conversation has no persisted trace yet.")
+            return
+        conv_id = str(conversation_id)
+        target_session_id = str(session.id)
+        capture_policy_bindings = self._capture_policy_bindings_accessor(
+            target_session_id, conv_id
+        )
+        screen_title = str(getattr(session, "title", "") or "Console")
+        agent_runs_db = self._agent_runs_db_accessor()
+
+        def build() -> TrajectorySnapshot:
+            return _build_trajectory_snapshot(
+                store,
+                conv_id,
+                agent_runs_db=agent_runs_db,
+            )
+
+        def present(snapshot: TrajectorySnapshot) -> None:
+            self._present_trajectory(
+                ConsoleTrajectoryLaunch(
+                    snapshot=snapshot,
+                    screen_title=screen_title,
+                    conversation_id=conv_id,
+                    revision_provider=lambda: store.get_payload_revision(conv_id),
+                    snapshot_builder=build,
+                    capture_policy_bindings=capture_policy_bindings,
+                )
+            )
+
+        def build_worker() -> None:
+            self._marshal_to_ui(present, build())
+
+        self._notify("Building trace…")
+        self._run_worker(
+            build_worker, thread=True, exclusive=True, group="trajectory-launch"
+        )
+
+
+__all__ = [
+    "ConsoleReviewSelectionController",
+    "ConsoleTrajectoryLaunch",
+    "_build_trajectory_snapshot",
+]

--- a/tldw_chatbook/UI/Console_Modules/review_selection.py
+++ b/tldw_chatbook/UI/Console_Modules/review_selection.py
@@ -16,11 +16,13 @@ from datetime import datetime
 from typing import Any
 
 from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from rich.markup import escape as escape_markup
 
 from tldw_chatbook.Chat.citation_trace_repository import ActiveCitationTraceState
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.Chat.trajectory import TrajectorySnapshot, derive_trajectory
+from tldw_chatbook.Widgets.Console.console_selection import SELECTION_QUOTE_CAP
 
 
 _FEEDBACK_MESSAGE_HEADERS = {
@@ -28,6 +30,43 @@ _FEEDBACK_MESSAGE_HEADERS = {
     "lgm": "[LGTM]",
     "comment": "[Comment]",
 }
+
+
+class _SelectionFeedbackRequest(BaseModel):
+    """Validated boundary values for one selection-feedback request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    action: str
+    quote: str = Field(min_length=1, max_length=SELECTION_QUOTE_CAP)
+    anchor_message_id: str | None = Field(default=None, min_length=1, max_length=255)
+
+    @field_validator("action")
+    @classmethod
+    def _validate_action(cls, value: str) -> str:
+        if value not in _FEEDBACK_MESSAGE_HEADERS:
+            raise ValueError("unsupported feedback action")
+        return value
+
+    @field_validator("quote")
+    @classmethod
+    def _validate_quote(cls, value: str) -> str:
+        from tldw_chatbook.Utils.input_validation import validate_text_input
+
+        if not value.strip() or not validate_text_input(
+            value, max_length=SELECTION_QUOTE_CAP, allow_html=True
+        ):
+            raise ValueError("invalid feedback quote")
+        return value
+
+    @field_validator("anchor_message_id")
+    @classmethod
+    def _validate_anchor_message_id(cls, value: str | None) -> str | None:
+        from tldw_chatbook.Utils.input_validation import validate_text_input
+
+        if value is not None and not validate_text_input(value, max_length=255):
+            raise ValueError("invalid feedback anchor")
+        return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -270,6 +309,25 @@ class ConsoleReviewSelectionController:
         present_trajectory: Callable[..., None],
         notify: Callable[..., None],
     ) -> None:
+        """Initialize the controller from explicit, late-bound collaborators.
+
+        Args:
+            store_accessor: Return the active Console chat store.
+            agent_conversation_id_accessor: Return the active run conversation ID.
+            change_review_provider_accessor: Build review operations for a conversation.
+            run_active_accessor: Report whether any Console run is active.
+            run_active_for_root: Report whether a workspace root has an active run.
+            workspace_roots_accessor: Return the active turn's workspace roots.
+            agent_runs_db_accessor: Return the optional agent-run database.
+            capture_policy_bindings_accessor: Resolve trajectory capture bindings.
+            native_messages_accessor: Return current native Console messages.
+            run_worker: Schedule a Textual worker.
+            show_feedback_comment: Present the feedback-comment modal.
+            dispatch_prompt: Dispatch composed feedback through the prompt queue.
+            marshal_to_ui: Marshal a callback onto the UI thread.
+            present_trajectory: Present a completed trajectory launch.
+            notify: Show a user-facing Console notification.
+        """
         self._store_accessor = store_accessor
         self._agent_conversation_id_accessor = agent_conversation_id_accessor
         self._change_review_provider_accessor = change_review_provider_accessor
@@ -367,7 +425,11 @@ class ConsoleReviewSelectionController:
         self.annotation_previews = previews
 
     def request_selection_note(self, quote: str) -> None:
-        """Schedule selection-note creation for non-blank input."""
+        """Schedule selection-note creation for non-blank input.
+
+        Args:
+            quote: Capped transcript selection to persist as a note.
+        """
         if not quote.strip():
             return
         self._run_worker(
@@ -379,9 +441,6 @@ class ConsoleReviewSelectionController:
     async def _create_console_selection_note(self, quote: str) -> None:
         """Derive note provenance and persist it off-thread."""
         from tldw_chatbook.Utils.input_validation import validate_text_input
-        from tldw_chatbook.Widgets.Console.console_selection import (
-            SELECTION_QUOTE_CAP,
-        )
 
         if not validate_text_input(
             quote, max_length=SELECTION_QUOTE_CAP + 64, allow_html=True
@@ -420,12 +479,35 @@ class ConsoleReviewSelectionController:
     def request_selection_feedback(
         self, action: str, quote: str, anchor_message_id: str | None
     ) -> None:
-        """Schedule one feedback flow for a non-blank transcript selection."""
-        if not quote.strip() or self.selection_feedback_inflight:
+        """Validate and schedule one transcript-selection feedback flow.
+
+        Args:
+            action: Supported feedback action identifier.
+            quote: Capped transcript selection included in the feedback.
+            anchor_message_id: Optional native message ID for durable attribution.
+        """
+        if self.selection_feedback_inflight:
+            return
+        if isinstance(quote, str) and not quote.strip():
+            return
+        try:
+            request = _SelectionFeedbackRequest(
+                action=action,
+                quote=quote,
+                anchor_message_id=anchor_message_id,
+            )
+        except ValidationError:
+            self._notify(
+                "Selection feedback is invalid or too large.", severity="warning"
+            )
             return
         self.selection_feedback_inflight = True
         self._run_worker(
-            self._console_selection_feedback_flow(action, quote, anchor_message_id),
+            self._console_selection_feedback_flow(
+                request.action,
+                request.quote,
+                request.anchor_message_id,
+            ),
             group="console-selection-feedback",
         )
 

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -50,6 +50,7 @@ from typing import Any, TYPE_CHECKING
 
 from textual.css.query import QueryError
 
+from tldw_chatbook.Chat.console_chat_models import FEEDBACK_ACTIVE_RUN_STATUSES
 from tldw_chatbook.Chat.console_fleet_attention import (
     FLEET_UNSEEN_REVISION_ATTR,
     clear_fleet_unseen_completion,
@@ -62,6 +63,9 @@ from tldw_chatbook.Widgets.Console.console_auto_speak_consent import (
 from tldw_chatbook.Widgets.Console.console_control_bar import ConsoleControlBar
 from tldw_chatbook.Widgets.Console.console_speech_controls import (
     ConsoleSpeechControls,
+)
+from tldw_chatbook.Widgets.Console.console_feedback_comment_modal import (
+    ConsoleFeedbackCommentModal,
 )
 
 from .agent import ConsoleAgentController
@@ -78,6 +82,11 @@ from .prompt_queue import (
 from .prompts import ConsolePromptsController
 from .reaction_preview import get_console_reaction_preview_coordinator
 from .realtime import ConsoleRealtimeController
+from .review_selection import (
+    ConsoleReviewSelectionController,
+    ConsoleTrajectoryLaunch,
+)
+from .capture_policy_bindings import build_capture_policy_bindings
 from .retrieval import ConsoleRetrievalController
 from .send_price import ConsoleSendPriceController
 from .session import ConsoleSessionController
@@ -187,6 +196,82 @@ def _query_console_owner(
         return screen.query_one(selector)
     except QueryError:
         return fallback
+
+
+def _review_selection_agent_conversation_id(screen: Any) -> str | None:
+    """Resolve the active run-store conversation identity."""
+    controller = screen._console_chat_controller
+    if controller is None:
+        return None
+    active = controller.store.active_session_id
+    return controller._agent_conversation_id(active) if active else None
+
+
+def _review_selection_workspace_roots(screen: Any) -> tuple[str, ...] | None:
+    """Resolve the active turn's current workspace roots."""
+    controller = screen._console_chat_controller
+    if controller is None:
+        return None
+    active = controller.store.active_session_id
+    if not active:
+        return None
+    return controller.resolve_turn_execution_context(active).workspace_roots
+
+
+def _review_selection_run_active(screen: Any) -> bool:
+    """Return whether the Console agent run is currently active."""
+    controller = screen._console_chat_controller
+    return bool(
+        controller is not None
+        and controller.run_state.status in FEEDBACK_ACTIVE_RUN_STATUSES
+    )
+
+
+def _review_selection_agent_runs_db(screen: Any) -> Any | None:
+    """Resolve the optional public AgentRunsDB read seam."""
+    if getattr(screen, "_agent", None) is None:
+        return None
+    bridge = screen._ensure_console_agent_bridge()
+    return getattr(bridge, "runs_db", None)
+
+
+def _review_selection_capture_policy_bindings(
+    screen: Any, session_id: str, conversation_id: str
+) -> Any | None:
+    """Build trajectory capture-policy bindings when the runtime supports them."""
+    runtime = screen._console_runtime()
+    if not hasattr(runtime, "chat_controller"):
+        return None
+    return build_capture_policy_bindings(
+        screen._ensure_console_chat_controller(),
+        session_id,
+        conversation_id,
+    )
+
+
+async def _show_console_feedback_comment(
+    screen: Any, action: str, quote: str
+) -> str | None:
+    """Present the selection-feedback comment modal."""
+    return await screen.app.push_screen_wait(
+        ConsoleFeedbackCommentModal(action=action, quote=quote)
+    )
+
+
+def _present_console_trajectory(screen: Any, launch: ConsoleTrajectoryLaunch) -> None:
+    """Present a trajectory view while preserving its lazy import boundary."""
+    from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
+
+    screen.app.push_screen(
+        TrajectoryScreen(
+            launch.snapshot,
+            screen_title=launch.screen_title,
+            conversation_id=launch.conversation_id,
+            revision_provider=launch.revision_provider,
+            snapshot_builder=launch.snapshot_builder,
+            capture_policy_bindings=launch.capture_policy_bindings,
+        )
+    )
 
 
 def build_console_controllers(
@@ -1390,6 +1475,45 @@ def build_console_controllers(
             )
         ),
         sync_ui=lambda: screen._sync_native_console_chat_ui(),
+    )
+    screen._review_selection = ConsoleReviewSelectionController(
+        store_accessor=lambda: screen._ensure_console_chat_store(),
+        agent_conversation_id_accessor=(
+            lambda: _review_selection_agent_conversation_id(screen)
+        ),
+        change_review_provider_accessor=(
+            lambda conversation_id: (
+                screen._ensure_console_agent_bridge().change_review_provider(
+                    conversation_id
+                )
+            )
+        ),
+        run_active_accessor=lambda: _review_selection_run_active(screen),
+        run_active_for_root=(
+            lambda root: (
+                screen._ensure_console_chat_controller().run_active_for_workspace(root)
+            )
+        ),
+        workspace_roots_accessor=lambda: _review_selection_workspace_roots(screen),
+        agent_runs_db_accessor=lambda: _review_selection_agent_runs_db(screen),
+        capture_policy_bindings_accessor=(
+            lambda session_id, conversation_id: (
+                _review_selection_capture_policy_bindings(
+                    screen, session_id, conversation_id
+                )
+            )
+        ),
+        native_messages_accessor=lambda: screen._native_console_messages(),
+        run_worker=lambda *args, **kwargs: screen.run_worker(*args, **kwargs),
+        show_feedback_comment=(
+            lambda action, quote: _show_console_feedback_comment(screen, action, quote)
+        ),
+        dispatch_prompt=lambda text: screen._prompt_queue.dispatch(text),
+        marshal_to_ui=(
+            lambda callback, *args: screen.app.call_from_thread(callback, *args)
+        ),
+        present_trajectory=lambda launch: _present_console_trajectory(screen, launch),
+        notify=lambda *args, **kwargs: screen.notify(*args, **kwargs),
     )
     screen._send_price = ConsoleSendPriceController(
         settings_accessor=(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1798,6 +1798,15 @@ class ChatScreen(BaseAppScreen):
     )
     _console_realtime = _ControllerState("_realtime", "session")
     _console_realtime_close_worker = _ControllerState("_realtime", "close_worker")
+    _console_annotation_loaded_conversation = _ControllerState(
+        "_review_selection", "annotation_loaded_conversation"
+    )
+    _console_annotation_previews = _ControllerState(
+        "_review_selection", "annotation_previews"
+    )
+    _console_selection_feedback_inflight = _ControllerState(
+        "_review_selection", "selection_feedback_inflight"
+    )
     _console_persisted_rows_cache = _ControllerState(
         "_workspace", "_console_persisted_rows_cache"
     )
@@ -3932,18 +3941,6 @@ class ChatScreen(BaseAppScreen):
         self._console_sync_in_progress = False
         self._console_sync_requested = False
         self._console_citation_counts: dict[str, int] = {}
-        # task-17169 slice 2: review-note previews keyed by NATIVE message id
-        # (the transcript marker's input), plus the conversation the map was
-        # last loaded for -- reloads happen only on conversation change; live
-        # Comment writes update the map in place.
-        self._console_annotation_previews: dict[str, tuple[str, ...]] = {}
-        self._console_annotation_loaded_conversation: str | None = None
-        # Qodo (PR #1723): mutual exclusion for the selection-feedback flow.
-        # The worker is deliberately NOT exclusive (a superseding exclusive
-        # cancel would strand a mounted comment modal -- see the flow's
-        # docstring), so exclusion is this guard instead: re-triggers while
-        # a flow is in flight are ignored, never queued and never cancelled.
-        self._console_selection_feedback_inflight = False
         # Same precedent, same reason (task-18515 review-note management
         # task 3 fix round): a rapid double marker-click / double-`n` before
         # the first worker's off-thread DB read resolves must not stack two

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -105,7 +105,6 @@ from ..Console_Modules.prompt_queue import (
 from ..Console_Modules.realtime import CONSOLE_REALTIME_CHIP_MESSAGES
 from ..Console_Modules.dispatch_recovery import ConsoleDispatchRecoveryRegion
 from ..Console_Modules.capture_policy_bindings import (
-    build_capture_policy_bindings,
     build_inspector_capture_policy_wiring,
 )
 from ..Console_Modules.left_rail import ConsoleLeftRail
@@ -154,8 +153,6 @@ from ...Chat.console_cost_tracker import (
     token_estimate_signature,
 )
 from ...Chat.console_exchange_capture import ExchangeCapture, capture_from_storage
-from ...Chat.provider_usage import ProviderUsage
-from ...Chat.trajectory import TrajectorySnapshot, derive_trajectory
 from ...LLM_Calls.pricing_catalog import get_pricing_catalog
 from ...Event_Handlers.Chat_Events.chat_events_console_dictionaries import (
     console_attachable_dictionaries,
@@ -427,9 +424,6 @@ from ...Widgets.Console.console_inspector_section import (
     ConsoleInspectorSectionState,
 )
 from ...Widgets.Console.console_command_popup import ConsoleCommandPopup
-from ...Widgets.Console.console_feedback_comment_modal import (
-    ConsoleFeedbackCommentModal,
-)
 from ...Widgets.Console.console_review_notes_modal import ConsoleReviewNotesModal
 from ...Widgets.Console.console_transcript import (
     ConsoleReviewNotesRequested,
@@ -443,6 +437,7 @@ from ...Widgets.Console.console_selection_menu import (
     ConsoleSideChatRequested,
     selection_menus_on_screen,
 )
+
 from ...Widgets.Console.console_side_chat_modal import ConsoleSideChatModal
 from ...Widgets.Console import console_project_instructions as project_instruction_ui
 from ...Widgets.Console.console_conversation_inspector import (
@@ -529,6 +524,9 @@ from ...Workspaces.display_state import (
 from ...Widgets.compact_model_bar import CompactModelBar
 from ...Widgets.Persona_Widgets.dictionary_picker import DictionaryPicker
 
+FeedbackRequested = ConsoleSelectionFeedbackRequested
+NoteRequested = ConsoleSelectionNoteRequested
+
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
 
@@ -580,16 +578,6 @@ _CONSOLE_RAIL_PREFERENCE_WRITE_LOCK = threading.Lock()
 CONSOLE_ACTIVE_RUN_STATUSES: tuple[ConsoleRunStatus, ...] = tuple(
     sorted(FEEDBACK_ACTIVE_RUN_STATUSES, key=lambda status: status.value)
 )
-# Console selection phase 3 (task 5): the bracketed header each feedback
-# action stamps on the composed next-user message (plan task 5 template:
-# header line, ``> ``-quoted selection, optional comment). Unknown action
-# strings fall back to the Comment header (mirrors the comment modal's
-# own ``_DEFAULT_HEADER`` fallback).
-CONSOLE_FEEDBACK_MESSAGE_HEADERS = {
-    ConsoleSelectionFeedbackRequested.ACTION_REQUEST_CHANGES: "[Request changes]",
-    ConsoleSelectionFeedbackRequested.ACTION_LGM: "[LGTM]",
-    ConsoleSelectionFeedbackRequested.ACTION_COMMENT: "[Comment]",
-}
 # Plan-B Task 7 Finding A: the conversation-browser `[N Sub-Agents]` badge
 # count previously re-queried the DB once per visible row on every 0.2s
 # poll tick. The batched replacement is still cheap to cache; this TTL is
@@ -1015,231 +1003,6 @@ CONSOLE_WORKBENCH_SHORTCUTS_SETUP_BLOCKED = tuple(
     ("Enter", "continue setup") if pair == ("Enter", "send / queue") else pair
     for pair in CONSOLE_WORKBENCH_SHORTCUTS
 )
-
-
-def _build_trajectory_snapshot(
-    store: Any,
-    conversation_id: str,
-    *,
-    agent_runs_db: Any | None = None,
-) -> "TrajectorySnapshot":
-    """Assemble the ``derive_trajectory`` inputs for one persisted conversation.
-
-    task-5 (console trajectory view). Best-effort at every seam: any source
-    that is unavailable contributes an empty iterable rather than failing
-    the launch -- the ledger degrades to fewer records, never to no screen.
-    Variant contents are process-local (see
-    ``ConsoleChatStore.variant_sets_for_conversation``): cold conversations
-    render without superseded variants by design.
-
-    Args:
-        store: Console store whose persistence owner supplies message/context facts.
-        conversation_id: Durable Console conversation identifier.
-        agent_runs_db: Optional public AgentRunsDB read seam captured by the caller.
-
-    Returns:
-        A completed pure-projection snapshot; the screen performs no DB reads.
-    """
-    messages: list[Any] = []
-    traj_rows: list[Any] = []
-    variant_sets: list[Any] = []
-    compaction_records: list[Any] = []
-    agent_runs: list[Any] = []
-    agent_steps: list[Any] = []
-    retrieval_runs: list[Any] = []
-    diagnostic_events: list[Any] = []
-    active_leaf: str | None = None
-
-    def capture_failed(
-        source: str, error: Exception, *, message_id: str | None = None
-    ) -> None:
-        logger.opt(exception=error).error(
-            "Trace source read failed: source={} conversation_id={}",
-            source,
-            conversation_id,
-        )
-        diagnostic_events.append(
-            {
-                "event_id": (
-                    f"capture-failed:{source}:{conversation_id}"
-                    f"{f':{message_id}' if message_id else ''}"
-                ),
-                "conversation_id": conversation_id,
-                "message_id": message_id,
-                "event_kind": "capture_failed",
-                "status": "capture_failed",
-                "summary": f"{source} capture failed",
-                "field_states": {
-                    "source": "capture_failed",
-                    **({"message_id": "observed"} if message_id else {}),
-                },
-                "sensitivity": "diagnostic",
-            }
-        )
-
-    persistence = getattr(store, "persistence", None)
-    db = getattr(persistence, "db", None)
-    if db is not None:
-        try:
-            messages = list(
-                db.get_messages_for_conversation(
-                    conversation_id,
-                    limit=1_000_000,
-                    # Text-only projection: skip the image BLOB I/O (task-260).
-                    include_image_data=False,
-                )
-            )
-        except Exception as error:  # noqa: BLE001 - launch must degrade, not fail
-            capture_failed("messages", error)
-            messages = []
-        try:
-            traj_rows = list(db.get_trajectory_rows(conversation_id))
-        except Exception as error:  # noqa: BLE001
-            capture_failed("trajectory", error)
-            traj_rows = []
-        try:
-            active_leaf = db.get_conversation_active_leaf(conversation_id)
-        except Exception as error:  # noqa: BLE001
-            capture_failed("active_leaf", error)
-            active_leaf = None
-    usage_by_id: dict[str, ProviderUsage] = {}
-    for message in messages:
-        if not isinstance(message, Mapping):
-            continue
-        usage = ProviderUsage.from_json(message.get("usage_json"))
-        if usage is not None:
-            usage_by_id[str(message.get("id"))] = usage
-    try:
-        variant_sets = list(store.variant_sets_for_conversation(conversation_id))
-    except Exception as error:  # noqa: BLE001
-        capture_failed("variants", error)
-        variant_sets = []
-    context_repository = getattr(persistence, "context_repository", None)
-    if context_repository is not None:
-        try:
-            # The projection itself filters purpose == "conversation_compaction".
-            offset = 0
-            while True:
-                page = list(
-                    context_repository.list_auxiliary_attempts(
-                        conversation_id, limit=500, offset=offset
-                    )
-                )
-                compaction_records.extend(
-                    {**record, "trace_lifecycle": True}
-                    if isinstance(record, Mapping)
-                    else record
-                    for record in page
-                )
-                if len(page) < 500:
-                    break
-                offset += len(page)
-        except Exception as error:  # noqa: BLE001
-            capture_failed("context", error)
-    turn_by_message: dict[str, str] = {}
-    for trajectory_row in traj_rows:
-        if isinstance(trajectory_row, Mapping):
-            row_message_id = trajectory_row.get("message_id")
-            row_turn_id = trajectory_row.get("turn_id")
-        else:
-            row_message_id = getattr(trajectory_row, "message_id", None)
-            row_turn_id = getattr(trajectory_row, "turn_id", None)
-        if row_message_id and row_turn_id:
-            turn_by_message[str(row_message_id)] = str(row_turn_id)
-    if agent_runs_db is not None:
-        try:
-            raw_runs = agent_runs_db.list_runs(conversation_id)
-            for raw_run in raw_runs:
-                try:
-                    run = dict(raw_run) if isinstance(raw_run, Mapping) else {}
-                    run_id = str(run.get("id") or "")
-                    if not run_id:
-                        continue
-                    assistant_message_id = str(run.get("assistant_message_id") or "")
-                    if assistant_message_id in turn_by_message:
-                        run["turn_id"] = turn_by_message[assistant_message_id]
-                    steps = list(run.get("steps", ()) or ())
-                    converted_steps = [
-                        {
-                            **step,
-                            "run_id": run_id,
-                            "conversation_id": conversation_id,
-                            "turn_id": run.get("turn_id"),
-                        }
-                        for step in steps
-                        if isinstance(step, Mapping)
-                    ]
-                    agent_runs.append(run)
-                    agent_steps.extend(converted_steps)
-                except Exception as error:  # noqa: BLE001
-                    capture_failed("agent", error)
-        except Exception as error:  # noqa: BLE001
-            capture_failed("agent", error)
-    citation_repository = getattr(persistence, "citation_repository", None)
-    if citation_repository is not None:
-        assistant_ids = [
-            str(message.get("id") or "")
-            for message in messages
-            if isinstance(message, Mapping)
-            and str(message.get("sender") or "").lower() == "assistant"
-            and message.get("id")
-        ]
-        try:
-            candidates = citation_repository.active_owner_candidate_message_ids(
-                assistant_ids
-            )
-        except Exception as error:  # noqa: BLE001
-            capture_failed("retrieval_candidates", error)
-            candidates = set()
-        for message in messages:
-            if not isinstance(message, Mapping):
-                continue
-            message_id = str(message.get("id") or "")
-            if (
-                not message_id
-                or str(message.get("sender") or "").lower() != "assistant"
-                or message_id not in candidates
-            ):
-                continue
-            try:
-                result = citation_repository.get_active_trace_for_current_message(
-                    message_id,
-                    str(message.get("content") or ""),
-                )
-                if (
-                    result.state is not ActiveCitationTraceState.ACTIVE
-                    or result.summary is None
-                    or not citation_repository.verify_active_trace_result(result)
-                ):
-                    continue
-                for run in result.summary.trace.evidence_runs:
-                    row = run.model_dump(mode="python")
-                    retrieval_runs.append(
-                        {
-                            **row,
-                            "conversation_id": conversation_id,
-                            "message_id": message_id,
-                            "turn_id": turn_by_message.get(message_id),
-                            "field_states": {"payload": "omitted"},
-                            "sensitivity": "retrieval_metadata",
-                            "trace_lifecycle": True,
-                        }
-                    )
-            except Exception as error:  # noqa: BLE001
-                capture_failed("retrieval", error, message_id=message_id)
-                continue
-    return derive_trajectory(
-        messages,
-        usage_by_id,
-        traj_rows,
-        variant_sets,
-        compaction_records,
-        active_leaf_message_id=active_leaf,
-        agent_runs=agent_runs,
-        agent_steps=agent_steps,
-        retrieval_runs=retrieval_runs,
-        diagnostic_events=diagnostic_events,
-    )
 
 
 #: TASK-362: the full Console keyboard vocabulary for the F1 help panel, grouped
@@ -3336,77 +3099,8 @@ class ChatScreen(BaseAppScreen):
         )
 
     def action_open_trajectory_view(self) -> None:
-        """Open Trace for the active Console conversation (``y``).
-
-        task-5: the snapshot is built off the UI thread (DB reads); the
-        screen is pushed with live tail-follow callables wired to the
-        store's payload-revision bus.
-
-        TASK-22213: `TrajectoryScreen` is imported here, not at module
-        scope, so the ~4,400-LOC trajectory family stays off the Chat
-        first-paint import leg. The first `y` press pays the one-time
-        import (tens of ms); every later press hits `sys.modules`.
-        """
-        from .trajectory_screen import TrajectoryScreen
-
-        store = self._console_chat_store or self._ensure_console_chat_store()
-        session = getattr(store, "_sessions", {}).get(
-            getattr(store, "active_session_id", None)
-        )
-        conversation_id = getattr(session, "persisted_conversation_id", None)
-        if not conversation_id:
-            self.notify("The active conversation has no persisted trace yet.")
-            return
-        conv_id = str(conversation_id)
-        target_session_id = str(session.id)
-        runtime = self._console_runtime()
-        capture_policy_bindings = None
-        if hasattr(runtime, "chat_controller"):
-            capture_policy_bindings = build_capture_policy_bindings(
-                self._ensure_console_chat_controller(),
-                target_session_id,
-                conv_id,
-            )
-        screen_title = str(getattr(session, "title", "") or "Console")
-        agent_controller = getattr(self, "_agent", None)
-        bridge = (
-            self._ensure_console_agent_bridge()
-            if agent_controller is not None
-            else None
-        )
-        agent_runs_db = getattr(bridge, "runs_db", None)
-
-        def build() -> TrajectorySnapshot:
-            return _build_trajectory_snapshot(
-                store,
-                conv_id,
-                agent_runs_db=agent_runs_db,
-            )
-
-        # task-16847: `Screen` defines NEITHER `call_from_thread` NOR
-        # `push_screen` (both are App-only in Textual 8) -- the original
-        # bare `self.` spelling of each raised AttributeError inside the
-        # thread worker, so pressing `y` never presented anything.
-        def present(snapshot: TrajectorySnapshot) -> None:
-            self.app.push_screen(
-                TrajectoryScreen(
-                    snapshot,
-                    screen_title=screen_title,
-                    conversation_id=conv_id,
-                    revision_provider=lambda: store.get_payload_revision(conv_id),
-                    snapshot_builder=build,
-                    capture_policy_bindings=capture_policy_bindings,
-                )
-            )
-
-        def build_worker() -> None:
-            snapshot = build()
-            self.app.call_from_thread(present, snapshot)
-
-        self.notify("Building trace…")
-        self.run_worker(
-            build_worker, thread=True, exclusive=True, group="trajectory-launch"
-        )
+        """Open Trace for the active Console conversation (``y``)."""
+        self._review_selection.open_trajectory_view()
 
     async def action_open_console_model_popover(self) -> None:
         """Open the Alt+M quick provider/model/temperature/streaming popover."""
@@ -12083,70 +11777,6 @@ class ChatScreen(BaseAppScreen):
             repository,
         )
 
-    def _sync_console_annotation_discovery(self, store: Any) -> None:
-        """Load persisted review annotations when the active conversation changes.
-
-        task-17169 slice 2 (the restore half of the inline marker): the map is
-        keyed by NATIVE message id, so a reload maps each stored row's
-        persisted message id back through the store's messages. Annotations
-        are local-only and written solely through this screen, so a reload is
-        needed only when the conversation changes -- live writes keep the map
-        current in between. The DB read runs off-thread (repo lesson: never
-        sqlite on the UI loop's sync tick) with exit_on_error=False.
-        """
-        session = getattr(store, "_sessions", {}).get(
-            getattr(store, "active_session_id", None)
-        )
-        conversation_id = getattr(session, "persisted_conversation_id", None)
-        if not conversation_id:
-            if self._console_annotation_loaded_conversation is not None:
-                self._console_annotation_loaded_conversation = None
-                self._console_annotation_previews = {}
-            return
-        conversation_id = str(conversation_id)
-        if conversation_id == self._console_annotation_loaded_conversation:
-            return
-        self._console_annotation_loaded_conversation = conversation_id
-        self._console_annotation_previews = {}
-        database = getattr(getattr(store, "persistence", None), "db", None)
-        if database is None:
-            return
-        self.run_worker(
-            self._load_console_annotation_previews(database, store, conversation_id),
-            exclusive=True,
-            group="console-annotation-previews",
-            exit_on_error=False,
-        )
-
-    async def _load_console_annotation_previews(
-        self, database: Any, store: Any, conversation_id: str
-    ) -> None:
-        """Worker body: read annotation rows and re-key them to native ids."""
-        try:
-            rows = await asyncio.to_thread(
-                database.get_transcript_annotations, conversation_id
-            )
-        except Exception:
-            logger.warning(
-                f"Console annotations: load failed for {conversation_id!r}",
-                exc_info=True,
-            )
-            return
-        if self._console_annotation_loaded_conversation != conversation_id:
-            return  # conversation switched while the read was in flight
-        native_by_persisted = {
-            message.persisted_message_id: message.id
-            for message in self._native_console_messages()
-            if message.persisted_message_id is not None
-        }
-        previews: dict[str, tuple[str, ...]] = {}
-        for row in rows:
-            native_id = native_by_persisted.get(row.get("message_id"))
-            if native_id is None:
-                continue
-            previews[native_id] = previews.get(native_id, ()) + (row["comment"],)
-        self._console_annotation_previews = previews
-
     def _sync_console_citation_count_discovery(self, messages: list[Any]) -> None:
         """Dispatch one count lookup worker when eligible inputs change."""
         signature = self._console_citation_signature(messages)
@@ -12395,7 +12025,7 @@ class ChatScreen(BaseAppScreen):
             # factory current every tick -- late-bound so a session switch
             # or a bridge becoming available never needs a fresh instance.
             transcript.set_change_review_provider_factory(
-                self._console_change_review_provider
+                self._review_selection._console_change_review_provider
             )
             self._sync_console_citation_count_discovery(messages)
             message_ids = {message.id for message in messages}
@@ -12444,7 +12074,7 @@ class ChatScreen(BaseAppScreen):
             # only -- the banner shows above the boundary message when it is on
             # the rendered path, and disappears (inert) otherwise.
             store = self._ensure_console_chat_store()
-            self._sync_console_annotation_discovery(store)
+            self._review_selection._sync_console_annotation_discovery(store)
             transcript.set_annotation_previews(self._console_annotation_previews)
             summary_boundary_id: str | None = None
             if store.active_session_id is not None:
@@ -14483,70 +14113,6 @@ class ChatScreen(BaseAppScreen):
             return None
         return str(run_id) if run_id else None
 
-    def _console_change_review_provider(self):
-        """The v-opener's provider recipe, shared with the turn file card.
-
-        Returns None whenever any collaborator is missing -- the card
-        degrades to the marker header; only the v opener toasts.
-        """
-        bridge = self._ensure_console_agent_bridge()
-        conversation_id = None
-        controller = self._console_chat_controller
-        if controller is not None:
-            try:
-                # The SAME id the run store keys by (persisted id when set,
-                # session id otherwise) -- change_snapshots joins agent_runs
-                # on it, so any other spelling shows an empty history.
-                active = controller.store.active_session_id
-                if active:
-                    conversation_id = controller._agent_conversation_id(active)
-            except Exception:  # noqa: BLE001 -- opener must degrade, not raise
-                conversation_id = None
-        provider = (
-            bridge.change_review_provider(conversation_id)
-            if bridge is not None and conversation_id
-            else None
-        )
-        if provider is None:
-            return None
-        # TASK-1974: reverts refuse while a run is active -- the engine's
-        # probe reads THIS controller's live run state each time.
-        if controller is not None:
-            # CONSOLE_ACTIVE_RUN_STATUSES is this module's own constant.
-            provider.run_active = lambda: (
-                controller.run_state.status in CONSOLE_ACTIVE_RUN_STATUSES
-            )
-            provider.run_active_for_root = controller.run_active_for_workspace
-        return provider
-
-    def _console_change_review_workspace_roots(self) -> "tuple[str, ...] | None":
-        """The live workspace roots to hand the Review screen (TASK-16801 arc B).
-
-        Without these, `current` mode never appears for a fresh conversation
-        that has no recorded turns yet -- the screen's own candidate set is
-        otherwise just the distinct roots across snapshot rows, which is
-        empty until an agent run has actually written something. This reads
-        the SAME field `console_chat_controller.py` turns into `change_roots`
-        for the tracker (`resolve_turn_execution_context(...).workspace_roots`),
-        so `current` mode detects against exactly the root the next turn
-        would track.
-
-        Same degrade posture as `_console_change_review_provider` just
-        above: any missing collaborator or raised exception yields ``None``
-        rather than breaking the opener -- `ChangeReviewScreen` already
-        treats ``None`` as "no live roots" (its pre-existing default).
-        """
-        controller = self._console_chat_controller
-        if controller is None:
-            return None
-        try:
-            active = controller.store.active_session_id
-            if not active:
-                return None
-            return controller.resolve_turn_execution_context(active).workspace_roots
-        except Exception:  # noqa: BLE001 -- opener must degrade, not raise
-            return None
-
     def _open_change_review(
         self,
         run_id: str | None = None,
@@ -14572,7 +14138,7 @@ class ChatScreen(BaseAppScreen):
                 two windows of the SAME run covering the same path (spec
                 §2). ``None`` when the caller has no snapshot row to pin to.
         """
-        provider = self._console_change_review_provider()
+        provider = self._review_selection._console_change_review_provider()
         if provider is None:
             self.app_instance.notify(
                 "Change review needs git and a saved conversation.",
@@ -14587,7 +14153,9 @@ class ChatScreen(BaseAppScreen):
         # roots -- see `_console_change_review_workspace_roots`'s docstring
         # for why this matters (it is what makes `current` mode reachable
         # from a fresh conversation with no recorded turns).
-        workspace_roots = self._console_change_review_workspace_roots()
+        workspace_roots = (
+            self._review_selection._console_change_review_workspace_roots()
+        )
 
         # initial_run_id/initial_path/initial_snapshot_id all ride the
         # constructor: a post-push select_turn/select_file call raced the
@@ -14636,7 +14204,7 @@ class ChatScreen(BaseAppScreen):
                 "Another Undo All is already in progress.", severity="warning"
             )
             return
-        provider = self._console_change_review_provider()
+        provider = self._review_selection._console_change_review_provider()
         if provider is None:
             card.finish_undo_all(success=False)
             self.app_instance.notify(
@@ -15995,239 +15563,16 @@ class ChatScreen(BaseAppScreen):
         )
 
     @on(ConsoleSelectionNoteRequested)
-    def on_console_selection_note_requested(
-        self, event: ConsoleSelectionNoteRequested
-    ) -> None:
-        """Save a transcript selection as a note (task-18156 Task 6).
-
-        Title = the quote's first line capped at 48 characters; content =
-        the quote plus a provenance line naming the session and date. The
-        write goes through the store's persistence DB (the same seam the
-        annotation write uses) off-thread -- never sqlite on the UI loop --
-        and every failure is a toast, never an exception: losing a note
-        must not disturb the selection flow that produced it.
-
-        Args:
-            event: The note request carrying the capped selection quote.
-        """
+    def on_console_selection_note_requested(self, event: NoteRequested) -> None:
         event.stop()
-        quote = event.quote.strip()
-        if not quote:
-            return
-        self.run_worker(
-            self._create_console_selection_note(event.quote),
-            group="console-selection-note",
-            exit_on_error=False,
-        )
-
-    async def _create_console_selection_note(self, quote: str) -> None:
-        """Worker body: derive title/content and write the note."""
-        from tldw_chatbook.Utils.input_validation import validate_text_input
-        from tldw_chatbook.Widgets.Console.console_selection import (
-            SELECTION_QUOTE_CAP,
-        )
-
-        # Boundary check through the shared module (PR #1813 review). The
-        # quote is already cap_quote-bounded at the transcript; this is the
-        # belt-and-suspenders size gate for any future caller. allow_html
-        # because transcript selections legitimately contain code --
-        # "<script" included -- and notes render as plain text.
-        if not validate_text_input(
-            quote, max_length=SELECTION_QUOTE_CAP + 64, allow_html=True
-        ):
-            self.notify("Selection is too large to save as a note.", severity="warning")
-            return
-        first_line = quote.strip().splitlines()[0]
-        title = first_line if len(first_line) <= 48 else first_line[:47] + "\u2026"
-        try:
-            controller = self._ensure_console_chat_controller()
-            store = controller.store
-            database = (
-                getattr(store.persistence, "db", None) if store.persistence else None
-            )
-            if database is None:
-                self.notify(
-                    "Notes are unavailable (no notes database).",
-                    severity="warning",
-                )
-                return
-            session = getattr(store, "_sessions", {}).get(store.active_session_id)
-            session_title = str(getattr(session, "title", "") or "Console")
-            from datetime import datetime as _dt
-
-            stamp = _dt.now().strftime("%Y-%m-%d")
-            content = f"{quote}\n\n\u2014 Console selection, {session_title}, {stamp}"
-            await asyncio.to_thread(database.add_note, title, content)
-        except Exception:
-            # Never log the title: it is arbitrary selected transcript text
-            # and can be a secret (PR #1813 review).
-            logger.warning(
-                f"Console selection note: write failed (title length {len(title)})",
-                exc_info=True,
-            )
-            self.notify("Could not create the note.", severity="warning")
-            return
-        # Selection text is untrusted markup: Textual's toast silently EATS
-        # bracketed spans ("[INFO] server up" loses its tag; "[x for x in y]"
-        # erases the whole title) -- and this toast is the only confirmation
-        # the user gets.
-        self.notify(f"Note created: {escape_markup(title)}")
+        self._review_selection.request_selection_note(event.quote)
 
     @on(ConsoleSelectionFeedbackRequested)
-    def on_console_selection_feedback_requested(
-        self, event: ConsoleSelectionFeedbackRequested
-    ) -> None:
-        """Compose structured review feedback and route it via the prompt queue.
-
-        Console selection phase 3 (task 5): the transcript's floating menu
-        posted this after its "Request changes" / "LGTM" / "Comment"
-        action on a selection in agent output. The flow collects an
-        optional comment, composes the plan-task-5 template -- action
-        header line, ``> ``-quoted selection (blank lines a bare ``>``,
-        mirroring ``insert_quote``), optional comment appended verbatim --
-        and dispatches through ``_prompt_queue``, the ONLY send seam: it
-        queues behind an active run, sends immediately otherwise, and
-        owns every refusal toast. The composer draft is never touched
-        (the user may be mid-typed), and ``submit_draft`` is never called
-        (it refuses during runs).
-
-        Synchronous handler dispatching a worker because
-        ``push_screen_wait`` raises ``NoActiveWorker`` outside one (see
-        ``EvalsScreen._on_delete_bench_pressed``'s identical note); the
-        action/quote are captured here, before the worker's first line
-        runs. The modal returns the stripped comment — ``""`` for a
-        comment-less submit (feedback still flows, no comment block) —
-        or ``None`` for Cancel/Escape/backdrop, which abandons the whole
-        feedback (plan task 5: modal escape dispatches nothing).
-        ``event.stop()`` because nothing above this screen subscribes --
-        the transcript already consumed the originating menu action.
-        """
+    def on_console_selection_feedback_requested(self, event: FeedbackRequested) -> None:
         event.stop()
-        if not event.quote.strip():
-            # Same blank-selection window as the quote/side-chat guards:
-            # the row range was cleared while the menu was open.
-            return
-        if self._console_selection_feedback_inflight:
-            # Rapid double-trigger (double-Enter before the menu unmounts):
-            # one flow, one modal, one dispatch, one durable record. Phase 4
-            # raised the stakes from a duplicate chat message to duplicate
-            # sidecar/annotation rows, so the documented phase-3 limitation
-            # is now closed rather than accepted.
-            return
-        self._console_selection_feedback_inflight = True
-        action, quote = event.action, event.quote
-        self.run_worker(
-            self._console_selection_feedback_flow(
-                action, quote, event.anchor_message_id
-            ),
-            group="console-selection-feedback",
+        self._review_selection.request_selection_feedback(
+            event.action, event.quote, event.anchor_message_id
         )
-
-    def _record_console_feedback_event(
-        self, action: str, quote: str, comment: str, anchor_message_id: str | None
-    ) -> None:
-        """Write the durable audit record for one dispatched feedback event.
-
-        task-17169 (phase 4): the feedback itself is ephemeral -- composed
-        into the next user message and gone. This lands it in the ADR-066
-        trajectory sidecar as an ``user_feedback`` event keyed to the
-        quoted row, so a run's review history survives a restart.
-
-        Called only for feedback that is actually dispatched (a cancelled
-        modal abandons the whole thing, so there is nothing to audit), and
-        only when the originating row supplied an anchor -- without one
-        there is no message to key the row to. It NEVER raises: the store
-        seam already swallows its own failures, and this guard covers the
-        lookup path too, because losing an audit record must not cost the
-        user the feedback they actually wrote.
-        """
-        if not anchor_message_id:
-            return
-        try:
-            controller = self._ensure_console_chat_controller()
-            session_id = controller.store.active_session_id
-            if not session_id:
-                return
-            controller.store.record_feedback_event(
-                session_id,
-                anchor_message_id=anchor_message_id,
-                action=action,
-                quote=quote,
-                comment=comment or None,
-            )
-            # Slice 2 of the both-homes decision (task-17169): a Comment with
-            # an actual note ALSO persists as a row-anchored annotation for
-            # the inline marker. Only Comment -- the spec's "Comment ...
-            # additionally persists an annotation" -- and only with text (an
-            # empty submit has nothing to mark the row with). Inside the same
-            # never-raises guard: neither durable write may cost the dispatch.
-            if action == ConsoleSelectionFeedbackRequested.ACTION_COMMENT and comment:
-                annotation_id = controller.store.record_feedback_annotation(
-                    session_id,
-                    anchor_message_id=anchor_message_id,
-                    quote=quote,
-                    comment=comment,
-                )
-                if annotation_id:
-                    # The inline marker updates immediately; the next sync
-                    # tick pushes the map to the mounted transcript.
-                    existing = self._console_annotation_previews.get(
-                        anchor_message_id, ()
-                    )
-                    self._console_annotation_previews[anchor_message_id] = existing + (
-                        comment,
-                    )
-        except Exception:
-            logger.warning(
-                "Console selection feedback: audit record failed for anchor "
-                f"{anchor_message_id!r}; the feedback itself was dispatched.",
-                exc_info=True,
-            )
-
-    async def _console_selection_feedback_flow(
-        self, action: str, quote: str, anchor_message_id: str | None = None
-    ) -> None:
-        """Comment modal, then compose and dispatch the feedback message.
-
-        Runs as a worker (see the handler above). NOT ``exclusive=True``:
-        this coroutine awaits ``push_screen_wait``, whose internal
-        ``asyncio.shield`` protects the wait -- not the already-mounted
-        modal -- from cancellation, so a superseding exclusive cancel
-        would strand a live modal with no owner for its result (the
-        ``EvalsScreen._on_delete_bench_pressed`` rationale).
-        """
-        try:
-            comment = await self.app.push_screen_wait(
-                ConsoleFeedbackCommentModal(action=action, quote=quote)
-            )
-            if comment is None:
-                return
-            lines = [CONSOLE_FEEDBACK_MESSAGE_HEADERS.get(action, "[Comment]")]
-            lines.extend(
-                f"> {line}" if line.strip() else ">" for line in quote.splitlines()
-            )
-            if comment:
-                lines.append(comment)
-            # Audit BEFORE the dispatch: the queue may block behind an active
-            # run, and the record is about what the user said, not about when
-            # the send drained.
-            # OFF-THREAD for the same reason the notes flow's writes are:
-            # `run_worker(coroutine)` runs on the event loop, so these two
-            # SQLite writes were blocking the UI, and a contended writer
-            # waits out the connection's 15s busy timeout.
-            await asyncio.to_thread(
-                self._record_console_feedback_event,
-                action,
-                quote,
-                comment,
-                anchor_message_id,
-            )
-            await self._prompt_queue.dispatch("\n".join(lines))
-        finally:
-            # Every exit path -- submit, cancel, or an error above -- releases
-            # the in-flight guard; a latched flag would silently kill the
-            # feature after its first use.
-            self._console_selection_feedback_inflight = False
 
     @on(ConsoleReviewNotesRequested)
     def on_console_review_notes_requested(
@@ -16468,8 +15813,10 @@ class ChatScreen(BaseAppScreen):
                 # id and paint its previews onto the new transcript for a
                 # frame. The discovery tick reloads the live conversation.
                 if _conversation_still_current():
-                    self._console_annotation_loaded_conversation = conversation_id
-                    await self._load_console_annotation_previews(
+                    self._review_selection.annotation_loaded_conversation = (
+                        conversation_id
+                    )
+                    await self._review_selection._load_console_annotation_previews(
                         database, store, conversation_id
                     )
                     await self._sync_native_console_transcript()


### PR DESCRIPTION
## Summary

- Extract the seven-method Console review and selection policy family into ConsoleReviewSelectionController.
- Keep exactly three Textual delegates and six reviewed presentation or ADR-068 methods on ChatScreen.
- Wire 15 explicit late-bound dependencies and three fail-loud compatibility descriptors without sibling-controller or durable-authority leakage.
- Keep persistence off the event loop and mutate annotation preview state only after worker completion.
- Reduce ChatScreen by a net 656 physical lines and seven unique direct methods without increasing the ratchet.

## Verification

- 160 focused UI, controller, wiring, and architecture tests passed.
- Targeted Ruff, Ruff format, compile, live-base drift, diagnostic inventory, backlog-ID, privacy, placeholder, and diff gates passed.
- Five bounded mutations produced the intended RED and returned GREEN after exact restoration: stale annotation load, latched in-flight guard, dispatch before audit, worker-thread preview mutation, and selected-text logging.
- No local full-suite run was performed.

Two unrelated persistent-diagnostic ledger assertions currently fail identically on the untouched origin/dev base in library_screen.py and watchlists_collections_screen.py. The task-owned inventory checker and exact relocation assertion pass.

ADR required: no. This applies the existing ADR-068 ownership boundary without changing durable authority or policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the seven-method Console review and selection policy family from `ChatScreen` into a new `ConsoleReviewSelectionController` without changing review, selection, annotation, note, or trajectory behavior.

**Refactors**
- Moves review provider/root policy, annotation discovery, selection feedback, note policy, trajectory snapshot loading, and launch sequencing into `tldw_chatbook/UI/Console_Modules/review_selection.py`.
- Wires 15 explicit late-bound dependencies and three fail-loud compatibility descriptors through the existing `build_console_controllers()` seam without sibling-controller or durable-authority leakage.
- Keeps exactly three Textual delegates and six reviewed presentation/ADR-068 methods on `ChatScreen`, cutting 656 net physical lines and 7 unique direct methods without raising the screen-size ratchet.
- Keeps persistence off the event loop and mutates annotation preview state only after worker completion.
- Adds focused controller, wiring, and source-inspected boundary tests; 160 targeted tests pass, and five bounded mutations produced the intended RED-to-GREEN restore cycles.
- Updates the production diagnostic inventory for the new owner; no ADR is required because the change applies the existing ADR-068 boundary.
- Two unrelated diagnostic-ledger assertions fail identically on the untouched `dev` base in `tldw_chatbook/UI/Screens/library_screen.py` and `watchlists_collections_screen.py`.

<sup>Written for commit 18b68ac9416bdb50129ebda7310b9635189ceb20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

