### PR TITLE
docs(perf): close out the 2026-08-27 holistic performance review

### DIFF
--- a/Docs/Design/2026-08-27-holistic-perf-review.md
+++ b/Docs/Design/2026-08-27-holistic-perf-review.md
@@ -17,6 +17,44 @@ findings against the correct baseline.
 
 ---
 
+## Outcome — closed 2026-08-28
+
+All ten findings shipped, plus the structural guard-policy task. Every "after" number below is the
+task's own interleaved-arm measurement, not an estimate; follow the task for its method.
+
+| task | finding | before | after |
+|---|---|---|---|
+| 23018 | Send price re-derived per keystroke | 5.848 ms median at 400 messages; **90/90 keys over 3 ms** | **0.368 ms; 0/90** |
+| 23020 | `trajectory_export` back on the first-paint leg | two guards **RED** | green; mount census 958 → 957 |
+| 23021 | Setup-modal snow (every new user's first screen) | 2.0–7.4% of a core; 124 widgets dirtied per tick; 37 repaints/15 s | **0.022–0.046%; 0 dirtied; 0 repaints** |
+| 23022 | Invisible `ProgressBar`s at 15 Hz forever | Lab 960 fires/15 s, 0.558–0.797% of a core | **0 fires, 0.094–0.095%** (Personas 0.215–0.341% → 0.064–0.071%) |
+| 23023 | One import statement for one integer constant | 273–286 ms, 143 modules; app boot closure 658 | **78–81 ms, 4 modules; 650** |
+| 23024 | Research composes 693 widgets per visit | 694 per visit, **83.6%** in `display=False` subtrees | **199 (−71%), 42.3%** |
+| 23025 | Library resize/focus re-walks the DOM | 71.6 DOM queries per resize frame; 25.4 per Tab | **10.6; 3.4** |
+| 23026 | Exchange capture stores the whole conversation forever | **21.25 MB** of blob per 200-turn conversation | **0.99 MB**; v52→v53 reclaim migration 537.9 ms |
+| 23027 | Notes sync re-reads and re-selects everything | 1,004 connections + 2,003 threads per 1,000-note sync | **3 and 3** |
+| 23028 | Timer census green while blind to the two largest clocks | 35 roots, both misses invisible | 36 roots, 0 problems, unresolvable roots now loud |
+| 23029 | All four boot budgets within 2–4% of breach | four constants, no policy | **ratchets (ADR-097)**: breaches name the culprit, headroom prints on every green run |
+
+**23026 converged two competing implementations.** A parallel session had shipped its own capture
+retention work; rather than pick a winner, both were read and reconciled under **ADR-096**, which
+fixes the ordering (allowlist → endpoint identity → instruction redaction → credential sanitization
+→ compaction → shared budget) so the two cannot diverge again.
+
+**Adopted while in breach, deliberately.** The import-weight ratchet measures **666 against its 660
+limit on pristine dev** — 17 modules added this week, ~12 of them through
+`Chat/chat_persistence_service.py`'s new module-scope imports. Per the owner's ruling the constant
+was **not** raised; the snapshot is pinned at the last in-budget set so the failure names all 17, and
+repayment is filed as **task-23112**. ADR-097 records this as a standing breach at adoption rather
+than papering over it.
+
+**Two owner calls left open.** (1) The four budget guards run only in the big, frequently-cancelled
+`Tests` workflow; moving them into `perf-guard.yml` would surface breaches per-PR in minutes, but
+would block all merges until 23112 lands. (2) `css/components/_agentic_terminal.tcss` is **270,217
+bytes — 42% of the entire boot CSS bundle** — and is still growing.
+
+---
+
 ## The finding that explains the complaint
 
 **Every printable keystroke re-derives the entire next request to price a tooltip.**

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9244,3 +9244,43 @@ tree gave 174 and 175). Use `-p no:randomly` on both sides or the sets are not
 comparable. Sampling is not enough either: five sampled failures all reproduced
 on base and pointed at "dev's problem", while the set diff exposed 79 that were
 ours. There is no undefined-name linter in this repo's CI to catch this class.
+
+## A PR that ran zero shards also reports zero failures — never baseline one PR's failure COUNT against another's (TASK-23029, 2026-08-28)
+
+**The incident.** PR #2166 showed nine failing shards (3 Core, 6 UI). To decide
+whether they were mine, I compared against PR #2160, open at the same time,
+which reported **zero** failures — which reads as "dev is fine, your branch
+broke it". #2160 had no `UI Tests` check runs *at all*: its `Tests` workflow
+never started its shards, the same burst-cancellation problem tracked in
+TASK-22250. Zero failures out of zero tests. Had I trusted it I would have
+gone hunting for a defect in a diff that could not contain one.
+
+**What actually settled it, in this order.** (1) A *structural* argument first,
+because it is free: `git diff <base>...HEAD --name-only` filtered to everything
+outside `Tests/Performance/`, `backlog/`, and one script came back **empty**, so
+the diff cannot reach `Tests/UI`. (2) Then reproduce: the named failures were run
+locally on the branch and failed there too, which — given (1) — means they fail on
+the base. (3) Only then read the failure text, which named the real cause anyway
+(`'ChatScreen' object has no attribute '_library_activity'` is a rename landing
+without its tests, not a perf change).
+
+**The rule.** Before using another PR's checks as a baseline, confirm it *ran the
+same checks*: `gh pr view <n> --json statusCheckRollup` and group by
+`status+conclusion` — `QUEUED`, `IN_PROGRESS`, and absent are all "no data", and
+only `COMPLETED` rows carry a verdict. A comparison between "0 failures of 0
+shards" and "9 failures of 12 shards" is not a comparison.
+
+## An auto-lander that polls by PR number will attribute the OLD head's verdict to a head you just pushed (2026-08-28)
+
+**The incident.** After force-pushing a rebased #2160, a background lander polling
+`gh pr view 2160` printed `GREEN -> merge` **eight seconds later** — far too fast
+for CI on the new commit. The verdict belonged to the pre-rebase head that had
+been green before the push. GitHub's per-head required check refused the merge, so
+the damage was zero and the PR simply stayed open; the lander's own log was the
+only thing that lied.
+
+**The rule.** A lander's "merged" line is a claim, not a result. Confirm with
+`gh pr view <n> --json state,mergeCommit,headRefOid` that `state == MERGED`,
+`mergeCommit` is non-null, **and** `headRefOid` equals the SHA you pushed. The
+same check catches the related case where a lander merges a head that is no longer
+the one you verified locally.


### PR DESCRIPTION
## Summary

Closes the 2026-08-27 holistic performance review. All ten findings shipped, plus the structural
guard-policy task, across eleven PRs (#2143–#2166). This PR is documentation only: it adds the
outcome table to the evidence doc and records two lessons from the landing itself.

## The measured outcome

Every "after" number is the task's own interleaved-arm probe, not an estimate.

| task | before | after |
|---|---|---|
| 23018 Send price per keystroke | 5.848 ms at 400 messages, **90/90 keys over 3 ms** | **0.368 ms, 0/90** |
| 23021 setup-modal snow | 2.0–7.4% of a core, 37 repaints/15 s | **0.022–0.046%, 0 repaints** |
| 23022 invisible `ProgressBar`s | Lab 960 fires/15 s, 0.56–0.80% | **0 fires, 0.094%** |
| 23023 one import for one constant | 273–286 ms / 143 modules | **78–81 ms / 4 modules** |
| 23024 Research eager slot pools | 694 widgets/visit, 83.6% hidden | **199 (−71%), 42.3%** |
| 23025 Library resize/focus | 71.6 DOM queries/resize frame | **10.6** |
| 23026 exchange capture | **21.25 MB** per 200-turn conversation | **0.99 MB** |
| 23027 notes sync | 1,004 connections + 2,003 threads / 1,000 notes | **3 and 3** |
| 23020 / 23028 / 23029 | guards red, blind, or unpinned | green, 36 roots with 0 problems, ratcheted |

## Two things worth reading beyond the table

**The import-weight ratchet was adopted while dev is in breach — on purpose.** It measures 666
against its 660 limit on pristine dev (17 modules added this week, ~12 through
`Chat/chat_persistence_service.py`'s module-scope imports). Per the owner's ruling the constant was
**not** raised: the snapshot is pinned at the last in-budget set so the failure names all 17, and
repayment is filed as **task-23112**. ADR-097 records it as a standing breach at adoption.

**23026 converged two competing implementations** rather than picking a winner — a parallel session
had shipped its own capture-retention work, and both were reconciled under ADR-096, which pins the
pipeline ordering so they cannot diverge again.

## Lessons added

- **A PR that ran zero shards also reports zero failures.** I nearly used one open PR's "0 failures"
  as the baseline proving another had broken CI; it had no `UI Tests` check runs at all. What settled
  it was structural and free: the diff touched nothing outside `Tests/Performance/`, `backlog/`, and
  one script, so it could not reach the failing tests.
- **An auto-lander polling by PR number reported the previous head's verdict** eight seconds after a
  force-push. GitHub's per-head required check refused the merge, so nothing broke — but verify
  `state`, `mergeCommit`, and `headRefOid` before believing a lander.

## Verification

`./scripts/preflight.sh` green (all six checks, including `check_index_plan_pins`). Documentation
only — no production code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the 2026-08-27 holistic performance review by recording the measured outcomes of all ten findings plus the guard-policy task, and adds two lessons from landing them.

- Adds a before/after outcome table to the perf review doc using each task's own interleaved-arm probe numbers.
- Documents the deliberate adoption of the import-weight ratchet at 666 against its 660 limit while dev is in breach, with repayment filed as task-23112.
- Records the ADR-096 convergence of two competing capture implementations and two owner calls left open for future work.
- Lessons: a PR that ran zero test shards reports zero failures and is not a valid baseline; an auto-lander polling by PR number can attribute the previous head's verdict to a just-pushed head.

<sup>Written for commit 487ce5838ca32b3515bb00c583b86f8cfcd578e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

