### PR TITLE
feat(console): capture and review minimized Library activity (TASK-19900.5)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -40,15 +40,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "00e3fd66f1b0a1863b64",
+      "call_count": 3,
+      "diagnostic_digest": "1da8e63bff29cc4744fb",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/library_rag_tool_provider.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "b1cbdcf3a0a107beb4dd",
+      "call_count": 3,
+      "diagnostic_digest": "b83af303c9b5805fbfae",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/library_tool_provider.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -250,8 +250,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 69,
-      "diagnostic_digest": "cb2d6e880e6b7ce7e420",
+      "call_count": 71,
+      "diagnostic_digest": "2a6afcd2666f4f125469",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -317,6 +317,13 @@
       "diagnostic_digest": "67382271602eea33afac",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_launch_wake.py",
+      "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "a2981c735b7e74924fd6",
+      "owner": "TASK-492",
+      "path": "tldw_chatbook/Chat/console_library_activity_buffer.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
@@ -3980,9 +3987,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 539,
+    "owner_files": 540,
     "persistent_sink_files": 8,
-    "task_492_calls": 1258,
-    "task_494_calls": 7388
+    "task_492_calls": 1261,
+    "task_494_calls": 7392
   }
 }

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -2794,6 +2794,43 @@ def test_make_invoke_tool_bypasses_wrapper_when_unlimited(db, monkeypatch):
     assert json.loads(result.content)["result"] == 4
 
 
+def test_make_invoke_tool_binds_exact_subagent_actor_on_timeout_thread(
+    db, monkeypatch
+):
+    """Provider capture sees child and parent identity on the actual tool thread."""
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Agents.run_context import (
+        CurrentRunActor,
+        current_run_actor,
+    )
+
+    service = _service_with_chat(db, lambda **_kwargs: provider_reply("unused"))
+    seen = []
+
+    def invoke_by_name(_name, _args):
+        seen.append(current_run_actor())
+        return ToolResult(ok=True, content="ok")
+
+    monkeypatch.setattr(service.registry, "invoke_by_name", invoke_by_name)
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(max_tool_call_seconds=1.0),
+    )
+    actor = CurrentRunActor("subagent", "run-child", "run-parent")
+    invoke_tool = service._make_invoke_tool(
+        cfg,
+        disclosed_names={"calculator"},
+        run_id=actor.run_id,
+        run_actor=actor,
+    )
+
+    assert invoke_tool(ToolCall(name="calculator", args={})).ok is True
+    assert seen == [actor]
+    assert current_run_actor() is None
+
+
 def test_make_invoke_tool_wraps_slow_custom_tool_in_timeout(db, monkeypatch):
     """A blocking custom tool provider must not wedge the run past
     max_tool_call_seconds -- the boundary this task exists to add."""

--- a/Tests/Agents/test_library_activity_capture.py
+++ b/Tests/Agents/test_library_activity_capture.py
@@ -1,0 +1,158 @@
+"""Trusted Direct/RAG provider activity-capture boundary tests."""
+
+from __future__ import annotations
+
+import json
+
+from tldw_chatbook.Agents.library_rag_tool_provider import (
+    LibraryRagToolProvider,
+    RAG_TOOL_NAME,
+)
+from tldw_chatbook.Agents.library_tool_provider import LibraryToolProvider
+from tldw_chatbook.Agents.run_context import CurrentRunActor, use_run_actor
+from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+
+
+class _DirectService:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def invoke(self, _name: str, _arguments: object) -> object:
+        return self.payload
+
+
+class _RagService:
+    def __init__(self, rows: list[LibraryRagResultRow]) -> None:
+        self.rows = rows
+
+    async def search(self, *_args, **_kwargs):
+        return {"results": self.rows}
+
+
+def _row(index: int) -> LibraryRagResultRow:
+    return LibraryRagResultRow.from_result(
+        {
+            "result_id": f"row-{index}",
+            "source_id": f"note-{index}",
+            "title": f"Title {index} " + "界" * 2_000,
+            "snippet": "body " + "x" * 6_000,
+            "score": 1.0,
+            "source_type": "note",
+        }
+    )
+
+
+def test_direct_provider_captures_primary_activity_before_returning_result():
+    events = []
+    provider = LibraryToolProvider(
+        _DirectService({"items": [{"id": "note:1", "type": "note", "title": "One"}]}),
+        activity_attempt_id="attempt-1",
+        activity_sink=events.append,
+    )
+
+    with use_run_actor(CurrentRunActor("primary", "run-1", None)):
+        result = provider.invoke("library:library_search_notes", {"query": "one"})
+
+    assert result.ok is True
+    assert len(events) == 1
+    event = events[0]
+    assert event.attempt_id == "attempt-1"
+    assert event.actor_kind == "primary"
+    assert event.run_id == "run-1"
+    assert event.parent_run_id is None
+    assert event.library_provider == "direct"
+    assert event.operation == "library_search_notes"
+
+
+def test_rag_capture_sees_authoritative_rows_before_model_payload_bounding():
+    events = []
+    rows = [_row(index) for index in range(10)]
+    provider = LibraryRagToolProvider(
+        _RagService(rows),
+        activity_attempt_id="attempt-rag",
+        activity_sink=events.append,
+    )
+
+    with use_run_actor(CurrentRunActor("subagent", "run-child", "run-parent")):
+        result = provider.invoke(
+            f"library:{RAG_TOOL_NAME}", {"query": "needle", "top_k": 10}
+        )
+
+    assert result.ok is True
+    assert len(events) == 1
+    assert len(events[0].source_refs) == 8
+    assert len(json.loads(result.content)["results"]) < len(rows)
+    assert events[0].actor_kind == "subagent"
+    assert events[0].parent_run_id == "run-parent"
+
+
+def test_capture_failure_withholds_direct_library_payload():
+    def reject(_event) -> None:
+        raise RuntimeError("must not escape")
+
+    provider = LibraryToolProvider(
+        _DirectService({"items": [{"id": "note:secret", "body": "SECRET BODY"}]}),
+        activity_attempt_id="attempt-1",
+        activity_sink=reject,
+    )
+
+    with use_run_actor(CurrentRunActor("primary", "run-1", None)):
+        result = provider.invoke("library:library_search_notes", {"query": "one"})
+
+    assert result.ok is False
+    assert "SECRET BODY" not in result.error
+    error = json.loads(result.error)["error"]
+    assert error["code"] == "storage_error"
+    assert error["message"] == (
+        "Library result withheld because activity could not be recorded."
+    )
+    assert error["details"] == {"category": "review_capture_failed"}
+
+
+def test_configured_capture_without_bound_actor_fails_closed():
+    provider = LibraryToolProvider(
+        _DirectService({"items": [{"id": "note:1"}]}),
+        activity_attempt_id="attempt-1",
+        activity_sink=lambda _event: None,
+    )
+
+    result = provider.invoke("library:library_search_notes", {"query": "one"})
+
+    assert result.ok is False
+    assert "could not be recorded" in result.error
+
+
+def test_attempts_remain_distinct_for_the_same_subagent_run():
+    events = []
+    actor = CurrentRunActor("subagent", "run-child", "run-parent")
+    with use_run_actor(actor):
+        for attempt_id in ("attempt-1", "attempt-2"):
+            provider = LibraryToolProvider(
+                _DirectService({"items": []}),
+                activity_attempt_id=attempt_id,
+                activity_sink=events.append,
+            )
+            assert provider.invoke("library:library_search_notes", {"query": "q"}).ok
+
+    assert [event.attempt_id for event in events] == ["attempt-1", "attempt-2"]
+    assert events[0].event_id != events[1].event_id
+
+
+def test_rag_provider_captures_refused_valid_operation():
+    events = []
+    provider = LibraryRagToolProvider(
+        _RagService([]),
+        activity_attempt_id="attempt-rag",
+        activity_sink=events.append,
+    )
+
+    with use_run_actor(CurrentRunActor("primary", "run-1", None)):
+        result = provider.invoke(
+            f"library:{RAG_TOOL_NAME}", {"query": "needle", "top_k": 0}
+        )
+
+    assert result.ok is False
+    assert len(events) == 1
+    assert events[0].status == "failed"
+    assert events[0].error_code == "invalid_argument"
+    assert events[0].query_preview == "needle"

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -58,6 +58,9 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: 17,749/593. Wave 3 recorded 18,909/598; dev grew the screen by 21 lines
 #: and 2 methods while wave 4 was in flight, which is the whole reason this
 #: file exists. First recorded after wave 2 (PR #1381) at 20,964/612.
+#: Lowered by TASK-19900.5 after Library provider construction and selected-
+#: turn activity projection moved into ``UI/Console_Modules/library_activity``:
+#: 17,026/566 -> 16,978/565.
 #:
 #: Always MEASURE after the final rebase. Wave 3 set its budget twice from a
 #: pre-rebase measurement and both landed red, because dev moved underneath
@@ -67,8 +70,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: The first closeout measurement was 16,968/562; dev then advanced through
 #: PR #2125 and subsequent Console work through PR #2147 before this ratchet
 #: landed. The final live measurement is: 17,727/593 -> 17,037/565.
+#: Lowered again by TASK-19900.5 after moving Library activity ownership into
+#: its Console module. The post-rebase measurement is 16,978/565.
 _BUDGETS: dict[str, tuple[str, int, int]] = {
-    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 17037, 565),
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 16978, 565),
 }
 
 # Task 22507.4 started from this reviewed measurement. The repository-wide

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -58,9 +58,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: 17,749/593. Wave 3 recorded 18,909/598; dev grew the screen by 21 lines
 #: and 2 methods while wave 4 was in flight, which is the whole reason this
 #: file exists. First recorded after wave 2 (PR #1381) at 20,964/612.
-#: Lowered by TASK-19900.5 after Library provider construction and selected-
-#: turn activity projection moved into ``UI/Console_Modules/library_activity``:
-#: 17,026/566 -> 16,978/565.
 #:
 #: Always MEASURE after the final rebase. Wave 3 set its budget twice from a
 #: pre-rebase measurement and both landed red, because dev moved underneath
@@ -70,10 +67,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: The first closeout measurement was 16,968/562; dev then advanced through
 #: PR #2125 and subsequent Console work through PR #2147 before this ratchet
 #: landed. The final live measurement is: 17,727/593 -> 17,037/565.
-#: Lowered again by TASK-19900.5 after moving Library activity ownership into
-#: its Console module. The post-rebase measurement is 16,978/565.
+#: Lowered again by TASK-19900.5 after moving Library provider construction and
+#: selected-turn activity projection into ``UI/Console_Modules/library_activity``.
+#: Concurrent dev work moved the final base to 17,059/566; the post-rebase
+#: feature tree measures 17,000/565.
 _BUDGETS: dict[str, tuple[str, int, int]] = {
-    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 16978, 565),
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 17000, 565),
 }
 
 # Task 22507.4 started from this reviewed measurement. The repository-wide

--- a/Tests/Chat/test_console_library_activity_buffer.py
+++ b/Tests/Chat/test_console_library_activity_buffer.py
@@ -120,6 +120,7 @@ def test_final_flush_is_one_bounded_attempt() -> None:
 
     assert first.status == second.status == "failed"
     assert first.pending_count == second.pending_count == 1
+    assert buffer.state("session-1") == first
     assert calls == 1
 
 
@@ -140,6 +141,7 @@ def test_promotion_failure_rolls_back_rows_and_retains_activity_for_retry(tmp_pa
     )
     store.admit_library_activity(session.id, user.id, _event(1))
     before = store.pending_library_activity(session.id)
+    revision_before_promotion = store.library_activity_revision(session.id)
 
     with pytest.raises(RuntimeError, match="injected promotion failure"):
         store.promote_ephemeral_session(
@@ -159,6 +161,7 @@ def test_promotion_failure_rolls_back_rows_and_retains_activity_for_retry(tmp_pa
     assert activity[0].message_id == durable_user_id
     assert activity[0].turn_id == durable_user_id
     assert store.pending_library_activity(session.id) == ()
+    assert store.library_activity_revision(session.id) > revision_before_promotion
 
 
 def test_close_performs_one_final_flush_for_a_durable_session(tmp_path) -> None:
@@ -182,3 +185,71 @@ def test_close_performs_one_final_flush_for_a_durable_session(tmp_path) -> None:
         if row.event_kind == "library_activity"
     ]
     assert len(activity) == 1
+
+
+def test_store_projects_pending_and_durable_activity_to_native_assistant(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "activity-projection.db", "activity-test")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="question"
+    )
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+    )
+    store.promote_ephemeral_session(session.id)
+    store.admit_library_activity(session.id, user.id, _event(1))
+
+    pending_view, pending_counts, pending_state = store.library_activity_snapshot(
+        session.id, assistant.id
+    )
+
+    assert [item.event.event_id for item in pending_view.actions] == ["event-1"]
+    assert pending_counts == ((assistant.id, 1),)
+    assert pending_state.status == "pending"
+    assert store.current_library_activity_turn_id(session.id) == user.id
+
+    assert store.flush_library_activity(session.id).status == "saved"
+    durable_view, durable_counts, durable_state = store.library_activity_snapshot(
+        session.id, assistant.id
+    )
+
+    assert [item.event.event_id for item in durable_view.actions] == ["event-1"]
+    assert durable_counts == ((assistant.id, 1),)
+    assert durable_state.status == "saved"
+
+
+def test_store_projection_follows_active_branch_without_losing_other_activity() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(ephemeral=True)
+    first_user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="first question"
+    )
+    first_assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="first answer"
+    )
+    store.admit_library_activity(session.id, first_user.id, _event(1))
+
+    second_user = store.create_sibling(
+        first_user.id,
+        role=ConsoleMessageRole.USER,
+        content="second question",
+    )
+    second_assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="second answer"
+    )
+    store.admit_library_activity(session.id, second_user.id, _event(2))
+
+    second_view, second_counts, _state = store.library_activity_snapshot(
+        session.id, second_assistant.id
+    )
+    assert [item.event.event_id for item in second_view.actions] == ["event-2"]
+    assert second_counts == ((second_assistant.id, 1),)
+
+    store.set_active_leaf(session.id, first_assistant.id)
+    first_view, first_counts, _state = store.library_activity_snapshot(
+        session.id, first_assistant.id
+    )
+    assert [item.event.event_id for item in first_view.actions] == ["event-1"]
+    assert first_counts == ((first_assistant.id, 1),)
+    assert len(store.pending_library_activity(session.id)) == 2

--- a/Tests/Chat/test_console_library_activity_buffer.py
+++ b/Tests/Chat/test_console_library_activity_buffer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 
 import pytest
 
@@ -124,6 +125,42 @@ def test_final_flush_is_one_bounded_attempt() -> None:
     assert calls == 1
 
 
+def test_final_flush_drains_every_bounded_batch() -> None:
+    seen: list[tuple[str, ...]] = []
+
+    def persist(_session_id, contribution) -> None:
+        seen.append(tuple(item.event.event_id for item in contribution.items))
+
+    buffer = ConsoleLibraryActivityBuffer(persist, batch_size=2)
+    for index in range(5):
+        buffer.admit("session-1", "turn-1", _event(index))
+
+    result = buffer.final_flush("session-1")
+
+    assert result.status == "saved"
+    assert result.saved_count == 5
+    assert result.pending_count == 0
+    assert seen == [
+        ("event-0", "event-1"),
+        ("event-2", "event-3"),
+        ("event-4",),
+    ]
+
+
+def test_discard_session_releases_pending_and_retry_state() -> None:
+    def fail(_session_id, _contribution) -> None:
+        raise RuntimeError
+
+    buffer = ConsoleLibraryActivityBuffer(fail, max_attempts=1)
+    buffer.admit("session-1", "turn-1", _event(1))
+    assert buffer.flush("session-1").status == "failed"
+
+    buffer.discard_session("session-1")
+
+    assert buffer.pending_events("session-1") == ()
+    assert buffer.state("session-1").status == "saved"
+
+
 class _FailingContribution:
     def write(self, *, writer, conversation_id, message_ids) -> None:
         raise RuntimeError("injected promotion failure")
@@ -185,6 +222,107 @@ def test_close_performs_one_final_flush_for_a_durable_session(tmp_path) -> None:
         if row.event_kind == "library_activity"
     ]
     assert len(activity) == 1
+
+
+def test_ephemeral_capture_stays_pending_without_consuming_retries() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="question"
+    )
+
+    first = store.capture_library_activity(session.id, user.id, _event(1))
+    second = store.capture_library_activity(session.id, user.id, _event(2))
+
+    assert first.status == second.status == "pending"
+    assert second.pending_count == 2
+    assert second.error_code is None
+    assert second.warning is None
+
+
+def test_close_drains_more_than_one_activity_batch(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "activity-close-many.db", "activity-test")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="question"
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+    )
+    conversation_id = store.promote_ephemeral_session(session.id)
+    for index in range(65):
+        store.admit_library_activity(session.id, user.id, _event(index))
+
+    store.close_session(session.id)
+
+    activity = [
+        row
+        for row in db.get_trajectory_rows(conversation_id)
+        if row.event_kind == "library_activity"
+    ]
+    assert len(activity) == 65
+
+
+def test_failed_close_discards_unreachable_activity(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "activity-close-failed.db", "activity-test")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="question"
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+    )
+    store.promote_ephemeral_session(session.id)
+    store.admit_library_activity(session.id, user.id, _event(1))
+
+    def fail(_session_id, _contribution) -> None:
+        raise RuntimeError
+
+    store._library_activity_buffer._persist_batch = fail  # noqa: SLF001
+
+    store.close_session(session.id)
+
+    assert store._library_activity_buffer.pending_events(session.id) == ()  # noqa: SLF001
+    assert session.id not in {item.id for item in store.sessions()}
+
+
+def test_close_serializes_against_late_provider_capture(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "activity-close-race.db", "activity-test")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="question"
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+    )
+    store.promote_ephemeral_session(session.id)
+    store.admit_library_activity(session.id, user.id, _event(1))
+    entered = Event()
+    release = Event()
+    persist = store._library_activity_buffer._persist_batch  # noqa: SLF001
+
+    def blocked_persist(session_id, contribution) -> None:
+        entered.set()
+        assert release.wait(2)
+        persist(session_id, contribution)
+
+    store._library_activity_buffer._persist_batch = blocked_persist  # noqa: SLF001
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        closing = pool.submit(store.close_session, session.id)
+        assert entered.wait(2)
+        late_capture = pool.submit(
+            store.admit_library_activity, session.id, user.id, _event(2)
+        )
+        assert not late_capture.done()
+        release.set()
+        closing.result(timeout=2)
+        with pytest.raises(KeyError):
+            late_capture.result(timeout=2)
+
+    assert store._library_activity_buffer.pending_events(session.id) == ()  # noqa: SLF001
 
 
 def test_store_projects_pending_and_durable_activity_to_native_assistant(tmp_path) -> None:

--- a/Tests/Chat/test_console_library_activity_buffer.py
+++ b/Tests/Chat/test_console_library_activity_buffer.py
@@ -1,0 +1,184 @@
+"""Store-owned pending persistence for minimized Library activity."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_library_activity_buffer import (
+    LIBRARY_ACTIVITY_NOT_SAVED_COPY,
+    ConsoleLibraryActivityBuffer,
+)
+from tldw_chatbook.Chat.library_activity import LibraryActivityEvent
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def _event(index: int) -> LibraryActivityEvent:
+    return LibraryActivityEvent(
+        version=1,
+        event_id=f"event-{index}",
+        attempt_id="attempt-1",
+        run_id="run-1",
+        actor_kind="primary",
+        parent_run_id=None,
+        library_provider="direct",
+        operation="library_search_notes",
+        status="succeeded",
+        result_count=1,
+        query_preview=f"query {index}",
+        source_refs=(),
+        error_code=None,
+        error_summary=None,
+    )
+
+
+def test_concurrent_admission_is_unique_and_keeps_one_stable_order() -> None:
+    buffer = ConsoleLibraryActivityBuffer(lambda _session_id, _batch: None)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(
+            pool.map(
+                lambda index: buffer.admit("session-1", "turn-1", _event(index)),
+                range(32),
+            )
+        )
+
+    first = buffer.pending_events("session-1")
+    second = buffer.pending_events("session-1")
+    assert first == second
+    assert len(first) == 32
+    assert {item.event.event_id for item in first} == {
+        f"event-{index}" for index in range(32)
+    }
+
+
+def test_failed_flush_retains_exact_batch_and_retry_confirms_once() -> None:
+    seen: list[tuple[str, ...]] = []
+
+    def persist(_session_id, contribution) -> None:
+        event_ids = tuple(item.event.event_id for item in contribution.items)
+        seen.append(event_ids)
+        if len(seen) == 1:
+            raise RuntimeError("private storage detail")
+
+    buffer = ConsoleLibraryActivityBuffer(persist, max_attempts=2)
+    buffer.admit("session-1", "turn-1", _event(1))
+    buffer.admit("session-1", "turn-1", _event(2))
+
+    first = buffer.flush("session-1")
+    assert first.status == "pending"
+    assert first.saved_count == 0
+    assert first.pending_count == 2
+    assert buffer.pending_events("session-1")
+
+    retried = buffer.retry("session-1")
+    assert retried.status == "saved"
+    assert retried.saved_count == 2
+    assert retried.pending_count == 0
+    assert seen == [("event-1", "event-2"), ("event-1", "event-2")]
+    assert buffer.pending_events("session-1") == ()
+
+
+def test_retry_exhaustion_exposes_bounded_not_saved_state() -> None:
+    calls = 0
+
+    def fail(_session_id, _contribution) -> None:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("must never surface")
+
+    buffer = ConsoleLibraryActivityBuffer(fail, max_attempts=2)
+    buffer.admit("session-1", "turn-1", _event(1))
+
+    assert buffer.flush("session-1").status == "pending"
+    exhausted = buffer.retry("session-1")
+
+    assert exhausted.status == "failed"
+    assert exhausted.error_code == "retry_exhausted"
+    assert exhausted.warning == LIBRARY_ACTIVITY_NOT_SAVED_COPY
+    assert calls == 2
+    assert len(buffer.pending_events("session-1")) == 1
+
+
+def test_final_flush_is_one_bounded_attempt() -> None:
+    calls = 0
+
+    def fail(_session_id, _contribution) -> None:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("unavailable")
+
+    buffer = ConsoleLibraryActivityBuffer(fail)
+    buffer.admit("session-1", "turn-1", _event(1))
+
+    first = buffer.final_flush("session-1")
+    second = buffer.final_flush("session-1")
+
+    assert first.status == second.status == "failed"
+    assert first.pending_count == second.pending_count == 1
+    assert calls == 1
+
+
+class _FailingContribution:
+    def write(self, *, writer, conversation_id, message_ids) -> None:
+        raise RuntimeError("injected promotion failure")
+
+
+def test_promotion_failure_rolls_back_rows_and_retains_activity_for_retry(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "activity-promotion.db", "activity-test")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="question"
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+    )
+    store.admit_library_activity(session.id, user.id, _event(1))
+    before = store.pending_library_activity(session.id)
+
+    with pytest.raises(RuntimeError, match="injected promotion failure"):
+        store.promote_ephemeral_session(
+            session.id, contributions=(_FailingContribution(),)
+        )
+
+    assert store.pending_library_activity(session.id) == before
+    assert db.get_connection().execute(
+        "SELECT COUNT(*) FROM message_trajectory_metadata"
+    ).fetchone()[0] == 0
+
+    conversation_id = store.promote_ephemeral_session(session.id)
+    rows = db.get_trajectory_rows(conversation_id)
+    activity = [row for row in rows if row.event_kind == "library_activity"]
+    durable_user_id = store._nodes_by_session[session.id][user.id].persisted_message_id
+    assert len(activity) == 1
+    assert activity[0].message_id == durable_user_id
+    assert activity[0].turn_id == durable_user_id
+    assert store.pending_library_activity(session.id) == ()
+
+
+def test_close_performs_one_final_flush_for_a_durable_session(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "activity-close.db", "activity-test")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="question"
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+    )
+    conversation_id = store.promote_ephemeral_session(session.id)
+    store.admit_library_activity(session.id, user.id, _event(1))
+
+    store.close_session(session.id)
+
+    activity = [
+        row
+        for row in db.get_trajectory_rows(conversation_id)
+        if row.event_kind == "library_activity"
+    ]
+    assert len(activity) == 1

--- a/Tests/Chat/test_library_activity.py
+++ b/Tests/Chat/test_library_activity.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from dataclasses import replace
 
+import pytest
+
 from tldw_chatbook.Chat.library_activity import (
     LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS,
     LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES,
@@ -13,6 +15,8 @@ from tldw_chatbook.Chat.library_activity import (
     LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT,
     LIBRARY_ACTIVITY_TITLE_MAX_CHARS,
     LibraryActivityCandidate,
+    decode_library_activity_event,
+    encode_library_activity_event,
     minimize_library_activity,
 )
 
@@ -114,3 +118,12 @@ def test_minimize_activity_marks_zero_results_empty():
     assert event.status == "empty"
     assert event.result_count == 0
     assert event.source_refs == ()
+
+
+def test_decode_activity_uses_strict_schema_types() -> None:
+    event = minimize_library_activity(_candidate(result={"items": [], "total": 0}))
+    payload = json.loads(encode_library_activity_event(event))
+    payload["result_count"] = True
+
+    with pytest.raises(ValueError, match="Invalid Library activity payload"):
+        decode_library_activity_event(json.dumps(payload))

--- a/Tests/Chat/test_library_activity.py
+++ b/Tests/Chat/test_library_activity.py
@@ -1,0 +1,116 @@
+"""Bounded, content-minimized Console Library activity contracts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+from tldw_chatbook.Chat.library_activity import (
+    LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS,
+    LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES,
+    LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS,
+    LIBRARY_ACTIVITY_SOURCE_ID_MAX_CHARS,
+    LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT,
+    LIBRARY_ACTIVITY_TITLE_MAX_CHARS,
+    LibraryActivityCandidate,
+    minimize_library_activity,
+)
+
+
+def _candidate(*, result: object, failure_code: str | None = None):
+    return LibraryActivityCandidate(
+        attempt_id="attempt-1",
+        actor_kind="subagent",
+        run_id="run-child",
+        parent_run_id="run-parent",
+        library_provider="direct",
+        operation="library_search_notes",
+        arguments={"query": "quarterly plan"},
+        structured_result=result,
+        failure_code=failure_code,
+    )
+
+
+def test_minimize_activity_keeps_only_bounded_review_fields():
+    secret = "sk-" + "a" * 48
+    rows = [
+        {
+            "id": f"note:{index}-" + "x" * 400,
+            "type": "note",
+            "title": f"Title {index} " + "界" * 300,
+            "body": "PRIVATE BODY",
+            "snippet": "PRIVATE SNIPPET",
+            "excerpt": "PRIVATE EXCERPT",
+            "path": "/Users/private/library/note.md",
+            "api_key": secret,
+        }
+        for index in range(12)
+    ]
+    candidate = _candidate(result={"items": rows, "total": len(rows)})
+    candidate = replace(
+        candidate,
+        arguments={
+            "query": "quarterly plan " + secret + " /Users/private/query.txt"
+        },
+    )
+
+    event = minimize_library_activity(candidate)
+    encoded = json.dumps(event.to_payload(), ensure_ascii=False).encode("utf-8")
+
+    assert event.version == 1
+    assert event.attempt_id == "attempt-1"
+    assert event.run_id == "run-child"
+    assert event.actor_kind == "subagent"
+    assert event.parent_run_id == "run-parent"
+    assert event.status == "succeeded"
+    assert event.result_count == 12
+    assert len(event.query_preview or "") <= LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS
+    assert len(event.source_refs) == LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT
+    assert all(
+        len(ref.source_id) <= LIBRARY_ACTIVITY_SOURCE_ID_MAX_CHARS
+        and len(ref.title) <= LIBRARY_ACTIVITY_TITLE_MAX_CHARS
+        for ref in event.source_refs
+    )
+    assert len(encoded) <= LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES
+    text = encoded.decode("utf-8")
+    assert "PRIVATE BODY" not in text
+    assert "PRIVATE SNIPPET" not in text
+    assert "PRIVATE EXCERPT" not in text
+    assert "/Users/private" not in text
+    assert secret not in text
+
+
+def test_minimize_activity_scrubs_structured_failure_without_exception_text():
+    secret = "Bearer abcdefghijklmnopqrstuvwxyz"
+    event = minimize_library_activity(
+        _candidate(
+            result={
+                "error": {
+                    "code": "storage_error",
+                    "message": (
+                        "sqlite failed at /Users/private/library.db " + secret
+                    ),
+                    "retryable": True,
+                    "details": {"traceback": "PRIVATE TRACEBACK"},
+                }
+            },
+            failure_code="storage_error",
+        )
+    )
+
+    assert event.status == "failed"
+    assert event.result_count == 0
+    assert event.error_code == "storage_error"
+    assert len(event.error_summary or "") <= LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS
+    encoded = json.dumps(event.to_payload(), ensure_ascii=False)
+    assert "/Users/private" not in encoded
+    assert secret not in encoded
+    assert "PRIVATE TRACEBACK" not in encoded
+
+
+def test_minimize_activity_marks_zero_results_empty():
+    event = minimize_library_activity(_candidate(result={"items": [], "total": 0}))
+
+    assert event.status == "empty"
+    assert event.result_count == 0
+    assert event.source_refs == ()

--- a/Tests/Chat/test_library_activity_projection.py
+++ b/Tests/Chat/test_library_activity_projection.py
@@ -1,0 +1,142 @@
+"""Pure selected-turn projection and sidecar-only trajectory behavior."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+from tldw_chatbook.Chat.library_activity import (
+    LibraryActivityEvent,
+    encode_library_activity_event,
+    project_library_activity,
+)
+from tldw_chatbook.Chat.trajectory import derive_trajectory
+
+
+def _event(event_id: str = "event-1") -> LibraryActivityEvent:
+    return LibraryActivityEvent(
+        version=1,
+        event_id=event_id,
+        attempt_id="attempt-1",
+        run_id="run-child",
+        actor_kind="subagent",
+        parent_run_id="run-parent",
+        library_provider="rag",
+        operation="search_library_rag",
+        status="succeeded",
+        result_count=2,
+        query_preview="bounded query",
+        source_refs=(),
+        error_code=None,
+        error_summary=None,
+    )
+
+
+def _row(
+    turn_id: str,
+    event: LibraryActivityEvent,
+    *,
+    seq: int,
+    message_id: str | None = None,
+    payload_json: str | None = None,
+):
+    return SimpleNamespace(
+        message_id=message_id or turn_id,
+        conversation_id="conversation-1",
+        turn_id=turn_id,
+        seq=seq,
+        event_kind="library_activity",
+        step_started_at=100.0 + seq,
+        first_token_at=None,
+        completed_at=None,
+        model=None,
+        provider=None,
+        payload_json=payload_json or encode_library_activity_event(event),
+    )
+
+
+def test_projection_filters_active_lineage_and_selected_turn() -> None:
+    rows = [
+        _row("turn-1", _event("event-1"), seq=2),
+        _row("turn-2", _event("event-2"), seq=4),
+        _row("off-branch", _event("event-3"), seq=3),
+    ]
+
+    view = project_library_activity(rows, ("turn-1", "turn-2"), "turn-2")
+
+    assert view.selected_turn_id == "turn-2"
+    assert [action.event.event_id for action in view.actions] == ["event-2"]
+    assert view.actions[0].event.actor_kind == "subagent"
+    assert view.actions[0].event.parent_run_id == "run-parent"
+    assert view.actions[0].occurred_at == 104.0
+    assert view.corrupt_row_count == 0
+
+
+def test_projection_reports_bounded_corrupt_status_without_partial_event() -> None:
+    rows = [
+        _row("turn-1", _event(), seq=1, payload_json='{"version":99}'),
+        _row("turn-1", replace(_event(), event_id="event-2"), seq=2),
+    ]
+
+    view = project_library_activity(rows, ("turn-1",), "turn-1")
+
+    assert [action.event.event_id for action in view.actions] == ["event-2"]
+    assert view.corrupt_row_count == 1
+    assert view.status == "corrupt"
+
+
+def test_library_activity_is_excluded_from_generic_trajectory() -> None:
+    messages = [
+        {
+            "id": "turn-1",
+            "sender": "user",
+            "content": "question",
+            "timestamp": 1.0,
+            "parent_message_id": None,
+            "deleted": False,
+        },
+        {
+            "id": "assistant-1",
+            "sender": "assistant",
+            "content": "answer",
+            "timestamp": 2.0,
+            "parent_message_id": "turn-1",
+            "deleted": False,
+        },
+    ]
+    rows = [
+        SimpleNamespace(
+            message_id="turn-1",
+            conversation_id="conversation-1",
+            turn_id="turn-1",
+            seq=1,
+            event_kind="user",
+            step_started_at=None,
+            first_token_at=None,
+            completed_at=None,
+            model=None,
+            provider=None,
+            payload_json=None,
+        ),
+        _row("turn-1", _event(), seq=2),
+        SimpleNamespace(
+            message_id="assistant-1",
+            conversation_id="conversation-1",
+            turn_id="turn-1",
+            seq=3,
+            event_kind="assistant",
+            step_started_at=None,
+            first_token_at=None,
+            completed_at=None,
+            model=None,
+            provider=None,
+            payload_json=None,
+        ),
+    ]
+
+    snapshot = derive_trajectory(
+        messages, {}, rows, (), (), active_leaf_message_id="assistant-1"
+    )
+    kinds = [record.kind for turn in snapshot.turns for record in turn.records]
+
+    assert kinds == ["user", "assistant"]

--- a/Tests/Chat/test_trajectory_export.py
+++ b/Tests/Chat/test_trajectory_export.py
@@ -20,6 +20,11 @@ from tldw_chatbook.Chat.console_context_repository import (
     AuxiliaryAttemptStatus,
     ConsoleContextRepository,
 )
+from tldw_chatbook.Chat.library_activity import (
+    LibraryActivityEvent,
+    LibraryActivitySourceRef,
+    encode_library_activity_event,
+)
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.Chat.trajectory import derive_trajectory
 from tldw_chatbook.Chat.trajectory_export import (
@@ -205,6 +210,80 @@ def _snapshot_from_export(payload: dict):
         payload["compaction_records"],
         payload.get("active_leaf_message_id"),
     )
+
+
+def _seed_library_activity(database: CharactersRAGDB, conversation_id: str) -> None:
+    user_id = database.get_messages_for_conversation(
+        conversation_id, limit=100, include_image_data=False
+    )[0]["id"]
+    event = LibraryActivityEvent(
+        version=1,
+        event_id="event-activity-1",
+        attempt_id="attempt-activity-1",
+        run_id="run-activity-1",
+        actor_kind="primary",
+        parent_run_id=None,
+        library_provider="direct",
+        operation="library_search_notes",
+        status="succeeded",
+        result_count=1,
+        query_preview="private bounded query",
+        source_refs=(
+            LibraryActivitySourceRef("note", "note-secret-id", "Private title"),
+        ),
+        error_code=None,
+        error_summary=None,
+    )
+    database.upsert_trajectory_rows(
+        [
+            TrajectoryRowWrite(
+                message_id=user_id,
+                conversation_id=conversation_id,
+                turn_id=user_id,
+                seq=None,
+                event_kind="library_activity",
+                step_started_at=1_755_165_601.0,
+                payload_json=encode_library_activity_event(event),
+            )
+        ]
+    )
+
+
+def test_library_activity_export_defaults_to_outcome_only_and_full_is_bounded(db):
+    conversation_id = _seed_conversation(db)
+    _seed_library_activity(db, conversation_id)
+
+    default = build_trajectory_export(db, conversation_id)
+    default_row = next(
+        row
+        for row in default["trajectory_rows"]
+        if row["event_kind"] == "library_activity"
+    )
+    default_activity = json.loads(default_row["payload_json"])
+    assert default_activity == {
+        "version": 1,
+        "operation": "library_search_notes",
+        "status": "succeeded",
+        "result_count": 1,
+        "source_types": ["note"],
+        "error_code": None,
+    }
+    assert "private bounded query" not in json.dumps(default)
+    assert "note-secret-id" not in json.dumps(default)
+    assert "Private title" not in json.dumps(default)
+
+    full = build_trajectory_export(db, conversation_id, include_payloads=True)
+    full_row = next(
+        row
+        for row in full["trajectory_rows"]
+        if row["event_kind"] == "library_activity"
+    )
+    full_activity = json.loads(full_row["payload_json"])
+    assert full_activity["query_preview"] == "private bounded query"
+    assert full_activity["source_refs"] == [
+        {"type": "note", "id": "note-secret-id", "title": "Private title"}
+    ]
+    assert len(full_row["payload_json"].encode("utf-8")) <= 8192
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Chat/test_trajectory_import.py
+++ b/Tests/Chat/test_trajectory_import.py
@@ -27,7 +27,11 @@ from tldw_chatbook.Chat.trajectory_import import (
     load_trajectory_snapshot,
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
-from Tests.Chat.test_trajectory_export import LONG_TOOL_RESULT, _seed_conversation
+from Tests.Chat.test_trajectory_export import (
+    LONG_TOOL_RESULT,
+    _seed_conversation,
+    _seed_library_activity,
+)
 
 
 @dataclass(frozen=True)
@@ -130,6 +134,24 @@ def test_import_legacy_conversation_without_sidecar(db, tmp_path) -> None:
 
     kinds = [record.kind for turn in snapshot.turns for record in turn.records]
     assert kinds == ["user", "assistant", "user", "assistant", "compaction"]
+
+
+def test_imported_library_activity_remains_inert_sidecar_data(db) -> None:
+    conversation_id = _seed_conversation(db)
+    _seed_library_activity(db, conversation_id)
+    document = build_trajectory_export(
+        db, conversation_id, include_payloads=True
+    )
+    assert any(
+        row["event_kind"] == "library_activity"
+        for row in document["trajectory_rows"]
+    )
+
+    snapshot = load_trajectory_snapshot(document)
+    kinds = [record.kind for turn in snapshot.turns for record in turn.records]
+
+    assert "library_activity" not in kinds
+    assert "note-secret-id" not in repr(snapshot)
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_library_activity.py
+++ b/Tests/UI/test_console_library_activity.py
@@ -1,0 +1,281 @@
+"""Selected-turn Library activity review contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Chat.console_library_activity_buffer import (
+    LIBRARY_ACTIVITY_NOT_SAVED_COPY,
+    LibraryActivityFlushResult,
+)
+from tldw_chatbook.Chat.library_activity import (
+    LibraryActivityEvent,
+    LibraryActivityRecord,
+    LibraryActivitySourceRef,
+    LibraryActivityView,
+)
+from tldw_chatbook.UI.Console_Modules.right_rail import (
+    ConsoleSelectedTurnActivity,
+)
+
+
+def _view() -> LibraryActivityView:
+    event = LibraryActivityEvent(
+        version=1,
+        event_id="event-1",
+        attempt_id="attempt-1",
+        run_id="run-child",
+        actor_kind="subagent",
+        parent_run_id="run-parent",
+        library_provider="rag",
+        operation="search_library_rag",
+        status="succeeded",
+        result_count=2,
+        query_preview="bounded query",
+        source_refs=(
+            LibraryActivitySourceRef("note", "note-1", "[red] literal title"),
+            LibraryActivitySourceRef("media", "media-2", "研究 🧪"),
+        ),
+        error_code=None,
+        error_summary=None,
+    )
+    return LibraryActivityView(
+        selected_turn_id="turn-1",
+        actions=(
+            LibraryActivityRecord(
+                turn_id="turn-1",
+                sequence=4,
+                occurred_at=1_725_000_000.0,
+                event=event,
+            ),
+        ),
+    )
+
+
+class _ActivityHarness(App):
+    def __init__(
+        self,
+        view: LibraryActivityView,
+        *,
+        citation_count: int = 0,
+        flush_result: LibraryActivityFlushResult | None = None,
+    ) -> None:
+        super().__init__()
+        self._view = view
+        self._citation_count = citation_count
+        self._flush_result = flush_result
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleSelectedTurnActivity(
+            self._view,
+            citation_count=self._citation_count,
+            flush_result=self._flush_result,
+        )
+
+
+async def test_selected_turn_orders_citations_before_activity_and_renders_facts() -> None:
+    app = _ActivityHarness(_view(), citation_count=3)
+
+    async with app.run_test(size=(42, 20)):
+        group = app.query_one("#console-selected-turn")
+        direct_children = [child.id for child in group.children]
+        statics = list(group.query(Static))
+        copy = [str(item.renderable) for item in statics]
+
+        assert direct_children.index("console-selected-turn-cited-sources") < (
+            direct_children.index("console-selected-turn-library-activity")
+        )
+        assert "Cited sources (3)" in copy
+        assert "Library activity (1 actions)" in copy
+        assert any(
+            "search_library_rag · subagent · RAG · succeeded · 2 results" in line
+            for line in copy
+        )
+        assert any("note · [red] literal title · note-1" in line for line in copy)
+        assert any("media · 研究 🧪 · media-2" in line for line in copy)
+        literal = next(item for item in statics if "[red] literal title" in str(item.renderable))
+        assert literal._render_markup is False
+
+
+async def test_selected_turn_has_explicit_empty_activity_state() -> None:
+    app = _ActivityHarness(
+        LibraryActivityView(selected_turn_id="turn-1", actions=()),
+        citation_count=0,
+    )
+
+    async with app.run_test():
+        assert str(
+            app.query_one("#console-library-activity-empty", Static).renderable
+        ) == "No Library activity for this turn."
+        assert str(
+            app.query_one("#console-selected-turn-cited-sources", Static).renderable
+        ) == "Cited sources (0)"
+
+
+async def test_selected_turn_becomes_visible_when_selection_arrives() -> None:
+    app = _ActivityHarness(LibraryActivityView(selected_turn_id=None, actions=()))
+
+    async with app.run_test() as pilot:
+        selected_turn = app.query_one(
+            "#console-selected-turn", ConsoleSelectedTurnActivity
+        )
+        selected_turn.sync_state(_view(), citation_count=0, flush_result=None)
+        await pilot.pause()
+
+        assert selected_turn.styles.display == "block"
+
+
+async def test_unsaved_activity_state_exposes_retry_without_owning_persistence() -> None:
+    app = _ActivityHarness(
+        _view(),
+        flush_result=LibraryActivityFlushResult(
+            "failed",
+            saved_count=0,
+            pending_count=1,
+            error_code="retry_exhausted",
+            warning=LIBRARY_ACTIVITY_NOT_SAVED_COPY,
+        ),
+    )
+
+    async with app.run_test():
+        warning = app.query_one("#console-library-activity-save-warning", Static)
+        retry = app.query_one("#console-library-activity-retry", Button)
+
+        assert str(warning.renderable) == LIBRARY_ACTIVITY_NOT_SAVED_COPY
+        assert retry.label.plain == "Retry"
+        assert retry.can_focus
+
+
+async def test_eight_references_remain_inside_the_selected_turn_section() -> None:
+    event = _view().actions[0].event
+    refs = tuple(
+        LibraryActivitySourceRef("note", f"note-{index}", f"Title {index}")
+        for index in range(8)
+    )
+    view = LibraryActivityView(
+        selected_turn_id="turn-1",
+        actions=(
+            LibraryActivityRecord(
+                turn_id="turn-1",
+                sequence=1,
+                occurred_at=1.0,
+                event=replace(event, source_refs=refs),
+            ),
+        ),
+    )
+    app = _ActivityHarness(view)
+
+    async with app.run_test(size=(34, 10)):
+        group = app.query_one("#console-selected-turn")
+        assert len(group.query(".console-library-activity-source-ref")) == 8
+        assert not app.query("#console-library-activity-top-level")
+
+
+async def test_error_copy_is_literal_and_invalid_time_degrades_safely() -> None:
+    event = replace(
+        _view().actions[0].event,
+        status="failed",
+        error_code="storage_error",
+        error_summary="[bold red]literal error[/]",
+    )
+    app = _ActivityHarness(
+        LibraryActivityView(
+            selected_turn_id="turn-1",
+            actions=(
+                LibraryActivityRecord(
+                    turn_id="turn-1",
+                    sequence=1,
+                    occurred_at=1e300,
+                    event=event,
+                ),
+            ),
+        )
+    )
+
+    async with app.run_test():
+        error = app.query_one("#console-library-activity-error-0", Static)
+        action = app.query_one("#console-library-activity-action-0", Static)
+        assert str(error.renderable) == "[bold red]literal error[/]"
+        assert error._render_markup is False
+        assert "time unavailable" in str(action.renderable)
+
+
+async def test_message_affordance_selects_turn_opens_inspector_and_focuses_activity() -> None:
+    from Tests.UI.test_console_right_rail import make_console_pilot
+    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+    from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+    async with make_console_pilot() as pilot:
+        screen = pilot.app.screen
+        store = screen._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
+        user = store.append_message(
+            session_id,
+            role=ConsoleMessageRole.USER,
+            content="Question",
+        )
+        assistant = store.append_message(
+            session_id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="Answer",
+        )
+        store.admit_library_activity(session_id, user.id, _view().actions[0].event)
+        screen._library_activity.invalidate_projection()
+        await screen._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        await pilot.click(f"#console-library-activity-{assistant.id}")
+        await pilot.pause(0.05)
+        await pilot.pause()
+
+        transcript = screen.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        selected_turn = screen.query_one("#console-selected-turn")
+        assert transcript.selected_message_id == assistant.id
+        assert selected_turn.styles.display == "block"
+        assert screen.query_one("#console-right-rail").display
+        assert pilot.app.focused is not None
+        assert (
+            pilot.app.focused.id
+            == "console-selected-turn-library-activity-heading"
+        )
+
+
+async def test_inspector_retry_delegates_to_store_owned_callback() -> None:
+    from Tests.UI.test_console_right_rail import make_console_pilot
+
+    called = asyncio.Event()
+
+    async def retry() -> None:
+        called.set()
+
+    async with make_console_pilot() as pilot:
+        screen = pilot.app.screen
+        screen._reveal_console_inspector_rail()
+        await pilot.pause()
+        rail = screen.query_one("#console-right-rail")
+        rail._library_activity_retry = retry
+        rail.sync_library_activity(
+            _view(),
+            citation_count=0,
+            flush_result=LibraryActivityFlushResult(
+                "failed",
+                saved_count=0,
+                pending_count=1,
+                error_code="retry_exhausted",
+                warning=LIBRARY_ACTIVITY_NOT_SAVED_COPY,
+            ),
+        )
+        await pilot.pause()
+        retry_button = rail.query_one("#console-library-activity-retry", Button)
+
+        retry_button.press()
+        await asyncio.wait_for(called.wait(), timeout=1)
+
+        assert called.is_set()

--- a/Tests/UI/test_console_library_tool_setting.py
+++ b/Tests/UI/test_console_library_tool_setting.py
@@ -108,6 +108,101 @@ def test_factory_reads_captured_context_without_rebuilding_controller(monkeypatc
     assert screen._console_chat_controller is controller
 
 
+def test_factory_wires_activity_capture_from_real_turn_context(monkeypatch):
+    from tldw_chatbook.Chat.console_chat_models import (
+        ConsoleMessageRole,
+        ConsoleProviderSelection,
+    )
+    from tldw_chatbook.Chat.console_dispatch_checkpoint import (
+        ConsoleEgressClass,
+        ConsoleLibraryItemScopeSnapshot,
+        ConsoleProviderIntent,
+        ConsoleResolvedDestination,
+        ConsoleTurnLibraryAuthority,
+    )
+    from tldw_chatbook.Chat.console_library_policy import (
+        AUTOMATIC_LIBRARY_SOURCE_TYPES,
+        ConsoleAssistantLibraryAccess,
+        ConsoleAutoRetrieve,
+        ConsoleLibraryPolicySnapshot,
+    )
+    from tldw_chatbook.Chat.console_turn_context import (
+        ConsoleTurnConfigurationSnapshot,
+        ConsoleTurnExecutionContext,
+    )
+    from tldw_chatbook.Chat.library_activity import LibraryActivityEvent
+
+    _patch_cli_config(monkeypatch, {"console": {"direct_library_tools": True}})
+    _app, screen = _build_screen()
+    store = screen._ensure_console_chat_store()
+    session = store.create_session(ephemeral=True)
+    user = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    authority = ConsoleTurnLibraryAuthority(
+        policy=ConsoleLibraryPolicySnapshot(
+            auto_retrieve=ConsoleAutoRetrieve.NEVER,
+            assistant_access=ConsoleAssistantLibraryAccess.ALLOWED,
+            policy_revision=1,
+            source="durable",
+            error_code=None,
+        ),
+        direct_library_tools=True,
+        source_types=AUTOMATIC_LIBRARY_SOURCE_TYPES,
+        scope_snapshot=ConsoleLibraryItemScopeSnapshot(
+            note_ids=(), media_ids=(), conversations_allowed=True
+        ),
+        provider_intent=ConsoleProviderIntent(
+            provider="openai", model="model-a", endpoint=None
+        ),
+        attempt_id="attempt-live",
+    )
+    context = ConsoleTurnExecutionContext(
+        configuration=ConsoleTurnConfigurationSnapshot.capture(
+            session_id=session.id,
+            provider_selection=ConsoleProviderSelection(
+                provider="openai", explicit_model="model-a"
+            ),
+        ),
+        library_authority=authority,
+        resolved_destination=ConsoleResolvedDestination(
+            provider="openai",
+            model="model-a",
+            endpoint_identity="https://api.openai.com",
+            egress_class=ConsoleEgressClass.PUBLIC_NETWORK,
+        ),
+    )
+
+    provider = screen._console_library_provider_factory(context)
+    event = LibraryActivityEvent(
+        version=1,
+        event_id="event-live",
+        attempt_id="attempt-live",
+        run_id="run-live",
+        actor_kind="primary",
+        parent_run_id=None,
+        library_provider="direct",
+        operation="library_search_notes",
+        status="succeeded",
+        result_count=1,
+        query_preview="query",
+        source_refs=(),
+        error_code=None,
+        error_summary=None,
+    )
+
+    assert provider is not None
+    assert provider._activity_attempt_id == "attempt-live"
+    assert provider._activity_sink is not None
+    provider._activity_sink(event)
+    pending = store.pending_library_activity(session.id)
+    assert [(item.owner_message_key, item.event) for item in pending] == [
+        (user.id, event)
+    ]
+
+
 def test_factory_assembles_service_only_from_local_app_attributes(monkeypatch):
     """The direct service is wired from the app's local service attributes --
     and only those (identity, not reconstruction)."""

--- a/Tests/UI/test_console_library_tool_setting.py
+++ b/Tests/UI/test_console_library_tool_setting.py
@@ -48,7 +48,7 @@ def _turn_context(*, direct: bool):
     )
 
 
-# --- ChatScreen provider factory --------------------------------------------
+# --- Library activity controller provider factory ---------------------------
 
 
 def test_factory_direct_mode_builds_library_tool_provider(monkeypatch):
@@ -60,7 +60,7 @@ def test_factory_direct_mode_builds_library_tool_provider(monkeypatch):
     _patch_cli_config(monkeypatch, {"console": {"direct_library_tools": True}})
     _app, screen = _build_screen()
 
-    provider = screen._console_library_provider_factory(_turn_context(direct=True))
+    provider = screen._library_activity.build_provider(_turn_context(direct=True))
 
     assert isinstance(provider, LibraryToolProvider)
     assert isinstance(provider._service, LocalLibraryToolService)
@@ -74,7 +74,7 @@ def test_factory_off_mode_builds_bounded_rag_provider(monkeypatch):
     _patch_cli_config(monkeypatch, {"console": {"direct_library_tools": False}})
     app, screen = _build_screen()
 
-    provider = screen._console_library_provider_factory(_turn_context(direct=False))
+    provider = screen._library_activity.build_provider(_turn_context(direct=False))
 
     assert isinstance(provider, LibraryRagToolProvider)
     assert provider._rag_service is getattr(app, "library_rag_search_service", None)
@@ -84,7 +84,7 @@ def test_factory_fails_closed_when_turn_context_is_missing(monkeypatch):
     _patch_cli_config(monkeypatch, {})
     _app, screen = _build_screen()
 
-    assert screen._console_library_provider_factory() is None
+    assert screen._library_activity.build_provider(None) is None
 
 
 def test_factory_reads_captured_context_without_rebuilding_controller(monkeypatch):
@@ -175,7 +175,7 @@ def test_factory_wires_activity_capture_from_real_turn_context(monkeypatch):
         ),
     )
 
-    provider = screen._console_library_provider_factory(context)
+    provider = screen._library_activity.build_provider(context)
     event = LibraryActivityEvent(
         version=1,
         event_id="event-live",
@@ -217,7 +217,7 @@ def test_factory_assembles_service_only_from_local_app_attributes(monkeypatch):
     app.local_chat_conversation_service = SimpleNamespace(marker="conversations")
     app.local_library_collections_service = SimpleNamespace(marker="collections")
 
-    provider = screen._console_library_provider_factory(_turn_context(direct=True))
+    provider = screen._library_activity.build_provider(_turn_context(direct=True))
 
     assert isinstance(provider, LibraryToolProvider)
     service = provider._service
@@ -241,7 +241,7 @@ def test_factory_wires_the_policy_enforcer_into_the_chunk_tool_service(monkeypat
     app, screen = _build_screen()
     app.local_media_reading_service = SimpleNamespace(marker="media")
 
-    provider = screen._console_library_provider_factory(_turn_context(direct=True))
+    provider = screen._library_activity.build_provider(_turn_context(direct=True))
 
     assert isinstance(provider, LibraryToolProvider)
     chunk_service = provider._service._media_chunk
@@ -271,7 +271,7 @@ def test_factory_chunk_read_tools_degrade_when_one_media_handle_is_missing(
     )
     app.local_media_reading_service = None
 
-    provider = screen._console_library_provider_factory(_turn_context(direct=True))
+    provider = screen._library_activity.build_provider(_turn_context(direct=True))
 
     assert isinstance(provider, LibraryToolProvider)
     assert provider._service._media_chunk is not None
@@ -303,7 +303,7 @@ def test_factory_missing_backend_yields_per_tool_feature_unavailable(monkeypatch
     app.local_chat_conversation_service = None
     app.local_library_collections_service = None
 
-    provider = screen._console_library_provider_factory(_turn_context(direct=True))
+    provider = screen._library_activity.build_provider(_turn_context(direct=True))
 
     assert isinstance(provider, LibraryToolProvider)
     # Catalog still exposes the full descriptor set (no total failure).
@@ -333,7 +333,7 @@ def test_factory_present_backend_serves_its_tool(monkeypatch):
     app.local_chat_conversation_service = None
     app.local_library_collections_service = None
 
-    provider = screen._console_library_provider_factory(_turn_context(direct=True))
+    provider = screen._library_activity.build_provider(_turn_context(direct=True))
     result = provider.invoke("library:library_list_notes", {"limit": 5})
 
     assert result.ok is True

--- a/Tests/UI/test_console_right_rail.py
+++ b/Tests/UI/test_console_right_rail.py
@@ -208,6 +208,7 @@ def _mounted_boundary_ids(rail) -> tuple[str, ...]:
     run_wrapper_children = tuple(child.id for child in run_wrapper.children)
     assert run_wrapper_children == (
         "console-run-inspector-state",
+        "console-selected-turn",
         "console-settings-summary",
     )
     inspector = run_wrapper.query_one(

--- a/Tests/UI/test_console_transcript_selection_contract.py
+++ b/Tests/UI/test_console_transcript_selection_contract.py
@@ -145,6 +145,33 @@ def test_citation_row_is_focusable_and_immediately_follows_owning_message() -> N
     assert button.can_focus
 
 
+def test_library_activity_affordance_follows_citations_and_owns_the_assistant() -> None:
+    transcript = ConsoleTranscript()
+    transcript.set_messages(_transcript_messages())
+    transcript.set_citation_counts({"assistant-native-id": 2})
+    transcript.set_library_activity_counts({"assistant-native-id": 3})
+
+    rows = transcript._transcript_rows()
+    assistant_turn = next(
+        row for row in rows if row.key == "assistant-turn:assistant-native-id"
+    )
+    assert [row.key for row in assistant_turn.nested_rows] == [
+        "message:assistant-native-id",
+        "citations:assistant-native-id",
+        "library-activity:assistant-native-id",
+    ]
+    activity_row = assistant_turn.nested_rows[2]
+    button = transcript._build_row_widget(activity_row, track=False)
+
+    assert activity_row.kind == "library-activity"
+    assert isinstance(button, Button)
+    assert button.label.plain == "Library activity (3 actions)"
+    assert button.id == "console-library-activity-assistant-native-id"
+    assert button.has_class("console-transcript-library-activity")
+    assert button.native_message_id == "assistant-native-id"
+    assert button.can_focus
+
+
 @pytest.mark.parametrize("counts", [{}, {"assistant-native-id": 0}])
 def test_zero_or_absent_citation_count_adds_no_row(counts: dict[str, int]) -> None:
     transcript = ConsoleTranscript()
@@ -152,6 +179,17 @@ def test_zero_or_absent_citation_count_adds_no_row(counts: dict[str, int]) -> No
     transcript.set_citation_counts(counts)
 
     assert all(row.kind != "citations" for row in transcript._transcript_rows())
+
+
+@pytest.mark.parametrize("counts", [{}, {"assistant-native-id": 0}])
+def test_zero_or_absent_activity_count_adds_no_row(counts: dict[str, int]) -> None:
+    transcript = ConsoleTranscript()
+    transcript.set_messages(_transcript_messages())
+    transcript.set_library_activity_counts(counts)
+
+    assert all(
+        row.kind != "library-activity" for row in transcript._transcript_rows()
+    )
 
 
 class _CitationTranscriptHarness(App):

--- a/backlog/tasks/task-19900.5 - Capture-and-review-minimized-assistant-Library-activity.md
+++ b/backlog/tasks/task-19900.5 - Capture-and-review-minimized-assistant-Library-activity.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-19900.5
 title: Capture and review minimized assistant Library activity
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-22'
+updated_date: '2026-08-28 00:21'
 labels:
   - console
   - agents
@@ -12,43 +14,52 @@ labels:
 dependencies:
   - task-19900.2
   - task-19900.4
-parent_task_id: TASK-19900
-priority: high
 documentation:
   - Docs/superpowers/specs/2026-08-22-console-library-controls-design.md
   - Docs/superpowers/plans/2026-08-22-console-library-controls.md
   - backlog/decisions/079-console-library-conversation-authority.md
+parent_task_id: TASK-19900
+priority: high
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Record bounded, device-local assistant Library operations at the trusted
 provider seam and expose them for the selected turn without turning them into
 evidence or model context.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] Direct and RAG operations capture versioned, bounded activity before
+<!-- AC:BEGIN -->
+- [ ] #1 Direct and RAG operations capture versioned, bounded activity before
       result truncation/model delivery with turn, attempt, run, and
       primary/subagent attribution.
-- [ ] Activity excludes source bodies, snippets, paths, credentials,
+- [ ] #2 Activity excludes source bodies, snippets, paths, credentials,
       unbounded identifiers/titles/queries, and arbitrary errors; logs remain
       payload-free.
-- [ ] Capture failure withholds the Library result, while durable persistence
+- [ ] #3 Capture failure withholds the Library result, while durable persistence
       remains in an app/store-owned buffer across navigation, retries, exposes
       an explicit not-saved-in-this-session recovery, and receives a final
       bounded close/promotion/shutdown flush without retroactively failing a
       completed turn.
-- [ ] Ephemeral promotion, concurrency, active-branch selection, and durable
+- [ ] #4 Ephemeral promotion, concurrency, active-branch selection, and durable
       turn-opener anchoring preserve attribution and all-or-nothing ownership;
       promotion contributes `library_activity` rows through the foundation's
       transaction seam and restores the activity buffer/session on failure.
-- [ ] Generic trajectory derivation cannot displace or duplicate an anchor;
+- [ ] #5 Generic trajectory derivation cannot displace or duplicate an anchor;
       one separate pure projection owns Library activity presentation.
-- [ ] The Selected turn Inspector distinguishes Cited sources and Library
+- [ ] #6 The Selected turn Inspector distinguishes Cited sources and Library
       activity, focuses the correct turn from message affordances, and shows an
       explicit empty state.
-- [ ] Activity never enters Sources, staged context, prompts, provider history,
+- [ ] #7 Activity never enters Sources, staged context, prompts, provider history,
       sync, or ordinary logs; new/changed paths log no payload or arbitrary
       exception text, default trajectory export redacts details, and explicit
       full export retains only the already bounded event.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no\nADR path: backlog/decisions/079-console-library-conversation-authority.md\nReason: this child implements ADR-079 bounded activity capture, local sidecar persistence, export redaction, and Inspector projection without changing an architectural boundary.\n\n1. Baseline the existing Direct/RAG provider, run-context, transaction-writer, trajectory/export, and selected-turn Inspector seams.\n2. Add RED tests and the minimum bounded activity codec plus primary/subagent attribution and capture-withholding behavior at both trusted provider result seams.\n3. Add RED tests and a store-owned concurrency-safe pending buffer, transaction contribution, pure selected-turn projection, promotion rollback behavior, and default/full export handling.\n4. Add RED production-shaped UI tests and thin Selected turn Inspector/message-focus wiring without mixing activity into Sources or generic trajectory.\n5. Run the Delivery 5 targeted battery, Ruff, compileall, CSS/screen ratchets where touched, mutation checks, and git diff --check; then complete ACs, notes, lessons review, and status.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-19900.5 - Capture-and-review-minimized-assistant-Library-activity.md
+++ b/backlog/tasks/task-19900.5 - Capture-and-review-minimized-assistant-Library-activity.md
@@ -80,7 +80,7 @@ projection that cannot enter the generic trajectory.
 Added the Selected turn Inspector section, assistant message affordance,
 not-saved Retry flow, and literal/bounded UI rendering. Provider construction
 and activity projection were moved into
-`UI/Console_Modules/library_activity.py`, reducing `chat_screen.py` to 16,978
+`UI/Console_Modules/library_activity.py`, reducing `chat_screen.py` to 17,000
 lines and 565 methods after the final rebase; the one-way ratchet was lowered
 to that measurement.
 
@@ -93,4 +93,16 @@ ratchet, and `git diff --check` passed. Both planned mutation checks failed when
 the source-body whitelist and sidecar-only trajectory exclusion were weakened,
 then passed after restoration. Three unrelated trajectory-capture failures were
 reproduced on pristine `origin/dev` and were not changed in this task.
+
+Post-PR review: rebased onto the latest `dev` and addressed all six Qodo
+findings. Durable decoding now uses strict extra-forbidden Pydantic v2 schemas;
+new public activity APIs document their contracts; ephemeral capture no longer
+consumes persistence retries; close drains every bounded durable batch under a
+shared capture/close lifecycle lock; and close explicitly releases any failed
+or temporary session buffer state so late daemon captures cannot become
+orphaned. Added focused ephemeral, multi-batch, failed-close, late-capture race,
+discard, and strict-schema regressions. The expanded delivery matrix passed 403
+tests with one known stale-schema test deselected. Reviewed all seven new
+payload-free diagnostic statements and regenerated the production diagnostic
+inventory.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19900.5 - Capture-and-review-minimized-assistant-Library-activity.md
+++ b/backlog/tasks/task-19900.5 - Capture-and-review-minimized-assistant-Library-activity.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-19900.5
 title: Capture and review minimized assistant Library activity
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-22'
-updated_date: '2026-08-28 00:21'
+updated_date: '2026-08-28 01:41'
 labels:
   - console
   - agents
@@ -32,27 +32,27 @@ evidence or model context.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Direct and RAG operations capture versioned, bounded activity before
+- [x] #1 Direct and RAG operations capture versioned, bounded activity before
       result truncation/model delivery with turn, attempt, run, and
       primary/subagent attribution.
-- [ ] #2 Activity excludes source bodies, snippets, paths, credentials,
+- [x] #2 Activity excludes source bodies, snippets, paths, credentials,
       unbounded identifiers/titles/queries, and arbitrary errors; logs remain
       payload-free.
-- [ ] #3 Capture failure withholds the Library result, while durable persistence
+- [x] #3 Capture failure withholds the Library result, while durable persistence
       remains in an app/store-owned buffer across navigation, retries, exposes
       an explicit not-saved-in-this-session recovery, and receives a final
       bounded close/promotion/shutdown flush without retroactively failing a
       completed turn.
-- [ ] #4 Ephemeral promotion, concurrency, active-branch selection, and durable
+- [x] #4 Ephemeral promotion, concurrency, active-branch selection, and durable
       turn-opener anchoring preserve attribution and all-or-nothing ownership;
       promotion contributes `library_activity` rows through the foundation's
       transaction seam and restores the activity buffer/session on failure.
-- [ ] #5 Generic trajectory derivation cannot displace or duplicate an anchor;
+- [x] #5 Generic trajectory derivation cannot displace or duplicate an anchor;
       one separate pure projection owns Library activity presentation.
-- [ ] #6 The Selected turn Inspector distinguishes Cited sources and Library
+- [x] #6 The Selected turn Inspector distinguishes Cited sources and Library
       activity, focuses the correct turn from message affordances, and shows an
       explicit empty state.
-- [ ] #7 Activity never enters Sources, staged context, prompts, provider history,
+- [x] #7 Activity never enters Sources, staged context, prompts, provider history,
       sync, or ordinary logs; new/changed paths log no payload or arbitrary
       exception text, default trajectory export redacts details, and explicit
       full export retains only the already bounded event.
@@ -63,3 +63,34 @@ evidence or model context.
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: no\nADR path: backlog/decisions/079-console-library-conversation-authority.md\nReason: this child implements ADR-079 bounded activity capture, local sidecar persistence, export redaction, and Inspector projection without changing an architectural boundary.\n\n1. Baseline the existing Direct/RAG provider, run-context, transaction-writer, trajectory/export, and selected-turn Inspector seams.\n2. Add RED tests and the minimum bounded activity codec plus primary/subagent attribution and capture-withholding behavior at both trusted provider result seams.\n3. Add RED tests and a store-owned concurrency-safe pending buffer, transaction contribution, pure selected-turn projection, promotion rollback behavior, and default/full export handling.\n4. Add RED production-shaped UI tests and thin Selected turn Inspector/message-focus wiring without mixing activity into Sources or generic trajectory.\n5. Run the Delivery 5 targeted battery, Ruff, compileall, CSS/screen ratchets where touched, mutation checks, and git diff --check; then complete ACs, notes, lessons review, and status.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented ADR-079's minimized activity channel at both trusted Library
+provider seams. Direct and RAG results now produce bounded v1 events with
+attempt/run/actor attribution before model delivery; unsafe payloads are
+withheld, and only whitelisted, redacted review fields are retained.
+
+Added the app/store-owned retry buffer, durable `library_activity` sidecars,
+promotion contribution/rollback handling, redacted/default and bounded/full
+trajectory export behavior, and a separate active-branch selected-turn
+projection that cannot enter the generic trajectory.
+
+Added the Selected turn Inspector section, assistant message affordance,
+not-saved Retry flow, and literal/bounded UI rendering. Provider construction
+and activity projection were moved into
+`UI/Console_Modules/library_activity.py`, reducing `chat_screen.py` to 16,978
+lines and 565 methods after the final rebase; the one-way ratchet was lowered
+to that measurement.
+
+ADR required: no. Existing ADR-079 is the governing decision; no boundary or
+storage-policy decision changed.
+
+Verification: the task-scoped delivery matrix passed 396 tests with one known
+stale-schema test deselected; Ruff, compileall, CSS bundle sync, the screen-size
+ratchet, and `git diff --check` passed. Both planned mutation checks failed when
+the source-body whitelist and sidecar-only trajectory exclusion were weakened,
+then passed after restoration. Three unrelated trajectory-capture failures were
+reproduced on pristine `origin/dev` and were not changed in this task.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -120,7 +120,7 @@ from .native_tools import (
     provider_supports_native_tools,
     schemas_to_openai_tools,
 )
-from .run_context import use_run_id
+from .run_context import CurrentRunActor, use_run_actor
 from .run_log import _setting
 from .run_log_eviction import (
     DEFAULT_MIN_RECENT_ROUNDS,
@@ -2240,6 +2240,7 @@ class AgentService:
         should_cancel: Callable[[], bool] = lambda: False,
         *,
         run_id: str,
+        run_actor: CurrentRunActor | None = None,
     ):
         """Build this run's ``LoopDeps.invoke_tool``.
 
@@ -2247,8 +2248,10 @@ class AgentService:
             config: This run's config (allow-list and budgets).
             disclosed_names: The tool names whose schemas this run has.
             should_cancel: Cooperative cancellation probe.
-            run_id: THIS run's id, bound via ``run_context.use_run_id``
-                around each invocation so the permission gates can find
+            run_id: THIS run's id, used for the legacy primary-actor fallback.
+            run_actor: Exact primary/subagent attribution, bound via
+                ``run_context.use_run_actor`` around each invocation so the
+                permission gates can find
                 this run's own approval stamps (PR2a Task 5). Bound
                 INSIDE the callable handed to ``_call_with_timeout``, so
                 it is established on the per-call daemon thread that
@@ -2263,6 +2266,8 @@ class AgentService:
                 a loud ``TypeError`` at the call site.
         """
 
+        actor = run_actor or CurrentRunActor("primary", run_id, None)
+
         def invoke_tool(call: ToolCall) -> ToolResult:
             if (
                 call.name not in config.allowed_tools
@@ -2274,7 +2279,7 @@ class AgentService:
             )
 
             def _invoke() -> ToolResult:
-                with use_run_id(run_id):
+                with use_run_actor(actor):
                     return self.registry.invoke_by_name(call.name, call.args)
 
             if timeout and timeout > 0:
@@ -4697,8 +4702,17 @@ class AgentService:
         # run's spawn -- so it is budget-counted (via spawn's own shared
         # sub_agent_spawns counter -- see Finding 2 above), cancellable, and
         # DB-lineage-tracked exactly like a spawn_subagent call.
+        run_actor = CurrentRunActor(
+            "subagent" if agent_kind == AGENT_KIND_SUBAGENT else "primary",
+            run_id,
+            parent_run_id,
+        )
         builtin_invoke_tool = self._make_invoke_tool(
-            config, disclosed_names, should_cancel, run_id=run_id
+            config,
+            disclosed_names,
+            should_cancel,
+            run_id=run_id,
+            run_actor=run_actor,
         )
 
         def invoke_tool(
@@ -5452,7 +5466,7 @@ class AgentService:
             # its verdicts against the run that will consume them.
             # (PR2a Task 7 binds this run's id as the `run_context` for the
             # whole loop below, so the approval bridge this hook calls can
-            # record which run armed each card -- see the `use_run_id`
+            # record which run armed each card -- see the `use_run_actor`
             # wrapper on `run_agent_loop`.)
             review_tool_calls=(
                 (lambda calls: self.review_tool_calls(calls, run_id))
@@ -5568,7 +5582,7 @@ class AgentService:
             # identity). One binding here covers both, and every future
             # loop-thread consumer, with no signature churn.
             #
-            # Nested inline sub-agent runs unwind LIFO (`use_run_id`
+            # Nested inline sub-agent runs unwind LIFO (`use_run_actor`
             # resets in its own `finally`), and a threaded child simply
             # sets its own value on its own thread.
             continuation_kwargs: dict[str, Any] = {}
@@ -5580,7 +5594,7 @@ class AgentService:
                 continuation_kwargs["restore_provider_target"] = restore_provider_target
             if resume_provider_continuation:
                 continuation_kwargs["resume_provider_continuation"] = True
-            with use_run_id(run_id):
+            with use_run_actor(run_actor):
                 outcome = run_agent_loop(
                     config,
                     run_messages,

--- a/tldw_chatbook/Agents/library_rag_tool_provider.py
+++ b/tldw_chatbook/Agents/library_rag_tool_provider.py
@@ -21,6 +21,7 @@ worker thread, where bridging the async retrieval service with
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Mapping
 from typing import Any
 
@@ -33,6 +34,12 @@ from tldw_chatbook.Agents.agent_models import (
 )
 from tldw_chatbook.Agents.library_tool_provider import (
     _BuiltinLibraryAuthorityIssuer,
+)
+from tldw_chatbook.Agents.run_context import current_run_actor
+from tldw_chatbook.Chat.library_activity import (
+    LibraryActivityCandidate,
+    LibraryActivitySink,
+    minimize_library_activity,
 )
 from tldw_chatbook.Library.library_expand_policy import (
     EXPANDABLE_SOURCE_TYPES,
@@ -49,6 +56,7 @@ from tldw_chatbook.Library.library_rag_service import (
 from tldw_chatbook.Library.library_tool_contract import (
     ERROR_INDEX_UNAVAILABLE,
     ERROR_INVALID_ARGUMENT,
+    ERROR_STORAGE_ERROR,
     LibraryToolError,
     MAX_RESULT_BYTES,
     MAX_SEARCH_QUERY_CHARS,
@@ -209,7 +217,13 @@ class LibraryRagToolProvider(_BuiltinLibraryAuthorityIssuer):
 
     SOURCE = "library"
 
-    def __init__(self, rag_service: Any) -> None:
+    def __init__(
+        self,
+        rag_service: Any,
+        *,
+        activity_attempt_id: str | None = None,
+        activity_sink: LibraryActivitySink | None = None,
+    ) -> None:
         """Bind the app-owned Library RAG search service (duck-typed ``search``).
 
         ``None`` (or a service without ``search``) is a supported construction:
@@ -218,6 +232,65 @@ class LibraryRagToolProvider(_BuiltinLibraryAuthorityIssuer):
         """
         self._initialize_builtin_authority_issuer()
         self._rag_service = rag_service
+        self._activity_attempt_id = activity_attempt_id
+        self._activity_sink = activity_sink
+
+    @staticmethod
+    def _capture_failure() -> ToolResult:
+        return _error_result(
+            LibraryToolError(
+                ERROR_STORAGE_ERROR,
+                "Library result withheld because activity could not be recorded.",
+                retryable=True,
+                details={"category": "review_capture_failed"},
+            )
+        )
+
+    def _capture_activity(self, arguments: Mapping[str, Any], outcome: object) -> bool:
+        if self._activity_sink is None:
+            return True
+        actor = current_run_actor()
+        if actor is None or not self._activity_attempt_id:
+            logger.warning(
+                "Library activity capture failed; result withheld "
+                "category=review_capture_failed"
+            )
+            return False
+        structured: object = outcome
+        if isinstance(outcome, ToolResult):
+            try:
+                structured = json.loads(outcome.error or outcome.content or "{}")
+            except (TypeError, ValueError):
+                structured = {"error": {"code": "activity_failed"}}
+        try:
+            event = minimize_library_activity(
+                LibraryActivityCandidate(
+                    attempt_id=self._activity_attempt_id,
+                    actor_kind=actor.kind,
+                    run_id=actor.run_id,
+                    parent_run_id=actor.parent_run_id,
+                    library_provider="rag",
+                    operation=RAG_TOOL_NAME,
+                    arguments=arguments,
+                    structured_result=structured,
+                    failure_code=None,
+                )
+            )
+            self._activity_sink(event)
+        except Exception:  # noqa: BLE001 - payload/exception text must not log
+            logger.warning(
+                "Library activity capture failed; result withheld "
+                "category=review_capture_failed"
+            )
+            return False
+        return True
+
+    def _refuse(self, arguments: Mapping[str, Any], message: str) -> ToolResult:
+        """Capture one valid RAG operation refused before backend dispatch."""
+        outcome = _invalid(message)
+        if not self._capture_activity(arguments, outcome):
+            return self._capture_failure()
+        return outcome
 
     def _tool_id(self) -> str:
         return f"{self.SOURCE}:{RAG_TOOL_NAME}"
@@ -250,23 +323,29 @@ class LibraryRagToolProvider(_BuiltinLibraryAuthorityIssuer):
         if args is None:
             args = {}
         if not isinstance(args, dict):
-            return _invalid("arguments must be a JSON object")
+            return self._refuse({}, "arguments must be a JSON object")
         unknown = sorted(set(args) - _ARGUMENT_KEYS)
         if unknown:
-            return _invalid(f"unsupported argument(s): {', '.join(unknown)}")
+            return self._refuse(
+                args, f"unsupported argument(s): {', '.join(unknown)}"
+            )
 
         query = args.get("query")
         if not isinstance(query, str) or not query.strip():
-            return _invalid("a non-empty query string is required")
+            return self._refuse(args, "a non-empty query string is required")
         query = query.strip()
         if len(query) > MAX_SEARCH_QUERY_CHARS:
-            return _invalid(f"query must be at most {MAX_SEARCH_QUERY_CHARS} characters")
+            return self._refuse(
+                args, f"query must be at most {MAX_SEARCH_QUERY_CHARS} characters"
+            )
 
         top_k = args.get("top_k", _DEFAULT_TOP_K)
         if isinstance(top_k, bool) or not isinstance(top_k, int):
-            return _invalid("top_k must be an integer")
+            return self._refuse(args, "top_k must be an integer")
         if not 1 <= top_k <= _MAX_TOP_K:
-            return _invalid(f"top_k must be between 1 and {_MAX_TOP_K}")
+            return self._refuse(
+                args, f"top_k must be between 1 and {_MAX_TOP_K}"
+            )
 
         source_types = args.get("source_types")
         if source_types is None:
@@ -280,13 +359,16 @@ class LibraryRagToolProvider(_BuiltinLibraryAuthorityIssuer):
                     for item in source_types
                 )
             ):
-                return _invalid(
+                return self._refuse(
+                    args,
                     "source_types must be a non-empty subset of: "
-                    + ", ".join(SUPPORTED_RAG_SOURCE_TYPES)
+                    + ", ".join(SUPPORTED_RAG_SOURCE_TYPES),
                 )
             selected = tuple(dict.fromkeys(source_types))
 
         outcome = self._run_search(query, selected, top_k)
+        if not self._capture_activity(args, outcome):
+            return self._capture_failure()
         if isinstance(outcome, ToolResult):
             return outcome
         return self._success_result(outcome, query, selected)

--- a/tldw_chatbook/Agents/library_tool_provider.py
+++ b/tldw_chatbook/Agents/library_tool_provider.py
@@ -30,6 +30,12 @@ from tldw_chatbook.Agents.agent_models import (
 from tldw_chatbook.Chat.console_library_policy import (
     ConsoleAssistantLibraryAccess,
 )
+from tldw_chatbook.Chat.library_activity import (
+    LibraryActivityCandidate,
+    LibraryActivitySink,
+    minimize_library_activity,
+)
+from tldw_chatbook.Agents.run_context import current_run_actor
 from tldw_chatbook.Library.library_tool_contract import (
     ERROR_INVALID_ARGUMENT,
     ERROR_STORAGE_ERROR,
@@ -122,10 +128,64 @@ class LibraryToolProvider(_BuiltinLibraryAuthorityIssuer):
 
     SOURCE = "library"
 
-    def __init__(self, service: Any) -> None:
+    def __init__(
+        self,
+        service: Any,
+        *,
+        activity_attempt_id: str | None = None,
+        activity_sink: LibraryActivitySink | None = None,
+    ) -> None:
         """Bind the shared synchronous Library service (duck-typed ``invoke``)."""
         self._initialize_builtin_authority_issuer()
         self._service = service
+        self._activity_attempt_id = activity_attempt_id
+        self._activity_sink = activity_sink
+
+    @staticmethod
+    def _capture_failure() -> ToolResult:
+        return _error_result(
+            LibraryToolError(
+                ERROR_STORAGE_ERROR,
+                "Library result withheld because activity could not be recorded.",
+                retryable=True,
+                details={"category": "review_capture_failed"},
+            )
+        )
+
+    def _capture_activity(
+        self, name: str, arguments: Mapping[str, Any], payload: object
+    ) -> bool:
+        if self._activity_sink is None:
+            return True
+        actor = current_run_actor()
+        if actor is None or not self._activity_attempt_id:
+            logger.warning(
+                "Library activity capture failed; result withheld "
+                "category=review_capture_failed"
+            )
+            return False
+        try:
+            event = minimize_library_activity(
+                LibraryActivityCandidate(
+                    attempt_id=self._activity_attempt_id,
+                    actor_kind=actor.kind,
+                    run_id=actor.run_id,
+                    parent_run_id=actor.parent_run_id,
+                    library_provider="direct",
+                    operation=name,
+                    arguments=arguments,
+                    structured_result=payload,
+                    failure_code=None,
+                )
+            )
+            self._activity_sink(event)
+        except Exception:  # noqa: BLE001 - payload/exception text must not log
+            logger.warning(
+                "Library activity capture failed; result withheld "
+                "category=review_capture_failed"
+            )
+            return False
+        return True
 
     def _tool_id(self, name: str) -> str:
         return f"{self.SOURCE}:{name}"
@@ -176,6 +236,8 @@ class LibraryToolProvider(_BuiltinLibraryAuthorityIssuer):
                 "The local Library store could not complete the read.",
                 retryable=True,
             ).to_payload()
+        if not self._capture_activity(name, arguments, payload):
+            return self._capture_failure()
         text = json_dumps_compact(payload)
         if isinstance(payload, Mapping) and "error" in payload:
             return ToolResult(ok=False, error=text)

--- a/tldw_chatbook/Agents/run_context.py
+++ b/tldw_chatbook/Agents/run_context.py
@@ -87,7 +87,11 @@ _CURRENT_RUN_ACTOR: ContextVar[CurrentRunActor | None] = ContextVar(
 
 
 def current_run_actor() -> CurrentRunActor | None:
-    """Return the actor bound to this tool thread, if any."""
+    """Return the actor bound to this tool thread, if any.
+
+    Returns:
+        Exact bound actor, or ``None`` outside an agent run.
+    """
     return _CURRENT_RUN_ACTOR.get()
 
 
@@ -104,7 +108,17 @@ def current_run_id() -> str:
 
 @contextmanager
 def use_run_actor(actor: CurrentRunActor) -> Iterator[None]:
-    """Bind exact provider-call attribution for the duration of a block."""
+    """Bind exact provider-call attribution for the duration of a block.
+
+    Args:
+        actor: Non-empty primary or subagent attribution to bind.
+
+    Yields:
+        None while the actor is bound on the current context.
+
+    Raises:
+        ValueError: If ``actor`` is not a valid non-empty attribution.
+    """
     if not isinstance(actor, CurrentRunActor) or not actor.run_id:
         raise ValueError("a non-empty CurrentRunActor is required")
     token = _CURRENT_RUN_ACTOR.set(actor)

--- a/tldw_chatbook/Agents/run_context.py
+++ b/tldw_chatbook/Agents/run_context.py
@@ -1,7 +1,7 @@
-"""The dispatching run's id, bound around a run's tool-facing work.
+"""The dispatching run actor, bound around a run's tool-facing work.
 
-Two bindings exist, both established by ``AgentService`` and both reading
-back through ``current_run_id()``. They are not redundant: they cover
+Two bindings exist, both established by ``AgentService`` and readable through
+``current_run_actor()``/``current_run_id()``. They are not redundant: they cover
 different THREADS, because the work they guard runs in different places.
 
 1. **Per-invocation** (PR2a Task 5, ``_make_invoke_tool``) -- bound around
@@ -26,7 +26,7 @@ different THREADS, because the work they guard runs in different places.
    built one layer below any run identity). One binding there covers both
    -- and every future loop-thread consumer -- with no signature churn.
 
-The two nest harmlessly: the inner binding sets the same id the outer one
+The two nest harmlessly: the inner binding sets the same actor the outer one
 holds, on a different thread.
 
 WHY A ContextVar AT ALL (PR2a Task 5). Both permission gates key this
@@ -44,7 +44,7 @@ signature is a Protocol (``tool_catalog.ToolProvider``) implemented by
 every provider and called generically by
 ``ToolCatalogRegistry.invoke_by_name``; widening it would touch every
 provider and hundreds of call sites for a value only three of them want.
-So the run id rides a ``ContextVar`` that ``AgentService`` binds around
+So the run actor rides a ``ContextVar`` that ``AgentService`` binds around
 each invocation instead -- the same shape, and for the same reason, as
 ``Tools/workspace_file_roots.run_workspace``, which already binds THIS
 run's workspace around ``BuiltinToolProvider.invoke``'s tool execution.
@@ -68,10 +68,27 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Iterator
+from dataclasses import dataclass
+from typing import Iterator, Literal
 
-#: The run id whose tool call is executing on this thread, or "" for none.
-_CURRENT_RUN_ID: ContextVar[str] = ContextVar("tldw_agent_run_id", default="")
+
+@dataclass(frozen=True, slots=True)
+class CurrentRunActor:
+    """Attribution for the primary or subagent invoking a provider tool."""
+
+    kind: Literal["primary", "subagent"]
+    run_id: str
+    parent_run_id: str | None
+
+
+_CURRENT_RUN_ACTOR: ContextVar[CurrentRunActor | None] = ContextVar(
+    "tldw_agent_run_actor", default=None
+)
+
+
+def current_run_actor() -> CurrentRunActor | None:
+    """Return the actor bound to this tool thread, if any."""
+    return _CURRENT_RUN_ACTOR.get()
 
 
 def current_run_id() -> str:
@@ -81,7 +98,20 @@ def current_run_id() -> str:
         The bound run id, or ``""`` when no agent run bound one on this
         thread (a direct provider call outside any run). Never raises.
     """
-    return _CURRENT_RUN_ID.get()
+    actor = current_run_actor()
+    return actor.run_id if actor is not None else ""
+
+
+@contextmanager
+def use_run_actor(actor: CurrentRunActor) -> Iterator[None]:
+    """Bind exact provider-call attribution for the duration of a block."""
+    if not isinstance(actor, CurrentRunActor) or not actor.run_id:
+        raise ValueError("a non-empty CurrentRunActor is required")
+    token = _CURRENT_RUN_ACTOR.set(actor)
+    try:
+        yield
+    finally:
+        _CURRENT_RUN_ACTOR.reset(token)
 
 
 @contextmanager
@@ -96,8 +126,9 @@ def use_run_id(run_id: str) -> Iterator[None]:
         None. The previous binding is restored on exit, including on an
         exception, so nested inline runs on one thread unwind correctly.
     """
-    token = _CURRENT_RUN_ID.set(run_id or "")
+    actor = CurrentRunActor("primary", run_id, None) if run_id else None
+    token = _CURRENT_RUN_ACTOR.set(actor)
     try:
         yield
     finally:
-        _CURRENT_RUN_ID.reset(token)
+        _CURRENT_RUN_ACTOR.reset(token)

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -42,6 +42,7 @@ from tldw_chatbook.Chat.console_transaction_contribution import (
     ConsoleTransactionContribution,
     _scoped_console_transaction_writer,
 )
+from tldw_chatbook.Chat.library_activity import LibraryActivityContribution
 from tldw_chatbook.Chat.console_prefill import PINNED_PREFILL_METADATA_KEY
 from tldw_chatbook.Chat.console_roleplay_metadata import (
     ConsoleRoleplayContext,
@@ -135,6 +136,32 @@ class ChatPersistenceService:
     def thinking_round_trip_version() -> int:
         """Return the thinking envelope version this local adapter round-trips."""
         return 1
+
+    def persist_console_library_activity(
+        self,
+        *,
+        conversation_id: str,
+        contribution: LibraryActivityContribution,
+        message_ids: Mapping[str, str],
+    ) -> None:
+        """Persist one bounded activity batch in a single owned transaction."""
+        if not isinstance(contribution, LibraryActivityContribution):
+            raise TypeError("contribution must be LibraryActivityContribution")
+        with self.db.transaction(immediate=True) as cursor:
+            conversation = cursor.execute(
+                "SELECT deleted FROM conversations WHERE id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if conversation is None or conversation["deleted"]:
+                raise RuntimeError("Durable conversation is unavailable.")
+            with _scoped_console_transaction_writer(
+                cursor, conversation_id
+            ) as writer:
+                contribution.write(
+                    writer=writer,
+                    conversation_id=conversation_id,
+                    message_ids=message_ids,
+                )
 
     @property
     def canonical_citation_writes_ready(self) -> bool:

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1185,6 +1185,7 @@ class ConsoleChatStore:
                 restored policies bypass this reader.
         """
         self.persistence = persistence
+        self._library_activity_lifecycle_lock = threading.RLock()
         self._library_activity_buffer = ConsoleLibraryActivityBuffer(
             self._persist_library_activity_batch
         )
@@ -3208,15 +3209,58 @@ class ConsoleChatStore:
         turn_id: str,
         event: LibraryActivityEvent,
     ) -> None:
-        """Retain one minimized provider event under its native USER opener."""
-        session = self._session_or_raise(session_id)
-        owner = self._nodes_by_session.get(session_id, {}).get(turn_id)
-        if owner is None or owner.role is not ConsoleMessageRole.USER:
-            raise ValueError("Library activity requires a USER turn opener.")
-        if session.id != session_id:
-            raise RuntimeError("Library activity session owner changed.")
-        self._library_activity_buffer.admit(session_id, turn_id, event)
-        self._bump_library_activity_revision(session_id)
+        """Retain one minimized provider event under its native USER opener.
+
+        Args:
+            session_id: Native Console session receiving the event.
+            turn_id: Native user-turn opener that owns the event.
+            event: Validated minimized activity event.
+
+        Raises:
+            KeyError: If the session was closed before admission.
+            ValueError: If the turn is not a user opener or the event is invalid.
+            RuntimeError: If ownership changed or the bounded buffer is full.
+        """
+        with self._library_activity_lifecycle_lock:
+            session = self._session_or_raise(session_id)
+            owner = self._nodes_by_session.get(session_id, {}).get(turn_id)
+            if owner is None or owner.role is not ConsoleMessageRole.USER:
+                raise ValueError("Library activity requires a USER turn opener.")
+            if session.id != session_id:
+                raise RuntimeError("Library activity session owner changed.")
+            self._library_activity_buffer.admit(session_id, turn_id, event)
+            self._bump_library_activity_revision(session_id)
+
+    def capture_library_activity(
+        self,
+        session_id: str,
+        turn_id: str,
+        event: LibraryActivityEvent,
+    ) -> LibraryActivityFlushResult:
+        """Admit and conditionally persist one provider event atomically.
+
+        Temporary sessions keep the event pending for atomic promotion. Durable
+        sessions attempt one ordinary flush before releasing the lifecycle lock.
+
+        Args:
+            session_id: Native Console session receiving the event.
+            turn_id: Native user-turn opener that owns the event.
+            event: Validated minimized activity event.
+
+        Returns:
+            Current activity persistence state.
+
+        Raises:
+            KeyError: If the session closed before capture acquired ownership.
+            ValueError: If the turn or event is invalid.
+            RuntimeError: If capture cannot be retained safely.
+        """
+        with self._library_activity_lifecycle_lock:
+            self.admit_library_activity(session_id, turn_id, event)
+            session = self._session_or_raise(session_id)
+            if session.ephemeral:
+                return self._library_activity_buffer.state(session_id)
+            return self.flush_library_activity(session_id)
 
     def pending_library_activity(
         self, session_id: str
@@ -3337,27 +3381,59 @@ class ConsoleChatStore:
         )
 
     def flush_library_activity(self, session_id: str) -> LibraryActivityFlushResult:
-        """Attempt one ordinary durable activity flush."""
-        self._session_or_raise(session_id)
-        result = self._library_activity_buffer.flush(session_id)
-        self._bump_library_activity_revision(session_id)
-        return result
+        """Attempt one ordinary durable activity flush.
+
+        Args:
+            session_id: Native Console session to flush.
+
+        Returns:
+            Current persistence state. Ephemeral sessions remain pending without
+            consuming a retry attempt.
+        """
+        with self._library_activity_lifecycle_lock:
+            session = self._session_or_raise(session_id)
+            if session.ephemeral:
+                return self._library_activity_buffer.state(session_id)
+            result = self._library_activity_buffer.flush(session_id)
+            self._bump_library_activity_revision(session_id)
+            return result
 
     def retry_library_activity(self, session_id: str) -> LibraryActivityFlushResult:
-        """Retry the retained activity batch once."""
-        self._session_or_raise(session_id)
-        result = self._library_activity_buffer.retry(session_id)
-        self._bump_library_activity_revision(session_id)
-        return result
+        """Retry the retained activity batch once.
+
+        Args:
+            session_id: Native Console session to retry.
+
+        Returns:
+            Current persistence state. Ephemeral sessions remain pending.
+        """
+        with self._library_activity_lifecycle_lock:
+            session = self._session_or_raise(session_id)
+            if session.ephemeral:
+                return self._library_activity_buffer.state(session_id)
+            result = self._library_activity_buffer.retry(session_id)
+            self._bump_library_activity_revision(session_id)
+            return result
 
     def final_flush_library_activity(
         self, session_id: str
     ) -> LibraryActivityFlushResult:
-        """Perform the session's one bounded close/promotion/shutdown flush."""
-        self._session_or_raise(session_id)
-        result = self._library_activity_buffer.final_flush(session_id)
-        self._bump_library_activity_revision(session_id)
-        return result
+        """Drain a durable session's activity before close or shutdown.
+
+        Args:
+            session_id: Native Console session being finalized.
+
+        Returns:
+            Aggregate final state. Ephemeral activity remains pending for
+            promotion or explicit session disposal.
+        """
+        with self._library_activity_lifecycle_lock:
+            session = self._session_or_raise(session_id)
+            if session.ephemeral:
+                return self._library_activity_buffer.state(session_id)
+            result = self._library_activity_buffer.final_flush(session_id)
+            self._bump_library_activity_revision(session_id)
+            return result
 
     def final_flush_all_library_activity(
         self,
@@ -3445,8 +3521,18 @@ class ConsoleChatStore:
         session_ids = list(self._sessions.keys())
         closed_index = session_ids.index(session_id)
 
-        self.final_flush_library_activity(session_id)
-        self._purge_session_runtime_state(session_id)
+        with self._library_activity_lifecycle_lock:
+            session = self._session_or_raise(session_id)
+            result = self.final_flush_library_activity(session_id)
+            if not session.ephemeral and result.status != "saved":
+                logger.warning(
+                    "Library activity discarded during session close "
+                    "status={} pending_count={}",
+                    result.status,
+                    result.pending_count,
+                )
+            self._library_activity_buffer.discard_session(session_id)
+            self._purge_session_runtime_state(session_id)
 
         if self.active_session_id != session_id:
             return self._sessions.get(self.active_session_id or "")

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -115,6 +115,10 @@ from tldw_chatbook.Chat.console_library_policy import (
 from tldw_chatbook.Chat.console_library_policy_coordinator import (
     ConsoleLibraryPolicyCoordinator,
 )
+from tldw_chatbook.Chat.console_library_activity_buffer import (
+    ConsoleLibraryActivityBuffer,
+    LibraryActivityFlushResult,
+)
 from tldw_chatbook.Chat.console_turn_preparation import (
     ConsolePreparationPauseKind,
     ConsolePreparationTransition,
@@ -124,6 +128,10 @@ from tldw_chatbook.Chat.console_turn_preparation import (
 )
 from tldw_chatbook.Chat.console_transaction_contribution import (
     ConsoleTransactionContribution,
+)
+from tldw_chatbook.Chat.library_activity import (
+    LibraryActivityContribution,
+    LibraryActivityEvent,
 )
 from tldw_chatbook.Chat.console_exchange_capture import CaptureDetail, capture_to_blob
 from tldw_chatbook.Chat.console_capture_policy_repository import (
@@ -525,6 +533,15 @@ class ConsoleChatPersistence(Protocol):
         conversation_kwargs: Mapping[str, object],
     ) -> ConsoleDispatchCheckpoint:
         """Atomically create/validate and accept one durable Console turn."""
+
+    def persist_console_library_activity(
+        self,
+        *,
+        conversation_id: str,
+        contribution: LibraryActivityContribution,
+        message_ids: Mapping[str, str],
+    ) -> None:
+        """Persist one activity batch in a caller-owned transaction."""
 
     def create_conversation(self, **kwargs) -> str:
         """Create a persisted conversation and return its ID."""
@@ -1165,6 +1182,9 @@ class ConsoleChatStore:
                 restored policies bypass this reader.
         """
         self.persistence = persistence
+        self._library_activity_buffer = ConsoleLibraryActivityBuffer(
+            self._persist_library_activity_batch
+        )
         self.workspace_context = workspace_context or ConsoleWorkspaceContext()
         self.sync_v2_chat_producer = sync_v2_chat_producer
         self.sync_v2_server_profile_id = sync_v2_server_profile_id
@@ -3178,6 +3198,94 @@ class ConsoleChatStore:
                     )
         return session, persisted
 
+    def admit_library_activity(
+        self,
+        session_id: str,
+        turn_id: str,
+        event: LibraryActivityEvent,
+    ) -> None:
+        """Retain one minimized provider event under its native USER opener."""
+        session = self._session_or_raise(session_id)
+        owner = self._nodes_by_session.get(session_id, {}).get(turn_id)
+        if owner is None or owner.role is not ConsoleMessageRole.USER:
+            raise ValueError("Library activity requires a USER turn opener.")
+        if session.id != session_id:
+            raise RuntimeError("Library activity session owner changed.")
+        self._library_activity_buffer.admit(session_id, turn_id, event)
+
+    def pending_library_activity(
+        self, session_id: str
+    ) -> tuple[object, ...]:
+        """Return one immutable process-local pending activity snapshot."""
+        self._session_or_raise(session_id)
+        return self._library_activity_buffer.pending_events(session_id)
+
+    def flush_library_activity(self, session_id: str) -> LibraryActivityFlushResult:
+        """Attempt one ordinary durable activity flush."""
+        self._session_or_raise(session_id)
+        return self._library_activity_buffer.flush(session_id)
+
+    def retry_library_activity(self, session_id: str) -> LibraryActivityFlushResult:
+        """Retry the retained activity batch once."""
+        self._session_or_raise(session_id)
+        return self._library_activity_buffer.retry(session_id)
+
+    def final_flush_library_activity(
+        self, session_id: str
+    ) -> LibraryActivityFlushResult:
+        """Perform the session's one bounded close/promotion/shutdown flush."""
+        self._session_or_raise(session_id)
+        return self._library_activity_buffer.final_flush(session_id)
+
+    def final_flush_all_library_activity(
+        self,
+    ) -> dict[str, LibraryActivityFlushResult]:
+        """Perform one bounded shutdown flush for every live Console session."""
+        return {
+            session_id: self.final_flush_library_activity(session_id)
+            for session_id in tuple(self._sessions)
+        }
+
+    def _persist_library_activity_batch(
+        self,
+        session_id: str,
+        contribution: LibraryActivityContribution,
+    ) -> None:
+        """Resolve native turn owners and delegate one atomic sidecar write."""
+        session = self._session_or_raise(session_id)
+        if session.ephemeral or session.persisted_conversation_id is None:
+            raise RuntimeError("Ephemeral Library activity awaits promotion.")
+        persistence = self.persistence
+        persist = getattr(persistence, "persist_console_library_activity", None)
+        if not callable(persist):
+            raise RuntimeError("Library activity persistence is unavailable.")
+
+        nodes = self._nodes_by_session.get(session_id, {})
+        message_ids: dict[str, str] = {}
+        for item in contribution.items:
+            owner = nodes.get(item.owner_message_key)
+            if owner is None:
+                owner = next(
+                    (
+                        candidate
+                        for candidate in nodes.values()
+                        if candidate.persisted_message_id == item.owner_message_key
+                    ),
+                    None,
+                )
+            if (
+                owner is None
+                or owner.role is not ConsoleMessageRole.USER
+                or not owner.persisted_message_id
+            ):
+                raise RuntimeError("Durable Library activity owner is unavailable.")
+            message_ids[item.owner_message_key] = owner.persisted_message_id
+        persist(
+            conversation_id=session.persisted_conversation_id,
+            contribution=contribution,
+            message_ids=message_ids,
+        )
+
     def close_session(self, session_id: str) -> ConsoleChatSession | None:
         """Close a native Console session and activate a neighboring session.
 
@@ -3215,6 +3323,7 @@ class ConsoleChatStore:
         session_ids = list(self._sessions.keys())
         closed_index = session_ids.index(session_id)
 
+        self.final_flush_library_activity(session_id)
         self._purge_session_runtime_state(session_id)
 
         if self.active_session_id != session_id:
@@ -12045,9 +12154,21 @@ class ConsoleChatStore:
         )
         if not callable(atomic_promote):
             raise RuntimeError("Persistence adapter cannot perform atomic promotion.")
+        activity_contribution = self._library_activity_buffer.promotion_contribution(
+            session_id
+        )
+        combined_contributions: tuple[ConsoleTransactionContribution, ...] = tuple(
+            contributions
+        )
+        if activity_contribution is not None:
+            combined_contributions = (
+                *combined_contributions,
+                activity_contribution,
+            )
         return self._promote_ephemeral_session_atomically(
             session,
-            contributions=contributions,
+            contributions=combined_contributions,
+            activity_contribution=activity_contribution,
         )
 
     def _promote_ephemeral_session_atomically(
@@ -12055,6 +12176,7 @@ class ConsoleChatStore:
         session: ConsoleChatSession,
         *,
         contributions: Sequence[ConsoleTransactionContribution],
+        activity_contribution: LibraryActivityContribution | None = None,
     ) -> str:
         """Stage a complete temporary transcript and publish after commit only."""
         if self.persistence is None:
@@ -12214,6 +12336,11 @@ class ConsoleChatStore:
             context_policy_overrides=session.context_policy_overrides,
             contributions=contributions,
         )
+
+        if activity_contribution is not None:
+            self._library_activity_buffer.confirm_contribution(
+                session_id, activity_contribution
+            )
 
         self.publish_committed_identity(session_id, identity)
         session.ephemeral = False

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -132,6 +132,9 @@ from tldw_chatbook.Chat.console_transaction_contribution import (
 from tldw_chatbook.Chat.library_activity import (
     LibraryActivityContribution,
     LibraryActivityEvent,
+    LibraryActivityView,
+    encode_library_activity_event,
+    project_library_activity,
 )
 from tldw_chatbook.Chat.console_exchange_capture import CaptureDetail, capture_to_blob
 from tldw_chatbook.Chat.console_capture_policy_repository import (
@@ -1185,6 +1188,7 @@ class ConsoleChatStore:
         self._library_activity_buffer = ConsoleLibraryActivityBuffer(
             self._persist_library_activity_batch
         )
+        self._library_activity_revisions: dict[str, int] = {}
         self.workspace_context = workspace_context or ConsoleWorkspaceContext()
         self.sync_v2_chat_producer = sync_v2_chat_producer
         self.sync_v2_server_profile_id = sync_v2_server_profile_id
@@ -3212,6 +3216,7 @@ class ConsoleChatStore:
         if session.id != session_id:
             raise RuntimeError("Library activity session owner changed.")
         self._library_activity_buffer.admit(session_id, turn_id, event)
+        self._bump_library_activity_revision(session_id)
 
     def pending_library_activity(
         self, session_id: str
@@ -3220,22 +3225,139 @@ class ConsoleChatStore:
         self._session_or_raise(session_id)
         return self._library_activity_buffer.pending_events(session_id)
 
+    def library_activity_revision(self, session_id: str) -> int:
+        """Return the process-local projection revision for one session."""
+
+        self._session_or_raise(session_id)
+        return self._library_activity_revisions.get(session_id, 0)
+
+    def current_library_activity_turn_id(self, session_id: str) -> str:
+        """Return the latest active-path USER opener's native identifier."""
+
+        self._session_or_raise(session_id)
+        nodes = self._nodes_by_session.get(session_id, {})
+        for message_id in reversed(self.active_path_message_ids(session_id)):
+            message = nodes.get(message_id)
+            if message is not None and message.role is ConsoleMessageRole.USER:
+                return message.id
+        raise RuntimeError("Library activity requires an active USER turn opener.")
+
+    def library_activity_snapshot(
+        self,
+        session_id: str,
+        selected_message_id: str | None,
+    ) -> tuple[
+        LibraryActivityView,
+        tuple[tuple[str, int], ...],
+        LibraryActivityFlushResult,
+    ]:
+        """Project durable and retained activity onto the active selected turn.
+
+        The returned count keys are native assistant message IDs so the
+        transcript can render a local affordance without learning durable
+        trajectory identity.
+        """
+
+        session = self._session_or_raise(session_id)
+        nodes = self._nodes_by_session.get(session_id, {})
+        active_path = self.active_path_message_ids(session_id)
+        durable_by_native: dict[str, str] = {}
+        active_turn_ids: list[str] = []
+        for native_id in active_path:
+            message = nodes.get(native_id)
+            if message is None or message.role is not ConsoleMessageRole.USER:
+                continue
+            durable_id = message.persisted_message_id or message.id
+            durable_by_native[message.id] = durable_id
+            active_turn_ids.append(durable_id)
+
+        rows: list[Any] = []
+        db = getattr(self.persistence, "db", None)
+        if session.persisted_conversation_id is not None and db is not None:
+            try:
+                rows.extend(db.get_trajectory_rows(session.persisted_conversation_id))
+            except Exception:  # noqa: BLE001 - payload-free review degradation
+                logger.warning("library_activity_projection_read_failed")
+
+        next_sequence = max(
+            (
+                int(getattr(row, "seq", 0) or 0)
+                for row in rows
+                if type(getattr(row, "seq", None)) is int
+            ),
+            default=0,
+        )
+        for item in self._library_activity_buffer.pending_events(session_id):
+            next_sequence += 1
+            owner_id = durable_by_native.get(
+                item.owner_message_key, item.owner_message_key
+            )
+            rows.append(
+                {
+                    "message_id": owner_id,
+                    "turn_id": owner_id,
+                    "seq": next_sequence,
+                    "event_kind": "library_activity",
+                    "step_started_at": item.captured_at,
+                    "payload_json": encode_library_activity_event(item.event),
+                }
+            )
+
+        selected_turn_id: str | None = None
+        if selected_message_id in active_path:
+            selected_index = active_path.index(selected_message_id)
+            for native_id in reversed(active_path[: selected_index + 1]):
+                message = nodes.get(native_id)
+                if message is not None and message.role is ConsoleMessageRole.USER:
+                    selected_turn_id = message.persisted_message_id or message.id
+                    break
+        view = project_library_activity(rows, active_turn_ids, selected_turn_id)
+
+        count_by_turn = {
+            turn_id: len(project_library_activity(rows, active_turn_ids, turn_id).actions)
+            for turn_id in active_turn_ids
+        }
+        counts: list[tuple[str, int]] = []
+        current_turn_id: str | None = None
+        for native_id in active_path:
+            message = nodes.get(native_id)
+            if message is None:
+                continue
+            if message.role is ConsoleMessageRole.USER:
+                current_turn_id = message.persisted_message_id or message.id
+            elif message.role is ConsoleMessageRole.ASSISTANT and current_turn_id:
+                count = count_by_turn.get(current_turn_id, 0)
+                if count:
+                    counts.append((message.id, count))
+        return view, tuple(counts), self._library_activity_buffer.state(session_id)
+
+    def _bump_library_activity_revision(self, session_id: str) -> None:
+        self._library_activity_revisions[session_id] = (
+            self._library_activity_revisions.get(session_id, 0) + 1
+        )
+
     def flush_library_activity(self, session_id: str) -> LibraryActivityFlushResult:
         """Attempt one ordinary durable activity flush."""
         self._session_or_raise(session_id)
-        return self._library_activity_buffer.flush(session_id)
+        result = self._library_activity_buffer.flush(session_id)
+        self._bump_library_activity_revision(session_id)
+        return result
 
     def retry_library_activity(self, session_id: str) -> LibraryActivityFlushResult:
         """Retry the retained activity batch once."""
         self._session_or_raise(session_id)
-        return self._library_activity_buffer.retry(session_id)
+        result = self._library_activity_buffer.retry(session_id)
+        self._bump_library_activity_revision(session_id)
+        return result
 
     def final_flush_library_activity(
         self, session_id: str
     ) -> LibraryActivityFlushResult:
         """Perform the session's one bounded close/promotion/shutdown flush."""
         self._session_or_raise(session_id)
-        return self._library_activity_buffer.final_flush(session_id)
+        result = self._library_activity_buffer.final_flush(session_id)
+        self._bump_library_activity_revision(session_id)
+        return result
 
     def final_flush_all_library_activity(
         self,
@@ -3392,6 +3514,7 @@ class ConsoleChatStore:
         self._deferred_project_instruction_state_session_ids.discard(session_id)
         self._roleplay_system_projection_candidates.pop(session_id, None)
         self._payload_revisions.pop(session_id, None)
+        self._library_activity_revisions.pop(session_id, None)
         self._conversation_context_epochs.pop(session_id, None)
         self._speech_preference_epochs.pop(session_id, None)
         self._character_emote_feed_by_session.pop(session_id, None)
@@ -7110,6 +7233,7 @@ class ConsoleChatStore:
         self._abandoned_exchange_run_tags.clear()
         self._exchange_blob_cache.clear()
         self._payload_revisions.clear()
+        self._library_activity_revisions.clear()
         self._conversation_context_epochs.clear()
         self._speech_preference_epochs.clear()
         self._nodes_by_session.clear()
@@ -12341,6 +12465,7 @@ class ConsoleChatStore:
             self._library_activity_buffer.confirm_contribution(
                 session_id, activity_contribution
             )
+            self._bump_library_activity_revision(session_id)
 
         self.publish_committed_identity(session_id, identity)
         session.ephemeral = False

--- a/tldw_chatbook/Chat/console_library_activity_buffer.py
+++ b/tldw_chatbook/Chat/console_library_activity_buffer.py
@@ -38,7 +38,18 @@ class LibraryActivityFlushResult:
 
 
 class ConsoleLibraryActivityBuffer:
-    """Retain minimized events until one caller-confirmed transaction saves them."""
+    """Retain events until one caller-confirmed transaction saves them.
+
+    Args:
+        persist_batch: Callback that atomically writes one contribution.
+        max_attempts: Ordinary write attempts before exposing failed state.
+        max_pending_per_session: Hard per-session event ceiling.
+        batch_size: Maximum events written by one persistence call.
+
+    Raises:
+        TypeError: If ``persist_batch`` is not callable.
+        ValueError: If a numeric bound is not positive.
+    """
 
     def __init__(
         self,
@@ -68,7 +79,17 @@ class ConsoleLibraryActivityBuffer:
     def admit(
         self, session_id: str, turn_id: str, event: LibraryActivityEvent
     ) -> None:
-        """Retain one already-minimized event under the owning session/turn."""
+        """Retain one already-minimized event under the owning session/turn.
+
+        Args:
+            session_id: Native Console session receiving the event.
+            turn_id: Native user-turn opener that owns the event.
+            event: Validated minimized activity event.
+
+        Raises:
+            ValueError: If an identifier or event is invalid or collides.
+            RuntimeError: If the bounded per-session buffer is full.
+        """
         if type(session_id) is not str or not session_id:
             raise ValueError("Library activity session id is required")
         if type(turn_id) is not str or not turn_id:
@@ -97,7 +118,14 @@ class ConsoleLibraryActivityBuffer:
     def pending_events(
         self, session_id: str
     ) -> tuple[LibraryActivityContributionItem, ...]:
-        """Return the immutable ordered pending snapshot for one session."""
+        """Return the immutable ordered pending snapshot for one session.
+
+        Args:
+            session_id: Native Console session to inspect.
+
+        Returns:
+            Pending contribution items in stable admission order.
+        """
         with self._lock:
             return tuple(
                 item
@@ -106,7 +134,14 @@ class ConsoleLibraryActivityBuffer:
             )
 
     def state(self, session_id: str) -> LibraryActivityFlushResult:
-        """Return the current bounded save state without attempting a write."""
+        """Return the current bounded save state without attempting a write.
+
+        Args:
+            session_id: Native Console session to inspect.
+
+        Returns:
+            Current saved, pending, or failed state.
+        """
 
         with self._lock:
             prior = self._final_results.get(session_id)
@@ -128,14 +163,26 @@ class ConsoleLibraryActivityBuffer:
     def promotion_contribution(
         self, session_id: str
     ) -> LibraryActivityContribution | None:
-        """Snapshot all current ephemeral events for an atomic promotion."""
+        """Snapshot all current ephemeral events for an atomic promotion.
+
+        Args:
+            session_id: Native ephemeral Console session being promoted.
+
+        Returns:
+            A contribution containing every pending event, or ``None``.
+        """
         items = self.pending_events(session_id)
         return LibraryActivityContribution(items) if items else None
 
     def confirm_contribution(
         self, session_id: str, contribution: LibraryActivityContribution
     ) -> None:
-        """Remove only the exact items confirmed by a successful transaction."""
+        """Remove only items confirmed by a successful transaction.
+
+        Args:
+            session_id: Native Console session that was promoted.
+            contribution: Exact contribution committed by the transaction.
+        """
         keys = {
             (
                 session_id,
@@ -156,23 +203,71 @@ class ConsoleLibraryActivityBuffer:
             self._final_results.pop(session_id, None)
 
     def flush(self, session_id: str) -> LibraryActivityFlushResult:
-        """Persist one bounded batch and remove only confirmed rows."""
+        """Persist one bounded batch and remove only confirmed rows.
+
+        Args:
+            session_id: Native durable Console session to flush.
+
+        Returns:
+            Result for the attempted batch and remaining pending count.
+        """
         return self._flush(session_id, final=False)
 
     def retry(self, session_id: str) -> LibraryActivityFlushResult:
-        """Retry the exact retained batch without duplicating confirmed rows."""
+        """Retry the exact retained batch without duplicating confirmed rows.
+
+        Args:
+            session_id: Native durable Console session to retry.
+
+        Returns:
+            Result for the retry and remaining pending count.
+        """
         return self._flush(session_id, final=False)
 
     def final_flush(self, session_id: str) -> LibraryActivityFlushResult:
-        """Perform at most one bounded close, promotion, or shutdown flush."""
+        """Drain bounded batches until saved or one final write fails.
+
+        Args:
+            session_id: Native durable Console session being finalized.
+
+        Returns:
+            Cached aggregate result across every attempted batch.
+        """
         with self._lock:
             prior = self._final_results.get(session_id)
             if prior is not None:
                 return prior
-        result = self._flush(session_id, final=True)
+        saved_count = 0
+        while True:
+            result = self._flush(session_id, final=True)
+            saved_count += result.saved_count
+            if result.status != "pending" or result.saved_count == 0:
+                break
+        result = LibraryActivityFlushResult(
+            result.status,
+            saved_count,
+            result.pending_count,
+            result.error_code,
+            result.warning,
+        )
         with self._lock:
             self._final_results.setdefault(session_id, result)
             return self._final_results[session_id]
+
+    def discard_session(self, session_id: str) -> None:
+        """Release every process-local activity reference for one session.
+
+        Args:
+            session_id: Native Console session whose activity is unreachable.
+        """
+        with self._lock:
+            keys = tuple(key for key in self._pending if key[0] == session_id)
+            for key in keys:
+                self._pending.pop(key, None)
+            self._retry_batches.pop(session_id, None)
+            self._attempts.pop(session_id, None)
+            self._flushing.discard(session_id)
+            self._final_results.pop(session_id, None)
 
     def _flush(self, session_id: str, *, final: bool) -> LibraryActivityFlushResult:
         with self._lock:

--- a/tldw_chatbook/Chat/console_library_activity_buffer.py
+++ b/tldw_chatbook/Chat/console_library_activity_buffer.py
@@ -105,6 +105,26 @@ class ConsoleLibraryActivityBuffer:
                 if key[0] == session_id
             )
 
+    def state(self, session_id: str) -> LibraryActivityFlushResult:
+        """Return the current bounded save state without attempting a write."""
+
+        with self._lock:
+            prior = self._final_results.get(session_id)
+            if prior is not None:
+                return prior
+            pending_count = self._pending_count(session_id)
+            if pending_count == 0:
+                return LibraryActivityFlushResult("saved", 0, 0)
+            attempts = self._attempts.get(session_id, 0)
+            exhausted = attempts >= self._max_attempts
+            return LibraryActivityFlushResult(
+                "failed" if exhausted else "pending",
+                0,
+                pending_count,
+                "retry_exhausted" if exhausted else None,
+                LIBRARY_ACTIVITY_NOT_SAVED_COPY if exhausted else None,
+            )
+
     def promotion_contribution(
         self, session_id: str
     ) -> LibraryActivityContribution | None:

--- a/tldw_chatbook/Chat/console_library_activity_buffer.py
+++ b/tldw_chatbook/Chat/console_library_activity_buffer.py
@@ -1,0 +1,228 @@
+"""Thread-safe pending persistence owned by the Console chat store."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from loguru import logger
+
+from tldw_chatbook.Chat.library_activity import (
+    LibraryActivityContribution,
+    LibraryActivityContributionItem,
+    LibraryActivityEvent,
+    encode_library_activity_event,
+)
+
+LIBRARY_ACTIVITY_NOT_SAVED_COPY = "Library activity not saved in this session"
+
+_DEFAULT_MAX_PENDING_PER_SESSION = 256
+_DEFAULT_BATCH_SIZE = 64
+_PendingKey = tuple[str, str, str, str, str]
+_PersistBatch = Callable[[str, LibraryActivityContribution], None]
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivityFlushResult:
+    """Bounded persistence state exposed to the Inspector/controller."""
+
+    status: Literal["saved", "pending", "failed"]
+    saved_count: int
+    pending_count: int
+    error_code: str | None = None
+    warning: str | None = None
+
+
+class ConsoleLibraryActivityBuffer:
+    """Retain minimized events until one caller-confirmed transaction saves them."""
+
+    def __init__(
+        self,
+        persist_batch: _PersistBatch,
+        *,
+        max_attempts: int = 2,
+        max_pending_per_session: int = _DEFAULT_MAX_PENDING_PER_SESSION,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
+    ) -> None:
+        if not callable(persist_batch):
+            raise TypeError("persist_batch must be callable")
+        if max_attempts < 1 or max_pending_per_session < 1 or batch_size < 1:
+            raise ValueError("Library activity buffer bounds must be positive")
+        self._persist_batch = persist_batch
+        self._max_attempts = max_attempts
+        self._max_pending_per_session = max_pending_per_session
+        self._batch_size = min(batch_size, max_pending_per_session)
+        self._lock = threading.RLock()
+        self._pending: OrderedDict[_PendingKey, LibraryActivityContributionItem] = (
+            OrderedDict()
+        )
+        self._retry_batches: dict[str, tuple[_PendingKey, ...]] = {}
+        self._attempts: dict[str, int] = {}
+        self._flushing: set[str] = set()
+        self._final_results: dict[str, LibraryActivityFlushResult] = {}
+
+    def admit(
+        self, session_id: str, turn_id: str, event: LibraryActivityEvent
+    ) -> None:
+        """Retain one already-minimized event under the owning session/turn."""
+        if type(session_id) is not str or not session_id:
+            raise ValueError("Library activity session id is required")
+        if type(turn_id) is not str or not turn_id:
+            raise ValueError("Library activity turn id is required")
+        encode_library_activity_event(event)
+        item = LibraryActivityContributionItem(
+            owner_message_key=turn_id,
+            event=event,
+            captured_at=time.time(),
+        )
+        key = (session_id, turn_id, event.attempt_id, event.run_id, event.event_id)
+        with self._lock:
+            existing = self._pending.get(key)
+            if existing is not None:
+                if existing.event != event:
+                    raise ValueError("Library activity identity collision")
+                return
+            pending_count = sum(
+                1 for pending_key in self._pending if pending_key[0] == session_id
+            )
+            if pending_count >= self._max_pending_per_session:
+                raise RuntimeError("Library activity pending buffer is full")
+            self._pending[key] = item
+            self._final_results.pop(session_id, None)
+
+    def pending_events(
+        self, session_id: str
+    ) -> tuple[LibraryActivityContributionItem, ...]:
+        """Return the immutable ordered pending snapshot for one session."""
+        with self._lock:
+            return tuple(
+                item
+                for key, item in self._pending.items()
+                if key[0] == session_id
+            )
+
+    def promotion_contribution(
+        self, session_id: str
+    ) -> LibraryActivityContribution | None:
+        """Snapshot all current ephemeral events for an atomic promotion."""
+        items = self.pending_events(session_id)
+        return LibraryActivityContribution(items) if items else None
+
+    def confirm_contribution(
+        self, session_id: str, contribution: LibraryActivityContribution
+    ) -> None:
+        """Remove only the exact items confirmed by a successful transaction."""
+        keys = {
+            (
+                session_id,
+                item.owner_message_key,
+                item.event.attempt_id,
+                item.event.run_id,
+                item.event.event_id,
+            )
+            for item in contribution.items
+        }
+        with self._lock:
+            for key in keys:
+                current = self._pending.get(key)
+                if current is not None and current in contribution.items:
+                    self._pending.pop(key, None)
+            self._retry_batches.pop(session_id, None)
+            self._attempts.pop(session_id, None)
+            self._final_results.pop(session_id, None)
+
+    def flush(self, session_id: str) -> LibraryActivityFlushResult:
+        """Persist one bounded batch and remove only confirmed rows."""
+        return self._flush(session_id, final=False)
+
+    def retry(self, session_id: str) -> LibraryActivityFlushResult:
+        """Retry the exact retained batch without duplicating confirmed rows."""
+        return self._flush(session_id, final=False)
+
+    def final_flush(self, session_id: str) -> LibraryActivityFlushResult:
+        """Perform at most one bounded close, promotion, or shutdown flush."""
+        with self._lock:
+            prior = self._final_results.get(session_id)
+            if prior is not None:
+                return prior
+        result = self._flush(session_id, final=True)
+        with self._lock:
+            self._final_results.setdefault(session_id, result)
+            return self._final_results[session_id]
+
+    def _flush(self, session_id: str, *, final: bool) -> LibraryActivityFlushResult:
+        with self._lock:
+            pending_count = self._pending_count(session_id)
+            if pending_count == 0:
+                return LibraryActivityFlushResult("saved", 0, 0)
+            if session_id in self._flushing:
+                return LibraryActivityFlushResult("pending", 0, pending_count)
+            keys = self._retry_batches.get(session_id)
+            if keys is None:
+                keys = tuple(
+                    key
+                    for key in self._pending
+                    if key[0] == session_id
+                )[: self._batch_size]
+            selected = tuple(
+                (key, self._pending[key]) for key in keys if key in self._pending
+            )
+            items = tuple(item for _, item in selected)
+            if not items:
+                self._retry_batches.pop(session_id, None)
+                return LibraryActivityFlushResult("pending", 0, pending_count)
+            contribution = LibraryActivityContribution(items)
+            self._flushing.add(session_id)
+
+        try:
+            self._persist_batch(session_id, contribution)
+        except Exception:  # noqa: BLE001 - never log payload or arbitrary exception text
+            with self._lock:
+                self._flushing.discard(session_id)
+                self._retry_batches[session_id] = keys
+                attempts = self._attempts.get(session_id, 0) + 1
+                self._attempts[session_id] = attempts
+                pending_count = self._pending_count(session_id)
+                exhausted = final or attempts >= self._max_attempts
+            logger.warning(
+                "Library activity persistence failed "
+                "category=storage_error status={} pending_count={}",
+                "failed" if exhausted else "pending",
+                pending_count,
+            )
+            return LibraryActivityFlushResult(
+                "failed" if exhausted else "pending",
+                0,
+                pending_count,
+                "retry_exhausted" if exhausted else "storage_error",
+                LIBRARY_ACTIVITY_NOT_SAVED_COPY if exhausted else None,
+            )
+
+        with self._lock:
+            self._flushing.discard(session_id)
+            for key, item in selected:
+                if self._pending.get(key) is item:
+                    self._pending.pop(key, None)
+            self._retry_batches.pop(session_id, None)
+            self._attempts.pop(session_id, None)
+            self._final_results.pop(session_id, None)
+            pending_count = self._pending_count(session_id)
+        return LibraryActivityFlushResult(
+            "pending" if pending_count else "saved",
+            len(items),
+            pending_count,
+        )
+
+    def _pending_count(self, session_id: str) -> int:
+        return sum(1 for key in self._pending if key[0] == session_id)
+
+
+__all__ = [
+    "LIBRARY_ACTIVITY_NOT_SAVED_COPY",
+    "ConsoleLibraryActivityBuffer",
+    "LibraryActivityFlushResult",
+]

--- a/tldw_chatbook/Chat/library_activity.py
+++ b/tldw_chatbook/Chat/library_activity.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 from uuid import uuid4
 
+from tldw_chatbook.Chat.console_transaction_contribution import (
+    ConsoleTransactionWriter,
+)
 from tldw_chatbook.Chat.trajectory import contains_local_path, redact_local_paths
 from tldw_chatbook.Utils.log_sanitizer import redact_log_line
 
+LIBRARY_ACTIVITY_EVENT_KIND = "library_activity"
 LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS = 160
 LIBRARY_ACTIVITY_TITLE_MAX_CHARS = 160
 LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS = 240
@@ -20,7 +25,28 @@ LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT = 8
 LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES = 8192
 
 _OPAQUE_ID_MAX_CHARS = 200
+_RESULT_COUNT_MAX = (1 << 31) - 1
+_VIEW_MAX_ACTIONS = 256
 _STABLE_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_EVENT_KEYS = frozenset(
+    {
+        "version",
+        "event_id",
+        "attempt_id",
+        "run_id",
+        "actor",
+        "library_provider",
+        "operation",
+        "status",
+        "result_count",
+        "query_preview",
+        "source_refs",
+        "error_code",
+        "error_summary",
+    }
+)
+_ACTOR_KEYS = frozenset({"kind", "run_id", "parent_run_id"})
+_SOURCE_REF_KEYS = frozenset({"type", "id", "title"})
 _ROW_KEYS = ("results", "items", "messages", "members")
 _ID_KEYS = (
     "id",
@@ -92,6 +118,92 @@ class LibraryActivityEvent:
             "error_code": self.error_code,
             "error_summary": self.error_summary,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivityContributionItem:
+    """One buffered event and its native durable-turn opener key."""
+
+    owner_message_key: str
+    event: LibraryActivityEvent
+    captured_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivityContribution:
+    """Persist an ordered batch through the existing Console transaction seam."""
+
+    items: tuple[LibraryActivityContributionItem, ...]
+
+    def write(
+        self,
+        *,
+        writer: ConsoleTransactionWriter,
+        conversation_id: str,
+        message_ids: Mapping[str, str],
+    ) -> None:
+        """Insert every event under its durable USER turn opener."""
+        if not self.items:
+            raise ValueError("Library activity contribution cannot be empty.")
+        prepared: list[tuple[str, str, float]] = []
+        for item in self.items:
+            owner_id = message_ids.get(item.owner_message_key)
+            if not isinstance(owner_id, str) or not owner_id:
+                raise ValueError("Library activity requires a durable turn opener.")
+            if not isinstance(item.captured_at, (int, float)) or isinstance(
+                item.captured_at, bool
+            ) or not math.isfinite(float(item.captured_at)):
+                raise ValueError("Library activity capture time is invalid.")
+            prepared.append(
+                (owner_id, encode_library_activity_event(item.event), item.captured_at)
+            )
+
+        rows = []
+        for owner_id, payload_json, captured_at in prepared:
+            rows.append(
+                (
+                    owner_id,
+                    conversation_id,
+                    owner_id,
+                    writer.next_trajectory_sequence(),
+                    LIBRARY_ACTIVITY_EVENT_KIND,
+                    captured_at,
+                    payload_json,
+                )
+            )
+        writer.executemany(
+            "INSERT INTO message_trajectory_metadata("
+            "message_id, conversation_id, turn_id, seq, event_kind, "
+            "step_started_at, payload_json"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivityRecord:
+    """One validated action projected under a selected durable turn."""
+
+    turn_id: str
+    sequence: int
+    occurred_at: float | None
+    event: LibraryActivityEvent
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivityView:
+    """Pure selected-turn activity projection for the Console Inspector."""
+
+    selected_turn_id: str | None
+    actions: tuple[LibraryActivityRecord, ...]
+    corrupt_row_count: int = 0
+
+    @property
+    def status(self) -> Literal["empty", "ready", "corrupt"]:
+        """Return the bounded presentation state for this projection."""
+        if self.corrupt_row_count:
+            return "corrupt"
+        return "ready" if self.actions else "empty"
 
 
 @dataclass(frozen=True, slots=True)
@@ -260,10 +372,234 @@ def minimize_library_activity(candidate: LibraryActivityCandidate) -> LibraryAct
     )
     if size > LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES:
         raise ValueError("bounded Library activity payload exceeds byte ceiling")
+    _validate_event(event)
     return event
 
 
+def encode_library_activity_event(event: LibraryActivityEvent) -> str:
+    """Encode one exact bounded v1 activity payload."""
+    _validate_event(event)
+    encoded = json.dumps(
+        event.to_payload(), ensure_ascii=False, separators=(",", ":")
+    )
+    if len(encoded.encode("utf-8")) > LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES:
+        raise ValueError("bounded Library activity payload exceeds byte ceiling")
+    return encoded
+
+
+def decode_library_activity_event(value: object) -> LibraryActivityEvent:
+    """Decode an exact v1 payload while rejecting additive or unsafe fields."""
+    if type(value) is not str:
+        raise ValueError("Invalid Library activity payload.")
+    try:
+        if len(value.encode("utf-8")) > LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES:
+            raise ValueError("Invalid Library activity payload.")
+    except UnicodeEncodeError as exc:
+        raise ValueError("Invalid Library activity payload.") from exc
+
+    def reject_constant(_value: str) -> None:
+        raise ValueError("Invalid Library activity payload.")
+
+    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        decoded: dict[str, object] = {}
+        for key, item in pairs:
+            if key in decoded:
+                raise ValueError("Invalid Library activity payload.")
+            decoded[key] = item
+        return decoded
+
+    try:
+        data = json.loads(
+            value,
+            parse_constant=reject_constant,
+            object_pairs_hook=unique_object,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("Invalid Library activity payload.") from exc
+    if type(data) is not dict or set(data) != _EVENT_KEYS:
+        raise ValueError("Invalid Library activity payload.")
+    actor = data["actor"]
+    refs = data["source_refs"]
+    if type(actor) is not dict or set(actor) != _ACTOR_KEYS or type(refs) is not list:
+        raise ValueError("Invalid Library activity payload.")
+    decoded_refs: list[LibraryActivitySourceRef] = []
+    for ref in refs:
+        if type(ref) is not dict or set(ref) != _SOURCE_REF_KEYS:
+            raise ValueError("Invalid Library activity payload.")
+        decoded_refs.append(
+            LibraryActivitySourceRef(
+                source_type=ref["type"],
+                source_id=ref["id"],
+                title=ref["title"],
+            )
+        )
+    event = LibraryActivityEvent(
+        version=data["version"],
+        event_id=data["event_id"],
+        attempt_id=data["attempt_id"],
+        run_id=data["run_id"],
+        actor_kind=actor["kind"],
+        parent_run_id=actor["parent_run_id"],
+        library_provider=data["library_provider"],
+        operation=data["operation"],
+        status=data["status"],
+        result_count=data["result_count"],
+        query_preview=data["query_preview"],
+        source_refs=tuple(decoded_refs),
+        error_code=data["error_code"],
+        error_summary=data["error_summary"],
+    )
+    if event.run_id != actor["run_id"]:
+        raise ValueError("Invalid Library activity payload.")
+    _validate_event(event)
+    return event
+
+
+def redacted_library_activity_payload(event: LibraryActivityEvent) -> str:
+    """Return the default-export outcome summary without query/source identity."""
+    _validate_event(event)
+    source_types = list(
+        dict.fromkeys(ref.source_type for ref in event.source_refs)
+    )
+    return json.dumps(
+        {
+            "version": event.version,
+            "operation": event.operation,
+            "status": event.status,
+            "result_count": event.result_count,
+            "source_types": source_types,
+            "error_code": event.error_code,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def project_library_activity(
+    rows: Sequence[Any],
+    active_turn_ids: Sequence[str],
+    selected_turn_id: str | None,
+) -> LibraryActivityView:
+    """Project valid activity for one selected turn on the active lineage."""
+    active = frozenset(active_turn_ids)
+    if selected_turn_id is None or selected_turn_id not in active:
+        return LibraryActivityView(selected_turn_id=selected_turn_id, actions=())
+
+    candidates: list[LibraryActivityRecord] = []
+    corrupt = 0
+    seen_event_ids: set[str] = set()
+    for row in rows:
+        if str(_field(row, "event_kind") or "") != LIBRARY_ACTIVITY_EVENT_KIND:
+            continue
+        turn_id = _field(row, "turn_id")
+        if turn_id != selected_turn_id:
+            continue
+        message_id = _field(row, "message_id")
+        sequence = _field(row, "seq")
+        if message_id != turn_id or type(sequence) is not int or sequence < 1:
+            corrupt += 1
+            continue
+        try:
+            event = decode_library_activity_event(_field(row, "payload_json"))
+        except ValueError:
+            corrupt += 1
+            continue
+        if event.event_id in seen_event_ids:
+            corrupt += 1
+            continue
+        seen_event_ids.add(event.event_id)
+        occurred_at = _finite_timestamp(_field(row, "step_started_at"))
+        candidates.append(
+            LibraryActivityRecord(
+                turn_id=turn_id,
+                sequence=sequence,
+                occurred_at=occurred_at,
+                event=event,
+            )
+        )
+    candidates.sort(key=lambda action: (action.sequence, action.event.event_id))
+    return LibraryActivityView(
+        selected_turn_id=selected_turn_id,
+        actions=tuple(candidates[:_VIEW_MAX_ACTIONS]),
+        corrupt_row_count=min(corrupt, _VIEW_MAX_ACTIONS),
+    )
+
+
+def _validate_event(event: LibraryActivityEvent) -> None:
+    if type(event.version) is not int or event.version != 1:
+        raise ValueError("Invalid Library activity event.")
+    for value in (event.event_id, event.attempt_id, event.run_id):
+        if _bounded_identifier(value, required=True) != value:
+            raise ValueError("Invalid Library activity event.")
+    if event.parent_run_id is not None and (
+        _bounded_identifier(event.parent_run_id) != event.parent_run_id
+    ):
+        raise ValueError("Invalid Library activity event.")
+    if event.actor_kind not in ("primary", "subagent"):
+        raise ValueError("Invalid Library activity event.")
+    if event.library_provider not in ("direct", "rag"):
+        raise ValueError("Invalid Library activity event.")
+    if not _STABLE_CODE_RE.fullmatch(event.operation):
+        raise ValueError("Invalid Library activity event.")
+    if event.status not in ("succeeded", "empty", "blocked", "failed"):
+        raise ValueError("Invalid Library activity event.")
+    if (
+        type(event.result_count) is not int
+        or event.result_count < 0
+        or event.result_count > _RESULT_COUNT_MAX
+    ):
+        raise ValueError("Invalid Library activity event.")
+    _validate_optional_text(
+        event.query_preview, LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS
+    )
+    if type(event.source_refs) is not tuple or len(event.source_refs) > (
+        LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT
+    ):
+        raise ValueError("Invalid Library activity event.")
+    for ref in event.source_refs:
+        if not isinstance(ref, LibraryActivitySourceRef):
+            raise ValueError("Invalid Library activity event.")
+        _validate_required_text(ref.source_type, 40)
+        _validate_required_text(ref.source_id, LIBRARY_ACTIVITY_SOURCE_ID_MAX_CHARS)
+        _validate_required_text(ref.title, LIBRARY_ACTIVITY_TITLE_MAX_CHARS)
+    if event.error_code is not None and (
+        type(event.error_code) is not str
+        or _STABLE_CODE_RE.fullmatch(event.error_code) is None
+    ):
+        raise ValueError("Invalid Library activity event.")
+    _validate_optional_text(
+        event.error_summary, LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS
+    )
+
+
+def _validate_required_text(value: object, limit: int) -> None:
+    if type(value) is not str or not value or len(value) > limit:
+        raise ValueError("Invalid Library activity event.")
+    if _bounded_text(value, limit) != value:
+        raise ValueError("Invalid Library activity event.")
+
+
+def _validate_optional_text(value: object, limit: int) -> None:
+    if value is None:
+        return
+    _validate_required_text(value, limit)
+
+
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _finite_timestamp(value: object) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
+    return None
+
+
 __all__ = [
+    "LIBRARY_ACTIVITY_EVENT_KIND",
     "LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS",
     "LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES",
     "LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS",
@@ -271,8 +607,16 @@ __all__ = [
     "LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT",
     "LIBRARY_ACTIVITY_TITLE_MAX_CHARS",
     "LibraryActivityCandidate",
+    "LibraryActivityContribution",
+    "LibraryActivityContributionItem",
     "LibraryActivityEvent",
+    "LibraryActivityRecord",
     "LibraryActivitySink",
     "LibraryActivitySourceRef",
+    "LibraryActivityView",
+    "decode_library_activity_event",
+    "encode_library_activity_event",
     "minimize_library_activity",
+    "project_library_activity",
+    "redacted_library_activity_payload",
 ]

--- a/tldw_chatbook/Chat/library_activity.py
+++ b/tldw_chatbook/Chat/library_activity.py
@@ -1,0 +1,278 @@
+"""Bounded, device-local review records for assistant Library operations."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+from uuid import uuid4
+
+from tldw_chatbook.Chat.trajectory import contains_local_path, redact_local_paths
+from tldw_chatbook.Utils.log_sanitizer import redact_log_line
+
+LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS = 160
+LIBRARY_ACTIVITY_TITLE_MAX_CHARS = 160
+LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS = 240
+LIBRARY_ACTIVITY_SOURCE_ID_MAX_CHARS = 200
+LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT = 8
+LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES = 8192
+
+_OPAQUE_ID_MAX_CHARS = 200
+_STABLE_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_ROW_KEYS = ("results", "items", "messages", "members")
+_ID_KEYS = (
+    "id",
+    "source_id",
+    "result_id",
+    "note_id",
+    "media_id",
+    "conversation_id",
+    "prompt_id",
+    "skill_id",
+    "collection_id",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivitySourceRef:
+    """One bounded source identity safe for local activity review."""
+
+    source_type: str
+    source_id: str
+    title: str
+
+    def to_payload(self) -> dict[str, str]:
+        """Return the stable v1 source-reference mapping."""
+        return {
+            "type": self.source_type,
+            "id": self.source_id,
+            "title": self.title,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivityEvent:
+    """One minimized built-in Library operation."""
+
+    version: Literal[1]
+    event_id: str
+    attempt_id: str
+    run_id: str
+    actor_kind: Literal["primary", "subagent"]
+    parent_run_id: str | None
+    library_provider: Literal["direct", "rag"]
+    operation: str
+    status: Literal["succeeded", "empty", "blocked", "failed"]
+    result_count: int
+    query_preview: str | None
+    source_refs: tuple[LibraryActivitySourceRef, ...]
+    error_code: str | None
+    error_summary: str | None
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the exact bounded v1 persistence/export payload."""
+        return {
+            "version": self.version,
+            "event_id": self.event_id,
+            "attempt_id": self.attempt_id,
+            "run_id": self.run_id,
+            "actor": {
+                "kind": self.actor_kind,
+                "run_id": self.run_id,
+                "parent_run_id": self.parent_run_id,
+            },
+            "library_provider": self.library_provider,
+            "operation": self.operation,
+            "status": self.status,
+            "result_count": self.result_count,
+            "query_preview": self.query_preview,
+            "source_refs": [ref.to_payload() for ref in self.source_refs],
+            "error_code": self.error_code,
+            "error_summary": self.error_summary,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryActivityCandidate:
+    """Trusted provider-boundary inputs awaiting minimization."""
+
+    attempt_id: str
+    actor_kind: Literal["primary", "subagent"]
+    run_id: str
+    parent_run_id: str | None
+    library_provider: Literal["direct", "rag"]
+    operation: str
+    arguments: Mapping[str, object]
+    structured_result: object
+    failure_code: str | None
+
+
+LibraryActivitySink = Callable[[LibraryActivityEvent], None]
+
+
+def _bounded_identifier(value: object, *, required: bool = False) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        if required:
+            raise ValueError("required activity identifier is empty")
+        return None
+    if contains_local_path(text) or redact_log_line(text, max_length=0) != text:
+        if required:
+            raise ValueError("activity identifier contains private data")
+        return None
+    return text[:_OPAQUE_ID_MAX_CHARS]
+
+
+def _bounded_text(value: object, limit: int) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    text = redact_local_paths(redact_log_line(text, max_length=0))
+    collapsed = " ".join(text.split())
+    return collapsed[:limit] or None
+
+
+def _value(result: object, name: str, default: object = None) -> object:
+    if isinstance(result, Mapping):
+        return result.get(name, default)
+    return getattr(result, name, default)
+
+
+def _rows(result: object) -> tuple[object, ...]:
+    for key in _ROW_KEYS:
+        raw = _value(result, key)
+        if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+            return tuple(raw)
+    return ()
+
+
+def _row_value(row: object, *names: str) -> object:
+    for name in names:
+        value = row.get(name) if isinstance(row, Mapping) else getattr(row, name, None)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _source_refs(result: object) -> tuple[LibraryActivitySourceRef, ...]:
+    refs: list[LibraryActivitySourceRef] = []
+    for row in _rows(result):
+        source_id = _bounded_identifier(_row_value(row, *_ID_KEYS))
+        if source_id is None:
+            continue
+        source_type = _bounded_text(
+            _row_value(row, "type", "source_type", "kind"), 40
+        ) or "library"
+        title = _bounded_text(
+            _row_value(row, "title", "name", "label"),
+            LIBRARY_ACTIVITY_TITLE_MAX_CHARS,
+        ) or "Untitled"
+        refs.append(
+            LibraryActivitySourceRef(
+                source_type=source_type,
+                source_id=source_id[:LIBRARY_ACTIVITY_SOURCE_ID_MAX_CHARS],
+                title=title,
+            )
+        )
+        if len(refs) == LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT:
+            break
+    return tuple(refs)
+
+
+def _error(result: object, explicit_code: str | None) -> tuple[str | None, str | None]:
+    raw = _value(result, "error")
+    if isinstance(raw, Mapping):
+        code = raw.get("code") or explicit_code
+        summary = raw.get("message")
+    else:
+        code = explicit_code
+        summary = None
+    stable_code = str(code or "").strip().lower()
+    if not _STABLE_CODE_RE.fullmatch(stable_code):
+        stable_code = "activity_failed" if code else ""
+    return (
+        stable_code or None,
+        _bounded_text(summary, LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS),
+    )
+
+
+def _result_count(result: object, rows: tuple[object, ...]) -> int:
+    for key in ("total", "returned", "result_count", "returned_message_count"):
+        raw = _value(result, key)
+        if isinstance(raw, int) and not isinstance(raw, bool):
+            return max(0, raw)
+    return len(rows)
+
+
+def minimize_library_activity(candidate: LibraryActivityCandidate) -> LibraryActivityEvent:
+    """Convert one trusted provider result into the bounded v1 review event."""
+    if candidate.actor_kind not in ("primary", "subagent"):
+        raise ValueError("unsupported activity actor kind")
+    if candidate.library_provider not in ("direct", "rag"):
+        raise ValueError("unsupported Library provider kind")
+    attempt_id = _bounded_identifier(candidate.attempt_id, required=True)
+    run_id = _bounded_identifier(candidate.run_id, required=True)
+    parent_run_id = _bounded_identifier(candidate.parent_run_id)
+    operation = str(candidate.operation or "").strip()
+    if not _STABLE_CODE_RE.fullmatch(operation):
+        raise ValueError("invalid Library activity operation")
+
+    rows = _rows(candidate.structured_result)
+    count = _result_count(candidate.structured_result, rows)
+    error_code, error_summary = _error(
+        candidate.structured_result, candidate.failure_code
+    )
+    raw_status = str(_value(candidate.structured_result, "status", "") or "").lower()
+    if raw_status == "blocked" or error_code == "blocked":
+        status: Literal["succeeded", "empty", "blocked", "failed"] = "blocked"
+    elif error_code is not None or raw_status == "failed":
+        status = "failed"
+    elif count == 0:
+        status = "empty"
+    else:
+        status = "succeeded"
+
+    query_preview = _bounded_text(
+        candidate.arguments.get("query"), LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS
+    )
+    event = LibraryActivityEvent(
+        version=1,
+        event_id=uuid4().hex,
+        attempt_id=attempt_id or "",
+        run_id=run_id or "",
+        actor_kind=candidate.actor_kind,
+        parent_run_id=parent_run_id,
+        library_provider=candidate.library_provider,
+        operation=operation,
+        status=status,
+        result_count=count,
+        query_preview=query_preview,
+        source_refs=_source_refs(candidate.structured_result),
+        error_code=error_code,
+        error_summary=error_summary,
+    )
+    size = len(
+        json.dumps(event.to_payload(), ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    )
+    if size > LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES:
+        raise ValueError("bounded Library activity payload exceeds byte ceiling")
+    return event
+
+
+__all__ = [
+    "LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS",
+    "LIBRARY_ACTIVITY_PAYLOAD_MAX_BYTES",
+    "LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS",
+    "LIBRARY_ACTIVITY_SOURCE_ID_MAX_CHARS",
+    "LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT",
+    "LIBRARY_ACTIVITY_TITLE_MAX_CHARS",
+    "LibraryActivityCandidate",
+    "LibraryActivityEvent",
+    "LibraryActivitySink",
+    "LibraryActivitySourceRef",
+    "minimize_library_activity",
+]

--- a/tldw_chatbook/Chat/library_activity.py
+++ b/tldw_chatbook/Chat/library_activity.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from typing import Any, Literal
 from uuid import uuid4
 
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
 from tldw_chatbook.Chat.console_transaction_contribution import (
     ConsoleTransactionWriter,
 )
@@ -28,25 +30,6 @@ _OPAQUE_ID_MAX_CHARS = 200
 _RESULT_COUNT_MAX = (1 << 31) - 1
 _VIEW_MAX_ACTIONS = 256
 _STABLE_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
-_EVENT_KEYS = frozenset(
-    {
-        "version",
-        "event_id",
-        "attempt_id",
-        "run_id",
-        "actor",
-        "library_provider",
-        "operation",
-        "status",
-        "result_count",
-        "query_preview",
-        "source_refs",
-        "error_code",
-        "error_summary",
-    }
-)
-_ACTOR_KEYS = frozenset({"kind", "run_id", "parent_run_id"})
-_SOURCE_REF_KEYS = frozenset({"type", "id", "title"})
 _ROW_KEYS = ("results", "items", "messages", "members")
 _ID_KEYS = (
     "id",
@@ -61,6 +44,54 @@ _ID_KEYS = (
 )
 
 
+class _LibraryActivityActorPayload(BaseModel):
+    """Strict deserialization schema for v1 actor attribution."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    kind: Literal["primary", "subagent"]
+    run_id: str = Field(min_length=1, max_length=_OPAQUE_ID_MAX_CHARS)
+    parent_run_id: str | None = Field(
+        default=None, max_length=_OPAQUE_ID_MAX_CHARS
+    )
+
+
+class _LibraryActivitySourceRefPayload(BaseModel):
+    """Strict deserialization schema for one bounded source reference."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    type: str = Field(min_length=1, max_length=40)
+    id: str = Field(min_length=1, max_length=LIBRARY_ACTIVITY_SOURCE_ID_MAX_CHARS)
+    title: str = Field(min_length=1, max_length=LIBRARY_ACTIVITY_TITLE_MAX_CHARS)
+
+
+class _LibraryActivityEventPayload(BaseModel):
+    """Strict deserialization schema for an exact v1 activity payload."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    version: Literal[1]
+    event_id: str = Field(min_length=1, max_length=_OPAQUE_ID_MAX_CHARS)
+    attempt_id: str = Field(min_length=1, max_length=_OPAQUE_ID_MAX_CHARS)
+    run_id: str = Field(min_length=1, max_length=_OPAQUE_ID_MAX_CHARS)
+    actor: _LibraryActivityActorPayload
+    library_provider: Literal["direct", "rag"]
+    operation: str = Field(pattern=_STABLE_CODE_RE.pattern)
+    status: Literal["succeeded", "empty", "blocked", "failed"]
+    result_count: int = Field(ge=0, le=_RESULT_COUNT_MAX)
+    query_preview: str | None = Field(
+        default=None, max_length=LIBRARY_ACTIVITY_QUERY_PREVIEW_MAX_CHARS
+    )
+    source_refs: list[_LibraryActivitySourceRefPayload] = Field(
+        max_length=LIBRARY_ACTIVITY_SOURCE_REF_MAX_COUNT
+    )
+    error_code: str | None = Field(default=None, pattern=_STABLE_CODE_RE.pattern)
+    error_summary: str | None = Field(
+        default=None, max_length=LIBRARY_ACTIVITY_ERROR_SUMMARY_MAX_CHARS
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class LibraryActivitySourceRef:
     """One bounded source identity safe for local activity review."""
@@ -70,7 +101,11 @@ class LibraryActivitySourceRef:
     title: str
 
     def to_payload(self) -> dict[str, str]:
-        """Return the stable v1 source-reference mapping."""
+        """Return the stable v1 source-reference mapping.
+
+        Returns:
+            Exact persistence mapping for this source reference.
+        """
         return {
             "type": self.source_type,
             "id": self.source_id,
@@ -98,7 +133,11 @@ class LibraryActivityEvent:
     error_summary: str | None
 
     def to_payload(self) -> dict[str, Any]:
-        """Return the exact bounded v1 persistence/export payload."""
+        """Return the exact bounded v1 persistence/export payload.
+
+        Returns:
+            JSON-compatible event mapping with explicit actor attribution.
+        """
         return {
             "version": self.version,
             "event_id": self.event_id,
@@ -142,7 +181,17 @@ class LibraryActivityContribution:
         conversation_id: str,
         message_ids: Mapping[str, str],
     ) -> None:
-        """Insert every event under its durable USER turn opener."""
+        """Insert every event under its durable user-turn opener.
+
+        Args:
+            writer: Transaction-scoped trajectory writer.
+            conversation_id: Durable conversation receiving the rows.
+            message_ids: Native-to-durable user-turn opener mapping.
+
+        Raises:
+            ValueError: If the contribution, owner mapping, or capture time is
+                invalid.
+        """
         if not self.items:
             raise ValueError("Library activity contribution cannot be empty.")
         prepared: list[tuple[str, str, float]] = []
@@ -200,7 +249,11 @@ class LibraryActivityView:
 
     @property
     def status(self) -> Literal["empty", "ready", "corrupt"]:
-        """Return the bounded presentation state for this projection."""
+        """Return the bounded presentation state for this projection.
+
+        Returns:
+            ``empty``, ``ready``, or ``corrupt`` for Inspector rendering.
+        """
         if self.corrupt_row_count:
             return "corrupt"
         return "ready" if self.actions else "empty"
@@ -319,7 +372,18 @@ def _result_count(result: object, rows: tuple[object, ...]) -> int:
 
 
 def minimize_library_activity(candidate: LibraryActivityCandidate) -> LibraryActivityEvent:
-    """Convert one trusted provider result into the bounded v1 review event."""
+    """Convert one trusted provider result into the bounded v1 review event.
+
+    Args:
+        candidate: Trusted provider-boundary result and exact run attribution.
+
+    Returns:
+        Minimized, size-bounded activity event.
+
+    Raises:
+        ValueError: If attribution, operation, identifiers, or payload bounds
+            are invalid.
+    """
     if candidate.actor_kind not in ("primary", "subagent"):
         raise ValueError("unsupported activity actor kind")
     if candidate.library_provider not in ("direct", "rag"):
@@ -377,7 +441,17 @@ def minimize_library_activity(candidate: LibraryActivityCandidate) -> LibraryAct
 
 
 def encode_library_activity_event(event: LibraryActivityEvent) -> str:
-    """Encode one exact bounded v1 activity payload."""
+    """Encode one exact bounded v1 activity payload.
+
+    Args:
+        event: Activity event to validate and encode.
+
+    Returns:
+        Compact JSON payload suitable for durable sidecar storage.
+
+    Raises:
+        ValueError: If event validation or the byte ceiling fails.
+    """
     _validate_event(event)
     encoded = json.dumps(
         event.to_payload(), ensure_ascii=False, separators=(",", ":")
@@ -388,7 +462,17 @@ def encode_library_activity_event(event: LibraryActivityEvent) -> str:
 
 
 def decode_library_activity_event(value: object) -> LibraryActivityEvent:
-    """Decode an exact v1 payload while rejecting additive or unsafe fields."""
+    """Decode an exact v1 payload while rejecting additive or unsafe fields.
+
+    Args:
+        value: JSON string at the durable activity boundary.
+
+    Returns:
+        Strictly validated domain event.
+
+    Raises:
+        ValueError: If JSON, schema, cross-field, privacy, or size validation fails.
+    """
     if type(value) is not str:
         raise ValueError("Invalid Library activity payload.")
     try:
@@ -416,47 +500,51 @@ def decode_library_activity_event(value: object) -> LibraryActivityEvent:
         )
     except (TypeError, ValueError, json.JSONDecodeError, RecursionError) as exc:
         raise ValueError("Invalid Library activity payload.") from exc
-    if type(data) is not dict or set(data) != _EVENT_KEYS:
-        raise ValueError("Invalid Library activity payload.")
-    actor = data["actor"]
-    refs = data["source_refs"]
-    if type(actor) is not dict or set(actor) != _ACTOR_KEYS or type(refs) is not list:
-        raise ValueError("Invalid Library activity payload.")
-    decoded_refs: list[LibraryActivitySourceRef] = []
-    for ref in refs:
-        if type(ref) is not dict or set(ref) != _SOURCE_REF_KEYS:
-            raise ValueError("Invalid Library activity payload.")
-        decoded_refs.append(
-            LibraryActivitySourceRef(
-                source_type=ref["type"],
-                source_id=ref["id"],
-                title=ref["title"],
-            )
-        )
+    try:
+        payload = _LibraryActivityEventPayload.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError("Invalid Library activity payload.") from exc
     event = LibraryActivityEvent(
-        version=data["version"],
-        event_id=data["event_id"],
-        attempt_id=data["attempt_id"],
-        run_id=data["run_id"],
-        actor_kind=actor["kind"],
-        parent_run_id=actor["parent_run_id"],
-        library_provider=data["library_provider"],
-        operation=data["operation"],
-        status=data["status"],
-        result_count=data["result_count"],
-        query_preview=data["query_preview"],
-        source_refs=tuple(decoded_refs),
-        error_code=data["error_code"],
-        error_summary=data["error_summary"],
+        version=payload.version,
+        event_id=payload.event_id,
+        attempt_id=payload.attempt_id,
+        run_id=payload.run_id,
+        actor_kind=payload.actor.kind,
+        parent_run_id=payload.actor.parent_run_id,
+        library_provider=payload.library_provider,
+        operation=payload.operation,
+        status=payload.status,
+        result_count=payload.result_count,
+        query_preview=payload.query_preview,
+        source_refs=tuple(
+            LibraryActivitySourceRef(
+                source_type=ref.type,
+                source_id=ref.id,
+                title=ref.title,
+            )
+            for ref in payload.source_refs
+        ),
+        error_code=payload.error_code,
+        error_summary=payload.error_summary,
     )
-    if event.run_id != actor["run_id"]:
+    if event.run_id != payload.actor.run_id:
         raise ValueError("Invalid Library activity payload.")
     _validate_event(event)
     return event
 
 
 def redacted_library_activity_payload(event: LibraryActivityEvent) -> str:
-    """Return the default-export outcome summary without query/source identity."""
+    """Return an outcome summary without query or source identity.
+
+    Args:
+        event: Activity event to validate and redact.
+
+    Returns:
+        Compact JSON containing only bounded outcome fields.
+
+    Raises:
+        ValueError: If the event is invalid.
+    """
     _validate_event(event)
     source_types = list(
         dict.fromkeys(ref.source_type for ref in event.source_refs)
@@ -480,7 +568,16 @@ def project_library_activity(
     active_turn_ids: Sequence[str],
     selected_turn_id: str | None,
 ) -> LibraryActivityView:
-    """Project valid activity for one selected turn on the active lineage."""
+    """Project valid activity for one selected turn on the active lineage.
+
+    Args:
+        rows: Durable and pending trajectory-shaped activity rows.
+        active_turn_ids: Durable user-turn IDs on the active branch.
+        selected_turn_id: Durable selected user-turn ID, if any.
+
+    Returns:
+        Bounded selected-turn projection with corrupt-row count.
+    """
     active = frozenset(active_turn_ids)
     if selected_turn_id is None or selected_turn_id not in active:
         return LibraryActivityView(selected_turn_id=selected_turn_id, actions=())

--- a/tldw_chatbook/Chat/trajectory.py
+++ b/tldw_chatbook/Chat/trajectory.py
@@ -75,7 +75,7 @@ KIND_USER_FEEDBACK = "user_feedback"
 _TOOL_KINDS = frozenset({KIND_TOOL_CALL, KIND_TOOL_RESULT})
 # The preparation disclosure is projected by its owning pure module. It is never
 # a message row or nested tool row in the generic trajectory.
-_SIDECAR_ONLY_KINDS = frozenset({"library_preparation"})
+_SIDECAR_ONLY_KINDS = frozenset({"library_activity", "library_preparation"})
 # Kinds that nest UNDER the message they key on rather than being that
 # message's own sidecar row. Feedback (task-17169) is keyed to the message
 # it critiques, so treating it as that message's row would displace the

--- a/tldw_chatbook/Chat/trajectory_export.py
+++ b/tldw_chatbook/Chat/trajectory_export.py
@@ -49,6 +49,12 @@ from .library_preparation import (
     decode_library_preparation_event,
     encode_library_preparation_event,
 )
+from .library_activity import (
+    LIBRARY_ACTIVITY_EVENT_KIND,
+    decode_library_activity_event,
+    encode_library_activity_event,
+    redacted_library_activity_payload,
+)
 from tldw_chatbook.Chat.trajectory import (
     TrajectoryRecord,
     TrajectorySnapshot,
@@ -1233,7 +1239,17 @@ def build_trajectory_export(
         data = _as_dict(row)
         kind = str(data.get("event_kind") or "")
         payload_json = data.get("payload_json")
-        if kind == LIBRARY_PREPARATION_EVENT_KIND:
+        if kind == LIBRARY_ACTIVITY_EVENT_KIND:
+            try:
+                activity = decode_library_activity_event(payload_json)
+                payload_json = (
+                    encode_library_activity_event(activity)
+                    if include_payloads
+                    else redacted_library_activity_payload(activity)
+                )
+            except ValueError:
+                payload_json = None
+        elif kind == LIBRARY_PREPARATION_EVENT_KIND:
             try:
                 payload_json = encode_library_preparation_event(
                     decode_library_preparation_event(payload_json)

--- a/tldw_chatbook/UI/Console_Modules/library_activity.py
+++ b/tldw_chatbook/UI/Console_Modules/library_activity.py
@@ -1,0 +1,224 @@
+"""Controller for minimized Console Library activity capture and review."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from tldw_chatbook.Chat.console_library_activity_buffer import (
+    LibraryActivityFlushResult,
+)
+from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
+from tldw_chatbook.Chat.library_activity import LibraryActivityEvent, LibraryActivityView
+
+
+class ConsoleLibraryActivityController:
+    """Own activity capture bindings and the selected-turn UI projection.
+
+    The controller owns no DOM. Every mutable dependency is a named late-bound
+    callable so session switches and test replacements remain visible.
+    ``app_instance`` is the justified snapshot exception: the app identity is
+    stable for the controller's lifetime while its service attributes remain
+    live reads during provider construction.
+    """
+
+    def __init__(
+        self,
+        *,
+        app_instance: Any,
+        ensure_store: Callable[[], Any],
+        transcript: Callable[[], Any | None],
+        inspector_rail: Callable[[], Any | None],
+        citation_counts: Callable[[], Mapping[str, int]],
+        reveal_inspector: Callable[[], None],
+        sync_native_ui: Callable[[], Awaitable[None]],
+        notify: Callable[..., None],
+    ) -> None:
+        self.app_instance = app_instance
+        self._ensure_store = ensure_store
+        self._transcript = transcript
+        self._inspector_rail = inspector_rail
+        self._citation_counts = citation_counts
+        self._reveal_inspector = reveal_inspector
+        self._sync_native_ui = sync_native_ui
+        self._notify = notify
+        self.counts: dict[str, int] = {}
+        self.view = LibraryActivityView(selected_turn_id=None, actions=())
+        self.flush_result = LibraryActivityFlushResult(
+            "saved", saved_count=0, pending_count=0
+        )
+        self._projection_token: tuple[
+            str | None, int, tuple[str, ...], str | None, int
+        ] | None = None
+
+    def capture_kwargs(self, turn_context: object) -> dict[str, object]:
+        """Return provider capture bindings for a production turn context."""
+        if not isinstance(turn_context, ConsoleTurnExecutionContext):
+            return {}
+        store = self._ensure_store()
+        session_id = turn_context.session_id
+        turn_id = store.current_library_activity_turn_id(session_id)
+
+        def capture(event: LibraryActivityEvent) -> None:
+            store.admit_library_activity(session_id, turn_id, event)
+            store.flush_library_activity(session_id)
+
+        return {
+            "activity_attempt_id": str(turn_context.library_authority.attempt_id),
+            "activity_sink": capture,
+        }
+
+    def build_provider(
+        self, turn_context: ConsoleTurnExecutionContext | None
+    ) -> Any | None:
+        """Resolve the run-pinned Direct or RAG Library provider."""
+        if turn_context is None:
+            return None
+        app = self.app_instance
+        activity_kwargs = self.capture_kwargs(turn_context)
+        if not turn_context.library_authority.direct_library_tools:
+            from tldw_chatbook.Agents.library_rag_tool_provider import (
+                LibraryRagToolProvider,
+            )
+
+            return LibraryRagToolProvider(
+                getattr(app, "library_rag_search_service", None),
+                **activity_kwargs,
+            )
+        from tldw_chatbook.Agents.library_tool_provider import LibraryToolProvider
+        from tldw_chatbook.Library.local_library_tool_service import (
+            LocalLibraryToolService,
+        )
+
+        media_chunk_service = None
+        media_reading_service = getattr(app, "local_media_reading_service", None)
+        media_db = getattr(app, "media_db", None) or getattr(
+            media_reading_service, "media_db", None
+        )
+        if media_db is not None or media_reading_service is not None:
+            from tldw_chatbook.Chunking.chunking_interop_library import (
+                get_chunking_service,
+            )
+            from tldw_chatbook.Library.local_media_chunk_tool_service import (
+                LocalMediaChunkToolService,
+            )
+
+            media_chunk_service = LocalMediaChunkToolService(
+                media_db,
+                media_reading_service,
+                template_interop=(
+                    get_chunking_service(media_db) if media_db is not None else None
+                ),
+                policy_enforcer=getattr(app, "service_policy_enforcer", None),
+            )
+        service = LocalLibraryToolService(
+            media_service=media_reading_service,
+            notes_service=getattr(app, "notes_service", None),
+            prompt_service=getattr(app, "local_prompt_service", None),
+            skills_service=getattr(app, "local_skills_service", None),
+            conversation_service=getattr(
+                app, "local_chat_conversation_service", None
+            ),
+            collections_service=getattr(
+                app, "local_library_collections_service", None
+            ),
+            media_chunk_service=media_chunk_service,
+            notes_scope_service=getattr(app, "notes_scope_service", None),
+            policy_enforcer=getattr(app, "service_policy_enforcer", None),
+        )
+        return LibraryToolProvider(service, **activity_kwargs)
+
+    def invalidate_projection(self) -> None:
+        """Force the next synchronization to rebuild its store projection."""
+        self._projection_token = None
+
+    def selected_message_id(self) -> str | None:
+        """Return the selected native message after owner normalization."""
+        transcript = self._transcript()
+        if transcript is None:
+            return None
+        selected = transcript.selected_message_id
+        if selected is None:
+            return None
+        return transcript.thinking_owner_message_id(selected) or selected
+
+    def selected_citation_count(self) -> int:
+        """Return the selected answer's cached citation count."""
+        selected = self.selected_message_id()
+        return max(0, self._citation_counts().get(selected or "", 0))
+
+    def sync_projection(self) -> None:
+        """Refresh the selected-turn projection when its stable token moves."""
+        store = self._ensure_store()
+        session_id = store.active_session_id
+        selected = self.selected_message_id()
+        if session_id is None:
+            self.counts = {}
+            self.view = LibraryActivityView(selected_turn_id=None, actions=())
+            self.invalidate_projection()
+            return
+        revision = store.library_activity_revision(session_id)
+        active_path = tuple(store.active_path_message_ids(session_id))
+        citation_count = self._citation_counts().get(selected or "", 0)
+        token = (session_id, revision, active_path, selected, citation_count)
+        if token == self._projection_token:
+            return
+        view, counts, flush_result = store.library_activity_snapshot(
+            session_id, selected
+        )
+        self.view = view
+        self.counts = dict(counts)
+        self.flush_result = flush_result
+        self._projection_token = token
+        rail = self._inspector_rail()
+        if rail is not None:
+            rail.sync_library_activity(
+                view,
+                citation_count=citation_count,
+                flush_result=flush_result,
+            )
+
+    def sync_transcript(self, transcript: Any) -> dict[str, int]:
+        """Publish native-assistant footer counts and return the visible map."""
+        self.sync_projection()
+        visible = {
+            message_id: count
+            for message_id, count in self.counts.items()
+            if type(count) is int and count > 0
+        }
+        transcript.set_library_activity_counts(visible)
+        return visible
+
+    def open_selected(self, button: Any) -> None:
+        """Select an assistant's owner, reveal Inspector, and focus activity."""
+        message_id = getattr(button, "native_message_id", None)
+        if type(message_id) is not str or not message_id:
+            return
+        transcript = self._transcript()
+        if transcript is None:
+            return
+        transcript.select_message(message_id)
+        self._reveal_inspector()
+        self.sync_projection()
+        rail = self._inspector_rail()
+        if rail is not None:
+            rail.request_library_activity_focus()
+
+    async def retry(self) -> None:
+        """Retry the retained store-owned activity batch once."""
+        store = self._ensure_store()
+        session_id = store.active_session_id
+        if session_id is None:
+            return
+        result = await asyncio.to_thread(store.retry_library_activity, session_id)
+        self.invalidate_projection()
+        self.sync_projection()
+        await self._sync_native_ui()
+        if result.status == "saved":
+            self._notify("Library activity saved.")
+        elif result.warning:
+            self._notify(result.warning, severity="warning")
+
+
+__all__ = ["ConsoleLibraryActivityController"]

--- a/tldw_chatbook/UI/Console_Modules/library_activity.py
+++ b/tldw_chatbook/UI/Console_Modules/library_activity.py
@@ -21,6 +21,16 @@ class ConsoleLibraryActivityController:
     ``app_instance`` is the justified snapshot exception: the app identity is
     stable for the controller's lifetime while its service attributes remain
     live reads during provider construction.
+
+    Args:
+        app_instance: Stable application identity providing live services.
+        ensure_store: Late-bound Console store accessor.
+        transcript: Late-bound transcript accessor.
+        inspector_rail: Late-bound Inspector accessor.
+        citation_counts: Late-bound assistant citation-count mapping.
+        reveal_inspector: Callback that exposes the Inspector region.
+        sync_native_ui: Async native Console synchronization callback.
+        notify: User-notification callback.
     """
 
     def __init__(
@@ -53,7 +63,18 @@ class ConsoleLibraryActivityController:
         ] | None = None
 
     def capture_kwargs(self, turn_context: object) -> dict[str, object]:
-        """Return provider capture bindings for a production turn context."""
+        """Return provider capture bindings for a production turn context.
+
+        Args:
+            turn_context: Candidate immutable Console turn context.
+
+        Returns:
+            Provider keyword arguments, or an empty mapping for test/legacy
+            contexts.
+
+        Raises:
+            RuntimeError: If the production context has no active user opener.
+        """
         if not isinstance(turn_context, ConsoleTurnExecutionContext):
             return {}
         store = self._ensure_store()
@@ -61,8 +82,7 @@ class ConsoleLibraryActivityController:
         turn_id = store.current_library_activity_turn_id(session_id)
 
         def capture(event: LibraryActivityEvent) -> None:
-            store.admit_library_activity(session_id, turn_id, event)
-            store.flush_library_activity(session_id)
+            store.capture_library_activity(session_id, turn_id, event)
 
         return {
             "activity_attempt_id": str(turn_context.library_authority.attempt_id),
@@ -72,7 +92,17 @@ class ConsoleLibraryActivityController:
     def build_provider(
         self, turn_context: ConsoleTurnExecutionContext | None
     ) -> Any | None:
-        """Resolve the run-pinned Direct or RAG Library provider."""
+        """Resolve the run-pinned Direct or RAG Library provider.
+
+        Args:
+            turn_context: Immutable production turn context, if available.
+
+        Returns:
+            Configured provider, or ``None`` without a turn context.
+
+        Raises:
+            RuntimeError: If production capture cannot bind an owning turn.
+        """
         if turn_context is None:
             return None
         app = self.app_instance
@@ -134,7 +164,11 @@ class ConsoleLibraryActivityController:
         self._projection_token = None
 
     def selected_message_id(self) -> str | None:
-        """Return the selected native message after owner normalization."""
+        """Return the selected native message after owner normalization.
+
+        Returns:
+            Native owner message ID, or ``None`` without a selection.
+        """
         transcript = self._transcript()
         if transcript is None:
             return None
@@ -144,7 +178,11 @@ class ConsoleLibraryActivityController:
         return transcript.thinking_owner_message_id(selected) or selected
 
     def selected_citation_count(self) -> int:
-        """Return the selected answer's cached citation count."""
+        """Return the selected answer's cached citation count.
+
+        Returns:
+            Non-negative number of cited sources.
+        """
         selected = self.selected_message_id()
         return max(0, self._citation_counts().get(selected or "", 0))
 
@@ -180,7 +218,14 @@ class ConsoleLibraryActivityController:
             )
 
     def sync_transcript(self, transcript: Any) -> dict[str, int]:
-        """Publish native-assistant footer counts and return the visible map."""
+        """Publish native-assistant footer counts and return the visible map.
+
+        Args:
+            transcript: Mounted Console transcript widget.
+
+        Returns:
+            Positive activity counts keyed by native assistant message ID.
+        """
         self.sync_projection()
         visible = {
             message_id: count
@@ -191,7 +236,11 @@ class ConsoleLibraryActivityController:
         return visible
 
     def open_selected(self, button: Any) -> None:
-        """Select an assistant's owner, reveal Inspector, and focus activity."""
+        """Select an assistant's owner, reveal Inspector, and focus activity.
+
+        Args:
+            button: Transcript activity affordance carrying a native message ID.
+        """
         message_id = getattr(button, "native_message_id", None)
         if type(message_id) is not str or not message_id:
             return
@@ -206,7 +255,11 @@ class ConsoleLibraryActivityController:
             rail.request_library_activity_focus()
 
     async def retry(self) -> None:
-        """Retry the retained store-owned activity batch once."""
+        """Retry the retained store-owned activity batch once.
+
+        Returns:
+            None after synchronizing projection and notification state.
+        """
         store = self._ensure_store()
         session_id = store.active_session_id
         if session_id is None:

--- a/tldw_chatbook/UI/Console_Modules/right_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/right_rail.py
@@ -51,8 +51,9 @@ the compound-widget boundary transparently, proven live in task 3's review.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import os
 
 from textual import on
@@ -61,6 +62,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches, QueryError
 from textual.events import DescendantBlur, DescendantFocus, Key, Resize
 from textual.geometry import Size
+from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Button, Input, Static, TextArea
 
@@ -72,6 +74,8 @@ from ...Chat.console_display_state import (
 )
 from ...Chat.console_session_settings import ConsoleSettingsSummaryState
 from ...Chat.console_live_work import PENDING_LAUNCH_CARD_ID
+from ...Chat.console_library_activity_buffer import LibraryActivityFlushResult
+from ...Chat.library_activity import LibraryActivityRecord, LibraryActivityView
 from ...Constants import (
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
@@ -107,6 +111,169 @@ class _FocusRecoveryIncident:
     target_id: str | None
     target_index: int | None
     remaining_reconcile_passes: int = 2
+
+
+class ConsoleSelectedTurnActivity(Vertical):
+    """Render cited-source and Library-operation review for one selected turn."""
+
+    class RetryRequested(Message):
+        """Request that the screen/controller retry retained activity writes."""
+
+    def __init__(
+        self,
+        view: LibraryActivityView,
+        *,
+        citation_count: int = 0,
+        flush_result: LibraryActivityFlushResult | None = None,
+        on_reconcile: Callable[[], None] | None = None,
+    ) -> None:
+        super().__init__(id="console-selected-turn")
+        self._view = view
+        self._citation_count = max(0, citation_count)
+        self._flush_result = flush_result
+        self._on_reconcile = on_reconcile
+        self.display = view.selected_turn_id is not None
+        self.styles.height = "auto"
+        self.styles.min_height = 0
+        self.styles.width = "100%"
+        self.styles.min_width = 0
+
+    def sync_state(
+        self,
+        view: LibraryActivityView,
+        *,
+        citation_count: int,
+        flush_result: LibraryActivityFlushResult | None,
+    ) -> None:
+        """Replace the pure selected-turn projection when it changed."""
+
+        normalized_count = max(0, citation_count)
+        self.display = view.selected_turn_id is not None
+        if (
+            view == self._view
+            and normalized_count == self._citation_count
+            and flush_result == self._flush_result
+        ):
+            return
+        self._view = view
+        self._citation_count = normalized_count
+        self._flush_result = flush_result
+        self.refresh(recompose=True)
+        if self._on_reconcile is not None:
+            self.call_after_refresh(self._on_reconcile)
+
+    @staticmethod
+    def _time_copy(record: LibraryActivityRecord) -> str:
+        if record.occurred_at is None:
+            return "time unavailable"
+        try:
+            occurred_at = datetime.fromtimestamp(
+                record.occurred_at, tz=timezone.utc
+            )
+        except (OSError, OverflowError, ValueError):
+            return "time unavailable"
+        return occurred_at.strftime("%H:%M:%S UTC")
+
+    @classmethod
+    def _action_widgets(
+        cls, record: LibraryActivityRecord, index: int
+    ) -> tuple[Widget, ...]:
+        event = record.event
+        mode = "Direct" if event.library_provider == "direct" else "RAG"
+        result_word = "result" if event.result_count == 1 else "results"
+        widgets: list[Widget] = [
+            Static(
+                (
+                    f"{event.operation} · {event.actor_kind} · {mode} · "
+                    f"{event.status} · {event.result_count} {result_word} · "
+                    f"{cls._time_copy(record)}"
+                ),
+                id=f"console-library-activity-action-{index}",
+                classes="console-library-activity-action",
+                markup=False,
+            )
+        ]
+        for ref_index, ref in enumerate(event.source_refs):
+            widgets.append(
+                Static(
+                    f"{ref.source_type} · {ref.title} · {ref.source_id}",
+                    id=f"console-library-activity-ref-{index}-{ref_index}",
+                    classes="console-library-activity-source-ref",
+                    markup=False,
+                )
+            )
+        if event.error_summary:
+            widgets.append(
+                Static(
+                    event.error_summary,
+                    id=f"console-library-activity-error-{index}",
+                    classes="console-library-activity-error",
+                    markup=False,
+                )
+            )
+        return tuple(widgets)
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Selected turn",
+            id="console-selected-turn-heading",
+            classes="console-inspector-group-heading destination-section",
+            markup=False,
+        )
+        yield Static(
+            f"Cited sources ({self._citation_count})",
+            id="console-selected-turn-cited-sources",
+            classes="console-selected-turn-subsection",
+            markup=False,
+        )
+        with Vertical(id="console-selected-turn-library-activity"):
+            yield Static(
+                f"Library activity ({len(self._view.actions)} actions)",
+                id="console-selected-turn-library-activity-heading",
+                classes="console-selected-turn-subsection",
+                markup=False,
+            )
+            body: list[Widget] = []
+            if not self._view.actions:
+                body.append(
+                    Static(
+                        "No Library activity for this turn.",
+                        id="console-library-activity-empty",
+                        markup=False,
+                    )
+                )
+            else:
+                for index, record in enumerate(self._view.actions):
+                    body.extend(self._action_widgets(record, index))
+            if self._view.corrupt_row_count:
+                body.append(
+                    Static(
+                        "Some Library activity could not be displayed.",
+                        id="console-library-activity-corrupt",
+                        markup=False,
+                    )
+                )
+            if self._flush_result is not None and self._flush_result.warning:
+                body.append(
+                    Static(
+                        self._flush_result.warning,
+                        id="console-library-activity-save-warning",
+                        markup=False,
+                    )
+                )
+                body.append(
+                    Button(
+                        "Retry",
+                        id="console-library-activity-retry",
+                        compact=True,
+                    )
+                )
+            yield ConsoleBoundedSection(*body, section_id="library-activity")
+
+    @on(Button.Pressed, "#console-library-activity-retry")
+    def _request_retry(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(self.RetryRequested())
 
 
 class _InspectorOuterBody(VerticalScroll):
@@ -233,6 +400,10 @@ class ConsoleInspectorRail(Vertical):
         project_instruction_state: ConsoleProjectInstructionState,
         settings_summary_state: ConsoleSettingsSummaryState,
         live_work_card_builder: Callable[[], Widget],
+        library_activity_view: LibraryActivityView | None = None,
+        library_activity_citation_count: int = 0,
+        library_activity_flush_result: LibraryActivityFlushResult | None = None,
+        library_activity_retry: Callable[[], Awaitable[None]] | None = None,
         ownership_policy: InspectorOwnershipPolicy | None = None,
         inspector_more_open: bool = False,
         **kwargs,
@@ -273,6 +444,12 @@ class ConsoleInspectorRail(Vertical):
                 ``ConsoleDictationController``'s late-binding constructor
                 rule -- see ``dictation.py``'s module docstring) always
                 mounts a brand-new instance instead.
+            library_activity_view: Pure selected-turn activity projection.
+            library_activity_citation_count: Cited-source count for the same
+                selected turn.
+            library_activity_flush_result: Current store-owned persistence
+                state for retained Library activity.
+            library_activity_retry: Store-owned retained-write retry callback.
             ownership_policy: Optional explicit Inspector ownership policy.
                 Production resolves the strict opt-in environment flag at
                 this composition boundary when omitted.
@@ -289,6 +466,15 @@ class ConsoleInspectorRail(Vertical):
         self._project_instruction_state = project_instruction_state
         self._settings_summary_state = settings_summary_state
         self._live_work_card_builder = live_work_card_builder
+        self._library_activity_view = library_activity_view or LibraryActivityView(
+            selected_turn_id=None,
+            actions=(),
+        )
+        self._library_activity_citation_count = max(
+            0, library_activity_citation_count
+        )
+        self._library_activity_flush_result = library_activity_flush_result
+        self._library_activity_retry = library_activity_retry
         self._ownership_policy = (
             ownership_policy or _resolve_inspector_ownership_policy()
         )
@@ -298,6 +484,7 @@ class ConsoleInspectorRail(Vertical):
         self._outer_reconcile_dirty = False
         self._outer_reconcile_owner_demand = False
         self._outer_owner_reconcile_count = 0
+        self._library_activity_focus_pending = False
         self._inspector_focus_active = False
         self._navigation_generation = 0
         self._section_focus_history: dict[str, tuple[Widget, tuple[Widget, ...]]] = {}
@@ -311,7 +498,51 @@ class ConsoleInspectorRail(Vertical):
     def on_unmount(self) -> None:
         """Discard pending generations when the Inspector leaves the DOM."""
 
+        self._library_activity_focus_pending = False
         self._clear_outer_reconcile_state()
+
+    def sync_library_activity(
+        self,
+        view: LibraryActivityView,
+        *,
+        citation_count: int,
+        flush_result: LibraryActivityFlushResult | None,
+    ) -> None:
+        """Keep the rail owner and mounted selected-turn child in sync."""
+
+        self._library_activity_view = view
+        self._library_activity_citation_count = max(0, citation_count)
+        self._library_activity_flush_result = flush_result
+        try:
+            selected_turn = self.query_one(
+                "#console-selected-turn", ConsoleSelectedTurnActivity
+            )
+        except (NoMatches, QueryError):
+            return
+        selected_turn.sync_state(
+            view,
+            citation_count=citation_count,
+            flush_result=flush_result,
+        )
+
+    def request_library_activity_focus(self) -> None:
+        """Focus activity after the selected-turn and outer rail settle."""
+
+        self._library_activity_focus_pending = True
+        self.request_outer_reconcile()
+
+    @on(ConsoleSelectedTurnActivity.RetryRequested)
+    def retry_library_activity(
+        self, event: ConsoleSelectedTurnActivity.RetryRequested
+    ) -> None:
+        """Keep Retry inside the Inspector region and delegate persistence."""
+        event.stop()
+        if self._library_activity_retry is not None:
+            self.run_worker(
+                self._library_activity_retry(),
+                group="console-library-activity-retry",
+                exclusive=True,
+            )
 
     @on(ConsoleStagedSourceOpenRequested)
     def open_staged_source(self, event: ConsoleStagedSourceOpenRequested) -> None:
@@ -423,6 +654,29 @@ class ConsoleInspectorRail(Vertical):
             return
         if owner_demand:
             self._outer_owner_reconcile_count += 1
+        if self._library_activity_focus_pending:
+            self._library_activity_focus_pending = False
+            self._focus_library_activity()
+
+    def _focus_library_activity(self) -> None:
+        """Focus and reveal the settled selected-turn activity heading."""
+
+        try:
+            heading = self.query_one(
+                "#console-selected-turn-library-activity-heading", Static
+            )
+            body = self.query_one("#console-inspector-rail-body", VerticalScroll)
+        except (NoMatches, QueryError):
+            return
+        heading.can_focus = True
+        self.screen.set_focus(heading, scroll_visible=False)
+        body.scroll_to_widget(
+            heading,
+            animate=False,
+            immediate=True,
+            force=True,
+            top=True,
+        )
 
     def _reconcile_outer_fold(self) -> bool:
         """Apply the counterfactual outer-hint predicate from laid-out geometry."""
@@ -1161,6 +1415,12 @@ class ConsoleInspectorRail(Vertical):
                     on_more_focus_removed=self._recover_keyed_boundary_focus,
                     more_open=self._inspector_more_open,
                     id="console-run-inspector-state",
+                )
+                yield ConsoleSelectedTurnActivity(
+                    self._library_activity_view,
+                    citation_count=self._library_activity_citation_count,
+                    flush_result=self._library_activity_flush_result,
+                    on_reconcile=self.request_outer_reconcile,
                 )
                 settings_summary = ConsoleSettingsSummary(
                     self._settings_summary_state,

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -75,6 +75,7 @@ from .dictation import ConsoleDictationController
 from .fleet import ConsoleFleetLifecycleController
 from .hands_free import ConsoleHandsFreeController
 from .image import ConsoleImageController
+from .library_activity import ConsoleLibraryActivityController
 from .library_policy import ConsoleLibraryPolicyController
 from .message import ConsoleMessageController
 from .prompt_queue import (
@@ -260,6 +261,14 @@ def _review_selection_capture_policy_bindings(
     )
 
 
+def _console_widget_or_none(screen: Any, selector: str) -> Any | None:
+    """Return one mounted Console widget without exposing query failures."""
+    try:
+        return screen.query_one(selector)
+    except QueryError:
+        return None
+
+
 async def _show_console_feedback_comment(
     screen: Any, action: str, quote: str
 ) -> str | None:
@@ -409,8 +418,8 @@ def build_console_controllers(
     """Construct the Console screen's controllers and coordinators.
 
     Assigns, in this order, `screen._image`, `screen._video`,
-    `screen._retrieval`, `screen._library_policy`, `screen._skill`,
-    `screen._workspace`, `screen._character`, `screen._fleet`,
+    `screen._retrieval`, `screen._library_policy`, `screen._library_activity`,
+    `screen._skill`, `screen._workspace`, `screen._character`, `screen._fleet`,
     `screen._session`, `screen._dictation`, `screen._hands_free`,
     `screen._realtime`, `screen._message`, `screen._console_auto_speak`,
     `screen._prompts`, `screen._agent`, `screen._raw_cli`,
@@ -738,6 +747,20 @@ def build_console_controllers(
                 conversation_id
             )
         ),
+    )
+    screen._library_activity = ConsoleLibraryActivityController(
+        app_instance=screen.app_instance,
+        ensure_store=lambda: screen._ensure_console_chat_store(),
+        transcript=lambda: _console_widget_or_none(
+            screen, "#console-native-transcript"
+        ),
+        inspector_rail=lambda: _console_widget_or_none(
+            screen, "#console-right-rail"
+        ),
+        citation_counts=lambda: screen._console_citation_counts,
+        reveal_inspector=lambda: screen._reveal_console_inspector_rail(),
+        sync_native_ui=lambda: screen._sync_native_console_chat_ui(),
+        notify=lambda *args, **kwargs: screen.app_instance.notify(*args, **kwargs),
     )
     screen._character = ConsoleCharacterController(
         app_config_accessor=(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5009,83 +5009,8 @@ class ChatScreen(BaseAppScreen):
     def _console_library_provider_factory(
         self, turn_context: ConsoleTurnExecutionContext | None = None
     ):
-        """Resolve the Library retrieval provider for one Console agent run.
-
-        ADR-079: the final turn authority pins the Library mode for one run;
-        a missing context fails closed. Direct mode assembles
-        ``LocalLibraryToolService`` purely from the app's local service
-        attributes (any missing backend degrades its own tools to
-        ``feature_unavailable``); off mode binds the bounded RAG provider to
-        the app-owned ``library_rag_search_service``.
-        """
-        if turn_context is None:
-            return None
-        app = self.app_instance
-        direct_library_tools = turn_context.library_authority.direct_library_tools
-        if not direct_library_tools:
-            from tldw_chatbook.Agents.library_rag_tool_provider import (
-                LibraryRagToolProvider,
-            )
-
-            return LibraryRagToolProvider(
-                getattr(app, "library_rag_search_service", None)
-            )
-        from tldw_chatbook.Agents.library_tool_provider import LibraryToolProvider
-        from tldw_chatbook.Library.local_library_tool_service import (
-            LocalLibraryToolService,
-        )
-
-        media_chunk_service = None
-        media_reading_service = getattr(app, "local_media_reading_service", None)
-        media_db = getattr(app, "media_db", None) or getattr(
-            media_reading_service, "media_db", None
-        )
-        if media_db is not None or media_reading_service is not None:
-            # The chunk tools need the media DB (row/chunk reads, template
-            # interop) on top of the reading service; built here so a missing
-            # handle degrades only its own tools, like every other backend.
-            from tldw_chatbook.Chunking.chunking_interop_library import (
-                get_chunking_service,
-            )
-            from tldw_chatbook.Library.local_media_chunk_tool_service import (
-                LocalMediaChunkToolService,
-            )
-
-            media_chunk_service = LocalMediaChunkToolService(
-                media_db,
-                media_reading_service,
-                template_interop=(
-                    get_chunking_service(media_db) if media_db is not None else None
-                ),
-                # chunking-agent-tools (Task 5, spec §6): the app's policy
-                # enforcer closes the Console-direct gate on the WRITING
-                # chunk tools (`library_save_chunk_spec`,
-                # `library_rechunk_media`) -- denials surface as named
-                # payloads before any backend touch. The same handle every
-                # other tool-bearing service receives
-                # (`service_policy_enforcer`, built off the app's runtime
-                # policy context).
-                policy_enforcer=getattr(app, "service_policy_enforcer", None),
-            )
-        service = LocalLibraryToolService(
-            media_service=media_reading_service,
-            notes_service=getattr(app, "notes_service", None),
-            prompt_service=getattr(app, "local_prompt_service", None),
-            skills_service=getattr(app, "local_skills_service", None),
-            conversation_service=getattr(app, "local_chat_conversation_service", None),
-            collections_service=getattr(app, "local_library_collections_service", None),
-            media_chunk_service=media_chunk_service,
-            # student-workflow (spec §4.3): the note-save folder seam -- the
-            # app's scope service (folders live only there); a missing handle
-            # degrades folder requests to feature_unavailable like every
-            # other optional backend.
-            notes_scope_service=getattr(app, "notes_scope_service", None),
-            # student-workflow (spec §6): the writing note tool's
-            # Console-direct gate (the chunk-tools pattern) -- the same app
-            # enforcer handle the writing chunk tools receive above.
-            policy_enforcer=getattr(app, "service_policy_enforcer", None),
-        )
-        return LibraryToolProvider(service)
+        """Delegate run-pinned Library provider construction."""
+        return self._library_activity.build_provider(turn_context)
 
     def _ensure_console_chat_controller(self) -> ConsoleChatController:
         """Return the native Console chat controller with fresh selection state.
@@ -10664,6 +10589,12 @@ class ChatScreen(BaseAppScreen):
                             else self._build_console_live_work_source_readiness_card()
                         )
                     ),
+                    library_activity_view=self._library_activity.view,
+                    library_activity_citation_count=(
+                        self._library_activity.selected_citation_count()
+                    ),
+                    library_activity_flush_result=self._library_activity.flush_result,
+                    library_activity_retry=self._library_activity.retry,
                     inspector_more_open=rail_state.inspector_more_open,
                 )
                 right_rail.can_focus = True
@@ -12121,6 +12052,9 @@ class ChatScreen(BaseAppScreen):
                 if type(count) is int and count > 0
             }
             transcript.set_citation_counts(visible_citation_counts)
+            visible_library_activity_counts = self._library_activity.sync_transcript(
+                transcript
+            )
             transcript.set_original_attempt_previews(
                 self._console_original_attempt_previews.copy()
             )
@@ -12215,6 +12149,7 @@ class ChatScreen(BaseAppScreen):
                 turn_activity,
                 tuple(sorted(self._console_original_attempt_previews.items())),
                 tuple(sorted(visible_citation_counts.items())),
+                tuple(sorted(visible_library_activity_counts.items())),
                 # task-18515: an annotation added, edited, or deleted must
                 # force a refresh on its own. Without this the marker row
                 # only changed when something ELSE in the key did -- phase 4
@@ -14584,6 +14519,7 @@ class ChatScreen(BaseAppScreen):
                 computed on demand when not given.
         """
         self._sync_console_pending_delete_confirmation()
+        self._library_activity.sync_projection()
         control_state = self._build_console_control_state(
             self._pending_console_launch_context
         )
@@ -16615,6 +16551,11 @@ class ChatScreen(BaseAppScreen):
         This ensures buttons work properly with screen-based navigation.
         """
         button_id = event.button.id
+
+        if event.button.has_class("console-transcript-library-activity"):
+            event.stop()
+            self._library_activity.open_selected(event.button)
+            return
 
         # Log for debugging
         logger.info(f"ChatScreen on_button_pressed called with button: {button_id}")

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -231,7 +231,6 @@ from ...Chat.console_chat_models import (
     ConsoleWorkspaceContext,
     derive_console_session_title,
 )
-from ...Chat.console_turn_context import ConsoleTurnExecutionContext
 from ...UI.character_display_text import sanitize_character_display_label
 from ...Chat.console_session_settings import (
     ConsoleSessionSettings,
@@ -5006,12 +5005,6 @@ class ChatScreen(BaseAppScreen):
         """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
         return self._prompts._ensure_console_prompt_history()
 
-    def _console_library_provider_factory(
-        self, turn_context: ConsoleTurnExecutionContext | None = None
-    ):
-        """Delegate run-pinned Library provider construction."""
-        return self._library_activity.build_provider(turn_context)
-
     def _ensure_console_chat_controller(self) -> ConsoleChatController:
         """Return the native Console chat controller with fresh selection state.
 
@@ -5052,7 +5045,7 @@ class ChatScreen(BaseAppScreen):
                 world_info_applier=self._console_world_info_applier,
                 rag_capture_provider=self._retrieval._capture_console_staged_rag,
                 default_session_settings=self._session._default_console_session_settings,
-                library_provider_factory=self._console_library_provider_factory,
+                library_provider_factory=self._library_activity.build_provider,
                 global_user_display_name=self._global_chat_display_name,
                 turn_context_provider=(
                     self._session._build_console_turn_execution_context
@@ -5120,7 +5113,7 @@ class ChatScreen(BaseAppScreen):
             "_default_session_settings": getattr(
                 session, "_default_console_session_settings", None
             ),
-            "_library_provider_factory": self._console_library_provider_factory,
+            "_library_provider_factory": self._library_activity.build_provider,
             "_global_user_display_name": self._global_chat_display_name,
             "_turn_context_provider": getattr(
                 session, "_build_console_turn_execution_context", None

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2745,6 +2745,7 @@ class ConsoleTranscript(VerticalScroll):
             "console-transcript-rule",
             "console-transcript-summary-banner",
             "console-transcript-citation-sources",
+            "console-transcript-library-activity",
             "console-transcript-annotations",
             # Textual scrollbars carry the generic system-widget class; ignore them
             # defensively if a scrollbar click ever bubbles up to the transcript.
@@ -2819,6 +2820,7 @@ class ConsoleTranscript(VerticalScroll):
         self._fork_eligibility_by_message_id: dict[str, ConsoleForkEligibility] = {}
         self._original_attempt_previews: dict[str, str] = {}
         self._citation_counts: dict[str, int] = {}
+        self._library_activity_counts: dict[str, int] = {}
         # task-17169: screen-owned review-note previews keyed by native
         # message id -- a message with entries gains an inline marker row.
         self._annotation_previews: dict[str, tuple[str, ...]] = {}
@@ -4344,7 +4346,21 @@ class ConsoleTranscript(VerticalScroll):
             and count > 0
         }
 
-    def set_annotation_previews(self, previews: Mapping[str, tuple[str, ...]]) -> None:
+    def set_library_activity_counts(self, counts: Mapping[str, int]) -> None:
+        """Replace screen-owned Library activity counts by assistant message ID."""
+
+        self._library_activity_counts = {
+            message_id: count
+            for message_id, count in counts.items()
+            if isinstance(message_id, str)
+            and message_id
+            and type(count) is int
+            and count > 0
+        }
+
+    def set_annotation_previews(
+        self, previews: Mapping[str, tuple[str, ...]]
+    ) -> None:
         """Replace screen-owned review-note previews keyed by native message ID.
 
         task-17169 slice 2: the screen's sync loop pushes this every tick
@@ -6224,6 +6240,26 @@ class ConsoleTranscript(VerticalScroll):
                         renderable=f"Cited sources ({citation_count})",
                     )
                 )
+            library_activity_count = self._library_activity_counts.get(message.id, 0)
+            if (
+                message.role is ConsoleMessageRole.ASSISTANT
+                and library_activity_count > 0
+            ):
+                rows.append(
+                    _TranscriptRow(
+                        key=f"library-activity:{message.id}",
+                        kind="library-activity",
+                        signature=(
+                            "library-activity",
+                            message.id,
+                            library_activity_count,
+                        ),
+                        message=message,
+                        renderable=(
+                            f"Library activity ({library_activity_count} actions)"
+                        ),
+                    )
+                )
             annotation_notes = self._annotation_previews.get(message.id)
             if annotation_notes:
                 # task-17169: inline review-note marker under the annotated
@@ -6754,6 +6790,14 @@ class ConsoleTranscript(VerticalScroll):
                 row.renderable,
                 id=f"console-citation-sources-{row.message.id}",
                 classes="console-transcript-citation-sources",
+            )
+            button.native_message_id = row.message.id
+            return button
+        if row.kind == "library-activity" and row.message is not None:
+            button = Button(
+                row.renderable,
+                id=f"console-library-activity-{row.message.id}",
+                classes="console-transcript-library-activity",
             )
             button.native_message_id = row.message.id
             return button


### PR DESCRIPTION
## Summary
- capture bounded, versioned Direct and RAG Library activity at the trusted provider seams with primary/subagent attribution and fail-closed delivery
- retain and persist activity through the store-owned buffer, promotion transaction contribution, redacted trajectory export, and separate active-branch projection
- add Selected turn Inspector review, assistant affordances, explicit empty/not-saved states, and Retry wiring without mixing activity into Sources or generic trajectory
- move Library provider construction and projection into the Console module controller, lowering the chat_screen ratchet to 16,978 lines / 565 methods

## Verification
- 396 passed, 1 deselected in the task-scoped delivery matrix
- Ruff passed for every changed Python path
- compileall passed for every changed production path
- CSS bundle sync passed
- screen-size ratchet passed at the post-rebase measurement
- git diff --check passed
- both planned mutation checks failed under the weakened privacy/trajectory boundaries and passed after restoration

## Baseline exclusions
- one stale schema-v45 transaction test and two trajectory-capture tests fail unchanged on pristine origin/dev; they are documented in the task notes and were not modified here

## Architecture
ADR required: no. This implements existing ADR-079 without changing its storage, ownership, privacy, or runtime boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Captures bounded, versioned Direct and RAG Library activity at the trusted provider seams and exposes it for selected-turn review in the Console. Events carry primary/subagent attribution, fail closed when privacy or trajectory boundaries are weakened, and stay out of Sources and the generic trajectory.

**New Features**
- Persists activity through a store-owned buffer, promotion transaction contribution, redacted trajectory export, and an active-branch projection.
- Adds a selected-turn right-rail review with explicit empty and not-saved states and Retry wiring.
- Keeps imported Library activity as inert sidecar data that never becomes model context or evidence.
- Closes lifecycle gaps so pending activity is bounded, thread-safe, and always flagged as unsaved until committed.

**Refactors**
- Moves Library provider construction and projection into `ConsoleLibraryActivityController`, lowering the `chat_screen` ratchet from 17,059/566 to 17,000/565.
- Delivery matrix passes 396 tests (1 deselected) with Ruff, compileall, CSS sync, and `git diff --check` green.
- The two planned mutation checks fail under weakened boundaries and pass after restoration; pre-existing failures on pristine `origin/dev` remain untouched.

<sup>Written for commit 60f573347fba9bf384b5764c452065dbe84cc8d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

