### PR TITLE
Add read-only virtual CLI with independent permissions

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -1004,7 +1004,7 @@ No folder setup is required. Relative paths used by Chatbook's built-in file
 tools and local `fs_*`/Git tools resolve in that Chat's scratch space unless a
 named Workspace explicitly adds authority:
 
-| Console context | Built-in file tools | Local `fs_*` / Git |
+| Console context | Built-in file tools | Local `fs_*` / Git and virtual CLI |
 |---|---|---|
 | Chat in Default | Private scratch only | Private scratch only |
 | Named Workspace, no selected project folder | Private scratch plus live explicit folder bindings | Private scratch only |
@@ -1026,6 +1026,28 @@ temporary residue, but a later process never discovers or attaches it.
 This boundary describes Chatbook-managed local tools only. Attachments,
 Library/RAG content, generated media, provider-hosted tools, and external MCP
 servers keep their own storage and authority contracts.
+
+### Read-only virtual CLI
+
+Console agents can see one model tool named `virtual_cli`. It accepts a
+structured `command` plus an `argv` array; it does not accept a command-line
+string, parse pipes or redirection, expand environment variables, or invoke a
+host shell. Its fixed read-only commands are `ls`, `cat`, `grep`, `find`,
+`stat`, `git_status`, `git_diff`, `git_log`, `git_blame`, and `git_branches`.
+
+The tool is discoverable whenever local tools are enabled, but discoverability
+is not authorization. Before each invocation, Chatbook resolves the selected
+command under the separate **Virtual CLI (read-only)** group in MCP ▸ Tools.
+Every command has its own Allow, Ask, or Off setting, defaults to Ask when no
+decision exists, and remains independent from the equivalent `fs_*` or Git
+tool permission. Allowing `cat` does not allow `grep`, and allowing `fs_read`
+does not allow virtual `cat`.
+
+Approved commands dispatch directly to the same confined read-only filesystem
+and Git implementations used by Chatbook's local tools. The active Chat scratch
+or selected Workspace binding, protected-path checks, Git exclusions, result
+limits, global tool kill switch, and approval audit therefore remain in force.
+There is no escape hatch to arbitrary programs or shell syntax.
 
 ### Raw CLI is not a local tool sandbox
 

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -90,6 +90,15 @@ kill switch remains authoritative. The controls read back persisted config
 truth after saving, and a failed save restores the persisted value instead of
 leaving an optimistic toggle on screen.
 
+Tools mode also lists a distinct **Virtual CLI (read-only)** local group. The
+model sees one structured `virtual_cli` tool, while this group exposes separate
+Allow/Ask/Off rows for `ls`, `cat`, `grep`, `find`, `stat`, `git_status`,
+`git_diff`, `git_log`, `git_blame`, and `git_branches`. These permissions are
+independent from equivalent `fs_*` and Git tool rows. The virtual tool accepts
+only a fixed command enum and an `argv` array, never a shell string; being
+listed in the catalog does not authorize a command, and an unset command stays
+Ask until it is approved.
+
 ## Other registration gates (Servers mode ▸ Tool gates)
 
 Select the built-in server's row in Servers mode; its detail pane has a

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -2831,6 +2831,36 @@ def test_make_invoke_tool_binds_exact_subagent_actor_on_timeout_thread(
     assert current_run_actor() is None
 
 
+def test_make_invoke_tool_binds_native_call_id_on_tool_thread(db, monkeypatch):
+    """Providers can scope one approval verdict to one native tool call."""
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Agents.run_context import current_tool_call_id
+
+    service = _service_with_chat(db, lambda **_kwargs: provider_reply("unused"))
+    seen = []
+
+    def invoke_by_name(_name, _args):
+        seen.append(current_tool_call_id())
+        return ToolResult(ok=True, content="ok")
+
+    monkeypatch.setattr(service.registry, "invoke_by_name", invoke_by_name)
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(max_tool_call_seconds=1.0),
+    )
+    invoke_tool = service._make_invoke_tool(
+        cfg,
+        disclosed_names={"calculator"},
+        run_id="run-1",
+    )
+
+    assert invoke_tool(ToolCall("calculator", {}, "native-call-7")).ok is True
+    assert seen == ["native-call-7"]
+    assert current_tool_call_id() == ""
+
+
 def test_make_invoke_tool_wraps_slow_custom_tool_in_timeout(db, monkeypatch):
     """A blocking custom tool provider must not wedge the run past
     max_tool_call_seconds -- the boundary this task exists to add."""

--- a/Tests/Agents/test_virtual_cli_provider.py
+++ b/Tests/Agents/test_virtual_cli_provider.py
@@ -1,0 +1,208 @@
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import ToolCall
+from tldw_chatbook.Agents.run_context import (
+    current_tool_call_id,
+    use_run_id,
+    use_tool_call_id,
+)
+from tldw_chatbook.Agents.virtual_cli_provider import (
+    VIRTUAL_CLI_SERVER_KEY,
+    VIRTUAL_CLI_TOOL_NAME,
+    VirtualCliProvider,
+)
+from tldw_chatbook.MCP.permission_store import EffectiveToolState, definition_hash
+from tldw_chatbook.Tools.virtual_cli_impls import VIRTUAL_CLI_COMMANDS
+
+ALLOW = EffectiveToolState(state="allow", origin="tool_override")
+ASK = EffectiveToolState(state="ask", origin="global_default")
+DENY = EffectiveToolState(state="deny", origin="tool_override")
+
+
+def make_provider(tmp_path: Path, state=ASK, **kwargs) -> VirtualCliProvider:
+    kwargs.setdefault("resolve_state", lambda _hub: state)
+    kwargs.setdefault("local_tools_enabled", lambda: True)
+    kwargs.setdefault("kill_switch", lambda: False)
+    return VirtualCliProvider(workspace_root=tmp_path, **kwargs)
+
+
+def test_provider_exposes_one_structured_model_tool(tmp_path):
+    provider = make_provider(tmp_path)
+
+    assert [(item.id, item.name) for item in provider.list_catalog()] == [
+        ("virtual_cli:virtual_cli", VIRTUAL_CLI_TOOL_NAME)
+    ]
+    schema = provider.load_schema("virtual_cli:virtual_cli")
+    assert schema.name == "virtual_cli"
+    assert schema.parameters["required"] == ["command", "argv"]
+    assert schema.parameters["additionalProperties"] is False
+    assert schema.parameters["properties"]["command"]["enum"] == list(
+        VIRTUAL_CLI_COMMANDS
+    )
+    assert schema.parameters["properties"]["argv"]["type"] == "array"
+    assert "shell" not in schema.parameters["properties"]
+    assert "command_line" not in schema.parameters["properties"]
+
+
+def test_tool_call_id_context_is_nested_and_restored():
+    assert current_tool_call_id() == ""
+    with use_tool_call_id("outer"):
+        assert current_tool_call_id() == "outer"
+        with use_tool_call_id("inner"):
+            assert current_tool_call_id() == "inner"
+        assert current_tool_call_id() == "outer"
+    assert current_tool_call_id() == ""
+
+
+def test_provider_projects_ten_distinct_permission_tools(tmp_path):
+    tools = make_provider(tmp_path).hub_tools()
+
+    assert [tool.name for tool in tools] == list(VIRTUAL_CLI_COMMANDS)
+    assert {tool.server_key for tool in tools} == {VIRTUAL_CLI_SERVER_KEY}
+    hashes = {
+        definition_hash(tool.description, tool.input_schema) for tool in tools
+    }
+    assert len(hashes) == len(VIRTUAL_CLI_COMMANDS)
+
+
+def test_pending_gate_uses_selected_command_and_call_identity(tmp_path):
+    provider = make_provider(tmp_path)
+    call = ToolCall(
+        "virtual_cli", {"command": "cat", "argv": ["README.md"]}, call_id="c2"
+    )
+
+    pending = provider.pending_gate_for(call)
+
+    assert pending is not None
+    assert pending.llm_name == "virtual_cli"
+    assert pending.server_key == VIRTUAL_CLI_SERVER_KEY
+    assert pending.tool_name == "cat"
+    assert pending.call_id == "c2"
+    assert pending.arguments == call.args
+
+
+def test_missing_permission_is_ask_and_discoverability_does_not_execute(tmp_path):
+    target = tmp_path / "note.txt"
+    target.write_text("secret", encoding="utf-8")
+    provider = make_provider(tmp_path)
+
+    result = provider.invoke(
+        "virtual_cli", {"command": "cat", "argv": ["note.txt"]}
+    )
+
+    assert not result.ok
+    assert result.outcome == "blocked"
+    assert "approve" in result.error.lower()
+
+
+def test_one_command_permission_does_not_authorize_another(tmp_path):
+    (tmp_path / "note.txt").write_text("hello", encoding="utf-8")
+    states = {"cat": ALLOW, "ls": DENY}
+    provider = make_provider(tmp_path, state=None, resolve_state=lambda hub: states[hub.name])
+
+    cat = provider.invoke("virtual_cli", {"command": "cat", "argv": ["note.txt"]})
+    listing = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+
+    assert cat.ok and "hello" in cat.content
+    assert not listing.ok and listing.outcome == "blocked"
+
+
+def test_approve_once_stamp_is_call_scoped(tmp_path):
+    (tmp_path / "note.txt").write_text("hello", encoding="utf-8")
+    provider = make_provider(tmp_path)
+    first = provider.pending_gate_for(
+        ToolCall("virtual_cli", {"command": "cat", "argv": ["note.txt"]}, "c1")
+    )
+    second = provider.pending_gate_for(
+        ToolCall("virtual_cli", {"command": "cat", "argv": ["note.txt"]}, "c2")
+    )
+    assert first is not None and second is not None
+    provider.apply_batch_decisions("run", {"c1": "approve_once"}, [first, second])
+
+    with use_run_id("run"), use_tool_call_id("c1"):
+        allowed = provider.invoke(
+            "virtual_cli", {"command": "cat", "argv": ["note.txt"]}
+        )
+    with use_run_id("run"), use_tool_call_id("c2"):
+        blocked = provider.invoke(
+            "virtual_cli", {"command": "cat", "argv": ["note.txt"]}
+        )
+
+    assert allowed.ok
+    assert not blocked.ok and blocked.outcome == "blocked"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {"kill_switch": lambda: True},
+        {"local_tools_enabled": lambda: False},
+    ),
+)
+def test_invocation_rechecks_global_gates(tmp_path, kwargs):
+    provider = make_provider(tmp_path, state=ALLOW, **kwargs)
+    provider._registry.execute = lambda *_args: pytest.fail("must not dispatch")
+
+    result = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+
+    assert not result.ok and result.outcome == "blocked"
+
+
+def test_kill_switch_flip_before_core_dispatch_fails_closed(tmp_path):
+    reads = iter((False, True))
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        kill_switch=lambda: next(reads),
+    )
+    provider._registry.execute = lambda *_args: pytest.fail("must not dispatch")
+
+    result = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+
+    assert not result.ok and result.outcome == "blocked"
+
+
+def test_invalid_argv_fails_before_permission_resolution(tmp_path):
+    resolves = []
+    provider = make_provider(
+        tmp_path,
+        state=None,
+        resolve_state=lambda hub: resolves.append(hub.name) or ALLOW,
+    )
+
+    result = provider.invoke(
+        "virtual_cli", {"command": "git_diff", "argv": ["--not-a-flag"]}
+    )
+
+    assert not result.ok
+    assert "invalid" in result.error.lower()
+    assert resolves == []
+
+
+def test_result_controls_are_sanitized_and_capped(tmp_path):
+    provider = make_provider(tmp_path, state=ALLOW)
+    provider._registry.execute = lambda *_args: "ok\x1b[31m\x07\n" + ("x" * 40000)
+
+    result = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+
+    assert result.ok
+    assert "\x1b" not in result.content and "\x07" not in result.content
+    assert "\n" in result.content
+    assert len(result.content.encode("utf-8")) <= 32 * 1024 + 20
+
+
+def test_permission_is_rechecked_after_review(tmp_path):
+    state = ASK
+    provider = make_provider(tmp_path, state=None, resolve_state=lambda _hub: state)
+    call = ToolCall("virtual_cli", {"command": "ls", "argv": ["."]}, "c1")
+    pending = provider.pending_gate_for(call)
+    assert pending is not None
+    provider.apply_batch_decisions("run", {"c1": "approve_once"}, [pending])
+    state = DENY
+
+    with use_run_id("run"), use_tool_call_id("c1"):
+        result = provider.invoke("virtual_cli", call.args)
+
+    assert not result.ok and result.outcome == "blocked"

--- a/Tests/Chat/test_console_virtual_cli_approval.py
+++ b/Tests/Chat/test_console_virtual_cli_approval.py
@@ -1,0 +1,158 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import ToolCall
+from tldw_chatbook.Agents.run_context import use_run_id, use_tool_call_id
+from tldw_chatbook.Agents.virtual_cli_provider import VirtualCliProvider
+from tldw_chatbook.Chat.console_chat_controller import (
+    ConsoleChatController,
+    build_virtual_cli_review_hook,
+)
+from tldw_chatbook.Chat.console_agent_bridge import _compose_run_registry_and_allowed
+from tldw_chatbook.MCP.permission_store import EffectiveToolState
+
+
+ASK = EffectiveToolState(state="ask", origin="global_default")
+ALLOW = EffectiveToolState(state="allow", origin="tool_override")
+
+
+def _provider(root: Path) -> VirtualCliProvider:
+    return VirtualCliProvider(
+        workspace_root=root,
+        resolve_state=lambda _hub: ASK,
+    )
+
+
+def test_review_hook_keeps_same_model_tool_calls_independent(tmp_path):
+    (tmp_path / "a.txt").write_text("allowed", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("blocked", encoding="utf-8")
+    provider = _provider(tmp_path)
+    calls = [
+        ToolCall(
+            "virtual_cli",
+            {"command": "cat", "argv": ["a.txt"]},
+            "call-a",
+        ),
+        ToolCall(
+            "virtual_cli",
+            {"command": "cat", "argv": ["b.txt"]},
+            "call-b",
+        ),
+    ]
+
+    def request(rows):
+        assert [(row.tool_name, row.call_id) for row in rows] == [
+            ("cat", "call-a"),
+            ("cat", "call-b"),
+        ]
+        return {"call-a": "approve_once", "call-b": "deny"}
+
+    hook = build_virtual_cli_review_hook(provider, request)
+    assert hook(calls, "run-1") == {"call-a": "proceed", "call-b": "proceed"}
+
+    with use_run_id("run-1"), use_tool_call_id("call-a"):
+        allowed = provider.invoke("virtual_cli", calls[0].args)
+    with use_run_id("run-1"), use_tool_call_id("call-b"):
+        blocked = provider.invoke("virtual_cli", calls[1].args)
+
+    assert allowed.ok and "allowed" in allowed.content
+    assert not blocked.ok and blocked.outcome == "blocked"
+
+
+def test_review_hook_clears_stale_stamps_before_a_raising_round(tmp_path):
+    (tmp_path / "a.txt").write_text("must not run", encoding="utf-8")
+    provider = _provider(tmp_path)
+    call = ToolCall(
+        "virtual_cli",
+        {"command": "cat", "argv": ["a.txt"]},
+        "call-a",
+    )
+    pending = provider.pending_gate_for(call)
+    assert pending is not None
+    provider.apply_batch_decisions(
+        "run-1", {"call-a": "approve_once"}, [pending]
+    )
+
+    def raise_during_review(_rows):
+        raise RuntimeError("approval bridge unavailable")
+
+    hook = build_virtual_cli_review_hook(provider, raise_during_review)
+    with pytest.raises(RuntimeError, match="approval bridge unavailable"):
+        hook([call], "run-1")
+
+    with use_run_id("run-1"), use_tool_call_id("call-a"):
+        result = provider.invoke("virtual_cli", call.args)
+    assert not result.ok and result.outcome == "blocked"
+
+
+def test_stamp_scope_hides_parent_verdicts_and_restores_them(tmp_path):
+    provider = _provider(tmp_path)
+    call = ToolCall(
+        "virtual_cli",
+        {"command": "cat", "argv": ["a.txt"]},
+        "call-a",
+    )
+    pending = provider.pending_gate_for(call)
+    assert pending is not None
+    provider.apply_batch_decisions(
+        "run-1", {"call-a": "approve_once"}, [pending]
+    )
+
+    with use_tool_call_id("call-a"):
+        with provider.stamp_scope("run-1"):
+            assert provider._pop_stamp("run-1", "cat") is None
+        assert provider._pop_stamp("run-1", "cat") == "approve_once"
+
+
+@pytest.mark.parametrize(
+    ("local_enabled", "kill_switch", "expected"),
+    ((True, False, True), (False, False, False), (True, True, False)),
+)
+def test_controller_composition_honors_local_master_and_kill_switch(
+    tmp_path, local_enabled, kill_switch, expected
+):
+    service = SimpleNamespace(
+        get_kill_switch=lambda: kill_switch,
+        gate_tool_test=lambda _hub: ALLOW,
+        approve_for_session=lambda *_args: None,
+        set_tool_state=lambda *_args, **_kwargs: None,
+        record_tool_decision=lambda *_args, **_kwargs: None,
+        is_session_approved=lambda *_args: False,
+    )
+    controller = object.__new__(ConsoleChatController)
+    controller.app = SimpleNamespace(unified_mcp_service=service)
+    turn_context = SimpleNamespace(
+        tool_configuration={"local_tools_enabled": local_enabled},
+        scratch_space=None,
+    )
+
+    provider, hook = controller._compose_virtual_cli_provider(
+        session_id="session-1",
+        turn_context=turn_context,
+        project_root=tmp_path,
+    )
+
+    assert (provider is not None) is expected
+    assert (hook is not None) is expected
+
+
+def test_run_registry_advertises_the_one_virtual_cli_model_tool(tmp_path):
+    provider = VirtualCliProvider(
+        workspace_root=tmp_path,
+        resolve_state=lambda _hub: EffectiveToolState(
+            state="allow", origin="tool_override"
+        ),
+    )
+
+    registry, allowed, _builtin_names, local_names = (
+        _compose_run_registry_and_allowed(
+            {},
+            virtual_cli_provider=provider,
+        )
+    )
+
+    assert "virtual_cli" in allowed
+    assert "virtual_cli" in local_names
+    assert registry.load_schema("virtual_cli:virtual_cli").name == "virtual_cli"

--- a/Tests/MCP/test_hub_tool_catalog.py
+++ b/Tests/MCP/test_hub_tool_catalog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
 from tldw_chatbook.MCP.hub_tool_catalog import (
     builtin_tools_from_inventory,
@@ -49,22 +51,28 @@ def test_local_record_without_snapshot_yields_nothing():
     )
 
 
-def test_reserved_external_profile_cannot_claim_workspace_tool_identity(tmp_path):
+@pytest.mark.parametrize(
+    ("reserved_id", "tool_name"),
+    (("__local__", "fs_write"), ("__virtual_cli__", "cat")),
+)
+def test_reserved_external_profile_cannot_claim_synthetic_tool_identity(
+    tmp_path, reserved_id, tool_name
+):
     workspace_tool = LocalToolProvider(workspace_root=tmp_path).hub_tool_for("fs_write")
     reserved_record = _local_record(
         tools=[
             {
-                "name": workspace_tool.name,
+                "name": tool_name,
                 "description": workspace_tool.description,
                 "inputSchema": workspace_tool.input_schema,
             }
         ]
     )
-    reserved_record["profile_id"] = "__local__"
+    reserved_record["profile_id"] = reserved_id
 
     assert workspace_tool.tool_id == "local:__local__::fs_write"
     assert local_tools_from_record(reserved_record) == []
-    reserved_record["profile_id"] = " __local__ "
+    reserved_record["profile_id"] = f" {reserved_id} "
     assert local_tools_from_record(reserved_record) == []
 
 

--- a/Tests/MCP/test_local_store.py
+++ b/Tests/MCP/test_local_store.py
@@ -156,7 +156,10 @@ def test_local_store_rejects_whitespace_embedding_profile_id(tmp_path):
     assert not (tmp_path / "local_mcp_store.json").exists()
 
 
-@pytest.mark.parametrize("profile_id", ("__local__", " __local__ "))
+@pytest.mark.parametrize(
+    "profile_id",
+    ("__local__", " __local__ ", "__virtual_cli__", " __virtual_cli__ "),
+)
 def test_local_store_rejects_reserved_workspace_profile_id_before_persistence(
     tmp_path,
     profile_id,
@@ -190,23 +193,24 @@ def test_local_store_reserved_workspace_profile_rule_is_case_sensitive(tmp_path)
     assert store.list_profiles() == [docs, case_distinct]
 
 
+@pytest.mark.parametrize("reserved_id", ("__local__", "__virtual_cli__"))
 def test_local_store_ignores_persisted_reserved_profile_and_associated_state(
-    tmp_path,
+    tmp_path, reserved_id
 ):
     path = tmp_path / "local_mcp_store.json"
     path.write_text(
         json.dumps(
             {
                 "profiles": [
-                    {"profile_id": "__local__", "command": "spoof-server"},
+                    {"profile_id": reserved_id, "command": "spoof-server"},
                     {"profile_id": "docs", "command": "docs-server"},
                 ],
                 "discovery_snapshots": {
-                    "__local__": {"tools": [{"name": "fs_write"}]},
+                    reserved_id: {"tools": [{"name": "fs_write"}]},
                     "docs": {"tools": [{"name": "search_docs"}]},
                 },
                 "profile_runtime_state": {
-                    "__local__": {"ok": True, "last_action": "start"},
+                    reserved_id: {"ok": True, "last_action": "start"},
                     "docs": {"ok": True, "last_action": "discover"},
                 },
             }

--- a/Tests/MCP/test_mcp_documentation_contract.py
+++ b/Tests/MCP/test_mcp_documentation_contract.py
@@ -266,6 +266,30 @@ def test_user_guide_explains_weak_match_similarity_provenance() -> None:
         assert contract in normalized
 
 
+def test_console_guide_documents_the_virtual_cli_security_boundary() -> None:
+    normalized = " ".join(
+        CONSOLE_AGENT_TOOLS_DOCUMENT.read_text(encoding="utf-8").split()
+    )
+    assert "one model tool named `virtual_cli`" in normalized
+    assert "does not accept a command-line string" in normalized
+    assert "discoverability is not authorization" in normalized
+    assert "Every command has its own Allow, Ask, or Off setting" in normalized
+    assert "allowing `fs_read` does not allow virtual `cat`" in normalized
+    for command in (
+        "ls",
+        "cat",
+        "grep",
+        "find",
+        "stat",
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    ):
+        assert f"`{command}`" in normalized
+
+
 def test_local_library_tools_documentation_uses_current_standalone_inventory() -> None:
     text = LOCAL_LIBRARY_TOOLS_DOCUMENT.read_text(encoding="utf-8")
     normalized = " ".join(text.split())

--- a/Tests/Tools/test_local_tool_impls.py
+++ b/Tests/Tools/test_local_tool_impls.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from tldw_chatbook.Tools import local_tool_impls
 from tldw_chatbook.Tools.local_tool_impls import (
     MAX_READ_CHARS,
     LocalToolError,
@@ -19,6 +20,45 @@ def test_resolve_workspace_path_confines(tmp_path):
     assert resolve_workspace_path("a/b", tmp_path) == (tmp_path / "a/b").resolve()
     with pytest.raises(LocalToolError, match="outside the workspace root"):
         resolve_workspace_path("../x", tmp_path)
+
+
+def test_stat_path_returns_only_allowlisted_workspace_metadata(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "note.txt"
+    target.write_text("hello", encoding="utf-8")
+
+    fields = dict(
+        line.split(": ", 1)
+        for line in local_tool_impls.stat_path(
+            "note.txt", workspace_root=ws
+        ).splitlines()
+    )
+
+    assert fields.keys() == {"path", "type", "size", "modified_ns", "mode"}
+    assert fields["path"] == "note.txt"
+    assert fields["type"] == "file"
+    assert fields["size"] == "5"
+    assert fields["modified_ns"].isdigit()
+    assert len(fields["mode"]) == 4
+
+
+def test_stat_path_uses_the_shared_confinement_and_sensitive_path_choke_point(
+    tmp_path, monkeypatch
+):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "safe.txt").write_text("safe", encoding="utf-8")
+
+    with pytest.raises(LocalToolError, match="outside the workspace root"):
+        local_tool_impls.stat_path("../outside.txt", workspace_root=ws)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.local_tool_impls.is_sensitive_path",
+        lambda path, **_kwargs: Path(path).name == "safe.txt",
+    )
+    with pytest.raises(LocalToolError, match="protected path"):
+        local_tool_impls.stat_path("safe.txt", workspace_root=ws)
 
 
 def test_list_directory_shows_dirs_first_then_files(tmp_path):

--- a/Tests/Tools/test_virtual_cli_impls.py
+++ b/Tests/Tools/test_virtual_cli_impls.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Tools import virtual_cli_impls
+from tldw_chatbook.Tools.local_tool_impls import LocalToolError
+
+
+def _registry(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return virtual_cli_impls.VirtualCliRegistry(workspace), workspace
+
+
+def test_virtual_cli_command_set_is_fixed_and_read_only():
+    assert virtual_cli_impls.VIRTUAL_CLI_COMMANDS == (
+        "ls",
+        "cat",
+        "grep",
+        "find",
+        "stat",
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    )
+
+
+@pytest.mark.parametrize(
+    ("command", "argv", "expected"),
+    (
+        ("ls", ["docs"], ("list_directory", "docs")),
+        ("cat", ["a.txt", "--offset", "2", "--limit", "4"], ("read_file", "a.txt", 2, 4)),
+        ("grep", ["needle", "--mode", "files"], ("grep_files", "needle", "files")),
+        ("find", ["**/*.py"], ("glob_files", "**/*.py")),
+        ("stat", ["a.txt"], ("stat_path", "a.txt")),
+        ("git_status", ["src"], ("git_status", "src")),
+        (
+            "git_diff",
+            ["--staged", "--range", "HEAD~1..HEAD", "--path", "a.py", "--stat"],
+            ("git_diff", True, "HEAD~1..HEAD", "a.py", True),
+        ),
+        ("git_log", ["--count", "7", "--path", "src"], ("git_log", 7, "src")),
+        ("git_blame", ["a.py", "--start", "2", "--end", "5"], ("git_blame", "a.py", 2, 5)),
+        ("git_branches", [], ("git_branches",)),
+    ),
+)
+def test_virtual_cli_dispatches_each_command_directly(
+    tmp_path, monkeypatch, command, argv, expected
+):
+    registry, _workspace = _registry(tmp_path)
+    seen = []
+
+    def fake(name):
+        def call(*args, **kwargs):
+            normalized = tuple(value for value in args if not isinstance(value, Path))
+            normalized += tuple(
+                kwargs[key]
+                for key in (
+                    "offset",
+                    "limit",
+                    "mode",
+                    "staged",
+                    "commit_range",
+                    "count",
+                    "path",
+                    "stat",
+                    "start_line",
+                    "end_line",
+                )
+                if key in kwargs
+            )
+            seen.append((name, *normalized))
+            return name
+
+        return call
+
+    for name in (
+        "list_directory",
+        "read_file",
+        "grep_files",
+        "glob_files",
+        "stat_path",
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    ):
+        monkeypatch.setattr(virtual_cli_impls, name, fake(name))
+
+    assert registry.execute(command, argv) == expected[0]
+    assert seen == [expected]
+
+
+@pytest.mark.parametrize(
+    ("command", "argv"),
+    (
+        ("rm", []),
+        ("cat", []),
+        ("cat", ["a", "b"]),
+        ("ls", [".", "extra"]),
+        ("grep", ["x", "--mo", "files"]),
+        ("grep", ["x", "--mode", "unknown"]),
+        ("find", []),
+        ("stat", ["a", "extra"]),
+        ("git_status", [".", "extra"]),
+        ("git_diff", ["--unknown"]),
+        ("git_log", ["--count", "zero"]),
+        ("git_blame", ["a.py", "--start", "0"]),
+        ("git_branches", ["extra"]),
+    ),
+)
+def test_virtual_cli_rejects_unknown_commands_and_argv_forms(tmp_path, command, argv):
+    registry, _workspace = _registry(tmp_path)
+    with pytest.raises(virtual_cli_impls.VirtualCliArgumentError):
+        registry.execute(command, argv)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        "a.txt",
+        [1],
+        ["x"] * 65,
+        ["x" * 4097],
+        ["x" * 4096] * 5,
+        ["bad\x00name"],
+    ),
+)
+def test_virtual_cli_rejects_non_array_and_oversized_argv(tmp_path, argv):
+    registry, _workspace = _registry(tmp_path)
+    with pytest.raises(virtual_cli_impls.VirtualCliArgumentError):
+        registry.execute("cat", argv)
+
+
+def test_shell_metacharacters_are_literal_path_text(tmp_path):
+    registry, workspace = _registry(tmp_path)
+    literal_name = "note; echo NOT_A_SHELL.txt"
+    (workspace / literal_name).write_text("literal", encoding="utf-8")
+
+    assert registry.execute("cat", [literal_name]) == "1\tliteral"
+
+
+def test_virtual_cli_reuses_workspace_confinement(tmp_path):
+    registry, _workspace = _registry(tmp_path)
+    with pytest.raises(LocalToolError, match="outside the workspace root"):
+        registry.execute("stat", ["../outside.txt"])

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -25,7 +25,7 @@ from textual import on
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
-from textual.app import App, ComposeResult
+from textual.app import ComposeResult
 from textual.widgets import Button, Select, Static
 
 import tldw_chatbook

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -1082,6 +1082,7 @@ def _pending(
     server_label: str = "Srv",
     reason: str = "ask",
     arguments: dict | None = None,
+    call_id: str = "",
 ) -> MCPPendingCall:
     return MCPPendingCall(
         llm_name=llm_name,
@@ -1090,6 +1091,7 @@ def _pending(
         server_label=server_label,
         arguments=arguments or {"a": 1},
         reason=reason,
+        call_id=call_id,
     )
 
 
@@ -1167,6 +1169,37 @@ def test_request_mcp_approvals_routes_one_decision_to_duplicate_names():
     decisions = controller.request_mcp_approvals(pending)
 
     assert decisions == {"mcp__srv__tool": "always_allow"}
+
+
+def test_request_mcp_approvals_preserves_native_call_ids_as_verdict_keys():
+    """Two same-tool native calls remain independently addressable."""
+    controller, _ = _build_controller()
+    received: list[dict | None] = []
+    controller.app = _FakeApp()
+    controller.set_pending_approval = received.append
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+    pending = [
+        _pending(call_id="call-a", arguments={"path": "a.txt"}),
+        _pending(call_id="call-b", arguments={"path": "b.txt"}),
+    ]
+
+    def _resolve_soon() -> None:
+        time.sleep(0.05)
+        payload = received[-1]
+        assert payload is not None
+        assert [call["call_id"] for call in payload["calls"]] == [
+            "call-a",
+            "call-b",
+        ]
+        controller.resolve_pending_approval(
+            {"call-a": "approve_once", "call-b": "deny"},
+            round_id=payload["round_id"],
+        )
+
+    threading.Thread(target=_resolve_soon).start()
+    decisions = controller.request_mcp_approvals(pending)
+
+    assert decisions == {"call-a": "approve_once", "call-b": "deny"}
 
 
 def test_request_mcp_approvals_timeout_denies_with_timeout_for_all_undecided():

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -8820,6 +8820,41 @@ async def test_tools_catalog_includes_local_agent_tools_as_own_group(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_tools_catalog_lists_virtual_cli_as_an_independent_group(monkeypatch):
+    _enable_local_tools(monkeypatch)
+    app = WorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        workbench = app.query_one(MCPWorkbench)
+        await workbench._mount_deferred_canvases()
+        await workbench._sync_children()
+
+        virtual = [
+            tool
+            for tool in workbench._last_hub_tools
+            if tool.server_key == "local:__virtual_cli__"
+        ]
+        assert {tool.name for tool in virtual} == {
+            "ls",
+            "cat",
+            "grep",
+            "find",
+            "stat",
+            "git_status",
+            "git_diff",
+            "git_log",
+            "git_blame",
+            "git_branches",
+        }
+        assert {tool.server_label for tool in virtual} == {
+            "Virtual CLI (read-only)"
+        }
+        assert all("independent" in tool.description.lower() for tool in virtual)
+        assert all(tool.executable is False for tool in virtual)
+
+
+@pytest.mark.asyncio
 async def test_local_agent_group_absent_when_master_flag_explicitly_off():
     app = WorkbenchApp()
     async with app.run_test() as pilot:

--- a/backlog/tasks/task-22509 - Read-only-virtual-CLI-with-independent-command-permissions.md
+++ b/backlog/tasks/task-22509 - Read-only-virtual-CLI-with-independent-command-permissions.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-22509
 title: Read-only virtual CLI with independent command permissions
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-27 04:52'
-updated_date: '2026-08-27 04:52'
+updated_date: '2026-08-28 14:13'
 labels:
   - console
   - tools
@@ -36,3 +36,9 @@ Give models a compact shell-like read-only interface over existing workspace and
 - [ ] #9 Focused tests cover schema and argv validation, unknown flags and commands, per-command permission isolation, reservation filtering, path confinement, sensitive paths, output sanitization, and mounted Tools behavior
 - [ ] #10 The Console tools guide documents the virtual command set, read-only boundary, independent permissions, and absence of shell syntax
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Docs/superpowers/plans/2026-08-26-read-only-virtual-cli.md using focused red-green cycles: 1. Add the fixed argv parser and direct read-only dispatch registry. 2. Reserve __virtual_cli__ at external-profile seams. 3. Add one model schema with per-command HubTool permissions and per-call identity. 4. Register the provider under existing local-tool/global gates. 5. Expose independent command rows in the canonical Tools UI. 6. Document and verify the boundary. ADR required: yes. ADR path: backlog/decisions/094-raw-and-virtual-cli-execution-boundaries.md. Reason: ADR-094 defines the synthetic principal, no-shell boundary, default Ask state, and independent command authority.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-22509 - Read-only-virtual-CLI-with-independent-command-permissions.md
+++ b/backlog/tasks/task-22509 - Read-only-virtual-CLI-with-independent-command-permissions.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-22509
 title: Read-only virtual CLI with independent command permissions
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-27 04:52'
-updated_date: '2026-08-28 14:13'
+updated_date: '2026-08-28 14:48'
 labels:
   - console
   - tools
@@ -25,16 +25,16 @@ Give models a compact shell-like read-only interface over existing workspace and
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One structured virtual_cli model tool accepts a fixed command enum and argv array and never parses or falls back to a shell string
-- [ ] #2 V1 exposes only read-only ls, cat, grep, find, stat, git_status, git_diff, git_log, git_blame, and git_branches commands
-- [ ] #3 Each virtual command resolves under local:__virtual_cli__ with its own stable definition hash and Allow, Ask, or Off state; missing state resolves to Ask and one command decision cannot authorize another
-- [ ] #4 The reserved __virtual_cli__ external profile identity and projected records are rejected or filtered at save, load, and catalog projection seams
-- [ ] #5 Approved commands dispatch to existing filesystem and read-only Git cores so workspace authority, sensitive-path denial, Git exclusions, and existing scan and result caps remain authoritative
-- [ ] #6 The virtual tool is model-only, available by default when local tools are enabled, blocked by the global tool kill switch, and never treats catalog discoverability as execution authorization
-- [ ] #7 Approval rows and stored decisions identify the selected virtual command, including batches with multiple virtual_cli calls, without permission-key collisions
-- [ ] #8 The canonical Tools destination displays virtual commands as a distinct group and explains that their permissions are independent from equivalent fs and Git tools
-- [ ] #9 Focused tests cover schema and argv validation, unknown flags and commands, per-command permission isolation, reservation filtering, path confinement, sensitive paths, output sanitization, and mounted Tools behavior
-- [ ] #10 The Console tools guide documents the virtual command set, read-only boundary, independent permissions, and absence of shell syntax
+- [x] #1 One structured virtual_cli model tool accepts a fixed command enum and argv array and never parses or falls back to a shell string
+- [x] #2 V1 exposes only read-only ls, cat, grep, find, stat, git_status, git_diff, git_log, git_blame, and git_branches commands
+- [x] #3 Each virtual command resolves under local:__virtual_cli__ with its own stable definition hash and Allow, Ask, or Off state; missing state resolves to Ask and one command decision cannot authorize another
+- [x] #4 The reserved __virtual_cli__ external profile identity and projected records are rejected or filtered at save, load, and catalog projection seams
+- [x] #5 Approved commands dispatch to existing filesystem and read-only Git cores so workspace authority, sensitive-path denial, Git exclusions, and existing scan and result caps remain authoritative
+- [x] #6 The virtual tool is model-only, available by default when local tools are enabled, blocked by the global tool kill switch, and never treats catalog discoverability as execution authorization
+- [x] #7 Approval rows and stored decisions identify the selected virtual command, including batches with multiple virtual_cli calls, without permission-key collisions
+- [x] #8 The canonical Tools destination displays virtual commands as a distinct group and explains that their permissions are independent from equivalent fs and Git tools
+- [x] #9 Focused tests cover schema and argv validation, unknown flags and commands, per-command permission isolation, reservation filtering, path confinement, sensitive paths, output sanitization, and mounted Tools behavior
+- [x] #10 The Console tools guide documents the virtual command set, read-only boundary, independent permissions, and absence of shell syntax
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,3 +42,13 @@ Give models a compact shell-like read-only interface over existing workspace and
 <!-- SECTION:PLAN:BEGIN -->
 Follow Docs/superpowers/plans/2026-08-26-read-only-virtual-cli.md using focused red-green cycles: 1. Add the fixed argv parser and direct read-only dispatch registry. 2. Reserve __virtual_cli__ at external-profile seams. 3. Add one model schema with per-command HubTool permissions and per-call identity. 4. Register the provider under existing local-tool/global gates. 5. Expose independent command rows in the canonical Tools UI. 6. Document and verify the boundary. ADR required: yes. ADR path: backlog/decisions/094-raw-and-virtual-cli-execution-boundaries.md. Reason: ADR-094 defines the synthetic principal, no-shell boundary, default Ask state, and independent command authority.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented one structured, model-only `virtual_cli` tool backed by a strict fixed-command argv parser and direct reuse of the existing confined filesystem and read-only Git cores. Added the independently reserved `local:__virtual_cli__` permission principal, ten stable command-level Hub rows, fresh per-command Allow/Ask/Off resolution, call-scoped approval stamps, global/root gate rechecks, and bounded sanitized output.
+
+Wired the provider into both disposable preview and live Console registries without changing the established provider-composer return contract. Native call IDs now survive the approval-card round trip, so multiple `virtual_cli` calls in one batch can receive different decisions. MCP ▸ Tools shows a non-executable **Virtual CLI (read-only)** group whose copy explicitly distinguishes these permissions from equivalent filesystem and Git tools; the Console and MCP user guides document the no-shell boundary.
+
+Verification on the rebased `dev` tree: 572 focused tests passed across command parsing/dispatch, provider gates, permission reservation, approval routing, Console preview/live composition, mounted Tools UI, and documentation contracts. Ruff passed for all changed production and new test code; the touched legacy local-tool test file passed with its pre-existing E401/E702 exclusions. `git diff --check` passed. The full suite was not run, following the repository's targeted-test policy. ADR: [ADR-094](../decisions/094-raw-and-virtual-cli-execution-boundaries.md); no new ADR was required.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -120,7 +120,7 @@ from .native_tools import (
     provider_supports_native_tools,
     schemas_to_openai_tools,
 )
-from .run_context import CurrentRunActor, use_run_actor
+from .run_context import CurrentRunActor, use_run_actor, use_tool_call_id
 from .run_log import _setting
 from .run_log_eviction import (
     DEFAULT_MIN_RECENT_ROUNDS,
@@ -2279,7 +2279,7 @@ class AgentService:
             )
 
             def _invoke() -> ToolResult:
-                with use_run_actor(actor):
+                with use_run_actor(actor), use_tool_call_id(call.call_id):
                     return self.registry.invoke_by_name(call.name, call.args)
 
             if timeout and timeout > 0:

--- a/tldw_chatbook/Agents/run_context.py
+++ b/tldw_chatbook/Agents/run_context.py
@@ -84,6 +84,9 @@ class CurrentRunActor:
 _CURRENT_RUN_ACTOR: ContextVar[CurrentRunActor | None] = ContextVar(
     "tldw_agent_run_actor", default=None
 )
+_CURRENT_TOOL_CALL_ID: ContextVar[str] = ContextVar(
+    "tldw_agent_tool_call_id", default=""
+)
 
 
 def current_run_actor() -> CurrentRunActor | None:
@@ -104,6 +107,11 @@ def current_run_id() -> str:
     """
     actor = current_run_actor()
     return actor.run_id if actor is not None else ""
+
+
+def current_tool_call_id() -> str:
+    """Return the native id of the tool call currently being dispatched."""
+    return _CURRENT_TOOL_CALL_ID.get()
 
 
 @contextmanager
@@ -146,3 +154,13 @@ def use_run_id(run_id: str) -> Iterator[None]:
         yield
     finally:
         _CURRENT_RUN_ACTOR.reset(token)
+
+
+@contextmanager
+def use_tool_call_id(call_id: str) -> Iterator[None]:
+    """Bind one tool-call id without changing its run attribution."""
+    token = _CURRENT_TOOL_CALL_ID.set(str(call_id or ""))
+    try:
+        yield
+    finally:
+        _CURRENT_TOOL_CALL_ID.reset(token)

--- a/tldw_chatbook/Agents/virtual_cli_provider.py
+++ b/tldw_chatbook/Agents/virtual_cli_provider.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import re
 import threading
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Callable, ContextManager, Mapping, Sequence
+from typing import Callable, ContextManager, Iterator, Mapping, Sequence
 
 from loguru import logger
 
@@ -159,7 +159,10 @@ class VirtualCliProvider:
             server_label=VIRTUAL_CLI_SERVER_LABEL,
             source="local",
             name=command,
-            description=f"Read-only virtual command: {usage}. No host shell is invoked.",
+            description=(
+                f"Read-only virtual command: {usage}. No host shell is invoked. "
+                "Permission is independent from equivalent filesystem and Git tools."
+            ),
             input_schema={
                 "type": "object",
                 "properties": {
@@ -242,6 +245,27 @@ class VirtualCliProvider:
         key = current_tool_call_id() or command
         with self._stamps_lock:
             return self._stamps.pop((run_id, key), None)
+
+    @contextmanager
+    def stamp_scope(self, run_id: str) -> Iterator[None]:
+        """Hide and restore this run's pending verdicts around a child run."""
+        with self._stamps_lock:
+            saved = {
+                key: value for key, value in self._stamps.items() if key[0] == run_id
+            }
+            self._stamps = {
+                key: value for key, value in self._stamps.items() if key[0] != run_id
+            }
+        try:
+            yield
+        finally:
+            with self._stamps_lock:
+                self._stamps = {
+                    key: value
+                    for key, value in self._stamps.items()
+                    if key[0] != run_id
+                }
+                self._stamps.update(saved)
 
     def invoke(self, tool_id: str, args: dict) -> ToolResult:
         name = tool_id.split(":", 1)[-1]

--- a/tldw_chatbook/Agents/virtual_cli_provider.py
+++ b/tldw_chatbook/Agents/virtual_cli_provider.py
@@ -1,0 +1,368 @@
+"""One model tool backed by independently gated read-only virtual commands."""
+
+from __future__ import annotations
+
+import re
+import threading
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Callable, ContextManager, Mapping, Sequence
+
+from loguru import logger
+
+from tldw_chatbook.MCP.hub_tool_catalog import HubTool
+from tldw_chatbook.MCP.permission_store import EffectiveToolState
+from tldw_chatbook.Tools.virtual_cli_impls import (
+    MAX_ARGV_ITEMS,
+    VIRTUAL_CLI_COMMANDS,
+    VirtualCliArgumentError,
+    VirtualCliRegistry,
+    parse_request,
+)
+
+from .agent_models import ToolCall, ToolCatalogEntry, ToolResult, ToolSchema
+from .local_tool_provider import (
+    LOCAL_DENY_REFUSAL,
+    LOCAL_GATE_ERROR_REFUSAL,
+    LOCAL_KILL_SWITCH_REFUSAL,
+    LOCAL_TIMEOUT_REFUSAL,
+)
+from .mcp_tool_provider import MCPPendingCall
+from .run_context import current_run_id, current_tool_call_id
+from .tool_catalog import redact_root_locator
+
+VIRTUAL_CLI_TOOL_NAME = "virtual_cli"
+VIRTUAL_CLI_SERVER_KEY = "local:__virtual_cli__"
+VIRTUAL_CLI_SERVER_LABEL = "Virtual CLI (read-only)"
+SOURCE = "virtual_cli"
+
+_MAX_RESULT_BYTES = 32 * 1024
+_MAX_ERROR_CHARS = 300
+_ANSI_ESCAPE = re.compile(
+    r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))"
+)
+
+_USAGE = {
+    "ls": "ls [PATH]",
+    "cat": "cat PATH [--offset N] [--limit N]",
+    "grep": "grep PATTERN [--mode content|files|count]",
+    "find": "find GLOB",
+    "stat": "stat PATH",
+    "git_status": "git_status [PATH]",
+    "git_diff": "git_diff [--staged] [--range REF] [--path PATH] [--stat]",
+    "git_log": "git_log [--count N] [--path PATH]",
+    "git_blame": "git_blame PATH [--start N] [--end N]",
+    "git_branches": "git_branches",
+}
+
+_MODEL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "enum": list(VIRTUAL_CLI_COMMANDS),
+            "description": "One fixed read-only virtual command.",
+        },
+        "argv": {
+            "type": "array",
+            "items": {"type": "string", "maxLength": 4096},
+            "maxItems": MAX_ARGV_ITEMS,
+            "description": "Arguments for the selected command; no shell syntax.",
+        },
+    },
+    "required": ["command", "argv"],
+    "additionalProperties": False,
+}
+
+
+def _sanitize_result(text: str) -> str:
+    text = _ANSI_ESCAPE.sub("", text)
+    text = "".join(
+        char
+        for char in text
+        if char in "\n\t" or (ord(char) >= 32 and not 127 <= ord(char) <= 159)
+    )
+    raw = text.encode("utf-8")
+    if len(raw) <= _MAX_RESULT_BYTES:
+        return text
+    return raw[:_MAX_RESULT_BYTES].decode("utf-8", errors="ignore") + "\n… [truncated]"
+
+
+class VirtualCliProvider:
+    """Expose one schema while resolving authority per selected command."""
+
+    def __init__(
+        self,
+        *,
+        workspace_root: Path,
+        resolve_state: Callable[[HubTool], EffectiveToolState] | None = None,
+        local_tools_enabled: Callable[[], bool] = lambda: True,
+        kill_switch: Callable[[], bool] = lambda: False,
+        approval_callback: Callable[[list[MCPPendingCall]], dict[str, str]] | None = None,
+        is_session_approved: Callable[[HubTool], bool] | None = None,
+        persist_approval: Callable[[HubTool, str], None] | None = None,
+        record_decision: Callable[[HubTool, str], None] | None = None,
+        root_guard: Callable[[], bool] | None = None,
+        authority_scope: Callable[[], ContextManager[Path]] | None = None,
+        result_redaction_root: Path | None = None,
+    ) -> None:
+        self._registry = VirtualCliRegistry(workspace_root)
+        self._resolve_state = resolve_state or (
+            lambda _hub: EffectiveToolState(state="ask", origin="global_default")
+        )
+        self._local_tools_enabled = local_tools_enabled
+        self._kill_switch = kill_switch
+        self._approval_callback = approval_callback
+        self._is_session_approved = is_session_approved
+        self._persist_approval = persist_approval
+        self._record_decision = record_decision
+        self._root_guard = root_guard
+        self._authority_scope = authority_scope
+        self._result_redaction_root = (
+            Path(result_redaction_root).resolve()
+            if result_redaction_root is not None
+            else None
+        )
+        self._stamps: dict[tuple[str, str], str] = {}
+        self._stamps_lock = threading.Lock()
+
+    def list_catalog(self) -> list[ToolCatalogEntry]:
+        return [
+            ToolCatalogEntry(
+                id=f"{SOURCE}:{VIRTUAL_CLI_TOOL_NAME}",
+                name=VIRTUAL_CLI_TOOL_NAME,
+                one_line_description="Run a fixed read-only virtual command without a host shell.",
+                source=SOURCE,
+            )
+        ]
+
+    def load_schema(self, tool_id: str) -> ToolSchema:
+        name = tool_id.split(":", 1)[-1]
+        if name != VIRTUAL_CLI_TOOL_NAME:
+            raise KeyError(f"Unknown virtual CLI tool: {tool_id}")
+        return ToolSchema(
+            id=tool_id,
+            name=VIRTUAL_CLI_TOOL_NAME,
+            description=(
+                "Run one allowlisted read-only workspace or Git command. "
+                "argv is structured and is never parsed by a host shell."
+            ),
+            parameters=_MODEL_SCHEMA,
+        )
+
+    def hub_tool_for(self, command: str) -> HubTool:
+        if command not in VIRTUAL_CLI_COMMANDS:
+            raise KeyError(command)
+        usage = _USAGE[command]
+        return HubTool(
+            server_key=VIRTUAL_CLI_SERVER_KEY,
+            server_label=VIRTUAL_CLI_SERVER_LABEL,
+            source="local",
+            name=command,
+            description=f"Read-only virtual command: {usage}. No host shell is invoked.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "argv": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": usage,
+                    }
+                },
+                "required": ["argv"],
+                "additionalProperties": False,
+            },
+            tags=(),
+            stale=False,
+            executable=True,
+        )
+
+    def hub_tools(self) -> list[HubTool]:
+        return [self.hub_tool_for(command) for command in VIRTUAL_CLI_COMMANDS]
+
+    @staticmethod
+    def _validated_args(args: Mapping[str, object]) -> tuple[str, Sequence[str]]:
+        if not isinstance(args, Mapping) or set(args) != {"command", "argv"}:
+            raise VirtualCliArgumentError(
+                "virtual_cli requires exactly command and argv"
+            )
+        command = args.get("command")
+        argv = args.get("argv")
+        if not isinstance(command, str):
+            raise VirtualCliArgumentError("command must be a string")
+        if not isinstance(argv, Sequence) or isinstance(argv, (str, bytes)):
+            raise VirtualCliArgumentError("argv must be an array of strings")
+        request, _parsed = parse_request(command, argv)
+        return request.command, request.argv
+
+    def pending_gate_for(self, call: ToolCall) -> MCPPendingCall | None:
+        if call.name != VIRTUAL_CLI_TOOL_NAME or not self._root_is_valid():
+            return None
+        try:
+            command, _argv = self._validated_args(call.args)
+            state = self._resolve_state(self.hub_tool_for(command))
+        except Exception:
+            return None
+        hub = self.hub_tool_for(command)
+        if state.state != "ask" or self._session_approved(hub):
+            return None
+        return MCPPendingCall(
+            llm_name=VIRTUAL_CLI_TOOL_NAME,
+            server_key=VIRTUAL_CLI_SERVER_KEY,
+            tool_name=command,
+            server_label=VIRTUAL_CLI_SERVER_LABEL,
+            arguments=dict(call.args),
+            reason=(
+                "config_changed"
+                if state.config_changed
+                else "risk_floored"
+                if state.risk_floored
+                else "ask"
+            ),
+            call_id=call.call_id or command,
+        )
+
+    def apply_batch_decisions(
+        self,
+        run_id: str,
+        decisions: dict[str, str],
+        pending: Sequence[MCPPendingCall] = (),
+    ) -> None:
+        with self._stamps_lock:
+            self._stamps = {
+                key: value for key, value in self._stamps.items() if key[0] != run_id
+            }
+            for row in pending:
+                key = row.call_id or row.tool_name
+                decision = decisions.get(key)
+                if decision is not None:
+                    self._stamps[(run_id, key)] = decision
+
+    def _pop_stamp(self, run_id: str, command: str) -> str | None:
+        key = current_tool_call_id() or command
+        with self._stamps_lock:
+            return self._stamps.pop((run_id, key), None)
+
+    def invoke(self, tool_id: str, args: dict) -> ToolResult:
+        name = tool_id.split(":", 1)[-1]
+        if name != VIRTUAL_CLI_TOOL_NAME:
+            return ToolResult(ok=False, error=f"Unknown virtual CLI tool: {name}")
+        try:
+            command, argv = self._validated_args(args)
+        except VirtualCliArgumentError as exc:
+            return ToolResult(ok=False, error=f"invalid virtual_cli request: {exc}")
+        hub = self.hub_tool_for(command)
+        if not self._root_is_valid() or not self._local_tools_are_enabled():
+            self._record(hub, "denied")
+            return ToolResult.blocked(LOCAL_KILL_SWITCH_REFUSAL)
+        if self._kill_switch_engaged():
+            self._record(hub, "denied")
+            return ToolResult.blocked(LOCAL_KILL_SWITCH_REFUSAL)
+        try:
+            state = self._resolve_state(hub)
+        except Exception:
+            self._record(hub, "denied")
+            return ToolResult.blocked(LOCAL_GATE_ERROR_REFUSAL)
+        if state.state == "deny":
+            self._record(hub, "denied")
+            return ToolResult.blocked(LOCAL_DENY_REFUSAL)
+        if state.state == "allow":
+            verdict = "allow"
+        else:
+            verdict = self._ask_verdict(hub, command, args)
+        if verdict != "allow":
+            self._record(hub, "denied-timeout" if verdict == "timeout" else "denied")
+            refusal = LOCAL_TIMEOUT_REFUSAL if verdict == "timeout" else LOCAL_DENY_REFUSAL
+            return ToolResult.blocked(refusal)
+
+        def execute() -> ToolResult:
+            if (
+                not self._root_is_valid()
+                or not self._local_tools_are_enabled()
+                or self._kill_switch_engaged()
+            ):
+                return ToolResult.blocked(LOCAL_KILL_SWITCH_REFUSAL)
+            try:
+                content = self._registry.execute(command, argv)
+                content = redact_root_locator(content, self._result_redaction_root)
+                return ToolResult(ok=True, content=_sanitize_result(content))
+            except Exception as exc:  # noqa: BLE001 - provider boundary
+                error = redact_root_locator(
+                    str(exc) or repr(exc), self._result_redaction_root
+                )
+                return ToolResult(ok=False, error=error[:_MAX_ERROR_CHARS])
+
+        scope = self._authority_scope() if self._authority_scope else nullcontext()
+        try:
+            with scope:
+                return execute()
+        except Exception:
+            return ToolResult.blocked("Private scratch space is unavailable; the tool was not run.")
+
+    def _ask_verdict(self, hub: HubTool, command: str, args: dict) -> str:
+        stamp = self._pop_stamp(current_run_id(), command)
+        if stamp in {"approve_once", "approve_session", "always_allow"}:
+            if stamp != "approve_once":
+                self._persist(hub, stamp)
+            return "allow"
+        if stamp in {"deny", "timeout"}:
+            return stamp
+        if self._session_approved(hub):
+            return "allow"
+        if self._approval_callback is None:
+            return "timeout"
+        pending = self.pending_gate_for(ToolCall(VIRTUAL_CLI_TOOL_NAME, args))
+        if pending is None:
+            return "timeout"
+        try:
+            decisions = self._approval_callback([pending]) or {}
+        except Exception:
+            return "timeout"
+        decision = decisions.get(pending.call_id or pending.llm_name, "timeout")
+        if decision in {"approve_session", "always_allow"}:
+            self._persist(hub, decision)
+        return "allow" if decision in {"approve_once", "approve_session", "always_allow"} else decision
+
+    def _root_is_valid(self) -> bool:
+        if self._root_guard is None:
+            return True
+        try:
+            return bool(self._root_guard())
+        except Exception:
+            return False
+
+    def _local_tools_are_enabled(self) -> bool:
+        try:
+            return bool(self._local_tools_enabled())
+        except Exception:
+            return False
+
+    def _kill_switch_engaged(self) -> bool:
+        try:
+            return bool(self._kill_switch())
+        except Exception:
+            return True
+
+    def _session_approved(self, hub: HubTool) -> bool:
+        if self._is_session_approved is None:
+            return False
+        try:
+            return bool(self._is_session_approved(hub))
+        except Exception:
+            return False
+
+    def _persist(self, hub: HubTool, decision: str) -> None:
+        if self._persist_approval is None:
+            return
+        try:
+            self._persist_approval(hub, decision)
+        except Exception as exc:
+            logger.warning(f"Virtual CLI approval persistence failed: {exc}")
+
+    def _record(self, hub: HubTool, decision: str) -> None:
+        if self._record_decision is None:
+            return
+        try:
+            self._record_decision(hub, decision)
+        except Exception as exc:
+            logger.warning(f"Virtual CLI decision audit failed: {exc}")

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -3014,6 +3014,7 @@ def _compose_run_registry_and_allowed(
     scratch_root: Path | None = None,
     scratch_lease: Callable[[], ContextManager[Path]] | None = None,
     local_provider: Any | None = None,
+    virtual_cli_provider: Any | None = None,
     library_provider: Any | None = None,
     library_authority: Any | None = None,
 ) -> tuple[ToolCatalogRegistry, tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
@@ -3022,16 +3023,15 @@ def _compose_run_registry_and_allowed(
     Called once per ``run_reply`` invocation (never cached across runs --
     the per-run freshness doctrine: a skill approved/edited/revoked since
     the last run must take effect on the very next one). Registers
-    ``BuiltinToolProvider`` first, then the already-composed local
-    provider, then (only when there is at least one non-colliding eligible
+    ``BuiltinToolProvider`` first, then the already-composed local and virtual
+    CLI providers, then (only when there is at least one non-colliding eligible
     entry) a ``SkillToolProvider`` snapshot, then (P5-T6, only when there
     is at least one non-colliding eligible entry) an already-composed MCP
-    provider -- shadowing order: builtins beat local beat skills beat MCP,
-    matching the allow-list's own ``builtins ∪ local ∪ skills ∪ mcp``
-    ordering. Local registers BEFORE skills/MCP (first-registrant-wins),
-    AND local names join the skill/MCP collision sets -- so a malicious
-    MCP server or skill can never shadow the fs_* names at ANY layer (the
-    registry's own resolution, or ``AgentService.invoke_tool``'s
+    provider -- shadowing order: builtins beat local/virtual CLI, which beat
+    skills, which beat MCP. Local model-tool names join the skill/MCP collision
+    sets, so a malicious MCP server or skill can never shadow the fs_* or
+    virtual_cli names at ANY layer (the registry's own resolution, or
+    ``AgentService.invoke_tool``'s
     skill-runner-first dispatch, which registration order alone cannot
     protect). For a temporary session (``ephemeral=True``) neither the
     skill nor the MCP provider is registered at all.
@@ -3082,6 +3082,8 @@ def _compose_run_registry_and_allowed(
         local_provider: This run's already-composed local tool provider
             (``LocalToolProvider``), or ``None`` when local tools are
             disabled this run.
+        virtual_cli_provider: This run's independently gated read-only virtual
+            CLI provider, or ``None`` when local tools are disabled this run.
         library_provider: task-1337 -- this run's already-composed Library
             retrieval provider: the descriptor-backed ``LibraryToolProvider``
             when direct Library tools are enabled, or the bounded
@@ -3099,10 +3101,10 @@ def _compose_run_registry_and_allowed(
 
     Returns:
         ``(registry, allowed_tools, builtin_names, local_names)`` -- the
-        per-run registry, its full allow-list (builtins + local + eligible
+        per-run registry, its full allow-list (builtins + local/virtual CLI + eligible
         skills + eligible MCP tools + spawn), just the builtin names, and
-        just the local names. ``_BridgeSkillRunner`` intersects a skill's
-        own declared ``allowed_tools`` against builtins + local (never
+        just the local model-tool names. ``_BridgeSkillRunner`` intersects a
+        skill's own declared ``allowed_tools`` against builtins + local
         against skill names, so a skill's sub-agent can never call another
         skill, and never against runtime/MCP names -- a skill narrows, it
         never grants), and ``run_reply`` uses the local names to keep its
@@ -3126,6 +3128,9 @@ def _compose_run_registry_and_allowed(
     if local_provider is not None:
         registry.register_provider(local_provider)
         local_names = tuple(e.name for e in local_provider.list_catalog())
+    if virtual_cli_provider is not None:
+        registry.register_provider(virtual_cli_provider)
+        local_names += tuple(e.name for e in virtual_cli_provider.list_catalog())
     # task-1337: Library retrieval (direct tools OR the bounded RAG fallback)
     # registers after builtins/local and before skills/MCP; its names join
     # every collision filter below so a skill or MCP tool can never shadow
@@ -3215,6 +3220,7 @@ def build_console_first_request_plan(
     mcp_provider: Any | None,
     builtin_gate: Any | None,
     local_provider: Any | None,
+    virtual_cli_provider: Any | None = None,
     library_provider: Any | None,
     library_authority: Any | None,
     workspace_id: str | None,
@@ -3238,6 +3244,7 @@ def build_console_first_request_plan(
         or mcp_provider is not None
         or builtin_gate is not None
         or local_provider is not None
+        or virtual_cli_provider is not None
         or library_provider is not None
         or scratch_root is not None
         or scratch_lease is not None
@@ -3254,6 +3261,7 @@ def build_console_first_request_plan(
                 scratch_root=scratch_root,
                 scratch_lease=scratch_lease,
                 local_provider=local_provider,
+                virtual_cli_provider=virtual_cli_provider,
                 library_provider=library_provider,
                 library_authority=library_authority,
             )
@@ -3694,6 +3702,7 @@ class ConsoleAgentBridge:
         mcp_provider: Any | None = None,
         builtin_gate: Any | None = None,
         local_provider: Any | None = None,
+        virtual_cli_provider: Any | None = None,
         scratch_root: Path | None = None,
         scratch_lease: Callable[[], ContextManager[Path]] | None = None,
         turn_skill_bindings: tuple[str, ...] = (),
@@ -3736,6 +3745,7 @@ class ConsoleAgentBridge:
             mcp_provider=mcp_provider,
             builtin_gate=builtin_gate,
             local_provider=local_provider,
+            virtual_cli_provider=virtual_cli_provider,
             library_provider=None,
             library_authority=None,
             workspace_id=workspace_id,
@@ -3819,6 +3829,7 @@ class ConsoleAgentBridge:
         request_skill_install_confirm: Callable[[str], bool] | None = None,
         request_skill_script_confirm: Callable[[dict], dict] | None = None,
         local_provider: Any | None = None,
+        virtual_cli_provider: Any | None = None,
         library_provider: Any | None = None,
         library_authority: Any | None = None,
         # PR2a Task 7: called with the run id of every sub-agent this turn
@@ -3972,6 +3983,7 @@ class ConsoleAgentBridge:
             mcp_provider=mcp_provider,
             builtin_gate=builtin_gate,
             local_provider=local_provider,
+            virtual_cli_provider=virtual_cli_provider,
             library_provider=library_provider,
             library_authority=library_authority,
             workspace_id=run_workspace_id,
@@ -4633,6 +4645,9 @@ class ConsoleAgentBridge:
                 else None,
                 getattr(local_provider, "stamp_scope", None)
                 if local_provider is not None
+                else None,
+                getattr(virtual_cli_provider, "stamp_scope", None)
+                if virtual_cli_provider is not None
                 else None,
             )
             if scope is not None

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -273,6 +273,7 @@ from tldw_chatbook.Agents.session_todo_store import (
     TodoChangeCallback,
 )
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+from tldw_chatbook.Agents.virtual_cli_provider import VirtualCliProvider
 from tldw_chatbook.config import (
     ConfigMutationResult,
     DEFAULT_CONSOLE_PROJECT_INSTRUCTIONS_MAX_BYTES,
@@ -1581,6 +1582,33 @@ def build_local_review_hook(
     return review_tool_calls
 
 
+def build_virtual_cli_review_hook(
+    provider: "VirtualCliProvider",
+    request_approvals: Callable[[list["MCPPendingCall"]], dict[str, str]],
+) -> Callable[[list["ToolCall"], str], dict[str, str]]:
+    """Gate each selected virtual command while exposing one model tool.
+
+    Approval rows are command-specific Hub entries but verdict stamps are
+    keyed by native call id, so multiple ``virtual_cli`` calls in one model
+    response remain independently addressable.
+    """
+
+    def review_tool_calls(calls: list["ToolCall"], run_id: str) -> dict[str, str]:
+        provider.apply_batch_decisions(run_id, {})
+        pending = [
+            row
+            for call in calls
+            if (row := provider.pending_gate_for(call)) is not None
+        ]
+        if not pending:
+            return {}
+        decisions = request_approvals(pending)
+        provider.apply_batch_decisions(run_id, decisions, pending)
+        return {(row.call_id or row.llm_name): "proceed" for row in pending}
+
+    return review_tool_calls
+
+
 def build_combined_review_hook(
     hooks: list[Callable[[list["ToolCall"]], dict[str, str]]],
 ) -> Callable[[list["ToolCall"]], dict[str, str]]:
@@ -1589,7 +1617,8 @@ def build_combined_review_hook(
     Each hook gates only the calls its provider owns (pending_gate_for
     returns None for foreign tools), so merging is collision-free --
     except when two providers own the SAME name (not possible today:
-    local names carry fs_/web_/todo_ prefixes, MCP names mcp__*), where
+    local names carry fs_/web_/todo_ prefixes, virtual CLI owns only
+    virtual_cli, and MCP names carry mcp__*), where
     the later hook's "proceed" would simply win; both stamps are still
     applied by each provider's own hook regardless.
 
@@ -8571,7 +8600,8 @@ class ConsoleChatController:
         round simply waits for one of the first two, however long the
         human takes -- the wait is marked in ``Agents.human_input_wait``
         so a per-call wrapper hosting it pauses its ceiling. Whichever
-        unique ``llm_name`` never received an explicit decision by then
+        addressable verdict key (native ``call_id`` when present, otherwise
+        ``llm_name``) never received an explicit decision by then
         fails closed to ``"deny"``
         (cancellation) or ``"timeout"`` (deadline) -- see
         ``MCPToolProvider._apply_verdict`` for how each decision string is
@@ -8582,9 +8612,9 @@ class ConsoleChatController:
         showing never clobbers it.
 
         Args:
-            pending: One turn's pending tool calls awaiting approval,
-                possibly containing repeated ``llm_name``s (T3: calls
-                sharing a name share one verdict).
+            pending: One turn's pending tool calls awaiting approval. Native
+                calls use their call id as the verdict key; id-less fence
+                calls sharing a name share one name-keyed verdict.
             session_id: The run's OWNING session (Task 3 threads it through
                 ``_run_agent_reply``). ``None`` preserves every pre-Task-9
                 call site's behavior (always mounts against whatever
@@ -8592,18 +8622,19 @@ class ConsoleChatController:
 
         Returns:
             A decision string (``approve_once``/``approve_session``/
-            ``always_allow``/``deny``/``timeout``) for every unique
-            ``llm_name`` in ``pending``.
+            ``always_allow``/``deny``/``timeout``) for every addressable
+            call-id-or-name verdict key in ``pending``.
         """
-        unique_names: list[str] = []
+        unique_keys: list[str] = []
         seen: set[str] = set()
-        call_by_name: dict[str, "MCPPendingCall"] = {}
+        call_by_key: dict[str, "MCPPendingCall"] = {}
         for call in pending:
-            if call.llm_name not in seen:
-                seen.add(call.llm_name)
-                unique_names.append(call.llm_name)
-                call_by_name[call.llm_name] = call
-        if not unique_names:
+            key = str(call.call_id or "") or call.llm_name
+            if key not in seen:
+                seen.add(key)
+                unique_keys.append(key)
+                call_by_key[key] = call
+        if not unique_keys:
             return {}
         if self.app is None:
             # ADR-067: with no app bridge nothing can ever surface or
@@ -8613,7 +8644,7 @@ class ConsoleChatController:
             # app with a missing card seam is NOT this case: the round
             # stays resolvable via `resolve_pending_approval`/cancel, and
             # `_marshal_pending_approval` already no-ops its missing seam.)
-            return {name: "deny" for name in unique_names}
+            return {key: "deny" for key in unique_keys}
 
         event = threading.Event()
         decisions: dict[str, str] = {}
@@ -8664,9 +8695,9 @@ class ConsoleChatController:
             "decisions": decisions,
             "session_id": owning_session_id,
             "run_id": owning_run_id,
-            # The names this round must answer for -- what `revoke_
+            # The verdict keys this round must answer for -- what `revoke_
             # approval_rounds_for_run` fills with "deny".
-            "names": tuple(unique_names),
+            "names": tuple(unique_keys),
             # Flipped by revocation. Re-read after the wait below so a
             # decision that lands in `decisions` AFTER the revoke (the
             # `ApprovalDecided` message is async, and `resolve_pending_
@@ -8701,6 +8732,7 @@ class ConsoleChatController:
                     "reason": call.reason,
                     "options": list(call.options),
                     "path_precheck_failed": call.path_precheck_failed,
+                    "call_id": call.call_id,
                 }
                 for call in pending
             ],
@@ -8797,19 +8829,19 @@ class ConsoleChatController:
                         # timeout is not itself a cancellation). Log directly
                         # here, best-effort, for exactly the names this branch
                         # is about to fail closed.
-                        cancelled_names = [
-                            name for name in unique_names if name not in decisions
+                        cancelled_keys = [
+                            key for key in unique_keys if key not in decisions
                         ]
-                        for name in unique_names:
-                            decisions.setdefault(name, "deny")
+                        for key in unique_keys:
+                            decisions.setdefault(key, "deny")
                         self._record_cancelled_approval_decisions(
-                            cancelled_names,
-                            call_by_name,
+                            cancelled_keys,
+                            call_by_key,
                         )
                         break
                     if deadline is not None and time.monotonic() >= deadline:
-                        for name in unique_names:
-                            decisions.setdefault(name, "timeout")
+                        for key in unique_keys:
+                            decisions.setdefault(key, "timeout")
                         break
             # PR2a Task 7: a revoked round answers "deny" for every name,
             # unconditionally -- it does not consult `decisions` at all.
@@ -8829,17 +8861,17 @@ class ConsoleChatController:
                 # these calls never reach `invoke()`'s own gate and would
                 # otherwise leave no record of having been denied.
                 self._record_cancelled_approval_decisions(
-                    list(unique_names), call_by_name
+                    list(unique_keys), call_by_key
                 )
-                return {name: "deny" for name in unique_names}
+                return {key: "deny" for key in unique_keys}
             # Any name the resolution path above didn't already cover (e.g.
             # a partial/empty decisions dict handed to `resolve_pending_
             # approval`) fails closed to "deny" rather than silently
             # dropping the call from the returned mapping.
-            for name in unique_names:
-                decisions.setdefault(name, "deny")
+            for key in unique_keys:
+                decisions.setdefault(key, "deny")
             # Finding F4: build the snapshot by keyed lookup over the
-            # (locally-owned, never-mutated) `unique_names` list rather
+            # (locally-owned, never-mutated) `unique_keys` list rather
             # than `dict(decisions)` -- the latter iterates `decisions`
             # itself, which `resolve_pending_approval` can concurrently
             # `.update()` from the UI thread; a same-size update can't
@@ -8849,7 +8881,7 @@ class ConsoleChatController:
             # above already guarantees every name resolves, so `.get`'s
             # own "deny" fallback here is a belt-and-suspenders no-op, not
             # a second source of truth.
-            return {name: decisions.get(name, "deny") for name in unique_names}
+            return {key: decisions.get(key, "deny") for key in unique_keys}
         finally:
             # F2b fix (Qodo wave): guard the pop -- `resolve_pending_
             # approval`'s round_id lookup and the `fleet_summary_counts`
@@ -8904,8 +8936,8 @@ class ConsoleChatController:
 
     def _record_cancelled_approval_decisions(
         self,
-        names: list[str],
-        call_by_name: dict[str, "MCPPendingCall"],
+        keys: list[str],
+        call_by_key: dict[str, "MCPPendingCall"],
     ) -> None:
         """Best-effort audit log for calls denied by a stop/unmount mid-approval.
 
@@ -8928,8 +8960,8 @@ class ConsoleChatController:
         record = getattr(service, "record_tool_decision", None)
         if not callable(record):
             return
-        for name in names:
-            call = call_by_name.get(name)
+        for key in keys:
+            call = call_by_key.get(key)
             if call is None:
                 continue
             try:
@@ -9571,6 +9603,95 @@ class ConsoleChatController:
             **self._todo_wiring(session_id),
         )
         return provider, build_local_review_hook(provider, bound_request_approvals)
+
+    def _compose_virtual_cli_provider(
+        self,
+        session_id: str | None = None,
+        turn_context: ConsoleTurnExecutionContext | None = None,
+        *,
+        project_root: Path | None = None,
+        project_root_identity: tuple[tuple[str, int, int, int], ...] | None = None,
+        project_root_guard: Callable[[], bool] | None = None,
+    ) -> tuple[
+        VirtualCliProvider | None,
+        Callable[[list["ToolCall"], str], dict[str, str]] | None,
+    ]:
+        """Compose the read-only virtual CLI over this run's local root."""
+        configured = (
+            turn_context.tool_configuration.get(
+                "local_tools_enabled", LOCAL_TOOLS_DEFAULT_ENABLED
+            )
+            if turn_context is not None
+            else get_cli_setting(
+                "console", "local_tools_enabled", LOCAL_TOOLS_DEFAULT_ENABLED
+            )
+        )
+        if not coerce_bool_setting(configured, LOCAL_TOOLS_DEFAULT_ENABLED):
+            return None, None
+        service = getattr(self.app, "unified_mcp_service", None)
+        if service is None:
+            return None, None
+        try:
+            if service.get_kill_switch():
+                return None, None
+        except Exception:  # noqa: BLE001 -- unreadable security state fails closed
+            return None, None
+
+        if project_root is None:
+            snapshot = turn_context.scratch_space if turn_context is not None else None
+            if snapshot is None:
+                return None, None
+            root = snapshot.root
+            authority_scope = functools.partial(self._scratch_spaces.lease, snapshot)
+        else:
+            root = project_root
+            authority_scope = None
+
+        root_guard = (
+            project_root_guard
+            if project_root_guard is not None
+            else lambda: (
+                _project_root_identity_matches(root, project_root_identity)
+                if project_root_identity is not None
+                else True
+            )
+        )
+        bound_request = functools.partial(
+            self.request_mcp_approvals, session_id=session_id
+        )
+
+        def persist(hub: "HubTool", decision: str) -> None:
+            if decision == "approve_session":
+                service.approve_for_session(hub.server_key, hub.name)
+            elif decision == "always_allow":
+                service.set_tool_state(hub.server_key, hub.name, "allow", tool=hub)
+
+        def record(hub: "HubTool", decision: str) -> None:
+            service.record_tool_decision(
+                hub.server_key,
+                hub.name,
+                decision=decision,
+                initiator="agent",
+            )
+
+        provider = VirtualCliProvider(
+            workspace_root=root,
+            resolve_state=service.gate_tool_test,
+            local_tools_enabled=lambda: coerce_bool_setting(
+                configured, LOCAL_TOOLS_DEFAULT_ENABLED
+            ),
+            kill_switch=lambda: bool(service.get_kill_switch()),
+            approval_callback=bound_request,
+            is_session_approved=lambda hub: service.is_session_approved(
+                hub.server_key, hub.name
+            ),
+            persist_approval=persist,
+            record_decision=record,
+            root_guard=root_guard,
+            authority_scope=authority_scope,
+            result_redaction_root=(root if project_root is None else None),
+        )
+        return provider, build_virtual_cli_review_hook(provider, bound_request)
 
     def _todo_wiring(self, session_id: str | None) -> _TodoWiring:
         """The todo_store/on_todo_change kwargs for ``_compose_local_provider``.
@@ -12253,6 +12374,14 @@ class ConsoleChatController:
             turn_context=turn_context,
             publish_mcp_counts=False,
         )
+        virtual_cli_provider, _virtual_cli_review_hook = (
+            self._compose_virtual_cli_provider(
+                session_id=session_id,
+                turn_context=turn_context,
+                project_root=selection.root,
+                project_root_identity=selection.root_identity,
+            )
+        )
         try:
             preview_result = await asyncio.to_thread(
                 bridge.build_project_instruction_preview_request,
@@ -12269,6 +12398,7 @@ class ConsoleChatController:
                 mcp_provider=mcp_provider,
                 builtin_gate=builtin_gate,
                 local_provider=local_provider,
+                virtual_cli_provider=virtual_cli_provider,
                 scratch_root=scratch_snapshot.root,
                 scratch_lease=scratch_lease,
                 turn_skill_bindings=turn_skill_bindings,
@@ -16699,6 +16829,21 @@ class ConsoleChatController:
             project_authority_guard=project_authority_guard,
             turn_context=turn_context,
         )
+        virtual_cli_provider, virtual_cli_review_hook = (
+            self._compose_virtual_cli_provider(
+                session_id=session_id,
+                turn_context=turn_context,
+                project_root=(
+                    project_selection.root if project_selection is not None else None
+                ),
+                project_root_identity=(
+                    project_selection.root_identity
+                    if project_selection is not None
+                    else None
+                ),
+                project_root_guard=project_authority_guard,
+            )
+        )
         self._mcp_provider = mcp_provider
 
         # task-545/T6: build THIS run's built-in permission gate and hand
@@ -16759,6 +16904,10 @@ class ConsoleChatController:
         # so the combined hook is a collision-free merge.
         if local_review_hook is not None:
             review_hook = build_combined_review_hook([review_hook, local_review_hook])
+        if virtual_cli_review_hook is not None:
+            review_hook = build_combined_review_hook(
+                [review_hook, virtual_cli_review_hook]
+            )
 
         # task-1337: THIS run's Library retrieval provider (direct tools or
         # the bounded RAG fallback), resolved ONCE here on the main loop via
@@ -16839,6 +16988,7 @@ class ConsoleChatController:
                 scratch_lease=scratch_lease,
                 review_tool_calls=review_hook,
                 local_provider=local_provider,
+                virtual_cli_provider=virtual_cli_provider,
                 library_provider=library_provider,
                 library_authority=library_provider_authority,
                 native_tools_enabled=bool(

--- a/tldw_chatbook/MCP/hub_tool_catalog.py
+++ b/tldw_chatbook/MCP/hub_tool_catalog.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 _MAX_TAGS = 5
-_RESERVED_EXTERNAL_PROFILE_ID = "__local__"
+_RESERVED_EXTERNAL_PROFILE_IDS = frozenset({"__local__", "__virtual_cli__"})
 
 
 @dataclass(frozen=True)
@@ -108,7 +108,7 @@ def local_tools_from_record(record: dict) -> list[HubTool]:
         empty list when there is no snapshot.
     """
     profile_id = _text(record.get("profile_id"))
-    if profile_id == _RESERVED_EXTERNAL_PROFILE_ID:
+    if profile_id in _RESERVED_EXTERNAL_PROFILE_IDS:
         return []
     snapshot = record.get("discovery_snapshot")
     if not isinstance(snapshot, Mapping):

--- a/tldw_chatbook/MCP/local_store.py
+++ b/tldw_chatbook/MCP/local_store.py
@@ -103,7 +103,7 @@ def _require_non_empty_field(value: str, field_name: str, record_type: str) -> s
 
 
 _PROFILE_ID_INVALID_CHARS_RE = re.compile(r"[:\s]")
-_RESERVED_EXTERNAL_PROFILE_ID = "__local__"
+_RESERVED_EXTERNAL_PROFILE_IDS = frozenset({"__local__", "__virtual_cli__"})
 
 
 def _validate_profile_id(value: str) -> str:
@@ -124,7 +124,7 @@ def _validate_profile_id(value: str) -> str:
     discouraged.
     """
     normalized = _require_non_empty_field(value, "profile_id", "Local MCP profile")
-    if normalized == _RESERVED_EXTERNAL_PROFILE_ID:
+    if normalized in _RESERVED_EXTERNAL_PROFILE_IDS:
         raise ValueError("Local MCP profile profile_id is reserved")
     if _PROFILE_ID_INVALID_CHARS_RE.search(normalized):
         raise ValueError(
@@ -650,7 +650,7 @@ class LocalMCPStoreState:
                 for item in (profiles_raw if isinstance(profiles_raw, list) else [])
             )
             if profile.profile_id
-            and profile.profile_id != _RESERVED_EXTERNAL_PROFILE_ID
+            and profile.profile_id not in _RESERVED_EXTERNAL_PROFILE_IDS
             and profile.command
         )
         governance_rules = tuple(
@@ -685,7 +685,7 @@ class LocalMCPStoreState:
                 str(server_id): dict(snapshot)
                 for server_id, snapshot in snapshots_raw.items()
                 if str(server_id).strip()
-                and _text(server_id) != _RESERVED_EXTERNAL_PROFILE_ID
+                and _text(server_id) not in _RESERVED_EXTERNAL_PROFILE_IDS
                 and isinstance(snapshot, Mapping)
             }
             if isinstance(snapshots_raw, Mapping)
@@ -697,7 +697,7 @@ class LocalMCPStoreState:
                 str(profile_id): dict(record)
                 for profile_id, record in runtime_state_raw.items()
                 if str(profile_id).strip()
-                and _text(profile_id) != _RESERVED_EXTERNAL_PROFILE_ID
+                and _text(profile_id) not in _RESERVED_EXTERNAL_PROFILE_IDS
                 and isinstance(record, Mapping)
             }
             if isinstance(runtime_state_raw, Mapping)

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -294,6 +294,41 @@ def read_file(
     return numbered
 
 
+def stat_path(path: str, *, workspace_root: Path) -> str:
+    """Return a small allowlisted metadata view for one workspace path.
+
+    Args:
+        path: File or directory to inspect.
+        workspace_root: Confinement root the path must resolve within.
+
+    Returns:
+        Workspace-relative path, kind, size, nanosecond mtime, and mode.
+
+    Raises:
+        LocalToolError: If the path is outside the workspace or protected.
+        OSError: If the resolved path cannot be inspected.
+    """
+    root = Path(workspace_root).resolve()
+    resolved = resolve_workspace_path(path, root, intent="read")
+    info = resolved.stat()
+    kind = (
+        "directory"
+        if resolved.is_dir()
+        else "file"
+        if resolved.is_file()
+        else "other"
+    )
+    return "\n".join(
+        (
+            f"path: {resolved.relative_to(root)}",
+            f"type: {kind}",
+            f"size: {info.st_size}",
+            f"modified_ns: {info.st_mtime_ns}",
+            f"mode: {info.st_mode & 0o7777:04o}",
+        )
+    )
+
+
 def write_file(path: str, content: str, *, workspace_root: Path) -> str:
     """Create or overwrite ``path`` with ``content`` (full-file write).
 

--- a/tldw_chatbook/Tools/virtual_cli_impls.py
+++ b/tldw_chatbook/Tools/virtual_cli_impls.py
@@ -1,0 +1,216 @@
+"""Structured read-only virtual CLI over existing workspace and Git cores."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Sequence, cast
+
+from .git_tool_impls import git_blame, git_branches, git_diff, git_log, git_status
+from .local_tool_impls import (
+    glob_files,
+    grep_files,
+    list_directory,
+    read_file,
+    stat_path,
+)
+
+VIRTUAL_CLI_COMMANDS = (
+    "ls",
+    "cat",
+    "grep",
+    "find",
+    "stat",
+    "git_status",
+    "git_diff",
+    "git_log",
+    "git_blame",
+    "git_branches",
+)
+VirtualCliCommand = Literal[
+    "ls",
+    "cat",
+    "grep",
+    "find",
+    "stat",
+    "git_status",
+    "git_diff",
+    "git_log",
+    "git_blame",
+    "git_branches",
+]
+
+MAX_ARGV_ITEMS = 64
+MAX_ARG_BYTES = 4 * 1024
+MAX_ARGV_BYTES = 16 * 1024
+
+
+class VirtualCliArgumentError(ValueError):
+    """Invalid command or argv for the virtual CLI."""
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise VirtualCliArgumentError(f"invalid arguments: {message}")
+
+
+def _parser() -> _ArgumentParser:
+    return _ArgumentParser(add_help=False, allow_abbrev=False, exit_on_error=False)
+
+
+def _integer_at_least(minimum: int):
+    def parse(value: str) -> int:
+        try:
+            parsed = int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError("must be an integer") from exc
+        if parsed < minimum:
+            raise argparse.ArgumentTypeError(f"must be >= {minimum}")
+        return parsed
+
+    return parse
+
+
+def _build_parsers() -> dict[str, _ArgumentParser]:
+    parsers: dict[str, _ArgumentParser] = {}
+
+    ls_parser = _parser()
+    ls_parser.add_argument("path", nargs="?", default=".")
+    parsers["ls"] = ls_parser
+
+    cat_parser = _parser()
+    cat_parser.add_argument("path")
+    cat_parser.add_argument("--offset", type=_integer_at_least(1), default=1)
+    cat_parser.add_argument("--limit", type=_integer_at_least(0))
+    parsers["cat"] = cat_parser
+
+    grep_parser = _parser()
+    grep_parser.add_argument("pattern")
+    grep_parser.add_argument("--mode", choices=("content", "files", "count"), default="content")
+    parsers["grep"] = grep_parser
+
+    find_parser = _parser()
+    find_parser.add_argument("pattern")
+    parsers["find"] = find_parser
+
+    stat_parser = _parser()
+    stat_parser.add_argument("path")
+    parsers["stat"] = stat_parser
+
+    status_parser = _parser()
+    status_parser.add_argument("path", nargs="?", default=".")
+    parsers["git_status"] = status_parser
+
+    diff_parser = _parser()
+    diff_parser.add_argument("--staged", action="store_true")
+    diff_parser.add_argument("--range", dest="commit_range")
+    diff_parser.add_argument("--path")
+    diff_parser.add_argument("--stat", action="store_true")
+    parsers["git_diff"] = diff_parser
+
+    log_parser = _parser()
+    log_parser.add_argument("--count", type=_integer_at_least(1), default=20)
+    log_parser.add_argument("--path")
+    parsers["git_log"] = log_parser
+
+    blame_parser = _parser()
+    blame_parser.add_argument("path")
+    blame_parser.add_argument("--start", type=_integer_at_least(1))
+    blame_parser.add_argument("--end", type=_integer_at_least(1))
+    parsers["git_blame"] = blame_parser
+
+    parsers["git_branches"] = _parser()
+    return parsers
+
+
+_PARSERS = _build_parsers()
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualCliRequest:
+    """One validated virtual command invocation."""
+
+    command: VirtualCliCommand
+    argv: tuple[str, ...]
+
+
+def validate_request(command: str, argv: Sequence[str]) -> VirtualCliRequest:
+    """Validate the structured outer request without parsing shell text."""
+    if not isinstance(command, str) or command not in VIRTUAL_CLI_COMMANDS:
+        raise VirtualCliArgumentError(f"unknown virtual CLI command: {command!r}")
+    if not isinstance(argv, (list, tuple)):
+        raise VirtualCliArgumentError("argv must be an array of strings")
+    if len(argv) > MAX_ARGV_ITEMS:
+        raise VirtualCliArgumentError(f"argv exceeds {MAX_ARGV_ITEMS} items")
+    total = 0
+    normalized: list[str] = []
+    for item in argv:
+        if not isinstance(item, str):
+            raise VirtualCliArgumentError("argv must contain only strings")
+        if "\x00" in item:
+            raise VirtualCliArgumentError("argv must not contain NUL")
+        size = len(item.encode("utf-8"))
+        if size > MAX_ARG_BYTES:
+            raise VirtualCliArgumentError(f"argv item exceeds {MAX_ARG_BYTES} UTF-8 bytes")
+        total += size
+        normalized.append(item)
+    if total > MAX_ARGV_BYTES:
+        raise VirtualCliArgumentError(f"argv exceeds {MAX_ARGV_BYTES} UTF-8 bytes")
+    return VirtualCliRequest(cast(VirtualCliCommand, command), tuple(normalized))
+
+
+class VirtualCliRegistry:
+    """Parse fixed argv forms and dispatch directly to policy-checked cores."""
+
+    def __init__(self, workspace_root: Path) -> None:
+        self._root = Path(workspace_root).resolve()
+
+    @property
+    def workspace_root(self) -> Path:
+        return self._root
+
+    def execute(self, command: str, argv: Sequence[str]) -> str:
+        request = validate_request(command, argv)
+        try:
+            args = _PARSERS[request.command].parse_args(list(request.argv))
+        except (argparse.ArgumentError, TypeError, ValueError) as exc:
+            if isinstance(exc, VirtualCliArgumentError):
+                raise
+            raise VirtualCliArgumentError(f"invalid arguments: {exc}") from exc
+
+        if request.command == "ls":
+            return list_directory(args.path, workspace_root=self._root)
+        if request.command == "cat":
+            return read_file(
+                args.path,
+                workspace_root=self._root,
+                offset=args.offset,
+                limit=args.limit,
+            )
+        if request.command == "grep":
+            return grep_files(args.pattern, workspace_root=self._root, mode=args.mode)
+        if request.command == "find":
+            return glob_files(args.pattern, workspace_root=self._root)
+        if request.command == "stat":
+            return stat_path(args.path, workspace_root=self._root)
+        if request.command == "git_status":
+            return git_status(self._root, args.path)
+        if request.command == "git_diff":
+            return git_diff(
+                self._root,
+                staged=args.staged,
+                commit_range=args.commit_range,
+                path=args.path,
+                stat=args.stat,
+            )
+        if request.command == "git_log":
+            return git_log(self._root, count=args.count, path=args.path)
+        if request.command == "git_blame":
+            return git_blame(
+                self._root,
+                args.path,
+                start_line=args.start,
+                end_line=args.end,
+            )
+        return git_branches(self._root)

--- a/tldw_chatbook/Tools/virtual_cli_impls.py
+++ b/tldw_chatbook/Tools/virtual_cli_impls.py
@@ -160,6 +160,18 @@ def validate_request(command: str, argv: Sequence[str]) -> VirtualCliRequest:
     return VirtualCliRequest(cast(VirtualCliCommand, command), tuple(normalized))
 
 
+def parse_request(command: str, argv: Sequence[str]) -> tuple[VirtualCliRequest, argparse.Namespace]:
+    """Validate the outer request and its command-specific argv grammar."""
+    request = validate_request(command, argv)
+    try:
+        parsed = _PARSERS[request.command].parse_args(list(request.argv))
+    except (argparse.ArgumentError, TypeError, ValueError) as exc:
+        if isinstance(exc, VirtualCliArgumentError):
+            raise
+        raise VirtualCliArgumentError(f"invalid arguments: {exc}") from exc
+    return request, parsed
+
+
 class VirtualCliRegistry:
     """Parse fixed argv forms and dispatch directly to policy-checked cores."""
 
@@ -171,13 +183,7 @@ class VirtualCliRegistry:
         return self._root
 
     def execute(self, command: str, argv: Sequence[str]) -> str:
-        request = validate_request(command, argv)
-        try:
-            args = _PARSERS[request.command].parse_args(list(request.argv))
-        except (argparse.ArgumentError, TypeError, ValueError) as exc:
-            if isinstance(exc, VirtualCliArgumentError):
-                raise
-            raise VirtualCliArgumentError(f"invalid arguments: {exc}") from exc
+        request, args = parse_request(command, argv)
 
         if request.command == "ls":
             return list_directory(args.path, workspace_root=self._root)

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -29,6 +29,7 @@ from tldw_chatbook.Agents.builtin_tool_gate import (
     tool_gate_breadcrumb,
 )
 from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
+from tldw_chatbook.Agents.virtual_cli_provider import VirtualCliProvider
 from tldw_chatbook.config import (
     coerce_bool_setting,
     get_cli_setting,
@@ -1766,11 +1767,15 @@ class MCPWorkbench(Container):
         ):
             return []
         try:
-            provider = LocalToolProvider(
-                workspace_root=resolve_server_workspace_root()
+            root = resolve_server_workspace_root()
+            providers = (
+                LocalToolProvider(workspace_root=root),
+                VirtualCliProvider(workspace_root=root),
             )
             return [
-                replace(hub, executable=False) for hub in provider.hub_tools()
+                replace(hub, executable=False)
+                for provider in providers
+                for hub in provider.hub_tools()
             ]
         except Exception as exc:  # noqa: BLE001 -- catalog view must never break the hub
             logger.warning(f"MCP local agent tool catalog unavailable: {exc}")


### PR DESCRIPTION
## Summary

- add one structured read-only virtual_cli model tool with a fixed command set and no shell fallback
- enforce independent Allow, Ask, or Off permissions for every virtual command through the reserved local:__virtual_cli__ principal
- expose the command permissions in the canonical Tools UI and document the security boundary

## Test plan

- [x] 572 focused tests covering parsing, dispatch, permissions, approval routing, Console composition, Tools UI, and docs
- [x] 75 post-commit Console approval tests
- [x] Ruff on changed production and test code
- [x] git diff --check
- [ ] Full suite not run per repository targeted-test policy

## Tracking

- TASK-22509
- ADR-094

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only `virtual_cli` model tool with ten fixed commands, each gated by its own Allow, Ask, or Off permission independent from existing `fs_*` and Git tools. Previously no virtual CLI existed; the new tool never parses shell syntax and scopes approval stamps per native call, so multiple `virtual_cli` calls in one turn can receive different decisions.

**Highlights**
- Registers the tool under the reserved `local:__virtual_cli__` principal and rejects external profiles trying to spoof that identity.
- Dispatches approved commands to the existing confined filesystem and read-only Git cores, keeping path checks, kill switch, result caps, and audit intact.
- Shows each command as a separate row in MCP ▸ Tools under the new Virtual CLI (read-only) group and documents the no-shell boundary in the user guides.
- Completes TASK-22509 with 572 focused tests covering parsing, permissions, approval routing, UI composition, and docs.

<sup>Written for commit d26a144922588e1bc8d47926872d639bf6cc5388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

