### PR TITLE
docs(backlog): correct TASK-22720 — the premise was wrong on both counts

### DIFF
--- a/backlog/tasks/task-22720 - Agent-bridge-run_reply-failure-is-swallowed-leaving-an-empty-assistant-row.md
+++ b/backlog/tasks/task-22720 - Agent-bridge-run_reply-failure-is-swallowed-leaving-an-empty-assistant-row.md
@@ -1,6 +1,6 @@
 ---
 id: TASK-22720
-title: Agent bridge run_reply failure is swallowed, leaving an empty assistant row
+title: Agent bridge placeholder-replacement test trips the unresolved-recovery guard
 status: To Do
 labels:
   - console
@@ -39,3 +39,39 @@ secondary and may well be a stale expectation in the test's own bridge double
       assistant row -- it is either surfaced or logged with its exception type
 - [ ] The xfail marker in `test_console_local_citation_boundary.py` is removed
       and the test passes
+
+
+## Correction 2026-08-27 — the filed premise was wrong on both counts
+
+Measured by instrumenting the controller's `except Exception` arm, not inferred.
+
+**1. The controller does NOT swallow the failure.** That handler builds
+`"Agent run failed: {describe_stream_failure(exc)}"`, calls
+`mark_message_failed`, appends a failure system row, and sets run state FAILED.
+The failure is surfaced, not lost. The title of this task is inaccurate.
+
+**2. What `run_reply` raises, and why:**
+
+    RuntimeError: Unresolved temporary dispatch recovery cannot be replaced.
+
+Raised from `ConsoleChatStore.restore_state` (console_chat_store.py:5046). The
+guard refuses to replace an UNRESOLVED dispatch recovery unless the restored
+message set still contains the recovery's own USER and ASSISTANT rows. The
+test's `_ReplacingBridge` deliberately builds `retained` with the assistant row
+EXCLUDED -- that is how it simulates "the placeholder went missing" -- so it
+trips the guard by construction.
+
+The guard looks correct: silently replacing an unresolved recovery whose
+assistant row has vanished would discard recovery state. So this is a stale TEST
+TECHNIQUE, not a product defect: the double simulates a missing placeholder in a
+way the store now forbids.
+
+**Open question for whoever picks this up** (do not guess it):
+what SHOULD happen when an agent replaces a placeholder that is gone? Either
+  (a) the test clears/resolves the dispatch recovery before `restore_state`, so
+      the simulation stops violating a real invariant; or
+  (b) the expectation changes to the surfaced "Agent run failed: ..." outcome,
+      if tripping the guard is the honest result of that scenario.
+
+Pre-existing either way: this was one of the original 40 failures in
+`test_console_local_citation_boundary.py`, failing before TASK-22301 touched it.


### PR DESCRIPTION
## Summary

One backlog file. No code changes.

TASK-22720 was filed by me during TASK-22301 from a symptom, and **its premise was
wrong on both counts.** This corrects the record before someone acts on it.

## What I claimed vs what is true

**Claimed:** the controller swallows an agent-bridge `run_reply` failure, leaving
an empty assistant row.

**Measured** (by instrumenting the controller's `except Exception` arm):

1. **The controller does not swallow it.** That handler builds
   `"Agent run failed: {describe_stream_failure(exc)}"`, calls
   `mark_message_failed`, appends a failure system row, and sets run state
   `FAILED`. The failure is surfaced.
2. **The actual exception is a legitimate guard firing:**

   ```
   RuntimeError: Unresolved temporary dispatch recovery cannot be replaced.
   ```

   Raised from `ConsoleChatStore.restore_state`, which refuses to replace an
   **unresolved** dispatch recovery unless the restored message set still
   contains that recovery's own USER and ASSISTANT rows. The test's
   `_ReplacingBridge` deliberately builds its retained set with the assistant row
   **excluded** — that is precisely how it simulates "the placeholder went
   missing" — so it trips the guard by construction.

Silently replacing an unresolved recovery whose assistant row has vanished would
discard recovery state, so the guard looks correct. This is a **stale test
technique**, not a product defect.

## What is left open, deliberately

The task now states the real question rather than answering it: when an agent
replaces a placeholder that is gone, should the test clear the dispatch recovery
first so its simulation stops violating a real invariant, or should the
expectation become the surfaced `"Agent run failed: ..."` outcome? That is a call
about intended behaviour, and inventing one would be worse than leaving it
stated.

Title corrected to match the mechanism. Still pre-existing either way — one of
the original 40 failures in `test_console_local_citation_boundary.py`, failing
before TASK-22301 touched it, and covered there by an `xfail(raises=AssertionError)`
naming this task.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the TASK-22720 backlog record — the filed premise was wrong on both counts. The controller does not swallow the agent-bridge failure; it surfaces it via `mark_message_failed` plus a failure system row, and the actual raised exception is a legitimate guard in `ConsoleChatStore.restore_state` that the test's bridge double trips by construction, making this a stale test technique rather than a product defect.

The corrected task records the open question — whether the test should clear the dispatch recovery first or expect the surfaced failure — without guessing which behavior is intended.

<sup>Written for commit 2726cf31becdc370c7354d57a9d8615e54b7e0b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

