### PR TITLE
fix(ui): stop a popped screen's focus from crashing a worker

### DIFF
--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -111,11 +111,21 @@ from tldw_chatbook.UI.Wizards.FirstRunSetupWizard import (
 )
 
 
+#: Ceiling for a settle wait, not a performance assertion (TASK-23113).
+#: These helpers return the instant their condition holds, so a larger ceiling
+#: costs a green run nothing -- it only widens the headroom before a loaded
+#: machine is mistaken for a stuck UI. The old 10s default was too tight for a
+#: full sweep: ~890 Textual harnesses share one process, and five different
+#: tests each failed once with "condition was not met within 10.0s" (or an
+#: equivalent settle) while passing alone and on pristine dev.
+_SETTLE_TIMEOUT_SECONDS = 30.0
+
+
 async def _wait_until(
     pilot,
     condition: Callable[[], bool],
     *,
-    timeout_seconds: float = 10.0,
+    timeout_seconds: float = _SETTLE_TIMEOUT_SECONDS,
     interval_seconds: float = 0.05,
 ) -> None:
     deadline = time.monotonic() + timeout_seconds
@@ -2557,7 +2567,7 @@ async def test_speech_step_install_button_visible_at_120x40_without_scrolling(
                     and not disk[0].disabled
                 )
 
-            await _wait_until(pilot, _speech_actions_ready, timeout_seconds=10.0)
+            await _wait_until(pilot, _speech_actions_ready)
 
             install_button = app.screen.query_one("#setup-speech-install", Button)
             disk_button = app.screen.query_one("#setup-speech-use-from-disk", Button)
@@ -3392,14 +3402,13 @@ async def test_local_provider_probe_feedback_is_visible_and_adjacent(
             # P-7: selection alone produces reachability feedback (nothing
             # listens on the endpoint in this environment).
             await _wait_until(
-                pilot, lambda: str(status.renderable) != "", timeout_seconds=15.0
+                pilot, lambda: str(status.renderable) != ""
             )
             # P-6: Test always ends in a visible verdict.
             provider.query_one("#setup-provider-test", Button).press()
             await _wait_until(
                 pilot,
                 lambda: str(status.renderable).startswith(("✗", "✓")),
-                timeout_seconds=15.0,
             )
             # Adjacency: the status renders above the auth collapsible, next
             # to the connection controls — not at the panel's bottom.
@@ -3559,7 +3568,6 @@ async def test_provider_test_button_requests_identity_encoding_from_a_real_peer(
                     pilot,
                     lambda: bool(server.accept_encodings)
                     and str(status.renderable).startswith(("✗", "✓")),
-                    timeout_seconds=25.0,
                 )
 
     assert server.accept_encodings, "the step never reached the models endpoint"
@@ -3693,7 +3701,6 @@ async def test_model_step_renders_auth_copy_on_both_handoff_branches(
             await _wait_until(
                 pilot,
                 lambda: _current_step_id(container) == STEP_MODEL,
-                timeout_seconds=20.0,
             )
             model_step = container.steps[container.current_step]
             # The placeholder is a non-empty label too, so waiting on
@@ -3709,7 +3716,6 @@ async def test_model_step_renders_auth_copy_on_both_handoff_branches(
                     ])
                     and all("loading models" not in label for label in labels)
                 ),
-                timeout_seconds=20.0,
             )
             rendered = " ".join(
                 str(button.label)
@@ -3804,7 +3810,6 @@ async def test_production_sized_catalog_reaches_the_model_picker(
                 await _wait_until(
                     pilot,
                     lambda: _current_step_id(container) == STEP_MODEL,
-                    timeout_seconds=20.0,
                 )
                 model_step = container.steps[container.current_step]
                 for _ in range(60):

--- a/Tests/UI/test_settings_panel_scoped_updates.py
+++ b/Tests/UI/test_settings_panel_scoped_updates.py
@@ -304,3 +304,58 @@ async def test_sync_rows_refresh_runs_once_per_visit(monkeypatch):
             "A later resume must refresh again: sync state can move while "
             "Settings is suspended."
         )
+
+
+def test_focus_owner_check_survives_a_detached_focused_widget():
+    """A popped screen's widget must not crash the sync-row refresh.
+
+    TASK-23113. ``DOMNode.screen`` RAISES ``NoScreen`` for a detached node,
+    so the original guard -- ``focused.screen is self`` -- exploded before it
+    could protect anything. ``App.focused`` legitimately outlives its screen:
+    push the first-run wizard over Settings and pop it, and the worker-driven
+    ``_apply_sync_rows`` lands with ``app.focused`` still pointing at a
+    NavigationButton that has left the tree. That surfaced as
+    ``WorkerFailed: NoScreen('node has no screen')`` and failed
+    ``test_rerun_over_settings_review_settings_returns_to_settings`` 3 times
+    in 10 isolated runs; 0 in 12 after the guard.
+    """
+    from textual.dom import NoScreen
+
+    from tldw_chatbook.UI.focus_ownership import (
+        focus_is_on_screen,
+        focused_id_on_screen,
+    )
+
+    screen = object()
+
+    class _Detached:
+        id = "nav-home"
+
+        @property
+        def screen(self):
+            raise NoScreen("node has no screen")
+
+    class _OnScreen:
+        id = "nav-home"
+
+        @property
+        def screen(self):
+            return screen
+
+    class _Elsewhere:
+        id = "nav-home"
+
+        @property
+        def screen(self):
+            return object()
+
+    # The regression: a detached widget must read as "not ours", not raise.
+    assert focus_is_on_screen(_Detached(), screen) is False
+    assert focused_id_on_screen(_Detached(), screen) is None
+    # And the ordinary answers are unchanged.
+    assert focus_is_on_screen(_OnScreen(), screen) is True
+    assert focused_id_on_screen(_OnScreen(), screen) == "nav-home"
+    assert focus_is_on_screen(_Elsewhere(), screen) is False
+    assert focused_id_on_screen(_Elsewhere(), screen) is None
+    assert focus_is_on_screen(None, screen) is False
+    assert focused_id_on_screen(None, screen) is None

--- a/backlog/tasks/task-23113 - Wizard-suite-has-order-load-dependent-flakes-a-different-test-fails-on-most-full-sweeps.md
+++ b/backlog/tasks/task-23113 - Wizard-suite-has-order-load-dependent-flakes-a-different-test-fails-on-most-full-sweeps.md
@@ -3,9 +3,11 @@ id: TASK-23113
 title: >-
   Wizard suite has order/load-dependent flakes: a different test fails on most
   full sweeps
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-28 22:11'
+updated_date: '2026-08-29 00:04'
 labels: []
 dependencies: []
 ---
@@ -22,20 +24,14 @@ Running Tests/UI/test_first_run_wizard_live_contract.py plus Tests/Wizards toget
 - [ ] #2 The shared state or timing causing cross-test interference is identified and documented
 <!-- AC:END -->
 
-## Observed (2026-08-28)
+## Implementation Plan
 
-Four distinct tests each failed exactly once across sweeps of the same two
-paths, and each passed alone immediately afterwards:
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce and capture the actual assertion delta.\n2. Find the shared state or timing that leaks between tests.\n3. Fix the leak (or the fence) and prove the sweep is repeatable.
+<!-- SECTION:PLAN:END -->
 
-- `Tests/Wizards/test_first_run_setup_wizard.py::test_mounted_model_owner_timeout_fences_late_result_and_keeps_manual_retry`
-- `Tests/UI/test_first_run_wizard_live_contract.py::test_recovery_save_failure_reprompts_then_succeeds_once[False]`
-- `Tests/Wizards/test_first_run_setup_wizard.py::TestComposeCrashPolicy::test_optional_step_failure_is_removed_and_reported_in_summary` (twice)
-- `Tests/UI/test_first_run_wizard_live_contract.py::test_rerun_over_settings_review_settings_returns_to_settings` (twice; also on record from the original UAT)
+## Implementation Notes
 
-Control: the identical sweep on a detached, pristine `origin/dev` failed the
-same way (`TestComposeCrashPolicy::test_optional_step_failure...`, 890
-passed). So this is inherent to the suite, not to any branch under review.
-
-Several of the affected tests are timing-fenced (explicit timeouts, worker
-settle waits), which is consistent with load sensitivity when ~890 Textual
-app harnesses run in one process.
+<!-- SECTION:NOTES:BEGIN -->
+Two causes, both fixed. (1) Root cause of the most reproducible flake: DOMNode.screen RAISES NoScreen for a detached node, so the guard 'focused.screen is self' exploded before it could protect anything. App.focused outlives its screen when the first-run wizard is pushed over Settings and popped, and the worker-driven _apply_sync_rows then crashed with WorkerFailed: NoScreen. Measured on test_rerun_over_settings_review_settings_returns_to_settings in isolation: 3/10 failures at baseline, 1/10 with the timeout change alone, 0/12 with the guard. Two sibling sites had the identical unguarded pattern (settings_screen focus-restore, evals_screen focus-restore); all three now route through UI/focus_ownership.py, and no unguarded 'focused.screen' read remains. (2) The live-contract settle ceiling was 10s, too tight for a full sweep where ~890 Textual harnesses share a process; raised to a single _SETTLE_TIMEOUT_SECONDS = 30 and the seven per-call overrides folded into it. A wait returns the instant its condition holds, so this costs a green run nothing. Result: 5 consecutive clean 892-test sweeps, where before roughly half failed with a different test each time. Not claiming eradication -- these are probabilistic -- but the mechanism behind the reproducible one is a real product bug that would also fire in production, and it is gone.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/evals_screen.py
+++ b/tldw_chatbook/UI/Screens/evals_screen.py
@@ -41,6 +41,8 @@ from textual.containers import Vertical
 from textual.css.query import QueryError
 from textual.widgets import Button, Static
 
+from tldw_chatbook.UI.focus_ownership import focus_is_on_screen
+
 from ...Chat.Chat_Functions import chat_api_call
 from ...DB.Evals_DB import ConflictError, EvalsDB
 from ...Evals.character_probe.cards import snapshot_cards
@@ -568,7 +570,7 @@ class EvalsScreen(LabScreen):
             unidentifiable, or on a widget that survives.
         """
         focused = self.app.focused if self.is_running else None
-        if focused is None or focused.screen is not self or not focused.id:
+        if not focus_is_on_screen(focused, self) or not focused.id:
             return None
         region_ids = ["lab-body", "lab-inspector"]
         if rail_dirty:

--- a/tldw_chatbook/UI/Screens/evals_screen.py
+++ b/tldw_chatbook/UI/Screens/evals_screen.py
@@ -41,8 +41,7 @@ from textual.containers import Vertical
 from textual.css.query import QueryError
 from textual.widgets import Button, Static
 
-from tldw_chatbook.UI.focus_ownership import focus_is_on_screen
-
+from ..focus_ownership import focus_is_on_screen
 from ...Chat.Chat_Functions import chat_api_call
 from ...DB.Evals_DB import ConflictError, EvalsDB
 from ...Evals.character_probe.cards import snapshot_cards

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -48,6 +48,10 @@ from textual.widgets import (
 )
 from textual.widgets.option_list import Option
 
+from tldw_chatbook.UI.focus_ownership import (
+    focus_is_on_screen,
+    focused_id_on_screen,
+)
 from tldw_chatbook.Utils.about_text import ABOUT_MARKDOWN, get_app_version
 
 from ...Chat.Chat_Deps import ChatConfigurationError
@@ -3211,7 +3215,7 @@ class SettingsScreen(BaseAppScreen):
             two rebuilt panes or on a widget with no id to find it by.
         """
         focused = self.app.focused if getattr(self, "is_running", False) else None
-        if focused is None or focused.screen is not self or not focused.id:
+        if not focus_is_on_screen(focused, self) or not focused.id:
             return None
         for ancestor in focused.ancestors_with_self:
             if getattr(ancestor, "id", None) in (
@@ -8127,11 +8131,7 @@ class SettingsScreen(BaseAppScreen):
             or manual_rows != self.manual_sync_rows
         )
         focused = self.app.focused
-        focused_id = (
-            focused.id
-            if focused is not None and focused.screen is self and focused.id
-            else None
-        )
+        focused_id = focused_id_on_screen(focused, self)
         self.server_sync_workspace_handoff_rows = handoff_rows
         self.manual_sync_rows = manual_rows
         if changed:

--- a/tldw_chatbook/UI/focus_ownership.py
+++ b/tldw_chatbook/UI/focus_ownership.py
@@ -1,0 +1,60 @@
+"""Whether the app's focus still belongs to a given screen.
+
+Deliberately dependency-light: it imports only ``NoScreen`` so that screens
+can use it without pulling in a module that defines widget classes (a
+class-level ``DEFAULT_CSS`` costs a Textual stylesheet parse-cache slot).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.dom import NoScreen
+
+__all__ = ["focus_is_on_screen", "focused_id_on_screen"]
+
+
+def focus_is_on_screen(focused: Any, screen: Any) -> bool:
+    """Return whether ``focused`` is still attached to ``screen``.
+
+    ``DOMNode.screen`` RAISES ``NoScreen`` for a detached node, so the
+    obvious guard -- ``focused.screen is screen`` -- explodes before it can
+    protect anything. ``App.focused`` legitimately outlives its screen: push
+    the first-run wizard over Settings and pop it, and a worker-driven
+    refresh can land with ``app.focused`` still pointing at a widget that has
+    left the tree. In Settings' sync-row refresh that raised
+    ``NoScreen('node has no screen')`` inside the worker and surfaced as a
+    WorkerFailed (TASK-23113).
+
+    Args:
+        focused: The currently focused widget, or None.
+        screen: The screen asking whether it still owns that focus.
+
+    Returns:
+        True only when ``focused`` is non-None and still attached to
+        ``screen``; False for None, a detached node, or another screen's.
+    """
+
+    if focused is None:
+        return False
+    try:
+        return focused.screen is screen
+    except NoScreen:
+        return False
+
+
+def focused_id_on_screen(focused: Any, screen: Any) -> str | None:
+    """Return ``focused``'s id, but only while it still lives on ``screen``.
+
+    Args:
+        focused: The currently focused widget, or None.
+        screen: The screen asking whether it still owns that focus.
+
+    Returns:
+        The focused widget's id when it is attached to ``screen`` and has
+        one, otherwise None.
+    """
+
+    if not focus_is_on_screen(focused, screen):
+        return None
+    return getattr(focused, "id", None) or None


### PR DESCRIPTION
**TASK-23113.** The wizard suite failed roughly one test per full sweep, a different one each time, every one passing alone. Chasing it found a **real product bug**, not just test flakiness.

## The bug

`DOMNode.screen` **raises** `NoScreen` for a detached node — so the guard `focused.screen is self` explodes before it can protect anything. And `App.focused` legitimately outlives its screen: push the first-run wizard over Settings, pop it, and the worker-driven `_apply_sync_rows` lands with `app.focused` still pointing at a `NavigationButton` that has left the tree:

```
WorkerFailed: Worker raised exception: NoScreen('node has no screen')
  settings_screen.py:8132 in _apply_sync_rows
  textual/dom.py:806 in screen
```

In production this kills the sync-row refresh the same way — it isn't test-only.

Two sibling sites had the identical unguarded pattern (Settings' and Evals' focus-restore paths). All three now route through `UI/focus_ownership.py`, and no unguarded `focused.screen` read remains in the tree. That module deliberately imports only `NoScreen`: the obvious home, `Utils/widget_helpers.py`, defines a class-level `DEFAULT_CSS`, and importing it from two more screens would spend a Textual stylesheet parse-cache slot for nothing.

## Measured, not asserted

On the most reproducible flake, `test_rerun_over_settings_review_settings_returns_to_settings`, run in isolation:

| tree | failures |
|---|---|
| baseline | **3/10** |
| settle-ceiling change only | 1/10 |
| + the `NoScreen` guard | **0/12** |

## Second change: the settle ceiling

`_wait_until`'s default was 10s — too tight for a full sweep where ~890 Textual harnesses share one process; five different tests each failed once on a settle. It's now a single `_SETTLE_TIMEOUT_SECONDS = 30`, with the seven per-call overrides folded into it. A wait returns the instant its condition holds, so **a green run pays nothing** — only the failure path gets longer.

## Result

**5 consecutive clean 892-test sweeps**, where before roughly half failed.

I'm not claiming eradication — these are probabilistic, and five clean runs can't prove a negative. What I can say is that the mechanism behind the reproducible one is fixed and pinned by a deterministic unit test, confirmed to raise `NoScreen` without the guard.

## Unrelated, flagged not fixed

`Tests/UI/test_settings_configuration_hub.py` has **6 failures on pristine `dev`**. I verified they're identical with and without this branch, so they're pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQ5JJaaUcLAhkHwy1dvSSE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-23113: a worker-driven sync-row refresh crashed with `NoScreen` when `App.focused` outlived a popped screen, and the test suite's 10s settle ceiling caused load-dependent flakes across full sweeps.

**Bug Fixes**
- Routes all three focus checks (Settings, Evals, and sync rows) through `focus_ownership.py`, which treats a detached widget as "not on screen" instead of raising.
- Pins the regression with a deterministic unit test: the reproducible test failed 3/10 runs at baseline and 0/12 with the guard.
- Raises `_wait_until`'s default settle to 30s and folds in seven per-call overrides; waits return the instant their condition holds, so green runs are unaffected.
- `Tests/UI/test_settings_configuration_hub.py` has 6 pre-existing failures on pristine `dev`, identical with and without this branch.

<sup>Written for commit 9a3d534c17ef9325b35a9c0c7edfc73776f5c049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

