### PR TITLE
fix(settings): UX critique burn-down — TASK-23104/23108/23109/23110

### DIFF
--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -50,10 +50,17 @@ Moving around: **click** a rail row, or **Tab** from the nav bar to drop focus
 into the rail at **Overview**, then **j**/**k** or **↑**/**↓** to move and
 **Enter** to open; Tab again walks into the detail pane's fields. **/** focuses
 the filter from anywhere; its status line reads "No filter | / focus category
-search", "Filter: \<text\> | N matches | Enter opens \<Category\>" (singular
-"1 match" for a lone hit, and the target gains "› \<Field\>" when your text
-named a field), or "Filter: \<text\> | 0 matches | Esc clears". **Enter** jumps
-to the top match and clears the filter; **Esc** just clears it. Some pages also
+search", "Filter: \<text\> | N matches | Enter opens \<Category\> (\<Group\>)"
+(singular "1 match" for a lone hit; when your text named a **setting**, the
+target becomes "\<Category\> › \<Field\> (\<Group\>)" — e.g. "reduce motion"
+promises "Appearance › Reduce motion (Interface)" — and with more than one
+match a "| Next: \<second match with its scope\>" segment disambiguates, so
+"theme" shows both the Theme category and Appearance's Theme setting), or
+"Filter: \<text\> | 0 matches | Esc clears". **Enter** jumps to the top match
+and clears the filter — landing focus **on the matched setting** when your text
+named one (typing a category's own name just opens the category); **Esc** just
+clears it. The filter knows every rendered setting's visible label, on every
+category. Some pages also
 carry jump buttons: **Open Providers & Models** and **Open Advanced Config** on
 Privacy & Security, five guided-path chips on Advanced Config, and **Open Theme
 editor** on Overview and Appearance.
@@ -645,7 +652,12 @@ hints as "Esc, s" while a field has focus. Only then do the letters work.
 
 **F6 does nothing on this screen.** Settings has no pane-cycle target, so it
 only shows a notice — use **Tab**, the rail keys, or the mouse. **F1** opens
-this screen's shortcut list, with the RAG-only keys shown only while on RAG.
+the active category's help: a "How this category works" section (its save
+contract, scope, runtime owner, whether writes are allowed, boundary, and
+recovery — the same contract the State banner and Scope Inspector carry)
+followed by the category's working shortcut keys, with the RAG-only keys shown
+only while on RAG. Every category has a non-empty help body; one without
+category-specific keys says so.
 
 Command palette (**Ctrl+P**) entries that land here: "Settings & Preferences:
 Open Settings Tab" opens the screen; "Settings & Preferences: Show Database
@@ -789,3 +801,15 @@ painted frame dismissed it and boot completed; `F9` at the same moment
 dismissed it and left the app on Home, not Settings; and with the setting off
 the same key left the splash up for its full 20 s. The rest of this page's
 content unchanged from the prior stamp.)*
+
+*Verified against feat/settings-ux-critique-burndown @ c38314a26 — 2026-08-28
+(TASK-23104/23108/23109/23110: the State banner renders exactly once per
+category with exactly one "State:" segment (domain pages and Overview used to
+show it doubled and self-colliding); unexpected model-discovery and RAG
+backfill failures now surface plain-language status/toast copy with a next
+step instead of raw exception text; F1 help gained the per-category contract
+body described above; and "/" search gained setting-level coverage with the
+scoped "Enter opens … (Group)" / "Next: …" echo line. Driven live headless:
+"reduce motion" surfaced "Appearance › Reduce motion (Interface)" and Enter
+landed focus on the control; "theme" echoed both scoped matches. The rest of
+this page's content unchanged from the prior stamp.)*

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -107,9 +107,12 @@ profile's index, in the background — you can keep using the app. It starts wit
 "Backfill started — this may take a while for large libraries." (pressing it
 again meanwhile gives "Backfill is already running.") and ends as one of:
 "Backfill complete: `N` indexed, `M` already up-to-date." · "Backfill finished
-with problems: `N` indexed, `M` failed. Last error: `…`" · "Backfill failed:
-`…`" · "Semantic indexing is unavailable (missing embeddings extras, or
-disabled in config)." · "No local databases are available to backfill."
+with problems: `N` indexed, `M` failed. `K` error(s) recorded — details are in
+Logs (F8)." · "Backfill failed before finishing (`ErrorType`). Run Backfill
+again — completed items are kept. Details are in Logs (F8)." · "Semantic
+indexing is unavailable (missing embeddings extras, or disabled in config)." ·
+"No local databases are available to backfill." Failure toasts stay plain
+language; per-item error detail lands in the log, never in the toast.
 
 ### The first-run starter panel
 
@@ -473,3 +476,11 @@ are the shim's `_guard_tokens_overlap` and the engine strategies' clamp
 (`tldw_chatbook/Chunking/engine/strategies/paragraphs.py`), pinned by
 `Tests/Chunking/`. No live TUI walkthrough; no behavior of this pane's own
 controls changed.*
+
+*Verified against feat/settings-ux-critique-burndown — 2026-08-28
+(TASK-23108 review round: the Backfill failure toasts documented above changed
+shape — the crash toast is plain language with the exception type name and a
+next step, and the partial-failure toast reports counts and points at Logs (F8)
+instead of embedding the last raw error string. Pinned by
+`Tests/UI/test_settings_rag_profile_region.py`'s backfill toast tests; no other
+behavior of this pane changed.)*

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2743,7 +2743,7 @@
     },
     {
       "call_count": 43,
-      "diagnostic_digest": "1f6907c7aa641c99ea8b",
+      "diagnostic_digest": "44a61bc810edce34e4b6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2742,8 +2742,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 43,
-      "diagnostic_digest": "44a61bc810edce34e4b6",
+      "call_count": 44,
+      "diagnostic_digest": "8018435fce04afdfb7cc",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3997,6 +3997,6 @@
     "owner_files": 541,
     "persistent_sink_files": 8,
     "task_492_calls": 1262,
-    "task_494_calls": 7396
+    "task_494_calls": 7397
   }
 }

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -10481,6 +10481,53 @@ async def test_field_search_enter_focuses_the_field():
         ), f"focused={focused!r}"
 
 
+def test_search_finds_reduce_motion_with_scope_text():
+    """TASK-23109: 'reduce motion' (the critique's unfindable setting) must
+    surface Appearance, and the echo line must carry category and group."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+
+    matches = screen._filtered_category_summaries("reduce motion")
+
+    assert matches and matches[0].category is SettingsCategoryId.APPEARANCE
+    status = screen._category_search_status_text("reduce motion")
+    assert "Appearance › Reduce motion (Interface)" in status
+
+
+def test_search_ambiguous_theme_disambiguates_with_scope():
+    """TASK-23109: 'theme' hits the Theme category and Appearance's Theme
+    setting; the results line names both with their scopes instead of a
+    bare-title coin flip."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+
+    status = screen._category_search_status_text("theme")
+
+    assert "Enter opens Theme (Interface)" in status
+    assert "Next: " in status, status
+    matches = screen._filtered_category_summaries("theme")
+    assert any(s.category is SettingsCategoryId.APPEARANCE for s in matches)
+
+
+@pytest.mark.asyncio
+async def test_search_enter_focuses_reduce_motion():
+    """TASK-23109 journey: Enter on 'reduce motion' opens Appearance with
+    the Reduce motion control focused."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        screen._submit_category_search("reduce motion")
+        for _ in range(8):
+            await pilot.pause()
+        assert screen.active_category == SettingsCategoryId.APPEARANCE.value
+        focused = host.focused
+        assert focused is not None and focused.id == (
+            "settings-appearance-reduce-motion"
+        ), f"focused={focused!r}"
+
+
 @pytest.mark.asyncio
 async def test_state_banner_is_pinned_outside_detail_scroll():
     """The State banner is pinned outside the detail scroll body.

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -10222,6 +10222,18 @@ def test_state_banner_leads_with_persistence_badge():
         assert text.startswith(f"State: {badge} | "), (category, text)
 
 
+def test_state_banner_text_has_exactly_one_state_segment():
+    """TASK-23104: scope strings used to embed their own "State: ..." on top
+    of the badge prefix, so domain categories and Overview rendered
+    "State: Read-only here | State: Active | ..." -- two contracts colliding
+    in one line."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    for category in SettingsCategoryId:
+        text = screen._category_state_banner_text(category)
+        assert text.count("State:") == 1, (category, text)
+
+
 def test_state_banner_dirty_branch_keeps_priority():
     """Unsaved changes outrank the badge -- the dirty banner is the model
     talking, and its copy must stay the strongest signal."""
@@ -10350,8 +10362,17 @@ async def test_every_category_renders_the_state_banner():
             screen._select_category(summary.category.value)
             await pilot.pause()
             await pilot.pause()
-            banner = screen.query_one("#settings-category-state-banner", Static)
-            assert str(banner.renderable).startswith("State: "), summary.category
+            # TASK-23104: exactly ONE banner -- Overview and the domain
+            # categories used to compose a second in-card copy on top of
+            # the pinned one, doubling the save-contract line.
+            banners = screen.query(".settings-state-banner")
+            assert len(banners) == 1, (
+                summary.category,
+                [str(b.renderable) for b in banners],
+            )
+            banner_text = str(banners.first(Static).renderable)
+            assert banner_text.startswith("State: "), summary.category
+            assert banner_text.count("State:") == 1, (summary.category, banner_text)
 
 
 # ---- critique round-4 batch: tasks 1644 and 1714-1716 ----

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -10626,7 +10626,9 @@ async def test_search_landing_on_disabled_field_explains_instead_of_no_op():
     async with host.run_test(size=(190, 55)) as pilot:
         await _settle_settings_mount_storm(pilot)
         screen = _active_destination_screen(host)
-        target_label = "Preferred Library rail width"
+        # The RENDERED row label (review finding 8 fixed the index's stale
+        # "Preferred Library rail width" phrasing).
+        target_label = "Preferred rail width"
         screen._submit_category_search(target_label)
         for _ in range(10):
             await pilot.pause()

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -8573,7 +8573,7 @@ async def test_settings_provider_model_discovery_shows_ambiguous_provider_recove
     assert "https://proxy.example.com/v1" not in status_text
 
 
-class _ExplodingDiscoveryScope:
+class ExplodingDiscoveryScope:
     """A scope service whose calls raise, for the unexpected-failure paths."""
 
     def __init__(self, exc: BaseException) -> None:
@@ -8592,7 +8592,7 @@ async def test_model_discovery_crash_status_is_plain_language_without_raw_except
     exception repr to the user -- plain summary, next step, type name only."""
     app = _build_test_app()
     app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4.1"}
-    app.llm_provider_catalog_scope_service = _ExplodingDiscoveryScope(
+    app.llm_provider_catalog_scope_service = ExplodingDiscoveryScope(
         RuntimeError("boom at https://api.example.com/v1 API_KEY=sk-super-secret")
     )
     screen = SettingsScreen(app)
@@ -8612,7 +8612,7 @@ async def test_discovered_model_save_crash_status_is_plain_language():
     """TASK-23108: same contract for the persistence path."""
     app = _build_test_app()
     app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4.1"}
-    app.llm_provider_catalog_scope_service = _ExplodingDiscoveryScope(
+    app.llm_provider_catalog_scope_service = ExplodingDiscoveryScope(
         OSError("disk sadness /home/user/.config/tldw_cli/config.toml")
     )
     screen = SettingsScreen(app)

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -10529,6 +10529,120 @@ async def test_search_enter_focuses_reduce_motion():
 
 
 @pytest.mark.asyncio
+async def test_search_description_tier_match_still_lands_on_the_field():
+    """Review finding 2 (TASK-23109): a description-tier category match with
+    a matching field keeps task-1715's field landing -- only own-TITLE
+    matches open the category plainly."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        screen._submit_category_search("context window")
+        for _ in range(10):
+            await pilot.pause()
+        assert screen.active_category == SettingsCategoryId.PROVIDERS_MODELS.value
+        focused = host.focused
+        assert focused is not None and focused.id == (
+            "settings-model-context-window"
+        ), f"focused={focused!r}"
+
+
+@pytest.mark.asyncio
+async def test_search_token_keeps_its_pre_existing_intra_category_landing():
+    """Review finding 13 (TASK-23109): completing the index appends rows, so
+    the intra-category winner must stay order-stable -- '/token' lands on
+    'Conversation max tokens', not the swept-in 'Token budget (per run)'."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        screen._submit_category_search("token")
+        for _ in range(10):
+            await pilot.pause()
+        assert screen.active_category == SettingsCategoryId.CONSOLE_BEHAVIOR.value
+        focused = host.focused
+        assert focused is not None and focused.id == (
+            "settings-console-context-budget-tokens"
+        ), f"focused={focused!r}"
+
+
+@pytest.mark.asyncio
+async def test_search_landing_expands_enclosing_collapsibles():
+    """Review finding 3a (TASK-23109): a field inside Collapsible(collapsed)
+    must be expanded and focused, not given focus at zero region."""
+    from textual.widgets import Collapsible
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        screen._submit_category_search("temperature")
+        for _ in range(12):
+            await pilot.pause()
+        assert screen.active_category == SettingsCategoryId.PROVIDERS_MODELS.value
+        focused = host.focused
+        assert focused is not None and focused.id == (
+            "settings-model-profile-temperature"
+        ), f"focused={focused!r}"
+        for node in focused.ancestors:
+            if isinstance(node, Collapsible):
+                assert node.collapsed is False, "landing left the fold closed"
+        assert focused.region.height > 0, "focused field has zero region"
+
+
+@pytest.mark.asyncio
+async def test_search_next_segment_is_dropped_on_short_terminals():
+    """Review finding 15 (TASK-23109): at 24 rows the fully scoped status
+    line wrapped to ~5 rail rows, pushing matches below the fold -- the
+    '| Next:' segment is dropped below the height threshold and kept on
+    full-size terminals."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(110, 24)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        short = screen._category_search_status_text("theme")
+        assert "Enter opens Theme (Interface)" in short
+        assert "Next:" not in short, short
+
+    host_tall = DestinationHarness(_build_test_app(), "settings")
+    async with host_tall.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host_tall)
+        tall = screen._category_search_status_text("theme")
+        assert "Next: Appearance › Theme (Interface)" in tall, tall
+
+
+@pytest.mark.asyncio
+async def test_search_landing_on_disabled_field_explains_instead_of_no_op():
+    """Review finding 3b (TASK-23109): .focus() is a silent no-op on a
+    disabled widget -- the landing must open the category and say why in
+    the status line instead."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        target_label = "Preferred Library rail width"
+        screen._submit_category_search(target_label)
+        for _ in range(10):
+            await pilot.pause()
+        assert screen.active_category == SettingsCategoryId.APPEARANCE.value
+        target = screen.query_one("#settings-appearance-library-media-library-width")
+        assert target.disabled, "precondition: width input disabled by default"
+        focused = host.focused
+        assert focused is None or focused.id != target.id
+        status = str(
+            screen.query_one("#settings-category-search-status", Static).renderable
+        )
+        assert "disabled right now" in status, status
+        assert target_label in status, status
+
+
+@pytest.mark.asyncio
 async def test_state_banner_is_pinned_outside_detail_scroll():
     """The State banner is pinned outside the detail scroll body.
 

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -42,6 +42,7 @@ from tldw_chatbook.UI.Screens.provider_model_resolution import (
 from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
 from tldw_chatbook.UI.Screens.settings_config_adapter import (
     SettingsConfigAdapter,
+    failure_status_text,
     redact_secret_text,
 )
 from tldw_chatbook.UI.Screens.settings_config_models import (
@@ -8570,6 +8571,70 @@ async def test_settings_provider_model_discovery_shows_ambiguous_provider_recove
 
     assert "https://api.openai.com/v1" not in status_text
     assert "https://proxy.example.com/v1" not in status_text
+
+
+class _ExplodingDiscoveryScope:
+    """A scope service whose calls raise, for the unexpected-failure paths."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def discover_models(self, **kwargs):
+        raise self._exc
+
+    async def persist_discovered_models_to_settings(self, **kwargs):
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_model_discovery_crash_status_is_plain_language_without_raw_exception():
+    """TASK-23108: an unexpected discovery failure must not hand the raw
+    exception repr to the user -- plain summary, next step, type name only."""
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4.1"}
+    app.llm_provider_catalog_scope_service = _ExplodingDiscoveryScope(
+        RuntimeError("boom at https://api.example.com/v1 API_KEY=sk-super-secret")
+    )
+    screen = SettingsScreen(app)
+
+    await screen._discover_provider_models()
+
+    status = screen._model_discovery_status
+    assert "boom" not in status
+    assert "sk-super-secret" not in status
+    assert status.startswith("Model discovery failed (RuntimeError).")
+    assert "run Discover again" in status
+    assert "Logs (F8)" in status
+
+
+@pytest.mark.asyncio
+async def test_discovered_model_save_crash_status_is_plain_language():
+    """TASK-23108: same contract for the persistence path."""
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4.1"}
+    app.llm_provider_catalog_scope_service = _ExplodingDiscoveryScope(
+        OSError("disk sadness /home/user/.config/tldw_cli/config.toml")
+    )
+    screen = SettingsScreen(app)
+    screen._model_discovery_selected_model_ids = {"gpt-4o-mini"}
+
+    await screen._save_selected_discovered_provider_models()
+
+    status = screen._model_discovery_status
+    assert "disk sadness" not in status
+    assert status.startswith("Could not save the discovered models (OSError).")
+    assert "Try Save again" in status
+    assert "Logs (F8)" in status
+
+
+def test_failure_status_text_never_carries_raw_exception_text():
+    """The helper's guarantee: only the type name crosses into the UI."""
+    exc = ValueError("token=sk-live-1234 leaked into the message")
+    text = failure_status_text("Something failed", exc, next_step="Try again.")
+    assert text == (
+        "Something failed (ValueError). Try again. Details are in Logs (F8)."
+    )
+    assert "sk-live-1234" not in text
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_settings_footer_hints.py
+++ b/Tests/UI/test_settings_footer_hints.py
@@ -333,8 +333,12 @@ def test_f1_help_has_contract_content_for_every_category():
         assert any(
             note.startswith("Save contract: ") for note in state.notes
         ), category
+        # Ownership: either the matrix's runtime-owner line, or the
+        # read-only domain pages' single "Owned by X" sentence
+        # (review finding 11 de-duplicated their four echoes).
         assert any(
-            note.startswith("Runtime owner: ") for note in state.notes
+            note.startswith(("Runtime owner: ", "Owned by "))
+            for note in state.notes
         ), category
         # Verbs: either real category shortcuts, or an explicit statement
         # that none exist here.
@@ -344,6 +348,56 @@ def test_f1_help_has_contract_content_for_every_category():
         # The ownership matrix must actually cover the category -- the
         # missing-record placeholder is developer copy, not help.
         assert "Ownership record missing" not in body, category
+        # Finding 11: no note's substantial value is repeated under a
+        # second prefix within one body. The ownership line is exempt --
+        # it stays explicit even when the boundary sentence names the
+        # same owner.
+        values = [
+            note.split(": ", 1)[1].strip().rstrip(".").lower()
+            for note in state.notes
+            if ": " in note and not note.startswith("Runtime owner: ")
+        ]
+        for value in values:
+            if len(value) >= 20:
+                carriers = [v for v in values if value in v]
+                assert len(carriers) == 1, (category, value)
+
+
+def test_f1_help_video_gen_states_a_coherent_write_contract():
+    """Review finding 6 (TASK-23110): Video Gen mutates like Image Gen --
+    its help must not pair a draft badge with read-only-ownership copy."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    body = screen._workbench_help_state(
+        SettingsCategoryId.VIDEO_GENERATION
+    ).render_text()
+    assert "Save contract: Draft — save/revert below." in body
+    assert "Writes here: yes." in body
+    assert "Console owns /generate-video" in body
+    assert "read-only defaults" not in body, body
+    assert "Settings shows read-only" not in body, body
+
+
+@pytest.mark.asyncio
+async def test_f1_help_renders_literal_brackets_in_notes():
+    """Review finding 7 (TASK-23110): the help body must not eat literal
+    bracket text as Textual markup -- Agents' boundary copy contains
+    "[tools]"."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _settle_settings(pilot)
+        await _click_settings_category(pilot, "agents")
+        screen = _active_destination_screen(host)
+        screen.action_show_workbench_help()
+        await pilot.pause()
+        panel = host.screen
+        assert isinstance(panel, WorkbenchHelpPanel)
+        assert "[tools] gates" in panel.state.render_text()
+        body = panel.query_one("#workbench-help-body", Static)
+        assert "[tools] gates" in str(body.render()), (
+            "help body consumed the literal [tools] text as markup"
+        )
 
 
 _TEST_STUB_TOAST = "No test action is available"

--- a/Tests/UI/test_settings_footer_hints.py
+++ b/Tests/UI/test_settings_footer_hints.py
@@ -400,6 +400,86 @@ async def test_f1_help_renders_literal_brackets_in_notes():
         )
 
 
+@pytest.mark.asyncio
+async def test_f1_help_panel_body_carries_category_contract_when_mounted():
+    """TASK-23110 (review round): the contract notes must survive the REAL
+    F1 flow, not just the builder.
+
+    ``test_f1_help_has_contract_content_for_every_category`` calls the
+    private ``_workbench_help_state`` builder directly, so every break
+    BETWEEN that builder and the panel the user actually reads would stay
+    green: notes dropped from the ``WorkbenchHelpState`` the action
+    constructs, a ``notes_heading`` that never reaches the body, or a body
+    widget fed something other than ``render_text()``. This test presses
+    the real path -- ``action_show_workbench_help`` on the mounted screen
+    -- and asserts against the rendered ``#workbench-help-body`` output for
+    BOTH contract shapes:
+
+    * a draft-save category (Storage): save contract, ownership, and its
+      real verbs;
+    * a read-only domain category (Schedules -- the page whose F1 body used
+      to open empty, which is what TASK-23110 fixed): the read-only
+      contract, the owning destination, and an explicit "no shortcuts"
+      statement instead of advertised dead keys.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _settle_settings(pilot)
+
+        # --- Draft-save category -------------------------------------
+        await _click_settings_category(pilot, "storage")
+        screen = _active_destination_screen(host)
+        screen.action_show_workbench_help()
+        await pilot.pause()
+        panel = host.screen
+        assert isinstance(panel, WorkbenchHelpPanel)
+        body = str(panel.query_one("#workbench-help-body", Static).render())
+
+        assert "Settings: Storage" in body, body
+        # Never a title-only scroll again.
+        assert len(body.strip().splitlines()) > 1, body
+        assert "How this category works" in body, body
+        assert "Save contract: Draft — save with s." in body, body
+        assert (
+            "Runtime owner: Settings persisted defaults; storage services "
+            "active handles." in body
+        ), body
+        assert "Writes here: yes." in body, body
+        for label in _expected_labels(SettingsCategoryId.STORAGE):
+            assert label in body, (
+                f"rendered F1 body must teach {label!r}, got {body!r}"
+            )
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # --- Read-only domain category -------------------------------
+        await _click_settings_category(pilot, "schedules")
+        screen = _active_destination_screen(host)
+        screen.action_show_workbench_help()
+        await pilot.pause()
+        panel = host.screen
+        assert isinstance(panel, WorkbenchHelpPanel)
+        body = str(panel.query_one("#workbench-help-body", Static).render())
+
+        assert "Settings: Schedules" in body, body
+        assert len(body.strip().splitlines()) > 1, body
+        assert "How this category works" in body, body
+        assert "Save contract: Read-only here." in body, body
+        assert (
+            "Owned by Schedules: workflow actions and setup happen on the "
+            "Schedules screen; Settings shows read-only defaults and status."
+            in body
+        ), body
+        assert "No shortcut keys are specific to this category." in body, body
+        # Honesty: a read-only page must not teach save/revert/test keys.
+        for label in _ALL_KNOWN_LABELS:
+            assert label not in body, (
+                f"read-only F1 body must not advertise {label!r}, got {body!r}"
+            )
+
+
 _TEST_STUB_TOAST = "No test action is available"
 _SAVE_STUB_TOAST = "has no save action yet"
 

--- a/Tests/UI/test_settings_footer_hints.py
+++ b/Tests/UI/test_settings_footer_hints.py
@@ -316,6 +316,36 @@ async def test_narrow_footer_collapses_but_f1_help_stays_truthful():
             assert label not in help_text
 
 
+def test_f1_help_has_contract_content_for_every_category():
+    """TASK-23110: every category's F1 help body carries the save contract,
+    ownership, and verbs -- no category may open an empty (title-only)
+    scroll body, as Schedules did."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    members = tuple(SettingsCategoryId)
+    assert len(members) == 26
+    for category in members:
+        state = screen._workbench_help_state(category)
+        body = state.render_text()
+        assert body.strip() != state.title.strip(), category
+        assert state.notes, category
+        assert all(note.strip() for note in state.notes), category
+        assert any(
+            note.startswith("Save contract: ") for note in state.notes
+        ), category
+        assert any(
+            note.startswith("Runtime owner: ") for note in state.notes
+        ), category
+        # Verbs: either real category shortcuts, or an explicit statement
+        # that none exist here.
+        assert state.shortcuts or any(
+            note.startswith("No shortcut keys") for note in state.notes
+        ), category
+        # The ownership matrix must actually cover the category -- the
+        # missing-record placeholder is developer copy, not help.
+        assert "Ownership record missing" not in body, category
+
+
 _TEST_STUB_TOAST = "No test action is available"
 _SAVE_STUB_TOAST = "has no save action yet"
 

--- a/Tests/UI/test_settings_rag_profile_region.py
+++ b/Tests/UI/test_settings_rag_profile_region.py
@@ -1464,8 +1464,12 @@ def test_rag_backfill_worker_failure_notifies_and_clears_in_flight_without_raisi
     assert bulk_rag_slot_in_flight(BACKFILL_SLOT) is False
     message, severity = fake_app.notifications[-1]
     assert severity == "error"
+    # TASK-23108: the toast is plain language with a next step; the raw
+    # exception text stays in the log, only the type name reaches the user.
     assert "Backfill failed" in message
-    assert "kaboom" in message
+    assert "kaboom" not in message
+    assert "RuntimeError" in message
+    assert "Run Backfill again" in message
 
 
 # --- M5 (SP3 final review): the shared RAG service must be resolved OUTSIDE

--- a/Tests/UI/test_settings_rag_profile_region.py
+++ b/Tests/UI/test_settings_rag_profile_region.py
@@ -1472,6 +1472,54 @@ def test_rag_backfill_worker_failure_notifies_and_clears_in_flight_without_raisi
     assert "Run Backfill again" in message
 
 
+def test_rag_backfill_partial_failure_toast_is_plain_language(
+    monkeypatch, tmp_path, fake_app
+):
+    """TASK-23108 review round (finding 4): the partial-failure toast used to
+    embed raw str(errors[-1]) verbatim -- it now reports counts and points at
+    the log, where the engine already records each failure's traceback."""
+    _wire_rag_profile_adapter(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        settings_screen_module, "semantic_indexing_available", lambda: True
+    )
+    monkeypatch.setattr(
+        settings_screen_module, "get_shared_rag_service", lambda: object()
+    )
+
+    async def _partial(
+        *, media_db, chachanotes_db, rag_service=None, progress_callback=None
+    ):
+        return {
+            "status": "error",
+            "indexed": 3,
+            "failed": 2,
+            "errors": [
+                "HTTPStatusError: 401 for url https://emb.example/v1?key=sk-raw",
+                "boom two",
+            ],
+        }
+
+    monkeypatch.setattr(settings_screen_module, "backfill_semantic_index", _partial)
+
+    app_instance = SimpleNamespace(
+        app_config={}, media_db=object(), chachanotes_db=None
+    )
+    screen = SettingsScreen(app_instance)
+    assert acquire_bulk_rag_slot(BACKFILL_SLOT) is None
+
+    worker = SettingsScreen.__dict__["_rag_backfill_worker"]
+    wrapped = getattr(worker, "__wrapped__", worker)
+    wrapped(screen)
+
+    message, severity = fake_app.notifications[-1]
+    assert severity == "error"
+    assert "Backfill finished with problems: 3 indexed, 2 failed." in message
+    assert "2 error(s) recorded" in message
+    assert "Logs (F8)" in message
+    assert "sk-raw" not in message
+    assert "boom two" not in message
+
+
 # --- M5 (SP3 final review): the shared RAG service must be resolved OUTSIDE
 # the transient asyncio.run loop and threaded through as the `rag_service`
 # kwarg -- mirrors SearchRAGWindow._run_index_backfill's PR #700-hardened

--- a/Tests/UI/test_settings_search_index.py
+++ b/Tests/UI/test_settings_search_index.py
@@ -15,12 +15,12 @@ A "rendered setting control" is:
   ``settings-input-row`` (the screen's toggle-button pattern -- "Reduce
   motion", "Context LLM", boolean flips rendered as Buttons).
 
-Non-setting utility controls are excluded through the explicit, commented
-allowlist below -- every exclusion says why it is not a searchable setting.
+Declared blindness (review finding 5/12): coverage gaps the harness cannot
+see are named in ``HARNESS_BLIND_CATEGORIES`` / ``DECLARED_UNMOUNTED_IDS``
+with the reason, instead of being silently absorbed.
 """
 
 import pytest
-from textual.containers import Horizontal
 from textual.widgets import (
     Button,
     Checkbox,
@@ -43,13 +43,17 @@ from Tests.UI.test_settings_category_sweep import (
     _settle_settings,
 )
 from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
-from tldw_chatbook.UI.Screens.settings_search_index import FIELD_SEARCH_INDEX
+from tldw_chatbook.UI.Screens.settings_search_index import (
+    FIELD_SEARCH_INDEX,
+    SPEECH_TTS_PROVIDER_FORM_FIELDS,
+)
 
 #: Widget types that hold a user-editable value.
 VALUE_WIDGET_TYPES = (Input, Select, Checkbox, Switch, TextArea, SelectionList)
 
 #: (category value, widget id) pairs that render a value widget which is NOT
-#: a searchable persisted setting. Every entry needs a justification.
+#: a searchable persisted setting. Every entry needs a justification, and
+#: every entry must actually render (asserted below).
 NON_SETTING_CONTROLS: frozenset[tuple[str, str]] = frozenset(
     {
         # The raw TOML editor IS the whole Advanced Config category; the
@@ -70,17 +74,80 @@ NON_SETTING_CONTROLS: frozenset[tuple[str, str]] = frozenset(
         # actions, not settings.
         ("providers-models", "settings-provider-api-key-clear"),
         ("providers-models", "settings-model-context-window-reset"),
+        # "Use Official OpenAI" preset button: a one-shot action that fills
+        # the adjacent (indexed) Base URL field -- an action, not a setting.
+        ("speech-tts", "settings-speech-openai-official-preset"),
     }
 )
 
+#: Categories whose setting controls the harness CANNOT compose, with the
+#: reason. The forward sweep does not require coverage here and the reverse
+#: sweep does not require their indexed ids to resolve (review finding 12:
+#: blindness must be declared, not silent).
+HARNESS_BLIND_CATEGORIES: dict[str, str] = {
+    "agents": (
+        "the harness builds the app with chachanotes_db=None, so "
+        "AgentsSettingsPanel composes only its no-database notice; the "
+        "AGENTS index rows are hand-pinned against "
+        "Widgets/settings_agents_panel.py"
+    ),
+}
 
-def _enclosing_input_row(widget) -> Horizontal | None:
-    parent = widget.parent
-    while parent is not None and not isinstance(parent, Horizontal):
-        parent = parent.parent
-    if parent is not None and "settings-input-row" in parent.classes:
-        return parent
+#: Indexed ids that never mount in the harness, with the reason. The
+#: Speech & TTS panel composes only the DEFAULT provider's configure form
+#: (openai in this harness), so the other providers' form fields resolve
+#: only after the user switches provider; their index rows are pinned
+#: against the panel SOURCE by
+#: test_speech_provider_form_fields_match_the_panel_source instead.
+DECLARED_UNMOUNTED_IDS: frozenset[str] = frozenset(
+    f"settings-speech-{provider_id}-{field_key.replace('_', '-')}"
+    for provider_id, fields in SPEECH_TTS_PROVIDER_FORM_FIELDS.items()
+    if provider_id != "openai"
+    for field_key, _label in fields
+)
+
+#: Per-category minimum number of setting controls the sweep must see --
+#: a floor per formful category rather than one global count, so one
+#: category's form silently failing to compose cannot hide behind the
+#: others (review finding 12).
+PER_CATEGORY_MIN_SETTINGS: dict[str, int] = {
+    "providers-models": 20,
+    "speech-tts": 15,
+    "appearance": 15,
+    "theme": 10,
+    "splash_screen": 5,
+    "storage": 5,
+    "console-behavior": 30,
+    "library-rag": 20,
+    "image_generation": 40,
+    "video_generation": 15,
+    "privacy-security": 1,
+}
+
+
+def _enclosing_input_row(widget):
+    """Nearest ancestor container carrying settings-input-row, ANY depth.
+
+    Review finding 12: the old version stopped at the first Horizontal, so
+    a control nested one container deeper than its row was invisible.
+    """
+    node = widget.parent
+    while node is not None:
+        classes = getattr(node, "classes", ())
+        if "settings-input-row" in classes:
+            return node
+        node = node.parent
     return None
+
+
+def _row_label_text(widget) -> str:
+    row = _enclosing_input_row(widget)
+    if row is None:
+        return ""
+    for child in row.query(Static):
+        if "settings-input-label" in child.classes:
+            return str(child.renderable)
+    return ""
 
 
 def _is_labeled_row_toggle_button(widget: Button) -> bool:
@@ -88,15 +155,13 @@ def _is_labeled_row_toggle_button(widget: Button) -> bool:
     row = _enclosing_input_row(widget)
     if row is None:
         return False
-    has_label = any(
-        isinstance(child, Static) and "settings-input-label" in child.classes
-        for child in row.children
-    )
-    if not has_label:
+    if not any(
+        "settings-input-label" in child.classes for child in row.query(Static)
+    ):
         return False
     interactive = [
         child
-        for child in row.children
+        for child in row.query("*")
         if isinstance(child, VALUE_WIDGET_TYPES + (Button,))
     ]
     return len(interactive) == 1
@@ -106,13 +171,19 @@ def _indexed_field_ids(category: SettingsCategoryId) -> set[str]:
     return {field_id for field_id, _label in FIELD_SEARCH_INDEX.get(category, ())}
 
 
+def _normalized_label(text: str) -> str:
+    return text.replace("⚠", "").strip().rstrip(":").strip().lower()
+
+
 @pytest.mark.asyncio
 async def test_every_rendered_setting_is_in_the_search_index():
-    """Every mounted setting control is searchable or explicitly excluded."""
+    """Forward, reverse, allowlist, and label sweeps in one mounted pass."""
     app = _build_test_app()
     host = DestinationHarness(app, "settings")
     missing: list[tuple[str, str]] = []
-    seen_setting_widgets = 0
+    label_drift: list[tuple[str, str, str]] = []
+    seen_by_category: dict[str, int] = {}
+    all_ids_by_category: dict[str, set[str]] = {}
 
     async with host.run_test(size=(190, 55)) as pilot:
         await _settle_settings(pilot)
@@ -120,11 +191,12 @@ async def test_every_rendered_setting_is_in_the_search_index():
             await _click_settings_category(pilot, category_value)
             screen = _active_destination_screen(host)
             category = SettingsCategoryId(category_value)
-            indexed = _indexed_field_ids(category)
-            try:
-                body = screen.query_one("#settings-detail-pane-body")
-            except Exception:
-                continue
+            indexed = FIELD_SEARCH_INDEX.get(category, ())
+            indexed_ids = {fid for fid, _ in indexed}
+            body = screen.query_one("#settings-detail-pane-body")
+            all_ids_by_category[category_value] = {
+                w.id for w in body.query("*") if w.id
+            }
             for widget in body.query("*"):
                 is_setting = isinstance(widget, VALUE_WIDGET_TYPES) or (
                     isinstance(widget, Button)
@@ -132,23 +204,82 @@ async def test_every_rendered_setting_is_in_the_search_index():
                 )
                 if not is_setting:
                     continue
+                # Review finding 12: id-less settings count toward the
+                # floor AND are flagged -- they cannot be focused by search.
+                seen_by_category[category_value] = (
+                    seen_by_category.get(category_value, 0) + 1
+                )
                 widget_id = widget.id or ""
                 if not widget_id:
-                    # A setting without an id cannot be focused by search.
                     missing.append((category_value, f"<no id: {widget!r}>"))
                     continue
-                seen_setting_widgets += 1
                 if (category_value, widget_id) in NON_SETTING_CONTROLS:
                     continue
-                if widget_id not in indexed:
+                if widget_id not in indexed_ids:
                     missing.append((category_value, widget_id))
+                    continue
+                # Label sweep (review finding 8): search is containment-
+                # based, so the guard is bidirectional containment -- some
+                # indexed label must contain the rendered row label (typing
+                # the visible words finds it) or be contained by it (an
+                # indexed short form of a long parenthetical row label).
+                # True drift ("hybrid alpha" vs "Hybrid balance",
+                # "Preferred Library rail width" vs "Preferred rail width")
+                # fails both directions.
+                rendered = _normalized_label(_row_label_text(widget))
+                if rendered:
+                    labels = {
+                        _normalized_label(label)
+                        for fid, label in indexed
+                        if fid == widget_id
+                    }
+                    if not any(
+                        rendered in label or label in rendered
+                        for label in labels
+                    ):
+                        label_drift.append(
+                            (category_value, widget_id, rendered)
+                        )
 
-    # The sweep must actually have seen the forms, or the guard is vacuous.
-    assert seen_setting_widgets >= 100, seen_setting_widgets
+    for category_value, minimum in PER_CATEGORY_MIN_SETTINGS.items():
+        assert category_value not in HARNESS_BLIND_CATEGORIES
+        seen = seen_by_category.get(category_value, 0)
+        assert seen >= minimum, (
+            f"{category_value}: saw only {seen} setting controls "
+            f"(floor {minimum}) -- did its form fail to compose?"
+        )
+
     assert not missing, (
         "Rendered settings missing from FIELD_SEARCH_INDEX "
         "(add them to settings_search_index.py, or justify an exclusion in "
         f"NON_SETTING_CONTROLS): {sorted(set(missing))}"
+    )
+    assert not label_drift, (
+        "Indexed labels drifted from the rendered row labels "
+        f"(fix settings_search_index.py): {sorted(set(label_drift))}"
+    )
+
+    # Allowlist rows must actually render (review finding 12).
+    for category_value, widget_id in NON_SETTING_CONTROLS:
+        assert widget_id in all_ids_by_category.get(category_value, set()), (
+            f"stale allowlist row: {category_value}/{widget_id} never rendered"
+        )
+
+    # Reverse direction (review finding 12): every indexed id resolves in a
+    # mounted app, unless its absence is declared with a reason.
+    unresolved: list[tuple[str, str]] = []
+    for category in SettingsCategoryId:
+        if category.value in HARNESS_BLIND_CATEGORIES:
+            continue
+        mounted = all_ids_by_category.get(category.value, set())
+        for field_id in _indexed_field_ids(category):
+            if field_id in DECLARED_UNMOUNTED_IDS:
+                continue
+            if field_id not in mounted:
+                unresolved.append((category.value, field_id))
+    assert not unresolved, (
+        "Indexed ids that never resolved in the mounted app (fix the id, or "
+        f"declare the gap with a reason): {sorted(unresolved)}"
     )
 
 
@@ -161,3 +292,49 @@ def test_non_setting_allowlist_has_no_stale_rows():
         assert widget_id not in _indexed_field_ids(category), (
             f"{widget_id} is both allowlisted and indexed"
         )
+
+
+def test_speech_provider_form_fields_match_the_panel_source():
+    """Source pin for the six provider forms the harness cannot mount.
+
+    The Speech panel composes only the default provider's configure form,
+    so SPEECH_TTS_PROVIDER_FORM_FIELDS (which the index derives its rows
+    from) is compared against the panel's _compose_provider_form source:
+    every self._input/_select/_switch(provider_id, "key", "Label") call
+    must have a matching table row and vice versa.
+    """
+    import re
+
+    import tldw_chatbook.Widgets.Settings_Widgets.speech_tts_settings_panel as panel
+
+    source = open(panel.__file__, encoding="utf-8").read()
+    start = source.find("def _compose_provider_form")
+    assert start != -1
+    end = source.find("\n    def ", start + 10)
+    body_lines = source[start:end].split("\n")
+
+    provider = None
+    from_source: set[tuple[str, str, str]] = set()
+    for i, line in enumerate(body_lines):
+        branch = re.search(r'provider_id == "([a-z_0-9]+)"', line)
+        if branch:
+            provider = branch.group(1)
+        if re.search(r"self\._(input|select|switch)\(", line):
+            chunk = "\n".join(body_lines[i : i + 6])
+            args = re.search(
+                r'provider_id,\s*\n?\s*"([a-z_0-9]+)",\s*\n?\s*"([^"]+)"', chunk
+            )
+            if args:
+                assert provider is not None, chunk
+                from_source.add((provider, args.group(1), args.group(2)))
+
+    from_table = {
+        (provider_id, key, label)
+        for provider_id, fields in SPEECH_TTS_PROVIDER_FORM_FIELDS.items()
+        for key, label in fields
+    }
+    assert from_source, "panel source extraction found no provider fields"
+    assert from_table == from_source, (
+        f"only in table: {sorted(from_table - from_source)}; "
+        f"only in panel: {sorted(from_source - from_table)}"
+    )

--- a/Tests/UI/test_settings_search_index.py
+++ b/Tests/UI/test_settings_search_index.py
@@ -1,0 +1,163 @@
+"""Drift guard for the Settings field-level search index (TASK-23109).
+
+The index in ``tldw_chatbook/UI/Screens/settings_search_index.py`` is
+hand-maintained (with derived sections), so this suite mounts every
+category in the real harness and fails when a rendered setting control is
+missing from it -- without this, a new setting silently becomes unfindable
+by "/" search (exactly how "Reduce motion" went missing between task-1715
+and TASK-23109).
+
+A "rendered setting control" is:
+
+* any value-editing widget (Input/Select/Checkbox/Switch/TextArea/
+  SelectionList) inside the detail-pane body, or
+* a Button that is the ONLY interactive widget in a labeled
+  ``settings-input-row`` (the screen's toggle-button pattern -- "Reduce
+  motion", "Context LLM", boolean flips rendered as Buttons).
+
+Non-setting utility controls are excluded through the explicit, commented
+allowlist below -- every exclusion says why it is not a searchable setting.
+"""
+
+import pytest
+from textual.containers import Horizontal
+from textual.widgets import (
+    Button,
+    Checkbox,
+    Input,
+    Select,
+    SelectionList,
+    Static,
+    Switch,
+    TextArea,
+)
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+)
+from Tests.UI.test_screen_navigation import _build_test_app
+from Tests.UI.test_settings_category_sweep import (
+    ALL_CATEGORY_IDS,
+    _click_settings_category,
+    _settle_settings,
+)
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+from tldw_chatbook.UI.Screens.settings_search_index import FIELD_SEARCH_INDEX
+
+#: Widget types that hold a user-editable value.
+VALUE_WIDGET_TYPES = (Input, Select, Checkbox, Switch, TextArea, SelectionList)
+
+#: (category value, widget id) pairs that render a value widget which is NOT
+#: a searchable persisted setting. Every entry needs a justification.
+NON_SETTING_CONTROLS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # The raw TOML editor IS the whole Advanced Config category; the
+        # category itself is already findable by name and owned keys.
+        ("advanced-config", "settings-advanced-config-editor"),
+        # Search boxes filter content; they are not settings.
+        ("internal-prompts", "internal-prompts-search"),
+        ("providers-models", "settings-provider-search"),
+        # Transient discovery output picker, not a persisted setting.
+        ("providers-models", "settings-discovered-models-list"),
+        # Manual-provider entry is the fallback leg of the already-indexed
+        # Provider select ("Other"); it has no stable label of its own.
+        ("providers-models", "settings-provider-manual-value"),
+        # Session view filter for the workspace list, not persisted config.
+        ("workspaces", "settings-workspaces-show-archived"),
+        # One-shot action buttons operating on the adjacent, already-indexed
+        # setting (clear the saved API key / reset the context window) --
+        # actions, not settings.
+        ("providers-models", "settings-provider-api-key-clear"),
+        ("providers-models", "settings-model-context-window-reset"),
+    }
+)
+
+
+def _enclosing_input_row(widget) -> Horizontal | None:
+    parent = widget.parent
+    while parent is not None and not isinstance(parent, Horizontal):
+        parent = parent.parent
+    if parent is not None and "settings-input-row" in parent.classes:
+        return parent
+    return None
+
+
+def _is_labeled_row_toggle_button(widget: Button) -> bool:
+    """The screen's Button-as-boolean-toggle pattern (e.g. Reduce motion)."""
+    row = _enclosing_input_row(widget)
+    if row is None:
+        return False
+    has_label = any(
+        isinstance(child, Static) and "settings-input-label" in child.classes
+        for child in row.children
+    )
+    if not has_label:
+        return False
+    interactive = [
+        child
+        for child in row.children
+        if isinstance(child, VALUE_WIDGET_TYPES + (Button,))
+    ]
+    return len(interactive) == 1
+
+
+def _indexed_field_ids(category: SettingsCategoryId) -> set[str]:
+    return {field_id for field_id, _label in FIELD_SEARCH_INDEX.get(category, ())}
+
+
+@pytest.mark.asyncio
+async def test_every_rendered_setting_is_in_the_search_index():
+    """Every mounted setting control is searchable or explicitly excluded."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    missing: list[tuple[str, str]] = []
+    seen_setting_widgets = 0
+
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings(pilot)
+        for category_value in ALL_CATEGORY_IDS:
+            await _click_settings_category(pilot, category_value)
+            screen = _active_destination_screen(host)
+            category = SettingsCategoryId(category_value)
+            indexed = _indexed_field_ids(category)
+            try:
+                body = screen.query_one("#settings-detail-pane-body")
+            except Exception:
+                continue
+            for widget in body.query("*"):
+                is_setting = isinstance(widget, VALUE_WIDGET_TYPES) or (
+                    isinstance(widget, Button)
+                    and _is_labeled_row_toggle_button(widget)
+                )
+                if not is_setting:
+                    continue
+                widget_id = widget.id or ""
+                if not widget_id:
+                    # A setting without an id cannot be focused by search.
+                    missing.append((category_value, f"<no id: {widget!r}>"))
+                    continue
+                seen_setting_widgets += 1
+                if (category_value, widget_id) in NON_SETTING_CONTROLS:
+                    continue
+                if widget_id not in indexed:
+                    missing.append((category_value, widget_id))
+
+    # The sweep must actually have seen the forms, or the guard is vacuous.
+    assert seen_setting_widgets >= 100, seen_setting_widgets
+    assert not missing, (
+        "Rendered settings missing from FIELD_SEARCH_INDEX "
+        "(add them to settings_search_index.py, or justify an exclusion in "
+        f"NON_SETTING_CONTROLS): {sorted(set(missing))}"
+    )
+
+
+def test_non_setting_allowlist_has_no_stale_rows():
+    """Every allowlist row names a category that exists and is not indexed."""
+    known_categories = set(ALL_CATEGORY_IDS)
+    for category_value, widget_id in NON_SETTING_CONTROLS:
+        assert category_value in known_categories, category_value
+        category = SettingsCategoryId(category_value)
+        assert widget_id not in _indexed_field_ids(category), (
+            f"{widget_id} is both allowlisted and indexed"
+        )

--- a/tldw_chatbook/UI/Screens/settings_config_adapter.py
+++ b/tldw_chatbook/UI/Screens/settings_config_adapter.py
@@ -46,6 +46,31 @@ def redact_secret_text(text: str) -> str:
     return _SECRET_ASSIGNMENT_PATTERN.sub(_replace, str(text))
 
 
+def failure_status_text(summary: str, exc: BaseException, *, next_step: str) -> str:
+    """Compose a plain-language failure line for user-facing Settings output.
+
+    TASK-23108: raw exception text must never be the primary user-facing
+    message -- it can embed URLs, header dumps, or secret fragments, and it
+    reads as developer output. The exception contributes only its type name;
+    the caller is responsible for logging the full (redacted) detail so it
+    stays reachable. The composed line still passes through
+    ``redact_secret_text`` as defence in depth.
+
+    Args:
+        summary: Plain-language statement of what failed, without trailing
+            punctuation (e.g. ``"Model discovery failed"``).
+        exc: The caught exception; only ``type(exc).__name__`` is shown.
+        next_step: The suggested user action, as a full sentence.
+
+    Returns:
+        ``"<summary> (<ExcType>). <next_step> Details are in Logs (F8)."``
+    """
+    kind = type(exc).__name__
+    return redact_secret_text(
+        f"{summary} ({kind}). {next_step} Details are in Logs (F8)."
+    )
+
+
 def _is_toml_scalar_value(text: str) -> bool:
     """Return whether text parses as a TOML value rather than a table."""
     try:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -6155,14 +6155,18 @@ class SettingsScreen(BaseAppScreen):
         # task-1715: field labels -- typing a setting's visible name
         # ("threshold") surfaces its category with an Enter-focuses-field
         # promise (see _top_field_match / _submit_category_search).
-        # TASK-23109: two field tiers -- a label that STARTS with the query
-        # ("Threshold (chars)") outranks a mid-label hit ("VAD threshold"),
-        # so completing the index cannot re-route an established landing.
-        field = self._top_field_match(query, summary.category)
-        if field is not None:
-            if field[1].lower().startswith(query):
-                return 3
-            return 4
+        # TASK-23109: two field tiers -- a category with a label that STARTS
+        # with the query ("Threshold (chars)") outranks one with only a
+        # mid-label hit ("VAD threshold"), so completing the index cannot
+        # re-route an established CROSS-category landing. The tier scans all
+        # of the category's labels; WHICH field wins within the category
+        # stays order-stable (_top_field_match), preserving pre-existing
+        # intra-category landings (review finding 13: "/token" must keep
+        # landing on "Conversation max tokens", not the swept-in
+        # "Token budget (per run)").
+        tier = self._field_match_rank_tier(query, summary.category)
+        if tier is not None:
+            return tier
         # task-1564: last tier -- the category's owned config keys. The Scope
         # Inspector already publishes them; indexing them lets "/" find the
         # category that OWNS a setting instead of forcing a 23-item scan.
@@ -6176,8 +6180,31 @@ class SettingsScreen(BaseAppScreen):
             return 5
         return None
 
-    #: Ranks produced by the field-label tiers of ``_category_search_rank``.
-    FIELD_MATCH_RANKS = frozenset({3, 4})
+    #: Ranks meaning the query matched the category's own name -- Enter on
+    #: these opens the category plainly, never a coincidental field
+    #: (review finding 2: description-tier matches such as "context window"
+    #: on Providers & Models DO land on their matching field).
+    TITLE_MATCH_RANKS = frozenset({0, 1})
+
+    @staticmethod
+    def _field_match_rank_tier(
+        query_text: str, category: SettingsCategoryId
+    ) -> int | None:
+        """Field-tier rank for a category: 3 (label-prefix), 4 (contains).
+
+        Scans every indexed label so the CATEGORY ranking can prefer a
+        prefix hit anywhere in the category, independent of which field
+        ``_top_field_match`` (order-stable) actually lands on.
+        """
+        query = query_text.strip().lower()
+        if not query:
+            return None
+        entries = FIELD_SEARCH_INDEX.get(category, ())
+        if any(label.lower().startswith(query) for _fid, label in entries):
+            return 3
+        if any(query in label.lower() for _fid, label in entries):
+            return 4
+        return None
 
     @staticmethod
     def _top_field_match(
@@ -6195,13 +6222,12 @@ class SettingsScreen(BaseAppScreen):
         query = query_text.strip().lower()
         if not query:
             return None
-        entries = FIELD_SEARCH_INDEX.get(category, ())
-        # TASK-23109: a label that starts with the query wins over a
-        # mid-label hit, mirroring the rank tiers in _category_search_rank.
-        for field_id, label in entries:
-            if label.lower().startswith(query):
-                return (field_id, label)
-        for field_id, label in entries:
+        # Order-stable single pass (review finding 13): the first containment
+        # hit in index order wins WITHIN a category, so completing the index
+        # (rows are appended) cannot re-route established landings. Prefix
+        # quality only affects CROSS-category ranking -- see
+        # _field_match_rank_tier.
+        for field_id, label in FIELD_SEARCH_INDEX.get(category, ()):
             if query in label.lower():
                 return (field_id, label)
         return None
@@ -6253,11 +6279,12 @@ class SettingsScreen(BaseAppScreen):
         Args:
             query: The active filter text.
             summary: The matched category.
-            field_landing: Whether Enter would land ON the matched field.
-                For the top match this is True only when the match CAME from
-                the field tier (typing a category's own title must open the
-                category plainly, not steal focus into its first field);
-                runner-up lines always name a matching field as information.
+            field_landing: Whether Enter would land ON the matched field
+                if this match were opened -- compute it with
+                ``_search_match_is_field_landing`` so the echo line and the
+                Enter behavior state the same contract (typing a category's
+                own title opens the category plainly, every other tier with
+                a matching field lands on it).
         """
         target = summary.title
         # task-1715: when the hit is (or contains) a matching field, promise
@@ -6271,8 +6298,31 @@ class SettingsScreen(BaseAppScreen):
     def _search_match_is_field_landing(
         self, query: str, summary: SettingsCategorySummary
     ) -> bool:
-        """Whether Enter on this top match lands focus on a matched field."""
-        return self._category_search_rank(summary, query) in self.FIELD_MATCH_RANKS
+        """Whether Enter on this top match lands focus on a matched field.
+
+        Review finding 2: only own-TITLE matches suppress the landing --
+        a description-tier match ("context window" on Providers & Models)
+        with a matching field still lands on that field, as task-1715 did.
+        """
+        rank = self._category_search_rank(summary, query)
+        if rank is None or rank in self.TITLE_MATCH_RANKS:
+            return False
+        return self._top_field_match(query, summary.category) is not None
+
+    #: Below this screen height the "| Next:" disambiguation segment is
+    #: dropped: in the 30-col rail the full scoped line wraps to ~5 rows,
+    #: which on a 24-row terminal pushed most matched category rows below
+    #: the fold mid-search (review finding 15, verified at 110x24 with a
+    #: 16-match query leaving 6 rail rows visible).
+    SEARCH_STATUS_NEXT_MIN_HEIGHT = 30
+
+    def _suppress_search_next_segment(self) -> bool:
+        """Whether the rail is too short to spend rows on '| Next:'."""
+        try:
+            height = int(self.size.height)
+        except Exception:
+            height = 0
+        return 0 < height < self.SEARCH_STATUS_NEXT_MIN_HEIGHT
 
     def _category_search_status_text(self, query_text: str | None = None) -> str:
         query = self._category_search_text(query_text)
@@ -6289,11 +6339,18 @@ class SettingsScreen(BaseAppScreen):
             status = (
                 f"Filter: {query} | {len(matches)} {match_label} | Enter opens {target}"
             )
-            if len(matches) > 1:
+            if len(matches) > 1 and not self._suppress_search_next_segment():
+                # Review finding 10: the Next segment states the SAME
+                # landing contract Enter would honour if this match were
+                # first -- never advertise a field landing the gate refuses.
                 status += (
                     " | Next: "
                     + self._search_match_scope_text(
-                        query, matches[1], field_landing=True
+                        query,
+                        matches[1],
+                        field_landing=self._search_match_is_field_landing(
+                            query, matches[1]
+                        ),
                     )
                 )
             return status
@@ -6411,13 +6468,10 @@ class SettingsScreen(BaseAppScreen):
                 else None
             )
             if field is not None:
-                field_id = field[0]
+                field_id, field_label = field
 
                 def _focus_matched_field() -> None:
-                    try:
-                        self.query_one(f"#{field_id}").focus()
-                    except QueryError:
-                        pass
+                    self._land_search_focus_on_field(field_id, field_label)
 
                 self._after_category_panes(_focus_matched_field)
             # task-1712: the filter has done its job -- clear it so the
@@ -6430,6 +6484,53 @@ class SettingsScreen(BaseAppScreen):
             except QueryError:
                 pass
             self._apply_category_search_filter()
+
+    def _land_search_focus_on_field(self, field_id: str, field_label: str) -> None:
+        """Land Enter's field promise on a real, usable control.
+
+        Review finding 3 (TASK-23109): a blind ``.focus()`` put focus on
+        zero-region widgets inside collapsed ``Collapsible``s (keystrokes
+        went into an off-screen Input) and silently no-opped on disabled
+        widgets. Expand the enclosing Collapsibles and scroll the target
+        into view first; if the target is disabled, keep the category open
+        and say why in the search status line instead of doing nothing.
+
+        Args:
+            field_id: The matched control's widget id.
+            field_label: Its indexed label, for the disabled explanation.
+        """
+        try:
+            widget = self.query_one(f"#{field_id}")
+        except QueryError:
+            return
+        if widget.disabled or any(
+            getattr(node, "disabled", False) for node in widget.ancestors
+        ):
+            self._set_static_text(
+                "#settings-category-search-status",
+                f"'{field_label}' is disabled right now — its category is "
+                "open; enable the option that controls it first.",
+            )
+            return
+        expanded = False
+        for node in widget.ancestors:
+            if isinstance(node, Collapsible) and node.collapsed:
+                node.collapsed = False
+                expanded = True
+
+        def _focus_now() -> None:
+            try:
+                widget.scroll_visible(animate=False)
+            except Exception:
+                logger.debug("Search landing could not scroll to the field.")
+            widget.focus()
+
+        if expanded:
+            # Let the expansion lay out before focusing, or the target still
+            # has a zero region when focus arrives.
+            self.call_after_refresh(_focus_now)
+        else:
+            _focus_now()
 
     def _category_state_banner_text(self, category: SettingsCategoryId) -> str:
         if (

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3124,7 +3124,11 @@ class SettingsScreen(BaseAppScreen):
         Reuses copy the screen already maintains -- the persistence badge
         (save contract), the State-banner scope line, and the ownership
         matrix -- so the help body cannot drift from the surfaces it
-        summarizes and never falls back to an empty scroll.
+        summarizes and never falls back to an empty scroll. Review
+        finding 11's copy rules: Overview's boundary keeps its owner
+        labels, the read-only domain pages say their one sentence once,
+        and a value another note already carries is not repeated under a
+        second prefix.
 
         Args:
             category: The Settings category to describe.
@@ -3133,17 +3137,74 @@ class SettingsScreen(BaseAppScreen):
             Non-empty tuple of plain-text help lines.
         """
         ownership = self._ownership_record(category)
-        notes = [
-            f"Save contract: {self._persistence_badge(category)}.",
-            f"Scope: {self._category_state_scope_text(category)}",
-            f"Runtime owner: {ownership.runtime_owner}.",
-            "Writes here: "
-            + ("yes." if ownership.writes_allowed else "no — view-only."),
-        ]
-        if ownership.boundary_copy:
-            notes.append(f"Boundary: {ownership.boundary_copy}")
-        if ownership.recovery_copy:
-            notes.append(f"Recovery: {ownership.recovery_copy}")
+        badge_note = f"Save contract: {self._persistence_badge(category)}."
+        if category is SettingsCategoryId.OVERVIEW:
+            notes = [
+                badge_note,
+                f"Scope: {self._category_state_scope_text(category)}",
+                (
+                    "Runtime owner: the owning destinations — Settings "
+                    "summarizes their status."
+                ),
+                # Labeled rows, not a subject-less "; ".join run-on.
+                *(
+                    f"{label}: {value}"
+                    for label, value in SETTINGS_OVERVIEW_BOUNDARY_ROWS
+                ),
+            ]
+            if ownership.recovery_copy:
+                notes.append(f"Recovery: {ownership.recovery_copy}")
+        elif (
+            category in DOMAIN_SETTINGS_CATEGORY_IDS
+            and not ownership.writes_allowed
+        ):
+            # One sentence, once -- Scope/Runtime owner/Boundary/Recovery
+            # all restated "X owns the workflow" on these pages.
+            contract = self._domain_category_contract(category)
+            owner = contract.owner_destination
+            notes = [
+                badge_note,
+                (
+                    f"Owned by {owner}: workflow actions and setup happen "
+                    f"on the {owner} screen; Settings shows read-only "
+                    "defaults and status."
+                ),
+            ]
+        else:
+            candidates = [
+                ("Scope: ", self._category_state_scope_text(category)),
+                ("Runtime owner: ", f"{ownership.runtime_owner}."),
+                (
+                    "Writes here: ",
+                    "yes." if ownership.writes_allowed else "no — view-only.",
+                ),
+                ("Boundary: ", ownership.boundary_copy),
+                ("Recovery: ", ownership.recovery_copy),
+            ]
+            normalized = [
+                (prefix, value, value.strip().rstrip(".").lower())
+                for prefix, value in candidates
+                if value
+            ]
+            notes = [badge_note]
+            seen_values: set[str] = set()
+            for prefix, value, norm in normalized:
+                # Skip a substantial value another note carries verbatim
+                # (Agents repeated one clause under two prefixes). The
+                # ownership line is exempt: it must stay explicit even when
+                # the boundary sentence names the same owner.
+                contained_elsewhere = (
+                    prefix != "Runtime owner: "
+                    and len(norm) >= 20
+                    and any(
+                        norm != other_norm and norm in other_norm
+                        for _p, _v, other_norm in normalized
+                    )
+                )
+                if contained_elsewhere or norm in seen_values:
+                    continue
+                seen_values.add(norm)
+                notes.append(f"{prefix}{value}")
         if not self._category_footer_shortcuts(category):
             notes.append("No shortcut keys are specific to this category.")
         return tuple(notes)
@@ -3601,6 +3662,40 @@ class SettingsScreen(BaseAppScreen):
                         ),
                         recovery_copy=(
                             "Revert unsaved edits, or edit image_generation values "
+                            "directly in Advanced Config."
+                        ),
+                    )
+                )
+                continue
+            if contract.category is SettingsCategoryId.VIDEO_GENERATION:
+                # TASK-23110 review (finding 6): Video Gen mutates like
+                # Image Gen -- the generic read-only record below paired a
+                # "Draft — save/revert below" badge with "read-only
+                # defaults" copy in F1 help.
+                records.append(
+                    SettingsOwnershipRecord(
+                        category=contract.category,
+                        owns_config_sections=(
+                            "video_generation.default_backend",
+                            "video_generation.enabled_backends",
+                            "video_generation.<backend>.*",
+                            "video_generation.retention",
+                            "video_generation.retention_ttl_hours",
+                            "video_generation.max_store_mb",
+                            "video_generation.confirm_cost_estimate",
+                        ),
+                        reads_runtime_state_from=contract.source_of_truth,
+                        writes_allowed=True,
+                        runtime_owner=(
+                            "Settings persisted defaults; Console /generate-video"
+                        ),
+                        boundary_copy=(
+                            "Settings owns persisted backend and generation-default "
+                            "config; Console owns /generate-video, cards, and "
+                            "playback."
+                        ),
+                        recovery_copy=(
+                            "Revert unsaved edits, or edit video_generation values "
                             "directly in Advanced Config."
                         ),
                     )

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -6583,6 +6583,8 @@ class SettingsScreen(BaseAppScreen):
             return "Defaults affect future Library/RAG retrieval and display."
         if category is SettingsCategoryId.IMAGE_GENERATION:
             return "Defaults affect future Console image generations."
+        if category is SettingsCategoryId.VIDEO_GENERATION:
+            return "Defaults affect future Console video generations."
         if category is SettingsCategoryId.DIAGNOSTICS:
             return "Validation and reload expose status without writing raw TOML."
         if category is SettingsCategoryId.APPEARANCE:
@@ -6604,13 +6606,14 @@ class SettingsScreen(BaseAppScreen):
             return "Use the editor's Apply/Save/Reset buttons below."
         if category is SettingsCategoryId.INTERNAL_PROMPTS:
             return "Each prompt saves and resets on its own."
+        # TASK-23104: the badge already leads the banner with "State: ..." --
+        # scope text must never embed a second "State:" segment of its own
+        # (domain categories used to render "State: Read-only here | State:
+        # Read-only | ...").
         if category in DOMAIN_SETTINGS_CATEGORY_IDS:
             contract = self._domain_category_contract(category)
-            return (
-                "State: Read-only | "
-                f"{contract.owner_destination} owns workflow actions and setup."
-            )
-        return "State: Active | Review readiness across Settings categories."
+            return f"{contract.owner_destination} owns workflow actions and setup."
+        return "Review readiness across Settings categories."
 
     def _render_category_state_banner(self, category: SettingsCategoryId) -> Static:
         banner = Static(
@@ -12534,8 +12537,10 @@ class SettingsScreen(BaseAppScreen):
     def _render_overview_detail(self) -> ComposeResult:
         presentation = self._settings_overview_presentation()
         yield Static("Overview", classes="destination-section settings-column-title")
+        # TASK-23104: no in-card State banner -- the detail-pane region already
+        # pins one above the scroll body for every category; a second copy
+        # here rendered the contract line twice.
         with Vertical(id="settings-overview-card", classes="settings-focus-card"):
-            yield self._render_category_state_banner(SettingsCategoryId.OVERVIEW)
             yield Static("Status", classes="destination-section")
             with Vertical(id="settings-overview-primary"):
                 for row in presentation.primary_rows:
@@ -15335,10 +15340,11 @@ class SettingsScreen(BaseAppScreen):
         yield Static(
             contract.title, classes="destination-section settings-column-title"
         )
+        # TASK-23104: no in-card State banner -- the detail-pane region already
+        # pins one above the scroll body for every category.
         with Vertical(
             id=f"settings-{category.value}-card", classes="settings-focus-card"
         ):
-            yield self._render_category_state_banner(category)
             yield Static("How this page works", classes="destination-section")
             yield self._detail_row("Owner destination", contract.owner_destination)
             yield self._detail_row(

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -194,7 +194,9 @@ from .settings_search_index import (
     FIELD_SEARCH_INDEX,
     LIBRARY_READER_DESTINATIONS,
     RAG_FIELD_GROUP_BY_ID as _RAG_FIELD_GROUP_BY_ID,
-    build_field_search_index as _build_field_search_index,
+    # Load-bearing re-export: Tests/UI/test_settings_console_status_row.py
+    # rebuilds the index via settings_screen_module._build_field_search_index.
+    build_field_search_index as _build_field_search_index,  # noqa: F401
 )
 from .settings_context_memory import (
     CONTEXT_MEMORY_CONFIG_KEYS,

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -185,7 +185,11 @@ from .provider_model_resolution import (
     EffectiveProviderModel,
     resolve_effective_provider_model,
 )
-from .settings_config_adapter import SettingsConfigAdapter, redact_secret_text
+from .settings_config_adapter import (
+    SettingsConfigAdapter,
+    failure_status_text,
+    redact_secret_text,
+)
 from .settings_context_memory import (
     CONTEXT_MEMORY_CONFIG_KEYS,
     SUMMARY_PROMPT_ID,
@@ -11017,10 +11021,20 @@ class SettingsScreen(BaseAppScreen):
             )
         except Exception as exc:
             # No traceback: the log file sink runs with diagnose=True, which would
-            # dump frame locals (api_key, headers) into the log file.
-            logger.warning(f"Provider model discovery failed: {type(exc).__name__}")
-            self._model_discovery_status = redact_secret_text(
-                f"Model discovery failed: {exc}"
+            # dump frame locals (api_key, headers) into the log file. The message
+            # text is redacted and logged so the detail stays reachable now that
+            # the status line is plain language (TASK-23108).
+            logger.warning(
+                "Provider model discovery failed: "
+                f"{type(exc).__name__}: {redact_secret_text(str(exc))}"
+            )
+            self._model_discovery_status = failure_status_text(
+                "Model discovery failed",
+                exc,
+                next_step=(
+                    "Check the provider endpoint and API key, then run "
+                    "Discover again."
+                ),
             )
             self._model_discovery_models = ()
             self._model_discovery_selected_model_ids = set()
@@ -11154,8 +11168,13 @@ class SettingsScreen(BaseAppScreen):
             )
         except Exception as exc:
             logger.exception("Provider model discovery persistence failed")
-            self._model_discovery_status = redact_secret_text(
-                f"Could not save discovered models: {exc}"
+            self._model_discovery_status = failure_status_text(
+                "Could not save the discovered models",
+                exc,
+                next_step=(
+                    "Try Save again; if it keeps failing, check that your "
+                    "config file is writable."
+                ),
             )
             self._refresh_model_discovery_widgets()
             return
@@ -14460,9 +14479,15 @@ class SettingsScreen(BaseAppScreen):
                 )
             )
         except Exception as e:
-            logger.error(f"RAG index backfill crashed: {e}")
+            logger.error(f"RAG index backfill crashed: {type(e).__name__}: {e}")
             self.app.call_from_thread(
-                self.app.notify, f"Backfill failed: {e}", severity="error"
+                self.app.notify,
+                failure_status_text(
+                    "Backfill failed before finishing",
+                    e,
+                    next_step="Run Backfill again — completed items are kept.",
+                ),
+                severity="error",
             )
             return
         finally:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -10939,13 +10939,16 @@ class SettingsScreen(BaseAppScreen):
                 staged_settings=staged_settings,
             )
         except Exception as exc:
-            # No traceback: the log file sink runs with diagnose=True, which would
-            # dump frame locals (api_key, headers) into the log file. The message
-            # text is redacted and logged so the detail stays reachable now that
-            # the status line is plain language (TASK-23108).
+            # Type name ONLY -- no traceback (the log file sink runs with
+            # diagnose=True, which would dump frame locals: api_key, headers)
+            # and no message text either: an httpx error's str() can embed
+            # "?key=..." URLs or Authorization headers, and redact_secret_text
+            # only catches "X = value" assignment shapes, so interpolating the
+            # message would write raw credentials into the on-disk log
+            # (TASK-23108 review round; sink-level redaction is the tracked
+            # follow-up).
             logger.warning(
-                "Provider model discovery failed: "
-                f"{type(exc).__name__}: {redact_secret_text(str(exc))}"
+                f"Provider model discovery failed: {type(exc).__name__}"
             )
             self._model_discovery_status = failure_status_text(
                 "Model discovery failed",
@@ -11086,7 +11089,13 @@ class SettingsScreen(BaseAppScreen):
                 model_ids=selected_model_ids,
             )
         except Exception as exc:
-            logger.exception("Provider model discovery persistence failed")
+            # Type name only -- logger.exception's traceback tail would print
+            # the raw exception message (and diagnose=True would dump frame
+            # locals); see the discovery-run branch above (TASK-23108 review).
+            logger.warning(
+                "Provider model discovery persistence failed: "
+                f"{type(exc).__name__}"
+            )
             self._model_discovery_status = failure_status_text(
                 "Could not save the discovered models",
                 exc,
@@ -14398,7 +14407,10 @@ class SettingsScreen(BaseAppScreen):
                 )
             )
         except Exception as e:
-            logger.error(f"RAG index backfill crashed: {type(e).__name__}: {e}")
+            # Type name only -- interpolating the message could write raw
+            # embedded credentials (remote-embedding HTTP errors) into the
+            # unredacted on-disk log (TASK-23108 review round, finding 1).
+            logger.error(f"RAG index backfill crashed: {type(e).__name__}")
             self.app.call_from_thread(
                 self.app.notify,
                 failure_status_text(
@@ -14414,8 +14426,16 @@ class SettingsScreen(BaseAppScreen):
         status = summary.get("status")
         errors = summary.get("errors") or []
         if status in ("unavailable", "error") or errors:
-            last_error = str(errors[-1]) if errors else None
-            detail = f" Last error: {last_error}" if last_error else ""
+            # TASK-23108 review round: no raw error text in the toast -- the
+            # engine already logs each failure with its traceback
+            # (ingestion_indexing's logger.opt(exception=True).error calls),
+            # so the toast stays plain language with a next step.
+            error_count = len(errors)
+            detail = (
+                f" {error_count} error(s) recorded — details are in Logs (F8)."
+                if error_count
+                else " Details are in Logs (F8)."
+            )
             self.app.call_from_thread(
                 self.app.notify,
                 f"Backfill finished with problems: {summary.get('indexed', 0)} "

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3276,30 +3276,85 @@ class SettingsScreen(BaseAppScreen):
                 logger.debug("Settings post-pane-swap callback failed.")
 
     def action_show_workbench_help(self) -> None:
-        """F1 help: list the ACTIVE category's working shortcuts (task-1340).
+        """F1 help: the ACTIVE category's contract and working shortcuts.
 
         app.py delegates F1 to the screen when this handler exists. Listing
         the per-category set (not the static BINDINGS superset) keeps help
         truthful, and keeps the bindings discoverable at narrow widths where
-        the footer collapses the screen hints to an ellipsis.
+        the footer collapses the screen hints to an ellipsis (task-1340).
         """
         from ..Workbench.help import (  # noqa: PLC0415 -- lazy: only needed on F1; keeps the help panel off the module import path (mirrors base_app_screen's local-import convention)
             WorkbenchHelpPanel,
+        )
+
+        self.app.push_screen(
+            WorkbenchHelpPanel(
+                self._workbench_help_state(self._active_category_id())
+            )
+        )
+
+    def _workbench_help_state(self, category: SettingsCategoryId):
+        """Build the F1 help content for one category (TASK-23110).
+
+        Every category gets a non-empty body: the save contract, ownership,
+        and verbs already maintained for the State banner, the footer, and
+        the Scope Inspector -- previously a category with no shortcuts
+        (e.g. Schedules) opened an entirely empty scroll body.
+
+        Args:
+            category: The Settings category to describe.
+
+        Returns:
+            A ``WorkbenchHelpState`` ready for ``WorkbenchHelpPanel``.
+        """
+        from ..Workbench.help import (  # noqa: PLC0415 -- lazy, see action_show_workbench_help
             WorkbenchHelpState,
         )
 
-        category = self._active_category_id()
         summary = self._category_summary_by_id(category)
         shortcuts = self._category_footer_shortcuts(category)
         if category is SettingsCategoryId.LIBRARY_RAG:
             # Same gating the footer applies: a/c/b only act in LIBRARY_RAG.
             shortcuts = shortcuts + self.LIBRARY_RAG_SHORTCUTS
-        state = WorkbenchHelpState(
+        return WorkbenchHelpState(
             route_id="settings",
             title=f"Settings: {summary.title}",
+            notes_heading="How this category works",
+            notes=self._category_help_notes(category),
             shortcuts=shortcuts,
         )
-        self.app.push_screen(WorkbenchHelpPanel(state))
+
+    def _category_help_notes(
+        self, category: SettingsCategoryId
+    ) -> tuple[str, ...]:
+        """Category-contract notes for the F1 help panel (TASK-23110).
+
+        Reuses copy the screen already maintains -- the persistence badge
+        (save contract), the State-banner scope line, and the ownership
+        matrix -- so the help body cannot drift from the surfaces it
+        summarizes and never falls back to an empty scroll.
+
+        Args:
+            category: The Settings category to describe.
+
+        Returns:
+            Non-empty tuple of plain-text help lines.
+        """
+        ownership = self._ownership_record(category)
+        notes = [
+            f"Save contract: {self._persistence_badge(category)}.",
+            f"Scope: {self._category_state_scope_text(category)}",
+            f"Runtime owner: {ownership.runtime_owner}.",
+            "Writes here: "
+            + ("yes." if ownership.writes_allowed else "no — view-only."),
+        ]
+        if ownership.boundary_copy:
+            notes.append(f"Boundary: {ownership.boundary_copy}")
+        if ownership.recovery_copy:
+            notes.append(f"Recovery: {ownership.recovery_copy}")
+        if not self._category_footer_shortcuts(category):
+            notes.append("No shortcut keys are specific to this category.")
+        return tuple(notes)
 
     def on_mount(self) -> None:
         # No super().on_mount(): the dispatcher already invokes

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -190,6 +190,12 @@ from .settings_config_adapter import (
     failure_status_text,
     redact_secret_text,
 )
+from .settings_search_index import (
+    FIELD_SEARCH_INDEX,
+    LIBRARY_READER_DESTINATIONS,
+    RAG_FIELD_GROUP_BY_ID as _RAG_FIELD_GROUP_BY_ID,
+    build_field_search_index as _build_field_search_index,
+)
 from .settings_context_memory import (
     CONTEXT_MEMORY_CONFIG_KEYS,
     SUMMARY_PROMPT_ID,
@@ -524,13 +530,6 @@ MAX_CATEGORY_SEARCH_QUERY_CHARS = 80
 # compact layout (fixed-width category sidebar, inspector pane hidden),
 # following the personas-workbench-compact precedent (task-1342).
 SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH = 100
-LIBRARY_READER_DESTINATIONS = (
-    ("media", "Media"),
-    ("conversations", "Conversations"),
-    ("notes", "Notes"),
-    ("prompts", "Prompts"),
-    ("skills", "Skills"),
-)
 PROVIDER_ENDPOINT_KEYS = ("api_base_url", "api_base", "base_url", "api_url", "endpoint")
 PROVIDER_MODEL_PROFILE_FIELD_KEYS = {
     "model_profile_temperature": "temperature",
@@ -1329,218 +1328,9 @@ DOMAIN_CONTRACT_BY_CATEGORY = _build_domain_contract_by_category(
 DOMAIN_SETTINGS_CATEGORY_IDS = frozenset(DOMAIN_CONTRACT_BY_CATEGORY)
 _WORKSPACE_RECORD_UNSET = object()
 
-# Task 3 (541 v2 UX AC3): RAG widget id -> guidance-group key. Mirrors the
-# ids `_library_rag_field_selector` and the LIBRARY_RAG compose branch mint
-# (search around "settings-library-rag-" in this file). Used by
-# `_rag_field_guidance_rows()` so the Scope Inspector follows the focused
-# field; falls back to `_active_rag_scope_group` (the last-expanded
-# Collapsible) when the focused widget isn't one of these.
-_RAG_FIELD_GROUP_BY_ID: dict[str, str] = {
-    "settings-library-rag-search-mode": "search",
-    "settings-library-rag-default-top-k": "search",
-    "settings-library-rag-fts-top-k": "search",
-    "settings-library-rag-vector-top-k": "search",
-    "settings-library-rag-hybrid-alpha": "search",
-    "settings-library-rag-score-threshold": "search",
-    "settings-library-rag-include-citations": "search",
-    "settings-library-rag-direct-library-tools": "search",
-    "settings-library-rag-citation-style": "search",
-    "settings-library-rag-snippet-max-chars": "search",
-    "settings-library-rag-max-context-size": "search",
-    "settings-library-rag-embedding-model": "embedding",
-    "settings-library-rag-embedding-device": "embedding",
-    "settings-library-rag-embedding-batch-size": "embedding",
-    "settings-library-rag-embedding-max-length": "embedding",
-    "settings-library-rag-chunk-size": "chunking",
-    "settings-library-rag-chunk-overlap": "chunking",
-    "settings-library-rag-chunking-method": "chunking",
-    "settings-library-rag-distance-metric": "vector_store",
-    "settings-library-rag-enable-reranking": "reranking",
-    "settings-library-rag-reranker-provider": "reranking",
-    "settings-library-rag-reranker-model": "reranking",
-    "settings-library-rag-reranker-top-k": "reranking",
-    "settings-library-rag-profile-select": "profile",
-    "settings-library-rag-profile-set-active": "profile",
-    "settings-library-rag-profile-clone": "profile",
-    "settings-library-rag-profile-rename": "profile",
-    "settings-library-rag-profile-delete": "profile",
-    "settings-library-rag-index-backfill": "index",
-}
-
-
-def _rag_field_search_label(field_id: str) -> str:
-    """Human label for a RAG field id (task-1715 field-level search).
-
-    Args:
-        field_id: A ``settings-library-rag-*`` widget id.
-
-    Returns:
-        The id suffix as a spaced title, e.g. "hybrid alpha".
-    """
-    return field_id.removeprefix("settings-library-rag-").replace("-", " ")
-
-
-#: task-1715: field-level search index -- "/" previously matched only
-#: category names/descriptions/owned keys, so "threshold" found nothing
-#: on a 23-category screen (critique r4 P1). Labels mirror the visible
-#: row labels; Enter focuses the matched field.
-FIELD_SEARCH_INDEX: dict["SettingsCategoryId", tuple[tuple[str, str], ...]] = {}
-
-
-def _build_field_search_index() -> None:
-    from .settings_storage_defaults import STORAGE_FIELD_LABELS as _labels
-
-    FIELD_SEARCH_INDEX.update(
-        {
-            SettingsCategoryId.CONSOLE_BEHAVIOR: (
-                (
-                    "settings-console-show-model-thinking",
-                    "Show model thinking",
-                ),
-                (
-                    "settings-console-rail-layout-scope",
-                    "Rail layout scope",
-                ),
-                (
-                    "settings-console-rail-layout-scope",
-                    "Global per workspace layout scope",
-                ),
-                (
-                    "settings-console-stack-collapsed-rail-labels",
-                    "Stack collapsed rail labels",
-                ),
-                (
-                    "settings-console-stack-collapsed-rail-labels",
-                    "Rail handle presentation",
-                ),
-                (
-                    "settings-console-stack-collapsed-rail-labels",
-                    "Stacked vertical Context Inspector",
-                ),
-                (
-                    "settings-console-status-row-position-toggle",
-                    "Status row placement",
-                ),
-                (
-                    "settings-console-status-row-position-toggle",
-                    "Status chips above below composer",
-                ),
-                ("settings-console-paste-collapse-threshold", "Threshold (chars)"),
-                ("settings-console-max-parallel-runs", "Max parallel agent runs"),
-                ("settings-console-tool-result-display-chars", "Display cap (chars)"),
-                ("settings-console-sidechat-model", "Side chat model"),
-                (
-                    "settings-console-sidechat-prompt-template",
-                    "Side chat prompt template",
-                ),
-                (
-                    "settings-console-sidechat-prompt-template",
-                    "More Details prompt",
-                ),
-                (
-                    "settings-console-context-budget-mode",
-                    "Conversation budget strategy",
-                ),
-                ("settings-console-context-budget-tokens", "Conversation max tokens"),
-                ("settings-console-context-compaction-mode", "When limit nears"),
-                (
-                    "settings-console-context-compaction-representation",
-                    "Compaction representation",
-                ),
-                (
-                    "settings-console-context-trigger-percent",
-                    "Compact at percent",
-                ),
-                (
-                    "settings-console-context-target-percent",
-                    "Reduce conversation to percent",
-                ),
-                (
-                    "settings-console-context-summary-max-tokens",
-                    "Summary response max tokens",
-                ),
-                (
-                    "settings-console-context-failure-behavior",
-                    "If compaction fails",
-                ),
-                (
-                    "settings-console-context-carry-forward-mode",
-                    "Keep after compaction",
-                ),
-            ),
-            SettingsCategoryId.APPEARANCE: (
-                ("settings-appearance-theme", "Theme"),
-                ("settings-appearance-palette-theme-limit", "Palette limit (themes)"),
-                ("settings-appearance-font-size", "Web font size (px)"),
-                ("settings-appearance-density", "Density"),
-                ("settings-appearance-transcript-style", "Console transcript"),
-                ("settings-appearance-animations-enabled", "Animations"),
-                ("settings-appearance-smooth-scrolling", "Smooth scrolling"),
-                (
-                    "settings-appearance-library-media-library-open",
-                    "Shared Library rail",
-                ),
-                (
-                    "settings-appearance-library-media-custom-widths",
-                    "Shared Library rail width mode",
-                ),
-                (
-                    "settings-appearance-library-media-library-width",
-                    "Preferred Library rail width",
-                ),
-                *(
-                    (
-                        f"settings-appearance-library-{destination}-items-{suffix}",
-                        f"{label} Items {description}",
-                    )
-                    for destination, label in LIBRARY_READER_DESTINATIONS
-                    for suffix, description in (
-                        ("open", "pane"),
-                        ("width", "width"),
-                    )
-                ),
-            ),
-            SettingsCategoryId.PROVIDERS_MODELS: (
-                ("settings-provider-value", "Provider"),
-                ("settings-provider-api-mode", "API mode"),
-                (
-                    "settings-provider-api-mode",
-                    "api_settings.<provider>.api_mode",
-                ),
-                ("settings-model-value", "Model"),
-                ("settings-provider-endpoint-value", "Endpoint"),
-                ("settings-provider-api-key", "API key"),
-                ("settings-provider-credential-env-var", "Credential env var"),
-                ("settings-model-context-window", "Model context window tokens"),
-            ),
-            SettingsCategoryId.SPEECH_TTS: (
-                ("settings-speech-default-provider", "Default TTS Provider"),
-                ("settings-speech-model-value", "TTS model"),
-                ("settings-speech-voice-value", "TTS voice"),
-                ("settings-speech-configure-provider", "audio.cpp audio_cpp"),
-                ("settings-speech-configure-provider", "OpenAI"),
-                ("settings-speech-configure-provider", "ElevenLabs"),
-                ("settings-speech-configure-provider", "Kokoro"),
-                ("settings-speech-configure-provider", "Chatterbox"),
-                ("settings-speech-configure-provider", "Higgs"),
-                ("settings-speech-configure-provider", "AllTalk"),
-            ),
-            SettingsCategoryId.STORAGE: tuple(
-                (f"settings-storage-{name.replace('_', '-')}", label)
-                for name, label in _labels.items()
-            ),
-            SettingsCategoryId.PRIVACY_SECURITY: (
-                ("settings-raw-cli-permitted", "Allow raw CLI host access"),
-            ),
-            SettingsCategoryId.LIBRARY_RAG: tuple(
-                (field_id, _rag_field_search_label(field_id))
-                for field_id in _RAG_FIELD_GROUP_BY_ID
-            ),
-        }
-    )
-
-
-_build_field_search_index()
+# task-1715 / TASK-23109: the field-level search index (and the RAG
+# field->group map it derives labels from) lives in settings_search_index.py;
+# imported at the top of this module with compatibility aliases.
 
 
 # Task 4 (541 v2 UX AC1): the Library/RAG editor field keys whose disabled
@@ -6365,8 +6155,14 @@ class SettingsScreen(BaseAppScreen):
         # task-1715: field labels -- typing a setting's visible name
         # ("threshold") surfaces its category with an Enter-focuses-field
         # promise (see _top_field_match / _submit_category_search).
-        if self._top_field_match(query, summary.category) is not None:
-            return 3
+        # TASK-23109: two field tiers -- a label that STARTS with the query
+        # ("Threshold (chars)") outranks a mid-label hit ("VAD threshold"),
+        # so completing the index cannot re-route an established landing.
+        field = self._top_field_match(query, summary.category)
+        if field is not None:
+            if field[1].lower().startswith(query):
+                return 3
+            return 4
         # task-1564: last tier -- the category's owned config keys. The Scope
         # Inspector already publishes them; indexing them lets "/" find the
         # category that OWNS a setting instead of forcing a 23-item scan.
@@ -6377,8 +6173,11 @@ class SettingsScreen(BaseAppScreen):
         except Exception:
             owned = ""
         if owned and query in owned:
-            return 4
+            return 5
         return None
+
+    #: Ranks produced by the field-label tiers of ``_category_search_rank``.
+    FIELD_MATCH_RANKS = frozenset({3, 4})
 
     @staticmethod
     def _top_field_match(
@@ -6396,7 +6195,13 @@ class SettingsScreen(BaseAppScreen):
         query = query_text.strip().lower()
         if not query:
             return None
-        for field_id, label in FIELD_SEARCH_INDEX.get(category, ()):
+        entries = FIELD_SEARCH_INDEX.get(category, ())
+        # TASK-23109: a label that starts with the query wins over a
+        # mid-label hit, mirroring the rank tiers in _category_search_rank.
+        for field_id, label in entries:
+            if label.lower().startswith(query):
+                return (field_id, label)
+        for field_id, label in entries:
             if query in label.lower():
                 return (field_id, label)
         return None
@@ -6425,6 +6230,50 @@ class SettingsScreen(BaseAppScreen):
             for summary in self._filtered_category_summaries(query_text)
         ]
 
+    def _category_group_title(self, category: SettingsCategoryId) -> str:
+        """The rail group a category lives in ("Core", "Interface", ...)."""
+        for group_title, category_ids in self._category_groups():
+            if category in category_ids:
+                return group_title
+        return ""
+
+    def _search_match_scope_text(
+        self,
+        query: str,
+        summary: SettingsCategorySummary,
+        *,
+        field_landing: bool,
+    ) -> str:
+        """One search match with its scope: 'Category [› Field] (Group)'.
+
+        TASK-23109: ambiguous matches ("theme" hits both the Theme category
+        and Appearance's Theme setting) disambiguate with the category and
+        rail-group scope instead of a bare title coin flip.
+
+        Args:
+            query: The active filter text.
+            summary: The matched category.
+            field_landing: Whether Enter would land ON the matched field.
+                For the top match this is True only when the match CAME from
+                the field tier (typing a category's own title must open the
+                category plainly, not steal focus into its first field);
+                runner-up lines always name a matching field as information.
+        """
+        target = summary.title
+        # task-1715: when the hit is (or contains) a matching field, promise
+        # the field-level landing in the echo line.
+        field = self._top_field_match(query, summary.category)
+        if field is not None and field_landing:
+            target = f"{target} › {field[1]}"
+        group = self._category_group_title(summary.category)
+        return f"{target} ({group})" if group else target
+
+    def _search_match_is_field_landing(
+        self, query: str, summary: SettingsCategorySummary
+    ) -> bool:
+        """Whether Enter on this top match lands focus on a matched field."""
+        return self._category_search_rank(summary, query) in self.FIELD_MATCH_RANKS
+
     def _category_search_status_text(self, query_text: str | None = None) -> str:
         query = self._category_search_text(query_text)
         if not query:
@@ -6432,15 +6281,22 @@ class SettingsScreen(BaseAppScreen):
         matches = self._filtered_category_summaries(query)
         match_label = "match" if len(matches) == 1 else "matches"
         if matches:
-            target = matches[0].title
-            # task-1715: when the top hit is (or contains) a matching
-            # field, promise the field-level landing in the echo line.
-            field = self._top_field_match(query, matches[0].category)
-            if field is not None:
-                target = f"{target} › {field[1]}"
-            return (
+            target = self._search_match_scope_text(
+                query,
+                matches[0],
+                field_landing=self._search_match_is_field_landing(query, matches[0]),
+            )
+            status = (
                 f"Filter: {query} | {len(matches)} {match_label} | Enter opens {target}"
             )
+            if len(matches) > 1:
+                status += (
+                    " | Next: "
+                    + self._search_match_scope_text(
+                        query, matches[1], field_landing=True
+                    )
+                )
+            return status
         return f"Filter: {query} | 0 matches | Esc clears"
 
     @staticmethod
@@ -6543,9 +6399,17 @@ class SettingsScreen(BaseAppScreen):
             if speech_target is not None:
                 self._after_category_panes(self._apply_speech_tts_navigation_context)
             # task-1715: if the query named a field, land ON the field --
-            # focusing it also fires its inspector guidance.
+            # focusing it also fires its inspector guidance. TASK-23109:
+            # only when the match CAME from the field tier -- typing a
+            # category's own title opens the category plainly instead of
+            # stealing focus into its first coincidentally-matching field.
             opened = SettingsCategoryId(category_values[0])
-            field = self._top_field_match(query_text, opened)
+            opened_summary = self._category_summary_by_id(opened)
+            field = (
+                self._top_field_match(query_text, opened)
+                if self._search_match_is_field_landing(query_text, opened_summary)
+                else None
+            )
             if field is not None:
                 field_id = field[0]
 

--- a/tldw_chatbook/UI/Screens/settings_search_index.py
+++ b/tldw_chatbook/UI/Screens/settings_search_index.py
@@ -1,0 +1,476 @@
+"""Setting-level search index for the Settings hub.
+
+task-1715 introduced field-level "/" search (typing a setting's visible
+label surfaces its category and Enter focuses the field). TASK-23109 moved
+the index here and completed its coverage: every rendered value-editing
+control in a category's detail pane must have a row, and the drift test
+``test_every_rendered_setting_is_in_the_search_index`` (in
+``Tests/UI/test_settings_search_index.py``) fails when a rendered setting
+is missing, so the hand-maintained table cannot silently rot.
+
+Labels mirror the visible row labels; a field may carry several rows when
+users know it by more than one name.
+"""
+
+from __future__ import annotations
+
+from .settings_config_models import SettingsCategoryId
+
+#: Library reader destinations rendered as per-destination Items pane/width
+#: rows on the Appearance category (shared with settings_screen).
+LIBRARY_READER_DESTINATIONS = (
+    ("media", "Media"),
+    ("conversations", "Conversations"),
+    ("notes", "Notes"),
+    ("prompts", "Prompts"),
+    ("skills", "Skills"),
+)
+
+# Task 3 (541 v2 UX AC3): RAG widget id -> guidance-group key. Mirrors the
+# ids `_library_rag_field_selector` and the LIBRARY_RAG compose branch mint
+# (search around "settings-library-rag-" in settings_screen.py). Used by
+# `_rag_field_guidance_rows()` so the Scope Inspector follows the focused
+# field; falls back to `_active_rag_scope_group` (the last-expanded
+# Collapsible) when the focused widget isn't one of these.
+RAG_FIELD_GROUP_BY_ID: dict[str, str] = {
+    "settings-library-rag-search-mode": "search",
+    "settings-library-rag-default-top-k": "search",
+    "settings-library-rag-fts-top-k": "search",
+    "settings-library-rag-vector-top-k": "search",
+    "settings-library-rag-hybrid-alpha": "search",
+    "settings-library-rag-score-threshold": "search",
+    "settings-library-rag-include-citations": "search",
+    "settings-library-rag-direct-library-tools": "search",
+    "settings-library-rag-citation-style": "search",
+    "settings-library-rag-snippet-max-chars": "search",
+    "settings-library-rag-max-context-size": "search",
+    "settings-library-rag-embedding-model": "embedding",
+    "settings-library-rag-embedding-device": "embedding",
+    "settings-library-rag-embedding-batch-size": "embedding",
+    "settings-library-rag-embedding-max-length": "embedding",
+    "settings-library-rag-chunk-size": "chunking",
+    "settings-library-rag-chunk-overlap": "chunking",
+    "settings-library-rag-chunking-method": "chunking",
+    "settings-library-rag-distance-metric": "vector_store",
+    "settings-library-rag-enable-reranking": "reranking",
+    "settings-library-rag-reranker-provider": "reranking",
+    "settings-library-rag-reranker-model": "reranking",
+    "settings-library-rag-reranker-top-k": "reranking",
+    "settings-library-rag-profile-select": "profile",
+    "settings-library-rag-profile-set-active": "profile",
+    "settings-library-rag-profile-clone": "profile",
+    "settings-library-rag-profile-rename": "profile",
+    "settings-library-rag-profile-delete": "profile",
+    "settings-library-rag-index-backfill": "index",
+}
+
+
+def _rag_field_search_label(field_id: str) -> str:
+    """Human label for a RAG field id (task-1715 field-level search).
+
+    Args:
+        field_id: A ``settings-library-rag-*`` widget id.
+
+    Returns:
+        The id suffix as a spaced title, e.g. "hybrid alpha".
+    """
+    return field_id.removeprefix("settings-library-rag-").replace("-", " ")
+
+
+#: task-1715: field-level search index -- "/" previously matched only
+#: category names/descriptions/owned keys, so "threshold" found nothing
+#: on a 23-category screen (critique r4 P1). Labels mirror the visible
+#: row labels; Enter focuses the matched field.
+FIELD_SEARCH_INDEX: dict[SettingsCategoryId, tuple[tuple[str, str], ...]] = {}
+
+
+def _backend_field_entries(
+    id_prefix: str,
+    backend_labels: dict[str, str],
+    field_schema: dict[str, tuple],
+) -> tuple[tuple[str, str], ...]:
+    """Index rows for a generation category's per-backend editor fields.
+
+    Derived from the same ``FIELD_SCHEMA``/``BACKEND_LABELS`` tables the form
+    builders render from (TASK-23109's durability requirement), so a new
+    backend or field becomes searchable without touching this module.
+
+    Args:
+        id_prefix: "imagegen" or "videogen" (the widget-id family).
+        backend_labels: ``BACKEND_LABELS`` from the category's helper module.
+        field_schema: ``FIELD_SCHEMA`` from the same module.
+
+    Returns:
+        ``(widget_id, label)`` rows, backend label prefixed for scope.
+    """
+    entries: list[tuple[str, str]] = []
+    for backend_id, backend_label in backend_labels.items():
+        entries.append(
+            (
+                f"settings-{id_prefix}-enabled-{backend_id}",
+                f"{backend_label} backend enabled",
+            )
+        )
+        for spec in field_schema.get(backend_id, ()):
+            entries.append(
+                (
+                    f"settings-{id_prefix}-field-{backend_id}-{spec.toml_key}",
+                    f"{backend_label} {spec.label}",
+                )
+            )
+    return tuple(entries)
+
+
+def build_field_search_index() -> None:
+    """(Re)build ``FIELD_SEARCH_INDEX`` from its per-category tables."""
+    from ...LLM_Provider_Catalog.model_catalog_settings import (
+        AUTO_REFRESH_PROVIDER_LIST_KEYS,
+    )
+    from .settings_image_gen_defaults import (
+        _GLOBAL_FLOAT_FIELD_SPECS as _imagegen_float_specs,
+        _GLOBAL_INT_FIELD_SPECS as _imagegen_int_specs,
+        BACKEND_LABELS as _imagegen_backend_labels,
+        FIELD_SCHEMA as _imagegen_field_schema,
+    )
+    from .settings_storage_defaults import STORAGE_FIELD_LABELS as _labels
+    from .settings_video_gen_defaults import (
+        _GLOBAL_INT_FIELD_SPECS as _videogen_int_specs,
+        BACKEND_LABELS as _videogen_backend_labels,
+        FIELD_SCHEMA as _videogen_field_schema,
+    )
+
+    FIELD_SEARCH_INDEX.update(
+        {
+            SettingsCategoryId.CONSOLE_BEHAVIOR: (
+                (
+                    "settings-console-show-model-thinking",
+                    "Show model thinking",
+                ),
+                (
+                    "settings-console-rail-layout-scope",
+                    "Rail layout scope",
+                ),
+                (
+                    "settings-console-rail-layout-scope",
+                    "Global per workspace layout scope",
+                ),
+                (
+                    "settings-console-stack-collapsed-rail-labels",
+                    "Stack collapsed rail labels",
+                ),
+                (
+                    "settings-console-stack-collapsed-rail-labels",
+                    "Rail handle presentation",
+                ),
+                (
+                    "settings-console-stack-collapsed-rail-labels",
+                    "Stacked vertical Context Inspector",
+                ),
+                (
+                    "settings-console-status-row-position-toggle",
+                    "Status row placement",
+                ),
+                (
+                    "settings-console-status-row-position-toggle",
+                    "Status chips above below composer",
+                ),
+                ("settings-console-paste-collapse-threshold", "Threshold (chars)"),
+                ("settings-console-max-parallel-runs", "Max parallel agent runs"),
+                ("settings-console-tool-result-display-chars", "Display cap (chars)"),
+                ("settings-console-sidechat-model", "Side chat model"),
+                (
+                    "settings-console-sidechat-prompt-template",
+                    "Side chat prompt template",
+                ),
+                (
+                    "settings-console-sidechat-prompt-template",
+                    "More Details prompt",
+                ),
+                (
+                    "settings-console-context-budget-mode",
+                    "Conversation budget strategy",
+                ),
+                ("settings-console-context-budget-tokens", "Conversation max tokens"),
+                ("settings-console-context-compaction-mode", "When limit nears"),
+                (
+                    "settings-console-context-compaction-representation",
+                    "Compaction representation",
+                ),
+                (
+                    "settings-console-context-trigger-percent",
+                    "Compact at percent",
+                ),
+                (
+                    "settings-console-context-target-percent",
+                    "Reduce conversation to percent",
+                ),
+                (
+                    "settings-console-context-summary-max-tokens",
+                    "Summary response max tokens",
+                ),
+                (
+                    "settings-console-context-failure-behavior",
+                    "If compaction fails",
+                ),
+                (
+                    "settings-console-context-carry-forward-mode",
+                    "Keep after compaction",
+                ),
+                # TASK-23109 completion sweep: labels mirror the rendered rows.
+                (
+                    "settings-console-exchange-capture-enabled",
+                    "Capture future provider exchanges",
+                ),
+                ("settings-console-exchange-capture-detail", "Capture detail"),
+                (
+                    "settings-console-collapse-large-pastes-toggle",
+                    "Collapse large pastes",
+                ),
+                ("settings-console-agent-max-total-tokens", "Token budget (per run)"),
+                (
+                    "settings-console-agent-max-wall-seconds",
+                    "Wall-clock limit (seconds)",
+                ),
+                (
+                    "settings-console-agent-max-tool-call-seconds",
+                    "Per-tool-call limit (seconds)",
+                ),
+                ("settings-console-agent-max-model-turns", "Model turns (backstop)"),
+                ("settings-console-agent-max-steps", "Steps (backstop)"),
+                (
+                    "settings-console-default-user-display-name",
+                    "Default chat display name",
+                ),
+                ("settings-console-default-streaming", "Streaming"),
+                ("settings-console-default-temperature", "Temperature"),
+                ("settings-console-default-top-p", "Top P"),
+                ("settings-console-default-min-p", "Min P"),
+                ("settings-console-default-top-k", "Top K"),
+                ("settings-console-default-max-tokens", "Response max tokens"),
+                ("settings-console-default-seed", "Seed"),
+                ("settings-console-default-presence-penalty", "Presence penalty"),
+                ("settings-console-default-frequency-penalty", "Frequency penalty"),
+                ("settings-console-default-reasoning-effort", "Reasoning effort"),
+                ("settings-console-default-reasoning-summary", "Reasoning summary"),
+                ("settings-console-default-verbosity", "Verbosity"),
+                ("settings-console-default-thinking-effort", "Thinking effort"),
+                (
+                    "settings-console-default-thinking-budget-tokens",
+                    "Thinking budget tokens",
+                ),
+                (
+                    "settings-console-background-effect-enabled",
+                    "Enable background effects",
+                ),
+                ("settings-console-background-effect-type", "Background effect"),
+                ("settings-console-background-effect-scope", "Background effect scope"),
+                (
+                    "settings-console-background-effect-intensity",
+                    "Background effect intensity",
+                ),
+                ("settings-console-background-effect-fps", "Background effect frame rate"),
+            ),
+            SettingsCategoryId.APPEARANCE: (
+                ("settings-appearance-theme", "Theme"),
+                ("settings-appearance-palette-theme-limit", "Palette limit (themes)"),
+                ("settings-appearance-font-size", "Web font size (px)"),
+                ("settings-appearance-density", "Density"),
+                ("settings-appearance-transcript-style", "Console transcript"),
+                ("settings-appearance-animations-enabled", "Animations"),
+                # TASK-23109: the setting the critique could not find by name.
+                ("settings-appearance-reduce-motion", "Reduce motion"),
+                ("settings-appearance-ascii-glyphs", "ASCII glyphs"),
+                ("settings-appearance-smooth-scrolling", "Smooth scrolling"),
+                (
+                    "settings-appearance-library-media-library-open",
+                    "Shared Library rail",
+                ),
+                (
+                    "settings-appearance-library-media-custom-widths",
+                    "Shared Library rail width mode",
+                ),
+                (
+                    "settings-appearance-library-media-library-width",
+                    "Preferred Library rail width",
+                ),
+                *(
+                    (
+                        f"settings-appearance-library-{destination}-items-{suffix}",
+                        f"{label} Items {description}",
+                    )
+                    for destination, label in LIBRARY_READER_DESTINATIONS
+                    for suffix, description in (
+                        ("open", "pane"),
+                        ("width", "width"),
+                    )
+                ),
+            ),
+            SettingsCategoryId.PROVIDERS_MODELS: (
+                ("settings-provider-value", "Provider"),
+                ("settings-provider-api-mode", "API mode"),
+                (
+                    "settings-provider-api-mode",
+                    "api_settings.<provider>.api_mode",
+                ),
+                ("settings-model-value", "Model"),
+                ("settings-provider-endpoint-value", "Endpoint"),
+                ("settings-provider-api-key", "API key"),
+                ("settings-provider-credential-env-var", "Credential env var"),
+                ("settings-model-context-window", "Model context window tokens"),
+                # TASK-23109 completion sweep: model-catalog refresh controls.
+                (
+                    "settings-model-catalog-auto-refresh",
+                    "Auto-refresh model lists on startup",
+                ),
+                ("settings-model-catalog-stale-hours", "Refresh after (hours)"),
+                *(
+                    entry
+                    for provider in AUTO_REFRESH_PROVIDER_LIST_KEYS
+                    for entry in (
+                        (
+                            f"settings-mc-auto-{provider.lower()}",
+                            f"{provider} auto-refresh model list",
+                        ),
+                        (
+                            f"settings-mc-write-{provider.lower()}",
+                            f"{provider} save fetched models to config",
+                        ),
+                    )
+                ),
+                # Model profile (per provider+model) sampling overrides.
+                ("settings-model-profile-temperature", "Temperature"),
+                ("settings-model-profile-top-p", "Top P"),
+                ("settings-model-profile-min-p", "Min P"),
+                ("settings-model-profile-top-k", "Top K"),
+                ("settings-model-profile-max-tokens", "Response max tokens"),
+                ("settings-model-profile-seed", "Seed"),
+                ("settings-model-profile-presence-penalty", "Presence penalty"),
+                ("settings-model-profile-frequency-penalty", "Frequency penalty"),
+                ("settings-model-profile-reasoning-effort", "Reasoning effort"),
+                ("settings-model-profile-reasoning-summary", "Reasoning summary"),
+                ("settings-model-profile-verbosity", "Verbosity"),
+                ("settings-model-profile-thinking-effort", "Thinking effort"),
+                (
+                    "settings-model-profile-thinking-budget-tokens",
+                    "Thinking budget tokens",
+                ),
+                ("settings-model-profile-streaming", "Streaming"),
+            ),
+            SettingsCategoryId.SPEECH_TTS: (
+                ("settings-speech-default-provider", "Default TTS Provider"),
+                ("settings-speech-model-value", "TTS model"),
+                ("settings-speech-voice-value", "TTS voice"),
+                ("settings-speech-configure-provider", "audio.cpp audio_cpp"),
+                ("settings-speech-configure-provider", "OpenAI"),
+                ("settings-speech-configure-provider", "ElevenLabs"),
+                ("settings-speech-configure-provider", "Kokoro"),
+                ("settings-speech-configure-provider", "Chatterbox"),
+                ("settings-speech-configure-provider", "Higgs"),
+                ("settings-speech-configure-provider", "AllTalk"),
+                # TASK-23109 completion sweep: labels mirror the rendered rows.
+                ("settings-speech-default-profile", "Default voice profile"),
+                ("settings-speech-model-policy", "Model policy"),
+                ("settings-speech-voice-policy", "Voice policy"),
+                ("settings-speech-output-format", "Output format"),
+                ("settings-speech-speed", "Speech speed"),
+                ("settings-speech-openai-authentication-mode", "OpenAI authentication"),
+                ("settings-speech-openai-base-url", "OpenAI TTS base URL"),
+                ("settings-speech-openai-organization-id", "OpenAI organization ID"),
+                (
+                    "settings-speech-realtime-enabled",
+                    "Enable realtime voice engine",
+                ),
+                ("settings-speech-realtime-provider", "Realtime provider"),
+                ("settings-speech-realtime-model", "Realtime model"),
+                ("settings-speech-realtime-voice", "Realtime voice"),
+                (
+                    "settings-speech-realtime-idle-timeout-minutes",
+                    "Realtime idle timeout (minutes)",
+                ),
+                ("settings-speech-realtime-turn-detection", "Turn detection"),
+                ("settings-speech-realtime-vad-threshold", "VAD threshold"),
+                (
+                    "settings-speech-realtime-vad-silence-ms",
+                    "End-of-turn silence (ms)",
+                ),
+                ("settings-speech-realtime-handsfree-engine", "Hands-free engine"),
+            ),
+            SettingsCategoryId.STORAGE: tuple(
+                (f"settings-storage-{name.replace('_', '-')}", label)
+                for name, label in _labels.items()
+            ),
+            SettingsCategoryId.PRIVACY_SECURITY: (
+                ("settings-raw-cli-permitted", "Allow raw CLI host access"),
+            ),
+            SettingsCategoryId.LIBRARY_RAG: (
+                *(
+                    (field_id, _rag_field_search_label(field_id))
+                    for field_id in RAG_FIELD_GROUP_BY_ID
+                ),
+                # TASK-23109: Console-integration toggles rendered above the
+                # profile editor (not part of the profile field-group map).
+                (
+                    "settings-library-rag-auto-retrieve-default",
+                    "Automatic retrieval",
+                ),
+                (
+                    "settings-library-rag-assistant-access-default",
+                    "Assistant Library access",
+                ),
+            ),
+            SettingsCategoryId.SPLASH_SCREEN: (
+                ("settings-splash-enabled", "Splash screen enabled"),
+                ("settings-splash-default-select", "Default splash card"),
+                ("settings-splash-show-progress", "Show progress"),
+                ("settings-splash-skip-on-keypress", "Skip on keypress"),
+                ("settings-splash-duration", "Splash duration (s)"),
+                ("settings-splash-animation-speed", "Animation speed"),
+            ),
+            SettingsCategoryId.THEME: (
+                ("settings-theme-name", "Theme name"),
+                ("settings-theme-dark-mode", "Dark theme"),
+                ("settings-theme-color-primary", "Primary color"),
+                ("settings-theme-color-secondary", "Secondary color"),
+                ("settings-theme-color-accent", "Accent color"),
+                ("settings-theme-color-background", "Background color"),
+                ("settings-theme-color-surface", "Surface color"),
+                ("settings-theme-color-panel", "Panel color"),
+                ("settings-theme-color-foreground", "Foreground color"),
+                ("settings-theme-color-success", "Success color"),
+                ("settings-theme-color-warning", "Warning color"),
+                ("settings-theme-color-error", "Error color"),
+            ),
+            SettingsCategoryId.IMAGE_GENERATION: (
+                ("settings-imagegen-default_backend", "Default image backend"),
+                *_backend_field_entries(
+                    "imagegen", _imagegen_backend_labels, _imagegen_field_schema
+                ),
+                ("settings-imagegen-context_llm_enabled", "Context LLM"),
+                *(
+                    (f"settings-imagegen-{key}", label)
+                    for key, label, _minimum in (
+                        *_imagegen_int_specs,
+                        *_imagegen_float_specs,
+                    )
+                ),
+            ),
+            SettingsCategoryId.VIDEO_GENERATION: (
+                ("settings-videogen-default_backend", "Default video backend"),
+                *_backend_field_entries(
+                    "videogen", _videogen_backend_labels, _videogen_field_schema
+                ),
+                ("settings-videogen-retention", "Video retention"),
+                (
+                    "settings-videogen-confirm_cost_estimate",
+                    "Confirm cost before paid generation",
+                ),
+                *(
+                    (f"settings-videogen-{key}", label)
+                    for key, label, _minimum in _videogen_int_specs
+                ),
+            ),
+        }
+    )
+
+
+build_field_search_index()

--- a/tldw_chatbook/UI/Screens/settings_search_index.py
+++ b/tldw_chatbook/UI/Screens/settings_search_index.py
@@ -66,7 +66,7 @@ RAG_FIELD_GROUP_BY_ID: dict[str, str] = {
 
 
 def _rag_field_search_label(field_id: str) -> str:
-    """Human label for a RAG field id (task-1715 field-level search).
+    """Config-key-ish alias for a RAG field id (task-1715 field-level search).
 
     Args:
         field_id: A ``settings-library-rag-*`` widget id.
@@ -75,6 +75,143 @@ def _rag_field_search_label(field_id: str) -> str:
         The id suffix as a spaced title, e.g. "hybrid alpha".
     """
     return field_id.removeprefix("settings-library-rag-").replace("-", " ")
+
+
+#: TASK-23109 review (finding 8): the RENDERED row label per RAG field --
+#: the id-derived alias above stays as a second row, but the visible words
+#: ("Hybrid balance", not "hybrid alpha") must be findable too. Fields
+#: without an entry (the profile lifecycle buttons) keep the alias only.
+RAG_FIELD_RENDERED_LABELS: dict[str, str] = {
+    "settings-library-rag-search-mode": "Search mode",
+    "settings-library-rag-default-top-k": "Default results",
+    "settings-library-rag-fts-top-k": "Keyword results",
+    "settings-library-rag-vector-top-k": "Vector results",
+    "settings-library-rag-hybrid-alpha": "Hybrid balance",
+    "settings-library-rag-score-threshold": "Min score",
+    "settings-library-rag-include-citations": "Include citations",
+    "settings-library-rag-citation-style": "Citation style",
+    "settings-library-rag-snippet-max-chars": "Snippet chars",
+    "settings-library-rag-max-context-size": "Context budget",
+    "settings-library-rag-embedding-model": "Embedding model",
+    "settings-library-rag-embedding-device": "Device",
+    "settings-library-rag-embedding-batch-size": "Batch size",
+    "settings-library-rag-embedding-max-length": "Max length",
+    "settings-library-rag-chunk-size": "Chunk size",
+    "settings-library-rag-chunk-overlap": "Chunk overlap",
+    "settings-library-rag-chunking-method": "Method",
+    "settings-library-rag-distance-metric": "Distance metric",
+    "settings-library-rag-enable-reranking": "Enable reranking",
+    "settings-library-rag-reranker-provider": "Reranker provider",
+    "settings-library-rag-reranker-model": "Reranker model",
+    "settings-library-rag-reranker-top-k": "Rerank results",
+    "settings-library-rag-profile-select": "Profile",
+}
+
+
+#: TASK-23109 review (finding 5): every TTS provider configure form's
+#: fields, as (field key, rendered label) per provider. The panel composes
+#: only the DEFAULT provider's form, so the runtime drift guard cannot see
+#: the other six -- this table is pinned against the panel SOURCE instead
+#: (``test_speech_provider_form_fields_match_the_panel_source``). Widget id
+#: = ``settings-speech-{provider}-{key.replace('_', '-')}`` (the panel's
+#: ``_field_dom_id``).
+SPEECH_TTS_PROVIDER_FORM_FIELDS: dict[str, tuple[tuple[str, str], ...]] = {
+    "audio_cpp": (
+        ("mode", "Server mode"),
+        ("base_url", "Server URL (HTTP/HTTPS origin only)"),
+        ("managed_setup_source", "Managed setup source"),
+        ("guided_backend_preference", "Compute backend"),
+        ("managed_startup_timeout_seconds", "Managed startup timeout (seconds)"),
+        (
+            "managed_health_check_interval_seconds",
+            "Managed health interval (seconds)",
+        ),
+        ("managed_termination_grace_seconds", "Managed termination grace (seconds)"),
+        ("guided_device", "Guided device index (blank = backend default)"),
+        ("guided_threads", "Guided CPU threads (blank = server default)"),
+        ("guided_max_request_body_bytes", "Guided max request body bytes"),
+        ("guided_busy_timeout_ms", "Guided busy timeout (milliseconds)"),
+        ("connect_timeout_seconds", "Connect timeout (seconds)"),
+        ("synthesis_timeout_seconds", "Synthesis timeout (seconds)"),
+        ("max_input_characters", "Max input characters"),
+        ("max_response_bytes", "Max response bytes"),
+        ("max_metadata_bytes", "Max metadata bytes"),
+        ("max_catalog_models", "Max catalog models"),
+        ("max_voices_per_model", "Max voices per model"),
+        ("max_identifier_characters", "Max identifier characters"),
+    ),
+    "openai": (
+        ("authentication_mode", "Authentication"),
+        ("base_url", "Base URL"),
+        ("organization_id", "Organization ID"),
+    ),
+    "elevenlabs": (
+        ("output_format", "Output format"),
+        ("stability", "Voice stability"),
+        ("similarity_boost", "Similarity boost"),
+        ("style", "Style"),
+        ("speaker_boost", "Speaker boost"),
+    ),
+    "kokoro": (
+        ("device", "Device"),
+        ("use_onnx", "Use ONNX"),
+        ("max_tokens", "Max tokens"),
+        ("voice_mixing", "Voice mixing"),
+        ("track_performance", "Performance tracking"),
+    ),
+    "chatterbox": (
+        ("device", "Device"),
+        ("temperature", "Temperature"),
+        ("chunk_size", "Chunk size"),
+        ("random_seed", "Random seed"),
+        ("candidates", "Candidates"),
+        ("validate_whisper", "Whisper validation"),
+        ("preprocess_text", "Text preprocessing"),
+        ("normalize_audio", "Audio normalization"),
+        ("target_db", "Target dB"),
+        ("max_chunk_size", "Max text chunk"),
+        ("streaming", "Streaming"),
+        ("stream_chunk_size", "Stream chunk size"),
+        ("crossfade", "Crossfade"),
+        ("crossfade_ms", "Crossfade duration (ms)"),
+    ),
+    "higgs": (
+        ("device", "Device"),
+        ("enable_flash_attention", "Enable flash attention"),
+        ("dtype", "Data type"),
+        ("max_reference_duration", "Max reference duration"),
+        ("language", "Default language"),
+        ("voice_cloning", "Voice cloning"),
+        ("multi_speaker", "Multi-speaker"),
+        ("speaker_delimiter", "Speaker delimiter"),
+        ("track_performance", "Performance tracking"),
+        ("max_new_tokens", "Max new tokens"),
+        ("temperature", "Temperature"),
+        ("top_p", "Top P"),
+        ("repetition_penalty", "Repetition penalty"),
+    ),
+    "alltalk": (
+        ("server_url", "Server URL"),
+        ("language", "Default language"),
+    ),
+}
+
+
+def _speech_provider_form_entries() -> tuple[tuple[str, str], ...]:
+    """Index rows for every TTS provider configure form (finding 5)."""
+    from .settings_speech_tts import TTS_PROVIDER_LABELS
+
+    entries: list[tuple[str, str]] = []
+    for provider_id, fields in SPEECH_TTS_PROVIDER_FORM_FIELDS.items():
+        provider_label = str(TTS_PROVIDER_LABELS.get(provider_id, provider_id))
+        for field_key, label in fields:
+            entries.append(
+                (
+                    f"settings-speech-{provider_id}-{field_key.replace('_', '-')}",
+                    f"{provider_label} {label}",
+                )
+            )
+    return tuple(entries)
 
 
 #: task-1715: field-level search index -- "/" previously matched only
@@ -122,7 +259,11 @@ def _backend_field_entries(
 
 
 def build_field_search_index() -> None:
-    """(Re)build ``FIELD_SEARCH_INDEX`` from its per-category tables."""
+    """(Re)build ``FIELD_SEARCH_INDEX`` from its per-category tables.
+
+    Clears first (review cleanup): plain ``update()`` could never remove a
+    stale category's rows on a rebuild.
+    """
     from ...LLM_Provider_Catalog.model_catalog_settings import (
         AUTO_REFRESH_PROVIDER_LIST_KEYS,
     )
@@ -139,6 +280,7 @@ def build_field_search_index() -> None:
         FIELD_SCHEMA as _videogen_field_schema,
     )
 
+    FIELD_SEARCH_INDEX.clear()
     FIELD_SEARCH_INDEX.update(
         {
             SettingsCategoryId.CONSOLE_BEHAVIOR: (
@@ -200,9 +342,14 @@ def build_field_search_index() -> None:
                     "settings-console-context-trigger-percent",
                     "Compact at percent",
                 ),
+                ("settings-console-context-trigger-percent", "Compact at (%)"),
                 (
                     "settings-console-context-target-percent",
                     "Reduce conversation to percent",
+                ),
+                (
+                    "settings-console-context-target-percent",
+                    "Reduce conversation to (%)",
                 ),
                 (
                     "settings-console-context-summary-max-tokens",
@@ -258,6 +405,7 @@ def build_field_search_index() -> None:
                     "settings-console-default-thinking-budget-tokens",
                     "Thinking budget tokens",
                 ),
+                ("settings-console-default-thinking-budget-tokens", "Think budget"),
                 (
                     "settings-console-background-effect-enabled",
                     "Enable background effects",
@@ -269,6 +417,13 @@ def build_field_search_index() -> None:
                     "Background effect intensity",
                 ),
                 ("settings-console-background-effect-fps", "Background effect frame rate"),
+                # Review finding 5: bare Button toggle with no labeled row --
+                # invisible to the drift guard's heuristic, indexed by hand.
+                (
+                    "settings-console-remote-images-toggle",
+                    "Render images linked in assistant replies",
+                ),
+                ("settings-console-remote-images-toggle", "Remote images"),
             ),
             SettingsCategoryId.APPEARANCE: (
                 ("settings-appearance-theme", "Theme"),
@@ -288,6 +443,10 @@ def build_field_search_index() -> None:
                 (
                     "settings-appearance-library-media-custom-widths",
                     "Shared Library rail width mode",
+                ),
+                (
+                    "settings-appearance-library-media-library-width",
+                    "Preferred rail width",
                 ),
                 (
                     "settings-appearance-library-media-library-width",
@@ -354,12 +513,15 @@ def build_field_search_index() -> None:
                     "settings-model-profile-thinking-budget-tokens",
                     "Thinking budget tokens",
                 ),
+                ("settings-model-profile-thinking-budget-tokens", "Think budget"),
                 ("settings-model-profile-streaming", "Streaming"),
             ),
             SettingsCategoryId.SPEECH_TTS: (
                 ("settings-speech-default-provider", "Default TTS Provider"),
                 ("settings-speech-model-value", "TTS model"),
+                ("settings-speech-model-value", "Model value"),
                 ("settings-speech-voice-value", "TTS voice"),
+                ("settings-speech-voice-value", "Voice value"),
                 ("settings-speech-configure-provider", "audio.cpp audio_cpp"),
                 ("settings-speech-configure-provider", "OpenAI"),
                 ("settings-speech-configure-provider", "ElevenLabs"),
@@ -367,22 +529,25 @@ def build_field_search_index() -> None:
                 ("settings-speech-configure-provider", "Chatterbox"),
                 ("settings-speech-configure-provider", "Higgs"),
                 ("settings-speech-configure-provider", "AllTalk"),
+                ("settings-speech-configure-provider", "Configure Provider"),
                 # TASK-23109 completion sweep: labels mirror the rendered rows.
                 ("settings-speech-default-profile", "Default voice profile"),
                 ("settings-speech-model-policy", "Model policy"),
                 ("settings-speech-voice-policy", "Voice policy"),
                 ("settings-speech-output-format", "Output format"),
+                ("settings-speech-speed", "Speed"),
                 ("settings-speech-speed", "Speech speed"),
-                ("settings-speech-openai-authentication-mode", "OpenAI authentication"),
-                ("settings-speech-openai-base-url", "OpenAI TTS base URL"),
-                ("settings-speech-openai-organization-id", "OpenAI organization ID"),
+                # Review finding 5: every provider configure form's fields,
+                # derived from SPEECH_TTS_PROVIDER_FORM_FIELDS (source-pinned
+                # against the panel; only the default provider's form mounts).
+                *_speech_provider_form_entries(),
                 (
                     "settings-speech-realtime-enabled",
                     "Enable realtime voice engine",
                 ),
                 ("settings-speech-realtime-provider", "Realtime provider"),
                 ("settings-speech-realtime-model", "Realtime model"),
-                ("settings-speech-realtime-voice", "Realtime voice"),
+                ("settings-speech-realtime-voice", "Realtime voice (optional)"),
                 (
                     "settings-speech-realtime-idle-timeout-minutes",
                     "Realtime idle timeout (minutes)",
@@ -391,7 +556,7 @@ def build_field_search_index() -> None:
                 ("settings-speech-realtime-vad-threshold", "VAD threshold"),
                 (
                     "settings-speech-realtime-vad-silence-ms",
-                    "End-of-turn silence (ms)",
+                    "End-of-turn silence",
                 ),
                 ("settings-speech-realtime-handsfree-engine", "Hands-free engine"),
             ),
@@ -403,6 +568,10 @@ def build_field_search_index() -> None:
                 ("settings-raw-cli-permitted", "Allow raw CLI host access"),
             ),
             SettingsCategoryId.LIBRARY_RAG: (
+                # Rendered labels first (finding 8: "Hybrid balance" must be
+                # findable, not only the id-derived "hybrid alpha"); the
+                # id-derived alias rows keep config-key vocabulary working.
+                *RAG_FIELD_RENDERED_LABELS.items(),
                 *(
                     (field_id, _rag_field_search_label(field_id))
                     for field_id in RAG_FIELD_GROUP_BY_ID
@@ -421,6 +590,7 @@ def build_field_search_index() -> None:
             SettingsCategoryId.SPLASH_SCREEN: (
                 ("settings-splash-enabled", "Splash screen enabled"),
                 ("settings-splash-default-select", "Default splash card"),
+                ("settings-splash-default-select", "Default card"),
                 ("settings-splash-show-progress", "Show progress"),
                 ("settings-splash-skip-on-keypress", "Skip on keypress"),
                 ("settings-splash-duration", "Splash duration (s)"),
@@ -442,6 +612,7 @@ def build_field_search_index() -> None:
             ),
             SettingsCategoryId.IMAGE_GENERATION: (
                 ("settings-imagegen-default_backend", "Default image backend"),
+                ("settings-imagegen-default_backend", "Default backend"),
                 *_backend_field_entries(
                     "imagegen", _imagegen_backend_labels, _imagegen_field_schema
                 ),
@@ -454,8 +625,24 @@ def build_field_search_index() -> None:
                     )
                 ),
             ),
+            # Review finding 5: the Agents form was entirely unindexed. The
+            # runtime drift guard is blind here by construction (its harness
+            # pins chachanotes_db=None, so AgentsSettingsPanel composes only
+            # a notice) -- declared in the guard's HARNESS_BLIND_CATEGORIES.
+            SettingsCategoryId.AGENTS: (
+                ("agents-name-input", "Agent name"),
+                ("agents-description-input", "Agent description"),
+                (
+                    "agents-instructions-area",
+                    "Agent instructions (appended to the sub-agent prompt)",
+                ),
+                ("agents-model-input", "Agent model override"),
+                ("agents-tools-input", "Agent tools"),
+                ("agents-enabled-switch", "Agent enabled"),
+            ),
             SettingsCategoryId.VIDEO_GENERATION: (
                 ("settings-videogen-default_backend", "Default video backend"),
+                ("settings-videogen-default_backend", "Default backend"),
                 *_backend_field_entries(
                     "videogen", _videogen_backend_labels, _videogen_field_schema
                 ),

--- a/tldw_chatbook/UI/Workbench/help.py
+++ b/tldw_chatbook/UI/Workbench/help.py
@@ -141,7 +141,14 @@ class WorkbenchHelpPanel(SafeModalDismissMixin, ModalScreen[None]):
     def compose(self) -> ComposeResult:
         with Vertical(id="workbench-help-panel", classes="workbench-help-panel"):
             with VerticalScroll(id="workbench-help-scroll"):
-                yield Static(self.state.render_text(), id="workbench-help-body")
+                # markup=False (TASK-23110 review): help notes are plain
+                # text that can contain literal brackets -- Settings ▸
+                # Agents' "[tools] gates" was being eaten as a markup tag.
+                yield Static(
+                    self.state.render_text(),
+                    id="workbench-help-body",
+                    markup=False,
+                )
             yield Button("Close", id="workbench-help-close", compact=True)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
Four Settings-screen fixes from the UX critique burn-down, one commit per task, plus a User Guide update and a reviewed diagnostic-inventory re-pin.

## TASK-23104 — State banner doubled and self-colliding (P1)
The save-contract carrier line had two defects: scope strings for the domain categories and the Overview fallback embedded their own `State: …` on top of the badge prefix, and Overview + the eight contract-rendered domain categories composed a second in-card banner under the pinned one. Fixed by dropping the in-card banners (the pinned detail-pane banner covers every category) and stripping the embedded prefixes; VIDEO_GENERATION gains its own scope line parallel to IMAGE_GENERATION instead of the contradictory read-only fallback.

Runtime evidence (headless tmux, isolated profile; whole-pane `State:` occurrence count = 1 in each capture):
- Overview: `State: Read-only here | Review readiness across Settings categories.`
- Schedules (domain): `State: Read-only here | Schedules owns workflow actions and setup.`
- Console Behavior (draft): `State: Draft — save with s | Changes affect global Console fallbacks after save.`

## TASK-23108 — raw exception text in user-facing status and toasts (P2)
The three named paths (model-discovery run, discovered-model save, RAG backfill) now present a plain-language summary with a suggested next step via a new `failure_status_text()` helper (`settings_config_adapter.py`) that surfaces only the exception type name and still routes through `redact_secret_text`. Full (redacted) detail stays reachable in the loguru log; the discovery-run log line now carries the redacted message it used to omit. loguru diagnose untouched. Sweep of the rest of `settings_screen.py` found no other user-facing bare-exception f-string — remaining `str(exc)` sites are typed domain errors with authored user-language messages (`WorkspaceRegistryServiceError`, screen-authored `ValueError` validation copy) or the Advanced Config family's contextualized, redacted TOML/path validation lines. Live check: a real connection failure takes the structured typed-error path ("Model discovery request failed. Check the endpoint URL, server availability, and credentials.") — the `except` branches fixed here are for unexpected crashes and are covered by direct unit tests.

## TASK-23110 — F1 category help hollow or empty (P3)
F1 help listed only shortcut keys, so a category with none (Schedules) opened an empty scroll body. The help state now carries a "How this category works" section built from copy the screen already maintains (persistence badge, State-banner scope line, ownership matrix). New test iterates all 26 `SettingsCategoryId` members asserting non-empty contract-bearing help. Runtime evidence on Schedules:
```
Settings: Schedules
How this category works:
- Save contract: Read-only here.
- Scope: Schedules owns workflow actions and setup.
- Runtime owner: Schedules.
- Writes here: no — view-only.
...
- No shortcut keys are specific to this category.
```
Storage shows the same section plus its s/r/t shortcut list.

## TASK-23109 — search matches categories only; no jump-to-setting (P2)
- Field index moved to `UI/Screens/settings_search_index.py` and completed to cover every rendered setting control (Console Behavior defaults/agent budgets/background effects, model-catalog + model-profile fields, Speech realtime/OpenAI fields, Splash Screen, Theme editor fields, two Library/RAG toggles, Image/Video Generation — the generation categories DERIVED from the same `BACKEND_LABELS`/`FIELD_SCHEMA` tables their forms render from).
- New drift guard `Tests/UI/test_settings_search_index.py` mounts every category and fails when a rendered value widget or labeled toggle-Button is missing from the index (a justified allowlist covers utility controls) — the failure mode that made "Reduce motion" unfindable cannot recur silently.
- Results line now carries scope and disambiguates ambiguity; graded field-tier ranking (label-prefix beats mid-label) keeps established landings stable, and typing a category's own title opens the category plainly instead of stealing focus into a coincidentally-matching field.

Runtime evidence ("reduce motion" journey, quoted from captures):
```
Filter: reduce motion | 1 match | Enter opens Appearance › Reduce motion (Interface)
```
Enter landed on Appearance with the Reduce motion control focused (style-diff evidence: its value cell renders bold+underline on the focused background `48;2;39;39;39` while the neighboring ASCII-glyphs row renders plain on `48;2;30;30;30`). Ambiguity case:
```
Filter: theme | 2 matches | Enter opens Theme (Interface) | Next: Appearance › Theme (Interface)
```

## Tests
- Targeted batch (hub + search index + footer hints + console status row + rag profile region + category sweep): **513 passed, 6 failed — the 6 are pre-existing on the base** (verified by running the identical command against pristine HEAD files: identical failure sets, all in the privacy-security cluster + parity file; base run 471 passed/11 failed vs branch 472/11 with the same names).
- Adjacent suites (speech panel, image/video gen defaults, appearance defaults): **250 passed**.
- New coverage: exactly-one-banner sweep, one-`State:`-segment unit test, three TASK-23108 plain-language tests + updated backfill contract test (129 passed in its file), 26-category F1 help test, drift guard (2 tests), reduce-motion/theme scope + Enter-focus tests.
- `./scripts/preflight.sh`: **all derived-artifact checks passed** (diagnostic inventory re-pinned after per-statement review; see commit f7f2ba69f3).

## Review round (15 verified findings — commits 3c70c26951..54509d7d60)

**Rebased onto dev `39957143e8` (PR #2158, cloud first-run discovery)** — sole conflict was the diagnostic-inventory pin, resolved by regenerating from the rebased tree (absorbing dev's own not-yet-pinned `virtual_cli_provider.py` row, reviewed); #2158's production diff adds no log/notify lines, so no new TASK-23108 policy application was needed, and both its discovery fixes and this PR's type-name-only logging + `failure_status_text` copy survive intact. Post-rebase gates: targeted batch (incl. the endpoint-probe suite #2158 extended) 596 passed / 6 failed (the same pre-existing privacy-security cluster — dev's new commits touch none of this PR's files except the inventory JSON), adjacent suites 265 passed, ruff clean, preflight green.

All 15 findings verified and fixed; none refuted. Per-finding disposition:

1. **SECURITY — raw exception text into the on-disk log (fixed, `3c70c26951`).** Verified: `redact_secret_text`'s regex matches only `X = value` assignment shapes — a probe showed `?key=AIza...` URLs and `Authorization: Bearer sk-...` pass through unredacted. Both discovery branches log the exception **type name only** again (the persistence branch also drops `logger.exception`, whose traceback tail printed the raw message). Per the standing rule the redaction regex was NOT widened. **Follow-up material: the rotating file sink itself has no redaction filter** — sink-level redaction is the durable fix and is not attempted in this PR.
2. **Field-landing gate over-suppressed description-tier matches (fixed, `2472ca0856`).** Gate now suppresses only own-title ranks (0/1); `/context window` + Enter focuses `#settings-model-context-window` again (pinned).
3. **Landing on collapsed/disabled widgets (fixed, `2472ca0856`).** The landing expands enclosing Collapsibles and scrolls before focusing; a disabled target opens the category and explains in the status line. Live captures: "temperature" → Model profile fold expanded, inspector reads `Focused setting: Temperature`, focused input visible (`region.height > 0` also pinned in the test); "preferred rail width" → Appearance opens with status `'Preferred rail width' is disabled right now — its category is open; enable the option that controls it first.`
4. **Backfill's second failure surface (fixed, `3c70c26951`).** Crash log line is type-name-only; the partial-failure toast reports counts (`N indexed, M failed. K error(s) recorded — details are in Logs (F8).`) instead of raw `str(errors[-1])` — the engine (`ingestion_indexing`) already logs each failure with its traceback. Partial-failure toast test added.
5. **Index coverage holes (fixed, `33ea08fa3a`).** AGENTS' 6 form controls, all 7 TTS provider configure forms (61 fields, via a `SPEECH_TTS_PROVIDER_FORM_FIELDS` table source-pinned against the panel's `_compose_provider_form` by a dedicated test), and the bare remote-images toggle Button are indexed. The guard's blindness is now declared: `HARNESS_BLIND_CATEGORIES` (agents: `chachanotes_db=None` composes only a notice) and `DECLARED_UNMOUNTED_IDS` (non-default provider forms), each with its reason.
6. **VIDEO_GENERATION ownership record (fixed, `ce0cb0adab`).** IMAGE_GENERATION-style record added (writes yes; Console owns `/generate-video`); a dedicated test asserts the coherent contract and that no read-only copy appears in the body.
7. **Help body ate literal `[tools]` as markup (fixed, `ce0cb0adab`).** `markup=False` on `#workbench-help-body` (no help builder uses markup); end-to-end test opens Agents F1 and asserts `[tools] gates` survives `render()`.
8. **Label drift (fixed, `33ea08fa3a`).** Rendered-label rows added (RAG "Hybrid balance" et al., "Speed", "Preferred rail width" — which the live disabled-landing capture caught failing first — plus `(%)`/Think budget/Default backend/Default card/Configure Provider aliases). The drift guard now runs a label sweep: some indexed label must contain, or be contained by, the rendered row label — the honest rule given that search matching is containment-based; true drift fails both directions.
9. **ruff RED (fixed, `33ea08fa3a`).** The load-bearing `_build_field_search_index` re-export keeps `# noqa: F401` with a comment naming its consumer (`Tests/UI/test_settings_console_status_row.py`). ruff clean across all touched files.
10. **`| Next:` hard-coded field landings (fixed, `2472ca0856`).** The segment computes the same gate Enter would honour for that match.
11. **Help-notes copy pass (fixed, `ce0cb0adab`).** Overview's boundary renders as labeled rows; the nine read-only domain pages state one ownership sentence once (`Owned by X: ...`); duplicated values are not repeated under a second prefix (ownership line kept explicit always). All 26 bodies read for sense.
12. **Drift guard hardening (fixed, `33ea08fa3a`).** No blanket except; per-category minimum floors; reverse sweep (every indexed id resolves or its absence is declared with a reason); allowlist rows must render; id-less settings count and are flagged; the input-row walk crosses nested containers — which immediately surfaced one more real control (the "Use Official OpenAI" preset action, allowlisted with justification).
13. **Intra-category landing re-routed (fixed, `2472ca0856`).** `_top_field_match` is order-stable single-pass again; cross-category prefix preference moved to a whole-category tier scan. `/token` keeps landing on "Conversation max tokens" (pinned).
14. **rag.md stale toast copy (fixed, `3c70c26951`).** Backfill section documents the plain-language shapes, with a fresh stamp.
15. **Status-line growth on short terminals (verified live, then fixed, `2472ca0856`).** At 110x24 a 16-match query wrapped the scoped line to 5 rail rows leaving 6 category rows visible; the `| Next:` segment is now dropped below 30 screen rows (after: 3 rows, 8+ matches visible). Pinned at both sizes.

**Cleanup tier:** `build_field_search_index` clears before updating. **Raw-`str(exc)` census (the "~18 sibling sites"):** re-examined against TASK-23108's AC ("user-facing f-string interpolating a bare exception") — none matches that shape. Per-group justification: (a) Workspaces' `str(exc)` sites surface `WorkspaceRegistryServiceError`, a typed domain error whose messages are authored plain-language copy (constants in `Workspaces/registry_service.py`); (b) `settings_screen` ValueError sites (agent budgets, model-profile values, context-window entry, console fps) surface the screen's own authored validation copy; (c) the Advanced Config / config-path family shows contextualized (`"Config validation: invalid - ..."`), `redact_secret_text`-wrapped messages from **local** TOML/OS errors where the parse message is the actionable content and no network/credential material flows through the exception.

Review-round gates: targeted settings batch **522 passed / 6 failed — the identical pre-existing privacy-security cluster from the base A/B** (failure sets compared by name, not count); adjacent suites (speech panel, image/video-gen defaults, appearance, agents category) **256 passed**; help-panel consumer suites 400 passed with 3 failures in Console files this branch never touches (pre-existing dev reds); **ruff clean**; **preflight green** (diagnostic inventory re-pinned after per-statement review: three type-name-only log lines + one constant debug line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2WwNRSyk6w9V7b9yh5Yht

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four Settings-screen issues from the UX critique burn-down: the State banner rendered twice with conflicting scopes, raw exception text leaked into user-facing status and toasts, F1 help was empty for shortcut-less categories, and `/` search couldn't find or jump to settings.

**Bug Fixes**
- State banner now renders once per category with a single `State:` segment; in-card duplicates are gone.
- Model discovery, discovered-model save, and RAG backfill failures show a plain-language summary with a next step; only the exception type name reaches the user, full detail stays in the log.
- F1 help carries a "How this category works" contract section for all 26 categories, and literal `[tools]`-style brackets survive rendering.
- `/` search covers every rendered setting control with scoped results and field-level landings; Enter expands collapsed sections before focusing and explains disabled controls.
- A drift-guard test mounts every category and fails when a rendered control is missing from the search index.
- A new integration test drives the real F1 help flow on the mounted screen, catching breaks between the help builder and the rendered panel.

<sup>Written for commit 8f29ccac99eb98c70fae78d0a101980a3daa51f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

