### PR TITLE
fix(console): closing a chat is not an owner change (TASK-22690)

### DIFF
--- a/Tests/Chat/test_console_close_during_postcommit_owner.py
+++ b/Tests/Chat/test_console_close_during_postcommit_owner.py
@@ -1,0 +1,58 @@
+"""Closing a chat must not read as an owner change (TASK-22690).
+
+The tail of `resume_durable_postcommit` refuses to settle a continuation whose
+OWNER changed underneath it. That guard is right, but it treated two different
+events as one: an owner that genuinely changed (a bug) and an owner that is
+legitimately GONE because the user closed the chat (ordinary). Closing mid-turn
+therefore raised `RuntimeError("Durable continuation owner changed.")`.
+
+This is the fourth site of the conflation TASK-22587 removed, and it is decided
+the same way: `retire_durable_acceptance` leaves a tombstone carrying the SAME
+fingerprint, so a matching tombstone proves the preparation was retired by a
+close rather than replaced.
+
+Measured at the raise before fixing anything: continuation absent, live
+fingerprint gone, tombstone present AND matching -- so the close had gone
+through `retire_durable_acceptance`, not the discard path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.Chat.test_console_close_during_durable_postcommit import _claimed_effect
+
+
+def test_a_retired_acceptance_is_reported_as_retired(tmp_path) -> None:
+    """The public predicate the owner check now consults."""
+
+    store, prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+    store.close_session("session-1")
+
+    assert store.durable_acceptance_retired(prep, fingerprint) is True
+
+
+def test_a_different_acceptance_is_not_reported_as_retired(tmp_path) -> None:
+    """NEGATIVE CONTROL.
+
+    Retirement must be keyed on THIS acceptance, not on the preparation id
+    merely having a tombstone -- otherwise an owner that genuinely changed
+    would be waved through as an ordinary close, which is exactly the failure
+    the guard exists to prevent.
+    """
+
+    from dataclasses import replace
+
+    store, prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+    store.close_session("session-1")
+    other = replace(fingerprint, assistant_message_id="a-different-turn")
+
+    assert store.durable_acceptance_retired(prep, other) is False
+
+
+def test_an_unknown_preparation_is_not_reported_as_retired(tmp_path) -> None:
+    """No tombstone at all is not evidence of a close."""
+
+    store, _prep, fingerprint = _claimed_effect(tmp_path, claim=False)
+
+    assert store.durable_acceptance_retired("never-existed", fingerprint) is False

--- a/Tests/Chat/test_console_local_citation_boundary.py
+++ b/Tests/Chat/test_console_local_citation_boundary.py
@@ -2949,21 +2949,6 @@ async def test_citation_repair_late_chunk_privacy_sentinels(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    strict=False,
-    raises=RuntimeError,
-    reason=(
-        "TASK-22690: closing a chat during an in-flight durable postcommit "
-        "raises 'Durable continuation owner changed.' -- a fourth raise site "
-        "of the class TASK-22587 fixed. TASK-22587 predicted these two tests "
-        "would reach a durable-path failure once their sessions stopped being "
-        "ephemeral. NARROWED to RuntimeError (Qodo review of #2128): an "
-        "unconditional xfail would also swallow failures in privacy cleanup, "
-        "session removal, message resurrection and cancellation -- everything "
-        "else these tests assert. Not skipped: it still runs and reports if it "
-        "starts passing."
-    ),
-)
 async def test_citation_repair_session_close_privacy_sentinels(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -3386,21 +3371,6 @@ async def test_citation_repair_shutdown_during_collection_privacy_has_no_user_st
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    strict=False,
-    raises=RuntimeError,
-    reason=(
-        "TASK-22690: closing a chat during an in-flight durable postcommit "
-        "raises 'Durable continuation owner changed.' -- a fourth raise site "
-        "of the class TASK-22587 fixed. TASK-22587 predicted these two tests "
-        "would reach a durable-path failure once their sessions stopped being "
-        "ephemeral. NARROWED to RuntimeError (Qodo review of #2128): an "
-        "unconditional xfail would also swallow failures in privacy cleanup, "
-        "session removal, message resurrection and cancellation -- everything "
-        "else these tests assert. Not skipped: it still runs and reports if it "
-        "starts passing."
-    ),
-)
 async def test_citation_repair_close_during_collection_never_resurrects_session_or_message():
     persistence = _ReadyCitationPersistence()
     controller, store, gateway, _bridge, _initial_body, _repaired_body = (

--- a/backlog/tasks/task-22690 - Closing-a-chat-mid-turn-raises-Durable-continuation-owner-changed.md
+++ b/backlog/tasks/task-22690 - Closing-a-chat-mid-turn-raises-Durable-continuation-owner-changed.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-22690
 title: Closing a chat mid-turn raises Durable continuation owner changed
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-26 23:51'
+updated_date: '2026-08-27 06:12'
 labels:
   - console
   - durable-turns
@@ -29,33 +31,7 @@ The retirement tombstone TASK-22587 introduced already makes the two cases decid
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Closing a chat during an in-flight durable postcommit does not raise Durable continuation owner changed
-- [ ] #2 A continuation whose owner genuinely CHANGED still raises (negative control, mutation-proven)
-- [ ] #3 The two xfail markers in test_console_local_citation_boundary are removed and the tests pass
+- [x] #1 Closing a chat during an in-flight durable postcommit does not raise Durable continuation owner changed
+- [x] #2 A continuation whose owner genuinely CHANGED still raises (negative control, mutation-proven)
+- [x] #3 The two xfail markers in test_console_local_citation_boundary are removed and the tests pass
 <!-- AC:END -->
-
-## Numbering provenance
-
-`backlog task create` assigned task-22618 from a stale local view; a sweep of
-all remotes and worktrees showed the real maximum was 22660 AND that 22618 was
-already taken. Renumbered to 22690 (max+30) under the leapfrog rule before the
-file was ever committed.
-
-## Blocked on #2128 (recorded 2026-08-26)
-
-Attempted on a clean `dev` base and could NOT be reproduced there. Two findings
-worth keeping so the next attempt does not repeat them:
-
-- Dropping the continuation on its own does not reach this raise.
-  `resume_durable_postcommit` returns "Committed turn continuation is
-  unavailable." early when the continuation is missing at ENTRY. The tail check
-  only fires when the continuation was present at entry and is gone by the end.
-- The two tests that do reach it only take the durable path with #2128's
-  ephemeral-to-durable conversion, which is not merged yet. On `dev` those
-  sessions are still ephemeral and never get near it.
-
-So this needs #2128 merged first. A candidate mechanism to check then: a close
-that goes through `discard_uncommitted_durable_preparation` rather than
-`retire_durable_acceptance` leaves NO tombstone, so `_durable_retired_locked`
-returns False and TASK-22587's benign-retirement path is never taken -- the
-generic RuntimeError is raised instead. Verify that before assuming it.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -6573,7 +6573,10 @@ class ConsoleChatController:
         return ConsoleSubmitResult(
             True,
             True,
-            "",
+            # TASK-22690: the generic copy every other close site uses. This
+            # returned "" when TASK-22587 added it, which reads to the caller
+            # as "no message" rather than "the session closed".
+            "Session closed.",
             session_id=session_id,
             user_message_id=commit.user_message_id,
             assistant_message_id=commit.assistant_message_id,
@@ -6968,6 +6971,21 @@ class ConsoleChatController:
         with self.store.durable_preparation_lock:
             current = self._durable_postcommit_continuations.get(preparation_id)
             if current is None or current.fingerprint != fingerprint:
+                if current is None and self.store.durable_acceptance_retired(
+                    preparation_id, fingerprint
+                ):
+                    # TASK-22690: the user closed the chat while this sequence
+                    # ran, so the close already dropped the continuation and
+                    # retired the preparation. The tombstone proves it is THIS
+                    # acceptance, which is what separates an ordinary close from
+                    # an owner that genuinely changed underneath us. A fourth
+                    # site of the conflation TASK-22587 removed.
+                    return self._postcommit_stopped_by_close(
+                        preparation_id=preparation_id,
+                        session_id=session_id,
+                        commit=commit,
+                        continuation=continuation,
+                    )
                 raise RuntimeError("Durable continuation owner changed.")
             self._durable_postcommit_continuations.pop(preparation_id, None)
             self._release_retired_prepared_evidence(current)

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -909,6 +909,9 @@ _APPROVAL_SCOPE_RANK: dict[str, int] = {
 
 
 CONSOLE_CONTINUE_INSTRUCTION = "Continue and extend the selected message."
+#: The generic copy for a turn ended by the session closing. One name for
+#: it so the six sites that reported a close cannot drift apart (TASK-22690).
+SESSION_CLOSED_COPY = "Session closed."
 PROVIDER_CONTINUATION_RECOVERY_REQUIRED = (
     "Recover the interrupted tool run before sending a new message: "
     "Resume or Discard it first."
@@ -6576,7 +6579,7 @@ class ConsoleChatController:
             # TASK-22690: the generic copy every other close site uses. This
             # returned "" when TASK-22587 added it, which reads to the caller
             # as "no message" rather than "the session closed".
-            "Session closed.",
+            SESSION_CLOSED_COPY,
             session_id=session_id,
             user_message_id=commit.user_message_id,
             assistant_message_id=commit.assistant_message_id,
@@ -7863,7 +7866,7 @@ class ConsoleChatController:
             if task is not None and task is not asyncio.current_task():
                 task.cancel()
             self._set_run_state(
-                ConsoleRunState(ConsoleRunStatus.STOPPED, "Session closed."),
+                ConsoleRunState(ConsoleRunStatus.STOPPED, SESSION_CLOSED_COPY),
                 # `session_id` here is the session being CLOSED, which the
                 # `_active_stream_belongs_to_session` guard above confirms
                 # owns the active stream -- not necessarily the currently
@@ -15751,7 +15754,7 @@ class ConsoleChatController:
         def commit_canceled() -> ConsoleCitationSelectionOutcome:
             if not owns_request():
                 visible_copy = (
-                    "Session closed."
+                    SESSION_CLOSED_COPY
                     if repair_session.cancel_reason == "session_close"
                     else initial_body
                 )
@@ -15763,7 +15766,7 @@ class ConsoleChatController:
                 current = self.store.get_message(assistant_message_id)
             except KeyError:
                 return ConsoleCitationSelectionOutcome(
-                    "Session closed.",
+                    SESSION_CLOSED_COPY,
                     "canceled",
                 )
             if current.content != initial_body:
@@ -15894,7 +15897,7 @@ class ConsoleChatController:
                 current_message = self.store.get_message(assistant_message_id)
             except KeyError:
                 return ConsoleCitationSelectionOutcome(
-                    "Session closed.",
+                    SESSION_CLOSED_COPY,
                     "canceled",
                 )
             if (
@@ -18111,7 +18114,7 @@ class ConsoleChatController:
                 "Session closed" there too would be a redundant, confusing
                 second signal for something the user just did on purpose.
         """
-        visible_copy = "Session closed."
+        visible_copy = SESSION_CLOSED_COPY
         self._set_run_state(
             ConsoleRunState(ConsoleRunStatus.STOPPED, visible_copy),
             session_id=session_id,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4047,6 +4047,22 @@ class ConsoleChatStore:
                 continue
             self._durable_tombstones.pop(victim, None)
 
+    def durable_acceptance_retired(
+        self,
+        preparation_id: str,
+        fingerprint: ConsoleDurableAcceptanceFingerprint,
+    ) -> bool:
+        """True when THIS acceptance was retired, rather than mutated.
+
+        The public form of the tombstone check TASK-22587 introduced. Callers
+        outside the store need it to tell "the user closed the chat" from "the
+        owner changed underneath me", which are otherwise indistinguishable
+        once the live fingerprint is gone.
+        """
+
+        with self._preparation_lock:
+            return self._durable_retired_locked(preparation_id, fingerprint)
+
     def release_durable_postcommit_activity(self, preparation_id: str) -> None:
         """Allow this preparation's tombstone to be evicted again.
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4052,12 +4052,23 @@ class ConsoleChatStore:
         preparation_id: str,
         fingerprint: ConsoleDurableAcceptanceFingerprint,
     ) -> bool:
-        """True when THIS acceptance was retired, rather than mutated.
+        """Return whether THIS acceptance was retired, rather than mutated.
 
         The public form of the tombstone check TASK-22587 introduced. Callers
         outside the store need it to tell "the user closed the chat" from "the
         owner changed underneath me", which are otherwise indistinguishable
         once the live fingerprint is gone.
+
+        Args:
+            preparation_id: The preparation whose retirement is in question.
+            fingerprint: The acceptance the caller believes it is settling.
+                Matching matters: a tombstone under this id for a DIFFERENT
+                acceptance is an owner change, not a close.
+
+        Returns:
+            True when a tombstone exists for ``preparation_id`` and carries
+            exactly ``fingerprint``; False otherwise, including when no
+            tombstone exists at all.
         """
 
         with self._preparation_lock:


### PR DESCRIPTION
## Summary

Closing a Console chat while a durable turn's postcommit sequence was running
raised `RuntimeError("Durable continuation owner changed.")`.

This is the **fourth site** of the conflation TASK-22587 removed, and the last one
blocking two tests that #2128 left `xfail`.

## The defect

The tail of `resume_durable_postcommit` refuses to settle a continuation whose
**owner changed** underneath it. That guard is correct — a continuation must not
be settled by the wrong turn. What it did not distinguish is *"the owner is
legitimately **gone** because the user closed the chat"*, which is ordinary, from
*"the owner **changed**"*, which is a bug. Both raised.

## My filed hypothesis was wrong, and measurement refuted it

The task predicted a close routed through
`discard_uncommitted_durable_preparation`, which leaves **no** tombstone — so
TASK-22587's benign-retirement path would never engage.

Instrumenting the actual raise showed the opposite:

```
continuation_present: False
live_fp:              False
tombstone_present:    True
tombstone_matches:    True   <-- the close DID go through retire_durable_acceptance
```

The tombstone was there all along. Implementing against the filed guess would
have produced a fix for a mechanism that does not exist. It was recorded as a
hypothesis to verify rather than a diagnosis, and verifying it is what caught it.

## Fix

Same decision procedure as TASK-22587: `retire_durable_acceptance` leaves a
tombstone carrying the **same** fingerprint, so a matching tombstone proves the
preparation was retired by a close rather than replaced.

- New public `ConsoleChatStore.durable_acceptance_retired(preparation_id, fingerprint)`.
- The owner check takes TASK-22587's existing terminal-benign path when the
  continuation is absent **and** retirement is proven; it still raises otherwise.

Also aligns the closed-session copy with the generic `"Session closed."` every
other close site uses. TASK-22587 left it `""`, which reads to a caller as
"no message" rather than "the session closed" — and a test asserting that copy is
what surfaced it.

## Mutation-proven

| mutation | result |
|---|---|
| remove the benign path | **2 failed** |
| make retirement ignore the fingerprint (negative control) | **1 failed** |

The negative control is the load-bearing one: retirement must key on **this**
acceptance, not on the id merely having a tombstone, or an owner that genuinely
changed would be waved through as an ordinary close — precisely what the guard
exists to prevent.

## Effect on the xfail backlog

Both TASK-22690 markers removed. `test_console_local_citation_boundary` goes
**94 passed / 1 xfailed**; only TASK-22720 remains.

## Verification

A/B of `Tests/Chat` against the merge-base, baseline verified byte-identical:

| | merge-base | this branch |
|---|---|---|
| collected | 7777 | 7780 (**+3**, the new tests) |
| failures | 74 | **74** |
| newly broken | — | **0** |

`0 fixed` is expected: the two recovered tests were `xfail` on the baseline, so
neither side counts them as failures — their recovery shows as the file's xfail
count dropping from 3 to 1.

TASK-22587's own 16 tests still pass. `./scripts/preflight.sh` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes closing a chat during an in-flight durable postcommit raising `RuntimeError("Durable continuation owner changed.")`. The postcommit guard treated an owner that legitimately went away (user closed the chat) the same as an owner that changed; now a matching tombstone from `retire_durable_acceptance` proves the close, so the guard takes the benign path while a genuinely changed owner still raises. Adds `ConsoleChatStore.durable_acceptance_retired` to expose that check, unifies the six "Session closed." sites behind `SESSION_CLOSED_COPY`, and removes two xfail markers.

<sup>Written for commit d2618204dc2ee08096bf91fa1ffb1807f5882f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

