### PR TITLE
perf(console): retire the setup-modal snow animation to a still frame (TASK-23021)

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -155,7 +155,10 @@ If no provider is configured when you open Console, the shell is replaced
 by a **Get started** card with three numbered steps — "Connect a provider
 (API key or local server)", "Pick a model", "Send your first message" —
 marked with ● (current) and ○ (pending) glyphs, plus the note "Composer
-unlocks after setup". Its button follows the current step (**Set up
+unlocks after setup". Behind the card, the workbench dims under a still
+field of scattered snow glyphs — a purely decorative backdrop that holds
+one frame (it re-scatters only when the window resizes) and costs nothing
+while the card waits. Its button follows the current step (**Set up
 provider**, then **Choose model**) and opens the Console Settings modal.
 The composer stays locked until a provider and model are configured; once
 they are, the empty transcript reads "Ready — type a message to begin."
@@ -466,7 +469,12 @@ are covered on the child pages, chiefly [Context & RAG](console/context-and-rag.
   "Console: Change model…".
 
 —
-*Verified against working tree — 2026-08-25 (TASK-21145: clickable setup-blocked reason; first send never intercepted by the project-instructions folder dialog on a fresh profile). Verified against 4646922ed — 2026-08-04 (PR-4 Task 6 live check, including
+*Verified against working tree — 2026-08-27 (TASK-23021: the Get started
+card's snow backdrop is now a still frame — mounted-harness check on the
+real unconfigured ChatScreen: field renders behind the card, no timers, no
+repaints between resizes; idle CPU 0.02–0.05% vs 2.0–7.4% with the retired
+animation re-emulated, interleaved 15 s windows). Verified against working
+tree — 2026-08-25 (TASK-21145: clickable setup-blocked reason; first send never intercepted by the project-instructions folder dialog on a fresh profile). Verified against 4646922ed — 2026-08-04 (PR-4 Task 6 live check, including
 a real-provider send round trip). Verified against e2c706303 — 2026-08-06
 (PR-T2, docs pass against shipped code/tests, live check pending Task 9):
 a legacy `[API] <provider>_api_key` now satisfies this screen's own

--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import random
 
 import pytest
@@ -411,33 +412,22 @@ async def test_setup_backdrop_seeded_rng_renders_flake_glyphs():
 
 
 @pytest.mark.asyncio
-async def test_setup_backdrop_tick_advances_positions_and_repaints():
+async def test_setup_backdrop_field_is_still_between_resizes():
+    """TASK-23021: the snow is a still frame -- positions and rendered text
+    must not change while the widget merely sits mounted."""
     app = _SnowBackdropApp(random.Random(42))
     async with app.run_test(size=(40, 10)):
         backdrop = app.query_one("#backdrop-under-test", ConsoleSetupBackdrop)
         positions_before = [(flake.x, flake.y) for flake in backdrop._flakes]
         text_before = str(backdrop.renderable)
 
-        backdrop._tick()
+        # Longer than several of the retired animation's 0.4 s intervals.
+        await asyncio.sleep(1.0)
 
         positions_after = [(flake.x, flake.y) for flake in backdrop._flakes]
         text_after = str(backdrop.renderable)
-        assert positions_after != positions_before
-        assert text_after != text_before
-
-
-@pytest.mark.asyncio
-async def test_setup_backdrop_tick_wraps_flake_past_bottom_to_top():
-    app = _SnowBackdropApp(random.Random(42))
-    async with app.run_test(size=(40, 10)):
-        backdrop = app.query_one("#backdrop-under-test", ConsoleSetupBackdrop)
-        flake = backdrop._flakes[0]
-        flake.y = backdrop._field_height - 0.05
-        flake.speed = 1.0
-
-        backdrop._tick()
-
-        assert flake.y == 0.0
+        assert positions_after == positions_before
+        assert text_after == text_before
 
 
 @pytest.mark.asyncio
@@ -448,22 +438,23 @@ async def test_setup_backdrop_resize_safe_at_tiny_size():
         await pilot.resize_terminal(1, 1)
         await pilot.pause()
         assert backdrop.flake_count >= 1
-        # Must not raise even at the smallest possible field.
-        backdrop._tick()
         await pilot.resize_terminal(40, 10)
         await pilot.pause()
         assert backdrop.flake_count == 10
 
 
 @pytest.mark.asyncio
-async def test_setup_modal_snow_timer_paused_until_blocking():
+async def test_setup_modal_backdrop_never_arms_a_timer_in_any_block_state():
+    """TASK-23021 retired the snow tick outright: blocking, unblocked, and
+    re-blocked states must all leave the backdrop with zero timers (the old
+    contract paused/resumed a real interval timer across these transitions)."""
     app = _SetupModalApp(_card_state())
     async with app.run_test(size=(100, 30)) as pilot:
         backdrop = app.query_one(
             f"#{CONSOLE_SETUP_MODAL_BACKDROP_ID}", ConsoleSetupBackdrop
         )
         # _SetupModalApp.on_mount() immediately syncs card-mode (blocking).
-        assert backdrop.timer_paused is False
+        assert len(backdrop._timers) == 0
 
         modal = app.query_one("#console-setup-modal", ConsoleSetupModal)
         modal.sync_card_state(
@@ -474,7 +465,7 @@ async def test_setup_modal_snow_timer_paused_until_blocking():
             action_tooltip="Pick a model.",
         )
         await pilot.pause()
-        assert backdrop.timer_paused is True
+        assert len(backdrop._timers) == 0
 
         modal.sync_card_state(
             _card_state(),
@@ -482,43 +473,7 @@ async def test_setup_modal_snow_timer_paused_until_blocking():
             action_tooltip="Open provider settings.",
         )
         await pilot.pause()
-        assert backdrop.timer_paused is False
-
-
-@pytest.mark.asyncio
-async def test_setup_backdrop_resume_before_mount_starts_timer_running():
-    # Regression: resume_snow() called before on_mount() creates the interval
-    # timer used to be a lost intent -- on_mount() unconditionally created the
-    # timer paused, so a resume() issued against the not-yet-existing timer
-    # never took effect. The widget must remember the intent and apply it once
-    # the timer exists.
-    backdrop = ConsoleSetupBackdrop(rng=random.Random(42))
-    backdrop.resume_snow()
-
-    class _ResumeBeforeMountApp(ConsolidatedCSSApp):
-        def compose(self):
-            yield backdrop
-
-    app = _ResumeBeforeMountApp()
-    async with app.run_test(size=(40, 10)):
-        assert backdrop._snow_timer is not None
-        assert backdrop._snow_timer._active.is_set() is True
-        assert backdrop.timer_paused is False
-
-
-@pytest.mark.asyncio
-async def test_setup_backdrop_no_resume_intent_stays_paused_after_mount():
-    backdrop = ConsoleSetupBackdrop(rng=random.Random(42))
-
-    class _NoResumeApp(ConsolidatedCSSApp):
-        def compose(self):
-            yield backdrop
-
-    app = _NoResumeApp()
-    async with app.run_test(size=(40, 10)):
-        assert backdrop._snow_timer is not None
-        assert backdrop._snow_timer._active.is_set() is False
-        assert backdrop.timer_paused is True
+        assert len(backdrop._timers) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_reduced_motion.py
+++ b/Tests/UI/test_console_reduced_motion.py
@@ -1,15 +1,19 @@
 """TASK-2154.10: reduced-motion option for the setup backdrop and splash (FR-08, AC-04).
 
 `appearance.reduce_motion = true` must render the Console setup backdrop and
-the startup splash as static frames (no animation timers), while the default
-(False) keeps the existing animated behavior byte-for-byte.
+the startup splash as static frames (no animation timers). For the SPLASH the
+default (False) keeps the animated behavior. For the setup BACKDROP the
+static frame became the only presentation in TASK-23021 (the animation's
+whole-screen repaint cost ~4% of a core at idle on every new user's first
+screen), so both settings must now produce the frozen field -- the setting's
+promise holds trivially, and these tests keep it pinned.
 """
 
 import random
 from unittest.mock import patch
 
 import pytest
-from textual.app import App, ComposeResult
+from textual.app import ComposeResult
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -34,14 +38,8 @@ def _fake_cli_setting(section, key=None, default=None):
 
 
 class BackdropHarness(ConsolidatedCSSApp):
-    def __init__(self, *, reduced_motion: bool):
-        super().__init__()
-        self._reduced_motion = reduced_motion
-
     def compose(self) -> ComposeResult:
-        yield ConsoleSetupBackdrop(
-            rng=random.Random(7), reduced_motion=self._reduced_motion
-        )
+        yield ConsoleSetupBackdrop(rng=random.Random(7))
 
 
 class ModalHarness(ConsolidatedCSSApp):
@@ -81,8 +79,14 @@ def _blocking_state() -> ConsoleSetupCardState:
 
 
 @pytest.mark.asyncio
-async def test_backdrop_reduced_motion_never_runs_tick_but_renders_static_frame():
-    app = BackdropHarness(reduced_motion=True)
+async def test_backdrop_renders_static_frame_and_arms_no_timer():
+    """TASK-23021 retired the snow animation for everyone: the field is one
+    still frame per (re)size, with no timers -- which is exactly what AC-04's
+    reduced-motion presentation always was. The setting's promise (this
+    backdrop never animates under reduce_motion) therefore holds trivially,
+    and is pinned here so a re-animated backdrop cannot ship without
+    re-answering both this test and the reduce_motion contract."""
+    app = BackdropHarness()
 
     async with app.run_test(size=(80, 24)):
         backdrop = app.query_one(ConsoleSetupBackdrop)
@@ -91,53 +95,36 @@ async def test_backdrop_reduced_motion_never_runs_tick_but_renders_static_frame(
         rendered = str(backdrop.render())
         assert any(glyph in rendered for glyph in ("·", "•", "*"))
 
-        # ...but the tick timer never runs, even when the modal asks it to.
-        backdrop.resume_snow()
-        assert backdrop.timer_paused is True
-
-
-@pytest.mark.asyncio
-async def test_backdrop_default_animates_and_ticks():
-    app = BackdropHarness(reduced_motion=False)
-
-    async with app.run_test(size=(80, 24)):
-        backdrop = app.query_one(ConsoleSetupBackdrop)
-        backdrop.resume_snow()
-        assert backdrop.timer_paused is False
-
-        before = [(flake.x, flake.y) for flake in backdrop._flakes]
-        backdrop._tick()
-        after = [(flake.x, flake.y) for flake in backdrop._flakes]
-        assert before != after
+        # ...and no timer exists to ever advance it.
+        assert len(backdrop._timers) == 0
 
 
 # ---------------------------------------------------------------------------
-# ConsoleSetupModal propagation
+# ConsoleSetupModal: the reduce_motion preference is still recorded, and the
+# backdrop stays frozen in BOTH settings.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_modal_reduced_motion_propagates_to_backdrop_while_blocking():
-    app = ModalHarness(_blocking_state(), reduced_motion=True)
+@pytest.mark.parametrize("reduced_motion", [True, False])
+async def test_modal_records_preference_and_backdrop_stays_frozen(
+    reduced_motion,
+):
+    app = ModalHarness(_blocking_state(), reduced_motion=reduced_motion)
 
     async with app.run_test(size=(80, 24)):
         modal = app.query_one("#console-setup-modal", ConsoleSetupModal)
         assert modal.is_blocking
-        backdrop = app.query_one(f"#{CONSOLE_SETUP_MODAL_BACKDROP_ID}", ConsoleSetupBackdrop)
-        assert backdrop.reduced_motion is True
-        assert backdrop.timer_paused is True
-
-
-@pytest.mark.asyncio
-async def test_modal_default_motion_resumes_snow_while_blocking():
-    app = ModalHarness(_blocking_state(), reduced_motion=False)
-
-    async with app.run_test(size=(80, 24)):
-        modal = app.query_one("#console-setup-modal", ConsoleSetupModal)
-        assert modal.is_blocking
-        backdrop = app.query_one(f"#{CONSOLE_SETUP_MODAL_BACKDROP_ID}", ConsoleSetupBackdrop)
-        assert backdrop.reduced_motion is False
-        assert backdrop.timer_paused is False
+        # The ChatScreen writes this on every guidance sync; the recorded
+        # preference must round-trip even though the backdrop no longer
+        # branches on it.
+        assert modal.reduced_motion is reduced_motion
+        backdrop = app.query_one(
+            f"#{CONSOLE_SETUP_MODAL_BACKDROP_ID}", ConsoleSetupBackdrop
+        )
+        assert len(backdrop._timers) == 0
+        rendered = str(backdrop.render())
+        assert any(glyph in rendered for glyph in ("·", "•", "*"))
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_setup_backdrop_repaint_cost.py
+++ b/Tests/UI/test_console_setup_backdrop_repaint_cost.py
@@ -1,89 +1,224 @@
-"""TASK-21134 item 1: the setup-modal snow must not burn a core while idle.
+"""TASK-23021: the setup-modal snow must not repaint at idle AT ALL.
 
-The backdrop covers the whole Console screen, so every repaint re-composites
-every line of it. Measured on dev ``68c061984``: 15.8 ms of CPU per tick at
-5 Hz -- ~6-15% of a core (load-dependent), burnt continuously by every
-not-yet-configured user, against a 0.09% floor with the field frozen. Density
-and glyph count are irrelevant to that cost; only the repaint RATE and whether
-the repaint also arms a layout pass are.
+TASK-21134 made the tick itself cheap (``layout=False``, ``markup=False``,
+5 Hz -> 2.5 Hz) and the burn survived one layer down: each tick's
+``Static.update`` dirtied the full-viewport backdrop, and Textual's
+compositor re-renders every widget overlapping the dirty crop -- measured on
+the real unconfigured Console screen (TASK-23021, interleaved A/B, 15 s
+getrusage windows with no ``pilot.pause()``): 124 widget renders x 44 rows,
+13-16 ms per repaint inside ``Screen._on_timer_update``, 3.6-4.3% of a core
+at idle vs a 0.04% floor with the tick neutralised. Shrinking the dirty
+region does not help -- ``Compositor.render_partial_update`` crops to the
+*bounding box* of the dirty cells, and flakes span the field, so a
+per-cell-dirty variant measured 2.7-3.6%; even a single 3x3 repaint at the
+same 2.5 Hz measured ~0.55%. On this screen ANY repeating repaint is too
+expensive for a decoration.
 
-These tests pin the three mechanics of the fix. Each was mutation-checked
-against the pre-fix code.
+So the contract is now structural, not a rate cap: the backdrop arms no
+timers and performs no repaints between resizes -- the flake field is a
+still frame. These tests pin that, and the quit/unmount walk covers the
+timer-teardown class of bug that has broken shutdown in this repo before.
+
+Each test was mutation-checked against a deliberately re-animated build
+(a 0.4 s ``set_interval`` re-added on mount, driving a repaint of the
+field); the mutation results are recorded in the TASK-23021 notes.
 """
 
+import ast
+import asyncio
+import inspect
 import random
 
 import pytest
-from textual.app import ComposeResult
-from textual.widgets import Static
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 
+from textual.app import ComposeResult
+
+from tldw_chatbook.Chat.console_onboarding_state import (
+    ConsoleSetupCardState,
+    ConsoleSetupStep,
+)
 from tldw_chatbook.Widgets.Console import console_setup_modal as setup_modal
-from tldw_chatbook.Widgets.Console.console_setup_modal import ConsoleSetupBackdrop
+from tldw_chatbook.Widgets.Console.console_setup_modal import (
+    CONSOLE_SETUP_MODAL_BACKDROP_ID,
+    ConsoleSetupBackdrop,
+    ConsoleSetupModal,
+)
+
+#: Longer than several of the retired animation's 0.4 s tick intervals, so a
+#: re-animated mutant repaints multiple times inside the window.
+_IDLE_WINDOW_S = 1.3
 
 
 class BackdropHarness(ConsolidatedCSSApp):
     def compose(self) -> ComposeResult:
-        yield ConsoleSetupBackdrop(rng=random.Random(21134))
+        yield ConsoleSetupBackdrop(rng=random.Random(23021))
+
+
+class ModalHarness(ConsolidatedCSSApp):
+    def compose(self) -> ComposeResult:
+        yield ConsoleSetupModal(id="console-setup-modal")
+
+    async def on_mount(self) -> None:
+        self.query_one("#console-setup-modal", ConsoleSetupModal).sync_card_state(
+            ConsoleSetupCardState(
+                mode="card",
+                steps=(ConsoleSetupStep(state="active", label="Add an API key"),),
+            )
+        )
+
+
+def _count_refreshes(backdrop: ConsoleSetupBackdrop) -> list:
+    """Instrument the widget's own repaint entry point.
+
+    ``Static.update`` funnels through ``self.refresh`` and so does any
+    direct ``refresh(...)`` a re-animated implementation could issue, so an
+    instance-level wrap observes every way this widget can dirty itself.
+    """
+    calls: list = []
+    real_refresh = backdrop.refresh
+
+    def counting_refresh(*regions, **kwargs):
+        calls.append((regions, kwargs))
+        return real_refresh(*regions, **kwargs)
+
+    backdrop.refresh = counting_refresh  # type: ignore[method-assign]
+    return calls
+
+
+def test_module_defines_no_repeating_clock():
+    """Structural guard: no timer constructor may return to this module.
+
+    The retired burn arrived via ``set_interval``; ``set_timer`` chains
+    (one-shots re-arming themselves) are the census-documented way the same
+    cost gets respelled, so both are barred at the AST level.
+    """
+    source = inspect.getsource(setup_modal)
+    tree = ast.parse(source)
+    clock_calls = [
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"set_interval", "set_timer"}
+    ]
+    assert clock_calls == [], (
+        f"console_setup_modal.py grew timer constructors {clock_calls}; "
+        "TASK-23021 measured any repeating repaint of this overlay at "
+        ">=0.5% of a core -- the flake field must stay a still frame."
+    )
 
 
 @pytest.mark.asyncio
-async def test_snow_tick_repaints_without_arming_a_layout_pass(monkeypatch):
-    """A tick cannot change the field's size, so it must not request layout."""
+async def test_backdrop_mounts_no_timers_and_never_repaints_at_idle():
+    """The dirty region ends at zero: between resizes the backdrop must not
+    dirty ANYTHING -- no timers registered, no refresh calls over a window
+    longer than three of the old tick intervals (slept, not pilot-paused)."""
     app = BackdropHarness()
 
     async with app.run_test(size=(80, 24)):
         backdrop = app.query_one(ConsoleSetupBackdrop)
         assert backdrop.flake_count > 0
+        assert len(backdrop._timers) == 0
 
-        seen: list[bool] = []
-        real_update = Static.update
-
-        def recording_update(self, content="", *, layout: bool = True) -> None:
-            if self is backdrop:
-                seen.append(layout)
-            real_update(self, content, layout=layout)
-
-        monkeypatch.setattr(Static, "update", recording_update)
-
-        backdrop._tick()
-        assert seen == [False], f"tick armed a layout pass: {seen}"
-
-        # The resize path really does change the field's dimensions, so it
-        # keeps asking for layout.
-        seen.clear()
-        backdrop._resize_flake_field()
-        assert seen == [True], f"resize skipped its layout pass: {seen}"
+        calls = _count_refreshes(backdrop)
+        await asyncio.sleep(_IDLE_WINDOW_S)
+        assert calls == [], (
+            f"backdrop repainted {len(calls)} time(s) while idle: {calls[:3]}"
+        )
+        assert len(backdrop._timers) == 0
 
 
 @pytest.mark.asyncio
-async def test_snow_field_is_not_parsed_as_console_markup():
-    """The field is spaces plus three glyphs -- markup parsing is pure waste."""
+async def test_backdrop_renders_deterministic_still_frame():
+    """Seeded rng + fixed size => a deterministic flake frame that does not
+    change while mounted (the animation really is retired, not just its
+    timer detached from this widget's registry)."""
     app = BackdropHarness()
 
     async with app.run_test(size=(80, 24)):
         backdrop = app.query_one(ConsoleSetupBackdrop)
-        assert backdrop._render_markup is False
+        frame_before = str(backdrop.renderable)
+        glyph_cells = sum(frame_before.count(g) for g in ("·", "•", "*"))
+        # Two flakes can share a cell, so painted glyphs may undercount
+        # slightly -- but a blank field is a failure.
+        assert 0 < glyph_cells <= backdrop.flake_count
+        assert glyph_cells >= backdrop.flake_count // 2
+
+        await asyncio.sleep(_IDLE_WINDOW_S)
+        assert str(backdrop.renderable) == frame_before
 
 
-def test_snow_repaint_rate_is_capped_and_drift_speed_is_preserved():
-    """Interval and displacement are a matched pair, not independent knobs.
+@pytest.mark.asyncio
+async def test_resize_redraws_once_then_field_is_still_again():
+    """The one remaining repaint path is a real size change, and it may lay
+    out (the field's dimensions genuinely changed). After the resize settles
+    the field must go back to complete stillness."""
+    app = BackdropHarness()
 
-    Halving the repaint rate only helps if the per-tick displacement grows to
-    match; otherwise the fix silently slows the snow down instead of making it
-    cheaper. Both halves are asserted so neither can be changed alone.
-    """
-    interval = setup_modal._SNOW_TICK_INTERVAL
+    async with app.run_test(size=(80, 24)) as pilot:
+        backdrop = app.query_one(ConsoleSetupBackdrop)
+        count_at_80x24 = backdrop.flake_count
 
-    # Repaint-rate ceiling: the whole-screen repaint may not run faster than
-    # 2.5 Hz. The pre-fix 0.2 s (5 Hz) fails here.
-    assert interval >= 0.4, f"snow repaints at {1 / interval:.1f} Hz"
+        await pilot.resize_terminal(40, 10)
+        await pilot.pause()
+        assert backdrop.flake_count < count_at_80x24
+        assert backdrop._field_width == 40
 
-    # On-screen drift is unchanged from the original 5 Hz field: flakes still
-    # fall at 2.0-7.0 rows/s and wobble up to 2.0 columns/s.
-    assert setup_modal._SNOW_MIN_SPEED / interval == pytest.approx(2.0)
-    assert setup_modal._SNOW_MAX_SPEED / interval == pytest.approx(7.0)
-    assert setup_modal._SNOW_MAX_WOBBLE / interval == pytest.approx(2.0)
+        calls = _count_refreshes(backdrop)
+        await asyncio.sleep(_IDLE_WINDOW_S)
+        assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_blocking_modal_backdrop_is_visible_and_inert():
+    """Through the real modal (card mode): the field paints behind the card
+    and stays inert -- zero timers, zero repaints while blocking."""
+    app = ModalHarness()
+
+    async with app.run_test(size=(80, 24)):
+        modal = app.query_one("#console-setup-modal", ConsoleSetupModal)
+        assert modal.is_blocking
+        backdrop = app.query_one(
+            f"#{CONSOLE_SETUP_MODAL_BACKDROP_ID}", ConsoleSetupBackdrop
+        )
+        assert backdrop.flake_count > 0
+        assert len(backdrop._timers) == 0
+
+        calls = _count_refreshes(backdrop)
+        await asyncio.sleep(_IDLE_WINDOW_S)
+        assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_unmount_mid_display_is_clean():
+    """Removing the blocking modal (backdrop and all) mid-display must not
+    raise and must leave no orphaned timers -- the timer-teardown failure
+    class that has broken quit in this repo before."""
+    app = ModalHarness()
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        modal = app.query_one("#console-setup-modal", ConsoleSetupModal)
+        assert modal.is_blocking
+        await modal.remove()
+        await pilot.pause()
+        assert not list(app.query(ConsoleSetupBackdrop))
+        # The app is still healthy after the removal.
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_quit_mid_display_is_clean():
+    """Exiting the app while the modal is blocking (the state every
+    unconfigured user quits from) shuts down without error."""
+    app = ModalHarness()
+
+    async with app.run_test(size=(80, 24)):
+        modal = app.query_one("#console-setup-modal", ConsoleSetupModal)
+        assert modal.is_blocking
+        # Exiting the run_test context now performs the real shutdown path
+        # with the backdrop mounted; any teardown error surfaces here.
+    assert app.return_code in (None, 0)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9129,3 +9129,31 @@ prefix removed the unbounded state without weakening start anchoring. Boundary
 tests must sit immediately below and above the former cap, include a much larger
 input, and partition the opener across chunks. A test that proves memory stays
 small is incomplete until it also proves the private/public channel assignment.
+
+## Simulate a candidate fix's cost with the framework's own primitives before building it
+
+**TASK-23021, 2026-08-27.** The setup-modal snow burned 4% of a core at idle;
+TASK-21134 had already made the tick cheap and the cost hid one layer down, in
+`Screen._on_timer_update`. The filing named a plausible fix: rewrite the
+full-viewport `Static` as a `render_line` widget that dirties only changed
+cells. Instead of building it, a probe arm reproduced only its *compositor
+footprint* — advance the flake physics and call `refresh(*Region(x,y,1,1)...)`
+for the changed cells, without touching the content. Measured interleaved on
+the real screen: **2.7–3.6% vs the shipped 3.6–4.3%** — the candidate was dead
+before a line of it existed. Mechanism: Textual's
+`Compositor.render_partial_update` crops to the *bounding box* of the dirty
+regions, and `_get_renders(crop)` re-renders every widget whose clip overlaps
+that crop — scattered one-cell dirties across a full-viewport widget re-render
+the world exactly like a full-viewport dirty (124 widget renders x 44 rows both
+ways). A second simulated arm (a single 3x3 dirty at the same 2.5 Hz) priced
+the floor of ANY animation on that screen at ~0.55% — ~30 widgets stack under
+every cell of an overlay — which is what justified retiring the animation
+outright rather than optimising it.
+
+**What to do.** When a proposed perf fix changes *what gets dirtied* rather
+than *what gets computed*, the framework will usually let you dirty exactly
+that shape from the existing widget (`Widget.refresh(*regions)`) — measure
+that arm interleaved with shipped and the floor before building the rewrite.
+And when the prior fix in the same spot "worked" while the cost moved down a
+layer, instrument the layer you claim to fix (`_on_timer_update` time,
+renders-per-update), not the layer you touched.

--- a/backlog/tasks/task-23021 - Setup-modal-snow-costs-4-3-of-a-core-on-every-new-user-s-first-screen.md
+++ b/backlog/tasks/task-23021 - Setup-modal-snow-costs-4-3-of-a-core-on-every-new-user-s-first-screen.md
@@ -2,8 +2,9 @@
 id: TASK-23021
 title: >-
   Setup-modal snow costs 4.3% of a core on every new user's first screen
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-27'
 labels:
   - performance
@@ -26,11 +27,11 @@ Measured identical against the 08-24 pin, so this is pre-existing, not a delta.
 
 ## Acceptance Criteria
 
-- [ ] Idle CPU on the unconfigured first-run screen is brought near the 0.096% floor, or the decoration is retired
-- [ ] The fix addresses the whole-screen dirty, not the tick rate - lowering the rate again is explicitly not sufficient
-- [ ] Measured with an interleaved A/B, CPU sampled over a window containing no `pilot.pause()`
-- [ ] `reduce_motion` still freezes it; the setting's existing meaning is unchanged
-- [ ] What a user sees is stated plainly in the PR
+- [x] Idle CPU on the unconfigured first-run screen is brought near the 0.096% floor, or the decoration is retired
+- [x] The fix addresses the whole-screen dirty, not the tick rate - lowering the rate again is explicitly not sufficient
+- [x] Measured with an interleaved A/B, CPU sampled over a window containing no `pilot.pause()`
+- [x] `reduce_motion` still freezes it; the setting's existing meaning is unchanged
+- [x] What a user sees is stated plainly in the PR
 
 ## Evidence
 
@@ -49,3 +50,110 @@ On constrained hardware: **13-30% of a core, permanently, for a decoration.** Th
 unusually load-sensitive (both arms drifted 5->9% together under load), which is itself the warning.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Implementation Plan
+
+1. Reproduce the finding on the real unconfigured first-run screen (mounted `ChatScreen` +
+   blocking `ConsoleSetupModal` at 170x48, app-CSS tier loaded) and instrument the exact
+   mechanism: per-repaint `Screen._on_timer_update` wall time, compositor renders-per-update
+   (widgets actually re-rendered), and the dirty-region census (region count, union bbox,
+   rows, full-screen?).
+2. Measure the candidate mechanisms BEFORE choosing, interleaved in one process, 15 s
+   getrusage windows containing no `pilot.pause()`: shipped Static tick, tick-neutralised
+   floor, a per-cell-dirty "render_line" simulation (refresh only the changed 1x1 cells),
+   and a minimal 3x3-cell repaint at the same 2.5 Hz.
+3. Implement whichever mechanism the numbers support; prove where the dirty region ends
+   (dirtied-widget count per tick, before and after).
+4. Rewrite the animation-contract tests to pin the new mechanism structurally (no CPU
+   thresholds as gates); mutation-check every test against a deliberately re-animated build
+   and a deliberate teardown bug.
+5. Walk unmount/quit mid-display; keep `reduce_motion`'s meaning intact; state plainly what
+   a user sees; final interleaved A/B fixed vs legacy-emulated; preflight.
+
+## Implementation Notes
+
+**The animation is retired; the decoration stays.** The backdrop now renders its snow field
+as a STILL frame -- same dim, same density, same ·/•/* glyphs behind the Get-started card --
+drawn once per (re)size, with no timer and no repaints in between. What a user sees: the
+snow no longer drifts; everything else about the first-run screen is unchanged.
+
+**Why retirement and not a cheaper repaint -- measured, not assumed.** All probes ran on the
+real unconfigured Console (mounted ChatScreen, blocking modal, field 170x44, 141 visible
+widgets, app-CSS tier loaded), arms interleaved in ONE process, 15 s `getrusage` windows with
+no `pilot.pause()` inside. Diagnosis A/B (ABBA x3, all runs):
+
+| arm | cpu% (all runs) | per-repaint | renders/update | dirty rows |
+|---|---|---|---|---|
+| shipped Static tick | 4.280 / 3.618 / 3.743 | 13.1-15.8 ms | 124 | 44/44 |
+| tick neutralised | 0.044 / 0.040 / 0.043 | - | 0 | 0 |
+| per-cell dirty (render_line shape) | 3.359 / 2.704 / 3.632 | 9.9-13.6 ms | 124 | 43.9/44 |
+| single 3x3 repaint @2.5 Hz | 0.583 / 0.537 / 0.551 | 1.7-1.8 ms | 31 | 3 |
+
+This reproduces the review to the millisecond (15.81 ms per repaint in the first window) and
+kills the two "keep the animation" candidates named in the filing:
+
+- **Per-cell dirty regions do not end the whole-screen dirty.** Textual's
+  `Compositor.render_partial_update` crops to the *bounding box* of the dirty regions, and
+  `_get_renders(crop)` re-renders every widget whose clip overlaps that crop. Flakes span
+  the field, so the bbox stays ~full-viewport and the compositor still walks 124 widget
+  renders x 44 rows -- 2.7-3.6%, statistically the shipped burn. A `render_line` rewrite
+  would inherit exactly this footprint.
+- **Even a minimal animation cannot approach the floor.** A single 9-cell repaint at the
+  same 2.5 Hz costs ~0.55% -- ~13x the floor and ~2x the app's worst normal idle destination
+  (0.26%) -- because ~30 widgets stack under any cell of this overlay. On this screen ANY
+  repeating repaint at any useful cadence stays an order of magnitude above the floor.
+
+So the durable fix (owner ruling: stability over quick wins) is no repaint at all. The
+reduced-motion presentation (TASK-2154.10's static frame) becomes the only presentation.
+
+**Final interleaved A/B on the fixed build** (fixed vs the retired tick re-emulated
+faithfully by a probe-side 0.4 s task issuing the same full-field
+`Static.update(~8 KB, layout=False)`; ABBA x3, all runs):
+
+- legacy: 7.367 / 5.831 / 4.936 / 3.231 / 2.036 / 2.836 % (load-sensitive, as the review
+  warned -- the machine was busier in the early windows; interleaving puts that drift on
+  both arms)
+- fixed: **0.026 / 0.033 / 0.046 / 0.039 / 0.022 / 0.025 %** -- at/below the 0.096% floor
+  (below the tick-neutralised arm, since no timer fires at all)
+- dirtied-widget count per tick: **124 -> 0**; `Screen._on_timer_update` work:
+  259-1008 ms per 15 s -> **0.0 ms**; repaints per 15 s: 37 -> 0.
+
+**Changes.**
+
+- `tldw_chatbook/Widgets/Console/console_setup_modal.py`: `ConsoleSetupBackdrop` loses the
+  tick timer, physics (`speed`/`wobble`), `resume_snow`/`pause_snow`/`timer_paused`, and its
+  `reduced_motion` branch; `_SnowFlake` is position+glyph only; `_render_flakes` runs only
+  from the mount/resize path (where `layout=True` is correct). `ConsoleSetupModal` drops
+  `_sync_snow_timer`/`on_mount`; its `reduced_motion` property remains as the recorded app
+  preference the ChatScreen writes each guidance sync (meaning unchanged -- the field it
+  used to freeze is frozen for everyone).
+- `Tests/UI/test_console_setup_backdrop_repaint_cost.py`: rewritten as the TASK-23021
+  contract -- structural assertions, no CPU gates: an AST guard that the module defines no
+  `set_interval`/`set_timer`; zero timers and zero `refresh` calls over idle windows longer
+  than three old tick intervals (slept, not pilot-paused); deterministic still frame;
+  resize-then-still; the blocking-modal path; and the unmount/quit-mid-display walks.
+- `Tests/UI/test_console_reduced_motion.py`, `Tests/UI/test_console_rail_sections.py`:
+  animation-behaviour tests replaced by stillness/no-timer equivalents; the reduce_motion
+  round-trip through the modal is still pinned in both settings.
+- `Docs/User_Guide/console.md`: Get-started section now describes the still backdrop;
+  Verified-against stamp updated (mounted-harness check on the real unconfigured screen).
+
+**Mutation results.** Mutant 1 (re-animated build: 0.4 s `set_interval` re-added on mount
+driving a field repaint): **10 of the 12 snow tests fail** (AST guard, all no-timer /
+no-repaint / stillness assertions, both reduced-motion tests, both rail-sections tests);
+the 2 survivors are the lifecycle walks, which discriminate teardown bugs, so Mutant 2
+(`on_unmount` raising) was run separately: **both lifecycle tests fail**. Clean build:
+all 55 tests across the three files pass. Restores were Edit-based.
+
+**Quit walk.** `test_unmount_mid_display_is_clean` (modal.remove() while blocking) and
+`test_quit_mid_display_is_clean` (run_test teardown from the blocking state) both pass;
+with no timers left on the widget the historical timer-outlives-widget class is
+structurally impossible, and the AST guard keeps it that way.
+
+**Not adopted (pre-existing on the pristine tip, byte-identical failure sets verified via
+`git archive` tree against the same venv):** the timer-census unclassified-sites failure
+(`console_chat_store.create_kwargs` + `chat_screen._expanded_tool_output_ids` -- the known
+red), 3 `test_console_modal_dismissal` inventory failures (`AttributeError: module
+'tldw_chatbook.Image_Generation' has no attribute 'worker'` inside the launch-graph AST
+walk), and `test_product_maturity_phase1_empty_setup_states[watchlists]` (Watchlists screen
+compose `AttributeError`).

--- a/tldw_chatbook/Widgets/Console/console_setup_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_setup_modal.py
@@ -8,8 +8,11 @@ Console-scoped: it lives inside the ChatScreen (never an app-level modal), so th
 top navigation tab bar stays reachable. The modal dismisses automatically the
 moment readiness + model are satisfied (the guidance sync drives it).
 
-The backdrop itself renders a drifting snow effect (``ConsoleSetupBackdrop``,
-styled after the classic ZSNES emulator background) behind the card. Textual's
+The backdrop itself renders a still snow field (``ConsoleSetupBackdrop``,
+styled after the classic ZSNES emulator background) behind the card -- drawn
+once per (re)size, never on a clock; see the comment above
+``_SNOW_FLAKE_GLYPHS`` for the measurements that retired the animation
+(TASK-23021). Textual's
 alpha-background compositing only blends a widget's background with its
 *ancestor* style chain (see ``DOMNode.background_colors`` /
 ``Widget.opacity``) -- it does not re-composite the actual rendered pixels of
@@ -20,7 +23,7 @@ read as fully opaque), while a distinctly different token (``$background``,
 darker than the Console shell's ``$ds-surface-panel``) blended at the same
 layer produces a real, measurably darker fill. The Console workbench text
 itself cannot "show through" the overlay under this widget architecture; the
-snow backdrop is the closest achievable dim + motion flourish given that
+snow backdrop is the closest achievable dim + decoration given that
 constraint.
 """
 
@@ -34,7 +37,6 @@ from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.events import Key
-from textual.timer import Timer
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Chat.console_onboarding_state import (
@@ -62,54 +64,58 @@ _TYPING_LOCKED_HINT = (
     "Typing is locked until setup finishes — press Enter to continue setup."
 )
 
-# Snow tuning: modest density (~1 flake per 30-50 cells), gentle tick cadence,
-# varied fall speed + a little horizontal wobble so the field doesn't look
-# mechanical. Mirrors the composer cursor-blink timer discipline: created
-# paused on mount, resumed only while blocking.
+# Snow tuning: modest density (~1 flake per 40 cells). The field is a STILL
+# frame -- drawn when the widget (re)sizes, never on a clock.
 #
-# TASK-21134: the cadence was 0.2 s (5 Hz) and cost a measured 15.8 ms of CPU
-# per tick -- ~7.9% of a core, burnt at idle by every not-yet-configured user,
-# against a 0.1% floor with the field frozen. The tick is expensive because the
-# backdrop covers the whole screen, so every repaint re-composites every line
-# of it; density and glyph count are irrelevant to that cost, only the repaint
-# RATE is. Halving the rate to 0.4 s and doubling the per-tick displacement
-# keeps the flakes drifting at the same cells-per-second (2-7 rows/s) for half
-# the CPU. Displacement and interval are therefore a matched pair: changing one
-# without the other changes how fast the snow appears to fall.
-_SNOW_TICK_INTERVAL = 0.4
+# TASK-21134 halved the old tick's rate (5 Hz -> 2.5 Hz) and dropped its
+# layout pass; the tick itself got cheap (30 ms per 15 s) and the burn
+# survived one layer down. TASK-23021 measured where it lived: this backdrop
+# spans the whole Console shell, so each tick's `Static.update` dirtied a
+# full-viewport region and Textual's compositor re-rendered every widget
+# overlapping the dirty crop -- 124 widget renders x 44 rows, 13-16 ms per
+# repaint inside `Screen._on_timer_update`, 3.6-4.3% of a core at idle on the
+# first screen every new user sees, against a 0.04% floor with the tick
+# neutralised. Shrinking the dirty region does not help: Textual's
+# `Compositor.render_partial_update` crops to the *bounding box* of the dirty
+# cells, and flakes span the field, so a per-cell-dirty variant (the
+# render_line shape) measured 2.7-3.6% -- statistically the same burn. Even a
+# single 3x3-cell repaint at the same 2.5 Hz measured ~0.55%, an order of
+# magnitude above the floor, because ~30 widgets stack under any cell of this
+# overlay. On this screen ANY repeating repaint is too expensive for a
+# decoration, so the animation is retired: the flakes hold still, the field
+# re-scatters only on resize, and idle cost is zero. `appearance.
+# reduce_motion` keeps its meaning -- the field it used to freeze is now
+# frozen for everyone.
 _SNOW_FLAKE_GLYPHS = ("·", "•", "*")  # ·, •, *
 _SNOW_DENSITY_CELLS = 40
-_SNOW_MIN_SPEED = 0.8
-_SNOW_MAX_SPEED = 2.8
-_SNOW_MAX_WOBBLE = 0.8
 
 
 @dataclass
 class _SnowFlake:
-    """Mutable position/velocity state for a single falling glyph."""
+    """Position state for a single glyph in the still flake field.
+
+    Kept as a mutable dataclass (not a bare tuple) because a resize clamps
+    existing flakes into the new bounds in place, so the field stays visually
+    stable across resizes instead of re-scattering wholesale.
+    """
 
     x: float
     y: float
-    speed: float
-    wobble: float
     glyph: str
 
 
 class ConsoleSetupBackdrop(Static):
-    """Dimmed backdrop behind the setup card with a drifting snow effect.
+    """Dimmed backdrop behind the setup card with a still snow field.
 
-    Renders a grid of falling glyphs (mixed ``·`` / ``•`` / ``*``) that drift
-    downward with a slight horizontal wobble, wrapping back to the top once
-    past the bottom edge. Flake state is seeded from an injectable
+    Renders a static scatter of glyphs (mixed ``·`` / ``•`` / ``*``) over the
+    dim fill -- the ZSNES-style flourish, minus the motion (see the module
+    comment above ``_SNOW_FLAKE_GLYPHS`` for the measured reason,
+    TASK-23021). The field is (re)drawn only when the widget's size changes;
+    between resizes the widget arms no timers, performs no repaints, and
+    dirties nothing. Flake placement is seeded from an injectable
     ``random.Random`` so tests can assert deterministic frames; production
     code leaves ``rng`` unset (default-seeded, non-deterministic) since the
     effect is purely decorative.
-
-    The tick timer is created paused on mount and only resumed while the
-    owning modal is actually blocking -- no background churn while the
-    Console is idle or the modal is hidden, matching the composer cursor
-    blink timer's discipline (``set_interval(..., pause=True)``, resumed /
-    paused alongside visibility).
     """
 
     # Fallback sizing so the widget still fills its host when mounted in a
@@ -127,7 +133,6 @@ class ConsoleSetupBackdrop(Static):
         self,
         *,
         rng: random.Random | None = None,
-        reduced_motion: bool = False,
         **kwargs: Any,
     ) -> None:
         kwargs.setdefault("id", CONSOLE_SETUP_MODAL_BACKDROP_ID)
@@ -140,62 +145,20 @@ class ConsoleSetupBackdrop(Static):
         kwargs.setdefault("markup", False)
         super().__init__(**kwargs)
         self._rng = rng if rng is not None else random.Random()
-        #: TASK-2154.10 (AC-04): when True the flake field renders one static
-        #: frame per resize and the tick timer never runs -- a static dim with
-        #: the same layout instead of a full-screen animation.
-        self.reduced_motion = reduced_motion
         self._flakes: list[_SnowFlake] = []
         self._field_width = 0
         self._field_height = 0
-        self._snow_timer: Timer | None = None
-        # Intent flag: tracks whether the timer *should* be running, even
-        # before the timer object exists (on_mount() runs after __init__, so
-        # resume_snow()/pause_snow() can be called first -- see on_mount()).
-        self._snow_should_run = False
 
     @property
     def flake_count(self) -> int:
         """Number of flakes currently tracked in the field."""
         return len(self._flakes)
 
-    @property
-    def timer_paused(self) -> bool:
-        """Whether the snow-tick timer is currently paused."""
-        return not self._snow_should_run
-
     def on_mount(self) -> None:
-        self._snow_timer = self.set_interval(
-            _SNOW_TICK_INTERVAL,
-            self._tick,
-            pause=True,
-        )
-        # Apply any resume intent recorded before the timer existed -- a
-        # resume_snow() call that raced ahead of on_mount() must not be lost.
-        if self._snow_should_run:
-            self._snow_timer.resume()
         self._resize_flake_field()
 
     def on_resize(self, event: object) -> None:
         self._resize_flake_field()
-
-    def resume_snow(self) -> None:
-        """Resume the tick timer -- called while the modal is blocking."""
-        if self.reduced_motion:
-            # TASK-2154.10 (AC-04): never arm the tick under reduced motion;
-            # the flake field stays on its last statically rendered frame.
-            self._snow_should_run = False
-            if self._snow_timer is not None:
-                self._snow_timer.pause()
-            return
-        self._snow_should_run = True
-        if self._snow_timer is not None:
-            self._snow_timer.resume()
-
-    def pause_snow(self) -> None:
-        """Pause the tick timer -- called while the modal is hidden."""
-        self._snow_should_run = False
-        if self._snow_timer is not None:
-            self._snow_timer.pause()
 
     def _resize_flake_field(self) -> None:
         """Adapt the flake field to the widget's current size.
@@ -221,63 +184,36 @@ class ConsoleSetupBackdrop(Static):
             self._flakes = self._flakes[:target_count]
         else:
             while len(self._flakes) < target_count:
-                self._flakes.append(self._new_flake(seed_y=True))
+                self._flakes.append(self._new_flake())
         self._render_flakes()
 
-    def _new_flake(self, *, seed_y: bool) -> _SnowFlake:
+    def _new_flake(self) -> _SnowFlake:
         width = max(self._field_width, 1)
         height = max(self._field_height, 1)
         return _SnowFlake(
             x=self._rng.uniform(0, max(width - 1, 0)),
-            y=self._rng.uniform(0, max(height - 1, 0)) if seed_y else 0.0,
-            speed=self._rng.uniform(_SNOW_MIN_SPEED, _SNOW_MAX_SPEED),
-            wobble=self._rng.uniform(-_SNOW_MAX_WOBBLE, _SNOW_MAX_WOBBLE),
+            y=self._rng.uniform(0, max(height - 1, 0)),
             glyph=self._rng.choice(_SNOW_FLAKE_GLYPHS),
         )
 
-    def _tick(self) -> None:
-        """Advance every flake one step and repaint the field."""
-        width, height = self._field_width, self._field_height
-        if width <= 0 or height <= 0:
-            return
-        for flake in self._flakes:
-            flake.y += flake.speed
-            flake.x += flake.wobble
-            if flake.x < 0:
-                flake.x = 0.0
-                flake.wobble = abs(flake.wobble) or _SNOW_MAX_WOBBLE
-            elif flake.x > width - 1:
-                flake.x = float(width - 1)
-                flake.wobble = -(abs(flake.wobble) or _SNOW_MAX_WOBBLE)
-            if flake.y >= height:
-                # Past the bottom: wrap to the top with a fresh x so the
-                # field doesn't look like it's raining in vertical lines.
-                flake.y = 0.0
-                flake.x = self._rng.uniform(0, max(width - 1, 0))
-        self._render_flakes(layout=False)
+    def _render_flakes(self) -> None:
+        """Draw the still flake field.
 
-    def _render_flakes(self, *, layout: bool = True) -> None:
-        """Repaint the flake field.
-
-        Args:
-            layout: Whether the repaint may also change the widget's size.
-                A tick passes ``False``: the field is always exactly
-                ``_field_height`` lines of ``_field_width`` columns, so a tick
-                cannot resize it, and arming a layout pass 2.5 times a second
-                for a decoration made the Console's idle screen re-layout
-                (TASK-21134). The resize path keeps ``True`` -- there the
-                field's dimensions really did just change.
+        Reached only from the mount/resize path, where the field's dimensions
+        really did just change -- so the default ``layout=True`` of
+        ``Static.update`` is correct here, and there is no repeating caller
+        left to need the TASK-21134 ``layout=False`` opt-out.
         """
         width, height = self._field_width, self._field_height
         if width <= 0 or height <= 0:
-            self.update("", layout=layout)
+            self.update("")
             return
         rows = [[" "] * width for _ in range(height)]
         for flake in self._flakes:
             fx, fy = int(flake.x), int(flake.y)
             if 0 <= fx < width and 0 <= fy < height:
                 rows[fy][fx] = flake.glyph
-        self.update("\n".join("".join(row) for row in rows), layout=layout)
+        self.update("\n".join("".join(row) for row in rows))
 
 
 def _coerce_card_state(value: object) -> ConsoleSetupCardState:
@@ -306,7 +242,12 @@ class ConsoleSetupModal(Vertical):
         #: FR-09 (TASK-2154.8): whether the typing-locked toast already fired
         #: for the current blocking episode; re-arms when the block lifts.
         self._typing_hint_shown = False
-        #: TASK-2154.10 (AC-04): freeze the snow backdrop on a static frame.
+        #: TASK-2154.10 (AC-04): the app's `appearance.reduce_motion` setting,
+        #: written by the ChatScreen on every guidance sync. Since TASK-23021
+        #: the snow backdrop renders a still frame for everyone, so the flag
+        #: no longer changes what this modal paints -- it is kept as the
+        #: recorded preference (and the conduit, should animation ever
+        #: return) rather than silently dropped from the screen's sync path.
         self._reduced_motion = False
         # Hidden until a card-mode state is synced in.
         self.display = False
@@ -318,22 +259,18 @@ class ConsoleSetupModal(Vertical):
 
     @property
     def reduced_motion(self) -> bool:
-        """Whether the snow backdrop renders statically (no animation)."""
+        """The recorded `appearance.reduce_motion` preference.
+
+        The snow backdrop is a still frame for everyone since TASK-23021, so
+        this no longer selects between an animated and a static presentation
+        -- see the attribute comment in ``__init__``.
+        """
         return self._reduced_motion
 
     @reduced_motion.setter
     def reduced_motion(self, value: bool) -> None:
-        """Set reduced motion, propagating to the mounted backdrop if any."""
+        """Record the app's reduced-motion preference."""
         self._reduced_motion = bool(value)
-        if not self.is_mounted:
-            return
-        try:
-            backdrop = self.query_one(
-                f"#{CONSOLE_SETUP_MODAL_BACKDROP_ID}", ConsoleSetupBackdrop
-            )
-        except Exception:
-            return
-        backdrop.reduced_motion = self._reduced_motion
 
     @property
     def is_blocking(self) -> bool:
@@ -405,25 +342,6 @@ class ConsoleSetupModal(Vertical):
             detected.display = blocking and self._detected_action is not None
             yield detected
 
-    def on_mount(self) -> None:
-        self._sync_snow_timer()
-
-    def _sync_snow_timer(self) -> None:
-        """Resume the backdrop's snow tick only while actually blocking."""
-        try:
-            backdrop = self.query_one(
-                f"#{CONSOLE_SETUP_MODAL_BACKDROP_ID}", ConsoleSetupBackdrop
-            )
-        except Exception:
-            return
-        backdrop.reduced_motion = self._reduced_motion
-        if self.is_blocking:
-            # resume_snow() itself is a no-op under reduced motion; the static
-            # frame from the last resize stays up either way.
-            backdrop.resume_snow()
-        else:
-            backdrop.pause_snow()
-
     def sync_card_state(
         self,
         card_state: ConsoleSetupCardState,
@@ -456,7 +374,6 @@ class ConsoleSetupModal(Vertical):
         self.display = blocking
         if not self.is_mounted:
             return
-        self._sync_snow_timer()
         for index in range(1, CONSOLE_SETUP_MODAL_STEP_COUNT + 1):
             step = self._step_at(index)
             try:


### PR DESCRIPTION
## Summary

The setup-modal snow burned **4.33% of a core at idle** — 13–30% on constrained hardware — on the
screen every new user lands on, before they type anything. It is now a **still frame**: same dimmed
backdrop, same scattered flakes, no drift, no timer, zero repaints between resizes.
Finding 23021 of the [2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md).

Idle CPU: **4.3% → 0.026–0.046%** (all runs reported; at or below the 0.096% neutralised floor).
Dirtied widgets per tick **124 → 0**. `_on_timer_update` **259–1,008 ms per 15 s → 0.0 ms**.

## Why retire the animation instead of making it cheaper — measured, not argued

TASK-21134 already halved the tick rate and set `layout=False`; both fixes were intact and
irrelevant, because the cost was never the tick — it was the repaint: a full-viewport `Static`
whose update dirties the whole 483-widget screen at 13–16 ms per repaint.

**The obvious better fix was simulated before being built, and it is dead.** A `render_line`-style
per-cell-dirty candidate was emulated with `refresh(*regions)` against the real compositor:

| candidate | CPU% (all runs) | widgets re-rendered per update |
|---|---|---|
| shipped `Static` tick | 4.28 / 3.62 / 3.74 | 124 |
| **per-cell dirty (render_line, simulated)** | **3.36 / 2.70 / 3.63** | **124** |
| single 3×3 repaint @2.5 Hz | 0.58 / 0.54 / 0.55 | 31 |
| no animation | 0.044 / 0.040 / 0.043 | 0 |

`Compositor.render_partial_update` crops to the **bounding box** of the dirty regions and
re-renders every widget overlapping it — scattered 1×1 dirties across a full-viewport widget
re-render the world. Even a 9-cell repaint at 2.5 Hz costs ~13× the floor, because ~30 widgets
stack under any cell. **No animated variant gets near the floor**, so the animation was retired
rather than optimised. This time the layer that hid the prior fix's cost was instrumented
directly — `_on_timer_update` wall time and renders-per-update, before and after.

## What a user sees

The same decoration, still instead of drifting; the field re-scatters on window resize.
`reduce_motion` keeps its meaning (the field it used to freeze is now frozen for everyone — pinned
under both settings by test). `Docs/User_Guide/console.md` updated with a fresh Verified-against
stamp.

## Lifecycle: the hazard class is now structurally impossible

The tick timer, physics, pause/resume plumbing and the modal's `_sync_snow_timer` are deleted.
With zero timers, the timer-outlives-widget class that has broken quit three times in this repo
cannot occur here — and an **AST guard** bars its return: re-adding a `set_interval` to the backdrop
fails 10 of 12 snow tests. Unmount-mid-display and quit-mid-display both walked and pinned.

## Mutation

- 0.4 s `set_interval` re-added driving a repaint → **10/12 snow tests fail**
- `on_unmount` raising → both lifecycle walks fail
Restores Edit-based.

## Verification

Rewritten suites **55 passed** (repaint-cost contract 7, reduced-motion 5, rail-sections 43); wider
modal-exercising batches 256 + 473 passed; collect-only sweep 63,287 / 0 errors; preflight green.
Every observed red proven byte-identical on a `git archive` pristine-tip tree.

A lesson is recorded: **simulate a candidate fix's dirty footprint with `refresh(*regions)` before
building it** — it killed this task's obvious better fix in an afternoon instead of a week.

## Out of scope — pre-existing dev reds worth filing

- 3× `test_console_modal_dismissal` inventory tests: `AttributeError: module
  'tldw_chatbook.Image_Generation' has no attribute 'worker'` in the launch-graph AST walk.
- 11× `test_console_internals_decomposition` (control-bar/RAG-action family), 4×
  `test_console_live_work_handoffs`, 1× product-maturity `[watchlists]` (Watchlists screen compose
  `AttributeError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the setup-modal snow animation to a still frame. The animation burned ~4.3% of a core at idle on every new user's first screen; the still frame keeps the same dimmed, flake-scattered backdrop at ~0.03% idle CPU.

- Users see the same decoration minus drift; the field re-scatters only on window resize.
- `reduce_motion` keeps its meaning — the field it used to freeze is now frozen for everyone.
- Cheaper animation variants were measured before retiring it: per-cell dirty regions still re-render the whole overlay (2.7–3.6%), and a single 3×3 repaint at 2.5 Hz cost ~0.55%, so no animated variant approaches the floor.
- The tick timer, physics, and pause/resume plumbing are deleted, making the timer-outlives-widget bug class structurally impossible.
- An AST guard fails 10 of 12 snow tests if `set_interval` or `set_timer` returns to the backdrop module.
- The repaint-cost, reduced-motion, and rail-section suites were rewritten to assert zero timers and zero repaints while idle; 55 tests pass plus 729 in wider batches.
- Pre-existing failures in the dismissal, decomposition, and watchlists suites are untouched and documented in the task ticket.

<sup>Written for commit cc396600595347707ba48cdc1d95cb4003f06ac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

