### PR TITLE
perf(boot): lazify the Research_Workspace facade and sever its one-integer pydantic edge (TASK-23023)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -3744,7 +3744,7 @@
     },
     {
       "call_count": 363,
-      "diagnostic_digest": "7b7a86e5606877e9a9e4",
+      "diagnostic_digest": "4c843c4a908209fdc5ac",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/App/test_construct_runtime_imports.py
+++ b/Tests/App/test_construct_runtime_imports.py
@@ -87,6 +87,21 @@ ALLOWED_CONSTRUCT_IMPORTS: frozenset[str] = frozenset(
         "tldw_chatbook.Video_Generation.config",
         "tldw_chatbook.Video_Generation.video_formats",
         "tldw_chatbook.Video_Generation.video_store",
+        # Research source-association readiness adapters
+        # (_wire_research_source_association). TASK-23023 made the
+        # Research_Workspace facade lazy, so this function-level import --
+        # which predates the task -- now resolves the two adapters at
+        # construct instead of finding them pre-imported by the (heavier)
+        # boot closure. The 26-model pydantic module `server_adapter` used
+        # to drag (`tldw_api.notes_workspace_schemas`) is severed and must
+        # NOT reappear here; `notes_workspace_limits` is its stdlib-only
+        # replacement and `quick_notes`/`tldw_api.exceptions` are the
+        # adapters' own light dependencies.
+        "tldw_chatbook.Research_Workspace.local_adapter",
+        "tldw_chatbook.Research_Workspace.quick_notes",
+        "tldw_chatbook.Research_Workspace.server_adapter",
+        "tldw_chatbook.tldw_api.exceptions",
+        "tldw_chatbook.tldw_api.notes_workspace_limits",
     }
 )
 

--- a/Tests/Packaging/test_research_workspace_import_closure.py
+++ b/Tests/Packaging/test_research_workspace_import_closure.py
@@ -1,0 +1,479 @@
+"""Import-closure guards for the Research_Workspace facade (TASK-23023).
+
+One import statement put 8 of this repo's modules on the boot path for a
+single integer constant:
+
+* ``Library/library_ingest_jobs.py`` (an ``app.py`` module-scope
+  dependency) imports the stdlib-only validator
+  ``Research_Workspace.source_operations.validate_source_operation_id``
+  *through the package*, so the package ``__init__`` ran -- and it eagerly
+  re-exported the whole tree: controller, overlay/layout stores, both
+  adapters, quick notes.
+* ``server_adapter`` in turn imported ``tldw_api.notes_workspace_schemas``
+  (782 LOC, 26 pydantic models, 20.6 ms self) to read one integer:
+  ``MAX_WORKSPACE_SOURCE_OWNER_ROWS``.
+
+Measured interleaved x3 on 2026-08-27: that one statement cost 273-286 ms /
+143 own modules standalone (eager) vs 78-81 ms / 4 own modules (lazy);
+``import tldw_chatbook.app`` dropped 658 -> 650 own modules. Same class as
+the TASK-21102/21107 facade leaks; the package ``__init__`` is now a PEP 562
+lazy facade and the bound constants live in the stdlib-only
+``tldw_api/notes_workspace_limits.py``.
+
+The mount/construct leg is covered too (the TASK-21731 lesson: an
+import-weight guard cannot see a cost that moved to screen mount):
+``Tests/Performance/test_ui_ready_module_census.py`` pins
+controller/layout_state/overlay_store/notes_workspace_schemas absent at
+``_ui_ready``, and the deferred-state test below drives the real screen
+from exactly the state boot leaves behind. ``local_adapter``/
+``server_adapter``/``quick_notes`` are deliberately NOT pinned absent
+anywhere: ``TldwCli.__init__``'s ``_wire_research_source_association``
+legitimately builds readiness adapters at construction, so they leave the
+IMPORT closure but stay on the construct leg (without the pydantic module,
+which is the heavy part).
+
+Subprocess-isolated for the same reason as the sibling closure guards:
+``sys.modules`` is process-global, so an earlier test that legitimately
+imported the Research Workspace tree would turn an in-process check into a
+false pass/fail.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Modules the lazy facade takes off the boot import path. `tldw_api.
+#: exceptions` also left the measured closure but is NOT pinned: it is a
+#: general-purpose module any boot feature may legitimately import.
+DEFERRED_MODULES = (
+    "tldw_chatbook.Research_Workspace.controller",
+    "tldw_chatbook.Research_Workspace.layout_state",
+    "tldw_chatbook.Research_Workspace.overlay_store",
+    "tldw_chatbook.Research_Workspace.local_adapter",
+    "tldw_chatbook.Research_Workspace.server_adapter",
+    "tldw_chatbook.Research_Workspace.quick_notes",
+    "tldw_chatbook.tldw_api.notes_workspace_schemas",
+)
+
+#: Boot-path members that must STAY in the closure (anti-vacuity: this guard
+#: is about what the facade drags in, not about whether it is reached).
+#: `app.py` imports source_association/source_operation_store/paste_staging/
+#: source_readiness at module scope; `library_ingest_jobs` imports
+#: source_operations, which imports contracts.
+EXPECTED_BOOT_MEMBERS = (
+    "tldw_chatbook.Research_Workspace",
+    "tldw_chatbook.Research_Workspace.contracts",
+    "tldw_chatbook.Research_Workspace.source_operations",
+    "tldw_chatbook.Research_Workspace.source_operation_store",
+    "tldw_chatbook.Research_Workspace.source_association",
+    "tldw_chatbook.Research_Workspace.paste_staging",
+    "tldw_chatbook.Research_Workspace.source_readiness",
+)
+
+#: Scratch profile for the full-boot tests, mirroring
+#: `test_ui_ready_module_census.py`: wizard completed, splash disabled, a
+#: valid-SHAPED nonsense key so Console boots configured. Nothing dials out.
+_PROBE_CONFIG_TOML = """\
+[first_run]
+setup_completed = true
+
+[splash_screen]
+enabled = false
+
+[api_settings.openai]
+api_key = "sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKL"
+"""
+
+
+def _run_isolated_python(
+    tmp_path: Path, code: str, *, full_profile: bool = False
+) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in a fresh interpreter with isolated config/data dirs.
+
+    Args:
+        tmp_path: Per-test scratch directory for the subprocess's HOME/XDG so
+            the app import can never read or write the live user config.
+        code: The Python source to execute with ``python -c``.
+        full_profile: When True, also write the boot-ready ``config.toml``
+            and pin the screen pre-importer off -- required by the tests that
+            boot the app to ``_ui_ready`` (the pre-importer's daemon thread
+            imports every screen module and would race the deferred-state
+            assertions nondeterministically).
+
+    Returns:
+        The completed process (never raises on nonzero exit).
+    """
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env.pop("TLDW_CONFIG_PATH", None)
+    if full_profile:
+        (config_home / "config.toml").write_text(_PROBE_CONFIG_TOML)
+        env["TLDW_CONFIG_PATH"] = str(config_home / "config.toml")
+        env["TLDW_SCREEN_PREIMPORT"] = "0"
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=300,
+    )
+
+
+_RESIDENT_HELPER = """
+import sys
+
+DEFERRED_MODULES = {deferred!r}
+
+
+def resident():
+    return [m for m in DEFERRED_MODULES if sys.modules.get(m) is not None]
+""".format(deferred=DEFERRED_MODULES)
+
+
+_APP_IMPORT_SNIPPET = _RESIDENT_HELPER + """
+EXPECTED_BOOT_MEMBERS = {expected!r}
+
+import tldw_chatbook.app  # noqa: F401
+
+loaded = resident()
+assert not loaded, f"deferred modules resident after app import: {{loaded}}"
+
+for expected in EXPECTED_BOOT_MEMBERS:
+    assert expected in sys.modules, f"expected closure member missing: {{expected}}"
+
+# The validator the whole chain exists for still answers from the deferred
+# state, without waking anything up.
+from tldw_chatbook.Library.library_ingest_jobs import validate_source_operation_id
+
+validate_source_operation_id("rsop-0123456789abcdef0123456789abcdef")
+assert not resident(), f"validating an id woke the deferred tree: {{resident()}}"
+print("APP_CLOSURE_OK")
+""".format(expected=EXPECTED_BOOT_MEMBERS)
+
+
+def test_app_import_does_not_execute_research_workspace_eager_reexports(
+    tmp_path: Path,
+) -> None:
+    """`import tldw_chatbook.app` resolves none of the deferred facade members.
+
+    The regression this pins measured 658 own modules at app import against
+    the 660 budget, 8 of them from this one facade (2026-08-27); the lazy
+    facade returns the count to 650.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _APP_IMPORT_SNIPPET)
+    assert result.returncode == 0, (
+        "import tldw_chatbook.app must not execute the Research_Workspace "
+        f"eager re-exports:\nstdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "APP_CLOSURE_OK" in result.stdout
+
+
+_FACADE_CONTRACT_SNIPPET = """
+import importlib
+import sys
+
+import tldw_chatbook.Research_Workspace as rw
+
+# Importing the bare package must resolve ZERO submodules.
+resident = [
+    m
+    for m in sys.modules
+    if m.startswith("tldw_chatbook.Research_Workspace.")
+    and sys.modules[m] is not None
+]
+assert not resident, f"package import pulled submodules: {resident}"
+
+# The map and __all__ must agree, or a name would be advertised that the
+# facade cannot serve (or served that tooling cannot see).
+assert sorted(rw.__all__) == sorted(rw._SUBMODULE_BY_NAME), (
+    set(rw.__all__) ^ set(rw._SUBMODULE_BY_NAME)
+)
+
+# Every advertised name resolves to the IDENTICAL object its submodule owns,
+# and is cached so the second lookup skips __getattr__.
+for name in rw.__all__:
+    value = getattr(rw, name)
+    owner = importlib.import_module(
+        "tldw_chatbook.Research_Workspace." + rw._SUBMODULE_BY_NAME[name]
+    )
+    assert value is getattr(owner, name), name
+    assert name in vars(rw), f"{name} not cached on the package module"
+
+# Unknown names fail the way a module attribute miss always has.
+try:
+    rw.NoSuchExport
+except AttributeError:
+    pass
+else:
+    raise AssertionError("unknown attribute did not raise AttributeError")
+
+assert set(rw.__all__) <= set(dir(rw))
+print("FACADE_CONTRACT_OK")
+"""
+
+
+def test_facade_names_resolve_lazily_to_the_owning_submodules(
+    tmp_path: Path,
+) -> None:
+    """The PEP 562 facade serves every ``__all__`` name, lazily and identically.
+
+    Absence is not the deliverable -- a deleted re-export would satisfy a
+    pure closure guard. This proves the bare package import is free AND that
+    all 31 advertised names still resolve to the exact objects their
+    submodules own (a typo in ``_SUBMODULE_BY_NAME`` fails here).
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _FACADE_CONTRACT_SNIPPET)
+    assert result.returncode == 0, (
+        f"facade contract failed:\nstdout={result.stdout}\n"
+        f"stderr={result.stderr[-4000:]}"
+    )
+    assert "FACADE_CONTRACT_OK" in result.stdout
+
+
+_SERVER_ADAPTER_SNIPPET = """
+import sys
+
+import tldw_chatbook.Research_Workspace.server_adapter as server_adapter
+
+assert "tldw_chatbook.tldw_api.notes_workspace_schemas" not in sys.modules, (
+    "server_adapter still imports the 26-model pydantic schema module"
+)
+assert server_adapter.MAX_WORKSPACE_SOURCE_OWNER_ROWS == 10_100
+
+# Single-sourced: the schema module re-imports the bounds from the limits
+# module, so the value the adapter enforces IS the object the schema fields
+# validate against -- no copy that can drift.
+from tldw_chatbook.tldw_api import notes_workspace_limits, notes_workspace_schemas
+
+assert (
+    notes_workspace_schemas.MAX_WORKSPACE_SOURCE_OWNER_ROWS
+    is notes_workspace_limits.MAX_WORKSPACE_SOURCE_OWNER_ROWS
+)
+assert (
+    notes_workspace_schemas.MAX_WORKSPACE_SOURCE_ROWS
+    is notes_workspace_limits.MAX_WORKSPACE_SOURCE_ROWS
+)
+assert (
+    server_adapter.MAX_WORKSPACE_SOURCE_OWNER_ROWS
+    is notes_workspace_limits.MAX_WORKSPACE_SOURCE_OWNER_ROWS
+)
+print("SERVER_ADAPTER_LIMITS_OK")
+"""
+
+
+def test_server_adapter_reads_the_owner_rows_bound_without_the_schema_module(
+    tmp_path: Path,
+) -> None:
+    """The adapter's bound comes from the stdlib-only limits module.
+
+    ``chunking_engine_version.py`` (TASK-21102) and ``search_modes.py``
+    (TASK-21731) are the exemplars: a pure value lifted out of the heavy
+    module that owned it, re-imported by that module so no second copy can
+    drift. Both properties are checked.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _SERVER_ADAPTER_SNIPPET)
+    assert result.returncode == 0, (
+        f"server_adapter limits contract failed:\nstdout={result.stdout}\n"
+        f"stderr={result.stderr[-4000:]}"
+    )
+    assert "SERVER_ADAPTER_LIMITS_OK" in result.stdout
+
+
+_DEFERRED_SCREEN_SNIPPET = _RESIDENT_HELPER + """
+import asyncio
+
+#: Screen-leg members that must stay absent through _ui_ready. The adapter/
+#: quick_notes members are excluded on purpose: app CONSTRUCTION legitimately
+#: resolves them for the readiness coordinator (see the module docstring of
+#: this test file).
+ABSENT_AT_READY = (
+    "tldw_chatbook.Research_Workspace.controller",
+    "tldw_chatbook.Research_Workspace.layout_state",
+    "tldw_chatbook.Research_Workspace.overlay_store",
+    "tldw_chatbook.tldw_api.notes_workspace_schemas",
+    "tldw_chatbook.UI.Screens.research_workspace_screen",
+)
+
+
+async def main() -> None:
+    import tldw_chatbook.app
+
+    assert not resident(), f"resident after app import: {resident()}"
+
+    app = tldw_chatbook.app.TldwCli()
+    async with app.run_test(size=(120, 40)):
+        while not getattr(app, "_ui_ready", False):
+            await asyncio.sleep(0.005)
+
+        on_leg = [m for m in ABSENT_AT_READY if sys.modules.get(m) is not None]
+        assert not on_leg, f"deferred members resident at _ui_ready: {on_leg}"
+
+        # Drive the route exactly as the nav bar does, from the deferred
+        # state: the route module import triggers the facade __getattr__.
+        from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+
+        await app.handle_screen_navigation(NavigateToScreen("research_workspace"))
+        await asyncio.sleep(0)
+
+        from tldw_chatbook.Research_Workspace.controller import (
+            ResearchWorkspaceController,
+        )
+        from tldw_chatbook.UI.Screens.research_workspace_screen import (
+            ResearchWorkspaceScreen,
+        )
+
+        screen = app.screen
+        assert isinstance(screen, ResearchWorkspaceScreen), screen
+        controller = getattr(screen, "_controller", None) or getattr(
+            screen, "controller", None
+        )
+        assert isinstance(controller, ResearchWorkspaceController), controller
+        assert sys.modules.get("tldw_chatbook.Research_Workspace.overlay_store"), (
+            "navigation did not resolve the deferred overlay store"
+        )
+    print("DEFERRED_SCREEN_OK")
+
+
+asyncio.run(main())
+"""
+
+
+@pytest.mark.integration
+def test_research_workspace_screen_mounts_from_the_deferred_state(
+    tmp_path: Path,
+) -> None:
+    """The real screen still opens once its imports are deferred.
+
+    Boots the actual app headless to ``_ui_ready`` (deferred members proven
+    absent at that moment -- the TASK-21731 "moved to mount" trap), then
+    navigates to the Research Workspace route: the route module import
+    resolves ``ResearchWorkspaceController`` etc. through the lazy facade,
+    the screen mounts, and its controller is the real class.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's profile.
+    """
+    result = _run_isolated_python(tmp_path, _DEFERRED_SCREEN_SNIPPET, full_profile=True)
+    assert result.returncode == 0, (
+        "Research Workspace screen failed from the deferred state:\n"
+        f"stdout={result.stdout[-2000:]}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "DEFERRED_SCREEN_OK" in result.stdout
+
+
+_BROKEN_SUBMODULE_SNIPPET = """
+import asyncio
+import sys
+
+BLOCKED = "tldw_chatbook.Research_Workspace.controller"
+
+
+class _BreakController:
+    \"\"\"Meta-path finder simulating an install with one broken submodule.\"\"\"
+
+    def find_spec(self, name, path=None, target=None):
+        if name == BLOCKED:
+            raise ImportError(f"simulated broken install for {name}")
+        return None
+
+
+sys.meta_path.insert(0, _BreakController())
+
+
+async def main() -> None:
+    # Boot must survive: the whole point of the lazy facade is that a broken
+    # screen-side submodule no longer takes `import tldw_chatbook.app` down.
+    import tldw_chatbook.app
+
+    app = tldw_chatbook.app.TldwCli()
+    async with app.run_test(size=(120, 40)):
+        while not getattr(app, "_ui_ready", False):
+            await asyncio.sleep(0.005)
+
+        from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+        from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+        assert isinstance(app.screen, ChatScreen), app.screen
+
+        # First use: the deferred import failure lands here, not at boot.
+        await app.handle_screen_navigation(NavigateToScreen("research_workspace"))
+        await asyncio.sleep(0)
+
+        # Legible, not fatal: the app is alive, the user stayed on the
+        # current screen, and was TOLD -- not left staring at an unchanged
+        # screen with a stuck nav highlight (the task-2720 defect).
+        assert isinstance(app.screen, ChatScreen), app.screen
+        messages = [n.message for n in app._notifications]
+        assert any("Couldn't open" in m for m in messages), messages
+
+        # ...and the rest of the app still navigates.
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await asyncio.sleep(0)
+        from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+        assert isinstance(app.screen, LibraryScreen), app.screen
+    print("BROKEN_SUBMODULE_LEGIBLE_OK")
+
+
+asyncio.run(main())
+"""
+
+
+@pytest.mark.integration
+def test_broken_deferred_submodule_fails_legibly_at_first_navigation(
+    tmp_path: Path,
+) -> None:
+    """Moving an import moves its failure -- this pins where that failure lands.
+
+    With ``Research_Workspace.controller`` unimportable, the eager facade
+    used to kill ``import tldw_chatbook.app`` outright (a dead app). Now the
+    app boots; the failure surfaces at first navigation as a user-visible
+    "Couldn't open" notification while the current screen stays mounted and
+    every other route keeps working. Runs in a subprocess with a meta-path
+    blocker because ``sys.modules`` is process-global.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's profile.
+    """
+    result = _run_isolated_python(
+        tmp_path, _BROKEN_SUBMODULE_SNIPPET, full_profile=True
+    )
+    assert result.returncode == 0, (
+        "broken-submodule first-navigation contract failed:\n"
+        f"stdout={result.stdout[-2000:]}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "BROKEN_SUBMODULE_LEGIBLE_OK" in result.stdout

--- a/Tests/Performance/test_ui_ready_module_census.py
+++ b/Tests/Performance/test_ui_ready_module_census.py
@@ -105,6 +105,17 @@ ABSENT_AT_READY_MODULES = (
     "tldw_chatbook.Chat.trajectory_export",
     "tldw_chatbook.UI.Widgets.trajectory_timeline",
     "tldw_chatbook.UI.Widgets.trace_filter_bar",
+    # TASK-23023: the Research_Workspace facade is lazy (PEP 562), so the
+    # screen-only members and the 26-model pydantic schema module
+    # `server_adapter` used to drag in for one integer stay off the whole
+    # first-paint window, not just off the import phase. NOT listed:
+    # local_adapter/server_adapter/quick_notes/contracts -- `TldwCli.
+    # __init__`'s `_wire_research_source_association` legitimately builds
+    # readiness adapters at construction, so those stay resident at ready.
+    "tldw_chatbook.Research_Workspace.controller",
+    "tldw_chatbook.Research_Workspace.layout_state",
+    "tldw_chatbook.Research_Workspace.overlay_store",
+    "tldw_chatbook.tldw_api.notes_workspace_schemas",
 )
 
 #: Anti-vacuity: if these are not resident, the boot did not actually mount

--- a/backlog/tasks/task-23023 - One-import-statement-costs-48-ms-and-8-boot-modules-for-a-single-integer-constant.md
+++ b/backlog/tasks/task-23023 - One-import-statement-costs-48-ms-and-8-boot-modules-for-a-single-integer-constant.md
@@ -2,7 +2,7 @@
 id: TASK-23023
 title: >-
   One import statement costs 48 ms and 8 boot modules for a single integer constant
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-27'
 labels:
@@ -27,11 +27,16 @@ is a live shell destination, so a user who never opens it pays this on every boo
 
 ## Acceptance Criteria
 
-- [ ] `import tldw_chatbook.app` no longer executes `Research_Workspace/__init__`'s eager re-exports
-- [ ] The boot closure drops by ~8 modules and the import cost by ~48 ms, measured with interleaved arms
-- [ ] `server_adapter` no longer imports a pydantic schema module to read one integer
-- [ ] The Research Workspace feature still works; a test drives it from the deferred state
-- [ ] The 660 budget is **not** raised
+- [x] `import tldw_chatbook.app` no longer executes `Research_Workspace/__init__`'s eager re-exports
+- [x] The boot closure drops by ~8 modules and the import cost by ~48 ms, measured with interleaved arms
+- [x] `server_adapter` no longer imports a pydantic schema module to read one integer
+- [x] The Research Workspace feature still works; a test drives it from the deferred state
+- [x] The 660 budget is **not** raised
+- [x] A deferred Research_Workspace import that raises at first navigation surfaces legibly
+      (user-visible failure, app and current screen survive, other routes keep working) --
+      lazification moves failures from boot to first use, and this class has broken the app before
+- [x] The deferral is proven at `_ui_ready` too, not only after import (the TASK-21731 lesson):
+      the screen-only members and the pydantic schema module are absent when the app becomes usable
 
 ## Evidence
 
@@ -50,3 +55,116 @@ Measured, interleaved x3 pairs (arm B = package `__init__` emptied in a scratch 
 dependency.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Implementation Plan
+
+1. Re-verify the finding on the branch base (`d7bb844d9b`): trace the chain, measure the statement
+   cost and the closure with interleaved arms (arm A = base files, arm B = fix), and name every
+   dropped module rather than trusting the reported 8.
+2. Make `Research_Workspace/__init__` a PEP 562 lazy facade (the `tldw_api`/`Local_Ingestion`
+   house pattern): `__all__` unchanged, a flat name -> submodule map, module `__getattr__` that
+   imports one submodule per ask and caches, `__dir__` for tooling. No importer rewrites needed --
+   `from tldw_chatbook.Research_Workspace import X` keeps working and a later direct submodule
+   import stays cheap.
+3. Lift `MAX_WORKSPACE_SOURCE_ROWS`/`MAX_WORKSPACE_SOURCE_OWNER_ROWS` into a stdlib-only
+   `tldw_api/notes_workspace_limits.py` (the `chunking_engine_version.py`/`search_modes.py`
+   pattern); `notes_workspace_schemas` re-imports them so there is one object per bound;
+   `server_adapter` reads the light module.
+4. Prove gone at `_ui_ready`, not relocated (the TASK-21731 lesson): census both arms at ready,
+   pin the truly-absent members in `test_ui_ready_module_census.py`, and record which members
+   legitimately move to the construct leg (`_wire_research_source_association`'s readiness
+   adapters) in `test_construct_runtime_imports.py`'s reviewed allowlist.
+5. Walk the first-use failure modes of the deferral; make the silent branch
+   (`_complete_screen_navigation`'s load-failure else) legible; cover it with a broken-submodule
+   subprocess test.
+6. New guards in `Tests/Packaging/test_research_workspace_import_closure.py`; mutation-test every
+   new test against a deliberately broken implementation; A/B every red suite against base.
+
+## Implementation Notes
+
+**What shipped.**
+
+1. `tldw_chatbook/Research_Workspace/__init__.py` -- PEP 562 lazy facade. All 31 re-exported
+   names resolve on first attribute access via `_SUBMODULE_BY_NAME` + module `__getattr__`
+   (identical objects, cached after first ask); importing the bare package resolves zero
+   submodules. The boot chain (`library_ingest_jobs` -> `source_operations`) now pays only the
+   package init + the stdlib-only validator.
+2. `tldw_chatbook/tldw_api/notes_workspace_limits.py` (new, stdlib-only) owns
+   `MAX_WORKSPACE_SOURCE_ROWS` and `MAX_WORKSPACE_SOURCE_OWNER_ROWS`; `notes_workspace_schemas`
+   re-imports both (one object per bound, no copy to drift) and `server_adapter` now imports the
+   light module -- the 26-model pydantic module is severed from the adapter entirely.
+3. `app.py` `_complete_screen_navigation`: the no-screen-class else branch now surfaces the
+   failure (`_notify_navigation_failure` toast + nav-bar rollback) and logs the blocking
+   exception via `screen_load_error()`. Rationale: lazification moves a broken submodule's
+   failure from boot (dead app) to first navigation, and that branch was the one silent path
+   left -- the exact task-2720 defect shape. AC added for this before implementing.
+4. Census guard (`test_ui_ready_module_census.py`): controller/layout_state/overlay_store/
+   notes_workspace_schemas added to `ABSENT_AT_READY_MODULES`. Construct guard
+   (`test_construct_runtime_imports.py`): local_adapter/server_adapter/quick_notes/
+   tldw_api.exceptions/notes_workspace_limits added as reviewed rows --
+   `_wire_research_source_association` (construct-time, pre-existing) genuinely builds the
+   readiness adapters, so those members move from the import phase to the construct phase
+   (both pre-paint) rather than disappearing; restructuring that wiring was deliberately NOT
+   done (stability-over-quick-wins).
+
+**Measured, arms interleaved x3 (arm A = base `d7bb844d9b` files, arm B = fix; isolated
+config; venv Python 3.12.11).**
+
+| | arm A (base) | arm B (fixed) |
+|---|---|---|
+| the one statement, standalone (`from ...source_operations import validate_source_operation_id`) | 286.1 / 273.6 / 273.5 ms, 143 own modules | **77.6 / 79.9 / 81.3 ms, 4 own modules** |
+| `import tldw_chatbook.app` own modules | 658 / 658 / 658 | **650 / 650 / 650** |
+| `notes_workspace_schemas` in boot closure | yes | **no** |
+| own modules at `_ui_ready` (warm 2nd boot) | 958 | **955** |
+
+The 8 dropped boot modules, named (`comm` over sorted censuses): `Research_Workspace.
+{controller, layout_state, overlay_store, local_adapter, server_adapter, quick_notes}`,
+`tldw_api.exceptions`, `tldw_api.notes_workspace_schemas`; nothing added in arm B (the limits
+module is not on the boot path at all). At `_ui_ready`: controller/layout_state/overlay_store/
+notes_workspace_schemas GONE; local_adapter/server_adapter/quick_notes resident via the
+construct-leg readiness wiring (now without the pydantic payload); `notes_workspace_limits`
+(21 lines, stdlib) is the only addition. Absolute ms differ from the tracer numbers in the
+finding (different probe: standalone statement in a cold interpreter vs marginal cost inside
+the app import; machine under load) -- the A/B deltas are the evidence.
+
+**New tests** (`Tests/Packaging/test_research_workspace_import_closure.py`, 5): app-import
+closure guard (+ validator anti-vacuity), facade contract (bare package pulls zero submodules;
+all 31 names resolve identically; map/`__all__` agreement; AttributeError on unknown),
+server_adapter limits contract (schema module absent + single-sourced bounds), deferred-state
+screen drive (real headless boot to `_ui_ready`, deferred members proven absent at ready,
+navigate to `research_workspace`, screen mounts with a real controller), and broken-submodule
+legibility (meta-path ImportError on `controller`: app boots, first navigation shows the
+"Couldn't open" notification, current screen survives, Library still opens).
+
+**Mutation results** (each new test red against a deliberately broken implementation):
+eager `__init__` restored -> 4/5 fail (closure, facade, deferred-state, legibility -- the
+last because a broken submodule again kills boot); `server_adapter` re-pointed at
+`notes_workspace_schemas` -> limits contract AND deferred-state fail (schemas resident at
+ready via the construct leg) while the import-closure test stays green -- exactly the blind
+spot the at-ready assertions exist for; `_SUBMODULE_BY_NAME` mis-mapped -> facade contract
+fails; `_notify_navigation_failure` call removed -> legibility test fails.
+
+**Test A/B (identical commands, both arms).** Branch-relevant sweep
+(`Tests/Research_Workspace Tests/Packaging Tests/Library Tests/tldw_api(workspace/notes)
+Tests/Utils/test_tldw_api_lazy Tests/App(construct/submit/retry)`): 3342 passed / 10 failed.
+9 of the 10 fail byte-identically with the base production files restored
+(`test_rag_boot_import_closure::test_chat_screen...` and `test_ui_ready_module_census` both
+red for exactly `Chat.trajectory_export` -- TASK-23020's in-flight family, same single member
+on both arms; `test_library_rag_state` x1 and `test_submit_library_ingest_job` x7 are
+pre-existing dev reds). The 10th (`test_construct_runtime_imports`) was mine: the guard doing
+its job on the construct-leg move; resolved with the reviewed allowlist rows above. UI
+navigation + research-screen suites and `test_app_import_weight.py` (budget untouched at 660)
+green.
+
+**Modified/added files.** `tldw_chatbook/Research_Workspace/__init__.py`,
+`tldw_chatbook/tldw_api/notes_workspace_limits.py` (new),
+`tldw_chatbook/tldw_api/notes_workspace_schemas.py`,
+`tldw_chatbook/Research_Workspace/server_adapter.py`, `tldw_chatbook/app.py`,
+`Tests/Packaging/test_research_workspace_import_closure.py` (new, 5 tests),
+`Tests/Performance/test_ui_ready_module_census.py`,
+`Tests/App/test_construct_runtime_imports.py`.
+
+**Known residual.** The default-on background screen pre-importer still warms every screen
+module (this family included) on a daemon thread seconds after first paint -- deliberate,
+off the critical path, finding 22214's territory, pinned OFF in the probes exactly as the
+census guard documents.

--- a/tldw_chatbook/Research_Workspace/__init__.py
+++ b/tldw_chatbook/Research_Workspace/__init__.py
@@ -1,42 +1,29 @@
-"""Research Workspace authority adapters and normalized contracts."""
+"""Research Workspace authority adapters and normalized contracts.
 
-from .contracts import (
-    BoundedPageResult,
-    CapabilityUnavailableError,
-    ProcessingRoute,
-    QualifiedWorkspaceRef,
-    ResearchCatalogItem,
-    ResearchCapability,
-    ResearchSourcePreview,
-    ResearchSourcePage,
-    ResearchSourceSummary,
-    SourceSelectionResult,
-    ResearchWorkspacePort,
-    ResearchWorkspaceSummary,
-    RetrievalMode,
-    SourceReadiness,
-    SourceReadinessState,
-    SourceIdentityMismatchError,
-    WorkspaceDataSource,
-)
-from .controller import (
-    ResearchRequestContext,
-    ResearchSurfaceRequest,
-    ResearchWorkspaceCatalogState,
-    ResearchWorkspaceController,
-)
-from .layout_state import ResearchPanePreferences
-from .overlay_store import ResearchPresentationOverlayStore
-from .local_adapter import LocalResearchWorkspaceAdapter
-from .server_adapter import ServerResearchWorkspaceAdapter
-from .quick_notes import (
-    ResearchNoteConflictError,
-    ResearchNotePage,
-    ResearchNotePageRequest,
-    ResearchNoteSaveRequest,
-    ResearchQuickNote,
-    ResearchQuickNotesService,
-)
+Lazy re-exports (PEP 562). The names in ``__all__`` resolve on first
+attribute access via module ``__getattr__`` -- the same pattern as
+``tldw_api/__init__.py`` and ``Local_Ingestion/__init__.py``. This package
+sits on the boot import path through its cheapest member:
+``Library/library_ingest_jobs.py`` (an ``app.py`` module-scope dependency)
+imports ``source_operations.validate_source_operation_id``, and ``app.py``
+itself imports four more stdlib-light submodules directly. When this
+``__init__`` eagerly re-exported the whole tree, that one validator import
+also executed ``server_adapter`` -> ``tldw_api.notes_workspace_schemas``
+(26 pydantic models) plus the controller/overlay/layout modules only the
+Research Workspace screen needs -- ~48 ms and 8 boot modules for a 6 ms
+validator (TASK-23023; same class as the TASK-21102/21107 facade leaks).
+
+Regular callers (``from tldw_chatbook.Research_Workspace import
+ResearchWorkspaceController``) are unaffected: the first access imports the
+owning submodule, returns the identical object, and caches it on this
+module so later lookups are plain attribute access. Direct submodule
+imports still run this ``__init__`` first per standard import semantics,
+but that is now free of eager submodule imports of its own.
+
+Guarded by ``Tests/Packaging/test_research_workspace_import_closure.py``.
+"""
+
+from typing import Any
 
 __all__ = [
     "BoundedPageResult",
@@ -71,3 +58,55 @@ __all__ = [
     "SourceIdentityMismatchError",
     "WorkspaceDataSource",
 ]
+
+#: Which submodule owns each re-exported name. Flat mapping so
+#: ``__getattr__`` only ever imports the one submodule a caller asked for.
+_SUBMODULE_BY_NAME = {
+    "BoundedPageResult": "contracts",
+    "CapabilityUnavailableError": "contracts",
+    "ProcessingRoute": "contracts",
+    "QualifiedWorkspaceRef": "contracts",
+    "ResearchCatalogItem": "contracts",
+    "ResearchCapability": "contracts",
+    "ResearchSourcePreview": "contracts",
+    "ResearchSourcePage": "contracts",
+    "ResearchSourceSummary": "contracts",
+    "SourceSelectionResult": "contracts",
+    "ResearchWorkspacePort": "contracts",
+    "ResearchWorkspaceSummary": "contracts",
+    "RetrievalMode": "contracts",
+    "SourceReadiness": "contracts",
+    "SourceReadinessState": "contracts",
+    "SourceIdentityMismatchError": "contracts",
+    "WorkspaceDataSource": "contracts",
+    "ResearchRequestContext": "controller",
+    "ResearchSurfaceRequest": "controller",
+    "ResearchWorkspaceCatalogState": "controller",
+    "ResearchWorkspaceController": "controller",
+    "ResearchPanePreferences": "layout_state",
+    "ResearchPresentationOverlayStore": "overlay_store",
+    "LocalResearchWorkspaceAdapter": "local_adapter",
+    "ServerResearchWorkspaceAdapter": "server_adapter",
+    "ResearchNoteConflictError": "quick_notes",
+    "ResearchNotePage": "quick_notes",
+    "ResearchNotePageRequest": "quick_notes",
+    "ResearchNoteSaveRequest": "quick_notes",
+    "ResearchQuickNote": "quick_notes",
+    "ResearchQuickNotesService": "quick_notes",
+}
+
+
+def __getattr__(name: str) -> Any:
+    submodule_name = _SUBMODULE_BY_NAME.get(name)
+    if submodule_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    submodule = importlib.import_module(f".{submodule_name}", __name__)
+    value = getattr(submodule, name)
+    globals()[name] = value  # cache so subsequent lookups skip __getattr__
+    return value
+
+
+def __dir__() -> "list[str]":
+    return sorted(set(__all__) | set(globals()))

--- a/tldw_chatbook/Research_Workspace/server_adapter.py
+++ b/tldw_chatbook/Research_Workspace/server_adapter.py
@@ -22,7 +22,7 @@ from tldw_chatbook.tldw_api.exceptions import (
     APIResponseError,
     AuthenticationError,
 )
-from tldw_chatbook.tldw_api.notes_workspace_schemas import (
+from tldw_chatbook.tldw_api.notes_workspace_limits import (
     MAX_WORKSPACE_SOURCE_OWNER_ROWS,
 )
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -11685,7 +11685,19 @@ class TldwCli(
 
             logger.info(f"Successfully switched to {screen_name} screen")
         else:
-            logger.error(f"Unknown screen requested: {requested_screen}")
+            # No class for the route: unroutable target, or the screen module
+            # failed to import (`load_screen_class` degrades ImportError/
+            # AttributeError to None). Since TASK-23023 resolved the
+            # Research_Workspace facade lazily, a submodule broken at install
+            # time surfaces HERE at first navigation instead of killing the
+            # whole app at boot -- and a log-only failure is exactly the
+            # task-2720 defect (stuck nav highlight, swallowed retries, no
+            # message). Tell the user and roll the nav bar back.
+            logger.error(
+                f"Unknown screen requested: {requested_screen} "
+                f"({screen_load_error(requested_screen)})"
+            )
+            self._notify_navigation_failure(screen_name)
 
     @on(TTSRequestEvent)
     async def handle_tts_request_event(self, event: TTSRequestEvent) -> None:

--- a/tldw_chatbook/tldw_api/notes_workspace_limits.py
+++ b/tldw_chatbook/tldw_api/notes_workspace_limits.py
@@ -1,0 +1,21 @@
+"""Bound constants for the workspace-source owner projections.
+
+Stdlib-only on purpose (TASK-23023). ``Research_Workspace/server_adapter.py``
+enforces these bounds on every owner-rows projection, and it used to import
+them from ``notes_workspace_schemas`` -- a 782-LOC, 26-model pydantic module
+-- paying that module's whole import cost for one integer.
+``notes_workspace_schemas`` re-imports these names from here (the
+``chunking_engine_version.py`` / ``search_modes.py`` pattern), so there is
+exactly one object per bound in the process and the value the adapter
+enforces cannot drift from the one the schema fields validate against.
+Guarded by ``Tests/Packaging/test_research_workspace_import_closure.py``.
+"""
+
+from __future__ import annotations
+
+#: Maximum rows in one workspace-source page.
+MAX_WORKSPACE_SOURCE_ROWS = 100
+
+# GET sources/status are unpaged owner projections. This finite bound covers
+# the public offset contract (10_000) plus one maximum page (100).
+MAX_WORKSPACE_SOURCE_OWNER_ROWS = 10_100

--- a/tldw_chatbook/tldw_api/notes_workspace_schemas.py
+++ b/tldw_chatbook/tldw_api/notes_workspace_schemas.py
@@ -337,10 +337,14 @@ class WorkspaceNoteResponse(BaseModel):
     version: int = 1
 
 
-MAX_WORKSPACE_SOURCE_ROWS = 100
-# GET sources/status are unpaged owner projections. This finite bound covers
-# the public offset contract (10_000) plus one maximum page (100).
-MAX_WORKSPACE_SOURCE_OWNER_ROWS = 10_100
+# Re-imported from the stdlib-only limits module (TASK-23023) so
+# `Research_Workspace/server_adapter.py` can enforce the same bounds without
+# importing this pydantic module; one object per bound, no copy to drift.
+from tldw_chatbook.tldw_api.notes_workspace_limits import (  # noqa: E402
+    MAX_WORKSPACE_SOURCE_OWNER_ROWS,
+    MAX_WORKSPACE_SOURCE_ROWS,
+)
+
 MAX_WORKSPACE_SOURCE_ID_CHARS = 1024
 MAX_WORKSPACE_SOURCE_TITLE_CHARS = 1000
 MAX_WORKSPACE_SOURCE_TEXT_CHARS = 12_000


### PR DESCRIPTION
## Summary

One import statement put ~48 ms and 8 modules on every boot, to read **one integer constant**
through a 26-model pydantic module. Finding 23023 of the
[2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md).

The chain: `app.py → Library/server_ingest_reconcile.py → library_ingest_jobs.py:77` imports a
**stdlib-only validator** *through* `Research_Workspace/__init__`, whose eager re-exports pull the
whole tree — including `server_adapter`, which imported `tldw_api.notes_workspace_schemas` (26
pydantic models, 782 LOC) for `MAX_WORKSPACE_SOURCE_OWNER_ROWS = 10_100`.

## What shipped

- **`Research_Workspace/__init__` is now a PEP 562 lazy facade** (the `tldw_api`/`Local_Ingestion`
  house pattern): all 31 `__all__` names resolve through module `__getattr__` to identical cached
  submodule objects; a bare package import resolves **zero** submodules — so the next
  `from Research_Workspace.X import y` cannot re-eager the tree.
- **New stdlib-only `tldw_api/notes_workspace_limits.py`** owns the two bounds;
  `notes_workspace_schemas.py` re-imports them (one object per bound, no drift) and
  `server_adapter` reads the light module. The pydantic edge is fully severed.
- **A silent navigation branch made legible**: `_complete_screen_navigation`'s load-failure else was
  log-only; it now raises the "Couldn't open…" toast and rolls the nav bar back. Added as an AC
  before implementing — lazification moves failures from boot to first use, and this was the dead
  end a first-use ImportError would have hit.

## Measured (interleaved ×3, arm A = base files, arm B = fix)

| | base | fixed |
|---|---|---|
| the statement, standalone | 286.1/273.6/273.5 ms · 143 own modules | **77.6/79.9/81.3 ms · 4 modules** |
| boot closure (`import tldw_chatbook.app`) | 658 | **650**, all three rounds |

The 660 budget is untouched and `test_app_import_weight.py` is 7/7 green — headroom goes from **2
modules to 10**. The 8 dropped modules are named by `comm`, and arm B adds **zero** (the limits
module is not on the boot path at all).

## Gone vs relocated — stated honestly

`_ui_ready` census: 958 → 955. **Gone at ready** and pinned in `ABSENT_AT_READY_MODULES`:
`controller`, `layout_state`, `overlay_store`, `notes_workspace_schemas` — the heavy payload.
**Honestly relocated and documented**: `local_adapter`/`server_adapter`/`quick_notes`/
`tldw_api.exceptions` moved from the import phase into `TldwCli.__init__`, because
`_wire_research_source_association` genuinely builds readiness adapters there. Both phases are
pre-paint and the pydantic edge is severed either way. This tripped `test_construct_runtime_imports`'
allowlist **exactly as that guard intends**; the rows are added with the cause named rather than the
guard relaxed. Restructuring the readiness wiring was deliberately not attempted (stability ruling).

## The deferred state is proven live, not assumed

- `test_research_workspace_screen_mounts_from_the_deferred_state`: real headless boot to
  `_ui_ready`, deferred members proven absent *at that moment*, then navigation drives the facade
  `__getattr__` and the screen mounts with a real controller.
- `test_broken_deferred_submodule_fails_legibly_at_first_navigation`: a meta-path blocker on
  `controller` — the app boots, the failure surfaces as a notification, Chat survives, Library still
  opens. **Under the old eager init the same blocker kills the app at import**, which is exactly how
  this test fails under mutation.

## Mutations — all caught, including a cross-axis kill

Eager init restored → 4/5 new tests fail. **`server_adapter` re-pointed at the schemas module → the
limits test AND the deferred-state test fail while the import-closure test stays green** — the
at-ready axis catching what the import axis structurally cannot. Facade map mis-entry → contract
test fails. Notify call removed → the legibility test fails.

## Verification

Branch-relevant sweep 3,342 passed / 10 failed → 9 byte-identical on base, 1 was this change's own
allowlist trip, resolved as above. Full collection: 63,292 tests, no errors. After rebasing over
TASK-23020's merge, the two previously-red census guards are **green on this branch** — 13/13 across
the guard set. Preflight green; the diagnostic inventory was reviewed row-by-row before regeneration
(one reworded `logger.error`, interpolating route id + screen-load exception only).

## Out of scope — pre-existing dev reds worth tracking

- `Tests/Library/test_library_rag_state.py::test_scope_source_type_map_matches_open_source_type_map_except_prompt`
- 7× `Tests/App/test_submit_library_ingest_job.py::test_invalid_audio_request_allows_next_job_to_dispatch[...]`
- 4× `Tests/UI/test_screen_navigation.py` Library-screen tests — plausibly from tip commit #2143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `Research_Workspace` a lazy facade so booting the app no longer imports 8 modules and pays ~48 ms just to read `MAX_WORKSPACE_SOURCE_OWNER_ROWS`. The constant moved to a new stdlib-only `tldw_api/notes_workspace_limits.py`; `notes_workspace_schemas` re-imports it so there's one object per bound, with no copy to drift.

Boot closure drops from 658 to 650 own modules (the 660 budget is untouched); the standalone statement drops from ~273-286 ms to ~78-81 ms.

**Refactors**
- The bare package import resolves zero submodules; all 31 `__all__` names resolve lazily on first access to the identical submodule objects.
- `local_adapter`, `server_adapter`, and `quick_notes` now load at `TldwCli` construction instead of at boot.
- Five new subprocess tests guard the closure, facade contract, limits single-sourcing, deferred-state screen drive, and broken-submodule legibility.

**Bug Fixes**
- A deferred submodule that fails to import now shows a "Couldn't open" notification at first navigation instead of killing the app at boot; the current screen and other routes keep working.

<sup>Written for commit bd8c8d9b3fd21f24032ffb7f40de8afa1926f829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

