### PR TITLE
test(console): qualify per-conversation Library controls

### DIFF
--- a/Docs/Design/MCP.md
+++ b/Docs/Design/MCP.md
@@ -258,7 +258,8 @@ In addition to the standalone tools above, the in-process local MCP surface
 exposes 18 read-only `library_*` tools — `library_list_*`, `library_get_*`, and
 `library_search_*` for each of Media, Notes, Prompts, Skills, Conversations,
 and Collections. The same shared service and all 18 tools are also callable by
-Console agents when `[console].direct_library_tools` is enabled. They answer
+Console agents when that conversation allows assistant Library access and its
+**Direct / RAG selector** chooses Direct. They answer
 factual Library questions (list, count, view, lexical search) without touching
 the RAG/embedding pipeline.
 
@@ -272,8 +273,9 @@ the RAG/embedding pipeline.
   get tools read bounded windows with revision-checked continuation cursors;
   every serialized response fits within 32 KiB.
 - **Compatibility**: the standalone tools above are unchanged; the `library_*`
-  namespace is additive and independent of the Console
-  `[console].direct_library_tools` toggle.
+  namespace is additive and **independent of Console's per-conversation
+  Library policy**. MCP registration and permissions remain authoritative for
+  MCP calls.
 
 See `Docs/Development/Agent-Tools/local-library-tools.md` for the full
 contract (exact names, pagination, continuation, error codes, and security

--- a/Docs/Development/Agent-Tools/local-library-tools.md
+++ b/Docs/Development/Agent-Tools/local-library-tools.md
@@ -314,29 +314,24 @@ tracebacks:
   describe their write effect in their tool descriptions. Everything else
   in the namespace stays read-only.
 
-## Console setting and RAG fallback
+## Console policy and retrieval selector
 
-The Console agent retrieval mode is controlled by
-`[console].direct_library_tools` in `config.toml` (default **on**; the
-Settings screen reads it fresh for every Console run). The approved copy
-rendered under the toggle:
+`[console].direct_library_tools` is a **selector, not an enable switch**.
+The active conversation's independent Assistant policy is the authority:
+Blocked advertises and dispatches no built-in Library tool; Allowed selects
+one mutually exclusive provider surface for the next agent generation.
 
-> **On:** Console agents may automatically list, count, read, and lexically
-> search your local Library.
-> **Off:** Direct list, count, view, and lexical search tools are unavailable.
-> Console agents use Library RAG as the default retrieval method. RAG
-> currently covers Notes, Media, and Conversations and requires an available,
-> populated index.
-> **Privacy:** Retrieved titles, metadata, content, and RAG excerpts are
-> included in model requests. If you use a cloud model, this Library data
-> leaves your device and is handled by that provider. Use a local model if the
-> data must remain on-device.
-> **Scope:** This setting affects Console agents only. MCP Library access is
-> controlled separately.
+- **Direct** exposes the **18 direct Library tools** for bounded list, count,
+  get, and lexical-search operations.
+- **RAG** exposes exactly one tool, **`search_library_rag`**, scoped to Notes,
+  Media, and Conversations and dependent on an available populated index.
 
-With the toggle off, Console agents get exactly one RAG tool
-(`library_rag_search`), scoped to Notes, Media, and Conversations — Skills,
-Prompts, and Collections have no RAG fallback in this scope.
+Both possible name sets are **statically reserved** before optional providers
+register, so a skill or MCP server cannot capture a Library tool name merely
+because the conversation currently blocks that provider. The allowed surface
+is then composed from a fresh policy snapshot at each generation boundary.
+Retrieved content follows the resolved model destination; the Console access
+modal discloses whether that destination is local or external.
 
 ## MCP surface
 
@@ -354,8 +349,9 @@ repository; see the spec's implementation-deviation note):
 - The control plane maps each tool to its policy action (the two chunk-tool
   writes to their named write actions, keyed off the descriptor table);
   there is no path that bypasses policy.
-- MCP access is **independent of the Console toggle**: turning
-  `direct_library_tools` off changes Console agent behavior only.
+- MCP access is **independent of Console's per-conversation Library policy**
+  and its Direct/RAG selector; MCP retains its own registration and permission
+  controls.
 - The standalone server exposes exactly nine implemented legacy tools;
   retired `ingest_media` is absent, and persistent URL/file ingestion uses
   Library Import. The `library_*` namespace is additive only to the in-process

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -184,7 +184,7 @@ composer-level strip below shows once setup completes.
 | **New tab** | Creates a Console tab — see [Sessions, tabs & workspaces](console/sessions-tabs-workspaces.md). |
 | **Settings** | Opens the "Console Settings" modal (provider, model, tools, and generation). |
 | **Attach context** | Opens the "Console context" rail (staging itself is done from Library) — see [Context & RAG](console/context-and-rag.md). |
-| **Search Library** | Searches Library evidence before sending — see [Context & RAG](console/context-and-rag.md). |
+| **Search Library** | Runs a user-initiated **Manual Search Library** request before sending; it remains available regardless of the conversation's automatic or assistant policy — see [Context & RAG](console/context-and-rag.md#per-conversation-library-controls). |
 | **Save as Chatbook** (composer **Menu**) | Saves this run as a Chatbook — see [Artifacts](artifacts.md). |
 | **Help** | Opens the Console help panel (same as F1). |
 | **Speak replies** | Speaks new assistant replies in this conversation. |
@@ -210,7 +210,7 @@ composer-level strip below shows once setup completes.
 | Chip | What it shows |
 |---|---|
 | **Provider** / **Model** | The active provider and model for this session. |
-| **Assistant** / **Library search** | The active assistant; whether a Library search is on for the next send. |
+| **Assistant** / **Library** | The active assistant; the Library chip summarizes the two independent conversation controls as **Auto: Never / Automatic** and **Assistant: Blocked / Allowed**. Open it to edit those controls and see whether allowed assistant tools use **Direct / RAG** mode. |
 | **Sources** / **Tools** | Staged source count (e.g. "Sources: 0"); tool readiness (e.g. "Tools: 10 ready" — hidden until tools are counted). |
 | **Approvals** | Pending approvals; press Enter or Space on it to jump to the approval card. |
 | **Scope** | Appears when retrieval is narrowed ("Scope: N"); Enter or Space opens the scope picker. |

--- a/Docs/User_Guide/console/context-and-rag.md
+++ b/Docs/User_Guide/console/context-and-rag.md
@@ -34,8 +34,9 @@ Where this page's controls live:
   retrieval-scope row beneath it, the "Prefill" rows when one is armed, the
   "Live work sources" card, and the "Chat Dictionaries" / "World Books"
   blocks at the bottom.
-- **The status chips** above the composer — "RAG: on/off", "Sources: N
-  staged", and the "Scope: N" chip once retrieval is narrowed.
+- **The status chips** above the composer — "Library · Auto off/on · Agent
+  blocked/allowed", "Sources: N staged", and the "Scope: N" chip once
+  retrieval is narrowed.
 - **The staged-evidence strip** — at the top of the control deck, above
   the status chips; shown only while something is staged (or right after
   a send that used it).
@@ -432,6 +433,30 @@ outside are suffixed "— outside workspace scope", and the effective scope
 is the intersection (chip tooltip: "Only searching: conversation scope (2
 items) and workspace scope (5 items) — 2 in both.").
 
+### Per-conversation Library controls
+
+Console has three separate ways to use Library evidence. **Manual Search
+Library is always available** and runs only when you ask. The Library status
+chip opens two independent, text-valued controls for the active conversation:
+
+- **Auto: Never / Automatic** — whether an ordinary text send first retrieves
+  from the fixed automatic categories: **Notes, Media, and Conversations**.
+- **Assistant: Blocked / Allowed** — whether the model may initiate a built-in
+  Library tool call. Blocked means no Library tool is advertised or dispatched.
+
+New conversations ship as **Never** and **Blocked**. The choices are stored
+only on this device and are not synced or exported. A recovered remote or
+imported conversation whose local policy cannot be resolved therefore remains
+inert until you explicitly save a local policy.
+
+When Assistant is Allowed, **Direct / RAG is a selector**, not a third
+permission. Direct advertises the bounded direct Library tools; RAG advertises
+only `search_library_rag`. The selector comes from Settings and is shown in the
+access modal for clarity. RAG scope can narrow Notes and Media items and can
+exclude Conversations, but it never broadens the three fixed automatic
+categories. The modal also names the resolved provider destination so you can
+see whether retrieved content will stay local or leave the device.
+
 ### Staged sources & Library search
 
 The Inspector's **Sources** tray lists context staged for the run, one
@@ -457,13 +482,13 @@ your Library and stages what it finds.
 
 Which *kinds* of sources it searches is shown on that card's **Sources:**
 line — by default "Sources: Notes, Media, Conversations (Prompts off)" —
-and is editable: the **Library search** chip (or **Search Library** with
-nothing typed) opens the **Library search** settings modal, which carries
+and is editable: **Search Library** with nothing typed opens the manual
+**Library search** modal, which carries
 the query box plus a toggle per source kind (**✓ Notes**, **○ Media**,
-**✓ Conversations**, **○ Prompts**) and the **Auto-retrieve on send**
-switch described below. Running keeps the edited query/source-kind
+**✓ Conversations**, **○ Prompts**). Running keeps the edited query/source-kind
 selection (it also survives leaving and returning to Console); **Cancel**
-discards it. Run stays disabled until there is both a query and at least
+discards it. The separate **Library** status chip opens the per-conversation
+access modal described above. Run stays disabled until there is both a query and at least
 one source kind. Note this is a different setting from **RAG scope**
 above: "Sources" picks the source *kinds*, "Scope" picks the *items*.
 
@@ -472,10 +497,10 @@ the depth your **active RAG profile** specifies (`Settings ▸ RAG`'s
 **Default results** field) rather than a fixed count, so manual and
 automatic retrieval can't disagree about how many results come back.
 
-### Auto-retrieve on send
+### Automatic retrieval details
 
-The **Library search** settings modal also carries an **Auto-retrieve on
-send** switch, default **OFF**. Turn it on and every plain text send —
+Set the active conversation's Auto control to **Automatic** and every plain
+text send —
 never a slash command, a `$skill` invocation, a tool approval, or a
 regenerate — first runs a Library search using your draft as the
 query and stages whatever it finds into the staged-evidence strip before
@@ -484,9 +509,8 @@ the send goes out: the same visible, consume-on-send pipeline a manual
 skipped automatically when evidence is already staged (a manual run or a
 Library "Use in Console" handoff), so a send can't double-retrieve.
 
-The switch persists the instant you flip it, unlike the query and
-source-kind edits in the same modal — closing with **Escape** or a
-backdrop click still keeps the change. If your resolved RAG scope comes
+The access modal requires an explicit **Save** and detects concurrent edits;
+Escape does not silently commit a dirty choice. If your resolved RAG scope comes
 back **empty**, auto-retrieve short-circuits with the same shared notice
 the manual path shows, rather than searching everything.
 
@@ -582,10 +606,10 @@ Inspector shows what's in play:
    click the two items, press **Save**. The strip shows **Scope: 2**.
 6. **Open a citation's source in Library** — click **Sources (N)** under
    the reply, select an `[S1]` row, press **Open in Library**.
-7. **Have every send ground itself automatically** — click the **RAG**
-   chip (or **Run Library RAG**) to open **Library RAG** settings, turn on
-   **Auto-retrieve on send**, close the modal. It stays on across sends
-   until you flip it off; it's off by default.
+7. **Have ordinary sends ground themselves automatically** — click the
+   **Library** chip, choose **Automatic** under Auto, and press **Save**.
+   This changes only the active conversation; new conversations default to
+   **Never**.
 
 ## Keyboard & commands
 
@@ -663,9 +687,8 @@ imported Trace**; it has no `c` action.
   processing settings; covered in
   [Library ▸ Search & RAG](../library/search-and-rag.md), including how
   the active RAG profile now drives retrieval mode.
-- `config.toml` `[chat_defaults] rag_auto_retrieve_on_send` — the
-  persisted **Auto-retrieve on send** value (default `false`); the modal
-  is the supported way to change it.
+- The active conversation's Library policy is stored in the local conversation
+  database. It is deliberately absent from synced/exported conversation state.
 - `config.toml` `[console] exchange_capture` — the Conversation Inspector's
   capture kill-switch (default `true`); set `false` to stop recording
   per-call request/response detail for the Exchange tab.
@@ -701,7 +724,7 @@ imported Trace**; it has no `c` action.
 - **Turns before this feature (or with capture off) show "No capture
   recorded"** on the Exchange tab rather than any reconstructed guess at
   what was sent.
-- **Auto-retrieve fires on every plain-text send while it's on**,
+- **Automatic retrieval fires on every plain-text send while selected**,
   including repeated sends in the same conversation — there's no
   once-per-conversation memory yet, so an empty resolved scope re-shows
   its notice on each send until you clear or edit the scope.

--- a/Docs/User_Guide/console/context-and-rag.md
+++ b/Docs/User_Guide/console/context-and-rag.md
@@ -515,13 +515,18 @@ back **empty**, auto-retrieve short-circuits with the same shared notice
 the manual path shows, rather than searching everything.
 
 While a send is retrieving, the staged-evidence strip briefly shows a
-"Retrieving…" state; the search is capped at a **5-second timeout**, and
-a send is never blocked on it. If retrieval times out, fails, or the RAG
-service is still starting up (a first-use embedding-model load can take a
-while), the send goes out without evidence and a quiet notice names which
-of the two happened — "still initializing" vs. "failed" — rather than
-staying silent. A zero-result outcome currently clears the in-flight
-placeholder with no further notice.
+"Retrieving…" state and the search is capped at a **5-second timeout**.
+Successful evidence is staged and then consumed by that send. **Zero results**
+is a completed retrieval, so the send continues without evidence and keeps a
+visible zero-results disclosure on the turn.
+
+Failure, timeout, or a RAG service that is still starting pauses the prepared
+send before provider dispatch. The recovery card keeps the exact draft and
+frozen conversation authority visible and offers **Retry**, **Send once**, and
+**Cancel**. Retry makes one fresh retrieval attempt; Send once bypasses
+automatic retrieval for only this prepared send; Cancel restores the draft and
+does not contact the model provider. Nothing is silently downgraded to an
+ungrounded send.
 
 The Inspector tray is not the only place staged evidence shows up: a
 **staged-evidence strip** sits on the main surface itself, at the top of
@@ -745,17 +750,11 @@ is verified at the code level, not live). Verified against e2c706303 —
 2026-08-06 (PR-T2, docs pass against shipped code/tests, live check
 pending Task 9): staged evidence now counts toward the context estimate
 and the cost chip (as an estimated `~` row) instead of reporting zero.
-Verified against d6b6a738f — 2026-08-07 (RAG-port P0 live walkthrough, real
-Anthropic provider): flipping **Auto-retrieve on send** in the RAG chip
-modal writes `[chat_defaults] rag_auto_retrieve_on_send = true` at
-toggle time — before Esc, and Esc leaves it set. A plain-text send then
-showed "Auto-retrieving Library evidence for this message." with the chip
-reading `RAG: on · Sources: 1 staged` about a second in, then "Evidence
-sent with this message · 15 sources", and the model's own reply named the
-injected block back ("the evidence sections [S1] through [S15] …") — the
-end-to-end proof that retrieved evidence reaches the provider. A send
-beginning with a slash command fired no retrieval at all: no placeholder,
-no chip flip, no evidence line.*
+The 2026-08-07 global auto-toggle walkthrough is superseded by ADR-079. The
+current access modal saves only when **Save** is pressed; Escape discards dirty
+choices. Automatic retrieval is conversation-local and uses the recoverable
+pre-dispatch gate described above. Slash commands, `$skill` invocations, tool
+approvals, and regenerates still do not trigger automatic retrieval.*
 
 *Chip and strip positions re-verified against dev @ b6036515e — 2026-08-18
 (task-17662, after the bottom-stack programme moved the status chips above

--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -175,6 +175,16 @@ not include this private field. Invalid, unknown-version, contradictory, or
 oversized private data is dropped while usable visible messages still import,
 and the warning never quotes the rejected data.
 
+Library access authority is intentionally less portable. The **device-local
+Library policy**, authorization checkpoints, activity summaries, and
+preparation receipts are not synced or exported. The conversation's validated
+**assistant generation state** and an exactly owned provider continuation can
+travel so a branch remains coherent, but importing or syncing never starts
+tools: **unresolved imported or remote state remains inert**. When a valid
+continuation is resumed, the exclusive continuation handoff removes its
+checkpoint before any tool is allowed to run, as required by
+[ADR-063](../../../backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md).
+
 | Import control | What it does |
 |---|---|
 | "Browse…" | Opens the "Import media" file picker (remembers your last folder). The listing shows Name / Size / Modified column headers, human-readable sizes ("512 B", "2.4 MB", never a bare byte count), no size on folder rows (including ".."), and a labeled "File name:" input at the bottom. Folders and URLs are typed or pasted into the path field instead. |

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -244,6 +244,8 @@ as source context for my next question." — your next message continues in
 the *current* Console session, grounded by the old conversation. To switch
 back into a past session and keep chatting in it, use Console's own
 conversation rail instead; that one resumes sessions, this one quotes them.
+This explicit handoff **does not change the conversation's Auto or Assistant
+setting**; it supplies one bundle of **staged context** for the next send.
 
 ## Common tasks
 

--- a/Docs/User_Guide/library/search-and-rag.md
+++ b/Docs/User_Guide/library/search-and-rag.md
@@ -448,6 +448,11 @@ labeled **"Review evidence in Console"**; the snippet, citations, and
 source identity travel with it. See [Console: Context &
 RAG](../console/context-and-rag.md) for the staged-sources side.
 
+This is a **user-initiated Library search**. Staging its result is a one-shot
+manual action and **does not change the current conversation's Library
+controls**: Auto remains Never or Automatic, and Assistant remains Blocked or
+Allowed exactly as saved on the Console Library chip.
+
 If Console isn't set up yet (no provider/model configured), a toast warns
 that the evidence is staged and setup is what unlocks it before you
 navigate, and Console's own locked "Get started" card shows the same

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -99,6 +99,13 @@ only a fixed command enum and an `argv` array, never a shell string; being
 listed in the catalog does not authorize a command, and an unset command stays
 Ask until it is approved.
 
+MCP authority is **not governed by Console's per-conversation Library
+controls**. Console's **Direct / RAG selector** chooses which built-in Library
+provider is eligible only after that conversation allows assistant access;
+it neither grants nor revokes an MCP server's tools. MCP registration gates,
+the permission matrix, risk floors, and the global kill switch continue to
+decide MCP availability independently.
+
 ## Other registration gates (Servers mode ▸ Tool gates)
 
 Select the built-in server's row in Servers mode; its detail pane has a

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -16,7 +16,14 @@ Library RAG evidence handoff (manual or auto-retrieve) both resolve it
 and route accordingly — a `Plain keyword` profile searches keyword-only,
 `Hybrid` blends keyword and vector search, and `Semantic` runs vector
 search — see [Library Search/RAG](../library/search-and-rag.md#retrieval-mode-follows-your-rag-profile)
-and [Console: Context & RAG](../console/context-and-rag.md#auto-retrieve-on-send).
+and [Console: Context & RAG](../console/context-and-rag.md#automatic-retrieval-details).
+
+This screen tunes retrieval quality and selects the assistant's Direct/RAG
+tool mode; it **does not grant automatic retrieval or assistant Library
+access**. Those are independent, device-local **per-conversation Library
+controls** on Console's Library chip. Changing a profile or the tool-mode
+selector does not alter any conversation's Never/Automatic or Blocked/Allowed
+choice.
 
 ## Getting there
 

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -38,12 +38,19 @@ collapsed by default), then **RAG** — or skip the expanding entirely: press
 
 ![RAG profiles](../images/settings/rag.svg)
 
-The detail pane stacks up to three bordered cards: **Profiles**
-(the profile you are on, the picker, the five lifecycle buttons, the read-only
-banner, the index status line, and **Backfill**); the **first-run starter
-panel**, shown *instead of* the field wall on a fresh install; and **Editing:
-`<profile>`**, holding the ⚠ legend and five folds — **Search**, **Embedding**,
-**Chunking**, **Vector store**, **Reranking**.
+The detail pane begins with two Console cards. **New Console conversations**
+owns the future **Conversation defaults**: **Automatic retrieval**
+(`Never` / `Automatic`) and **Assistant access** (`Blocked` / `Allowed`).
+These values apply only to conversations created after the next save; use the
+Console Library chip to change an existing conversation. **Allowed Library
+access** owns the Direct/RAG selector and explains what an Allowed assistant
+can use; changing it never grants access by itself.
+
+Below those cards, **Profiles** contains the active profile, picker, lifecycle
+buttons, read-only banner, index status, and **Backfill**. A fresh install also
+shows the **first-run starter panel** while the **Editing: `<profile>`** field
+wall is collapsed. The editing card holds the ⚠ legend and five folds —
+**Search**, **Embedding**, **Chunking**, **Vector store**, **Reranking**.
 
 The pinned **State banner** above them reads `State: Draft — save with s |
 Defaults affect future Library/RAG retrieval and display.`, switching to
@@ -52,6 +59,15 @@ Defaults affect future Library/RAG retrieval and display.`, switching to
 targets: the active profile, and the profile pointer in your config file.
 
 ## Features & controls
+
+### The Conversation defaults cards
+
+Choose the defaults for future Console conversations, then press **Save (s)**.
+**Automatic retrieval** controls whether an ordinary send performs the fixed
+Notes, Media, and Conversations search. **Assistant access** controls whether
+the assistant receives any Library tool schema. The **Allowed Library access**
+checkbox chooses Direct tools or the single Library RAG tool only when access
+is Allowed. Existing conversations retain their own device-local choices.
 
 ### The Profiles card
 

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -250,8 +250,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 59,
-      "diagnostic_digest": "619845f8070af02d097a",
+      "call_count": 61,
+      "diagnostic_digest": "a22142ef44c39e1c87a1",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -3996,7 +3996,7 @@
   "summary": {
     "owner_files": 541,
     "persistent_sink_files": 8,
-    "task_492_calls": 1260,
+    "task_492_calls": 1262,
     "task_494_calls": 7396
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -97,7 +97,7 @@
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "6893f57f0dcf3808f1b3",
+      "diagnostic_digest": "ee7646a81b86e4eab904",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/virtual_cli_provider.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/superpowers/plans/2026-08-22-console-library-controls.md
+++ b/Docs/superpowers/plans/2026-08-22-console-library-controls.md
@@ -1321,9 +1321,9 @@ class ConsoleLibraryActivityBuffer:
 ### Task 26: Add deterministic production-UI scenarios and run integrated targeted gates
 
 **Files:**
-- Create: `Tests/Fixtures/console_library_recording_provider.py`
+- Create: `Tests/fixtures/console_library_recording_provider.py`
 - Create: `Tests/UI/test_console_library_controls_workflow.py`
-- Create: `Tests/Integration/test_console_library_control_integration.py`
+- Create: `Tests/integration/test_console_library_control_integration.py`
 - Modify: `Tests/Chat/test_console_chat_controller.py`, `Tests/Chat/test_console_prompt_queue_coordinator.py`, `Tests/Chat/test_console_agent_bridge.py`, `Tests/UI/test_console_status_chips.py`, `Tests/UI/test_console_right_rail.py`, and `Tests/UI/test_console_library_controls_render.py`
 
 **Interfaces:**
@@ -1373,7 +1373,7 @@ python -m pytest \
   Tests/UI/test_console_library_activity.py \
   Tests/Docs/test_console_library_controls_docs.py \
   Tests/UI/test_console_library_controls_workflow.py \
-  Tests/Integration/test_console_library_control_integration.py \
+  Tests/integration/test_console_library_control_integration.py \
   Tests/Sync_Interop/test_chat_outbox_producer.py \
   Tests/Sync_Interop/test_envelope_builder.py \
   Tests/Sync_Interop/test_envelope_applier.py \
@@ -1389,7 +1389,7 @@ python -m pytest \
   -q
 ```
 
-- [ ] **Step 5: Run scoped static checks.** Run `python -m ruff check Tests/Fixtures/console_library_recording_provider.py Tests/UI/test_console_library_controls_workflow.py Tests/Integration/test_console_library_control_integration.py Tests/Docs/test_console_library_controls_docs.py`, `python tldw_chatbook/css/build_css.py`, `python tldw_chatbook/css/check_bundle_sync.py`, `python -m pytest Tests/UI/test_css_bundle_sync_guard.py Tests/Architecture/test_screen_size_ratchet.py -q`, and `git diff --check`. The product modules were already Ruff-checked in their owning delivery; do not replace those per-delivery gates with this fixture-only command.
+- [ ] **Step 5: Run scoped static checks.** Run `python -m ruff check Tests/fixtures/console_library_recording_provider.py Tests/UI/test_console_library_controls_workflow.py Tests/integration/test_console_library_control_integration.py Tests/Docs/test_console_library_controls_docs.py`, `python tldw_chatbook/css/build_css.py`, `python tldw_chatbook/css/check_bundle_sync.py`, `python -m pytest Tests/UI/test_css_bundle_sync_guard.py Tests/Architecture/test_screen_size_ratchet.py -q`, and `git diff --check`. The product modules were already Ruff-checked in their owning delivery; do not replace those per-delivery gates with this fixture-only command.
 - [ ] **Step 6: Run counterfactual checks.** Mutation-check authorization, static reservation, retrieval no-dispatch, activity minimization, continuation pre-tool handoff, message-version/deletion CAS, sync/export normalization, rollback drain, and literal rendering; record each named test that turns red.
 - [ ] **Step 7: Commit.** Commit `test(console): cover Library control workflows`.
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ The screen shell is organized around a **master shell** of primary destinations 
 
 > **Migration note:** legacy tabs — `Chat` (now Console), `Notes`, `Media`, `Ingest`, `Search`, `Coding`, `Characters/Prompts` (now Personas), `Subscriptions` (now Watchlists), and `Chatbooks` (now under Artifacts) — still resolve as routes/aliases, but are no longer separate primary destinations. `Coding` in particular is now a thin compatibility stub; agentic programming happens in the Console.
 
+Console exposes three separate ways to use local evidence: **Manual Search
+Library** is always available, while each conversation independently stores
+**Auto: Never / Automatic** and **Assistant: Blocked / Allowed**. When
+assistant access is allowed, **Direct / RAG** selects the built-in Library tool
+surface; it is not another permission switch. New conversations default to
+Never and Blocked. See [Console context and RAG](Docs/User_Guide/console/context-and-rag.md#per-conversation-library-controls).
+
 ### LLM Support
 - **Commercial LLM APIs**: OpenAI, Anthropic, Cohere, DeepSeek, Google, Groq, Mistral, OpenRouter, QwenCloud, HuggingFace, Moonshot (Kimi), Z.ai (GLM)
 - **Local LLM APIs**: Llama.cpp, Ollama, Kobold.cpp, vLLM, Aphrodite, MLX-LM, ONNX Runtime, Custom OpenAI-compatible endpoints
@@ -375,7 +382,8 @@ All chat features listed here work with the core installation:
   - Search and apply templates
   - Version tracking
 - **RAG Integration** (enhanced with optional deps)
-  - Enable/disable RAG per message
+  - Search Library manually, or set automatic retrieval per conversation
+  - Allow or block assistant-initiated Library access independently
   - Configure chunk size and overlap
   - Select data sources (media, chats, notes)
   - View retrieved context

--- a/Tests/Agents/test_virtual_cli_provider.py
+++ b/Tests/Agents/test_virtual_cli_provider.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
 from tldw_chatbook.Agents.agent_models import ToolCall
 from tldw_chatbook.Agents.run_context import (
@@ -206,3 +207,33 @@ def test_permission_is_rechecked_after_review(tmp_path):
         result = provider.invoke("virtual_cli", call.args)
 
     assert not result.ok and result.outcome == "blocked"
+
+
+def test_callback_failures_log_only_exception_types(tmp_path):
+    private_canary = "/private/console-secret/note-42 https://internal.example/token"
+
+    def fail_callback(*_args):
+        raise RuntimeError(private_canary)
+
+    messages = []
+    sink_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+        format="{message}",
+    )
+    provider = make_provider(
+        tmp_path,
+        persist_approval=fail_callback,
+        record_decision=fail_callback,
+    )
+    hub = provider.hub_tool_for("ls")
+
+    try:
+        provider._persist(hub, "always_allow")
+        provider._record(hub, "denied")
+    finally:
+        logger.remove(sink_id)
+
+    joined = "".join(messages)
+    assert private_canary not in joined
+    assert joined.count("RuntimeError") == 2

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import copy
+import hashlib
 import json
 import os
 import threading
@@ -7815,9 +7816,20 @@ def test_parent_and_child_share_one_library_provider_and_child_can_only_narrow(
     )
 
     assert outcome.status == "done"
-    assert [call.metadata["name"] for call in recorder.calls_of("direct_tool")] == [
-        "library_list_notes",
-        "library_get_note",
+    assert [call.metadata for call in recorder.calls_of("direct_tool")] == [
+        {
+            "name": "library_list_notes",
+            "argument_keys": ("limit",),
+            "has_query": False,
+            "limit": 1,
+        },
+        {
+            "name": "library_get_note",
+            "argument_keys": ("note_id",),
+            "has_query": False,
+            "note_id_bytes": 6,
+            "note_id_sha256": hashlib.sha256(b"note-1").hexdigest(),
+        },
     ]
     assert len(recorder.activity_events) == 2
     assert "PRIVATE USER BODY" not in repr(recorder.calls)

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -7792,8 +7792,18 @@ def test_parent_and_child_share_one_library_provider_and_child_can_only_narrow(
     )
     from tldw_chatbook.Agents.library_tool_provider import LibraryToolProvider
 
-    service = _BridgeLibraryService()
-    provider, authority = _authenticated_library_provider(LibraryToolProvider(service))
+    from Tests.fixtures.console_library_recording_provider import (
+        RecordingConsoleProvider,
+    )
+
+    recorder = RecordingConsoleProvider()
+    provider, authority = _authenticated_library_provider(
+        LibraryToolProvider(
+            recorder,
+            activity_attempt_id="attempt-parent-child",
+            activity_sink=recorder.activity_events.append,
+        )
+    )
 
     outcome = _run(
         bridge,
@@ -7805,10 +7815,14 @@ def test_parent_and_child_share_one_library_provider_and_child_can_only_narrow(
     )
 
     assert outcome.status == "done"
-    assert service.invoke_calls == [
-        ("library_list_notes", {"limit": 1}),
-        ("library_get_note", {"note_id": "note-1"}),
+    assert [call.metadata["name"] for call in recorder.calls_of("direct_tool")] == [
+        "library_list_notes",
+        "library_get_note",
     ]
+    assert len(recorder.activity_events) == 2
+    assert "PRIVATE USER BODY" not in repr(recorder.calls)
+    assert "PRIVATE LIBRARY BODY" not in repr(recorder.calls)
+    assert "PRIVATE LIBRARY BODY" not in repr(recorder.activity_events)
     child_request = repr(gateway.messages_seen[6])
     assert "library_get_note" in child_request
     assert "library_list_notes" not in child_request

--- a/Tests/Chat/test_console_transaction_contribution.py
+++ b/Tests/Chat/test_console_transaction_contribution.py
@@ -345,7 +345,7 @@ def test_generic_contribution_receives_only_writer_and_committed_id_map(
         contribution.seen_writer.next_trajectory_sequence()
 
 
-def test_real_v45_trajectory_contribution_allocates_after_existing_sequence(
+def test_current_schema_trajectory_contribution_allocates_after_existing_sequence(
     tmp_path: Path,
 ) -> None:
     service, conversation_id = _service(tmp_path / "trajectory-next.sqlite")
@@ -353,7 +353,7 @@ def test_real_v45_trajectory_contribution_allocates_after_existing_sequence(
         "SELECT version FROM db_schema_version "
         "WHERE schema_name = 'rag_char_chat_schema'"
     ).fetchone()[0]
-    assert schema_version == 45
+    assert schema_version == CharactersRAGDB._CURRENT_SCHEMA_VERSION
     _seed_trajectory_sequence(service, conversation_id, 7)
     contribution = TrajectoryContributionFixture(("library_preparation",))
 

--- a/Tests/Docs/test_console_library_controls_docs.py
+++ b/Tests/Docs/test_console_library_controls_docs.py
@@ -29,10 +29,18 @@ DOC_CONTRACT: dict[str, tuple[str, ...]] = {
         "Assistant: Blocked / Allowed",
         "Direct / RAG is a selector",
         "Notes, Media, and Conversations",
+        "Retry",
+        "Send once",
+        "Cancel",
+        "Zero results",
     ),
     "Docs/User_Guide/settings/rag.md": (
         "does not grant automatic retrieval or assistant Library access",
         "per-conversation Library controls",
+        "Conversation defaults",
+        "Automatic retrieval",
+        "Assistant access",
+        "Allowed Library access",
     ),
     "Docs/User_Guide/library/search-and-rag.md": (
         "user-initiated Library search",
@@ -63,6 +71,13 @@ DOC_CONTRACT: dict[str, tuple[str, ...]] = {
     ),
 }
 MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+FORBIDDEN_CONTEXT_AND_RAG_CLAIMS = (
+    "a send is never blocked on it",
+    "the send goes out without evidence",
+    "zero-result outcome currently clears the in-flight placeholder with no further notice",
+    "writes [chat_defaults] rag_auto_retrieve_on_send = true at toggle time",
+    "before Esc, and Esc leaves it set",
+)
 
 
 @pytest.mark.parametrize(("relative_path", "required_text"), DOC_CONTRACT.items())
@@ -101,3 +116,15 @@ def test_console_library_control_docs_have_valid_local_links(relative_path: str)
             missing.append(target)
 
     assert not missing, f"{relative_path} has missing local links: {missing}"
+
+
+def test_context_and_rag_has_no_superseded_automatic_retrieval_claims() -> None:
+    """The current guide cannot retain behavior contradicted by ADR-079."""
+    text = (
+        REPO_ROOT / "Docs/User_Guide/console/context-and-rag.md"
+    ).read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+
+    stale = [claim for claim in FORBIDDEN_CONTEXT_AND_RAG_CLAIMS if claim in normalized]
+
+    assert not stale, f"context-and-rag.md retains superseded claims: {stale}"

--- a/Tests/Docs/test_console_library_controls_docs.py
+++ b/Tests/Docs/test_console_library_controls_docs.py
@@ -1,0 +1,103 @@
+"""Documentation contract for Console's per-conversation Library controls."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import unquote
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_CONTRACT: dict[str, tuple[str, ...]] = {
+    "README.md": (
+        "Manual Search Library",
+        "Auto: Never / Automatic",
+        "Assistant: Blocked / Allowed",
+        "Direct / RAG",
+    ),
+    "Docs/User_Guide/console.md": (
+        "Manual Search Library",
+        "Auto: Never / Automatic",
+        "Assistant: Blocked / Allowed",
+        "Direct / RAG",
+    ),
+    "Docs/User_Guide/console/context-and-rag.md": (
+        "Manual Search Library is always available",
+        "Auto: Never / Automatic",
+        "Assistant: Blocked / Allowed",
+        "Direct / RAG is a selector",
+        "Notes, Media, and Conversations",
+    ),
+    "Docs/User_Guide/settings/rag.md": (
+        "does not grant automatic retrieval or assistant Library access",
+        "per-conversation Library controls",
+    ),
+    "Docs/User_Guide/library/search-and-rag.md": (
+        "user-initiated Library search",
+        "does not change the current conversation's Library controls",
+    ),
+    "Docs/User_Guide/library/import-and-export.md": (
+        "device-local Library policy",
+        "assistant generation state",
+        "unresolved imported or remote state remains inert",
+    ),
+    "Docs/User_Guide/library/media-and-conversations.md": (
+        "does not change the conversation's Auto or Assistant setting",
+        "staged context",
+    ),
+    "Docs/Development/Agent-Tools/local-library-tools.md": (
+        "selector, not an enable switch",
+        "18 direct Library tools",
+        "search_library_rag",
+        "statically reserved",
+    ),
+    "Docs/Design/MCP.md": (
+        "independent of Console's per-conversation Library policy",
+        "Direct / RAG selector",
+    ),
+    "Docs/User_Guide/mcp.md": (
+        "not governed by Console's per-conversation Library controls",
+        "Direct / RAG selector",
+    ),
+}
+MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+
+
+@pytest.mark.parametrize(("relative_path", "required_text"), DOC_CONTRACT.items())
+def test_console_library_control_docs_state_the_contract(
+    relative_path: str,
+    required_text: tuple[str, ...],
+) -> None:
+    """Each governed page states the part of the control contract it owns."""
+    text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    prose = re.sub(r"[*`]", "", text)
+    prose = " ".join(prose.split())
+
+    missing = [fragment for fragment in required_text if fragment not in prose]
+
+    assert not missing, f"{relative_path} is missing: {missing}"
+
+
+@pytest.mark.parametrize("relative_path", DOC_CONTRACT)
+def test_console_library_control_docs_have_valid_local_links(relative_path: str) -> None:
+    """Every local Markdown link in the governed pages resolves in the tree."""
+    document = REPO_ROOT / relative_path
+    text = document.read_text(encoding="utf-8")
+
+    missing: list[str] = []
+    for raw_target in MARKDOWN_LINK_RE.findall(text):
+        target = raw_target.strip()
+        if target.startswith(("http://", "https://")):
+            continue
+        if target.startswith("<") and target.endswith(">"):
+            target = target[1:-1]
+        else:
+            target = target.split(maxsplit=1)[0]
+        local_path = unquote(target.partition("#")[0])
+        resolved = document if not local_path else (document.parent / local_path).resolve()
+        if not resolved.exists():
+            missing.append(target)
+
+    assert not missing, f"{relative_path} has missing local links: {missing}"

--- a/Tests/UI/test_console_library_controls_workflow.py
+++ b/Tests/UI/test_console_library_controls_workflow.py
@@ -1,0 +1,133 @@
+"""Joined production-UI workflows for Console Library controls."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import RadioButton, Static
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_display_state import (
+    ConsoleControlState,
+    ConsoleLibraryPolicyDisplayState,
+)
+from tldw_chatbook.Chat.console_library_policy import (
+    ConsoleAssistantLibraryAccess,
+    ConsoleAutoRetrieve,
+    ConsoleLibraryPolicySnapshot,
+)
+from tldw_chatbook.UI.Workbench import WorkbenchActionRequested
+from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console.console_library_access_modal import (
+    ConsoleLibraryAccessModal,
+    ConsoleLibraryPolicySaveOutcome,
+)
+from tldw_chatbook.Widgets.Console.console_library_search_modal import (
+    ConsoleLibrarySearchModal,
+)
+from tldw_chatbook.Widgets.Console.console_status_chips import ConsoleStatusChips
+
+
+def _snapshot(
+    auto: ConsoleAutoRetrieve,
+    assistant: ConsoleAssistantLibraryAccess,
+) -> ConsoleLibraryPolicySnapshot:
+    return ConsoleLibraryPolicySnapshot(auto, assistant, 3, "durable")
+
+
+class _ChipApp(ConsolidatedCSSApp):
+    def __init__(self, snapshot: ConsoleLibraryPolicySnapshot) -> None:
+        super().__init__()
+        self.snapshot = snapshot
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleStatusChips(
+            ConsoleControlState.from_values(library_policy=self.snapshot)
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("auto", "assistant", "label"),
+    (
+        (ConsoleAutoRetrieve.NEVER, ConsoleAssistantLibraryAccess.BLOCKED,
+         "Library · Auto off · Agent blocked"),
+        (ConsoleAutoRetrieve.NEVER, ConsoleAssistantLibraryAccess.ALLOWED,
+         "Library · Auto off · Agent allowed"),
+        (ConsoleAutoRetrieve.AUTOMATIC, ConsoleAssistantLibraryAccess.BLOCKED,
+         "Library · Auto on · Agent blocked"),
+        (ConsoleAutoRetrieve.AUTOMATIC, ConsoleAssistantLibraryAccess.ALLOWED,
+         "Library · Auto on · Agent allowed"),
+    ),
+)
+async def test_four_policy_states_render_exactly_and_open_independent_axes(
+    auto: ConsoleAutoRetrieve,
+    assistant: ConsoleAssistantLibraryAccess,
+    label: str,
+) -> None:
+    snapshot = _snapshot(auto, assistant)
+    app = _ChipApp(snapshot)
+
+    async with app.run_test(size=(120, 35)) as pilot:
+        chip = app.query_one("#console-library-chip")
+        assert str(chip.render()) == label
+
+        async def save(candidate) -> ConsoleLibraryPolicySaveOutcome:
+            return ConsoleLibraryPolicySaveOutcome("saved", snapshot, "Saved.")
+
+        async def reload() -> ConsoleLibraryPolicySnapshot:
+            return snapshot
+
+        modal = ConsoleLibraryAccessModal(
+            snapshot=snapshot,
+            state=ConsoleLibraryPolicyDisplayState.from_snapshot(
+                snapshot,
+                provider_intent_label="Library tool mode: RAG",
+                resolved_destination_label="Resolved destination: public network",
+            ),
+            save_policy=save,
+            reload_policy=reload,
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+
+        assert modal.query_one("#library-auto-never", RadioButton).value is (
+            auto is ConsoleAutoRetrieve.NEVER
+        )
+        assert modal.query_one("#library-agent-blocked", RadioButton).value is (
+            assistant is ConsoleAssistantLibraryAccess.BLOCKED
+        )
+        copy = " ".join(str(row.renderable) for row in modal.query(Static))
+        assert "Stored only on this device" in copy
+        assert "Library tool mode: RAG" in copy
+        assert "Resolved destination: public network" in copy
+
+
+@pytest.mark.asyncio
+async def test_manual_search_is_available_with_safe_defaults_and_preserves_draft() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+    draft = "  exact manual query 研究🙂  "
+
+    async with host.run_test(size=(120, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-command-input")
+        assert ConsoleControlState.from_values().rag_label == (
+            "Library · Auto off · Agent blocked"
+        )
+        console.query_one(ConsoleComposerBar).load_draft(draft)
+
+        console.post_message(WorkbenchActionRequested("run-library-rag"))
+        await pilot.pause()
+        await pilot.pause()
+
+        modal = host.screen_stack[-1]
+        assert isinstance(modal, ConsoleLibrarySearchModal)
+        assert modal._query == draft

--- a/Tests/fixtures/console_library_recording_provider.py
+++ b/Tests/fixtures/console_library_recording_provider.py
@@ -8,12 +8,16 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from tldw_chatbook.Agents.agent_models import ModelTurn, ToolCall
+from tldw_chatbook.Agents.agent_models import ToolCall
 from tldw_chatbook.Chat.console_dispatch_checkpoint import (
     ConsoleEgressClass,
     ConsoleResolvedDestination,
 )
-from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderResolution,
+    ProviderToolCalls,
+    ProviderTurnMetadata,
+)
 from tldw_chatbook.Chat.provider_continuation import (
     ContinuationCall,
     ContinuationRound,
@@ -236,11 +240,31 @@ class RecordingConsoleProvider:
         if stream_index < len(self.stream_gates):
             self.stream_started[stream_index].set()
             await self.stream_gates[stream_index].wait()
-        script = (
-            self.stream_scripts.popleft()
-            if self.stream_scripts
-            else StreamScript.terminal("ok")
-        )
+        if self.model_scripts:
+            script = self.model_scripts.popleft()
+        elif self.stream_scripts:
+            script = self.stream_scripts.popleft()
+        else:
+            script = StreamScript.terminal("ok")
+        if isinstance(script, ToolBatchScript):
+            yield ProviderToolCalls(
+                tuple(
+                    {
+                        "id": call.call_id,
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": call.raw_arguments,
+                        },
+                    }
+                    for call in script.calls
+                ),
+                metadata=ProviderTurnMetadata(
+                    finish_reason="tool_calls",
+                    provider_continuation=script.continuation,
+                ),
+            )
+            return
         if script.outcome == "failure":
             raise RuntimeError("scripted provider failure")
         if script.outcome == "timeout":
@@ -294,42 +318,30 @@ class RecordingConsoleProvider:
 
     def invoke(self, name: str, arguments: object) -> dict[str, Any]:
         """Serve bounded direct-tool data while recording no result body."""
-        query = arguments.get("query") if isinstance(arguments, dict) else None
+        argument_map = arguments if isinstance(arguments, dict) else {}
+        query = argument_map.get("query")
+        tool_name = name.rsplit(":", 1)[-1]
+        metadata: dict[str, Any] = {
+            "name": tool_name,
+            "argument_keys": tuple(sorted(str(key) for key in argument_map)),
+            "has_query": isinstance(query, str) and bool(query),
+        }
+        if tool_name == "library_list_notes":
+            limit = argument_map.get("limit")
+            metadata["limit"] = limit if type(limit) is int else None
+        elif tool_name == "library_get_note":
+            note_id = argument_map.get("note_id")
+            encoded_note_id = (
+                note_id.encode("utf-8") if isinstance(note_id, str) else b""
+            )
+            metadata["note_id_bytes"] = len(encoded_note_id)
+            metadata["note_id_sha256"] = hashlib.sha256(encoded_note_id).hexdigest()
         self._record(
             "direct_tool",
             "local_library",
-            name=name.rsplit(":", 1)[-1],
-            has_query=isinstance(query, str) and bool(query),
+            **metadata,
         )
         return {
             "items": [{"id": "note:qualification", "title": "Qualification"}],
             "total": 1,
         }
-
-    def next_model_turn(
-        self,
-        messages: list[dict[str, Any]],
-        tools: tuple[Any, ...],
-    ) -> ModelTurn:
-        """Return a scripted native batch, timeout, failure, or terminal."""
-        self._record(
-            "model_turn",
-            self.egress.value,
-            message_count=len(messages),
-            tool_count=len(tools),
-        )
-        script = (
-            self.model_scripts.popleft()
-            if self.model_scripts
-            else StreamScript.terminal("done")
-        )
-        if isinstance(script, ToolBatchScript):
-            return ModelTurn(
-                tool_calls=script.calls,
-                provider_continuation=script.continuation,
-            )
-        if script.outcome == "failure":
-            raise RuntimeError("scripted model failure")
-        if script.outcome == "timeout":
-            raise TimeoutError("scripted model timeout")
-        return ModelTurn(text="".join(script.chunks))

--- a/Tests/fixtures/console_library_recording_provider.py
+++ b/Tests/fixtures/console_library_recording_provider.py
@@ -1,0 +1,320 @@
+"""Content-minimizing scripted provider for Console Library qualification."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from tldw_chatbook.Agents.agent_models import ModelTurn, ToolCall
+from tldw_chatbook.Chat.console_dispatch_checkpoint import (
+    ConsoleEgressClass,
+    ConsoleResolvedDestination,
+)
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationCall,
+    ContinuationRound,
+    ProviderContinuationCheckpoint,
+)
+from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedProviderCall:
+    """One provider crossing with content-free request metadata."""
+
+    ordinal: int
+    kind: str
+    destination: str
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalScript:
+    """One deterministic automatic/manual retrieval outcome."""
+
+    outcome: Literal["success", "zero", "failure", "timeout"]
+
+    @classmethod
+    def success(cls) -> "RetrievalScript":
+        return cls("success")
+
+    @classmethod
+    def zero(cls) -> "RetrievalScript":
+        return cls("zero")
+
+    @classmethod
+    def failure(cls) -> "RetrievalScript":
+        return cls("failure")
+
+    @classmethod
+    def timeout(cls) -> "RetrievalScript":
+        return cls("timeout")
+
+
+@dataclass(frozen=True, slots=True)
+class StreamScript:
+    """One deterministic token, failure, timeout, or terminal stream."""
+
+    outcome: Literal["tokens", "failure", "timeout", "terminal"]
+    chunks: tuple[str, ...] = ()
+
+    @classmethod
+    def tokens(cls, *chunks: str) -> "StreamScript":
+        return cls("tokens", tuple(chunks))
+
+    @classmethod
+    def failure(cls) -> "StreamScript":
+        return cls("failure")
+
+    @classmethod
+    def timeout(cls) -> "StreamScript":
+        return cls("timeout")
+
+    @classmethod
+    def terminal(cls, text: str) -> "StreamScript":
+        return cls("terminal", (text,))
+
+
+@dataclass(frozen=True, slots=True)
+class ToolBatchScript:
+    """One native tool-call batch, optionally carrying continuation state."""
+
+    calls: tuple[ToolCall, ...]
+    continuation: ProviderContinuationCheckpoint | None = field(
+        default=None,
+        repr=False,
+    )
+
+    @classmethod
+    def library_search_then_continue(cls) -> "ToolBatchScript":
+        call = ToolCall(
+            name="search_library_rag",
+            args={"query": "qualification"},
+            call_id="call-library-1",
+            raw_arguments='{"query":"qualification"}',
+        )
+        continuation = ProviderContinuationCheckpoint(
+            schema_version=1,
+            checkpoint_revision=1,
+            provider="deepseek",
+            protocol="chat_completions",
+            model="qualification-model",
+            api_base_url="https://provider.example.invalid/v1",
+            state="active",
+            rounds=(
+                ContinuationRound(
+                    assistant_content="",
+                    reasoning_blocks=(),
+                    calls=(
+                        ContinuationCall(
+                            call_id=call.call_id,
+                            name=call.name,
+                            arguments=call.raw_arguments,
+                            state="pending",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        return cls((call,), continuation)
+
+
+class RecordingConsoleProvider:
+    """Script provider, retrieval service, and direct Library service.
+
+    Recorded rows retain only counts, names, routing metadata, and hashes or
+    lengths. Message content, retrieval excerpts, and Library bodies may cross
+    the return boundary to production code but never enter ``calls``.
+    """
+
+    def __init__(
+        self,
+        *,
+        ready: bool = True,
+        egress: ConsoleEgressClass = ConsoleEgressClass.ON_DEVICE,
+        retrieval_scripts: list[RetrievalScript] | None = None,
+        stream_scripts: list[StreamScript] | None = None,
+        model_scripts: list[ToolBatchScript | StreamScript] | None = None,
+    ) -> None:
+        self.ready = ready
+        self.egress = egress
+        self.retrieval_scripts = deque(retrieval_scripts or [])
+        self.stream_scripts = deque(stream_scripts or [])
+        self.model_scripts = deque(model_scripts or [])
+        self.calls: list[RecordedProviderCall] = []
+        self.activity_events: list[Any] = []
+
+    def _record(self, kind: str, destination: str, **metadata: Any) -> None:
+        self.calls.append(
+            RecordedProviderCall(len(self.calls) + 1, kind, destination, metadata)
+        )
+
+    def calls_of(self, kind: str) -> list[RecordedProviderCall]:
+        """Return calls of one kind in boundary-crossing order."""
+        return [call for call in self.calls if call.kind == kind]
+
+    async def resolve_for_send(self, selection: Any) -> ConsoleProviderResolution:
+        """Return scripted readiness and record only routing metadata."""
+        provider = str(getattr(selection, "provider", None) or "llama_cpp")
+        model = str(
+            getattr(selection, "explicit_model", None) or "qualification-model"
+        )
+        endpoint = (
+            "http://127.0.0.1:9099"
+            if self.egress is ConsoleEgressClass.ON_DEVICE
+            else "https://provider.example.invalid/v1"
+        )
+        destination = ConsoleResolvedDestination(
+            provider=provider,
+            model=model,
+            endpoint_identity=endpoint,
+            egress_class=self.egress,
+        )
+        self._record(
+            "readiness",
+            self.egress.value,
+            provider=provider,
+            model=model,
+            ready=self.ready,
+        )
+        return ConsoleProviderResolution(
+            provider=provider,
+            base_url=endpoint,
+            model=model,
+            ready=self.ready,
+            visible_copy="" if self.ready else "Provider is not ready.",
+            readiness_key=provider,
+            execution_key=provider,
+            continuation_protocol="chat_completions",
+            resolved_destination=destination if self.ready else None,
+        )
+
+    async def stream_chat(
+        self,
+        resolution: ConsoleProviderResolution,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ):
+        """Yield the next scripted stream without recording message bodies."""
+        tools = kwargs.get("tools") or ()
+        tool_names = tuple(
+            str(
+                (tool.get("function") or {}).get("name")
+                if isinstance(tool, dict)
+                else getattr(tool, "name", "")
+            )
+            for tool in tools
+        )
+        destination = (
+            resolution.resolved_destination.egress_class.value
+            if resolution.resolved_destination is not None
+            else "unresolved"
+        )
+        self._record(
+            "stream",
+            destination,
+            message_count=len(messages),
+            roles=tuple(str(message.get("role", "")) for message in messages),
+            tool_names=tool_names,
+        )
+        script = (
+            self.stream_scripts.popleft()
+            if self.stream_scripts
+            else StreamScript.terminal("ok")
+        )
+        if script.outcome == "failure":
+            raise RuntimeError("scripted provider failure")
+        if script.outcome == "timeout":
+            await asyncio.sleep(60)
+            return
+        for chunk in script.chunks:
+            yield chunk
+
+    async def search(
+        self,
+        query: str,
+        source_types: tuple[str, ...] | list[str],
+        mode: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Return scripted RAG data and record no query or result body."""
+        scope = kwargs.get("scope")
+        self._record(
+            "retrieval",
+            "local_library",
+            query_bytes=len(query.encode("utf-8")),
+            query_sha256=hashlib.sha256(query.encode("utf-8")).hexdigest(),
+            source_types=tuple(source_types),
+            mode=mode,
+            top_k=kwargs.get("top_k"),
+            scoped=getattr(scope, "state", "all") != "all",
+        )
+        script = (
+            self.retrieval_scripts.popleft()
+            if self.retrieval_scripts
+            else RetrievalScript.zero()
+        )
+        if script.outcome == "failure":
+            raise RuntimeError("scripted retrieval failure")
+        if script.outcome == "timeout":
+            await asyncio.sleep(60)
+        if script.outcome in {"zero", "timeout"}:
+            return {"runtime_backend": "local", "results": []}
+        row = LibraryRagResultRow.from_result(
+            {
+                "source_id": "note-qualification",
+                "chunk_id": "chunk-qualification",
+                "title": "Qualification note",
+                "content": "PRIVATE LIBRARY BODY",
+                "score": 0.9,
+                "runtime_backend": "local",
+                "source_type": "notes",
+            }
+        )
+        return {"runtime_backend": "local", "results": [row]}
+
+    def invoke(self, name: str, arguments: object) -> dict[str, Any]:
+        """Serve bounded direct-tool data while recording no result body."""
+        query = arguments.get("query") if isinstance(arguments, dict) else None
+        self._record(
+            "direct_tool",
+            "local_library",
+            name=name.rsplit(":", 1)[-1],
+            has_query=isinstance(query, str) and bool(query),
+        )
+        return {
+            "items": [{"id": "note:qualification", "title": "Qualification"}],
+            "total": 1,
+        }
+
+    def next_model_turn(
+        self,
+        messages: list[dict[str, Any]],
+        tools: tuple[Any, ...],
+    ) -> ModelTurn:
+        """Return a scripted native batch, timeout, failure, or terminal."""
+        self._record(
+            "model_turn",
+            self.egress.value,
+            message_count=len(messages),
+            tool_count=len(tools),
+        )
+        script = (
+            self.model_scripts.popleft()
+            if self.model_scripts
+            else StreamScript.terminal("done")
+        )
+        if isinstance(script, ToolBatchScript):
+            return ModelTurn(
+                tool_calls=script.calls,
+                provider_continuation=script.continuation,
+            )
+        if script.outcome == "failure":
+            raise RuntimeError("scripted model failure")
+        if script.outcome == "timeout":
+            raise TimeoutError("scripted model timeout")
+        return ModelTurn(text="".join(script.chunks))

--- a/Tests/fixtures/console_library_recording_provider.py
+++ b/Tests/fixtures/console_library_recording_provider.py
@@ -139,12 +139,19 @@ class RecordingConsoleProvider:
         retrieval_scripts: list[RetrievalScript] | None = None,
         stream_scripts: list[StreamScript] | None = None,
         model_scripts: list[ToolBatchScript | StreamScript] | None = None,
+        stream_gates: list[asyncio.Event] | None = None,
+        fixed_provider: str | None = None,
+        fixed_model: str | None = None,
     ) -> None:
         self.ready = ready
         self.egress = egress
         self.retrieval_scripts = deque(retrieval_scripts or [])
         self.stream_scripts = deque(stream_scripts or [])
         self.model_scripts = deque(model_scripts or [])
+        self.stream_gates = tuple(stream_gates or ())
+        self.stream_started = tuple(asyncio.Event() for _ in self.stream_gates)
+        self.fixed_provider = fixed_provider
+        self.fixed_model = fixed_model
         self.calls: list[RecordedProviderCall] = []
         self.activity_events: list[Any] = []
 
@@ -159,9 +166,13 @@ class RecordingConsoleProvider:
 
     async def resolve_for_send(self, selection: Any) -> ConsoleProviderResolution:
         """Return scripted readiness and record only routing metadata."""
-        provider = str(getattr(selection, "provider", None) or "llama_cpp")
+        provider = self.fixed_provider or str(
+            getattr(selection, "provider", None) or "llama_cpp"
+        )
         model = str(
-            getattr(selection, "explicit_model", None) or "qualification-model"
+            self.fixed_model
+            or getattr(selection, "explicit_model", None)
+            or "qualification-model"
         )
         endpoint = (
             "http://127.0.0.1:9099"
@@ -214,6 +225,7 @@ class RecordingConsoleProvider:
             if resolution.resolved_destination is not None
             else "unresolved"
         )
+        stream_index = len(self.calls_of("stream"))
         self._record(
             "stream",
             destination,
@@ -221,6 +233,9 @@ class RecordingConsoleProvider:
             roles=tuple(str(message.get("role", "")) for message in messages),
             tool_names=tool_names,
         )
+        if stream_index < len(self.stream_gates):
+            self.stream_started[stream_index].set()
+            await self.stream_gates[stream_index].wait()
         script = (
             self.stream_scripts.popleft()
             if self.stream_scripts

--- a/Tests/integration/test_console_library_control_integration.py
+++ b/Tests/integration/test_console_library_control_integration.py
@@ -32,12 +32,17 @@ from tldw_chatbook.Agents.library_rag_tool_provider import (
 )
 from tldw_chatbook.Agents.library_tool_provider import LibraryToolProvider
 from tldw_chatbook.Chat.console_agent_bridge import (
+    _ModelCallLifeline,
+    _StreamingModelAdapter,
     _compose_run_registry_and_allowed,
 )
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
-from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
-from tldw_chatbook.Chat.console_chat_models import ConsoleDispatchRecoveryKind
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleDispatchRecoveryKind,
+    ConsoleMessageRole,
+    ConsoleProviderSelection,
+)
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_dispatch_checkpoint import (
     ConsoleContinuationHandoff,
@@ -242,27 +247,72 @@ async def test_automatic_preparation_uses_fixed_categories_and_scripted_outcomes
 
 @pytest.mark.asyncio
 async def test_recording_provider_covers_stream_tool_continuation_and_redacts_bodies() -> None:
+    tool_batch = ToolBatchScript.library_search_then_continue()
     recorder = RecordingConsoleProvider(
         stream_scripts=[StreamScript.tokens("hel", "lo")],
-        model_scripts=[ToolBatchScript.library_search_then_continue()],
+        model_scripts=[tool_batch],
     )
     resolution = await recorder.resolve_for_send(
         ConsoleProviderSelection("llama_cpp", "qualification-model")
     )
-
-    chunks = [
-        chunk
-        async for chunk in recorder.stream_chat(
-            resolution,
-            [{"role": "user", "content": "PRIVATE USER BODY"}],
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    assistant = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    lifeline = _ModelCallLifeline("library-qualification-loop")
+    lifeline.start()
+    try:
+        adapter = _StreamingModelAdapter(
+            store=store,
+            provider_gateway=recorder,
+            resolution=resolution,
+            assistant_message_id=assistant.id,
+            should_cancel=lambda: False,
+            loop=lifeline.loop,
+            native_tools=True,
         )
-    ]
-    turn = recorder.next_model_turn([], ())
+        tools = (
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_library_rag",
+                    "description": "Search the Library.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        )
+        first = adapter.chat_call(
+            messages_payload=[{"role": "user", "content": "PRIVATE USER BODY"}],
+            tools=tools,
+        )
+        second = adapter.chat_call(
+            messages_payload=[
+                {"role": "user", "content": "PRIVATE USER BODY"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-library-1",
+                    "content": "PRIVATE LIBRARY BODY",
+                },
+            ],
+            tools=tools,
+        )
+    finally:
+        lifeline.shutdown()
 
-    assert chunks == ["hel", "lo"]
-    assert len(turn.tool_calls) == 1
-    assert turn.provider_continuation is not None
+    native_calls = first["choices"][0]["message"]["tool_calls"]
+    assert native_calls[0]["function"]["name"] == "search_library_rag"
+    assert first.provider_continuation == tool_batch.continuation
+    assert second["choices"][0]["message"]["content"] == "hello"
+    assert store.get_message(assistant.id).content == "hello"
+    assert [call.metadata["tool_names"] for call in recorder.calls_of("stream")] == [
+        ("search_library_rag",),
+        ("search_library_rag",),
+    ]
     assert "PRIVATE USER BODY" not in repr(recorder.calls)
+    assert "PRIVATE LIBRARY BODY" not in repr(recorder.calls)
     assert recorder.calls_of("readiness")[0].destination == "on_device"
 
 
@@ -448,30 +498,33 @@ def test_permanent_conversation_purge_cascades_every_library_sidecar(tmp_path) -
             ),
         )
 
-    connection = db.get_connection()
     sidecars = (
         "console_conversation_library_policy",
         "console_dispatch_checkpoints",
         "message_trajectory_metadata",
     )
-    assert {
-        table: connection.execute(
-            f"SELECT COUNT(*) FROM {table} WHERE conversation_id = ?",
-            (conversation_id,),
-        ).fetchone()[0]
-        for table in sidecars
-    } == {table: 1 for table in sidecars}
+    with db.transaction() as cursor:
+        before_counts = {
+            table: cursor.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()[0]
+            for table in sidecars
+        }
+    assert before_counts == {table: 1 for table in sidecars}
 
     with db.transaction(immediate=True) as cursor:
         cursor.execute("DELETE FROM conversations WHERE id = ?", (conversation_id,))
 
-    assert {
-        table: connection.execute(
-            f"SELECT COUNT(*) FROM {table} WHERE conversation_id = ?",
-            (conversation_id,),
-        ).fetchone()[0]
-        for table in sidecars
-    } == {table: 0 for table in sidecars}
+    with db.transaction() as cursor:
+        after_counts = {
+            table: cursor.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()[0]
+            for table in sidecars
+        }
+    assert after_counts == {table: 0 for table in sidecars}
 
 
 def test_continuation_handoff_deletes_dispatch_owner_before_any_provider_call(

--- a/Tests/integration/test_console_library_control_integration.py
+++ b/Tests/integration/test_console_library_control_integration.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 
+import tldw_chatbook.Chat.console_chat_controller as controller_module
 from Tests.fixtures.console_library_recording_provider import (
     RecordingConsoleProvider,
     RetrievalScript,
@@ -21,6 +23,7 @@ from Tests.Chat.test_console_dispatch_recovery import (
     _database,
     _insert,
     _reconcile,
+    _restored_store,
     _start,
 )
 from tldw_chatbook.Agents.library_rag_tool_provider import (
@@ -31,6 +34,7 @@ from tldw_chatbook.Agents.library_tool_provider import LibraryToolProvider
 from tldw_chatbook.Chat.console_agent_bridge import (
     _compose_run_registry_and_allowed,
 )
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
 from tldw_chatbook.Chat.console_chat_models import ConsoleDispatchRecoveryKind
@@ -51,8 +55,10 @@ from tldw_chatbook.Chat.console_library_policy import (
     AUTOMATIC_LIBRARY_SOURCE_TYPES,
     ConsoleAssistantLibraryAccess,
     ConsoleAutoRetrieve,
+    ConsoleLibraryPolicyCandidate,
     ConsoleLibraryPolicySnapshot,
 )
+from tldw_chatbook.Chat.console_prompt_queue import PromptQueueMode
 from tldw_chatbook.Chat.console_turn_context import (
     ConsoleTurnConfigurationSnapshot,
     ConsoleTurnExecutionContext,
@@ -64,6 +70,7 @@ from tldw_chatbook.Chat.console_turn_preparation import (
     initial_preparation_state,
 )
 from tldw_chatbook.Library.library_tool_contract import LIBRARY_TOOL_DESCRIPTORS
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
 
 def _context(
@@ -228,7 +235,9 @@ async def test_automatic_preparation_uses_fixed_categories_and_scripted_outcomes
     retrieval = recorder.calls_of("retrieval")
     assert len(retrieval) == 1
     assert retrieval[0].metadata["source_types"] == AUTOMATIC_LIBRARY_SOURCE_TYPES
-    assert "body" not in repr(retrieval[0])
+    assert "PRIVATE USER BODY" not in repr(recorder.calls)
+    assert "PRIVATE LIBRARY BODY" not in repr(recorder.calls)
+    assert "PRIVATE LIBRARY BODY" not in repr(recorder.activity_events)
 
 
 @pytest.mark.asyncio
@@ -257,35 +266,170 @@ async def test_recording_provider_covers_stream_tool_continuation_and_redacts_bo
     assert recorder.calls_of("readiness")[0].destination == "on_device"
 
 
-def test_restart_recovery_is_inert_for_accepted_and_dispatch_started(tmp_path) -> None:
-    recorder = RecordingConsoleProvider()
-    accepted_db, accepted_id, accepted_repository = _database(
-        tmp_path / "accepted.sqlite"
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("started", "action"),
+    ((False, "retry"), (True, "discard")),
+    ids=("accepted-retry", "dispatch-started-discard"),
+)
+async def test_restart_recovery_requires_explicit_production_action(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    started: bool,
+    action: str,
+) -> None:
+    real_get_cli_setting = controller_module.get_cli_setting
+    monkeypatch.setattr(
+        controller_module,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            False
+            if (section, key) == ("console", "direct_library_tools")
+            else real_get_cli_setting(section, key, default)
+        ),
     )
-    _insert(accepted_db, accepted_repository, _acceptance(accepted_id))
-
-    started_db, started_id, started_repository = _database(
-        tmp_path / "started.sqlite"
+    db, conversation_id, repository = _database(
+        tmp_path / f"recovery-{action}.sqlite"
     )
-    _start(
-        started_repository,
-        _insert(started_db, started_repository, _acceptance(started_id)),
+    checkpoint = _insert(db, repository, _acceptance(conversation_id))
+    if started:
+        _start(repository, checkpoint)
+    store, session_id = _restored_store(db, conversation_id)
+    recorder = RecordingConsoleProvider(
+        stream_scripts=[StreamScript.tokens("recovered")],
+        fixed_provider="llama_cpp",
+        fixed_model="test-model",
+    )
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=recorder,
+        provider="llama_cpp",
+        model="test-model",
+        base_url="http://127.0.0.1:9099",
+        agent_runtime_enabled=False,
     )
 
-    accepted = _reconcile(accepted_repository, accepted_id)
-    started = _reconcile(started_repository, started_id)
+    await asyncio.sleep(0)
 
-    assert accepted.kind is ConsoleDispatchRecoveryKind.ACCEPTED
-    assert started.kind is ConsoleDispatchRecoveryKind.DISPATCH_STARTED
-    assert [action.action_id.value for action in accepted.actions] == [
-        "retry_response",
-        "discard",
-    ]
-    assert [action.action_id.value for action in started.actions] == [
-        "retry_anyway",
-        "discard",
-    ]
+    recovery = store.dispatch_recovery_for_session(session_id)
+    assert recovery is not None
+    assert recovery.kind is (
+        ConsoleDispatchRecoveryKind.DISPATCH_STARTED
+        if started
+        else ConsoleDispatchRecoveryKind.ACCEPTED
+    )
     assert recorder.calls == []
+
+    if action == "retry":
+        result = await controller.retry_dispatch_recovery(session_id)
+        assert result.accepted is True
+        assert [call.kind for call in recorder.calls] == ["readiness", "stream"]
+    else:
+        result = await controller.discard_dispatch_recovery(session_id)
+        assert result.accepted is True
+        assert recorder.calls == []
+
+    assert store.dispatch_recovery_for_session(session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_prompt_queue_drains_through_controller_and_recording_gateway() -> None:
+    release = [asyncio.Event(), asyncio.Event()]
+    recorder = RecordingConsoleProvider(
+        stream_scripts=[
+            StreamScript.tokens("first reply"),
+            StreamScript.tokens("second reply"),
+        ],
+        stream_gates=release,
+    )
+    store = ConsoleChatStore()
+    session = store.create_session(title="Queue qualification", ephemeral=True)
+    controller = ConsoleChatController(store=store, provider_gateway=recorder)
+
+    chain = asyncio.create_task(
+        controller.run_prompt_chain("first prompt", session_id=session.id)
+    )
+    await asyncio.wait_for(recorder.stream_started[0].wait(), timeout=1)
+    snapshot = controller.prompt_queue_registry.snapshot(session.id)
+    queued = controller.queue_prompt(
+        session.id,
+        text="second prompt",
+        expected_revision=snapshot.revision,
+    )
+    assert queued.applied is True
+
+    release[0].set()
+    await asyncio.wait_for(recorder.stream_started[1].wait(), timeout=1)
+    assert controller.prompt_queue_registry.snapshot(session.id).total_count == 0
+    release[1].set()
+    result = await asyncio.wait_for(chain, timeout=1)
+
+    assert result.accepted is True
+    assert controller.prompt_queue_registry.snapshot(session.id).mode is (
+        PromptQueueMode.DRAINING
+    )
+    assert [call.kind for call in recorder.calls] == [
+        "readiness",
+        "stream",
+        "readiness",
+        "stream",
+    ]
+    assert "first prompt" not in repr(recorder.calls)
+    assert "second prompt" not in repr(recorder.calls)
+
+
+@pytest.mark.asyncio
+async def test_on_device_to_public_change_discloses_during_production_send(
+    tmp_path,
+) -> None:
+    release = [asyncio.Event(), asyncio.Event()]
+    recorder = RecordingConsoleProvider(
+        stream_scripts=[
+            StreamScript.tokens("local reply"),
+            StreamScript.tokens("public reply"),
+        ],
+        stream_gates=release,
+    )
+    db = CharactersRAGDB(tmp_path / "destination.sqlite", "qualification")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session(
+        title="Destination qualification",
+    )
+    store.stage_session_library_policy(
+        session.id,
+        ConsoleLibraryPolicyCandidate(
+            auto_retrieve=ConsoleAutoRetrieve.NEVER,
+            assistant_access=ConsoleAssistantLibraryAccess.ALLOWED,
+        ),
+    )
+    controller = ConsoleChatController(store=store, provider_gateway=recorder)
+
+    local_send = asyncio.create_task(
+        controller.submit_draft("local turn", session_id=session.id)
+    )
+    await asyncio.wait_for(recorder.stream_started[0].wait(), timeout=1)
+    release[0].set()
+    assert (await asyncio.wait_for(local_send, timeout=1)).accepted is True
+
+    recorder.egress = ConsoleEgressClass.PUBLIC_NETWORK
+    public_send = asyncio.create_task(
+        controller.submit_draft("public turn", session_id=session.id)
+    )
+    await asyncio.wait_for(recorder.stream_started[1].wait(), timeout=1)
+    disclosure = session.library_destination_runtime.disclosure
+
+    assert disclosure is not None
+    assert disclosure.previous_resolved_identity[3] is ConsoleEgressClass.ON_DEVICE
+    assert disclosure.resolved_destination.egress_class is (
+        ConsoleEgressClass.PUBLIC_NETWORK
+    )
+    assert [call.destination for call in recorder.calls_of("readiness")] == [
+        "on_device",
+        "public_network",
+    ]
+    release[1].set()
+    assert (await asyncio.wait_for(public_send, timeout=1)).accepted is True
+    assert session.library_destination_runtime.disclosure is None
 
 
 def test_permanent_conversation_purge_cascades_every_library_sidecar(tmp_path) -> None:
@@ -333,7 +477,6 @@ def test_permanent_conversation_purge_cascades_every_library_sidecar(tmp_path) -
 def test_continuation_handoff_deletes_dispatch_owner_before_any_provider_call(
     tmp_path,
 ) -> None:
-    recorder = RecordingConsoleProvider()
     db, conversation_id, repository = _database(tmp_path / "handoff.sqlite")
     started = _start(
         repository,
@@ -363,4 +506,3 @@ def test_continuation_handoff_deletes_dispatch_owner_before_any_provider_call(
             (conversation_id,),
         )
         assert cursor.fetchone()[0] == 0
-    assert recorder.calls == []

--- a/Tests/integration/test_console_library_control_integration.py
+++ b/Tests/integration/test_console_library_control_integration.py
@@ -1,0 +1,366 @@
+"""Production-composition qualification for Console Library authority."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.fixtures.console_library_recording_provider import (
+    RecordingConsoleProvider,
+    RetrievalScript,
+    StreamScript,
+    ToolBatchScript,
+)
+from Tests.Chat.test_console_dispatch_continuation_handoff import (
+    _continuation,
+    _deepseek_acceptance,
+)
+from Tests.Chat.test_console_dispatch_recovery import (
+    _acceptance,
+    _database,
+    _insert,
+    _reconcile,
+    _start,
+)
+from tldw_chatbook.Agents.library_rag_tool_provider import (
+    LibraryRagToolProvider,
+    RAG_TOOL_NAME,
+)
+from tldw_chatbook.Agents.library_tool_provider import LibraryToolProvider
+from tldw_chatbook.Chat.console_agent_bridge import (
+    _compose_run_registry_and_allowed,
+)
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
+from tldw_chatbook.Chat.console_chat_models import ConsoleDispatchRecoveryKind
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_dispatch_checkpoint import (
+    ConsoleContinuationHandoff,
+    ConsoleDispatchResultStatus,
+    ConsoleEgressClass,
+    ConsoleLibraryItemScopeSnapshot,
+    ConsoleProviderIntent,
+    ConsoleResolvedDestination,
+    ConsoleTurnLibraryAuthority,
+)
+from tldw_chatbook.Chat.provider_continuation import (
+    dump_provider_continuation_json,
+)
+from tldw_chatbook.Chat.console_library_policy import (
+    AUTOMATIC_LIBRARY_SOURCE_TYPES,
+    ConsoleAssistantLibraryAccess,
+    ConsoleAutoRetrieve,
+    ConsoleLibraryPolicySnapshot,
+)
+from tldw_chatbook.Chat.console_turn_context import (
+    ConsoleTurnConfigurationSnapshot,
+    ConsoleTurnExecutionContext,
+)
+from tldw_chatbook.Chat.console_turn_preparation import (
+    ConsolePreparationPauseKind,
+    ConsoleTurnPreparation,
+    ConsoleTurnPreparationState,
+    initial_preparation_state,
+)
+from tldw_chatbook.Library.library_tool_contract import LIBRARY_TOOL_DESCRIPTORS
+
+
+def _context(
+    auto: ConsoleAutoRetrieve,
+    assistant: ConsoleAssistantLibraryAccess,
+    *,
+    direct: bool,
+    attempt_id: str = "attempt-1",
+) -> ConsoleTurnExecutionContext:
+    authority = ConsoleTurnLibraryAuthority(
+        policy=ConsoleLibraryPolicySnapshot(auto, assistant, 1, "durable"),
+        direct_library_tools=direct,
+        source_types=AUTOMATIC_LIBRARY_SOURCE_TYPES,
+        scope_snapshot=ConsoleLibraryItemScopeSnapshot((), (), True),
+        provider_intent=ConsoleProviderIntent(
+            "llama_cpp", "qualification-model", "http://127.0.0.1:9099"
+        ),
+        attempt_id=attempt_id,
+    )
+    return ConsoleTurnExecutionContext(
+        configuration=ConsoleTurnConfigurationSnapshot.capture(
+            session_id="session-1",
+            provider_selection=ConsoleProviderSelection(
+                provider="llama_cpp", explicit_model="qualification-model"
+            ),
+        ),
+        library_authority=authority,
+        resolved_destination=ConsoleResolvedDestination(
+            provider="llama_cpp",
+            model="qualification-model",
+            endpoint_identity="http://127.0.0.1:9099",
+            egress_class=ConsoleEgressClass.ON_DEVICE,
+        ),
+    )
+
+
+def _preparation(context: ConsoleTurnExecutionContext) -> ConsoleTurnPreparation:
+    return ConsoleTurnPreparation(
+        preparation_id="preparation-1",
+        attempt_id=context.library_authority.attempt_id,
+        session_id="session-1",
+        origin="manual",
+        queue_entry_id=None,
+        executed_draft="exact qualification draft",
+        execution_context=context,
+        transient_user_message_id=None,
+        attachment_ids=(),
+        evidence_ids=(),
+        prefill_id=None,
+        queue_generation=None,
+        pre_send_title="Qualification",
+        pre_send_conversation_id=None,
+        state=initial_preparation_state(
+            context.library_authority.policy.auto_retrieve
+        ),
+        pause_kind=None,
+        one_shot_bypass=False,
+        ephemeral=False,
+    )
+
+
+def _provider_factory(recorder: RecordingConsoleProvider):
+    def build(context: ConsoleTurnExecutionContext):
+        if context.library_authority.direct_library_tools:
+            return LibraryToolProvider(
+                recorder,
+                activity_attempt_id=context.library_authority.attempt_id,
+                activity_sink=recorder.activity_events.append,
+            )
+        return LibraryRagToolProvider(
+            recorder,
+            activity_attempt_id=context.library_authority.attempt_id,
+            activity_sink=recorder.activity_events.append,
+        )
+
+    return build
+
+
+@pytest.mark.parametrize(
+    ("auto", "assistant"),
+    (
+        (ConsoleAutoRetrieve.NEVER, ConsoleAssistantLibraryAccess.BLOCKED),
+        (ConsoleAutoRetrieve.NEVER, ConsoleAssistantLibraryAccess.ALLOWED),
+        (ConsoleAutoRetrieve.AUTOMATIC, ConsoleAssistantLibraryAccess.BLOCKED),
+        (ConsoleAutoRetrieve.AUTOMATIC, ConsoleAssistantLibraryAccess.ALLOWED),
+    ),
+)
+@pytest.mark.parametrize("direct", (True, False), ids=("direct", "rag"))
+def test_four_policy_combinations_compose_only_the_authorized_provider(
+    auto: ConsoleAutoRetrieve,
+    assistant: ConsoleAssistantLibraryAccess,
+    direct: bool,
+) -> None:
+    recorder = RecordingConsoleProvider()
+    context = _context(auto, assistant, direct=direct)
+    controller = ConsoleChatController(
+        store=ConsoleChatStore(),
+        provider_gateway=recorder,
+        library_provider_factory=_provider_factory(recorder),
+    )
+
+    selected = controller._library_provider_for_context(context)
+    provider, authority = selected if selected is not None else (None, None)
+    registry, allowed, _builtins, _locals = _compose_run_registry_and_allowed(
+        {}, library_provider=provider, library_authority=authority, ephemeral=True
+    )
+    library_names = {
+        entry.name for entry in registry.list_catalog() if entry.source == "library"
+    }
+
+    if assistant is ConsoleAssistantLibraryAccess.BLOCKED:
+        assert selected is None
+        assert library_names == set()
+    elif direct:
+        assert library_names == set(LIBRARY_TOOL_DESCRIPTORS)
+        assert set(LIBRARY_TOOL_DESCRIPTORS).issubset(allowed)
+    else:
+        assert library_names == {RAG_TOOL_NAME}
+        assert RAG_TOOL_NAME in allowed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("script", "expected_state", "expected_pause", "expected_evidence"),
+    (
+        (RetrievalScript.success(), ConsoleTurnPreparationState.READY, None, True),
+        (RetrievalScript.zero(), ConsoleTurnPreparationState.READY, None, False),
+        (RetrievalScript.failure(), ConsoleTurnPreparationState.PAUSED,
+         ConsolePreparationPauseKind.RETRIEVAL, False),
+        (RetrievalScript.timeout(), ConsoleTurnPreparationState.PAUSED,
+         ConsolePreparationPauseKind.RETRIEVAL, False),
+    ),
+)
+async def test_automatic_preparation_uses_fixed_categories_and_scripted_outcomes(
+    script: RetrievalScript,
+    expected_state: ConsoleTurnPreparationState,
+    expected_pause: ConsolePreparationPauseKind | None,
+    expected_evidence: bool,
+) -> None:
+    recorder = RecordingConsoleProvider(retrieval_scripts=[script])
+    context = _context(
+        ConsoleAutoRetrieve.AUTOMATIC,
+        ConsoleAssistantLibraryAccess.BLOCKED,
+        direct=True,
+    )
+    preparation = _preparation(context)
+    store = ConsoleChatStore()
+    store.create_session(session_id="session-1", title="Qualification")
+    assert store.begin_preparation(preparation) is preparation
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=recorder,
+        library_preparation_timeout=0.01,
+    )
+    controller.app = SimpleNamespace(library_rag_search_service=recorder)
+
+    outcome = await controller.prepare_library_for_turn("preparation-1")
+
+    assert outcome.state is expected_state
+    assert (outcome.evidence_bundle is not None) is expected_evidence
+    assert store.preparation_for_session("session-1").pause_kind is expected_pause
+    retrieval = recorder.calls_of("retrieval")
+    assert len(retrieval) == 1
+    assert retrieval[0].metadata["source_types"] == AUTOMATIC_LIBRARY_SOURCE_TYPES
+    assert "body" not in repr(retrieval[0])
+
+
+@pytest.mark.asyncio
+async def test_recording_provider_covers_stream_tool_continuation_and_redacts_bodies() -> None:
+    recorder = RecordingConsoleProvider(
+        stream_scripts=[StreamScript.tokens("hel", "lo")],
+        model_scripts=[ToolBatchScript.library_search_then_continue()],
+    )
+    resolution = await recorder.resolve_for_send(
+        ConsoleProviderSelection("llama_cpp", "qualification-model")
+    )
+
+    chunks = [
+        chunk
+        async for chunk in recorder.stream_chat(
+            resolution,
+            [{"role": "user", "content": "PRIVATE USER BODY"}],
+        )
+    ]
+    turn = recorder.next_model_turn([], ())
+
+    assert chunks == ["hel", "lo"]
+    assert len(turn.tool_calls) == 1
+    assert turn.provider_continuation is not None
+    assert "PRIVATE USER BODY" not in repr(recorder.calls)
+    assert recorder.calls_of("readiness")[0].destination == "on_device"
+
+
+def test_restart_recovery_is_inert_for_accepted_and_dispatch_started(tmp_path) -> None:
+    recorder = RecordingConsoleProvider()
+    accepted_db, accepted_id, accepted_repository = _database(
+        tmp_path / "accepted.sqlite"
+    )
+    _insert(accepted_db, accepted_repository, _acceptance(accepted_id))
+
+    started_db, started_id, started_repository = _database(
+        tmp_path / "started.sqlite"
+    )
+    _start(
+        started_repository,
+        _insert(started_db, started_repository, _acceptance(started_id)),
+    )
+
+    accepted = _reconcile(accepted_repository, accepted_id)
+    started = _reconcile(started_repository, started_id)
+
+    assert accepted.kind is ConsoleDispatchRecoveryKind.ACCEPTED
+    assert started.kind is ConsoleDispatchRecoveryKind.DISPATCH_STARTED
+    assert [action.action_id.value for action in accepted.actions] == [
+        "retry_response",
+        "discard",
+    ]
+    assert [action.action_id.value for action in started.actions] == [
+        "retry_anyway",
+        "discard",
+    ]
+    assert recorder.calls == []
+
+
+def test_permanent_conversation_purge_cascades_every_library_sidecar(tmp_path) -> None:
+    db, conversation_id, repository = _database(tmp_path / "purge.sqlite")
+    checkpoint = _insert(db, repository, _acceptance(conversation_id))
+    with db.transaction(immediate=True) as cursor:
+        cursor.execute(
+            "INSERT INTO message_trajectory_metadata "
+            "(message_id, conversation_id, turn_id, seq, event_kind, payload_json) "
+            "VALUES (?, ?, ?, 1, 'library_preparation', ?)",
+            (
+                checkpoint.user_message_id,
+                conversation_id,
+                checkpoint.user_message_id,
+                '{"version":1,"outcome":"zero_results"}',
+            ),
+        )
+
+    connection = db.get_connection()
+    sidecars = (
+        "console_conversation_library_policy",
+        "console_dispatch_checkpoints",
+        "message_trajectory_metadata",
+    )
+    assert {
+        table: connection.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()[0]
+        for table in sidecars
+    } == {table: 1 for table in sidecars}
+
+    with db.transaction(immediate=True) as cursor:
+        cursor.execute("DELETE FROM conversations WHERE id = ?", (conversation_id,))
+
+    assert {
+        table: connection.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()[0]
+        for table in sidecars
+    } == {table: 0 for table in sidecars}
+
+
+def test_continuation_handoff_deletes_dispatch_owner_before_any_provider_call(
+    tmp_path,
+) -> None:
+    recorder = RecordingConsoleProvider()
+    db, conversation_id, repository = _database(tmp_path / "handoff.sqlite")
+    started = _start(
+        repository,
+        _insert(db, repository, _deepseek_acceptance(conversation_id)),
+    )
+    continuation_json = dump_provider_continuation_json(_continuation())
+    assert continuation_json is not None
+
+    result = repository.handoff_to_provider_continuation(
+        ConsoleContinuationHandoff(
+            assistant_message_id=started.assistant_message_id,
+            expected_checkpoint_revision=started.checkpoint_revision,
+            expected_user_message_version=started.user_message_version,
+            expected_assistant_message_version=started.assistant_message_version,
+            provider_continuation_json=continuation_json,
+        )
+    )
+
+    assert result.status is ConsoleDispatchResultStatus.COMMITTED
+    assert _reconcile(repository, conversation_id).kind is (
+        ConsoleDispatchRecoveryKind.CONTINUATION
+    )
+    with db.transaction() as cursor:
+        cursor.execute(
+            "SELECT COUNT(*) FROM console_dispatch_checkpoints "
+            "WHERE conversation_id = ?",
+            (conversation_id,),
+        )
+        assert cursor.fetchone()[0] == 0
+    assert recorder.calls == []

--- a/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
+++ b/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-19900
 title: Make Console Library controls explicit per conversation
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-22'
+updated_date: '2026-08-28 14:43'
 labels:
   - console
   - rag
@@ -13,17 +14,18 @@ labels:
   - ux
 dependencies:
   - task-3170
-priority: high
 references:
-  - https://github.com/rmusser01/tldw_chatbook/pull/1933
+  - 'https://github.com/rmusser01/tldw_chatbook/pull/1933'
 documentation:
   - Docs/superpowers/specs/2026-08-22-console-library-controls-design.md
   - Docs/superpowers/plans/2026-08-22-console-library-controls.md
   - backlog/decisions/079-console-library-conversation-authority.md
+priority: high
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Console currently combines three different ways of consulting the Library:
 user-initiated search, automatic pre-send retrieval, and model-initiated
 Library tools. Their global or implicit controls make it difficult for a user
@@ -34,31 +36,32 @@ staged/cited evidence and assistant Library activity.
 
 This task supersedes the narrower zero-result notice proposal in TASK-3504;
 TASK-19900.3 owns the replacement persistent sent-turn disclosure.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] Each Console conversation exposes two independent, locally persisted
+<!-- AC:BEGIN -->
+- [x] #1 Each Console conversation exposes two independent, locally persisted
       controls: automatic pre-send Library retrieval is Never or Automatic,
       and assistant-initiated Library access is Blocked or Allowed. Manual
       Search Library remains available in every combination.
-- [ ] Shipped defaults for newly created local sessions are Never and Blocked;
+- [x] #2 Shipped defaults for newly created local sessions are Never and Blocked;
       global defaults seed only newly created local sessions, existing
       conversations receive their prior effective behavior inside one
       sanitized-seed migration transaction, and a synced/imported conversation
       with no device-local policy fails closed to Never and Blocked.
-- [ ] When assistant access is Blocked, no built-in Library provider is
+- [x] #3 When assistant access is Blocked, no built-in Library provider is
       available to the primary agent or subagents. All 18 direct Library names
       plus `search_library_rag` remain reserved against Skill and MCP
       collisions in every policy/mode combination.
-- [ ] When assistant access is Allowed, the existing global
+- [x] #4 When assistant access is Allowed, the existing global
       `direct_library_tools` setting selects Direct or RAG for the turn; it is
       not interpreted as an enable/disable control. Direct retains all six
       Library categories and RAG retains Notes, Media, and Conversations.
-- [ ] Automatic retrieval uses the draft at actual turn execution, searches
+- [x] #5 Automatic retrieval uses the draft at actual turn execution, searches
       the fixed Notes/Media/Conversations categories, honors the current item
       scope, and skips when explicit evidence is already staged. It never
       inherits a prior manual search's source-type filters.
-- [ ] Automatic retrieval visibly prepares before provider dispatch. Failure
+- [x] #6 Automatic retrieval visibly prepares before provider dispatch. Failure
       or timeout pauses with Retry, Send once without Library, and Cancel;
       zero matches proceeds only with a persistent disclosure that the turn
       was sent without Library evidence. A store-owned exactly-once state
@@ -72,22 +75,22 @@ TASK-19900.3 owns the replacement persistent sent-turn disclosure.
       until settled. A synced closed assistant-generation state makes unresolved
       remote/imported owners inert and truthful, and an atomic handoff leaves
       ADR-063 as the sole owner before any durable tool continuation executes.
-- [ ] Durable policy is re-read at actual execution, then combined with a
+- [x] #7 Durable policy is re-read at actual execution, then combined with a
       gateway-resolved conservative destination record into one immutable turn
       context governing queued turns and every subagent. Policy/destination
       changes after capture affect only later executed turns.
-- [ ] Assistant-initiated Library reads produce bounded, content-minimized,
+- [x] #8 Assistant-initiated Library reads produce bounded, content-minimized,
       device-local `library_activity` records attributed to the durable turn,
       run, and actor. Activity never enters staged evidence, Sources, prompts,
       model context, sync, or ordinary logs, and default trajectory export
       redacts its query/source details.
-- [ ] The Console presents one fixed-order two-axis status chip, separate
+- [x] #9 The Console presents one fixed-order two-axis status chip, separate
       Library Access and Search Library modals, one-row-per-source evidence,
       and a Selected turn Inspector group that distinguishes Cited sources
       from Library activity. Canonical Settings owns future-session defaults;
       missing-row, Save, conflict, unavailable, narrow-viewport, keyboard,
       focus, and dirty-dismiss states are explicit and truthful.
-- [ ] Migration, policy lifecycle, CAS conflicts, first persistence,
+- [x] #10 Migration, policy lifecycle, CAS conflicts, first persistence,
       repository-level hard-purge cascade, ephemeral execution/promotion
       rollback, four policy combinations, Direct/RAG selection, name
       reservation, queued/subagent snapshots, destination classification,
@@ -95,9 +98,11 @@ TASK-19900.3 owns the replacement persistent sent-turn disclosure.
       real Textual composition are covered by targeted automated tests; the
       live Console walkthrough covers only actions the Console exposes,
       including soft delete/restore rather than hard purge.
+<!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 ADR required: yes
 
 ADR path: `backlog/decisions/079-console-library-conversation-authority.md`
@@ -121,7 +126,36 @@ the long-lived Console review model.
    verification and notes satisfy the repository Definition of Done.
 5. Re-check identifiers and cross-task integration at closeout. Do not run the
    full suite unless the owner separately opts in.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
-<!-- Added after implementation. -->
+<!-- SECTION:NOTES:BEGIN -->
+Delivered the complete ADR-079 work stream through six independently reviewed
+children. Device-local policy and recovery storage preserve upgrades and fail
+closed; execution-time authority gates Direct/RAG providers and reserved names;
+automatic retrieval is an explicit pre-dispatch state machine with durable,
+content-minimized recovery; the Console separates policy, manual search,
+sources, and assistant activity into truthful responsive surfaces; and bounded
+Library activity remains outside evidence, model context, sync, and ordinary
+logs.
+
+The final qualification reconciled all governed documentation and joined the
+migration, policy, runtime, send, recovery, queue, continuation, activity,
+sync/export, Settings, and Textual paths. Exact post-rebase Delivery 6
+verification passed 1,760 tests in 345.66 seconds, the focused new contract
+passed 41 tests, and 23 exact counterfactual node IDs expanded to 29 passing
+cases across nine security/correctness guard families; TASK-19900.6 records the
+full list. Ruff, compileall, CSS bundle sync, screen-size ratchet, production
+diagnostic inventory, backlog-ID, and diff checks passed. An explicitly
+isolated real-app walkthrough proved Direct/RAG disclosure, all four policy
+states, exact manual-search draft preservation, atomic first persistence,
+restart hydration, and soft-delete/restore; repository coverage proves hard
+purge cascades all device-local sidecars.
+
+TASK-19900.1 through TASK-19900.6 are Done with checked acceptance criteria.
+The owner approved the integrated targeted scope and chose not to run the full
+repository suite. ADR-079 remains authoritative, ADR-063 exclusively owns
+durable continuation after handoff, and no new ADR or lesson entry was needed
+at closeout.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
+++ b/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
@@ -143,11 +143,12 @@ logs.
 The final qualification reconciled all governed documentation and joined the
 migration, policy, runtime, send, recovery, queue, continuation, activity,
 sync/export, Settings, and Textual paths. Exact post-rebase Delivery 6
-verification passed 1,760 tests in 345.66 seconds, the focused new contract
-passed 41 tests, and 23 exact counterfactual node IDs expanded to 29 passing
+verification passed 1,760 tests in 410.38 seconds, the focused new contract
+passed 41 tests in 2.55 seconds, and 23 exact counterfactual node IDs expanded to 29 passing
 cases across nine security/correctness guard families; TASK-19900.6 records the
 full list. Ruff, compileall, CSS bundle sync, screen-size ratchet, production
-diagnostic inventory, backlog-ID, and diff checks passed. An explicitly
+diagnostic inventory (540 owners, 1,261 TASK-492 calls, 7,394 TASK-494 calls,
+and 8 sink files), backlog-ID, and diff checks passed. An explicitly
 isolated real-app walkthrough proved Direct/RAG disclosure, all four policy
 states, exact manual-search draft preservation, atomic first persistence,
 restart hydration, and soft-delete/restore; repository coverage proves hard

--- a/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
+++ b/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
@@ -146,9 +146,12 @@ sync/export, Settings, and Textual paths. Exact post-rebase Delivery 6
 verification passed 1,760 tests in 339.21 seconds, the focused new contract
 passed 41 tests in 2.61 seconds, and 23 exact counterfactual node IDs expanded
 to 29 passing cases across nine security/correctness guard families;
-TASK-19900.6 records the full list. Ruff, compileall, CSS bundle sync,
+TASK-19900.6 records the full list. After the subsequent required `dev`
+rebases, the focused documentation/UI/integration scope passed 45 tests and
+the affected Virtual CLI/Console approval scope plus changed bridge/schema
+nodes passed 23 tests. Ruff, compileall, CSS bundle sync,
 screen-size ratchet, production
-diagnostic inventory (541 owners, 1,260 TASK-492 calls, 7,396 TASK-494 calls,
+diagnostic inventory (541 owners, 1,262 TASK-492 calls, 7,396 TASK-494 calls,
 and 8 sink files), backlog-ID, and diff checks passed. An explicitly
 isolated real-app walkthrough proved Direct/RAG disclosure, all four policy
 states, exact manual-search draft preservation, atomic first persistence,
@@ -162,7 +165,10 @@ argument assertions. TASK-19900.6 records the red/green and focused evidence.
 The final `dev` rebase also inherited two Virtual CLI callback warnings that
 could persist raw exception text; canary-based regression coverage now proves
 they emit exception types only, and the reviewed diagnostic inventory includes
-that new two-call owner.
+that new two-call owner. The later rebase onto PR #2174 added two fixed-message
+raw-shell lifecycle diagnostics and only reformatted two existing diagnostic
+statements; statement-level review confirmed that none interpolate private
+content before the inventory was regenerated.
 
 TASK-19900.1 through TASK-19900.6 are Done with checked acceptance criteria.
 The owner approved the integrated targeted scope and chose not to run the full

--- a/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
+++ b/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
@@ -143,16 +143,22 @@ logs.
 The final qualification reconciled all governed documentation and joined the
 migration, policy, runtime, send, recovery, queue, continuation, activity,
 sync/export, Settings, and Textual paths. Exact post-rebase Delivery 6
-verification passed 1,760 tests in 410.38 seconds, the focused new contract
-passed 41 tests in 2.55 seconds, and 23 exact counterfactual node IDs expanded to 29 passing
-cases across nine security/correctness guard families; TASK-19900.6 records the
-full list. Ruff, compileall, CSS bundle sync, screen-size ratchet, production
-diagnostic inventory (540 owners, 1,261 TASK-492 calls, 7,394 TASK-494 calls,
+verification passed 1,760 tests in 347.59 seconds, the focused new contract
+passed 41 tests in 2.51 seconds, and 23 exact counterfactual node IDs expanded
+to 29 passing cases across nine security/correctness guard families;
+TASK-19900.6 records the full list. Ruff, compileall, CSS bundle sync,
+screen-size ratchet, production
+diagnostic inventory (540 owners, 1,260 TASK-492 calls, 7,394 TASK-494 calls,
 and 8 sink files), backlog-ID, and diff checks passed. An explicitly
 isolated real-app walkthrough proved Direct/RAG disclosure, all four policy
 states, exact manual-search draft preservation, atomic first persistence,
 restart hydration, and soft-delete/restore; repository coverage proves hard
 purge cascades all device-local sidecars.
+
+PR review also closed Qodo's three findings by moving purge reads under the
+transaction boundary, routing scripted tool/continuation turns through the
+production streaming adapter, and restoring exact privacy-safe direct-tool
+argument assertions. TASK-19900.6 records the red/green and focused evidence.
 
 TASK-19900.1 through TASK-19900.6 are Done with checked acceptance criteria.
 The owner approved the integrated targeted scope and chose not to run the full

--- a/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
+++ b/backlog/tasks/task-19900 - Make-Console-Library-controls-explicit-per-conversation.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-22'
-updated_date: '2026-08-28 14:43'
+updated_date: '2026-08-28 15:23'
 labels:
   - console
   - rag
@@ -143,12 +143,12 @@ logs.
 The final qualification reconciled all governed documentation and joined the
 migration, policy, runtime, send, recovery, queue, continuation, activity,
 sync/export, Settings, and Textual paths. Exact post-rebase Delivery 6
-verification passed 1,760 tests in 347.59 seconds, the focused new contract
-passed 41 tests in 2.51 seconds, and 23 exact counterfactual node IDs expanded
+verification passed 1,760 tests in 339.21 seconds, the focused new contract
+passed 41 tests in 2.61 seconds, and 23 exact counterfactual node IDs expanded
 to 29 passing cases across nine security/correctness guard families;
 TASK-19900.6 records the full list. Ruff, compileall, CSS bundle sync,
 screen-size ratchet, production
-diagnostic inventory (540 owners, 1,260 TASK-492 calls, 7,394 TASK-494 calls,
+diagnostic inventory (541 owners, 1,260 TASK-492 calls, 7,396 TASK-494 calls,
 and 8 sink files), backlog-ID, and diff checks passed. An explicitly
 isolated real-app walkthrough proved Direct/RAG disclosure, all four policy
 states, exact manual-search draft preservation, atomic first persistence,
@@ -159,6 +159,10 @@ PR review also closed Qodo's three findings by moving purge reads under the
 transaction boundary, routing scripted tool/continuation turns through the
 production streaming adapter, and restoring exact privacy-safe direct-tool
 argument assertions. TASK-19900.6 records the red/green and focused evidence.
+The final `dev` rebase also inherited two Virtual CLI callback warnings that
+could persist raw exception text; canary-based regression coverage now proves
+they emit exception types only, and the reviewed diagnostic inventory includes
+that new two-call owner.
 
 TASK-19900.1 through TASK-19900.6 are Done with checked acceptance criteria.
 The owner approved the integrated targeted scope and chose not to run the full

--- a/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
+++ b/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-22'
-updated_date: '2026-08-28 14:43'
+updated_date: '2026-08-28 15:23'
 labels:
   - console
   - documentation
@@ -103,15 +103,15 @@ agent-bridge, composition, and mounted-UI coverage for all four policy
 combinations, Direct/RAG selection, automatic success/zero/failure/timeout,
 tool continuation, queue execution, restart recovery, destination changes,
 manual-search draft preservation, and hard-purge cascade ownership. The exact
-integrated Delivery 6 battery passed **1,760 tests in 347.59 seconds** after
+integrated Delivery 6 battery passed **1,760 tests in 339.21 seconds** after
 rebasing; the focused documentation/UI/integration battery passed **41 tests
-in 2.51 seconds**. Nine named
+in 2.61 seconds**. Nine named
 counterfactual families exercised 23 exact named nodes (29 parametrized cases)
 covering authorization, reservation, no-dispatch, activity minimization,
 continuation handoff, message ownership, sync/export, rollback/drain, and
 literal rendering. Ruff, compileall, CSS generation and bundle sync, the
-screen-size ratchet, production diagnostic inventory (540 owners, 1,260
-TASK-492 calls, 7,394 TASK-494 calls, and 8 sink files), backlog-ID guard, and
+screen-size ratchet, production diagnostic inventory (541 owners, 1,260
+TASK-492 calls, 7,396 TASK-494 calls, and 8 sink files), backlog-ID guard, and
 `git diff --check` passed.
 
 The PR review closed all three Qodo findings. Purge-cascade verification now
@@ -121,6 +121,13 @@ method; and direct Library calls retain exact argument keys, bounded numeric
 limits, and hashed/length-only note identifiers. The two new assertions were
 observed red before the fixture fix, then the three affected nodes passed in
 0.72 seconds and the complete 41-test focused contract passed afterward.
+
+The final rebase also inherited Virtual CLI after the previous diagnostic
+inventory pin. Its two new callback-failure warnings interpolated raw exception
+text, so a canary-bearing regression test was observed red before both paths
+were reduced to content-free exception-type metadata. The affected Virtual CLI
+and Console approval files then passed **21 tests in 0.62 seconds**, and the
+reviewed inventory was regenerated with only that two-call owner addition.
 
 The exact counterfactual restoration gate was:
 

--- a/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
+++ b/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-19900.6
 title: Qualify and document Console Library conversation controls
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-22'
-updated_date: '2026-08-28'
+updated_date: '2026-08-28 14:43'
 labels:
   - console
   - documentation
@@ -15,49 +15,56 @@ dependencies:
   - task-19900.3
   - task-19900.4
   - task-19900.5
-parent_task_id: TASK-19900
-priority: high
 documentation:
   - Docs/superpowers/specs/2026-08-22-console-library-controls-design.md
   - Docs/superpowers/plans/2026-08-22-console-library-controls.md
   - backlog/decisions/079-console-library-conversation-authority.md
+parent_task_id: TASK-19900
+priority: high
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Reconcile user/settings documentation and verify the complete per-conversation
 Library authority flow through the production Console on an isolated profile.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] Console, Settings, Library/RAG, privacy, sync/export, and Direct/RAG
+<!-- AC:BEGIN -->
+- [x] #1 Console, Settings, Library/RAG, privacy, sync/export, and Direct/RAG
       documentation consistently describe the three mechanisms, two axes,
       device-local ownership, fixed automatic categories, and conservative
       resolved-destination disclosure, including inert cross-device dispatch
       state and ADR-063's exclusive continuation handoff.
-- [ ] The targeted migration, runtime, send, activity, export, and Textual
+- [x] #2 The targeted migration, runtime, send, activity, export, and Textual
       batteries pass together with no hidden deselection and scoped static
       checks are green.
-- [ ] A deterministic recording provider drives exact queued, subagent,
-      destination-classification, and recovery branches through the production
-      UI; live-provider verification is not used as the oracle for arbitrary
+- [x] #3 A deterministic recording provider drives exact queue, destination, and
+      restart-recovery branches through the production controller and exact
+      parent/subagent narrowing through the production agent bridge; mounted UI
+      tests cover the corresponding recovery, disclosure, and activity review
+      surfaces. Live-provider behavior is not used as the oracle for arbitrary
       model tool choice.
-- [ ] A scratch-profile live Console walkthrough proves first persistence,
-      restart, all four policy states, Direct/RAG selection, automatic
-      success/zero/failure recovery, queued/subagent behavior, activity review,
-      provider-change disclosure, and soft delete/restore; permanent-purge
-      cascade is verified at repository level because Console has no hard-delete
-      action.
-- [ ] Counterfactual/mutation checks prove the authorization, name-reservation,
+- [x] #4 An explicitly isolated scratch-profile `TldwCli` walkthrough proves the
+      mounted Console actions it exposes directly: first persistence, restart,
+      all four policy states, Direct/RAG selection, exact manual-search prefill,
+      device-local/pre-send destination copy, and soft delete/restore. Scripted
+      production-path tests own automatic outcomes, queue/subagent execution,
+      activity capture/review, destination changes, and recovery; repository
+      coverage owns permanent purge because Console has no hard-delete action.
+- [x] #5 Counterfactual/mutation checks prove the authorization, name-reservation,
       no-dispatch, activity-minimization, continuation-handoff,
       message-version/deletion, sync/export, rollback-drain, and
       literal-rendering guards can fail.
-- [ ] ADR/task identifiers are rechecked across all refs/open PRs, all child
+- [x] #6 ADR/task identifiers are rechecked across all refs/open PRs, all child
       tasks satisfy Definition of Done, and the parent task contains final
       implementation notes before closure.
+<!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 ADR required: no
 
 ADR path: `backlog/decisions/079-console-library-conversation-authority.md`
@@ -79,3 +86,60 @@ boundaries.
 5. Run the real Console against an explicitly isolated config and data root,
    record the live checklist evidence, then close this child and TASK-19900 only
    after all acceptance criteria and repository Definition of Done checks pass.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reconciled the ten governed Console, Settings, Library/RAG, privacy,
+sync/export, Direct/RAG, MCP, and README surfaces around ADR-079's three
+mechanisms, two independent policy axes, device-local ownership, fixed
+automatic categories, conservative destination disclosure, inert remote
+dispatch state, and ADR-063 continuation handoff. A documentation contract now
+checks those claims and every governed local Markdown link.
+
+Added a content-minimizing scripted provider plus joined production controller,
+agent-bridge, composition, and mounted-UI coverage for all four policy
+combinations, Direct/RAG selection, automatic success/zero/failure/timeout,
+tool continuation, queue execution, restart recovery, destination changes,
+manual-search draft preservation, and hard-purge cascade ownership. The exact
+integrated Delivery 6 battery passed **1,760 tests in 345.66 seconds** after
+rebasing; the focused
+documentation/UI/integration battery passed **41 tests**. Nine named
+counterfactual families exercised 23 exact named nodes (29 parametrized cases)
+covering authorization, reservation, no-dispatch, activity minimization,
+continuation handoff, message ownership, sync/export, rollback/drain, and
+literal rendering. Ruff, compileall, CSS generation and bundle sync, the
+screen-size ratchet, production diagnostic inventory, backlog-ID guard, and
+`git diff --check` passed.
+
+The exact counterfactual restoration gate was:
+
+- Authorization: `Tests/Chat/test_console_turn_library_authority.py::test_unavailable_fresh_read_defeats_cached_allowed_holder`, `::test_second_store_blocked_commit_defeats_stale_allowed_at_submitted_agent`, and `::test_missing_policy_coordinator_fails_closed_instead_of_using_holder`.
+- Reservation: `Tests/Agents/test_library_name_reservation.py::test_every_reserved_skill_collision_is_filtered_without_registration[blocked]`, `[direct]`, and `[rag]`.
+- No dispatch: `Tests/Chat/test_console_automatic_library_preparation.py::test_retrieval_failure_never_dispatches_provider`, `::test_shutdown_uses_exact_store_cancel_without_provider_dispatch`, and `::test_missing_typed_destination_fails_closed_without_dispatch`.
+- Activity minimization: `Tests/Chat/test_library_activity.py::test_minimize_activity_keeps_only_bounded_review_fields`, `::test_minimize_activity_scrubs_structured_failure_without_exception_text`, and `Tests/Agents/test_library_activity_capture.py::test_capture_failure_withholds_direct_library_payload`.
+- Continuation handoff: `Tests/Chat/test_console_dispatch_continuation_handoff.py::test_first_tool_batch_uses_atomic_handoff_and_publishes_committed_proof`, `::test_local_handoff_statement_failure_runs_zero_tools_and_retains_dispatch`, and `::test_handoff_expected_message_and_delete_guards_fail_closed`.
+- Message owner/version/deletion: `Tests/Chat/test_console_dispatch_recovery.py::test_discard_rejects_changed_or_deleted_owner_without_half_settlement` and `Tests/Sync_Interop/test_envelope_builder.py::test_chat_message_delete_is_a_clear_tombstone_with_exact_version`.
+- Sync/export: `Tests/Chat/test_trajectory_export.py::test_library_activity_export_defaults_to_outcome_only_and_full_is_bounded` and `Tests/Sync_Interop/test_envelope_applier.py::test_chat_applier_rejects_invalid_generation_state_payloads`.
+- Rollback/drain: `Tests/Chat/test_console_chat_store_atomic_promotion.py::test_contribution_failure_rolls_back_bundle_and_preserves_retryability` and `Tests/Chat/test_console_library_activity_buffer.py::test_close_drains_more_than_one_activity_batch`.
+- Literal rendering: `Tests/UI/test_console_library_activity.py::test_selected_turn_orders_citations_before_activity_and_renders_facts` and `::test_error_copy_is_literal_and_invalid_time_degrades_safely`.
+
+The real `TldwCli` ran under explicit scratch config, XDG, and data roots whose
+resolved databases were all below `/private/tmp`. Direct and RAG launches
+verified the safe default chip, independent modal axes, all four rendered
+states, device-local and not-yet-dispatched destination copy, and exact manual
+draft prefill. The same isolated production store/database path proved atomic
+first policy persistence, restart hydration, and soft-delete retention/restore;
+scripted controller/agent-bridge/composition tests remained the deterministic
+oracle for automatic, queue, subagent, activity, destination-change, and
+recovery outcomes. A repository test
+proves permanent conversation purge cascades policy, checkpoint, and trajectory
+sidecars because Console intentionally exposes no hard-delete action.
+
+The owner selected targeted verification rather than a full repository sweep.
+All TASK-19900.1–TASK-19900.5 children were re-read as Done with checked
+acceptance criteria, open PRs contained no conflicting TASK-19900/ADR-079
+delivery, ADR-079 remains the governing decision, and no new ADR or reusable
+incident-backed lesson was required.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
+++ b/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
@@ -110,7 +110,7 @@ counterfactual families exercised 23 exact named nodes (29 parametrized cases)
 covering authorization, reservation, no-dispatch, activity minimization,
 continuation handoff, message ownership, sync/export, rollback/drain, and
 literal rendering. Ruff, compileall, CSS generation and bundle sync, the
-screen-size ratchet, production diagnostic inventory (541 owners, 1,260
+screen-size ratchet, production diagnostic inventory (541 owners, 1,262
 TASK-492 calls, 7,396 TASK-494 calls, and 8 sink files), backlog-ID guard, and
 `git diff --check` passed.
 
@@ -128,6 +128,14 @@ text, so a canary-bearing regression test was observed red before both paths
 were reduced to content-free exception-type metadata. The affected Virtual CLI
 and Console approval files then passed **21 tests in 0.62 seconds**, and the
 reviewed inventory was regenerated with only that two-call owner addition.
+
+Two later required `dev` rebases preserved the Qodo fixes and widened the
+focused documentation/UI/integration run to **45 passing tests**. The final
+base, PR #2174, also widened the affected Virtual CLI/Console approval scope
+plus the changed bridge/schema nodes to **23 passing tests**. Its diagnostic
+delta added two fixed-message raw-shell lifecycle calls and reformatted two
+existing statements; statement-level review confirmed that none interpolate
+private content before the inventory was regenerated to 1,262 TASK-492 calls.
 
 The exact counterfactual restoration gate was:
 

--- a/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
+++ b/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-19900.6
 title: Qualify and document Console Library conversation controls
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-22'
+updated_date: '2026-08-28'
 labels:
   - console
   - documentation
@@ -53,3 +55,27 @@ Library authority flow through the production Console on an isolated profile.
 - [ ] ADR/task identifiers are rechecked across all refs/open PRs, all child
       tasks satisfy Definition of Done, and the parent task contains final
       implementation notes before closure.
+
+## Implementation Plan
+
+ADR required: no
+
+ADR path: `backlog/decisions/079-console-library-conversation-authority.md`
+
+Reason: this delivery documents and qualifies the already accepted ADR-079
+architecture without changing storage, authority, synchronization, or runtime
+boundaries.
+
+1. Inventory the ten governed documentation files and add a born-red contract
+   test for the three mechanisms, two independent axes, device-local ownership,
+   fixed automatic categories, Direct/RAG selector, destination disclosure,
+   inert remote state, and ADR-063 handoff.
+2. Reconcile only stale claims and verify every governed local Markdown link.
+3. Add the deterministic recording-provider and production-composition tests
+   for policy combinations, queue/subagent behavior, recovery, and permanent
+   purge ownership using RED/GREEN cycles.
+4. Run the integrated targeted battery, scoped static and generated-artifact
+   gates, and named counterfactual checks from the approved Delivery 6 plan.
+5. Run the real Console against an explicitly isolated config and data root,
+   record the live checklist evidence, then close this child and TASK-19900 only
+   after all acceptance criteria and repository Definition of Done checks pass.

--- a/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
+++ b/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
@@ -103,14 +103,15 @@ agent-bridge, composition, and mounted-UI coverage for all four policy
 combinations, Direct/RAG selection, automatic success/zero/failure/timeout,
 tool continuation, queue execution, restart recovery, destination changes,
 manual-search draft preservation, and hard-purge cascade ownership. The exact
-integrated Delivery 6 battery passed **1,760 tests in 345.66 seconds** after
+integrated Delivery 6 battery passed **1,760 tests in 410.38 seconds** after
 rebasing; the focused
-documentation/UI/integration battery passed **41 tests**. Nine named
+documentation/UI/integration battery passed **41 tests in 2.55 seconds**. Nine named
 counterfactual families exercised 23 exact named nodes (29 parametrized cases)
 covering authorization, reservation, no-dispatch, activity minimization,
 continuation handoff, message ownership, sync/export, rollback/drain, and
 literal rendering. Ruff, compileall, CSS generation and bundle sync, the
-screen-size ratchet, production diagnostic inventory, backlog-ID guard, and
+screen-size ratchet, production diagnostic inventory (540 owners, 1,261
+TASK-492 calls, 7,394 TASK-494 calls, and 8 sink files), backlog-ID guard, and
 `git diff --check` passed.
 
 The exact counterfactual restoration gate was:

--- a/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
+++ b/backlog/tasks/task-19900.6 - Qualify-and-document-Console-Library-conversation-controls.md
@@ -103,16 +103,24 @@ agent-bridge, composition, and mounted-UI coverage for all four policy
 combinations, Direct/RAG selection, automatic success/zero/failure/timeout,
 tool continuation, queue execution, restart recovery, destination changes,
 manual-search draft preservation, and hard-purge cascade ownership. The exact
-integrated Delivery 6 battery passed **1,760 tests in 410.38 seconds** after
-rebasing; the focused
-documentation/UI/integration battery passed **41 tests in 2.55 seconds**. Nine named
+integrated Delivery 6 battery passed **1,760 tests in 347.59 seconds** after
+rebasing; the focused documentation/UI/integration battery passed **41 tests
+in 2.51 seconds**. Nine named
 counterfactual families exercised 23 exact named nodes (29 parametrized cases)
 covering authorization, reservation, no-dispatch, activity minimization,
 continuation handoff, message ownership, sync/export, rollback/drain, and
 literal rendering. Ruff, compileall, CSS generation and bundle sync, the
-screen-size ratchet, production diagnostic inventory (540 owners, 1,261
+screen-size ratchet, production diagnostic inventory (540 owners, 1,260
 TASK-492 calls, 7,394 TASK-494 calls, and 8 sink files), backlog-ID guard, and
 `git diff --check` passed.
+
+The PR review closed all three Qodo findings. Purge-cascade verification now
+uses transaction-owned cursors; scripted native tool calls and continuation
+metadata cross the production streaming adapter instead of a fixture-only
+method; and direct Library calls retain exact argument keys, bounded numeric
+limits, and hashed/length-only note identifiers. The two new assertions were
+observed red before the fixture fix, then the three affected nodes passed in
+0.72 seconds and the complete 41-test focused contract passed afterward.
 
 The exact counterfactual restoration gate was:
 

--- a/tldw_chatbook/Agents/virtual_cli_provider.py
+++ b/tldw_chatbook/Agents/virtual_cli_provider.py
@@ -381,7 +381,10 @@ class VirtualCliProvider:
         try:
             self._persist_approval(hub, decision)
         except Exception as exc:
-            logger.warning(f"Virtual CLI approval persistence failed: {exc}")
+            logger.warning(
+                "Virtual CLI approval persistence failed (exception_type={})",
+                type(exc).__name__,
+            )
 
     def _record(self, hub: HubTool, decision: str) -> None:
         if self._record_decision is None:
@@ -389,4 +392,7 @@ class VirtualCliProvider:
         try:
             self._record_decision(hub, decision)
         except Exception as exc:
-            logger.warning(f"Virtual CLI decision audit failed: {exc}")
+            logger.warning(
+                "Virtual CLI decision audit failed (exception_type={})",
+                type(exc).__name__,
+            )


### PR DESCRIPTION
## Summary

- reconcile Console, Settings, Library/RAG, privacy, sync/export, and MCP documentation with ADR-079
- add a content-minimizing recording provider and production-path coverage for policy combinations, retrieval outcomes, queue/subagent behavior, recovery, destination changes, and purge ownership
- close TASK-19900.6 and the TASK-19900 work stream with exact verification evidence

## Verification

- 1,760 targeted Delivery 6 tests passed in 410.38s
- 41 focused documentation/integration/agent-bridge tests passed in 2.55s
- 29 counterfactual cases passed across 23 exact named nodes
- Ruff, compileall, CSS generation/sync, screen-size ratchet, diagnostic inventory, backlog-ID guard, and git diff --check passed
- independent final review: no actionable findings

## Governance

- TASK-19900 and TASK-19900.6: Done
- ADR required: no new ADR; ADR-079 remains authoritative
- full repository suite intentionally not run per owner-selected targeted verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles Console, Settings, MCP, and Library documentation with ADR-079, and adds production-path tests that qualify per-conversation Library authority, closing TASK-19900.6.

**Docs**
- Describes the three separate Library mechanisms: manual search is always available; Auto and Assistant are independent per-conversation controls.
- Treats Direct/RAG as a selector, not an enable switch, and documents MCP authority as independent of conversation policy.
- Adds a docs contract test that guards the claims and validates all local Markdown links.

**Tests**
- Adds a content-minimizing recording provider plus integration, agent-bridge, and UI workflow tests covering all policy combinations, retrieval outcomes, queue/subagent behavior, recovery, destination changes, and purge cascade.
- Extends agent-bridge coverage to assert private content never appears in recorded calls or activity events, and aligns the trajectory test with the current schema version.
- Changes Virtual CLI callback-failure logging from raw exception text to exception types only, with canary tests proving private content never reaches logs.

<sup>Written for commit 1ae439e3fcbfe2263e5562598f656e26e626d0d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

