### PR TITLE
test(citations): the settlement-failure None is not data loss (TASK-22617)

### DIFF
--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -2340,9 +2340,14 @@ def test_one_terminal_write_ready_finalizer_fails_closed_to_ordinary_message() -
 #     was ever armed, the continuation survives the failure, and the resume's
 #     owner-publication effect forwards `continuation.terminal_citation_
 #     finalizer` (TASK-22302) -- re-arming and persisting the trace.
-#   - Defence in depth, pinned at store level below: even if a None publish
-#     DID run while armed, `_hydrate_durable_turn_owner_messages` never clears
-#     armed state on None (the arming `if` is simply skipped).
+#   - The unreachability above holds only at EFFECT granularity. Inside owner
+#     publication itself, arming precedes the checkpoint call that registers
+#     the recovery, so a failure in that window DOES reach the None publish
+#     with a finalizer armed (Qodo caught this ordering gap on #2146; the
+#     window test below confirms it empirically). There the store's
+#     non-clearing contract is load-bearing, not defence in depth: a None
+#     publish never clears armed state, only declines to arm -- pinned both
+#     through the realistic window and directly at store level.
 # ---------------------------------------------------------------------------
 
 
@@ -2486,11 +2491,10 @@ async def test_a_none_recovery_publish_never_clears_an_armed_finalizer(
 ) -> None:
     """Defence in depth for TASK-22617, pinned where it is reachable.
 
-    Production cannot currently reach `publish_durable_recovery_owner(...,
-    None)` while a finalizer is armed (the ordering tests above pin why). This
-    pins the store-level property that keeps the None safe even if a future
-    caller breaks that ordering: a None publish must never CLEAR armed state,
-    only decline to arm.
+    The realistic route to this state is the arming-to-registration window
+    inside owner publication (see the window test above). This pins the same
+    property directly at store level, with no controller in the loop: a None
+    publish must never CLEAR armed state, only decline to arm.
     """
 
     stack = real_citation_stack_factory("settle-sticky")
@@ -2531,4 +2535,67 @@ async def test_a_none_recovery_publish_never_clears_an_armed_finalizer(
 
     assert stack.store._terminal_citation_finalizers.get(assistant.id) is finalizer, (
         "a None recovery publish cleared an armed terminal citation finalizer"
+    )
+
+
+@pytest.mark.asyncio
+async def test_settlement_failure_inside_owner_publication_window(
+    real_citation_stack_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failure BETWEEN arming and recovery registration (Qodo #2 on #2146).
+
+    Inside `publish_durable_turn_owners`, `_hydrate_durable_turn_owner_messages`
+    ARMS the finalizer before `publish_durable_dispatch_checkpoint` registers
+    the dispatch recovery. A failure in that window reaches the failure arm
+    with a finalizer armed AND no recovery registered -- so the None publish
+    RUNS while armed, which the effect-granular ordering tests above cannot
+    reach. This is where the store's non-clearing behaviour stops being
+    defence in depth and becomes load-bearing: the None publish must leave the
+    armed finalizer alone, and the resume must still persist the trace.
+    """
+
+    stack = real_citation_stack_factory("settle-window")
+    builder, prompt_id = _real_captured_builder(stack.repository)
+    controller = _real_controller(stack, builder, prompt_id)
+
+    original_checkpoint = stack.store.publish_durable_dispatch_checkpoint
+    checkpoint_calls = 0
+
+    def checkpoint_fail_once(*args, **kwargs):
+        nonlocal checkpoint_calls
+        checkpoint_calls += 1
+        if checkpoint_calls == 1:
+            raise RuntimeError("injected checkpoint publication")
+        return original_checkpoint(*args, **kwargs)
+
+    monkeypatch.setattr(
+        stack.store, "publish_durable_dispatch_checkpoint", checkpoint_fail_once
+    )
+    publish_calls = _spy_recovery_publish(stack, monkeypatch)
+    first = await controller.submit_draft("question")
+    assert first.accepted is True, "harness precondition: the turn was accepted"
+    assert stack.store._terminal_citation_finalizers != {}, (
+        "harness precondition violated: arming no longer precedes checkpoint "
+        "publication inside owner publication, so the window this test covers "
+        "has closed -- re-examine TASK-22617's ordering model"
+    )
+    assert publish_calls == [False], (
+        "harness precondition violated: the failure arm's None publish did "
+        "not run in the arming-to-registration window; this test no longer "
+        "covers the armed+None combination"
+    )
+    assert stack.store._terminal_citation_finalizers != {}, (
+        "the None recovery publish cleared the armed finalizer -- the store's "
+        "non-clearing behaviour is load-bearing in this window and broke"
+    )
+
+    resumed = await controller.resume_durable_postcommit(first.preparation_id)
+
+    assert resumed.accepted is True
+    assistant = _real_assistant(stack.store)
+    assert assistant.content == _BODY_SENTINEL
+    assert _citation_row_counts(stack.db)["rag_citation_traces"] == 1, (
+        "a settlement failure between finalizer arming and recovery "
+        "registration lost the citation trace"
     )

--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -2314,3 +2314,221 @@ def test_one_terminal_write_ready_finalizer_fails_closed_to_ordinary_message() -
     assert persistence.create_calls[0]["message_id"] == message.id
     assert persistence.create_calls[0]["content"] == completed.content
     assert "citation_write" not in persistence.create_calls[0]
+
+
+# ---------------------------------------------------------------------------
+# TASK-22617: does a settlement failure lose the citation trace?
+#
+# `resume_durable_postcommit`'s `except BaseException:` arm publishes a
+# recovery owner with `terminal_citation_finalizer=None` hard-coded, while the
+# enclosing continuation's finalizer IS in scope. Two readings were filed: the
+# same data-loss class as TASK-22302, or a deliberate guard against attributing
+# content whose delivery is unknown.
+#
+# These tests establish the answer empirically, one per ordering of failure vs
+# finalizer arming. The verdict is NOT data loss, and the mechanism is
+# structural (measured, not read):
+#
+#   - `durable_owner_publication` -- the effect that ARMS the finalizer -- also
+#     registers the session's dispatch recovery (`publish_durable_turn_owners`
+#     -> `publish_durable_dispatch_checkpoint` -> `_dispatch_recoveries_by_
+#     session[...] = recovery`). The failure arm only publishes a recovery
+#     owner when no recovery exists, so the None publish is UNREACHABLE once a
+#     finalizer is armed. Instrumented: across both orderings it fired exactly
+#     once, in the pre-arming test.
+#   - In the one reachable ordering (failure BEFORE owner publication) nothing
+#     was ever armed, the continuation survives the failure, and the resume's
+#     owner-publication effect forwards `continuation.terminal_citation_
+#     finalizer` (TASK-22302) -- re-arming and persisting the trace.
+#   - Defence in depth, pinned at store level below: even if a None publish
+#     DID run while armed, `_hydrate_durable_turn_owner_messages` never clears
+#     armed state on None (the arming `if` is simply skipped).
+# ---------------------------------------------------------------------------
+
+
+def _spy_recovery_publish(stack, monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+    """Record each `publish_durable_recovery_owner` call's finalizer-presence.
+
+    The mechanism TASK-22617 rests on is WHETHER the failure arm's None publish
+    runs, and a post-hoc `dispatch_recovery_for_session` check cannot see that:
+    the arm itself restores a recovery after its publish gate, so the recovery
+    is non-None afterwards in every ordering (a mutation proved that assert
+    vacuous). Observe the call, not the aftermath.
+    """
+
+    calls: list[bool] = []
+    original = stack.store.publish_durable_recovery_owner
+
+    def spy(*args, **kwargs):
+        calls.append(kwargs.get("terminal_citation_finalizer") is not None)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(stack.store, "publish_durable_recovery_owner", spy)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_settlement_failure_before_arming_still_persists_the_trace(
+    real_citation_stack_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failure BEFORE `durable_owner_publication`: nothing armed yet.
+
+    The recovery owner is published with `terminal_citation_finalizer=None`
+    while no finalizer has ever been armed. If the resume did not re-arm via
+    the continuation, the trace would be unpersistable from here on.
+    """
+
+    stack = real_citation_stack_factory("settle-early")
+    builder, prompt_id = _real_captured_builder(stack.repository)
+    controller = _real_controller(stack, builder, prompt_id)
+
+    original = stack.store.publish_durable_turn_identity
+    calls = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("injected identity publication")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(stack.store, "publish_durable_turn_identity", fail_once)
+    publish_calls = _spy_recovery_publish(stack, monkeypatch)
+    first = await controller.submit_draft("question")
+    assert first.accepted is True, "harness precondition: the turn was accepted"
+    assert publish_calls == [False], (
+        "positive control: the failure arm's recovery publish (with a None "
+        "finalizer) must RUN in the pre-arming ordering -- if it stopped "
+        "running, the sibling test's zero-calls assertion proves nothing"
+    )
+    assert first.preparation_id in controller._durable_postcommit_continuations
+    assert stack.store._terminal_citation_finalizers == {}, (
+        "harness precondition violated: the finalizer was already armed, so "
+        "this test would no longer cover the fail-BEFORE-arming ordering"
+    )
+    assert _citation_row_counts(stack.db)["rag_citation_traces"] == 0
+
+    resumed = await controller.resume_durable_postcommit(first.preparation_id)
+
+    assert resumed.accepted is True
+    assert calls == 2, "harness precondition: the resume re-ran the effect"
+    assistant = _real_assistant(stack.store)
+    assert assistant.content == _BODY_SENTINEL
+    assert _citation_row_counts(stack.db)["rag_citation_traces"] == 1, (
+        "a settlement failure before finalizer arming lost the citation "
+        "trace: the recovery owner's None was load-bearing after all"
+    )
+
+
+@pytest.mark.asyncio
+async def test_settlement_failure_after_arming_keeps_the_armed_finalizer(
+    real_citation_stack_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failure AFTER `durable_owner_publication`: the finalizer is armed.
+
+    The None publish in the failure arm is UNREACHABLE here, and that is the
+    load-bearing fact this test pins: the same effect that armed the finalizer
+    already registered the dispatch recovery, so the arm's `dispatch_recovery_
+    for_session is None` gate skips the publish. The armed finalizer survives
+    untouched and fires when the resume completes the turn.
+    """
+
+    stack = real_citation_stack_factory("settle-late")
+    builder, prompt_id = _real_captured_builder(stack.repository)
+    controller = _real_controller(stack, builder, prompt_id)
+
+    original = stack.store._project_workspace_membership_after_commit
+    calls = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("injected workspace projection")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        stack.store, "_project_workspace_membership_after_commit", fail_once
+    )
+    publish_calls = _spy_recovery_publish(stack, monkeypatch)
+    first = await controller.submit_draft("question")
+    assert first.accepted is True, "harness precondition: the turn was accepted"
+    assert first.preparation_id in controller._durable_postcommit_continuations
+    assert stack.store._terminal_citation_finalizers != {}, (
+        "harness precondition violated: owner publication did not arm the "
+        "finalizer, so this test no longer covers the fail-AFTER-arming "
+        "ordering (did the effect order change?)"
+    )
+    assert publish_calls == [], (
+        "the mechanism this test pins broke: the failure arm's None publish "
+        "RAN while a finalizer was armed. Owner publication is supposed to "
+        "have registered the dispatch recovery already, gating that publish "
+        "off -- re-examine TASK-22617 before trusting the None"
+    )
+
+    resumed = await controller.resume_durable_postcommit(first.preparation_id)
+
+    assert resumed.accepted is True
+    assert calls == 2, "harness precondition: the resume re-ran the effect"
+    assistant = _real_assistant(stack.store)
+    assert assistant.content == _BODY_SENTINEL
+    assert _citation_row_counts(stack.db)["rag_citation_traces"] == 1, (
+        "publishing the recovery owner with terminal_citation_finalizer=None "
+        "cleared the already-armed finalizer and lost the citation trace"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_none_recovery_publish_never_clears_an_armed_finalizer(
+    real_citation_stack_factory,
+) -> None:
+    """Defence in depth for TASK-22617, pinned where it is reachable.
+
+    Production cannot currently reach `publish_durable_recovery_owner(...,
+    None)` while a finalizer is armed (the ordering tests above pin why). This
+    pins the store-level property that keeps the None safe even if a future
+    caller breaks that ordering: a None publish must never CLEAR armed state,
+    only decline to arm.
+    """
+
+    stack = real_citation_stack_factory("settle-sticky")
+    builder, prompt_id = _real_captured_builder(stack.repository)
+    controller = _real_controller(stack, builder, prompt_id)
+
+    # A completed turn retires its acceptance (its cached commit then raises
+    # ConsoleDurableAcceptanceRetired), so use a turn whose settlement FAILED:
+    # the acceptance stays live and the commit stays retrievable.
+    def fail_always(*args, **kwargs):
+        raise RuntimeError("injected identity publication")
+
+    original = stack.store.publish_durable_turn_identity
+    stack.store.publish_durable_turn_identity = fail_always
+    try:
+        result = await controller.submit_draft("question")
+    finally:
+        stack.store.publish_durable_turn_identity = original
+    assert result.accepted is True
+
+    session_id = stack.store.active_session_id
+    assistant = _real_assistant(stack.store)
+    finalizer = object()
+    stack.store._terminal_citation_finalizers[assistant.id] = finalizer
+    commit = stack.store.durable_turn_commit_for(
+        result.preparation_id,
+        fingerprint=stack.store.durable_acceptance_fingerprint_for(
+            result.preparation_id
+        ),
+    )
+    assert commit is not None, "harness precondition: the commit is cached"
+
+    stack.store.publish_durable_recovery_owner(
+        session_id,
+        commit,
+        terminal_citation_finalizer=None,
+    )
+
+    assert stack.store._terminal_citation_finalizers.get(assistant.id) is finalizer, (
+        "a None recovery publish cleared an armed terminal citation finalizer"
+    )

--- a/backlog/tasks/task-22617 - Settlement-failure-recovery-discards-the-citation-finalizer.md
+++ b/backlog/tasks/task-22617 - Settlement-failure-recovery-discards-the-citation-finalizer.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-22617
 title: Settlement-failure recovery discards the citation finalizer
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-26 19:20'
+updated_date: '2026-08-27 20:27'
 labels:
   - console
   - citations
@@ -28,8 +30,17 @@ Reading 2 is plausible enough that this must not be 'fixed' by pattern-matching 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The BaseException path in resume_durable_postcommit is reproduced in a test that observes whether a citation trace survives a settlement failure
-- [ ] #2 A decision is recorded, with evidence, on whether dropping the finalizer there is data loss or a deliberate guard against attributing unsent content
-- [ ] #3 If it is data loss: the finalizer is forwarded, and the fix is mutation-proven (revert it, watch the new test go red)
-- [ ] #4 If it is deliberate: the hard-coded None carries a comment naming the reason, so the next reader does not file this again
+- [x] #1 The BaseException path in resume_durable_postcommit is reproduced in a test that observes whether a citation trace survives a settlement failure
+- [x] #2 A decision is recorded, with evidence, on whether dropping the finalizer there is data loss or a deliberate guard against attributing unsent content
+- [x] #3 If it is data loss: N/A -- established NOT data loss (see notes); the deliberate branch (#4) applied instead
+- [x] #4 If it is deliberate: the hard-coded None carries a comment naming the reason, so the next reader does not file this again
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Locate the BaseException arm's publish_durable_recovery_owner call on current dev and map the FULL lifecycle after it: what happens to a recovery owner on retry/resume -- is the finalizer ever re-armed, or is the trace unpersistable from then on?
+2. Write the reproduction: durable turn with a real citation finalizer armed, settlement fails after the terminal effect, recovery owner published. Observe rag_citation_traces.
+3. Decide from evidence: if the retry path rebuilds/re-arms the finalizer, dropping it here is safe (document per AC4). If nothing downstream can ever persist the trace, it is data loss (fix per AC3).
+4. Either way: mutation-prove whatever test lands.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-22617 - Settlement-failure-recovery-discards-the-citation-finalizer.md
+++ b/backlog/tasks/task-22617 - Settlement-failure-recovery-discards-the-citation-finalizer.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-22617
 title: Settlement-failure recovery discards the citation finalizer
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-26 19:20'
-updated_date: '2026-08-27 20:27'
+updated_date: '2026-08-27 20:55'
 labels:
   - console
   - citations
@@ -44,3 +44,41 @@ Reading 2 is plausible enough that this must not be 'fixed' by pattern-matching 
 3. Decide from evidence: if the retry path rebuilds/re-arms the finalizer, dropping it here is safe (document per AC4). If nothing downstream can ever persist the trace, it is data loss (fix per AC3).
 4. Either way: mutation-prove whatever test lands.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+VERDICT: not data loss -- and not quite either filed reading. Established by
+instrumentation on the real citation stack, then pinned by tests.
+
+MECHANISM (measured, not read): `durable_owner_publication` -- the effect that
+ARMS the terminal citation finalizer -- also registers the session's dispatch
+recovery via `publish_durable_turn_owners` -> `publish_durable_dispatch_
+checkpoint`. The failure arm gates its recovery publish on "no recovery
+exists", so the None publish is UNREACHABLE once a finalizer is armed. A spy
+confirmed it fires exactly once across both failure orderings: in the
+pre-arming one. There, nothing was ever armed, the continuation survives, and
+the resume's owner publication forwards `continuation.terminal_citation_
+finalizer` (TASK-22302), so the trace persists on retry.
+
+THREE TESTS on the real stack (test_console_terminal_citation_persistence.py),
+THREE MUTATIONS all red: (M1) a None publish that CLEARS armed state; (M2) the
+resume publish dropping the finalizer; (M3) owner publication no longer
+registering the recovery -- M3 is what makes "unreachable while armed"
+falsifiable rather than folklore.
+
+TWO OF MY OWN ASSERTIONS DIED EN ROUTE: the fail-after-arming test first
+claimed to guard a clobber its scenario cannot reach (M1 stayed green); its
+replacement post-hoc recovery check was mis-timed (the arm restores a recovery
+AFTER its publish gate, so the check is true in every ordering). Both replaced
+by a call spy on the publish, with the pre-arming test as positive control.
+
+AC3 (data-loss branch) N/A; AC4 done -- the None site carries the full
+evidence-backed reason in-code.
+
+Verification: A/B of Tests/Chat vs merge-base -- 0 newly broken, +3 collected,
+94 failures both sides; file itself 96 passed; preflight green.
+
+Files: tldw_chatbook/Chat/console_chat_controller.py (comment only),
+Tests/Chat/test_console_terminal_citation_persistence.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -7103,6 +7103,20 @@ class ConsoleChatController:
                 self.store.publish_durable_recovery_owner(
                     session_id,
                     commit,
+                    # TASK-22617: deliberately None, established by test rather
+                    # than assumption -- `continuation.terminal_citation_
+                    # finalizer` IS in scope here, and this is not the
+                    # TASK-22302 data-loss class. The recovery gate above makes
+                    # this publish reachable only BEFORE `durable_owner_
+                    # publication` (that effect registers the dispatch
+                    # recovery), so no finalizer has ever been armed when this
+                    # runs; the continuation survives the failure, and the
+                    # resume's owner publication forwards its finalizer, so the
+                    # trace still persists on retry. Forwarding it HERE would
+                    # arm a deferred finalizer on a turn whose delivery is
+                    # unknown -- provenance worse than absent. Pinned by the
+                    # TASK-22617 tests in
+                    # test_console_terminal_citation_persistence.py.
                     terminal_citation_finalizer=None,
                     defer_terminal_persistence=(
                         continuation.citation_repair_session is not None

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -7106,17 +7106,22 @@ class ConsoleChatController:
                     # TASK-22617: deliberately None, established by test rather
                     # than assumption -- `continuation.terminal_citation_
                     # finalizer` IS in scope here, and this is not the
-                    # TASK-22302 data-loss class. The recovery gate above makes
-                    # this publish reachable only BEFORE `durable_owner_
-                    # publication` (that effect registers the dispatch
-                    # recovery), so no finalizer has ever been armed when this
-                    # runs; the continuation survives the failure, and the
-                    # resume's owner publication forwards its finalizer, so the
-                    # trace still persists on retry. Forwarding it HERE would
-                    # arm a deferred finalizer on a turn whose delivery is
-                    # unknown -- provenance worse than absent. Pinned by the
-                    # TASK-22617 tests in
-                    # test_console_terminal_citation_persistence.py.
+                    # TASK-22302 data-loss class. Two facts carry it, one per
+                    # failure ordering. (1) At effect granularity this publish
+                    # only runs BEFORE `durable_owner_publication` -- that
+                    # effect registers the dispatch recovery the gate above
+                    # checks -- and there nothing was ever armed; the resume's
+                    # owner publication forwards the continuation's finalizer,
+                    # so the trace persists on retry. (2) INSIDE owner
+                    # publication there is a window (arming happens before the
+                    # checkpoint call registers the recovery) where this DOES
+                    # run with a finalizer armed; there the store's
+                    # non-clearing contract is load-bearing -- a None publish
+                    # never clears armed state, only declines to arm.
+                    # Forwarding the finalizer here instead would arm it on a
+                    # turn whose delivery is unknown -- provenance worse than
+                    # absent. All three orderings pinned by the TASK-22617
+                    # tests in test_console_terminal_citation_persistence.py.
                     terminal_citation_finalizer=None,
                     defer_terminal_persistence=(
                         continuation.citation_repair_session is not None


### PR DESCRIPTION
## Summary

TASK-22617 asked which of two readings is right for the hard-coded
`terminal_citation_finalizer=None` in `resume_durable_postcommit`'s
`except BaseException:` arm — the TASK-22302 data-loss class, or a deliberate
guard against attributing unsent content. The task's own instruction was to
establish it **by test before changing anything**.

**Verdict: not data loss — and not quite either filed reading.** One comment in
the product (no behaviour change), three tests, three mutations all red.

## The mechanism, measured rather than read

`durable_owner_publication` — the effect that **arms** the finalizer — also
**registers the session's dispatch recovery** (`publish_durable_turn_owners` →
`publish_durable_dispatch_checkpoint`). The failure arm gates its recovery
publish on `dispatch_recovery_for_session(...) is None`, so:

- **The None publish is unreachable once a finalizer is armed.** A spy on
  `publish_durable_recovery_owner` confirmed it fires exactly once across both
  failure orderings: in the *pre-arming* one.
- In that one reachable ordering nothing was ever armed, the continuation
  survives the failure, and the resume's owner publication forwards
  `continuation.terminal_citation_finalizer` (TASK-22302) — the trace persists
  on retry. Both orderings end with `rag_citation_traces == 1` on real SQLite.
- Forwarding the finalizer at the None site would arm a deferred finalizer on a
  turn whose delivery is unknown — the provenance hazard reading 2 feared — for
  no benefit.

## Mutations

| mutation | result |
|---|---|
| M1: a None publish CLEARS armed state | **RED** (store-level stickiness pin) |
| M2: the resume publish drops the finalizer | **RED** (re-proves the TASK-22302 forward is load-bearing) |
| M3: owner publication stops registering the recovery | **RED** — this is what makes "unreachable while armed" falsifiable rather than folklore |

## Two of my own assertions died en route

Reported because they are the interesting part:

1. The fail-after-arming test first claimed to guard a clobber its scenario can
   never reach — **M1 stayed green** and exposed it.
2. Its replacement asserted `dispatch_recovery_for_session(...) is not None`
   after the failed submit — mis-timed, because the failure arm *restores* a
   recovery after its publish gate, so that check is true in every ordering.
   **M3 stayed green** against it.

Both replaced with a call spy on the publish itself, with the pre-arming test
asserting the spy **does** fire — the positive control that keeps the sibling's
zero-calls assertion falsifiable.

## Verification

A/B of `Tests/Chat` against the merge-base, baseline verified byte-identical:

| | merge-base | this branch |
|---|---|---|
| collected | 8798 | 8801 (**+3**) |
| failures | 94 | **94** |
| newly broken | — | **0** |

`test_console_terminal_citation_persistence.py` itself: 96 passed. Preflight
green. The None site now carries the evidence-backed reason in-code (AC4), so
this does not get filed a third time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settles TASK-22617 by test: the hard-coded `terminal_citation_finalizer=None` in `resume_durable_postcommit`'s settlement-failure arm is not data loss. No behavior changes; the diff adds four tests pinning the mechanism, a comment documenting the verdict at the None site, and marks the task Done.

**Evidence pinned**

- The failure arm's None publish is unreachable once a finalizer is armed, because the effect that arms the finalizer also registers the session's dispatch recovery, gating that publish off.
- Three mutations went red, including one that removes the recovery registration, making the "unreachable while armed" claim falsifiable.
- Two earlier assertions proved vacuous and were replaced with a call spy, with the pre-arming test acting as the positive control.
- Inside owner publication there is a window where arming precedes recovery registration; a failure there does reach the None publish while armed, and a fourth test pins that the store's non-clearing contract is load-bearing in that window.

<sup>Written for commit ca3c10caee54cd2b477c81ee83827c8b37458813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

