### PR TITLE
test(wizard): pin the provider-to-model catalog handoff on a real peer

### DIFF
--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -98,6 +98,7 @@ from tldw_chatbook.UI.Wizards.first_run_setup_state import (
     build_first_run_model_discovery_key,
 )
 from tldw_chatbook.UI.Wizards.FirstRunSetupWizard import (
+    _PICKER_MODEL_LIMIT,
     FirstRunSetupWizard,
     ModelStep,
     NotesSyncStep,
@@ -3749,6 +3750,11 @@ async def test_production_sized_catalog_reaches_the_model_picker(
     * the discovery module's identity encoding -- removing that header
       fails here as ``invalid_response``, because the peer compresses.
 
+    It also pins ModelStep's own handoff: the assertion is on
+    ``_discovered_model_ids``, the full set the step produced, because the
+    rendered picker is capped at ``_PICKER_MODEL_LIMIT`` and would hide any
+    trim that kept the first 20.
+
     It does NOT pin the settings_endpoint_probe encoding fix: this path
     never presses Test, so the probe module is not exercised. That one is
     covered by
@@ -3810,6 +3816,7 @@ async def test_production_sized_catalog_reaches_the_model_picker(
                     if labels and all("loading models" not in x for x in labels):
                         break
                 outcomes = dict(provider._selected_provider_outcomes)
+                handed_off_ids = model_step._discovered_model_ids
 
     # The boundary that used to reject: a production-sized catalog must come
     # back as a success with every model, not as an error the step renders as
@@ -3825,15 +3832,28 @@ async def test_production_sized_catalog_reaches_the_model_picker(
         "the newest model is missing; a trim drops it first"
     )
 
+    # The boundary that actually matters for a trim: what ModelStep produced
+    # when it consumed that outcome, before the picker's bounded slice. The
+    # rendered list cannot stand in for this -- the picker shows only
+    # _PICKER_MODEL_LIMIT entries, so any trim that keeps the first 20 is
+    # invisible there.
+    assert len(handed_off_ids) == catalog_size, (
+        f"ModelStep's handoff produced {len(handed_off_ids)} of {catalog_size} "
+        "ids -- a bound between discovery and the picker trimmed the catalog"
+    )
+    assert handed_off_ids[-1] == newest_model, (
+        "the newest model is missing from the handoff; a trim drops it first"
+    )
+
     # ...and the step renders a real choice list rather than a failure row.
-    # The picker deliberately shows only the first models[:20]; the point
-    # here is that it shows models at all, which it did not when the catalog
-    # exceeded the extractor's bound.
     assert labels, "the picker rendered nothing"
     assert not any("Couldn't reach" in label for label in labels), (
         f"a reachable peer with a full catalog rendered as a failure: {labels}"
     )
     assert labels[0].startswith("model-0"), labels[:3]
+    assert len(labels) == _PICKER_MODEL_LIMIT, (
+        f"the picker's bounded slice changed: {len(labels)} rows"
+    )
 
     # Identity encoding on the discovery request, asserted from the
     # server's point of view. Note this covers the discovery module's

--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -3723,3 +3723,121 @@ async def test_model_step_renders_auth_copy_on_both_handoff_branches(
         "the generic server-unreachable copy is the exact wrong advice for a "
         f"401: {rendered!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# TASK-23090: the catalog-size defects were caught by a manual live walk, not
+# by the suite. This drives the real ProviderStep -> ModelStep handoff against
+# a real local HTTP peer so a bound that trims or rejects a production-sized
+# catalog between discovery and the rendered picker fails here instead.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.loopback_network
+@pytest.mark.asyncio
+async def test_production_sized_catalog_reaches_the_model_picker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A 128-model catalog must survive discovery and reach the picker.
+
+    Pins two of the three live-key defects through the real handoff, both
+    confirmed by reverting them:
+
+    * the wizard's typed-result bound -- reverting it to 100 fails here,
+      which is the defect that rendered "Couldn't reach the server" for a
+      valid key;
+    * the discovery module's identity encoding -- removing that header
+      fails here as ``invalid_response``, because the peer compresses.
+
+    It does NOT pin the settings_endpoint_probe encoding fix: this path
+    never presses Test, so the probe module is not exercised. That one is
+    covered by
+    ``test_provider_test_button_requests_identity_encoding_from_a_real_peer``.
+
+    Args:
+        monkeypatch: Pytest fixture used to isolate config/HOME state.
+        tmp_path: Pytest fixture providing the throwaway profile directory.
+    """
+    catalog_size = 128
+    newest_model = "gpt-5.4-pro"
+    model_ids = [f"model-{index}" for index in range(catalog_size - 1)]
+    model_ids.append(newest_model)  # newest last, as the real API orders them
+
+    with _RecordingModelsServer(model_ids) as server:
+        app = _build_fresh_wizard_app(monkeypatch, tmp_path)
+        # The app snapshots [providers] into providers_models at init, and
+        # its catalog loader reads that attribute -- a fresh test app has an
+        # empty snapshot, which discovery reports as "no matching provider
+        # model list in [providers]" before it ever issues a request.
+        from tldw_chatbook.config import get_cli_providers_and_models
+
+        app.providers_models = get_cli_providers_and_models()
+        with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+            async with app.run_test(size=(140, 45)) as pilot:
+                await _wait_until(
+                    pilot, lambda: type(app.screen).__name__ == "FirstRunSetupWizard"
+                )
+                container = app.screen.query_one(SetupWizardContainer)
+                await _wait_until(pilot, lambda: container.can_proceed)
+                _press(app.screen, "#wizard-next")
+                await _wait_until(
+                    pilot, lambda: _current_step_id(container) == STEP_PROVIDER
+                )
+
+                provider = next(
+                    s for s in container.steps if isinstance(s, ProviderStep)
+                )
+                provider.select_provider("llama_cpp")
+                await pilot.pause(0.4)
+                provider.query_one("#setup-provider-endpoint", Input).value = (
+                    server.base_url
+                )
+                await pilot.pause(0.4)
+
+                _press(app.screen, "#wizard-next")
+                await _wait_until(
+                    pilot,
+                    lambda: _current_step_id(container) == STEP_MODEL,
+                    timeout_seconds=20.0,
+                )
+                model_step = container.steps[container.current_step]
+                for _ in range(60):
+                    await pilot.pause(0.5)
+                    labels = [
+                        str(b.label)
+                        for b in model_step.query("#setup-model-choice RadioButton")
+                    ]
+                    if labels and all("loading models" not in x for x in labels):
+                        break
+                outcomes = dict(provider._selected_provider_outcomes)
+
+    # The boundary that used to reject: a production-sized catalog must come
+    # back as a success with every model, not as an error the step renders as
+    # "Couldn't reach the server".
+    assert len(outcomes) == 1
+    outcome = next(iter(outcomes.values()))
+    assert outcome.status == "success", (
+        f"a {catalog_size}-model catalog did not survive discovery: "
+        f"{outcome.status} / {getattr(outcome.error, 'kind', None)}"
+    )
+    assert len(outcome.models) == catalog_size
+    assert outcome.models[-1].model_id == newest_model, (
+        "the newest model is missing; a trim drops it first"
+    )
+
+    # ...and the step renders a real choice list rather than a failure row.
+    # The picker deliberately shows only the first models[:20]; the point
+    # here is that it shows models at all, which it did not when the catalog
+    # exceeded the extractor's bound.
+    assert labels, "the picker rendered nothing"
+    assert not any("Couldn't reach" in label for label in labels), (
+        f"a reachable peer with a full catalog rendered as a failure: {labels}"
+    )
+    assert labels[0].startswith("model-0"), labels[:3]
+
+    # Identity encoding on the discovery request, asserted from the
+    # server's point of view. Note this covers the discovery module's
+    # header, not settings_endpoint_probe's -- see the docstring.
+    assert server.accept_encodings and all(
+        "gzip" not in encoding.casefold() for encoding in server.accept_encodings
+    ), server.accept_encodings

--- a/backlog/tasks/task-23090 - Cover-the-first-run-ProviderStep-to-ModelStep-catalog-handoff-against-a-real-HTTP-peer.md
+++ b/backlog/tasks/task-23090 - Cover-the-first-run-ProviderStep-to-ModelStep-catalog-handoff-against-a-real-HTTP-peer.md
@@ -3,9 +3,11 @@ id: TASK-23090
 title: >-
   Cover the first-run ProviderStep-to-ModelStep catalog handoff against a real
   HTTP peer
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-28 15:22'
+updated_date: '2026-08-28 21:29'
 labels: []
 dependencies: []
 ---
@@ -23,21 +25,14 @@ PR #2158's regression tests are unit-level: they mock the transport or call _mod
 - [ ] #3 The test fails if a bound between discovery and the picker trims or rejects the catalog
 <!-- AC:END -->
 
-## Known blocker (measured, 2026-08-28)
+## Implementation Plan
 
-A first attempt got the real HTTP peer and the wizard talking -- the probe
-request was observed carrying `Accept-Encoding: identity` -- but discovery
-itself short-circuited before any request:
+<!-- SECTION:PLAN:BEGIN -->
+1. Find why resolve_provider_list_key reports 'missing' in the fresh harness.\n2. Make the provider resolvable the way a real config does.\n3. Drive ProviderStep to ModelStep against the real HTTP peer and assert the full catalog reaches the picker.
+<!-- SECTION:PLAN:END -->
 
-    DBG staged: {'api_settings': {'llama_cpp': {'api_url':
-      'http://127.0.0.1:61462/v1/chat/completions', 'credential_source':
-      'draft', 'api_key': '...'}}}
-    DBG prov outcomes: {...: ('error', 'missing_endpoint')}
-    DBG hits: []
+## Implementation Notes
 
-`missing_endpoint` here is the `resolve_provider_list_key(...) == "missing"`
-branch ("No matching provider model list exists in [providers]"), not a bad
-URL -- `_resolve_endpoint` accepts all three endpoint forms in isolation.
-Seeding `[providers]` in the fresh test config did not clear it, so the
-harness needs the provider-catalog wiring understood before this test can
-assert on the picker. That investigation is the work, not an afterthought.
+<!-- SECTION:NOTES:BEGIN -->
+Blocker in the task body was misdiagnosed: the 'missing_endpoint' was the [providers] branch, but the cause was not the config file. The app's LocalLLMProviderCatalogService loader reads self.providers_models, snapshotted at app init, and a fresh test app has an empty snapshot -- so discovery reported 'no matching provider model list' before issuing any request no matter what was written to [providers]. Setting app.providers_models = get_cli_providers_and_models() after the config write clears it. Test drives ProviderStep (llama_cpp, typed endpoint) to ModelStep against a real threaded HTTP peer serving 128 models. Pins two defects, each confirmed by reverting it: the wizard's typed-result bound (revert to 100 -> discovery result rejected) and the discovery module's identity encoding (remove header -> invalid_response). Explicitly does NOT pin settings_endpoint_probe's encoding fix, since this path never presses Test; the sibling test covers that. Also recorded: the picker renders models[:20] by design, so the catalog-bound fix took the step from zero models to a real list, not from 100 to 128 visible.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23113 - Wizard-suite-has-order-load-dependent-flakes-a-different-test-fails-on-most-full-sweeps.md
+++ b/backlog/tasks/task-23113 - Wizard-suite-has-order-load-dependent-flakes-a-different-test-fails-on-most-full-sweeps.md
@@ -1,0 +1,41 @@
+---
+id: TASK-23113
+title: >-
+  Wizard suite has order/load-dependent flakes: a different test fails on most
+  full sweeps
+status: To Do
+assignee: []
+created_date: '2026-08-28 22:11'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Running Tests/UI/test_first_run_wizard_live_contract.py plus Tests/Wizards together produces roughly one failure per sweep, and it is a different test each time. Every one passes in isolation. This is measured on pristine origin/dev, so it is not caused by any recent change, but it makes the suite unreliable as a merge gate and will eventually cost someone a debugging session chasing a failure that has nothing to do with their diff.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The full wizard sweep passes repeatedly without per-run flakes
+- [ ] #2 The shared state or timing causing cross-test interference is identified and documented
+<!-- AC:END -->
+
+## Observed (2026-08-28)
+
+Four distinct tests each failed exactly once across sweeps of the same two
+paths, and each passed alone immediately afterwards:
+
+- `Tests/Wizards/test_first_run_setup_wizard.py::test_mounted_model_owner_timeout_fences_late_result_and_keeps_manual_retry`
+- `Tests/UI/test_first_run_wizard_live_contract.py::test_recovery_save_failure_reprompts_then_succeeds_once[False]`
+- `Tests/Wizards/test_first_run_setup_wizard.py::TestComposeCrashPolicy::test_optional_step_failure_is_removed_and_reported_in_summary` (twice)
+- `Tests/UI/test_first_run_wizard_live_contract.py::test_rerun_over_settings_review_settings_returns_to_settings` (twice; also on record from the original UAT)
+
+Control: the identical sweep on a detached, pristine `origin/dev` failed the
+same way (`TestComposeCrashPolicy::test_optional_step_failure...`, 890
+passed). So this is inherent to the suite, not to any branch under review.
+
+Several of the affected tests are timing-fenced (explicit timeouts, worker
+settle waits), which is consistent with load sensitivity when ~890 Textual
+app harnesses run in one process.

--- a/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
+++ b/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
@@ -3172,6 +3172,11 @@ class ProviderStep(SetupStep):
 
 MODEL_DISCOVERY_TIMEOUT_SECONDS = 8.0
 
+# How many discovered models the radio picker renders. The full set stays on
+# the step as _discovered_model_ids; the adjacent "Or enter a model name"
+# input is the escape hatch for anything past this bound.
+_PICKER_MODEL_LIMIT = 20
+
 
 class ModelStep(SetupStep):
     """Pick a default model for the chosen provider.
@@ -3201,6 +3206,11 @@ class ModelStep(SetupStep):
             raise TypeError("Model discovery requires FirstRunProviderDraft.")
         self._discover_models = discover_models
         self._explicit_provider_draft = provider_draft
+        # The complete id set the last handoff produced. The picker renders
+        # a bounded slice of it (see _PICKER_MODEL_LIMIT), so without this
+        # the step keeps no record of what it actually received and a trim
+        # introduced in the handoff is invisible from the outside.
+        self._discovered_model_ids: tuple[str, ...] = ()
         self._shown_for_provider: Optional[str] = None
         self._shown_for_discovery_key: wizard_state.FirstRunModelDiscoveryKey | None = (
             None
@@ -3610,8 +3620,9 @@ class ModelStep(SetupStep):
             models = wizard_state.curated_models_for_provider(
                 get_cli_providers_and_models(), provider_value
             )
+        self._discovered_model_ids = tuple(models)
         await self._render_models(
-            models[:20],
+            models[:_PICKER_MODEL_LIMIT],
             discovery_state=discovery_state,
             failure_category=failure_category,
             discovery_key=discovery_key,


### PR DESCRIPTION
**TASK-23090** — the half of Qodo's coverage ask on #2158 that I deferred with a measured blocker, now closed.

## The blocker was misdiagnosed

My note on #2158 said discovery short-circuited on the `[providers]` catalog lookup and that seeding `[providers]` didn't clear it. The error was real, but the cause wasn't the config file: the app's `LocalLLMProviderCatalogService` loader reads `self.providers_models`, which is **snapshotted at app init**, and a fresh test app has an empty snapshot. So discovery reported "no matching provider model list" before issuing any request, no matter what landed in the config. Seeding that attribute after the config write clears it.

## What the test pins

Drives ProviderStep (llama_cpp, typed endpoint) through to ModelStep against a **real threaded HTTP peer** serving 128 models and content-negotiating like api.openai.com. Two of the three live-key defects, each confirmed by reverting it:

| Revert | Result |
|---|---|
| wizard's typed-result bound → 100 | discovery's success is rejected; step renders "Couldn't reach the server" |
| discovery module's `Accept-Encoding: identity` removed | peer compresses → `invalid_response` |

## What it deliberately does *not* pin

`settings_endpoint_probe`'s encoding fix. This path never presses Test, so that module isn't exercised — reverting it leaves this test **green**. I verified that rather than assuming, and the docstring says so, so the gap doesn't look covered. `test_provider_test_button_requests_identity_encoding_from_a_real_peer` covers that one.

## A correction to something I claimed earlier

`ModelStep` renders `models[:20]` by design. So the catalog-bound fix took the picker **from zero models to a real list**, not from 100 to 128 visible ones. My "the newest 28 were dropped" framing on #2158 was true of the extractor's output but not of what a user sees, which is capped at 20 either way. The fix still matters — a rejected result meant *no* list at all — but it mattered for a different reason than I gave.

## Verification

- 892 passed — wizard suites + live contract
- `./scripts/preflight.sh` — all derived-artifact checks passed
- One known order-dependent flake (`test_rerun_over_settings_review_settings_returns_to_settings`, already on record) appeared once; passes alone and on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQ5JJaaUcLAhkHwy1dvSSE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live-contract test that drives ProviderStep to ModelStep against a real threaded HTTP peer serving 128 models, pinning handoff defects unit tests missed.

- The test fails if the wizard's typed-result bound rejects a production-sized catalog or the discovery module drops the `Accept-Encoding: identity` header.
- It also fails on a handoff trim: the assertion is on ModelStep's full discovered set, since the rendered picker caps at 20 rows and ProviderStep's stored outcome predates the conversion; ModelStep now records `_discovered_model_ids` and the cap is the named `_PICKER_MODEL_LIMIT`.
- The `settings_endpoint_probe` encoding fix is deliberately not covered; a sibling test pins it.
- The task file corrects the earlier misdiagnosis: the blocker was an empty `providers_models` snapshot at app init, not the config file, and notes the picker renders `models[:20]` by design.
- Adds a backlog task documenting the wizard suite's order/load-dependent flakes, where a different test fails on most full sweeps but each passes in isolation; measured on a pristine `origin/dev` control.

<sup>Written for commit 1943498f9e58e60379f952760b5be97288a41dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

