### PR TITLE
perf(chat): take trajectory_export back off the Chat first-paint leg (TASK-23020)

### DIFF
--- a/Tests/Chat/test_console_exchange_export.py
+++ b/Tests/Chat/test_console_exchange_export.py
@@ -23,7 +23,9 @@ from tldw_chatbook.Chat.console_exchange_export import (
     project_exchange_export,
 )
 from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
-from tldw_chatbook.Chat.trajectory_export import TraceExportProfile
+# The chat-leg surface under test imports the enum from the light leaf
+# (TASK-23020); its tests model the same seam.
+from tldw_chatbook.Chat.trace_export_profiles import TraceExportProfile
 from tldw_chatbook.Chat.console_provider_gateway import (
     ConsoleProviderGateway,
     ConsoleProviderResolution,

--- a/Tests/Packaging/test_exchange_export_trajectory_deferral.py
+++ b/Tests/Packaging/test_exchange_export_trajectory_deferral.py
@@ -1,0 +1,407 @@
+"""Per-edge guards for the exchange-export / trajectory-engine split (TASK-23020).
+
+TASK-22213 took the trajectory family (`Chat/trajectory_export.py` and its
+siblings, ~4,400 LOC) off the Chat first-paint leg. ~24 hours later #2126 put
+`trajectory_export` back, through THREE module-scope edges the leg-wide
+guards could only report as "something re-eagered it":
+
+* ``Chat/console_exchange_export.py`` -> ``Chat.trajectory_export``
+  (one name: ``TraceExportProfile``, a three-member enum)
+* ``Widgets/Console/console_exchange_export_dialog.py`` ->
+  ``Chat.trajectory_export`` (the same single name)
+* ``Widgets/Console/console_exchange_export_dialog.py`` ->
+  ``Widgets/Console/trace_export_dialog.py`` (three presentation names),
+  whose module scope imports the whole exporter plus ``Chat.trajectory``
+
+All three ride ``console_conversation_inspector`` ->
+``UI/Screens/chat_screen.py`` onto the first paint. The fix moved the shared
+vocabulary into two light leaves -- ``Chat/trace_export_profiles.py`` (the
+enum, stdlib-only) and ``Widgets/Console/trace_export_profile_ui.py`` (copy,
+labels, Full confirmation) -- re-imported by the heavy side so nothing can
+drift.
+
+This file guards each edge INDIVIDUALLY, so a red here names the offending
+file instead of leaving the next person to re-trace the import graph the
+way the leg-wide nets (``test_rag_boot_import_closure.py``, the `_ui_ready`
+census) do. Subprocess-isolated for the standard reason: ``sys.modules`` is
+process-global, and half this suite legitimately imports the trajectory
+stack.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: The deferred trajectory engine plus the dialog that eagerly imports it.
+#: None of these may be resident after importing any chat-leg exchange-export
+#: module. `Chat.trajectory` is NOT here -- it is a legitimate chat-leg
+#: resident (see test_rag_boot_import_closure.py's comment).
+FORBIDDEN_ON_CHAT_LEG = (
+    "tldw_chatbook.Chat.trajectory_export",
+    "tldw_chatbook.Chat.trajectory_import",
+    "tldw_chatbook.UI.Screens.trajectory_screen",
+    "tldw_chatbook.UI.Widgets.trajectory_timeline",
+    "tldw_chatbook.UI.Widgets.trace_filter_bar",
+    "tldw_chatbook.Widgets.Console.trace_export_dialog",
+)
+
+#: The light leaves that replaced the forbidden imports. Their residency is
+#: the anti-vacuity half: proof the module under test still consumes the
+#: vocabulary, just through the cheap seam.
+ENUM_LEAF = "tldw_chatbook.Chat.trace_export_profiles"
+UI_LEAF = "tldw_chatbook.Widgets.Console.trace_export_profile_ui"
+
+
+def _run_isolated_python(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """Run a snippet in a fresh interpreter with isolated config/data dirs.
+
+    Args:
+        tmp_path: Per-test scratch dir for HOME/XDG so the import can never
+            read or write the live user config.
+        code: Python source for ``python -c``.
+
+    Returns:
+        The completed process (never raises on nonzero exit).
+    """
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env.pop("TLDW_CONFIG_PATH", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=180,
+    )
+
+
+_PER_EDGE_SNIPPET = """
+import sys
+
+MODULE = {module!r}
+FORBIDDEN = {forbidden!r}
+EXPECTED_LEAVES = {leaves!r}
+
+__import__(MODULE)
+
+resident = [
+    name
+    for name in FORBIDDEN
+    if sys.modules.get(name) is not None
+]
+assert not resident, (
+    f"{{MODULE}} put the trajectory engine back on the Chat first-paint "
+    f"leg: {{resident}}. Its module scope (or something it imports) must "
+    "take TraceExportProfile from Chat/trace_export_profiles.py and the "
+    "profile copy from Widgets/Console/trace_export_profile_ui.py -- "
+    "never from Chat/trajectory_export.py or trace_export_dialog.py "
+    "(TASK-23020)."
+)
+
+missing = [name for name in EXPECTED_LEAVES if name not in sys.modules]
+assert not missing, (
+    f"anti-vacuity: {{MODULE}} no longer resolves the light leaves "
+    f"{{missing}} -- this guard is no longer watching a live seam and must "
+    "be re-pointed, not deleted."
+)
+print("EDGE_OK")
+"""
+
+
+@pytest.mark.parametrize(
+    ("module", "leaves"),
+    [
+        # The Chat-layer projector needs only the enum leaf.
+        ("tldw_chatbook.Chat.console_exchange_export", (ENUM_LEAF,)),
+        # The dialog needs the enum AND the shared presentation.
+        (
+            "tldw_chatbook.Widgets.Console.console_exchange_export_dialog",
+            (ENUM_LEAF, UI_LEAF),
+        ),
+        # The inspector is the module chat_screen actually imports; it must
+        # stay clean TRANSITIVELY (this is the edge #2126 rode).
+        (
+            "tldw_chatbook.Widgets.Console.console_conversation_inspector",
+            (ENUM_LEAF, UI_LEAF),
+        ),
+    ],
+)
+def test_chat_leg_exchange_export_module_stays_off_the_trajectory_engine(
+    tmp_path: Path, module: str, leaves: tuple[str, ...]
+) -> None:
+    """Importing each chat-leg exchange-export module resolves no engine module.
+
+    One test per file so the failure NAMES the offender -- the leg-wide
+    guards can only say "something re-eagered trajectory_export".
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+        module: The chat-leg module to import bare.
+        leaves: Light modules that must be resident afterwards (anti-vacuity).
+    """
+    code = _PER_EDGE_SNIPPET.format(
+        module=module, forbidden=FORBIDDEN_ON_CHAT_LEG, leaves=leaves
+    )
+    result = _run_isolated_python(tmp_path, code)
+    assert result.returncode == 0, (
+        f"per-edge closure failed for {module}:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "EDGE_OK" in result.stdout
+
+
+_LEAVES_ARE_LIGHT_SNIPPET = """
+import sys
+
+FORBIDDEN = {forbidden!r}
+
+# The enum leaf must be stdlib-only: importing it (past its package inits)
+# adds exactly itself to this repo's resident modules.
+import tldw_chatbook.Chat  # package inits may carry their own weight
+
+before = {{m for m in sys.modules if m.startswith("tldw_chatbook")}}
+import tldw_chatbook.Chat.trace_export_profiles  # noqa: F401
+
+added = {{m for m in sys.modules if m.startswith("tldw_chatbook")}} - before
+assert added == {{"tldw_chatbook.Chat.trace_export_profiles"}}, (
+    f"the enum leaf stopped being stdlib-only; it now drags {{sorted(added)}}"
+)
+
+# The UI leaf may add only itself, the confirmation dialog, and their
+# support -- never anything in the forbidden engine set.
+import tldw_chatbook.Widgets.Console.trace_export_profile_ui  # noqa: F401
+
+resident = [m for m in FORBIDDEN if sys.modules.get(m) is not None]
+assert not resident, (
+    f"trace_export_profile_ui re-eagered the trajectory engine: {{resident}}. "
+    "It must never import trajectory_export, trajectory, or "
+    "trace_export_dialog (TASK-23020)."
+)
+print("LEAVES_LIGHT_OK")
+"""
+
+
+def test_the_replacement_leaves_are_themselves_light(tmp_path: Path) -> None:
+    """The seam modules the fix introduced cannot re-grow the forbidden edge.
+
+    The failure mode TASK-23020 exists to prevent is a future one-line
+    import quietly re-eagering the engine; the most attractive place for
+    that line is inside these two leaves (e.g. "import the copy back from
+    trace_export_dialog"). Pin them shut.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    code = _LEAVES_ARE_LIGHT_SNIPPET.format(forbidden=FORBIDDEN_ON_CHAT_LEG)
+    result = _run_isolated_python(tmp_path, code)
+    assert result.returncode == 0, (
+        f"leaf lightness contract failed:\nstdout={result.stdout}\n"
+        f"stderr={result.stderr[-4000:]}"
+    )
+    assert "LEAVES_LIGHT_OK" in result.stdout
+
+
+_ONE_OBJECT_SNIPPET = """
+import sys
+
+from tldw_chatbook.Chat import trace_export_profiles
+from tldw_chatbook.Widgets.Console import trace_export_profile_ui
+
+# Loading the heavy side ON DEMAND must hand back the SAME objects the
+# chat leg already holds -- the split is a relocation, not a fork.
+from tldw_chatbook.Chat import trajectory_export
+from tldw_chatbook.Widgets.Console import trace_export_dialog
+
+assert (
+    trajectory_export.TraceExportProfile
+    is trace_export_profiles.TraceExportProfile
+), "trajectory_export forked TraceExportProfile"
+assert (
+    trace_export_dialog.TRACE_EXPORT_PROFILE_COPY
+    is trace_export_profile_ui.TRACE_EXPORT_PROFILE_COPY
+), "trace_export_dialog forked TRACE_EXPORT_PROFILE_COPY"
+assert (
+    trace_export_dialog.TRACE_EXPORT_PROFILE_LABELS
+    is trace_export_profile_ui.TRACE_EXPORT_PROFILE_LABELS
+), "trace_export_dialog forked TRACE_EXPORT_PROFILE_LABELS"
+assert (
+    trace_export_dialog.full_trace_confirmation
+    is trace_export_profile_ui.full_trace_confirmation
+), "trace_export_dialog forked full_trace_confirmation"
+
+# ...and the deferred dialog class still resolves (absence-only guards are
+# satisfied by deleting the feature).
+from textual.screen import ModalScreen
+
+assert issubclass(trace_export_dialog.TraceExportDialog, ModalScreen)
+print("ONE_OBJECT_OK")
+"""
+
+
+def test_profile_vocabulary_is_one_object_across_both_sides(
+    tmp_path: Path,
+) -> None:
+    """Both export stacks share the leaf objects; neither side forked them.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _ONE_OBJECT_SNIPPET)
+    assert result.returncode == 0, (
+        f"one-object contract failed:\nstdout={result.stdout}\n"
+        f"stderr={result.stderr[-4000:]}"
+    )
+    assert "ONE_OBJECT_OK" in result.stdout
+
+
+_DIALOG_FROM_DEFERRED_STATE_SNIPPET = """
+import asyncio
+import json
+import sys
+
+FORBIDDEN = {forbidden!r}
+
+
+def assert_engine_absent(moment):
+    resident = [m for m in FORBIDDEN if sys.modules.get(m) is not None]
+    assert not resident, f"trajectory engine resident {{moment}}: {{resident}}"
+
+
+from tldw_chatbook.Widgets.Console.console_exchange_export_dialog import (
+    ConsoleExchangeExportDialog,
+)
+
+assert_engine_absent("after importing the exchange export dialog")
+
+from textual.widgets import Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.Chat.console_exchange_capture import (
+    CaptureDetail,
+    ExchangeCapture,
+)
+from tldw_chatbook.Chat.trace_export_profiles import TraceExportProfile
+
+capture = ExchangeCapture(
+    run_tag="run",
+    seq=1,
+    created_at="2026-08-27T00:00:00Z",
+    provider="anthropic",
+    model="claude-test",
+    endpoint="https://example.test/v1",
+    request={{"messages_payload": [{{"role": "user", "content": "hello"}}]}},
+    response={{"content": "deferred-state answer", "tool_calls": []}},
+    status="complete",
+    usage_json=None,
+    omitted_keys=(),
+    capture_detail=CaptureDetail.FULL,
+)
+
+
+class Harness(ConsolidatedCSSApp):
+    def __init__(self):
+        super().__init__()
+        self.clipboard_items = []
+
+    def compose(self):
+        yield Static("background")
+
+    def copy_to_clipboard(self, text):
+        self.clipboard_items.append(text)
+
+
+async def main():
+    app = Harness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        dialog = ConsoleExchangeExportDialog(
+            capture,
+            expected_capture_revision=1,
+            capture_revision_provider=lambda: 1,
+        )
+        await app.push_screen(dialog)
+        await pilot.pause()
+        assert_engine_absent("after mounting the dialog")
+
+        # The default profile's copy renders from the light UI leaf.
+        rendered = str(
+            dialog.query_one("#exchange-export-profile-copy", Static).render()
+        )
+        assert "Redacted diagnostic" in rendered, rendered
+
+        # Full profile: the shared confirmation still gates the disclosure.
+        await dialog.select_profile(TraceExportProfile.FULL_TRACE)
+        confirmations = []
+
+        async def confirm():
+            confirmations.append(True)
+            return True
+
+        dialog._confirm_full_export = confirm
+        assert await dialog.export_selected() is True
+        assert confirmations == [True], confirmations
+        assert len(app.clipboard_items) == 1
+
+        payload = json.loads(app.clipboard_items[0])
+        assert payload["provider"] == "anthropic"
+        assert payload["capture_detail"] == "full"
+        assert payload["response"]["content"] == "deferred-state answer"
+
+
+asyncio.run(main())
+
+# The ENTIRE flow -- open, profile switch, confirm, project, disclose --
+# ran without ever resolving the trajectory engine. That is the deliverable:
+# the exchange export surface no longer needs it at all.
+assert_engine_absent("after the full export flow")
+print("DIALOG_DEFERRED_OK")
+"""
+
+
+def test_exchange_export_dialog_works_from_the_deferred_state(
+    tmp_path: Path,
+) -> None:
+    """The dialog opens, confirms, and discloses with the engine never loaded.
+
+    Absence is not the deliverable -- a deleted feature would satisfy a pure
+    closure guard. This drives the real dialog (mount, profile copy render,
+    Full-trace confirmation via the relocated ``full_trace_confirmation``,
+    projection, clipboard disclosure) in a subprocess starting from exactly
+    the state the Chat leg boots into, and asserts the trajectory engine is
+    absent before, during, and after.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    code = _DIALOG_FROM_DEFERRED_STATE_SNIPPET.format(
+        forbidden=FORBIDDEN_ON_CHAT_LEG
+    )
+    result = _run_isolated_python(tmp_path, code)
+    assert result.returncode == 0, (
+        f"deferred-state dialog flow failed:\nstdout={result.stdout}\n"
+        f"stderr={result.stderr[-4000:]}"
+    )
+    assert "DIALOG_DEFERRED_OK" in result.stdout

--- a/Tests/Packaging/test_rag_boot_import_closure.py
+++ b/Tests/Packaging/test_rag_boot_import_closure.py
@@ -53,6 +53,18 @@ DEFERRED_PREFIXES = (
 #: legitimately imports it (snapshot dataclasses + `derive_trajectory` for
 #: the `y` action's off-thread build), and `agent_service` needs its
 #: redaction helpers on the same leg.
+#:
+#: KNOWN BREACH ROUTE (TASK-23020): ~24 h after 22213 shipped, #2126 put
+#: `trajectory_export` back on this leg through files the chat_screen
+#: comment did not name -- `console_conversation_inspector` ->
+#: `console_exchange_export_dialog` / `Chat/console_exchange_export.py`,
+#: each importing ONE name (`TraceExportProfile`), plus the dialog dragging
+#: `trace_export_dialog` (whose module scope imports the whole exporter).
+#: The vocabulary now lives in `Chat/trace_export_profiles.py` and the
+#: shared copy in `Widgets/Console/trace_export_profile_ui.py`; if THIS
+#: test reds on `trajectory_export` again, start at those four files --
+#: `Tests/Packaging/test_exchange_export_trajectory_deferral.py` checks
+#: each one individually and its failure names the offender.
 CHAT_LEG_DEFERRED_MODULES = (
     "tldw_chatbook.UI.Screens.trajectory_screen",
     "tldw_chatbook.Chat.trajectory_import",
@@ -212,6 +224,15 @@ from textual.screen import Screen
 from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
 
 assert issubclass(TrajectoryScreen, Screen)
+
+# ...and the exporter, now loaded on demand, shares ONE profile-enum object
+# with the leaf the chat leg imports (TASK-23020's split cannot drift).
+from tldw_chatbook.Chat import trace_export_profiles, trajectory_export
+
+assert (
+    trajectory_export.TraceExportProfile
+    is trace_export_profiles.TraceExportProfile
+), "trajectory_export's TraceExportProfile drifted from the trace_export_profiles leaf"
 print("CHAT_SCREEN_CLOSURE_OK")
 """.format(chat_leg=CHAT_LEG_DEFERRED_MODULES)
 

--- a/Tests/UI/test_console_exchange_export_dialog.py
+++ b/Tests/UI/test_console_exchange_export_dialog.py
@@ -12,7 +12,9 @@ from textual.widgets import Input, RadioButton, Static
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from tldw_chatbook.Chat.console_exchange_capture import CaptureDetail, ExchangeCapture
-from tldw_chatbook.Chat.trajectory_export import TraceExportProfile
+# The chat-leg surface under test imports the enum from the light leaf
+# (TASK-23020); its tests model the same seam.
+from tldw_chatbook.Chat.trace_export_profiles import TraceExportProfile
 from tldw_chatbook.Widgets.Console.console_exchange_export_dialog import (
     ConsoleExchangeExportDialog,
 )

--- a/backlog/tasks/task-23020 - trajectory-export-is-back-on-the-Chat-first-paint-leg-two-guards-RED-on-dev.md
+++ b/backlog/tasks/task-23020 - trajectory-export-is-back-on-the-Chat-first-paint-leg-two-guards-RED-on-dev.md
@@ -2,8 +2,9 @@
 id: TASK-23020
 title: >-
   trajectory_export is back on the Chat first-paint leg - two guards RED on dev
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-27'
 labels:
   - performance
@@ -27,12 +28,12 @@ through a file the comment does not name.
 
 ## Acceptance Criteria
 
-- [ ] `Tests/Performance/test_ui_ready_module_census.py::test_ui_ready_module_census_stays_at_the_pinned_size` passes
-- [ ] `Tests/Packaging/test_rag_boot_import_closure.py::test_chat_screen_import_does_not_execute_the_deferred_packages` passes
-- [ ] All three edges are broken, verified by an import tracer recording `(importer, imported)` — not by grep
-- [ ] The export dialogs still work; a test drives them from the deferred state
-- [ ] Neither guard is relaxed to accommodate the regression
-- [ ] The guard names the offending edge well enough that the next person does not have to trace it
+- [x] `Tests/Performance/test_ui_ready_module_census.py::test_ui_ready_module_census_stays_at_the_pinned_size` passes
+- [x] `Tests/Packaging/test_rag_boot_import_closure.py::test_chat_screen_import_does_not_execute_the_deferred_packages` passes
+- [x] All three edges are broken, verified by an import tracer recording `(importer, imported)` — not by grep
+- [x] The export dialogs still work; a test drives them from the deferred state
+- [x] Neither guard is relaxed to accommodate the regression
+- [x] The guard names the offending edge well enough that the next person does not have to trace it
 
 ## Evidence
 
@@ -49,3 +50,108 @@ the import-weight guard stays green. Import self-time 1.67-1.98 ms; the cost is 
 the milliseconds.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Implementation Plan
+
+1. Confirm both guards RED on pristine `d7bb844d9b` (they were: both name
+   `tldw_chatbook.Chat.trajectory_export`).
+2. Re-trace the edges with an `__import__`-wrapping tracer recording
+   `(importer, imported)` on BOTH legs (bare `chat_screen` import; headless
+   boot to `_ui_ready`), not grep -- dev had moved ~90 commits since the
+   review's trace.
+3. Break every edge by relocating the shared vocabulary into light leaves
+   re-imported by the heavy side (the `search_modes`/
+   `chunking_engine_version` pattern), so no edge fix depends on the others
+   and no copy can drift.
+4. Extend the guards to NAME the breach route per file; add per-edge closure
+   tests plus a deferred-state functional test of the export dialog.
+5. Mutation-test by restoring one edge at a time (four mutants) and
+   recording which tests kill each.
+
+## Implementation Notes
+
+**Edges found by the tracer on `d7bb844d9b`** (same set on the import and
+mount legs; the third differs from the review's line numbers only because
+dev moved):
+
+1. `Chat/console_exchange_export.py:18` -> `Chat.trajectory_export`
+   (`TraceExportProfile`, the FIRST-load edge)
+2. `Widgets/Console/console_exchange_export_dialog.py:22` ->
+   `Chat.trajectory_export` (same single name)
+3. `Widgets/Console/console_exchange_export_dialog.py:25` ->
+   `Widgets/Console/trace_export_dialog.py`, whose module scope imports the
+   whole exporter (edge 4: `trace_export_dialog:16,17` ->
+   `Chat.trajectory` + `Chat.trajectory_export`)
+
+All ride `console_conversation_inspector` (module-scope import at
+`chat_screen.py:448`) onto the Chat first paint.
+
+**Shape chosen: relocation into two light leaves, re-imported by the heavy
+side.**
+
+- `Chat/trace_export_profiles.py` (new, stdlib-only): `TraceExportProfile`
+  moved here verbatim; `trajectory_export.py` re-imports it, so the deferred
+  family's import sites keep working and the enum stays ONE object.
+- `Widgets/Console/trace_export_profile_ui.py` (new, light):
+  `TRACE_EXPORT_PROFILE_COPY` / `TRACE_EXPORT_PROFILE_LABELS` /
+  `full_trace_confirmation` moved here; `trace_export_dialog.py` re-imports
+  (and keeps re-exporting) them.
+- The two chat-leg modules import only the leaves; deferring to function
+  scope was rejected because the failure mode is exactly a future
+  module-scope one-liner -- the leaf shape gives the correct import an
+  obvious home, and the re-import direction makes the seam-level wrong move
+  (`trace_export_profile_ui` importing from `trace_export_dialog`) a loud
+  circular-import failure rather than a silent re-eager.
+- A side effect worth naming: the exchange-export flow now never resolves
+  the trajectory engine at all -- `trace_export_dialog` also left the leg
+  (it was resident pre-fix), so the leg swapped 2 heavy modules for 2 leaves
+  (mount census 958 -> 957, budget 970).
+
+**Guard naming (AC 6):** `chat_screen.py`'s forbidding comment now names
+the transitive route and the two leaves; the closure guard's
+`CHAT_LEG_DEFERRED_MODULES` comment documents the breach route and points
+at the per-edge guard; new
+`Tests/Packaging/test_exchange_export_trajectory_deferral.py` checks each
+file individually so a red names the offender: per-edge closure (x3
+modules), leaf-lightness (the leaves cannot re-grow the edge), one-object
+identity across both sides, and a subprocess deferred-state test driving
+the real dialog (mount, profile copy render, Full confirmation, projection,
+clipboard disclosure) with the engine asserted absent before/during/after.
+The existing chat-screen closure guard gained an on-demand identity
+assertion; neither target guard was relaxed (no budget, list, or assertion
+weakened -- both diffs are comment/anti-vacuity additions only).
+
+**Verification.** Tracer on both legs post-fix: zero edges into the family;
+only the three legitimate `Chat.trajectory` importers remain
+(`console_chat_store`, `agent_service`, `review_selection`). Both target
+guards green (census: 1 passed, 7.7s; closure file: 6 passed, 5.2s). Wider
+run: 214 passed across the trajectory/exchange test files + 44
+inspector/closure, 155-passed packaging/performance/architecture sweep.
+Mutation results (one mutant per edge, implementation committed first,
+restores via `git restore`):
+
+- **M-A** (`console_exchange_export` -> trajectory_export): killed by 5 --
+  all 3 per-edge tests, the deferred-state dialog test, the leg-wide
+  closure guard; census guard also red (mount-leg net proven live).
+- **M-B** (dialog -> trajectory_export): killed by 4 (dialog + inspector
+  per-edge, deferred-state, leg-wide guard).
+- **M-C** (dialog -> trace_export_dialog for the copy): killed by the same
+  4 -- `trace_export_dialog` is itself in the per-edge FORBIDDEN set.
+- **M-D** (`trace_export_profile_ui` -> trace_export_dialog): killed by 6,
+  including its dedicated killer `test_the_replacement_leaves_are_
+  themselves_light`, via the deliberate circular-import failure.
+
+**Files.** New: `tldw_chatbook/Chat/trace_export_profiles.py`,
+`tldw_chatbook/Widgets/Console/trace_export_profile_ui.py`,
+`Tests/Packaging/test_exchange_export_trajectory_deferral.py`. Modified:
+`Chat/trajectory_export.py`, `Chat/console_exchange_export.py`,
+`Widgets/Console/console_exchange_export_dialog.py`,
+`Widgets/Console/trace_export_dialog.py`, `UI/Screens/chat_screen.py`
+(comment), `Tests/Packaging/test_rag_boot_import_closure.py` (comments +
+identity assertion), two exchange-side tests repointed at the leaf.
+
+Out of scope, found while verifying: two pre-existing architecture reds on
+pristine `d7bb844d9b` (`test_chat_screen_remains_within_reviewed_projection_
+without_ratchet_raise` pins ChatScreen at 17,727 lines vs 17,013 actual;
+`test_closeout_evidence_explains_the_remaining_absolute_deficit`), plus the
+already-documented `test_rag_citation_provenance_benchmark.py` reds.

--- a/tldw_chatbook/Chat/console_exchange_export.py
+++ b/tldw_chatbook/Chat/console_exchange_export.py
@@ -15,7 +15,14 @@ from tldw_chatbook.Chat.console_exchange_capture import (
 from tldw_chatbook.Chat.console_project_instructions import (
     canonical_provider_endpoint_identity,
 )
-from tldw_chatbook.Chat.trajectory_export import TraceExportProfile
+# The profile vocabulary comes from the stdlib-only leaf, NEVER from
+# `Chat.trajectory_export`: this module is on the Chat first-paint leg at
+# module scope (console_exchange_export_dialog -> console_conversation_
+# inspector -> chat_screen), and importing even one name from the exporter
+# executes its ~1,400 LOC plus `Chat.trajectory` before first paint
+# (TASK-23020, the regression #2126 shipped; guard:
+# `Tests/Packaging/test_exchange_export_trajectory_deferral.py`).
+from tldw_chatbook.Chat.trace_export_profiles import TraceExportProfile
 
 __all__ = [
     "ExchangeExportProjection",

--- a/tldw_chatbook/Chat/trace_export_profiles.py
+++ b/tldw_chatbook/Chat/trace_export_profiles.py
@@ -1,0 +1,48 @@
+"""The disclosure-profile vocabulary shared by every governed export surface.
+
+``TraceExportProfile`` is the three-member contract two otherwise unrelated
+export stacks agree on:
+
+* the deferred trajectory family (``Chat/trajectory_export.py`` and its
+  consumers ``trajectory_import``/``trajectory_screen``/
+  ``Widgets/Console/trace_export_dialog.py``), which must stay OFF the Chat
+  first-paint leg entirely (TASK-22213); and
+* the Console exchange-export surface (``Chat/console_exchange_export.py``,
+  ``Widgets/Console/console_exchange_export_dialog.py``), which sits ON that
+  leg at module scope via ``console_conversation_inspector`` ->
+  ``UI/Screens/chat_screen.py``.
+
+TASK-23020: #2126 imported this enum from ``Chat/trajectory_export.py`` on
+the exchange side, and that single-name import dragged the whole 1,463-LOC
+exporter (plus ``Chat.trajectory``) onto the Chat first-paint window within
+~24 hours of TASK-22213 shipping the deferral. This leaf exists so both
+sides can share ONE enum object without the light side ever touching the
+heavy module:
+
+* Chat-leg modules import ``TraceExportProfile`` from HERE, never from
+  ``Chat.trajectory_export`` and never through
+  ``Widgets/Console/trace_export_dialog.py``.
+* ``Chat/trajectory_export.py`` re-imports it from here (the
+  ``RAG_Search/search_modes.py`` pattern), so no second copy can drift and
+  the deferred family's existing import sites keep working.
+
+Guards: ``Tests/Packaging/test_exchange_export_trajectory_deferral.py``
+(names the offending file when an edge re-eagers),
+``Tests/Packaging/test_rag_boot_import_closure.py`` and
+``Tests/Performance/test_ui_ready_module_census.py`` (the leg-wide nets).
+This module must stay import-cheap: stdlib only.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ["TraceExportProfile"]
+
+
+class TraceExportProfile(str, Enum):
+    """Privacy policy applied to a governed export bundle."""
+
+    SAFE_SUMMARY = "safe_summary"
+    REDACTED_DIAGNOSTIC = "redacted_diagnostic"
+    FULL_TRACE = "full_trace"

--- a/tldw_chatbook/Chat/trajectory_export.py
+++ b/tldw_chatbook/Chat/trajectory_export.py
@@ -32,11 +32,17 @@ import re
 import tempfile
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from enum import Enum
 from pathlib import Path
 from typing import Any
 
 from .assistant_generation_state import normalize_assistant_generation_state
+# One object, re-imported from the stdlib-only leaf (TASK-23020): Chat-leg
+# modules (console_exchange_export and the exchange export dialog) read the
+# profile vocabulary from `trace_export_profiles` so a single-name import
+# can never drag this 1,400+-LOC module onto the Chat first-paint window
+# again. The re-import keeps this module's public surface (and the deferred
+# trajectory family's import sites) unchanged, and makes drift impossible.
+from .trace_export_profiles import TraceExportProfile
 from .library_preparation import (
     LIBRARY_PREPARATION_EVENT_KIND,
     LibraryPreparationValidationError,
@@ -212,14 +218,8 @@ def _serialize_variant_set(variant_set: Any) -> dict:
 # ---------------------------------------------------------------------------
 # Trace v2 (pure snapshot -> privacy-governed collaboration bundle)
 # ---------------------------------------------------------------------------
-
-
-class TraceExportProfile(str, Enum):
-    """Privacy policy applied to a Trace v2 collaboration bundle."""
-
-    SAFE_SUMMARY = "safe_summary"
-    REDACTED_DIAGNOSTIC = "redacted_diagnostic"
-    FULL_TRACE = "full_trace"
+# `TraceExportProfile` lives in `trace_export_profiles.py` (TASK-23020) and is
+# re-imported above; see the import-site comment for why.
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -55,6 +55,18 @@ from .chat_screen_state import TaskResumeState
 # `action_open_trajectory_view`; the guard is
 # `Tests/Packaging/test_rag_boot_import_closure.py`
 # (`test_chat_screen_import_does_not_execute_the_deferred_packages`).
+#
+# The same constraint holds TRANSITIVELY, through files this comment cannot
+# see from here (TASK-23020: #2126 breached it ~24 h after 22213 shipped, via
+# `console_conversation_inspector` -> `console_exchange_export_dialog` /
+# `Chat/console_exchange_export.py`, each importing ONE enum name from
+# `Chat.trajectory_export`). Anything reachable from this module at import
+# time must take `TraceExportProfile` from `Chat/trace_export_profiles.py`
+# and the shared profile copy from
+# `Widgets/Console/trace_export_profile_ui.py` -- never from
+# `Chat.trajectory_export` or `Widgets/Console/trace_export_dialog.py`.
+# Per-file guard that names the offender:
+# `Tests/Packaging/test_exchange_export_trajectory_deferral.py`.
 from .provider_model_resolution import (
     ResolvedProviderModelOption,
     resolve_effective_provider_model,

--- a/tldw_chatbook/Widgets/Console/console_exchange_export_dialog.py
+++ b/tldw_chatbook/Widgets/Console/console_exchange_export_dialog.py
@@ -19,10 +19,17 @@ from tldw_chatbook.Chat.console_exchange_export import (
     ExchangeExportUnavailable,
     project_exchange_export,
 )
-from tldw_chatbook.Chat.trajectory_export import TraceExportProfile
+# This module is on the Chat first-paint leg at module scope
+# (console_conversation_inspector -> chat_screen), so the profile vocabulary
+# and its shared presentation come from the two light leaves -- NEVER from
+# `Chat.trajectory_export` (1,400+ LOC executed for one enum name) and NEVER
+# from `trace_export_dialog` (whose module scope imports that whole engine).
+# Both wrong imports were exactly the TASK-23020 regression (#2126); guard:
+# `Tests/Packaging/test_exchange_export_trajectory_deferral.py`.
+from tldw_chatbook.Chat.trace_export_profiles import TraceExportProfile
 from tldw_chatbook.Utils.atomic_file_ops import atomic_write_text
 from tldw_chatbook.Utils.path_validation import validate_path_simple
-from tldw_chatbook.Widgets.Console.trace_export_dialog import (
+from tldw_chatbook.Widgets.Console.trace_export_profile_ui import (
     TRACE_EXPORT_PROFILE_COPY,
     TRACE_EXPORT_PROFILE_LABELS,
     full_trace_confirmation,

--- a/tldw_chatbook/Widgets/Console/trace_export_dialog.py
+++ b/tldw_chatbook/Widgets/Console/trace_export_dialog.py
@@ -13,10 +13,10 @@ from textual.events import DescendantBlur, DescendantFocus
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, RadioButton, RadioSet, Static
 
+from tldw_chatbook.Chat.trace_export_profiles import TraceExportProfile
 from tldw_chatbook.Chat.trajectory import TrajectorySnapshot
 from tldw_chatbook.Chat.trajectory_export import (
     TraceExportPreflight,
-    TraceExportProfile,
     build_trace_export,
     preflight_trace_export,
     write_trajectory_export,
@@ -25,46 +25,25 @@ from tldw_chatbook.Utils.path_validation import validate_path_simple
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
 
+# Re-exported for this dialog's own (deferred-family) consumers. The shared
+# copy/labels/confirmation live in `trace_export_profile_ui` (TASK-23020) so
+# the Chat-first-paint-leg exchange export dialog can import them WITHOUT
+# resolving this module -- this module's imports above drag the whole
+# `Chat/trajectory_export.py` engine, which must stay off that leg
+# (TASK-22213; guard:
+# `Tests/Packaging/test_exchange_export_trajectory_deferral.py`).
+from tldw_chatbook.Widgets.Console.trace_export_profile_ui import (
+    TRACE_EXPORT_PROFILE_COPY,
+    TRACE_EXPORT_PROFILE_LABELS,
+    full_trace_confirmation,
+)
+
 __all__ = [
     "TRACE_EXPORT_PROFILE_COPY",
     "TRACE_EXPORT_PROFILE_LABELS",
     "TraceExportDialog",
     "full_trace_confirmation",
 ]
-
-
-TRACE_EXPORT_PROFILE_COPY = {
-    TraceExportProfile.SAFE_SUMMARY: (
-        "Safe summary — causal structure, status, and coarse timing; payload bodies omitted."
-    ),
-    TraceExportProfile.REDACTED_DIAGNOSTIC: (
-        "Redacted diagnostic — useful debugging context with paths, identifiers, "
-        "and sensitive values governed. Recommended for collaboration."
-    ),
-    TraceExportProfile.FULL_TRACE: (
-        "Full trace — includes ordinary captured detail after an additional warning. "
-        "Credentials remain forbidden."
-    ),
-}
-
-TRACE_EXPORT_PROFILE_LABELS = {
-    TraceExportProfile.SAFE_SUMMARY: "Safe summary",
-    TraceExportProfile.REDACTED_DIAGNOSTIC: "Redacted diagnostic (recommended)",
-    TraceExportProfile.FULL_TRACE: "Full trace",
-}
-
-
-def full_trace_confirmation(*, noun: str) -> ConfirmationDialog:
-    """Build the shared every-disclosure Full export warning."""
-    return ConfirmationDialog(
-        title=f"Export full {noun}?",
-        message=(
-            "Full trace may include prompts, injected instructions, tool arguments, "
-            "outputs, and local paths. Credentials remain structurally blocked."
-        ),
-        confirm_label=f"Export full {noun.lower()}",
-        cancel_label="Go back",
-    )
 
 
 class TraceExportDialog(SafeModalDismissMixin, ModalScreen[Path | None]):

--- a/tldw_chatbook/Widgets/Console/trace_export_profile_ui.py
+++ b/tldw_chatbook/Widgets/Console/trace_export_profile_ui.py
@@ -1,0 +1,66 @@
+"""Shared presentation for the disclosure profiles, off the heavy export stack.
+
+The per-profile copy, radio labels, and the every-disclosure Full-export
+confirmation are shared by two dialogs:
+
+* ``trace_export_dialog.py`` (Trace v2, deferred with the trajectory family
+  -- TASK-22213), which re-exports these names for its own consumers; and
+* ``console_exchange_export_dialog.py``, which is on the Chat first-paint
+  leg at module scope (via ``console_conversation_inspector`` ->
+  ``UI/Screens/chat_screen.py``).
+
+TASK-23020: the exchange dialog used to import these three names FROM
+``trace_export_dialog``, whose module scope imports the whole
+``Chat/trajectory_export.py`` engine -- one of the edges that put 1,463 LOC
+back on the first-paint window ~24 hours after TASK-22213 removed it. They
+live here so the Chat leg can present the profiles without resolving any
+export engine. Keep this module light: the enum leaf
+(``Chat/trace_export_profiles.py``) and ``ConfirmationDialog`` only --
+never ``trajectory_export``, ``trajectory``, or ``trace_export_dialog``.
+Guard: ``Tests/Packaging/test_exchange_export_trajectory_deferral.py``.
+"""
+
+from __future__ import annotations
+
+from tldw_chatbook.Chat.trace_export_profiles import TraceExportProfile
+from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
+
+__all__ = [
+    "TRACE_EXPORT_PROFILE_COPY",
+    "TRACE_EXPORT_PROFILE_LABELS",
+    "full_trace_confirmation",
+]
+
+
+TRACE_EXPORT_PROFILE_COPY = {
+    TraceExportProfile.SAFE_SUMMARY: (
+        "Safe summary — causal structure, status, and coarse timing; payload bodies omitted."
+    ),
+    TraceExportProfile.REDACTED_DIAGNOSTIC: (
+        "Redacted diagnostic — useful debugging context with paths, identifiers, "
+        "and sensitive values governed. Recommended for collaboration."
+    ),
+    TraceExportProfile.FULL_TRACE: (
+        "Full trace — includes ordinary captured detail after an additional warning. "
+        "Credentials remain forbidden."
+    ),
+}
+
+TRACE_EXPORT_PROFILE_LABELS = {
+    TraceExportProfile.SAFE_SUMMARY: "Safe summary",
+    TraceExportProfile.REDACTED_DIAGNOSTIC: "Redacted diagnostic (recommended)",
+    TraceExportProfile.FULL_TRACE: "Full trace",
+}
+
+
+def full_trace_confirmation(*, noun: str) -> ConfirmationDialog:
+    """Build the shared every-disclosure Full export warning."""
+    return ConfirmationDialog(
+        title=f"Export full {noun}?",
+        message=(
+            "Full trace may include prompts, injected instructions, tool arguments, "
+            "outputs, and local paths. Credentials remain structurally blocked."
+        ),
+        confirm_label=f"Export full {noun.lower()}",
+        cancel_label="Go back",
+    )


### PR DESCRIPTION
## Summary

`Chat.trajectory_export` was back on the Chat first-paint leg, breaking TASK-22213's guarantee ~24
hours after it shipped and leaving **two guards red on pristine dev** for every branch to inherit.
Finding 23020 of the [2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md).

## The edges — four, all load-bearing, all must break

Traced by import tracer on both the import and mount legs (the breach arrives on the **mount** leg,
which import-time probes cannot see):

1. `Chat/console_exchange_export.py:18` → `trajectory_export` — one name, `TraceExportProfile`
2. `Widgets/Console/console_exchange_export_dialog.py:22` → the same single name
3. `console_exchange_export_dialog.py:25` → `trace_export_dialog.py` (3 presentation names)
4. `trace_export_dialog.py:16,17` → `Chat.trajectory` + `Chat.trajectory_export`

Each single-name import dragged 1,463 LOC plus `Chat.trajectory`. `chat_screen.py:52-57` carried a
comment forbidding exactly this; #2126 routed around it through files the comment did not name.

## The shape: relocate to light leaves, heavy side re-imports

New `Chat/trace_export_profiles.py` (the enum, stdlib-only) and
`Widgets/Console/trace_export_profile_ui.py` (copy/labels/confirmation) — the repo's
`search_modes` exemplar. `trajectory_export.py` and `trace_export_dialog.py` **re-import** them, so
the enum stays one object (identity-asserted in tests) and the deferred family's import sites are
unchanged.

Function-scope deferral was rejected deliberately: the failure mode here is precisely a future
module-scope one-liner. This shape gives the correct import an obvious home, and the re-import
direction makes the seam-level wrong move a **loud circular-import failure** rather than a silent
re-eagering.

Side effect: the exchange-export flow now never resolves the trajectory engine at all, and
`trace_export_dialog` also left the leg — mount census 958 → 957 against the 970 budget.

## Guards — green without relaxation, and taught the breach

- `test_ui_ready_module_census…pinned_size`: **passes**
- `test_rag_boot_import_closure.py`: **6 passed** — diff is comments plus an identity assertion
- Comments extended to name the files this breach came through, in both `chat_screen.py` and the
  closure guard
- New per-edge guard `Tests/Packaging/test_exchange_export_trajectory_deferral.py` (**6 passed**),
  including a subprocess test driving the **real dialog from the deferred state** — mount, copy
  render, Full confirmation, projection, clipboard disclosure — with the engine asserted absent
  before, during and after.

## Mutation: one mutant per edge, all killed

| mutant (edge restored) | killed by |
|---|---|
| A: `console_exchange_export` → trajectory_export | 5 tests + the census guard independently |
| B: dialog → trajectory_export | 4 |
| C: dialog → trace_export_dialog for the copy | 4 |
| D: `trace_export_profile_ui` → trace_export_dialog | 6, incl. its dedicated leaf-lightness killer |

## Verification

Affected trajectory/exchange suites **214 passed**; inspector + closure **44 passed**; broad
Packaging/Performance/Architecture sweep **155 passed, 2 failed — both A/B-confirmed pre-existing**
on pristine `d7bb844d9b`. Preflight green. Rebased over #2145; the task file carries ticked ACs.

## Out of scope, pre-existing dev reds observed

- `test_chat_screen_remains_within_reviewed_projection_without_ratchet_raise` pins ChatScreen at
  17,727 lines vs 17,013 actual — **the pin went stale in the shrinking direction**.
- `test_console_wave6_closeout_inventory.py::test_closeout_evidence_explains_the_remaining_absolute_deficit`, same A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-23020 by removing `trajectory_export` from the Chat first-paint import path, restoring the TASK-22213 deferral guarantee. The fix relocates the profile enum and shared UI helpers to lightweight leaves, and adds per-edge tests so a future regression is caught by name.

**Changes:**
- Moved `TraceExportProfile` to the stdlib-only `trace_export_profiles` module and the profile copy, labels, and confirmation to `trace_export_profile_ui`.
- Updated `console_exchange_export`, `console_exchange_export_dialog`, and `trace_export_dialog` to import from those leaves; the heavy exporters re-import them to keep a single object identity.
- Added per-edge closure tests, a leaf-lightness check, and a deferred-state dialog flow test that runs the real export without resolving the engine.

<sup>Written for commit 6fa964196f8a8bb12f34c17ae84d6e2797f8ef8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

