### PR TITLE
perf(console): derive the next-send price on hover, not on every keystroke (TASK-23018)

### DIFF
--- a/Docs/User_Guide/console/chat-basics.md
+++ b/Docs/User_Guide/console/chat-basics.md
@@ -41,6 +41,22 @@ task...".
   Mic and Attach have their own page:
   [attachments, images & voice](attachments-images-voice.md).
 
+### What the next send will cost
+
+When there is something to send, Send reads **Send | $** (or **Queue | $**
+mid-run). That suffix means an estimate is available; **hover Send** to read
+it. The tooltip breaks out the estimated input tokens and cost, the reply-token
+ceiling and its cost at the configured limit, and the provider/model plus the
+date of the rates used. Attachments and media already in the conversation are
+listed but not priced, and anything the app cannot work out honestly reads
+"Next request: cost unavailable" rather than guessing.
+
+The estimate is worked out when you hover, from the draft and conversation as
+they are at that moment — so it is always the current number, and typing costs
+nothing while the pointer is elsewhere. A blocked Send (setup incomplete, a run
+in flight, an auto-wake turn delivering) shows the reason for the block instead
+of a price.
+
 ### Collapsed rail labels
 
 Collapsed Console rails use horizontal **Context->** and **<-Inspect** handles
@@ -346,4 +362,7 @@ painted probes). The Send→Queue behaviour described above was re-verified
 live against dev @ a71e62e4b — 2026-08-24 (TASK-22000: the page was
 correct and the app was not; mid-run the button now reads **Queue**, is
 enabled with a draft, and admits a FIFO follow-up that drains after the
-current turn).*
+current turn).* *The "What the next send will cost" section was added against
+dev @ 40ba8fe74d — 2026-08-27 (TASK-23018: the estimate shipped in #2114 was
+undocumented and was being re-derived on every keystroke; it is now derived on
+hover, and the tooltip content above was read off a live 400-message session).*

--- a/Tests/UI/test_console_send_disabled_state.py
+++ b/Tests/UI/test_console_send_disabled_state.py
@@ -116,6 +116,9 @@ async def test_typing_enables_send_and_clears_reason_immediately():
         assert send_button.disabled is False
         assert reason.styles.display == "none"
         assert send_button.label.plain == "Send | $"
+        # TASK-23018: typing advertises the price with the label suffix; the
+        # estimate itself is derived when the pointer reaches Send.
+        await pilot.hover("#console-send-message")
         assert str(send_button.tooltip).startswith("Next request:")
 
         # Deleting back to empty restores both, again synchronously.
@@ -170,6 +173,8 @@ async def test_setup_block_shows_reason_and_clears_when_unblocked():
         assert send_button.disabled is False
         assert reason.styles.display == "none"
         assert send_button.label.plain == "Send | $"
+        # TASK-23018: see above -- the price lands on the pointer, not the key.
+        await pilot.hover("#console-send-message")
         assert str(send_button.tooltip).startswith("Next request:")
 
 

--- a/Tests/UI/test_console_send_price.py
+++ b/Tests/UI/test_console_send_price.py
@@ -153,10 +153,17 @@ async def test_composer_price_affordance_tracks_send_queue_attachment_and_width(
         assert calls == []
 
         composer.load_draft("priced draft")
+        # TASK-23018: the affordance (label + width) is decided without ever
+        # deriving the price; the derivation waits for the pointer.
         assert send_button.label.plain == "Send | $"
+        assert calls == []
+        assert send_button.tooltip == ConsoleComposerBar.SEND_READY_TOOLTIP
+
+        await pilot.hover("#console-send-message")
         assert send_button.tooltip == (
             "Next request: up to ~$0.01\nDraft: priced draft"
         )
+        assert calls == ["priced draft"]
         assert send_button.styles.width.value == cell_len("Send | $") + 2
         assert actions.styles.width.value == BASE_ACTIONS_WIDTH + 4
 
@@ -222,7 +229,7 @@ async def test_composer_blocker_tooltip_and_unsuffixed_label_win_over_price(
         return "Next request: up to ~$0.01"
 
     app = _PriceComposerApp(tooltip_provider)
-    async with app.run_test(size=(100, 24)):
+    async with app.run_test(size=(100, 24)) as pilot:
         composer = app.query_one(ConsoleComposerBar)
         send_button = composer.query_one("#console-send-message", Button)
         composer.load_draft("sendable")
@@ -241,6 +248,19 @@ async def test_composer_blocker_tooltip_and_unsuffixed_label_win_over_price(
         assert send_button.disabled is True
         assert send_button.label.plain == "Queue"
         assert send_button.styles.width.value == 7
+        assert send_button.tooltip == expected_tooltip
+        assert calls_before_block == len(calls)
+
+        # TASK-23018: pricing is now hover-triggered, so the blocked copy has
+        # to survive the pointer moving around Send too. Note that hovering
+        # the blocked Send itself is INERT by construction -- Textual does
+        # not deliver `Enter` to a disabled widget (verified: `mouse_over`
+        # becomes the button, no handler runs) -- so the load-bearing
+        # gesture here is the pointer landing on a SIBLING, which does post
+        # a bubbling `Enter` to the composer.
+        await pilot.hover("#console-send-message")
+        assert send_button.tooltip == expected_tooltip
+        await pilot.hover("#console-dictation")
         assert send_button.tooltip == expected_tooltip
         assert calls_before_block == len(calls)
 
@@ -265,7 +285,7 @@ async def test_composer_price_provider_failure_never_blocks_send():
         raise RuntimeError("pricing unavailable")
 
     app = _PriceComposerApp(broken_provider)
-    async with app.run_test(size=(100, 24)):
+    async with app.run_test(size=(100, 24)) as pilot:
         composer = app.query_one(ConsoleComposerBar)
         send_button = composer.query_one("#console-send-message", Button)
 
@@ -273,6 +293,9 @@ async def test_composer_price_provider_failure_never_blocks_send():
 
         assert send_button.disabled is False
         assert send_button.label.plain == "Send | $"
+
+        await pilot.hover("#console-send-message")
+        assert send_button.disabled is False
         assert send_button.tooltip == "Next request: cost unavailable"
 
 
@@ -530,6 +553,10 @@ async def test_mounted_console_refreshes_send_price_without_changing_cost_chip()
         composer.load_draft("hello")
 
         assert send_button.label.plain == "Send | $"
+        # TASK-23018: the price is derived on hover, and every resync below
+        # happens under this parked pointer -- which is exactly the state the
+        # freshness guarantee has to hold in.
+        await pilot.hover("#console-send-message")
         tooltip = str(send_button.tooltip)
         assert "Next request:" in tooltip
         assert "Input:" in tooltip
@@ -642,6 +669,7 @@ async def test_mounted_console_prices_a_sendable_follow_up_as_queue():
         composer.load_draft("queued follow-up")
 
         assert send_button.label.plain == "Queue | $"
+        await pilot.hover("#console-send-message")
         assert "Next request:" in str(send_button.tooltip)
 
         gateway.release.set()
@@ -814,3 +842,308 @@ def test_build_next_send_price_normalizes_provenance_identifiers(
     )
 
     assert result.tooltip.splitlines()[-1] == expected_provenance
+
+
+#
+#######################################################################################################################
+#
+# TASK-23018: the next-send price must not be derived on the keystroke path
+#
+
+
+def _counting_rows(unpacks: list[int]) -> tuple:
+    """Build history rows that count how often they are unpacked.
+
+    ``presentation_for_draft`` unpacks every ``(role, content)`` pair once
+    per set of counter rows it builds, and nothing else in the call iterates
+    an individual row -- so this counter sees exactly the O(session) list
+    comprehension the token cache is supposed to skip on a hit.
+    """
+
+    class _Pair(tuple):
+        def __new__(cls, role: str, content: str):
+            return super().__new__(cls, (role, content))
+
+        def __iter__(self):
+            unpacks[0] += 1
+            return super().__iter__()
+
+    return (_Pair("system", "system"), _Pair("user", "history"))
+
+
+@pytest.mark.parametrize(
+    ("draft", "attachment", "history_raises"),
+    [
+        ("priced draft", False, False),
+        ("   ", False, False),
+        ("   ", True, False),
+        ("<script>alert(1)</script>", False, False),
+        ("hello\x00world", False, False),
+        ("priced draft", False, True),
+        ("   ", True, True),
+    ],
+)
+def test_console_send_price_availability_agrees_with_presentation(
+    draft, attachment, history_raises
+):
+    """The cheap label question answers exactly the expensive one."""
+    controller, store, session, state, _calls = _controller_fixture()
+    if attachment:
+        store.add_pending_attachment(
+            session.id,
+            PendingAttachment(
+                file_path="/tmp/a.png",
+                display_name="a.png",
+                file_type="image",
+                insert_mode="attachment",
+                data=b"image",
+                mime_type="image/png",
+                original_size=5,
+                processed_size=5,
+            ),
+        )
+    if history_raises:
+        state["projection"] = None
+
+        def _raise(_session_id):
+            raise KeyError("no such session")
+
+        controller._provider_history_accessor = _raise
+
+    assert controller.availability_for_draft(draft) == (
+        controller.presentation_for_draft(draft) is not None
+    )
+
+
+def test_console_send_price_availability_never_projects_the_session():
+    """The keystroke-path question must not touch the transcript at all."""
+    controller, store, session, _state, calls = _controller_fixture()
+
+    def _explode(_session_id):
+        raise AssertionError("availability projected the session history")
+
+    controller._provider_history_accessor = _explode
+
+    assert controller.availability_for_draft("priced draft") is True
+    assert controller.availability_for_draft("   ") is False
+    assert controller.availability_for_draft("<script>alert(1)</script>") is True
+    store.add_pending_attachment(
+        session.id,
+        PendingAttachment(
+            file_path="/tmp/a.png",
+            display_name="a.png",
+            file_type="image",
+            insert_mode="attachment",
+            data=b"image",
+            mime_type="image/png",
+            original_size=5,
+            processed_size=5,
+        ),
+    )
+    assert controller.availability_for_draft("   ") is True
+    assert calls == []
+
+
+def test_console_send_price_cache_hit_does_not_rebuild_the_counter_rows():
+    """A memo hit must not pay the O(session) row rebuild it is memoizing."""
+    unpacks = [0]
+    controller, _store, _session, _state, calls = _controller_fixture(
+        rows=_counting_rows(unpacks)
+    )
+
+    controller.presentation_for_draft("draft")
+    after_miss = unpacks[0]
+    controller.presentation_for_draft("draft")
+
+    assert len(calls) == 1, "the second call was not a cache hit"
+    assert after_miss >= 2, "the miss never built the counter rows"
+    assert unpacks[0] == after_miss
+
+
+@pytest.mark.asyncio
+async def test_composer_reprices_send_under_a_parked_pointer():
+    """A draft edit with the pointer resting on Send re-derives the price."""
+    calls = []
+
+    def tooltip_provider(draft):
+        calls.append(draft)
+        return f"Next request: up to ~$0.01\nDraft: {draft}"
+
+    app = _PriceComposerApp(tooltip_provider)
+    async with app.run_test(size=(100, 24)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        send_button = composer.query_one("#console-send-message", Button)
+
+        composer.load_draft("first")
+        await pilot.hover("#console-send-message")
+        assert send_button.tooltip == "Next request: up to ~$0.01\nDraft: first"
+
+        composer.load_draft("second draft")
+
+        assert send_button.tooltip == (
+            "Next request: up to ~$0.01\nDraft: second draft"
+        )
+        assert calls[-1] == "second draft"
+
+
+@pytest.mark.asyncio
+async def test_composer_drops_the_derived_price_when_the_pointer_leaves_send():
+    """No derived price is left sitting on Send once the pointer moves away."""
+    app = _PriceComposerApp(lambda draft: f"Next request: {draft}")
+    async with app.run_test(size=(100, 24)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        send_button = composer.query_one("#console-send-message", Button)
+
+        composer.load_draft("priced")
+        await pilot.hover("#console-send-message")
+        assert send_button.tooltip == "Next request: priced"
+
+        await pilot.hover("#console-dictation")
+
+        assert send_button.tooltip == ConsoleComposerBar.SEND_READY_TOOLTIP
+
+
+@pytest.mark.asyncio
+async def test_composer_drops_the_derived_price_when_the_pointer_leaves_the_composer():
+    """Leaving the composer entirely posts only `Leave` -- it must still clear."""
+    app = _PriceComposerApp(lambda draft: f"Next request: {draft}")
+    async with app.run_test(size=(100, 24)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        send_button = composer.query_one("#console-send-message", Button)
+
+        composer.load_draft("priced")
+        await pilot.hover("#console-send-message")
+        assert send_button.tooltip == "Next request: priced"
+
+        # Empty screen below the composer: no descendant `Enter` bubbles
+        # here, so only the `Leave` handler can take the price back off.
+        await pilot.hover(offset=(0, 23))
+
+        assert send_button.tooltip == ConsoleComposerBar.SEND_READY_TOOLTIP
+
+
+@pytest.mark.asyncio
+async def test_composer_pointer_elsewhere_never_overwrites_the_idle_send_tooltip():
+    """A sibling hover must not turn the empty-draft copy into the ready copy."""
+    app = _PriceComposerApp(lambda draft: f"Next request: {draft}")
+    async with app.run_test(size=(100, 24)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        send_button = composer.query_one("#console-send-message", Button)
+
+        assert send_button.disabled is True
+        assert send_button.tooltip == "Type a message to send."
+
+        await pilot.hover("#console-dictation")
+
+        assert send_button.tooltip == "Type a message to send."
+
+
+@pytest.mark.asyncio
+async def test_composer_hover_price_is_inert_once_send_is_gone():
+    """Teardown safety: a hover event after Send is pruned must not raise."""
+    from textual.events import Enter, Leave
+
+    app = _PriceComposerApp(lambda draft: f"Next request: {draft}")
+    async with app.run_test(size=(100, 24)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        send_button = composer.query_one("#console-send-message", Button)
+        composer.load_draft("priced")
+        await pilot.hover("#console-send-message")
+        assert send_button.tooltip == "Next request: priced"
+
+        await send_button.remove()
+        await pilot.pause()
+
+        composer.on_enter(Enter(composer))
+        composer.on_leave(Leave(composer))
+        composer._sync_current_action_state()
+
+
+@pytest.mark.asyncio
+async def test_mounted_console_quits_cleanly_with_the_pointer_on_send():
+    """Shutdown walk: hover-triggered pricing must not hold up quit.
+
+    This mechanism deliberately uses no timer and no worker precisely
+    because debounced/timed work has broken quit in this repo before; the
+    test pins that quitting mid-hover still returns the exit value.
+    """
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        send_button = console.query_one("#console-send-message", Button)
+        composer.load_draft("about to quit")
+        await pilot.hover("#console-send-message")
+        assert "Next request:" in str(send_button.tooltip)
+
+        host.exit(0)
+        await pilot.pause()
+
+    assert host.return_value == 0
+
+
+@pytest.mark.asyncio
+async def test_mounted_console_never_derives_the_send_price_while_typing():
+    """TASK-23018: printable keys must not re-derive the next request.
+
+    The regression this pins made every keystroke project the whole session's
+    provider history and re-count its tokens -- 5.85 ms per key on a
+    400-message session against a 0.37 ms baseline. The Send label's "| $"
+    suffix must survive, and one hover must still produce a real price.
+    """
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        send_button = console.query_one("#console-send-message", Button)
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        for index in range(40):
+            store.append_message(
+                session_id,
+                role=(
+                    ConsoleMessageRole.USER
+                    if index % 2 == 0
+                    else ConsoleMessageRole.ASSISTANT
+                ),
+                content=f"transcript row {index}",
+            )
+
+        controller = console._send_price
+        projections: list[str] = []
+        history = controller._provider_history_accessor
+        controller._provider_history_accessor = lambda session: (
+            projections.append(session) or history(session)
+        )
+
+        composer.focus()
+        await pilot.pause()
+        for key in "abcdefgh":
+            await pilot.press(key)
+        await pilot.pause()
+
+        assert composer.draft_text() == "abcdefgh"
+        assert send_button.label.plain == "Send | $"
+        assert send_button.disabled is False
+        assert projections == [], (
+            "typing re-derived the next send "
+            f"({len(projections)} whole-session projections for 8 keys)"
+        )
+
+        await pilot.hover("#console-send-message")
+
+        assert len(projections) == 1
+        tooltip = str(send_button.tooltip)
+        assert "Next request:" in tooltip
+        assert "Input:" in tooltip
+        assert "anthropic" in tooltip

--- a/backlog/tasks/task-23018 - Console-Send-price-is-re-derived-on-every-keystroke.md
+++ b/backlog/tasks/task-23018 - Console-Send-price-is-re-derived-on-every-keystroke.md
@@ -1,0 +1,182 @@
+---
+id: TASK-23018
+title: Console Send price is re-derived on every keystroke
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-27 00:40'
+updated_date: '2026-08-27 01:20'
+labels:
+  - performance
+  - console
+  - input-latency
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #2114 (`1d59f96def`, "show estimated next-send price on Send button", merged 2026-08-26) put the whole next-request derivation on the printable-keystroke path. Once the Console draft is non-empty, every subsequent key re-projects the entire session's provider history and re-counts its tokens purely to render a hover tooltip nobody is looking at, so per-key input latency grows with conversation length. The estimate itself is worth keeping — a user wants to know what the next send costs — but it must be produced when it can actually be seen, not once per character.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Typing a printable character into a non-empty Console draft performs zero whole-session provider-history projections, whatever the conversation length
+- [x] #2 Per-keystroke handler cost no longer scales with the number of messages in the session
+- [x] #3 The Send button still shows its "| $" price affordance in exactly the states it did before, and its enabled/disabled state and label are unchanged
+- [x] #4 Hovering Send shows a price derived from the live draft and the live session — never a stale number from an earlier draft
+- [x] #5 A pricing failure still degrades to "Next request: cost unavailable" and never blocks Send
+- [x] #6 The token memo can actually be served from cache on the surviving path, and a cache hit does not pay an O(session) rebuild
+- [x] #7 Every new test fails against a deliberately broken implementation
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. Re-verify the filing first-hand on the base (`40ba8fe74d`): time `ChatScreen.on_key` from inside the handler, interleaved arms in both orders, plus an A/A control; count the mechanism (session snapshots, token-cache hits/misses) rather than trusting wall clock alone.
+2. Split `ConsoleSendPriceController` into a cheap availability half and the expensive presentation half, sharing one decision helper so the two can never disagree.
+3. Make the composer ask only the cheap question per keystroke, and derive the rendered tooltip on the hover seam.
+4. Fix the memo's hit path; measure whether relocating the memo itself is worth it, and decline it with numbers if it is not.
+5. Mutation-test every new gate; walk the unmount and quit paths.
+
+## Implementation Notes
+
+### The finding, re-verified on the base
+
+Reproduced, and worse than filed. Measured inside `ChatScreen.on_key` (never through
+`pilot.press()+pause()` wall time), 30 keys per arm, arms interleaved in both orders:
+
+| session | pricer ON (median) | pricer OFF (median) | keys over 3 ms |
+|---|---|---|---|
+| empty | 0.870 ms | 0.370 ms | 0 / 90 |
+| 400 messages | **5.848 ms** | 0.368 ms | **90 / 90** |
+
+A/A control at 400 messages (both arms pricer-ON, same loop shape): 5.735 vs 5.677 ms
+median — a ~0.06 ms noise floor on the median, so the 5.85 → 0.37 separation is ~94% of
+the handler and two orders of magnitude outside the control.
+
+Mechanism confirmed: **1,200 `dataclasses.replace` message copies per keystroke inside
+`on_key`** at 400 messages (three whole-session snapshot passes), and another 1,200
+outside it from the screen's own `_sync_native_console_chat_ui` resync — **2,400 copies
+per key in total**, both reaching `sync_action_state`. `dataclasses.replace` was 43% of
+the profiled keystroke. The token memo measured **0 hits / 30 misses** over 30 keys,
+exactly as filed: `token_estimate_signature` ends with the live draft row.
+
+Correction to the brief, from measuring the derivation's internals (400 messages, n=20,
+un-profiled): `presentation_for_draft` is 4.28 ms median, of which the history
+projection is 2.85 ms (67%), the row/signature rebuilds are 1.30 ms (30%) and the token
+counter is **0.138 ms (3%)**. The memo therefore guards the cheapest 3% of the call
+while its own draft-inclusive signature is built over the whole session — see the memo
+note below.
+
+### What changed
+
+**`UI/Console_Modules/send_price.py`** — the availability decision is split out of the
+derivation. `_resolve_context()` settles every "is there a tooltip at all?" branch
+(draft validation, store/session presence, pending attachments) without projecting the
+transcript or counting a token, and returns either a `_DraftPriceContext` or the final
+answer. `availability_for_draft()` and `presentation_for_draft()` both route through it,
+so the cheap answer is `presentation_for_draft(...) is not None` by construction. One
+deliberate normalisation: a `KeyError` from the history projection now degrades to the
+"cost unavailable" copy instead of withdrawing a tooltip the `| $` label has already
+promised (previously reachable only when `pending_attachments` succeeded and the
+projection did not — i.e. never, synchronously).
+
+**`Widgets/Console/console_composer_bar.py`** — `sync_action_state` now asks only the
+cheap availability provider; the rendered tooltip is derived in
+`_refresh_send_price_for_pointer()`, called from `on_enter`/`on_leave` and from
+`sync_action_state` when the pointer is already on Send. The Send label, width,
+enabled/disabled state and every blocked/idle tooltip branch are untouched.
+
+**`UI/Screens/chat_screen.py`** — wires the new `send_price_available_provider` seam.
+
+### Why hover, not a debounce
+
+A debounce would still have to answer "is the number on screen the current one?" with a
+timer, and timed/debounced work has broken quit in this repo three times. Hover needs no
+timer at all: Textual posts `Enter` the moment the pointer arrives and shows the tooltip
+`App.TOOLTIP_DELAY` (0.5 s) later, so there is ~500 ms of headroom for a 4 ms
+derivation, and the tooltip is a mouse-only surface — hover is *exactly* the set of
+moments the value can be seen. Freshness is structural rather than argued: the value is
+derived at display time from the live draft and live session, and while the pointer is
+parked on Send every `sync_action_state` re-derives (Textual's `tooltip` setter
+re-reads a displayed tooltip), so a draft edit under a stationary pointer repaints the
+real number.
+
+Two framework details are load-bearing and are pinned by tests: the pointer test reads
+`App.mouse_over` rather than `Button.mouse_hover`, because `Widget.watch_disabled`
+clears `mouse_hover` when Send goes disabled under the pointer; and the handlers read
+the pointer's *current* position rather than the triggering event's node, because that
+same `watch_disabled` queues a synthetic `Leave` that can be delivered after Send is
+sendable again.
+
+### The memo
+
+Fixed the part that measurement supports: the O(session) counter-row list is now built
+inside the miss callback, so a cache hit no longer pays for rows it never reads — and
+because the derivation is now on demand, the memo can be served at all (repeat hover
+with an unchanged draft: 1 counter call, not 2; measured 30 misses → 1 miss over a
+30-key + hover sequence).
+
+**Declined, with numbers:** relocating the memo to a draft-free signature. The token
+count is 0.138 ms of a 4.28 ms derivation (3%) and the estimator already memoises
+per-string (`_ESTIMATE_CACHE`, TASK-18602), while splitting it would mean computing the
+history and draft halves separately and reimplementing `count_tokens_messages`'s
+chat-format framing base outside `token_counter.py` — a second definition of the pricing
+arithmetic to keep in sync, for 3% of a call that now happens on hover. The expensive
+half is the history projection, which no memo can skip because building any signature
+requires it, and whose only cheap staleness key (`ConsoleChatStore.get_payload_revision`)
+documents itself as best-effort ("a missed bump means a stale chip … not a wrong send") —
+acceptable for a chip, not for a money number shown on demand.
+
+### Result
+
+Same measurement method, same machine, interleaved:
+
+| session | before (median) | after (median) | pricer-OFF baseline |
+|---|---|---|---|
+| empty | 0.870 ms | 0.377 ms | 0.370 ms |
+| 400 messages | 5.848 ms | 0.390 ms | 0.355 ms |
+| 2,000 messages | (scales) | 0.379 ms | 0.358 ms |
+
+Keys over 3 ms: 90/90 → 0/90. Whole-session projections per keystroke: 1 → 0. Token-cache
+misses over 30 keys: 30 → 0 (1 on the hover). The residual cost of the availability probe
+is ~0.03 ms and is flat in conversation length. The hover-derived tooltip is byte-identical
+to the pre-fix string.
+
+**Out of scope, unchanged, reported separately:** the same keystroke still costs one full
+screen reflow — measured **132 `Widget.arrange` and 1.00 `Screen._refresh_layout` per key**
+— from five over-determined layout armers in the same file. Bit-identical before and after
+this change (3,960 arrange / 30 reflows over 30 keys in both arms), so it did not
+contaminate the A/B. Pre-existing; not touched here.
+
+### Mutation results (11 mutants, 11 killed)
+
+| mutant | killed by |
+|---|---|
+| M1 keystroke path derives the price again | `..._never_derives_the_send_price_while_typing`, `..._price_affordance_tracks_send_queue_attachment_and_width` |
+| M2 no re-derive under a parked pointer | `..._reprices_send_under_a_parked_pointer`, `..._refreshes_send_price_without_changing_cost_chip` |
+| M3 `on_enter` no-op | 8 tests |
+| M4 `on_leave` no-op | `..._drops_the_derived_price_when_the_pointer_leaves_the_composer` |
+| M5 availability always True | `..._availability_agrees_with_presentation`, `..._availability_never_projects_the_session` |
+| M6 availability delegates to the expensive path | `..._never_derives_the_send_price_while_typing` |
+| M7 counter rows rebuilt eagerly | `..._cache_hit_does_not_rebuild_the_counter_rows` |
+| M8 pointer test uses `Button.mouse_hover` | `..._price_affordance_tracks_send_queue_attachment_and_width` |
+| M9 hover refresh ignores the blocked/idle gate | 4 tests |
+| M10 projection `KeyError` withdraws the tooltip | `..._availability_agrees_with_presentation` |
+| M11 price failure raises instead of degrading | `..._price_provider_failure_never_blocks_send` |
+
+M4 and M9 survived the first round. Neither was an assertion-strength problem — both were
+*reach*: leaving Send for a sibling posts a bubbling `Enter`, so `on_enter` alone covered
+the leave case, and Textual does not deliver `Enter` to a **disabled** widget at all
+(verified: `mouse_over` becomes the button, no handler runs), so hovering a blocked Send
+is inert by construction. Two tests were added on gestures that do reach — leaving the
+composer entirely, and a sibling hover while Send is idle/blocked — and both mutants then
+died.
+
+### Files
+
+- `tldw_chatbook/UI/Console_Modules/send_price.py`
+- `tldw_chatbook/Widgets/Console/console_composer_bar.py`
+- `tldw_chatbook/UI/Screens/chat_screen.py`
+- `Tests/UI/test_console_send_price.py`

--- a/tldw_chatbook/UI/Console_Modules/send_price.py
+++ b/tldw_chatbook/UI/Console_Modules/send_price.py
@@ -34,6 +34,30 @@ class ConsoleNextSendPrice:
     tooltip: str
 
 
+#: The honest degraded copy. Pricing must never block Send, so every failure
+#: below renders this instead of raising.
+UNAVAILABLE_PRICE = ConsoleNextSendPrice("Next request: cost unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class _DraftPriceContext:
+    """The cheap half of the price decision (TASK-23018).
+
+    Everything that decides *whether* a price tooltip exists at all, settled
+    without projecting the session transcript or counting a single token.
+    ``ConsoleSendPriceController._resolve_context`` returns one of these when
+    -- and only when -- the expensive half is worth running, so
+    :meth:`ConsoleSendPriceController.availability_for_draft` can answer the
+    Send button's label question on the keystroke path while the rendered
+    tooltip is derived on demand.
+    """
+
+    session_id: str
+    validated_draft: str
+    has_draft: bool
+    attachment_count: int
+
+
 class ConsoleSendPriceController:
     """Read-only coordinator for the next Console request price preview."""
 
@@ -57,8 +81,79 @@ class ConsoleSendPriceController:
         self._token_counter = token_counter
         self._token_cache = TokenEstimateCache(max_entries=1)
 
+    def _resolve_context(
+        self, draft_text: str
+    ) -> "_DraftPriceContext | ConsoleNextSendPrice | None":
+        """Settle the availability question without touching the transcript.
+
+        Args:
+            draft_text: Current composer text before send validation.
+
+        Returns:
+            A :class:`_DraftPriceContext` when a real estimate should be
+            derived, or the final answer already (the degraded copy, or
+            ``None`` when there is nothing to price).
+
+        Raises:
+            Exception: Whatever the store accessor raises; both public
+                entry points below own that translation.
+        """
+        store = self._chat_store_accessor()
+        session_id = store.active_session_id if store is not None else None
+        raw_has_draft = bool(str(draft_text or "").strip())
+        validated_draft, validation_error = validate_console_draft(
+            draft_text,
+            allow_empty=True,
+        )
+        if validation_error is not None:
+            return UNAVAILABLE_PRICE if raw_has_draft else None
+        has_draft = bool(validated_draft.strip())
+        if store is None or session_id is None:
+            return UNAVAILABLE_PRICE if has_draft else None
+        try:
+            attachment_count = len(store.pending_attachments(session_id))
+        except KeyError:
+            return UNAVAILABLE_PRICE if has_draft else None
+        if not has_draft and attachment_count == 0:
+            return None
+        return _DraftPriceContext(
+            session_id=session_id,
+            validated_draft=validated_draft,
+            has_draft=has_draft,
+            attachment_count=attachment_count,
+        )
+
+    def availability_for_draft(self, draft_text: str) -> bool:
+        """Return whether a price tooltip exists for ``draft_text``.
+
+        Answers exactly ``presentation_for_draft(draft_text) is not None``
+        -- both route through :meth:`_resolve_context`, so the two cannot
+        drift -- but without the whole-session history projection or any
+        token counting. TASK-23018: this is the only price question the
+        composer is allowed to ask per keystroke, because the Send button's
+        ``| $`` label suffix depends on it; the rendered tooltip itself is
+        derived on demand when the pointer actually reaches Send.
+
+        Args:
+            draft_text: Current composer text before send validation.
+
+        Returns:
+            True when hovering Send would show a price tooltip.
+        """
+        try:
+            resolved = self._resolve_context(draft_text)
+        except Exception:  # noqa: BLE001 -- mirrors presentation_for_draft
+            # presentation_for_draft renders the degraded copy for this, so a
+            # tooltip does exist.
+            return True
+        return resolved is not None
+
     def presentation_for_draft(self, draft_text: str) -> ConsoleNextSendPrice | None:
         """Return a best-effort next-request estimate for the current draft.
+
+        Expensive: projects the whole session's provider history and counts
+        its tokens. Never call this on the keystroke path -- see
+        :meth:`availability_for_draft`.
 
         Args:
             draft_text: Current composer text before send validation.
@@ -67,55 +162,32 @@ class ConsoleSendPriceController:
             The price preview, or ``None`` when there is nothing to send.
         """
         try:
+            resolved = self._resolve_context(draft_text)
+            if not isinstance(resolved, _DraftPriceContext):
+                return resolved
+
             settings = self._settings_accessor()
             provider = settings.provider
             model = settings.model or ""
             normalized_provider = provider_config_key(provider)
-
-            store = self._chat_store_accessor()
-            session_id = store.active_session_id if store is not None else None
-            raw_has_draft = bool(str(draft_text or "").strip())
-            validated_draft, validation_error = validate_console_draft(
-                draft_text,
-                allow_empty=True,
-            )
-            if validation_error is not None:
-                return (
-                    ConsoleNextSendPrice("Next request: cost unavailable")
-                    if raw_has_draft
-                    else None
-                )
-            has_draft = bool(validated_draft.strip())
-            if store is None or session_id is None:
-                return (
-                    ConsoleNextSendPrice("Next request: cost unavailable")
-                    if has_draft
-                    else None
-                )
+            session_id = resolved.session_id
             try:
-                attachment_count = len(store.pending_attachments(session_id))
                 projection = self._provider_history_accessor(session_id)
             except KeyError:
-                return (
-                    ConsoleNextSendPrice("Next request: cost unavailable")
-                    if has_draft
-                    else None
-                )
-
-            if not has_draft and attachment_count == 0:
-                return None
+                # `_resolve_context` already decided a tooltip is warranted,
+                # so a projection failure degrades to the honest copy rather
+                # than silently withdrawing the tooltip the `| $` label
+                # suffix has already promised.
+                return UNAVAILABLE_PRICE
 
             row_pairs = list(projection.rows)
-            if has_draft:
-                row_pairs.append(("user", validated_draft))
+            if resolved.has_draft:
+                row_pairs.append(("user", resolved.validated_draft))
             staged_text = console_prompted_evidence_text(
                 self._pending_launch_accessor()
             )
             if staged_text.strip():
                 row_pairs.append(("user", staged_text))
-            counter_rows = [
-                {"role": role, "content": content} for role, content in row_pairs
-            ]
             signature = token_estimate_signature(
                 row_pairs,
                 model,
@@ -125,8 +197,15 @@ class ConsoleSendPriceController:
                 input_tokens = self._token_cache.estimate(
                     session_id,
                     signature,
+                    # Built inside the miss callback: the counter rows are an
+                    # O(session) list of dicts that a cache HIT never reads,
+                    # and eagerly building them made every hit cost more than
+                    # it saved (TASK-23018).
                     lambda: self._token_counter(
-                        counter_rows,
+                        [
+                            {"role": role, "content": content}
+                            for role, content in row_pairs
+                        ],
                         model,
                         normalized_provider,
                     ),
@@ -141,11 +220,11 @@ class ConsoleSendPriceController:
                 pricing=pricing,
                 provider=provider,
                 model=model,
-                attachment_count=attachment_count,
+                attachment_count=resolved.attachment_count,
                 historical_media_count=projection.historical_media_count,
             )
         except Exception:
-            return ConsoleNextSendPrice("Next request: cost unavailable")
+            return UNAVAILABLE_PRICE
 
     def tooltip_for_draft(self, draft_text: str) -> str | None:
         """Return only the rendered tooltip for widget consumption.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10826,6 +10826,13 @@ class ChatScreen(BaseAppScreen):
                 send_price_tooltip_provider=(
                     lambda draft: self._send_price.tooltip_for_draft(draft)
                 ),
+                # TASK-23018: the cheap half. `sync_action_state` runs on
+                # every printable keystroke and only needs to know WHETHER a
+                # price exists (the Send label's "| $" suffix); the tooltip
+                # itself is derived on hover.
+                send_price_available_provider=(
+                    lambda draft: self._send_price.availability_for_draft(draft)
+                ),
             )
             # TASK-1364: the composer shares the screen's prompt-history
             # store with the controller (which records accepted sends) so

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -29,7 +29,15 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.content import Content
 from textual.css.query import NoMatches
-from textual.events import Click, DescendantBlur, DescendantFocus, Key, MouseUp
+from textual.events import (
+    Click,
+    DescendantBlur,
+    DescendantFocus,
+    Enter,
+    Key,
+    Leave,
+    MouseUp,
+)
 from textual.geometry import Region
 from textual.message import Message
 from textual.widget import Widget
@@ -471,6 +479,14 @@ class ConsoleComposerBar(Horizontal):
     DICTATION_IDLE_TOOLTIP = (
         "Dictate into the draft with the configured speech-to-text provider."
     )
+    #: Shown on an enabled Send whenever the next-send price is not the copy
+    #: on the button -- i.e. whenever the pointer is not on Send, which is the
+    #: only state in which a tooltip can be displayed at all.
+    SEND_READY_TOOLTIP = "Send the active Console session draft."
+    #: The degraded price copy, kept byte-identical to the controller's own
+    #: failure copy so a provider that raises and a provider that fails
+    #: internally read the same to the user.
+    SEND_PRICE_UNAVAILABLE_TOOLTIP = "Next request: cost unavailable"
 
     def __init__(
         self,
@@ -479,10 +495,21 @@ class ConsoleComposerBar(Horizontal):
         collapse_large_pastes: bool = True,
         paste_collapse_threshold: int = DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
         send_price_tooltip_provider: Callable[[str], str | None] | None = None,
+        send_price_available_provider: Callable[[str], bool] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
+        # TASK-23018: two seams, deliberately. The AVAILABLE provider must be
+        # cheap -- it runs on the keystroke path because the Send label's
+        # "| $" suffix depends on it. The TOOLTIP provider re-derives the
+        # whole next request and is only ever called when the pointer is
+        # actually on Send, where a 0.5s hover delay pays for it.
         self._send_price_tooltip_provider = send_price_tooltip_provider
+        self._send_price_available_provider = send_price_available_provider
+        #: Whether the last `sync_action_state` decided a price tooltip
+        #: exists. Gates the hover handlers so they never overwrite a
+        #: blocked/idle Send tooltip.
+        self._send_price_available = False
         self._collapsed = bool(collapsed)
         self.can_focus = not self._collapsed
         self.styles.height = self.MIN_DRAFT_ROWS + self.COMPOSER_CHROME_ROWS
@@ -1686,6 +1713,111 @@ class ConsoleComposerBar(Horizontal):
             # until the next ordinary voice-status repaint restores it.
             strip.styles.display = "none"
 
+    def _send_price_is_available(self) -> bool:
+        """Answer the cheap "is there a price to show?" question.
+
+        Runs on the keystroke path, so it must never reach the transcript.
+        A missing seam or a raising one both resolve to True: the derivation
+        itself degrades to an honest "cost unavailable" tooltip, so the
+        ``| $`` suffix still has something behind it.
+
+        Returns:
+            True when Send should advertise a next-send price.
+        """
+        provider = self._send_price_available_provider
+        if provider is None:
+            return True
+        try:
+            return bool(provider(self.draft_text()))
+        except Exception:  # noqa: BLE001 -- pricing cannot block Send
+            return True
+
+    def _derive_send_price_tooltip(self) -> str:
+        """Render the next-send price for the CURRENT draft, right now.
+
+        Deliberately uncached: it is called only when the pointer is on Send,
+        so it always reads the live draft and the live session and can never
+        show a number the composer has since moved past.
+
+        Returns:
+            The rendered price tooltip, or the honest degraded copy.
+        """
+        provider = self._send_price_tooltip_provider
+        if provider is None:
+            return self.SEND_READY_TOOLTIP
+        try:
+            tooltip = provider(self.draft_text())
+        except Exception:  # noqa: BLE001 -- pricing presentation cannot block Send
+            return self.SEND_PRICE_UNAVAILABLE_TOOLTIP
+        return tooltip or self.SEND_READY_TOOLTIP
+
+    @staticmethod
+    def _node_is_send(node: Any | None, send_button: Button) -> bool:
+        """Whether ``node`` is the Send button or lives inside it."""
+        if node is None:
+            return False
+        return any(
+            candidate is send_button
+            for candidate in getattr(node, "ancestors_with_self", ())
+        )
+
+    def _pointer_is_on_send(self, send_button: Button) -> bool:
+        """Whether the pointer currently rests on the Send button.
+
+        Reads ``App.mouse_over`` rather than ``Button.mouse_hover``: Textual
+        clears ``mouse_hover`` when a widget is disabled under the pointer
+        (``Widget.watch_disabled``), so a Send that goes empty and then
+        sendable again -- staging an attachment, say -- without the mouse
+        moving would otherwise never re-derive its price.
+
+        Args:
+            send_button: The composer's Send button.
+
+        Returns:
+            True when the pointer is on Send.
+        """
+        try:
+            under_pointer = self.app.mouse_over
+        except Exception:  # noqa: BLE001 -- no active app (teardown/unmounted)
+            return False
+        return self._node_is_send(under_pointer, send_button)
+
+    def _refresh_send_price_for_pointer(self) -> None:
+        """Put the price on Send while the pointer is on it, take it off when not.
+
+        Reads the pointer's CURRENT position rather than the position the
+        triggering event carried: Textual queues a synthetic ``Leave`` when a
+        widget is disabled under the pointer (``Widget.watch_disabled``), and
+        that message can be delivered after Send has already become sendable
+        again -- a stale "the pointer left" that never happened.
+        """
+        if not self._send_price_available:
+            # Send is blocked or empty; its tooltip belongs to the blocked
+            # copy and pricing must not overwrite it.
+            return
+        try:
+            send_button = self.query_one("#console-send-message", Button)
+        except NoMatches:
+            return
+        send_button.tooltip = (
+            self._derive_send_price_tooltip()
+            if self._pointer_is_on_send(send_button)
+            else self.SEND_READY_TOOLTIP
+        )
+
+    def on_enter(self, event: Enter) -> None:
+        """Derive the Send price when the pointer arrives (TASK-23018).
+
+        Textual shows a tooltip ``App.TOOLTIP_DELAY`` (0.5s) after the
+        pointer settles and posts ``Enter`` immediately, so deriving here is
+        both far off the keystroke path and always in time.
+        """
+        self._refresh_send_price_for_pointer()
+
+    def on_leave(self, event: Leave) -> None:
+        """Take the derived price back off Send when the pointer leaves."""
+        self._refresh_send_price_for_pointer()
+
     def sync_action_state(
         self,
         *,
@@ -1739,15 +1871,21 @@ class ConsoleComposerBar(Horizontal):
         normalized_send_label = send_label.strip() or "Send"
         self._send_label = normalized_send_label
         send_ready = has_draft and not send_blocked
-        price_tooltip = None
+        # TASK-23018: this used to call the TOOLTIP provider, which re-derives
+        # the entire next request (whole-session provider projection + token
+        # count) -- measured at 5.85 ms per keypress on a 400-message session
+        # against a 0.37 ms baseline, scaling with conversation length, on a
+        # method reached from `insert_text` for every printable key. Only the
+        # cheap availability question is asked here now; the rendered tooltip
+        # is derived in `_refresh_send_price_for_pointer` when it reaches
+        # Send, which is the only moment a tooltip can be seen.
+        price_available = send_ready and self._send_price_tooltip_provider is not None
+        if price_available:
+            price_available = self._send_price_is_available()
+        self._send_price_available = price_available
         displayed_send_label = normalized_send_label
-        if send_ready and self._send_price_tooltip_provider is not None:
-            try:
-                price_tooltip = self._send_price_tooltip_provider(self.draft_text())
-            except Exception:  # noqa: BLE001 -- pricing presentation cannot block Send
-                price_tooltip = "Next request: cost unavailable"
-            if price_tooltip:
-                displayed_send_label = f"{normalized_send_label} | $"
+        if price_available:
+            displayed_send_label = f"{normalized_send_label} | $"
 
         self._send_button_width = max(6, cell_len(displayed_send_label) + 2)
         send_button.label = displayed_send_label
@@ -1780,10 +1918,14 @@ class ConsoleComposerBar(Horizontal):
             send_button.tooltip = (
                 "Wait for the active Console run to finish before sending."
             )
-        elif price_tooltip:
-            send_button.tooltip = price_tooltip
+        elif price_available and self._pointer_is_on_send(send_button):
+            # The pointer is already parked on Send (typing with the mouse at
+            # rest, or a re-sync mid-hover). Textual re-reads `.tooltip` from
+            # the setter while a tooltip is displayed, so re-deriving here is
+            # what keeps a VISIBLE price honest as the draft changes.
+            send_button.tooltip = self._derive_send_price_tooltip()
         elif has_draft:
-            send_button.tooltip = "Send the active Console session draft."
+            send_button.tooltip = self.SEND_READY_TOOLTIP
         else:
             send_button.tooltip = "Type a message to send."
         send_button.set_class(send_ready, "console-action-primary")

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -1811,11 +1811,27 @@ class ConsoleComposerBar(Horizontal):
         Textual shows a tooltip ``App.TOOLTIP_DELAY`` (0.5s) after the
         pointer settles and posts ``Enter`` immediately, so deriving here is
         both far off the keystroke path and always in time.
+
+        Args:
+            event: The arriving pointer event. Deliberately unread --
+                ``_refresh_send_price_for_pointer`` resolves the *current*
+                pointer from ``App.mouse_over`` instead, because
+                ``Button.watch_disabled`` can queue a synthetic ``Leave``
+                that arrives after Send is sendable again, so the event's
+                own node is not a reliable answer to "where is the pointer
+                now". Accepted to match Textual's handler signature.
         """
         self._refresh_send_price_for_pointer()
 
     def on_leave(self, event: Leave) -> None:
-        """Take the derived price back off Send when the pointer leaves."""
+        """Take the derived price back off Send when the pointer leaves.
+
+        Args:
+            event: The departing pointer event. Deliberately unread, for the
+                same reason as :meth:`on_enter` -- the current pointer is
+                read from ``App.mouse_over`` rather than trusted from the
+                event's node. Accepted to match Textual's handler signature.
+        """
         self._refresh_send_price_for_pointer()
 
     def sync_action_state(


### PR DESCRIPTION
## Summary

Every printable keystroke re-derived the entire next request to price a tooltip. The estimate is
kept; it is now derived when the pointer reaches Send, which is the only moment it can be seen.

Finding 1 of the [2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md), and the direct
answer to the reported input lag. Introduced by #2114 four days ago.

## The regression reproduced — worse than filed

Timed **inside `ChatScreen.on_key`** (never through `pilot.press()` wall time), 30 keys per arm, arms
interleaved in **both** orders, on base `40ba8fe74d`:

| session | pricer ON | pricer OFF | keys > 3 ms |
|---|---|---|---|
| empty | 0.870 ms | 0.370 ms | 0 / 90 |
| 400 messages | **5.848 ms** | 0.368 ms | **90 / 90** |

An A/A control (both arms ON, same loop shape) separates by 0.06 ms, so the effect is ~94% of the
handler and far outside the noise floor. **1,200 `dataclasses.replace` copies per key inside
`on_key`** — 43% of the profile — plus another 1,200 from the screen's own resync, so **2,400 per
key**. Token memo: **0 hits / 30 misses**, because its signature includes the live draft.

**One correction to the filing.** Timing the derivation's internals: 4.28 ms = history projection
**2.85 ms (67%)** + row/signature rebuilds 1.30 ms (30%) + token counter **0.138 ms (3%)**. The memo
guards the cheapest 3% of the call — so "fix the memo" was never going to be the fix.

## The change

`ConsoleSendPriceController` now splits the **cheap availability question** (draft validation, store
and session, pending attachments — no transcript walk, no tokens) from the **expensive
presentation**, both routed through one `_resolve_context` so they cannot drift. The composer asks
only the cheap question per keystroke, which is all the `| $` label suffix needs.

**Hover rather than a debounce, deliberately: it needs no timer.** Timer changes have broken quit
three times in this repo. Textual posts `Enter` immediately and shows a tooltip 0.5 s later, and
tooltips are mouse-only — so hover is exactly the set of moments the value can be seen.

**Correctness when shown is structural, not argued.** The value is derived at display time from the
live draft and live session, and while the pointer rests on Send every `sync_action_state`
re-derives, so editing under a parked pointer repaints the real number. Two framework details are
load-bearing and pinned by tests: the pointer test reads `App.mouse_over`, not `Button.mouse_hover`
(`watch_disabled` clears the latter), and the handlers read the *current* pointer rather than the
event's node (that same `watch_disabled` queues a synthetic `Leave` that can arrive after Send is
sendable again).

## After

| session | before | after | pricer-OFF floor |
|---|---|---|---|
| empty | 0.870 ms | **0.377 ms** | 0.370 ms |
| 400 messages | 5.848 ms | **0.390 ms** | 0.355 ms |
| 2,000 messages | (scales) | **0.379 ms** | 0.358 ms |

**Flat in conversation length**, and at the pricer-off floor. Keys > 3 ms: 90/90 → **0/90**.
Projections per key 1 → 0. The hover tooltip is **byte-identical** to the pre-fix string.

**Control for the unrelated layer:** 132 `Widget.arrange` + 1.00 `Screen._refresh_layout` per key,
**bit-identical** with and without the regression restored (3,960/30 in both arms). The pre-existing
five-armer reflow layer is untouched and did not contaminate this A/B.

## Mutation: 11 mutants, 11 killed

Regression restored → 2 tests · no re-derive under a parked pointer → 2 · `on_enter` no-op → 8 ·
`on_leave` no-op → 1 · availability broken / made expensive → 2 / 1 · eager counter rows → 1 ·
`mouse_hover` instead of `mouse_over` → 1 · blocked-gate removed → 4 · `KeyError` withdraws the
tooltip → 1 · failure raises → 1.

**Two survived round one, and neither was assertion strength — both were reach.** Leaving Send for a
sibling posts a bubbling `Enter`, so `on_enter` alone already covered the leave case; and **Textual
delivers no `Enter` to a disabled widget**, so hovering a blocked Send is inert by construction. Two
tests were added on gestures that do reach, and both mutants died.

## The memo

Fixed what measurement supports: the O(session) counter-row list is now built inside the miss
callback, so a hit no longer pays for rows it never reads — and because derivation is on demand, the
memo can hit at all.

**Declined with numbers:** relocating it to a draft-free signature buys 0.138 ms of a 4.28 ms call,
and would require reimplementing `count_tokens_messages`'s chat-format framing outside
`token_counter.py`. The expensive half is the projection, which no memo can skip — any signature
requires it — and whose only cheap staleness key documents itself as best-effort. Fine for a chip,
not for a money number.

## Quit / unmount

No timer and no worker added. Walked and tested: composer or button pruned mid-hover (`NoMatches` and
`NoActiveAppError` both caught), quit with the pointer parked on Send (`exit(0)` returns 0), provider
raising mid-derivation (degrades to "cost unavailable" — the mutation proves that path load-bearing),
and the stale-`Leave`-after-re-enable path that motivated reading the live pointer.

## Verification

`Tests/UI/test_console_send_price.py`: **54 passed** (38 before — 4 updated to hover, 13 added).
Reach sweep of 62 files / 2,083 tests: 2,038 passed, 45 failed, **every one A/B-proven identical on
pristine `40ba8fe74d`** (same node ids, same harness shape). Preflight green, all six checks.

Also included: `Docs/User_Guide/console/chat-basics.md` gains a "What the next send will cost"
section — the #2114 feature shipped undocumented.

## Worth filing separately

- **45 tests are red on pristine dev** across the Console composer/chat-flow surface, several with
  *"your conversation database could not be opened"* or a missing pytest tmp path — plausibly **one
  environmental root cause, not 45 bugs**. Given this repo's history of CI producing no verdict, that
  is the higher-value follow-up.
- **The next-send price is mouse-only.** True before this change too, but now explicit: a
  keyboard-only user has no route to the estimate. Worth an owner call.
- The pre-existing per-keystroke reflow layer (132 `arrange` per key from five over-determined
  armers) is confirmed present and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the input lag from #2114 where every printable keystroke re-derived the next-send price — projecting the whole session's history and re-counting tokens — costing 5.85 ms per key on a 400-message session. Typing now only runs a cheap availability check; the full estimate is derived when the pointer reaches Send, dropping per-key cost to ~0.39 ms flat in conversation length with a byte-identical tooltip.

**Bug Fixes**
- Splits the cheap availability question (draft validation, store/session, pending attachments) from the expensive presentation via one shared context resolver so the two can't drift.
- Re-derives on every resync while the pointer is parked on Send, so a draft edit under a stationary mouse repaints the current number.
- The hover handlers read the live pointer position rather than the event's node, since a disabled-state change can queue a synthetic Leave that arrives after Send is usable again.
- Builds the token-cache counter rows inside the miss callback only, so a cache hit no longer pays for the O(session) rebuild.
- The estimate is now reachable only by hovering Send — a pre-existing limitation for keyboard-only users, now made structural.
- Adds a "What the next send will cost" section to the Console user guide, since the #2114 feature shipped undocumented.
- 45 composer-surface tests fail on pristine dev during verification, apparently one environmental root cause and unrelated to this change.

<sup>Written for commit 3babb9b77211fb5b266b57fa5b8fc3bc32a03ffd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

