### PR TITLE
fix(wizard): report the real discovery failure, not a flat "request failed"

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -96,6 +96,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 2,
+      "diagnostic_digest": "6893f57f0dcf3808f1b3",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Agents/virtual_cli_provider.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 1,
       "diagnostic_digest": "ebd5049a714019fa236d",
       "owner": "TASK-494",
@@ -3987,9 +3994,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 540,
+    "owner_files": 541,
     "persistent_sink_files": 8,
     "task_492_calls": 1260,
-    "task_494_calls": 7394
+    "task_494_calls": 7396
   }
 }

--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -3573,3 +3573,146 @@ async def test_provider_test_button_requests_identity_encoding_from_a_real_peer(
         "a reachable, gzip-capable peer must verify as reachable, not fail "
         f"the way the live incident did: {status.renderable!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# TASK-23091 (Qodo review, PR #2171): the category helper is unit-tested, but
+# the two _load_models handoff branches that consume it are what actually
+# render copy. Without wizard-level coverage a wiring revert would put
+# "Couldn't reach the server" back in front of users while every unit test
+# stayed green.
+# ---------------------------------------------------------------------------
+
+
+def _recorded_auth_failure_result():
+    from tldw_chatbook.LLM_Provider_Catalog.model_discovery_contracts import (
+        ModelDiscoveryError,
+        ModelDiscoveryResult,
+    )
+
+    return ModelDiscoveryResult(
+        provider="openai",
+        provider_list_key="openai",
+        endpoint_fingerprint="https://api.openai.com/v1",
+        status="error",
+        error=ModelDiscoveryError(
+            kind="missing_credentials",
+            message="The models endpoint rejected the configured credentials.",
+            recovery_hint="Check the API key configured for this provider.",
+        ),
+    )
+
+
+@pytest.mark.parametrize("handoff", ["models_mapping", "outcome_unavailable"])
+@pytest.mark.asyncio
+async def test_model_step_renders_auth_copy_on_both_handoff_branches(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, handoff: str
+) -> None:
+    """A rejected key must read as a rejected key on either handoff path.
+
+    Both _load_models branches previously hardcoded the generic category, so
+    a 401 rendered as "Couldn't reach the server ... Check it's running" --
+    pointing away from the fix, which lives one step Back. This drives the
+    real wizard to the Model step and asserts the rendered radio copy, so
+    reverting either call site fails here even though the helper's own unit
+    tests would still pass.
+
+    Args:
+        monkeypatch: Pytest fixture used to isolate config/HOME state and,
+            for the second branch, to force the outcome-unavailable path.
+        tmp_path: Pytest fixture providing the throwaway profile directory.
+        handoff: Which _load_models branch to exercise.
+    """
+    app = _build_fresh_wizard_app(monkeypatch, tmp_path)
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(140, 45)) as pilot:
+            await _wait_until(
+                pilot, lambda: type(app.screen).__name__ == "FirstRunSetupWizard"
+            )
+            container = app.screen.query_one(SetupWizardContainer)
+            await _wait_until(pilot, lambda: container.can_proceed)
+            _press(app.screen, "#wizard-next")
+            await _wait_until(
+                pilot, lambda: _current_step_id(container) == STEP_PROVIDER
+            )
+
+            provider = next(s for s in container.steps if isinstance(s, ProviderStep))
+            provider.select_provider("openai")
+            await pilot.pause(0.4)
+            # A credential is required for the step to commit at all.
+            provider.query_one("#setup-provider-api-key", Input).value = "rejected-key"
+            await pilot.pause(0.3)
+
+            outcome = _recorded_auth_failure_result()
+
+            def _fake_begin(provider_draft, *, sync_live_credential=True):
+                # Stand in for the network at the exact seam where commit
+                # starts discovery, recording what a real 401 leaves behind:
+                # a failed discovery whose typed outcome says "credentials".
+                draft = (
+                    provider._effective_provider_draft()
+                    if isinstance(provider_draft, str) or provider_draft is None
+                    else provider_draft
+                )
+                key = provider._model_discovery_key(draft)
+                provider._selected_discovery_key = key
+                provider._selected_discovery_state = "failed"
+                provider._selected_provider_outcomes = {key: outcome}
+                provider._selected_provider_models = {key: []}
+                container._first_run_provider_discovery_owner = provider
+                container._first_run_selected_provider_outcomes = {}
+                if handoff == "models_mapping":
+                    # Branch 1: models handed off, empty, owner failed.
+                    container._first_run_selected_provider_models = {key: []}
+                else:
+                    # Branch 2: nothing handed off and no typed outcome comes
+                    # back, so the owner's recorded state is the only source.
+                    container._first_run_selected_provider_models = {}
+
+            monkeypatch.setattr(
+                provider, "_begin_selected_provider_discovery", _fake_begin
+            )
+            if handoff != "models_mapping":
+
+                async def _no_outcome(*_args, **_kwargs):
+                    return None
+
+                monkeypatch.setattr(
+                    provider, "_outcome_from_selected_discovery", _no_outcome
+                )
+
+            _press(app.screen, "#wizard-next")
+            await _wait_until(
+                pilot,
+                lambda: _current_step_id(container) == STEP_MODEL,
+                timeout_seconds=20.0,
+            )
+            model_step = container.steps[container.current_step]
+            # The placeholder is a non-empty label too, so waiting on
+            # "any text" can read the loading state and pass by accident.
+            await _wait_until(
+                pilot,
+                lambda: (
+                    (labels := [
+                        str(button.label)
+                        for button in model_step.query(
+                            "#setup-model-choice RadioButton"
+                        )
+                    ])
+                    and all("loading models" not in label for label in labels)
+                ),
+                timeout_seconds=20.0,
+            )
+            rendered = " ".join(
+                str(button.label)
+                for button in model_step.query("#setup-model-choice RadioButton")
+            )
+
+    assert "Authentication failed" in rendered, (
+        f"a rejected key rendered as something else on the {handoff!r} branch: "
+        f"{rendered!r}"
+    )
+    assert "Check it's running" not in rendered, (
+        "the generic server-unreachable copy is the exact wrong advice for a "
+        f"401: {rendered!r}"
+    )

--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -3637,24 +3637,24 @@ async def test_model_step_renders_auth_copy_on_both_handoff_branches(
             )
 
             provider = next(s for s in container.steps if isinstance(s, ProviderStep))
-            provider.select_provider("openai")
-            await pilot.pause(0.4)
-            # A credential is required for the step to commit at all.
-            provider.query_one("#setup-provider-api-key", Input).value = "rejected-key"
-            await pilot.pause(0.3)
-
             outcome = _recorded_auth_failure_result()
 
             def _fake_begin(provider_draft, *, sync_live_credential=True):
-                # Stand in for the network at the exact seam where commit
-                # starts discovery, recording what a real 401 leaves behind:
-                # a failed discovery whose typed outcome says "credentials".
+                # Stand in for the network at the exact seam where selection
+                # and commit start discovery, recording what a real 401
+                # leaves behind: a failed discovery whose typed outcome says
+                # "credentials". Installed BEFORE select_provider, which
+                # kicks off a real discovery worker of its own -- otherwise
+                # this test would do genuine network work and depend on its
+                # timing rather than isolating the handoff.
                 draft = (
                     provider._effective_provider_draft()
                     if isinstance(provider_draft, str) or provider_draft is None
                     else provider_draft
                 )
                 key = provider._model_discovery_key(draft)
+                if key is None:
+                    return
                 provider._selected_discovery_key = key
                 provider._selected_discovery_state = "failed"
                 provider._selected_provider_outcomes = {key: outcome}
@@ -3680,6 +3680,13 @@ async def test_model_step_renders_auth_copy_on_both_handoff_branches(
                 monkeypatch.setattr(
                     provider, "_outcome_from_selected_discovery", _no_outcome
                 )
+
+            provider.select_provider("openai")
+            await pilot.pause(0.3)
+            # A credential is required for the step to commit at all, and
+            # entering it is what re-keys the discovery commit then records.
+            provider.query_one("#setup-provider-api-key", Input).value = "rejected-key"
+            await pilot.pause(0.3)
 
             _press(app.screen, "#wizard-next")
             await _wait_until(

--- a/Tests/Wizards/test_first_run_setup_wizard.py
+++ b/Tests/Wizards/test_first_run_setup_wizard.py
@@ -13095,3 +13095,87 @@ def test_malformed_entry_in_the_tail_is_still_rejected():
 
     with pytest.raises(ValueError, match="discovery"):
         _model_ids_from_discovery_result(replace(result, models=poisoned))
+
+
+# ---------------------------------------------------------------------------
+# TASK-23091: ModelStep's handoff paths flattened every failure to
+# "request failed", so an authentication rejection told the user to check
+# whether their server was running. That wording masked the real cause for
+# most of the TASK-23089 investigation.
+# ---------------------------------------------------------------------------
+
+
+def _errored_discovery_result(kind: str):
+    from tldw_chatbook.LLM_Provider_Catalog.model_discovery_contracts import (
+        ModelDiscoveryError,
+        ModelDiscoveryResult,
+    )
+
+    return ModelDiscoveryResult(
+        provider="openai",
+        provider_list_key="openai",
+        endpoint_fingerprint="https://api.openai.com/v1",
+        status="error",
+        error=ModelDiscoveryError(
+            kind=kind,
+            message="The models endpoint rejected the configured credentials.",
+            recovery_hint="Check the API key configured for this provider.",
+        ),
+    )
+
+
+def test_handed_off_auth_failure_keeps_its_authentication_category():
+    """A rejected key must not be reported as an unreachable server.
+
+    ProviderStep records the typed outcome even on handoff paths where
+    ModelStep never receives one directly. Flattening those to
+    "request failed" rendered "Couldn't reach the server ... Check it's
+    running" for a 401 -- unactionable, and the opposite of the fix the
+    user needs (the key lives one step Back).
+    """
+    from tldw_chatbook.UI.Wizards import first_run_setup_state as wizard_state
+    from tldw_chatbook.UI.Wizards.FirstRunSetupWizard import (
+        _handed_off_failure_category,
+    )
+
+    key = object()
+    owner = SimpleNamespace(
+        _selected_provider_outcomes={key: _errored_discovery_result(
+            "missing_credentials"
+        )}
+    )
+
+    category = _handed_off_failure_category(owner, key)
+
+    assert category == "authentication"
+    # The category is only useful if it still reaches the auth copy branch.
+    assert wizard_state.classify_discovery_failure("connection_failed", category) == (
+        wizard_state.PROVIDER_PROBE_AUTH
+    )
+
+
+def test_handed_off_failure_without_a_recorded_outcome_stays_generic():
+    """Without a typed outcome there is nothing more specific to say."""
+    from tldw_chatbook.UI.Wizards import first_run_setup_state as wizard_state
+    from tldw_chatbook.UI.Wizards.FirstRunSetupWizard import (
+        _handed_off_failure_category,
+    )
+
+    for owner in (None, SimpleNamespace(_selected_provider_outcomes={})):
+        category = _handed_off_failure_category(owner, object())
+        assert category == "request failed"
+        assert wizard_state.classify_discovery_failure(
+            "connection_failed", category
+        ) == wizard_state.PROVIDER_PROBE_CONNECTION
+
+
+def test_handed_off_failure_category_survives_a_malformed_outcome():
+    """A junk recorded outcome degrades to the generic wording, never raises."""
+    from tldw_chatbook.UI.Wizards.FirstRunSetupWizard import (
+        _handed_off_failure_category,
+    )
+
+    key = object()
+    owner = SimpleNamespace(_selected_provider_outcomes={key: object()})
+
+    assert _handed_off_failure_category(owner, key) == "request failed"

--- a/backlog/tasks/task-23091 - Model-step-reports-the-real-discovery-failure-instead-of-a-hardcoded-request-failed.md
+++ b/backlog/tasks/task-23091 - Model-step-reports-the-real-discovery-failure-instead-of-a-hardcoded-request-failed.md
@@ -1,0 +1,38 @@
+---
+id: TASK-23091
+title: >-
+  Model step reports the real discovery failure instead of a hardcoded 'request
+  failed'
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-28 15:45'
+updated_date: '2026-08-28 15:58'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When ProviderStep hands off a failed discovery without a typed outcome in hand, ModelStep hardcodes the failure category to 'request failed'. The user is then told to check whether the server is running even when the real cause was a rejected API key, which is both unactionable and contradicts the provider-aware error copy added for UAT M-4. This masked the true cause for most of the TASK-23089 investigation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A discovery that failed on authentication renders the authentication copy, not 'Couldn't reach the server'
+- [ ] #2 The generic 'request failed' wording is used only when no typed outcome is available
+- [ ] #3 Regression coverage pins the category derived from a recorded provider outcome
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Derive the category from the ProviderStep's recorded typed outcome when one exists.\n2. Keep 'request failed' only as the no-outcome fallback.\n3. Cover both paths with tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+ProviderStep already records the typed ModelDiscoveryResult for a selection, so _handed_off_failure_category recovers the real category from it on both handoff paths; 'request failed' now appears only when no typed outcome exists, and a malformed recorded outcome degrades to the generic wording rather than raising. Tests pin all three paths and assert the recovered category still reaches classify_discovery_failure's AUTH branch (a correct category that no longer selects the auth copy would be worthless); the auth case was confirmed to fail against the previous behavior. Also refreshed the production diagnostic inventory pin in a separate commit -- that drift is inherited from dev (preflight fails identically on pristine origin/dev), reviewed per protocol, with a note to the owner that both new statements interpolate exception text that can carry a filesystem path.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
+++ b/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
@@ -988,6 +988,12 @@ def _legacy_model_ids(values: object) -> tuple[str, ...]:
     return tuple(model_ids)
 
 
+# The category a failed discovery falls back to when nothing more specific is
+# known. It drives user-visible copy (see classify_discovery_failure), so the
+# fallback branches must not drift apart from each other.
+GENERIC_DISCOVERY_FAILURE_CATEGORY = "request failed"
+
+
 def _model_discovery_ui_outcome(result: object) -> tuple[list[str], str, str]:
     """Interpret one typed discovery result into bounded Model-step state."""
 
@@ -1008,7 +1014,7 @@ def _model_discovery_ui_outcome(result: object) -> tuple[list[str], str, str]:
     category = {
         "invalid_response": "invalid response",
         "missing_credentials": "authentication",
-    }.get(error_kind, "request failed")
+    }.get(error_kind, GENERIC_DISCOVERY_FAILURE_CATEGORY)
     return [], "connection_failed", category
 
 
@@ -1034,12 +1040,12 @@ def _handed_off_failure_category(owner: object, discovery_key: object) -> str:
 
     outcomes = getattr(owner, "_selected_provider_outcomes", None)
     if not isinstance(outcomes, Mapping) or discovery_key not in outcomes:
-        return "request failed"
+        return GENERIC_DISCOVERY_FAILURE_CATEGORY
     try:
         _models, _state, category = _model_discovery_ui_outcome(outcomes[discovery_key])
     except ValueError:
-        return "request failed"
-    return category or "request failed"
+        return GENERIC_DISCOVERY_FAILURE_CATEGORY
+    return category or GENERIC_DISCOVERY_FAILURE_CATEGORY
 
 
 def _first_run_discovery_staged_settings(

--- a/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
+++ b/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
@@ -1012,6 +1012,36 @@ def _model_discovery_ui_outcome(result: object) -> tuple[list[str], str, str]:
     return [], "connection_failed", category
 
 
+def _handed_off_failure_category(owner: object, discovery_key: object) -> str:
+    """Recover the real failure category from the owner's recorded outcome.
+
+    ProviderStep records the typed ``ModelDiscoveryResult`` for a selection
+    even on the handoff paths where ModelStep never receives one directly.
+    Without this, those paths reported a flat "request failed", so an
+    authentication rejection rendered as "Couldn't reach the server. Check
+    it's running" -- telling the user to check a server when the problem was
+    their key, and defeating the provider-aware copy added for UAT M-4. That
+    wording masked the true cause for most of the TASK-23089 investigation.
+
+    Args:
+        owner: The ProviderStep that owned the discovery, if any.
+        discovery_key: The exact discovery identity ModelStep is rendering.
+
+    Returns:
+        The category derived from the recorded outcome, or "request failed"
+        when no typed outcome is available to be more specific than that.
+    """
+
+    outcomes = getattr(owner, "_selected_provider_outcomes", None)
+    if not isinstance(outcomes, Mapping) or discovery_key not in outcomes:
+        return "request failed"
+    try:
+        _models, _state, category = _model_discovery_ui_outcome(outcomes[discovery_key])
+    except ValueError:
+        return "request failed"
+    return category or "request failed"
+
+
 def _first_run_discovery_staged_settings(
     provider_draft: wizard_state.FirstRunProviderDraft,
     discovery_key: wizard_state.FirstRunModelDiscoveryKey,
@@ -3473,7 +3503,7 @@ class ModelStep(SetupStep):
                 and owner._selected_discovery_state == "failed"
             ):
                 discovery_state = "connection_failed"
-                failure_category = "request failed"
+                failure_category = _handed_off_failure_category(owner, discovery_key)
             discover = None
         elif (
             isinstance(owner, ProviderStep)
@@ -3501,7 +3531,7 @@ class ModelStep(SetupStep):
                 and owner._selected_discovery_state == "failed"
             ):
                 discovery_state = "connection_failed"
-                failure_category = "request failed"
+                failure_category = _handed_off_failure_category(owner, discovery_key)
             # ProviderStep owns setup network work for this selection. If the
             # user advances before it finishes, use curated fallback rather
             # than issuing the same provider catalog request from ModelStep.


### PR DESCRIPTION
Follow-up recorded during TASK-23089, now **TASK-23091**.

## The defect

ModelStep's two handoff paths hardcoded `failure_category = "request failed"` whenever ProviderStep reported a failed discovery without handing over a typed outcome. That category drives the copy, so an **authentication rejection rendered as "Couldn't reach the server … Check it's running"** — telling the user to check a server when the problem was their API key, and pointing away from the fix, which lives one step Back. It also defeated the provider-aware error copy added for UAT M-4.

Not hypothetical: that wording is what sent me chasing endpoints and credentials for most of the TASK-23089 investigation while the real answer was a rejected result one layer down.

## The fix

ProviderStep already records the typed `ModelDiscoveryResult` for the selection, so `_handed_off_failure_category` recovers the real category from it. `"request failed"` now appears only when there genuinely is no typed outcome to be more specific than, and a malformed recorded outcome degrades to the generic wording rather than raising.

Tests cover all three paths. The auth case was confirmed to fail against the previous behavior (`'request failed' != 'authentication'`) and additionally asserts the recovered category still reaches `classify_discovery_failure`'s `PROVIDER_PROBE_AUTH` branch — a correct category that no longer selected the auth copy would be worthless.

## Second commit: inherited inventory drift

`f3664e0a7` refreshes the production diagnostic inventory pin. That drift is **not from this branch** — preflight fails identically on pristine `origin/dev`, so an upstream commit added diagnostics without regenerating the pin and left the required check red downstream. Reviewed per the protocol rather than a blind `--write`: one new file, `Agents/virtual_cli_provider.py`, two added statements, none removed, no sink-topology change.

Flagging one thing for that file's owner rather than silently blessing it: both statements interpolate exception text into a persistent sink, and a persistence failure's exception commonly carries a filesystem path (`OSError.filename`). That's their call, not something to change from here, but it's exactly what the review step exists to surface.

## Verification

- 889 passed — full wizard suites
- `./scripts/preflight.sh` — all derived-artifact checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQ5JJaaUcLAhkHwy1dvSSE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the wizard's Model step showing "Couldn't reach the server" for rejected credentials by recovering the real failure category from the provider's recorded outcome on both handoff paths.

**Bug Fixes**
- `_handed_off_failure_category` reads the typed outcome from `ProviderStep`; "request failed" appears only when no typed outcome exists.
- The fallback is shared as `GENERIC_DISCOVERY_FAILURE_CATEGORY`, so the fallback branches cannot drift apart.
- A malformed recorded outcome degrades to the generic wording instead of raising.
- Tests cover all three unit paths and add a live wizard test that drives both handoff branches to assert the auth copy renders; the test's discovery stub is installed before selection, so it never hits the real network.

**Diagnostic inventory pin**
- The pin refresh is drift inherited from `dev` — preflight fails identically on pristine `origin/dev`.
- One new file, `Agents/virtual_cli_provider.py`, two added statements, none removed, no sink-topology change.
- Both new statements interpolate exception text (which can carry a filesystem path) into a persistent sink; flagged for the owner, not changed here.

<sup>Written for commit cb5a865579067cbc06ca8ea8cc6dd140c46e0e86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

