### PR TITLE
chore(backlog): file Settings+Schedules UX critique tasks 23100-23111

### DIFF
--- a/.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md
+++ b/.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md
@@ -1,0 +1,128 @@
+---
+target: Scheduled Tasks screen (Settings + Scheduled Tasks combined run)
+total_score: 24
+max_score: 40
+na_heuristics: 
+p0_count: 1
+p1_count: 2
+timestamp: 2026-08-28T06-32-49Z
+slug: tbook-ui-screens-scheduling-schedules-workbench-py
+---
+# Design Critique — Settings & Scheduled Tasks (combined run, 2026-08-27)
+
+Method: dual-agent (A: live-TUI design review, isolated profile, 235×52 + 235×40 · B: detector + static evidence)
+Brief: first-time and power-user workflows — create a repeating scheduled task; change settings. Mode: Operate.
+
+## Design Health Score
+
+### Scheduled Tasks (SchedulesWorkbench) — 24/40 (Acceptable)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | Disabled task still shows Status "Waiting" + concrete Next Run (live-verified); "Sync completed." toast while bar reads "Last pull: — Last push: —" |
+| 2 | Match System / Real World | 2 | Detail humanizes ("Daily at 09:00 UTC") but form demands raw ISO-8601, 5-field cron, IANA tz; reminder/task/schedule noun drift |
+| 3 | User Control and Freedom | 3 | Dirty-form discard guard, delete confirm, Esc clears marks; no undo after delete |
+| 4 | Consistency and Standards | 3 | Footer 1:1 with bindings (ADR-031); but queue shortcuts advertised on Conflicts tab; create modal breaks workbench idiom |
+| 5 | Error Prevention | 2 | Past-time guard, cron/tz validation — undermined by focusable invisible cron field that accepts typing (P0) |
+| 6 | Recognition Rather Than Recall | 2 | Empty state teaches `c`; 3 presets; custom recurrence = cron recall; ●/◇ glyphs have no legend |
+| 7 | Flexibility and Efficiency | 3 | Single-letter verbs, real bulk ops (x + space/d), run-now, debounced filter; no sort, no palette "create task" |
+| 8 | Aesthetic and Minimalist Design | 3 | Clean three-pane layout; sync/owner bar permanently occupies top row even for purely local use |
+| 9 | Error Recovery | 2 | Failure toasts name task + next step; "Run now (retry)"; but form errors cluster at bottom and can reference an invisible field |
+| 10 | Help and Documentation | 2 | Tooltips with visible text mirrors (UX-073) good; no task-level help; cron helper clips; zero tooltips in workbench queue itself (B) |
+| **Total** | | **24/40** | **Acceptable** |
+
+### Settings (SettingsScreen) — 29/40 (Good)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 4 | Banner + rail asterisk + inspector "Unsaved changes" + "Saved as: …" + live theme apply — genuinely excellent |
+| 2 | Match System / Real World | 3 | Mostly plain; leaks: "agent_runs.db (SQLite) — immediate CRUD, no draft", "table-shaped TOML top-level value", roadmap copy in Schedules category |
+| 3 | User Control and Freedom | 3 | Revert w/ confirm; drafts survive full screen navigation (live-verified); no undo after save |
+| 4 | Consistency and Standards | 2 | Five+ save models coexist; the mitigating State banner renders doubled and self-colliding (P1) |
+| 5 | Error Prevention | 3 | Validation-gated saves, "Needs correction | msg", invalid-field→selector mapping, revert confirm |
+| 6 | Recognition Rather Than Recall | 3 | `/` search with live match count; grouped rail; search matches categories not fields; Appearance-vs-Theme ambiguity |
+| 7 | Flexibility and Efficiency | 3 | s/r/t per-category verbs, contextual accelerators honestly advertised; no cross-category "jump to setting" |
+| 8 | Aesthetic and Minimalist Design | 2 | State banner rendered twice; "Configuration: X; Status: X" duplication; collapsed Overview sections burn ~6 rows each |
+| 9 | Error Recovery | 3 | Validation message leads banner; atomic save + .bak + "Load Backup"; but 3+ paths surface raw exception text (B) |
+| 10 | Help and Documentation | 2 | F1 help for "Settings: Schedules" opened completely empty (live-verified); Appearance help = 3 shortcut keys |
+| **Total** | | **29/40** | **Good** |
+
+## Design Specificity Verdict
+
+**LLM assessment (unanchored):** Settings is authored, distinctively so — the save-contract State banner, ownership honesty ("Writes allowed: No - change this in Schedules instead"), credential-source disclosure, and per-category test verbs are direct expressions of the product's local-first identity; almost nothing could be transplanted. Schedules is an authored shell around a generic core: the workbench (sync-ownership bar, Conflicts tab with count, Console handoff, honest late-dispatch copy) is product-native, but the creation flow — the most important interaction — is a category-interchangeable CRUD modal (Title/Body/Kind/cron/ISO-8601/IANA tz) any cron GUI from 2005 could ship.
+
+**Deterministic scan:** unavailable for this stack — detect.mjs scans only web file types (.html/.css/.jsx/…; not .py/.tcss), so both runs exited 0 with zero scannable files. Not a clean bill of health; no findings to false-positive-check. Static fallback evidence instead:
+- Theming discipline is excellent: 0 hardcoded colors in owned TCSS vs 1,198 theme-token uses (one stray hex belongs to a Console block). But `task_detail.py:78-91` hardcodes 11 Rich style strings ("bold white on grey50" etc.) and `settings_screen.py:16657` sets a literal "gray".
+- **Scheduling has zero screen-specific `:focus` rules** (all of `_scheduling.tcss`, `ReminderForm.DEFAULT_CSS`, widget-default blocks) — corroborates the live P0 (typing into an invisible focused field).
+- Tooltip coverage: scheduling detail widgets ~73%, but `schedules_workbench.py` itself 0; settings ~29% with `help_text`/hint counterweights.
+- Raw exception text reaches users: `settings_screen.py:10871` ("Model discovery failed: {exc}"), `:11006`, `:14281` ("Backfill failed: {e}" toast).
+- Scale: `settings_screen.py` is 23,350 lines, one class of ~21,000 lines, 811 methods, 26 categories.
+
+**Overlays:** n/a — terminal UI, no DOM to inject into. Live evidence came from driving the real app over tmux instead.
+
+**Where A and B disagree productively:** B's static color-only scan found text counterparts everywhere and concluded "no pure color-only signal confirmed"; A's live pass found the real color-only carriers are *dim-contrast disabled buttons* (Enable/Disable pair, sync-bar Clear) — a class static analysis can't see. Conversely, B caught the raw-exception strings and the hardcoded Rich styles that A missed.
+
+## Workflow Walkthroughs (evidence summary)
+
+**Jordan (first-timer), repeating task:** Two modal gates precede work (setup wizard — skippable, well-worded; then a "Check model lists online?" consent dialog that silently swallowed a nav click). Schedules is discoverable; the empty state is a peak: "No scheduled tasks yet. Press c to schedule your first task." Creation lands with toast + queue row + visible "Next Run: 2026-08-28 09:00 UTC". Valleys: the "Run At (ISO-8601):" label; choosing "Custom cron…" makes *nothing visibly appear* (clipped field); disabling a task leaves Status "Waiting" with a live Next Run.
+
+**Alex (power user):** ~19 keystrokes + title for a daily-9:00 repeating task via palette → `c` → presets. Every management verb is one letter with bulk variants (x/space/d). Gaps: no queue sort, no palette command to create/run directly, edit round-trips through the modal, cron typed into an invisible field.
+
+**Settings (both):** `/` filter with live match counts, s/r/t verbs, live theme apply, drafts survive navigating away and back (verified). Gaps: search matches categories not individual settings ("theme" → Theme file-editor vs Appearance coin-flip); F1 help empty for some categories; State banner doubled.
+
+## Overall Impression
+
+Settings is the stronger surface — a genuinely product-specific status/save-contract system undermined by its own presentation bug and by the sheer number of save models it must explain. Schedules nails the workbench loop (discover → create → confirm → manage) but hides its truth at the two moments that matter most: expressing a custom recurrence (clipped form) and knowing whether a task will actually fire (disabled ≠ visibly disabled). The single biggest opportunity: make the recurring-task form as honest and self-explaining as the rest of the product already is.
+
+## What's Working
+
+1. **The save-contract system (Settings):** pinned State banner naming the active save model per category, footer verbs that appear 1:1 with what works, per-category test actions, and text-carried dirty state in three places. Best-in-class TUI status choreography.
+2. **Draft durability (Settings):** change a value, walk to another screen, return — category, filter, draft, and dirty state all intact (`settings_screen.py:2864-2933`). "Preserved user work" as a first-class behavior.
+3. **Honesty under uncertainty (Schedules):** late-dispatch copy refuses to invent causes ("skipped, not replayed"), "Run now" tooltip states real semantics, disabled buttons carry visible text reasons (UX-073). The product's stated personality executed in copy.
+
+## Priority Issues
+
+1. **[P0] The recurring form's cron field, helper, and live preview clip invisible at common terminal heights — and still receive focus and keystrokes.** At 235×52, choosing "Recurring" shows Frequency, three blank rows, then Timezone; Tab lands on the invisible cron Input; typed garbage silently flips the preset to "Custom cron…". Cause: `ReminderForm` stacks fields in a plain `Vertical` inside a `max-height: 55` container with no scrolling (`forms/reminder_form.py:35-42, 116-186`) while the Body TextArea keeps ~7 rows; B confirms zero `:focus` styling anywhere in scheduling. **Why:** the personas converge here — Jordan concludes the feature is broken, Alex types cron blind, Sam types into a void. The form's best safety feature (live "Runs: …" preview) becomes dead code. **Fix:** make the field column a `VerticalScroll` with scroll-to-focus; cap Body at 3 rows; compress the two long helper Statics; verify at 24 rows. **Command:** /impeccable adapt (heights), then /impeccable harden.
+
+2. **[P1] Disabled schedules are indistinguishable from armed ones.** Toast says "'Morning digest' disabled." but queue Status stays `Waiting` and Next Run still shows a concrete future time (persists across refresh). `_task_status()` returns `last_status`, which disabling never touches (`task_detail.py:186-190`; `schedules_workbench.py:697-700`); the only persistent carrier is the dim Enable/Disable pair — color-only. **Why:** a disabled job displaying a future run time is a false promise discovered only when the digest never arrives; violates Design Principle 8 and the color-never-sole-carrier commitment. **Fix:** derive display status — `enabled is False` → badge `Disabled` (enum + styles already exist, `task_detail.py:52/84`) and Next Run `— (disabled)`. **Command:** /impeccable harden.
+
+3. **[P1] The State banner — sole carrier of the save contract — is duplicated and self-colliding.** Renders "State: Read-only here | State: Active | …" (composition at `settings_screen.py:6413` prepends `State:` to scope strings that embed their own at 6466/6479-6482), and the whole banner appears twice (pinned 16631 + in-card 12405/15116). **Why:** the banner exists because five save models coexist; a stuttering duplicated contract line teaches users to stop reading it — un-fixing the original problem. **Fix:** strip embedded `State:` prefixes from `_category_state_scope_text`; drop the in-card banner where the pinned one is present. **Command:** /impeccable clarify.
+
+4. **[P1] The create form's input vocabulary is expert-only.** "Run At (ISO-8601):" requiring `2026-07-20T14:00:00+00:00`; timezone as free-text IANA name; recurrence beyond 3 presets (daily 9:00 / Monday 9:00 / hourly) requires raw cron — no "every weekday", no time-of-day control on presets. **Why:** Jordan can't express "weekdays at 8" without learning cron; even Alex must type a full RFC timestamp for a one-time run. Violates "plain language, forgiving input." **Fix:** accept forgiving datetimes ("2026-08-28 09:00", default tz = system) with the existing preview disambiguating; Timezone becomes a searchable Select defaulting to system; add "Every weekday at…" + editable preset times; keep cron behind "Custom cron…". **Command:** /impeccable shape (interaction), then /impeccable clarify (labels).
+
+5. **[P2] The sync surface over-promises and mixes signals.** `s` toasts "Sync completed." while the bar reads "Last pull: — Last push: —"; the owner bar permanently shows `Server (http://127.0.0.1:8000)` + `Clear` even when the header chip says "Local schedules"; Clear's disabled state is color-only. **Why:** "completed" with no recorded pull/push is status-requiring-log-reading (an explicit anti-reference); server plumbing is visually first on a local-first screen. **Fix:** local owner → "Synced — nothing to pull or push" or real timestamps; collapse the owner bar to one line; hide Clear until an error exists. **Command:** /impeccable distill.
+
+### Further issues (tracked, lower severity)
+
+- **[P2] Terminology drift:** nav "Schedules" / form "New Scheduled Task" / toast "Reminder created." / guard "Only reminder tasks can be edited here." Standardize on "scheduled task"; where projections differ, say so ("Managed by Watchlists — edit it there").
+- **[P2] Bulk-mark is invisible infrastructure:** `x` marks (●) and missed (◇) have no legend, no marked-count, no hint that space/d go bulk. Reuse `#scheduling-pane-notice`: "2 marked — space toggles all · d deletes all · esc clears".
+- **[P2] Raw exception text in Settings user paths** (B): `settings_screen.py:10871, 11006, 14281` — wrap in plain-language summaries, keep detail behind Diagnostics.
+- **[P2] Settings search matches categories, not settings** — "jump to setting" doesn't exist; "theme" yields a Theme-editor vs Appearance coin flip.
+- **[P3] F1 help hollow/empty** for some categories (Schedules category: empty body, live-verified). Feed it the inspector's contract rows + state-scope copy.
+- **[P3] Next Run is absolute UTC only** — no relative ("in 14h") or local-time rendering.
+- **[P3] Hardcoded Rich status colors** (`task_detail.py:78-91`, fallback `:242`) and one inline `styles.color = "gray"` (`settings_screen.py:16657`) bypass theme tokens.
+- **[P3] Overview duplication:** "Configuration: OpenAI / gpt-5.6-terra; Status: OpenAI / gpt-5.6-terra".
+
+## Persona Red Flags
+
+**Jordan (first-timer):** consent dialog silently ate a nav click (no shake/toast); "Run At (ISO-8601):" is the scariest string of the journey; "Custom cron…" appeared to do nothing (clipped); disabled task still reads Waiting; Settings "theme" search forces a coin flip. Saved by: the empty-state CTA, "That time is in the past — pick a future time.", the discard guard.
+
+**Alex (power user):** fast path genuinely fast (~19 keystrokes + title); red flags: cron typed into an invisible field with the validation preview also invisible; no queue sort; no palette command for create/run; edit round-trips through a modal instead of inline pane editing. (Ctrl+digit hotkeys untestable through tmux — environment limitation, not judged.)
+
+**Sam (keyboard-only):** strong baseline — text-carried toggle states, visible-text disabled reasons, words in status badges, Cancel-first delete dialog, focus-help line mirroring tooltips. Breakers: Tab lands on the clipped cron input with no visible focus indicator anywhere; Enable-vs-Disable applicability is dim-contrast only; ● mark announced nowhere but the glyph; Clear's disabled state color-only.
+
+## Minor Observations
+
+- Queue footer keys stay advertised on the Conflicts tab where they act on an invisible selection.
+- Empty queue renders full table header + filter before the CTA draws the eye.
+- "Agents" sits under Troubleshooting in the Settings rail; "(view)" suffixes are a nice honesty touch.
+- Schedules settings category exposes roadmap copy ("Planned: add schedule defaults after…").
+- Delete-recovery contracts differ across the app (Schedules: permanent; Notes: trash+recover).
+- Width-responsiveness is thoughtful (hidden panes announce themselves, `schedules_workbench.py:790-800`) — better than the form's height handling.
+- Setup wizard copy "everything here can be changed later in Settings" is exactly right.
+
+## Questions to Consider
+
+1. If the State banner needs eight badge variants to explain the save models, is the badge the fix — or is the number of save models the bug? What would collapsing Splash/Workspaces/Agents into the draft-save-with-`s` contract cost?
+2. Why is creating a schedule a modal at all? Every peer surface edits in the detail pane of a persistent workbench; a pane-based editor gets scrolling, the state banner, and footer-key consistency for free — the P0 disappears structurally.
+3. What is the queue *for* — inventory or forecast? A surface promising "when jobs run" arguably leads with a next-24-hours timeline (sorted by next fire, disabled rows visibly parked), not an unsorted CRUD table.

--- a/.impeccable/critique/2026-08-28T06-32-49Z__tldw-chatbook-ui-screens-settings-screen-py.md
+++ b/.impeccable/critique/2026-08-28T06-32-49Z__tldw-chatbook-ui-screens-settings-screen-py.md
@@ -1,0 +1,128 @@
+---
+target: Settings screen (Settings + Scheduled Tasks combined run)
+total_score: 29
+max_score: 40
+na_heuristics: 
+p0_count: 0
+p1_count: 1
+timestamp: 2026-08-28T06-32-49Z
+slug: tldw-chatbook-ui-screens-settings-screen-py
+---
+# Design Critique — Settings & Scheduled Tasks (combined run, 2026-08-27)
+
+Method: dual-agent (A: live-TUI design review, isolated profile, 235×52 + 235×40 · B: detector + static evidence)
+Brief: first-time and power-user workflows — create a repeating scheduled task; change settings. Mode: Operate.
+
+## Design Health Score
+
+### Scheduled Tasks (SchedulesWorkbench) — 24/40 (Acceptable)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | Disabled task still shows Status "Waiting" + concrete Next Run (live-verified); "Sync completed." toast while bar reads "Last pull: — Last push: —" |
+| 2 | Match System / Real World | 2 | Detail humanizes ("Daily at 09:00 UTC") but form demands raw ISO-8601, 5-field cron, IANA tz; reminder/task/schedule noun drift |
+| 3 | User Control and Freedom | 3 | Dirty-form discard guard, delete confirm, Esc clears marks; no undo after delete |
+| 4 | Consistency and Standards | 3 | Footer 1:1 with bindings (ADR-031); but queue shortcuts advertised on Conflicts tab; create modal breaks workbench idiom |
+| 5 | Error Prevention | 2 | Past-time guard, cron/tz validation — undermined by focusable invisible cron field that accepts typing (P0) |
+| 6 | Recognition Rather Than Recall | 2 | Empty state teaches `c`; 3 presets; custom recurrence = cron recall; ●/◇ glyphs have no legend |
+| 7 | Flexibility and Efficiency | 3 | Single-letter verbs, real bulk ops (x + space/d), run-now, debounced filter; no sort, no palette "create task" |
+| 8 | Aesthetic and Minimalist Design | 3 | Clean three-pane layout; sync/owner bar permanently occupies top row even for purely local use |
+| 9 | Error Recovery | 2 | Failure toasts name task + next step; "Run now (retry)"; but form errors cluster at bottom and can reference an invisible field |
+| 10 | Help and Documentation | 2 | Tooltips with visible text mirrors (UX-073) good; no task-level help; cron helper clips; zero tooltips in workbench queue itself (B) |
+| **Total** | | **24/40** | **Acceptable** |
+
+### Settings (SettingsScreen) — 29/40 (Good)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 4 | Banner + rail asterisk + inspector "Unsaved changes" + "Saved as: …" + live theme apply — genuinely excellent |
+| 2 | Match System / Real World | 3 | Mostly plain; leaks: "agent_runs.db (SQLite) — immediate CRUD, no draft", "table-shaped TOML top-level value", roadmap copy in Schedules category |
+| 3 | User Control and Freedom | 3 | Revert w/ confirm; drafts survive full screen navigation (live-verified); no undo after save |
+| 4 | Consistency and Standards | 2 | Five+ save models coexist; the mitigating State banner renders doubled and self-colliding (P1) |
+| 5 | Error Prevention | 3 | Validation-gated saves, "Needs correction | msg", invalid-field→selector mapping, revert confirm |
+| 6 | Recognition Rather Than Recall | 3 | `/` search with live match count; grouped rail; search matches categories not fields; Appearance-vs-Theme ambiguity |
+| 7 | Flexibility and Efficiency | 3 | s/r/t per-category verbs, contextual accelerators honestly advertised; no cross-category "jump to setting" |
+| 8 | Aesthetic and Minimalist Design | 2 | State banner rendered twice; "Configuration: X; Status: X" duplication; collapsed Overview sections burn ~6 rows each |
+| 9 | Error Recovery | 3 | Validation message leads banner; atomic save + .bak + "Load Backup"; but 3+ paths surface raw exception text (B) |
+| 10 | Help and Documentation | 2 | F1 help for "Settings: Schedules" opened completely empty (live-verified); Appearance help = 3 shortcut keys |
+| **Total** | | **29/40** | **Good** |
+
+## Design Specificity Verdict
+
+**LLM assessment (unanchored):** Settings is authored, distinctively so — the save-contract State banner, ownership honesty ("Writes allowed: No - change this in Schedules instead"), credential-source disclosure, and per-category test verbs are direct expressions of the product's local-first identity; almost nothing could be transplanted. Schedules is an authored shell around a generic core: the workbench (sync-ownership bar, Conflicts tab with count, Console handoff, honest late-dispatch copy) is product-native, but the creation flow — the most important interaction — is a category-interchangeable CRUD modal (Title/Body/Kind/cron/ISO-8601/IANA tz) any cron GUI from 2005 could ship.
+
+**Deterministic scan:** unavailable for this stack — detect.mjs scans only web file types (.html/.css/.jsx/…; not .py/.tcss), so both runs exited 0 with zero scannable files. Not a clean bill of health; no findings to false-positive-check. Static fallback evidence instead:
+- Theming discipline is excellent: 0 hardcoded colors in owned TCSS vs 1,198 theme-token uses (one stray hex belongs to a Console block). But `task_detail.py:78-91` hardcodes 11 Rich style strings ("bold white on grey50" etc.) and `settings_screen.py:16657` sets a literal "gray".
+- **Scheduling has zero screen-specific `:focus` rules** (all of `_scheduling.tcss`, `ReminderForm.DEFAULT_CSS`, widget-default blocks) — corroborates the live P0 (typing into an invisible focused field).
+- Tooltip coverage: scheduling detail widgets ~73%, but `schedules_workbench.py` itself 0; settings ~29% with `help_text`/hint counterweights.
+- Raw exception text reaches users: `settings_screen.py:10871` ("Model discovery failed: {exc}"), `:11006`, `:14281` ("Backfill failed: {e}" toast).
+- Scale: `settings_screen.py` is 23,350 lines, one class of ~21,000 lines, 811 methods, 26 categories.
+
+**Overlays:** n/a — terminal UI, no DOM to inject into. Live evidence came from driving the real app over tmux instead.
+
+**Where A and B disagree productively:** B's static color-only scan found text counterparts everywhere and concluded "no pure color-only signal confirmed"; A's live pass found the real color-only carriers are *dim-contrast disabled buttons* (Enable/Disable pair, sync-bar Clear) — a class static analysis can't see. Conversely, B caught the raw-exception strings and the hardcoded Rich styles that A missed.
+
+## Workflow Walkthroughs (evidence summary)
+
+**Jordan (first-timer), repeating task:** Two modal gates precede work (setup wizard — skippable, well-worded; then a "Check model lists online?" consent dialog that silently swallowed a nav click). Schedules is discoverable; the empty state is a peak: "No scheduled tasks yet. Press c to schedule your first task." Creation lands with toast + queue row + visible "Next Run: 2026-08-28 09:00 UTC". Valleys: the "Run At (ISO-8601):" label; choosing "Custom cron…" makes *nothing visibly appear* (clipped field); disabling a task leaves Status "Waiting" with a live Next Run.
+
+**Alex (power user):** ~19 keystrokes + title for a daily-9:00 repeating task via palette → `c` → presets. Every management verb is one letter with bulk variants (x/space/d). Gaps: no queue sort, no palette command to create/run directly, edit round-trips through the modal, cron typed into an invisible field.
+
+**Settings (both):** `/` filter with live match counts, s/r/t verbs, live theme apply, drafts survive navigating away and back (verified). Gaps: search matches categories not individual settings ("theme" → Theme file-editor vs Appearance coin-flip); F1 help empty for some categories; State banner doubled.
+
+## Overall Impression
+
+Settings is the stronger surface — a genuinely product-specific status/save-contract system undermined by its own presentation bug and by the sheer number of save models it must explain. Schedules nails the workbench loop (discover → create → confirm → manage) but hides its truth at the two moments that matter most: expressing a custom recurrence (clipped form) and knowing whether a task will actually fire (disabled ≠ visibly disabled). The single biggest opportunity: make the recurring-task form as honest and self-explaining as the rest of the product already is.
+
+## What's Working
+
+1. **The save-contract system (Settings):** pinned State banner naming the active save model per category, footer verbs that appear 1:1 with what works, per-category test actions, and text-carried dirty state in three places. Best-in-class TUI status choreography.
+2. **Draft durability (Settings):** change a value, walk to another screen, return — category, filter, draft, and dirty state all intact (`settings_screen.py:2864-2933`). "Preserved user work" as a first-class behavior.
+3. **Honesty under uncertainty (Schedules):** late-dispatch copy refuses to invent causes ("skipped, not replayed"), "Run now" tooltip states real semantics, disabled buttons carry visible text reasons (UX-073). The product's stated personality executed in copy.
+
+## Priority Issues
+
+1. **[P0] The recurring form's cron field, helper, and live preview clip invisible at common terminal heights — and still receive focus and keystrokes.** At 235×52, choosing "Recurring" shows Frequency, three blank rows, then Timezone; Tab lands on the invisible cron Input; typed garbage silently flips the preset to "Custom cron…". Cause: `ReminderForm` stacks fields in a plain `Vertical` inside a `max-height: 55` container with no scrolling (`forms/reminder_form.py:35-42, 116-186`) while the Body TextArea keeps ~7 rows; B confirms zero `:focus` styling anywhere in scheduling. **Why:** the personas converge here — Jordan concludes the feature is broken, Alex types cron blind, Sam types into a void. The form's best safety feature (live "Runs: …" preview) becomes dead code. **Fix:** make the field column a `VerticalScroll` with scroll-to-focus; cap Body at 3 rows; compress the two long helper Statics; verify at 24 rows. **Command:** /impeccable adapt (heights), then /impeccable harden.
+
+2. **[P1] Disabled schedules are indistinguishable from armed ones.** Toast says "'Morning digest' disabled." but queue Status stays `Waiting` and Next Run still shows a concrete future time (persists across refresh). `_task_status()` returns `last_status`, which disabling never touches (`task_detail.py:186-190`; `schedules_workbench.py:697-700`); the only persistent carrier is the dim Enable/Disable pair — color-only. **Why:** a disabled job displaying a future run time is a false promise discovered only when the digest never arrives; violates Design Principle 8 and the color-never-sole-carrier commitment. **Fix:** derive display status — `enabled is False` → badge `Disabled` (enum + styles already exist, `task_detail.py:52/84`) and Next Run `— (disabled)`. **Command:** /impeccable harden.
+
+3. **[P1] The State banner — sole carrier of the save contract — is duplicated and self-colliding.** Renders "State: Read-only here | State: Active | …" (composition at `settings_screen.py:6413` prepends `State:` to scope strings that embed their own at 6466/6479-6482), and the whole banner appears twice (pinned 16631 + in-card 12405/15116). **Why:** the banner exists because five save models coexist; a stuttering duplicated contract line teaches users to stop reading it — un-fixing the original problem. **Fix:** strip embedded `State:` prefixes from `_category_state_scope_text`; drop the in-card banner where the pinned one is present. **Command:** /impeccable clarify.
+
+4. **[P1] The create form's input vocabulary is expert-only.** "Run At (ISO-8601):" requiring `2026-07-20T14:00:00+00:00`; timezone as free-text IANA name; recurrence beyond 3 presets (daily 9:00 / Monday 9:00 / hourly) requires raw cron — no "every weekday", no time-of-day control on presets. **Why:** Jordan can't express "weekdays at 8" without learning cron; even Alex must type a full RFC timestamp for a one-time run. Violates "plain language, forgiving input." **Fix:** accept forgiving datetimes ("2026-08-28 09:00", default tz = system) with the existing preview disambiguating; Timezone becomes a searchable Select defaulting to system; add "Every weekday at…" + editable preset times; keep cron behind "Custom cron…". **Command:** /impeccable shape (interaction), then /impeccable clarify (labels).
+
+5. **[P2] The sync surface over-promises and mixes signals.** `s` toasts "Sync completed." while the bar reads "Last pull: — Last push: —"; the owner bar permanently shows `Server (http://127.0.0.1:8000)` + `Clear` even when the header chip says "Local schedules"; Clear's disabled state is color-only. **Why:** "completed" with no recorded pull/push is status-requiring-log-reading (an explicit anti-reference); server plumbing is visually first on a local-first screen. **Fix:** local owner → "Synced — nothing to pull or push" or real timestamps; collapse the owner bar to one line; hide Clear until an error exists. **Command:** /impeccable distill.
+
+### Further issues (tracked, lower severity)
+
+- **[P2] Terminology drift:** nav "Schedules" / form "New Scheduled Task" / toast "Reminder created." / guard "Only reminder tasks can be edited here." Standardize on "scheduled task"; where projections differ, say so ("Managed by Watchlists — edit it there").
+- **[P2] Bulk-mark is invisible infrastructure:** `x` marks (●) and missed (◇) have no legend, no marked-count, no hint that space/d go bulk. Reuse `#scheduling-pane-notice`: "2 marked — space toggles all · d deletes all · esc clears".
+- **[P2] Raw exception text in Settings user paths** (B): `settings_screen.py:10871, 11006, 14281` — wrap in plain-language summaries, keep detail behind Diagnostics.
+- **[P2] Settings search matches categories, not settings** — "jump to setting" doesn't exist; "theme" yields a Theme-editor vs Appearance coin flip.
+- **[P3] F1 help hollow/empty** for some categories (Schedules category: empty body, live-verified). Feed it the inspector's contract rows + state-scope copy.
+- **[P3] Next Run is absolute UTC only** — no relative ("in 14h") or local-time rendering.
+- **[P3] Hardcoded Rich status colors** (`task_detail.py:78-91`, fallback `:242`) and one inline `styles.color = "gray"` (`settings_screen.py:16657`) bypass theme tokens.
+- **[P3] Overview duplication:** "Configuration: OpenAI / gpt-5.6-terra; Status: OpenAI / gpt-5.6-terra".
+
+## Persona Red Flags
+
+**Jordan (first-timer):** consent dialog silently ate a nav click (no shake/toast); "Run At (ISO-8601):" is the scariest string of the journey; "Custom cron…" appeared to do nothing (clipped); disabled task still reads Waiting; Settings "theme" search forces a coin flip. Saved by: the empty-state CTA, "That time is in the past — pick a future time.", the discard guard.
+
+**Alex (power user):** fast path genuinely fast (~19 keystrokes + title); red flags: cron typed into an invisible field with the validation preview also invisible; no queue sort; no palette command for create/run; edit round-trips through a modal instead of inline pane editing. (Ctrl+digit hotkeys untestable through tmux — environment limitation, not judged.)
+
+**Sam (keyboard-only):** strong baseline — text-carried toggle states, visible-text disabled reasons, words in status badges, Cancel-first delete dialog, focus-help line mirroring tooltips. Breakers: Tab lands on the clipped cron input with no visible focus indicator anywhere; Enable-vs-Disable applicability is dim-contrast only; ● mark announced nowhere but the glyph; Clear's disabled state color-only.
+
+## Minor Observations
+
+- Queue footer keys stay advertised on the Conflicts tab where they act on an invisible selection.
+- Empty queue renders full table header + filter before the CTA draws the eye.
+- "Agents" sits under Troubleshooting in the Settings rail; "(view)" suffixes are a nice honesty touch.
+- Schedules settings category exposes roadmap copy ("Planned: add schedule defaults after…").
+- Delete-recovery contracts differ across the app (Schedules: permanent; Notes: trash+recover).
+- Width-responsiveness is thoughtful (hidden panes announce themselves, `schedules_workbench.py:790-800`) — better than the form's height handling.
+- Setup wizard copy "everything here can be changed later in Settings" is exactly right.
+
+## Questions to Consider
+
+1. If the State banner needs eight badge variants to explain the save models, is the badge the fix — or is the number of save models the bug? What would collapsing Splash/Workspaces/Agents into the draft-save-with-`s` contract cost?
+2. Why is creating a schedule a modal at all? Every peer surface edits in the detail pane of a persistent workbench; a pane-based editor gets scrolling, the state banner, and footer-key consistency for free — the P0 disappears structurally.
+3. What is the queue *for* — inventory or forecast? A surface promising "when jobs run" arguably leads with a next-24-hours timeline (sorted by next fire, disabled rows visibly parked), not an unsorted CRUD table.

--- a/backlog/tasks/task-23100 - Schedules-create-form-clips-recurring-fields-at-common-terminal-heights-while-keeping-focus.md
+++ b/backlog/tasks/task-23100 - Schedules-create-form-clips-recurring-fields-at-common-terminal-heights-while-keeping-focus.md
@@ -1,0 +1,28 @@
+---
+id: TASK-23100
+title: >-
+  Schedules create form clips recurring fields at common terminal heights while
+  keeping focus
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:05'
+labels:
+  - ux
+  - schedules
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ReminderForm stacks its fields in a plain Vertical inside a max-height:55 container with no scrolling (forms/reminder_form.py:35-42,116-186) while the Body TextArea keeps ~7 rows. At 235x52, selecting Recurring leaves the cron Input, its syntax helper, and the live 'Runs:' preview clipped invisible - yet the invisible input still receives Tab focus and keystrokes, and typing silently flips the Frequency preset to 'Custom cron...'. Scheduling also has zero screen-specific :focus styling, so the focused-invisible state has no visible carrier. P0 from the 2026-08-28 Settings+Schedules design critique (evidence: .impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md). Owner direction: patch the modal now; a separate spike task in this batch decides the long-term modal-vs-pane shape.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 At 80x24 and 235x52, every ReminderForm field, helper, and the live schedule preview is visible or scrolls into view when focused; a focused widget is never rendered invisible
+- [ ] #2 Selecting 'Recurring' visibly reveals the recurrence controls at supported terminal sizes
+- [ ] #3 The live 'Runs: ...' preview stays visible while the cron field is being edited
+- [ ] #4 Verification is a runtime capture (tmux capture-pane) at both sizes, not a style-value probe
+<!-- AC:END -->

--- a/backlog/tasks/task-23101 - Disabled-scheduled-tasks-still-display-Waiting-with-a-concrete-Next-Run.md
+++ b/backlog/tasks/task-23101 - Disabled-scheduled-tasks-still-display-Waiting-with-a-concrete-Next-Run.md
@@ -1,0 +1,26 @@
+---
+id: TASK-23101
+title: Disabled scheduled tasks still display Waiting with a concrete Next Run
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:05'
+labels:
+  - ux
+  - schedules
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Disabling a task toasts "'X' disabled." but the queue Status column and detail badge keep showing last_status ('Waiting') and a real future Next Run - _task_status() returns last_status, which disabling never touches (task_detail.py:186-190; schedules_workbench.py:697-700). The only persistent carrier is the dimmed Enable/Disable button pair (color-only). A disabled job displaying a future run time is a false promise discovered only when the job never fires; violates Design Principle 8 (explicit blocked/unavailable states) and the color-never-sole-carrier accessibility commitment. The Disabled enum and badge styles already exist (task_detail.py:52/84). P1 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A disabled task shows a text 'Disabled' status in both the queue row and the detail badge
+- [ ] #2 Next Run for a disabled task no longer displays a concrete future time (e.g. '- (disabled)')
+- [ ] #3 The displayed state survives queue refresh and app restart
+- [ ] #4 Enabled/disabled state is carried by text, not only button dimming
+<!-- AC:END -->

--- a/backlog/tasks/task-23102 - Schedule-creation-inputs-are-expert-only-ISO-8601-raw-cron-free-text-IANA-timezone.md
+++ b/backlog/tasks/task-23102 - Schedule-creation-inputs-are-expert-only-ISO-8601-raw-cron-free-text-IANA-timezone.md
@@ -1,0 +1,28 @@
+---
+id: TASK-23102
+title: >-
+  Schedule creation inputs are expert-only: ISO-8601, raw cron, free-text IANA
+  timezone
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:05'
+labels:
+  - ux
+  - schedules
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The create form requires 'Run At (ISO-8601):' full timestamps (e.g. 2026-07-20T14:00:00+00:00), a free-text IANA timezone, and raw 5-field cron for any recurrence beyond three presets (daily 9:00 / Monday 9:00 / hourly) - no 'every weekday', no time-of-day control on presets (forms/reminder_form.py:114-186). PRODUCT.md commits to plain language and forgiving input; a first-time user cannot express 'weekdays at 8' without learning cron, and even experts must type a full RFC timestamp for a one-time run. P1 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A one-time task can be created by typing a forgiving local datetime such as '2026-08-28 09:00' (no offset); the live preview confirms the interpretation before save
+- [ ] #2 Timezone is a selectable list defaulting to the system zone, not a free-text field
+- [ ] #3 Recurrence presets cover at least 'every weekday at <time>' with an editable time-of-day, without cron
+- [ ] #4 Raw cron remains available behind 'Custom cron...' with its live preview intact
+<!-- AC:END -->

--- a/backlog/tasks/task-23103 - Design-spike-pane-based-schedule-editor-vs-create-edit-modal.md
+++ b/backlog/tasks/task-23103 - Design-spike-pane-based-schedule-editor-vs-create-edit-modal.md
@@ -1,0 +1,26 @@
+---
+id: TASK-23103
+title: 'Design spike: pane-based schedule editor vs create-edit modal'
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:05'
+labels:
+  - ux
+  - schedules
+  - design
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Schedule creation is a modal while every peer workbench surface edits in the detail pane; the modal's fixed-height layout is also the structural cause of the field-clipping defect filed in this batch. Decide the durable shape: keep-and-patch the modal, or move create/edit into the detail pane (which inherits scrolling, the state banner, and footer-key consistency structurally). Decision only, no implementation - per the stability-over-quick-wins ruling, pick the durable shape rather than the expedient one. Raised as provocative question 2 of the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A written decision (task notes or ADR) compares modal vs pane-based editing against the workbench idiom, keyboard flow, and terminal-height constraints
+- [ ] #2 The decision names which follow-up tasks it spawns or closes
+- [ ] #3 No implementation beyond throwaway prototyping
+<!-- AC:END -->

--- a/backlog/tasks/task-23104 - Settings-State-banner-renders-doubled-and-self-colliding.md
+++ b/backlog/tasks/task-23104 - Settings-State-banner-renders-doubled-and-self-colliding.md
@@ -1,0 +1,25 @@
+---
+id: TASK-23104
+title: Settings State banner renders doubled and self-colliding
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:05'
+labels:
+  - ux
+  - settings
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The banner composition at settings_screen.py:6413 prepends 'State: {badge} | ' to scope strings that already embed their own 'State: ...' (6466, 6479-6482), producing 'State: Read-only here | State: Active | ...'; and the whole banner renders twice on Overview and all 11 domain categories (pinned at 16631 plus in-card via 12405/15116). The banner is the sole carrier of the save contract (task-1717 built it because five save models coexist); a stuttering duplicated contract line teaches users to stop reading it, un-fixing the original problem. P1 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tldw-chatbook-ui-screens-settings-screen-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each settings category renders exactly one State banner
+- [ ] #2 The banner text contains exactly one 'State:' segment; scope text no longer embeds a second
+- [ ] #3 Verified at runtime on Overview, one domain-defaults category, and one draft-model category
+<!-- AC:END -->

--- a/backlog/tasks/task-23105 - Schedules-sync-surface-over-promises-Sync-completed-with-empty-timestamps-always-on-server-bar.md
+++ b/backlog/tasks/task-23105 - Schedules-sync-surface-over-promises-Sync-completed-with-empty-timestamps-always-on-server-bar.md
@@ -1,0 +1,27 @@
+---
+id: TASK-23105
+title: >-
+  Schedules sync surface over-promises: Sync completed with empty timestamps,
+  always-on server bar
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:06'
+labels:
+  - ux
+  - schedules
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pressing s toasts 'Sync completed.' while the sync bar still reads 'Last pull: - Last push: -'; the owner bar permanently shows Server (http://127.0.0.1:8000) and a Clear button even when the header chip says 'Local schedules'; Clear's disabled state is color-only. 'Completed' with no recorded transfer is status-requiring-log-reading (an explicit PRODUCT.md anti-reference), and server plumbing is visually first on a local-first screen. P2 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After a sync that transfers nothing on a local-owner setup, the reported outcome says nothing was pulled or pushed (or the timestamps update)
+- [ ] #2 When the owner is Local, server plumbing collapses to a single line and Clear is hidden until an error exists
+- [ ] #3 Disabled states in the sync bar are carried by text, not color alone
+<!-- AC:END -->

--- a/backlog/tasks/task-23106 - Schedules-terminology-drift-schedule-vs-scheduled-task-vs-reminder.md
+++ b/backlog/tasks/task-23106 - Schedules-terminology-drift-schedule-vs-scheduled-task-vs-reminder.md
@@ -1,0 +1,25 @@
+---
+id: TASK-23106
+title: 'Schedules terminology drift: schedule vs scheduled task vs reminder'
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:06'
+labels:
+  - ux
+  - schedules
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+One object carries three nouns: nav 'Schedules', form 'New Scheduled Task', toast 'Reminder created.', guard 'Only reminder tasks can be edited here.', delete dialog 'Scheduled task'. First-time users must wonder whether a 'reminder' differs from the 'task' they just made (it does internally - reminders vs read-only projections - but the queue never explains that either). P2 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User-facing copy on the Schedules screen uses one noun ('scheduled task') for user-created items
+- [ ] #2 Rows managed by other systems state what they are and where to edit them (e.g. 'Managed by Watchlists - edit it there')
+- [ ] #3 No user-facing toast or guard string exposes the internal 'reminder' noun without the projection distinction being explained
+<!-- AC:END -->

--- a/backlog/tasks/task-23107 - Schedules-bulk-mark-mechanism-is-invisible-no-legend-count-or-bulk-mode-hint.md
+++ b/backlog/tasks/task-23107 - Schedules-bulk-mark-mechanism-is-invisible-no-legend-count-or-bulk-mode-hint.md
@@ -1,0 +1,26 @@
+---
+id: TASK-23107
+title: >-
+  Schedules bulk-mark mechanism is invisible: no legend, count, or bulk-mode
+  hint
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:06'
+labels:
+  - ux
+  - schedules
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pressing x prefixes a row with a filled-circle mark and missed-while-away rows carry a diamond glyph, but there is no legend, no marked-count, and no indication that space/d switch to bulk mode when marks exist. Cheap fix shape: reuse the existing #scheduling-pane-notice line ('2 marked - space toggles all, d deletes all, esc clears'). P2 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 When one or more rows are marked, visible text states the marked count and which keys act on all marked rows and how to clear the marks
+- [ ] #2 The missed-while-away glyph has a visible text explanation on screen
+<!-- AC:END -->

--- a/backlog/tasks/task-23108 - Settings-surfaces-raw-exception-text-in-user-facing-status-and-toasts.md
+++ b/backlog/tasks/task-23108 - Settings-surfaces-raw-exception-text-in-user-facing-status-and-toasts.md
@@ -1,0 +1,25 @@
+---
+id: TASK-23108
+title: Settings surfaces raw exception text in user-facing status and toasts
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:06'
+labels:
+  - ux
+  - settings
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Three paths hand exception reprs straight to the user: settings_screen.py:10871 ('Model discovery failed: {exc}'), :11006 ('Could not save discovered models: {exc}'), :14281 ('Backfill failed: {e}' toast). Users need a plain-language summary with a next step; technical detail belongs in logs/Diagnostics. Existing redact_secret_text wrapping must be preserved. P2 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tldw-chatbook-ui-screens-settings-screen-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The three named paths present a plain-language failure summary with a suggested next step; raw exception text is not the primary user-facing message
+- [ ] #2 Technical detail remains reachable (log or Diagnostics) and secret redaction is preserved
+- [ ] #3 A sweep of settings_screen.py finds no other user-facing f-string interpolating a bare exception
+<!-- AC:END -->

--- a/backlog/tasks/task-23109 - Settings-search-matches-categories-only-no-jump-to-setting.md
+++ b/backlog/tasks/task-23109 - Settings-search-matches-categories-only-no-jump-to-setting.md
@@ -1,0 +1,24 @@
+---
+id: TASK-23109
+title: Settings search matches categories only - no jump-to-setting
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:06'
+labels:
+  - ux
+  - settings
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The / filter matches category names, not individual settings: searching 'theme' yields a coin flip between Theme (the theme-file editor) and Appearance (where the switch-app-theme setting lives), and a setting like 'reduce motion' cannot be found by name at all. P2 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tldw-chatbook-ui-screens-settings-screen-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Searching a setting's label (e.g. 'reduce motion') surfaces that setting, and Enter navigates to its category with the setting focused or visibly highlighted
+- [ ] #2 Ambiguous matches disambiguate with scope text (category and group) in the results line
+<!-- AC:END -->

--- a/backlog/tasks/task-23110 - Settings-F1-category-help-is-hollow-or-empty.md
+++ b/backlog/tasks/task-23110 - Settings-F1-category-help-is-hollow-or-empty.md
@@ -1,0 +1,24 @@
+---
+id: TASK-23110
+title: Settings F1 category help is hollow or empty
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:06'
+labels:
+  - ux
+  - settings
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+F1 help for 'Settings: Schedules' opened a completely empty scroll body (live-verified); for Appearance it lists only three shortcut keys. The content that would make it useful already exists - the Scope Inspector's contract rows and each category's state-scope copy. P3 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tldw-chatbook-ui-screens-settings-screen-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 F1 help for every settings category shows non-empty, category-relevant content (at minimum the save contract, ownership, and available verbs)
+- [ ] #2 No category opens an empty help body
+<!-- AC:END -->

--- a/backlog/tasks/task-23111 - Schedules-Next-Run-is-absolute-UTC-only-no-relative-or-local-time.md
+++ b/backlog/tasks/task-23111 - Schedules-Next-Run-is-absolute-UTC-only-no-relative-or-local-time.md
@@ -1,0 +1,24 @@
+---
+id: TASK-23111
+title: Schedules Next Run is absolute UTC only - no relative or local time
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:06'
+labels:
+  - ux
+  - schedules
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Queue and detail render Next Run as absolute UTC ('2026-08-28 09:00 UTC') with no relative form ('in 14h') and no local-time conversion; a user on a recurring 'daily 09:00 Europe/Berlin' schedule must mentally convert every row. P3 from the 2026-08-28 critique (.impeccable/critique/2026-08-28T06-32-49Z__tbook-ui-screens-scheduling-schedules-workbench-py.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Next Run displays include a relative or local-time form alongside the absolute time
+- [ ] #2 The rendering is consistent between the queue column and the detail pane
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
Files the 12 backlog tasks produced by the 2026-08-28 dual-assessment UX critique of the **Settings** screen and the **Schedules** workbench (live TUI walkthrough at 235x52/235x40 in an isolated profile + static evidence sweep), plus the two critique snapshots the task descriptions cite as evidence.

- **Scores:** Settings 29/40 (trend 31 -> 24 -> 24 -> 30 -> 29), Schedules 24/40 (first run)
- **23100 (P0):** ReminderForm clips recurring fields (cron input, helper, live preview) at common terminal heights while the invisible field keeps focus and accepts keystrokes
- **23101-23102, 23104 (P1):** disabled tasks display Waiting + concrete Next Run; expert-only create vocabulary (ISO-8601/cron/IANA); Settings State banner doubled and self-colliding
- **23103:** design spike, pane-based schedule editor vs create/edit modal (decision only; owner ruling: patch the modal now)
- **23105-23109 (P2):** sync over-promise, terminology drift, invisible bulk-mark, raw exception text in Settings toasts, no jump-to-setting search
- **23110-23111 (P3):** hollow F1 category help, UTC-only Next Run

## ID hygiene
Backlog CLI offered 22516 against a true max of 23089 (full sweep: 125 remote refs + 235 worktrees). Batch renumbered to the 23100+ block; two-namespace duplicate check (filename prefix + frontmatter id) clean on the merged view, re-verified free across all refs at commit time.

Task-only change: no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2WwNRSyk6w9V7b9yh5Yht

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files the 12 backlog tasks and two critique snapshots from the 2026-08-28 dual-assessment UX critique of the Settings screen (29/40) and the Schedules workbench (24/40). Task-only change: no code touched.

**Task breakdown**
- 23100 (P0) — `ReminderForm` clips recurring fields at common terminal heights while the invisible cron input keeps focus and keystrokes.
- 23101–23102, 23104 (P1) — disabled tasks read `Waiting` with a live Next Run; create inputs are expert-only (ISO-8601, raw cron, free-text IANA tz); Settings State banner renders doubled and self-colliding.
- 23103 — design spike deciding pane-based schedule editor vs create/edit modal, per owner ruling to patch the modal now.
- 23105–23109 (P2) — sync surface over-promises, schedule/task/reminder terminology drift, bulk-mark mechanism has no legend or count, raw exception text in Settings toasts, search matches categories only.
- 23110–23111 (P3) — F1 category help is hollow or empty, Next Run renders absolute UTC only.

**ID hygiene**
- Backlog CLI offered 22516 against a true max of 23089 (full sweep: 125 remote refs + 235 worktrees); batch renumbered to the 23100+ block and re-verified free across all refs at commit time.

<sup>Written for commit d7b63a1e91a87ef324d9138c2f14cae97176e208. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

