### PR TITLE
perf(research): grow the source/receipt slot pools on demand (TASK-23024)

### DIFF
--- a/Docs/User_Guide/research_workspace.md
+++ b/Docs/User_Guide/research_workspace.md
@@ -186,5 +186,7 @@ Grounded Chat exposes a canonical message owner.
   records the authority, canonical-owner, overlay, and unlink boundaries.
 
 —
-*Verified against `codex/research-workspace` — 2026-08-24. Targeted Research
-Workspace verification was run; the full pytest suite was not run.*
+*Verified against `fix/task-23024` — 2026-08-27. Targeted Research
+Workspace verification was run (source rows and operation receipts now
+mount as data arrives rather than as pre-built empty pools — no visible
+behavior change); the full pytest suite was not run.*

--- a/Tests/UI/test_research_slot_pool_growth.py
+++ b/Tests/UI/test_research_slot_pool_growth.py
@@ -1,0 +1,367 @@
+"""Demand-grown Research slot pools: empty is free, max still recycles.
+
+TASK-23024: `ResearchSourceList` / `ResearchSourceReceiptList` used to
+compose their full 25/20 slot pools eagerly, so an empty Research profile
+mounted ~470 widgets in `display=False` subtrees on every visit. The pools
+now start empty and grow with content; these tests pin the growth contract
+and — because the pool exists to avoid mount/unmount churn — that recycling
+at the maximum row count still mounts and unmounts nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+import textual.widget as textual_widget_module
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Research_Workspace import (
+    QualifiedWorkspaceRef,
+    ResearchCapability,
+    ResearchSourcePage,
+    ResearchSourceSummary,
+    WorkspaceDataSource,
+)
+from tldw_chatbook.Research_Workspace.source_operations import (
+    CanonicalItemType,
+    ResearchSourceOperation,
+    SourceOperationStage,
+    SourceOperationStatus,
+)
+from tldw_chatbook.UI.Research_Workspace_Modules.source_list import (
+    MAX_VISIBLE_SOURCE_ROWS,
+    ResearchSourceList,
+    _ResearchSourceRowSlot,
+)
+from tldw_chatbook.UI.Research_Workspace_Modules.source_receipt import (
+    MAX_VISIBLE_SOURCE_RECEIPTS,
+    ResearchSourceReceiptList,
+    _ResearchSourceReceiptSlot,
+)
+from tldw_chatbook.UI.Research_Workspace_Modules.sources_region import (
+    ResearchSourcesRegion,
+)
+
+
+REF = QualifiedWorkspaceRef(WorkspaceDataSource.LOCAL, "workspace-local")
+AVAILABLE = ResearchCapability(True, "available", "Available.", "local")
+
+
+class _RegionHarness(App[None]):
+    def compose(self) -> ComposeResult:
+        yield ResearchSourcesRegion(id="research-sources-pane")
+
+
+def _page(tag: str, rows: int, *, desired: tuple[str, ...] = ()) -> ResearchSourcePage:
+    items = tuple(
+        ResearchSourceSummary(
+            ref=REF,
+            source_id=f"membership-{tag}-{index}",
+            catalog_item_id=f"{tag}-{index}",
+            title=f"Source {tag} {index}",
+            source_type="pdf",
+            updated_at="2026-08-24T00:00:00Z",
+        )
+        for index in range(rows)
+    )
+    return ResearchSourcePage(
+        items=items, limit=rows or 1, total=rows, desired_source_ids=desired
+    )
+
+
+def _operations(tag: str, count: int) -> tuple[ResearchSourceOperation, ...]:
+    return tuple(
+        ResearchSourceOperation(
+            operation_id=f"operation-{tag}-{index}",
+            idempotency_key=f"probe:{tag}:{index}",
+            data_source=WorkspaceDataSource.LOCAL,
+            workspace_id="workspace-local",
+            canonical_item_type=CanonicalItemType.LOCAL_LIBRARY,
+            desired_selected=True,
+            created_at="2026-08-24T12:00:00Z",
+            updated_at="2026-08-24T12:00:00Z",
+            ingest_job_id=f"job-{tag}-{index}",
+            canonical_item_id=f"{tag}-{index}",
+            workspace_source_id=f"membership-{tag}-{index}",
+            catalog_status=SourceOperationStatus.SUCCEEDED,
+            association_status=SourceOperationStatus.SUCCEEDED,
+            readiness_status=SourceOperationStatus.FAILED,
+            error_stage=SourceOperationStage.READINESS,
+            error_code="readiness_refresh_failed",
+            error_message="Readiness could not be refreshed.",
+            revision=1,
+        )
+        for index in range(count)
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_profile_mounts_zero_row_and_receipt_slots() -> None:
+    """An unused Research profile pays for no slot widgets at all."""
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        source_list = app.query_one(ResearchSourceList)
+        receipts = app.query_one(ResearchSourceReceiptList)
+
+        assert len(list(source_list.query(_ResearchSourceRowSlot))) == 0
+        assert len(list(source_list.children)) == 0
+        assert len(list(receipts.query(_ResearchSourceReceiptSlot))) == 0
+        # The receipt frame is intact without any slots: heading then bound.
+        child_ids = [child.id for child in receipts.children]
+        assert child_ids == [
+            "research-source-receipts-heading",
+            "research-source-receipts-bound",
+        ]
+        assert "0 recent operation(s)." in str(
+            receipts.query_one("#research-source-receipts-bound", Static).render()
+        )
+
+
+@pytest.mark.asyncio
+async def test_slot_pool_grows_with_content_and_is_capped_at_max() -> None:
+    """Slots mounted == min(rows, MAX); contents land in the grown slots."""
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        source_list = app.query_one(ResearchSourceList)
+
+        source_list.sync_page(_page("small", 3))
+        await pilot.pause()
+        assert len(list(source_list.query(_ResearchSourceRowSlot))) == 3
+        assert "Source small 2" in str(
+            source_list.query_one("#research-source-row-title-2", Static).render()
+        )
+
+        source_list.sync_page(_page("big", MAX_VISIBLE_SOURCE_ROWS + 5))
+        await pilot.pause()
+        slots = list(source_list.query(_ResearchSourceRowSlot))
+        assert len(slots) == MAX_VISIBLE_SOURCE_ROWS
+        assert all(slot.display for slot in slots)
+        last = MAX_VISIBLE_SOURCE_ROWS - 1
+        assert f"Source big {last}" in str(
+            source_list.query_one(
+                f"#research-source-row-title-{last}", Static
+            ).render()
+        )
+
+
+@pytest.mark.asyncio
+async def test_page_swaps_at_max_recycle_without_mount_churn() -> None:
+    """At MAX rows, paging constructs and unmounts nothing (the pool's job)."""
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        source_list = app.query_one(ResearchSourceList)
+        receipts = app.query_one(ResearchSourceReceiptList)
+        source_list.sync_page(_page("seed", MAX_VISIBLE_SOURCE_ROWS))
+        receipts.sync_operations(
+            _operations("seed", MAX_VISIBLE_SOURCE_RECEIPTS), incomplete=False
+        )
+        await pilot.pause()
+
+        slots_before = list(source_list.query(_ResearchSourceRowSlot))
+        receipt_slots_before = list(receipts.query(_ResearchSourceReceiptSlot))
+        assert len(slots_before) == MAX_VISIBLE_SOURCE_ROWS
+        assert len(receipt_slots_before) == MAX_VISIBLE_SOURCE_RECEIPTS
+
+        constructed = {"count": 0}
+        original_init = textual_widget_module.Widget.__init__
+
+        def counting_init(self, *args, **kwargs):
+            constructed["count"] += 1
+            original_init(self, *args, **kwargs)
+
+        textual_widget_module.Widget.__init__ = counting_init
+        try:
+            for swap in range(5):
+                source_list.sync_page(
+                    _page(f"swap{swap}", MAX_VISIBLE_SOURCE_ROWS)
+                )
+                receipts.sync_operations(
+                    _operations(f"swap{swap}", MAX_VISIBLE_SOURCE_RECEIPTS),
+                    incomplete=False,
+                )
+                await pilot.pause()
+        finally:
+            textual_widget_module.Widget.__init__ = original_init
+
+        assert constructed["count"] == 0
+        slots_after = list(source_list.query(_ResearchSourceRowSlot))
+        receipt_slots_after = list(receipts.query(_ResearchSourceReceiptSlot))
+        # Identity-stable: the same slot objects, still mounted, same order.
+        assert [id(slot) for slot in slots_after] == [
+            id(slot) for slot in slots_before
+        ]
+        assert [id(slot) for slot in receipt_slots_after] == [
+            id(slot) for slot in receipt_slots_before
+        ]
+        # And they carry the LAST swap's data — recycled, not stale.
+        assert "Source swap4 0" in str(
+            source_list.query_one("#research-source-row-title-0", Static).render()
+        )
+        assert "operation-swap4-0" in str(
+            receipts.query_one(
+                "#research-source-receipt-owner-0", Static
+            ).render()
+        )
+
+
+@pytest.mark.asyncio
+async def test_shrink_recycles_slots_via_display_false_not_unmount() -> None:
+    """A smaller page hides surplus slots; it never unmounts them."""
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        source_list = app.query_one(ResearchSourceList)
+        source_list.sync_page(_page("fill", MAX_VISIBLE_SOURCE_ROWS))
+        await pilot.pause()
+
+        source_list.sync_page(_page("less", 3))
+        await pilot.pause()
+        slots = list(source_list.query(_ResearchSourceRowSlot))
+        assert len(slots) == MAX_VISIBLE_SOURCE_ROWS
+        assert [slot.display for slot in slots] == [True] * 3 + [False] * (
+            MAX_VISIBLE_SOURCE_ROWS - 3
+        )
+        assert "Source less 0" in str(
+            source_list.query_one("#research-source-row-title-0", Static).render()
+        )
+
+        source_list.sync_page(None)
+        await pilot.pause()
+        slots = list(source_list.query(_ResearchSourceRowSlot))
+        assert len(slots) == MAX_VISIBLE_SOURCE_ROWS
+        assert not any(slot.display for slot in slots)
+
+
+@pytest.mark.asyncio
+async def test_receipt_slots_mount_before_bound_disclosure() -> None:
+    """Grown receipt slots keep child order: heading, receipts…, bound."""
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        receipts = app.query_one(ResearchSourceReceiptList)
+        receipts.sync_operations(_operations("first", 2), incomplete=False)
+        await pilot.pause()
+        # Grow again to prove later batches also land before the bound line.
+        receipts.sync_operations(
+            _operations("more", MAX_VISIBLE_SOURCE_RECEIPTS + 5), incomplete=False
+        )
+        await pilot.pause()
+
+        child_ids = [child.id for child in receipts.children]
+        assert child_ids[0] == "research-source-receipts-heading"
+        assert child_ids[-1] == "research-source-receipts-bound"
+        assert child_ids[1:-1] == [
+            f"research-source-receipt-{index}"
+            for index in range(MAX_VISIBLE_SOURCE_RECEIPTS)
+        ]
+        assert "More receipts may exist" in str(
+            receipts.query_one("#research-source-receipts-bound", Static).render()
+        )
+
+
+@pytest.mark.asyncio
+async def test_dom_order_matches_slot_index_order_across_growth_steps() -> None:
+    """Two growth steps still yield index order 0..N-1 in the DOM.
+
+    `ResearchSourcesRegion.visible_owner_ids`/`selected_source_ids` pair DOM
+    query order with page-row order, so out-of-order growth would silently
+    mis-attribute selections.
+    """
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        source_list = app.query_one(ResearchSourceList)
+        source_list.sync_page(_page("step1", 10))
+        await pilot.pause()
+        source_list.sync_page(_page("step2", MAX_VISIBLE_SOURCE_ROWS))
+        await pilot.pause()
+
+        indexes = [
+            slot.index for slot in source_list.query(_ResearchSourceRowSlot)
+        ]
+        assert indexes == list(range(MAX_VISIBLE_SOURCE_ROWS))
+        titles = [
+            str(
+                source_list.query_one(
+                    f"#research-source-row-title-{index}", Static
+                ).render()
+            )
+            for index in (0, 9, 10, MAX_VISIBLE_SOURCE_ROWS - 1)
+        ]
+        assert "Source step2 0" in titles[0]
+        assert "Source step2 9" in titles[1]
+        assert "Source step2 10" in titles[2]
+        assert f"Source step2 {MAX_VISIBLE_SOURCE_ROWS - 1}" in titles[3]
+
+
+@pytest.mark.asyncio
+async def test_selection_reads_are_synchronous_with_first_growth() -> None:
+    """The region's selection reads see fresh rows in the same message turn.
+
+    `_render_page` calls `sync_page` and then `_sync_capabilities()` (which
+    reads `selected_source_ids()`) synchronously, so slot-level state must
+    be readable before the newly grown slots' subtrees finish mounting.
+    """
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        region = app.query_one(ResearchSourcesRegion)
+        region.sync_workspace(
+            _page("sync", 2, desired=("sync-0",)),
+            readiness=(),
+            capabilities={
+                "set_selected_scope": AVAILABLE,
+                "preview_source": AVAILABLE,
+                "remove_source": AVAILABLE,
+            },
+            folders=(),
+            operations=(),
+        )
+        # Deliberately NO pilot.pause() here: this is the synchronous
+        # contract production relies on.
+        assert region.visible_owner_ids() == ("sync-0", "sync-1")
+        assert region.selected_source_ids() == ("membership-sync-0",)
+        assert not region.query_one(
+            "#research-source-preview-selected", Button
+        ).disabled
+
+
+@pytest.mark.asyncio
+async def test_unmount_and_quit_mid_growth_are_safe() -> None:
+    """Removing the list (or quitting) right after a growth sync cannot crash."""
+
+    app = _RegionHarness()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        source_list = app.query_one(ResearchSourceList)
+        source_list.sync_page(_page("grow", MAX_VISIBLE_SOURCE_ROWS))
+        # Remove in the same message turn as the growth mount.
+        await source_list.remove()
+        await pilot.pause()
+        # A post-removal sync must still be inert, not an exception.
+        source_list.sync_page(_page("after", 5))
+        await pilot.pause()
+        assert app.query(ResearchSourceList).nodes == []
+
+    # Quit walk: exit the app in the same turn as a fresh growth sync.
+    app2 = _RegionHarness()
+    async with app2.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        receipts = app2.query_one(ResearchSourceReceiptList)
+        app2.query_one(ResearchSourceList).sync_page(
+            _page("quit", MAX_VISIBLE_SOURCE_ROWS)
+        )
+        receipts.sync_operations(
+            _operations("quit", MAX_VISIBLE_SOURCE_RECEIPTS), incomplete=False
+        )
+        # No pause: run_test teardown happens with the mounts still pending.

--- a/Tests/UI/test_research_source_receipt.py
+++ b/Tests/UI/test_research_source_receipt.py
@@ -109,6 +109,9 @@ async def test_enabled_receipt_retry_emits_exact_operation_and_failed_stage() ->
         await pilot.pause()
         receipts = app.query_one(ResearchSourceReceiptList)
         receipts.sync_operations((_operation(),), incomplete=False)
+        # TASK-23024: the first sync mounts the demand-grown slot; let it
+        # settle before pressing the retry button inside it.
+        await pilot.pause()
         receipts.query_one("#research-source-receipt-retry-0", Button).press()
         await pilot.pause()
 

--- a/Tests/UI/test_research_sources_region.py
+++ b/Tests/UI/test_research_sources_region.py
@@ -50,8 +50,10 @@ async def test_sources_region_mounts_complete_control_inventory_once() -> None:
         await pilot.pause()
         mounted_seconds = monotonic() - started
         region = app.query_one(ResearchSourcesRegion)
-        assert len(list(region.query("_ResearchSourceRowSlot"))) == 25
-        assert len(list(region.walk_children())) < 650
+        # TASK-23024: the slot pool grows with content; an empty profile
+        # composes zero row slots (they used to be 25 eager slots).
+        assert len(list(region.query("_ResearchSourceRowSlot"))) == 0
+        assert len(list(region.walk_children())) < 200
         assert mounted_seconds < 1.0
 
         expected_ids = {
@@ -288,6 +290,9 @@ async def test_row_owner_actions_follow_typed_capabilities() -> None:
                 "remove_source": unavailable,
             },
         )
+        # TASK-23024: the first sync mounts the demand-grown slot; let the
+        # mount settle before querying the slot's children.
+        await pilot.pause()
 
         assert source_list.query_one("#research-source-row-preview-0", Button).disabled
         assert source_list.query_one("#research-source-row-remove-0", Button).disabled
@@ -325,6 +330,8 @@ async def test_enabled_row_controls_emit_exact_owner_actions() -> None:
                 "reorder_sources": available,
             },
         )
+        # TASK-23024: let the demand-grown slots finish mounting first.
+        await pilot.pause()
         for widget_id in (
             "research-source-row-select-0",
             "research-source-row-details-0",
@@ -568,7 +575,6 @@ async def test_filters_sort_and_folder_focus_update_stable_rows_without_recompos
         await pilot.pause()
         region = app.query_one(ResearchSourcesRegion)
         source_list = region.query_one("#research-source-list", ResearchSourceList)
-        first_slot = source_list.query_one("#research-source-row-0")
         region.sync_workspace(
             page,
             readiness=(),
@@ -578,6 +584,11 @@ async def test_filters_sort_and_folder_focus_update_stable_rows_without_recompos
             ),
             operations=(),
         )
+        # TASK-23024: slots mount on the first sync; capture the first slot
+        # once it exists so the stable-row identity assertion below still
+        # proves page refreshes never rebuild the region.
+        await pilot.pause()
+        first_slot = source_list.query_one("#research-source-row-0")
         region.query_one("#research-source-sort", Select).value = "title_asc"
         await pilot.pause()
         assert "Alpha" in str(

--- a/backlog/tasks/task-23024 - Research-workspace-composes-693-widgets-per-visit-79-of-them-never-painted.md
+++ b/backlog/tasks/task-23024 - Research-workspace-composes-693-widgets-per-visit-79-of-them-never-painted.md
@@ -2,8 +2,9 @@
 id: TASK-23024
 title: >-
   Research workspace composes 693 widgets per visit, 79% of them never painted
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-27'
 labels:
   - performance
@@ -28,10 +29,45 @@ pay the maximum case, on every visit. Screens are never cached, so this is paid 
 
 ## Acceptance Criteria
 
-- [ ] Widgets composed on an empty profile scale with content, not with the maximum
-- [ ] Widget count per visit and recompose wall time measured before and after, interleaved
-- [ ] Scrolling and row recycling still work at the maximum row count - the pool exists to avoid mount/unmount churn and that benefit must survive
-- [ ] The `display=False` proportion is reported after the change
+- [x] Widgets composed on an empty profile scale with content, not with the maximum
+- [x] Widget count per visit and recompose wall time measured before and after, interleaved
+- [x] Scrolling and row recycling still work at the maximum row count - the pool exists to avoid mount/unmount churn and that benefit must survive
+- [x] The `display=False` proportion is reported after the change
+
+## Implementation Plan
+
+1. Verify the finding's numbers on base c4e52794e2 with a config-isolated probe
+   (real `ResearchWorkspaceScreen` under the bundled production stylesheet):
+   widgets constructed per visit, mounted total, display=False proportion,
+   whole-screen recompose wall time.
+2. Convert both eager slot pools to demand-grown pools with a zero floor:
+   - `source_list.py`: `ResearchSourceList` composes no slots; `sync_page`
+     grows the pool to `min(len(rows), MAX_VISIBLE_SOURCE_ROWS)` and never
+     shrinks it (recycling above the floor is unchanged — surplus slots go
+     `display=False`).
+   - `source_receipt.py`: same shape; receipt slots mount before the bound
+     disclosure `Static` so child order is preserved.
+   - Slots keep direct references to their child widgets (built at
+     construction) so `sync_source`/`sync_operation` stay synchronous even
+     while the slot's subtree is still mounting; this also deletes 13
+     `query_one` calls per row sync.
+3. Update the three existing UI test files where they pin the eager pool
+   (the `== 25` inventory assertion) or query slot internals in the same
+   message-loop turn as the first growth (add a `pilot.pause()` — a frame has
+   to paint before a user could interact anyway).
+4. New regression tests, each proven to fail against a deliberately broken
+   implementation (eager pool restored; growth capped below demand; receipts
+   mounted after the bound Static; pool shrunk on smaller pages): empty case
+   composes zero slots; growth tracks demand exactly; slot identity is stable
+   across page swaps at the max (no mount/unmount churn); shrink recycles via
+   display=False; DOM order matches index order; synchronous
+   `visible_owner_ids`/`selected_source_ids` contract; unmount/quit walk
+   mid-growth.
+5. Interleaved A/B measurement (base modules injected from the pinned commit
+   vs the fixed tree, alternating arms + A/A control), churn counts during
+   page swaps at 25 rows before vs after, and the display=False proportion
+   after the change.
+6. Preflight, targeted suites, task bookkeeping, commit.
 
 ## Evidence
 
@@ -40,3 +76,55 @@ Composition measured: 265 Buttons, 201 Statics, 91 Horizontals. Recompose 1735/1
 trials.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Implementation Notes
+
+Both eager slot pools now start empty and grow on demand:
+`ResearchSourceList` composes zero slots and `sync_page` grows the pool to
+`min(len(rows), MAX_VISIBLE_SOURCE_ROWS)`; `ResearchSourceReceiptList` does
+the same up to `MAX_VISIBLE_SOURCE_RECEIPTS`, mounting new slots before the
+bounded-result disclosure so child order stays heading, receipts…, bound.
+Pools never shrink — surplus slots recycle via `display = False` exactly as
+before, so paging at the maximum still mounts/unmounts nothing. Slots keep
+direct references to their child widgets (built at construction), which
+keeps `sync_source`/`sync_operation` synchronous while a fresh slot's
+subtree is still mounting, preserves the region's same-turn
+`selected_source_ids()`/`visible_owner_ids()` contract, and deletes 13
+`query_one` calls per row sync.
+
+Measured on the real screen under the production bundled stylesheet
+(config-isolated subprocess probe; base arm = the two pinned-commit modules
+injected into `sys.modules`, arms interleaved in both orders plus an A/A
+control). Deterministic axes, byte-stable across every run:
+
+- Widgets constructed per visit (empty profile): **694 → 199 (−71%)**;
+  mounted under the screen 691 → 196.
+- `display=False` subtree share on an empty visit: **578/691 (83.6%) →
+  83/196 (42.3%)**; at 25 rows + 20 receipts both builds converge to the
+  identical 691-widget DOM (43/691 = 6.2% hidden).
+- Churn during 10 page+receipt swaps at the maximum with scrolling:
+  0 constructions, 0 unregistrations, widget identity set unchanged — in
+  BOTH arms.
+
+Whole-screen recompose (wall time; A/A noise floor on this machine was
+1166–2154 ms across consecutive identical base runs, so the ratio is the
+honest number): base 986–2154 ms vs fixed 241–667 ms in the quiet windows,
+3275–4709 ms vs 830–1274 ms in a loaded window — **~3–4x faster in every
+interleaved pairing, both orders**. The one-time first fill (0→25 rows +
+20 receipts) pays the growth the eager pool used to pay per visit
+(~380–435 ms call vs ~93–161 ms, quiet window); steady-state swap syncs
+overlap between arms (14–36 ms means).
+
+Every new test in `Tests/UI/test_research_slot_pool_growth.py` was proven
+to fail against at least one deliberately broken implementation (eager
+pools restored; growth capped below demand; receipts mounted after the
+bound Static; shrink unmounting the pool; slot state dropped for unmounted
+slots; the naive query_one-based sync, which crashes mid-growth). Existing
+tests updated only where they pinned the eager pool (`== 25`) or queried a
+grown slot's children in the same message-loop turn as the first growth.
+
+Modified: `tldw_chatbook/UI/Research_Workspace_Modules/source_list.py`,
+`source_receipt.py`; `Tests/UI/test_research_sources_region.py`,
+`test_research_source_receipt.py`; `Docs/User_Guide/research_workspace.md`
+(stamp). Added: `Tests/UI/test_research_slot_pool_growth.py` (8 tests).
+47/47 research-UI tests pass; preflight green.

--- a/tldw_chatbook/UI/Research_Workspace_Modules/source_list.py
+++ b/tldw_chatbook/UI/Research_Workspace_Modules/source_list.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from textual import on
-from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.widgets import Button, Static
@@ -31,61 +30,92 @@ def _desired_owner_id(source: ResearchSourceSummary) -> str:
 
 
 class _ResearchSourceRowSlot(Vertical):
+    """One recyclable source row.
+
+    The child widgets are built at construction and kept as direct
+    references, so ``sync_source`` stays synchronous (and cheap) even while
+    the slot's subtree is still being mounted by the message loop
+    (TASK-23024): slots are mounted on demand as rows arrive, and the first
+    ``sync_source`` for a fresh slot runs before its children hit the DOM.
+    """
+
     def __init__(self, index: int) -> None:
-        super().__init__(id=f"research-source-row-{index}")
+        title = Static("", id=f"research-source-row-title-{index}")
+        select = Button(
+            "Select",
+            id=f"research-source-row-select-{index}",
+            compact=True,
+        )
+        badges = Static("", id=f"research-source-row-badges-{index}")
+        selection = Static("", id=f"research-source-row-selection-{index}")
+        readiness = Static("", id=f"research-source-row-readiness-{index}")
+        details = Button(
+            "Details", id=f"research-source-row-details-{index}", compact=True
+        )
+        folders = Button(
+            "Folders", id=f"research-source-row-folders-{index}", compact=True
+        )
+        preview = Button(
+            "Preview / annotate",
+            id=f"research-source-row-preview-{index}",
+            compact=True,
+        )
+        move_copy = Button(
+            "Move / Copy",
+            id=f"research-source-row-copy-{index}",
+            compact=True,
+            disabled=True,
+        )
+        up = Button(
+            "^",
+            id=f"research-source-row-up-{index}",
+            name="Move source up",
+            tooltip="Move source up",
+            compact=True,
+            disabled=True,
+        )
+        down = Button(
+            "v",
+            id=f"research-source-row-down-{index}",
+            name="Move source down",
+            tooltip="Move source down",
+            compact=True,
+            disabled=True,
+        )
+        remove = Button(
+            "Remove", id=f"research-source-row-remove-{index}", compact=True
+        )
+        super().__init__(
+            Horizontal(title, select, classes="research-source-row-heading"),
+            badges,
+            selection,
+            readiness,
+            Horizontal(
+                details,
+                folders,
+                preview,
+                move_copy,
+                up,
+                down,
+                remove,
+                classes="research-source-row-actions",
+            ),
+            id=f"research-source-row-{index}",
+        )
         self.index = index
         self.source: ResearchSourceSummary | None = None
         self.desired_owner_id = ""
         self.desired_selected = False
-
-    def compose(self) -> ComposeResult:
-        with Horizontal(classes="research-source-row-heading"):
-            yield Static("", id=f"research-source-row-title-{self.index}")
-            yield Button(
-                "Select",
-                id=f"research-source-row-select-{self.index}",
-                compact=True,
-            )
-        yield Static("", id=f"research-source-row-badges-{self.index}")
-        yield Static("", id=f"research-source-row-selection-{self.index}")
-        yield Static("", id=f"research-source-row-readiness-{self.index}")
-        with Horizontal(classes="research-source-row-actions"):
-            yield Button(
-                "Details", id=f"research-source-row-details-{self.index}", compact=True
-            )
-            yield Button(
-                "Folders", id=f"research-source-row-folders-{self.index}", compact=True
-            )
-            yield Button(
-                "Preview / annotate",
-                id=f"research-source-row-preview-{self.index}",
-                compact=True,
-            )
-            yield Button(
-                "Move / Copy",
-                id=f"research-source-row-copy-{self.index}",
-                compact=True,
-                disabled=True,
-            )
-            yield Button(
-                "^",
-                id=f"research-source-row-up-{self.index}",
-                name="Move source up",
-                tooltip="Move source up",
-                compact=True,
-                disabled=True,
-            )
-            yield Button(
-                "v",
-                id=f"research-source-row-down-{self.index}",
-                name="Move source down",
-                tooltip="Move source down",
-                compact=True,
-                disabled=True,
-            )
-            yield Button(
-                "Remove", id=f"research-source-row-remove-{self.index}", compact=True
-            )
+        self._title = title
+        self._select = select
+        self._badges = badges
+        self._selection = selection
+        self._readiness = readiness
+        self._preview = preview
+        self._move_copy = move_copy
+        self._up = up
+        self._down = down
+        self._remove = remove
 
     def sync_source(
         self,
@@ -126,43 +156,35 @@ class _ResearchSourceRowSlot(Vertical):
             if readiness is not None
             else "Unavailable"
         )
-        self.query_one(f"#research-source-row-title-{self.index}", Static).update(
-            source.title
-        )
-        self.query_one(f"#research-source-row-badges-{self.index}", Static).update(
-            f"{source.source_type.title()} · {badge}"
-        )
-        self.query_one(f"#research-source-row-selection-{self.index}", Static).update(
-            f"Selected intent: {'Yes' if direct else 'No'}"
-        )
-        self.query_one(f"#research-source-row-readiness-{self.index}", Static).update(
-            f"Readiness: {readiness_label}"
-        )
-        select = self.query_one(f"#research-source-row-select-{self.index}", Button)
+        self._title.update(source.title)
+        self._badges.update(f"{source.source_type.title()} · {badge}")
+        self._selection.update(f"Selected intent: {'Yes' if direct else 'No'}")
+        self._readiness.update(f"Readiness: {readiness_label}")
+        select = self._select
         select.label = "Deselect" if direct else "Select"
         select.disabled = not selection_available
         select.tooltip = (
             "Change selected intent" if selection_available else selection_reason
         )
-        preview = self.query_one(f"#research-source-row-preview-{self.index}", Button)
+        preview = self._preview
         preview.disabled = not preview_available
         preview.tooltip = (
             "Preview and annotate" if preview_available else preview_reason
         )
-        remove = self.query_one(f"#research-source-row-remove-{self.index}", Button)
+        remove = self._remove
         remove.disabled = not remove_available
         remove.tooltip = (
             "Remove workspace association" if remove_available else remove_reason
         )
-        move_copy = self.query_one(f"#research-source-row-copy-{self.index}", Button)
+        move_copy = self._move_copy
         move_copy.disabled = not move_copy_available
         move_copy.tooltip = (
             "Move or copy this source"
             if move_copy_available
             else "The selected owner exposes no canonical Move / Copy action."
         )
-        up = self.query_one(f"#research-source-row-up-{self.index}", Button)
-        down = self.query_one(f"#research-source-row-down-{self.index}", Button)
+        up = self._up
+        down = self._down
         up.disabled = not (reorder_available and self.index > 0)
         down.disabled = not (reorder_available and self.index + 1 < row_count)
         up.tooltip = "Move source up" if reorder_available else reorder_reason
@@ -170,7 +192,15 @@ class _ResearchSourceRowSlot(Vertical):
 
 
 class ResearchSourceList(Vertical):
-    """Twenty-five pre-mounted slots; page refreshes never rebuild the region."""
+    """Demand-grown slot pool; page refreshes never rebuild the region.
+
+    The pool starts empty (an unused Research profile pays for zero row
+    widgets, TASK-23024) and grows monotonically with the largest page seen,
+    capped at ``MAX_VISIBLE_SOURCE_ROWS``. Slots are never unmounted:
+    shrinking a page recycles surplus slots via ``display = False`` exactly
+    as the fully pre-mounted pool did, so paging at the maximum row count
+    still mounts and unmounts nothing.
+    """
 
     class SelectionToggled(Message):
         def __init__(
@@ -193,11 +223,28 @@ class ResearchSourceList(Vertical):
             self.source_id = source_id
             self.delta = delta
 
-    def compose(self) -> ComposeResult:
-        for index in range(MAX_VISIBLE_SOURCE_ROWS):
-            yield _ResearchSourceRowSlot(index)
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._slots: list[_ResearchSourceRowSlot] = []
+
+    def _ensure_slot_pool(self, needed: int) -> None:
+        """Grow the mounted slot pool to ``needed`` rows (never shrink)."""
+
+        needed = min(needed, MAX_VISIBLE_SOURCE_ROWS)
+        if needed <= len(self._slots):
+            return
+        new_slots = [
+            _ResearchSourceRowSlot(index)
+            for index in range(len(self._slots), needed)
+        ]
+        self._slots.extend(new_slots)
+        if self.is_attached:
+            self.mount(*new_slots)
 
     def on_mount(self) -> None:
+        detached = [slot for slot in self._slots if slot.parent is None]
+        if detached:
+            self.mount(*detached)
         self.sync_page(None)
 
     def sync_page(
@@ -210,6 +257,7 @@ class ResearchSourceList(Vertical):
         temporary_sort: bool = False,
     ) -> None:
         rows = page.items if page is not None else ()
+        self._ensure_slot_pool(len(rows))
         desired_ids = frozenset(page.desired_source_ids if page is not None else ())
         readiness_by_id = {item.source_id: item for item in readiness}
         capabilities = capabilities or {}
@@ -222,7 +270,7 @@ class ResearchSourceList(Vertical):
         # Keep the visible parity control honest even if an unknown capability key
         # is accidentally projected into this view.
         move_copy_available = False
-        for index, slot in enumerate(self.query(_ResearchSourceRowSlot)):
+        for index, slot in enumerate(self._slots):
             source = rows[index] if index < len(rows) else None
             slot.sync_source(
                 source,

--- a/tldw_chatbook/UI/Research_Workspace_Modules/source_receipt.py
+++ b/tldw_chatbook/UI/Research_Workspace_Modules/source_receipt.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from textual import on
-from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.widgets import Button, Static
@@ -24,22 +23,37 @@ def _status_label(status: SourceOperationStatus) -> str:
 
 
 class _ResearchSourceReceiptSlot(Vertical):
+    """One recyclable receipt row.
+
+    Children are built at construction and kept as direct references so
+    ``sync_operation`` stays synchronous even while the slot's subtree is
+    still being mounted (TASK-23024) — slots mount on demand as operations
+    arrive.
+    """
+
     def __init__(self, index: int) -> None:
-        super().__init__(id=f"research-source-receipt-{index}")
+        owner = Static("", id=f"research-source-receipt-owner-{index}")
+        stages = Static("", id=f"research-source-receipt-stages-{index}")
+        error = Static("", id=f"research-source-receipt-error-{index}")
+        retry = Button(
+            "Retry",
+            id=f"research-source-receipt-retry-{index}",
+            compact=True,
+            disabled=True,
+        )
+        super().__init__(
+            owner,
+            stages,
+            error,
+            Horizontal(retry, classes="research-source-receipt-actions"),
+            id=f"research-source-receipt-{index}",
+        )
         self.index = index
         self.operation: ResearchSourceOperation | None = None
-
-    def compose(self) -> ComposeResult:
-        yield Static("", id=f"research-source-receipt-owner-{self.index}")
-        yield Static("", id=f"research-source-receipt-stages-{self.index}")
-        yield Static("", id=f"research-source-receipt-error-{self.index}")
-        with Horizontal(classes="research-source-receipt-actions"):
-            yield Button(
-                "Retry",
-                id=f"research-source-receipt-retry-{self.index}",
-                compact=True,
-                disabled=True,
-            )
+        self._owner = owner
+        self._stages = stages
+        self._error = error
+        self._retry = retry
 
     def sync_operation(self, operation: ResearchSourceOperation | None) -> None:
         self.operation = operation
@@ -51,19 +65,19 @@ class _ResearchSourceReceiptSlot(Vertical):
             if operation.canonical_item_type is CanonicalItemType.LOCAL_LIBRARY
             else "Media"
         )
-        self.query_one(f"#research-source-receipt-owner-{self.index}", Static).update(
+        self._owner.update(
             f"{operation.data_source.value.title()} workspace {operation.workspace_id} · "
             f"operation {operation.operation_id}"
         )
-        self.query_one(f"#research-source-receipt-stages-{self.index}", Static).update(
+        self._stages.update(
             f"{catalog_owner}: {_status_label(operation.catalog_status)} | "
             f"Workspace association: {_status_label(operation.association_status)} | "
             f"Index/readiness: {_status_label(operation.readiness_status)}"
         )
-        error = self.query_one(f"#research-source-receipt-error-{self.index}", Static)
+        error = self._error
         error.update(operation.error_message)
         error.display = bool(operation.error_message)
-        retry = self.query_one(f"#research-source-receipt-retry-{self.index}", Button)
+        retry = self._retry
         labels = {
             SourceOperationStage.CATALOG: f"Retry {catalog_owner} ingest",
             SourceOperationStage.ASSOCIATION: "Retry workspace link",
@@ -74,7 +88,14 @@ class _ResearchSourceReceiptSlot(Vertical):
 
 
 class ResearchSourceReceiptList(Vertical):
-    """Twenty stable receipt slots plus a bounded-result disclosure."""
+    """Demand-grown receipt slots plus a bounded-result disclosure.
+
+    The pool starts empty (TASK-23024) and grows with the operations shown,
+    capped at ``MAX_VISIBLE_SOURCE_RECEIPTS``; surplus slots recycle via
+    ``display = False`` and are never unmounted. New slots always mount
+    before the bounded-result disclosure so child order stays
+    heading, receipts…, bound.
+    """
 
     class RetryRequested(Message):
         def __init__(self, operation_id: str, stage: SourceOperationStage) -> None:
@@ -82,16 +103,40 @@ class ResearchSourceReceiptList(Vertical):
             self.operation_id = operation_id
             self.stage = stage
 
-    def compose(self) -> ComposeResult:
-        yield Static(
+    def __init__(self, *args, **kwargs) -> None:
+        heading = Static(
             "Receipts · Library/Media | Workspace association | Index/readiness",
             id="research-source-receipts-heading",
         )
-        for index in range(MAX_VISIBLE_SOURCE_RECEIPTS):
-            yield _ResearchSourceReceiptSlot(index)
-        yield Static("", id="research-source-receipts-bound")
+        bound = Static("", id="research-source-receipts-bound")
+        super().__init__(heading, bound, *args, **kwargs)
+        self._bound = bound
+        self._slots: list[_ResearchSourceReceiptSlot] = []
+
+    def _ensure_slot_pool(self, needed: int) -> None:
+        """Grow the mounted slot pool to ``needed`` receipts (never shrink)."""
+
+        needed = min(needed, MAX_VISIBLE_SOURCE_RECEIPTS)
+        if needed <= len(self._slots):
+            return
+        new_slots = [
+            _ResearchSourceReceiptSlot(index)
+            for index in range(len(self._slots), needed)
+        ]
+        self._slots.extend(new_slots)
+        if self.is_attached:
+            self._mount_slots(new_slots)
+
+    def _mount_slots(self, slots: list[_ResearchSourceReceiptSlot]) -> None:
+        if self._bound.parent is self:
+            self.mount(*slots, before=self._bound)
+        else:
+            self.mount(*slots)
 
     def on_mount(self) -> None:
+        detached = [slot for slot in self._slots if slot.parent is None]
+        if detached:
+            self._mount_slots(detached)
         self.sync_operations((), incomplete=False)
 
     def sync_operations(
@@ -100,10 +145,10 @@ class ResearchSourceReceiptList(Vertical):
         *,
         incomplete: bool,
     ) -> None:
-        for index, slot in enumerate(self.query(_ResearchSourceReceiptSlot)):
+        self._ensure_slot_pool(len(operations))
+        for index, slot in enumerate(self._slots):
             slot.sync_operation(operations[index] if index < len(operations) else None)
-        bound = self.query_one("#research-source-receipts-bound", Static)
-        bound.update(
+        self._bound.update(
             "More receipts may exist · open Library operation status for the full history."
             if incomplete or len(operations) > MAX_VISIBLE_SOURCE_RECEIPTS
             else f"{len(operations)} recent operation(s)."


### PR DESCRIPTION
## Summary

The Research workspace (F10) was the most expensive screen in the app: **693 widgets constructed on
every visit, 79% of them inside `display=False` subtrees** — built, mounted and CSS-matched, never
painted, because both slot pools composed their full maximum on an empty profile. Finding 23024 of
the [2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md).

Both pools now **start empty and grow on demand**, capped at the old maxima, never shrinking — so
the recycling benefit the pools exist for survives untouched at high row counts.

## Measured — deterministic counts byte-stable across all 13 runs

| | before | after |
|---|---|---|
| constructed per empty visit | **694** | **199 (−71%)** |
| `display=False` proportion, empty | 578/691 (83.6%) | 83/196 (42.3%) |
| DOM at 25 rows + 20 receipts | 691 widgets | **identical 691-widget DOM** (6.2% hidden) |
| recycling at max: 10 page+receipt swaps | 0 constructions | **0 constructions, 0 unregistrations, widget-identity set unchanged — both arms, every run** |

Wall clock is reported as a **ratio, deliberately**: the A/A control showed a 1166–2154 ms spread on
consecutive identical base runs, so absolute ms would be noise-laundering. Recompose is **~3–4×
faster in every interleaved pairing, both orders**. The one-time cost moved where it belongs: the
first 0→25 fill pays growth once, instead of every visit paying the maximum.

## The design detail that keeps the contract

Slots build their children at construction and keep **direct references**, because Textual mounts
composed children a message-turn later — and the region's `_render_page` → `_sync_capabilities`
reads `selected_source_ids()`/`visible_owner_ids()` **synchronously in the same turn**. Growing
lazily without this would have broken that contract; it also deletes 13 `query_one` calls per row
sync. MUT-F (naive `query_one` sync) exists precisely to prove this: it crashes the
unmount/quit-mid-growth walk with `NoMatches`.

New slots mount `before=` the bounded-result disclosure so child order stays
heading → receipts → bound (MUT-C pins it). TASK-23023's lazy facade is untouched.

## Mutations — 8 new tests, each red under ≥1 of six mutants

Eager pools restored · growth capped below demand · receipts after bound · shrink-unmounts ·
state dropped for unmounted slots · naive query_one sync. All Edit-applied and Edit-reverted.
Quit walk: `remove()` in the same turn as a growth mount, post-removal syncs, and teardown with
mounts pending — all clean.

## Verification

**47/47 research-UI tests pass**; 14 passed after rebase onto the tip carrying 23020/23021/23023.
Existing tests updated only where they pinned the eager pool itself (`== 25` → `== 0`) or raced
first growth (added a `pilot.pause()`). Preflight green.

## Out of scope, recorded

- The residual 42% hidden on empty visits is real toggleable chrome, not pool-shaped.
- Whole-screen recompose still costs ~250–650 ms even empty; screens remain uncached — the review's
  broader point stands.
- `visible_owner_ids`/`selected_source_ids` still use string-selector `query()`; could read
  `_slots` directly, but not per-frame — scoped out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the Research workspace (F10) slot pools from eagerly pre-composing the full 25/20 maxima to growing with content, cutting widgets constructed per empty visit from 694 to 199 (-71%) and making whole-screen recompose ~3–4× faster.

- Pools start empty, grow with content, and cap at the old maxima; they never shrink, so paging at max rows still mounts and unmounts nothing (0 constructions across 10 swaps, both arms).
- At 25 rows + 20 receipts, both builds converge to the identical 691-widget DOM.
- Slots keep direct references to their built children, which keeps sync synchronous while subtrees mount and drops 13 `query_one` calls per row sync.
- New receipt slots mount before the bound disclosure, keeping child order heading → receipts → bound.
- 8 new tests in `Tests/UI/test_research_slot_pool_growth.py` pin growth, recycling, order, and the synchronous-read contract; each was red under a deliberately broken implementation.

**Verification**
- 47/47 research-UI tests pass; existing tests were updated only where they pinned the eager pool or raced first growth.

<sup>Written for commit 8734f7a07b83a5d981adcffa01b51dd4c3cd652a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

