### PR TITLE
docs(tests): file the nine root causes behind dev's 95 failing UI tests

### DIFF
--- a/backlog/tasks/task-23144 - Bare ChatScreen shells miss the Library-activity controller and 46 tests die in setup.md
+++ b/backlog/tasks/task-23144 - Bare ChatScreen shells miss the Library-activity controller and 46 tests die in setup.md
@@ -1,0 +1,48 @@
+---
+id: TASK-23144
+title: >-
+  Bare ChatScreen shells miss the Library-activity controller and 46 tests die
+  in setup
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - console
+priority: high
+dependencies: []
+---
+
+## Description
+
+46 tests fail with `AttributeError: 'ChatScreen' object has no attribute '_library_activity'` —
+every test in `Tests/UI/test_console_citation_sources.py` (41) and
+`Tests/UI/test_console_composer_menu.py` (5). Production is correct: the controller is installed by
+`build_console_controllers`, which only runs from `ChatScreen.__init__`, and these tests build
+shells via `ChatScreen.__new__(ChatScreen)`. They die during **setup**, before asserting anything.
+
+The sharp part: this is the exact failure mode `Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py`
+was written to ratchet (TASK-21381, which fixed 115 such failures across 8 files). The guard is an
+AST scan hard-coded to look for `stub_fleet_controller` only, so it cannot see a **second**
+controller entering the same kwargs build. Widening the guard is the durable half of this task —
+without it the next controller added to that build repeats this.
+
+## Acceptance Criteria
+
+- [ ] Both files pass, with bare shells wiring the Library-activity controller through a shared stub
+- [ ] The architecture ratchet asserts that **every** controller the chat-store wiring reads is
+  stubbed — not just the fleet controller — so a newly added controller fails at the guard rather
+  than in dozens of unrelated tests
+- [ ] The widened guard is proven by a negative control (removing a stub makes it fail)
+
+## Evidence
+
+Installed at `tldw_chatbook/UI/Console_Modules/wiring.py:751`. The setup chain that dies:
+`screen._console_chat_store = ...` -> `_console_runtime().set_chat_store()` ->
+`_ensure_console_chat_controller` (`chat_screen.py:5008`) -> `chat_screen.py:5116`
+`"_library_provider_factory": self._library_activity.build_provider`. Shells built at
+`Tests/UI/test_console_citation_sources.py:480`. Guard's blind spot: `_calls_fleet_stub`,
+`Tests/Architecture/test_bare_chat_screen_shells_wire_the_fleet.py:87`.
+
+Introduced by `d8d5f9f2b1` (2026-08-27) "feat(console): capture and review minimized Library
+activity (TASK-19900.5) (#2154)", which updated 3 UI test files but not these two.

--- a/backlog/tasks/task-23145 - Reader test doubles lack the scroller seam production now reads.md
+++ b/backlog/tasks/task-23145 - Reader test doubles lack the scroller seam production now reads.md
@@ -1,0 +1,36 @@
+---
+id: TASK-23145
+title: Reader test doubles lack the scroller seam production now reads
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - library
+priority: medium
+dependencies: []
+---
+
+## Description
+
+6 tests in `Tests/UI/test_library_media_reader_flow.py` fail with
+`AttributeError: 'types.SimpleNamespace' object has no attribute 'scroller'`. Production is correct
+and deliberately explicit: the reader resolves the scroll offset through the virtualized scroller
+rather than the body. The doubles were never updated when that seam moved.
+
+## Acceptance Criteria
+
+- [ ] All 6 tests pass with body doubles exposing the scroller seam production actually reads
+- [ ] The tests assert the offset is read **through** the scroller, so a future seam change fails
+  loudly instead of a double silently satisfying the old shape
+
+## Evidence
+
+Production: `tldw_chatbook/UI/Screens/library_screen.py:37003` `content = body.scroller` (also
+`:37121`, `:37391`). Doubles return `SimpleNamespace(scroll_x=0, scroll_y=17)` with no `.scroller`
+at `Tests/UI/test_library_media_reader_flow.py:755`, `:794`, `:1097`.
+
+Introduced by `f08e942295` (authored 2026-08-26) "fix(library): resolve the reader scroller
+explicitly and scroll to matches exactly (TASK-22500)", landed on dev 2026-08-28 via merge
+`b5eaa9cf64` (PR #2129). That commit updated `Tests/UI/test_library_shell.py` for the same seam but
+not this file.

--- a/backlog/tasks/task-23146 - Transcript double lacks selected_message_id after the fork-from-message change.md
+++ b/backlog/tasks/task-23146 - Transcript double lacks selected_message_id after the fork-from-message change.md
@@ -1,0 +1,32 @@
+---
+id: TASK-23146
+title: Transcript double lacks selected_message_id after the fork-from-message change
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+All 3 tests in `Tests/UI/test_console_turn_activity_line.py` fail with
+`AttributeError: 'types.SimpleNamespace' object has no attribute 'selected_message_id'`. Production
+is correct; the transcript double predates the fork-from-message feature.
+
+## Acceptance Criteria
+
+- [ ] All 3 tests pass with a transcript double carrying the attributes the sync path reads
+- [ ] The double's shape is derived from the production contract rather than patched attribute by
+  attribute as each `AttributeError` appears
+
+## Evidence
+
+`tldw_chatbook/UI/Screens/chat_screen.py:11994` `selected_id = transcript.selected_message_id`, at
+the top of `_sync_native_console_transcript` (starts `:11983`).
+
+Introduced by `5d9b4bec5a` (2026-08-27) "feat(console): fork chat from a selected message (#2152)",
+which updated 5 other UI test files but not this one. Also needs `set_fork_eligibilities`.

--- a/backlog/tasks/task-23147 - Console Library controls tests still assert the pre-redesign labels and RAG flow.md
+++ b/backlog/tasks/task-23147 - Console Library controls tests still assert the pre-redesign labels and RAG flow.md
@@ -1,0 +1,50 @@
+---
+id: TASK-23147
+title: >-
+  Console Library controls tests still assert the pre-redesign labels and RAG
+  flow
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+13 tests assert the Console Library controls as they behaved before the approved redesign — 11 in
+`Tests/UI/test_console_internals_decomposition.py` and both snapshots in
+`Tests/UI/test_workbench_visual_snapshots.py`. Every symptom is specified behaviour in
+`Docs/superpowers/specs/2026-08-22-console-library-controls-design.md`; these are stale tests, and
+the redesign PR updated ~18 other test files but not these two.
+
+Three sub-symptoms:
+1. **Chip label** — tests expect `Library search: off`; the spec's new strings (lines 1038-1041)
+   are `Library · Auto off · Agent blocked` and siblings.
+2. **RAG staging** — both Run controls now open a modal instead of running retrieval, so nothing is
+   ever staged and 6 tests time out waiting for staged evidence (spec §5, line 656ff).
+3. **Path-shaped-draft prefill** — the query is now always prefilled with the exact composer draft,
+   and `_console_draft_looks_like_rag_query` was **deliberately deleted** by the spec (lines
+   669-670) and the plan's Step 4. Its guard test is now testing a removed behaviour and should be
+   deleted, citing those spec lines. This was checked precisely because it looks like a regression
+   and is not one.
+
+## Acceptance Criteria
+
+- [ ] Label assertions match the four chip strings the spec specifies
+- [ ] The 6 RAG tests drive the modal (accepting a search result) rather than expecting the button
+  to retrieve directly
+- [ ] The path-shaped-draft guard test is deleted, with the spec lines cited in the deletion
+- [ ] Both workbench snapshots regenerate against the redesigned controls
+
+## Evidence
+
+`tldw_chatbook/Chat/console_display_state.py:752` `rag_label=library_display.chip_label`, built at
+`:624-627`. Modal routing: `chat_screen.py:2771` and `:9999-10003`. Unconditional prefill:
+`tldw_chatbook/UI/Console_Modules/retrieval.py:407-411`.
+
+Introduced by `d7bb844d9b` (2026-08-27) "fix(console): restore explicit Library policy and search
+controls (#2143)".

--- a/backlog/tasks/task-23148 - Workbench geometry tests still assume two-edge rail handles.md
+++ b/backlog/tasks/task-23148 - Workbench geometry tests still assume two-edge rail handles.md
@@ -1,0 +1,38 @@
+---
+id: TASK-23148
+title: Workbench geometry tests still assume two-edge rail handles
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description
+
+11 assertions in `Tests/UI/test_workbench_visual_snapshots.py` still compute a rail handle's
+content width as `region - 2`. Rail handles are now framed on **one** vertical edge, so the correct
+arithmetic is `region - 1`. The file has been red since 2026-08-23.
+
+Someone already hit this and patched **exactly one** of the stale numbers, leaving the rest — which
+is the argument for pinning the contract rather than the arithmetic.
+
+## Acceptance Criteria
+
+- [ ] The stale expected values are corrected (`9`->`10` at line 287, `content_width=11`->`12` at
+  line 485, and the one `expected_rail_widths` entry `34`->`35`)
+- [ ] A test asserts each handle carries **exactly one** vertical border, so the next edge-count
+  change fails on the contract instead of on six unexplained integers
+
+## Evidence
+
+`tldw_chatbook/UI/Screens/chat_screen.py:10368` `_frame_console_region(left_handle,
+edges=("right",))` and `:10617` `(right_handle, edges=("left",))`; rationale in
+`tldw_chatbook/UI/Console_Modules/frame.py:8-10` (TASK-20937.3, "one edge-owned surface").
+
+Introduced by `a581f28e0a` (2026-08-23) "Redesign Console edge rails and workspace tree (#2034)",
+whose diff is literally `-...(left_handle, bottom=False)` -> `+...(left_handle, edges=("right",))`
+and which did not touch this test file. `04e29673a2` later fixed one number and left the others.

--- a/backlog/tasks/task-23149 - Library focus tests stub a focus path production no longer takes.md
+++ b/backlog/tasks/task-23149 - Library focus tests stub a focus path production no longer takes.md
@@ -1,0 +1,41 @@
+---
+id: TASK-23149
+title: Library focus tests stub a focus path production no longer takes
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - library
+priority: medium
+dependencies: []
+---
+
+## Description
+
+6 tests in `Tests/UI/test_screen_navigation.py` fail from two distinct, both-stale causes.
+
+**Four** fail because production switched from a deferred `row.focus()` to an immediate
+`self.set_focus(row)` and renamed the post-refresh callback to a generation-guarded variant.
+`Screen.set_focus` reads `widget.focusable`, which the fake row button does not define.
+
+**Two** fail because they capture *every* `call_after_refresh` and now catch a **layout** sync that
+is not a focus grab at all. The assertion is simply over-broad — production is correct.
+
+## Acceptance Criteria
+
+- [ ] The fake row button carries the attributes `Screen.set_focus` reads (`focusable`, `has_class`)
+- [ ] Focus is asserted by the widget `set_focus` targets, not by a `.focus()` stub that production
+  no longer calls
+- [ ] The two compose tests filter captured callbacks to focus callbacks only, so an unrelated
+  layout callback entering `compose_content` cannot fail them again
+
+## Evidence
+
+Immediate focus at `tldw_chatbook/UI/Screens/library_screen.py:9215`, `:9230`; the renamed callback
+is `_focus_library_list_entry_if_current`. Introduced by `04e29673a2` (2026-08-27) "Close amended
+Console decomposition ratchet (#2137)" — its diff shows `-row.focus()` / `+self.set_focus(row)`.
+
+The extra captured callable is `LibraryScreen._sync_library_ordinary_rail_width_contract`, added to
+`compose_content` at `library_screen.py:12949` by `9de08fa193` (2026-08-26) "feat(library): bound
+ordinary rail geometry", on dev via merge `6bed8d6f59` (PR #2124).

--- a/backlog/tasks/task-23150 - Console Behavior card grew past the test viewport and clicks land on nothing.md
+++ b/backlog/tasks/task-23150 - Console Behavior card grew past the test viewport and clicks land on nothing.md
@@ -1,0 +1,47 @@
+---
+id: TASK-23150
+title: Console Behavior card grew past the test viewport and clicks land on nothing
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - settings
+priority: medium
+dependencies: []
+---
+
+## Description
+
+All 3 tests in `Tests/UI/test_settings_console_rail_labels.py` fail. The production save path is
+intact — the decisive evidence is inside the third test, where values set **programmatically**
+stage correctly while the one reached by `pilot.click` does not, and the checkbox's own `.value`
+stays `False`, so the widget never received the toggle.
+
+The Console Behavior card grew roughly 46 lines above that checkbox across two 2026-08-26 commits,
+at the test's 190x55 viewport.
+
+**One caveat carried over from the diagnosis and deliberately not closed:** "below the fold" was
+inferred from the two commits plus the zero-effect click, *not* asserted against the viewport. The
+first step of this task is to verify it.
+
+## Acceptance Criteria
+
+- [ ] The checkbox's region is asserted to be inside the visible container **before** anything is
+  changed, confirming or refuting the below-the-fold diagnosis
+- [ ] The tests scroll or focus the control into view (or drive it by key) rather than clicking a
+  fixed position
+- [ ] A visibility assertion fails loudly on future layout growth instead of silently clicking air
+- [ ] If the card genuinely no longer fits a realistic terminal, that is filed as a separate UX task
+  rather than absorbed here
+
+## Evidence
+
+Production seams all present and unchanged: handler `settings_screen.py:19612`, key in
+`CONSOLE_BEHAVIOR_SAVE_ORDER` (`:915`), save branch `:22520`, adapter call `:23110` (the
+monkeypatched name). Checkbox at `settings_screen.py:13345`, now below an exchange-capture block and
+a thinking-visibility block.
+
+Growth blames to `c6218918d1` (32 lines, "Codex/full semantic capture (#2126)") and `4aa87159ee`
+(14 lines, "feat: add Console thinking visibility and history controls"), both 2026-08-26. The test
+file was last updated 2026-08-24 (`a0d61d9957`).

--- a/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
+++ b/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
@@ -1,0 +1,43 @@
+---
+id: TASK-23151
+title: Library on_resize does unconditional Notes work on every frame again
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - performance
+  - library
+  - regression
+priority: high
+dependencies: []
+---
+
+## Description
+
+The 2026-08-02 ratchet `test_library_note_fifty_same_side_resize_sequences_do_zero_notes_work`
+asserts that a resize which does not cross a layout band does **zero** Notes work. It now measures
+**300** calls to `_apply_library_notes_stage_visibility` across 50 resizes (both parametrised
+initial sizes). This is a genuine production regression, not a stale test: the ratchet is
+correct and must stay at `== 0`.
+
+This is the same defect class TASK-23025 eliminated from the resize path days earlier — per-frame
+work reaching the DOM on frames that changed nothing — so it also erodes a fix the 2026-08-27
+performance review just shipped.
+
+## Acceptance Criteria
+
+- [ ] A same-side resize sequence that crosses no layout band performs zero Notes stage-visibility
+  work, with the existing ratchet unchanged and still asserting `== 0`
+- [ ] Band-crossing resizes still apply stage visibility exactly once per crossing
+- [ ] The emergency-return path added by the introducing commit keeps its behaviour (a regression
+  test covers the narrow-emergency case it was added for)
+
+## Evidence
+
+`tldw_chatbook/UI/Screens/library_screen.py:7284` calls `_apply_library_notes_stage_visibility()`
+**before** the `if compact == self._library_notes_compact: ... return` early-out at `:7285-7287`
+that makes same-side resizes a no-op. 50 resizes x 6 call sites = 300. The same commit added the
+call to `_update_library_notes_responsive_state` (`:7237`).
+
+Introduced by `6161bd1fe19` (2026-08-26) "feat(library): add narrow emergency return path", on dev
+via merge `6bed8d6f59` (PR #2124). Reproduces standalone, so it is not test pollution.

--- a/backlog/tasks/task-23152 - Library prompts canvas sync swallows its exception so its failures cannot be diagnosed.md
+++ b/backlog/tasks/task-23152 - Library prompts canvas sync swallows its exception so its failures cannot be diagnosed.md
@@ -1,0 +1,44 @@
+---
+id: TASK-23152
+title: >-
+  Library prompts canvas sync swallows its exception so its failures cannot be
+  diagnosed
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - library
+  - diagnostics
+priority: high
+dependencies: []
+---
+
+## Description
+
+`Tests/UI/test_library_prompts_canvas.py` has 3 failing tests when run with other UI files and
+**5** when run alone (the file is order-sensitive in both directions). Symptoms are a 30-second
+"Prompt browse never settled" wait, a `TextArea` identity change indicating the content pane was
+remounted when the test expects it preserved, and `NoMatches` on the conflict bar. Runs are
+littered with `Library prompts canvas sync failed.`
+
+**A verdict cannot be reached in the current code.** That log line is a bare `except Exception`
+that discards the error, unlike every sibling handler in the same file, so the real exception is
+invisible. Restoring the traceback is a prerequisite for diagnosis, and is worth doing on its own
+merits.
+
+## Acceptance Criteria
+
+- [ ] The canvas-sync failure path logs its exception (`logger.opt(exception=True)`), matching the
+  sibling handlers in the same module
+- [ ] With the traceback available, each failing test is classified stale-vs-broken and fixed
+  accordingly, with the actual error recorded in the implementation notes
+- [ ] The file passes both standalone and in a whole-directory run (its order-sensitivity is
+  resolved, not worked around by a run-order constraint)
+
+## Evidence
+
+`tldw_chatbook/UI/Screens/library_screen.py:1939` — `except Exception: logger.debug(f"Library
+{kind} canvas sync failed.")`, with no `opt(exception=True)`; siblings at `:1896`, `:1915`, `:1944`
+do carry it. Failing tests date from `eaaddb1f5e` (2026-07-12), so the break is recent; the
+plausible cause is the Prompts adaptive-reader migration (`3e8b104f6f` -> `f1275c8846`,
+2026-08-25/26) plus `04e29673a2`'s canvas edit — **not asserted**, pending the swallowed traceback.

--- a/backlog/tasks/task-23153 - One Library notes test passes alone and fails in-file.md
+++ b/backlog/tasks/task-23153 - One Library notes test passes alone and fails in-file.md
@@ -1,0 +1,32 @@
+---
+id: TASK-23153
+title: One Library notes test passes alone and fails in-file
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - tests
+  - library
+priority: low
+dependencies: []
+---
+
+## Description
+
+`Tests/UI/test_library_shell.py::test_library_note_failed_discard_clears_shortcut_lock_status` fails
+in a whole-file run and **passes standalone**. The widget it waits for still exists, and its label
+appears in the failure's own visible-text dump — so this is test pollution, not a production defect.
+Filed separately from the real regression in the same file so the two are not conflated.
+
+## Acceptance Criteria
+
+- [ ] The polluting interaction is identified (which earlier test leaves the state behind, and what
+  state), and named in the implementation notes
+- [ ] The test passes both standalone and in a whole-file run, without relying on run order
+- [ ] Isolation is fixed at the leaking source rather than by adding cleanup only to the victim, if
+  the source is shared
+
+## Evidence
+
+Widget present at `tldw_chatbook/Widgets/Library/library_notes_canvas.py:1084`. Failure is
+`#library-note-discard-new never became visible`.


### PR DESCRIPTION
## Summary

While verifying a CI failure on an unrelated PR I found `dev` carrying a large test red, and
characterized it rather than routing around it. **95 failing tests, 9 independent root causes, 7
merges landed 2026-08-23..28** — four merges on 08-27 alone account for 68 of the failures. There is
no single shared refactor. This PR files them; it changes no code.

Every task carries the production `file:line` that decides the verdict, the introducing commit, and
acceptance criteria that pin the **contract** rather than the failing number.

## The two that are production defects

- **TASK-23151 — a real perf regression.** A resize that crosses no layout band now performs **300**
  Notes stage-visibility calls where its 2026-08-02 ratchet demands **zero**: the call sits just
  *above* the early-return that makes same-side resizes a no-op. This is the same defect class
  TASK-23025 removed from the resize path days earlier, so it erodes a fix the performance review
  just shipped. Reproduces standalone. The ratchet is right and stays at `== 0`.
- **TASK-23152 — undiagnosable as written.** The prompts-canvas sync failure path is a bare
  `except Exception` that discards the error, unlike every sibling handler in the same module. The
  first acceptance criterion is restoring the traceback; the verdict comes after.

## The seven stale tests

`23144` (46 failures) `23145` (6) `23146` (3) `23147` (13) `23148` (11) `23149` (6) `23150` (3),
plus `23153` for one order-dependent test filed separately so it is not conflated with the real
regression in the same file.

Two are worth reading:

- **23144** is the sharpest. Its 46 failures are the exact mode
  `test_bare_chat_screen_shells_wire_the_fleet.py` was written to ratchet (TASK-21381, which fixed
  115 such failures). The guard is an AST scan hard-coded to `stub_fleet_controller`, so it could
  not see a **second** controller entering the same kwargs build. Widening it is the durable half.
- **23147** includes a deletion that looks like a regression and is not: the removed
  `_console_draft_looks_like_rag_query` guard was explicitly ordered gone by the approved design doc
  (lines 669-670). I checked precisely because it looked wrong.

One caveat is carried into **23150** rather than hidden: its "the control grew below the fold"
diagnosis was inferred from two commits plus a click with zero effect, not asserted against the
viewport. Verifying that is the task's first acceptance criterion.

## Verification

`./scripts/preflight.sh` green, including the duplicate-task-id check. Task ids swept
case-insensitively across all remotes and worktrees (highest claimed: 23114) and assigned by the
leapfrog rule. Documentation only — no production or test code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files dev's 95 failing UI tests as ten tracked tasks spanning nine independent root causes, each carrying the production `file:line` that proves the verdict and acceptance criteria that pin the contract. Documentation only — no code changes.

**The two production defects**
- TASK-23151: a resize crossing no layout band performs 300 Notes stage-visibility calls where its ratchet demands zero — the same defect class TASK-23025 just eliminated.
- TASK-23152: the prompts-canvas sync failure path is a bare `except Exception` that discards the error, so its failures cannot be diagnosed until the traceback is restored.

**The seven stale tests**
- TASK-23144 alone accounts for 46 failures — the exact failure mode the architecture ratchet was written to prevent, but the AST guard only looks for the fleet controller.
- TASK-23153 is filed separately from the real regression in the same file so the two aren't conflated.

<sup>Written for commit c0bc3ab026587af252297e61e120f68682c73e4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

