### PR TITLE
fix(console): align staged evidence cost estimate with sent prompt

### DIFF
--- a/Docs/superpowers/plans/2026-08-27-console-context-cost-evidence-parity.md
+++ b/Docs/superpowers/plans/2026-08-27-console-context-cost-evidence-parity.md
@@ -10,8 +10,10 @@
 
 **Design:** `Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md`
 
-**ADR required:** no  
-**ADR path:** N/A  
+**ADR required:** no
+
+**ADR path:** N/A
+
 **Reason:** Routine parity bug fix reusing existing normalization, authority, and formatting boundaries.
 
 ---
@@ -57,24 +59,77 @@ def test_prompted_evidence_keeps_empty_local_content_as_header_only() -> None:
     assert console_prompted_source_count(launch) == 1
 ```
 
-- [ ] **Step 3: Write a failing adapter-contract test**
+- [ ] **Step 3: Add a green send-adapter characterization test**
 
-Import the proposed `normalize_console_evidence_references()` helper and verify that a valid chunked reference, an invalid source-kind reference, and a second valid reference produce two normalized candidates with ranks `(1, 2)`, preserve `source_id`, select the non-empty `chunk_id` as result lineage, and map `score=None` to `0.0`.
+Through the existing public `capture_console_staged_evidence_for_chat()` seam, build a launch containing a valid chunked `m1` reference with `score=None`, an invalid source-kind reference, and a valid `m2` reference. Use `_CaptureApp(repository=repository, media_ids=("m1", "m2"))` and assert the recorded retrieval payload contains exactly two candidates with ranks `(1, 2)`, source IDs `(m1, m2)`, first-candidate `chunk_id == "chunk-1"`, and first-candidate `score == 0.0`. This is a pre-refactor characterization test and must pass before extraction; it does not import a helper that does not exist yet.
 
-- [ ] **Step 4: Run the RED tests**
+- [ ] **Step 4: Add the authority-shrink regression in the RED phase**
+
+In `Tests/RAG/test_local_citation_capture.py`, import the existing public estimate functions and add:
+
+```python
+@pytest.mark.asyncio
+async def test_console_estimate_stays_pre_authority_while_send_rechecks() -> None:
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="staged evidence",
+        payload={
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-authority-shrink",
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title="Source 1",
+                        snippet="Body 1",
+                        authority_label="local",
+                    ),
+                    EvidenceReference(
+                        evidence_id="S2",
+                        source_id="m2",
+                        source_type="media",
+                        title="Source 2",
+                        snippet="Body 2",
+                        authority_label="local",
+                    ),
+                ),
+            ).to_payload(),
+        },
+    )
+    assert console_prompted_source_count(launch) == 2
+    assert console_prompted_evidence_text(launch) == (
+        "[S1] MEDIA — Source 1\nBody 1\n---\n"
+        "[S2] MEDIA — Source 2\nBody 2"
+    )
+
+    captured = await cre.capture_console_staged_evidence_for_chat(
+        _CaptureApp(media_ids=("m2",)),
+        launch,
+        user_message="question",
+    )
+    assert captured.context == "[S1] MEDIA — Source 2\nBody 2"
+    assert captured.citation_repair_contract is not None
+    assert captured.citation_repair_contract.allowed_ordinals == (1,)
+```
+
+The estimate assertions fail on the current raw-snippet implementation while the send assertions characterize the existing authority boundary.
+
+- [ ] **Step 5: Run the characterization and RED tests**
 
 Run:
 
 ```bash
 ../../.venv/bin/pytest -q \
+  Tests/RAG/test_local_citation_capture.py::test_console_send_adapter_preserves_chunk_lineage_score_and_rank
+../../.venv/bin/pytest -q \
   Tests/UI/test_console_staged_evidence_strip.py \
   -k "prompted_evidence or prompted_source_count"
 ../../.venv/bin/pytest -q \
-  Tests/RAG/test_local_citation_capture.py \
-  -k "console_evidence_reference_adapter"
+  Tests/RAG/test_local_citation_capture.py::test_console_estimate_stays_pre_authority_while_send_rechecks
 ```
 
-Expected: failures show raw snippet joining, a count of 65, empty-content omission, and the missing adapter helper.
+Expected: the characterization test passes; the estimator tests fail on raw snippet joining, a count of 65, empty-content omission, and missing canonical framing before production changes.
 
 ---
 
@@ -87,7 +142,7 @@ Expected: failures show raw snippet joining, a count of 65, empty-content omissi
 
 - [ ] **Step 1: Add the minimal pure Console-reference adapter**
 
-Implement the existing send mapping once:
+Import `EvidenceReference` from `tldw_chatbook.Chat.citation_evidence_models`, then implement the existing send mapping once:
 
 ```python
 def normalize_console_evidence_references(
@@ -157,8 +212,12 @@ After the existing authority check, call `format_console_evidence_context(author
 Run:
 
 ```bash
-../../.venv/bin/pytest -q Tests/RAG/test_local_citation_capture.py \
-  -k "console_evidence_reference_adapter or console_staged_local_evidence"
+../../.venv/bin/pytest -q \
+  Tests/RAG/test_local_citation_capture.py::test_console_send_adapter_preserves_chunk_lineage_score_and_rank \
+  Tests/RAG/test_local_citation_capture.py::test_console_staged_local_evidence_records_exact_prompt_capture \
+  Tests/RAG/test_local_citation_capture.py::test_console_prompt_evidence_set_id_uses_record_method_return \
+  Tests/RAG/test_local_citation_capture.py::test_console_canonical_capture_failure_keeps_exact_repair_contract \
+  Tests/RAG/test_local_citation_capture.py::test_console_builder_unavailable_returns_exact_repair_contract
 ```
 
 Expected: PASS.
@@ -182,6 +241,8 @@ git commit -m "refactor(console): share staged evidence formatting"
 - Modify: `Tests/UI/test_console_staged_evidence_strip.py`
 
 - [ ] **Step 1: Add one private formatted-context seam**
+
+Import `LocalEvidenceContext`, `format_console_evidence_context`, and `normalize_console_evidence_references` from `tldw_chatbook.RAG_Search.local_citation_capture`, then add:
 
 ```python
 def _console_prompted_evidence_context(
@@ -210,6 +271,8 @@ Run:
 ```bash
 ../../.venv/bin/pytest -q Tests/UI/test_console_staged_evidence_strip.py \
   -k "prompted_evidence or prompted_source_count or staged_source_count"
+../../.venv/bin/pytest -q \
+  Tests/UI/test_console_staged_evidence_strip.py::test_context_estimate_counts_staged_evidence_before_send
 ../../.venv/bin/pytest -q Tests/Chat/test_console_session_settings.py \
   -k "context_estimate"
 ```
@@ -227,21 +290,14 @@ git commit -m "fix(console): align evidence cost estimate with prompt"
 
 ---
 
-### Task 4: Pin authority shrinkage and verify the finished task
+### Task 4: Verify and close the finished task
 
 **Files:**
-- Modify: `Tests/RAG/test_local_citation_capture.py`
 - Modify: `backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md`
 
-- [ ] **Step 1: Add a focused authority-shrink regression**
-
-Build a two-reference Console launch whose estimate includes both canonical prompt blocks, then send through an app authority double that exposes only the second backing row. Assert that estimate-time code performs no authority I/O, the send context contains only the surviving source re-numbered as `[S1]`, and the repair contract contains one ordinal.
-
-- [ ] **Step 2: Run one-time dependency and static checks**
+- [ ] **Step 1: Run isolated static checks**
 
 ```bash
-../../.venv/bin/python -c \
-  "import tldw_chatbook.Chat.console_display_state; import tldw_chatbook.RAG_Search.local_citation_capture"
 ../../.venv/bin/ruff check \
   tldw_chatbook/RAG_Search/local_citation_capture.py \
   tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py \
@@ -249,33 +305,46 @@ Build a two-reference Console launch whose estimate includes both canonical prom
   tldw_chatbook/UI/Screens/chat_screen.py \
   Tests/RAG/test_local_citation_capture.py \
   Tests/UI/test_console_staged_evidence_strip.py
-git diff --check origin/dev...HEAD
+git diff --check
 ```
 
-Expected: all commands exit 0. Do not add a permanent subprocess import test.
+Expected: both commands exit 0. The focused pytest runs import both affected modules under the repository's isolated test profile, so no live-profile import probe or permanent subprocess test is added.
 
-- [ ] **Step 3: Run focused behavior verification**
+- [ ] **Step 2: Run focused behavior verification**
 
 ```bash
-../../.venv/bin/pytest -q Tests/RAG/test_local_citation_capture.py \
-  -k "console_staged or console_evidence or authority"
+../../.venv/bin/pytest -q \
+  Tests/RAG/test_local_citation_capture.py::test_console_send_adapter_preserves_chunk_lineage_score_and_rank \
+  Tests/RAG/test_local_citation_capture.py::test_console_estimate_stays_pre_authority_while_send_rechecks \
+  Tests/RAG/test_local_citation_capture.py::test_console_staged_local_evidence_records_exact_prompt_capture \
+  Tests/RAG/test_local_citation_capture.py::test_console_prompt_evidence_set_id_uses_record_method_return \
+  Tests/RAG/test_local_citation_capture.py::test_console_canonical_capture_failure_keeps_exact_repair_contract \
+  Tests/RAG/test_local_citation_capture.py::test_console_builder_unavailable_returns_exact_repair_contract
 ../../.venv/bin/pytest -q Tests/UI/test_console_staged_evidence_strip.py \
   -k "prompted_evidence or prompted_source_count or staged_source_count"
+../../.venv/bin/pytest -q \
+  Tests/UI/test_console_staged_evidence_strip.py::test_context_estimate_counts_staged_evidence_before_send
 ../../.venv/bin/pytest -q Tests/Chat/test_console_session_settings.py \
   -k "context_estimate"
 ```
 
 Expected: PASS. The unrelated full-file mounted-send baseline remains tracked separately: its second durable turn is refused before capture because the thread-local `:memory:` fixture opens without schema. Do not mask that failure or alter production behavior in this task.
 
-- [ ] **Step 4: Complete backlog and implementation notes**
+- [ ] **Step 3: Complete backlog and implementation notes**
 
 Use the Backlog CLI to check every acceptance criterion, add concise Implementation Notes with the ADR decision and verification evidence, and set TASK-2525 to Done only after every task Definition-of-Done requirement is satisfied.
 
-- [ ] **Step 5: Commit task closeout**
+- [ ] **Step 4: Commit task closeout**
 
 ```bash
-git add backlog/tasks/task-2525\ -\ Console-context-cost-estimate-has-three-small-modelling-gaps.md \
-  Tests/RAG/test_local_citation_capture.py
+git add backlog/tasks/task-2525\ -\ Console-context-cost-estimate-has-three-small-modelling-gaps.md
 git commit -m "test(console): verify evidence estimate parity"
 ```
 
+- [ ] **Step 5: Verify the committed branch range**
+
+```bash
+git diff --check origin/dev...HEAD
+```
+
+Expected: exit 0 after every task change is committed.

--- a/Docs/superpowers/plans/2026-08-27-console-context-cost-evidence-parity.md
+++ b/Docs/superpowers/plans/2026-08-27-console-context-cost-evidence-parity.md
@@ -1,0 +1,281 @@
+# Console Context-Cost Evidence Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Console context and cost estimates use the same canonical local-evidence normalization, prompt framing, and 64-entry cap as the send path while remaining zero-I/O.
+
+**Architecture:** Add one pure Console-reference adapter and one pure Console prompt-formatting wrapper to the existing local citation boundary. Reuse both from the send adapter and from a private Console display-state formatter, then derive estimated text and count from that one formatted result. Preserve the send path's asynchronous authority check and document that estimate-time results are pre-authority.
+
+**Tech Stack:** Python 3.11+, Pydantic evidence models, pytest, Textual Console display state
+
+**Design:** `Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md`
+
+**ADR required:** no  
+**ADR path:** N/A  
+**Reason:** Routine parity bug fix reusing existing normalization, authority, and formatting boundaries.
+
+---
+
+### Task 1: Pin canonical estimate behavior with failing tests
+
+**Files:**
+- Modify: `Tests/UI/test_console_staged_evidence_strip.py:44-115,183-220`
+- Modify: `Tests/RAG/test_local_citation_capture.py:1220-1485`
+
+- [ ] **Step 1: Extend the local evidence test builder only where needed**
+
+Allow `_reference()` to accept optional `source_type`, `snippet`, `score`, and `metadata` values so the tests can express empty content, rejected source kinds, score fallback, and chunk lineage without constructing ad-hoc payload dictionaries.
+
+- [ ] **Step 2: Write failing public-estimator tests**
+
+Add focused tests equivalent to:
+
+```python
+def test_prompted_evidence_uses_canonical_headers_and_separators() -> None:
+    launch = _mixed_launch()
+    assert console_prompted_evidence_text(launch) == (
+        "[S1] MEDIA — Source 1\nBody 1\n---\n"
+        "[S2] MEDIA — Source 3\nBody 3"
+    )
+    assert console_prompted_source_count(launch) == 2
+
+
+def test_prompted_evidence_applies_the_send_cap() -> None:
+    launch = _launch(65)
+    text = console_prompted_evidence_text(launch)
+    assert console_prompted_source_count(launch) == 64
+    assert "[S64] MEDIA — Source 64" in text
+    assert "Source 65" not in text
+    assert text.count("\n---\n") == 63
+
+
+def test_prompted_evidence_keeps_empty_local_content_as_header_only() -> None:
+    launch = _launch_from_references(
+        _reference(1, snippet=""),
+    )
+    assert console_prompted_evidence_text(launch) == "[S1] MEDIA — Source 1\n"
+    assert console_prompted_source_count(launch) == 1
+```
+
+- [ ] **Step 3: Write a failing adapter-contract test**
+
+Import the proposed `normalize_console_evidence_references()` helper and verify that a valid chunked reference, an invalid source-kind reference, and a second valid reference produce two normalized candidates with ranks `(1, 2)`, preserve `source_id`, select the non-empty `chunk_id` as result lineage, and map `score=None` to `0.0`.
+
+- [ ] **Step 4: Run the RED tests**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/UI/test_console_staged_evidence_strip.py \
+  -k "prompted_evidence or prompted_source_count"
+../../.venv/bin/pytest -q \
+  Tests/RAG/test_local_citation_capture.py \
+  -k "console_evidence_reference_adapter"
+```
+
+Expected: failures show raw snippet joining, a count of 65, empty-content omission, and the missing adapter helper.
+
+---
+
+### Task 2: Extract the shared normalization and formatting boundary
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/local_citation_capture.py:1-40,294-480`
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py:40-55,1690-1760`
+- Test: `Tests/RAG/test_local_citation_capture.py`
+
+- [ ] **Step 1: Add the minimal pure Console-reference adapter**
+
+Implement the existing send mapping once:
+
+```python
+def normalize_console_evidence_references(
+    references: Sequence[EvidenceReference],
+) -> tuple[NormalizedLocalResult, ...]:
+    normalized: list[NormalizedLocalResult] = []
+    for reference in references:
+        if reference.source_owner.strip().lower() != "local":
+            continue
+        metadata: dict[str, Any] = {
+            "source_type": reference.source_type,
+            "source_id": reference.source_id,
+        }
+        chunk_id = reference.metadata.get("chunk_id")
+        if isinstance(chunk_id, str) and chunk_id:
+            metadata["chunk_id"] = chunk_id
+        try:
+            normalized.append(
+                normalize_local_result(
+                    {
+                        "source": reference.source_type,
+                        "id": chunk_id if isinstance(chunk_id, str) and chunk_id else reference.source_id,
+                        "title": reference.title,
+                        "content": reference.snippet,
+                        "score": reference.score if reference.score is not None else 0.0,
+                        "metadata": metadata,
+                    },
+                    candidate_rank=len(normalized) + 1,
+                )
+            )
+        except LocalResultNormalizationError:
+            continue
+    return tuple(normalized)
+```
+
+- [ ] **Step 2: Add the shared Console formatting wrapper**
+
+```python
+def format_console_evidence_context(
+    normalized_results: Sequence[NormalizedLocalResult],
+) -> LocalEvidenceContext:
+    return format_local_evidence_context(
+        normalized_results,
+        max_length=sum(
+            len(candidate.title) + len(candidate.content) + 32
+            for candidate in normalized_results
+        ),
+    )
+```
+
+Export both helpers through `__all__`. Do not change the generic formatter's 90-character default or other RAG callers.
+
+- [ ] **Step 3: Route the send adapter through the shared helpers**
+
+Replace only the duplicated Console reference loop and allowance expression. Preserve logging with:
+
+```python
+references = bundle.available_references()
+normalized = normalize_console_evidence_references(references)
+rejected_count = len(references) - len(normalized)
+```
+
+After the existing authority check, call `format_console_evidence_context(authorization.candidates)`. Leave all authority, builder, repair-contract, and error behavior unchanged.
+
+- [ ] **Step 4: Run the adapter tests GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q Tests/RAG/test_local_citation_capture.py \
+  -k "console_evidence_reference_adapter or console_staged_local_evidence"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the shared boundary**
+
+```bash
+git add tldw_chatbook/RAG_Search/local_citation_capture.py \
+  tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py \
+  Tests/RAG/test_local_citation_capture.py
+git commit -m "refactor(console): share staged evidence formatting"
+```
+
+---
+
+### Task 3: Derive estimate text and count from one formatted result
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_display_state.py:1-25,797-862`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py:4320-4345,5270-5305,6590-6610`
+- Modify: `Tests/UI/test_console_staged_evidence_strip.py`
+
+- [ ] **Step 1: Add one private formatted-context seam**
+
+```python
+def _console_prompted_evidence_context(
+    launch: ConsoleLiveWorkLaunch | None,
+) -> LocalEvidenceContext | None:
+    bundle = evidence_bundle_from_launch(launch)
+    if bundle is None:
+        return None
+    return format_console_evidence_context(
+        normalize_console_evidence_references(bundle.available_references())
+    )
+```
+
+- [ ] **Step 2: Make both public estimate helpers projections**
+
+`console_prompted_source_count()` returns `len(formatted.entries)` and `console_prompted_evidence_text()` returns `formatted.context`, with zero/empty fallbacks when no bundle exists. Remove both duplicated owner predicates and raw snippet joining.
+
+- [ ] **Step 3: Correct semantic documentation**
+
+Update both helper docstrings and the relevant context/cost comments to say “formatted pre-authority estimate.” Update the sent-notice fallback documentation to remain authoritative when repair-contract ordinals exist and explicitly best-effort only when it must fall back to the launch estimate.
+
+- [ ] **Step 4: Run the estimator tests GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q Tests/UI/test_console_staged_evidence_strip.py \
+  -k "prompted_evidence or prompted_source_count or staged_source_count"
+../../.venv/bin/pytest -q Tests/Chat/test_console_session_settings.py \
+  -k "context_estimate"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit estimator parity**
+
+```bash
+git add tldw_chatbook/Chat/console_display_state.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/UI/test_console_staged_evidence_strip.py
+git commit -m "fix(console): align evidence cost estimate with prompt"
+```
+
+---
+
+### Task 4: Pin authority shrinkage and verify the finished task
+
+**Files:**
+- Modify: `Tests/RAG/test_local_citation_capture.py`
+- Modify: `backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md`
+
+- [ ] **Step 1: Add a focused authority-shrink regression**
+
+Build a two-reference Console launch whose estimate includes both canonical prompt blocks, then send through an app authority double that exposes only the second backing row. Assert that estimate-time code performs no authority I/O, the send context contains only the surviving source re-numbered as `[S1]`, and the repair contract contains one ordinal.
+
+- [ ] **Step 2: Run one-time dependency and static checks**
+
+```bash
+../../.venv/bin/python -c \
+  "import tldw_chatbook.Chat.console_display_state; import tldw_chatbook.RAG_Search.local_citation_capture"
+../../.venv/bin/ruff check \
+  tldw_chatbook/RAG_Search/local_citation_capture.py \
+  tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py \
+  tldw_chatbook/Chat/console_display_state.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/UI/test_console_staged_evidence_strip.py
+git diff --check origin/dev...HEAD
+```
+
+Expected: all commands exit 0. Do not add a permanent subprocess import test.
+
+- [ ] **Step 3: Run focused behavior verification**
+
+```bash
+../../.venv/bin/pytest -q Tests/RAG/test_local_citation_capture.py \
+  -k "console_staged or console_evidence or authority"
+../../.venv/bin/pytest -q Tests/UI/test_console_staged_evidence_strip.py \
+  -k "prompted_evidence or prompted_source_count or staged_source_count"
+../../.venv/bin/pytest -q Tests/Chat/test_console_session_settings.py \
+  -k "context_estimate"
+```
+
+Expected: PASS. The unrelated full-file mounted-send baseline remains tracked separately: its second durable turn is refused before capture because the thread-local `:memory:` fixture opens without schema. Do not mask that failure or alter production behavior in this task.
+
+- [ ] **Step 4: Complete backlog and implementation notes**
+
+Use the Backlog CLI to check every acceptance criterion, add concise Implementation Notes with the ADR decision and verification evidence, and set TASK-2525 to Done only after every task Definition-of-Done requirement is satisfied.
+
+- [ ] **Step 5: Commit task closeout**
+
+```bash
+git add backlog/tasks/task-2525\ -\ Console-context-cost-estimate-has-three-small-modelling-gaps.md \
+  Tests/RAG/test_local_citation_capture.py
+git commit -m "test(console): verify evidence estimate parity"
+```
+

--- a/Docs/superpowers/plans/2026-08-27-console-context-cost-evidence-parity.md
+++ b/Docs/superpowers/plans/2026-08-27-console-context-cost-evidence-parity.md
@@ -26,7 +26,25 @@
 
 - [ ] **Step 1: Extend the local evidence test builder only where needed**
 
-Allow `_reference()` to accept optional `source_type`, `snippet`, `score`, and `metadata` values so the tests can express empty content, rejected source kinds, score fallback, and chunk lineage without constructing ad-hoc payload dictionaries.
+Allow `_reference()` to accept optional `source_type`, `snippet`, `score`, and `metadata` values so the tests can express empty content, rejected source kinds, score fallback, and chunk lineage without constructing ad-hoc payload dictionaries. Add this exact launch helper:
+
+```python
+def _launch_from_references(
+    *references: EvidenceReference,
+) -> ConsoleLiveWorkLaunch:
+    bundle = EvidenceBundle(
+        bundle_id="bundle-custom",
+        query="question",
+        source="Library Search/RAG",
+        references=references,
+    )
+    return ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Library Search/RAG retrieval",
+        payload={"query": "question", "evidence_bundle": bundle.to_payload()},
+        status="staged",
+    )
+```
 
 - [ ] **Step 2: Write failing public-estimator tests**
 
@@ -57,65 +75,26 @@ def test_prompted_evidence_keeps_empty_local_content_as_header_only() -> None:
     )
     assert console_prompted_evidence_text(launch) == "[S1] MEDIA — Source 1\n"
     assert console_prompted_source_count(launch) == 1
+
+
+def test_prompted_evidence_excludes_noncanonical_local_references() -> None:
+    launch = _launch_from_references(
+        _reference(1),
+        _reference(2, source_type="unsupported"),
+        _reference(3),
+    )
+    assert console_prompted_evidence_text(launch) == (
+        "[S1] MEDIA — Source 1\nBody 1\n---\n"
+        "[S2] MEDIA — Source 3\nBody 3"
+    )
+    assert console_prompted_source_count(launch) == 2
 ```
 
 - [ ] **Step 3: Add a green send-adapter characterization test**
 
 Through the existing public `capture_console_staged_evidence_for_chat()` seam, build a launch containing a valid chunked `m1` reference with `score=None`, an invalid source-kind reference, and a valid `m2` reference. Use `_CaptureApp(repository=repository, media_ids=("m1", "m2"))` and assert the recorded retrieval payload contains exactly two candidates with ranks `(1, 2)`, source IDs `(m1, m2)`, first-candidate `chunk_id == "chunk-1"`, and first-candidate `score == 0.0`. This is a pre-refactor characterization test and must pass before extraction; it does not import a helper that does not exist yet.
 
-- [ ] **Step 4: Add the authority-shrink regression in the RED phase**
-
-In `Tests/RAG/test_local_citation_capture.py`, import the existing public estimate functions and add:
-
-```python
-@pytest.mark.asyncio
-async def test_console_estimate_stays_pre_authority_while_send_rechecks() -> None:
-    launch = ConsoleLiveWorkLaunch.from_values(
-        source="Library Search/RAG",
-        title="staged evidence",
-        payload={
-            "evidence_bundle": EvidenceBundle(
-                bundle_id="bundle-authority-shrink",
-                references=(
-                    EvidenceReference(
-                        evidence_id="S1",
-                        source_id="m1",
-                        source_type="media",
-                        title="Source 1",
-                        snippet="Body 1",
-                        authority_label="local",
-                    ),
-                    EvidenceReference(
-                        evidence_id="S2",
-                        source_id="m2",
-                        source_type="media",
-                        title="Source 2",
-                        snippet="Body 2",
-                        authority_label="local",
-                    ),
-                ),
-            ).to_payload(),
-        },
-    )
-    assert console_prompted_source_count(launch) == 2
-    assert console_prompted_evidence_text(launch) == (
-        "[S1] MEDIA — Source 1\nBody 1\n---\n"
-        "[S2] MEDIA — Source 2\nBody 2"
-    )
-
-    captured = await cre.capture_console_staged_evidence_for_chat(
-        _CaptureApp(media_ids=("m2",)),
-        launch,
-        user_message="question",
-    )
-    assert captured.context == "[S1] MEDIA — Source 2\nBody 2"
-    assert captured.citation_repair_contract is not None
-    assert captured.citation_repair_contract.allowed_ordinals == (1,)
-```
-
-The estimate assertions fail on the current raw-snippet implementation while the send assertions characterize the existing authority boundary.
-
-- [ ] **Step 5: Run the characterization and RED tests**
+- [ ] **Step 4: Run the characterization and RED tests**
 
 Run:
 
@@ -125,8 +104,6 @@ Run:
 ../../.venv/bin/pytest -q \
   Tests/UI/test_console_staged_evidence_strip.py \
   -k "prompted_evidence or prompted_source_count"
-../../.venv/bin/pytest -q \
-  Tests/RAG/test_local_citation_capture.py::test_console_estimate_stays_pre_authority_while_send_rechecks
 ```
 
 Expected: the characterization test passes; the estimator tests fail on raw snippet joining, a count of 65, empty-content omission, and missing canonical framing before production changes.
@@ -239,8 +216,76 @@ git commit -m "refactor(console): share staged evidence formatting"
 - Modify: `tldw_chatbook/Chat/console_display_state.py:1-25,797-862`
 - Modify: `tldw_chatbook/UI/Screens/chat_screen.py:4320-4345,5270-5305,6590-6610`
 - Modify: `Tests/UI/test_console_staged_evidence_strip.py`
+- Modify: `Tests/RAG/test_local_citation_capture.py`
 
-- [ ] **Step 1: Add one private formatted-context seam**
+- [ ] **Step 1: Add the authority-shrink regression before estimator code**
+
+In `Tests/RAG/test_local_citation_capture.py`, import the existing public estimate functions and add:
+
+```python
+@pytest.mark.asyncio
+async def test_console_estimate_stays_pre_authority_while_send_rechecks(
+    monkeypatch,
+) -> None:
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="staged evidence",
+        payload={
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-authority-shrink",
+                query="question",
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title="Source 1",
+                        snippet="Body 1",
+                        authority_label="local",
+                    ),
+                    EvidenceReference(
+                        evidence_id="S2",
+                        source_id="m2",
+                        source_type="media",
+                        title="Source 2",
+                        snippet="Body 2",
+                        authority_label="local",
+                    ),
+                ),
+            ).to_payload(),
+        },
+    )
+    app = _CaptureApp(media_ids=("m2",))
+    authority_queries = 0
+    execute_query = app.media_db.execute_query
+
+    def _counting_execute_query(query, params):
+        nonlocal authority_queries
+        authority_queries += 1
+        return execute_query(query, params)
+
+    monkeypatch.setattr(app.media_db, "execute_query", _counting_execute_query)
+    assert console_prompted_source_count(launch) == 2
+    assert console_prompted_evidence_text(launch) == (
+        "[S1] MEDIA — Source 1\nBody 1\n---\n"
+        "[S2] MEDIA — Source 2\nBody 2"
+    )
+    assert authority_queries == 0
+
+    captured = await cre.capture_console_staged_evidence_for_chat(
+        app,
+        launch,
+        user_message="question",
+    )
+    assert authority_queries >= 1
+    assert captured.context == "[S1] MEDIA — Source 2\nBody 2"
+    assert captured.citation_repair_contract is not None
+    assert captured.citation_repair_contract.allowed_ordinals == (1,)
+```
+
+Run this node before editing `console_display_state.py`. Expected: FAIL on the formatted estimate assertion, after successful fixture construction; the authority query count remains zero before send.
+
+- [ ] **Step 2: Add one private formatted-context seam**
 
 Import `LocalEvidenceContext`, `format_console_evidence_context`, and `normalize_console_evidence_references` from `tldw_chatbook.RAG_Search.local_citation_capture`, then add:
 
@@ -256,15 +301,15 @@ def _console_prompted_evidence_context(
     )
 ```
 
-- [ ] **Step 2: Make both public estimate helpers projections**
+- [ ] **Step 3: Make both public estimate helpers projections**
 
 `console_prompted_source_count()` returns `len(formatted.entries)` and `console_prompted_evidence_text()` returns `formatted.context`, with zero/empty fallbacks when no bundle exists. Remove both duplicated owner predicates and raw snippet joining.
 
-- [ ] **Step 3: Correct semantic documentation**
+- [ ] **Step 4: Correct semantic documentation**
 
 Update both helper docstrings and the relevant context/cost comments to say “formatted pre-authority estimate.” Update the sent-notice fallback documentation to remain authoritative when repair-contract ordinals exist and explicitly best-effort only when it must fall back to the launch estimate.
 
-- [ ] **Step 4: Run the estimator tests GREEN**
+- [ ] **Step 5: Run the estimator tests GREEN**
 
 Run:
 
@@ -273,18 +318,21 @@ Run:
   -k "prompted_evidence or prompted_source_count or staged_source_count"
 ../../.venv/bin/pytest -q \
   Tests/UI/test_console_staged_evidence_strip.py::test_context_estimate_counts_staged_evidence_before_send
+../../.venv/bin/pytest -q \
+  Tests/RAG/test_local_citation_capture.py::test_console_estimate_stays_pre_authority_while_send_rechecks
 ../../.venv/bin/pytest -q Tests/Chat/test_console_session_settings.py \
   -k "context_estimate"
 ```
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit estimator parity**
+- [ ] **Step 6: Commit estimator parity**
 
 ```bash
 git add tldw_chatbook/Chat/console_display_state.py \
   tldw_chatbook/UI/Screens/chat_screen.py \
-  Tests/UI/test_console_staged_evidence_strip.py
+  Tests/UI/test_console_staged_evidence_strip.py \
+  Tests/RAG/test_local_citation_capture.py
 git commit -m "fix(console): align evidence cost estimate with prompt"
 ```
 

--- a/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
@@ -58,7 +58,7 @@ Use red/green focused tests to prove:
 - An invalid reference between two valid chunked references is omitted while the valid results retain successful-normalization order, sequential ranks, chunk lineage, and score fallback semantics.
 - A 65-reference bundle reports and formats 64 sources, omitting the final source; the estimator's formatted context matches the shared formatter exactly.
 - A two-source Console case estimates both sources without authority I/O, while a send-time authority rejection removes one and re-formats the survivor.
-- A one-time fresh-interpreter import command verifies the dependency direction; no permanent subprocess regression test is added unless a real import cycle is observed.
+- The focused pytest processes exercise the dependency direction inside their isolated test profiles; no live-profile import command or permanent subprocess regression test is added unless a real import cycle is observed.
 - Updated docstrings and call-site comments consistently distinguish the formatted pre-authority estimate from authoritative send results.
 - Existing Console estimate tests continue to pass.
 - Existing local citation formatting and send-boundary tests remain green.
@@ -67,6 +67,8 @@ Run only the targeted suites required by the repository guidance; a full sweep r
 
 ## ADR Check
 
-ADR required: no  
-ADR path: N/A  
+ADR required: no
+
+ADR path: N/A
+
 Reason: This is a routine parity bug fix that reuses existing normalization, authority, and prompt-formatting boundaries without changing architecture or policy.

--- a/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
@@ -17,7 +17,7 @@ Add two small pure helpers beside the existing local citation normalization and 
 - A Console evidence adapter will accept the bundle's available `EvidenceReference` values, retain only local references, translate them into `NormalizedLocalResult` values through the existing `normalize_local_result()` boundary, and preserve their current order.
 - A prompt-formatting wrapper will compute the send path's existing full-candidate character allowance and call `format_local_evidence_context()`. This prevents either consumer from accidentally using the formatter's unrelated 90-character default or duplicating the allowance formula.
 
-The adapter preserves the send path's current mapping contract: `source_type` supplies source identity, `source_id` supplies lineage, a non-empty string `metadata["chunk_id"]` becomes both the result ID and chunk lineage, a missing score becomes `0.0`, and candidate ranks are assigned sequentially after successful normalization. Empty snippet text remains valid and produces a counted header-only prompt entry; changing that send policy is outside this task.
+The adapter preserves the send path's current mapping contract: `source_type` supplies the canonical source kind, `source_id` supplies authority/source identity, and a non-empty string `metadata["chunk_id"]` supplies both result identity and chunk lineage. A missing score becomes `0.0`, and candidate ranks are assigned sequentially after successful normalization. Empty snippet text remains valid and produces a counted header-only prompt entry; changing that send policy is outside this task.
 
 Both consumers will use these helpers:
 

--- a/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
@@ -12,41 +12,51 @@ The estimator independently filters staged references and joins raw snippets wit
 
 ## Design
 
-Add one pure helper beside the existing local citation normalization and formatting functions. It will accept staged `EvidenceReference` values, retain only available local references, translate them into `NormalizedLocalResult` values through the existing `normalize_local_result()` boundary, and preserve their current order.
+Add two small pure helpers beside the existing local citation normalization and formatting functions:
+
+- A Console evidence adapter will accept the bundle's available `EvidenceReference` values, retain only local references, translate them into `NormalizedLocalResult` values through the existing `normalize_local_result()` boundary, and preserve their current order.
+- A prompt-formatting wrapper will compute the send path's existing full-candidate character allowance and call `format_local_evidence_context()`. This prevents either consumer from accidentally using the formatter's unrelated 90-character default or duplicating the allowance formula.
+
+The adapter preserves the send path's current mapping contract: `source_type` supplies source identity, `source_id` supplies lineage, a non-empty string `metadata["chunk_id"]` becomes both the result ID and chunk lineage, a missing score becomes `0.0`, and candidate ranks are assigned sequentially after successful normalization. Empty snippet text remains valid and produces a counted header-only prompt entry; changing that send policy is outside this task.
 
 Both consumers will use this helper:
 
-- The send path will normalize with the helper, perform its existing asynchronous authority re-check, and pass the surviving candidates to `format_local_evidence_context()`.
-- The estimator will normalize with the helper and immediately pass those candidates to `format_local_evidence_context()` without I/O.
+- The send path will normalize with the adapter, perform its existing asynchronous authority re-check, and pass the surviving candidates to the shared prompt-formatting wrapper.
+- The estimator will normalize with the adapter and immediately pass those candidates to the same prompt-formatting wrapper without I/O.
 
 The estimator's prompted-source count will be the number of entries returned by the formatter. Its prompted-evidence text will be the formatter's exact context string. This makes the two estimates derive from one canonical formatted result and automatically includes the existing `[S#]` headers, source labels, title text, `\n---\n` separators, and 64-entry cap.
 
-The formatter will keep the send path's existing character allowance calculation so this change does not introduce a second truncation policy. No cache or new abstraction layer is needed.
+The wrapper will keep the send path's existing character allowance calculation, `sum(len(title) + len(content) + 32 for candidate in candidates)`, so this change does not introduce a second truncation policy. Per-entry UTF-8 limits remain enforced by `format_local_evidence_context()`. No cache or new abstraction layer is needed.
 
 ## Data Flow
 
 1. Parse the staged evidence bundle from the Console launch context.
 2. Select its available references.
-3. Normalize eligible local references with the shared pure helper.
-4. For estimates, format immediately and derive both text and count from the result.
+3. Normalize eligible local references with the shared pure adapter.
+4. For estimates, use the shared full-candidate formatting wrapper immediately and derive both text and count from the result.
 5. For sends, retain the existing authority review before formatting.
 
-Invalid or non-normalizable references remain excluded, matching current send behavior. Missing or invalid bundles continue to produce empty estimate text and a zero count.
+Invalid or non-normalizable references remain excluded, matching current send behavior. Empty snippets remain included as header-only entries. Missing or invalid bundles continue to produce empty estimate text and a zero count.
 
 ## Boundaries and Non-Goals
 
 - Estimation performs no filesystem, database, server, or authority-check I/O.
 - A later authority change may make the final sent evidence smaller than the estimate; this is intentional and fail-closed.
+- `console_staged_source_count()` continues to report the true staged total for the UI. Only `console_prompted_source_count()` and prompted evidence text reflect normalization, formatting omissions, and the 64-entry prompt cap.
 - No database schema, UI layout, dependency, provider contract, or persistence behavior changes.
 - The pre-existing failing UI assertion in `test_console_send_consumes_staging_and_shows_the_sent_transient` is outside this modelling fix; it fails on an unchanged `origin/dev` checkout because the capture mock is invoked only for a send that has staged evidence.
+- The dependency direction is intentionally `Chat.console_display_state` to the pure `RAG_Search.local_citation_capture` helpers. That module imports only lower-level Chat citation models/builders, not Console display state; a fresh-interpreter import smoke test will guard against a cycle.
 
 ## Verification
 
 Use red/green focused tests to prove:
 
-- Prompted evidence includes the same headers and separators as the send formatter.
-- Count and text exclude blocked, server-owned, empty, and otherwise non-normalizable references consistently.
-- A 65-reference bundle reports and formats 64 sources, omitting the final source.
+- Prompted evidence includes the same headers and separators as the send formatter for multiple sources whose combined text exceeds the formatter's 90-character default.
+- Count and text exclude blocked, server-owned, and otherwise non-normalizable references consistently, while an empty local snippet remains a counted header-only entry.
+- An invalid reference between two valid chunked references is omitted while the valid results retain successful-normalization order, sequential ranks, chunk lineage, and score fallback semantics.
+- A 65-reference bundle reports and formats 64 sources, omitting the final source; the estimator's formatted context matches the shared formatter exactly.
+- A two-source Console case estimates both sources without authority I/O, while a send-time authority rejection removes one and re-formats the survivor.
+- A fresh-interpreter import smoke test covers the new dependency direction.
 - Existing Console estimate tests continue to pass.
 - Existing local citation formatting and send-boundary tests remain green.
 

--- a/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
@@ -19,7 +19,7 @@ Add two small pure helpers beside the existing local citation normalization and 
 
 The adapter preserves the send path's current mapping contract: `source_type` supplies source identity, `source_id` supplies lineage, a non-empty string `metadata["chunk_id"]` becomes both the result ID and chunk lineage, a missing score becomes `0.0`, and candidate ranks are assigned sequentially after successful normalization. Empty snippet text remains valid and produces a counted header-only prompt entry; changing that send policy is outside this task.
 
-Both consumers will use this helper:
+Both consumers will use these helpers:
 
 - The send path will normalize with the adapter, perform its existing asynchronous authority re-check, and pass the surviving candidates to the shared prompt-formatting wrapper.
 - The estimator will normalize with the adapter and immediately pass those candidates to the same prompt-formatting wrapper without I/O.
@@ -27,6 +27,8 @@ Both consumers will use this helper:
 The estimator's prompted-source count will be the number of entries returned by the formatter. Its prompted-evidence text will be the formatter's exact context string. This makes the two estimates derive from one canonical formatted result and automatically includes the existing `[S#]` headers, source labels, title text, `\n---\n` separators, and 64-entry cap.
 
 The wrapper will keep the send path's existing character allowance calculation, `sum(len(title) + len(content) + 32 for candidate in candidates)`, so this change does not introduce a second truncation policy. Per-entry UTF-8 limits remain enforced by `format_local_evidence_context()`. No cache or new abstraction layer is needed.
+
+The affected docstrings and call-site comments will describe this result as the formatted **pre-authority estimate**, not as an unconditional claim about what reaches the model. The sent-notice path continues to prefer the capture result's authoritative repair-contract ordinals; its launch-only fallback is explicitly best-effort because it cannot reproduce send-time authority checks without I/O.
 
 ## Data Flow
 
@@ -44,8 +46,8 @@ Invalid or non-normalizable references remain excluded, matching current send be
 - A later authority change may make the final sent evidence smaller than the estimate; this is intentional and fail-closed.
 - `console_staged_source_count()` continues to report the true staged total for the UI. Only `console_prompted_source_count()` and prompted evidence text reflect normalization, formatting omissions, and the 64-entry prompt cap.
 - No database schema, UI layout, dependency, provider contract, or persistence behavior changes.
-- The pre-existing failing UI assertion in `test_console_send_consumes_staging_and_shows_the_sent_transient` is outside this modelling fix; it fails on an unchanged `origin/dev` checkout because the capture mock is invoked only for a send that has staged evidence.
-- The dependency direction is intentionally `Chat.console_display_state` to the pure `RAG_Search.local_citation_capture` helpers. That module imports only lower-level Chat citation models/builders, not Console display state; a fresh-interpreter import smoke test will guard against a cycle.
+- The dependency direction is intentionally `Chat.console_display_state` to the pure `RAG_Search.local_citation_capture` helpers. That module imports only lower-level Chat citation models/builders, not Console display state.
+- `test_console_send_consumes_staging_and_shows_the_sent_transient` has a separate deterministic baseline fixture failure on unchanged `origin/dev`: its second durable turn is refused before evidence capture because the mounted harness's thread-local `:memory:` SQLite connection has no `conversations` or `world_books` schema. This does not invalidate the pure estimator baseline. Any harness repair remains a focused test-infrastructure change, not a TASK-2525 production change, and must be kept separate from the modelling diff.
 
 ## Verification
 
@@ -56,7 +58,8 @@ Use red/green focused tests to prove:
 - An invalid reference between two valid chunked references is omitted while the valid results retain successful-normalization order, sequential ranks, chunk lineage, and score fallback semantics.
 - A 65-reference bundle reports and formats 64 sources, omitting the final source; the estimator's formatted context matches the shared formatter exactly.
 - A two-source Console case estimates both sources without authority I/O, while a send-time authority rejection removes one and re-formats the survivor.
-- A fresh-interpreter import smoke test covers the new dependency direction.
+- A one-time fresh-interpreter import command verifies the dependency direction; no permanent subprocess regression test is added unless a real import cycle is observed.
+- Updated docstrings and call-site comments consistently distinguish the formatted pre-authority estimate from authoritative send results.
 - Existing Console estimate tests continue to pass.
 - Existing local citation formatting and send-boundary tests remain green.
 

--- a/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-context-cost-evidence-parity-design.md
@@ -1,0 +1,59 @@
+# Console Context-Cost Evidence Parity Design
+
+**Task:** TASK-2525 — Console context-cost estimate has three small modelling gaps
+
+## Goal
+
+Make the Console context and price estimates model staged local evidence using the same eligibility, normalization, formatting, and 64-source limit as the send path. The estimate remains a zero-I/O preview; the send-time authority check can still remove sources whose authority changes after staging.
+
+## Current Problem
+
+The estimator independently filters staged references and joins raw snippets with blank lines. The send path instead normalizes references, adds source headers and separators, and limits the formatted prompt to 64 sources. Consequently, the estimate can undercount prompt characters and report more sources than the send path can include. The duplicated `source_owner == "local"` predicate can also drift.
+
+## Design
+
+Add one pure helper beside the existing local citation normalization and formatting functions. It will accept staged `EvidenceReference` values, retain only available local references, translate them into `NormalizedLocalResult` values through the existing `normalize_local_result()` boundary, and preserve their current order.
+
+Both consumers will use this helper:
+
+- The send path will normalize with the helper, perform its existing asynchronous authority re-check, and pass the surviving candidates to `format_local_evidence_context()`.
+- The estimator will normalize with the helper and immediately pass those candidates to `format_local_evidence_context()` without I/O.
+
+The estimator's prompted-source count will be the number of entries returned by the formatter. Its prompted-evidence text will be the formatter's exact context string. This makes the two estimates derive from one canonical formatted result and automatically includes the existing `[S#]` headers, source labels, title text, `\n---\n` separators, and 64-entry cap.
+
+The formatter will keep the send path's existing character allowance calculation so this change does not introduce a second truncation policy. No cache or new abstraction layer is needed.
+
+## Data Flow
+
+1. Parse the staged evidence bundle from the Console launch context.
+2. Select its available references.
+3. Normalize eligible local references with the shared pure helper.
+4. For estimates, format immediately and derive both text and count from the result.
+5. For sends, retain the existing authority review before formatting.
+
+Invalid or non-normalizable references remain excluded, matching current send behavior. Missing or invalid bundles continue to produce empty estimate text and a zero count.
+
+## Boundaries and Non-Goals
+
+- Estimation performs no filesystem, database, server, or authority-check I/O.
+- A later authority change may make the final sent evidence smaller than the estimate; this is intentional and fail-closed.
+- No database schema, UI layout, dependency, provider contract, or persistence behavior changes.
+- The pre-existing failing UI assertion in `test_console_send_consumes_staging_and_shows_the_sent_transient` is outside this modelling fix; it fails on an unchanged `origin/dev` checkout because the capture mock is invoked only for a send that has staged evidence.
+
+## Verification
+
+Use red/green focused tests to prove:
+
+- Prompted evidence includes the same headers and separators as the send formatter.
+- Count and text exclude blocked, server-owned, empty, and otherwise non-normalizable references consistently.
+- A 65-reference bundle reports and formats 64 sources, omitting the final source.
+- Existing Console estimate tests continue to pass.
+- Existing local citation formatting and send-boundary tests remain green.
+
+Run only the targeted suites required by the repository guidance; a full sweep requires explicit user approval.
+
+## ADR Check
+
+ADR required: no  
+ADR path: N/A  
+Reason: This is a routine parity bug fix that reuses existing normalization, authority, and prompt-formatting boundaries without changing architecture or policy.

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import math
 import re
+import sqlite3
 import sys
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
@@ -953,6 +954,30 @@ class _ExistingMediaDB:
         )
 
 
+class _InMemoryMediaDB:
+    """Minimal real SQLite authority store for prompt-boundary tests."""
+
+    is_memory_db = True
+
+    def __init__(self, *existing_ids: str) -> None:
+        self.connection = sqlite3.connect(":memory:")
+        self.connection.execute(
+            "CREATE TABLE Media (id TEXT PRIMARY KEY, deleted INTEGER NOT NULL)"
+        )
+        self.connection.executemany(
+            "INSERT INTO Media (id, deleted) VALUES (?, 0)",
+            ((source_id,) for source_id in existing_ids),
+        )
+        self.query_count = 0
+
+    def execute_query(self, query, params):
+        self.query_count += 1
+        return self.connection.execute(query, params)
+
+    def close(self) -> None:
+        self.connection.close()
+
+
 class _CaptureRepository:
     def __init__(self):
         self.builders = []
@@ -1373,9 +1398,7 @@ async def test_console_send_adapter_preserves_chunk_lineage_score_and_rank():
 
 
 @pytest.mark.asyncio
-async def test_console_estimate_stays_pre_authority_while_send_rechecks(
-    monkeypatch,
-) -> None:
+async def test_console_estimate_stays_pre_authority_while_send_rechecks() -> None:
     launch = ConsoleLiveWorkLaunch.from_values(
         source="Library Search/RAG",
         title="staged evidence",
@@ -1404,32 +1427,28 @@ async def test_console_estimate_stays_pre_authority_while_send_rechecks(
             ).to_payload(),
         },
     )
-    app = _CaptureApp(media_ids=("m2",))
-    authority_queries = 0
-    execute_query = app.media_db.execute_query
+    app = _CaptureApp(media_ids=())
+    media_db = _InMemoryMediaDB("m2")
+    app.media_db = media_db
+    try:
+        assert console_prompted_source_count(launch) == 2
+        assert console_prompted_evidence_text(launch) == (
+            "[S1] MEDIA — Source 1\nBody 1\n---\n"
+            "[S2] MEDIA — Source 2\nBody 2"
+        )
+        assert media_db.query_count == 0
 
-    def _counting_execute_query(query, params):
-        nonlocal authority_queries
-        authority_queries += 1
-        return execute_query(query, params)
-
-    monkeypatch.setattr(app.media_db, "execute_query", _counting_execute_query)
-    assert console_prompted_source_count(launch) == 2
-    assert console_prompted_evidence_text(launch) == (
-        "[S1] MEDIA — Source 1\nBody 1\n---\n"
-        "[S2] MEDIA — Source 2\nBody 2"
-    )
-    assert authority_queries == 0
-
-    captured = await cre.capture_console_staged_evidence_for_chat(
-        app,
-        launch,
-        user_message="question",
-    )
-    assert authority_queries >= 1
-    assert captured.context == "[S1] MEDIA — Source 2\nBody 2"
-    assert captured.citation_repair_contract is not None
-    assert captured.citation_repair_contract.allowed_ordinals == (1,)
+        captured = await cre.capture_console_staged_evidence_for_chat(
+            app,
+            launch,
+            user_message="question",
+        )
+        assert media_db.query_count >= 1
+        assert captured.context == "[S1] MEDIA — Source 2\nBody 2"
+        assert captured.citation_repair_contract is not None
+        assert captured.citation_repair_contract.allowed_ordinals == (1,)
+    finally:
+        media_db.close()
 
 
 @pytest.mark.asyncio

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -21,6 +21,10 @@ from tldw_chatbook.Chat.citation_evidence_models import (
     EvidenceBundle,
     EvidenceReference,
 )
+from tldw_chatbook.Chat.console_display_state import (
+    console_prompted_evidence_text,
+    console_prompted_source_count,
+)
 from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
 from tldw_chatbook.Chat.citation_trace_builder import (
@@ -1366,6 +1370,66 @@ async def test_console_send_adapter_preserves_chunk_lineage_score_and_rank():
     ] == ["m1", "m2"]
     assert candidates[0].lineage["chunk_id"] == "chunk-1"
     assert candidates[0].score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_console_estimate_stays_pre_authority_while_send_rechecks(
+    monkeypatch,
+) -> None:
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="staged evidence",
+        payload={
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-authority-shrink",
+                query="question",
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title="Source 1",
+                        snippet="Body 1",
+                        authority_label="local",
+                    ),
+                    EvidenceReference(
+                        evidence_id="S2",
+                        source_id="m2",
+                        source_type="media",
+                        title="Source 2",
+                        snippet="Body 2",
+                        authority_label="local",
+                    ),
+                ),
+            ).to_payload(),
+        },
+    )
+    app = _CaptureApp(media_ids=("m2",))
+    authority_queries = 0
+    execute_query = app.media_db.execute_query
+
+    def _counting_execute_query(query, params):
+        nonlocal authority_queries
+        authority_queries += 1
+        return execute_query(query, params)
+
+    monkeypatch.setattr(app.media_db, "execute_query", _counting_execute_query)
+    assert console_prompted_source_count(launch) == 2
+    assert console_prompted_evidence_text(launch) == (
+        "[S1] MEDIA — Source 1\nBody 1\n---\n"
+        "[S2] MEDIA — Source 2\nBody 2"
+    )
+    assert authority_queries == 0
+
+    captured = await cre.capture_console_staged_evidence_for_chat(
+        app,
+        launch,
+        user_message="question",
+    )
+    assert authority_queries >= 1
+    assert captured.context == "[S1] MEDIA — Source 2\nBody 2"
+    assert captured.citation_repair_contract is not None
+    assert captured.citation_repair_contract.allowed_ordinals == (1,)
 
 
 @pytest.mark.asyncio

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -1302,6 +1302,73 @@ async def test_console_staged_local_evidence_records_exact_prompt_capture():
 
 
 @pytest.mark.asyncio
+async def test_console_send_adapter_preserves_chunk_lineage_score_and_rank():
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository, media_ids=("m1", "m2"))
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Library Search/RAG retrieval",
+        payload={
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-lineage",
+                query="question",
+                source="Library Search/RAG",
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title="Source 1",
+                        snippet="Body 1",
+                        authority_label="local",
+                        source_owner="local",
+                        score=None,
+                        metadata={"chunk_id": "chunk-1"},
+                    ),
+                    EvidenceReference(
+                        evidence_id="S2",
+                        source_id="invalid-2",
+                        source_type="unsupported",
+                        title="Invalid source",
+                        snippet="Must be excluded",
+                        authority_label="local",
+                        source_owner="local",
+                    ),
+                    EvidenceReference(
+                        evidence_id="S3",
+                        source_id="m2",
+                        source_type="media",
+                        title="Source 2",
+                        snippet="Body 2",
+                        authority_label="local",
+                        source_owner="local",
+                        score=0.5,
+                    ),
+                ),
+            ).to_payload(),
+        },
+        status="staged",
+    )
+
+    captured = await cre.capture_console_staged_evidence_for_chat(
+        app,
+        launch,
+        user_message="ordinary prompt",
+    )
+
+    assert captured.citation_builder is repository.builders[0]
+    assert captured.prompt_evidence_set_id is not None
+    candidates = captured.citation_builder.evidence_run_payloads[0].candidates
+    assert len(candidates) == 2
+    assert [candidate.rank for candidate in candidates] == [1, 2]
+    assert [
+        candidate.source_identity["source_id"] for candidate in candidates
+    ] == ["m1", "m2"]
+    assert candidates[0].lineage["chunk_id"] == "chunk-1"
+    assert candidates[0].score == 0.0
+
+
+@pytest.mark.asyncio
 async def test_console_prompt_evidence_set_id_uses_record_method_return(monkeypatch):
     authoritative_prompt_set_id = "prompt-set-authoritative-console-return"
     original_record = CitationTraceBuilder.record_prompt_evidence_set

--- a/Tests/UI/test_console_staged_evidence_strip.py
+++ b/Tests/UI/test_console_staged_evidence_strip.py
@@ -55,37 +55,49 @@ def _reference(
     title: str | None = None,
     status: str = "available",
     source_owner: str = "local",
+    source_type: str = "media",
+    snippet: str | None = None,
+    score: float | None = None,
+    metadata: dict[str, object] | None = None,
 ) -> EvidenceReference:
     return EvidenceReference(
         evidence_id=f"S{index}",
         source_id=f"media-{index}",
-        source_type="media",
+        source_type=source_type,
         title=title if title is not None else f"Source {index}",
-        snippet=f"Body {index}",
+        snippet=snippet if snippet is not None else f"Body {index}",
         authority_label="local",
         status=status,
         source_owner=source_owner,
+        score=score,
+        metadata={} if metadata is None else metadata,
     )
 
 
-def _mixed_launch() -> ConsoleLiveWorkLaunch:
-    """Four staged references, of which only two can ever reach the prompt."""
+def _launch_from_references(
+    *references: EvidenceReference,
+) -> ConsoleLiveWorkLaunch:
     bundle = EvidenceBundle(
-        bundle_id="bundle-mixed",
+        bundle_id="bundle-custom",
         query="question",
         source="Library Search/RAG",
-        references=(
-            _reference(1),
-            _reference(2, status="blocked"),
-            _reference(3),
-            _reference(4, source_owner="server"),
-        ),
+        references=references,
     )
     return ConsoleLiveWorkLaunch.from_values(
         source="Library Search/RAG",
         title="Library Search/RAG retrieval",
         payload={"query": "question", "evidence_bundle": bundle.to_payload()},
         status="staged",
+    )
+
+
+def _mixed_launch() -> ConsoleLiveWorkLaunch:
+    """Four staged references, of which only two can ever reach the prompt."""
+    return _launch_from_references(
+        _reference(1),
+        _reference(2, status="blocked"),
+        _reference(3),
+        _reference(4, source_owner="server"),
     )
 
 
@@ -194,19 +206,47 @@ def test_prompted_source_count_applies_the_captures_own_filter() -> None:
     assert console_prompted_source_count(None) == 0
 
 
-def test_prompted_evidence_text_applies_the_same_filter_as_the_count() -> None:
-    """task-6: the text the context/cost estimates count must match exactly
-    what `console_prompted_source_count` counts -- same filter, same
-    references. `capture_console_staged_evidence_for_chat` re-validates
-    identity/authority but never re-fetches content, so each reference's
-    (already truncated) `snippet` is exactly what reaches the prompt."""
+def test_prompted_evidence_uses_canonical_headers_and_separators() -> None:
     launch = _mixed_launch()
-    text = console_prompted_evidence_text(launch)
-    assert "Body 1" in text
-    assert "Body 3" in text
-    assert "Body 2" not in text  # blocked
-    assert "Body 4" not in text  # server-owned
+
+    assert console_prompted_evidence_text(launch) == (
+        "[S1] MEDIA — Source 1\nBody 1\n---\n"
+        "[S2] MEDIA — Source 3\nBody 3"
+    )
+    assert console_prompted_source_count(launch) == 2
     assert console_prompted_evidence_text(None) == ""
+
+
+def test_prompted_evidence_applies_the_send_cap() -> None:
+    launch = _launch(65)
+
+    text = console_prompted_evidence_text(launch)
+
+    assert console_prompted_source_count(launch) == 64
+    assert "[S64] MEDIA — Source 64\nBody 64" in text
+    assert "Source 65" not in text
+    assert text.count("\n---\n") == 63
+
+
+def test_prompted_evidence_keeps_empty_local_content_as_header_only() -> None:
+    launch = _launch_from_references(_reference(1, snippet=""))
+
+    assert console_prompted_evidence_text(launch) == "[S1] MEDIA — Source 1\n"
+    assert console_prompted_source_count(launch) == 1
+
+
+def test_prompted_evidence_excludes_noncanonical_local_references() -> None:
+    launch = _launch_from_references(
+        _reference(1),
+        _reference(2, source_type="unsupported"),
+        _reference(3),
+    )
+
+    assert console_prompted_evidence_text(launch) == (
+        "[S1] MEDIA — Source 1\nBody 1\n---\n"
+        "[S2] MEDIA — Source 3\nBody 3"
+    )
+    assert console_prompted_source_count(launch) == 2
 
 
 def test_prompted_evidence_text_is_empty_for_a_bundleless_launch() -> None:

--- a/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
+++ b/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
@@ -4,7 +4,7 @@ title: Console context/cost estimate has three small modelling gaps
 status: Done
 assignee: []
 created_date: '2026-08-06 02:21'
-updated_date: '2026-08-27 14:55'
+updated_date: '2026-08-27 15:01'
 labels:
   - console
   - rag
@@ -80,4 +80,6 @@ Files: tldw_chatbook/RAG_Search/local_citation_capture.py, tldw_chatbook/Event_H
 Verification: Ruff passed on all changed Python files; git diff --check passed; 6 focused RAG capture/authority tests passed; 7 prompted/staged estimator tests passed; the exact pre-send context-estimate test passed; and 8 existing Chat context-estimate tests passed. Full suite was not run per repository guidance.
 
 Tradeoff: estimates intentionally avoid authority I/O and remain formatted pre-authority previews; the send path rechecks authority and fails closed. ADR required: no. ADR path: N/A. Reason: routine parity fix reusing existing boundaries. No new generalizable lesson was produced.
+
+Final review corrected `build_console_context_estimate()` documentation to describe `staged_text` as canonical formatted pre-authority evidence that authoritative send capture may shrink; runtime behavior was unchanged.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
+++ b/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2525
 title: Console context/cost estimate has three small modelling gaps
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-06 02:21'
-updated_date: '2026-08-27 14:22'
+updated_date: '2026-08-27 14:55'
 labels:
   - console
   - rag
@@ -44,16 +44,16 @@ modelling gaps between what the estimate counts and what the send actually assem
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The context/cost estimate accounts for the per-source header + separator overhead `format_local_evidence_
+- [x] #1 The context/cost estimate accounts for the per-source header + separator overhead `format_local_evidence_
       context` adds (either by including a fixed/estimated per-source overhead, or by computing the estimate
       through the same formatting function used at send time), OR the estimate's docstring/UX copy is updated to
       state the known under-count explicitly if not fixed
-- [ ] #2 The estimate does not silently over-count past `EVIDENCE_ENTRIES_PER_PROMPT_MAX` staged sources — either
+- [x] #2 The estimate does not silently over-count past `EVIDENCE_ENTRIES_PER_PROMPT_MAX` staged sources — either
       it caps its own count at the same limit, or this is explicitly documented as a known, safe-direction
       divergence
-- [ ] #3 `console_prompted_source_count` and `console_prompted_evidence_text`'s shared `source_owner == "local"`
+- [x] #3 `console_prompted_source_count` and `console_prompted_evidence_text`'s shared `source_owner == "local"`
       eligibility predicate is extracted into one helper both functions call, so the two can no longer drift
-- [ ] #4 Existing tests for both functions (`Tests/UI/test_console_staged_evidence_strip.py`,
+- [x] #4 Existing tests for both functions (`Tests/UI/test_console_staged_evidence_strip.py`,
       `Tests/Chat/test_console_session_settings.py`) stay green
 <!-- AC:END -->
 
@@ -69,3 +69,15 @@ ADR required: no
 ADR path: N/A
 Reason: Routine parity bug fix reusing existing normalization, authority, and formatting boundaries.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Aligned Console context/cost estimates with the send path by sharing canonical EvidenceReference normalization and prompt formatting. The zero-I/O estimator now includes source headers and separators, excludes noncanonical references, and applies the 64-entry cap; send-time authority remains authoritative and may shrink the pre-authority estimate.
+
+Files: tldw_chatbook/RAG_Search/local_citation_capture.py, tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py, tldw_chatbook/Chat/console_display_state.py, tldw_chatbook/UI/Screens/chat_screen.py, Tests/RAG/test_local_citation_capture.py, and Tests/UI/test_console_staged_evidence_strip.py.
+
+Verification: Ruff passed on all changed Python files; git diff --check passed; 6 focused RAG capture/authority tests passed; 7 prompted/staged estimator tests passed; the exact pre-send context-estimate test passed; and 8 existing Chat context-estimate tests passed. Full suite was not run per repository guidance.
+
+Tradeoff: estimates intentionally avoid authority I/O and remain formatted pre-authority previews; the send path rechecks authority and fails closed. ADR required: no. ADR path: N/A. Reason: routine parity fix reusing existing boundaries. No new generalizable lesson was produced.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
+++ b/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
@@ -4,7 +4,7 @@ title: Console context/cost estimate has three small modelling gaps
 status: Done
 assignee: []
 created_date: '2026-08-06 02:21'
-updated_date: '2026-08-27 15:01'
+updated_date: '2026-08-27 15:17'
 labels:
   - console
   - rag
@@ -82,4 +82,6 @@ Verification: Ruff passed on all changed Python files; git diff --check passed; 
 Tradeoff: estimates intentionally avoid authority I/O and remain formatted pre-authority previews; the send path rechecks authority and fails closed. ADR required: no. ADR path: N/A. Reason: routine parity fix reusing existing boundaries. No new generalizable lesson was produced.
 
 Final review corrected `build_console_context_estimate()` documentation to describe `staged_text` as canonical formatted pre-authority evidence that authoritative send capture may shrink; runtime behavior was unchanged.
+
+PR review follow-up named and documented the per-candidate Console framing allowance, and replaced the authority-shrink test's database double with a real in-memory SQLite `Media` table. The focused authority/send tests passed (2), the prompted/staged estimator selection passed (7), Ruff passed, and `git diff --check` passed; runtime behavior remained unchanged.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
+++ b/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2525
 title: Console context/cost estimate has three small modelling gaps
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-06 02:21'
+updated_date: '2026-08-27 14:06'
 labels:
   - console
   - rag
@@ -15,6 +16,7 @@ priority: low
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 PR-T2 Task 6 made staged Library evidence count toward Console's context estimate and cost chip instead of
 reporting zero, by tokenizing `EvidenceReference.snippet` (via the new `console_prompted_evidence_text()`,
 `Chat/console_display_state.py`). Task 6's own review (whole-branch review, dual-blind against the actual send
@@ -38,17 +40,25 @@ modelling gaps between what the estimate counts and what the send actually assem
    `reference.source_owner.strip().lower() == "local"` (`:632` and `:671`) to decide which references are
    prompt-eligible. Identical today, but two copies of "which references reach the model" can silently drift if
    either is edited without the other.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] The context/cost estimate accounts for the per-source header + separator overhead `format_local_evidence_
+<!-- AC:BEGIN -->
+- [ ] #1 The context/cost estimate accounts for the per-source header + separator overhead `format_local_evidence_
       context` adds (either by including a fixed/estimated per-source overhead, or by computing the estimate
       through the same formatting function used at send time), OR the estimate's docstring/UX copy is updated to
       state the known under-count explicitly if not fixed
-- [ ] The estimate does not silently over-count past `EVIDENCE_ENTRIES_PER_PROMPT_MAX` staged sources — either
+- [ ] #2 The estimate does not silently over-count past `EVIDENCE_ENTRIES_PER_PROMPT_MAX` staged sources — either
       it caps its own count at the same limit, or this is explicitly documented as a known, safe-direction
       divergence
-- [ ] `console_prompted_source_count` and `console_prompted_evidence_text`'s shared `source_owner == "local"`
+- [ ] #3 `console_prompted_source_count` and `console_prompted_evidence_text`'s shared `source_owner == "local"`
       eligibility predicate is extracted into one helper both functions call, so the two can no longer drift
-- [ ] Existing tests for both functions (`Tests/UI/test_console_staged_evidence_strip.py`,
+- [ ] #4 Existing tests for both functions (`Tests/UI/test_console_staged_evidence_strip.py`,
       `Tests/Chat/test_console_session_settings.py`) stay green
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused red tests for canonical framing, normalization, empty content, and the 64-entry cap.\n2. Extract shared Console evidence normalization and full-candidate formatting helpers, then route the send adapter through them.\n3. Derive estimate text and count from one formatted pre-authority result and correct semantic documentation.\n4. Add authority-shrink coverage, run focused verification and static checks, then complete task notes and acceptance criteria.\n\nADR required: no\nADR path: N/A\nReason: Routine parity bug fix reusing existing normalization, authority, and formatting boundaries.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
+++ b/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
@@ -4,7 +4,7 @@ title: Console context/cost estimate has three small modelling gaps
 status: In Progress
 assignee: []
 created_date: '2026-08-06 02:21'
-updated_date: '2026-08-27 14:06'
+updated_date: '2026-08-27 14:18'
 labels:
   - console
   - rag
@@ -60,5 +60,12 @@ modelling gaps between what the estimate counts and what the send actually assem
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add focused red tests for canonical framing, normalization, empty content, and the 64-entry cap.\n2. Extract shared Console evidence normalization and full-candidate formatting helpers, then route the send adapter through them.\n3. Derive estimate text and count from one formatted pre-authority result and correct semantic documentation.\n4. Add authority-shrink coverage, run focused verification and static checks, then complete task notes and acceptance criteria.\n\nADR required: no\nADR path: N/A\nReason: Routine parity bug fix reusing existing normalization, authority, and formatting boundaries.
+1. Add focused red estimator and authority-shrink tests plus a green send-adapter characterization.
+2. Extract shared Console evidence normalization and full-candidate formatting helpers, then route the send adapter through them.
+3. Derive estimate text and count from one formatted pre-authority result and correct semantic documentation.
+4. Run focused isolated verification and static checks, then complete task notes and acceptance criteria.
+
+ADR required: no
+ADR path: N/A
+Reason: Routine parity bug fix reusing existing normalization, authority, and formatting boundaries.
 <!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
+++ b/backlog/tasks/task-2525 - Console-context-cost-estimate-has-three-small-modelling-gaps.md
@@ -4,7 +4,7 @@ title: Console context/cost estimate has three small modelling gaps
 status: In Progress
 assignee: []
 created_date: '2026-08-06 02:21'
-updated_date: '2026-08-27 14:18'
+updated_date: '2026-08-27 14:22'
 labels:
   - console
   - rag
@@ -60,9 +60,9 @@ modelling gaps between what the estimate counts and what the send actually assem
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add focused red estimator and authority-shrink tests plus a green send-adapter characterization.
+1. Add focused red estimator tests plus a green send-adapter characterization.
 2. Extract shared Console evidence normalization and full-candidate formatting helpers, then route the send adapter through them.
-3. Derive estimate text and count from one formatted pre-authority result and correct semantic documentation.
+3. Add authority-shrink RED coverage, derive estimate text and count from one formatted pre-authority result, and correct semantic documentation.
 4. Run focused isolated verification and static checks, then complete task notes and acceptance criteria.
 
 ADR required: no

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -17,6 +17,11 @@ from tldw_chatbook.Chat.console_project_instructions import (
     ProjectInstructionControlState,
 )
 from tldw_chatbook.Chat.rag_scope import EffectiveScope, RagScope
+from tldw_chatbook.RAG_Search.local_citation_capture import (
+    LocalEvidenceContext,
+    format_console_evidence_context,
+    normalize_console_evidence_references,
+)
 from tldw_chatbook.UI.character_display_text import sanitize_character_display_label
 
 CONSOLE_INSPECTOR_REVIEW_APPROVAL_ID = "console-inspector-review-approval"
@@ -794,72 +799,48 @@ def console_staged_source_count(launch: ConsoleLiveWorkLaunch | None) -> int:
     return len(bundle.references) or 1
 
 
-def console_prompted_source_count(launch: ConsoleLiveWorkLaunch | None) -> int:
-    """Return how many staged references a Console send will actually prompt.
+def _console_prompted_evidence_context(
+    launch: ConsoleLiveWorkLaunch | None,
+) -> LocalEvidenceContext | None:
+    """Build the formatted pre-authority estimate without performing I/O."""
+    bundle = evidence_bundle_from_launch(launch)
+    if bundle is None:
+        return None
+    return format_console_evidence_context(
+        normalize_console_evidence_references(bundle.available_references())
+    )
 
-    Distinct from :func:`console_staged_source_count`, which answers "how
-    much is staged". This answers "how much reaches the model", and it
-    applies exactly the filter
-    ``capture_console_staged_evidence_for_chat`` applies before formatting
-    the prompt blocks: available status (``EvidenceBundle.
-    available_references``) AND ``source_owner == "local"``. A four-result
-    bundle carrying two blocked references stages four and sends two.
+
+def console_prompted_source_count(launch: ConsoleLiveWorkLaunch | None) -> int:
+    """Return the formatted pre-authority estimate of prompted source count.
+
+    The actual send rechecks local authority and may carry fewer entries.
 
     Args:
         launch: Currently staged live-work launch, if any.
 
     Returns:
-        Count of references eligible to enter the prompt; ``0`` when nothing
-        is staged or the launch carries no evidence bundle (a bundleless
-        launch yields no prompt context at all).
+        Count of canonical formatted entries; ``0`` without an evidence
+        bundle.
     """
-    bundle = evidence_bundle_from_launch(launch)
-    if bundle is None:
-        return 0
-    return sum(
-        1
-        for reference in bundle.available_references()
-        if reference.source_owner.strip().lower() == "local"
-    )
+    formatted = _console_prompted_evidence_context(launch)
+    return len(formatted.entries) if formatted is not None else 0
 
 
 def console_prompted_evidence_text(launch: ConsoleLiveWorkLaunch | None) -> str:
-    """Return the staged evidence text a Console send will actually prompt.
+    """Return the zero-I/O formatted pre-authority evidence estimate.
 
-    task-6: the Console context/cost estimates used to report zero for
-    staged evidence because nothing carried its TEXT that far --
-    ``ConsoleStagedSource`` is label-only. This is the pure, zero-I/O
-    source of truth for that text, read at estimate time (settings
-    summary, cost chip) before any send happens.
-
-    Applies exactly the same filter as :func:`console_prompted_source_count`
-    (``EvidenceBundle.available_references`` AND ``source_owner == "local"``)
-    because it answers the same question that function counts: "how much
-    reaches the model". ``reference.snippet`` is the right field to read,
-    not a full re-fetch, because the actual send path
-    (``capture_console_staged_evidence_for_chat``) re-validates identity and
-    authority but never re-fetches content -- it hands the provider exactly
-    this (already length-limited, see ``EVIDENCE_SNIPPET_CHAR_LIMIT``)
-    snippet verbatim. That length limit is also why an oversized source
-    (e.g. a 942 KB document) still yields a bounded, non-zero estimate here:
-    the snippet was already capped when the reference was staged.
+    The actual send rechecks local authority and may carry less context.
 
     Args:
         launch: Currently staged live-work launch, if any.
 
     Returns:
-        Prompt-eligible reference snippets joined with blank lines, in
-        bundle order; ``""`` when nothing is staged or nothing is
-        prompt-eligible.
+        Canonical prompt-formatted context, or ``""`` without an evidence
+        bundle or formatted entries.
     """
-    bundle = evidence_bundle_from_launch(launch)
-    if bundle is None:
-        return ""
-    return "\n\n".join(
-        reference.snippet
-        for reference in bundle.available_references()
-        if reference.source_owner.strip().lower() == "local" and reference.snippet
-    )
+    formatted = _console_prompted_evidence_context(launch)
+    return formatted.context if formatted is not None else ""
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -981,15 +981,13 @@ def build_console_context_estimate(
     """Estimate current context tokens for display in Console settings.
 
     Args:
-        staged_text: The staged evidence text a send would actually carry
-            (task-6) -- e.g. the joined snippets of staged, prompt-eligible
-            evidence references. Passed in by the caller so this builder
-            stays pure (no I/O, no bundle parsing here); blank/whitespace
-            text contributes nothing, matching how an unset staged context
-            already behaves. Folded into `used_tokens` as one additional
-            message so the context estimate stops silently reporting zero
-            for content it is about to send -- `staged_source_count` still
-            drives only the label's "; N sources staged" suffix, unchanged.
+        staged_text: Canonical formatted pre-authority evidence used for cost
+            estimation (task-6). Passed in by the caller so this builder stays
+            pure (no I/O, no bundle parsing here); blank/whitespace text
+            contributes nothing. Authoritative send capture may shrink this
+            context after rechecking local authority. Folded into `used_tokens`
+            as one additional message; `staged_source_count` still drives only
+            the label's "; N sources staged" suffix, unchanged.
     """
     model_name = _string_value(model)
     if not model_name:

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -46,7 +46,9 @@ from ...RAG_Search.local_citation_capture import (
     LocalEvidenceContext,
     LocalResultNormalizationError,
     NormalizedLocalResult,
+    format_console_evidence_context,
     format_local_evidence_context,
+    normalize_console_evidence_references,
     normalize_local_result,
 )
 from ...RAG_Search.pipeline_builder_simple import BUILTIN_PIPELINES, execute_pipeline
@@ -1695,40 +1697,9 @@ async def capture_console_staged_evidence_for_chat(
         )
         return LocalRagContextResult(None, None)
 
-    normalized: list[NormalizedLocalResult] = []
-    rejected_count = 0
-    for reference in bundle.available_references():
-        if reference.source_owner.strip().lower() != "local":
-            rejected_count += 1
-            continue
-        metadata: Dict[str, Any] = {
-            "source_type": reference.source_type,
-            "source_id": reference.source_id,
-        }
-        chunk_id = reference.metadata.get("chunk_id")
-        if isinstance(chunk_id, str) and chunk_id:
-            metadata["chunk_id"] = chunk_id
-        result_id = (
-            chunk_id if isinstance(chunk_id, str) and chunk_id else reference.source_id
-        )
-        try:
-            normalized.append(
-                normalize_local_result(
-                    {
-                        "source": reference.source_type,
-                        "id": result_id,
-                        "title": reference.title,
-                        "content": reference.snippet,
-                        "score": (
-                            reference.score if reference.score is not None else 0.0
-                        ),
-                        "metadata": metadata,
-                    },
-                    candidate_rank=len(normalized) + 1,
-                )
-            )
-        except LocalResultNormalizationError:
-            rejected_count += 1
+    references = bundle.available_references()
+    normalized = normalize_console_evidence_references(references)
+    rejected_count = len(references) - len(normalized)
     if rejected_count:
         logger.info(
             "Console RAG evidence excluded; "
@@ -1740,7 +1711,7 @@ async def capture_console_staged_evidence_for_chat(
     request_session = _capture_request_scope_session(app)
     authorization = await _authorize_local_results_for_prompt(
         app,
-        tuple(normalized),
+        normalized,
         request_session=request_session,
     )
     if not authorization.completed:
@@ -1748,13 +1719,7 @@ async def capture_console_staged_evidence_for_chat(
             "Console RAG evidence unavailable; reason=prompt_authority_failure"
         )
         return LocalRagContextResult(None, None)
-    formatted = format_local_evidence_context(
-        authorization.candidates,
-        max_length=sum(
-            len(candidate.title) + len(candidate.content) + 32
-            for candidate in authorization.candidates
-        ),
-    )
+    formatted = format_console_evidence_context(authorization.candidates)
     context = formatted.context if formatted.context.strip() else None
     if context is None:
         return LocalRagContextResult(None, None)

--- a/tldw_chatbook/RAG_Search/local_citation_capture.py
+++ b/tldw_chatbook/RAG_Search/local_citation_capture.py
@@ -47,6 +47,8 @@ _OFFSET_ALIASES = {
 }
 _TITLE_UTF8_BYTES_MAX = 4 * 1024
 _SEPARATOR = "\n---\n"
+# Slack for the marker, source label, punctuation, newline, and separator.
+_CONSOLE_FRAMING_ALLOWANCE_PER_CANDIDATE = 32
 _SOURCE_LABELS = {
     CanonicalSourceKind.MEDIA_DB: "MEDIA",
     CanonicalSourceKind.NOTES: "NOTES",
@@ -531,7 +533,9 @@ def format_console_evidence_context(
     return format_local_evidence_context(
         normalized_results,
         max_length=sum(
-            len(candidate.title) + len(candidate.content) + 32
+            len(candidate.title)
+            + len(candidate.content)
+            + _CONSOLE_FRAMING_ALLOWANCE_PER_CANDIDATE
             for candidate in normalized_results
         ),
     )

--- a/tldw_chatbook/RAG_Search/local_citation_capture.py
+++ b/tldw_chatbook/RAG_Search/local_citation_capture.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 import unicodedata
 
+from ..Chat.citation_evidence_models import EvidenceReference
 from ..Chat.citation_source_locators import CanonicalSourceKind
 from ..Chat.citation_trace_builder import (
     LocalPromptEvidenceCapture,
@@ -371,6 +372,54 @@ def normalize_local_result(
     )
 
 
+def normalize_console_evidence_references(
+    references: Sequence[EvidenceReference],
+) -> tuple[NormalizedLocalResult, ...]:
+    """Normalize Console-staged local references for prompt capture.
+
+    Args:
+        references: Available references from the staged evidence bundle.
+
+    Returns:
+        Canonical local results in successful-normalization order.
+    """
+
+    normalized: list[NormalizedLocalResult] = []
+    for reference in references:
+        if reference.source_owner.strip().lower() != "local":
+            continue
+        metadata: dict[str, Any] = {
+            "source_type": reference.source_type,
+            "source_id": reference.source_id,
+        }
+        chunk_id = reference.metadata.get("chunk_id")
+        if isinstance(chunk_id, str) and chunk_id:
+            metadata["chunk_id"] = chunk_id
+        try:
+            normalized.append(
+                normalize_local_result(
+                    {
+                        "source": reference.source_type,
+                        "id": (
+                            chunk_id
+                            if isinstance(chunk_id, str) and chunk_id
+                            else reference.source_id
+                        ),
+                        "title": reference.title,
+                        "content": reference.snippet,
+                        "score": (
+                            reference.score if reference.score is not None else 0.0
+                        ),
+                        "metadata": metadata,
+                    },
+                    candidate_rank=len(normalized) + 1,
+                )
+            )
+        except LocalResultNormalizationError:
+            continue
+    return tuple(normalized)
+
+
 def _content_prefix_within_budgets(
     content: str, *, character_budget: int, utf8_byte_budget: int
 ) -> str:
@@ -467,6 +516,27 @@ def format_local_evidence_context(
     )
 
 
+def format_console_evidence_context(
+    normalized_results: Sequence[NormalizedLocalResult],
+) -> LocalEvidenceContext:
+    """Format all Console-staged candidates with the canonical prompt cap.
+
+    Args:
+        normalized_results: Canonical Console candidates in retrieval order.
+
+    Returns:
+        Exact formatted context, entry captures, and omitted candidate ranks.
+    """
+
+    return format_local_evidence_context(
+        normalized_results,
+        max_length=sum(
+            len(candidate.title) + len(candidate.content) + 32
+            for candidate in normalized_results
+        ),
+    )
+
+
 __all__ = [
     "FINAL_SCORE_KIND_KEY",
     "FINAL_SCORE_KIND_RERANKER",
@@ -476,6 +546,8 @@ __all__ = [
     "NormalizedLocalResult",
     "SEMANTIC_SCORE_KIND_KEY",
     "SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY",
+    "format_console_evidence_context",
     "format_local_evidence_context",
+    "normalize_console_evidence_references",
     "normalize_local_result",
 ]

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4368,12 +4368,12 @@ class ChatScreen(BaseAppScreen):
             # task-6: staged evidence used to move only the label's "; N
             # sources staged" suffix (`staged_source_count` above) while
             # `used_tokens` silently reported zero for content the send
-            # will actually carry. `console_prompted_evidence_text` reads
-            # the same in-memory, zero-I/O staged bundle
+            # is likely to carry. `console_prompted_evidence_text` reads
+            # the same in-memory, zero-I/O staged bundle and produces the
+            # formatted pre-authority estimate
             # `_current_console_workspace_context` already parses above --
-            # no extra DB round trip -- and applies the exact filter the
-            # send path applies, so the estimate stays true without
-            # simulating a send.
+            # no extra DB round trip. The actual send may shrink this after
+            # its authority check.
             staged_text=console_prompted_evidence_text(
                 self._pending_console_launch_context
             ),
@@ -5332,8 +5332,8 @@ class ChatScreen(BaseAppScreen):
         1. ``citation_repair_contract.allowed_ordinals`` -- one ordinal per
            FORMATTED prompt entry, so this is the exact count, and the
            capture attaches the contract to every context-bearing return.
-        2. :func:`console_prompted_source_count` -- the same
-           available-and-local filter applied to the bundle, used when the
+        2. :func:`console_prompted_source_count` -- a best-effort formatted
+           pre-authority estimate used only when the authoritative repair
            contract could not be built.
 
         Args:
@@ -6643,8 +6643,9 @@ class ChatScreen(BaseAppScreen):
             # the cost chip entirely -- `ConsoleStagedSource` carries no
             # text, so a session with zero messages but several staged
             # sources (even a 942 KB one) showed "0 tok". Feed the same
-            # prompt-eligible staged text the context estimate now counts
-            # (`console_prompted_evidence_text`, pure/zero-I/O) in as one
+            # formatted pre-authority staged-text estimate the context
+            # estimate now counts (`console_prompted_evidence_text`,
+            # pure/zero-I/O) in as one
             # more transcript row satisfying `build_cost_snapshot`'s
             # duck-typed contract (`.role`/`.content`/`.usage`) with
             # `usage=None` -- it prices through the ESTIMATED-row branch,


### PR DESCRIPTION
## Summary

- Centralize Console-staged EvidenceReference normalization and canonical evidence formatting so the estimator and send path share one mapping boundary.
- Make context/cost previews formatted pre-authority, zero-I/O estimates that include headers and separators, honor the 64-entry cap, and retain header-only empty snippets.
- Preserve send-time authority rechecks and authoritative sent-source reporting, with focused regressions and TASK-2525 closeout documentation.

## Verification

- Ruff passed on all changed Python files.
- RAG capture and authority regressions: 6 passed.
- UI prompted/staged estimator cases: 7 passed, 26 deselected.
- Exact pre-send context estimate: 1 passed.
- Chat context-estimate cases: 8 passed, 112 deselected.
- git diff --check origin/dev...HEAD passed.
- Final whole-branch and post-rebase reviews found no remaining issues.

The full suite was not run, following the repository targeted-test policy. ADR required: no; this reuses the existing capture and authority boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Console context/cost estimate to model staged evidence the same way the send path does, closing TASK-2525. The estimate now includes canonical source headers and separators, applies the 64-entry prompt cap, and keeps header-only entries for empty snippets; send-time authority checks still apply and can shrink what actually reaches the model.

**Behavior changes**
- Estimate text and count derive from one shared normalized result, removing the duplicated local-eligibility filter.
- `console_prompted_evidence_text()` and `console_prompted_source_count()` are now formatted pre-authority estimates and may differ from the sent context after authority rechecks.
- The estimate remains zero-I/O and never performs the send path's authority queries.

<sup>Written for commit 5e8d1c402b31d6baecb67da46008c34e481e23ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

