### PR TITLE
perf(ui): pause hidden progress clocks — indeterminate bars no longer tick unseen (TASK-23022)

### DIFF
--- a/Tests/Architecture/test_progress_widget_clock_guard.py
+++ b/Tests/Architecture/test_progress_widget_clock_guard.py
@@ -1,0 +1,226 @@
+# test_progress_widget_clock_guard.py
+# Description: Package-wide guard: stock textual progress widgets are forbidden (TASK-23022)
+"""
+TASK-23022: textual's stock ``ProgressBar``/``LoadingIndicator`` arm repeating
+clocks (15 Hz indeterminate refresh + 1 Hz ETA sampler; 16 Hz indicator) that
+``display = False`` does not stop -- measured as 88% of the Lab screen's idle
+CPU. The repo's timer census cannot see this class of clock at all: the
+``set_interval`` calls live inside textual, not in any package file.
+
+The durable defense is therefore structural: **no package file may construct
+or subclass the stock widgets**. Every use must go through
+``tldw_chatbook/Widgets/pausable_progress.py``, whose drop-in replacements
+pause all their clocks while hidden. With that invariant, a hidden
+indeterminate progress widget arming a permanent clock cannot be written by
+accident -- new code that tries fails this guard with a pointer to the house
+classes.
+
+Importing the stock names stays legal (they are the right type arguments for
+``query_one``/``isinstance``); only *constructing* and *subclassing* are
+flagged. The scanner unwraps ``ast.Subscript`` on callees, because the
+subscripted-generic spelling of a call is otherwise invisible to a
+``Name``/``Attribute``-only match (the trap recorded in
+``backlog/docs/lessons-textual.md``, TASK-15771), and it resolves
+``import`` aliases so ``from textual.widgets import ProgressBar as PB`` or
+``textual.widgets.ProgressBar(...)`` cannot slip past. Positive-control
+fixtures below hold the scanner itself to account: each forbidden spelling
+must be flagged, so the guard cannot rot into a vacuous pass.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+REPO_ROOT = PACKAGE_ROOT.parent
+
+#: The one module allowed to touch the stock classes: it exists to wrap them.
+HOUSE_MODULE = "tldw_chatbook/Widgets/pausable_progress.py"
+
+#: Stock textual widget classes that arm hide-proof clocks.
+STOCK_CLASSES = {"ProgressBar", "LoadingIndicator", "Bar"}
+
+#: Modules the stock classes may be imported from.
+TEXTUAL_WIDGET_MODULES = {
+    "textual.widgets",
+    "textual.widgets._progress_bar",
+    "textual.widgets._loading_indicator",
+}
+
+GUIDANCE = (
+    "construct/subclass PausableProgressBar / PausableLoadingIndicator from "
+    "tldw_chatbook.Widgets.pausable_progress instead: the stock widgets arm "
+    "repeating clocks that `display = False` does not stop (TASK-23022)"
+)
+
+
+def _unwrap_subscript(node: ast.expr) -> ast.expr:
+    while isinstance(node, ast.Subscript):
+        node = node.value
+    return node
+
+
+def _scan_module(source: str, filename: str) -> list[str]:
+    """Return violation descriptions for one module's source."""
+    tree = ast.parse(source, filename=filename)
+
+    # -- pass 1: aliases ----------------------------------------------------
+    # names bound to a stock class in this module
+    class_aliases: set[str] = set()
+    # names bound to a textual widgets module (import textual.widgets as tw /
+    # from textual import widgets)
+    module_aliases: set[str] = set()
+    # names bound to the top-level ``textual`` package
+    textual_aliases: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in TEXTUAL_WIDGET_MODULES:
+                for alias in node.names:
+                    if alias.name in STOCK_CLASSES:
+                        class_aliases.add(alias.asname or alias.name)
+            elif node.module == "textual":
+                for alias in node.names:
+                    if alias.name == "widgets":
+                        module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in TEXTUAL_WIDGET_MODULES:
+                    if alias.asname:
+                        # import textual.widgets as tw -> tw.ProgressBar(...)
+                        module_aliases.add(alias.asname)
+                    else:
+                        # import textual.widgets binds the name ``textual``;
+                        # the use is textual.widgets.ProgressBar(...)
+                        textual_aliases.add("textual")
+                elif alias.name == "textual":
+                    textual_aliases.add(alias.asname or "textual")
+
+    def is_stock_reference(node: ast.expr) -> str | None:
+        node = _unwrap_subscript(node)
+        if isinstance(node, ast.Name) and node.id in class_aliases:
+            return node.id
+        if isinstance(node, ast.Attribute) and node.attr in STOCK_CLASSES:
+            value = _unwrap_subscript(node.value)
+            if isinstance(value, ast.Name) and value.id in module_aliases:
+                return f"{value.id}.{node.attr}"
+            if (
+                isinstance(value, ast.Attribute)
+                and value.attr == "widgets"
+                and isinstance(_unwrap_subscript(value.value), ast.Name)
+                and _unwrap_subscript(value.value).id in textual_aliases
+            ):
+                return f"textual.widgets.{node.attr}"
+        return None
+
+    # -- pass 2: constructions and subclassings -----------------------------
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            reference = is_stock_reference(node.func)
+            if reference is not None:
+                violations.append(
+                    f"{filename}:{node.lineno}: constructs stock {reference}(...)"
+                )
+        elif isinstance(node, ast.ClassDef):
+            for base in node.bases:
+                reference = is_stock_reference(base)
+                if reference is not None:
+                    violations.append(
+                        f"{filename}:{node.lineno}: class {node.name} subclasses "
+                        f"stock {reference}"
+                    )
+    return violations
+
+
+def _scan_package() -> list[str]:
+    violations: list[str] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel == HOUSE_MODULE:
+            continue
+        violations.extend(_scan_module(path.read_text(encoding="utf-8"), rel))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# positive controls: every forbidden spelling must be caught, or the package
+# assertion below proves nothing
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_FIXTURES = {
+    "plain call": (
+        "from textual.widgets import ProgressBar\n"
+        "def f():\n"
+        "    return ProgressBar(total=None)\n"
+    ),
+    "aliased call": (
+        "from textual.widgets import LoadingIndicator as LI\n"
+        "def f():\n"
+        "    return LI()\n"
+    ),
+    "attribute call": (
+        "import textual.widgets\n"
+        "def f():\n"
+        "    return textual.widgets.ProgressBar()\n"
+    ),
+    "widgets-module alias call": (
+        "from textual import widgets as tw\n"
+        "def f():\n"
+        "    return tw.LoadingIndicator()\n"
+    ),
+    "subscripted-generic call": (
+        "from textual.widgets import ProgressBar\n"
+        "def f():\n"
+        "    return ProgressBar[int](total=None)\n"
+    ),
+    "subclass": (
+        "from textual.widgets import ProgressBar\n"
+        "class Mine(ProgressBar):\n"
+        "    pass\n"
+    ),
+    "private-module Bar import call": (
+        "from textual.widgets._progress_bar import Bar\n"
+        "def f():\n"
+        "    return Bar()\n"
+    ),
+}
+
+_COMPLIANT_FIXTURE = (
+    "from textual.widgets import ProgressBar, LoadingIndicator\n"
+    "from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar\n"
+    "def f(app):\n"
+    "    bar = PausableProgressBar(total=None)\n"
+    "    typed = app.query_one('#x', ProgressBar)\n"  # type reference: legal
+    "    ok = isinstance(typed, LoadingIndicator)\n"  # type reference: legal
+    "    return bar, ok\n"
+)
+
+
+def test_scanner_flags_every_forbidden_spelling() -> None:
+    for label, fixture in _FORBIDDEN_FIXTURES.items():
+        assert _scan_module(fixture, f"<fixture:{label}>"), (
+            f"scanner missed the forbidden {label!r} spelling -- the package "
+            "assertion below is now vacuous"
+        )
+
+
+def test_scanner_allows_type_references_and_house_classes() -> None:
+    assert _scan_module(_COMPLIANT_FIXTURE, "<fixture:compliant>") == []
+
+
+def test_house_module_is_scanned_nowhere_else() -> None:
+    """The allowlist entry must exist -- a rename would exempt nothing."""
+    assert (REPO_ROOT / HOUSE_MODULE).is_file(), (
+        f"{HOUSE_MODULE} moved or was deleted; update HOUSE_MODULE or the "
+        "guard exempts a ghost"
+    )
+
+
+def test_no_stock_progress_widget_use_outside_the_house_module() -> None:
+    violations = _scan_package()
+    assert not violations, (
+        "Stock textual progress widgets found outside "
+        f"{HOUSE_MODULE}; {GUIDANCE}:\n  " + "\n  ".join(violations)
+    )

--- a/Tests/Widgets/test_pausable_progress.py
+++ b/Tests/Widgets/test_pausable_progress.py
@@ -1,0 +1,384 @@
+# test_pausable_progress.py
+# Description: Behavior coverage for PausableProgressBar/PausableLoadingIndicator (TASK-23022)
+"""
+TASK-23022: a hidden or off-screen indeterminate progress widget must not run
+a timer. Textual's stock ``ProgressBar(total=None)`` arms a 15 Hz
+``auto_refresh`` on its ``Bar`` plus an unconditional 1 Hz ETA sampler, and
+``LoadingIndicator`` arms 16 Hz at mount; ``display = False`` stops none of
+them (textual gates only the repaint on ``is_on_screen``, never the timer).
+Measured on the Lab screen: 960 of 1018 timer fires in 15 s changed zero
+pixels -- 88% of that screen's idle CPU.
+
+These tests hold the house replacements to the full contract:
+
+* hidden => ZERO timer fires (primary evidence is the fire count, matching
+  the review's methodology; CPU is load-sensitive, fires are deterministic);
+* shown  => the indeterminate animation still runs (fires occur AND the
+  rendered highlight actually moves -- a paused-but-armed clock would pass a
+  pure ``auto_refresh`` probe);
+* hide/show cycling pauses and resumes;
+* reactives changing while hidden (total -> None re-arms the Bar's clock in
+  stock textual) cannot leak a running timer;
+* a widget removed while hidden leaves no timer task behind, and app exit is
+  clean -- pausing/resuming on visibility is exactly the lifecycle shape
+  that has broken quit in this repo before.
+
+Fire counting wraps ``Timer._tick`` and filters to timers owned by the
+widgets under test, so unrelated app clocks cannot contaminate a count.
+A stock-widget control asserts the harness measures (hidden stock bar MUST
+fire), so a hidden-fires==0 assertion can never pass vacuously.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.timer import Timer
+from textual.widgets import LoadingIndicator, ProgressBar
+from textual.widgets._progress_bar import Bar
+
+from tldw_chatbook.Widgets.ModelArtifacts.install_progress import ModelInstallProgress
+from tldw_chatbook.Widgets.pausable_progress import (
+    PausableBar,
+    PausableLoadingIndicator,
+    PausableProgressBar,
+)
+
+#: Idle window long enough for a live 15-16 Hz clock to fire several times
+#: even on a loaded machine, short enough to keep the suite quick.
+WINDOW = 0.5
+
+#: Minimum fires we accept as proof a 15-16 Hz clock is actually running
+#: over WINDOW (nominal ~7; generous margin for scheduler jitter).
+MIN_LIVE_FIRES = 3
+
+
+class FireLog:
+    """Counts Timer._tick invocations per target widget."""
+
+    def __init__(self) -> None:
+        self.fires: list[object] = []
+
+    def count_for(self, *targets: object) -> int:
+        return sum(1 for target in self.fires if target in targets)
+
+    def count_for_types(self, *types: type) -> int:
+        return sum(1 for target in self.fires if isinstance(target, types))
+
+
+@pytest.fixture
+def fire_log(monkeypatch: pytest.MonkeyPatch) -> FireLog:
+    log = FireLog()
+    original_tick = Timer._tick
+
+    async def counting_tick(self: Timer, *, next_timer: float, count: int):
+        try:
+            target = self.target
+        except Exception:  # pragma: no cover - target already gone
+            target = None
+        log.fires.append(target)
+        return await original_tick(self, next_timer=next_timer, count=count)
+
+    monkeypatch.setattr(Timer, "_tick", counting_tick)
+    return log
+
+
+def _live_timers(widgets: Iterable[object]) -> list[Timer]:
+    """Every not-yet-stopped Timer owned by the given widgets."""
+    return [
+        timer
+        for widget in widgets
+        for timer in list(widget._timers)
+        if timer._task is not None
+    ]
+
+
+def _all_paused(widgets: Iterable[object]) -> bool:
+    timers = _live_timers(widgets)
+    return bool(timers) and all(not t._active.is_set() for t in timers)
+
+
+class _SingleWidgetApp(App[None]):
+    def __init__(self, widget) -> None:
+        super().__init__()
+        self._widget = widget
+        self.animation_level = "full"
+
+    def compose(self) -> ComposeResult:
+        yield self._widget
+
+
+# ---------------------------------------------------------------------------
+# harness control: the stock widget MUST fire while hidden, or fire counting
+# proves nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_control_hidden_stock_progress_bar_fires(fire_log: FireLog) -> None:
+    """Stock hidden indeterminate bar fires -- proves the harness measures."""
+    bar = ProgressBar(total=None, show_eta=False)
+    bar.display = False
+    app = _SingleWidgetApp(bar)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(WINDOW)
+        inner = app.query_one(Bar)
+        assert fire_log.count_for(bar, inner) >= MIN_LIVE_FIRES, (
+            "the stock control stopped firing while hidden; if textual now "
+            "pauses these clocks itself, the pausable shape may be obsolete -- "
+            "re-evaluate TASK-23022 rather than deleting this control"
+        )
+
+
+# ---------------------------------------------------------------------------
+# hidden => no fires
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hidden_indeterminate_pausable_bar_never_fires(
+    fire_log: FireLog,
+) -> None:
+    bar = PausableProgressBar(total=None, show_eta=False)
+    bar.display = False
+    app = _SingleWidgetApp(bar)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(WINDOW)
+        inner = app.query_one(PausableBar)
+        assert fire_log.count_for(bar, inner) == 0
+        assert _all_paused([bar, inner])
+
+
+@pytest.mark.asyncio
+async def test_hidden_pausable_loading_indicator_never_fires(
+    fire_log: FireLog,
+) -> None:
+    indicator = PausableLoadingIndicator()
+    indicator.display = False
+    app = _SingleWidgetApp(indicator)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(WINDOW)
+        assert fire_log.count_for(indicator) == 0
+        assert _all_paused([indicator])
+
+
+@pytest.mark.asyncio
+async def test_indicator_hidden_by_ancestor_display_never_fires(
+    fire_log: FireLog,
+) -> None:
+    """Hiding an ANCESTOR must silence the clock too (the CCP overlay shape)."""
+    from textual.containers import Container
+
+    class _AncestorApp(App[None]):
+        def compose(self) -> ComposeResult:
+            container = Container(PausableLoadingIndicator(id="inner"))
+            container.display = False
+            yield container
+
+    app = _AncestorApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(WINDOW)
+        indicator = app.query_one("#inner", PausableLoadingIndicator)
+        assert fire_log.count_for(indicator) == 0
+        assert _all_paused([indicator])
+
+
+# ---------------------------------------------------------------------------
+# shown => still animates (do not break the working case)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_visible_indeterminate_bar_fires_and_animates(
+    fire_log: FireLog,
+) -> None:
+    bar = PausableProgressBar(total=None, show_eta=False)
+    app = _SingleWidgetApp(bar)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inner = app.query_one(PausableBar)
+        assert inner.auto_refresh == pytest.approx(1 / 15)
+        first = inner.render_indeterminate().highlight_range
+        await asyncio.sleep(WINDOW)
+        second = inner.render_indeterminate().highlight_range
+        assert fire_log.count_for(bar, inner) >= MIN_LIVE_FIRES
+        # The highlight travels 30 cells/s; over WINDOW it must have moved.
+        assert first != second
+
+
+@pytest.mark.asyncio
+async def test_visible_pausable_loading_indicator_fires(fire_log: FireLog) -> None:
+    indicator = PausableLoadingIndicator()
+    app = _SingleWidgetApp(indicator)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(WINDOW)
+        assert fire_log.count_for(indicator) >= MIN_LIVE_FIRES
+
+
+# ---------------------------------------------------------------------------
+# hide/show cycling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hide_stops_fires_and_show_resumes_them(fire_log: FireLog) -> None:
+    bar = PausableProgressBar(total=None, show_eta=False)
+    app = _SingleWidgetApp(bar)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inner = app.query_one(PausableBar)
+
+        bar.display = False
+        await pilot.pause()
+        fire_log.fires.clear()
+        await asyncio.sleep(WINDOW)
+        assert fire_log.count_for(bar, inner) == 0
+
+        bar.display = True
+        await pilot.pause()
+        fire_log.fires.clear()
+        await asyncio.sleep(WINDOW)
+        assert fire_log.count_for(bar, inner) >= MIN_LIVE_FIRES
+
+
+@pytest.mark.asyncio
+async def test_total_flips_while_hidden_cannot_leak_a_running_timer(
+    fire_log: FireLog,
+) -> None:
+    """Stock Bar.watch_percentage re-arms 15 Hz on total=None -- even hidden.
+
+    The re-armed timer goes through the intercepted ``set_interval``, so it
+    must be born paused.
+    """
+    bar = PausableProgressBar(total=None, show_eta=False)
+    bar.display = False
+    app = _SingleWidgetApp(bar)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inner = app.query_one(PausableBar)
+        bar.update(total=100, progress=25)  # determinate: Bar clock stops
+        bar.update(total=None)  # indeterminate again: stock would re-arm LIVE
+        await pilot.pause()
+        fire_log.fires.clear()
+        await asyncio.sleep(WINDOW)
+        assert fire_log.count_for(bar, inner) == 0
+        assert _all_paused([bar, inner])
+
+
+# ---------------------------------------------------------------------------
+# lifecycle: unmount while hidden, and app exit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_while_hidden_leaves_no_timer_behind(fire_log: FireLog) -> None:
+    bar = PausableProgressBar(total=None, show_eta=False)
+    bar.display = False
+    app = _SingleWidgetApp(bar)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inner = app.query_one(PausableBar)
+        timers = [t for w in (bar, inner) for t in list(w._timers)]
+        assert timers, "expected the framework to have armed clocks"
+        await bar.remove()
+        await pilot.pause()
+        for timer in timers:
+            assert timer._task is None or timer._task.done(), (
+                f"timer {timer.name!r} still has a live task after remove()"
+            )
+        fire_log.fires.clear()
+        await asyncio.sleep(0.2)
+        assert fire_log.count_for(bar, inner) == 0
+
+
+@pytest.mark.asyncio
+async def test_app_exit_with_hidden_paused_widget_is_clean(
+    fire_log: FireLog,
+) -> None:
+    bar = PausableProgressBar(total=None, show_eta=False)
+    bar.display = False
+    app = _SingleWidgetApp(bar)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inner = app.query_one(PausableBar)
+        timers = [t for w in (bar, inner) for t in list(w._timers)]
+        assert timers
+    # run_test's context exit shuts the app down; every timer task must be
+    # stopped, not left pending ("Task was destroyed but it is pending!").
+    for timer in timers:
+        assert timer._task is None or timer._task.done(), (
+            f"timer {timer.name!r} survived app shutdown"
+        )
+    fire_log.fires.clear()
+    await asyncio.sleep(0.2)
+    assert fire_log.count_for(bar, inner) == 0
+
+
+# ---------------------------------------------------------------------------
+# integration: the shipped hidden-bar composite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_model_install_progress_is_silent_at_idle(fire_log: FireLog) -> None:
+    """The six ModelInstallProgress embeds idle with ZERO progress-clock fires."""
+    widget = ModelInstallProgress()
+    app = _SingleWidgetApp(widget)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(WINDOW)
+        assert (
+            fire_log.count_for_types(ProgressBar, Bar, LoadingIndicator) == 0
+        )
+        bar = app.query_one("#model-install-progress-bar", ProgressBar)
+        assert isinstance(bar, PausableProgressBar)
+        assert not bar.display
+
+
+# ---------------------------------------------------------------------------
+# structural parity with the stock widget (pins the copied compose against
+# textual upstream drift)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"show_eta": False},
+        {"show_eta": False, "show_percentage": False},
+        {"show_bar": False},
+    ],
+)
+async def test_pausable_progress_bar_matches_stock_structure(kwargs: dict) -> None:
+    stock = ProgressBar(total=None, **kwargs)
+    pausable = PausableProgressBar(total=None, **kwargs)
+
+    class _PairApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield stock
+            yield pausable
+
+    app = _PairApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        stock_children = list(stock.children)
+        pausable_children = list(pausable.children)
+        assert len(stock_children) == len(pausable_children)
+        for stock_child, pausable_child in zip(stock_children, pausable_children):
+            assert isinstance(pausable_child, type(stock_child)), (
+                f"PausableProgressBar composed {type(pausable_child).__name__} "
+                f"where stock composes {type(stock_child).__name__}; "
+                "ProgressBar.compose upstream has drifted -- update "
+                "PausableProgressBar.compose to match"
+            )
+            assert pausable_child.id == stock_child.id

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -220,6 +220,49 @@ class-level replacement plus framework dispatch that splits in two.
 
 ---
 
+## `display = False` does not stop a widget's timers — and a paused Timer you don't hold is garbage-collected mid-pause
+
+**TASK-23022, 2026-08-27.** Six progress widgets mounted `display: none`
+(`ModelInstallProgress`'s indeterminate bar on four Lab views + Library, the
+Personas CCP overlay's `LoadingIndicator`, plus a seventh found in the audit on
+the Console inspector rail) burned **960 of 1018 timer fires / 15 s changing
+zero pixels — 88% of the Lab screen's idle CPU**. Textual 8.2.8 gates only the
+*repaint* on `is_on_screen` (`dom.py`'s `automatic_refresh`, itself a
+`find_widget` raise/catch per fire); the timers themselves —
+`Bar.watch_percentage`'s 15 Hz `auto_refresh` when `percentage is None`,
+`ProgressBar.on_mount`'s unconditional `set_interval(1, self.update)` (armed
+even with `show_eta=False`), `LoadingIndicator._on_mount`'s 16 Hz — run
+forever regardless of `display`. Three mechanism facts that shaped the fix
+(`Widgets/pausable_progress.py`; guarded by
+`Tests/Architecture/test_progress_widget_clock_guard.py`):
+
+1. **You cannot suppress a base class's `on_mount` by overriding it.**
+   `_get_dispatch_methods` walks the MRO and dispatches every class's own
+   naming-convention handler — subclass and base BOTH run. To govern a clock a
+   base arms, intercept `set_interval` itself (every arm flows through it) or
+   `event.prevent_default()` away the whole chain.
+2. **`Show`/`Hide` events track the LAYOUT map, not the viewport.** The
+   compositor arranges with `visible_only=False`, so `display`-hidden subtrees
+   leave the map (Hide fires, scrolled-out widgets don't), and a widget
+   mounted hidden receives *neither* event — the initial state must be
+   "paused until first Show".
+3. **A paused `Timer` whose reference was discarded is destroyed by cycle GC
+   mid-pause.** Running timers are rooted by the event loop (sleep handle /
+   Event waiter); a *paused* one blocked on its own `Event.wait()` exists only
+   in the task↔timer reference cycle. With weak tracking the paused ETA timer
+   vanished — "Task was destroyed but it is pending!" on stderr, and the clock
+   would silently never resume on Show. Hold paused timers **strongly**.
+   (`Timer._skip` defaults True, so resume fast-forwards without a fire
+   burst, and `Timer.stop()` works from the paused state, so unmount/quit
+   teardown is unaffected — both verified by lifecycle tests and a live
+   Ctrl+Q walk.)
+
+Fires are the evidence currency here: idle CPU % is load-sensitive, but
+fires / 15 s reproduced the review's numbers exactly (1017 vs 1018) across
+every interleaved run.
+
+---
+
 ## Related
 
 - `lessons-testing-evidence.md` — includes the Pilot-harness traps (detached widget

--- a/backlog/tasks/task-23022 - Invisible-ProgressBars-run-a-15-Hz-timer-forever-88-of-the-Lab-screen-s-idle-CPU.md
+++ b/backlog/tasks/task-23022 - Invisible-ProgressBars-run-a-15-Hz-timer-forever-88-of-the-Lab-screen-s-idle-CPU.md
@@ -2,9 +2,11 @@
 id: TASK-23022
 title: >-
   Invisible ProgressBars run a 15 Hz timer forever - 88% of the Lab screen's idle CPU
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-27'
+updated_date: '2026-08-27'
 labels:
   - performance
   - idle
@@ -27,25 +29,85 @@ inside `textual/dom.py`.
 
 ## Acceptance Criteria
 
-- [ ] A hidden or off-screen indeterminate `ProgressBar`/`LoadingIndicator` does not run a timer
-- [ ] The six live instances are fixed: `model_curated_view.py:471`, `model_installed_view.py:346` and `:352`, `model_remote_view.py:605`, `library_screen.py:12626`, `UI/CCP_Modules/ccp_loading_indicators.py:71`
-- [ ] The remaining 13 `ProgressBar(` and 6 `LoadingIndicator()` sites are audited and each is fixed or recorded as safe
-- [ ] A guard prevents a new hidden indeterminate progress widget from arming a permanent clock - the timer census cannot see this class today, so extending it is part of the work
-- [ ] Before/after idle CPU measured with interleaved arms
+- [x] A hidden or off-screen indeterminate `ProgressBar`/`LoadingIndicator` does not run a timer
+- [x] The six live instances are fixed: `model_curated_view.py:471`, `model_installed_view.py:346` and `:352`, `model_remote_view.py:605`, `library_screen.py:12626`, `UI/CCP_Modules/ccp_loading_indicators.py:71`
+- [x] The remaining 13 `ProgressBar(` and 6 `LoadingIndicator()` sites are audited and each is fixed or recorded as safe
+- [x] A guard prevents a new hidden indeterminate progress widget from arming a permanent clock - the timer census cannot see this class today, so extending it is part of the work
+- [x] Before/after idle CPU measured with interleaved arms
 
-## Evidence
+## Implementation Plan
 
-Interleaved A/B on F7, `on/off/off/on` x3, sole change = the three Textual clock arms neutralised:
+1. Reproduce the mechanism against the pinned textual 8.2.8: `Bar.watch_percentage` arms
+   `auto_refresh = 1/15` when percentage is None; `ProgressBar.on_mount` arms an unconditional
+   `set_interval(1, self.update)`; `LoadingIndicator._on_mount` arms `auto_refresh = 1/16`;
+   `display = False` never touches any of them.
+2. Build one house module (`Widgets/pausable_progress.py`) with drop-in subclasses that pause
+   every clock while the widget is outside the layout map (Show/Hide events + a `set_interval`
+   interception that catches base-class arms a subclass cannot suppress).
+3. Convert the live instances and every audited site to the house classes.
+4. Guard: forbid constructing/subclassing the stock widgets anywhere else in the package
+   (AST scan with alias resolution + positive-control fixtures). Census extension itself is
+   TASK-23028's scope, per the wave plan.
+5. Prove both halves with Pilot tests (hidden => zero fires; shown => fires AND the highlight
+   moves), mutation-test every test, walk unmount/quit.
+6. Interleaved live A/B on F7 and Personas: timer fires / 15 s (primary) + getrusage idle CPU.
 
-| arm | idle % of a core (median of 6) | timer fires / 15 s |
-|---|---|---|
-| shipped | **0.616** (0.574-0.667) | **1018** (67.9/s) |
-| framework clocks off | **0.076** (0.071-0.079) | **58** (3.9/s) |
+## Implementation Notes
 
-Mechanism: `Widgets/ModelArtifacts/install_progress.py:120-126` composes `ProgressBar(total=None)`
-then sets `bar.display = False`. `textual/_progress_bar.py:92-97` arms the 15 Hz refresh; `:287-289`
-also arms an unconditional `set_interval(1, self.update)`. `textual/dom.py:554-563` gates the
-repaint on `is_on_screen`, not the timer. Personas carries a `LoadingIndicator` at **16 Hz** inside a
-permanently `display:none` widget.
+**Approach.** One new module, `tldw_chatbook/Widgets/pausable_progress.py`:
+`HiddenClocksPausedMixin` intercepts `set_interval` (so even the clock armed by
+`ProgressBar.on_mount` - which a subclass override cannot suppress, because Textual dispatches
+naming-convention handlers for every class in the MRO - is captured), starts timers paused until
+the widget's first `Show`, and pauses/resumes on `Hide`/`Show`. A paused `Timer`'s task blocks on
+its `Event.wait()` - zero wakeups - and `Timer._skip` fast-forwards on resume, so no catch-up
+burst. `PausableProgressBar` mirrors `ProgressBar.compose` with a `PausableBar` swap (no upstream
+seam exists; a structural-parity test pins the copy against textual bumps).
+`PausableLoadingIndicator` is the mixin applied to `LoadingIndicator`. Tracked timers are held
+**strongly**: with weak tracking, the paused ETA timer (whose reference `ProgressBar.on_mount`
+discards) exists only in the task<->timer reference cycle, and cycle GC destroys it mid-pause
+("Task was destroyed but it is pending!") - observed during development.
 
-Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+**Sites.** The six live instances all funnel through two files: the five `ModelInstallProgress`
+embeds (model_curated/installed x2/remote views, library_screen; paths moved to `UI/Screens/` on
+this base, plus `FirstRunSetupWizard`) share one compose in
+`Widgets/ModelArtifacts/install_progress.py`, now `PausableProgressBar`; the Personas CCP overlay
+(`ccp_loading_indicators.py`) now composes `PausableLoadingIndicator`. The audit found a
+**seventh live instance** the finding did not list: `console_conversation_inspector.py`'s
+16 Hz `LoadingIndicator` mounted `display: none` on the persistent Console rail - fixed the same
+way. All 13 remaining `ProgressBar(` and 9 remaining `LoadingIndicator(` sites (base drift from
+the finding's 6) were converted to the house classes - several were latent instances of the same
+bug (speech playground x2 hidden bars, status_dashboard hidden bar, enhanced_sidebar x2
+`classes="hidden"` indicators, CodeRepoCopyPaste hidden overlay, detailed_progress x2
+indeterminate bars) and the rest are visible-while-mounted (wizards, dialogs, splash, stats);
+uniform conversion makes the guard exemption-free. `CCPLoadingWidget` is NOT permanently dead:
+`LoadingManager.setup()` mounts it on Personas and `with_loading` handlers show it during
+operations, so pause-while-hidden is the right shape there, not unmounting.
+
+**Guard.** `Tests/Architecture/test_progress_widget_clock_guard.py`: no package file may
+construct or subclass stock `ProgressBar`/`LoadingIndicator`/`Bar` (type references for
+`query_one`/`isinstance` stay legal). AST scan resolves import aliases, attribute spellings and
+the subscripted-generic call form; seven positive-control fixtures keep the scanner honest (one
+caught a real scanner gap - `import textual.widgets` binds `textual` - during development).
+Extending the timer census itself is TASK-23028 (wave B); notes for it are in the task report.
+
+**Evidence.** Live interleaved A/B (tmux-driven real app, fresh isolated profile, 15 s pause-free
+windows, fires counted by patching `Timer._tick`, CPU via `getrusage`):
+
+| screen | arm | progress-widget fires / 15 s | total fires | idle % of a core |
+|---|---|---|---|---|
+| Lab (F7) | shipped | 960 / 962 / 960 | 1017 / 1019 / 1017 | 0.732 / 0.797 / 0.558 |
+| Lab (F7) | fixed | **0 / 0 / 0** | 57 / 57 / 57 | **0.094 / 0.095 / 0.095** |
+| Personas | shipped | 240 / 240 / 240 | 285 | 0.341 / 0.215 / 0.223 |
+| Personas | fixed | **0 / 0 / 0** | 45 | **0.066 / 0.064 / 0.071** |
+
+The shipped arm reproduces the review exactly (review: 1018 fires, 0.616%). 15 Pilot tests prove
+both halves (hidden => 0 fires with a stock-widget control proving the harness measures; shown =>
+fires AND `render_indeterminate().highlight_range` moves) plus lifecycle (remove-while-hidden
+stops every timer task; app exit clean; live Ctrl+Q from Lab exits 0). Six mutations (M0 dead
+harness, M1 no pause-at-create, M2 dead `_on_hide`, M3 dead `_on_show`, M4/M4b compose drift,
+M5 site regressed to stock, M6 timer escaping pump teardown) each killed by named tests.
+
+**Files.** New: `tldw_chatbook/Widgets/pausable_progress.py`,
+`Tests/Widgets/test_pausable_progress.py`,
+`Tests/Architecture/test_progress_widget_clock_guard.py`. Modified: 17 site files (see the
+commit) - construction class swaps plus imports only.

--- a/tldw_chatbook/UI/CCP_Modules/ccp_loading_indicators.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_loading_indicators.py
@@ -5,11 +5,13 @@ from functools import wraps
 from contextlib import asynccontextmanager
 from datetime import datetime
 
-from textual.widgets import LoadingIndicator, Static
+from textual.widgets import Static
 from textual.containers import Center
 from textual.reactive import reactive
 from textual import work
 from loguru import logger
+
+from tldw_chatbook.Widgets.pausable_progress import PausableLoadingIndicator
 
 logger = logger.bind(module="CCPLoadingIndicators")
 
@@ -66,9 +68,15 @@ class CCPLoadingWidget(Static):
             self.add_class("inline")
 
     def compose(self):
-        """Compose the loading widget with a LoadingIndicator and text."""
+        """Compose the loading widget with a LoadingIndicator and text.
+
+        TASK-23022: this widget is mounted ``display: none`` on the Personas
+        screen and only shown while an operation runs. A stock
+        LoadingIndicator arms a 16 Hz clock at mount that hiding never stops;
+        the pausable variant is silent until the overlay becomes visible.
+        """
         with Center():
-            yield LoadingIndicator()
+            yield PausableLoadingIndicator()
             yield Static(self.loading_text, classes="loading-text")
 
     def watch_is_loading(self, is_loading: bool) -> None:

--- a/tldw_chatbook/UI/CodeRepoCopyPasteWindow.py
+++ b/tldw_chatbook/UI/CodeRepoCopyPasteWindow.py
@@ -26,7 +26,6 @@ from textual.widgets import (
     Select,
     Static,
     TextArea,
-    LoadingIndicator,
 )
 from textual.reactive import reactive
 from textual.message import Message
@@ -36,6 +35,7 @@ from textual.css.query import NoMatches
 from tldw_chatbook.Widgets.Coding_Widgets.repo_tree_widgets import TreeView
 from ..Utils.github_api_client import GitHubAPIClient, GitHubAPIError
 from ..config import get_cli_config_path
+from tldw_chatbook.Widgets.pausable_progress import PausableLoadingIndicator
 
 if TYPE_CHECKING:
     from ..app import TldwCli
@@ -266,7 +266,7 @@ class CodeRepoCopyPasteWindow(ModalScreen):
             # Loading overlay
             with Container(classes="loading-overlay hidden", id="loading-overlay"):
                 with Container(classes="loading-content"):
-                    yield LoadingIndicator()
+                    yield PausableLoadingIndicator()
                     yield Label(
                         "Loading repository...",
                         classes="loading-label",

--- a/tldw_chatbook/UI/Screens/stats_screen.py
+++ b/tldw_chatbook/UI/Screens/stats_screen.py
@@ -7,7 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Dict, Any, Optional
 
 from textual.app import ComposeResult
-from textual.widgets import Label, LoadingIndicator, Button
+from textual.widgets import Label, Button
 from textual.containers import VerticalScroll, Horizontal, Container, Grid
 from textual.reactive import reactive
 from textual import work
@@ -17,6 +17,7 @@ from tldw_chatbook.Stats.user_statistics import UserStatistics
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Workbench.workbench_state import WorkbenchHeaderState, WorkbenchStatus
 from ..Workbench.workbench_widgets import DestinationHeader
+from tldw_chatbook.Widgets.pausable_progress import PausableLoadingIndicator
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -216,7 +217,7 @@ class StatsScreen(BaseAppScreen):
                 Container(
                     # Initial content - will be replaced by refresh_stats_display
                     Container(
-                        LoadingIndicator(),
+                        PausableLoadingIndicator(),
                         Label("Initializing statistics...", classes="loading-text"),
                         classes="loading-container",
                     ),
@@ -262,7 +263,7 @@ class StatsScreen(BaseAppScreen):
                 logger.debug("Showing loading state")
                 content.mount(
                     Container(
-                        LoadingIndicator(),
+                        PausableLoadingIndicator(),
                         Label("Loading your statistics...", classes="loading-text"),
                         classes="loading-container",
                     )

--- a/tldw_chatbook/UI/Speech/speech_playground_pane.py
+++ b/tldw_chatbook/UI/Speech/speech_playground_pane.py
@@ -54,7 +54,6 @@ from tldw_chatbook.UI.Lab_Modules.lab_speech_status import (
 from textual.widgets import (
     Button,
     Collapsible,
-    ProgressBar,
     RichLog,
     Input,
     Select,
@@ -115,6 +114,7 @@ from tldw_chatbook.TTS.profile_reference_types import (
 from tldw_chatbook.Third_Party.textual_fspicker import Filters
 from tldw_chatbook.Utils.input_validation import validate_text_input
 from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen as FileOpen
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 _AUDIO_CPP_RUNTIME_POLL_SECONDS = 5.0
 
@@ -2904,11 +2904,13 @@ class SpeechPlaygroundPane(
                 classes="speech-player-transport hidden",
             ):
                 # `total` and `hidden` both matter. Without `total` a
-                # ProgressBar renders its indeterminate pulse, so an idle
+                # progress bar renders its indeterminate pulse, so an idle
                 # screen animates two bars forever; without `hidden` it is
                 # on screen with nothing to report. Legacy carried both and
                 # the rebuild dropped them -- visible only on a live run.
-                yield ProgressBar(
+                # TASK-23022: PausableProgressBar additionally stops the
+                # hidden bar's 1 Hz ETA sampler, which `hidden` never did.
+                yield PausableProgressBar(
                     id="audio-progress-bar",
                     total=100,
                     show_eta=False,
@@ -2948,7 +2950,7 @@ class SpeechPlaygroundPane(
                 classes="speech-generation-text",
                 markup=False,
             )
-            yield ProgressBar(
+            yield PausableProgressBar(
                 id="generation-progress",
                 total=100,
                 show_eta=True,

--- a/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
@@ -50,6 +50,7 @@ from ...Chatbooks.database_paths import (
     get_private_chatbooks_dir,
 )
 from ...Chatbooks.chatbook_models import ContentType
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 from ...Chatbooks.server_chatbook_service import (
     build_server_job_record,
     record_server_job,
@@ -702,7 +703,7 @@ class ProgressStep(WizardStep):
             )
 
             # Progress bar
-            yield ProgressBar(
+            yield PausableProgressBar(
                 total=100, show_percentage=True, show_eta=False, id="export-progress"
             )
 

--- a/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
@@ -61,6 +61,7 @@ from ..server_chatbook_service_lease import (
     server_chatbook_service_lease,
 )
 from ...Widgets.enhanced_file_picker import EnhancedFileOpen
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 if TYPE_CHECKING:
     pass
@@ -815,7 +816,7 @@ class ImportProgressStep(WizardStep):
             )
 
             # Progress bar
-            yield ProgressBar(
+            yield PausableProgressBar(
                 total=100, show_percentage=True, show_eta=False, id="import-progress"
             )
 

--- a/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
@@ -102,6 +102,7 @@ from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.LLM_Calls.pricing_catalog import get_pricing_catalog
 from tldw_chatbook.Utils.path_validation import validate_path
+from tldw_chatbook.Widgets.pausable_progress import PausableLoadingIndicator
 from tldw_chatbook.Utils.token_counter import estimate_tokens
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
 from tldw_chatbook.Widgets.Console.console_project_instructions import (
@@ -598,7 +599,12 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
                                 session_id=self._project_instruction_session_id,
                                 id="console-context-project-instructions",
                             )
-                        yield LoadingIndicator(id="console-inspector-next-send-loading")
+                        # TASK-23022: mounted display:none on the persistent Console rail;
+                        # the pausable variant keeps its 16 Hz clock off until
+                        # the .loading class actually shows it.
+                        yield PausableLoadingIndicator(
+                            id="console-inspector-next-send-loading"
+                        )
 
                         with TabbedContent(id="console-inspector-next-send-tabs"):
                             with TabPane(

--- a/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
@@ -11,6 +11,7 @@ from textual.widget import Widget
 from textual.widgets import ProgressBar, Static
 
 from tldw_chatbook.UI.Screens.model_browser_state import format_mib
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 if TYPE_CHECKING:
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
@@ -117,7 +118,11 @@ class ModelInstallProgress(Widget):
         """Compose the stable progress display."""
         yield Static("Waiting to install", id="model-install-progress-phase")
         yield Static("", id="model-install-progress-detail", markup=False)
-        bar = ProgressBar(
+        # TASK-23022: this bar is mounted hidden on every screen that embeds
+        # ModelInstallProgress. A stock indeterminate ProgressBar arms a 15 Hz
+        # refresh plus a 1 Hz ETA sampler that `display = False` does not
+        # stop; PausableProgressBar keeps both clocks silent until shown.
+        bar = PausableProgressBar(
             total=None,
             show_eta=False,
             id="model-install-progress-bar",

--- a/tldw_chatbook/Widgets/NewIngest/ProcessingDashboard.py
+++ b/tldw_chatbook/Widgets/NewIngest/ProcessingDashboard.py
@@ -13,7 +13,8 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.message import Message
 from textual.widget import Widget
-from textual.widgets import Button, ProgressBar, Static
+from textual.widgets import Button, Static
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 
 class ImmediateButton(Button):
@@ -189,7 +190,7 @@ class JobStatusWidget(CaptureSafePostMixin, Widget):
                 yield ImmediateButton("Pause", id=f"pause-{self.job.job_id}")
                 yield ImmediateButton("Resume", id=f"resume-{self.job.job_id}")
                 yield ImmediateButton("Cancel", id=f"cancel-{self.job.job_id}")
-            yield ProgressBar(
+            yield PausableProgressBar(
                 total=100, id=f"progress-{self.job.job_id}", classes="job-progress"
             )
 
@@ -241,7 +242,7 @@ class ProcessingDashboard(CaptureSafePostMixin, Widget):
             with Horizontal(classes="dashboard-header"):
                 yield Static("Processing Dashboard", classes="dashboard-title")
                 yield Static("Idle", id="overall-message", classes="overall-status")
-            yield ProgressBar(total=100, id="overall-progress")
+            yield PausableProgressBar(total=100, id="overall-progress")
             yield Static("Jobs", classes="jobs-title")
             yield Vertical(id="jobs-container")
             yield Static("No active jobs", id="empty-state")

--- a/tldw_chatbook/Widgets/audio_troubleshooting_dialog.py
+++ b/tldw_chatbook/Widgets/audio_troubleshooting_dialog.py
@@ -21,6 +21,10 @@ from textual.screen import ModalScreen
 from textual.reactive import reactive
 from textual import work
 from loguru import logger
+from tldw_chatbook.Widgets.pausable_progress import (
+    PausableLoadingIndicator,
+    PausableProgressBar,
+)
 import asyncio
 
 from ..Audio.dictation_service_lazy import (
@@ -161,7 +165,7 @@ class AudioTroubleshootingDialog(ModalScreen[bool]):
                 # Status Overview
                 with Container(id="status-container", classes="status-section"):
                     yield Label("Checking audio system...", id="status-text")
-                    yield LoadingIndicator(id="status-loading")
+                    yield PausableLoadingIndicator(id="status-loading")
 
                 # Device Selection
                 with Collapsible(title="🎤 Audio Devices", collapsed=False):
@@ -176,7 +180,7 @@ class AudioTroubleshootingDialog(ModalScreen[bool]):
                 # Level Meter
                 with Collapsible(title="📊 Input Level", collapsed=False):
                     yield Label("Microphone Level:")
-                    yield ProgressBar(
+                    yield PausableProgressBar(
                         total=100,
                         show_eta=False,
                         id="level-meter",

--- a/tldw_chatbook/Widgets/detailed_progress.py
+++ b/tldw_chatbook/Widgets/detailed_progress.py
@@ -16,6 +16,7 @@ from textual.widget import Widget
 from textual.reactive import reactive
 from textual.timer import Timer
 from loguru import logger
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 # Configure logger
 logger = logger.bind(module="detailed_progress")
@@ -95,10 +96,10 @@ class DetailedProgressBar(Widget):
                 yield Static("", id="current-item", classes="current-item")
 
             # Main progress bar
-            yield ProgressBar(id="main-progress", show_eta=False, show_percentage=True)
+            yield PausableProgressBar(id="main-progress", show_eta=False, show_percentage=True)
 
             # Sub-progress for current stage
-            yield ProgressBar(
+            yield PausableProgressBar(
                 id="stage-progress",
                 show_eta=False,
                 show_percentage=True,

--- a/tldw_chatbook/Widgets/dictation_performance_widget.py
+++ b/tldw_chatbook/Widgets/dictation_performance_widget.py
@@ -6,12 +6,13 @@ Widget for displaying dictation performance metrics and analytics.
 from typing import Dict
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Container, Grid
-from textual.widgets import Label, Static, ProgressBar, Button
+from textual.widgets import Label, Static, Button
 from textual.widget import Widget
 from textual.reactive import reactive
 from textual import work
 
 from ..Audio.dictation_metrics import get_performance_monitor
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 
 class DictationPerformanceWidget(Widget):
@@ -274,7 +275,7 @@ class DictationPerformanceWidget(Widget):
                     wpm_percent = (
                         (stats["average_wpm"] / max_wpm * 100) if max_wpm > 0 else 0
                     )
-                    bar = ProgressBar(total=100, show_eta=False)
+                    bar = PausableProgressBar(total=100, show_eta=False)
                     bar.advance(wpm_percent)
                     container.mount(bar)
 

--- a/tldw_chatbook/Widgets/document_generation_modal.py
+++ b/tldw_chatbook/Widgets/document_generation_modal.py
@@ -18,10 +18,11 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, ScrollableContainer
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Static, LoadingIndicator
+from textual.widgets import Button, Label, Static
 from textual.reactive import reactive
 from textual.binding import Binding
 from loguru import logger
+from tldw_chatbook.Widgets.pausable_progress import PausableLoadingIndicator
 
 
 class DocumentGenerationModal(ModalScreen):
@@ -151,7 +152,7 @@ class DocumentGenerationModal(ModalScreen):
 
             # Loading state
             with Container(id="loading-container", classes="loading-container"):
-                yield LoadingIndicator()
+                yield PausableLoadingIndicator()
                 yield Label("", id="loading-message", classes="loading-message")
 
             # Document options

--- a/tldw_chatbook/Widgets/enhanced_sidebar.py
+++ b/tldw_chatbook/Widgets/enhanced_sidebar.py
@@ -17,6 +17,7 @@ from textual.binding import Binding
 from textual.message import Message
 from textual import work
 from loguru import logger
+from tldw_chatbook.Widgets.pausable_progress import PausableLoadingIndicator
 
 
 class SidebarSection(Container):
@@ -58,12 +59,12 @@ class SidebarSection(Container):
             ):
                 if self.content:
                     yield self.content
-                yield LoadingIndicator(classes="section-loading hidden")
+                yield PausableLoadingIndicator(classes="section-loading hidden")
         else:
             yield Static(self.title, classes="section-title")
             if self.content:
                 yield self.content
-            yield LoadingIndicator(classes="section-loading hidden")
+            yield PausableLoadingIndicator(classes="section-loading hidden")
 
     def watch_is_loading(self, is_loading: bool) -> None:
         """Watch loading state changes."""

--- a/tldw_chatbook/Widgets/loading_states.py
+++ b/tldw_chatbook/Widgets/loading_states.py
@@ -17,6 +17,10 @@ from textual.message import Message
 from textual import work
 from datetime import datetime
 from loguru import logger
+from tldw_chatbook.Widgets.pausable_progress import (
+    PausableLoadingIndicator,
+    PausableProgressBar,
+)
 
 
 class LoadingState(Container):
@@ -57,10 +61,10 @@ class LoadingState(Container):
         with Container(classes="loading-state-container"):
             # Loading view
             with Container(classes="loading-view", id="loading-view"):
-                yield LoadingIndicator()
+                yield PausableLoadingIndicator()
                 yield Static(self.placeholder_text, classes="loading-text")
                 if self.show_progress:
-                    yield ProgressBar(total=100, id="loading-progress")
+                    yield PausableProgressBar(total=100, id="loading-progress")
 
             # Error view
             with Container(classes="error-view hidden", id="error-view"):

--- a/tldw_chatbook/Widgets/pausable_progress.py
+++ b/tldw_chatbook/Widgets/pausable_progress.py
@@ -1,0 +1,171 @@
+"""Progress indicators whose framework clocks stop while the widget is hidden.
+
+TASK-23022. Textual's stock progress widgets arm repeating clocks that
+``display = False`` does not stop:
+
+* ``ProgressBar(total=None)`` makes the composed ``Bar`` indeterminate, which
+  arms ``auto_refresh = 1/15`` -- a 15 Hz ``set_interval`` that runs forever.
+  ``textual/dom.py`` gates only the *repaint* on ``is_on_screen`` (itself a
+  ``find_widget`` raise/catch per fire), never the timer.
+* ``ProgressBar.on_mount`` also arms an unconditional ``set_interval(1,
+  self.update)`` (the ETA sampler), even with ``show_eta=False``.
+* ``LoadingIndicator._on_mount`` arms ``auto_refresh = 1/16``.
+
+Measured on the Lab screen: 960 of 1018 timer fires in 15 s changed zero
+pixels -- 88% of that screen's idle CPU (see the 2026-08-27 holistic perf
+review).
+
+The classes here are drop-in replacements that pause every repeating clock
+armed on the widget while it is outside the screen's layout map (``display``
+false on itself or any ancestor), and resume them when it is shown again. A
+*visible* indeterminate bar still animates. Scrolled-out-but-displayed
+widgets keep their clocks, matching stock semantics.
+
+Mechanism: ``set_interval`` is intercepted, so every clock the framework arms
+-- including ones armed by base-class ``on_mount`` handlers that a subclass
+cannot suppress (Textual dispatches naming-convention handlers for every
+class in the MRO) -- is tracked and started paused until the widget's first
+``Show`` event. A paused ``Timer``'s task blocks on its ``Event.wait()``:
+zero wakeups, zero fires. ``Timer._skip`` (default) fast-forwards the
+schedule on resume, so a long pause does not produce a catch-up burst, and
+``Timer.stop()`` works from the paused state, so unmount/quit teardown
+(``MessagePump._close_messages`` -> ``Timer._stop_all``) is unaffected.
+
+A guard (``Tests/Architecture/test_progress_widget_clock_guard.py``) keeps
+new code pointed here: constructing or subclassing the stock classes anywhere
+else in the package fails it.
+"""
+
+from __future__ import annotations
+
+from textual import events
+from textual.app import ComposeResult
+from textual.timer import Timer, TimerCallback
+from textual.widgets import LoadingIndicator, ProgressBar
+from textual.widgets._progress_bar import Bar, ETAStatus, PercentageStatus
+
+__all__ = [
+    "HiddenClocksPausedMixin",
+    "PausableBar",
+    "PausableLoadingIndicator",
+    "PausableProgressBar",
+]
+
+
+class HiddenClocksPausedMixin:
+    """Pause this widget's repeating clocks while it is not displayed.
+
+    Mix in ahead of a ``Widget`` subclass. Every timer armed through
+    ``set_interval`` (by any class in the MRO, including watchers and the
+    ``auto_refresh`` setter) runs only while the widget is in the screen's
+    layout map: timers are created paused until the first ``Show`` event,
+    paused again on ``Hide``, and resumed on ``Show``.
+
+    Contract: this mixin owns the run/pause state of every non-``pause=True``
+    interval timer on the widget. A timer armed with ``pause=True`` is left
+    alone entirely -- the caller keeps ownership of it.
+    """
+
+    #: Class-level default: clocks are considered stopped until the first
+    #: ``Show`` event arrives (a widget mounted hidden never receives one).
+    _clocks_running: bool = False
+
+    def _tracked_clocks(self) -> list[Timer]:
+        # STRONG references, deliberately. A paused Timer whose creator
+        # discarded the return value (ProgressBar.on_mount does) is otherwise
+        # only alive through the task<->timer reference cycle: the paused task
+        # is blocked on the timer's own Event, so no event-loop root holds it,
+        # cycle GC destroys it mid-pause ("Task was destroyed but it is
+        # pending!"), and the clock would silently never resume on Show.
+        # Observed with a WeakSet during TASK-23022 development.
+        clocks = getattr(self, "_hidden_paused_clocks", None)
+        if clocks is None:
+            clocks = []
+            self._hidden_paused_clocks = clocks
+        return clocks
+
+    def set_interval(
+        self,
+        interval: float,
+        callback: TimerCallback | None = None,
+        *,
+        name: str | None = None,
+        repeat: int = 0,
+        pause: bool = False,
+    ) -> Timer:
+        """Arm an interval timer that runs only while the widget is shown."""
+        timer = super().set_interval(  # type: ignore[misc]
+            interval, callback, name=name, repeat=repeat, pause=pause
+        )
+        if not pause:
+            self._tracked_clocks().append(timer)
+            if not self._clocks_running:
+                # Synchronous with creation: the timer's task cannot run
+                # before control returns to the event loop, so a widget
+                # mounted hidden never fires even once.
+                timer.pause()
+        return timer
+
+    def _prune_stopped_clocks(self) -> list[Timer]:
+        """Drop timers that were stopped (e.g. by the auto_refresh setter)."""
+        clocks = self._tracked_clocks()
+        clocks[:] = [timer for timer in clocks if timer._task is not None]
+        return clocks
+
+    def _on_show(self, event: events.Show) -> None:
+        self._clocks_running = True
+        for timer in self._prune_stopped_clocks():
+            timer.resume()
+
+    def _on_hide(self, event: events.Hide) -> None:
+        self._clocks_running = False
+        for timer in self._prune_stopped_clocks():
+            timer.pause()
+
+
+class PausableBar(HiddenClocksPausedMixin, Bar):
+    """``Bar`` whose 15 Hz indeterminate clock stops while hidden.
+
+    ``Bar.watch_percentage`` re-arms ``auto_refresh = 1/15`` whenever the
+    bound percentage becomes ``None`` -- including while hidden. The arm goes
+    through ``set_interval``, so the mixin intercepts it and the new timer is
+    born paused; it resumes on the next ``Show``.
+    """
+
+
+class PausableProgressBar(HiddenClocksPausedMixin, ProgressBar):
+    """Drop-in ``ProgressBar`` that is silent while hidden.
+
+    While the widget (or an ancestor) is ``display: none`` neither the
+    indeterminate 15 Hz refresh nor the 1 Hz ETA sampler fires. A visible
+    indeterminate bar animates exactly like the stock widget.
+    """
+
+    def compose(self) -> ComposeResult:
+        # Mirror of ProgressBar.compose (textual 8.2.8) with Bar swapped for
+        # PausableBar. Textual offers no seam to substitute the Bar class.
+        # Tests/Widgets/test_pausable_progress.py pins structural parity with
+        # the stock widget so upstream drift fails loudly on a bump.
+        if self.show_bar:
+            yield (
+                PausableBar(
+                    id="bar", clock=self._clock, bar_renderable=self.BAR_RENDERABLE
+                )
+                .data_bind(ProgressBar.percentage)
+                .data_bind(ProgressBar.gradient)
+            )
+        if self.show_percentage:
+            yield PercentageStatus(id="percentage").data_bind(ProgressBar.percentage)
+        if self.show_eta:
+            yield ETAStatus(id="eta").data_bind(eta=ProgressBar._display_eta)
+
+
+class PausableLoadingIndicator(HiddenClocksPausedMixin, LoadingIndicator):
+    """Drop-in ``LoadingIndicator`` whose 16 Hz clock stops while hidden.
+
+    The base arms ``auto_refresh = 1/16`` in ``_on_mount``; the mixin's
+    ``set_interval`` interception pauses that timer at creation when the
+    indicator is mounted hidden, and Show/Hide toggle it thereafter. The
+    animation position derives from wall-clock time, so a resumed indicator
+    continues mid-cycle rather than restarting.
+    """

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -21,6 +21,7 @@ from ..config import get_cli_setting
 # Import the registration system and load all effects
 from ..Utils.Splash_Screens import load_all_effects, get_effect_class
 from ..Utils.Splash_Screens.card_definitions import get_all_card_definitions
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 
 class SplashScreen(Container):
@@ -288,7 +289,7 @@ class SplashScreen(Container):
 
         # Progress bar (if enabled)
         if self.show_progress:
-            yield ProgressBar(
+            yield PausableProgressBar(
                 total=100,
                 show_eta=False,
                 show_percentage=True,

--- a/tldw_chatbook/Widgets/status_dashboard.py
+++ b/tldw_chatbook/Widgets/status_dashboard.py
@@ -10,6 +10,7 @@ from textual.widget import Widget
 from textual.reactive import reactive
 from textual.timer import Timer
 from loguru import logger
+from tldw_chatbook.Widgets.pausable_progress import PausableProgressBar
 
 
 class StatusDashboard(Widget):
@@ -88,7 +89,7 @@ class StatusDashboard(Widget):
                         )
 
             # Progress bar
-            yield ProgressBar(
+            yield PausableProgressBar(
                 id="progress-bar",
                 total=self.progress_total,
                 show_eta=False,


### PR DESCRIPTION
## Summary

`ProgressBar(total=None)` arms a **15 Hz timer that never stops** — `display = False` gates only the
repaint, never the clock. On the Lab screen that was 960 of 1018 timer fires per 15 s changing zero
pixels: **88% of the screen's idle CPU**. Finding 23022 of the
[2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md).

## The mechanism

One new module, `Widgets/pausable_progress.py`. `HiddenClocksPausedMixin` **intercepts
`set_interval`** — catching even the clock `ProgressBar.on_mount` arms, which a subclass override
cannot suppress because Textual dispatches naming-convention handlers for every class in the MRO —
starts timers **paused until the widget's first `Show`**, and pauses/resumes on `Hide`/`Show`. A
paused `Timer` blocks on `Event.wait()` (zero wakeups), and `Timer._skip` fast-forwards on resume,
so there is no catch-up burst. A visible indeterminate bar still animates; both halves are pinned.

Two hard-won details are recorded in the code and tests:
- **Tracked timers are held strongly.** With weak tracking, the paused ETA timer — whose reference
  `ProgressBar.on_mount` discards — exists only in the task↔timer reference cycle, and cycle GC
  destroys it mid-pause ("Task was destroyed but it is pending!"). Observed during development.
- `PausableProgressBar` mirrors `ProgressBar.compose` because no upstream seam exists; a
  **structural-parity test** pins the copy against future Textual bumps.

## The audit found a seventh live instance the finding missed

A **16 Hz `LoadingIndicator` mounted `display: none` on the persistent Console rail**
(`console_conversation_inspector.py`) — paying the worst rate in the app on every screen where the
rail exists. Fixed the same way.

All **22 remaining** `ProgressBar(`/`LoadingIndicator(` sites were converted to the house classes —
several were latent instances of the same bug (speech playground ×2, status_dashboard,
enhanced_sidebar ×2, CodeRepoCopyPaste overlay, detailed_progress ×2) — which makes the new
architecture guard (`Tests/Architecture/test_progress_widget_clock_guard.py`) **exemption-free**:
no allowlist for anyone to quietly grow. `CCPLoadingWidget` is *not* dead code
(`LoadingManager.setup()` mounts it and `with_loading` shows it), so pause-while-hidden is the right
shape there, not unmounting.

## Verification

New suites: **19 passed** (guard 7 + pausable behaviour 12), plus 589-test widget/inspector batch
with every red A/B-proven pre-existing. Preflight green.

**A baseline note reviewers should know:** during final verification,
`Tests/Widgets/test_console_video_card_rows.py` showed 2 reds that looked like this branch's —
they are **dev's**, introduced by #2152 (fork-chat) *while this branch was being verified*: the
same 2 tests fail on a pristine checkout of current dev and fail identically with this branch's
entire diff reverted in-worktree. Filed separately rather than adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-23022: hidden indeterminate progress bars and loading indicators ran their timer clocks forever, wasting ~88% idle CPU on the Lab screen. Adds `PausableProgressBar` and `PausableLoadingIndicator` in `Widgets/pausable_progress.py` that pause all their clocks while hidden and resume on show.

- Converts all 22 stock `ProgressBar`/`LoadingIndicator` uses (including a seventh hidden indicator on the Console rail the finding missed) to the pausable classes.
- Adds an architecture guard test forbidding construction/subclassing of stock progress widgets anywhere else, and a structural-parity test that pins the copied `compose` against Textual bumps.
- Verifies no behavior change for visible widgets: hidden bars have zero timer fires, visible bars still animate, and unmount/quit leaves no timers behind.
- Note: two failing tests in `test_console_video_card_rows.py` are pre-existing on `dev` (from a recent merge on `dev`) and fail identically on a clean checkout.

<sup>Written for commit 63464b174b57b28f05effa8a943a77d8b82ab236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

