### PR TITLE
fix(capture): bound Safe exchange capture per ADR-096 — aggregate marker, no digests (TASK-23026)

### DIFF
--- a/Docs/User_Guide/console/context-and-rag.md
+++ b/Docs/User_Guide/console/context-and-rag.md
@@ -615,21 +615,28 @@ Full choice; turning it back on warns before Full resumes.
 
 Safe retains routing/provenance, status, usage, omission/truncation
 inventories, the system prompt, tools, sampling parameters, the response, and
-a **bounded** excerpt of the request's message history: the newest 8 payload
-rows — this turn's new content plus immediate context — verbatim, with every
-older row replaced in place by a content-free fingerprint (role, size, and a
-`sha256:` prefix, so you can still verify which row was sent where without
-its body being re-stored on every send). Full may retain the entire semantic
-provider input and output verbatim: for Anthropic that includes system,
-messages, and tools, plus injected AGENTS/workspace instructions, RAG
-snippets, tool schemas, arguments, and results. Capture occurs at the
-semantic provider-adapter boundary, not raw HTTP; llama.cpp is the documented
-exception because its adapter payload is the literal outgoing request (its
-Safe capture bounds the wire `messages` list the same way). Elided history
-ranges are named on the same "Omitted by capture policy" line as everything
-else capture withholds. Databases holding older, unbounded Safe captures are
-trimmed once, automatically, the first time the app opens them after
-upgrading — no manual purge needed.
+a **bounded** excerpt of the request's message history: the initial system
+context row, the latest user request, and the newest eight message rows —
+verbatim — with all older context represented by one **content-free aggregate
+marker** (how many rows were sent, how many were elided, and their role
+counts; deliberately no content, snippets, per-row sizes, or hashes, so
+nothing stored can be used to confirm guesses about the omitted text). Safe
+history elided at capture time cannot be recovered later by the Inspector or
+its exports. Full is the explicit choice for exact semantic diagnostic
+history: it may retain the entire provider input and output verbatim — for
+Anthropic that includes system, messages, and tools, plus injected
+AGENTS/workspace instructions, RAG snippets, tool schemas, arguments, and
+results — and it keeps ADR-092's privacy warning and scoped purge boundaries.
+Capture occurs at the semantic provider-adapter boundary, not raw HTTP;
+llama.cpp is the documented exception because its adapter payload is the
+literal outgoing request (its Safe capture bounds the wire `messages` list
+the same way). Elision shows up on the same "Omitted by capture policy" line
+as everything else capture withholds (`messages_payload.history`), and the
+Exchange tab's Messages title states both the sent and elided counts.
+Databases holding older, unbounded Safe captures are compacted once,
+automatically, the first time the app opens them after upgrading — no manual
+purge needed — though corrupt/unreadable records can't be rewritten, and
+compaction does not erase prior backups or exports.
 
 Structured credential fields are excluded and credential-bearing endpoint
 userinfo, query, and fragments are removed. That structural protection cannot
@@ -741,8 +748,9 @@ code/tests (`console_conversation_inspector.py`, `console_exchange_
 capture.py`, the design spec's UI and Risks sections); live verification of
 the Exchange tab against a real provider is a separate, later pass.*
 
-*Verified against the task-23026 working tree — 2026-08-27 (Safe capture
-history bounding: retention text above matches `console_exchange_capture.py`'s
-`elide_safe_history_rows`/`CAPTURE_SAFE_HISTORY_TAIL_ROWS` and the v52→v53
-one-time trim in `ChaChaNotes_DB.py`; code-level pass backed by the pure,
-gateway, and migration test suites — not a live-provider walkthrough).*
+*Verified against the task-23026 working tree — 2026-08-27 (ADR-096 Safe
+capture retention: text above matches `console_exchange_capture.py`'s
+`compact_safe_history_rows`/`CAPTURE_SAFE_HISTORY_TAIL_ROWS`, the Inspector's
+Messages-title counts, and the v52→v53 one-time compaction in
+`ChaChaNotes_DB.py`; code-level pass backed by the pure, gateway, migration,
+and inspector test suites — not a live-provider walkthrough).*

--- a/Docs/User_Guide/console/context-and-rag.md
+++ b/Docs/User_Guide/console/context-and-rag.md
@@ -613,13 +613,23 @@ Inspector or a live Trace to change exactly one future scope: **Next send**
 On/Off and Safe/Full setting. Turning Capture **Off** does not erase a dormant
 Full choice; turning it back on warns before Full resumes.
 
-Safe retains bounded routing/provenance, status, usage, and omission/truncation
-inventories. Full may retain semantic provider input and output: for Anthropic
-that includes system, messages, and tools, plus injected AGENTS/workspace
-instructions, RAG snippets, tool schemas, arguments, and results. Capture
-occurs at the semantic provider-adapter boundary, not raw HTTP; llama.cpp is
-the documented exception because its adapter payload is the literal outgoing
-request.
+Safe retains routing/provenance, status, usage, omission/truncation
+inventories, the system prompt, tools, sampling parameters, the response, and
+a **bounded** excerpt of the request's message history: the newest 8 payload
+rows — this turn's new content plus immediate context — verbatim, with every
+older row replaced in place by a content-free fingerprint (role, size, and a
+`sha256:` prefix, so you can still verify which row was sent where without
+its body being re-stored on every send). Full may retain the entire semantic
+provider input and output verbatim: for Anthropic that includes system,
+messages, and tools, plus injected AGENTS/workspace instructions, RAG
+snippets, tool schemas, arguments, and results. Capture occurs at the
+semantic provider-adapter boundary, not raw HTTP; llama.cpp is the documented
+exception because its adapter payload is the literal outgoing request (its
+Safe capture bounds the wire `messages` list the same way). Elided history
+ranges are named on the same "Omitted by capture policy" line as everything
+else capture withholds. Databases holding older, unbounded Safe captures are
+trimmed once, automatically, the first time the app opens them after
+upgrading — no manual purge needed.
 
 Structured credential fields are excluded and credential-bearing endpoint
 userinfo, query, and fragments are removed. That structural protection cannot
@@ -730,3 +740,9 @@ lives on unchanged as the Next Send tab. Docs pass against shipped
 code/tests (`console_conversation_inspector.py`, `console_exchange_
 capture.py`, the design spec's UI and Risks sections); live verification of
 the Exchange tab against a real provider is a separate, later pass.*
+
+*Verified against the task-23026 working tree — 2026-08-27 (Safe capture
+history bounding: retention text above matches `console_exchange_capture.py`'s
+`elide_safe_history_rows`/`CAPTURE_SAFE_HISTORY_TAIL_ROWS` and the v52→v53
+one-time trim in `ChaChaNotes_DB.py`; code-level pass backed by the pure,
+gateway, and migration test suites — not a live-provider walkthrough).*

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -628,8 +628,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 363,
-      "diagnostic_digest": "b9679458c9e6b0b56531",
+      "call_count": 365,
+      "diagnostic_digest": "d38f2be9ae273dbdaa17",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3990,6 +3990,6 @@
     "owner_files": 540,
     "persistent_sink_files": 8,
     "task_492_calls": 1261,
-    "task_494_calls": 7392
+    "task_494_calls": 7394
   }
 }

--- a/Docs/superpowers/specs/2026-08-27-console-safe-capture-retention-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-safe-capture-retention-design.md
@@ -1,0 +1,263 @@
+# Console Safe Capture Retention Design
+
+**Date:** 2026-08-27
+
+**Status:** Design approved; written-spec review pending
+
+**Task:** [TASK-23026](../../../backlog/tasks/task-23026%20-%20Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md)
+
+**Decision:** [ADR-096](../../../backlog/decisions/096-console-safe-capture-retention.md)
+
+**Amends:** [ADR-092](../../../backlog/decisions/092-console-full-semantic-capture-policy.md)
+
+## Summary
+
+Safe exchange capture currently stores the full provider message history again on every
+provider call. A 200-turn production-shaped probe grew from 2.8 KB at turn 1 to 145.4 KB
+at turn 200 and retained 15.40 MB for one conversation. The default capture mode is Safe,
+so this is an automatic local storage and privacy cost rather than an opt-in diagnostic
+cost.
+
+Safe capture will instead retain a bounded diagnostic excerpt: the first system row, the
+most recent user row, and the newest eight rows. All other message rows are replaced by one
+content-free aggregate marker. Full capture remains the explicit, consent-gated mode for
+exact semantic history within ADR-092's credential, binary, and size protections.
+
+A versioned, atomic data migration applies the same compaction to existing Safe exchange
+rows. This reclaims legacy growth without requiring users to discover a purge action.
+
+## Goals
+
+- Make each Safe request capture bounded by the current diagnostic excerpt rather than by
+  the conversation's full age.
+- Preserve enough context to identify the original system framing, current user request,
+  and immediate assistant/tool loop around the provider call.
+- Make elision explicit in both the captured request and `omitted_keys`.
+- Apply the same policy to generic `messages_payload` and llama.cpp's literal
+  `wire_payload.messages` capture.
+- Reclaim already-persisted Safe captures automatically and transactionally.
+- Leave Full capture semantics, capture scope, and explicit Full purge behavior unchanged.
+
+## Non-goals
+
+- Reconstructing omitted Safe history from references, deltas, hashes, other exchanges,
+  transcripts, or messages.
+- Adding timed retention, a background pruning service, or a new purge control.
+- Changing provider requests, model context construction, transcripts, Trace events,
+  message sync, or FTS ownership.
+- Changing the Inspector layout or export-profile controls.
+- Promising forensic erasure from SQLite free pages, WAL files, backups, or prior exports.
+
+## Current ownership and failure
+
+`ConsoleProviderGateway` builds semantic request captures at the provider boundary.
+`build_request_capture` allowlists fields, canonicalizes endpoint identity, removes nested
+credential fields, redacts automatic project-instruction bodies in Safe mode, stubs binary
+content, and applies the shared capture budget. The resulting `ExchangeCapture` is compressed
+and stored in local-only `message_exchanges` rows.
+
+The generic path places the entire accumulated conversation in `messages_payload`. The
+llama.cpp path separately copies the literal wire request under `wire_payload`, including its
+own full `messages` list. Because every later call contains all earlier messages, retaining
+those lists in every exchange produces quadratic cumulative storage.
+
+Exchange bodies have one durable application owner: `message_exchanges`. They do not enter
+the message transcript, sync log, FTS tables, or Trace trajectory ledger. Inspector export
+projects the stored exchange and cannot recover data that capture omitted.
+
+## Safe retention contract
+
+### Retained rows
+
+For a list with original zero-based positions, Safe capture retains the union of:
+
+1. the first mapping row whose `role` is exactly `system`;
+2. the last mapping row whose `role` is exactly `user`; and
+3. the final eight physical rows in the list.
+
+Overlapping selections are deduplicated. Retained rows remain in their original relative
+order and keep their already-sanitized values. Non-mapping rows are eligible only through
+the eight-row tail. If every row is retained, the list is unchanged and no history-elision
+entry is added.
+
+This contract preserves the three debugging facts Safe capture is expected to answer:
+
+- what initial system framing was in effect;
+- what current user request drove the call; and
+- what recent assistant/tool interaction immediately preceded and followed that request.
+
+It does not claim to preserve the entire causal history. Users who deliberately need that
+evidence must choose Full before the send.
+
+### One aggregate marker
+
+When rows are omitted, the capture inserts exactly one internal marker at the position of
+the first omitted row. Other retained rows remain ordered as above. Because the omitted
+rows can be non-contiguous, the marker explicitly summarizes all omitted rows rather than
+pretending to represent only one contiguous gap.
+
+The marker has a versioned, capture-owned shape and contains only:
+
+- an internal kind/version discriminator;
+- the original row count;
+- the omitted row count;
+- normalized omitted-role counts for `system`, `user`, `assistant`, `tool`, and `other`;
+- the original positions of retained rows.
+
+Unknown, missing, or non-string roles contribute only to `other`; their raw values are not
+retained. The marker contains no content, snippets, content lengths, hashes, IDs, timestamps,
+or reconstructable references. In particular, Safe capture does not retain a digest that
+could be used to test guesses about omitted private text.
+
+The helper recognizes its own valid versioned marker and produces a fixed point when a
+stored Safe request is projected through the capture builder again. An input marker never
+disables compaction of surrounding rows. Malformed lookalikes are ordinary rows and remain
+subject to the normal bounded selection.
+
+### Ordering with existing protections
+
+Safe request processing occurs in this order:
+
+1. reject unknown top-level kwargs and inventory them in `omitted_keys`;
+2. canonicalize credential-free endpoint identity;
+3. redact tagged automatic project-instruction bodies;
+4. remove nested structured credential fields and stub binary/base64 values;
+5. compact the sanitized message history;
+6. apply the existing shared uncompressed capture budget.
+
+This ordering prevents the aggregate marker from describing raw secret or binary values and
+keeps project-instruction bodies outside Safe storage. Existing project-instruction redaction
+metadata remains visible even if its marker row is later among the omitted history.
+
+Generic history elision adds the stable path `messages_payload.history` to `omitted_keys`.
+llama.cpp history elision adds `wire_payload.messages.history`. The aggregate marker carries
+the counts; the omission inventory carries only the stable path, so repeated projection does
+not create duplicate or ever-changing strings.
+
+### Full capture
+
+The compactor is never invoked for `CaptureDetail.FULL`. Full continues to preserve semantic
+message text exactly as ADR-092 defines while still enforcing its invariant protections:
+unknown kwargs and structured credentials remain excluded, raw binary remains stubbed,
+endpoints remain credential-free, and capture/decompression budgets remain bounded.
+
+This task does not add automatic retention or pruning for Full. Full is deliberately enabled,
+clearly consented, queryable by provenance, and already has conversation-scoped logical purge.
+
+## llama.cpp parity
+
+The existing llama.cpp capture closure owns a literal `wire_payload` outside the generic
+allowlist builder. It must call the same pure list compactor after its existing Safe project-
+instruction handling and sanitization. Both the streaming request and the stream-to-complete
+fallback request use that helper and add `wire_payload.messages.history` when history is
+elided. Full literal wire capture bypasses compaction.
+
+No second retention algorithm or provider-specific tail size is introduced.
+
+## Existing-data migration
+
+ChaChaNotes advances from schema v52 to v53, subject to a final version-head recheck before
+implementation lands. The step changes no table shape; its version records completion of a
+one-time Safe capture data rewrite.
+
+Within the migration chain's existing outer immediate transaction, the step:
+
+1. keyset-pages `message_exchanges` rows whose queryable `capture_detail` is `safe` in bounded
+   batches, without loading every row ID or blob into memory;
+2. safely decodes each blob through the production decoder;
+3. applies the same pure Safe request compactor to generic and llama.cpp stored shapes;
+4. merges stable history-elision paths into the stored `omitted_keys` inventory;
+5. rewrites only blobs whose decoded capture changed; and
+6. advances the schema version atomically with the data changes.
+
+Full rows, small Safe rows, and already-compacted Safe rows remain byte-identical. A recognized
+oversize, corrupt, or unavailable blob is left byte-identical and counted as skipped; the
+schema version may advance because retrying the same unreadable data cannot reclaim it. Only
+the existing `CaptureUnavailableError`/`CaptureCorruptError` family is a per-row skip. Any
+unexpected programming or SQLite error aborts the migration, rolls back all rewrites and the
+version stamp, and is retryable on the next open.
+
+Migration diagnostics report aggregate examined/changed/skipped counts and exception class at
+most. They never log capture bodies, user text, blob bytes, message identifiers, or exception
+values that may contain decoded content.
+
+The synchronous step is intentionally simpler than a background retention worker. Its runtime
+and peak-memory behavior will be measured on the historical 200-turn fixture. A separate
+background design is warranted only if that evidence shows the bounded batched migration is
+not acceptable.
+
+## Runtime failure behavior
+
+Compaction is a pure transformation over JSON-compatible capture values. Non-list message
+fields keep the current defensive pass-through behavior. Unexpected capture-construction
+failure remains best-effort: it can suppress capture for that provider call but must not block
+or mutate the live provider request. Logs remain content-free.
+
+## Inspector and export behavior
+
+No new screen is required. The Exchange tab renders the stored request, so it naturally shows
+the aggregate marker in place of omitted history. Its existing “Omitted by capture policy” line
+shows the stable history path alongside credential, project-instruction, and truncation entries.
+
+Safe Summary and Redacted Diagnostic export can expose only the compacted Safe representation.
+Re-running the Safe builder is idempotent. Full Trace export of a Full capture remains unchanged;
+Safe export cannot join other exchanges or transcripts to reconstruct omitted rows.
+
+## Verification contract
+
+Implementation follows test-driven development. Focused verification must include:
+
+- pure helper selection, marker contents, normalized role counts, ordering, and fixed-point
+  idempotency;
+- first-system and latest-user retention when each falls outside the final eight rows;
+- long assistant/tool loops and malformed/non-list inputs;
+- absence of omitted body fragments, body lengths, hashes, raw unknown roles, and credentials;
+- unchanged Full capture behavior;
+- identical Safe behavior for generic and both llama.cpp capture paths;
+- a production-shaped `ConsoleProviderGateway.stream_chat` probe across 200 growing turns,
+  demonstrating that per-call retained history plateaus and cumulative capture growth is linear,
+  with the measured sizes recorded in TASK-23026 implementation notes;
+- a real historical v52 fixture proving automatic rewrite, unchanged Full/small/already-compact
+  blobs, corrupt-blob skip, re-entry, rollback on unexpected failure, bounded batching, and
+  `PRAGMA integrity_check`;
+- privacy assertions across durable DB blobs, loaded in-memory captures, Inspector/export
+  projections, and captured logs; and
+- the complete ChaChaNotes migration test suite because the schema head changes.
+
+A bespoke SIGKILL harness is not required. Transaction rollback, reopen/re-entry, and integrity
+tests directly prove the failure property without introducing process-control machinery.
+
+## Documentation
+
+The Console user guide will state:
+
+- Safe keeps the initial system context, latest user request, and newest eight message rows, with
+  a content-free aggregate marker for older context;
+- Safe history omitted before capture cannot be recovered by Inspector export;
+- Full is the explicit choice for exact semantic diagnostic history and retains ADR-092's
+  privacy warning and scoped purge boundaries; and
+- migration automatically compacts readable legacy Safe exchange rows but cannot rewrite
+  corrupt/unavailable records or erase prior backups and exports.
+
+## Alternatives considered
+
+### One fingerprint row per omitted message
+
+Rejected. It still grows one metadata row per historical message, remains quadratic across all
+turn captures, and content digests create a guess-verification oracle for omitted private text.
+
+### Store deltas or references between exchanges
+
+Rejected for Safe. It adds reference integrity, deletion, export, corruption, and reconstruction
+semantics to preserve exact history that the explicit Full mode already provides.
+
+### Keep only the newest fixed tail
+
+Rejected. Long tool loops can push the current user request outside a small tail, and the initial
+system framing remains valuable diagnostic context.
+
+### Timed deletion or background pruning
+
+Deferred. The immediate defect is repeated full-history storage. A bounded write-time contract
+plus one transactional rewrite fixes both future and existing Safe growth without a scheduler or
+new user-facing retention policy.

--- a/Tests/Chat/test_console_exchange_capture.py
+++ b/Tests/Chat/test_console_exchange_capture.py
@@ -2,6 +2,7 @@
 import json
 import zlib
 
+import pytest
 from hypothesis import given, strategies as st
 
 from tldw_chatbook.Chat.console_exchange_capture import (
@@ -532,3 +533,304 @@ def test_stub_gate_still_fires_at_canonical_length_over_threshold():
 
     assert stubbed["content"] != canonical
     assert stubbed["content"].startswith("[")
+
+
+# ---------------------------------------------------------------------------
+# task-23026: a Safe capture must not persist the whole conversation per
+# turn. Every send's payload carries the entire history so far; storing it
+# verbatim per turn re-stored the conversation O(n²) (21.33 MB measured for
+# one 200-turn conversation through the real gateway path), default-on,
+# with no retention path. Under Safe only the newest
+# CAPTURE_SAFE_HISTORY_TAIL_ROWS rows stay verbatim; older rows become
+# content-free fingerprint rows in place.
+# ---------------------------------------------------------------------------
+import hashlib as _hashlib
+
+from tldw_chatbook.Chat.console_exchange_capture import (
+    CAPTURE_ELIDED_ROW_KEY,
+    CAPTURE_SAFE_HISTORY_TAIL_ROWS,
+    elide_safe_history_rows,
+    trim_safe_capture_blob,
+)
+
+_TAIL = CAPTURE_SAFE_HISTORY_TAIL_ROWS
+
+
+def _incompressible_filler(seed: str, chars: int) -> str:
+    """Semi-incompressible prose-like filler (hex words). A repeated-word
+    filler compresses ~100x inside the blob's zlib, which lets a
+    disabled-elision mutant slip under byte-size assertions — proven by
+    mutation M1 during task-23026."""
+    words = []
+    counter = 0
+    while sum(len(w) + 1 for w in words) < chars:
+        words.append(
+            _hashlib.sha256(f"{seed}:{counter}".encode()).hexdigest()[:10]
+        )
+        counter += 1
+    return " ".join(words)[:chars]
+
+
+def _history_rows(count: int) -> list[dict]:
+    return [
+        {
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"HISTORY-BODY-{i:03d} " + _incompressible_filler(f"r{i}", 180),
+        }
+        for i in range(count)
+    ]
+
+
+def _canonical(row) -> str:
+    return json.dumps(
+        row, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+    )
+
+
+def test_safe_capture_keeps_tail_verbatim_and_fingerprints_prefix():
+    rows = _history_rows(_TAIL + 12)
+    request, omitted = build_request_capture(
+        {**_kwargs(), "messages_payload": rows},
+        capture_detail=CaptureDetail.SAFE,
+    )
+
+    payload = request["messages_payload"]
+    # Shape and count survive: the Inspector's "Messages (N)" stays truthful.
+    assert len(payload) == _TAIL + 12
+    # The newest rows — the turn's delta plus immediate context — are verbatim.
+    assert payload[-_TAIL:] == rows[-_TAIL:]
+    # Every older row is a content-free fingerprint IN PLACE.
+    rendered = json.dumps(payload[: len(rows) - _TAIL])
+    assert "HISTORY-BODY-" not in rendered
+    for index, marker in enumerate(payload[: len(rows) - _TAIL]):
+        assert marker[CAPTURE_ELIDED_ROW_KEY] is True
+        assert marker["role"] == rows[index]["role"]
+        assert str(len(rows[index]["content"])) in marker["content"]
+        # The fingerprint is verifiable: sha256 of the row's canonical
+        # (sanitized) JSON — the exact form the earlier capture whose tail
+        # this row was new in retained verbatim.
+        digest = _hashlib.sha256(_canonical(rows[index]).encode()).hexdigest()[:16]
+        assert f"sha256:{digest}" in marker["content"]
+    # The withholding is named through the Inspector's existing
+    # "Omitted by capture policy" mechanism.
+    assert (
+        f"messages_payload[0..{len(rows) - _TAIL - 1}].content "
+        "(conversation history elided)" in omitted
+    )
+
+
+def test_full_capture_retains_the_whole_history_verbatim():
+    """Full is the explicit, consent-gated, purgeable verbatim mode
+    (ADR-092) — elision must never touch it."""
+    rows = _history_rows(_TAIL + 12)
+    request, omitted = build_request_capture(
+        {**_kwargs(), "messages_payload": rows},
+        capture_detail=CaptureDetail.FULL,
+    )
+    assert request["messages_payload"] == rows
+    assert not any("history elided" in entry for entry in omitted)
+
+
+def test_short_safe_payload_is_untouched():
+    rows = _history_rows(_TAIL)
+    request, omitted = build_request_capture(
+        {**_kwargs(), "messages_payload": rows},
+        capture_detail=CaptureDetail.SAFE,
+    )
+    assert request["messages_payload"] == rows
+    assert not any("history elided" in entry for entry in omitted)
+
+
+def test_elision_is_idempotent_for_export_reprojection():
+    """The export path re-runs build_request_capture over a STORED request
+    (project_exchange_export). A fingerprint row must pass through
+    untouched — re-marking it would replace the fingerprint with a marker
+    measuring the MARKER's own length."""
+    rows = _history_rows(_TAIL + 5)
+    first, _ = build_request_capture(
+        {"messages_payload": rows}, capture_detail=CaptureDetail.SAFE
+    )
+    second, omitted = build_request_capture(
+        {"messages_payload": first["messages_payload"]},
+        capture_detail=CaptureDetail.SAFE,
+    )
+    assert second["messages_payload"] == first["messages_payload"]
+    # The original row's char count survives the second pass — the marker
+    # was not re-measured.
+    assert str(len(rows[0]["content"])) in second["messages_payload"][0]["content"]
+
+
+def test_elided_project_instruction_row_keeps_tag_and_never_its_body():
+    """A project-instruction row that has aged into the elided prefix must
+    stay body-free (the C1 promise) while its origin tag survives, so the
+    Inspector can still show such a row was sent."""
+    rows = _history_rows(_TAIL + 3)
+    rows[0] = _project_instruction_row()
+    request, _ = build_request_capture(
+        {"messages_payload": rows}, capture_detail=CaptureDetail.SAFE
+    )
+    marker = request["messages_payload"][0]
+    assert _PROJECT_INSTRUCTION_SENTINEL not in json.dumps(request)
+    assert marker[EPHEMERAL_ORIGIN_KEY] == "project_instructions"
+    assert marker[CAPTURE_ELIDED_ROW_KEY] is True
+
+
+def test_redaction_never_remeasures_a_fingerprint_row():
+    """_redact_project_instruction_rows must skip rows already elided —
+    otherwise the export re-run would replace a tagged fingerprint with a
+    redaction marker measuring the fingerprint's own length."""
+    rows = _history_rows(_TAIL + 3)
+    rows[0] = _project_instruction_row()
+    first, _ = build_request_capture(
+        {"messages_payload": rows}, capture_detail=CaptureDetail.SAFE
+    )
+    second, _ = build_request_capture(
+        {"messages_payload": first["messages_payload"]},
+        capture_detail=CaptureDetail.SAFE,
+    )
+    assert second["messages_payload"][0] == first["messages_payload"][0]
+
+
+def test_non_list_rows_pass_through_elision():
+    assert elide_safe_history_rows(None, CaptureDetail.SAFE) == (None, ())
+    assert elide_safe_history_rows("x", CaptureDetail.SAFE) == ("x", ())
+
+
+def test_per_turn_blob_size_growth_is_fingerprint_sized_not_content_sized():
+    """The blob for a deep-history turn may grow only by the small
+    per-row fingerprint index, never by re-copied content: 100 extra
+    history rows of ~190 chars each (~19 KB of content) must add far less
+    than their content size to the stored blob."""
+
+    def blob_for(row_count: int) -> int:
+        request, omitted = build_request_capture(
+            {**_kwargs(), "messages_payload": _history_rows(row_count)},
+            capture_detail=CaptureDetail.SAFE,
+        )
+        cap = ExchangeCapture(
+            run_tag="r1", seq=0, created_at="t", provider="p", model="m",
+            endpoint=None, request=request, response={"content": "pong"},
+            status="complete", usage_json=None, omitted_keys=omitted,
+        )
+        return len(capture_to_blob(cap))
+
+    shallow = blob_for(20)
+    deep = blob_for(120)
+    per_row_cost = (deep - shallow) / 100
+    assert per_row_cost < 60, (
+        f"deep-history turns re-store content: {per_row_cost:.0f} bytes per "
+        "elided row (fingerprints should compress to well under 60)"
+    )
+
+
+def test_trim_safe_capture_blob_trims_stored_safe_blobs():
+    """The v52→v53 migration's pure helper: a pre-elision stored Safe blob
+    is trimmed to exactly the shape build_request_capture now produces,
+    with everything not deliberately trimmed preserved value-identical."""
+    rows = _history_rows(_TAIL + 12)
+    # A pre-task-23026 capture: history verbatim (built at FULL to bypass
+    # elision, then stamped safe — the historical builder retained
+    # ordinary rows verbatim under Safe).
+    request, omitted = build_request_capture(
+        {**_kwargs(), "messages_payload": rows},
+        capture_detail=CaptureDetail.FULL,
+    )
+    legacy = ExchangeCapture(
+        run_tag="r1", seq=3, created_at="t", provider="p", model="m",
+        endpoint="https://example.test/v1", request=request,
+        response={"content": "pong", "tool_calls": [], "synthetic_fallback": False},
+        status="stopped", usage_json='{"input": 5}', omitted_keys=omitted,
+        capture_detail=CaptureDetail.SAFE,
+    )
+    trimmed_blob = trim_safe_capture_blob(capture_to_blob(legacy))
+
+    assert trimmed_blob is not None
+    restored = capture_from_blob(trimmed_blob)
+    payload = restored.request["messages_payload"]
+    assert payload[-_TAIL:] == rows[-_TAIL:]
+    assert "HISTORY-BODY-000" not in json.dumps(payload)
+    assert payload[0][CAPTURE_ELIDED_ROW_KEY] is True
+    # Everything not deliberately trimmed is value-identical.
+    assert restored.response == legacy.response
+    assert restored.status == legacy.status
+    assert restored.usage_json == legacy.usage_json
+    assert restored.run_tag == legacy.run_tag
+    assert restored.seq == legacy.seq
+    assert restored.provider == legacy.provider
+    assert restored.endpoint == legacy.endpoint
+    assert restored.capture_detail is CaptureDetail.SAFE
+    untouched = {
+        k: v for k, v in restored.request.items() if k != "messages_payload"
+    }
+    # JSON-normalized comparison: the blob round-trip renders tuples (e.g.
+    # truncation_inventory) as lists; the VALUES must be identical.
+    assert json.loads(json.dumps(untouched, default=str)) == json.loads(
+        json.dumps(
+            {k: v for k, v in legacy.request.items() if k != "messages_payload"},
+            default=str,
+        )
+    )
+    # The elided range is folded into the stored omission inventory.
+    assert any("history elided" in entry for entry in restored.omitted_keys)
+    assert set(legacy.omitted_keys).issubset(set(restored.omitted_keys))
+
+
+def test_trim_safe_capture_blob_returns_none_when_nothing_to_trim():
+    request, omitted = build_request_capture(
+        _kwargs(), capture_detail=CaptureDetail.SAFE
+    )
+    cap = ExchangeCapture(
+        run_tag="r1", seq=0, created_at="t", provider="p", model="m",
+        endpoint=None, request=request, response={}, status="complete",
+        usage_json=None, omitted_keys=omitted,
+    )
+    assert trim_safe_capture_blob(capture_to_blob(cap)) is None
+
+
+def test_trim_safe_capture_blob_never_touches_full_blobs():
+    rows = _history_rows(_TAIL + 12)
+    request, omitted = build_request_capture(
+        {**_kwargs(), "messages_payload": rows},
+        capture_detail=CaptureDetail.FULL,
+    )
+    cap = ExchangeCapture(
+        run_tag="r1", seq=0, created_at="t", provider="p", model="m",
+        endpoint=None, request=request, response={}, status="complete",
+        usage_json=None, omitted_keys=omitted,
+        capture_detail=CaptureDetail.FULL,
+    )
+    assert trim_safe_capture_blob(capture_to_blob(cap)) is None
+
+
+def test_trim_safe_capture_blob_trims_llamacpp_wire_messages():
+    wire_rows = _history_rows(_TAIL + 6)
+    cap = ExchangeCapture(
+        run_tag="r1", seq=0, created_at="t", provider="llama_cpp", model="m",
+        endpoint=None,
+        request={
+            "model": "m",
+            "wire_payload": {"model": "m", "messages": wire_rows, "stream": True},
+            "truncation_inventory": (),
+        },
+        response={}, status="complete", usage_json=None, omitted_keys=(),
+    )
+    trimmed_blob = trim_safe_capture_blob(capture_to_blob(cap))
+
+    assert trimmed_blob is not None
+    restored = capture_from_blob(trimmed_blob)
+    wire = restored.request["wire_payload"]
+    assert wire["messages"][-_TAIL:] == wire_rows[-_TAIL:]
+    assert wire["messages"][0][CAPTURE_ELIDED_ROW_KEY] is True
+    assert "HISTORY-BODY-000" not in json.dumps(wire)
+    assert wire["stream"] is True
+    assert any(
+        entry.startswith("wire_payload.messages[0..")
+        for entry in restored.omitted_keys
+    )
+
+
+def test_trim_safe_capture_blob_raises_capture_unavailable_on_corrupt_blob():
+    from tldw_chatbook.Chat.console_exchange_capture import CaptureUnavailableError
+
+    with pytest.raises(CaptureUnavailableError):
+        trim_safe_capture_blob(b"not-a-zlib-blob")

--- a/Tests/Chat/test_console_exchange_capture.py
+++ b/Tests/Chat/test_console_exchange_capture.py
@@ -536,20 +536,25 @@ def test_stub_gate_still_fires_at_canonical_length_over_threshold():
 
 
 # ---------------------------------------------------------------------------
-# task-23026: a Safe capture must not persist the whole conversation per
-# turn. Every send's payload carries the entire history so far; storing it
-# verbatim per turn re-stored the conversation O(n²) (21.33 MB measured for
-# one 200-turn conversation through the real gateway path), default-on,
-# with no retention path. Under Safe only the newest
-# CAPTURE_SAFE_HISTORY_TAIL_ROWS rows stay verbatim; older rows become
-# content-free fingerprint rows in place.
+# task-23026 / ADR-096: a Safe capture must not persist the whole
+# conversation per turn. Every send's payload carries the entire history so
+# far; storing it verbatim per turn re-stored the conversation O(n²)
+# (21.33 MB measured for one 200-turn conversation through the real gateway
+# path), default-on, with no retention path. Under Safe the retained set is
+# first-system ∪ last-user ∪ final-eight rows; everything else becomes ONE
+# content-free aggregate marker (spec:
+# Docs/superpowers/specs/2026-08-27-console-safe-capture-retention-design.md).
 # ---------------------------------------------------------------------------
 import hashlib as _hashlib
 
 from tldw_chatbook.Chat.console_exchange_capture import (
-    CAPTURE_ELIDED_ROW_KEY,
+    CAPTURE_HISTORY_ELISION_KIND,
+    CAPTURE_HISTORY_ELISION_VERSION,
+    CAPTURE_HISTORY_MARKER_KEYS,
+    CAPTURE_HISTORY_MARKER_ROLES,
     CAPTURE_SAFE_HISTORY_TAIL_ROWS,
-    elide_safe_history_rows,
+    compact_safe_history_rows,
+    history_elision_marker,
     trim_safe_capture_blob,
 )
 
@@ -559,7 +564,7 @@ _TAIL = CAPTURE_SAFE_HISTORY_TAIL_ROWS
 def _incompressible_filler(seed: str, chars: int) -> str:
     """Semi-incompressible prose-like filler (hex words). A repeated-word
     filler compresses ~100x inside the blob's zlib, which lets a
-    disabled-elision mutant slip under byte-size assertions — proven by
+    disabled-compaction mutant slip under byte-size assertions — proven by
     mutation M1 during task-23026."""
     words = []
     counter = 0
@@ -581,72 +586,111 @@ def _history_rows(count: int) -> list[dict]:
     ]
 
 
-def _canonical(row) -> str:
-    return json.dumps(
-        row, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
-    )
+def _tool_loop_rows() -> list[dict]:
+    """A payload whose first system row AND last user row both sit outside
+    the final eight physical rows (a long assistant/tool loop) — the two
+    retention rules the tail alone cannot satisfy."""
+    rows = [{"role": "system", "content": "SYS-FRAMING " + _incompressible_filler("s", 80)}]
+    rows += _history_rows(10)
+    rows.append({"role": "user", "content": "LAST-USER-REQUEST " + _incompressible_filler("u", 80)})
+    for i in range(10):
+        rows.append({"role": "assistant", "content": f"TOOL-CALL-{i:02d} " + _incompressible_filler(f"a{i}", 80)})
+        rows.append({"role": "tool", "content": f"TOOL-RESULT-{i:02d} " + _incompressible_filler(f"t{i}", 80)})
+    return rows
 
 
-def test_safe_capture_keeps_tail_verbatim_and_fingerprints_prefix():
-    rows = _history_rows(_TAIL + 12)
+def test_safe_capture_retains_contract_set_and_inserts_one_marker():
+    rows = _tool_loop_rows()
     request, omitted = build_request_capture(
         {**_kwargs(), "messages_payload": rows},
         capture_detail=CaptureDetail.SAFE,
     )
 
     payload = request["messages_payload"]
-    # Shape and count survive: the Inspector's "Messages (N)" stays truthful.
-    assert len(payload) == _TAIL + 12
-    # The newest rows — the turn's delta plus immediate context — are verbatim.
-    assert payload[-_TAIL:] == rows[-_TAIL:]
-    # Every older row is a content-free fingerprint IN PLACE.
-    rendered = json.dumps(payload[: len(rows) - _TAIL])
-    assert "HISTORY-BODY-" not in rendered
-    for index, marker in enumerate(payload[: len(rows) - _TAIL]):
-        assert marker[CAPTURE_ELIDED_ROW_KEY] is True
-        assert marker["role"] == rows[index]["role"]
-        assert str(len(rows[index]["content"])) in marker["content"]
-        # The fingerprint is verifiable: sha256 of the row's canonical
-        # (sanitized) JSON — the exact form the earlier capture whose tail
-        # this row was new in retained verbatim.
-        digest = _hashlib.sha256(_canonical(rows[index]).encode()).hexdigest()[:16]
-        assert f"sha256:{digest}" in marker["content"]
-    # The withholding is named through the Inspector's existing
-    # "Omitted by capture policy" mechanism.
-    assert (
-        f"messages_payload[0..{len(rows) - _TAIL - 1}].content "
-        "(conversation history elided)" in omitted
-    )
+    marker = history_elision_marker(payload)
+    assert marker is not None
+    markers = [row for row in payload if history_elision_marker([row])]
+    assert markers == [marker], "exactly one aggregate marker"
+
+    # Retained set: first system row, last user row, final eight rows —
+    # deduplicated, original order, values untouched.
+    expected_retained = [rows[0], rows[11]] + rows[-_TAIL:]
+    assert [row for row in payload if not history_elision_marker([row])] == expected_retained
+    # Marker sits at the position of the first omitted row (right after
+    # the retained system row).
+    assert history_elision_marker([payload[1]]) == marker
+
+    # Marker contents: counts + retained positions only.
+    total = len(rows)
+    retained_positions = sorted({0, 11} | set(range(total - _TAIL, total)))
+    assert marker["original_rows"] == total
+    assert marker["omitted_rows"] == total - len(retained_positions)
+    assert marker["retained_positions"] == retained_positions
+    omitted_rows = [
+        row for pos, row in enumerate(rows) if pos not in retained_positions
+    ]
+    for role in ("system", "user", "assistant", "tool"):
+        assert marker["omitted_roles"][role] == sum(
+            1 for row in omitted_rows if row.get("role") == role
+        )
+
+    # No omitted body survives, and the withholding is named through the
+    # STABLE inventory path (never an ever-changing range string).
+    rendered = json.dumps(payload)
+    for row in omitted_rows:
+        assert row["content"] not in rendered
+    assert "messages_payload.history" in omitted
+
+
+def test_safe_capture_keeps_first_system_and_last_user_outside_tail():
+    rows = _tool_loop_rows()
+    compacted, elided = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    assert elided == ("messages_payload.history",)
+    kept = [row for row in compacted if not history_elision_marker([row])]
+    assert kept[0] == rows[0] and kept[0]["role"] == "system"
+    assert kept[1] == rows[11] and kept[1]["role"] == "user"
+    assert kept[2:] == rows[-_TAIL:]
 
 
 def test_full_capture_retains_the_whole_history_verbatim():
     """Full is the explicit, consent-gated, purgeable verbatim mode
-    (ADR-092) — elision must never touch it."""
+    (ADR-092) — compaction must never touch it."""
     rows = _history_rows(_TAIL + 12)
     request, omitted = build_request_capture(
         {**_kwargs(), "messages_payload": rows},
         capture_detail=CaptureDetail.FULL,
     )
     assert request["messages_payload"] == rows
-    assert not any("history elided" in entry for entry in omitted)
+    assert not any("history" in entry for entry in omitted)
 
 
-def test_short_safe_payload_is_untouched():
+def test_fully_retained_safe_payload_is_untouched_with_no_marker():
+    # 8 rows: the tail covers everything.
     rows = _history_rows(_TAIL)
     request, omitted = build_request_capture(
         {**_kwargs(), "messages_payload": rows},
         capture_detail=CaptureDetail.SAFE,
     )
     assert request["messages_payload"] == rows
-    assert not any("history elided" in entry for entry in omitted)
+    assert not any("history" in entry for entry in omitted)
+
+    # 10 rows where the two head rows are the first system and last user:
+    # union covers everything, so the list is unchanged and no marker is
+    # added even though it is longer than the tail.
+    rows = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "ask"},
+    ] + [{"role": "assistant", "content": f"a{i}"} for i in range(_TAIL)]
+    compacted, elided = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    assert compacted == rows
+    assert elided == ()
 
 
-def test_elision_is_idempotent_for_export_reprojection():
+def test_reprojection_of_a_compacted_payload_is_a_fixed_point():
     """The export path re-runs build_request_capture over a STORED request
-    (project_exchange_export). A fingerprint row must pass through
-    untouched — re-marking it would replace the fingerprint with a marker
-    measuring the MARKER's own length."""
-    rows = _history_rows(_TAIL + 5)
+    (project_exchange_export): the compacted list must map to itself —
+    no nested markers, no changed counts, no new inventory entries."""
+    rows = _tool_loop_rows()
     first, _ = build_request_capture(
         {"messages_payload": rows}, capture_detail=CaptureDetail.SAFE
     )
@@ -655,52 +699,159 @@ def test_elision_is_idempotent_for_export_reprojection():
         capture_detail=CaptureDetail.SAFE,
     )
     assert second["messages_payload"] == first["messages_payload"]
-    # The original row's char count survives the second pass — the marker
-    # was not re-measured.
-    assert str(len(rows[0]["content"])) in second["messages_payload"][0]["content"]
+    assert not any("history" in entry for entry in omitted)
 
 
-def test_elided_project_instruction_row_keeps_tag_and_never_its_body():
-    """A project-instruction row that has aged into the elided prefix must
-    stay body-free (the C1 promise) while its origin tag survives, so the
-    Inspector can still show such a row was sent."""
+def test_input_marker_never_disables_compaction_of_surrounding_rows():
+    stale_marker = {
+        "kind": CAPTURE_HISTORY_ELISION_KIND,
+        "version": CAPTURE_HISTORY_ELISION_VERSION,
+        "original_rows": 40,
+        "omitted_rows": 30,
+        "omitted_roles": {role: 6 for role in CAPTURE_HISTORY_MARKER_ROLES},
+        "retained_positions": [0, 1],
+    }
+    rows = [stale_marker] + _history_rows(_TAIL + 12)
+    compacted, elided = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    assert elided == ("messages_payload.history",)
+    markers = [row for row in compacted if history_elision_marker([row])]
+    assert len(markers) == 1
+    fresh = markers[0]
+    # The fresh marker describes THIS pass over the real rows, not the
+    # stale metadata.
+    assert fresh["original_rows"] == _TAIL + 12
+    assert fresh is not stale_marker and fresh != stale_marker
+    kept = [row for row in compacted if not history_elision_marker([row])]
+    assert kept[-_TAIL:] == rows[-_TAIL:]
+
+
+def test_malformed_marker_lookalike_is_an_ordinary_row():
+    lookalike = {
+        "kind": CAPTURE_HISTORY_ELISION_KIND,
+        "version": CAPTURE_HISTORY_ELISION_VERSION,
+        "original_rows": 40,
+        "omitted_rows": 30,
+        "omitted_roles": {role: 6 for role in CAPTURE_HISTORY_MARKER_ROLES},
+        "retained_positions": [0, 1],
+        "sha256": "ab12cd34",  # extra key: NOT a valid marker
+    }
+    assert history_elision_marker([lookalike]) is None
+    # In the omitted prefix it is compacted away like any ordinary row and
+    # counts toward `other` (no `role` key).
+    rows = [lookalike] + _history_rows(_TAIL + 12)
+    compacted, _ = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    marker = history_elision_marker(compacted)
+    assert marker is not None
+    assert marker["omitted_roles"]["other"] >= 1
+    assert "ab12cd34" not in json.dumps(compacted)
+    # In the tail it is retained verbatim like any ordinary row.
+    rows = _history_rows(_TAIL + 12) + [lookalike]
+    compacted, _ = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    assert compacted[-1] == lookalike
+
+
+def test_marker_shape_guard_a_digest_cannot_be_reintroduced_silently():
+    """ADR-096 explicitly forbids the marker carrying content, snippets,
+    per-row lengths, hashes/digests, IDs, or timestamps — a sha256 prefix
+    would let anyone with DB access confirm guesses about omitted private
+    text. This guard pins the marker's EXACT shape: any new key, any
+    string value beyond the kind discriminator, or any non-count payload
+    turns it red."""
+    rows = _tool_loop_rows()
+    compacted, _ = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    marker = history_elision_marker(compacted)
+    assert marker is not None
+
+    # Exact frozen key set — a silently added digest key fails here.
+    assert set(marker.keys()) == CAPTURE_HISTORY_MARKER_KEYS
+    # The ONLY string anywhere in the marker is the kind discriminator —
+    # a digest/snippet VALUE fails here.
+    def _strings(value):
+        if isinstance(value, str):
+            yield value
+        elif isinstance(value, dict):
+            for key, nested in value.items():
+                yield key
+                yield from _strings(nested)
+        elif isinstance(value, (list, tuple)):
+            for nested in value:
+                yield from _strings(nested)
+    string_values = set(_strings(marker)) - CAPTURE_HISTORY_MARKER_KEYS - set(
+        CAPTURE_HISTORY_MARKER_ROLES
+    )
+    assert string_values == {CAPTURE_HISTORY_ELISION_KIND}
+    # Counts are plain ints; positions are plain ints.
+    assert type(marker["original_rows"]) is int
+    assert type(marker["omitted_rows"]) is int
+    assert all(type(v) is int for v in marker["omitted_roles"].values())
+    assert all(type(v) is int for v in marker["retained_positions"])
+    # And nothing digest-shaped appears anywhere in the compacted output.
+    assert "sha256" not in json.dumps(compacted)
+
+
+def test_unknown_roles_count_only_toward_other_and_never_reach_the_marker():
+    rows = (
+        [
+            {"role": None, "content": "NULL-ROLE-BODY"},
+            {"role": 123, "content": "INT-ROLE-BODY"},
+            {"role": "wizard", "content": "CUSTOM-ROLE-BODY"},
+        ]
+        + _history_rows(_TAIL + 4)
+    )
+    compacted, _ = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    marker = history_elision_marker(compacted)
+    assert marker is not None
+    assert marker["omitted_roles"]["other"] == 3
+    rendered = json.dumps(compacted)
+    assert "wizard" not in rendered
+    assert "NULL-ROLE-BODY" not in rendered
+
+
+def test_non_mapping_rows_are_eligible_only_through_the_tail():
+    rows = ["BARE-PREFIX-STRING"] + _history_rows(_TAIL + 4) + ["BARE-TAIL-STRING"]
+    compacted, _ = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    rendered = json.dumps(compacted)
+    assert "BARE-PREFIX-STRING" not in rendered
+    assert compacted[-1] == "BARE-TAIL-STRING"
+    marker = history_elision_marker(compacted)
+    assert marker is not None and marker["omitted_roles"]["other"] >= 1
+
+
+def test_project_instruction_body_never_survives_safe_compaction():
+    """C1 continuity: an instruction row in the omitted region disappears
+    entirely (redaction metadata in omitted_keys remains); one in the tail
+    keeps only its redaction marker, never the body."""
     rows = _history_rows(_TAIL + 3)
     rows[0] = _project_instruction_row()
-    request, _ = build_request_capture(
+    request, omitted = build_request_capture(
         {"messages_payload": rows}, capture_detail=CaptureDetail.SAFE
     )
-    marker = request["messages_payload"][0]
     assert _PROJECT_INSTRUCTION_SENTINEL not in json.dumps(request)
-    assert marker[EPHEMERAL_ORIGIN_KEY] == "project_instructions"
-    assert marker[CAPTURE_ELIDED_ROW_KEY] is True
+    # The redaction step recorded its path before compaction; the design
+    # keeps that metadata visible even though the row is now omitted.
+    assert "messages_payload[0].content" in omitted
+    assert "messages_payload.history" in omitted
 
-
-def test_redaction_never_remeasures_a_fingerprint_row():
-    """_redact_project_instruction_rows must skip rows already elided —
-    otherwise the export re-run would replace a tagged fingerprint with a
-    redaction marker measuring the fingerprint's own length."""
-    rows = _history_rows(_TAIL + 3)
-    rows[0] = _project_instruction_row()
-    first, _ = build_request_capture(
-        {"messages_payload": rows}, capture_detail=CaptureDetail.SAFE
-    )
-    second, _ = build_request_capture(
-        {"messages_payload": first["messages_payload"]},
+    tail_instruction = _history_rows(_TAIL + 3)
+    tail_instruction[-1] = _project_instruction_row()
+    request, _ = build_request_capture(
+        {"messages_payload": tail_instruction},
         capture_detail=CaptureDetail.SAFE,
     )
-    assert second["messages_payload"][0] == first["messages_payload"][0]
+    assert _PROJECT_INSTRUCTION_SENTINEL not in json.dumps(request)
+    assert "omitted by capture policy" in request["messages_payload"][-1]["content"]
 
 
-def test_non_list_rows_pass_through_elision():
-    assert elide_safe_history_rows(None, CaptureDetail.SAFE) == (None, ())
-    assert elide_safe_history_rows("x", CaptureDetail.SAFE) == ("x", ())
+def test_non_list_rows_pass_through_compaction():
+    assert compact_safe_history_rows(None, CaptureDetail.SAFE) == (None, ())
+    assert compact_safe_history_rows("x", CaptureDetail.SAFE) == ("x", ())
 
 
-def test_per_turn_blob_size_growth_is_fingerprint_sized_not_content_sized():
-    """The blob for a deep-history turn may grow only by the small
-    per-row fingerprint index, never by re-copied content: 100 extra
-    history rows of ~190 chars each (~19 KB of content) must add far less
-    than their content size to the stored blob."""
+def test_per_turn_blob_size_growth_is_marker_sized_not_content_sized():
+    """The blob for a deep-history turn grows only by the aggregate
+    marker's retained-position list (O(1)), never by re-copied content:
+    100 extra history rows of ~190 chars each (~19 KB of content) must add
+    almost nothing to the stored blob."""
 
     def blob_for(row_count: int) -> int:
         request, omitted = build_request_capture(
@@ -717,19 +868,20 @@ def test_per_turn_blob_size_growth_is_fingerprint_sized_not_content_sized():
     shallow = blob_for(20)
     deep = blob_for(120)
     per_row_cost = (deep - shallow) / 100
-    assert per_row_cost < 60, (
-        f"deep-history turns re-store content: {per_row_cost:.0f} bytes per "
-        "elided row (fingerprints should compress to well under 60)"
+    assert per_row_cost < 5, (
+        f"deep-history turns re-store content: {per_row_cost:.1f} bytes per "
+        "omitted row (the aggregate marker should cost ~0)"
     )
 
 
-def test_trim_safe_capture_blob_trims_stored_safe_blobs():
-    """The v52→v53 migration's pure helper: a pre-elision stored Safe blob
-    is trimmed to exactly the shape build_request_capture now produces,
-    with everything not deliberately trimmed preserved value-identical."""
+def test_trim_safe_capture_blob_compacts_stored_safe_blobs():
+    """The v52→v53 migration's pure helper: a pre-compaction stored Safe
+    blob is compacted to exactly the shape build_request_capture now
+    produces, with everything not deliberately compacted preserved
+    value-identical."""
     rows = _history_rows(_TAIL + 12)
     # A pre-task-23026 capture: history verbatim (built at FULL to bypass
-    # elision, then stamped safe — the historical builder retained
+    # compaction, then stamped safe — the historical builder retained
     # ordinary rows verbatim under Safe).
     request, omitted = build_request_capture(
         {**_kwargs(), "messages_payload": rows},
@@ -747,10 +899,13 @@ def test_trim_safe_capture_blob_trims_stored_safe_blobs():
     assert trimmed_blob is not None
     restored = capture_from_blob(trimmed_blob)
     payload = restored.request["messages_payload"]
-    assert payload[-_TAIL:] == rows[-_TAIL:]
+    marker = history_elision_marker(payload)
+    assert marker is not None
+    assert marker["original_rows"] == _TAIL + 12
+    kept = [row for row in payload if not history_elision_marker([row])]
+    assert kept == rows[-_TAIL:]
     assert "HISTORY-BODY-000" not in json.dumps(payload)
-    assert payload[0][CAPTURE_ELIDED_ROW_KEY] is True
-    # Everything not deliberately trimmed is value-identical.
+    # Everything not deliberately compacted is value-identical.
     assert restored.response == legacy.response
     assert restored.status == legacy.status
     assert restored.usage_json == legacy.usage_json
@@ -770,12 +925,14 @@ def test_trim_safe_capture_blob_trims_stored_safe_blobs():
             default=str,
         )
     )
-    # The elided range is folded into the stored omission inventory.
-    assert any("history elided" in entry for entry in restored.omitted_keys)
+    # The stable elision path is folded into the stored omission inventory.
+    assert "messages_payload.history" in restored.omitted_keys
     assert set(legacy.omitted_keys).issubset(set(restored.omitted_keys))
+    # Fixed point: compacting the compacted blob changes nothing.
+    assert trim_safe_capture_blob(trimmed_blob) is None
 
 
-def test_trim_safe_capture_blob_returns_none_when_nothing_to_trim():
+def test_trim_safe_capture_blob_returns_none_when_nothing_to_compact():
     request, omitted = build_request_capture(
         _kwargs(), capture_detail=CaptureDetail.SAFE
     )
@@ -802,7 +959,7 @@ def test_trim_safe_capture_blob_never_touches_full_blobs():
     assert trim_safe_capture_blob(capture_to_blob(cap)) is None
 
 
-def test_trim_safe_capture_blob_trims_llamacpp_wire_messages():
+def test_trim_safe_capture_blob_compacts_llamacpp_wire_messages():
     wire_rows = _history_rows(_TAIL + 6)
     cap = ExchangeCapture(
         run_tag="r1", seq=0, created_at="t", provider="llama_cpp", model="m",
@@ -819,14 +976,13 @@ def test_trim_safe_capture_blob_trims_llamacpp_wire_messages():
     assert trimmed_blob is not None
     restored = capture_from_blob(trimmed_blob)
     wire = restored.request["wire_payload"]
-    assert wire["messages"][-_TAIL:] == wire_rows[-_TAIL:]
-    assert wire["messages"][0][CAPTURE_ELIDED_ROW_KEY] is True
+    marker = history_elision_marker(wire["messages"])
+    assert marker is not None
+    kept = [row for row in wire["messages"] if not history_elision_marker([row])]
+    assert kept == wire_rows[-_TAIL:]
     assert "HISTORY-BODY-000" not in json.dumps(wire)
     assert wire["stream"] is True
-    assert any(
-        entry.startswith("wire_payload.messages[0..")
-        for entry in restored.omitted_keys
-    )
+    assert "wire_payload.messages.history" in restored.omitted_keys
 
 
 def test_trim_safe_capture_blob_raises_capture_unavailable_on_corrupt_blob():

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -52,6 +52,8 @@ from tldw_chatbook.Chat.provider_continuation import (
 )
 from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
 from tldw_chatbook.Chat.console_exchange_capture import (
+    CAPTURE_ELIDED_ROW_KEY,
+    CAPTURE_SAFE_HISTORY_TAIL_ROWS,
     CaptureBudget,
     CaptureDetail,
     build_request_capture,
@@ -8266,3 +8268,177 @@ class TestLlamaCppExchangeCapture:
         assert out == streamed
         assert call_count["n"] == 0
         assert aggregate.exchange_captures() == []
+
+
+class TestSafeHistoryElisionThroughGateway:
+    """task-23026: the gateway's OWN captures bound the per-turn history
+    copy under Safe. Measured before the bound, through this exact path:
+    turn-200 blob 217.1 KB, 21.33 MB total for one 200-turn conversation,
+    default-on, with no retention path."""
+
+    @staticmethod
+    def _generic_resolution() -> ConsoleProviderResolution:
+        return ConsoleProviderResolution(
+            provider="openai",
+            base_url="https://proxy.example.test/v1",
+            model="gpt-4.1",
+            ready=True,
+            execution_key="openai",
+            api_key="k",
+            streaming=False,
+        )
+
+    @staticmethod
+    def _history(rows: int) -> list[dict]:
+        return [{"role": "system", "content": "sys"}] + [
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"GATEWAY-HISTORY-{i:03d} " + ("lorem " * 20),
+            }
+            for i in range(rows)
+        ]
+
+    @staticmethod
+    async def _drain(gen):
+        return [chunk async for chunk in gen]
+
+    @pytest.mark.asyncio
+    async def test_generic_safe_capture_elides_history_and_names_the_range(self):
+        def fake_chat_api_call(**kwargs):
+            return {"choices": [{"message": {"content": "pong"}}]}
+
+        signals = ConsoleProviderStreamSignals(exchange_capture_enabled=True)
+        history_rows = CAPTURE_SAFE_HISTORY_TAIL_ROWS + 10
+        await self._drain(
+            ConsoleProviderGateway(chat_api_call_fn=fake_chat_api_call).stream_chat(
+                self._generic_resolution(), self._history(history_rows), signals=signals
+            )
+        )
+
+        (capture,) = signals.exchange_captures()
+        payload = capture.request["messages_payload"]
+        # The leading system row is extracted into system_message by the
+        # kwargs builder, so the payload is exactly the history rows.
+        assert len(payload) == history_rows
+        assert payload[-1]["content"].startswith(f"GATEWAY-HISTORY-{history_rows - 1:03d}")
+        assert payload[0][CAPTURE_ELIDED_ROW_KEY] is True
+        assert "GATEWAY-HISTORY-000" not in json.dumps(payload)
+        assert any(
+            "conversation history elided" in entry for entry in capture.omitted_keys
+        )
+        # The provider call itself is untouched: elision is capture-only.
+        assert capture.response["content"] == "pong"
+
+    @pytest.mark.asyncio
+    async def test_generic_full_capture_keeps_history_verbatim(self):
+        def fake_chat_api_call(**kwargs):
+            return {"choices": [{"message": {"content": "pong"}}]}
+
+        signals = ConsoleProviderStreamSignals(
+            exchange_capture_enabled=True, capture_detail=CaptureDetail.FULL
+        )
+        history_rows = CAPTURE_SAFE_HISTORY_TAIL_ROWS + 10
+        await self._drain(
+            ConsoleProviderGateway(chat_api_call_fn=fake_chat_api_call).stream_chat(
+                self._generic_resolution(), self._history(history_rows), signals=signals
+            )
+        )
+
+        (capture,) = signals.exchange_captures()
+        assert "GATEWAY-HISTORY-000" in json.dumps(
+            capture.request["messages_payload"]
+        )
+        assert not any(
+            "conversation history elided" in entry for entry in capture.omitted_keys
+        )
+
+    @pytest.mark.asyncio
+    async def test_generic_elision_leaves_transcript_output_byte_identical(self):
+        def fake_chat_api_call(**kwargs):
+            return {"choices": [{"message": {"content": "exact bytes"}}]}
+
+        resolution = self._generic_resolution()
+        messages = self._history(CAPTURE_SAFE_HISTORY_TAIL_ROWS + 10)
+        with_capture = await self._drain(
+            ConsoleProviderGateway(chat_api_call_fn=fake_chat_api_call).stream_chat(
+                resolution,
+                [dict(m) for m in messages],
+                signals=ConsoleProviderStreamSignals(exchange_capture_enabled=True),
+            )
+        )
+        without = await self._drain(
+            ConsoleProviderGateway(chat_api_call_fn=fake_chat_api_call).stream_chat(
+                resolution, [dict(m) for m in messages], signals=None
+            )
+        )
+        assert with_capture == without
+
+    @staticmethod
+    def _llamacpp_resolution() -> ConsoleProviderResolution:
+        return ConsoleProviderResolution(
+            provider="llama_cpp",
+            base_url="http://127.0.0.1:9099",
+            model="m",
+            ready=True,
+            execution_key="llama_cpp",
+            api_key="local-secret",
+            streaming=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_llamacpp_safe_wire_capture_elides_history(self, monkeypatch):
+        async def fake_stream(self, **kwargs):
+            yield "ok"
+
+        monkeypatch.setattr(
+            ConsoleProviderGateway, "stream_llamacpp_chat", fake_stream
+        )
+        signals = ConsoleProviderStreamSignals(exchange_capture_enabled=True)
+        history_rows = CAPTURE_SAFE_HISTORY_TAIL_ROWS + 6
+        await self._drain(
+            ConsoleProviderGateway().stream_chat(
+                self._llamacpp_resolution(), self._history(history_rows), signals=signals
+            )
+        )
+
+        (capture,) = signals.exchange_captures()
+        wire_messages = capture.request["wire_payload"]["messages"]
+        assert wire_messages[-1]["content"].startswith(
+            f"GATEWAY-HISTORY-{history_rows - 1:03d}"
+        )
+        assert wire_messages[0][CAPTURE_ELIDED_ROW_KEY] is True
+        assert "GATEWAY-HISTORY-000" not in json.dumps(wire_messages)
+        assert any(
+            entry.startswith("wire_payload.messages[0..")
+            for entry in capture.omitted_keys
+        )
+
+    @pytest.mark.asyncio
+    async def test_llamacpp_full_wire_capture_keeps_history_verbatim(
+        self, monkeypatch
+    ):
+        async def fake_stream(self, **kwargs):
+            yield "ok"
+
+        monkeypatch.setattr(
+            ConsoleProviderGateway, "stream_llamacpp_chat", fake_stream
+        )
+        signals = ConsoleProviderStreamSignals(
+            exchange_capture_enabled=True, capture_detail=CaptureDetail.FULL
+        )
+        await self._drain(
+            ConsoleProviderGateway().stream_chat(
+                self._llamacpp_resolution(),
+                self._history(CAPTURE_SAFE_HISTORY_TAIL_ROWS + 6),
+                signals=signals,
+            )
+        )
+
+        (capture,) = signals.exchange_captures()
+        assert "GATEWAY-HISTORY-000" in json.dumps(
+            capture.request["wire_payload"]["messages"]
+        )
+        assert not any(
+            entry.startswith("wire_payload.messages[0..")
+            for entry in capture.omitted_keys
+        )

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -52,11 +52,11 @@ from tldw_chatbook.Chat.provider_continuation import (
 )
 from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
 from tldw_chatbook.Chat.console_exchange_capture import (
-    CAPTURE_ELIDED_ROW_KEY,
     CAPTURE_SAFE_HISTORY_TAIL_ROWS,
     CaptureBudget,
     CaptureDetail,
     build_request_capture,
+    history_elision_marker,
 )
 from tldw_chatbook.Chat.console_thinking_history import ProviderThinkingSidecar
 from tldw_chatbook.Chat.thinking_blocks import (
@@ -8271,10 +8271,11 @@ class TestLlamaCppExchangeCapture:
 
 
 class TestSafeHistoryElisionThroughGateway:
-    """task-23026: the gateway's OWN captures bound the per-turn history
-    copy under Safe. Measured before the bound, through this exact path:
-    turn-200 blob 217.1 KB, 21.33 MB total for one 200-turn conversation,
-    default-on, with no retention path."""
+    """task-23026 / ADR-096: the gateway's OWN captures bound the per-turn
+    history copy under Safe (first-system + last-user + final-eight rows,
+    one content-free aggregate marker). Measured before the bound, through
+    this exact path: turn-200 blob 217.1 KB, 21.33 MB total for one
+    200-turn conversation, default-on, with no retention path."""
 
     @staticmethod
     def _generic_resolution() -> ConsoleProviderResolution:
@@ -8303,7 +8304,7 @@ class TestSafeHistoryElisionThroughGateway:
         return [chunk async for chunk in gen]
 
     @pytest.mark.asyncio
-    async def test_generic_safe_capture_elides_history_and_names_the_range(self):
+    async def test_generic_safe_capture_compacts_history_and_names_the_path(self):
         def fake_chat_api_call(**kwargs):
             return {"choices": [{"message": {"content": "pong"}}]}
 
@@ -8318,15 +8319,18 @@ class TestSafeHistoryElisionThroughGateway:
         (capture,) = signals.exchange_captures()
         payload = capture.request["messages_payload"]
         # The leading system row is extracted into system_message by the
-        # kwargs builder, so the payload is exactly the history rows.
-        assert len(payload) == history_rows
-        assert payload[-1]["content"].startswith(f"GATEWAY-HISTORY-{history_rows - 1:03d}")
-        assert payload[0][CAPTURE_ELIDED_ROW_KEY] is True
-        assert "GATEWAY-HISTORY-000" not in json.dumps(payload)
-        assert any(
-            "conversation history elided" in entry for entry in capture.omitted_keys
+        # kwargs builder, so the payload is the 18 history rows — compacted
+        # to one marker + the retained set.
+        marker = history_elision_marker(payload)
+        assert marker is not None
+        assert marker["original_rows"] == history_rows
+        kept = [row for row in payload if not history_elision_marker([row])]
+        assert kept[-1]["content"].startswith(
+            f"GATEWAY-HISTORY-{history_rows - 1:03d}"
         )
-        # The provider call itself is untouched: elision is capture-only.
+        assert "GATEWAY-HISTORY-000" not in json.dumps(payload)
+        assert "messages_payload.history" in capture.omitted_keys
+        # The provider call itself is untouched: compaction is capture-only.
         assert capture.response["content"] == "pong"
 
     @pytest.mark.asyncio
@@ -8348,12 +8352,10 @@ class TestSafeHistoryElisionThroughGateway:
         assert "GATEWAY-HISTORY-000" in json.dumps(
             capture.request["messages_payload"]
         )
-        assert not any(
-            "conversation history elided" in entry for entry in capture.omitted_keys
-        )
+        assert "messages_payload.history" not in capture.omitted_keys
 
     @pytest.mark.asyncio
-    async def test_generic_elision_leaves_transcript_output_byte_identical(self):
+    async def test_generic_compaction_leaves_transcript_output_byte_identical(self):
         def fake_chat_api_call(**kwargs):
             return {"choices": [{"message": {"content": "exact bytes"}}]}
 
@@ -8386,7 +8388,7 @@ class TestSafeHistoryElisionThroughGateway:
         )
 
     @pytest.mark.asyncio
-    async def test_llamacpp_safe_wire_capture_elides_history(self, monkeypatch):
+    async def test_llamacpp_safe_wire_capture_compacts_history(self, monkeypatch):
         async def fake_stream(self, **kwargs):
             yield "ok"
 
@@ -8403,15 +8405,16 @@ class TestSafeHistoryElisionThroughGateway:
 
         (capture,) = signals.exchange_captures()
         wire_messages = capture.request["wire_payload"]["messages"]
-        assert wire_messages[-1]["content"].startswith(
+        marker = history_elision_marker(wire_messages)
+        assert marker is not None
+        kept = [row for row in wire_messages if not history_elision_marker([row])]
+        # The wire list keeps its system framing row and the newest tail.
+        assert kept[0]["role"] == "system"
+        assert kept[-1]["content"].startswith(
             f"GATEWAY-HISTORY-{history_rows - 1:03d}"
         )
-        assert wire_messages[0][CAPTURE_ELIDED_ROW_KEY] is True
         assert "GATEWAY-HISTORY-000" not in json.dumps(wire_messages)
-        assert any(
-            entry.startswith("wire_payload.messages[0..")
-            for entry in capture.omitted_keys
-        )
+        assert "wire_payload.messages.history" in capture.omitted_keys
 
     @pytest.mark.asyncio
     async def test_llamacpp_full_wire_capture_keeps_history_verbatim(
@@ -8438,7 +8441,4 @@ class TestSafeHistoryElisionThroughGateway:
         assert "GATEWAY-HISTORY-000" in json.dumps(
             capture.request["wire_payload"]["messages"]
         )
-        assert not any(
-            entry.startswith("wire_payload.messages[0..")
-            for entry in capture.omitted_keys
-        )
+        assert "wire_payload.messages.history" not in capture.omitted_keys

--- a/Tests/DB/test_chachanotes_console_thinking_migration.py
+++ b/Tests/DB/test_chachanotes_console_thinking_migration.py
@@ -260,7 +260,7 @@ def test_console_thinking_migration_is_additive_without_evidence_backfill(
 
     db = CharactersRAGDB(db_path, client_id="v52-test")
     try:
-        assert _schema_version(db) == CharactersRAGDB._CURRENT_SCHEMA_VERSION == 52
+        assert _schema_version(db) == CharactersRAGDB._CURRENT_SCHEMA_VERSION == 53
         assert db.get_message_by_id(assistant_id)["thinking_blocks_json"] is None
         assert db.get_message_by_id(user_id)["thinking_blocks_json"] is None
         assert (

--- a/Tests/DB/test_chachanotes_v53_safe_capture_trim.py
+++ b/Tests/DB/test_chachanotes_v53_safe_capture_trim.py
@@ -1,0 +1,422 @@
+"""v52→v53: stored Safe exchange captures lose their per-turn history copy.
+
+task-23026: before elision existed, every Safe (default-on) exchange capture
+persisted the ENTIRE conversation so far — 21.33 MB measured for one 200-turn
+conversation — with no retention path (the only purge is user-invoked and
+Full-filtered). The migration applies the same trim the builder now performs
+at capture time to every already-stored Safe blob, so existing databases
+reclaim the space without the user knowing a manual purge exists.
+
+Correctness bar (this DB's established one): atomic, re-enterable,
+interrupt-safe (real-SIGKILL form, per
+``Tests/DB/test_chachanotes_v47_messages_fts_backfill.py``), integrity_check
+clean, and value-identical content for everything not deliberately trimmed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from Tests.ChaChaNotesDB.historical_bootstrap import chachanotes_db_at_version
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, SchemaError
+from tldw_chatbook.Chat.console_exchange_capture import (
+    CAPTURE_ELIDED_ROW_KEY,
+    CAPTURE_SAFE_HISTORY_TAIL_ROWS,
+    CaptureDetail,
+    ExchangeCapture,
+    build_request_capture,
+    capture_from_storage,
+    capture_to_blob,
+    trim_safe_capture_blob,
+)
+
+SCHEMA_NAME = CharactersRAGDB._SCHEMA_NAME
+_TAIL = CAPTURE_SAFE_HISTORY_TAIL_ROWS
+
+
+def _version(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (SCHEMA_NAME,),
+        ).fetchone()
+        return int(row[0])
+    finally:
+        conn.close()
+
+
+def _filler(seed: str, chars: int) -> str:
+    """Semi-incompressible prose-like filler (hex words): a repeated-word
+    filler compresses ~100x under the blob's zlib, which made the ORIGINAL
+    blobs unrealistically tiny and inverted every size comparison."""
+    import hashlib
+
+    words = []
+    counter = 0
+    while sum(len(w) + 1 for w in words) < chars:
+        words.append(hashlib.sha256(f"{seed}:{counter}".encode()).hexdigest()[:10])
+        counter += 1
+    return " ".join(words)[:chars]
+
+
+def _history_rows(count: int) -> list[dict]:
+    return [
+        {
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"MIGRATION-HISTORY-{i:03d} " + _filler(f"row{i}", 180),
+        }
+        for i in range(count)
+    ]
+
+
+def _legacy_safe_blob(rows: int, *, seq: int = 0) -> bytes:
+    """A pre-task-23026 Safe blob: ordinary history rows retained verbatim
+    (built at Full to bypass today's elision, stamped Safe — exactly what
+    the historical Safe builder produced for untagged rows)."""
+    request, omitted = build_request_capture(
+        {
+            "api_endpoint": "openai",
+            "system_message": "sys",
+            "messages_payload": _history_rows(rows),
+            "model": "gpt-4.1",
+            "temp": 0.7,
+            "api_key": "sk-SECRET",
+        },
+        capture_detail=CaptureDetail.FULL,
+    )
+    return capture_to_blob(
+        ExchangeCapture(
+            run_tag="legacy-run", seq=seq, created_at="2026-08-01T00:00:00Z",
+            provider="openai", model="gpt-4.1", endpoint=None,
+            request=request,
+            response={"content": "pong", "tool_calls": [], "synthetic_fallback": False},
+            status="complete", usage_json='{"input": 9}', omitted_keys=omitted,
+            capture_detail=CaptureDetail.SAFE,
+        )
+    )
+
+
+def _legacy_wire_blob(rows: int) -> bytes:
+    return capture_to_blob(
+        ExchangeCapture(
+            run_tag="legacy-wire", seq=0, created_at="2026-08-01T00:00:00Z",
+            provider="llama_cpp", model="m", endpoint=None,
+            request={
+                "model": "m",
+                "wire_payload": {
+                    "model": "m",
+                    "messages": _history_rows(rows),
+                    "stream": True,
+                },
+                "truncation_inventory": (),
+            },
+            response={"content": "ok"}, status="complete", usage_json=None,
+            omitted_keys=(), capture_detail=CaptureDetail.SAFE,
+        )
+    )
+
+
+def _full_blob(rows: int) -> bytes:
+    request, omitted = build_request_capture(
+        {"messages_payload": _history_rows(rows), "model": "m"},
+        capture_detail=CaptureDetail.FULL,
+    )
+    return capture_to_blob(
+        ExchangeCapture(
+            run_tag="full-run", seq=0, created_at="2026-08-01T00:00:00Z",
+            provider="openai", model="m", endpoint=None, request=request,
+            response={"content": "pong"}, status="complete", usage_json=None,
+            omitted_keys=omitted, capture_detail=CaptureDetail.FULL,
+        )
+    )
+
+
+def _exchange_row(run_tag: str, seq: int, detail: str, blob: bytes) -> dict:
+    return {
+        "run_tag": run_tag,
+        "seq": seq,
+        "status": "complete",
+        "abandoned": False,
+        "capture_detail": detail,
+        "capture_blob": blob,
+        "created_at": "2026-08-01T00:00:00Z",
+    }
+
+
+def _seed_v52(db_path: Path) -> str:
+    """Build a genuine v52 database holding every migration-relevant row
+    class, seeded through production APIs. Returns the message id."""
+    with chachanotes_db_at_version(db_path, 52, client_id="v53-seed") as db:
+        conv_id = db.add_conversation({"title": "t"})
+        message_id = db.add_message(
+            {"conversation_id": conv_id, "sender": "user", "content": "hi"}
+        )
+        db.append_message_exchanges_local(
+            message_id,
+            [
+                _exchange_row("oversized-safe", 0, "safe", _legacy_safe_blob(_TAIL + 12)),
+                _exchange_row("small-safe", 0, "safe", _legacy_safe_blob(_TAIL)),
+                _exchange_row("wire-safe", 0, "safe", _legacy_wire_blob(_TAIL + 6)),
+                _exchange_row("full-verbatim", 0, "full", _full_blob(_TAIL + 12)),
+                _exchange_row("corrupt", 0, "safe", b"not-a-zlib-blob"),
+            ],
+        )
+    return message_id
+
+
+def _blobs_by_run_tag(db: CharactersRAGDB, message_id: str) -> dict[str, bytes]:
+    return {
+        row["run_tag"]: bytes(row["capture_blob"])
+        for row in db.get_message_exchanges(message_id)
+    }
+
+
+def test_v53_trims_safe_blobs_and_leaves_everything_else_value_identical(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "historical-v52.sqlite"
+    message_id = _seed_v52(db_path)
+    with chachanotes_db_at_version(db_path, 52, client_id="v53-before") as before_db:
+        before = _blobs_by_run_tag(before_db, message_id)
+    assert _version(db_path) == 52
+
+    db = CharactersRAGDB(db_path, client_id="v53-upgrade")
+    try:
+        assert _version(db_path) == CharactersRAGDB._CURRENT_SCHEMA_VERSION == 53
+        after = _blobs_by_run_tag(db, message_id)
+
+        # 1. The oversized Safe blob was trimmed and still decodes under its
+        #    declared provenance.
+        assert after["oversized-safe"] != before["oversized-safe"]
+        assert len(after["oversized-safe"]) < len(before["oversized-safe"])
+        restored = capture_from_storage(after["oversized-safe"], "safe")
+        original = capture_from_storage(before["oversized-safe"], "safe")
+        payload = restored.request["messages_payload"]
+        assert payload[-_TAIL:] == original.request["messages_payload"][-_TAIL:]
+        assert payload[0][CAPTURE_ELIDED_ROW_KEY] is True
+        assert "MIGRATION-HISTORY-000 " not in json.dumps(payload)
+        # Value-identical content for everything not deliberately trimmed.
+        assert restored.response == original.response
+        assert restored.status == original.status
+        assert restored.usage_json == original.usage_json
+        assert restored.run_tag == original.run_tag
+        assert {
+            k: v for k, v in restored.request.items() if k != "messages_payload"
+        } == {
+            k: v for k, v in original.request.items() if k != "messages_payload"
+        }
+        assert set(original.omitted_keys).issubset(set(restored.omitted_keys))
+        assert any("history elided" in e for e in restored.omitted_keys)
+
+        # 2. The llama.cpp wire-literal Safe blob was trimmed the same way.
+        wire_restored = capture_from_storage(after["wire-safe"], "safe")
+        wire = wire_restored.request["wire_payload"]
+        assert wire["messages"][0][CAPTURE_ELIDED_ROW_KEY] is True
+        assert "MIGRATION-HISTORY-000 " not in json.dumps(wire)
+        assert wire["stream"] is True
+
+        # 3. A short Safe blob, a Full blob, and an undecodable blob are
+        #    byte-untouched — Full is the deliberate verbatim mode, and one
+        #    corrupt row must never brick (or be "repaired" by) the upgrade.
+        assert after["small-safe"] == before["small-safe"]
+        assert after["full-verbatim"] == before["full-verbatim"]
+        assert after["corrupt"] == before["corrupt"] == b"not-a-zlib-blob"
+
+        # 4. The database is structurally sound.
+        integrity = db.get_connection().execute("PRAGMA integrity_check").fetchone()
+        assert tuple(integrity) == ("ok",)
+
+        # 5. Re-entry converges: the trim is a fixed point on migrated blobs.
+        assert trim_safe_capture_blob(after["oversized-safe"]) is None
+        assert trim_safe_capture_blob(after["wire-safe"]) is None
+    finally:
+        db.close_connection()
+
+    # 6. A second open performs no further blob writes.
+    db_again = CharactersRAGDB(db_path, client_id="v53-again")
+    try:
+        assert _blobs_by_run_tag(db_again, message_id) == after
+    finally:
+        db_again.close_connection()
+
+
+def test_v53_failure_mid_walk_rolls_back_blobs_and_version_together(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Atomicity, in-process failure form (the media v8→v9 rollback
+    precedent): a database error AFTER earlier successful blob rewrites
+    must rewind the rewrites AND the version stamp, leaving a working v52
+    database that a later clean open upgrades completely."""
+    db_path = tmp_path / "historical-v52.sqlite"
+    message_id = _seed_v52(db_path)
+    with chachanotes_db_at_version(db_path, 52, client_id="v53-before") as before_db:
+        before = _blobs_by_run_tag(before_db, message_id)
+
+    import tldw_chatbook.Chat.console_exchange_capture as capture_module
+
+    real_trim = capture_module.trim_safe_capture_blob
+    calls = {"n": 0}
+
+    def sabotaged_trim(blob: bytes):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            # Not raised here (the per-row guard would skip it): RETURN a
+            # value sqlite cannot bind, so the failure lands on the UPDATE
+            # after at least one earlier row committed its rewrite into the
+            # open transaction.
+            return object()
+        return real_trim(blob)
+
+    monkeypatch.setattr(capture_module, "trim_safe_capture_blob", sabotaged_trim)
+    with pytest.raises(SchemaError):
+        CharactersRAGDB(db_path, client_id="v53-sabotaged")
+    assert calls["n"] >= 2
+
+    # Everything rolled back together: still v52, blobs byte-identical.
+    assert _version(db_path) == 52
+    with chachanotes_db_at_version(db_path, 52, client_id="v53-inspect") as db52:
+        assert _blobs_by_run_tag(db52, message_id) == before
+
+    # A later clean open completes the upgrade.
+    monkeypatch.setattr(capture_module, "trim_safe_capture_blob", real_trim)
+    recovered = CharactersRAGDB(db_path, client_id="v53-recovered")
+    try:
+        assert _version(db_path) == 53
+        after = _blobs_by_run_tag(recovered, message_id)
+        assert after["oversized-safe"] != before["oversized-safe"]
+        assert tuple(
+            recovered.get_connection()
+            .execute("PRAGMA integrity_check")
+            .fetchone()
+        ) == ("ok",)
+    finally:
+        recovered.close_connection()
+
+
+def test_v53_survives_sigkill_mid_migration(tmp_path: Path) -> None:
+    """Interrupt-safety, real-kill form (the v47 backfill technique): a
+    child process is SIGKILLed while the migration walks the blobs. The
+    file must reopen (WAL recovery), still be v52-shaped or fully
+    migrated — never in between — and a clean reopen must converge on the
+    byte-identical end state of an uninterrupted control run."""
+    db_path = tmp_path / "killed-v52.sqlite"
+    message_id = _seed_v52(db_path)
+    # Extra oversized Safe rows widen the kill window.
+    with chachanotes_db_at_version(db_path, 52, client_id="v53-widen") as db52:
+        db52.append_message_exchanges_local(
+            message_id,
+            [
+                _exchange_row(f"widen-{i}", i, "safe", _legacy_safe_blob(_TAIL + 12, seq=i))
+                for i in range(6)
+            ],
+        )
+        before = _blobs_by_run_tag(db52, message_id)
+
+    # Control arm: an identical database upgraded without interruption.
+    control_path = tmp_path / "control-v52.sqlite"
+    control_message_id = _seed_v52(control_path)
+    with chachanotes_db_at_version(control_path, 52, client_id="v53-widen-c") as dbc:
+        dbc.append_message_exchanges_local(
+            control_message_id,
+            [
+                _exchange_row(f"widen-{i}", i, "safe", _legacy_safe_blob(_TAIL + 12, seq=i))
+                for i in range(6)
+            ],
+        )
+    control = CharactersRAGDB(control_path, client_id="v53-control")
+    try:
+        control_blobs = _blobs_by_run_tag(control, control_message_id)
+    finally:
+        control.close_connection()
+
+    sentinel = tmp_path / "trim-progress"
+    child_code = f"""
+import sys, time
+sys.path.insert(0, {str(Path(__file__).resolve().parents[2])!r})
+import tldw_chatbook.Chat.console_exchange_capture as capture_module
+real_trim = capture_module.trim_safe_capture_blob
+def slow_trim(blob):
+    with open({str(sentinel)!r}, "a") as handle:
+        handle.write("r\\n")
+    time.sleep(0.3)
+    return real_trim(blob)
+capture_module.trim_safe_capture_blob = slow_trim
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+CharactersRAGDB({str(db_path)!r}, client_id="v53-killed").close_connection()
+print("done", flush=True)
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            if sentinel.exists() and sentinel.read_text().count("r") >= 2:
+                break
+            if child.poll() is not None:
+                break
+            time.sleep(0.02)
+        assert child.poll() is None, (
+            "child finished before it could be killed; widen the seed "
+            f"(stdout={child.stdout.read()!r} stderr={child.stderr.read()!r})"
+        )
+        assert sentinel.exists() and sentinel.read_text().count("r") >= 2, (
+            "no trim call observed before the deadline"
+        )
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=30)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=30)
+
+    # The kill landed mid-transaction: nothing may be half-applied.
+    assert _version(db_path) == 52
+
+    resumed = CharactersRAGDB(db_path, client_id="v53-after-kill")
+    try:
+        assert _version(db_path) == 53
+        after = _blobs_by_run_tag(resumed, message_id)
+        # Convergence with the uninterrupted control arm, byte for byte.
+        assert after == control_blobs
+        assert after["oversized-safe"] != before["oversized-safe"]
+        integrity = (
+            resumed.get_connection().execute("PRAGMA integrity_check").fetchone()
+        )
+        assert tuple(integrity) == ("ok",)
+    finally:
+        resumed.close_connection()
+
+
+def test_fresh_database_lands_on_v53_with_no_exchange_rows(tmp_path: Path) -> None:
+    db = CharactersRAGDB(tmp_path / "fresh.sqlite", client_id="v53-fresh")
+    try:
+        assert (
+            db.get_connection()
+            .execute(
+                "SELECT version FROM db_schema_version WHERE schema_name = ?",
+                (SCHEMA_NAME,),
+            )
+            .fetchone()[0]
+            == 53
+        )
+        assert (
+            db.get_connection()
+            .execute("SELECT COUNT(*) FROM message_exchanges")
+            .fetchone()[0]
+            == 0
+        )
+    finally:
+        db.close_connection()

--- a/Tests/DB/test_chachanotes_v53_safe_capture_trim.py
+++ b/Tests/DB/test_chachanotes_v53_safe_capture_trim.py
@@ -28,13 +28,13 @@ import pytest
 from Tests.ChaChaNotesDB.historical_bootstrap import chachanotes_db_at_version
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, SchemaError
 from tldw_chatbook.Chat.console_exchange_capture import (
-    CAPTURE_ELIDED_ROW_KEY,
     CAPTURE_SAFE_HISTORY_TAIL_ROWS,
     CaptureDetail,
     ExchangeCapture,
     build_request_capture,
     capture_from_storage,
     capture_to_blob,
+    history_elision_marker,
     trim_safe_capture_blob,
 )
 
@@ -201,8 +201,11 @@ def test_v53_trims_safe_blobs_and_leaves_everything_else_value_identical(
         restored = capture_from_storage(after["oversized-safe"], "safe")
         original = capture_from_storage(before["oversized-safe"], "safe")
         payload = restored.request["messages_payload"]
-        assert payload[-_TAIL:] == original.request["messages_payload"][-_TAIL:]
-        assert payload[0][CAPTURE_ELIDED_ROW_KEY] is True
+        marker = history_elision_marker(payload)
+        assert marker is not None
+        assert marker["original_rows"] == _TAIL + 12
+        kept = [row for row in payload if not history_elision_marker([row])]
+        assert kept == original.request["messages_payload"][-_TAIL:]
         assert "MIGRATION-HISTORY-000 " not in json.dumps(payload)
         # Value-identical content for everything not deliberately trimmed.
         assert restored.response == original.response
@@ -215,14 +218,15 @@ def test_v53_trims_safe_blobs_and_leaves_everything_else_value_identical(
             k: v for k, v in original.request.items() if k != "messages_payload"
         }
         assert set(original.omitted_keys).issubset(set(restored.omitted_keys))
-        assert any("history elided" in e for e in restored.omitted_keys)
+        assert "messages_payload.history" in restored.omitted_keys
 
         # 2. The llama.cpp wire-literal Safe blob was trimmed the same way.
         wire_restored = capture_from_storage(after["wire-safe"], "safe")
         wire = wire_restored.request["wire_payload"]
-        assert wire["messages"][0][CAPTURE_ELIDED_ROW_KEY] is True
+        assert history_elision_marker(wire["messages"]) is not None
         assert "MIGRATION-HISTORY-000 " not in json.dumps(wire)
         assert wire["stream"] is True
+        assert "wire_payload.messages.history" in wire_restored.omitted_keys
 
         # 3. A short Safe blob, a Full blob, and an undecodable blob are
         #    byte-untouched — Full is the deliberate verbatim mode, and one

--- a/Tests/UI/test_console_conversation_inspector.py
+++ b/Tests/UI/test_console_conversation_inspector.py
@@ -47,6 +47,8 @@ from tldw_chatbook.Chat.console_exchange_capture import (
     CaptureDetail,
     ExchangeCapture,
     build_request_capture,
+    compact_safe_history_rows,
+    history_elision_marker,
     CapturePolicyResolution,
     CapturePolicySource,
 )
@@ -1737,3 +1739,36 @@ async def test_revision_change_during_first_async_call_mount_discards_all_calls(
         assert mount_calls.value == 1
         assert modal._exchange_capture_by_call_key == {}
         assert not turn.query(".console-inspector-exchange-call")
+
+
+def test_messages_section_title_states_original_and_elided_counts() -> None:
+    """task-23026 / ADR-096: a Safe capture's stored list is COMPACTED, so
+    the physical row count alone would under-state what the call actually
+    sent. When the aggregate history-elision marker is present, the
+    Messages title must surface its original/omitted counts; without a
+    marker the plain physical count remains."""
+    rows = [{"role": "system", "content": "sys"}] + [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"row {i}"}
+        for i in range(17)
+    ]
+    compacted, _ = compact_safe_history_rows(rows, CaptureDetail.SAFE)
+    assert history_elision_marker(compacted) is not None  # sanity
+
+    inspector = object.__new__(ConsoleConversationInspector)
+    compacted_capture = _capture(
+        "run-1", 0, "t", "m", request={"messages_payload": compacted}
+    )
+    title = str(
+        inspector._build_messages_section(compacted_capture, "k").title
+    )
+    assert f"{len(rows)} sent" in title
+    marker = history_elision_marker(compacted)
+    assert f"{marker['omitted_rows']} elided by capture policy" in title
+
+    plain_capture = _capture(
+        "run-1", 0, "t", "m", request={"messages_payload": rows[-3:]}
+    )
+    plain_title = str(
+        inspector._build_messages_section(plain_capture, "k").title
+    )
+    assert plain_title == "Messages (3)"

--- a/backlog/decisions/096-console-safe-capture-retention.md
+++ b/backlog/decisions/096-console-safe-capture-retention.md
@@ -1,0 +1,105 @@
+# ADR-096: Bound Safe exchange-capture history
+
+Status: Accepted
+
+Date: 2026-08-27
+
+Related Task: [TASK-23026](../tasks/task-23026%20-%20Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md)
+
+Related Spec: [Console Safe Capture Retention](../../Docs/superpowers/specs/2026-08-27-console-safe-capture-retention-design.md)
+
+Amends: [ADR-092](092-console-full-semantic-capture-policy.md), which deferred
+automatic pruning and retention policy. ADR-092 remains authoritative for capture
+scope, Full consent and semantics, invariant credential/binary protections, export,
+and conversation-scoped Full purge.
+
+## Context
+
+Safe exchange capture is enabled by default and currently persists the complete
+accumulated provider message list on every call. A production-shaped 200-turn probe
+retained 15.40 MB for one conversation because each later exchange repeated every
+earlier message. Soft-deleted conversations retain these local blobs, and the only
+existing purge intentionally targets Full rows.
+
+This is both a storage and privacy-retention defect. Fixing it changes durable data,
+migration behavior, and the meaning of Safe capture, so the decision must amend
+ADR-092 rather than remain a local implementation detail.
+
+## Decision
+
+1. **Bound Safe history at capture time.** Safe retains the first system row, the
+   most recent user row, and the final eight physical message rows, deduplicated and
+   kept in original order.
+2. **Use one content-free aggregate marker.** All other rows are represented by one
+   versioned capture marker containing only original/omitted row counts, normalized
+   role counts, and retained original positions. It contains no content, length,
+   digest, identifier, timestamp, or reconstructable reference.
+3. **Make elision visible and idempotent.** Generic capture inventories
+   `messages_payload.history`; llama.cpp inventories
+   `wire_payload.messages.history`. Re-projecting a stored Safe request reaches a
+   fixed point rather than nesting markers or changing omission entries.
+4. **Preserve protection order.** Credential exclusion, endpoint canonicalization,
+   Safe project-instruction redaction, nested-credential removal, and binary stubbing
+   occur before compaction; the existing shared size budget remains afterward.
+5. **Apply one policy to both request shapes.** Generic `messages_payload` and the
+   llama.cpp literal `wire_payload.messages` use the same pure compactor for primary
+   and fallback calls.
+6. **Leave Full semantics unchanged.** Full bypasses history compaction and remains
+   the explicit mode for exact semantic diagnostic context within ADR-092's invariant
+   protections. This decision adds no automatic Full retention or purge behavior.
+7. **Rewrite existing Safe rows automatically.** A versioned ChaChaNotes data
+   migration keyset-pages Safe `message_exchanges` in bounded batches and rewrites
+   only captures changed by the same compactor. Full, small, and already-compacted
+   blobs remain byte-identical.
+8. **Fail narrowly and transactionally.** Recognized corrupt/unavailable Safe blobs
+   are left untouched and counted without content-bearing logs. Unexpected code or
+   SQLite errors roll back the entire migration and version stamp. Capture remains
+   best-effort and cannot block a live provider call.
+9. **Keep ownership local.** Compaction changes only `message_exchanges` capture
+   bodies and their export projection. It adds no transcript, sync, FTS, Trace, or
+   provider-request mutation.
+
+## Consequences
+
+- Safe per-call history becomes bounded and cumulative exchange storage becomes
+  linear in call count rather than quadratic in conversation length.
+- Safe answers what initial system context, latest user request, and immediate
+  assistant/tool loop surrounded a call, but it is no longer an exact historical
+  record. The marker and `omitted_keys` state this honestly.
+- Readable historical Safe blobs are compacted on database open without a manual
+  purge. The one-time migration adds startup work proportional to Safe exchange row
+  count but holds only a bounded batch in memory.
+- Corrupt or unavailable legacy blobs cannot be safely rewritten and may remain
+  oversized. The migration reports only aggregate skip evidence and does not claim
+  forensic erasure from SQLite free pages, WAL, backups, or exports.
+- Full remains potentially sensitive and storage-heavy by deliberate user choice.
+  Its existing consent, queryable provenance, and scoped logical purge remain the
+  governing controls.
+
+## Alternatives considered
+
+### Retain one fingerprint per omitted row
+
+Rejected. Metadata would still grow with full history on every call, leaving
+quadratic cumulative growth, while hashes could confirm guesses about omitted text.
+
+### Persist deltas or cross-exchange references
+
+Rejected. Reconstruction, deletion, corruption, and export semantics would add a
+second exact-history system when Full already serves that explicit diagnostic need.
+
+### Retain only a newest-row tail
+
+Rejected. Tool loops can push the current user request outside the tail, while the
+initial system row remains important to explain provider behavior.
+
+### Add timed deletion or a background pruning worker
+
+Deferred. Bounded write-time Safe capture plus a one-time transactional rewrite fixes
+the demonstrated defect without a scheduler or new retention-policy surface.
+
+## Links
+
+- [Approved design](../../Docs/superpowers/specs/2026-08-27-console-safe-capture-retention-design.md)
+- [TASK-23026](../tasks/task-23026%20-%20Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md)
+- [ADR-092](092-console-full-semantic-capture-policy.md)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -85,7 +85,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-091](091-bounded-epub-archive-admission.md) | Accepted | Isolate ebook parsing in one-worker pool generations and reject EPUB ZIP structures whose expanded resource cost exceeds fixed safety bounds. |
 | [ADR-092](092-console-full-semantic-capture-policy.md) | Accepted | Keep Safe as the default while allowing scoped Full semantic exchange capture with frozen run policy, invariant credential/binary protections, distinct export profiles, and conversation-scoped erasure. |
 | [ADR-093](093-offline-tiktoken-runtime-assets.md) | Accepted | Ship a closed immutable tiktoken table inventory for offline estimates and chunking while preserving explicit cache authority. |
-| [ADR-094](094-raw-and-virtual-cli-execution-boundaries.md) | Accepted | Define separate user raw-CLI and model virtual-CLI execution boundaries with explicit fail-closed authority. |
+| [ADR-096](096-console-safe-capture-retention.md) | Accepted | Bound default Safe exchange capture to the first system row, latest user row, and newest eight rows; compact readable legacy Safe blobs transactionally while leaving Full semantics unchanged. |
 
 ## Historical Decision Material
 

--- a/backlog/tasks/task-23026 - Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md
+++ b/backlog/tasks/task-23026 - Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md
@@ -2,7 +2,7 @@
 id: TASK-23026
 title: >-
   Exchange capture stores the whole conversation on every send, forever
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-27'
@@ -84,83 +84,105 @@ Reason: the task changes durable capture retention, privacy semantics, and the C
 
 ## Implementation Notes
 
-**Approach.** Bounded excerpt + per-row references, applied at the one pure seam every
-capture flows through (`build_request_capture`), plus a one-time automatic trim of
-already-stored blobs in the schema migration chain.
+**Approach.** Implemented to the approved design (ADR-096 /
+`Docs/superpowers/specs/2026-08-27-console-safe-capture-retention-design.md`): a bounded
+diagnostic excerpt plus ONE content-free aggregate marker, applied at the one pure seam
+every capture flows through (`build_request_capture`), plus a one-time automatic
+compaction of already-stored blobs in the schema migration chain. A first
+implementation used per-row sha256 fingerprints; the owner converged it to ADR-096,
+which forbids retaining any digest of elided text (a digest is a guess-verification
+oracle for omitted private content) — the fingerprints were removed entirely.
 
-- **Safe (the default) is now bounded.** `elide_safe_history_rows` in
-  `Chat/console_exchange_capture.py`: the newest `CAPTURE_SAFE_HISTORY_TAIL_ROWS = 8`
-  `messages_payload` rows (this turn's delta plus immediate context) persist verbatim;
-  every older row is replaced IN PLACE by a content-free fingerprint row — `role` and
-  `__tldw_ephemeral_origin` tag preserved, `capture_elided: True`, content replaced by
-  `[conversation history elided by capture policy -- N chars, sha256:<16 hex>]`. The
-  digest is sha256 over the row's canonical sanitized JSON — exactly the form the earlier
-  capture whose tail the row was new in retained — so row identity is verifiable across
-  turns and against the transcript without re-storing bodies. Idempotent (structural
-  `capture_elided` key, never content matching), because `console_exchange_export.py`
-  re-runs the builder over stored requests. The llama.cpp wire-literal branch
-  (`capture_wire_payload` in `console_provider_gateway.py`) bounds its `messages` list
-  identically, path-prefixed `wire_payload.messages`. **Full is untouched**: it is the
-  explicit, consent-gated, purgeable verbatim mode (ADR-092), and the existing
-  user-invoked purge already covers it.
-- **What Safe still answers** (AC 3): "what did this call hand the provider adapter" —
-  full system prompt, tools, sampling/routing params, response, usage, per-call status,
-  the complete payload shape (row count/order/roles/sizes stay truthful in the
-  Inspector's Messages section), the turn's NEW content verbatim, and a verifiable
-  fingerprint for each elided history row. Elided bodies remain recoverable from the
-  transcript, from the earlier capture where the row was in the tail (hash-checkable), or
-  by opting a conversation into Full for a debugging session.
-- **Reclaim** (AC 2): ChaChaNotes v52→v53 (`_migrate_from_v52_to_v53`) walks
-  `message_exchanges WHERE capture_detail='safe'` and rewrites each blob through the pure
-  `trim_safe_capture_blob` (returns `None` when nothing changes; never touches Full;
-  per-row undecodable blobs are skipped, so one corrupt row cannot brick the DB).
-  DML-only Python step — no DDL, no `.sql`, no `VALID_TABLES`/index-census entries.
-  Correctness evidence in `Tests/DB/test_chachanotes_v53_safe_capture_trim.py`: value
-  identity for everything not deliberately trimmed, `PRAGMA integrity_check` clean,
-  re-entry fixed-point, in-process failure mid-walk rewinds blobs AND version stamp
-  together, and a real-SIGKILL child (v47-backfill technique) rolls back to v52 and then
-  converges byte-identically with an uninterrupted control run. Schema v53 swept against
-  all 808 refs and every worktree — no collision (this programme has collided four
-  times).
-- **omitted_keys stance** (AC 5, recorded beside the allowlist in the module): capture
-  exists to answer "what was sent", so conversation content is the subject and is
-  retained BY DESIGN — governed by the user-controllable Safe/Full detail policy, not
-  the allowlist. Credentials never persist at any level; project-instruction bodies
-  never persist under Safe; and every withholding — dropped kwarg, redacted instruction
-  body, elided history range (`messages_payload[0..N].content (conversation history
-  elided)`) — is named in `omitted_keys`, which the Inspector already renders verbatim.
+- **Safe (the default) is now bounded** (`compact_safe_history_rows` in
+  `Chat/console_exchange_capture.py`): the retained set is first-`system` row ∪
+  last-`user` row ∪ final eight physical rows (deduplicated, original order, values
+  untouched; non-mapping rows eligible only via the tail). Everything else is
+  represented by one versioned marker at the first omitted position carrying ONLY:
+  kind/version discriminator, original row count, omitted row count, normalized
+  omitted-role counts (system/user/assistant/tool/other — unknown/missing/non-string
+  roles count toward `other` and their raw values never reach the marker), and the
+  retained rows' original positions. No content, snippets, per-row lengths, hashes,
+  IDs, or timestamps. Idempotent by strict structural marker recognition (exact key
+  set + types): re-projection through the export path is a fixed point, an input
+  marker never disables compaction of surrounding rows, malformed lookalikes are
+  ordinary rows. Ordering per ADR-096: allowlist → endpoint identity → instruction
+  redaction → credential/binary sanitization → compaction → shared budget. The
+  llama.cpp wire-literal branch (streaming AND its stream→complete fallback) compacts
+  its `messages` list through the same helper. **Full is untouched** (explicit,
+  consent-gated, purgeable verbatim mode — ADR-092).
+- **What Safe still answers** (AC 3, per the design): what initial system framing was
+  in effect, what current user request drove the call, and what immediate
+  assistant/tool loop surrounded it — plus full system prompt, tools, sampling
+  params, response, usage, status, and honest counts of what was elided. It is no
+  longer an exact historical record; users who need that choose Full before the send.
+- **Elision visibility** (AC 5): the stable paths `messages_payload.history` /
+  `wire_payload.messages.history` fold into `omitted_keys` (rendered on the
+  Inspector's existing "Omitted by capture policy" line; stable so repeated
+  projection cannot create duplicate or ever-changing strings), and the Exchange
+  tab's Messages title now reads "Messages (N sent; M elided by capture policy)"
+  from the marker — the compacted physical count alone would under-state the send.
+  omitted_keys stance recorded beside the allowlist: conversation content is the
+  capture's subject, retained by design under the Safe/Full policy; credentials
+  never persist; instruction bodies never persist under Safe; every withholding is
+  named.
+- **Reclaim** (AC 2): ChaChaNotes v52→v53 (`_migrate_from_v52_to_v53`) keyset-pages
+  Safe `message_exchanges` rows in bounded batches (100 rows), rewrites only blobs
+  the pure `trim_safe_capture_blob` changed, inside the migration chain's outer
+  immediate transaction. Only the `CaptureUnavailableError`/`CaptureCorruptError`
+  family is a per-row skip (unreadable rows stay byte-identical and are counted;
+  the version may still advance); any unexpected error aborts and rolls back blobs
+  AND version stamp together. Diagnostics are aggregate-only (examined/compacted/
+  skipped + exception class), never content. Full, small, and already-compacted
+  blobs stay byte-identical. Evidence
+  (`Tests/DB/test_chachanotes_v53_safe_capture_trim.py`): value-identity for
+  everything not deliberately compacted, `PRAGMA integrity_check` clean, re-entry
+  fixed point, in-process mid-walk failure rolls back to a working v52, and a
+  real-SIGKILL child (v47-backfill technique) rolls back then converges
+  byte-identically with an uninterrupted control run. Migration probe on a
+  200-turn/21.25 MB historical fixture: open+migrate **537.9 ms**, Python peak
+  allocation 21.4 MB (bounded by the batch), blob bytes 21.25 MB → **0.99 MB**.
+  The db FILE size is unchanged until SQLite reuses the freed pages — logical
+  reclaim only; no VACUUM, and no forensic-erasure claim (ADR-096).
 - **Growth re-measured** (AC 4), real production path (`stream_chat` →
-  `_chat_api_kwargs_from_prepared` → `build_request_capture` → `capture_to_blob`), same
-  inputs both arms: turn-1 blob 0.9 KB → 0.9 KB; turn-200 blob **217.1 KB → 10.1 KB**;
-  200-turn total **21.33 MB → 1.48 MB** (14.4x). Residual growth is the ~25 B/row
-  compressed fingerprint index plus the bounded verbatim tail.
-- **Readers audited**: Inspector (`console_conversation_inspector.py` — renders rows as
-  collapsibles + JSON; fingerprint rows render as ordinary rows, counts stay truthful),
-  export projections (`console_exchange_export.py` — idempotency pinned), store/flush
-  (`console_chat_store.py` — opaque blob pass-through), loader (`chat_screen.py` —
-  `capture_from_storage`, unchanged). Capture failure still never blocks a send
-  (existing gateway pin `test_never_break_send_when_build_request_capture_raises` covers
-  the new code path).
-- **Mutation results** (all reverted): M1 disable elision → 6 tests red (and exposed a
-  non-discriminating growth guard whose "lorem" filler compressed ~100x — filler made
-  semi-incompressible, guard proven red-capable); M2 re-fingerprint elided rows → red;
-  M3 redaction re-measures fingerprints → red; M4 migration trim no-op → 3 migration
-  tests red; M6 digest not over row body → red; M7 wire elision dropped → red; M8 trim
-  touches Full → red.
-- **Tests**: +23 new (13 pure, 5 gateway, 4 migration, 1 updated version pin);
-  touched-surface total 567 green (169 core + 398 gateway/inspector). Full
-  `Tests/DB/ + Tests/ChaChaNotesDB/`: 1931 passed; 7 pre-existing dev reds
-  (A/B-identical failure sets on pristine base c4e52794e2: 1x v27 character-authority
-  column pin broken by v52's `thinking_history_policy`, 3x sync_log_retention, 2x v47
-  fts backfill, 1x provider_continuation) — not adopted.
+  `_chat_api_kwargs_from_prepared` → `build_request_capture` → `capture_to_blob`),
+  same inputs all arms: per-turn blob 0.9 KB at turn 1, then **plateaus flat at
+  5.2 KB** (marker + 8-row tail) from turn 50 through turn 200 — cumulative growth
+  is linear. 200-turn totals: **21.33 MB before → 1.01 MB after** (the interim
+  fingerprint design measured 1.48 MB and still grew per-row; the aggregate marker
+  is O(1)).
+- **Readers audited**: Inspector (renders the marker row naturally; Messages title
+  now surfaces sent/elided counts — pinned in
+  `Tests/UI/test_console_conversation_inspector.py`), export projections
+  (`console_exchange_export.py` — fixed-point pinned; Safe export cannot
+  reconstruct omitted rows), store/flush and loader (opaque blob pass-through,
+  unchanged). Capture failure still never blocks a send (existing gateway pin
+  covers the new path).
+- **Mutation results** (all reverted, each killed by a named test): N1 compaction
+  disabled → 17 red across pure/gateway/migration/inspector; N2 marker recognition
+  removed → fixed-point + input-marker tests red; **N3 digest reintroduced
+  "silently" (sha256 key added AND the frozen key set extended in the same edit) →
+  killed by `test_marker_shape_guard_a_digest_cannot_be_reintroduced_silently`**
+  (only-string-is-the-kind-discriminator + no-"sha256"-anywhere assertions); N5
+  input marker disables compaction → red; N6 last-user retention rule removed →
+  red; N7 stored-blob compaction no-op → 3 migration tests red; N9 marker
+  validator accepts key supersets → malformed-lookalike test red. Earlier
+  fingerprint-round mutations also exposed a non-discriminating growth guard
+  ("lorem" filler compressed ~100x) — all history fixtures now use
+  semi-incompressible hex-word filler.
+- **Tests**: 15 pure-contract tests, 5 gateway-path tests, 4 migration tests, 1
+  Inspector title pin, 1 updated schema-version pin. Touched-surface totals: 170
+  (capture/export/store/controller/policy/exchanges/thinking/atomicity) + 398
+  (gateway + inspector suites) green. Known pre-existing dev reds (A/B-identical
+  on pristine base): 7 in Tests/DB//Tests/ChaChaNotesDB (v27 authority pin broken
+  by v52's `thinking_history_policy`, 3x sync_log_retention, 2x v47 fts backfill,
+  1x provider_continuation) — not adopted.
 - **Modified**: `Chat/console_exchange_capture.py`, `Chat/console_provider_gateway.py`,
-  `DB/ChaChaNotes_DB.py` (v53), `Docs/User_Guide/console/context-and-rag.md` (Safe/Full
-  retention paragraph now matches the code — the shipped text already promised "bounded"
-  Safe retention the code did not honor), tests as above.
-- **Diagnostic inventory**: +2 `logger.info` rows in `ChaChaNotes_DB.py` reviewed via
-  `check_persistent_diagnostic_inventory.py --statements --since 5d9b4bec5a` before
-  `--write`: both are the migration chain's established start/finish pattern,
-  interpolating only `db_path_str` and two integer counters — no capture content, user
-  text, or secrets (capture blobs are deliberately never logged, even on the
-  corrupt-row skip path).
-
+  `DB/ChaChaNotes_DB.py` (v53), `Widgets/Console/console_conversation_inspector.py`
+  (honest Messages title), `Docs/User_Guide/console/context-and-rag.md`, tests as
+  above. Schema v53 swept against all remote refs and every worktree at bump time
+  and re-swept before each commit — no collision.
+- **Diagnostic inventory**: the migration's `logger.info` rows reviewed via
+  `check_persistent_diagnostic_inventory.py --statements` before `--write`: the
+  established start/finish pattern, interpolating only `db_path_str` and integer
+  counters — no capture content, user text, or secrets; the failure wrap logs the
+  exception CLASS only (ADR-096: exception values may contain decoded content).

--- a/backlog/tasks/task-23026 - Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md
+++ b/backlog/tasks/task-23026 - Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md
@@ -2,8 +2,9 @@
 id: TASK-23026
 title: >-
   Exchange capture stores the whole conversation on every send, forever
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-27'
 labels:
   - storage
@@ -27,11 +28,11 @@ database it bloats is the one boot migrations and backups walk.
 
 ## Acceptance Criteria
 
-- [ ] A long conversation does not accumulate a full copy of itself per turn - store a reference, a delta, or a bounded excerpt
-- [ ] Existing oversized captures are reclaimable without the user knowing to run a manual purge
-- [ ] Whatever capture retains is still sufficient for the debugging the feature exists to support - say what that is
-- [ ] Growth re-measured over 200 turns after the change
-- [ ] `omitted_keys` behaviour is reviewed: it currently omits only `api_key`, while the payload carries the user's entire conversation
+- [x] A long conversation does not accumulate a full copy of itself per turn - store a reference, a delta, or a bounded excerpt
+- [x] Existing oversized captures are reclaimable without the user knowing to run a manual purge
+- [x] Whatever capture retains is still sufficient for the debugging the feature exists to support - say what that is
+- [x] Growth re-measured over 200 turns after the change
+- [x] `omitted_keys` behaviour is reviewed: it currently omits only `api_key`, while the payload carries the user's entire conversation
 
 ## Evidence
 
@@ -40,3 +41,114 @@ independently at 15.35 MB. An earlier probe reported this feature **clean** at 0
 had been built from a hand-made input rather than the real caller's kwargs, and was refuted.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Implementation Plan
+
+1. **Baseline measurement first**, through the REAL production path (not hand-made kwargs): drive
+   `ConsoleProviderGateway.stream_chat` with a fake `chat_api_call_fn` for 200 growing turns and
+   record per-turn `capture_to_blob` size + total, under Safe (the default).
+2. **Bound Safe capture's history retention** in the pure builder (`console_exchange_capture.py`):
+   under `CaptureDetail.SAFE`, `build_request_capture` keeps the newest
+   `CAPTURE_SAFE_HISTORY_TAIL_ROWS` rows of `messages_payload` verbatim (the turn's delta plus
+   immediate context) and replaces each older prefix row IN PLACE with a small fingerprint row
+   (role + origin tag preserved, `capture_elided: True`, content replaced by
+   `[... N chars, sha256:<16 hex>]`). The elision is idempotent (already-elided rows pass through
+   untouched — the export path re-runs the builder over stored requests) and is surfaced through
+   the existing `omitted_keys` visibility mechanism the Inspector already renders. FULL captures
+   are untouched: Full is the deliberate, consent-gated, purgeable verbatim mode (ADR-092).
+   Apply the same bounding to the llama.cpp wire-literal branch's `messages` list.
+3. **Reclaim existing oversized captures without user action**: schema v52 -> v53 migration that
+   walks `message_exchanges` rows with `capture_detail = 'safe'`, applies the identical trim to
+   each stored blob via a pure `trim_safe_capture_blob` helper, and rewrites only rows that
+   changed — inside the migration chain's single outer transaction (atomic; SIGKILL rolls back to
+   v52 and the deterministic trim re-runs), re-enterable via the guarded version bump, per-row
+   corrupt blobs skipped (never brick the DB). Full rows byte-untouched.
+4. **Tests**: pure-builder elision/idempotency/inventory pins, a bounded-growth pin through the
+   real gateway path, migration tests (historical bootstrap at v52, content-hash equality of
+   everything not deliberately trimmed, `integrity_check`, SIGKILL interrupt-safety, re-entry,
+   corrupt-blob skip, Full untouched), each proven to fail against a deliberately broken
+   implementation (mutation results in Notes).
+5. **Re-measure** the same 200-turn run after the change; update the user guide's Safe/Full
+   retention paragraph; state the `omitted_keys` privacy stance below; preflight; commit.
+
+## Implementation Notes
+
+**Approach.** Bounded excerpt + per-row references, applied at the one pure seam every
+capture flows through (`build_request_capture`), plus a one-time automatic trim of
+already-stored blobs in the schema migration chain.
+
+- **Safe (the default) is now bounded.** `elide_safe_history_rows` in
+  `Chat/console_exchange_capture.py`: the newest `CAPTURE_SAFE_HISTORY_TAIL_ROWS = 8`
+  `messages_payload` rows (this turn's delta plus immediate context) persist verbatim;
+  every older row is replaced IN PLACE by a content-free fingerprint row — `role` and
+  `__tldw_ephemeral_origin` tag preserved, `capture_elided: True`, content replaced by
+  `[conversation history elided by capture policy -- N chars, sha256:<16 hex>]`. The
+  digest is sha256 over the row's canonical sanitized JSON — exactly the form the earlier
+  capture whose tail the row was new in retained — so row identity is verifiable across
+  turns and against the transcript without re-storing bodies. Idempotent (structural
+  `capture_elided` key, never content matching), because `console_exchange_export.py`
+  re-runs the builder over stored requests. The llama.cpp wire-literal branch
+  (`capture_wire_payload` in `console_provider_gateway.py`) bounds its `messages` list
+  identically, path-prefixed `wire_payload.messages`. **Full is untouched**: it is the
+  explicit, consent-gated, purgeable verbatim mode (ADR-092), and the existing
+  user-invoked purge already covers it.
+- **What Safe still answers** (AC 3): "what did this call hand the provider adapter" —
+  full system prompt, tools, sampling/routing params, response, usage, per-call status,
+  the complete payload shape (row count/order/roles/sizes stay truthful in the
+  Inspector's Messages section), the turn's NEW content verbatim, and a verifiable
+  fingerprint for each elided history row. Elided bodies remain recoverable from the
+  transcript, from the earlier capture where the row was in the tail (hash-checkable), or
+  by opting a conversation into Full for a debugging session.
+- **Reclaim** (AC 2): ChaChaNotes v52→v53 (`_migrate_from_v52_to_v53`) walks
+  `message_exchanges WHERE capture_detail='safe'` and rewrites each blob through the pure
+  `trim_safe_capture_blob` (returns `None` when nothing changes; never touches Full;
+  per-row undecodable blobs are skipped, so one corrupt row cannot brick the DB).
+  DML-only Python step — no DDL, no `.sql`, no `VALID_TABLES`/index-census entries.
+  Correctness evidence in `Tests/DB/test_chachanotes_v53_safe_capture_trim.py`: value
+  identity for everything not deliberately trimmed, `PRAGMA integrity_check` clean,
+  re-entry fixed-point, in-process failure mid-walk rewinds blobs AND version stamp
+  together, and a real-SIGKILL child (v47-backfill technique) rolls back to v52 and then
+  converges byte-identically with an uninterrupted control run. Schema v53 swept against
+  all 808 refs and every worktree — no collision (this programme has collided four
+  times).
+- **omitted_keys stance** (AC 5, recorded beside the allowlist in the module): capture
+  exists to answer "what was sent", so conversation content is the subject and is
+  retained BY DESIGN — governed by the user-controllable Safe/Full detail policy, not
+  the allowlist. Credentials never persist at any level; project-instruction bodies
+  never persist under Safe; and every withholding — dropped kwarg, redacted instruction
+  body, elided history range (`messages_payload[0..N].content (conversation history
+  elided)`) — is named in `omitted_keys`, which the Inspector already renders verbatim.
+- **Growth re-measured** (AC 4), real production path (`stream_chat` →
+  `_chat_api_kwargs_from_prepared` → `build_request_capture` → `capture_to_blob`), same
+  inputs both arms: turn-1 blob 0.9 KB → 0.9 KB; turn-200 blob **217.1 KB → 10.1 KB**;
+  200-turn total **21.33 MB → 1.48 MB** (14.4x). Residual growth is the ~25 B/row
+  compressed fingerprint index plus the bounded verbatim tail.
+- **Readers audited**: Inspector (`console_conversation_inspector.py` — renders rows as
+  collapsibles + JSON; fingerprint rows render as ordinary rows, counts stay truthful),
+  export projections (`console_exchange_export.py` — idempotency pinned), store/flush
+  (`console_chat_store.py` — opaque blob pass-through), loader (`chat_screen.py` —
+  `capture_from_storage`, unchanged). Capture failure still never blocks a send
+  (existing gateway pin `test_never_break_send_when_build_request_capture_raises` covers
+  the new code path).
+- **Mutation results** (all reverted): M1 disable elision → 6 tests red (and exposed a
+  non-discriminating growth guard whose "lorem" filler compressed ~100x — filler made
+  semi-incompressible, guard proven red-capable); M2 re-fingerprint elided rows → red;
+  M3 redaction re-measures fingerprints → red; M4 migration trim no-op → 3 migration
+  tests red; M6 digest not over row body → red; M7 wire elision dropped → red; M8 trim
+  touches Full → red.
+- **Tests**: +23 new (13 pure, 5 gateway, 4 migration, 1 updated version pin);
+  touched-surface total 567 green (169 core + 398 gateway/inspector). Full
+  `Tests/DB/ + Tests/ChaChaNotesDB/`: 1931 passed; 7 pre-existing dev reds
+  (A/B-identical failure sets on pristine base c4e52794e2: 1x v27 character-authority
+  column pin broken by v52's `thinking_history_policy`, 3x sync_log_retention, 2x v47
+  fts backfill, 1x provider_continuation) — not adopted.
+- **Modified**: `Chat/console_exchange_capture.py`, `Chat/console_provider_gateway.py`,
+  `DB/ChaChaNotes_DB.py` (v53), `Docs/User_Guide/console/context-and-rag.md` (Safe/Full
+  retention paragraph now matches the code — the shipped text already promised "bounded"
+  Safe retention the code did not honor), tests as above.
+- **Diagnostic inventory**: +2 `logger.info` rows in `ChaChaNotes_DB.py` reviewed via
+  `check_persistent_diagnostic_inventory.py --statements --since 5d9b4bec5a` before
+  `--write`: both are the migration chain's established start/finish pattern,
+  interpolating only `db_path_str` and two integer counters — no capture content, user
+  text, or secrets (capture blobs are deliberately never logged, even on the
+  corrupt-row skip path).

--- a/backlog/tasks/task-23026 - Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md
+++ b/backlog/tasks/task-23026 - Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md
@@ -2,7 +2,7 @@
 id: TASK-23026
 title: >-
   Exchange capture stores the whole conversation on every send, forever
-status: Done
+status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-08-27'
@@ -41,6 +41,17 @@ independently at 15.35 MB. An earlier probe reported this feature **clean** at 0
 had been built from a hand-made input rather than the real caller's kwargs, and was refuted.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Approved Design
+
+- [Console Safe Capture Retention design](../../Docs/superpowers/specs/2026-08-27-console-safe-capture-retention-design.md)
+- [ADR-096: Bound Safe exchange-capture history](../decisions/096-console-safe-capture-retention.md)
+
+ADR required: yes
+
+ADR path: `backlog/decisions/096-console-safe-capture-retention.md`
+
+Reason: the task changes durable capture retention, privacy semantics, and the ChaChaNotes data migration contract.
 
 ## Implementation Plan
 
@@ -152,3 +163,4 @@ already-stored blobs in the schema migration chain.
   interpolating only `db_path_str` and two integer counters — no capture content, user
   text, or secrets (capture blobs are deliberately never logged, even on the
   corrupt-row skip path).
+

--- a/tldw_chatbook/Chat/console_exchange_capture.py
+++ b/tldw_chatbook/Chat/console_exchange_capture.py
@@ -43,22 +43,23 @@ CAPTURE_REQUEST_ALLOWLIST: frozenset[str] = frozenset({
 # "api_key_resolved" (credential-adjacent marker) — they surface in
 # omitted_keys instead.
 #
-# Privacy stance for what IS on the list (task-23026): capture exists to
-# answer "what did we actually hand the provider adapter on this call", so
-# the conversation content is the subject, not an accident — it is retained
-# by design, under the user-controllable Safe/Full detail policy rather
-# than the allowlist. Under Safe (the default) retention is BOUNDED: the
-# newest ``CAPTURE_SAFE_HISTORY_TAIL_ROWS`` payload rows (this turn's delta
-# plus immediate context) persist verbatim, and every older history row is
-# replaced in place by a content-free fingerprint (role, origin tag, char
-# count, sha256 prefix) — the bodies of those rows are already durably
-# stored once in the ``messages`` table and once in the earlier capture
-# whose tail they were new in, so a per-turn re-copy stored nothing new
-# and grew O(n²) (measured 21.33 MB for one 200-turn conversation).
-# Full — explicit, consent-gated, purgeable (ADR-092) — retains the whole
-# payload verbatim. Credentials never persist at any detail level, and
-# every withholding (dropped key, redacted instruction body, elided
-# history range) is named in ``omitted_keys`` so the Inspector shows it.
+# Privacy stance for what IS on the list (task-23026, ADR-096): capture
+# exists to answer "what did we actually hand the provider adapter on this
+# call", so the conversation content is the subject, not an accident — it
+# is retained by design, under the user-controllable Safe/Full detail
+# policy rather than the allowlist. Under Safe (the default) retention is
+# BOUNDED per ADR-096's contract: the first system row, the latest user
+# row, and the final eight physical payload rows persist verbatim; every
+# other row is represented by ONE content-free aggregate marker (counts
+# and retained positions only — no content, snippets, per-row lengths,
+# hashes, IDs, or timestamps; a digest of omitted text is explicitly
+# forbidden because it would let anyone with DB access confirm guesses
+# about private content). Storing the whole history per turn grew O(n²) —
+# measured 21.33 MB for one 200-turn conversation. Full — explicit,
+# consent-gated, purgeable (ADR-092) — retains the whole payload verbatim.
+# Credentials never persist at any detail level, and every withholding
+# (dropped key, redacted instruction body, elided history) is named in
+# ``omitted_keys`` so the Inspector shows it.
 
 #: Strings at/above this length are candidates for base64 stubbing.
 _STUB_MIN_CHARS = 4096
@@ -73,18 +74,32 @@ _SEMANTIC_JSON_STRING_KEYS = frozenset({"arguments", "input", "result", "output"
 EXCHANGE_BLOB_MAX_BYTES = 16 * 1024 * 1024
 CAPTURE_JSON_MAX_BYTES = 64 * 1024 * 1024
 
-#: How many trailing ``messages_payload`` rows a Safe capture keeps verbatim.
-#: The tail always covers the turn's NEW rows (one user row on the direct
-#: path; assistant tool_calls + tool results on an agent-loop call) plus a
-#: few rows of immediate context; everything older is fingerprinted in
-#: place (task-23026).
+#: How many trailing physical payload rows a Safe capture keeps verbatim
+#: (ADR-096). The tail always covers the turn's NEW rows (one user row on
+#: the direct path; assistant tool_calls + tool results on an agent-loop
+#: call) plus a few rows of immediate context.
 CAPTURE_SAFE_HISTORY_TAIL_ROWS = 8
 
-#: Structural marker on a fingerprint row produced by
-#: :func:`elide_safe_history_rows`. Keyed structurally (never by content
-#: prefix) so re-running the builder over a stored request — the export
-#: projection path — passes already-elided rows through untouched.
-CAPTURE_ELIDED_ROW_KEY = "capture_elided"
+#: Versioned kind discriminator of the ONE aggregate history-elision
+#: marker :func:`compact_safe_history_rows` inserts (ADR-096). Recognition
+#: is structural and strict (`_is_valid_history_elision_marker`); a
+#: malformed lookalike is an ordinary row.
+CAPTURE_HISTORY_ELISION_KIND = "tldw.exchange_capture.safe_history_elision"
+CAPTURE_HISTORY_ELISION_VERSION = 1
+
+#: The marker's EXACT key set. ADR-096 forbids the marker carrying
+#: anything beyond these — in particular content, snippets, per-row
+#: lengths, hashes/digests, IDs, or timestamps. The shape-guard test pins
+#: this frozen set so a digest cannot be reintroduced silently.
+CAPTURE_HISTORY_MARKER_KEYS = frozenset({
+    "kind", "version", "original_rows", "omitted_rows",
+    "omitted_roles", "retained_positions",
+})
+
+#: Normalized role buckets the marker counts omitted rows into. Unknown,
+#: missing, or non-string roles count only toward ``other`` — their raw
+#: values are never retained in the marker.
+CAPTURE_HISTORY_MARKER_ROLES = ("system", "user", "assistant", "tool", "other")
 
 
 class CaptureDetail(str, Enum):
@@ -338,12 +353,6 @@ def _redact_project_instruction_rows(
         if capture_detail is CaptureDetail.FULL or not (
             isinstance(row, Mapping)
             and row.get(EPHEMERAL_ORIGIN_KEY) == _PROJECT_INSTRUCTION_ORIGIN
-            # task-23026: a fingerprint row from `elide_safe_history_rows`
-            # is already content-free — re-marking it would replace the
-            # fingerprint with a marker measuring the MARKER's length, so
-            # the export path's re-run of this builder over a stored
-            # request must pass it through untouched.
-            and not row.get(CAPTURE_ELIDED_ROW_KEY)
         ):
             rows.append(row)
             continue
@@ -410,97 +419,161 @@ def _retain_with_budget(
     return {"truncated": True}
 
 
-def _canonical_row_json(row: Any) -> str:
-    return json.dumps(
-        row, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
-    )
+def _is_valid_history_elision_marker(row: Any) -> bool:
+    """Strict structural recognition of the capture's own marker (ADR-096).
 
-
-def _fingerprint_row(row: Any) -> dict[str, Any]:
-    """Replace one history row with a content-free, verifiable fingerprint.
-
-    The sha256 prefix is computed over the row's canonical sanitized JSON,
-    which is exactly the form an earlier capture retained when this row was
-    in its verbatim tail — so a viewer can confirm identity across turns
-    (and against the transcript) without the body, the same contract the
-    binary stubs already make.
+    Recognition is by exact versioned shape, never by content prefix: the
+    key set must equal ``CAPTURE_HISTORY_MARKER_KEYS`` exactly, the kind
+    and version must match, counts must be real non-negative ints (bools
+    rejected), ``omitted_roles`` must carry exactly the five normalized
+    buckets with int values, and ``retained_positions`` must be a list of
+    ints. A malformed lookalike is an ordinary row and remains subject to
+    the normal bounded selection.
     """
-    digest = hashlib.sha256(
-        _canonical_row_json(row).encode("utf-8", errors="replace")
-    ).hexdigest()[:16]
-    role = row.get("role") if isinstance(row, Mapping) else None
-    content = row.get("content") if isinstance(row, Mapping) else row
-    if isinstance(content, str):
-        chars = len(content)
-    elif content is None:
-        chars = 0
-    else:
-        chars = len(_canonical_row_json(content))
-    out: dict[str, Any] = {
-        "role": str(role) if role is not None else "?",
-        CAPTURE_ELIDED_ROW_KEY: True,
-        "content": (
-            f"[conversation history elided by capture policy -- "
-            f"{chars} chars, sha256:{digest}]"
-        ),
-    }
-    if isinstance(row, Mapping) and EPHEMERAL_ORIGIN_KEY in row:
-        out[EPHEMERAL_ORIGIN_KEY] = row[EPHEMERAL_ORIGIN_KEY]
-    return out
+    if not isinstance(row, Mapping):
+        return False
+    if set(row.keys()) != CAPTURE_HISTORY_MARKER_KEYS:
+        return False
+    if row.get("kind") != CAPTURE_HISTORY_ELISION_KIND:
+        return False
+    version = row.get("version")
+    if type(version) is not int or version != CAPTURE_HISTORY_ELISION_VERSION:
+        return False
+    for key in ("original_rows", "omitted_rows"):
+        value = row.get(key)
+        if type(value) is not int or value < 0:
+            return False
+    roles = row.get("omitted_roles")
+    if not isinstance(roles, Mapping):
+        return False
+    if set(roles.keys()) != set(CAPTURE_HISTORY_MARKER_ROLES):
+        return False
+    if any(type(value) is not int or value < 0 for value in roles.values()):
+        return False
+    positions = row.get("retained_positions")
+    if not isinstance(positions, list):
+        return False
+    return all(type(position) is int for position in positions)
 
 
-def elide_safe_history_rows(
+def history_elision_marker(rows: Any) -> Mapping[str, Any] | None:
+    """Return the list's valid history-elision marker, if any.
+
+    Public reader for the Inspector: lets the Messages section title state
+    the original row count honestly when the stored list is compacted.
+    """
+    if not isinstance(rows, (list, tuple)):
+        return None
+    for row in rows:
+        if _is_valid_history_elision_marker(row):
+            return row
+    return None
+
+
+def _normalized_omitted_role(row: Any) -> str:
+    if isinstance(row, Mapping):
+        role = row.get("role")
+        if isinstance(role, str) and role in ("system", "user", "assistant", "tool"):
+            return role
+    return "other"
+
+
+def compact_safe_history_rows(
     rows: Any,
     capture_detail: CaptureDetail,
     *,
     path: str = "messages_payload",
 ) -> tuple[Any, tuple[str, ...]]:
-    """Bound a Safe capture's per-turn conversation-history copy (task-23026).
+    """Bound a Safe capture's per-turn conversation-history copy (ADR-096).
 
     Every send's payload carries the whole conversation so far, so
     persisting it verbatim per turn re-stored the entire history O(n²)
     (21.33 MB measured for one 200-turn conversation). Under Safe — the
-    default — only the newest ``CAPTURE_SAFE_HISTORY_TAIL_ROWS`` rows (the
-    turn's new rows plus immediate context) stay verbatim; each older row
-    is replaced IN PLACE by a fingerprint row (role + origin tag + char
-    count + sha256 prefix), so the payload's exact shape, order, and
-    per-row identity remain inspectable and the count the Inspector shows
-    stays truthful. Idempotent: rows already carrying
-    ``CAPTURE_ELIDED_ROW_KEY`` pass through unchanged, so the export
-    projection's re-run over a stored request is a fixed point.
+    default — the retained set is the union of: the first mapping row
+    whose ``role`` is exactly ``system``, the last mapping row whose
+    ``role`` is exactly ``user``, and the final
+    ``CAPTURE_SAFE_HISTORY_TAIL_ROWS`` physical rows — deduplicated, in
+    original relative order, values untouched. Non-mapping rows are
+    eligible only through the tail. Every other row is represented by ONE
+    content-free aggregate marker inserted at the position of the first
+    omitted row (counts and retained positions only — never content,
+    snippets, per-row lengths, digests, IDs, or timestamps: a digest would
+    let anyone with database access confirm guesses about omitted private
+    text).
+
+    Idempotent by marker recognition: a recognized valid marker is
+    transparent to selection and preserved when nothing else is omitted,
+    so re-projecting a stored Safe request (the export path re-runs this
+    builder) is a fixed point. An input marker never disables compaction
+    of surrounding rows — when new rows must be omitted, stale markers are
+    dropped and exactly one fresh marker describes this pass.
 
     Args:
         rows: The sanitized ``messages_payload`` (or wire ``messages``)
             list; any non-list shape passes through untouched.
-        capture_detail: Full skips elision entirely — Full is the explicit,
-            consent-gated, purgeable verbatim mode (ADR-092).
-        path: Inventory path prefix for the returned omission entry.
+        capture_detail: Full skips compaction entirely — Full is the
+            explicit, consent-gated, purgeable verbatim mode (ADR-092).
+        path: Stable omission-inventory prefix; the entry is
+            ``f"{path}.history"`` so repeated projection cannot create
+            duplicate or ever-changing strings.
 
     Returns:
-        The (possibly new) row list and a 0- or 1-entry inventory tuple
-        naming the elided range, rendered by the Inspector's existing
-        "Omitted by capture policy" line.
+        The (possibly new) row list and a 0- or 1-entry inventory tuple,
+        rendered by the Inspector's existing "Omitted by capture policy"
+        line.
     """
     if capture_detail is CaptureDetail.FULL or not isinstance(rows, list):
         return rows, ()
-    if len(rows) <= CAPTURE_SAFE_HISTORY_TAIL_ROWS:
+    real = [
+        (position, row)
+        for position, row in enumerate(rows)
+        if not _is_valid_history_elision_marker(row)
+    ]
+    if not real:
         return rows, ()
-    cut = len(rows) - CAPTURE_SAFE_HISTORY_TAIL_ROWS
-    out: list[Any] = []
-    elided_any = False
-    for index, row in enumerate(rows):
-        if index >= cut or (
-            isinstance(row, Mapping) and row.get(CAPTURE_ELIDED_ROW_KEY)
-        ):
-            out.append(row)
-            continue
-        out.append(_fingerprint_row(row))
-        elided_any = True
-    if not elided_any:
-        return rows, ()
-    return out, (
-        f"{path}[0..{cut - 1}].content (conversation history elided)",
+    retained: set[int] = set()
+    for position, row in real:
+        if isinstance(row, Mapping) and row.get("role") == "system":
+            retained.add(position)
+            break
+    for position, row in reversed(real):
+        if isinstance(row, Mapping) and row.get("role") == "user":
+            retained.add(position)
+            break
+    tail_start = max(0, len(rows) - CAPTURE_SAFE_HISTORY_TAIL_ROWS)
+    retained.update(
+        position for position, _row in real if position >= tail_start
     )
+    omitted = [
+        (position, row) for position, row in real if position not in retained
+    ]
+    if not omitted:
+        # Fixed point: nothing new to omit — the list (including any
+        # already-present marker) is returned unchanged.
+        return rows, ()
+    role_counts = {role: 0 for role in CAPTURE_HISTORY_MARKER_ROLES}
+    for _position, row in omitted:
+        role_counts[_normalized_omitted_role(row)] += 1
+    marker: dict[str, Any] = {
+        "kind": CAPTURE_HISTORY_ELISION_KIND,
+        "version": CAPTURE_HISTORY_ELISION_VERSION,
+        "original_rows": len(real),
+        "omitted_rows": len(omitted),
+        "omitted_roles": role_counts,
+        "retained_positions": sorted(retained),
+    }
+    first_omitted = omitted[0][0]
+    out: list[Any] = []
+    for position, row in enumerate(rows):
+        if position == first_omitted:
+            out.append(marker)
+        if _is_valid_history_elision_marker(row):
+            # Stale metadata from a previous compaction of a DIFFERENT row
+            # set — exactly one fresh marker describes this pass.
+            continue
+        if position in retained:
+            out.append(row)
+    return out, (f"{path}.history",)
 
 
 def build_request_capture(
@@ -543,10 +616,10 @@ def build_request_capture(
                     value = "[invalid endpoint]"
             value = sanitize_capture_value(value)
             if key == "messages_payload":
-                # task-23026: after sanitization (so fingerprints hash the
-                # exact form an earlier capture's tail retained), bound the
-                # per-turn history copy under Safe.
-                value, elided_paths = elide_safe_history_rows(
+                # ADR-096 ordering: compaction runs AFTER redaction and
+                # sanitization (so the marker can never describe raw
+                # secret/binary values) and BEFORE the shared budget.
+                value, elided_paths = compact_safe_history_rows(
                     value, capture_detail
                 )
                 omitted.extend(elided_paths)
@@ -695,23 +768,23 @@ def capture_from_storage(blob: bytes, declared_detail: object) -> ExchangeCaptur
 
 
 def trim_safe_capture_blob(blob: bytes) -> bytes | None:
-    """Apply Safe history elision to one STORED capture blob (task-23026).
+    """Apply ADR-096 Safe history compaction to one STORED capture blob.
 
     Pure helper for the ChaChaNotes v52→v53 migration: captures persisted
-    before elision existed carry the whole conversation per turn. This
-    decodes the blob, bounds ``request.messages_payload`` (and the
+    before compaction existed carry the whole conversation per turn. This
+    decodes the blob, compacts ``request.messages_payload`` (and the
     llama.cpp branch's ``request.wire_payload.messages``) exactly the way
-    :func:`build_request_capture` now does at capture time, folds the
-    elided range into ``omitted_keys``, and re-encodes. Everything else —
-    response, usage, status, provenance, the retained tail — is preserved
-    value-identical.
+    :func:`build_request_capture` now does at capture time, merges the
+    stable history-elision paths into ``omitted_keys``, and re-encodes.
+    Everything else — response, usage, status, provenance, the retained
+    rows — is preserved value-identical.
 
     Args:
         blob: One ``message_exchanges.capture_blob`` value.
 
     Returns:
-        The trimmed replacement blob, or ``None`` when nothing changed
-        (already trimmed, short payload, or a Full capture — Full is the
+        The compacted replacement blob, or ``None`` when nothing changed
+        (already compacted, small payload, or a Full capture — Full is the
         deliberate verbatim mode and is never rewritten here).
 
     Raises:
@@ -726,20 +799,20 @@ def trim_safe_capture_blob(blob: bytes) -> bytes | None:
     new_request = dict(capture.request)
     new_paths: list[str] = []
     rows = new_request.get("messages_payload")
-    trimmed_rows, elided = elide_safe_history_rows(rows, CaptureDetail.SAFE)
+    compacted_rows, elided = compact_safe_history_rows(rows, CaptureDetail.SAFE)
     if elided:
-        new_request["messages_payload"] = trimmed_rows
+        new_request["messages_payload"] = compacted_rows
         new_paths.extend(elided)
     wire = new_request.get("wire_payload")
     if isinstance(wire, Mapping):
-        trimmed_wire_rows, wire_elided = elide_safe_history_rows(
+        compacted_wire_rows, wire_elided = compact_safe_history_rows(
             wire.get("messages"),
             CaptureDetail.SAFE,
             path="wire_payload.messages",
         )
         if wire_elided:
             new_wire = dict(wire)
-            new_wire["messages"] = trimmed_wire_rows
+            new_wire["messages"] = compacted_wire_rows
             new_request["wire_payload"] = new_wire
             new_paths.extend(wire_elided)
     if not new_paths:

--- a/tldw_chatbook/Chat/console_exchange_capture.py
+++ b/tldw_chatbook/Chat/console_exchange_capture.py
@@ -42,6 +42,23 @@ CAPTURE_REQUEST_ALLOWLIST: frozenset[str] = frozenset({
 # Deliberately OFF the allowlist: "api_key" (credential) and
 # "api_key_resolved" (credential-adjacent marker) — they surface in
 # omitted_keys instead.
+#
+# Privacy stance for what IS on the list (task-23026): capture exists to
+# answer "what did we actually hand the provider adapter on this call", so
+# the conversation content is the subject, not an accident — it is retained
+# by design, under the user-controllable Safe/Full detail policy rather
+# than the allowlist. Under Safe (the default) retention is BOUNDED: the
+# newest ``CAPTURE_SAFE_HISTORY_TAIL_ROWS`` payload rows (this turn's delta
+# plus immediate context) persist verbatim, and every older history row is
+# replaced in place by a content-free fingerprint (role, origin tag, char
+# count, sha256 prefix) — the bodies of those rows are already durably
+# stored once in the ``messages`` table and once in the earlier capture
+# whose tail they were new in, so a per-turn re-copy stored nothing new
+# and grew O(n²) (measured 21.33 MB for one 200-turn conversation).
+# Full — explicit, consent-gated, purgeable (ADR-092) — retains the whole
+# payload verbatim. Credentials never persist at any detail level, and
+# every withholding (dropped key, redacted instruction body, elided
+# history range) is named in ``omitted_keys`` so the Inspector shows it.
 
 #: Strings at/above this length are candidates for base64 stubbing.
 _STUB_MIN_CHARS = 4096
@@ -55,6 +72,19 @@ _SEMANTIC_JSON_STRING_KEYS = frozenset({"arguments", "input", "result", "output"
 
 EXCHANGE_BLOB_MAX_BYTES = 16 * 1024 * 1024
 CAPTURE_JSON_MAX_BYTES = 64 * 1024 * 1024
+
+#: How many trailing ``messages_payload`` rows a Safe capture keeps verbatim.
+#: The tail always covers the turn's NEW rows (one user row on the direct
+#: path; assistant tool_calls + tool results on an agent-loop call) plus a
+#: few rows of immediate context; everything older is fingerprinted in
+#: place (task-23026).
+CAPTURE_SAFE_HISTORY_TAIL_ROWS = 8
+
+#: Structural marker on a fingerprint row produced by
+#: :func:`elide_safe_history_rows`. Keyed structurally (never by content
+#: prefix) so re-running the builder over a stored request — the export
+#: projection path — passes already-elided rows through untouched.
+CAPTURE_ELIDED_ROW_KEY = "capture_elided"
 
 
 class CaptureDetail(str, Enum):
@@ -308,6 +338,12 @@ def _redact_project_instruction_rows(
         if capture_detail is CaptureDetail.FULL or not (
             isinstance(row, Mapping)
             and row.get(EPHEMERAL_ORIGIN_KEY) == _PROJECT_INSTRUCTION_ORIGIN
+            # task-23026: a fingerprint row from `elide_safe_history_rows`
+            # is already content-free — re-marking it would replace the
+            # fingerprint with a marker measuring the MARKER's length, so
+            # the export path's re-run of this builder over a stored
+            # request must pass it through untouched.
+            and not row.get(CAPTURE_ELIDED_ROW_KEY)
         ):
             rows.append(row)
             continue
@@ -374,6 +410,99 @@ def _retain_with_budget(
     return {"truncated": True}
 
 
+def _canonical_row_json(row: Any) -> str:
+    return json.dumps(
+        row, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+    )
+
+
+def _fingerprint_row(row: Any) -> dict[str, Any]:
+    """Replace one history row with a content-free, verifiable fingerprint.
+
+    The sha256 prefix is computed over the row's canonical sanitized JSON,
+    which is exactly the form an earlier capture retained when this row was
+    in its verbatim tail — so a viewer can confirm identity across turns
+    (and against the transcript) without the body, the same contract the
+    binary stubs already make.
+    """
+    digest = hashlib.sha256(
+        _canonical_row_json(row).encode("utf-8", errors="replace")
+    ).hexdigest()[:16]
+    role = row.get("role") if isinstance(row, Mapping) else None
+    content = row.get("content") if isinstance(row, Mapping) else row
+    if isinstance(content, str):
+        chars = len(content)
+    elif content is None:
+        chars = 0
+    else:
+        chars = len(_canonical_row_json(content))
+    out: dict[str, Any] = {
+        "role": str(role) if role is not None else "?",
+        CAPTURE_ELIDED_ROW_KEY: True,
+        "content": (
+            f"[conversation history elided by capture policy -- "
+            f"{chars} chars, sha256:{digest}]"
+        ),
+    }
+    if isinstance(row, Mapping) and EPHEMERAL_ORIGIN_KEY in row:
+        out[EPHEMERAL_ORIGIN_KEY] = row[EPHEMERAL_ORIGIN_KEY]
+    return out
+
+
+def elide_safe_history_rows(
+    rows: Any,
+    capture_detail: CaptureDetail,
+    *,
+    path: str = "messages_payload",
+) -> tuple[Any, tuple[str, ...]]:
+    """Bound a Safe capture's per-turn conversation-history copy (task-23026).
+
+    Every send's payload carries the whole conversation so far, so
+    persisting it verbatim per turn re-stored the entire history O(n²)
+    (21.33 MB measured for one 200-turn conversation). Under Safe — the
+    default — only the newest ``CAPTURE_SAFE_HISTORY_TAIL_ROWS`` rows (the
+    turn's new rows plus immediate context) stay verbatim; each older row
+    is replaced IN PLACE by a fingerprint row (role + origin tag + char
+    count + sha256 prefix), so the payload's exact shape, order, and
+    per-row identity remain inspectable and the count the Inspector shows
+    stays truthful. Idempotent: rows already carrying
+    ``CAPTURE_ELIDED_ROW_KEY`` pass through unchanged, so the export
+    projection's re-run over a stored request is a fixed point.
+
+    Args:
+        rows: The sanitized ``messages_payload`` (or wire ``messages``)
+            list; any non-list shape passes through untouched.
+        capture_detail: Full skips elision entirely — Full is the explicit,
+            consent-gated, purgeable verbatim mode (ADR-092).
+        path: Inventory path prefix for the returned omission entry.
+
+    Returns:
+        The (possibly new) row list and a 0- or 1-entry inventory tuple
+        naming the elided range, rendered by the Inspector's existing
+        "Omitted by capture policy" line.
+    """
+    if capture_detail is CaptureDetail.FULL or not isinstance(rows, list):
+        return rows, ()
+    if len(rows) <= CAPTURE_SAFE_HISTORY_TAIL_ROWS:
+        return rows, ()
+    cut = len(rows) - CAPTURE_SAFE_HISTORY_TAIL_ROWS
+    out: list[Any] = []
+    elided_any = False
+    for index, row in enumerate(rows):
+        if index >= cut or (
+            isinstance(row, Mapping) and row.get(CAPTURE_ELIDED_ROW_KEY)
+        ):
+            out.append(row)
+            continue
+        out.append(_fingerprint_row(row))
+        elided_any = True
+    if not elided_any:
+        return rows, ()
+    return out, (
+        f"{path}[0..{cut - 1}].content (conversation history elided)",
+    )
+
+
 def build_request_capture(
     kwargs: Mapping[str, Any],
     *,
@@ -413,6 +542,14 @@ def build_request_capture(
                 except ValueError:
                     value = "[invalid endpoint]"
             value = sanitize_capture_value(value)
+            if key == "messages_payload":
+                # task-23026: after sanitization (so fingerprints hash the
+                # exact form an earlier capture's tail retained), bound the
+                # per-turn history copy under Safe.
+                value, elided_paths = elide_safe_history_rows(
+                    value, capture_detail
+                )
+                omitted.extend(elided_paths)
             request[key] = _retain_with_budget(
                 value, active_budget, key, truncation_inventory
             )
@@ -555,3 +692,59 @@ def capture_from_storage(blob: bytes, declared_detail: object) -> ExchangeCaptur
     if detail is None or capture.capture_detail is not detail:
         raise CaptureCorruptError("capture provenance mismatch")
     return capture
+
+
+def trim_safe_capture_blob(blob: bytes) -> bytes | None:
+    """Apply Safe history elision to one STORED capture blob (task-23026).
+
+    Pure helper for the ChaChaNotes v52→v53 migration: captures persisted
+    before elision existed carry the whole conversation per turn. This
+    decodes the blob, bounds ``request.messages_payload`` (and the
+    llama.cpp branch's ``request.wire_payload.messages``) exactly the way
+    :func:`build_request_capture` now does at capture time, folds the
+    elided range into ``omitted_keys``, and re-encodes. Everything else —
+    response, usage, status, provenance, the retained tail — is preserved
+    value-identical.
+
+    Args:
+        blob: One ``message_exchanges.capture_blob`` value.
+
+    Returns:
+        The trimmed replacement blob, or ``None`` when nothing changed
+        (already trimmed, short payload, or a Full capture — Full is the
+        deliberate verbatim mode and is never rewritten here).
+
+    Raises:
+        CaptureUnavailableError: If the blob cannot be decoded (corrupt or
+            over the safety limits) — the caller leaves such a row as-is.
+    """
+    capture = capture_from_blob(blob)
+    if capture.capture_detail is not CaptureDetail.SAFE:
+        return None
+    if not isinstance(capture.request, dict):
+        return None
+    new_request = dict(capture.request)
+    new_paths: list[str] = []
+    rows = new_request.get("messages_payload")
+    trimmed_rows, elided = elide_safe_history_rows(rows, CaptureDetail.SAFE)
+    if elided:
+        new_request["messages_payload"] = trimmed_rows
+        new_paths.extend(elided)
+    wire = new_request.get("wire_payload")
+    if isinstance(wire, Mapping):
+        trimmed_wire_rows, wire_elided = elide_safe_history_rows(
+            wire.get("messages"),
+            CaptureDetail.SAFE,
+            path="wire_payload.messages",
+        )
+        if wire_elided:
+            new_wire = dict(wire)
+            new_wire["messages"] = trimmed_wire_rows
+            new_request["wire_payload"] = new_wire
+            new_paths.extend(wire_elided)
+    if not new_paths:
+        return None
+    merged_omitted = tuple(sorted(set(capture.omitted_keys).union(new_paths)))
+    return capture_to_blob(
+        replace(capture, request=new_request, omitted_keys=merged_omitted)
+    )

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -36,7 +36,7 @@ from tldw_chatbook.Chat.console_exchange_capture import (
     CaptureDetail,
     ExchangeCapture,
     build_request_capture,
-    elide_safe_history_rows,
+    compact_safe_history_rows,
     sanitize_capture_value,
 )
 from tldw_chatbook.Chat.console_project_instructions import (
@@ -3161,13 +3161,13 @@ class ConsoleProviderGateway:
                                 )
                     sanitized = sanitize_capture_value(captured)
                     if isinstance(sanitized, dict):
-                        elided_rows, elided_paths = elide_safe_history_rows(
+                        compacted_rows, elided_paths = compact_safe_history_rows(
                             sanitized.get("messages"),
                             detail,
                             path="wire_payload.messages",
                         )
                         if elided_paths:
-                            sanitized["messages"] = elided_rows
+                            sanitized["messages"] = compacted_rows
                         return sanitized, elided_paths
                     return sanitized, ()
 

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -36,6 +36,7 @@ from tldw_chatbook.Chat.console_exchange_capture import (
     CaptureDetail,
     ExchangeCapture,
     build_request_capture,
+    elide_safe_history_rows,
     sanitize_capture_value,
 )
 from tldw_chatbook.Chat.console_project_instructions import (
@@ -3112,13 +3113,18 @@ class ConsoleProviderGateway:
 
                 def capture_wire_payload(
                     raw_wire: Mapping[str, Any], detail: CaptureDetail
-                ) -> Any:
+                ) -> tuple[Any, tuple[str, ...]]:
+                    """Returns the sanitized wire capture plus the Safe
+                    history-elision inventory (task-23026) — the same
+                    O(n²)-copy bound the generic path gets from
+                    ``build_request_capture``, applied to this branch's
+                    literal ``messages`` list."""
                     captured = deepcopy(raw_wire)
                     if detail is not CaptureDetail.SAFE:
-                        return sanitize_capture_value(captured)
+                        return sanitize_capture_value(captured), ()
                     captured_messages = captured.get("messages")
                     if not isinstance(captured_messages, list):
-                        return sanitize_capture_value(captured)
+                        return sanitize_capture_value(captured), ()
                     semantic_messages = [
                         thaw_json(item)
                         for item in prepared.semantic.flattened_messages()
@@ -3153,7 +3159,17 @@ class ConsoleProviderGateway:
                                     "[project instruction body omitted by "
                                     f"capture policy -- {len(content)} chars]"
                                 )
-                    return sanitize_capture_value(captured)
+                    sanitized = sanitize_capture_value(captured)
+                    if isinstance(sanitized, dict):
+                        elided_rows, elided_paths = elide_safe_history_rows(
+                            sanitized.get("messages"),
+                            detail,
+                            path="wire_payload.messages",
+                        )
+                        if elided_paths:
+                            sanitized["messages"] = elided_rows
+                        return sanitized, elided_paths
+                    return sanitized, ()
 
                 # This branch builds its own HTTP body -- the one place
                 # capture IS the literal wire payload (spec Non-goals).
@@ -3181,7 +3197,7 @@ class ConsoleProviderGateway:
                             capture_detail=call_signals.capture_detail,
                             budget=budget,
                         )
-                        sanitized_wire = capture_wire_payload(
+                        sanitized_wire, wire_elided = capture_wire_payload(
                             wire, call_signals.capture_detail
                         )
                         capture_request["wire_payload"] = (
@@ -3189,6 +3205,7 @@ class ConsoleProviderGateway:
                             if budget.retain(sanitized_wire)
                             else {"truncated": True}
                         )
+                        omitted = tuple(sorted(set(omitted).union(wire_elided)))
                         call_signals.begin_exchange(
                             provider=str(resolution.provider or ""),
                             model=str(resolution.model or ""),
@@ -3272,7 +3289,7 @@ class ConsoleProviderGateway:
                         capture_detail=retry_signals.capture_detail,
                         budget=budget,
                     )
-                    sanitized_wire = capture_wire_payload(
+                    sanitized_wire, wire_elided = capture_wire_payload(
                         wire_payload, retry_signals.capture_detail
                     )
                     capture_request["wire_payload"] = (
@@ -3280,6 +3297,7 @@ class ConsoleProviderGateway:
                         if budget.retain(sanitized_wire)
                         else {"truncated": True}
                     )
+                    omitted = tuple(sorted(set(omitted).union(wire_elided)))
                     capture_request["retry_of"] = (
                         "llama.cpp stream produced no content; retried non-streaming"
                     )

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -572,7 +572,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 52  # Console thinking evidence and replay policy.
+    _CURRENT_SCHEMA_VERSION = 53  # Safe exchange-capture history trim (task-23026).
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -6906,6 +6906,109 @@ UPDATE db_schema_version
                 f"Migration from V51 to V52 failed for '{self._SCHEMA_NAME}': {exc}"
             ) from exc
 
+    def _migrate_from_v52_to_v53(self, conn: sqlite3.Connection) -> None:
+        """Trim stored Safe exchange captures' per-turn history copy.
+
+        Before task-23026, every Safe (default-on) exchange capture
+        persisted the ENTIRE conversation-so-far verbatim — 21.33 MB for
+        one 200-turn conversation, with no retention path (the only purge
+        is user-invoked and Full-filtered). ``build_request_capture`` now
+        bounds Safe retention at capture time; this step applies the
+        identical trim (``trim_safe_capture_blob``, a pure helper) to every
+        already-stored Safe blob so existing databases reclaim the space
+        without the user knowing a manual purge exists. Full captures are
+        the deliberate, consent-gated, purgeable verbatim mode (ADR-092)
+        and are never rewritten.
+
+        DML-only (no DDL, so no ``.sql`` file, ``VALID_TABLES`` entry, or
+        index-census row). Runs inside ``_initialize_schema``'s outer
+        immediate transaction: a crash or SIGKILL anywhere in the walk
+        rolls the blob rewrites AND the version stamp back to v52
+        together, and the deterministic trim simply re-runs on the next
+        open. Trimming is idempotent (already-elided rows pass through),
+        so re-entry converges. A blob that cannot be decoded is left
+        exactly as it was — one corrupt row must never brick the database.
+
+        Args:
+            conn: The active connection, inside ``_initialize_schema``'s
+                outer immediate transaction.
+
+        Raises:
+            SchemaError: If the entry version is wrong, the rewrite hits a
+                database error, or the guarded version update fails.
+        """
+        self._require_migration_entry_version(conn, 52, "V52→V53")
+        logger.info(
+            f"Migrating schema from V52 to V53 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
+        )
+        from tldw_chatbook.Chat.console_exchange_capture import (
+            trim_safe_capture_blob,
+        )
+
+        trimmed = skipped = 0
+        try:
+            with self.transaction() as cursor:
+                cursor.execute(
+                    """
+                    SELECT id FROM message_exchanges
+                     WHERE capture_detail = 'safe'
+                     ORDER BY id
+                    """
+                )
+                row_ids = [row[0] for row in cursor.fetchall()]
+                for row_id in row_ids:
+                    cursor.execute(
+                        "SELECT capture_blob FROM message_exchanges WHERE id = ?",
+                        (row_id,),
+                    )
+                    fetched = cursor.fetchone()
+                    if fetched is None or fetched[0] is None:
+                        continue
+                    try:
+                        new_blob = trim_safe_capture_blob(bytes(fetched[0]))
+                    except Exception:
+                        # Undecodable/hostile blob (CaptureUnavailableError,
+                        # CaptureCorruptError, or anything a hostile stored
+                        # shape throws in the pure trim): leave the row
+                        # untouched — one bad row must never brick the DB.
+                        # No exception detail is logged: capture blobs hold
+                        # conversation text and must never reach a sink.
+                        skipped += 1
+                        continue
+                    if new_blob is None:
+                        continue
+                    cursor.execute(
+                        "UPDATE message_exchanges SET capture_blob = ? WHERE id = ?",
+                        (new_blob, row_id),
+                    )
+                    trimmed += 1
+                version_cursor = cursor.execute(
+                    """
+                    UPDATE db_schema_version
+                       SET version = 53
+                     WHERE schema_name = ?
+                       AND version = 52
+                    """,
+                    (self._SCHEMA_NAME,),
+                )
+                if version_cursor.rowcount != 1:
+                    raise SchemaError(
+                        f"[{self._SCHEMA_NAME} V52→V53] Migration version update was not applied"
+                    )
+            if self._get_db_version(conn) != 53:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V52→V53] Migration version check failed"
+                )
+            logger.info(
+                f"[{self._SCHEMA_NAME} V52→V53] Migration completed for DB: "
+                f"{self.db_path_str} (trimmed {trimmed} Safe capture(s), "
+                f"skipped {skipped} undecodable)."
+            )
+        except (OSError, sqlite3.Error, CharactersRAGDBError, SchemaError) as exc:
+            raise SchemaError(
+                f"Migration from V52 to V53 failed for '{self._SCHEMA_NAME}': {exc}"
+            ) from exc
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -7106,6 +7209,7 @@ UPDATE db_schema_version
                     49: self._migrate_from_v49_to_v50,
                     50: self._migrate_from_v50_to_v51,
                     51: self._migrate_from_v51_to_v52,
+                    52: self._migrate_from_v52_to_v53,
                 }
 
                 if current_db_version == 0:

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -6906,82 +6906,99 @@ UPDATE db_schema_version
                 f"Migration from V51 to V52 failed for '{self._SCHEMA_NAME}': {exc}"
             ) from exc
 
-    def _migrate_from_v52_to_v53(self, conn: sqlite3.Connection) -> None:
-        """Trim stored Safe exchange captures' per-turn history copy.
+    #: v52→v53 keyset-page size: bounds how many Safe capture blobs are
+    #: resident at once during the one-time rewrite (ADR-096: bounded
+    #: batches, never every row ID or blob in memory).
+    _V53_SAFE_CAPTURE_BATCH_ROWS = 100
 
-        Before task-23026, every Safe (default-on) exchange capture
-        persisted the ENTIRE conversation-so-far verbatim — 21.33 MB for
-        one 200-turn conversation, with no retention path (the only purge
-        is user-invoked and Full-filtered). ``build_request_capture`` now
-        bounds Safe retention at capture time; this step applies the
-        identical trim (``trim_safe_capture_blob``, a pure helper) to every
-        already-stored Safe blob so existing databases reclaim the space
-        without the user knowing a manual purge exists. Full captures are
-        the deliberate, consent-gated, purgeable verbatim mode (ADR-092)
-        and are never rewritten.
+    def _migrate_from_v52_to_v53(self, conn: sqlite3.Connection) -> None:
+        """Compact stored Safe exchange captures' per-turn history copy.
+
+        ADR-096 / task-23026: every Safe (default-on) exchange capture
+        used to persist the ENTIRE conversation-so-far verbatim — 21.33 MB
+        for one 200-turn conversation, with no retention path (the only
+        purge is user-invoked and Full-filtered). ``build_request_capture``
+        now bounds Safe retention at capture time (first system row, last
+        user row, final eight rows, one content-free aggregate marker);
+        this step applies the identical compaction
+        (``trim_safe_capture_blob``, a pure helper) to every already-stored
+        Safe blob so existing databases reclaim the space without the user
+        knowing a manual purge exists. Full captures are the deliberate,
+        consent-gated, purgeable verbatim mode (ADR-092) and are never
+        rewritten; small and already-compacted Safe blobs stay
+        byte-identical.
 
         DML-only (no DDL, so no ``.sql`` file, ``VALID_TABLES`` entry, or
-        index-census row). Runs inside ``_initialize_schema``'s outer
-        immediate transaction: a crash or SIGKILL anywhere in the walk
-        rolls the blob rewrites AND the version stamp back to v52
-        together, and the deterministic trim simply re-runs on the next
-        open. Trimming is idempotent (already-elided rows pass through),
-        so re-entry converges. A blob that cannot be decoded is left
-        exactly as it was — one corrupt row must never brick the database.
+        index-census row). Keyset-pages Safe rows in bounded batches
+        (``_V53_SAFE_CAPTURE_BATCH_ROWS``), inside ``_initialize_schema``'s
+        outer immediate transaction: a crash or SIGKILL anywhere in the
+        walk rolls the blob rewrites AND the version stamp back to v52
+        together, and the deterministic compaction re-runs on the next
+        open (idempotent — a recognized marker is a fixed point). Only the
+        ``CaptureUnavailableError``/``CaptureCorruptError`` family is a
+        per-row skip (retrying unreadable data cannot reclaim it, so the
+        version may still advance); any unexpected programming or SQLite
+        error aborts and rolls back everything. Diagnostics report
+        aggregate counts only — never capture bodies, blob bytes, row
+        identifiers, or exception values.
 
         Args:
             conn: The active connection, inside ``_initialize_schema``'s
                 outer immediate transaction.
 
         Raises:
-            SchemaError: If the entry version is wrong, the rewrite hits a
-                database error, or the guarded version update fails.
+            SchemaError: If the entry version is wrong, the rewrite hits an
+                unexpected error, or the guarded version update fails.
         """
         self._require_migration_entry_version(conn, 52, "V52→V53")
         logger.info(
             f"Migrating schema from V52 to V53 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         from tldw_chatbook.Chat.console_exchange_capture import (
+            CaptureUnavailableError,
             trim_safe_capture_blob,
         )
 
-        trimmed = skipped = 0
+        examined = changed = skipped = 0
         try:
             with self.transaction() as cursor:
-                cursor.execute(
-                    """
-                    SELECT id FROM message_exchanges
-                     WHERE capture_detail = 'safe'
-                     ORDER BY id
-                    """
-                )
-                row_ids = [row[0] for row in cursor.fetchall()]
-                for row_id in row_ids:
+                last_row_id = 0
+                while True:
                     cursor.execute(
-                        "SELECT capture_blob FROM message_exchanges WHERE id = ?",
-                        (row_id,),
+                        """
+                        SELECT id, capture_blob FROM message_exchanges
+                         WHERE capture_detail = 'safe'
+                           AND id > ?
+                         ORDER BY id
+                         LIMIT ?
+                        """,
+                        (last_row_id, self._V53_SAFE_CAPTURE_BATCH_ROWS),
                     )
-                    fetched = cursor.fetchone()
-                    if fetched is None or fetched[0] is None:
-                        continue
-                    try:
-                        new_blob = trim_safe_capture_blob(bytes(fetched[0]))
-                    except Exception:
-                        # Undecodable/hostile blob (CaptureUnavailableError,
-                        # CaptureCorruptError, or anything a hostile stored
-                        # shape throws in the pure trim): leave the row
-                        # untouched — one bad row must never brick the DB.
-                        # No exception detail is logged: capture blobs hold
-                        # conversation text and must never reach a sink.
-                        skipped += 1
-                        continue
-                    if new_blob is None:
-                        continue
-                    cursor.execute(
-                        "UPDATE message_exchanges SET capture_blob = ? WHERE id = ?",
-                        (new_blob, row_id),
-                    )
-                    trimmed += 1
+                    batch = cursor.fetchall()
+                    if not batch:
+                        break
+                    for row_id, blob in batch:
+                        last_row_id = int(row_id)
+                        if blob is None:
+                            continue
+                        examined += 1
+                        try:
+                            new_blob = trim_safe_capture_blob(bytes(blob))
+                        except CaptureUnavailableError:
+                            # Recognized undecodable blob (corrupt or over
+                            # the safety limits): left byte-identical and
+                            # counted — retrying cannot reclaim it. Any
+                            # OTHER exception propagates and rolls back the
+                            # whole step (ADR-096 decision 8).
+                            skipped += 1
+                            continue
+                        if new_blob is None:
+                            continue
+                        cursor.execute(
+                            "UPDATE message_exchanges SET capture_blob = ? WHERE id = ?",
+                            (new_blob, row_id),
+                        )
+                        changed += 1
                 version_cursor = cursor.execute(
                     """
                     UPDATE db_schema_version
@@ -7001,12 +7018,13 @@ UPDATE db_schema_version
                 )
             logger.info(
                 f"[{self._SCHEMA_NAME} V52→V53] Migration completed for DB: "
-                f"{self.db_path_str} (trimmed {trimmed} Safe capture(s), "
-                f"skipped {skipped} undecodable)."
+                f"{self.db_path_str} (examined {examined}, compacted {changed}, "
+                f"skipped {skipped} unreadable)."
             )
         except (OSError, sqlite3.Error, CharactersRAGDBError, SchemaError) as exc:
             raise SchemaError(
-                f"Migration from V52 to V53 failed for '{self._SCHEMA_NAME}': {exc}"
+                f"Migration from V52 to V53 failed for '{self._SCHEMA_NAME}': "
+                f"{type(exc).__name__}"
             ) from exc
 
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):

--- a/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
@@ -97,7 +97,10 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleContextSnapshot
 from tldw_chatbook.Chat.console_cost_tracker import ConsoleCostRow, ConsoleCostRowTotals
 from tldw_chatbook.Chat.console_display_state import ConsoleProjectInstructionState
 from tldw_chatbook.Chat.console_ephemeral import blocked_reason
-from tldw_chatbook.Chat.console_exchange_capture import ExchangeCapture
+from tldw_chatbook.Chat.console_exchange_capture import (
+    ExchangeCapture,
+    history_elision_marker,
+)
 from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.LLM_Calls.pricing_catalog import get_pricing_catalog
@@ -1087,7 +1090,18 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
     ) -> Collapsible:
         messages = capture.request.get("messages_payload")
         count = len(messages) if isinstance(messages, list) else 0
-        title = f"Messages ({count})"
+        # ADR-096: a Safe capture's stored list is COMPACTED — the physical
+        # count alone would under-state what the call actually sent, so the
+        # aggregate marker's original/omitted counts are surfaced in the
+        # title rather than presenting the compacted list as complete.
+        marker = history_elision_marker(messages)
+        if marker is not None:
+            title = (
+                f"Messages ({marker['original_rows']} sent; "
+                f"{marker['omitted_rows']} elided by capture policy)"
+            )
+        else:
+            title = f"Messages ({count})"
         return Collapsible(
             title=Content.from_text(title, markup=False),
             collapsed=True,


### PR DESCRIPTION
## Summary

Safe exchange capture stored the **entire conversation again on every send** — 15.4 MB for one
200-turn conversation, on by default, with no retention path. Finding 23026 of the
[2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md).

Safe capture now retains a bounded excerpt per **ADR-096**: the first `system` row, the last
`user` row, and the newest eight rows — everything else replaced by **one content-free aggregate
marker** (versioned discriminator, original/omitted row counts, normalized role counts, retained
positions). Full capture is untouched: explicit, consent-gated, purgeable, per ADR-092.

## Measured (real gateway path, same inputs)

| | before | after |
|---|---|---|
| per-turn blob at turn 200 | 217.1 KB | **5.2 KB — flat from turn 50 on** (the marker is O(1)) |
| 200-turn total | 21.33 MB | **1.01 MB** |
| existing 21.25 MB fixture reclaimed by migration | — | 0.99 MB in **537.9 ms**, batch-bounded peak 21.4 MB |

## The design history, plainly

This PR is a **convergence of two independent attempts at the same task**. This branch implemented
first (a fingerprinted-tail design); a concurrent Codex session produced ADR-096, whose design was
approved. The designs conflicted on one material point: the fingerprints kept a `sha256` prefix per
elided row — and **a digest of elided text is a guess-confirmation oracle** for anyone with database
access. The owner ruled for ADR-096; the implementation, migration and test work survived, the
digests did not. History preserved honestly: interim implementation → cherry-picked design commit
(credited to its author) → convergence. A dedicated guard test now fails if anything digest-shaped
is reintroduced into a Safe capture.

## The migration (ChaChaNotes v52 → v53)

Rewrites every `capture_detail='safe'` blob through the pure trim, keyset-paged in 100-row batches
inside the chain's atomic transaction. Evidence: value-identity for untouched rows; Full/corrupt/
short blobs byte-identical; `integrity_check` ok; re-entry fixed point; mid-walk failure rewinds
blobs and stamp together; a **real SIGKILL** child rolls back to v52 then converges byte-identically
with an uninterrupted control. v53 swept for collisions across **813 refs and every worktree**
(four schema collisions this programme — the sweep is not optional); sole claimant.

## Readers, all found and kept working

Inspector (renders the marker; the Messages title now reads "N sent; M elided by capture policy"
from the marker, so the compacted physical count cannot under-state the send — pinned by a UI
test) · export (elision idempotent via strict marker recognition; never re-measures a marker) ·
store/loader (opaque pass-through). Capture failure still never blocks a send. The user guide's
Safe/Full paragraph — which promised "bounded" retention the code didn't honor — now matches
reality.

## Mutations — all red, all reverted

Compaction disabled → 17 red · marker recognition removed → fixed-point red · **digest
reintroduced (key added AND frozen key-set extended in the same edit) → killed by the shape
guard** · input-marker-disables-compaction → red · last-user rule dropped → red · migration no-op →
3 red · trim touches Full → red · validator accepts key supersets → red. One mutation exposed a
non-discriminating growth guard whose filler compressed ~100×; the filler was made incompressible
and the guard proven red-capable.

## Verification

+26 new tests (contract 15, gateway 5, migration 4, Inspector pin, version pin); 55 green on the
rebased tip; 174 core + 399 gateway/inspector green pre-rebase; 7 pre-existing dev DB reds
A/B-identical to pristine base, not adopted (filed separately). Preflight green; the two added
inventory rows are the established migration-step shape.

## For the Codex session's owner

The duplicate implementation-in-progress on `codex/task-23026-safe-capture-retention` should be
stood down — its approved design is what shipped here, cherry-picked with credit. `stash@{0}`
("task-23026 pre-design inactive draft") is this branch's recovered interim work and can be
dropped at your discretion; per the repo stash rule I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safe exchange capture under the default Safe mode no longer persists the entire conversation on every send, which previously grew unboundedly (21.33 MB for one 200-turn conversation) with no retention path. Safe now retains the first system row, last user row, and newest eight rows, and replaces everything else with a single content-free aggregate marker (counts and positions only, no digests or content). Full capture stays verbatim, explicit, and purgeable per ADR-092.

- The v52→v53 migration rewrites already-stored Safe blobs through the same trim in bounded batches, atomically and re-entrantly; no manual action needed.
- Digests of elided text are intentionally absent because they would let anyone with DB access confirm guesses about private content; a guard test fails if one reappears.
- The Inspector's Messages title now shows sent and elided counts so the compacted list can't understate a send.

<sup>Written for commit edaa19c87a4bf4ce65bc17ba70493ac2fcf66311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

