### PR TITLE
perf(library): gate resize/focus paths on cheap state; grow install progress on demand (TASK-23025)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -575,3 +575,10 @@ selection behave the same as before. The Rendered (Markdown) view was
 measured but not changed by this task — very large documents opened in
 Rendered mode remain slow to first paint; tracked separately in
 TASK-22660.)*
+
+*Verified against fix/task-23025 — 2026-08-28 (TASK-23025, performance — no
+workflow changes: resizing the terminal and Tab/arrow focus moves no longer
+re-walk the Library DOM on every frame, and the model-install progress line
+is now built on first use instead of on every visit. The compact/emergency
+width crossings, the Details disclosure, and install progress all look and
+behave exactly as before.)*

--- a/Tests/UI/test_library_resize_focus_gates_t23025.py
+++ b/Tests/UI/test_library_resize_focus_gates_t23025.py
@@ -1,0 +1,416 @@
+"""TASK-23025: resize/focus cheap-state gates and per-visit deferrals.
+
+The Library screen's resize handler ran its three query-heavy layout legs on
+EVERY resize frame (measured 71.6 DOM queries/frame on the landing route);
+the width-crossing early return sat AFTER the query work. It now decides
+from cheap state -- cached widget references and width-bucket arithmetic --
+whether a frame can change anything, before any query work. Same treatment
+for ``research_workspace_screen.py``'s ``_apply_pane_layout``, which was
+completely ungated. The focus path (25.4 queries per Tab) is bounded by
+route-gating the scroll-observer probes and resolving invariant chrome
+through the ref cache. The model-install progress pair -- invisible on the
+default route -- now grows on demand (the TASK-23024 slot-pool pattern);
+the rail Details body deferral was considered and reverted because its
+children are a queried-while-closed contract (see the test pinning it).
+
+Query-count assertions attribute each ``query``/``query_one`` call to the
+nearest non-framework repo frame, exactly like the measurement probe that
+produced the before/after numbers, so a reverted gate fails them by an
+order of magnitude rather than by noise.
+"""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from textual.dom import DOMNode
+from textual.widgets import Button, Static
+
+from Tests.UI.test_library_shell import (
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _active_library_screen,
+    _build_test_app,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_condition,
+    _wait_for_library_shell,
+    _wait_for_selector,
+)
+from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_INGEST_MEDIA
+from tldw_chatbook.Widgets.Library.library_rail import LibraryRail
+from tldw_chatbook.Widgets.ModelArtifacts.install_progress import (
+    InstallProgressed,
+    ModelInstallProgress,
+)
+
+_SITE_PACKAGES = "/site-packages/"
+
+
+def _nearest_repo_frame() -> str:
+    """Return the filename of the nearest tldw_chatbook frame, mirroring the
+    measurement probe's attribution."""
+    frame = sys._getframe(2)
+    for _ in range(40):
+        if frame is None:
+            return ""
+        filename = frame.f_code.co_filename
+        if "tldw_chatbook/" in filename and _SITE_PACKAGES not in filename:
+            return filename
+        frame = frame.f_back
+    return ""
+
+
+@contextmanager
+def _counting_queries(module_fragment: str, counts: dict[str, int]):
+    """Count DOM queries whose nearest repo frame is in ``module_fragment``."""
+    real_query = DOMNode.query
+    real_query_one = DOMNode.query_one
+
+    def counting_query(self, *args, **kwargs):
+        if counts.get("enabled") and module_fragment in _nearest_repo_frame():
+            counts["n"] += 1
+        return real_query(self, *args, **kwargs)
+
+    def counting_query_one(self, *args, **kwargs):
+        if counts.get("enabled") and module_fragment in _nearest_repo_frame():
+            counts["n"] += 1
+        return real_query_one(self, *args, **kwargs)
+
+    DOMNode.query = counting_query
+    DOMNode.query_one = counting_query_one
+    try:
+        yield counts
+    finally:
+        DOMNode.query = real_query
+        DOMNode.query_one = real_query_one
+
+
+async def _settled_library(host, pilot):
+    screen = _active_library_screen(host)
+    await _wait_for_library_shell(screen, pilot)
+    await pilot.pause()
+    return screen
+
+
+@pytest.mark.asyncio
+async def test_resize_gate_skips_library_query_work_on_non_crossing_frames():
+    """Steady non-crossing resize frames issue ZERO library_screen queries.
+
+    Born-red against the pre-gate implementation: the same three frames
+    issued ~60 library-attributed queries each (the ingest/contract/stage
+    legs ran unconditionally, the crossing check sat after them).
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _settled_library(host, pilot)
+        counts = {"n": 0, "enabled": False}
+        with _counting_queries("UI/Screens/library_screen.py", counts):
+            # Warm-up frame: seeds the ref cache and the applied signature.
+            await pilot.resize_terminal(169, 48)
+            await pilot.pause()
+            await pilot.pause()
+            assert screen._library_resize_applied_signature is not None
+            counts["enabled"] = True
+            for width in (168, 167, 166):
+                await pilot.resize_terminal(width, 48)
+                await pilot.pause()
+                await pilot.pause()
+            counts["enabled"] = False
+        assert counts["n"] == 0, (
+            f"{counts['n']} library_screen-attributed DOM queries across 3 "
+            "non-crossing resize frames; the cheap-state gate should have "
+            "returned before any query work"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resize_compact_crossing_still_transitions_both_ways_twice():
+    """The 120-column compact crossing keeps working through the gate."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _settled_library(host, pilot)
+        assert screen._library_notes_compact is False
+
+        for _ in range(2):  # twice: a stale applied-signature would eat round 2
+            await pilot.resize_terminal(110, 48)
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_notes_compact,
+                message="narrow resize never crossed into compact",
+            )
+            grid = screen.query_one("#library-shell-grid")
+            assert grid.has_class("library-notes-compact")
+
+            await pilot.resize_terminal(170, 48)
+            await _wait_for_condition(
+                pilot,
+                lambda: not screen._library_notes_compact,
+                message="wide resize never crossed back out of compact",
+            )
+            grid = screen.query_one("#library-shell-grid")
+            assert not grid.has_class("library-notes-compact")
+
+
+@pytest.mark.asyncio
+async def test_resize_emergency_crossing_still_engages_and_restores():
+    """The <64-column emergency takeover engages and restores through the gate."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _settled_library(host, pilot)
+        assert screen._library_emergency_stage is None
+
+        await pilot.resize_terminal(60, 48)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_emergency_stage is not None,
+            message="60-column resize never engaged the emergency stage",
+        )
+        rail = screen.query_one("#library-rail")
+        canvas = screen.query_one("#library-canvas")
+        assert rail.display != canvas.display, (
+            "emergency stage should show exactly one of rail/canvas"
+        )
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_emergency_stage is None,
+            message="wide resize never restored the ordinary stage",
+        )
+        assert screen.query_one("#library-rail").display
+        assert screen.query_one("#library-canvas").display
+
+
+@pytest.mark.asyncio
+async def test_resize_ingest_rail_autocollapse_crossing_still_works():
+    """The Ingest route's 100-column rail auto-collapse crosses both ways."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _settled_library(host, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_INGEST_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-ingest-path")
+        await pilot.pause()
+        assert screen._library_rail_collapsed is False
+
+        await pilot.resize_terminal(90, 48)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_ingest_auto_collapsed_rail,
+            message="narrow Ingest resize never auto-collapsed the rail",
+        )
+        assert screen._library_rail_collapsed is True
+        assert screen.query_one("#library-rail").display is False
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen._library_ingest_auto_collapsed_rail,
+            message="wide Ingest resize never restored the rail",
+        )
+        assert screen._library_rail_collapsed is False
+        assert screen.query_one("#library-rail").display is True
+
+
+@pytest.mark.asyncio
+async def test_tab_focus_path_library_query_volume_is_bounded():
+    """A Tab on the landing route costs at most 1 library_screen query.
+
+    Born-red against the ungated observer installer: each press probed all
+    eight scroll-owner regions (seven guaranteed-failing whole-tree walks)
+    plus per-call rail/canvas/footer lookups -- 9+ library-attributed
+    queries per press.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        await _settled_library(host, pilot)
+        counts = {"n": 0, "enabled": False}
+        with _counting_queries("UI/Screens/library_screen.py", counts):
+            await pilot.press("tab")  # warm-up: seeds the ref caches
+            await pilot.pause()
+            for _ in range(3):
+                counts["n"] = 0
+                counts["enabled"] = True
+                await pilot.press("tab")
+                await pilot.pause()
+                counts["enabled"] = False
+                assert counts["n"] <= 1, (
+                    f"{counts['n']} library_screen-attributed DOM queries "
+                    "for one Tab press on the landing route"
+                )
+
+
+@pytest.mark.asyncio
+async def test_details_disclosure_children_stay_queryable_while_closed():
+    """The closed Details body keeps its queried-while-closed contract.
+
+    TASK-23025 considered growing the Details body on demand and reverted
+    it: the counts line and the workspace Console-handoff state are read
+    while the disclosure is closed (test_destination_shells,
+    test_post_release_workspaces_library_depth, the landing-hub counts
+    test). This pins that contract so a future deferral has to face it
+    deliberately.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _settled_library(host, pilot)
+        body = screen.query_one("#library-rail-section-body-details")
+        assert body.display is False
+        assert screen.query_one("#library-details-group-status", Static)
+        assert screen.query_one("#library-details-body", Static)
+        assert screen.query_one("#library-workspaces-depth-panel")
+
+        screen.query_one(
+            "#console-rail-section-toggle-library-details", Button
+        ).press()
+        await pilot.pause()
+        await pilot.pause()
+        assert body.display is True
+        assert screen.query_one("#library-details-group-status", Static).display
+
+
+@pytest.mark.asyncio
+async def test_install_progress_grows_on_demand_renders_and_unmounts_cleanly():
+    """The install label+bar pair mounts on first progress, then updates.
+
+    Born-red against the eager implementation (pair mounted display=False on
+    every visit) AND against a deferral whose handlers forget to mount.
+    Ends by popping the screen with the deferred pair mounted -- the
+    unmount/quit walk for the grown subtree.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _settled_library(host, pilot)
+        assert not list(screen.query("#library-model-install-progress")), (
+            "idle visit should not construct the install progress pair"
+        )
+        assert not list(screen.query("#library-model-install-progress-label"))
+
+        mib = 1024 * 1024
+        screen._library_model_install_progress_label = "Parakeet v2"
+        first = SimpleNamespace(
+            phase="fetch",
+            ref=None,
+            file="model.bin",
+            bytes_done=10 * mib,
+            bytes_total=100 * mib,
+        )
+        screen.post_message(InstallProgressed(first))
+        await pilot.pause()
+        await pilot.pause()
+
+        progress = screen.query_one(
+            "#library-model-install-progress", ModelInstallProgress
+        )
+        label = screen.query_one("#library-model-install-progress-label", Static)
+        assert progress.display and label.display
+        assert str(label.render()) == "Parakeet v2"
+        phase = progress.query_one("#model-install-progress-phase", Static)
+        assert "Downloading model" in str(phase.render())
+        detail = progress.query_one("#model-install-progress-detail", Static)
+        first_detail = str(detail.render())
+        assert "model.bin" in first_detail
+
+        # Second event takes the update path on the now-mounted pair; the
+        # byte counter must actually advance.
+        second = SimpleNamespace(
+            phase="fetch",
+            ref=None,
+            file="model.bin",
+            bytes_done=90 * mib,
+            bytes_total=100 * mib,
+        )
+        screen.post_message(InstallProgressed(second))
+        await pilot.pause()
+        second_detail = str(detail.render())
+        assert "model.bin" in second_detail
+        assert second_detail != first_detail, (
+            "second progress event did not update the mounted pair"
+        )
+
+        # Unmount walk: pop the screen with the grown subtree mounted.
+        host.pop_screen()
+        await pilot.pause()
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_research_pane_layout_gate_skips_queries_and_keeps_crossings():
+    """_apply_pane_layout returns before query work when nothing changed.
+
+    Born-red against the ungated implementation: every resize frame paid
+    ~11 query_one calls regardless of whether the derived layout changed.
+    The band crossings (wide/medium/narrow) must keep working through the
+    gate.
+    """
+    from tldw_chatbook.UI.Screens.research_workspace_screen import (
+        ResearchWorkspaceScreen,
+    )
+    from Tests.UI.consolidated_css import ConsolidatedCSSApp
+
+    class _Harness(ConsolidatedCSSApp):
+        async def on_mount(self) -> None:
+            await self.push_screen(ResearchWorkspaceScreen(SimpleNamespace()))
+
+    host = _Harness()
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+        assert screen._pane_layout is not None and screen._pane_layout.mode == "wide"
+
+        counts = {"n": 0, "enabled": False}
+        with _counting_queries(
+            "UI/Screens/research_workspace_screen.py", counts
+        ):
+            await pilot.resize_terminal(158, 40)  # warm-up, still wide
+            await pilot.pause()
+            counts["enabled"] = True
+            for width in (157, 156, 155):
+                await pilot.resize_terminal(width, 40)
+                await pilot.pause()
+            counts["enabled"] = False
+        assert counts["n"] == 0, (
+            f"{counts['n']} research_workspace_screen-attributed DOM queries "
+            "across 3 same-band resize frames"
+        )
+
+        # Crossings still apply through the gate.
+        await pilot.resize_terminal(120, 40)
+        await pilot.pause()
+        assert screen._pane_layout.mode == "medium"
+        grid = screen.query_one("#research-workspace-grid")
+        assert grid.has_class("layout-medium")
+        assert screen.query_one("#research-pane-mode-strip").display
+
+        await pilot.resize_terminal(84, 24)
+        await pilot.pause()
+        assert screen._pane_layout.mode == "narrow"
+        grid = screen.query_one("#research-workspace-grid")
+        assert grid.has_class("layout-narrow")
+        shell = screen.query_one("#research-workspace-shell")
+        assert shell.has_class("height-compact")  # height bucket applied too
+
+        await pilot.resize_terminal(160, 40)
+        await pilot.pause()
+        assert screen._pane_layout.mode == "wide"
+        grid = screen.query_one("#research-workspace-grid")
+        assert grid.has_class("layout-wide")
+        shell = screen.query_one("#research-workspace-shell")
+        assert not shell.has_class("height-compact")

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -263,6 +263,30 @@ every interleaved run.
 
 ---
 
+## A cached widget reference cannot be validated by `is_mounted` — it lags detachment, and `_pruning` marks the corpse first
+
+**TASK-23025, 2026-08-28.** To get Library resize frames and focus changes off
+the per-frame DOM walks (71.6 queries/frame), invariant chrome references were
+cached and validated with `cached.is_mounted` before use. The existing test
+`test_compact_notes_list_keeps_its_scroll_offset_across_a_sync` caught the
+hole: a targeted canvas sync REPLACES `#library-notes-list`, and the scroll
+restore, resolving its owner through the cache, scrolled the doomed old list
+("notes list scroll fell 12 -> 0"). Mechanism, from Textual 8.2.8 source:
+`App._prune` marks the whole pruned subtree `_pruning = True` and posts
+`Prune()` *synchronously*, but the actual detach (`_unregister` →
+`_detach`, which nulls `_parent`) and the `_is_mounted = False` flip happen
+later when the message is processed — so there is a window where the corpse
+still answers `is_mounted` as True while `query_one` (which walks the live
+tree) already resolves the replacement. Validation that matches what a query
+would return is: `not widget._pruning and widget.is_mounted` **and** the
+`_parent` chain walks back to the caching screen (a handful of attribute
+hops — still ~zero cost next to a DOM walk). With that check the cache is
+bit-for-bit equivalent to querying; the mutation arm (validation weakened
+back to `is_mounted`-only) re-fails the same pre-existing scroll test.
+Related earlier incident: task-2200 ("`is_mounted` ≠ in-the-DOM").
+
+---
+
 ## Related
 
 - `lessons-testing-evidence.md` — includes the Pilot-harness traps (detached widget

--- a/backlog/tasks/task-23025 - Library-screen-costs-2-3x-more-per-visit-and-2-7x-more-per-resize-frame.md
+++ b/backlog/tasks/task-23025 - Library-screen-costs-2-3x-more-per-visit-and-2-7x-more-per-resize-frame.md
@@ -2,8 +2,9 @@
 id: TASK-23025
 title: >-
   Library screen costs 2.3x more per visit and 2.7x more per resize frame
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-27'
 labels:
   - performance
@@ -29,10 +30,33 @@ One whole-screen recompose now constructs 103 widgets at ~640-790 ms.
 
 ## Acceptance Criteria
 
-- [ ] Per-visit widget count and per-resize-frame query count measured before and after, interleaved
-- [ ] The resize handler returns early **before** doing query work when the layout cannot have changed
-- [ ] `research_workspace_screen.py:252` -> `_apply_pane_layout` gets the same gate; it is currently ungated
-- [ ] No behaviour change to layout at any terminal width, including the width-crossing cases the current code handles
+- [x] Per-visit widget count and per-resize-frame query count measured before and after, interleaved
+- [x] The resize handler returns early **before** doing query work when the layout cannot have changed
+- [x] `research_workspace_screen.py:252` -> `_apply_pane_layout` gets the same gate; it is currently ungated
+- [x] No behaviour change to layout at any terminal width, including the width-crossing cases the current code handles
+- [x] `on_descendant_focus`'s per-Tab query volume is bounded (no all-region scroll-owner probing on routes that cannot mount those regions), measured before and after
+- [x] Compose-time blocks invisible on the default route grow on demand where their closed-state is not a queried contract (the model-install progress pair), with an unmount walk for the deferred subtree
+
+## Implementation Plan
+
+1. Measure the base (fix/task-23022, `63464b174b`): widgets constructed per Library visit
+   (with per-call-site attribution to find the +90), DOM queries per resize frame, and
+   queries per Tab, using the LibraryHarness pilot with instrumented `Widget.__init__`
+   and `DOMNode.query`/`query_one`.
+2. Resize gate: cache the invariant `#library-shell-grid`/rail/canvas references
+   (validated by the cheap `is_mounted` flag, identity-invalidated on recompose) and
+   derive a bucket signature (compact/emergency/ingest-collapse buckets + the resolved
+   ordinary rail contract + the cheap route/stage flags the legs consume) from attribute
+   reads only; return from `on_resize` before any `query`/`query_one` when the signature
+   matches the last applied one. Same gate shape for `_apply_pane_layout` in
+   `research_workspace_screen.py` (derived `ResearchPaneLayout` + height bucket +
+   relocate-focus applicability).
+3. Per-visit construction: defer the compose-time blocks that are `display=False` on the
+   default route (grow-on-demand, the TASK-23024 house pattern), guided by the census.
+4. Focus path: bound `on_descendant_focus` query volume for plain row navigation.
+5. Pin width-crossing behaviour with tests that FAIL against a deliberately broken
+   implementation (gate moved after queries / deferred block eagerly restored); walk
+   unmount/quit for anything deferred; interleave before/after measurements; preflight.
 
 ## Evidence
 
@@ -40,3 +64,73 @@ Interleaved A/B, 2 runs per arm, identical every run. Console is worse in absolu
 (171-185 queries/frame) but **improved** slightly - pre-existing, not this delta.
 
 Source: `Docs/Design/2026-08-27-holistic-perf-review.md`.
+
+## Implementation Notes
+
+Branch stacked on `fix/task-23022` (both tasks touch `library_screen.py`); diff
+for review is `fix/task-23022...HEAD`.
+
+**Resize gate (library_screen.py).** `on_resize` now derives a bucket/flag
+signature from cheap state -- cached widget references (`region` /
+`content_region` attribute reads) plus route/stage flags -- mirroring every
+width-derived decision its three legs make: the ingest-collapse bucket (100),
+the resolved `OrdinaryRailStyleContract` itself (so the custom-width clamp band
+stays exact), the emergency bucket (64), and the compact bucket (120). A frame
+whose signature equals the last applied one returns before ANY `query`/
+`query_one`. The signature is recorded pre-legs, so a frame whose legs mutate
+flags runs once more on the next event and settles; a skip can never hide a
+crossing because every compared bucket is part of the signature. The media
+reader leg (TASK-22228 item 7) is untouched above the gate.
+
+**Reference caches.** `_library_layout_ref` (positive-only) and
+`_library_compose_scoped_ref` / the reader-shell probe (negative-capable, valid
+because those ids are constructed exclusively in `compose_content`) are
+invalidated at `compose_content` -- the choke point every whole-screen
+recompose passes through -- and every hit is validated by
+`_library_ref_is_live`: NOT `is_mounted`, which lags detachment while
+`App._prune` has already marked the corpse `_pruning` (the pre-existing
+notes-list scroll test caught exactly this; see the new lessons-textual entry).
+
+**Focus path.** The scroll-observer installer probes only regions the current
+route can mount (7 guaranteed-failing whole-tree walks per Tab removed);
+`_library_notes_focus_stage`, `_library_notes_scroll_owner`,
+`_library_landing_focus_control_id` and the per-refresh footer-context loop
+resolve through the caches.
+
+**Research screen.** `_apply_pane_layout` returns before its ~11 `query_one`
+calls when the derived `ResearchPaneLayout`, the height-compact bucket, and the
+relocate-focus applicability are all unchanged.
+
+**Per-visit deferral.** The model-install pair (ModelInstallProgress + label)
+composes only while an install is retained; the first `InstallProgressed`
+event grows it (handlers try the update path first, mount on `NoMatches`,
+which also preserves the mocked-`query_one` unit-test contract). The rail
+Details body deferral was implemented and REVERTED: its closed-state children
+are a queried contract (counts line, `#library-use-in-console` handoff state)
+pinned by seven tests across four files -- changing that is its own task; a
+new test pins the contract so a future deferral must face it deliberately.
+
+**Measured (interleaved x3 per arm, alternating, landing route,
+LibraryHarness, config-isolated under Tests/conftest):**
+
+| metric | base `63464b174b` (x3) | after (x3) |
+|---|---|---|
+| DOM queries / resize frame | 71.8 / 71.6 / 71.6 | 10.6 / 10.6 / 10.6 |
+| DOM queries / Tab | 25.6 / 25.4 / 25.4 | 3.4 / 3.4 / 3.6 |
+| widgets constructed / visit | 156 / 156 / 156 | 149 / 149 / 149 |
+| research queries / same-band frame | 41.0 / 41.0 / 41.0 | 11.0 / 11.0 / 11.0 |
+
+All remaining after-arm resize/Tab queries attribute to the nav bar's own
+handlers (`UI/Navigation/main_navigation.py`); library_screen-attributed
+queries on steady frames: 0 (pinned by test). The 110/170-column crossing
+probe behaves identically on both arms every round. Crossings (compact both
+ways twice, emergency engage/restore, ingest auto-collapse both ways) pinned
+by born-red tests in `Tests/UI/test_library_resize_focus_gates_t23025.py`;
+nine mutants each killed by a named test (see PR/report).
+
+**Files:** `tldw_chatbook/UI/Screens/library_screen.py`,
+`tldw_chatbook/UI/Screens/research_workspace_screen.py`,
+`tldw_chatbook/Widgets/Library/library_rail.py` (details-children compose
+factored into `_compose_details_body_children`, behaviour unchanged),
+`Tests/UI/test_library_resize_focus_gates_t23025.py` (new),
+`Docs/User_Guide/library.md` stamp, `backlog/docs/lessons-textual.md`.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -31,6 +31,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import DescendantFocus, Key
 from textual.css.query import NoMatches, QueryError
+from textual.dom import DOMNode
 from textual.errors import NoWidget
 from textual.geometry import Region
 from textual.timer import Timer
@@ -109,6 +110,7 @@ from ...Utils.adaptive_reader_state import (
 from ...Utils.library_rail_width import (
     LIBRARY_EMERGENCY_WIDTH,
     OrdinaryRailPresentation,
+    OrdinaryRailStyleContract,
     ordinary_emergency_required,
     resolve_ordinary_rail_contract,
 )
@@ -782,6 +784,16 @@ LIBRARY_MEDIA_HANDOFF_EXCERPT_CHARS = 500
 LIBRARY_RAG_RESULTS_STATIC_WIDGET_IDS = frozenset({"library-rag-results-heading"})
 LIBRARY_NOTES_COMPACT_BREAKPOINT = 120
 LIBRARY_INGEST_RAIL_COLLAPSE_BREAKPOINT = 100
+# TASK-23025: the five adaptive reader shells, all constructed exclusively in
+# ``compose_content`` -- the basis for the one-probe-per-recompose negative
+# cache in ``_library_adaptive_reader_shell_active``.
+_LIBRARY_READER_SHELL_SELECTOR = (
+    "#library-media-reader-shell, "
+    "#library-conversations-reader-shell, "
+    "#library-notes-reader-shell, "
+    "#library-prompts-reader-shell, "
+    "#library-skills-reader-shell"
+)
 LIBRARY_NOTES_SOURCE_DATABASE = "database"
 LIBRARY_NOTES_SOURCE_FILES = "files"
 LIBRARY_CANVAS_KIND_NOTES = "notes"
@@ -3887,6 +3899,25 @@ class LibraryScreen(BaseAppScreen):
         self._library_rail_collapsed: bool = False
         self._library_ingest_auto_collapsed_rail: bool = False
         self._library_notes_stage: Literal["rail", "notes"] = "rail"
+        # TASK-23025: cheap-state gates for the per-frame resize/focus paths.
+        # ``_library_layout_ref_cache`` holds positive widget references for
+        # the invariant shell chrome (validated by the O(1) ``is_mounted``
+        # flag and cleared at compose_content, the one choke point every
+        # whole-screen recompose passes through), so steady-state resize
+        # frames and focus changes read attributes instead of walking the
+        # DOM. ``_library_resize_applied_signature`` records the bucket/flag
+        # signature the resize legs last applied; a frame whose signature is
+        # unchanged returns before any query work. The reader-shell probe is
+        # the one NEGATIVE cache: reader shells only (un)mount via
+        # compose_content (all five ``*-reader-shell`` ids are constructed
+        # there and nowhere else), so one probe per compose generation is
+        # exact.
+        self._library_layout_ref_cache: dict[str, Widget] = {}
+        self._library_compose_ref_cache: dict[str, Widget | None] = {}
+        self._library_resize_applied_signature: tuple[Any, ...] | None = None
+        self._library_compose_generation = 0
+        self._library_reader_shell_ref: Widget | None = None
+        self._library_reader_shell_probe_generation = -1
         self._library_emergency_stage: Literal["rail-only", "canvas-only"] | None = None
         self._library_stage_interaction_generation = 0
         self._library_emergency_restore_receipt: (
@@ -4767,18 +4798,20 @@ class LibraryScreen(BaseAppScreen):
         """Map a live focused widget to the portable Library stage."""
         if focused is None:
             return self._library_notes_stage
-        try:
-            rail = self.query_one("#library-rail", Widget)
-            canvas = self.query_one("#library-canvas", Widget)
-        except (NoMatches, QueryError):
+        # TASK-23025: this runs several times per focus change; resolve the
+        # invariant rail/canvas hosts through the ref cache instead of two
+        # fresh DOM walks per call.
+        rail = self._library_layout_ref("#library-rail")
+        canvas = self._library_layout_ref("#library-canvas")
+        if rail is None or canvas is None:
             return self._library_notes_stage
         if self._library_notes_widget_is_within(focused, rail):
             return "rail"
         if self._library_notes_widget_is_within(focused, canvas):
             return "notes"
-        work_panes = self.query("#library-note-work-pane")
-        if work_panes and self._library_notes_widget_is_within(
-            focused, work_panes.first(Widget)
+        work_pane = self._library_compose_scoped_ref("#library-note-work-pane")
+        if work_pane is not None and self._library_notes_widget_is_within(
+            focused, work_pane
         ):
             return "notes"
         return self._library_notes_stage
@@ -4878,9 +4911,8 @@ class LibraryScreen(BaseAppScreen):
         """Return the stable id of a focused returning-landing action."""
         if focused is None or not focused.id:
             return ""
-        try:
-            landing = self.query_one("#library-landing-canvas", Widget)
-        except (NoMatches, QueryError):
+        landing = self._library_layout_ref("#library-landing-canvas")
+        if landing is None:
             return ""
         if not self._library_notes_widget_is_within(focused, landing):
             return ""
@@ -4935,10 +4967,10 @@ class LibraryScreen(BaseAppScreen):
         }.get(region)
         if selector is None:
             return None
-        try:
-            return self.query_one(selector, Widget)
-        except (NoMatches, QueryError):
-            return None
+        # TASK-23025: positive ref cache -- a mounted owner is one attribute
+        # read; absence still costs one walk, so callers should not probe
+        # regions their route cannot mount (see the observer installer).
+        return self._library_layout_ref(selector)
 
     def _capture_library_notes_focus_identity(
         self, *, stage_from_focus: bool = True
@@ -7086,18 +7118,28 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_interaction_focus = current
 
     def _install_library_notes_scroll_observers(self) -> None:
-        """Watch current named scroll owners only while their mounted tree lives."""
+        """Watch current named scroll owners only while their mounted tree lives.
+
+        TASK-23025: probe only regions the current route can mount. Every
+        non-rail region here is a Notes-workflow surface (Database Notes or
+        File Notes canvases); outside those routes each probe was a
+        guaranteed-failing whole-tree ``query_one`` walk, seven of them per
+        focus change on the landing/list routes.
+        """
+        regions: tuple[str, ...] = ("rail",)
+        if self._library_notes_compact_workflow_active():
+            regions = (
+                "rail",
+                "navigator",
+                "editor",
+                "preview",
+                "context",
+                "create",
+                "lasting_add",
+                "lasting_roots",
+            )
         owners: dict[int, Widget] = {}
-        for region in (
-            "rail",
-            "navigator",
-            "editor",
-            "preview",
-            "context",
-            "create",
-            "lasting_add",
-            "lasting_roots",
-        ):
+        for region in regions:
             owner = self._library_notes_scroll_owner(region)
             if owner is not None:
                 owners[id(owner)] = owner
@@ -7246,6 +7288,164 @@ class LibraryScreen(BaseAppScreen):
         identity = self._remember_library_notes_responsive_focus(identity)
         self._transition_library_notes_presentation(compact, identity)
 
+    def _library_ref_is_live(self, widget: Widget) -> bool:
+        """Return whether a cached reference is still this screen's live node.
+
+        TASK-23025: ``is_mounted`` alone is NOT a validity check --
+        ``_is_mounted`` lags detachment, and ``App._prune`` marks the doomed
+        subtree ``_pruning`` synchronously while the detach happens later
+        (the task-2200 lesson: ``is_mounted`` != in-the-DOM; a targeted
+        canvas sync's replaced notes list measured exactly this, the scroll
+        restore landing on the pruned corpse). Walking the ``_parent`` chain
+        back to this screen is a handful of attribute hops -- still far
+        cheaper than a DOM walk -- and matches what ``query_one`` would
+        resolve.
+        """
+        if getattr(widget, "_pruning", False) or not widget.is_mounted:
+            return False
+        node: DOMNode | None = widget
+        while node is not None:
+            if node is self:
+                return True
+            node = node._parent
+        return False
+
+    def _library_layout_ref(self, selector: str) -> Widget | None:
+        """Resolve one invariant shell-chrome widget through the ref cache.
+
+        TASK-23025: positive references only, validated by
+        ``_library_ref_is_live`` and cleared in ``compose_content`` (the
+        choke point every whole-screen recompose passes through), so hot
+        per-frame paths read attributes instead of re-walking the DOM. A
+        miss falls back to one id-selector ``query_one`` and re-caches;
+        absence is never cached, so a widget that mounts later is still
+        found.
+        """
+        cached = self._library_layout_ref_cache.get(selector)
+        if cached is not None and self._library_ref_is_live(cached):
+            return cached
+        try:
+            widget = self.query_one(selector, Widget)
+        except (NoMatches, QueryError):
+            self._library_layout_ref_cache.pop(selector, None)
+            return None
+        self._library_layout_ref_cache[selector] = widget
+        return widget
+
+    def _library_compose_scoped_ref(self, selector: str) -> Widget | None:
+        """Positive AND negative ref cache for compose_content-exclusive ids.
+
+        TASK-23025: only valid for ids constructed exclusively inside
+        ``compose_content`` (e.g. the note work pane) -- cached absence
+        would otherwise go stale when a widget mounts through another seam.
+        The cache, including cached absence, is cleared in
+        ``compose_content``.
+        """
+        if selector in self._library_compose_ref_cache:
+            cached = self._library_compose_ref_cache[selector]
+            if cached is None:
+                return None
+            if self._library_ref_is_live(cached):
+                return cached
+        try:
+            widget: Widget | None = self.query_one(selector, Widget)
+        except (NoMatches, QueryError):
+            widget = None
+        self._library_compose_ref_cache[selector] = widget
+        return widget
+
+    def _library_adaptive_reader_shell_active(self) -> bool:
+        """Report adaptive reader-shell presence without a per-frame walk.
+
+        All five ``*-reader-shell`` ids are constructed exclusively in
+        ``compose_content``, so shells (un)mount only across a compose
+        generation -- one failed probe per recompose is exact, and a
+        mounted shell is revalidated by its own ``is_mounted`` flag.
+        """
+        cached = self._library_reader_shell_ref
+        if cached is not None and self._library_ref_is_live(cached):
+            return True
+        if (
+            self._library_reader_shell_probe_generation
+            == self._library_compose_generation
+        ):
+            return False
+        self._library_reader_shell_probe_generation = self._library_compose_generation
+        shells = self.query(_LIBRARY_READER_SHELL_SELECTOR)
+        self._library_reader_shell_ref = shells.first(Widget) if shells else None
+        return self._library_reader_shell_ref is not None
+
+    def _library_resize_layout_signature(self) -> tuple[Any, ...] | None:
+        """Signature of every width-derived decision the resize legs make.
+
+        TASK-23025 (AC: gate before query work): built from cached widget
+        references and cheap flags only -- ``region``/``content_region``
+        attribute reads, never a DOM walk. Mirrors, in order, the inputs of
+        ``_sync_library_ingest_rail_for_width`` (ingest collapse bucket),
+        ``_sync_library_ordinary_rail_width_contract`` (the resolved
+        contract itself, so the custom-width clamp band stays exact),
+        ``_apply_library_notes_stage_visibility`` (its route/stage flags
+        plus ``_apply_library_emergency_geometry``'s bucket), and the
+        compact-crossing check. Returns ``None`` when it cannot be decided
+        cheaply; callers then run the full legs, exactly as before.
+        """
+        shell = self._library_layout_ref("#library-shell-grid")
+        rail = self._library_layout_ref("#library-rail")
+        canvas = self._library_layout_ref("#library-canvas")
+        if shell is None or rail is None or canvas is None:
+            return None
+        width = shell.region.width
+        if width <= 0:
+            return None
+        viewport = self.size.width if self.is_mounted else 0
+        effective = min(width, viewport) if viewport > 0 else width
+        content_width = shell.content_region.width
+        emergency_width = min(width, viewport)
+        reader_active = self._library_adaptive_reader_shell_active()
+        contract: OrdinaryRailStyleContract | None = None
+        if not reader_active and content_width >= LIBRARY_EMERGENCY_WIDTH:
+            if not rail.display:
+                presentation = OrdinaryRailPresentation.HIDDEN
+            elif not canvas.display:
+                presentation = OrdinaryRailPresentation.RAIL_ONLY
+            else:
+                presentation = OrdinaryRailPresentation.ALONGSIDE
+            shared = self._library_reader_shared_preferences
+            contract = resolve_ordinary_rail_contract(
+                content_width,
+                presentation,
+                shared.custom_widths_enabled,
+                shared.library_width,
+            )
+        return (
+            self._library_compose_generation,
+            shell,
+            rail,
+            canvas,
+            self._library_selected_row_id,
+            self._library_notes_source,
+            self._library_notes_view,
+            self._library_notes_stage,
+            self._library_notes_compact,
+            self._library_rail_collapsed,
+            self._library_ingest_auto_collapsed_rail,
+            self._library_emergency_stage,
+            self._file_notes_active(),
+            rail.display,
+            canvas.display,
+            reader_active,
+            self._library_reader_shared_preferences,
+            width < LIBRARY_NOTES_COMPACT_BREAKPOINT,
+            effective < LIBRARY_INGEST_RAIL_COLLAPSE_BREAKPOINT,
+            (
+                ordinary_emergency_required(emergency_width)
+                if emergency_width > 0
+                else None
+            ),
+            content_width < LIBRARY_EMERGENCY_WIDTH,
+            contract,
+        )
+
     def on_resize(self, event: events.Resize) -> None:
         """Capture only a crossing, decided by the measured invariant grid."""
         del event
@@ -7274,6 +7474,19 @@ class LibraryScreen(BaseAppScreen):
                 self._sync_library_media_reader_layout_from_shell,
                 focus_intent=focus_intent,
             )
+        # TASK-23025: decide from cheap state -- cached references and
+        # width-bucket arithmetic -- whether this frame can change anything
+        # the legs below derive, BEFORE any of their query work. The
+        # signature is recorded pre-legs, so a frame whose legs mutate flags
+        # simply runs once more on the next event and then settles; a skip
+        # can never hide a crossing because every bucket the legs compare is
+        # part of the signature.
+        signature = self._library_resize_layout_signature()
+        if signature is not None:
+            if signature == self._library_resize_applied_signature:
+                self._library_notes_pre_resize_focus = None
+                return
+            self._library_resize_applied_signature = signature
         try:
             width = self.query_one("#library-shell-grid").region.width
         except (NoMatches, QueryError):
@@ -7477,15 +7690,18 @@ class LibraryScreen(BaseAppScreen):
             and self._library_notes_stage == "notes"
             and self._library_notes_workflow_active()
         )
+        # TASK-23025: this method runs on EVERY screen refresh (see the
+        # ``refresh`` override), several times per resize frame and focus
+        # change -- resolve the stable footer chrome through the ref cache
+        # and skip the no-op display writes.
         for selector in (
             "#footer-word-count",
             "#footer-token-count",
             "#internal-db-size-indicator",
         ):
-            try:
-                self.query_one(selector, Widget).display = not hide_ancillary
-            except (NoMatches, QueryError):
-                continue
+            indicator = self._library_layout_ref(selector)
+            if indicator is not None and indicator.display == hide_ancillary:
+                indicator.display = not hide_ancillary
 
     def _rehydrate_library_notes_after_recompose(
         self, restore: _LibraryNotesRecomposeCapture
@@ -12815,6 +13031,16 @@ class LibraryScreen(BaseAppScreen):
         return widgets
 
     def compose_content(self) -> ComposeResult:
+        # TASK-23025: every whole-screen recompose passes through here (the
+        # task-2856 choke-point guarantee below), so this is the one place
+        # the layout ref cache and the resize gate's applied signature must
+        # be invalidated -- the widgets they point at are about to be
+        # replaced.
+        self._library_compose_generation += 1
+        self._library_layout_ref_cache.clear()
+        self._library_compose_ref_cache.clear()
+        self._library_reader_shell_ref = None
+        self._library_resize_applied_signature = None
         shell_input = self._build_library_shell_input()
         shell = build_library_shell_state(
             shell_input, selected_row_id=self._library_selected_row_id
@@ -12878,20 +13104,21 @@ class LibraryScreen(BaseAppScreen):
         )
         lifecycle_status.display = bool(lifecycle_status_copy)
         yield lifecycle_status
-        install_progress = ModelInstallProgress(
-            self._parakeet_v2_install_progress,
-            id="library-model-install-progress",
-        )
-        install_progress.display = self._parakeet_v2_install_progress is not None
-        install_label = Static(
-            self._library_model_install_progress_label,
-            id="library-model-install-progress-label",
-            classes="library-ingest-quiet-line",
-            markup=False,
-        )
-        install_label.display = install_progress.display
-        yield install_label
-        yield install_progress
+        # TASK-23025: the install label+bar pair (a ModelInstallProgress with
+        # its PausableProgressBar machinery) was mounted display=False on
+        # every visit for a state most users never enter. Grow on demand
+        # instead (the TASK-23024 slot-pool pattern): compose it only while
+        # an install is retained; the InstallProgressed handlers mount it on
+        # first use via ``_mount_library_model_install_progress``.
+        if (
+            self._parakeet_v2_install_progress is not None
+            or self._library_model_install_progress_label
+        ):
+            install_label, install_progress = (
+                self._build_library_model_install_progress_widgets()
+            )
+            yield install_label
+            yield install_progress
         if shell.canvas_kind in LIBRARY_NOTES_SOURCE_STRIP_CANVAS_KINDS:
             adaptive_database_notes = (
                 shell.canvas_kind
@@ -32170,6 +32397,48 @@ class LibraryScreen(BaseAppScreen):
                 retry(retry_job_id)
         self.refresh(recompose=True)
 
+    def _build_library_model_install_progress_widgets(
+        self,
+    ) -> tuple[Static, ModelInstallProgress]:
+        """Construct the deferred install label+bar pair from retained state.
+
+        TASK-23025: shared by ``compose_content`` (recompose while an
+        install is retained) and the grow-on-demand mount below, so both
+        paths build the identical pair.
+        """
+        install_progress = ModelInstallProgress(
+            self._parakeet_v2_install_progress,
+            id="library-model-install-progress",
+        )
+        install_progress.display = self._parakeet_v2_install_progress is not None
+        install_label = Static(
+            self._library_model_install_progress_label,
+            id="library-model-install-progress-label",
+            classes="library-ingest-quiet-line",
+            markup=False,
+        )
+        install_label.display = install_progress.display
+        return install_label, install_progress
+
+    def _mount_library_model_install_progress(self) -> bool:
+        """Mount the deferred install pair on first use.
+
+        Returns:
+            True when a fresh pair was mounted. The fresh
+            ``ModelInstallProgress`` renders the retained event from its own
+            ``on_mount``, and its children are still composing -- the caller
+            must NOT also call ``update_progress`` on it synchronously.
+        """
+        if self.query("#library-model-install-progress"):
+            return False
+        anchor = self._library_layout_ref("#library-lifecycle-status")
+        parent = anchor.parent if anchor is not None else None
+        if not isinstance(parent, Widget):
+            return False
+        label, progress = self._build_library_model_install_progress_widgets()
+        parent.mount(label, progress, after=anchor)
+        return True
+
     @on(InstallProgressed)
     def handle_model_install_progressed(self, event: InstallProgressed) -> None:
         """Retain and render progress after the consent modal is dismissed."""
@@ -32181,6 +32450,10 @@ class LibraryScreen(BaseAppScreen):
                 "#library-model-install-progress", ModelInstallProgress
             )
         except NoMatches:
+            # TASK-23025: the pair is deferred off the idle compose; the
+            # first event grows it (its on_mount renders the retained
+            # progress, so no update call is needed here).
+            self._mount_library_model_install_progress()
             return
         label.update(self._library_model_install_progress_label)
         label.display = True
@@ -33378,6 +33651,10 @@ class LibraryScreen(BaseAppScreen):
                 "#library-model-install-progress", ModelInstallProgress
             )
         except (NoMatches, QueryError):
+            # TASK-23025: the pair is deferred off the idle compose; the
+            # first event grows it (its on_mount renders the retained
+            # progress, so no update call is needed here).
+            self._mount_library_model_install_progress()
             return
         label.update("Silero VAD dependency")
         label.display = True

--- a/tldw_chatbook/UI/Screens/research_workspace_screen.py
+++ b/tldw_chatbook/UI/Screens/research_workspace_screen.py
@@ -125,6 +125,10 @@ class ResearchWorkspaceScreen(BaseAppScreen):
         self.pane_preferences = ResearchPanePreferences()
         self.active_pane: ResearchPaneName = "chat"
         self._pane_layout: ResearchPaneLayout | None = None
+        # TASK-23025: the height bucket last applied by _apply_pane_layout,
+        # so a resize frame that changes neither the derived layout nor this
+        # bucket returns before any query work.
+        self._pane_layout_height_compact: bool | None = None
         self._overlay_revision = 0
         self._overlay_ref: QualifiedWorkspaceRef | None = None
         self._pane_preferences_ref: QualifiedWorkspaceRef | None = None
@@ -366,13 +370,32 @@ class ResearchWorkspaceScreen(BaseAppScreen):
         layout = derive_research_pane_layout(
             width, self.pane_preferences, active_pane=self.active_pane
         )
+        height_compact = self.size.height < 30
+        # TASK-23025 (AC: gate before query work): the derived layout is a
+        # pure width-band function and everything below is a projection of
+        # (layout, height bucket). When neither changed -- and no hidden
+        # pane holds focus that a relocate pass would move -- this frame
+        # cannot change anything, so return before the ~11 query_one calls.
+        # ``_pane_for_widget`` walks ancestors of the focused widget only;
+        # it performs no DOM queries.
+        if (
+            layout == self._pane_layout
+            and height_compact == self._pane_layout_height_compact
+            and (
+                not relocate_hidden_focus
+                or focused_pane is None
+                or focused_pane in layout.visible_panes
+            )
+        ):
+            return
         self._pane_layout = layout
+        self._pane_layout_height_compact = height_compact
 
         grid = self.query_one("#research-workspace-grid")
         for mode in ("wide", "medium", "narrow"):
             grid.set_class(layout.mode == mode, f"layout-{mode}")
         shell = self.query_one("#research-workspace-shell")
-        shell.set_class(self.size.height < 30, "height-compact")
+        shell.set_class(height_compact, "height-compact")
 
         for pane in ("sources", "chat", "studio"):
             self.query_one(f"#research-{pane}-pane").display = (

--- a/tldw_chatbook/Widgets/Library/library_rail.py
+++ b/tldw_chatbook/Widgets/Library/library_rail.py
@@ -689,46 +689,58 @@ class LibraryRail(PostRecomposeCallback, RecomposeCaptureGuard, Vertical):
         )
         details_body.styles.height = "auto"
         details_body.display = details_open
+        # TASK-23025 considered growing this body on demand (it is ~13
+        # widgets mounted display=False on the default route), but the
+        # closed body's children are a QUERIED contract: the counts line and
+        # the workspace Console-handoff state are read while the disclosure
+        # is closed by seven tests across four files (e.g.
+        # ``#library-use-in-console`` disabled-state in
+        # test_destination_shells). Deferring it is a contract change, left
+        # to its own task.
         with details_body:
-            yield Static(
-                "Status",
-                id="library-details-group-status",
-                classes="library-details-group library-details-group-first",
-            )
-            details_lines = self.shell.details_lines
-            runtime_value = details_lines[0] if details_lines else ""
-            yield Static(
-                # F-013: "Source", not "Runtime" -- the line says where the
-                # Library's content lives (this device or a server), and
-                # "Runtime" taught nothing.
-                library_dim_label_text("Source", runtime_value),
-                id="library-details-runtime",
-                classes="library-details-row",
-            )
-            counts_or_error = details_lines[1] if len(details_lines) > 1 else ""
-            yield Static(
-                counts_or_error,
-                id="library-details-body",
-                classes="library-details-row",
-                markup=False,
-            )
-            if len(details_lines) > 2 and details_lines[2]:
-                # F-014: the DB-size telemetry relocated out of the app
-                # footer lives here -- third Status row, only when the
-                # shell actually carries it (never an "N/A" triplet).
-                yield Static(
-                    library_dim_label_text("DB sizes", details_lines[2]),
-                    id="library-details-db-sizes",
-                    classes="library-details-row",
-                )
-            if self.workspaces_body_factory is not None:
-                yield from self.workspaces_body_factory()
+            yield from self._compose_details_body_children()
         if self.lifecycle is LibraryLifecycle.EXPANDED and self.onboarding_all_empty:
             yield Button(
                 "Back to Get started",
                 id="library-rail-back-to-starter",
                 compact=True,
             )
+
+    def _compose_details_body_children(self) -> ComposeResult:
+        """Build the Details disclosure's children from current shell state."""
+        yield Static(
+            "Status",
+            id="library-details-group-status",
+            classes="library-details-group library-details-group-first",
+        )
+        details_lines = self.shell.details_lines
+        runtime_value = details_lines[0] if details_lines else ""
+        yield Static(
+            # F-013: "Source", not "Runtime" -- the line says where the
+            # Library's content lives (this device or a server), and
+            # "Runtime" taught nothing.
+            library_dim_label_text("Source", runtime_value),
+            id="library-details-runtime",
+            classes="library-details-row",
+        )
+        counts_or_error = details_lines[1] if len(details_lines) > 1 else ""
+        yield Static(
+            counts_or_error,
+            id="library-details-body",
+            classes="library-details-row",
+            markup=False,
+        )
+        if len(details_lines) > 2 and details_lines[2]:
+            # F-014: the DB-size telemetry relocated out of the app
+            # footer lives here -- third Status row, only when the
+            # shell actually carries it (never an "N/A" triplet).
+            yield Static(
+                library_dim_label_text("DB sizes", details_lines[2]),
+                id="library-details-db-sizes",
+                classes="library-details-row",
+            )
+        if self.workspaces_body_factory is not None:
+            yield from self.workspaces_body_factory()
 
     def _row(self, row_id: str) -> LibraryRailRow:
         """Return one canonical row from the full shell state."""


### PR DESCRIPTION
## Summary

Library's resize handler ran **72 DOM queries per frame** with its early-return *after* the query
work, and Tab-navigation ran 25 queries per keypress with a whole-screen-recompose path reachable.
Finding 23025 of the [2026-08-27 review](Docs/Design/2026-08-27-holistic-perf-review.md).
(Authored stacked on TASK-23022's branch for the shared `library_screen.py`; that base merged as
#2156, so this now targets dev directly.)

## Measured — interleaved ×3 per arm, identical every round

| metric | before | after |
|---|---|---|
| Library queries per resize frame | **71.8** | **10.6** — library-attributed: **0**; the residue is `main_navigation`'s own handlers |
| queries per Tab | **25.6** | **3.4** |
| Research same-band resize frame | 41.0 | **11.0** — `_apply_pane_layout`-attributed: 0 |
| widgets per visit | 156 | 149 |

`on_resize` now derives a bucket/flag signature from cached refs and arithmetic (compact 120,
ingest-collapse 100, emergency 64, the resolved rail-style contract, route/stage flags) and returns
**before any query** when nothing can have changed. The research screen's ungated
`_apply_pane_layout` gets the same shape. Focus-path scroll-observer probes are route-gated — seven
guaranteed-failing DOM walks per Tab removed.

## Where the +90 widgets actually came from — the attribution corrects the framing

Per-call-site attribution shows the growth is **not** hidden bloat: it is the rail's *visible*
feature content **built twice per visit** (the loading→loaded rail recompose) — 15 feature rows ×2,
30 section chrome ×2, the workspaces block. Only ~27 mounted widgets sat in `display=False`
subtrees. So the big per-visit win here is the double-build, which is out of this task's scope, and
the honest per-visit delta is modest (156 → 149): the install-progress pair now grows on first
`InstallProgressed`, using TASK-23024's house pattern.

**A deferral was implemented and deliberately reverted**: the Details body's closed-state children
are a *queried contract* (counts line, use-in-Console handoff state) pinned by 7 tests across 4
files. A new test now pins that contract explicitly, and the grow-on-demand option is recorded for
the owner to renegotiate.

## A known trap recurred and was caught by a pre-existing test

The ref-cache liveness walk originally trusted `is_mounted` — but **`is_mounted` lags detachment
while `_pruning` is already set** (the documented `is_mounted ≠ in-the-DOM` trap). The pre-existing
notes-list scroll test caught it; the walk now checks the pruning state, and mutation M10
(liveness weakened back to `is_mounted`) is killed by that same pre-existing test. Recorded in
`lessons-textual.md`.

## Mutations — 9/9 killed, Edit-based restores verified empty-diff

Gate removed · gate always-skips (all 3 width-crossing tests) · observers ungated (7 vs ≤1) ·
eager install pair · never-mount · research gate removed (48 vs 0) · research over-skips
(`wide != medium`) · footer cache reverted · details closed-empty · liveness weakened. One consumer
test my first cut broke (`test_parakeet_v2_install_ui`, a mocked-`query_one` contract) drove the
handler reorder — update-first, mount on `NoMatches` — now green.

## Verification

New: 8/8 green after rebase onto dev (which now carries the 23022 base). Branch-relevant suites:
~1,600 across 13 suites, with **every red A/B'd against the stacked base** — all pre-existing,
including the known 4 `screen_navigation` reds (this work neither fixes nor adds any) and two
full-suite-only load artifacts that pass 4/4 standalone. Preflight green. Quit walk: the deferred
pair mounted live, screen popped with it mounted, clean exit — its bar is 23022's
`PausableProgressBar`, whose lifecycle guards ran green.

## Out of scope, worth filing

- **`test_library_note_fifty_same_side_resize_sequences_do_zero_notes_work` is red on the base**:
  its "same-side" sequences actually cross the 64-col emergency bucket, so its asserted 0 is
  unreachable for real crossings (this gate *reduces* its counts but cannot reach 0).
- The rail's loading→loaded **double-build** is the real per-visit cost and deserves its own task.
- Bare-`object.__new__` screen fixtures missing `_library_ingest_start_consent` (2 reds on base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements TASK-23025's performance criteria: Library resize frames drop from ~72 DOM queries to ~11 (0 attributed to the screen), Tab moves drop from ~25 to ~3 queries, and widgets per visit drop from 156 to 149. Resize/focus handlers now return before any query work when nothing can have changed, and the install-progress pair grows on first use instead of being built on every visit. Width-crossing and focus behavior are unchanged, with a new born-red test suite pinning every crossing and query bound.

**Gating**
- A signature of width buckets, the resolved rail contract, and route/stage flags is derived from cached refs and arithmetic; unchanged frames return immediately.
- `research_workspace_screen`'s pane layout gets the same gate (41 → 11 queries on same-band frames).
- Tab focus probes only the scroll-owner regions the current route can mount.
- Cached refs are validated by a liveness walk that checks pruning state — `is_mounted` lags detachment (a pre-existing notes-list scroll test caught this and now pins it).

**Deferral**
- The install label+bar mounts on the first `InstallProgressed` event; handlers update if present, mount on `NoMatches`.
- The rail Details body stays composed while closed — its children are a queried contract pinned by 7 tests across 4 files — so that deferral was reverted and the contract is now pinned by a new test.

<sup>Written for commit 444b452d6b854e40e37d6b2ee62ce28ce8d4e42b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

