### PR TITLE
fix(library): gate the resize stage-visibility leg instead of moving it (TASK-23151)

### DIFF
--- a/Tests/UI/test_library_resize_focus_gates_t23025.py
+++ b/Tests/UI/test_library_resize_focus_gates_t23025.py
@@ -24,7 +24,10 @@ on its own cheap signature rather than moved, because the 64-cell emergency
 band is a different band from the 120-cell compact one and only the leg above
 the return can cross it. The crossing tests here pin the COST -- exactly one
 application per crossing -- so neither wrong shape (unconditional, or
-relocated below the return) can pass.
+relocated below the return) can pass. The gate's own branches (skip on an
+unchanged signature, apply on a changed one, fail open on an unavailable one,
+plus the three inputs the signature shapes deliberately) are pinned by focused
+unit tests against a fake screen, below the harness tests.
 """
 
 from __future__ import annotations
@@ -49,7 +52,14 @@ from Tests.UI.test_library_shell import (
     _wait_for_library_shell,
     _wait_for_selector,
 )
-from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_INGEST_MEDIA
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_ROW_BROWSE_MEDIA,
+    LIBRARY_ROW_INGEST_MEDIA,
+)
+from tldw_chatbook.UI.Screens.library_screen import (
+    LIBRARY_NOTES_SOURCE_DATABASE,
+    LibraryScreen,
+)
 from tldw_chatbook.Widgets.Library.library_rail import LibraryRail
 from tldw_chatbook.Widgets.ModelArtifacts.install_progress import (
     InstallProgressed,
@@ -303,6 +313,309 @@ async def test_stage_visibility_runs_once_per_emergency_band_crossing():
             f"{applied.call_count} stage-visibility applications after the "
             "crossing settled; the gate did not re-arm"
         )
+
+
+class _FakeStageWidget:
+    """Attribute-only stand-in for a widget the stage signature reads.
+
+    The signature carries widget references by identity and reads only
+    ``region.width`` and ``display`` off them, so nothing here has to be a
+    real Textual widget.
+    """
+
+    def __init__(
+        self,
+        *,
+        widget_id: str | None = None,
+        width: int = 0,
+        display: bool = True,
+    ) -> None:
+        self.id = widget_id
+        self.region = SimpleNamespace(width=width)
+        self.display = display
+
+
+class _StageGateScreen:
+    """Fake screen carrying exactly the state the stage-visibility gate reads.
+
+    TASK-23151 unit coverage: the gate, the signature it compares and the seam
+    that records it are taken UNBOUND from ``LibraryScreen``, so these tests
+    exercise the shipped functions -- not a re-implementation -- without a
+    Textual harness. Only the leg itself is replaced, by a counter, because
+    "did the leg run" is the whole contract under test. The cheap route/flag
+    predicates the signature calls into are real too; a stub of
+    ``_library_ordinary_route_active`` would hide the effective-emergency
+    subtlety these tests exist to pin.
+    """
+
+    _library_notes_stage_signature = LibraryScreen._library_notes_stage_signature
+    _apply_library_notes_stage_visibility_for_resize = (
+        LibraryScreen._apply_library_notes_stage_visibility_for_resize
+    )
+    _apply_library_notes_stage_visibility = (
+        LibraryScreen._apply_library_notes_stage_visibility
+    )
+    _library_ordinary_route_active = LibraryScreen._library_ordinary_route_active
+    _library_notes_compact_stage_applies = (
+        LibraryScreen._library_notes_compact_stage_applies
+    )
+    _library_notes_compact_workflow_active = (
+        LibraryScreen._library_notes_compact_workflow_active
+    )
+    _library_notes_workflow_active = LibraryScreen._library_notes_workflow_active
+    _file_notes_active = LibraryScreen._file_notes_active
+    _library_notes_focused_task_active = (
+        LibraryScreen._library_notes_focused_task_active
+    )
+
+    def __init__(
+        self,
+        *,
+        width: int = 100,
+        row_id: str = LIBRARY_ROW_INGEST_MEDIA,
+        reader_active: bool = False,
+    ) -> None:
+        self.is_mounted = True
+        self.size = SimpleNamespace(width=width)
+        self.shell = _FakeStageWidget(widget_id="library-shell-grid", width=width)
+        self.rail = _FakeStageWidget(widget_id="library-rail")
+        self.canvas = _FakeStageWidget(widget_id="library-canvas")
+        self.refs: dict[str, _FakeStageWidget | None] = {
+            "#library-shell-grid": self.shell,
+            "#library-rail": self.rail,
+            "#library-canvas": self.canvas,
+        }
+        self.reader_active = reader_active
+        self.leg_calls = 0
+        self.leg_failure: Exception | None = None
+        # Cheap state the signature reads directly.
+        self._library_compose_generation = 0
+        self._library_reader_shell_ref = (
+            _FakeStageWidget(widget_id="library-notes-reader-shell")
+            if reader_active
+            else None
+        )
+        self._library_selected_row_id = row_id
+        self._library_notes_source = LIBRARY_NOTES_SOURCE_DATABASE
+        self._library_notes_view = "list"
+        self._library_notes_stage = "rail"
+        self._library_notes_compact = False
+        self._library_rail_collapsed = False
+        self._library_emergency_stage: str | None = None
+        self._library_emergency_restore_receipt = None
+        self._library_reader_shared_preferences = SimpleNamespace(
+            library_open=True, custom_widths_enabled=False, library_width=34
+        )
+        self._library_notes_stage_applied_signature: tuple | None = None
+
+    def set_width(self, width: int) -> None:
+        """Resize both the viewport and the shell grid, as a real frame does."""
+        self.size = SimpleNamespace(width=width)
+        self.shell.region = SimpleNamespace(width=width)
+
+    def _library_layout_ref(self, selector: str) -> _FakeStageWidget | None:
+        return self.refs.get(selector)
+
+    def _library_adaptive_reader_shell_active(self) -> bool:
+        return self.reader_active
+
+    def _apply_library_notes_stage_legs(self) -> None:
+        """Stand in for the query-heavy leg: count it, optionally fail it."""
+        self.leg_calls += 1
+        if self.leg_failure is not None:
+            raise self.leg_failure
+
+
+def test_stage_gate_skips_resize_frames_that_cross_no_band():
+    """TASK-23151 unit: an unchanged signature skips the leg entirely.
+
+    The band-free same-side resize is the exact shape that measured 201 and
+    100 applications against a ratchet demanding 0.
+    """
+    screen = _StageGateScreen(width=100)
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 1, "the cold gate must apply once to arm itself"
+
+    for width in (96, 92, 88):
+        screen.set_width(width)
+        screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 1, (
+        f"{screen.leg_calls} stage-visibility applications across 3 resize "
+        "frames that cross no band the stage leg reads; the gate should have "
+        "skipped all three"
+    )
+
+
+def test_stage_gate_applies_exactly_once_per_emergency_band_crossing():
+    """TASK-23151 unit: a changed signature applies the leg, once."""
+    screen = _StageGateScreen(width=80)
+    screen._apply_library_notes_stage_visibility_for_resize()  # arm
+    screen.leg_calls = 0
+
+    screen.set_width(63)  # below LIBRARY_EMERGENCY_WIDTH (64)
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 1, (
+        f"{screen.leg_calls} applications for one crossing into the emergency "
+        "band"
+    )
+
+    # Re-armed: repeating the same frame is free again.
+    for _ in range(3):
+        screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 1, (
+        f"{screen.leg_calls} applications after the crossing settled; the "
+        "gate did not re-arm"
+    )
+
+    screen.set_width(64)  # back out of the band
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 2, (
+        f"{screen.leg_calls - 1} applications for one emergency-band release"
+    )
+
+
+def test_stage_gate_fails_open_when_the_signature_cannot_be_computed():
+    """TASK-23151 unit: an unavailable signature must never suppress the leg.
+
+    ``_library_notes_stage_signature`` returns ``None`` when it cannot decide
+    cheaply (unmounted, or a shell/rail/canvas reference missing mid-recompose).
+    Both sides of the comparison are then ``None``, so a gate that compared
+    them for equality would silently skip the work forever.
+    """
+    screen = _StageGateScreen(width=100)
+    screen._apply_library_notes_stage_visibility_for_resize()  # arm
+    assert screen._library_notes_stage_applied_signature is not None
+
+    screen.refs["#library-rail"] = None  # mid-recompose: reference gone
+    assert screen._library_notes_stage_signature() is None
+    for _ in range(3):
+        screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 4, (
+        f"{screen.leg_calls - 1} of 3 frames applied the leg while the "
+        "signature was unavailable; the gate must fail open"
+    )
+    assert screen._library_notes_stage_applied_signature is None
+
+
+def test_stage_signature_carries_the_effective_not_raw_emergency_decision():
+    """TASK-23151 unit: the width bucket only counts on an ordinary route.
+
+    ``_apply_library_emergency_geometry`` gates its takeover on
+    ``_library_ordinary_route_active()``, so on a browse route the same
+    63-cell frame changes nothing -- carrying the RAW bucket would make every
+    such crossing look like a change and re-run the leg for nothing.
+    """
+    inert = _StageGateScreen(width=80, row_id=LIBRARY_ROW_BROWSE_MEDIA)
+    inert._apply_library_notes_stage_visibility_for_resize()  # arm
+    inert.leg_calls = 0
+    inert.set_width(63)
+    inert._apply_library_notes_stage_visibility_for_resize()
+    assert inert.leg_calls == 0, (
+        "the emergency width bucket flipped the signature on a route where "
+        "the emergency geometry is inert"
+    )
+
+    # Control: the identical crossing, differing only in the route id.
+    ordinary = _StageGateScreen(width=80, row_id=LIBRARY_ROW_INGEST_MEDIA)
+    ordinary._apply_library_notes_stage_visibility_for_resize()  # arm
+    ordinary.leg_calls = 0
+    ordinary.set_width(63)
+    ordinary._apply_library_notes_stage_visibility_for_resize()
+    assert ordinary.leg_calls == 1, (
+        "the ordinary route's emergency-band crossing was skipped"
+    )
+
+
+def test_stage_gate_applies_when_legacy_rail_display_changes_outside_the_leg():
+    """TASK-23151 unit: while the legacy path owns rail/canvas, they count.
+
+    The stage toggles WRITE ``rail.display``/``canvas.display``, so an outside
+    mutation of either has to re-run the leg rather than be gated away.
+    """
+    screen = _StageGateScreen(width=100, reader_active=False)
+    screen._apply_library_notes_stage_visibility_for_resize()  # arm
+    screen.leg_calls = 0
+
+    screen.rail.display = False  # something else hid the rail
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 1, (
+        "an outside rail.display change was gated away while the legacy path "
+        "owned the toggles"
+    )
+
+    screen.canvas.display = False
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 2, (
+        "an outside canvas.display change was gated away while the legacy "
+        "path owned the toggles"
+    )
+
+
+def test_stage_gate_ignores_reader_owned_rail_display_under_adaptive_shell():
+    """TASK-23151 unit: under an adaptive reader shell the rail is not ours.
+
+    The leg returns before the legacy toggles when a reader shell is mounted;
+    the reader's own ``sync_layout`` then hides the rail purely as a function
+    of width. Carrying ``rail.display`` there made every same-side resize look
+    like a change and held the wide case at 100 applications.
+    """
+    screen = _StageGateScreen(width=100, reader_active=True)
+    screen._apply_library_notes_stage_visibility_for_resize()  # arm
+    screen.leg_calls = 0
+
+    # A narrower same-band frame; the reader's sync_layout hides the rail.
+    screen.set_width(90)
+    screen.rail.display = False
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 0, (
+        f"{screen.leg_calls} stage-visibility applications for a same-band "
+        "frame whose rail was hidden by the reader shell that owns it"
+    )
+
+
+def test_every_stage_visibility_seam_arms_the_gate_not_only_the_resize_one():
+    """TASK-23151 unit: the applied signature is recorded inside the leg seam.
+
+    The screen has ~20 seams calling ``_apply_library_notes_stage_visibility``
+    directly. Recording only inside the resize gate left the record stale
+    after any of them, so each resize burst paid exactly one needless
+    application.
+    """
+    screen = _StageGateScreen(width=100)
+    screen._apply_library_notes_stage_visibility()  # a non-resize seam
+    assert screen.leg_calls == 1
+
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 1, (
+        "the resize gate re-applied a leg a non-resize seam had just settled; "
+        "the applied signature is not being recorded inside the seam"
+    )
+    assert screen._library_notes_stage_applied_signature is not None
+
+
+def test_a_raising_stage_leg_leaves_the_gate_re_armed_not_stale():
+    """TASK-23151 unit: the record is cleared BEFORE the legs run.
+
+    A leg that raises has settled nothing, so leaving the previous signature
+    in place would gate away the retry.
+    """
+    screen = _StageGateScreen(width=100)
+    screen._apply_library_notes_stage_visibility_for_resize()  # arm
+    assert screen._library_notes_stage_applied_signature is not None
+
+    screen.leg_failure = RuntimeError("stage leg blew up")
+    with pytest.raises(RuntimeError):
+        screen._apply_library_notes_stage_visibility()
+    assert screen._library_notes_stage_applied_signature is None, (
+        "a raising leg left a stale applied signature behind"
+    )
+
+    screen.leg_failure = None
+    screen.leg_calls = 0
+    screen._apply_library_notes_stage_visibility_for_resize()
+    assert screen.leg_calls == 1, (
+        "the retry after a raising leg was gated away by a stale signature"
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_resize_focus_gates_t23025.py
+++ b/Tests/UI/test_library_resize_focus_gates_t23025.py
@@ -17,6 +17,14 @@ Query-count assertions attribute each ``query``/``query_one`` call to the
 nearest non-framework repo frame, exactly like the measurement probe that
 produced the before/after numbers, so a reverted gate fails them by an
 order of magnitude rather than by noise.
+
+TASK-23151 extended the same contract to the stage-visibility leg, which the
+narrow-emergency work had re-added ABOVE the crossing return: it is now gated
+on its own cheap signature rather than moved, because the 64-cell emergency
+band is a different band from the 120-cell compact one and only the leg above
+the return can cross it. The crossing tests here pin the COST -- exactly one
+application per crossing -- so neither wrong shape (unconditional, or
+relocated below the return) can pass.
 """
 
 from __future__ import annotations
@@ -24,6 +32,7 @@ from __future__ import annotations
 import sys
 from contextlib import contextmanager
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 from textual.dom import DOMNode
@@ -131,32 +140,50 @@ async def test_resize_gate_skips_library_query_work_on_non_crossing_frames():
 
 @pytest.mark.asyncio
 async def test_resize_compact_crossing_still_transitions_both_ways_twice():
-    """The 120-column compact crossing keeps working through the gate."""
+    """The 120-column compact crossing keeps working through the gate.
+
+    TASK-23151 additionally pins the COST of each crossing: exactly one
+    stage-visibility application per crossing.
+    """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
     host = LibraryHarness(app)
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = await _settled_library(host, pilot)
         assert screen._library_notes_compact is False
+        applied = Mock(wraps=screen._apply_library_notes_stage_visibility)
+        screen._apply_library_notes_stage_visibility = applied
 
         for _ in range(2):  # twice: a stale applied-signature would eat round 2
+            applied.reset_mock()
             await pilot.resize_terminal(110, 48)
             await _wait_for_condition(
                 pilot,
                 lambda: screen._library_notes_compact,
                 message="narrow resize never crossed into compact",
             )
+            await pilot.pause()
             grid = screen.query_one("#library-shell-grid")
             assert grid.has_class("library-notes-compact")
+            assert applied.call_count == 1, (
+                f"{applied.call_count} stage-visibility applications for one "
+                "crossing into compact"
+            )
 
+            applied.reset_mock()
             await pilot.resize_terminal(170, 48)
             await _wait_for_condition(
                 pilot,
                 lambda: not screen._library_notes_compact,
                 message="wide resize never crossed back out of compact",
             )
+            await pilot.pause()
             grid = screen.query_one("#library-shell-grid")
             assert not grid.has_class("library-notes-compact")
+            assert applied.call_count == 1, (
+                f"{applied.call_count} stage-visibility applications for one "
+                "crossing out of compact"
+            )
 
 
 @pytest.mark.asyncio
@@ -189,6 +216,93 @@ async def test_resize_emergency_crossing_still_engages_and_restores():
         )
         assert screen.query_one("#library-rail").display
         assert screen.query_one("#library-canvas").display
+
+
+@pytest.mark.asyncio
+async def test_stage_visibility_runs_once_per_emergency_band_crossing():
+    """TASK-23151: the stage leg is gated, not moved, above the crossing return.
+
+    The narrow emergency band (64 cells) is a DIFFERENT band from the compact
+    breakpoint (120), so an 80 <-> 63 resize crosses only the former. The
+    stage-visibility leg therefore has to sit above ``on_resize``'s
+    compact-crossing early return -- which is why TASK-23151's regression put
+    unconditional per-frame Notes work back on every same-side frame.
+
+    This pins both halves at once, and fails under either wrong shape: a
+    same-side frame that does stage work (the regression) fails the ``== 0``
+    legs, and a fix that simply deletes or relocates the call below the
+    crossing return fails the ``== 1`` legs with a stranded emergency stage.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=(110, 30)) as pilot:
+        screen = await _settled_library(host, pilot)
+        assert screen._library_emergency_stage is None
+        assert screen._library_notes_compact is True
+
+        applied = Mock(wraps=screen._apply_library_notes_stage_visibility)
+        screen._apply_library_notes_stage_visibility = applied
+
+        # These frames DO change the wider resize signature -- they cross the
+        # 100-cell Ingest auto-collapse bucket, so ``on_resize``'s outer gate
+        # cannot skip them and the legs really run -- but they cross neither
+        # band the stage leg reads. This is the shape the regression turned
+        # into per-frame Notes work.
+        for width in (105, 98, 96, 102):
+            await pilot.resize_terminal(width, 30)
+            await pilot.pause()
+            await pilot.pause()
+        assert applied.call_count == 0, (
+            f"{applied.call_count} stage-visibility applications across 4 "
+            "resize frames that cross no band the stage leg reads"
+        )
+        assert screen._library_emergency_stage is None
+
+        # Crossing INTO the emergency band. No compact crossing happens here
+        # (102 and 63 are both below 120), so this gate is the only thing
+        # that can engage the takeover.
+        applied.reset_mock()
+        await pilot.resize_terminal(63, 30)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_emergency_stage is not None,
+            message="63-column resize never engaged the emergency stage",
+        )
+        assert applied.call_count == 1, (
+            f"{applied.call_count} stage-visibility applications for one "
+            "emergency-band crossing"
+        )
+        rail = screen.query_one("#library-rail")
+        canvas = screen.query_one("#library-canvas")
+        assert rail.display != canvas.display
+
+        # Crossing back OUT restores the ordinary two-pane stage, again with
+        # no compact crossing to fall back on.
+        applied.reset_mock()
+        await pilot.resize_terminal(64, 30)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_emergency_stage is None,
+            message="64-column resize never released the emergency stage",
+        )
+        assert applied.call_count == 1, (
+            f"{applied.call_count} stage-visibility applications for one "
+            "emergency-band release"
+        )
+        assert screen.query_one("#library-rail").display
+        assert screen.query_one("#library-canvas").display
+
+        # And the gate re-arms: further same-side frames are free again.
+        applied.reset_mock()
+        for width in (105, 98, 96, 102):
+            await pilot.resize_terminal(width, 30)
+            await pilot.pause()
+            await pilot.pause()
+        assert applied.call_count == 0, (
+            f"{applied.call_count} stage-visibility applications after the "
+            "crossing settled; the gate did not re-arm"
+        )
 
 
 @pytest.mark.asyncio

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9444,3 +9444,58 @@ visibility are independent in Textual. The same review found the mirror image in
 Settings search landing: `.focus()` is a silent no-op on a disabled widget and happily
 focuses a field inside a collapsed disclosure, so a "landing" can succeed in code while
 the user sees nothing move.
+
+## A per-frame gate's signature must carry the DECISION, not the raw input
+
+**TASK-23151, 2026-08-28.** `library_screen.py` now has three cheap-state gates
+that skip per-frame work when a signature tuple is unchanged. Building the third
+one, two of its slots were wrong in ways that reasoning could not see and only
+`assert n == 0` could — the ratchet went 201/100 applications before the fix,
+then 1/100, then 1/1, then 0/0, one wrong slot at a time.
+
+- **Raw bucket instead of the effective decision.** The slot held
+  `ordinary_emergency_required(width)` — true below 64 cells. But
+  `_apply_library_emergency_geometry` acts only when that AND
+  `_library_ordinary_route_active()` hold, and on the Notes route it never
+  holds. So the bucket flipped on every 60-cell frame of a route where the
+  geometry is inert, and the gate applied for nothing. Carrying the conjunction
+  the code actually branches on fixed it.
+- **A value another subsystem owns.** `rail.display` was carried "to catch an
+  outside mutation". Under an adaptive reader shell, the reader's own
+  `sync_layout` owns the rail and hides it purely as a function of width — so
+  the slot changed on every same-side resize, holding the wide case at 100
+  applications. The leg returns before its own rail toggles in that branch, i.e.
+  it never reads the value there. Carrying it only while the legacy path owns it
+  fixed it.
+
+Neither was found by reading the code. Both were found by printing the index of
+the differing tuple slot on each skipped-then-unskipped frame — a ten-line probe
+that names the slot, versus a plausible story about why the gate "should" work.
+
+A third shape mattered too: recording the applied signature inside the GATE left
+exactly one application per burst, because any other seam's call left the record
+cleared. Recording it inside the applied function itself — cleared first, then
+re-taken after the legs, since they mutate flags the signature reads — arms the
+gate from all ~20 seams and gets the true zero.
+
+**What to do.** When a gate skips work, do not accept "the signature looks
+right". Instrument which slot differs on the frames that still run, and require
+the ratchet's own number to reach the asserted value; and for each slot ask two
+questions — does the guarded code branch on this raw value or on a conjunction,
+and does anything outside the guarded code write it?
+
+## `ruff format` on a whole file here reformats code you did not touch
+
+**TASK-23151, 2026-08-28.** After adding ~110 lines to `library_screen.py`,
+`ruff format --check` flagged the file, so the fix was formatted. It rewrote
+**20+ unrelated regions** across the 38k-line file (diffstat went from 125/2 to
+209/67), burying a five-hunk change in churn and forcing a full restore from
+`HEAD` plus a manual re-apply of every edit. The pre-check that made it look
+safe — piping the `HEAD` blob through `ruff format --check --stdin-filename` —
+printed nothing and was read as "clean"; it is not a reliable clean signal.
+
+**What to do.** This repo is not `ruff format`-clean under the installed ruff,
+and no CI job enforces it. Never run the formatter over a whole file to tidy
+your own addition — hand-wrap the lines you added instead, and check your diff
+hunk list (`git diff -U0 | grep '^@@'`) before committing: every hunk should be
+one you can name.

--- a/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
+++ b/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
@@ -124,6 +124,18 @@ pollution). `Tests/UI/test_library_resize_focus_gates_t23025.py` 9 passed;
 `test_library_notes_reader.py` + `test_library_entry_compose_once.py` +
 `test_library_honesty_accessibility.py` 139 passed. `./scripts/preflight.sh` green.
 
+**Review round (Qodo, Testability).** The gate was covered only through the Textual harness, so
+its own branches had no focused test. Added 8 unit tests driving the shipped functions -- taken
+unbound from `LibraryScreen` onto a fake screen (`_StageGateScreen`), with only the leg itself
+replaced by a counter -- covering skip (unchanged signature), apply (changed signature, exactly
+once, then re-armed), fail-open (unavailable signature, where both sides of the comparison are
+`None`), and the three shapes measurement forced: the effective-not-raw emergency decision, the
+rail/canvas display carried only while the legacy path owns them, and the record being taken
+inside `_apply_library_notes_stage_visibility` so every seam arms the gate (plus the clear-first
+ordering that keeps a raising leg from leaving a stale record). Each assertion was mutation-tested
+against the branch it covers; the four single-line shape mutations each redden exactly one test.
+`Tests/UI/test_library_resize_focus_gates_t23025.py` now 17 passed, both ratchet params still 0.
+
 Modified files: `tldw_chatbook/UI/Screens/library_screen.py`,
 `Tests/UI/test_library_resize_focus_gates_t23025.py`,
 `backlog/docs/lessons-testing-evidence.md`.

--- a/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
+++ b/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
@@ -1,10 +1,6 @@
 ---
 id: TASK-23151
 title: Library on_resize does unconditional Notes work on every frame again
-status: To Do
-assignee: []
-created_date: '2026-08-28'
-
 status: Done
 assignee: []
 created_date: '2026-08-28'
@@ -13,16 +9,11 @@ labels:
   - performance
   - library
   - regression
-priority: high
-dependencies: []
-
 dependencies: []
 priority: high
 ---
 
 ## Description
-
-
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 The 2026-08-02 ratchet `test_library_note_fifty_same_side_resize_sequences_do_zero_notes_work`
@@ -34,14 +25,6 @@ correct and must stay at `== 0`.
 This is the same defect class TASK-23025 eliminated from the resize path days earlier — per-frame
 work reaching the DOM on frames that changed nothing — so it also erodes a fix the 2026-08-27
 performance review just shipped.
-
-## Acceptance Criteria
-
-- [ ] A same-side resize sequence that crosses no layout band performs zero Notes stage-visibility
-  work, with the existing ratchet unchanged and still asserting `== 0`
-- [ ] Band-crossing resizes still apply stage visibility exactly once per crossing
-- [ ] The emergency-return path added by the introducing commit keeps its behaviour (a regression
-
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -61,8 +44,6 @@ call to `_update_library_notes_responsive_state` (`:7237`).
 
 Introduced by `6161bd1fe19` (2026-08-26) "feat(library): add narrow emergency return path", on dev
 via merge `6bed8d6f59` (PR #2124). Reproduces standalone, so it is not test pollution.
-
-
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
+++ b/backlog/tasks/task-23151 - Library on_resize does unconditional Notes work on every frame again.md
@@ -4,16 +4,27 @@ title: Library on_resize does unconditional Notes work on every frame again
 status: To Do
 assignee: []
 created_date: '2026-08-28'
+
+status: Done
+assignee: []
+created_date: '2026-08-28'
+updated_date: '2026-08-28 23:32'
 labels:
   - performance
   - library
   - regression
 priority: high
 dependencies: []
+
+dependencies: []
+priority: high
 ---
 
 ## Description
 
+
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
 The 2026-08-02 ratchet `test_library_note_fifty_same_side_resize_sequences_do_zero_notes_work`
 asserts that a resize which does not cross a layout band does **zero** Notes work. It now measures
 **300** calls to `_apply_library_notes_stage_visibility` across 50 resizes (both parametrised
@@ -30,6 +41,15 @@ performance review just shipped.
   work, with the existing ratchet unchanged and still asserting `== 0`
 - [ ] Band-crossing resizes still apply stage visibility exactly once per crossing
 - [ ] The emergency-return path added by the introducing commit keeps its behaviour (a regression
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A same-side resize sequence that crosses no layout band performs zero Notes stage-visibility
+  work, with the existing ratchet unchanged and still asserting `== 0`
+- [x] #2 Band-crossing resizes still apply stage visibility exactly once per crossing
+- [x] #3 The emergency-return path added by the introducing commit keeps its behaviour (a regression
   test covers the narrow-emergency case it was added for)
 
 ## Evidence
@@ -41,3 +61,70 @@ call to `_update_library_notes_responsive_state` (`:7237`).
 
 Introduced by `6161bd1fe19` (2026-08-26) "feat(library): add narrow emergency return path", on dev
 via merge `6bed8d6f59` (PR #2124). Reproduces standalone, so it is not test pollution.
+
+
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read `6161bd1fe19` and establish WHY the call sits above the crossing return before moving
+   anything; measure the ratchet's real call counts first.
+2. Decide between the two shapes the evidence allows -- relocate the call below the crossing
+   early-out, or gate it on a changed stage signature (the TASK-23025 pattern in this file).
+3. Implement the chosen shape and prove the other one is wrong with a mutation.
+4. Prove a band CROSSING still applies stage visibility exactly once, for both bands.
+5. Run the whole of `Tests/UI/test_library_shell.py` plus the Library resize/reader/honesty files
+   and compare failure name sets against pristine dev.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Shape chosen: gate, not move.** Reading `6161bd1fe19` shows the call was added above the
+crossing early-out because the ordinary emergency band (`LIBRARY_EMERGENCY_WIDTH`, 64 cells) is a
+DIFFERENT band from `LIBRARY_NOTES_COMPACT_BREAKPOINT` (120). A 63 <-> 64 resize crosses only the
+former, and the commit's own tests drive exactly that (`...restore_is_defeated_by_newer_return_
+interaction` resizes 80 -> 63 -> 64 -> 63 -> 64, never touching 120). Moving the call below the
+crossing return therefore strands the emergency takeover entirely -- verified by mutation: the new
+regression test fails with "63-column resize never engaged the emergency stage".
+
+The fix adds `_library_notes_stage_signature()` -- a cheap tuple (cached refs from
+`_library_layout_ref`, plus flags; no DOM walk) of exactly the inputs
+`_apply_library_notes_stage_visibility` turns into writes -- and
+`_apply_library_notes_stage_visibility_for_resize()`, which the two resize legs
+(`on_resize` and `_update_library_notes_responsive_state`) now call in place of the raw leg. The
+signature carries the EFFECTIVE emergency decision (`_library_ordinary_route_active()` AND the
+width bucket), not the raw width bucket, because on the non-ordinary routes the geometry is inert
+and the raw bucket flips for nothing.
+
+Two things the first attempt got wrong, both found by measurement rather than reasoning:
+
+- Carrying `rail.display`/`canvas.display` unconditionally kept the wide case at 100 calls. Under
+  an adaptive reader shell those are owned by the reader's own `sync_layout`, which hides the rail
+  purely as a function of width -- and the stage leg returns before its own toggles in that branch,
+  so it never reads them. They are now carried only while the legacy path owns them.
+- Recording the applied signature only inside the resize gate left exactly 1 call per burst (the
+  first frame after any other seam had applied). `_apply_library_notes_stage_visibility` is now a
+  thin wrapper that clears the record, runs the legs (`_apply_library_notes_stage_legs`, the
+  unchanged body), and records the POST-apply signature -- so every one of the screen's ~20 seams
+  arms the gate, and a leg that raises leaves it re-armed rather than stale.
+
+Measured with the ratchet itself: 201 and 100 applications before, 0 and 0 after. Crossings still
+cost exactly one application each -- compact band both ways, twice over (pinned in
+`test_resize_compact_crossing_still_transitions_both_ways_twice`), and the emergency band in and
+out (`test_stage_visibility_runs_once_per_emergency_band_crossing`, which is born-red against BOTH
+wrong shapes: 2 != 0 against the unconditional call, and a stranded emergency stage against the
+relocated one).
+
+**Verification.** `Tests/UI/test_library_shell.py` runs 823 passed / 0 failed with
+`-p no:randomly` on this branch, so there is no failure name set to diff -- it is empty, a strict
+subset of any dev baseline (which carries the two ratchet params plus the TASK-23153 in-file
+pollution). `Tests/UI/test_library_resize_focus_gates_t23025.py` 9 passed;
+`test_library_notes_reader.py` + `test_library_entry_compose_once.py` +
+`test_library_honesty_accessibility.py` 139 passed. `./scripts/preflight.sh` green.
+
+Modified files: `tldw_chatbook/UI/Screens/library_screen.py`,
+`Tests/UI/test_library_resize_focus_gates_t23025.py`,
+`backlog/docs/lessons-testing-evidence.md`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3944,6 +3944,14 @@ class LibraryScreen(BaseAppScreen):
         self._library_layout_ref_cache: dict[str, Widget] = {}
         self._library_compose_ref_cache: dict[str, Widget | None] = {}
         self._library_resize_applied_signature: tuple[Any, ...] | None = None
+        # TASK-23151: the resize legs' stage-visibility call runs ABOVE the
+        # compact-crossing early-out, because the emergency band (64 cells)
+        # is a different band from the compact breakpoint (120) and a 63<->64
+        # crossing must still re-apply geometry. This records the signature
+        # ``_apply_library_notes_stage_visibility`` last settled -- refreshed
+        # by that function on EVERY call, so no seam can leave it stale --
+        # and a resize frame matching it skips the leg entirely.
+        self._library_notes_stage_applied_signature: tuple[Any, ...] | None = None
         self._library_compose_generation = 0
         self._library_reader_shell_ref: Widget | None = None
         self._library_reader_shell_probe_generation = -1
@@ -5822,7 +5830,118 @@ class LibraryScreen(BaseAppScreen):
         )
         return True
 
+    def _library_notes_stage_signature(self) -> tuple[Any, ...] | None:
+        """Signature of every input the stage-visibility leg turns into a write.
+
+        TASK-23151: built from cached widget references and cheap flags only
+        (the TASK-23025 pattern in this file) so a resize frame can decide,
+        before any query work, whether ``_apply_library_notes_stage_visibility``
+        could write anything different. It mirrors, in order, the compact
+        class inputs, ``_apply_library_emergency_geometry``'s effective
+        decision (route gate AND width bucket -- the raw bucket alone flips
+        on non-ordinary routes where the geometry is inert), and the
+        single-stage/focused-task flags the display toggles derive from.
+        Returns ``None`` when it cannot be decided cheaply; callers then run
+        the full leg, exactly as before.
+
+        Returns:
+            The signature tuple, or ``None`` when it cannot be computed cheaply.
+        """
+        if not self.is_mounted:
+            return None
+        shell = self._library_layout_ref("#library-shell-grid")
+        rail = self._library_layout_ref("#library-rail")
+        canvas = self._library_layout_ref("#library-canvas")
+        if shell is None or rail is None or canvas is None:
+            return None
+        # The emergency leg measures exactly this width, so the signature must
+        # too -- a wider grid inside a narrower viewport is still an emergency.
+        width = min(shell.region.width, self.size.width)
+        if width <= 0:
+            return None
+        reader_active = self._library_adaptive_reader_shell_active()
+        emergency = self._library_ordinary_route_active() and (
+            ordinary_emergency_required(width)
+        )
+        reader_shell_id = (
+            getattr(self._library_reader_shell_ref, "id", None)
+            if reader_active
+            else None
+        )
+        return (
+            self._library_compose_generation,
+            shell,
+            rail,
+            canvas,
+            reader_active,
+            reader_shell_id,
+            self._library_selected_row_id,
+            self._library_notes_source,
+            self._library_notes_view,
+            self._library_notes_stage,
+            self._library_notes_compact,
+            self._library_rail_collapsed,
+            self._library_notes_compact_stage_applies(),
+            self._library_notes_focused_task_active(),
+            self._library_emergency_stage,
+            self._library_emergency_restore_receipt is not None,
+            self._library_reader_shared_preferences,
+            # Rail/canvas display are what the legacy stage toggles WRITE, so
+            # they are carried to catch an outside mutation -- but only while
+            # the legacy path owns them. Under an adaptive reader shell the
+            # leg returns before the toggles and the reader's own
+            # ``sync_layout`` owns the rail, hiding it purely as a function of
+            # width; carrying it there made every same-side resize look like a
+            # change (TASK-23151).
+            rail.display if not reader_active else None,
+            canvas.display if not reader_active else None,
+            emergency,
+            # Below the hard floor the emergency leg is the ONLY writer of the
+            # rail width contract (``_sync_library_ordinary_rail_width_contract``
+            # returns early there), so the raw width matters inside the band
+            # and nowhere else.
+            width if emergency else None,
+        )
+
+    def _apply_library_notes_stage_visibility_for_resize(self) -> None:
+        """Run the stage-visibility leg only on a frame that can change it.
+
+        TASK-23151: the resize legs must call this leg above their
+        compact-crossing early-out, because the ordinary emergency band
+        (``LIBRARY_EMERGENCY_WIDTH``, 64 cells) is a different band from
+        ``LIBRARY_NOTES_COMPACT_BREAKPOINT`` (120) and a 63<->64 resize
+        crosses only the former. Calling it unconditionally, however, put
+        per-frame DOM work back on every same-side resize -- the exact defect
+        the 2026-08-02 zero-work ratchet exists to hold at zero. Gate, do not
+        move: moving the call below the crossing return would strand the
+        narrow emergency return path.
+        """
+        signature = self._library_notes_stage_signature()
+        if (
+            signature is not None
+            and signature == self._library_notes_stage_applied_signature
+        ):
+            return
+        self._apply_library_notes_stage_visibility()
+
     def _apply_library_notes_stage_visibility(self) -> None:
+        """Apply compact classes and mutually exclusive mounted stage visibility.
+
+        TASK-23151: every call -- from any of this screen's ~20 seams, not
+        only the resize legs -- records the signature of the state it just
+        settled, so ``_apply_library_notes_stage_visibility_for_resize`` can
+        skip a frame that cannot change the result. The record is taken
+        AFTER the legs because they mutate flags the signature reads (rail
+        and canvas display, the emergency stage), and it is cleared first so
+        a leg that raises leaves the gate re-armed rather than stale.
+        """
+        self._library_notes_stage_applied_signature = None
+        self._apply_library_notes_stage_legs()
+        self._library_notes_stage_applied_signature = (
+            self._library_notes_stage_signature()
+        )
+
+    def _apply_library_notes_stage_legs(self) -> None:
         """Apply compact classes and mutually exclusive mounted stage visibility."""
         if not self.is_mounted:
             return
@@ -7305,7 +7424,7 @@ class LibraryScreen(BaseAppScreen):
             return
         self._sync_library_ingest_rail_for_width(width)
         self._sync_library_ordinary_rail_width_contract()
-        self._apply_library_notes_stage_visibility()
+        self._apply_library_notes_stage_visibility_for_resize()
         compact = width < LIBRARY_NOTES_COMPACT_BREAKPOINT
         if compact == self._library_notes_compact:
             self._library_notes_pre_resize_focus = None
@@ -7524,7 +7643,7 @@ class LibraryScreen(BaseAppScreen):
             return
         self._sync_library_ingest_rail_for_width(width)
         self._sync_library_ordinary_rail_width_contract()
-        self._apply_library_notes_stage_visibility()
+        self._apply_library_notes_stage_visibility_for_resize()
         compact = width < LIBRARY_NOTES_COMPACT_BREAKPOINT
         if compact == self._library_notes_compact:
             self._library_notes_pre_resize_focus = None
@@ -13072,6 +13191,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_compose_ref_cache.clear()
         self._library_reader_shell_ref = None
         self._library_resize_applied_signature = None
+        self._library_notes_stage_applied_signature = None
         shell_input = self._build_library_shell_input()
         shell = build_library_shell_state(
             shell_input, selected_row_id=self._library_selected_row_id


### PR DESCRIPTION
## Summary

A resize that crosses no layout band was doing Notes stage-visibility work on every frame, against a
2026-08-02 ratchet that demands **zero**. Same defect class TASK-23025 removed from this path days
earlier, reintroduced by `6161bd1fe19` (PR #2124).

| param | before | after |
|---|---|---|
| 80x24, sweep 100/60/80, compact | **201** | **0** |
| 120x30, sweep 170/140/120, wide | **100** | **0** |

(The filing said 300; the real numbers are 201 and 100.) **The ratchet is unchanged and still
asserts `== 0`.**

## Gate, not move — and the reason matters

The obvious fix is to push the call below the compact-crossing early-return. That is wrong. The
**ordinary emergency band (`LIBRARY_EMERGENCY_WIDTH` = 64) is a different band from
`LIBRARY_NOTES_COMPACT_BREAKPOINT` (120)**. A 63↔64 resize crosses only the former, and the
introducing commit's own tests drive exactly that (80→63→64→63→64, never touching 120). Moving the
call strands the emergency takeover entirely.

So the call stays where it is and is gated on a cheap `_library_notes_stage_signature()` — the
TASK-23025 pattern. Two details found by measurement, not by reading:

- The signature carries the **effective** emergency decision (`_library_ordinary_route_active()` AND
  the width bucket), not the raw bucket, which flips on routes where the geometry is inert.
- `rail.display`/`canvas.display` are carried **only while the legacy path owns them**; under an
  adaptive reader shell the reader's own `sync_layout` hides the rail purely as a function of width,
  and carrying it there held the wide case at 100 calls.
- The applied signature is recorded inside `_apply_library_notes_stage_visibility` itself, so all
  ~20 seams arm the gate. Recording only in the gate left exactly 1 call per burst.

## Both wrong shapes were made to fail

New `test_stage_visibility_runs_once_per_emergency_band_crossing`, mutation-verified against each:

- ungated call → `2 != 0` on the same-side legs;
- call relocated below the crossing return → *"63-column resize never engaged the emergency stage"*.

The pre-existing `test_resize_emergency_crossing_still_engages_and_restores` **passes** under that
second mutation (it uses 170→60→170, crossing both bands), so this test adds real coverage rather
than duplicating it. Crossing cost is pinned at exactly one application per crossing, both bands,
both directions.

## Verification

`Tests/UI/test_library_shell.py`: **823 passed, 0 failed** — an empty failure set, so no diff against
any dev baseline is possible. Wider Library geometry batch (11 files, 217 tests): 5 failures, and
restoring `library_screen.py` to pristine HEAD reproduced the **identical 5-name set** — pre-existing.
`./scripts/preflight.sh` green.

## Two traps worth recording

- **`ruff format` on this file is a trap.** Formatting the addition rewrote 20+ unrelated regions of
  the 38k-line file (diffstat 125/2 → 209/67). The file was restored and every edit re-applied by
  hand; the final diff is 6 named hunks. The repo is not `ruff format`-clean under the installed
  ruff and no CI job enforces it.
- **`backlog task edit` renamed the task file** from spaces to hyphens, which would have collided
  with PR #2178's copy on merge. Renamed back; preflight's duplicate-id check is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the Library resize stage-visibility leg on a cheap signature so same-side resizes do zero Notes work again (201/100 applications per sweep before, 0/0 after), while band crossings still apply exactly once. The leg is gated rather than moved because the emergency band (64 cells) is a different band from the compact breakpoint (120), so a 63↔64 resize must still engage the emergency stage.

- The gate signature carries the effective emergency decision (route-active AND width bucket), not the raw bucket, which flips on routes where the geometry is inert.
- `rail.display`/`canvas.display` are carried only while the legacy path owns them; under an adaptive reader shell the reader's own `sync_layout` owns them.
- The applied signature is recorded inside `_apply_library_notes_stage_visibility` itself, so all ~20 seams arm the gate.
- New harness test pins one application per crossing for both bands; 8 new unit tests cover gate branches on a fake screen.
- Restores the TASK-23151 backlog file a rebase resolver mangled by keeping both sides (duplicate status keys and acceptance blocks).

<sup>Written for commit a2eac5dba640488c653a67d9dd4e26db3136deae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

