### PR TITLE
perf(notes-sync): revalidate per item instead of re-reading the world every pass (TASK-23027)

### DIFF
--- a/Tests/Notes/test_notes_sync_observation_reuse.py
+++ b/Tests/Notes/test_notes_sync_observation_reuse.py
@@ -1,0 +1,609 @@
+"""TASK-23027: per-item observation reuse in the production runtime adapter.
+
+The adapter used to re-read every file and re-select every note on every
+``observe_root`` pass. Reuse is only allowed after a per-item freshness check
+(file stat identity; bulk note versions), so the tests here prove, per
+mutation class, that reuse DOES NOT happen when it must not -- and that a
+fully warm no-change pass performs zero per-file reads and zero per-note
+selects while producing observations equal to a cold pass.
+
+Every world is real: a real temp sync root, a real ``CharactersRAGDB``, the
+real device-state store, the real Posix filesystem adapter, and the real
+authority/service seams. No hand-made observation doubles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import tldw_chatbook.Notes.notes_sync_runtime as runtime_module
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Notes.note_folder_repository import LocalNoteFolderRepository
+from tldw_chatbook.Notes.notes_device_state_store import (
+    NotesDeviceStateStore,
+    NotesSyncBindingRecord,
+    NotesSyncRootRecord,
+)
+from tldw_chatbook.Notes.notes_scope_service import NotesScopeService, ScopeType
+from tldw_chatbook.Notes.notes_sync_authority import (
+    NotesScopeSyncAuthority,
+    NotesSyncAuthorityError,
+)
+from tldw_chatbook.Notes.notes_sync_executor import NotesSyncExecutor
+from tldw_chatbook.Notes.notes_sync_filesystem import PosixNotesSyncFilesystem
+from tldw_chatbook.Notes.notes_sync_models import (
+    NotesSyncBindingState,
+    NotesSyncDirection,
+    NotesSyncRootState,
+)
+from tldw_chatbook.Notes.notes_sync_reconciler import plan_reconciliation
+from tldw_chatbook.Notes.notes_sync_runtime import _ProductionRuntimeAdapter
+
+pytestmark = pytest.mark.unit
+
+_USER = "test-user"
+_N = 4
+
+
+class _CountingLocalNotes:
+    """The production call surface over a real DB, with read counters."""
+
+    def __init__(self, db: CharactersRAGDB) -> None:
+        self._db = db
+        self.get_note_calls = 0
+        self.version_state_calls = 0
+
+    def get_note_by_id(self, _user_id: str, note_id: str):
+        self.get_note_calls += 1
+        return self._db.get_note_by_id(note_id)
+
+    def get_note_version_states(self, _user_id: str, note_ids):
+        self.version_state_calls += 1
+        return self._db.get_note_version_states(note_ids)
+
+    def update_note(self, _user_id: str, note_id: str, data, expected_version: int):
+        return self._db.update_note(note_id, data, expected_version)
+
+    def soft_delete_note(self, _user_id: str, note_id: str, version: int):
+        return self._db.soft_delete_note(note_id, version)
+
+    def add_note(self, _user_id: str, title: str, content: str, note_id=None):
+        return self._db.add_note(title, content, note_id=note_id)
+
+
+@dataclass
+class _World:
+    root_dir: Path
+    db: CharactersRAGDB
+    local_notes: _CountingLocalNotes
+    scope_service: NotesScopeService
+    authority: NotesScopeSyncAuthority
+    store: NotesDeviceStateStore
+    root: NotesSyncRootRecord
+    adapter: _ProductionRuntimeAdapter
+    fs_observe_calls: list[str]
+
+    def fresh_adapter(self) -> _ProductionRuntimeAdapter:
+        """A cold adapter over the same durable state: the ground truth."""
+
+        return _ProductionRuntimeAdapter(
+            self.store,
+            self.scope_service,
+            local_user_id=_USER,
+            recovery_capacity_bytes=64 * 1024 * 1024,
+        )
+
+    def reset_counters(self) -> None:
+        self.local_notes.get_note_calls = 0
+        self.local_notes.version_state_calls = 0
+        self.fs_observe_calls.clear()
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _content(index: int) -> str:
+    return f"note body {index}\n"
+
+
+def _rel(index: int) -> str:
+    return f"note-{index:04d}.md"
+
+
+def _note_id(index: int) -> str:
+    return f"note-{index:04d}"
+
+
+@pytest.fixture()
+def world(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _World:
+    root_dir = (tmp_path / "sync-root").resolve()
+    root_dir.mkdir(mode=0o700)
+    db = CharactersRAGDB(tmp_path / "chachanotes.sqlite3", client_id=_USER)
+    local_notes = _CountingLocalNotes(db)
+    scope_service = NotesScopeService(
+        local_notes_service=local_notes,
+        server_service=None,
+        folder_repository=LocalNoteFolderRepository(db),
+    )
+    authority = NotesScopeSyncAuthority(
+        scope_service,
+        scope=ScopeType.LOCAL_NOTE,
+        user_id=_USER,
+        note_scope_id="local_note",
+    )
+    store = NotesDeviceStateStore(tmp_path / "device-state.sqlite3")
+    store.initialize()
+    root = NotesSyncRootRecord(
+        root_id="root-1",
+        note_scope_id="local_note",
+        logical_folder_id="folder-1",
+        canonical_path=str(root_dir),
+        direction=NotesSyncDirection.BIDIRECTIONAL,
+        state=NotesSyncRootState.ACTIVE,
+    )
+    store.create_root(root)
+
+    fs = PosixNotesSyncFilesystem(root_dir)
+    with fs:
+        for index in range(_N):
+            (root_dir / _rel(index)).write_text(_content(index), encoding="utf-8")
+            db.add_note(f"Note {index}", _content(index), note_id=_note_id(index))
+            snapshot = fs.observe(_rel(index))
+            store.create_binding(
+                NotesSyncBindingRecord(
+                    binding_id=f"binding-{index:04d}",
+                    root_id="root-1",
+                    note_scope_id="local_note",
+                    note_id=_note_id(index),
+                    normalized_relative_path=_rel(index),
+                    stable_identity_digest=NotesSyncExecutor.stable_identity_digest(
+                        snapshot
+                    ),
+                    state=NotesSyncBindingState.ACTIVE,
+                    serialization=snapshot.observation.serialization,
+                    content_digest=_digest(_content(index)),
+                    note_version=1,
+                )
+            )
+
+    fs_observe_calls: list[str] = []
+    real_observe = PosixNotesSyncFilesystem.observe
+
+    def counting_observe(self, relative_path, **kwargs):
+        fs_observe_calls.append(str(relative_path))
+        return real_observe(self, relative_path, **kwargs)
+
+    monkeypatch.setattr(PosixNotesSyncFilesystem, "observe", counting_observe)
+
+    adapter = _ProductionRuntimeAdapter(
+        store,
+        scope_service,
+        local_user_id=_USER,
+        recovery_capacity_bytes=64 * 1024 * 1024,
+    )
+    built = _World(
+        root_dir=root_dir,
+        db=db,
+        local_notes=local_notes,
+        scope_service=scope_service,
+        authority=authority,
+        store=store,
+        root=root,
+        adapter=adapter,
+        fs_observe_calls=fs_observe_calls,
+    )
+    yield built
+    adapter.close()
+    db.close_connection()
+
+
+async def _observe(adapter: _ProductionRuntimeAdapter, root: NotesSyncRootRecord):
+    request = await adapter.observe_root(root)
+    token = plan_reconciliation(request).observation_token
+    adapter.release_observation(token)
+    return request
+
+
+def _by_binding(request) -> dict[str, object]:
+    return {item.binding_id: item for item in request.bindings}
+
+
+async def _assert_matches_cold(world: _World, warm_request) -> None:
+    """The reused pass must equal what a cold adapter reads from scratch."""
+
+    cold = world.fresh_adapter()
+    cold_request = await _observe(cold, world.root)
+    assert warm_request == cold_request
+    cold.close()
+
+
+# ---------------------------------------------------------------------------
+# The warm no-change pass: zero re-reads, zero re-selects, equal output.
+# ---------------------------------------------------------------------------
+
+
+async def test_warm_unchanged_pass_reads_no_files_and_selects_no_notes(
+    world: _World,
+) -> None:
+    first = await _observe(world.adapter, world.root)
+    world.reset_counters()
+
+    second = await _observe(world.adapter, world.root)
+
+    assert world.fs_observe_calls == []
+    assert world.local_notes.get_note_calls == 0
+    assert world.local_notes.version_state_calls == 1
+    assert second == first
+    await _assert_matches_cold(world, second)
+
+
+async def test_cold_pass_still_reads_everything(world: _World) -> None:
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert sorted(world.fs_observe_calls) == [_rel(i) for i in range(_N)]
+    assert world.local_notes.get_note_calls == _N
+    assert len(request.bindings) == _N
+
+
+# ---------------------------------------------------------------------------
+# Mutation classes: each must break reuse for exactly the changed item.
+# ---------------------------------------------------------------------------
+
+
+async def test_file_edit_is_observed_after_a_warm_pass(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+    (world.root_dir / _rel(0)).write_text("edited body 0\n", encoding="utf-8")
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert _rel(0) in world.fs_observe_calls
+    observed = _by_binding(request)["binding-0000"]
+    assert observed.file_digest == _digest("edited body 0\n")
+    await _assert_matches_cold(world, request)
+
+
+async def test_same_length_file_edit_is_observed_after_a_warm_pass(
+    world: _World,
+) -> None:
+    """Size stays identical; only mtime/ctime can catch this class."""
+
+    original = _content(1)
+    flipped = original.replace("body", "ydob")
+    assert len(flipped) == len(original) and flipped != original
+    await _observe(world.adapter, world.root)
+    (world.root_dir / _rel(1)).write_text(flipped, encoding="utf-8")
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert _rel(1) in world.fs_observe_calls
+    observed = _by_binding(request)["binding-0001"]
+    assert observed.file_digest == _digest(flipped)
+    await _assert_matches_cold(world, request)
+
+
+async def test_added_file_is_observed_after_a_warm_pass(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+    (world.root_dir / "brand-new.md").write_text("fresh\n", encoding="utf-8")
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert "brand-new.md" in world.fs_observe_calls
+    added = [
+        item for item in request.bindings if item.relative_path == "brand-new.md"
+    ]
+    assert len(added) == 1 and added[0].file_digest == _digest("fresh\n")
+    await _assert_matches_cold(world, request)
+
+
+async def test_deleted_file_disappears_after_a_warm_pass(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+    (world.root_dir / _rel(2)).unlink()
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    observed = _by_binding(request)["binding-0002"]
+    assert observed.file_digest is None
+    await _assert_matches_cold(world, request)
+
+
+async def test_renamed_file_is_observed_under_its_new_path(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+    (world.root_dir / _rel(3)).rename(world.root_dir / "moved.md")
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert "moved.md" in world.fs_observe_calls
+    observed = _by_binding(request)["binding-0003"]
+    # Same inode → the identity match binds the moved file to its binding.
+    assert observed.relative_path == "moved.md"
+    assert observed.file_digest == _digest(_content(3))
+    await _assert_matches_cold(world, request)
+
+
+async def test_mtime_only_touch_forces_a_re_read(world: _World) -> None:
+    """Same bytes, same size — a touched stat must still invalidate reuse."""
+
+    await _observe(world.adapter, world.root)
+    target = world.root_dir / _rel(0)
+    stat = target.stat()
+    os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns + 5_000_000_000))
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert world.fs_observe_calls == [_rel(0)]
+    observed = _by_binding(request)["binding-0000"]
+    assert observed.file_digest == _digest(_content(0))
+    await _assert_matches_cold(world, request)
+
+
+async def test_db_side_note_edit_is_selected_after_a_warm_pass(
+    world: _World,
+) -> None:
+    await _observe(world.adapter, world.root)
+    snapshot = await world.authority.observe(_note_id(0))
+    await world.authority.replace(
+        snapshot, title="Note 0", content="db edited body\n"
+    )
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert world.local_notes.get_note_calls == 1
+    observed = _by_binding(request)["binding-0000"]
+    assert observed.note_digest == _digest("db edited body\n")
+    assert observed.note_version == snapshot.version + 1
+    await _assert_matches_cold(world, request)
+
+
+async def test_db_side_note_delete_is_selected_after_a_warm_pass(
+    world: _World,
+) -> None:
+    await _observe(world.adapter, world.root)
+    snapshot = await world.authority.observe(_note_id(1))
+    await world.authority.delete(snapshot)
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    assert world.local_notes.get_note_calls == 1
+    observed = _by_binding(request)["binding-0001"]
+    assert observed.note_digest is None
+    await _assert_matches_cold(world, request)
+
+
+async def test_new_binding_between_passes_is_observed(world: _World) -> None:
+    """Bindings are never cached — a fresh row must appear immediately."""
+
+    await _observe(world.adapter, world.root)
+    (world.root_dir / "late.md").write_text("late\n", encoding="utf-8")
+    with PosixNotesSyncFilesystem(world.root_dir) as fs:
+        snapshot = fs.observe("late.md")
+    world.db.add_note("Late", "late\n", note_id="note-late")
+    world.store.create_binding(
+        NotesSyncBindingRecord(
+            binding_id="binding-late",
+            root_id="root-1",
+            note_scope_id="local_note",
+            note_id="note-late",
+            normalized_relative_path="late.md",
+            stable_identity_digest=NotesSyncExecutor.stable_identity_digest(snapshot),
+            state=NotesSyncBindingState.ACTIVE,
+            serialization=snapshot.observation.serialization,
+            content_digest=_digest("late\n"),
+            note_version=1,
+        )
+    )
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    observed = _by_binding(request)["binding-late"]
+    assert observed.note_digest == _digest("late\n")
+    assert observed.bound is True
+    await _assert_matches_cold(world, request)
+
+
+# ---------------------------------------------------------------------------
+# Walks: skip-then-change, failure mid-pass, cancellation mid-pass.
+# ---------------------------------------------------------------------------
+
+
+async def test_skip_then_real_change_never_stays_skipped(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+    warm = await _observe(world.adapter, world.root)
+    assert world.fs_observe_calls.count(_rel(0)) == 1  # fixture pass only
+
+    (world.root_dir / _rel(0)).write_text("changed now\n", encoding="utf-8")
+    changed = await _observe(world.adapter, world.root)
+    observed = _by_binding(changed)["binding-0000"]
+    assert observed.file_digest == _digest("changed now\n")
+    assert changed != warm
+
+    # And the pass after the change is warm again — over the NEW content.
+    world.reset_counters()
+    settled = await _observe(world.adapter, world.root)
+    assert world.fs_observe_calls == []
+    assert _by_binding(settled)["binding-0000"].file_digest == _digest(
+        "changed now\n"
+    )
+
+
+async def test_failed_pass_leaves_reuse_and_store_usable(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+
+    real = NotesScopeService.get_note_for_sync
+    calls = {"count": 0}
+
+    async def failing(self, **kwargs):
+        calls["count"] += 1
+        raise RuntimeError("private backend outage")
+
+    NotesScopeService.get_note_for_sync = failing
+    try:
+        (world.root_dir / _rel(0)).write_text("outage edit\n", encoding="utf-8")
+        # Sanity: authority observe is service-backed, so it must fail too.
+        with pytest.raises(NotesSyncAuthorityError):
+            await world.authority.observe(_note_id(1))
+    finally:
+        NotesScopeService.get_note_for_sync = real
+
+    async def flip_note(content: str) -> None:
+        snapshot = await world.authority.observe(_note_id(1))
+        await world.authority.replace(snapshot, title="Note 1", content=content)
+
+    await flip_note("post outage\n")
+    NotesScopeService.get_note_for_sync = failing
+    with pytest.raises(NotesSyncAuthorityError):
+        await _observe(world.adapter, world.root)
+    NotesScopeService.get_note_for_sync = real
+
+    request = await _observe(world.adapter, world.root)
+    observed = _by_binding(request)["binding-0001"]
+    assert observed.note_digest == _digest("post outage\n")
+    await _assert_matches_cold(world, request)
+
+
+async def test_bulk_version_read_failure_propagates(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+
+    real = NotesScopeService.get_note_version_states_for_sync
+
+    async def failing(self, **kwargs):
+        raise RuntimeError("private backend outage")
+
+    NotesScopeService.get_note_version_states_for_sync = failing
+    try:
+        with pytest.raises(NotesSyncAuthorityError):
+            await _observe(world.adapter, world.root)
+    finally:
+        NotesScopeService.get_note_version_states_for_sync = real
+
+    request = await _observe(world.adapter, world.root)
+    await _assert_matches_cold(world, request)
+
+
+async def test_cancel_mid_pass_leaves_adapter_usable(world: _World) -> None:
+    """Quit with a sync in flight: cancel inside the pass, then observe again."""
+
+    await _observe(world.adapter, world.root)
+    (world.root_dir / _rel(0)).write_text("mid flight\n", encoding="utf-8")
+
+    entered = asyncio.Event()
+    release = threading.Event()
+    real_observe = PosixNotesSyncFilesystem.observe
+    loop = asyncio.get_running_loop()
+
+    def blocking_observe(self, relative_path, **kwargs):
+        loop.call_soon_threadsafe(entered.set)
+        assert release.wait(5.0)
+        return real_observe(self, relative_path, **kwargs)
+
+    PosixNotesSyncFilesystem.observe = blocking_observe
+    task = asyncio.create_task(world.adapter.observe_root(world.root))
+    try:
+        await asyncio.wait_for(entered.wait(), 5.0)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        PosixNotesSyncFilesystem.observe = real_observe
+        release.set()
+
+    request = await _observe(world.adapter, world.root)
+    observed = _by_binding(request)["binding-0000"]
+    assert observed.file_digest == _digest("mid flight\n")
+    await _assert_matches_cold(world, request)
+
+
+# ---------------------------------------------------------------------------
+# Interleaving: concurrent DB writes never leave the cache permanently stale
+# and every observed (version, content) pair is a really committed pair.
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_note_writer_yields_only_committed_pairs(
+    world: _World,
+) -> None:
+    await _observe(world.adapter, world.root)
+    committed: dict[int, str] = {}
+    snapshot = await world.authority.observe(_note_id(0))
+    committed[snapshot.version] = snapshot.content
+    stop = threading.Event()
+    failures: list[BaseException] = []
+
+    def writer() -> None:
+        try:
+            expected_version = snapshot.version
+            flip = 0
+            while not stop.is_set():
+                flip += 1
+                content = f"flip {flip}\n"
+                world.db.update_note(
+                    _note_id(0), {"content": content}, expected_version
+                )
+                expected_version += 1
+                committed[expected_version] = content
+                time.sleep(0.001)
+        except BaseException as error:  # pragma: no cover - failure reporting
+            failures.append(error)
+
+    thread = threading.Thread(target=writer)
+    thread.start()
+    try:
+        for _ in range(10):
+            request = await _observe(world.adapter, world.root)
+            observed = _by_binding(request)["binding-0000"]
+            assert observed.note_version in committed
+            assert observed.note_digest == _digest(committed[observed.note_version])
+    finally:
+        stop.set()
+        thread.join(5.0)
+    assert not failures
+
+    # Quiescent: the final pass equals a cold read of the final state.
+    request = await _observe(world.adapter, world.root)
+    await _assert_matches_cold(world, request)
+
+
+# ---------------------------------------------------------------------------
+# Budget: an over-budget item is simply not cached; correctness unchanged.
+# ---------------------------------------------------------------------------
+
+
+async def test_over_budget_items_are_re_read_not_mis_served(
+    world: _World, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(runtime_module, "_OBSERVATION_REUSE_BUDGET_BYTES", 40)
+    await _observe(world.adapter, world.root)
+    world.reset_counters()
+
+    request = await _observe(world.adapter, world.root)
+
+    # Under a 40-byte budget only the first file fits; the rest re-read.
+    assert len(world.fs_observe_calls) == _N - 1
+    await _assert_matches_cold(world, request)
+
+
+async def test_close_drops_the_reuse_cache(world: _World) -> None:
+    await _observe(world.adapter, world.root)
+    assert world.adapter._observation_reuse
+    world.adapter.close()
+    assert not world.adapter._observation_reuse

--- a/Tests/Notes/test_notes_sync_version_states.py
+++ b/Tests/Notes/test_notes_sync_version_states.py
@@ -1,0 +1,195 @@
+"""TASK-23027: the narrow (version, deleted) projection behind note reuse.
+
+Layer by layer: ``CharactersRAGDB.get_note_version_states`` (chunked, one
+snapshot, tombstones included), the ``NotesInteropService`` wrapper, the
+``NotesScopeService`` seam (bulk preferred, per-note fallback for backends
+without the projection, scope gate), and ``NotesScopeSyncAuthority.
+observe_versions`` (deleted rows excluded at its own level -- the runtime's
+version comparison would also catch a tombstone because deletion bumps the
+version, so the filter is deliberate belt-and-braces and needs its own test).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Notes.Notes_Library import NotesInteropService
+from tldw_chatbook.Notes.notes_scope_service import NotesScopeService, ScopeType
+from tldw_chatbook.Notes.notes_sync_authority import (
+    NotesScopeSyncAuthority,
+    NotesSyncAuthorityError,
+)
+
+pytestmark = pytest.mark.unit
+
+_USER = "test-user"
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(tmp_path / "chachanotes.sqlite3", client_id=_USER)
+    yield database
+    database.close_connection()
+
+
+def test_version_states_cover_active_tombstone_and_missing(
+    db: CharactersRAGDB,
+) -> None:
+    db.add_note("Alive", "alive body", note_id="note-alive")
+    db.add_note("Doomed", "doomed body", note_id="note-doomed")
+    db.update_note("note-alive", {"content": "alive v2"}, 1)
+    db.soft_delete_note("note-doomed", 1)
+
+    states = db.get_note_version_states(
+        ["note-alive", "note-doomed", "note-never-existed"]
+    )
+
+    assert states == {
+        "note-alive": {"version": 2, "deleted": False},
+        "note-doomed": {"version": 2, "deleted": True},
+    }
+
+
+def test_version_states_chunk_past_500_ids(db: CharactersRAGDB) -> None:
+    db.add_note("First", "first", note_id="note-first")
+    db.add_note("Last", "last", note_id="note-last")
+    # Real ids in different 500-id chunks; 499 unknown ids between them.
+    ids = ["note-first"] + [f"missing-{i}" for i in range(499)] + ["note-last"]
+
+    states = db.get_note_version_states(ids)
+
+    assert states == {
+        "note-first": {"version": 1, "deleted": False},
+        "note-last": {"version": 1, "deleted": False},
+    }
+
+
+def test_version_states_empty_input_reads_nothing(db: CharactersRAGDB) -> None:
+    assert db.get_note_version_states([]) == {}
+
+
+def test_interop_service_wrapper_passes_through(
+    db: CharactersRAGDB, tmp_path: Path
+) -> None:
+    base_dir = tmp_path / "notes-base"
+    base_dir.mkdir(mode=0o700)
+    service = NotesInteropService(
+        base_db_directory=base_dir,
+        api_client_id="test-app",
+        global_db_to_use=db,
+    )
+    db.add_note("Wrapped", "wrapped body", note_id="note-wrapped")
+
+    states = service.get_note_version_states(_USER, ["note-wrapped"])
+
+    assert states == {"note-wrapped": {"version": 1, "deleted": False}}
+
+
+async def test_scope_service_prefers_the_bulk_projection(db: CharactersRAGDB) -> None:
+    calls = {"bulk": 0, "single": 0}
+
+    class _Backend:
+        def get_note_version_states(self, _user_id, note_ids):
+            calls["bulk"] += 1
+            return db.get_note_version_states(note_ids)
+
+        def get_note_by_id(self, _user_id, note_id):
+            calls["single"] += 1
+            return db.get_note_by_id(note_id)
+
+    db.add_note("Bulk", "bulk body", note_id="note-bulk")
+    service = NotesScopeService(local_notes_service=_Backend(), server_service=None)
+
+    states = await service.get_note_version_states_for_sync(
+        scope=ScopeType.LOCAL_NOTE, note_ids=["note-bulk"], user_id=_USER
+    )
+
+    assert states == {"note-bulk": {"version": 1, "deleted": False}}
+    assert calls == {"bulk": 1, "single": 0}
+
+
+async def test_scope_service_falls_back_per_note_without_the_projection(
+    db: CharactersRAGDB,
+) -> None:
+    class _LegacyBackend:
+        def get_note_by_id(self, _user_id, note_id):
+            return db.get_note_by_id(note_id)
+
+    db.add_note("Legacy", "legacy body", note_id="note-legacy")
+    db.add_note("Gone", "gone body", note_id="note-gone")
+    db.soft_delete_note("note-gone", 1)
+    service = NotesScopeService(
+        local_notes_service=_LegacyBackend(), server_service=None
+    )
+
+    states = await service.get_note_version_states_for_sync(
+        scope=ScopeType.LOCAL_NOTE,
+        note_ids=["note-legacy", "note-gone", "note-missing"],
+        user_id=_USER,
+    )
+
+    # get_note_by_id filters tombstones, so deleted and missing are absent --
+    # both are treated as "changed" by the caller, which is the safe answer.
+    assert states == {"note-legacy": {"version": 1, "deleted": False}}
+
+
+async def test_scope_service_rejects_non_local_scope(db: CharactersRAGDB) -> None:
+    service = NotesScopeService(local_notes_service=object(), server_service=None)
+    with pytest.raises(RuntimeError, match="server_contract_missing"):
+        await service.get_note_version_states_for_sync(
+            scope=ScopeType.SERVER_NOTE, note_ids=["note-x"], user_id=_USER
+        )
+
+
+class _DirectBackend:
+    def __init__(self, db: CharactersRAGDB) -> None:
+        self._db = db
+
+    def get_note_version_states(self, _user_id, note_ids):
+        return self._db.get_note_version_states(note_ids)
+
+    def get_note_by_id(self, _user_id, note_id):
+        return self._db.get_note_by_id(note_id)
+
+
+async def test_authority_excludes_tombstones_at_its_own_level(
+    db: CharactersRAGDB,
+) -> None:
+    db.add_note("Alive", "alive body", note_id="note-alive")
+    db.add_note("Doomed", "doomed body", note_id="note-doomed")
+    db.soft_delete_note("note-doomed", 1)
+    authority = NotesScopeSyncAuthority(
+        NotesScopeService(
+            local_notes_service=_DirectBackend(db), server_service=None
+        ),
+        scope=ScopeType.LOCAL_NOTE,
+        user_id=_USER,
+        note_scope_id="local_note",
+    )
+
+    versions = await authority.observe_versions(("note-alive", "note-doomed"))
+
+    assert versions == {"note-alive": 1}
+
+
+async def test_authority_wraps_backend_failure_into_bounded_reason(
+    db: CharactersRAGDB,
+) -> None:
+    class _FailingBackend:
+        def get_note_version_states(self, _user_id, note_ids):
+            raise RuntimeError("private backend outage with details")
+
+    authority = NotesScopeSyncAuthority(
+        NotesScopeService(
+            local_notes_service=_FailingBackend(), server_service=None
+        ),
+        scope=ScopeType.LOCAL_NOTE,
+        user_id=_USER,
+        note_scope_id="local_note",
+    )
+
+    with pytest.raises(NotesSyncAuthorityError, match="note_observation_failed"):
+        await authority.observe_versions(("note-any",))

--- a/Tests/Notes/test_notes_sync_worker_coroutine.py
+++ b/Tests/Notes/test_notes_sync_worker_coroutine.py
@@ -1,0 +1,139 @@
+"""TASK-23027: the per-worker-thread event loop behind the executor seams.
+
+``run_worker_coroutine`` replaced 22 ``to_thread(lambda: asyncio.run(...))``
+sites (plus the runtime's note-observation batch). These tests pin the
+properties the replacement must keep: same-thread completion, exception
+transparency, loop reuse per thread (the connection-churn fix), loop isolation
+across threads, support for coroutines that offload internally, and immunity
+to cancellation of the awaiting task. A source-level ratchet keeps the
+retired ``asyncio.run`` pattern from creeping back into the executor.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import threading
+from pathlib import Path
+
+import pytest
+
+import tldw_chatbook.Notes.notes_sync_executor as executor_module
+from tldw_chatbook.Notes.notes_sync_executor import run_worker_coroutine
+
+pytestmark = pytest.mark.unit
+
+
+def test_returns_the_coroutine_result() -> None:
+    async def answer() -> int:
+        return 41 + 1
+
+    assert run_worker_coroutine(answer()) == 42
+
+
+def test_propagates_the_coroutine_exception() -> None:
+    async def boom() -> None:
+        raise RuntimeError("private failure")
+
+    with pytest.raises(RuntimeError, match="private failure"):
+        run_worker_coroutine(boom())
+
+
+def test_reuses_one_loop_per_thread() -> None:
+    """The whole point: no per-call loop construction on a worker thread."""
+
+    loops: list[object] = []
+
+    async def capture() -> None:
+        loops.append(asyncio.get_running_loop())
+
+    def worker() -> None:
+        run_worker_coroutine(capture())
+        run_worker_coroutine(capture())
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(5.0)
+    assert len(loops) == 2
+    assert loops[0] is loops[1]
+
+
+def test_different_threads_use_different_loops() -> None:
+    loops: list[object] = []
+    lock = threading.Lock()
+
+    async def capture() -> None:
+        with lock:
+            loops.append(asyncio.get_running_loop())
+
+    threads = [
+        threading.Thread(target=lambda: run_worker_coroutine(capture()))
+        for _ in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(5.0)
+    assert len(loops) == 2
+    assert loops[0] is not loops[1]
+
+
+def test_supports_internal_to_thread_offloads() -> None:
+    """The folder-repository seam awaits asyncio.to_thread internally."""
+
+    async def offloading() -> int:
+        return await asyncio.to_thread(lambda: 7)
+
+    def worker(result: list[int]) -> None:
+        result.append(run_worker_coroutine(offloading()))
+
+    result: list[int] = []
+    thread = threading.Thread(target=worker, args=(result,))
+    thread.start()
+    thread.join(5.0)
+    assert result == [7]
+
+
+async def test_cancelling_the_awaiting_task_never_interrupts_the_coroutine() -> None:
+    """Same guarantee asyncio.run gave: the worker-side coroutine finishes."""
+
+    started = asyncio.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    loop = asyncio.get_running_loop()
+
+    async def mutation() -> None:
+        loop.call_soon_threadsafe(started.set)
+        assert release.wait(5.0)
+        finished.set()
+
+    task = asyncio.create_task(
+        asyncio.to_thread(lambda: run_worker_coroutine(mutation()))
+    )
+    await asyncio.wait_for(started.wait(), 5.0)
+    task.cancel()
+    release.set()
+    # The thread-side coroutine must complete regardless of the cancel.
+    assert await asyncio.to_thread(finished.wait, 5.0)
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def test_executor_module_has_no_asyncio_run_call_sites() -> None:
+    """Ratchet: the retired per-call asyncio.run pattern must not return."""
+
+    source = Path(inspect.getsourcefile(executor_module)).read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+    offenders = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "run"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "asyncio"
+    ]
+    assert offenders == []

--- a/backlog/tasks/task-23027 - Notes-sync-re-reads-every-file-and-re-selects-every-note-on-every-sync.md
+++ b/backlog/tasks/task-23027 - Notes-sync-re-reads-every-file-and-re-selects-every-note-on-every-sync.md
@@ -2,8 +2,9 @@
 id: TASK-23027
 title: >-
   Notes sync re-reads every file and re-selects every note on every sync
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-27'
 labels:
   - performance
@@ -25,11 +26,11 @@ Three compounding inefficiencies in the notes-sync path, all pre-existing and in
 
 ## Acceptance Criteria
 
-- [ ] A sync with no filesystem changes does not re-read every file or re-select every note - use the signature that is already computed
-- [ ] The nested `asyncio.run`-in-a-thread pattern is removed from the per-note path
-- [ ] Connections opened per sync are bounded; measured before and after at N=1000
-- [ ] Worst event-loop stall during a no-op sync is measured and reported
-- [ ] Sync correctness is unchanged - this area has a data-loss history, so a faster path that risks a lost or mis-ordered write is not acceptable
+- [x] A sync with no filesystem changes does not re-read every file or re-select every note - use the signature that is already computed
+- [x] The nested `asyncio.run`-in-a-thread pattern is removed from the per-note path
+- [x] Connections opened per sync are bounded; measured before and after at N=1000
+- [x] Worst event-loop stall during a no-op sync is measured and reported
+- [x] Sync correctness is unchanged - this area has a data-loss history, so a faster path that risks a lost or mis-ordered write is not acceptable
 
 ## Evidence
 
@@ -37,3 +38,114 @@ Counted live at N=1000. The loop-stall figures come from a probe with no renderi
 are a **floor**, not a ceiling.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Implementation Plan
+
+1. Reproduce all three findings on this base with an isolated-config probe (temp DB, temp root,
+   N=1000): wall, per-note SELECTs, file opens, sqlite connects, worst loop stall — interleaved arms.
+2. Fix 1 (skip the re-read): per-item observation reuse inside `_ProductionRuntimeAdapter.observe_root`,
+   validated by the SAME metadata the existing watcher signature trusts — a cached file snapshot is
+   reused only when the current discovery stat equals the snapshot's own open-time `reviewed_state`
+   (device, inode, size, mtime_ns, ctime_ns); a cached note snapshot is reused only when one bulk
+   (id → version, deleted) read confirms the exact version the snapshot carries. Bindings and root
+   state are always re-read (they are cheap and they gate `bound`), so no signature has to cover them.
+   Prove per mutation class — file edited / added / deleted / renamed / mtime-only touch / DB-side
+   note edit / DB-side note delete — that reuse does NOT happen and observations equal a cold pass.
+3. Fix 2 (kill `to_thread(lambda: asyncio.run(...))`): one persistent event loop per worker thread
+   (module helper in `notes_sync_executor.py`), used by all 22 executor sites and the runtime's
+   `observe_notes`. Thread placement, `_joined_thread_call` shielding, and interleaving semantics
+   are unchanged — only the per-call loop construction goes away.
+4. Fix 3 (bound connections): measure first. The abandoned connections are expected to be the
+   per-`asyncio.run` throwaway inner-loop executor threads meeting thread-local DB handles; loop
+   reuse should bound them. If the measurement disagrees, apply the held-connection shape instead.
+5. Tests: mutation-class coverage for reuse, cold/warm equivalence, skip-then-real-change walk,
+   quit-with-sync-in-flight at the new reuse points, error-mid-sync leaves store usable, and
+   executor-path interleaving (concurrent writer vs reused observation). Every new test run against
+   a deliberately broken implementation; per-test mutation results recorded.
+6. Re-measure at N=1000 interleaved; run the Notes suites A/B against base for reds; preflight.
+
+## Implementation Notes
+
+All three legs of the finding reproduced on base `c4e52794e2` before any change (isolated-config
+probe, N=1000, nothing changed: 356-396 ms, 1,000 per-note SELECTs, 1,000 file opens, worst loop
+stall 26.5-28.3 ms; executor path: 8.0 `asyncio.run` per synced note, 1,004 connections opened per
+1,000-note sync).
+
+**Fix 1 - per-item observation reuse, not a whole-pass signature skip.** The filing suggested using
+`_discovery_signature` to skip the pass wholesale. That shape was rejected after reading the code:
+the stored `_root_signatures` map is OVERWRITTEN by the watcher's `changed_root_ids` before the
+hinted reconcile runs (so a signature-keyed skip would skip the very pass the watcher just asked
+for -- a data-miss bug), and the signature covers only the filesystem, never DB-side note edits or
+binding transitions. Instead `_ProductionRuntimeAdapter` now keeps one `_ObservationReuse` cache
+per root, and `observe_root` revalidates every entry per pass against authoritative state read
+fresh THIS pass: a file snapshot is reused only when the current discovery stat (device, inode,
+size, mtime_ns, ctime_ns -- the same metadata the shipped watcher signature already trusts) equals
+the stat captured at the moment the cached bytes were read; a note snapshot is reused only when
+one bulk `observe_versions` read confirms the exact version it carries (every notes write path
+bumps `version` under optimistic locking). Bindings and root state are never cached --
+`list_bindings` runs fresh every pass -- so binding/root transitions need no signature coverage at
+all. The cache is content-bounded (32 MiB/root; over-budget items are simply re-read), rebuilt
+off-loop only on success, and dropped on `close()`. The boot reconcile's FIRST pass stays a full
+cold read by design: trusting persisted state to skip reads at boot would miss offline edits, and
+sync correctness outranks the win. Every later no-change pass (sync-now, check, watcher hint,
+post-apply verification) is the one that stops paying.
+
+**Fix 2 - `run_worker_coroutine` replaces `to_thread(lambda: asyncio.run(...))`.** The authority
+seam is async-shaped but its work is synchronous (or internally thread-offloaded), so those
+coroutines must be finished on the worker thread. The new module helper keeps ONE event loop per
+worker thread (`threading.local`) instead of building and tearing down a loop -- and, on the folder-
+repository seams, a throwaway default-executor thread -- per call. All 22 executor sites plus the
+runtime's note-observation batch now use it. Thread placement, `_joined_thread_call`'s
+finish-before-redelivering-cancellation shielding, and interleaving semantics are byte-identical;
+only the per-call loop/executor/connection churn disappears. An AST ratchet test keeps
+`asyncio.run` out of the executor.
+
+**Fix 3 - connections: hold, not close.** Measured first, per the WAL-anchor counter-lesson: the
+~1 abandoned connection per synced note was the per-`asyncio.run` throwaway inner-executor thread
+meeting `CharactersRAGDB`'s thread-local connection (fresh thread -> fresh connection -> thread
+dies with `shutdown_default_executor`). No `close()` was added anywhere -- loop reuse alone bounds
+connections to pool width: 1,004 -> 3 per 1,000-note sync (the 3 are one-time pool-thread
+warmups), threads started 2,003 -> 3.
+
+**Measured (interleaved A/B in one process, quiet machine; A = pre-change path, B = shipped):**
+
+- observe_root, N=1000, nothing changed: wall 392 -> 84 ms median; per-note SELECTs 1,000 -> 0
+  (one bulk version SELECT replaces them); file opens 1,000 -> 0; worst loop stall 27.3 -> 26.0 ms
+  (the stall is the pre-existing loop-side build/plan tail, present in both arms; an earlier
+  apparent stall regression to ~80-100 ms was disproved by interleaving -- it was concurrent
+  machine load). Under heavy concurrent load the same interleaved pair read 1,332 -> 165 ms.
+- executor per synced note (UPDATE_NOTE, K=20 x3 interleaved): 13.1 -> 6.6 ms/note; connections
+  1.10 -> 0.15/note; threads 2.10 -> 0.15/note. At K=1000: connections 1,004 -> 3.
+
+**Signature-coverage proof per mutation class** (each asserts the warm pass re-reads the changed
+item AND equals a cold adapter's ground-truth pass): file edited; file edited same-length (only
+mtime/ctime can catch it); file added; file deleted; file renamed (same inode, new path); mtime-
+only touch (same bytes -- must re-read); DB-side note edit; DB-side note delete; new binding
+between passes. Walks: skip-then-real-change never stays skipped (and re-warms over the NEW
+content); failed pass leaves cache and store usable; bulk-read failure propagates instead of
+serving stale; cancel mid-pass (quit with sync in flight) leaves the adapter usable and the next
+pass correct; concurrent writer x10 warm passes yields only committed (version, content) pairs and
+settles to cold ground truth.
+
+**Mutation results: 15 deliberate single-point defects, 15 detected** (restores Edit-based and
+re-verified green): stat compare drops mtime/ctime (4 reds); stat compare always-true (6); cached
+note served without version check (8); note cache keyed by binding_id -- wrong identity space (3,
+incl. the warm zero-selects test); cache never rebuilt after first pass (1: skip-then-change);
+helper builds a new loop per call (1); helper swallows exceptions (7); `asyncio.run` reintroduced
+at one executor site (1: AST ratchet); authority includes tombstones (1 -- at its own level only,
+because version-bump-on-delete is a second line of defence, tested per the TASK-21127 lesson); DB
+projection drops tombstones (1); chunk loop truncated at 500 (1); service ignores the bulk
+projection (2); reuse budget ignored (1); `close()` keeps the cache (1); bulk-read failure
+swallowed into stale reuse (1).
+
+**Files:** `tldw_chatbook/Notes/notes_sync_runtime.py` (reuse cache + revalidation, worker-loop
+helper use, off-loop cache rebuild, periodic yields on the awaitless hit path),
+`tldw_chatbook/Notes/notes_sync_executor.py` (`run_worker_coroutine` + 22 site swaps),
+`tldw_chatbook/Notes/notes_sync_authority.py` (`observe_versions`),
+`tldw_chatbook/Notes/notes_scope_service.py` (`get_note_version_states_for_sync`, with a per-note
+fallback for backends without the projection), `tldw_chatbook/Notes/Notes_Library.py` and
+`tldw_chatbook/DB/ChaChaNotes_DB.py` (`get_note_version_states`: chunked-at-500, one read
+transaction, tombstones included), plus new tests
+`Tests/Notes/test_notes_sync_observation_reuse.py` (18),
+`Tests/Notes/test_notes_sync_worker_coroutine.py` (7),
+`Tests/Notes/test_notes_sync_version_states.py` (9).

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -14980,6 +14980,48 @@ UPDATE db_schema_version
         row = cursor.fetchone()
         return dict(row) if row else None
 
+    def get_note_version_states(
+        self, note_ids: Sequence[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Read only (version, deleted) for the given note ids, in one snapshot.
+
+        TASK-23027: the lasting-sync observer needs a change signal for every
+        bound note without hydrating each full row. Every notes write path
+        (``add_note``, ``update_note``, ``soft_delete_note``) bumps ``version``
+        under optimistic locking, so ``(version, deleted)`` changing -- or the
+        id disappearing -- is exactly "this note changed". Chunked at 500 ids
+        per statement (mirrors ``get_message_image_blobs``), all chunks inside
+        one read transaction so the result is a single consistent snapshot.
+
+        Args:
+            note_ids: Note UUIDs to probe; unknown ids are absent from the
+                result.
+
+        Returns:
+            Mapping of note id to ``{"version": int, "deleted": bool}``,
+            including soft-deleted rows so callers can distinguish a tombstone
+            from an id that never existed.
+        """
+        ids = [str(note_id) for note_id in note_ids if note_id]
+        if not ids:
+            return {}
+        result: Dict[str, Dict[str, Any]] = {}
+        with self.transaction() as cursor:
+            for start in range(0, len(ids), 500):
+                chunk = ids[start : start + 500]
+                placeholders = ",".join("?" for _ in chunk)
+                cursor.execute(
+                    "SELECT id, version, deleted FROM notes"
+                    f" WHERE id IN ({placeholders})",
+                    chunk,
+                )
+                for row in cursor.fetchall():
+                    result[row["id"]] = {
+                        "version": row["version"],
+                        "deleted": bool(row["deleted"]),
+                    }
+        return result
+
     def get_note_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """
         Retrieves a specific note by its title.

--- a/tldw_chatbook/Notes/Notes_Library.py
+++ b/tldw_chatbook/Notes/Notes_Library.py
@@ -283,6 +283,18 @@ class NotesInteropService:
 
         return result
 
+    def get_note_version_states(
+        self, user_id: str, note_ids: Sequence[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Read only (version, deleted) for the given note ids (TASK-23027).
+
+        One consistent snapshot for the lasting-sync observer's change check;
+        see ``CharactersRAGDB.get_note_version_states`` for the contract.
+        """
+
+        db = self._get_db(user_id)
+        return db.get_note_version_states(note_ids)
+
     def list_notes(
         self, user_id: str, limit: int = 100, offset: int = 0
     ) -> List[Dict[str, Any]]:

--- a/tldw_chatbook/Notes/notes_scope_service.py
+++ b/tldw_chatbook/Notes/notes_scope_service.py
@@ -1150,6 +1150,43 @@ class NotesScopeService:
             raise RuntimeError("note_missing")
         return dict(record)
 
+    async def get_note_version_states_for_sync(
+        self,
+        *,
+        scope: ScopeType | str,
+        note_ids: Sequence[Any],
+        user_id: str | None = None,
+    ) -> Mapping[str, Mapping[str, Any]]:
+        """Read only (version, deleted) per note id through the sync seam.
+
+        TASK-23027: one narrow bulk read that lets the lasting-sync observer
+        decide which bound notes changed without re-selecting every full row.
+        Same scope and policy gate as :meth:`get_note_for_sync`. A backing
+        service without the bulk projection is served per-note through
+        ``get_note_by_id`` (identical answers, original cost).
+        """
+
+        normalized_scope = self._normalize_scope(scope)
+        if normalized_scope is not ScopeType.LOCAL_NOTE:
+            raise RuntimeError("server_contract_missing")
+        self._enforce_policy(self._note_action_id(normalized_scope, "detail"))
+        local_user_id = self._require_user_id(user_id)
+        bulk_read = getattr(self.local_notes_service, "get_note_version_states", None)
+        if callable(bulk_read):
+            states = bulk_read(local_user_id, [str(n) for n in note_ids])
+            return {str(key): dict(value) for key, value in states.items()}
+        result: dict[str, Mapping[str, Any]] = {}
+        for note_id in note_ids:
+            record = self.local_notes_service.get_note_by_id(
+                local_user_id, str(note_id)
+            )
+            if isinstance(record, Mapping) and "version" in record:
+                result[str(note_id)] = {
+                    "version": record["version"],
+                    "deleted": bool(record.get("deleted", False)),
+                }
+        return result
+
     async def replace_note_for_sync(
         self,
         *,

--- a/tldw_chatbook/Notes/notes_sync_authority.py
+++ b/tldw_chatbook/Notes/notes_sync_authority.py
@@ -261,6 +261,37 @@ class NotesScopeSyncAuthority:
             ) from None
         return self._snapshot(record, expected_note_id=note_id)
 
+    async def observe_versions(
+        self, note_ids: tuple[str, ...]
+    ) -> Mapping[str, int]:
+        """Read only the live version of each given note, in one snapshot.
+
+        TASK-23027: the change signal behind observation reuse. Every notes
+        write path bumps ``version`` under optimistic locking, so a note whose
+        version still matches a held :class:`NotesSyncNoteSnapshot` has not
+        changed since that snapshot was read. Deleted or missing ids are
+        absent from the result -- callers must treat absence as "changed" and
+        fall back to a full :meth:`observe`.
+        """
+
+        try:
+            states = await self._service.get_note_version_states_for_sync(
+                scope=self._scope,
+                note_ids=note_ids,
+                user_id=self._user_id,
+            )
+        except Exception as exc:
+            raise NotesSyncAuthorityError(
+                _bounded_reason(exc, "note_observation_failed")
+            ) from None
+        versions: dict[str, int] = {}
+        for note_id, state in states.items():
+            version = state.get("version")
+            if type(version) is not int or bool(state.get("deleted", False)):
+                continue
+            versions[str(note_id)] = version
+        return versions
+
     async def replace(
         self,
         expected: NotesSyncNoteSnapshot,

--- a/tldw_chatbook/Notes/notes_sync_executor.py
+++ b/tldw_chatbook/Notes/notes_sync_executor.py
@@ -6,12 +6,13 @@ import asyncio
 import base64
 import hashlib
 import json
+import threading
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, TypeVar, cast
 
 from tldw_chatbook.Notes.notes_device_state_store import (
     NotesDeviceStateError,
@@ -81,6 +82,43 @@ _RESOLUTION_JOURNAL_ACTIONS = {
     "resolve_keep_note": NotesSyncActionKind.UPDATE_FILE,
     "resolve_keep_both": NotesSyncActionKind.UPDATE_NOTE,
 }
+
+
+_T = TypeVar("_T")
+
+_WORKER_LOOPS = threading.local()
+
+
+def run_worker_coroutine(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run one authority coroutine to completion on this worker thread.
+
+    Drop-in replacement for the retired per-call ``asyncio.run(...)`` inside
+    the executor's thread-offloaded seams (TASK-23027). The authority seam is
+    async-shaped but its work is synchronous (or already thread-offloaded), so
+    these coroutines must be finished on the worker thread that was handed
+    them. ``asyncio.run`` did that by building and tearing down a full event
+    loop per call -- ~684 microseconds each, nine calls per synced note -- and,
+    whenever the coroutine itself used ``asyncio.to_thread`` (the folder
+    repository seam), a throwaway default-executor thread whose thread-local
+    SQLite connection was abandoned with it: ~1 leaked connection per synced
+    note at N=1000.
+
+    This keeps ONE event loop alive per worker thread instead. The coroutine
+    still runs exactly where and how it always did: on this thread, to
+    completion, unreachable by cancellation of the awaiting task (the same
+    property ``asyncio.run`` provided). Only the per-call loop construction,
+    executor churn, and connection churn disappear. The kept loops are bounded
+    by the width of the thread pools that host these calls
+    (``asyncio.to_thread`` reuses pooled threads); each loop is reclaimed with
+    its thread.
+    """
+
+    loop = getattr(_WORKER_LOOPS, "loop", None)
+    if loop is None or loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        _WORKER_LOOPS.loop = loop
+    return loop.run_until_complete(coro)
 
 
 def _resolution_override_required(
@@ -1168,7 +1206,7 @@ class NotesSyncExecutor:
             ) or (not override_required and direction_override is not None):
                 raise RuntimeError("recovery_authority_changed")
         current_note = await asyncio.to_thread(
-            lambda: asyncio.run(self._notes.observe(note_id))
+            lambda: run_worker_coroutine(self._notes.observe(note_id))
         )
         current_file = await self._observe_reconstructed_file(
             relative_path,
@@ -1823,7 +1861,7 @@ class NotesSyncExecutor:
                 else:
                     await self._require_undo_post_authority(request, metadata)
                     _, cancelled = await self._joined_thread_call(
-                        lambda: asyncio.run(
+                        lambda: run_worker_coroutine(
                             self._restore_undo_authority_anchored(
                                 request, payload, source_metadata
                             )
@@ -1923,7 +1961,7 @@ class NotesSyncExecutor:
                 if stage == "binding_updated":
                     if metadata.get("source_kind") == "resolve_keep_both":
                         _, cancelled = await self._joined_thread_call(
-                            lambda: asyncio.run(
+                            lambda: run_worker_coroutine(
                                 self._cleanup_undo_copy_anchored(
                                     request.operation_id, source_metadata, payload
                                 )
@@ -2613,7 +2651,7 @@ class NotesSyncExecutor:
             self._require_new_candidate_owner(request)
             desired = await self._desired_managed_memberships(request)
             _, cancelled = await self._joined_thread_call(
-                lambda: asyncio.run(
+                lambda: run_worker_coroutine(
                     self._notes.reconcile_managed_memberships(
                         owner_id=request.root_id,
                         desired=desired,
@@ -2698,7 +2736,7 @@ class NotesSyncExecutor:
             note, file = await self._require_new_desired(request)
             if request.action_kind is NotesSyncActionKind.CREATE_NOTE:
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(self._notes.delete(note))
+                    lambda: run_worker_coroutine(self._notes.delete(note))
                 )
             else:
                 assert type(file) is NotesSyncFileSnapshot
@@ -2721,7 +2759,7 @@ class NotesSyncExecutor:
         )
         desired = await self._desired_managed_memberships(request)
         _, cancelled = await self._joined_thread_call(
-            lambda: asyncio.run(
+            lambda: run_worker_coroutine(
                 self._notes.reconcile_managed_memberships(
                     owner_id=request.root_id,
                     desired=desired,
@@ -3279,7 +3317,7 @@ class NotesSyncExecutor:
                 if request.action_kind is not NotesSyncActionKind.MOVE_FILE:
                     desired.append((request.logical_folder_id, note.note_id))
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(
+                    lambda: run_worker_coroutine(
                         self._notes.reconcile_managed_memberships(
                             owner_id=request.root_id,
                             desired=tuple(sorted(set(desired))),
@@ -3351,7 +3389,7 @@ class NotesSyncExecutor:
             assert request.file is not None
             await self._require_note_missing(self._request_note_id(request))
             _, cancelled = await self._joined_thread_call(
-                lambda: asyncio.run(
+                lambda: run_worker_coroutine(
                     self._notes.create(
                         note_id=self._request_note_id(request),
                         title=request.desired_title,
@@ -3434,7 +3472,7 @@ class NotesSyncExecutor:
 
     async def _observe_note(self, note_id: str) -> NotesSyncNoteSnapshot:
         return await asyncio.to_thread(
-            lambda: asyncio.run(self._notes.observe(note_id))
+            lambda: run_worker_coroutine(self._notes.observe(note_id))
         )
 
     async def _observe_file_path(self, relative_path: str) -> _FileSnapshot:
@@ -3912,7 +3950,7 @@ class NotesSyncExecutor:
                     self._require_reviewed_owner(request)
                     if request.action_kind is NotesSyncActionKind.UPDATE_NOTE:
                         _, cancelled = await self._joined_thread_call(
-                            lambda: asyncio.run(
+                            lambda: run_worker_coroutine(
                                 self._notes.replace(
                                     request.note,
                                     title=request.desired_title,
@@ -3949,7 +3987,7 @@ class NotesSyncExecutor:
                 desired = await self._desired_managed_memberships(request)
                 self._require_reviewed_owner(request)
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(
+                    lambda: run_worker_coroutine(
                         self._notes.reconcile_managed_memberships(
                             owner_id=request.root_id,
                             desired=desired,
@@ -4016,43 +4054,43 @@ class NotesSyncExecutor:
             cancelled = False
             if stage == "recovery_admitted":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(
+                    lambda: run_worker_coroutine(
                         self._establish_conflict_folders(request, checkpoint=True)
                     )
                 )
             elif stage == "folders_established":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(
+                    lambda: run_worker_coroutine(
                         self._create_conflict_copy(request, checkpoint=True)
                     )
                 )
             elif stage == "copy_created":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(
+                    lambda: run_worker_coroutine(
                         self._create_conflict_placement(request, checkpoint=True)
                     )
                 )
             elif stage == "placement_created":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(
+                    lambda: run_worker_coroutine(
                         self._verify_conflict_copy_pair(request, checkpoint=True)
                     )
                 )
             elif stage == "copy_verified":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(self._update_bound_note(request))
+                    lambda: run_worker_coroutine(self._update_bound_note(request))
                 )
             elif stage == "bound_note_updated":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(self._reverify_keep_both_file(request))
+                    lambda: run_worker_coroutine(self._reverify_keep_both_file(request))
                 )
             elif stage == "file_reverified":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(self._commit_keep_both_binding(request))
+                    lambda: run_worker_coroutine(self._commit_keep_both_binding(request))
                 )
             elif stage == "binding_updated":
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(self._final_verify_keep_both(request))
+                    lambda: run_worker_coroutine(self._final_verify_keep_both(request))
                 )
             elif stage == "verified":
                 await self._verify_conflict_copy_pair(request, checkpoint=False)
@@ -4917,7 +4955,7 @@ class NotesSyncExecutor:
             self._require_restore_owner(request, note, file)
             if request.action_kind is NotesSyncActionKind.UPDATE_NOTE:
                 _, cancelled = await self._joined_thread_call(
-                    lambda: asyncio.run(
+                    lambda: run_worker_coroutine(
                         self._notes.replace(
                             note,
                             title=request.note.title,
@@ -5092,7 +5130,7 @@ class NotesSyncExecutor:
             request, exclude_binding_id=request.binding_id
         )
         _, cancelled = await self._joined_thread_call(
-            lambda: asyncio.run(
+            lambda: run_worker_coroutine(
                 self._notes.reconcile_managed_memberships(
                     owner_id=request.root_id,
                     desired=desired,
@@ -5211,7 +5249,7 @@ class NotesSyncExecutor:
         request: NotesSyncExecutionRequest,
     ) -> tuple[NotesSyncNoteSnapshot, _FileSnapshot]:
         note = await asyncio.to_thread(
-            lambda: asyncio.run(self._notes.observe(request.note.note_id))
+            lambda: run_worker_coroutine(self._notes.observe(request.note.note_id))
         )
         if type(request.file) is WindowsNotesSyncObservation:
             candidates = await asyncio.to_thread(self._filesystem.observe)

--- a/tldw_chatbook/Notes/notes_sync_runtime.py
+++ b/tldw_chatbook/Notes/notes_sync_runtime.py
@@ -72,6 +72,7 @@ from tldw_chatbook.Notes.notes_sync_executor import (
     NotesSyncExecutor,
     NotesSyncKeepBothAuthority,
     NotesSyncUndoProjection,
+    run_worker_coroutine,
 )
 from tldw_chatbook.Notes.notes_sync_filesystem import (
     NotesSyncFileSnapshot,
@@ -410,6 +411,59 @@ class _ObservedBinding:
     file: NotesSyncFileSnapshot | None
 
 
+# TASK-23027: total content bytes one root's observation-reuse cache may
+# retain. Items past the budget are simply not cached (they are re-read next
+# pass), so the bound never affects correctness.
+_OBSERVATION_REUSE_BUDGET_BYTES = 32 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _ObservationReuse:
+    """One root's previously observed snapshots, revalidated per pass.
+
+    TASK-23027: ``observe_root`` used to re-read every file and re-select
+    every note on every pass -- 350-370 ms, 1,000 SELECTs and 1,017 file opens
+    at N=1000 with nothing changed, at boot among other times. Each entry here
+    is reused only after a per-item freshness check against authoritative
+    state read fresh THIS pass:
+
+    - a file snapshot is reused only when the current discovery stat (device,
+      inode, size, mtime_ns, ctime_ns) equals the stat captured at the moment
+      the cached bytes were read (``reviewed_state``) -- the same metadata the
+      shipped watcher signature already trusts to declare a root unchanged;
+    - a note snapshot is reused only when one bulk ``observe_versions`` read
+      confirms the exact version the snapshot carries (every notes write path
+      bumps ``version`` under optimistic locking, and deletion is a version
+      bump too).
+
+    Bindings and root state are NOT cached: ``list_bindings`` runs fresh every
+    pass, so binding transitions need no signature coverage at all.
+    """
+
+    files: Mapping[str, NotesSyncFileSnapshot]
+    notes: Mapping[str, NotesSyncNoteSnapshot]
+
+    def __repr__(self) -> str:
+        return "_ObservationReuse(<private>)"
+
+
+def _file_snapshot_current(
+    snapshot: NotesSyncFileSnapshot, identity: object
+) -> bool:
+    """Whether ``snapshot``'s open-time stat equals the current discovery stat."""
+
+    if type(snapshot) is not NotesSyncFileSnapshot:
+        return False
+    state = snapshot.reviewed_state
+    return (
+        state.identity.device == identity.device
+        and state.identity.inode == identity.inode
+        and state.size == identity.size
+        and state.mtime_ns == identity.modified_ns
+        and state.ctime_ns == identity.changed_ns
+    )
+
+
 class _ProductionRuntimeAdapter:
     """Small concrete bridge over the completed TASK-19005/19007 boundaries."""
 
@@ -428,6 +482,7 @@ class _ProductionRuntimeAdapter:
         self._filesystems: dict[str, PosixNotesSyncFilesystem] = {}
         self._bundles: dict[str, Mapping[str, _ObservedBinding]] = {}
         self._root_signatures: dict[str, tuple[object, ...]] = {}
+        self._observation_reuse: dict[str, _ObservationReuse] = {}
         file_limit = min(recovery_capacity_bytes, 10 * 1024 * 1024)
         self._discovery_bounds = ImportBounds(
             max_files=1_000,
@@ -491,12 +546,29 @@ class _ProductionRuntimeAdapter:
         )
         if discovery.failures:
             raise RuntimeError("root_discovery_incomplete")
+        # TASK-23027: reuse is validated per item against state read fresh
+        # this pass; see _ObservationReuse. A miss (edit, add, rename, touch,
+        # or a cold cache) takes exactly the pre-existing read path.
+        reuse = self._observation_reuse.get(root.root_id)
         discovered: dict[str, NotesSyncFileSnapshot] = {}
+        reused_files = 0
         for candidate in discovery.candidates:
             relative_path = candidate.source.source_path.relative_to(
                 Path(root.canonical_path)
             ).as_posix()
             if Path(relative_path).suffix.casefold() not in _SYNC_FILE_EXTENSIONS:
+                continue
+            cached_file = reuse.files.get(relative_path) if reuse else None
+            if cached_file is not None and _file_snapshot_current(
+                cached_file, candidate.identity
+            ):
+                discovered[relative_path] = cached_file
+                # A cache hit removes this loop's only await; yield
+                # periodically so a fully warm pass cannot turn the whole
+                # walk into one contiguous event-loop stall.
+                reused_files += 1
+                if reused_files % 64 == 0:
+                    await asyncio.sleep(0)
                 continue
             try:
                 discovered[relative_path] = await asyncio.to_thread(
@@ -526,7 +598,28 @@ class _ProductionRuntimeAdapter:
         def observe_notes() -> dict[str, NotesSyncNoteSnapshot | None]:
             async def observe_all() -> dict[str, NotesSyncNoteSnapshot | None]:
                 observed_notes: dict[str, NotesSyncNoteSnapshot | None] = {}
-                for binding in bindings:
+                pending = list(bindings)
+                # TASK-23027: one bulk version read decides which cached note
+                # snapshots are still exact; only changed, deleted, missing,
+                # or never-cached notes pay the per-note observe. A failed
+                # bulk read propagates like any other observation failure.
+                if reuse is not None and reuse.notes and pending:
+                    current_versions = await notes.observe_versions(
+                        tuple(binding.note_id for binding in pending)
+                    )
+                    still_pending: list[NotesSyncBindingRecord] = []
+                    for binding in pending:
+                        cached_note = reuse.notes.get(binding.note_id)
+                        if (
+                            cached_note is not None
+                            and current_versions.get(binding.note_id)
+                            == cached_note.version
+                        ):
+                            observed_notes[binding.binding_id] = cached_note
+                        else:
+                            still_pending.append(binding)
+                    pending = still_pending
+                for binding in pending:
                     try:
                         observed_notes[binding.binding_id] = await notes.observe(
                             binding.note_id
@@ -537,7 +630,7 @@ class _ProductionRuntimeAdapter:
                         observed_notes[binding.binding_id] = None
                 return observed_notes
 
-            return asyncio.run(observe_all())
+            return run_worker_coroutine(observe_all())
 
         note_observations = await asyncio.to_thread(observe_notes)
         claimed_paths: set[str] = set()
@@ -649,6 +742,39 @@ class _ProductionRuntimeAdapter:
             raise RuntimeError("observation_capacity_exceeded")
         self._bundles[token] = MappingProxyType(bundle)
         self._root_signatures[root.root_id] = self._discovery_signature(discovery)
+        # TASK-23027: rebuild the reuse cache from this pass's observations,
+        # only on success -- a failed pass leaves the previous entries, which
+        # stay safe because every entry is revalidated before reuse. The
+        # rebuild is pure work over already-frozen locals, so it runs
+        # off-loop rather than widening this method's loop-side tail.
+
+        def build_reuse() -> _ObservationReuse:
+            reuse_budget = _OBSERVATION_REUSE_BUDGET_BYTES
+            reusable_files: dict[str, NotesSyncFileSnapshot] = {}
+            for relative_path, file in discovered.items():
+                if type(file) is not NotesSyncFileSnapshot:
+                    continue
+                cost = len(file.raw_bytes) + len(file.text)
+                if cost > reuse_budget:
+                    continue
+                reuse_budget -= cost
+                reusable_files[relative_path] = file
+            reusable_notes: dict[str, NotesSyncNoteSnapshot] = {}
+            for binding in bindings:
+                note = note_observations[binding.binding_id]
+                if note is None:
+                    continue
+                cost = len(note.content) + len(note.title)
+                if cost > reuse_budget:
+                    continue
+                reuse_budget -= cost
+                reusable_notes[note.note_id] = note
+            return _ObservationReuse(
+                files=MappingProxyType(reusable_files),
+                notes=MappingProxyType(reusable_notes),
+            )
+
+        self._observation_reuse[root.root_id] = await asyncio.to_thread(build_reuse)
         return request
 
     @staticmethod
@@ -899,6 +1025,7 @@ class _ProductionRuntimeAdapter:
         for filesystem in self._filesystems.values():
             filesystem.__exit__(None, None, None)
         self._filesystems.clear()
+        self._observation_reuse.clear()
 
 
 class NotesSyncRuntimeOwner:


### PR DESCRIPTION
## Summary

Notes sync re-read every file and re-selected every note on every pass — **350–396 ms, 1,000
SELECTs and 1,000 file opens at N=1000 with nothing changed** — and ran that at boot. Plus
`to_thread(lambda: asyncio.run(coro))` at 22 sites (~8 per synced note) and ~1 abandoned SQLite
connection per note. Finding 23027 of the
[2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md). All three reproduced on base
before any change.

## The filing's prescribed fix was rejected as unsafe — and here is the proof

The finding said "use the `_discovery_signature` that is already computed to skip the pass."
**That skip would lose data two ways**: the watcher's `changed_root_ids` overwrites
`_root_signatures` *before* the hinted reconcile runs — so a signature-keyed skip would skip the
very pass the watcher just requested — and the signature never sees DB-side changes at all.

Shipped instead: **per-item revalidation**. A file snapshot is reused only when its current
discovery stat (device, inode, size, mtime_ns, ctime_ns — the same metadata the shipped watcher
already trusts) equals the stat captured when its bytes were read; a note snapshot only when one
bulk version read (a new narrow seam down to `CharactersRAGDB.get_note_version_states`) confirms
its exact version. Bindings and root state are never cached. Boot's first pass stays a deliberate
full cold read — offline edits; correctness outranks.

**Coverage proven per mutation class**, each asserting re-read *and* equality with a cold adapter's
ground truth: file edited · **same-length edit** (only mtime/ctime can catch it) · added · deleted ·
renamed (same inode, new path) · mtime-only touch · DB-side note edit · DB-side note delete · new
binding between passes.

## The asyncio restructure

`run_worker_coroutine` — one persistent loop per worker thread — replaced all 22 sites. Thread
placement, cancellation shielding and interleaving semantics unchanged, pinned by a direct
cancellation test, a concurrent-writer test (10 warm passes against a live writer yield only
committed (version, content) pairs, settling to cold ground truth), and the full suites. An AST
ratchet blocks `asyncio.run` from returning.

## The connection decision — held, not closed

Measured first: the abandoned connection per note was the per-`asyncio.run` throwaway executor
thread meeting the DB's thread-local connection. With persistent worker loops: connections per
1,000-note sync **1,004 → 3**, threads **2,003 → 3**. **No close paths added** — the WAL-anchor
counter-lesson respected.

## Before / after at N=1000 (interleaved arms, one process)

| | before | after |
|---|---|---|
| no-change pass wall | 392 ms | **84 ms** |
| per-note SELECTs | 1,000 | **0** (one bulk SELECT) |
| file opens | 1,000 | **0** |
| under heavy load | 1,332 ms | 165 ms |
| executor per note | 13.1 ms | **6.6 ms** |

An earlier apparent 80–100 ms stall "regression" was **disproved by interleaving** — machine load.
The residual ~26 ms loop stall is pre-existing Python in both arms (hydration/plan/pathlib), noted
as a follow-up candidate.

## Mutation: 15/15 detected

Including: stat-compare drops mtime/ctime → 4 reds · always-true reuse → 6 · no version check → 8 ·
wrong key space → 3 (incl. warm zero-selects) · cache never rebuilt → the skip-then-change walk ·
`asyncio.run` reintroduced → the ratchet · bulk-read failure swallowed → red (never serves stale).
All restores Edit-based and diff-reviewed.

## Walks

Quit with sync in flight (cancel mid-observe → adapter usable, next pass correct); skip-then-real-
change (never stays skipped, re-warms over new content); error mid-sync (failed pass leaves cache
and store usable).

## Verification

**34 new tests green** (observation reuse 18, version states 7, worker coroutine 9).
`Tests/Notes`: **3,179 passed / 1 failed / 5 skipped** — the one red fails identically on pristine
base (pre-existing, the known cutover test). Preflight green after rebase onto current dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-23027 — notes sync no longer re-reads every file and re-selects every note when nothing changed: a no-change 1,000-note pass drops from 392 ms to 84 ms, with per-note SELECTs (1,000 → 0) and file opens (1,000 → 0).

- File snapshots are reused only when the current discovery stat (device, inode, size, mtime_ns, ctime_ns) equals the stat captured when their bytes were read; note snapshots only when one bulk version read confirms their exact version.
- The prescribed whole-pass signature skip was rejected: it would skip passes the watcher just requested and can't see DB-side changes; boot's first pass stays a full cold read for offline-edit safety.
- Replaces all 22 `to_thread(lambda: asyncio.run(...))` sites with one persistent event loop per worker thread; placement and cancellation semantics unchanged.
- No close paths added — the ~1 abandoned connection per note was the per-`asyncio.run` throwaway executor thread; loop reuse bounds connections (1,004 → 3 per 1,000-note sync).
- 34 new tests cover each mutation class (edit, same-length edit, add, delete, rename, mtime-touch, DB-side edit/delete, new binding); all 15 deliberate single-point defects were detected.

<sup>Written for commit 21977d441a36a923658695887144f7beb04169ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

