### PR TITLE
perf(boot): pay the ratchet debt — 666 → 646 modules without moving the limit (TASK-23112)

### DIFF
--- a/Tests/Packaging/test_chat_persistence_import_closure.py
+++ b/Tests/Packaging/test_chat_persistence_import_closure.py
@@ -1,0 +1,230 @@
+"""Import-closure guard: `Chat_Functions` reaches `ChatPersistenceService` lazily.
+
+TASK-23112 / ADR-097. ``Chat/chat_persistence_service.py`` grew by ~900 lines
+and picked up module-scope imports of ``Chat.attachment_core``,
+``Chat.console_chat_fork``, ``Chat.library_activity`` and
+``Video_Generation.video_metadata``. It rode onto the boot path through one
+module-scope line in ``Chat/Chat_Functions.py``, which ``app.py`` reaches via
+``Library.library_local_rag_search_service -> library_rag_service ->
+library_rag_state -> library_rag_answer_service``. Measured with an
+import-parent tracer, that single edge put **18** ``tldw_chatbook`` modules in
+the ``import tldw_chatbook.app`` closure (666 -> 648 own modules when
+deferred), breaching the 660 ratchet.
+
+``ChatPersistenceService`` is constructed in exactly one place in
+``Chat_Functions`` -- ``save_chat_history_to_db_wrapper`` -- and that function
+is only ever called from a user-driven save, never at import time and never
+during ``TldwCli.__init__``. (The TASK-22223 trap -- "a function-scope import
+is not lazy if the function runs at module import" -- is what the residency
+assertion below actually rules out; the reasoning alone is not evidence.)
+
+Scope note, so this guard is not read as more than it is: this is a removal
+from the IMPORT closure, not from the whole boot. ``Chat.console_runtime``
+imports the same service inside ``ensure_console_runtime``, so it is resident
+again by the time the app reaches ``_ui_ready`` (it is in
+``Tests/Performance/boot_budget_snapshots/ui_ready_modules.txt`` both before
+and after this change). What moved is the eager import; what this file keeps
+visible is future drift back onto the import path.
+
+Subprocess-isolated for the same reason as ``test_app_import_diet_closure.py``
+(TASK-21108), whose pattern this file follows: ``sys.modules`` is
+process-global, so an earlier test in the session that legitimately imported
+the service would false-fail an in-process check.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The modules the deferred edge kept off the boot import path, as measured by
+# the import-parent tracer (baseline 666 -> 648). Each was FIRST imported via
+# `Chat_Functions -> chat_persistence_service`; nothing else on the boot path
+# reaches them.
+DEFERRED_BOOT_MODULES = (
+    "tldw_chatbook.Chat.chat_persistence_service",
+    "tldw_chatbook.Chat.attachment_core",
+    "tldw_chatbook.Chat.console_chat_fork",
+    "tldw_chatbook.Chat.console_context_policy",
+    "tldw_chatbook.Chat.console_context_repository",
+    "tldw_chatbook.Chat.console_dispatch_checkpoint",
+    "tldw_chatbook.Chat.console_dispatch_repository",
+    "tldw_chatbook.Chat.console_library_policy_repository",
+    "tldw_chatbook.Chat.console_prefill",
+    "tldw_chatbook.Chat.console_roleplay_identity",
+    "tldw_chatbook.Chat.console_roleplay_metadata",
+    "tldw_chatbook.Chat.message_metadata",
+    "tldw_chatbook.Event_Handlers.Chat_Events",
+    "tldw_chatbook.Event_Handlers.Chat_Events.chat_image_events",
+    "tldw_chatbook.Utils.file_handlers",
+    "tldw_chatbook.Video_Generation",
+    "tldw_chatbook.Video_Generation.video_formats",
+    "tldw_chatbook.Video_Generation.video_metadata",
+)
+
+
+def _run_isolated_python(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in a fresh interpreter with isolated config/data dirs.
+
+    Args:
+        tmp_path: Per-test scratch directory for the subprocess's HOME/XDG so
+            the app import can never read or write the live user config.
+        code: The Python source to execute with ``python -c``.
+
+    Returns:
+        The completed process (never raises on nonzero exit).
+    """
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env.pop("TLDW_CONFIG_PATH", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=180,
+    )
+
+
+_APP_CLOSURE_SNIPPET = f"""
+import sys
+
+import tldw_chatbook.app  # noqa: F401
+
+forbidden = {DEFERRED_BOOT_MODULES!r}
+resident = sorted(m for m in forbidden if sys.modules.get(m) is not None)
+assert not resident, (
+    "chat_persistence_service subtree resident after `import tldw_chatbook.app`: "
+    + repr(resident)
+    + " -- something took a module-scope dependency on it again. Defer it (see "
+    "Chat/Chat_Functions.py:save_chat_history_to_db_wrapper) rather than raising "
+    "MAX_TLDW_MODULE_COUNT (ADR-097)."
+)
+
+# Anti-vacuity. If Chat_Functions itself left the boot closure, every
+# assertion above would pass without testing the deferral at all.
+for expected in (
+    "tldw_chatbook.Chat.Chat_Functions",
+    # The seam Chat_Functions still imports eagerly from the same package, so
+    # "the Chat package is simply absent" cannot masquerade as a pass.
+    "tldw_chatbook.Chat.console_project_instructions",
+):
+    assert expected in sys.modules, "expected closure member missing: " + expected
+
+print("CHAT_PERSISTENCE_CLOSURE_OK")
+"""
+
+
+_REAL_USE_PATH_SNIPPET = """
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import tldw_chatbook.Chat.Chat_Functions as chat_functions
+
+assert "tldw_chatbook.Chat.chat_persistence_service" not in sys.modules, (
+    "importing Chat_Functions still executes chat_persistence_service"
+)
+assert not hasattr(chat_functions, "ChatPersistenceService"), (
+    "ChatPersistenceService is bound at Chat_Functions module scope again"
+)
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+scratch = Path(tempfile.mkdtemp(prefix="tldw_persistence_closure_"))
+db = CharactersRAGDB(scratch / "chachanotes.sqlite", "task_23112_closure_client")
+try:
+    conversation_id, status = chat_functions.save_chat_history_to_db_wrapper(
+        db=db,
+        chatbot_history=[
+            {"role": "user", "content": "Hello there"},
+            {"role": "assistant", "content": "General Kenobi"},
+        ],
+        conversation_id=None,
+        media_content_for_char_assoc=None,
+        character_name_for_chat=None,
+    )
+    assert conversation_id is not None, "real save path returned no conversation: " + status
+    assert "success" in status.lower(), status
+    messages = db.get_messages_for_conversation(conversation_id)
+    assert len(messages) == 2, messages
+finally:
+    db.close_connection()
+    shutil.rmtree(scratch, ignore_errors=True)
+
+# The deferred import fired on the real use path, and resolved to the real
+# module (not a stub or a shadowed name).
+module = sys.modules.get("tldw_chatbook.Chat.chat_persistence_service")
+assert module is not None, (
+    "save_chat_history_to_db_wrapper completed without importing "
+    "chat_persistence_service -- the deferred import is disconnected"
+)
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+
+assert ChatPersistenceService is module.ChatPersistenceService
+
+print("CHAT_PERSISTENCE_USE_PATH_OK")
+"""
+
+
+def test_app_import_does_not_execute_chat_persistence_service(tmp_path: Path) -> None:
+    """`import tldw_chatbook.app` must not pull the persistence service subtree.
+
+    Regression guard for the TASK-23112 breach: before the fix, all 18 modules
+    listed in ``DEFERRED_BOOT_MODULES`` were resident after a plain app import,
+    which is what took the own-module count from 648 to 666 against the 660
+    ratchet.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _APP_CLOSURE_SNIPPET)
+    assert result.returncode == 0, (
+        "chat_persistence_service must stay off the app import closure:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "CHAT_PERSISTENCE_CLOSURE_OK" in result.stdout
+
+
+def test_deferred_persistence_service_resolves_on_the_real_save_path(
+    tmp_path: Path,
+) -> None:
+    """The deferred import still resolves where it is actually used.
+
+    Drives ``save_chat_history_to_db_wrapper`` against a real
+    ``CharactersRAGDB`` in a fresh interpreter, asserting the conversation and
+    both messages land AND that the deferred module became resident as a
+    result. A deferral that silently stopped resolving (renamed module,
+    shadowed name, cycle) would fail here rather than at 3am.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _REAL_USE_PATH_SNIPPET)
+    assert result.returncode == 0, (
+        "the deferred ChatPersistenceService import failed on its real use path:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "CHAT_PERSISTENCE_USE_PATH_OK" in result.stdout

--- a/Tests/Packaging/test_raw_cli_import_closure.py
+++ b/Tests/Packaging/test_raw_cli_import_closure.py
@@ -1,0 +1,292 @@
+"""Import-closure guard: `console_raw_cli` reaches its executor lazily.
+
+TASK-23112 / ADR-097. ``app.py`` imports ``Chat/console_raw_cli.py`` at module
+scope (for ``RawCliRuntime``, constructed in ``TldwCli.__init__``), and that
+module used to import ``Tools.raw_cli_executor`` at module scope. Measured with
+an import-parent tracer, the edge put ``Tools.raw_cli_executor`` and
+``Agents.run_log`` on the boot import path (648 -> 646 own modules when
+deferred; the sibling ``Tools``/``Tools.tool_executor``/``Agents``/
+``Agents.run_log_format`` stay resident because ``UI.Tools_Settings_Window ->
+Agents.local_tool_provider -> Agents.tool_catalog`` imports them anyway --
+a pre-existing boot edge this task did not touch).
+
+Two things had to move together, because ``RawCliRuntime`` is constructed
+during ``TldwCli.__init__``: the module-scope import (now the lazy
+``_raw_cli_executor()`` accessor) AND the default ``RawShellExecutor()``
+construction (now ``RawCliRuntime._executor_or_default()``, resolved on the
+first ``execute()``). Deferring only the import would have satisfied the
+import-weight ratchet while a real boot still paid the modules at construction
+-- the exact half-fix recorded in TASK-21200's lesson.
+
+Subprocess-isolated for the same reason as ``test_app_import_diet_closure.py``
+(TASK-21108), whose pattern this file follows.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_isolated_python(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in a fresh interpreter with isolated config/data dirs.
+
+    Args:
+        tmp_path: Per-test scratch directory for the subprocess's HOME/XDG so
+            the app import can never read or write the live user config.
+        code: The Python source to execute with ``python -c``.
+
+    Returns:
+        The completed process (never raises on nonzero exit).
+    """
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env.pop("TLDW_CONFIG_PATH", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=180,
+    )
+
+
+_APP_CLOSURE_SNIPPET = """
+import sys
+
+import tldw_chatbook.app  # noqa: F401
+
+forbidden = (
+    "tldw_chatbook.Tools.raw_cli_executor",
+    "tldw_chatbook.Agents.run_log",
+)
+resident = sorted(m for m in forbidden if sys.modules.get(m) is not None)
+assert not resident, (
+    "raw CLI executor resident after `import tldw_chatbook.app`: "
+    + repr(resident)
+    + " -- defer it (Chat/console_raw_cli.py:_raw_cli_executor) rather than "
+    "raising MAX_TLDW_MODULE_COUNT (ADR-097)."
+)
+
+# Anti-vacuity: console_raw_cli itself must still be in the closure, or the
+# assertion above would pass without exercising the deferral.
+assert "tldw_chatbook.Chat.console_raw_cli" in sys.modules, (
+    "console_raw_cli left the app import closure; this guard no longer tests "
+    "the deferral"
+)
+
+print("RAW_CLI_CLOSURE_OK")
+"""
+
+
+_CONSTRUCTION_SNIPPET = """
+import sys
+
+from tldw_chatbook.Chat.console_raw_cli import RawCliRuntime
+
+assert "tldw_chatbook.Tools.raw_cli_executor" not in sys.modules, (
+    "importing console_raw_cli still executes Tools.raw_cli_executor"
+)
+
+# TldwCli.__init__ builds exactly this object. Constructing it must not pull
+# the executor either -- that is the half of the fix an import-only deferral
+# would have missed (TASK-21200 lesson).
+runtime = RawCliRuntime(lambda: False)
+assert "tldw_chatbook.Tools.raw_cli_executor" not in sys.modules, (
+    "constructing RawCliRuntime executed Tools.raw_cli_executor"
+)
+assert runtime._executor is None
+
+# First real use resolves the default executor, once, and caches it.
+executor = runtime._executor_or_default()
+assert executor is not None
+from tldw_chatbook.Tools.raw_cli_executor import RawShellExecutor
+
+assert isinstance(executor, RawShellExecutor)
+assert runtime._executor_or_default() is executor, "default executor rebuilt per call"
+
+# An injected executor still wins and is never replaced.
+sentinel = object()
+injected = RawCliRuntime(lambda: False, executor=sentinel)
+assert injected._executor is sentinel
+assert injected._executor_or_default() is sentinel
+
+print("RAW_CLI_CONSTRUCTION_OK")
+"""
+
+
+_REAL_USE_PATH_SNIPPET = """
+import sys
+from pathlib import Path
+
+import pydantic
+
+from tldw_chatbook.Chat.console_raw_cli import (
+    LocalCommandCallArgs,
+    LocalCommandResultArgs,
+    RawCliRuntime,
+)
+
+# 1. The deferred byte limits still gate the pydantic validators. Both
+# constants live in Tools.raw_cli_executor; if the deferred lookup broke, the
+# over-limit payloads below would be accepted.
+from tldw_chatbook.Tools.raw_cli_executor import (
+    MAX_RAW_COMMAND_BYTES,
+    MAX_RAW_PREVIEW_BYTES,
+    RawCliRequest,
+    RawCliResult,
+)
+
+ok = LocalCommandCallArgs(
+    invocation_id="inv-1",
+    command="echo hello",
+    shell="bash",
+    cwd="/tmp",
+)
+assert ok.command == "echo hello"
+
+try:
+    LocalCommandCallArgs(
+        invocation_id="inv-2",
+        command="x" * (MAX_RAW_COMMAND_BYTES + 1),
+        shell="bash",
+        cwd="/tmp",
+    )
+except pydantic.ValidationError:
+    pass
+else:  # pragma: no cover - only on a broken deferred lookup
+    raise AssertionError("MAX_RAW_COMMAND_BYTES no longer gates the command field")
+
+
+def _result_args(**overrides):
+    fields = dict(
+        invocation_id="inv-r",
+        shell="bash",
+        cwd="/tmp",
+        stdout_preview="out",
+        stderr_preview="err",
+        elapsed_seconds=1.0,
+        exit_code=0,
+        terminal_state="exited",
+        truncated=False,
+        cleanup_proven=True,
+    )
+    fields.update(overrides)
+    return LocalCommandResultArgs(**fields)
+
+
+assert _result_args().stdout_preview == "out"
+
+# Per-field limit (the `_validate_preview` field validator).
+try:
+    _result_args(stdout_preview="x" * (MAX_RAW_PREVIEW_BYTES + 1))
+except pydantic.ValidationError:
+    pass
+else:  # pragma: no cover - only on a broken deferred lookup
+    raise AssertionError("MAX_RAW_PREVIEW_BYTES no longer gates a preview field")
+
+# Combined limit (the `_validate_combined_preview` model validator).
+half = "x" * ((MAX_RAW_PREVIEW_BYTES // 2) + 1)
+try:
+    _result_args(stdout_preview=half, stderr_preview=half)
+except pydantic.ValidationError:
+    pass
+else:  # pragma: no cover - only on a broken deferred lookup
+    raise AssertionError("MAX_RAW_PREVIEW_BYTES no longer gates the combined preview")
+
+# 2. The refusal path: execute() on a runtime that was never armed runs
+# `validate_raw_cli_request` and `_refused_result` -- both deferred lookups --
+# without spawning a process.
+runtime = RawCliRuntime(lambda: False)
+request = RawCliRequest(
+    invocation_id="inv-3",
+    caller="user",
+    console_session_id="session-1",
+    command="echo hello",
+    initial_directory=Path("/tmp"),
+    shell="bash",
+    timeout_seconds=1.0,
+)
+events = []
+result = runtime.execute(request, events.append)
+assert isinstance(result, RawCliResult), type(result)
+assert result.invocation_id == "inv-3"
+assert result.exit_code is None
+assert events == []
+
+print("RAW_CLI_USE_PATH_OK")
+"""
+
+
+def test_app_import_does_not_execute_the_raw_cli_executor(tmp_path: Path) -> None:
+    """`import tldw_chatbook.app` must not pull `Tools.raw_cli_executor`.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _APP_CLOSURE_SNIPPET)
+    assert result.returncode == 0, (
+        "Tools.raw_cli_executor must stay off the app import closure:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "RAW_CLI_CLOSURE_OK" in result.stdout
+
+
+def test_raw_cli_runtime_construction_stays_executor_free(tmp_path: Path) -> None:
+    """Constructing `RawCliRuntime` must not import or build the executor.
+
+    ``TldwCli.__init__`` constructs this object, so an import-only deferral
+    would leave a real boot paying the same modules a moment later.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _CONSTRUCTION_SNIPPET)
+    assert result.returncode == 0, (
+        "RawCliRuntime construction pulled the deferred executor:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "RAW_CLI_CONSTRUCTION_OK" in result.stdout
+
+
+def test_deferred_raw_cli_executor_resolves_on_its_real_use_paths(
+    tmp_path: Path,
+) -> None:
+    """Every deferred name still resolves where the module actually uses it.
+
+    Covers the two live call shapes that no longer have a module-scope binding:
+    the pydantic field validators reading ``MAX_RAW_COMMAND_BYTES``, and
+    ``RawCliRuntime.execute``'s ``validate_raw_cli_request`` +
+    ``_refused_result`` pair (exercised through the unarmed-refusal path, which
+    spawns no process).
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _REAL_USE_PATH_SNIPPET)
+    assert result.returncode == 0, (
+        "a deferred raw CLI name failed on its real use path:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr[-4000:]}"
+    )
+    assert "RAW_CLI_USE_PATH_OK" in result.stdout

--- a/Tests/Packaging/test_raw_cli_import_closure.py
+++ b/Tests/Packaging/test_raw_cli_import_closure.py
@@ -132,6 +132,52 @@ injected = RawCliRuntime(lambda: False, executor=sentinel)
 assert injected._executor is sentinel
 assert injected._executor_or_default() is sentinel
 
+# Concurrent first use builds exactly ONE executor, not one per racing thread
+# (Qodo review, PR #2180): the post-import check and the construction must
+# happen together under the lock. A build-then-discard shape returns the same
+# cached object to every caller and so passes the identity checks above while
+# still constructing N times -- only counting constructions catches it.
+import threading
+import time
+
+import tldw_chatbook.Tools.raw_cli_executor as _executor_module
+
+builds = []
+_real_init = _executor_module.RawShellExecutor.__init__
+
+
+def _counting_init(self):
+    builds.append(1)
+    # Hold the constructor open long enough that every racing thread is
+    # certainly inside the window. Without this the real __init__ (which only
+    # grabs a spawn context) finishes inside one GIL switch interval, so the
+    # racy shape serialises by luck and the assertion below cannot fail --
+    # a test that passes on the bug it exists to catch.
+    time.sleep(0.05)
+    _real_init(self)
+
+
+_executor_module.RawShellExecutor.__init__ = _counting_init
+try:
+    racing = RawCliRuntime(lambda: False)
+    start = threading.Barrier(8)
+    seen = []
+
+    def _race():
+        start.wait()
+        seen.append(racing._executor_or_default())
+
+    threads = [threading.Thread(target=_race) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+finally:
+    _executor_module.RawShellExecutor.__init__ = _real_init
+
+assert len(builds) == 1, f"default executor built {len(builds)} times under concurrency"
+assert len({id(obj) for obj in seen}) == 1, "racing callers got different executors"
+
 print("RAW_CLI_CONSTRUCTION_OK")
 """
 

--- a/Tests/Performance/boot_budget_snapshots/boot_import_modules.txt
+++ b/Tests/Performance/boot_budget_snapshots/boot_import_modules.txt
@@ -1,9 +1,5 @@
 # tldw_chatbook.* modules resident after `import tldw_chatbook.app`.
-# 657 modules, measured at dev c6218918d1 (2026-08-28) -- the last in-budget
-# dev state; dev tip b5eaa9cf64 measures 666 (> the 660 ratchet), so this
-# snapshot is deliberately pinned at the pre-breach set to keep the breach
-# diff naming the culprits (TASK-23029). Written ONLY by
-# scripts/update_boot_budget_snapshots.py (ADR-097) once dev is back in budget.
+# 646 modules. Written ONLY by scripts/update_boot_budget_snapshots.py (ADR-097).
 tldw_chatbook
 tldw_chatbook.ACP_Interop
 tldw_chatbook.ACP_Interop.runtime_process
@@ -58,7 +54,6 @@ tldw_chatbook.Chat.chat_conversation_scope_service
 tldw_chatbook.Chat.chat_conversation_service
 tldw_chatbook.Chat.chat_handoff_models
 tldw_chatbook.Chat.chat_loop_scope_service
-tldw_chatbook.Chat.chat_persistence_service
 tldw_chatbook.Chat.citation_artifact_ownership
 tldw_chatbook.Chat.citation_evidence_models
 tldw_chatbook.Chat.citation_legacy_migration
@@ -71,20 +66,13 @@ tldw_chatbook.Chat.citation_trace_identity
 tldw_chatbook.Chat.citation_trace_models
 tldw_chatbook.Chat.citation_trace_repository
 tldw_chatbook.Chat.console_chat_models
-tldw_chatbook.Chat.console_context_policy
-tldw_chatbook.Chat.console_context_repository
-tldw_chatbook.Chat.console_dispatch_checkpoint
-tldw_chatbook.Chat.console_dispatch_repository
 tldw_chatbook.Chat.console_image_edit_operations
 tldw_chatbook.Chat.console_library_policy
-tldw_chatbook.Chat.console_library_policy_repository
 tldw_chatbook.Chat.console_live_work
-tldw_chatbook.Chat.console_prefill
 tldw_chatbook.Chat.console_project_instructions
 tldw_chatbook.Chat.console_provider_endpoints
 tldw_chatbook.Chat.console_provider_support
-tldw_chatbook.Chat.console_roleplay_identity
-tldw_chatbook.Chat.console_roleplay_metadata
+tldw_chatbook.Chat.console_raw_cli
 tldw_chatbook.Chat.console_runtime
 tldw_chatbook.Chat.console_scratch_space
 tldw_chatbook.Chat.console_session_settings
@@ -92,8 +80,8 @@ tldw_chatbook.Chat.console_speech
 tldw_chatbook.Chat.console_speech_preferences
 tldw_chatbook.Chat.console_transaction_contribution
 tldw_chatbook.Chat.conversation_local_marks_service
+tldw_chatbook.Chat.library_activity
 tldw_chatbook.Chat.local_server_discovery
-tldw_chatbook.Chat.message_metadata
 tldw_chatbook.Chat.provider_continuation
 tldw_chatbook.Chat.provider_endpoint_contract
 tldw_chatbook.Chat.provider_readiness
@@ -102,6 +90,8 @@ tldw_chatbook.Chat.provider_usage
 tldw_chatbook.Chat.rag_scope
 tldw_chatbook.Chat.server_chat_conversation_service
 tldw_chatbook.Chat.server_chat_loop_service
+tldw_chatbook.Chat.thinking_blocks
+tldw_chatbook.Chat.trajectory
 tldw_chatbook.Chat_Grammars_Interop
 tldw_chatbook.Chat_Grammars_Interop.chat_grammars_scope_service
 tldw_chatbook.Chat_Grammars_Interop.local_chat_grammars_service
@@ -346,13 +336,7 @@ tldw_chatbook.Research_Interop.server_research_search_service
 tldw_chatbook.Research_Interop.server_research_service
 tldw_chatbook.Research_Workspace
 tldw_chatbook.Research_Workspace.contracts
-tldw_chatbook.Research_Workspace.controller
-tldw_chatbook.Research_Workspace.layout_state
-tldw_chatbook.Research_Workspace.local_adapter
-tldw_chatbook.Research_Workspace.overlay_store
 tldw_chatbook.Research_Workspace.paste_staging
-tldw_chatbook.Research_Workspace.quick_notes
-tldw_chatbook.Research_Workspace.server_adapter
 tldw_chatbook.Research_Workspace.source_association
 tldw_chatbook.Research_Workspace.source_operation_store
 tldw_chatbook.Research_Workspace.source_operations
@@ -589,6 +573,7 @@ tldw_chatbook.Utils.fts5_match_forms
 tldw_chatbook.Utils.input_validation
 tldw_chatbook.Utils.instance_lock
 tldw_chatbook.Utils.library_rail_width
+tldw_chatbook.Utils.log_sanitizer
 tldw_chatbook.Utils.optional_deps
 tldw_chatbook.Utils.path_validation
 tldw_chatbook.Utils.paths
@@ -600,6 +585,7 @@ tldw_chatbook.Utils.sensitive_llm_logging
 tldw_chatbook.Utils.sensitive_paths
 tldw_chatbook.Utils.text
 tldw_chatbook.Utils.text_selection_crash_guard
+tldw_chatbook.Utils.tiktoken_runtime
 tldw_chatbook.Utils.token_counter
 tldw_chatbook.Utils.ui_responsiveness
 tldw_chatbook.Voice_Assistant_Interop
@@ -620,6 +606,7 @@ tldw_chatbook.Widgets.Settings_Widgets.speech_tts_panel_types
 tldw_chatbook.Widgets.confirmation_dialog
 tldw_chatbook.Widgets.glyph_fallback
 tldw_chatbook.Widgets.modal_dismissal
+tldw_chatbook.Widgets.pausable_progress
 tldw_chatbook.Widgets.splash_screen
 tldw_chatbook.Workspaces
 tldw_chatbook.Workspaces.conversation_browser_state
@@ -658,6 +645,4 @@ tldw_chatbook.runtime_policy.server_parity_state
 tldw_chatbook.runtime_policy.source_state
 tldw_chatbook.runtime_policy.types
 tldw_chatbook.tldw_api
-tldw_chatbook.tldw_api.exceptions
 tldw_chatbook.tldw_api.kanban_schemas
-tldw_chatbook.tldw_api.notes_workspace_schemas

--- a/Tests/Performance/test_app_import_weight.py
+++ b/Tests/Performance/test_app_import_weight.py
@@ -107,11 +107,19 @@ ELIMINATED_MODULES = ("torch", "transformers")
 #   lives in boot_budget_snapshots/boot_import_modules.txt; refresh it only
 #   via `scripts/update_boot_budget_snapshots.py`.
 #
-#   STANDING BREACH: dev b5eaa9cf64 measures 666 (2026-08-28) -- this guard
-#   is red on dev until the 17 modules named in its failure message are
-#   deferred (ADR-097 "Standing breach at adoption"; repayment tracked as
-#   task-23112). The snapshot is deliberately pinned at c6218918d1's 657
-#   in-budget set so the breach keeps naming the culprits.
+#   The ADR-097 standing breach (dev b5eaa9cf64: 666 vs the 660 ratchet) was
+#   repaid by TASK-23112, NOT by raising this constant: 646 measured
+#   (headroom 14), snapshot re-pinned at that set. Two deferrals did it, each
+#   re-measured with an import-parent tracer: `Chat_Functions` now reaches
+#   `ChatPersistenceService` inside `save_chat_history_to_db_wrapper`
+#   (666 -> 648, 18 modules), and `Chat/console_raw_cli.py` reaches
+#   `Tools.raw_cli_executor` through a lazy accessor with the default
+#   `RawShellExecutor` built on first execute (648 -> 646). ADR-097's
+#   tightening convention does NOT fire here: the 20-module reduction is under
+#   the 30-module standard slack, and 646 + 30 = 676 is above 660, so lowering
+#   would be raising. Per-edge guards:
+#   `Tests/Packaging/test_chat_persistence_import_closure.py` and
+#   `Tests/Packaging/test_raw_cli_import_closure.py`.
 #
 #   Know what this does NOT catch. Measured by reverting each 21108 deferral
 #   on its own and re-running this probe: panel only -> 649, notes-sync chain

--- a/backlog/decisions/097-boot-budget-ratchets.md
+++ b/backlog/decisions/097-boot-budget-ratchets.md
@@ -19,6 +19,13 @@ of breach:
 | boot CSS bytes (`Tests/Performance/test_boot_css_byte_budget.py`) | `MAX_BOOT_PARSED_CSS_BYTES` | 860,000 | 842,236 | 854,720 (headroom 5,280) |
 | screen pre-import payload (`Tests/Performance/test_screen_preimport_payload_budget.py`) | `MAX_PASS_ADDED_MODULES` / `MAX_PASS_ADDED_LOC` / `MAX_SINGLE_ROUTE_ADDED_LOC` | 500 / 380,000 / 145,000 | 481 / 368,814 | 488 / 374,697 / 137,494 |
 
+The import-weight breach in that last column was repaid by TASK-23112 (646,
+headroom 14) — see "Standing breach at adoption" below. Measured on dev
+`473e7c9298` at the same time, the other three read 968/970 (headroom **2**),
+854,943/860,000 and 488/500 + 375,925/380,000 + 137,783/145,000: the `_ui_ready`
+census consumed 5 of its 7 remaining modules in three commits, which is the same
+consumption pattern this ADR was written about.
+
 Three holistic reviews in six days (2026-08-22, 08-24, 08-27) each bought
 headroom that ordinary merge traffic consumed within days. The sharpest
 instance: the guards forbidding `Chat.trajectory_export` on the first-paint
@@ -98,7 +105,44 @@ commit, with the owner's explicit sign-off recorded in the PR.
 |---|---|---|---|---|---|
 | — | — | — | — | *(none granted yet)* | — |
 
-## Standing breach at adoption (not an exception — a debt)
+## Standing breach at adoption (not an exception — a debt) — REPAID
+
+**Repaid 2026-08-28 by TASK-23112: 666 → 646 own modules, ratchet still 660,
+no ledger row.** Two deferrals, each re-measured with an import-parent tracer
+rather than inferred from the diff:
+
+* `Chat/Chat_Functions.py` now imports `ChatPersistenceService` inside
+  `save_chat_history_to_db_wrapper` (its only construction site, never reached
+  at import or during `TldwCli.__init__`): **−18 modules** — every module below
+  that only the persistence service reached (`attachment_core`,
+  `console_chat_fork` + `Event_Handlers.Chat_Events` + `chat_image_events`,
+  `video_metadata` + `video_formats` + the package, the console
+  context/dispatch/library-policy repositories, `Utils.file_handlers`, …).
+* `Chat/console_raw_cli.py` reaches `Tools.raw_cli_executor` through a lazy
+  `_raw_cli_executor()` accessor, and builds the default `RawShellExecutor` on
+  first `execute()` rather than in `RawCliRuntime.__init__` (which `app.py`
+  calls during construction): **−2 modules**.
+
+Two of the traced items below did **not** survive measurement, and the
+attribution is why: the import-parent tracer records only the FIRST importer,
+so an edge can look load-bearing while a second boot-path importer keeps the
+module resident regardless. `Chat.thinking_blocks` is imported at module scope
+by `Chat/Chat_Functions.py` as well as by `console_runtime`, so deferring the
+`console_runtime` edge buys **0**; `Chat.library_activity` (with
+`Chat.trajectory` and `Utils.log_sanitizer`) is also imported by
+`Agents/library_tool_provider.py`, reached via the pre-existing
+`app -> UI.Tools_Settings_Window -> Agents.local_tool_provider ->
+Agents.tool_catalog -> Agents.library_rag_tool_provider` chain, so those three
+stayed. `Widgets.pausable_progress` and `Utils.tiktoken_runtime` were verified
+genuine, as the trace predicted.
+
+The tightening convention does not fire: the reduction (20) is under the
+30-module standard slack, and `646 + 30 = 676` is above 660, so lowering the
+constant would be raising it. Per-edge guards:
+`Tests/Packaging/test_chat_persistence_import_closure.py`,
+`Tests/Packaging/test_raw_cli_import_closure.py`.
+
+The original debt, for the record:
 
 At this ADR's adoption, dev (`b5eaa9cf64`) already breaches the import-weight
 ratchet: **666 own modules against 660**. The constant was NOT raised. Vs the
@@ -119,7 +163,7 @@ removed (TASK-23023's Research_Workspace diet). The added edges, traced:
   each; both look like genuine boot-path needs.
 
 Under this ADR the debt is repaid by deferral/shedding, not by raising 660.
-The `boot_import_modules.txt` snapshot is pinned at the `c6218918d1` set so
-the guard's failure message keeps naming exactly these modules until the debt
-is cleared; once dev is back under 660, re-pin via the update script. The
-repayment is tracked as **TASK-23112**.
+The `boot_import_modules.txt` snapshot was pinned at the `c6218918d1` set so
+the guard's failure message kept naming exactly these modules until the debt
+was cleared; it is now re-pinned at the post-repayment 646-module set. The
+repayment is **TASK-23112** (see above).

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9339,3 +9339,70 @@ but its own runtime side effect made the documented command non-repeatable.
 runtime behavior. Suppress bytecode in the documented command and inside the task-local runner,
 then run the exact verifier twice and assert that neither cache directories nor unmanifested files
 appear. A single PASS does not prove an evidence verifier is idempotent.
+
+---
+
+## An import-parent tracer names the FIRST importer, so its attribution is an upper bound — re-measure after every deferral
+
+**TASK-23112, 2026-08-28.** ADR-097's standing import-weight breach (666 own
+modules against the 660 ratchet) came with a traced list of the 17 added edges,
+produced by the house `sys.meta_path` import-parent recorder. Four edges were
+named as the debt. Two of them, deferred, would have bought **exactly zero
+modules**, and the trace could not have told you:
+
+* `Chat.console_runtime -> Chat.thinking_blocks` was real — and irrelevant.
+  `Chat/Chat_Functions.py:98` also imports `thinking_blocks` at module scope,
+  and `Chat_Functions` is on the boot path. Whoever imports first gets the
+  attribution; the other importer is invisible.
+* `chat_persistence_service -> Chat.library_activity` (with `Chat.trajectory`
+  and `Utils.log_sanitizer`) was likewise real and likewise irrelevant:
+  `Agents/library_tool_provider.py` imports it too, reached through
+  `app -> UI.Tools_Settings_Window -> Agents.local_tool_provider ->
+  Agents.tool_catalog -> Agents.library_rag_tool_provider`.
+
+The recorder stores one parent per module — the module whose body triggered the
+*first* import — so the parent map is a tree over a graph. A subtree's size is
+therefore the **maximum** a deferral can buy, never the actual number. Measured:
+the `chat_persistence_service` subtree was 31 modules and deferring its single
+boot-path consumer removed 18; the `console_raw_cli` subtree was 8 and deferring
+its executor import removed 2 (`Tools`, `Tools.tool_executor`, `Agents`,
+`Agents.run_log_format` stayed, pulled by the `Tools_Settings_Window` chain).
+
+**What to do.** Treat a traced chain as *where to look*, never as *what it is
+worth*. Re-run the count in a fresh interpreter after each individual deferral
+and diff the module sets; that is the only statement about savings you can
+defend. And when a deferral buys zero, say so in the notes with the second
+importer named — otherwise the next person re-files the same edge. (Companion
+to the existing rule that a tracer beats reading `-X importtime` or the diff:
+the tracer is still the right instrument, it just answers "who imported this
+first", not "who needs it".)
+
+---
+
+## To prove a failure is pre-existing, use a detached worktree at the base — not a file swap in your own tree
+
+**TASK-23112, 2026-08-28.** Establishing that four red tests belonged to dev and
+not to the change under review meant running them against pristine sources. The
+obvious method — copy `git show HEAD:<file>` over the working copy, run, copy the
+saved version back — failed twice in one session, in two different ways:
+
+1. **The run outlived its shell.** A 10-minute-capped command was killed by the
+   harness; the `trap ... EXIT` restore never ran, and the working tree was left
+   holding `HEAD` content with the implementation silently gone. Nothing failed
+   loudly — the next command just measured the wrong tree.
+2. **The saved copy went stale.** Two more edits landed after the "mine" snapshot
+   was taken; copying it back reverted them. `git diff --stat` was the only thing
+   that noticed (83 insertions became 80), and only because the number had been
+   read before.
+
+`git stash` is not the alternative here — it is repo-wide across 100+ worktrees
+and banned. The safe form is `git worktree add --detach <path> <base-sha>`, run
+the tests there, `git worktree remove --force`. Your own tree is never touched,
+the comparison is against the exact base commit rather than "HEAD content of the
+two files I happened to think about", and a killed run leaves nothing to restore.
+It settled the two `Tests/ProductionApp/` failures with byte-identical assertion
+messages on both sides.
+
+**What to do.** Never mutate the tree you are trying to evaluate. If you do it
+anyway, `git diff --stat` before AND after the swap and compare the numbers —
+that is the only cheap detector for both failure modes above.

--- a/backlog/tasks/task-23112 - Boot-import-closure-breached-its-660-ratchet-defer-the-17-new-eager-modules.md
+++ b/backlog/tasks/task-23112 - Boot-import-closure-breached-its-660-ratchet-defer-the-17-new-eager-modules.md
@@ -1,21 +1,21 @@
 ---
 id: TASK-23112
-title: >-
-  Boot import closure breached its 660 ratchet -- defer the 17 new eager
-  modules
-status: To Do
+title: Boot import closure breached its 660 ratchet -- defer the 17 new eager modules
+status: Done
 assignee: []
 created_date: '2026-08-28'
+updated_date: '2026-08-28 23:33'
 labels:
   - performance
   - startup
-priority: high
 dependencies:
   - task-23029
+priority: high
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 `test_app_import_own_module_count_stays_at_the_post_diet_size` is RED on
 pristine dev (`b5eaa9cf64`, 2026-08-28): **666** own modules after `import
 tldw_chatbook.app` against the **660** ratchet. Under ADR-097 (boot budgets
@@ -44,21 +44,166 @@ Beware the known traps: a deferral changes WHICH objects the build binds
 (lessons, TASK-21108), a lazy facade protects nothing consumers import
 directly (TASK-21200), and tests that patch moved names disconnect silently
 (TASK-19830).
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] `test_app_import_own_module_count_stays_at_the_post_diet_size` passes
+<!-- AC:BEGIN -->
+- [x] #1 `test_app_import_own_module_count_stays_at_the_post_diet_size` passes
   on dev with `MAX_TLDW_MODULE_COUNT` still 660 (no exception-ledger entry)
-- [ ] The deferred imports still resolve on their real use paths (targeted
+- [x] #2 The deferred imports still resolve on their real use paths (targeted
   tests per moved edge, per the closure-guard house pattern in
   `Tests/Packaging/`)
-- [ ] The `boot_import_modules.txt` snapshot is re-pinned via
+- [x] #3 The `boot_import_modules.txt` snapshot is re-pinned via
   `scripts/update_boot_budget_snapshots.py` once the count is back under
   budget (the script refuses while over budget)
-- [ ] If reality lands well under 660, apply ADR-097's tightening convention
-  (lower to measured + 30)
+- [x] #4 If reality lands well under 660, apply ADR-097's tightening convention
+  (lower to measured + 30) -- assessed and correctly NOT applied: 646 measured,
+  and `646 + 30 = 676` is above 660, so "tightening" would raise the ratchet.
+  The reduction (20 modules) is also under the guard's 30-module standard slack,
+  which is the threshold the convention is written against.
 
 ## Evidence
 
 TASK-23029's implementation notes carry the full trace and the guard's new
 breach message, which names all 17 modules.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-derive the trace with an import-parent recorder (`sys.meta_path` finder
+   that names the module whose body triggered each import) rather than reading
+   the diff; record the baseline count.
+2. For each named edge, find where the imported symbols are actually used, and
+   whether the enclosing function runs at import time or during
+   `TldwCli.__init__` (TASK-22223 / TASK-21200 traps).
+3. Defer the highest-yield edge first; **re-measure after each deferral** so
+   every claimed saving is a measured delta, not an inferred one.
+4. Verify the two edges the trace called "genuine boot-path needs" instead of
+   assuming.
+5. Write one subprocess-isolated closure guard per moved edge in
+   `Tests/Packaging/`, each with an anti-vacuity check and a real-use-path
+   proof; mutation-test every guard (re-add the eager import, watch it go red).
+6. Re-pin `boot_import_modules.txt`, re-run all four boot budgets, run the
+   affected suites, and confirm any red reproduces on pristine sources before
+   attributing it to this change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Repaid ADR-097's standing import-weight breach by deferral only: **666 -> 646**
+own modules against the unchanged **660** ratchet (headroom 14), no
+exception-ledger row. Two edges moved; every number below is a measured
+re-run of the tracer, not an estimate.
+
+**1. `Chat/Chat_Functions.py` -> `chat_persistence_service` (-18 modules,
+666 -> 648).** `ChatPersistenceService` had exactly one use site,
+`save_chat_history_to_db_wrapper`, and one module-scope import; `app.py`
+reaches the module through `Library.library_local_rag_search_service ->
+library_rag_service -> library_rag_state -> library_rag_answer_service ->
+Chat_Functions`. Moving the import into the function took the whole subtree
+off the boot path -- `attachment_core`, `console_chat_fork` (+
+`Event_Handlers.Chat_Events` + `chat_image_events`), `video_metadata` (+
+`video_formats` + the package), `console_context_repository`,
+`console_dispatch_repository`/`_checkpoint`, `console_library_policy_repository`,
+`console_prefill`, `console_roleplay_metadata`/`_identity`, `message_metadata`,
+`console_context_policy`, `Utils.file_handlers`. This is the consumer-side fix
+the TASK-21200 lesson warns about, so the two questions it says to ask were
+answered with evidence rather than reasoning: the enclosing function never runs
+at import or during `TldwCli.__init__`, and the module was already resident at
+`_ui_ready` before this change (`console_runtime.ensure_console_runtime`
+imports it during mount), so nothing was *relocated* into first paint -- the
+`_ui_ready` census is byte-identical at 968 with and without the change.
+
+**2. `Chat/console_raw_cli.py` -> `Tools.raw_cli_executor` (-2 modules,
+648 -> 646).** `app.py` imports `console_raw_cli` at module scope and
+constructs `RawCliRuntime` inside `TldwCli.__init__`, so an import-only
+deferral would have been the exact half-fix TASK-21200 records (guard green,
+boot unchanged). Both halves moved: a lazy `_raw_cli_executor()` module
+accessor replaces the module-scope import (with `TYPE_CHECKING` for the three
+annotation-only names and a string forward reference in the `RawCliEventSink`
+alias, which is an assignment and would otherwise still resolve eagerly), and
+the default `RawShellExecutor` is now built by `RawCliRuntime.
+_executor_or_default()` on the first `execute()` instead of in `__init__`.
+The dedicated construction guard fails on the half-fix while the closure guard
+passes -- verified by mutation. Only 2 modules moved rather than the traced 6
+because `Tools`, `Tools.tool_executor`, `Agents` and `Agents.run_log_format`
+are also pulled by the pre-existing `app -> UI.Tools_Settings_Window ->
+Agents.local_tool_provider -> Agents.tool_catalog` chain.
+
+**Two traced edges were refuted by measurement and deliberately left alone.**
+The import-parent tracer records only the FIRST importer, which makes an edge
+look load-bearing when a second boot-path importer keeps the module resident
+anyway. `Chat.console_runtime -> Chat.thinking_blocks` buys **0**:
+`Chat_Functions.py:98` imports `thinking_blocks` at module scope too.
+`Chat.library_activity` (with `Chat.trajectory` and `Utils.log_sanitizer`) is
+also imported by `Agents/library_tool_provider.py`, reached through the
+pre-existing `UI.Tools_Settings_Window -> Agents.local_tool_provider ->
+Agents.tool_catalog -> Agents.library_rag_tool_provider` chain, so deferring it
+at `chat_persistence_service` bought nothing and deferring it at
+`library_tool_provider` is a different (deprecated-window) chain, out of this
+task's scope. The two edges the trace called "genuine" were verified, not
+assumed: `tldw_chatbook/__init__` *calls* `install_tiktoken_runtime()` at
+package scope (ADR-093 ordering requirement), and `Widgets/splash_screen.py`
+yields `PausableProgressBar` from `compose()`. Both stay.
+
+**Tightening convention: assessed, correctly not applied.** ADR-097 says to
+lower the constant to `measured + standard slack` when a PR reduces the
+measured value by more than that slack. The reduction here is 20 modules
+(under the 30-module slack) and `646 + 30 = 676` is above 660, so lowering
+would be raising. `MAX_TLDW_MODULE_COUNT` stays at 660.
+
+**Trade-off accepted.** `Chat.console_raw_cli` itself (1 module) stays on the
+boot path: removing it would mean making `app.raw_cli_runtime` lazy, and eight
+consumers read it via `getattr(app, "raw_cli_runtime", None)` while tests
+assign doubles to it -- a binding-semantics change (TASK-21108) out of
+proportion to one stdlib-only module.
+
+**Modified/added files.**
+- `tldw_chatbook/Chat/Chat_Functions.py` -- import moved into
+  `save_chat_history_to_db_wrapper`.
+- `tldw_chatbook/Chat/console_raw_cli.py` -- lazy `_raw_cli_executor()`
+  accessor, `TYPE_CHECKING` block, forward-referenced `RawCliEventSink`,
+  `RawCliRuntime._executor_or_default()`.
+- `Tests/Packaging/test_chat_persistence_import_closure.py` (new, 2 tests) and
+  `Tests/Packaging/test_raw_cli_import_closure.py` (new, 3 tests) -- closure +
+  construction + real-use-path guards, all mutation-tested.
+- `Tests/Performance/boot_budget_snapshots/boot_import_modules.txt` -- re-pinned
+  at 646 via `scripts/update_boot_budget_snapshots.py --only import-weight`.
+- `Tests/Performance/test_app_import_weight.py` -- the standing-breach comment
+  replaced by the repayment record.
+- `backlog/decisions/097-boot-budget-ratchets.md` -- "Standing breach at
+  adoption" marked REPAID with the measured deltas and the two refutations.
+
+**Verification.** All four boot budgets green: boot-import-weight 646/660
+(headroom 14, snapshot in sync), ui-ready-census 968/970, boot-css-bytes
+854943/860000, preimport-payload 488/500 + 375925/380000 + 137783/145000 LOC.
+`./scripts/preflight.sh` green. `Tests/Packaging/` 211 passed. Every new guard
+was mutation-tested (re-add the eager import / restore the eager executor
+construction; each goes red, and the construction guard is the one that catches
+the import-only half-fix).
+
+Suites run and their four pre-existing failures, each confirmed on a pristine
+checkout before being dismissed:
+
+* raw-CLI / agent-runs / console slice (18 files, 507 passed): two failures,
+  reproduced with both changed files restored to `HEAD` content --
+  `test_agent_runs_db.py::test_local_command_resume_projection_bounds_raw_rows_before_json_projection`
+  (an SQL-shape assertion) and
+  `test_console_runtime_ownership.py::test_attach_and_detach_cover_exactly_the_same_slot_set`
+  (`'ChatScreen' object has no attribute '_library_activity'`).
+* `Tests/Chat/test_chat_functions.py` + `Tests/ProductionApp/` (165 passed):
+  two failures --
+  `test_chat_root_state_removal.py::test_visible_console_stop_cancels_native_run_without_root_worker_state`
+  and
+  `test_retired_destination_root_state.py::test_registered_destinations_own_state_without_retired_root_mirrors`.
+  Both reproduce with byte-identical assertion messages in a throwaway
+  `git worktree` detached at the base commit `473e7c9298`.
+
+Method note worth repeating: swapping `HEAD` file content in and out of the
+working tree to establish "pre-existing" is fragile -- a run that outlives its
+shell leaves the tree pristine, and restoring from a stale copy silently reverts
+later edits (it did, twice, here). A detached `git worktree` at the base commit
+is the safe form and is what settled the ProductionApp pair.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23155 - The _ui_ready census has 3 modules of headroom and will breach on an ordinary merge.md
+++ b/backlog/tasks/task-23155 - The _ui_ready census has 3 modules of headroom and will breach on an ordinary merge.md
@@ -1,0 +1,47 @@
+---
+id: TASK-23155
+title: The _ui_ready census has 3 modules of headroom and will breach on an ordinary merge
+status: To Do
+assignee: []
+created_date: '2026-08-28'
+labels:
+  - performance
+  - startup
+priority: high
+dependencies:
+  - task-23029
+  - task-23112
+---
+
+## Description
+
+The `_ui_ready` module census measures **967 against its 970 ratchet — headroom 3**, up from the
+963 that ADR-097 recorded at `b5eaa9cf64` a few commits earlier. At this repo's merge rate that
+breaches within a day or two, and under ADR-097 the limit does not rise: the modules have to defer
+or shed.
+
+This is the same shape as TASK-23112, which was filed for the import-weight ratchet and repaid it
+666 → 646. That one is worth reading first — it establishes that the import-parent tracer's
+attribution is an **upper bound** (it records only the first importer), so two of four edges its
+filing named bought nothing, and the real deferrals were found by re-measuring after each step.
+
+Filing this before it goes red is the point: a ratchet that only gets attention when it breaks
+blocks whoever happens to merge next, which is rarely the person who spent the headroom.
+
+## Acceptance Criteria
+
+- [ ] The `_ui_ready` census passes with meaningful headroom and `MAX_UI_READY_MODULES` unchanged
+  (no exception-ledger row)
+- [ ] The modules that consumed the headroom since `b5eaa9cf64` are named, each with the commit that
+  introduced its edge, and each deferral's yield is **measured** rather than inferred from the tracer
+- [ ] Every deferred import is proven to still resolve on its real use path by a subprocess-isolated
+  guard, mutation-tested (re-adding the eager import turns it red)
+- [ ] ADR-097's tightening convention is assessed against the final number and either applied or
+  explicitly declined with the arithmetic shown
+
+## Evidence
+
+Headroom line from a green run on `fix/task-23112`:
+`ui-ready-census: 967/970 modules (headroom 3); snapshot drift +5/-1`. TASK-23112 verified against a
+pristine base worktree that its own change does not move this census (968 both arms at the time),
+so the consumption is dev's, not that task's.

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -2193,6 +2193,13 @@ def save_chat_history_to_db_wrapper(
         - `Optional[str]`: The conversation ID (new or existing). None on critical failure
                            to create a conversation entry.
         - `str`: A status message indicating success or failure.
+
+    Raises:
+        ImportError: If `chat_persistence_service` cannot be imported. The import is
+            deferred (TASK-23112) and deliberately sits above the `try` below, so a
+            broken or partial install surfaces as an ImportError here rather than
+            being swallowed into a "save failed" status string. Every other failure
+            mode is still reported through the returned status message.
     """
     # Deferred (TASK-23112 / ADR-097): a module-scope import here put
     # `chat_persistence_service` and 17 of its dependencies on the

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -86,7 +86,6 @@ from tldw_chatbook.Utils.sensitive_llm_logging import (  # noqa: E402
 )
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram  # noqa: E402
 from tldw_chatbook.config import load_settings  # noqa: E402
-from .chat_persistence_service import ChatPersistenceService  # noqa: E402
 from .console_project_instructions import EPHEMERAL_ORIGIN_KEY  # noqa: E402
 from .provider_continuation import (  # noqa: E402
     ProviderContinuationCheckpoint,
@@ -2195,6 +2194,18 @@ def save_chat_history_to_db_wrapper(
                            to create a conversation entry.
         - `str`: A status message indicating success or failure.
     """
+    # Deferred (TASK-23112 / ADR-097): a module-scope import here put
+    # `chat_persistence_service` and 17 of its dependencies on the
+    # `import tldw_chatbook.app` closure (app.py reaches this module through
+    # Library.library_local_rag_search_service), breaching the 660-module
+    # ratchet. This is the service's only construction site in this module and
+    # this function runs only on a user-driven save -- never at import time,
+    # never during `TldwCli.__init__`. Kept ABOVE the `try` below so an import
+    # failure surfaces as an ImportError instead of being swallowed into a
+    # "save failed" status string. Guarded by
+    # `Tests/Packaging/test_chat_persistence_import_closure.py`.
+    from .chat_persistence_service import ChatPersistenceService
+
     log_counter("save_chat_history_to_db_attempt")
     start_time = time.time()
     logging.info(

--- a/tldw_chatbook/Chat/console_raw_cli.py
+++ b/tldw_chatbook/Chat/console_raw_cli.py
@@ -741,18 +741,20 @@ class RawCliRuntime:
         Deferred (TASK-23112): `RawShellExecutor` lives in the lazily imported
         `Tools.raw_cli_executor`, and this runtime is constructed during
         `TldwCli.__init__`. Resolving here keeps both the import and the
-        executor construction off the startup path. Idempotent and guarded by
-        the runtime's re-entrant lock, so concurrent first executes share one
-        executor. The module import happens BEFORE the lock is taken, so the
-        runtime lock is never held across the import lock.
+        executor construction off the startup path. Idempotent: the module
+        import happens BEFORE the lock is taken, so the runtime lock is never
+        held across the import lock, but the post-import check and the
+        construction are performed together under the lock so concurrent first
+        executes build exactly one executor rather than building several and
+        discarding all but one.
         """
         with self._lock:
             if self._executor is not None:
                 return self._executor
-        executor = _raw_cli_executor().RawShellExecutor()
+        module = _raw_cli_executor()
         with self._lock:
             if self._executor is None:
-                self._executor = executor
+                self._executor = module.RawShellExecutor()
             return self._executor
 
     def _latest_permitted_locked(self) -> bool:

--- a/tldw_chatbook/Chat/console_raw_cli.py
+++ b/tldw_chatbook/Chat/console_raw_cli.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 import math
 import threading
 import time
-from typing import Any, Literal, TypeAlias
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -20,15 +21,38 @@ from tldw_chatbook.Chat.console_chat_models import (
     RawCliPresentation,
 )
 from tldw_chatbook.STT.executor_process_tree import ExecutorProcessTree
-from tldw_chatbook.Tools.raw_cli_executor import (
-    MAX_RAW_COMMAND_BYTES,
-    MAX_RAW_PREVIEW_BYTES,
-    RawCliRequest,
-    RawCliResult,
-    RawCliStreamEvent,
-    RawShellExecutor,
-    validate_raw_cli_request,
-)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from tldw_chatbook.Tools.raw_cli_executor import (
+        RawCliRequest,
+        RawCliResult,
+        RawCliStreamEvent,
+    )
+
+
+def _raw_cli_executor() -> ModuleType:
+    """Return ``Tools.raw_cli_executor``, importing it on first use.
+
+    Deferred (TASK-23112 / ADR-097). ``app.py`` imports this module at module
+    scope for ``RawCliRuntime``, so a module-scope import here reached
+    ``Tools`` + ``Tools.tool_executor`` + ``Tools.raw_cli_executor`` +
+    ``Agents`` + ``Agents.run_log`` + ``Agents.run_log_format`` during
+    ``import tldw_chatbook.app``. Nothing needs any of them until a raw CLI
+    request is actually validated or executed, and every call site below runs
+    only on a user-driven raw CLI turn -- never at import time and never during
+    ``TldwCli.__init__`` (the executor default is built lazily too, see
+    ``RawCliRuntime._executor_or_default``).
+
+    Measured saving: 2 modules (``Tools.raw_cli_executor`` and
+    ``Agents.run_log``). The other four stay on the boot path regardless, pulled
+    by ``app -> UI.Tools_Settings_Window -> Agents.local_tool_provider ->
+    Agents.tool_catalog``. Guarded by
+    ``Tests/Packaging/test_raw_cli_import_closure.py``.
+    """
+    from tldw_chatbook.Tools import raw_cli_executor
+
+    return raw_cli_executor
+
 
 RAW_CLI_SHUTDOWN_TIMEOUT_SECONDS = 5.0
 LOCAL_COMMAND_AGENT_KIND = "local_command"
@@ -39,7 +63,9 @@ LOCAL_COMMAND_RUN_LOG_DIR = "local-command-runs"
 _RAW_CLI_COMPACT_OUTPUT_BYTES = 4 * 1024
 
 RawCliArmReason: TypeAlias = Literal["armed", "locked", "shutdown"]
-RawCliEventSink: TypeAlias = Callable[[RawCliStreamEvent], None]
+# Forward-referenced so the alias does not resolve `RawCliStreamEvent` at
+# import time (it lives in the deferred `Tools.raw_cli_executor`).
+RawCliEventSink: TypeAlias = Callable[["RawCliStreamEvent"], None]
 RawCliRegisteredSink: TypeAlias = Callable[[], None]
 RawCliStartedSink: TypeAlias = Callable[[float], None]
 
@@ -191,7 +217,7 @@ class LocalCommandCallArgs(_LocalCommandResumeModel):
     def _validate_command(cls, value: str) -> str:
         return _resume_utf8_text(
             value,
-            max_bytes=MAX_RAW_COMMAND_BYTES,
+            max_bytes=_raw_cli_executor().MAX_RAW_COMMAND_BYTES,
             nonblank=True,
             nul_free=True,
         )
@@ -256,7 +282,9 @@ class LocalCommandResultArgs(_LocalCommandResumeModel):
     @field_validator("stdout_preview", "stderr_preview")
     @classmethod
     def _validate_preview(cls, value: str) -> str:
-        return _resume_utf8_text(value, max_bytes=MAX_RAW_PREVIEW_BYTES)
+        return _resume_utf8_text(
+            value, max_bytes=_raw_cli_executor().MAX_RAW_PREVIEW_BYTES
+        )
 
     @field_validator("elapsed_seconds", mode="before")
     @classmethod
@@ -270,7 +298,7 @@ class LocalCommandResultArgs(_LocalCommandResumeModel):
         preview_bytes = len(self.stdout_preview.encode("utf-8")) + len(
             self.stderr_preview.encode("utf-8")
         )
-        if preview_bytes > MAX_RAW_PREVIEW_BYTES:
+        if preview_bytes > _raw_cli_executor().MAX_RAW_PREVIEW_BYTES:
             raise ValueError("combined raw CLI preview exceeds its live limit")
         return self
 
@@ -468,7 +496,11 @@ class RawCliRuntime:
         ):
             raise ValueError("shutdown timeout must be a finite nonnegative number")
         self._read_permitted = read_permitted
-        self._executor = executor if executor is not None else RawShellExecutor()
+        # `None` means "use the default shell executor", built on first
+        # execute() rather than here: this constructor runs during
+        # `TldwCli.__init__`, and `RawShellExecutor` lives in the deferred
+        # `Tools.raw_cli_executor` (TASK-23112).
+        self._executor: Any | None = executor
         self._shutdown_timeout_seconds = float(shutdown_timeout_seconds)
         self._lock = threading.RLock()
         self._admission_lock = threading.Lock()
@@ -565,7 +597,7 @@ class RawCliRuntime:
         on_started: RawCliStartedSink | None = None,
     ) -> RawCliResult:
         """Synchronously execute one request through the guarded admission seam."""
-        request = validate_raw_cli_request(request)
+        request = _raw_cli_executor().validate_raw_cli_request(request)
         if not callable(on_event):
             raise TypeError("on_event must be callable")
         if on_registered is not None and not callable(on_registered):
@@ -624,7 +656,7 @@ class RawCliRuntime:
         try:
             if on_registered is not None:
                 on_registered()
-            return self._executor.execute(
+            return self._executor_or_default().execute(
                 request,
                 cancel_event=active.cancel_event,
                 on_event=on_event,
@@ -703,6 +735,26 @@ class RawCliRuntime:
                 self._shutdown_result = result
                 return result
 
+    def _executor_or_default(self) -> Any:
+        """Return the executor, building the default one on first execute().
+
+        Deferred (TASK-23112): `RawShellExecutor` lives in the lazily imported
+        `Tools.raw_cli_executor`, and this runtime is constructed during
+        `TldwCli.__init__`. Resolving here keeps both the import and the
+        executor construction off the startup path. Idempotent and guarded by
+        the runtime's re-entrant lock, so concurrent first executes share one
+        executor. The module import happens BEFORE the lock is taken, so the
+        runtime lock is never held across the import lock.
+        """
+        with self._lock:
+            if self._executor is not None:
+                return self._executor
+        executor = _raw_cli_executor().RawShellExecutor()
+        with self._lock:
+            if self._executor is None:
+                self._executor = executor
+            return self._executor
+
     def _latest_permitted_locked(self) -> bool:
         try:
             return self._read_permitted() is True
@@ -729,7 +781,7 @@ class RawCliRuntime:
 
     @staticmethod
     def _refused_result(request: RawCliRequest) -> RawCliResult:
-        return RawCliResult(
+        return _raw_cli_executor().RawCliResult(
             invocation_id=request.invocation_id,
             caller=request.caller,
             resolved_shell=request.shell,


### PR DESCRIPTION
## Summary

The import-weight ratchet was **red on dev at 666/660** — the standing breach ADR-097 was adopted
with, filed as this task. It is now **646/660, headroom 14**, with `MAX_TLDW_MODULE_COUNT` untouched
and no exception-ledger row. That is the whole point: the ratchet does not move, the cost does.

| step | change | count |
|---|---|---|
| baseline (dev `473e7c9298`) | — | **666** |
| 1 | `Chat_Functions.py` → `ChatPersistenceService` moved into `save_chat_history_to_db_wrapper` | **648** (−18) |
| 2 | `console_raw_cli.py` → `Tools.raw_cli_executor` behind a lazy accessor, default executor built on first `execute()` | **646** (−2) |

**The tightening convention was assessed and correctly NOT applied**: the 20-module reduction is
under the guard's 30-module slack, and `646 + 30 = 676` is above 660 — "tightening" would have been
raising. Noted in the AC, the ADR, and the guard comment.

## The task's own trace was wrong on two of four edges

The import-parent tracer records only the **first** importer, so its attribution is an upper bound,
not an answer. Measuring after each deferral rather than trusting the trace:

- `console_runtime → thinking_blocks` buys **0** — `Chat_Functions.py:98` imports it at module scope too.
- `chat_persistence_service → library_activity` (+ `trajectory`, `log_sanitizer`) buys **0** — it is
  held by a pre-existing `app → Tools_Settings_Window → … → library_rag_tool_provider` chain.
- The `console_raw_cli` edge was traced at 6 modules; **2** actually left.
- The two edges the task called "genuine" were **verified rather than assumed**: `__init__` *calls*
  `install_tiktoken_runtime()` at package scope (ADR-093 ordering) and `splash_screen.compose()`
  yields `PausableProgressBar`. Both stay.

## The deferred paths are proven, not asserted

New subprocess-isolated guards in `Tests/Packaging/`, **all mutation-tested** (re-add the eager
import → red; restore eager executor construction → red):

- `test_chat_persistence_import_closure.py` — closure, anti-vacuity, and a **real save** through a
  live `CharactersRAGDB` asserting the conversation and both messages land *and* that the deferred
  module became resident.
- `test_raw_cli_import_closure.py` — closure; construction (`RawCliRuntime(...)` pulls nothing,
  `_executor_or_default()` builds once, caches, respects an injected executor); and the deferred
  names on their real paths, including `execute()` on an unarmed runtime driving the validator and
  refusal path without spawning a process.

The construction guard **fails on the import-only half-fix while the closure guard passes** — the
TASK-21200 lazy-facade trap, made detectable rather than described.

## Deliberately not changed

`Chat.console_raw_cli` itself (1 module) stays: removing it means making `app.raw_cli_runtime` lazy,
and eight consumers read it via `getattr` while tests assign doubles — a TASK-21108 binding change
out of proportion to one stdlib-only module. The `library_activity` trio and
`chat_persistence_service`'s own module-scope imports buy 0 measured modules for the reasons above.

## Flagging for a follow-up

**The `_ui_ready` census is at 967/970 — headroom 3**, up from the 963 ADR-097 recorded three
commits earlier, and it will breach on an ordinary merge. Verified against a pristine base worktree
that this change does not move it. Recorded in the ADR's context table.

## Verification

All four budgets green: **646/660**, 967/970, 854,943/860,000, 488/500 + 375,925/380,000.
`Tests/Packaging/` 211 passed; the four guards plus Packaging together 221 passed. Affected suites
carry 4 failures, **all four reproducing on a detached worktree at the base commit** with
byte-identical assertion messages. `./scripts/preflight.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repays ADR-097's standing boot-import breach: the import weight drops 666 → 646 own modules against the unchanged 660 ratchet, with no exception-ledger row or constant change.

**Code changes**
- `ChatPersistenceService` is now imported inside `save_chat_history_to_db_wrapper`, its only construction site and a user-driven path (−18 modules measured); the import sits above the `try` so a broken install surfaces as a documented `ImportError`.
- `console_raw_cli.py` reaches `Tools.raw_cli_executor` lazily and builds the default `RawShellExecutor` on first `execute()`, not during `RawCliRuntime.__init__`, which boot calls (−2 modules measured). Construction happens under the runtime lock, so concurrent first executes build exactly one executor.
- Two traced edges that measured zero were refuted and left alone; the tightening convention was assessed and not applied (646 + 30 = 676 is above 660).
- `Chat.console_raw_cli` stays on the boot path; removing it would force a binding-semantics change out of proportion to one stdlib-only module.

**Testing**
- Added subprocess-isolated closure guards in `Tests/Packaging/` with real-use-path proofs, each mutation-tested; the construction guard catches the import-only half-fix.
- Re-pinned the boot snapshot at 646; all four boot budgets are green. Four failures in affected suites reproduce on a detached worktree at the base commit, so they are pre-existing.
- Filed `TASK-23155` for the `_ui_ready` census at 967/970, which will breach on an ordinary merge and is unchanged by this diff.

<sup>Written for commit 31c28305f7247a8862eb643be1e06e3ebec07a52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

