### PR TITLE
chore(backlog): close out the Settings+Schedules UX critique arc

### DIFF
--- a/backlog/decisions/099-schedule-editor-shape.md
+++ b/backlog/decisions/099-schedule-editor-shape.md
@@ -1,0 +1,69 @@
+# ADR-099: Schedule creation and editing stay modal
+
+Status: Proposed
+Date: 2026-08-28
+Related Task: TASK-23103 (spike; spawned by the 2026-08-28 Settings+Schedules UX critique)
+
+## Decision
+
+Schedule create/edit remains a modal (`ReminderForm(ModalScreen)`), upgraded in
+place rather than replaced by a detail-pane editor. The modal is the durable
+shape because it is the only one of the candidate shapes that works at every
+supported terminal size without a second code path. The idiom gaps that made
+the modal feel foreign to the workbench are fixed inside the modal
+(TASK-23100 scrolling/height-robustness, TASK-23102 vocabulary; footer-style
+key hints and theme-token styling fold into that work), not by relocating the
+form.
+
+## Context
+
+The 2026-08-28 critique found the creation flow to be the weakest part of an
+otherwise product-native workbench, with a P0 rooted in the modal's fixed
+height (`ReminderForm` stacked fields in a plain `Vertical` inside a
+`max-height: 55` container with no scrolling), and asked the structural
+question: every peer surface (Workflows, Watchlists, Settings) edits in the
+detail pane of a persistent workbench — why is Schedules different? A
+pane-based editor would inherit screen scrolling, the state banner, and
+footer-key consistency structurally, and would keep the queue (existing tasks
+and their next runs) visible while scheduling.
+
+Three shapes were compared against the workbench idiom, keyboard flow, and
+terminal-height/width constraints:
+
+1. **Modal, patched.** Works at every terminal size; creation stays reachable
+   from the empty state (`c`) even at the 80×24 floor. Costs: the height
+   robustness had to be built (TASK-23100), and workbench conventions
+   (footer-visible key hints, shared styling, state text) must be duplicated
+   inside the modal deliberately.
+2. **Detail-pane editor.** Best idiom fit and context visibility — but the
+   workbench already hides the detail and inspector panes at narrow widths
+   ("Detail and inspector hidden — widen the window …", the responsive path in
+   `schedules_workbench.py`), and creation must work there. A pane editor
+   therefore requires a modal fallback at narrow widths, i.e. two code paths
+   for the single most important interaction. It also moves form lifecycle
+   (dirty-state guarding across queue selection changes) into the workbench,
+   which the modal currently provides for free by construction.
+3. **Pushed full editor screen.** Height/width-safe like the modal, but it is
+   still navigationally modal (the queue is not visible), costs the most to
+   build, and abandons the discard-guard and focus behavior the modal already
+   has.
+
+The deciding constraint is the width cliff: shape 2 is only better than
+shape 1 on terminals wide enough to show the detail pane, and strictly worse
+below that — the fallback modal it needs *is* shape 1. Under the standing
+stability-over-quick-wins ruling, one shape that works everywhere beats a
+better shape that needs a second shape as a safety net.
+
+## Consequences
+
+- TASK-23100 and TASK-23102 invest in the modal and are not throwaway.
+- The modal owns idiom parity deliberately: key hints rendered visibly inside
+  the form (not only in bindings), theme-token styling, text-carried state.
+  These ride with TASK-23102's form rework; no new task is spawned.
+- The pane-editor question is closed, not deferred. Reopen only if a future
+  schedule editor must show live queue context while editing (e.g. a
+  conflict-aware picker), and then reconsider all three shapes against the
+  width floor rather than defaulting to the pane.
+- The queue-as-forecast question from the same critique (lead with a
+  next-24-hours timeline) is orthogonal to editor shape and remains open in
+  the critique snapshot; this ADR neither adopts nor rejects it.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9406,3 +9406,41 @@ messages on both sides.
 **What to do.** Never mutate the tree you are trying to evaluate. If you do it
 anyway, `git diff --stat` before AND after the swap and compare the numbers —
 that is the only cheap detector for both failure modes above.
+
+## A focusable widget can be painting nothing (TASK-23100, 2026-08-28)
+
+A UX critique drove the real Schedules create form and found that choosing "Recurring"
+rendered the Frequency select, three blank rows, then Timezone. The cron input, its
+syntax helper, and the live "Runs: ..." preview were not there -- but Tab still landed
+on the cron input and it still accepted keystrokes, silently flipping the preset to
+"Custom cron...". Typing went into a widget the user could not see, and the form's best
+safety feature (the plain-English preview of what the schedule would do) was dead code
+at ordinary terminal sizes.
+
+Two mechanisms combined, and both are easy to reproduce elsewhere:
+
+- The field container had `max-height` with no scrolling, and Textual's auto-height
+  container **clamps by clipping**, so overflow is neither scrollable nor visible.
+- The field groups were plain `Vertical`s. Their default `height: 1fr` measured about
+  **one row** inside the scroll's virtual size while painting six, so the scroll region
+  believed the content fit. Measured during the fix: virtual height 17 against a painted
+  22.
+
+A first fix computed a height budget in Python (`overhead = 10 + error_line_count`). It
+worked at the sizes it was tested at and failed at ~45x24, because a wrapped error line
+occupies two terminal rows while the counter counted one -- re-introducing the same
+class of bug with arithmetic instead of layout. The durable fix was structural: a
+docked-bottom footer plus a `1fr` scroll area, the pattern `voice_blend_dialog.py` and
+`feedback_dialog.py` already use, which deletes the arithmetic and the resize hook
+entirely.
+
+**What to do.** Never accept a style-value probe as evidence that a widget is visible --
+`styles.height` and a green `query_one` both pass for a zero-region widget inside a shut
+`Collapsible` or a clipped container. Assert **paint** via the compositor
+(`get_widget_at` / `export_screenshot` / a tmux `capture-pane`), at the narrow floor as
+well as a comfortable size; 80x24 and a ~45-column case catch what 235x52 hides. When a
+form can scroll, assert that focusing a field brings it into view, because focus and
+visibility are independent in Textual. The same review found the mirror image in the
+Settings search landing: `.focus()` is a silent no-op on a disabled widget and happily
+focuses a field inside a collapsed disclosure, so a "landing" can succeed in code while
+the user sees nothing move.

--- a/backlog/tasks/task-23100 - Schedules-create-form-clips-recurring-fields-at-common-terminal-heights-while-keeping-focus.md
+++ b/backlog/tasks/task-23100 - Schedules-create-form-clips-recurring-fields-at-common-terminal-heights-while-keeping-focus.md
@@ -3,9 +3,10 @@ id: TASK-23100
 title: >-
   Schedules create form clips recurring fields at common terminal heights while
   keeping focus
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:05'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -26,3 +27,9 @@ ReminderForm stacks its fields in a plain Vertical inside a max-height:55 contai
 - [ ] #3 The live 'Runs: ...' preview stays visible while the cron field is being edited
 - [ ] #4 Verification is a runtime capture (tmux capture-pane) at both sizes, not a style-value probe
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+ReminderForm's field column is now a VerticalScroll with the previews, validation line and Save/Cancel docked in a footer, so no field can be clipped while focusable. Two root causes were found: the auto-height container clamps by clipping, and the field groups were plain Verticals whose default height:1fr measured ~1 row in the scroll's virtual size while painting six -- the invisible-but-focusable trap. The review round replaced the initial height arithmetic (overhead = 10 + error_line_count, which under-counted wrapped lines at ~45x24) with a docked footer + 1fr scroll area, matching voice_blend_dialog/feedback_dialog. Compositor-verified at 45x24, 80x24 and 235x52. PR #2169.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23101 - Disabled-scheduled-tasks-still-display-Waiting-with-a-concrete-Next-Run.md
+++ b/backlog/tasks/task-23101 - Disabled-scheduled-tasks-still-display-Waiting-with-a-concrete-Next-Run.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23101
 title: Disabled scheduled tasks still display Waiting with a concrete Next Run
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:05'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -24,3 +25,9 @@ Disabling a task toasts "'X' disabled." but the queue Status column and detail b
 - [ ] #3 The displayed state survives queue refresh and app restart
 - [ ] #4 Enabled/disabled state is carried by text, not only button dimming
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Display status now derives DISABLED from the persisted enabled field and Next Run renders '- (disabled)' instead of a concrete future time. The review round split _underlying_status from the display status so retry affordances, the conflict card and the 'missed' text filter keep consulting last_status (Run now works on disabled tasks), and extended suppression to DISABLED/PAUSED watchlist projections. Qodo caught a further ordering hole: _format_next_run returned '-' on a null next_run_at before the disabled check, so a completed one-time reminder (dispatch disables it and clears the timestamp) showed '-' beside a Disabled badge. PR #2169.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23102 - Schedule-creation-inputs-are-expert-only-ISO-8601-raw-cron-free-text-IANA-timezone.md
+++ b/backlog/tasks/task-23102 - Schedule-creation-inputs-are-expert-only-ISO-8601-raw-cron-free-text-IANA-timezone.md
@@ -3,9 +3,10 @@ id: TASK-23102
 title: >-
   Schedule creation inputs are expert-only: ISO-8601, raw cron, free-text IANA
   timezone
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:05'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -26,3 +27,9 @@ The create form requires 'Run At (ISO-8601):' full timestamps (e.g. 2026-07-20T1
 - [ ] #3 Recurrence presets cover at least 'every weekday at <time>' with an editable time-of-day, without cron
 - [ ] #4 Raw cron remains available behind 'Custom cron...' with its live preview intact
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plain-language scheduling input: parse_forgiving_datetime accepts '2026-08-28 09:00' (naive treated as system-local; full ISO still accepted), timezone is a Select defaulting to the detected system zone, and presets cover daily/weekday/Monday with an editable time-of-day. Raw cron stays behind 'Custom cron...' with its live preview. Review round hardened three edges: editing a one-time task then switching to Recurring no longer shows both preset and raw-cron fields (which silently discarded the typed cron), a stored timezone that does not resolve in local tzdata is preserved as an explicit option instead of being silently rewritten on an unrelated save, and system-zone detection failure now labels the default honestly rather than claiming UTC is the machine zone. PR #2169.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23103 - Design-spike-pane-based-schedule-editor-vs-create-edit-modal.md
+++ b/backlog/tasks/task-23103 - Design-spike-pane-based-schedule-editor-vs-create-edit-modal.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23103
 title: 'Design spike: pane-based schedule editor vs create-edit modal'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:05'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -24,3 +25,11 @@ Schedule creation is a modal while every peer workbench surface edits in the det
 - [ ] #2 The decision names which follow-up tasks it spawns or closes
 - [ ] #3 No implementation beyond throwaway prototyping
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Decision: the create/edit modal stays and is upgraded in place; see backlog/decisions/099-schedule-editor-shape.md (ADR-099).
+
+Deciding constraint is the width cliff: the workbench already hides the detail and inspector panes at narrow widths, while creation must still work from the 80x24 empty state. A detail-pane editor therefore needs a modal fallback anyway -- two code paths for the single most important interaction -- so one shape that works everywhere wins under the standing stability-over-quick-wins ruling. TASK-23100 and TASK-23102 invest in the modal and are not throwaway; the pane question is closed, not deferred.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23104 - Settings-State-banner-renders-doubled-and-self-colliding.md
+++ b/backlog/tasks/task-23104 - Settings-State-banner-renders-doubled-and-self-colliding.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23104
 title: Settings State banner renders doubled and self-colliding
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:05'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - settings
@@ -23,3 +24,9 @@ The banner composition at settings_screen.py:6413 prepends 'State: {badge} | ' t
 - [ ] #2 The banner text contains exactly one 'State:' segment; scope text no longer embeds a second
 - [ ] #3 Verified at runtime on Overview, one domain-defaults category, and one draft-model category
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Each settings category renders exactly one State banner containing exactly one 'State:' segment. Two defects were behind the stutter: the pinned banner prepended 'State: {badge} | ' to scope strings that already embedded their own 'State: ...', and Overview plus the eleven domain categories composed the banner a second time in-card. Video Generation also got a real scope line instead of the contradictory read-only fallback. This matters because the banner is the sole carrier of the save contract (task-1717 built it precisely because five save models coexist), and a stuttering duplicated line teaches users to stop reading it. PR #2170.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23105 - Schedules-sync-surface-over-promises-Sync-completed-with-empty-timestamps-always-on-server-bar.md
+++ b/backlog/tasks/task-23105 - Schedules-sync-surface-over-promises-Sync-completed-with-empty-timestamps-always-on-server-bar.md
@@ -3,9 +3,10 @@ id: TASK-23105
 title: >-
   Schedules sync surface over-promises: Sync completed with empty timestamps,
   always-on server bar
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:06'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -25,3 +26,9 @@ Pressing s toasts 'Sync completed.' while the sync bar still reads 'Last pull: -
 - [ ] #2 When the owner is Local, server plumbing collapses to a single line and Clear is hidden until an error exists
 - [ ] #3 Disabled states in the sync bar are carried by text, not color alone
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+SyncEngine.sync_now now returns a frozen SyncOutcome (ok / not_applicable / error plus pulled and pushed counts) instead of the UI diffing pull/push timestamps around the call. That diff could not tell a policy no-op from a failure, because the engine catches server and transaction errors into persisted sync-error state and returns normally -- so a failed sync toasted an information-severity 'nothing was pulled or pushed'. Error outcomes now post SyncFailed at error severity. The owner bar collapses to one line for a local owner, and the s key is gated on the same _server_available() predicate the collapse uses, so the bar and the action can no longer contradict each other. A persisted error and its Clear button are deliberately kept visible in collapsed mode -- honesty beats compactness. PR #2169.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23106 - Schedules-terminology-drift-schedule-vs-scheduled-task-vs-reminder.md
+++ b/backlog/tasks/task-23106 - Schedules-terminology-drift-schedule-vs-scheduled-task-vs-reminder.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23106
 title: 'Schedules terminology drift: schedule vs scheduled task vs reminder'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:06'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -23,3 +24,9 @@ One object carries three nouns: nav 'Schedules', form 'New Scheduled Task', toas
 - [ ] #2 Rows managed by other systems state what they are and where to edit them (e.g. 'Managed by Watchlists - edit it there')
 - [ ] #3 No user-facing toast or guard string exposes the internal 'reminder' noun without the projection distinction being explained
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+User-facing copy on the Schedules screen now uses one noun, 'scheduled task', and rows owned by other systems say so and where to edit them ('Managed by Watchlists - edit it there'). The invariant is pinned by an AST walk over string literals rather than a line-based grep: the first sweep's exclusions were vacuous (any line containing 'notify(' was skipped, and three single-line notify calls already existed in the swept module), so it could not have caught the regressions it was named for. The AST version was mutation-tested with three planted offenders. PR #2169.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23107 - Schedules-bulk-mark-mechanism-is-invisible-no-legend-count-or-bulk-mode-hint.md
+++ b/backlog/tasks/task-23107 - Schedules-bulk-mark-mechanism-is-invisible-no-legend-count-or-bulk-mode-hint.md
@@ -3,9 +3,10 @@ id: TASK-23107
 title: >-
   Schedules bulk-mark mechanism is invisible: no legend, count, or bulk-mode
   hint
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:06'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -24,3 +25,9 @@ Pressing x prefixes a row with a filled-circle mark and missed-while-away rows c
 - [ ] #1 When one or more rows are marked, visible text states the marked count and which keys act on all marked rows and how to clear the marks
 - [ ] #2 The missed-while-away glyph has a visible text explanation on screen
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The pane notice now states the actionable marked count, how many marks the filter is hiding, and which keys act on them ('2 marked (1 hidden by the filter) - space toggles all, d deletes all, esc clears'), plus a legend for the ran-late glyph. The review round found the underlying defect: marking had no type guard, so a read-only projection row could be marked, and with no actionable marks the bulk verbs fell through to the single-row action on the highlighted, unmarked task -- pressing d opened a delete dialog for a task the user never marked. Marking is now reminder-only, marks are pruned on load, and bulk verbs never fall through while marks exist. PR #2169.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23108 - Settings-surfaces-raw-exception-text-in-user-facing-status-and-toasts.md
+++ b/backlog/tasks/task-23108 - Settings-surfaces-raw-exception-text-in-user-facing-status-and-toasts.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23108
 title: Settings surfaces raw exception text in user-facing status and toasts
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:06'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - settings
@@ -23,3 +24,9 @@ Three paths hand exception reprs straight to the user: settings_screen.py:10871 
 - [ ] #2 Technical detail remains reachable (log or Diagnostics) and secret redaction is preserved
 - [ ] #3 A sweep of settings_screen.py finds no other user-facing f-string interpolating a bare exception
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The three named failure paths present a plain-language summary with a next step via failure_status_text(), and the backfill partial-failure toast no longer pastes the raw last error. The review round caught a security regression introduced by the first cut: the new copy tells users 'Details are in Logs (F8)', and the same change had started writing exception message text to the rotating file sink after only redact_secret_text -- whose regex matches 'X = value' assignments and therefore passes '?key=<token>' URLs and 'Authorization: Bearer ...' straight through, where the pre-existing code had logged the exception type name only. All these paths are back to type-name-only, confirmed at statement level by the diagnostic-inventory drift report. The sink itself still has no redaction; that gap is filed separately. PR #2170.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23109 - Settings-search-matches-categories-only-no-jump-to-setting.md
+++ b/backlog/tasks/task-23109 - Settings-search-matches-categories-only-no-jump-to-setting.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23109
 title: Settings search matches categories only - no jump-to-setting
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:06'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - settings
@@ -22,3 +23,9 @@ The / filter matches category names, not individual settings: searching 'theme' 
 - [ ] #1 Searching a setting's label (e.g. 'reduce motion') surfaces that setting, and Enter navigates to its category with the setting focused or visibly highlighted
 - [ ] #2 Ambiguous matches disambiguate with scope text (category and group) in the results line
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Setting-level search lives in a new UI/Screens/settings_search_index.py, and Enter lands on the setting itself: the landing expands enclosing Collapsibles and scrolls before focusing (fields inside a shut disclosure are focusable at zero height, so keystrokes went into an off-screen input), and a disabled target opens its category with an explanation instead of silently doing nothing. Coverage grew to include the Agents form, all seven TTS provider forms and the Console remote-images toggle; a drift guard mounts every category and fails on any rendered-but-unindexed setting, with its harness blind spots declared rather than silent. Ranking keeps established landings from being re-routed by newly indexed rows, and the status line's growth is bounded so the category rail does not lose rows mid-search. PR #2170.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23110 - Settings-F1-category-help-is-hollow-or-empty.md
+++ b/backlog/tasks/task-23110 - Settings-F1-category-help-is-hollow-or-empty.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23110
 title: Settings F1 category help is hollow or empty
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:06'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - settings
@@ -22,3 +23,9 @@ F1 help for 'Settings: Schedules' opened a completely empty scroll body (live-ve
 - [ ] #1 F1 help for every settings category shows non-empty, category-relevant content (at minimum the save contract, ownership, and available verbs)
 - [ ] #2 No category opens an empty help body
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+F1 help for every settings category now renders a 'How this category works' section built from the persistence badge, scope line and ownership matrix; a test iterates all 26 SettingsCategoryId members. Two fixes came out of review: the help body rendered through a markup-enabled Static, so the Agents boundary copy's literal '[tools]' was parsed as a markup tag and silently deleted from the sentence it existed to make, and the promoted ownership strings needed a copy pass (Overview was a subject-less run-on, read-only domain pages restated one sentence four times). PR #2170.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23111 - Schedules-Next-Run-is-absolute-UTC-only-no-relative-or-local-time.md
+++ b/backlog/tasks/task-23111 - Schedules-Next-Run-is-absolute-UTC-only-no-relative-or-local-time.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-23111
 title: Schedules Next Run is absolute UTC only - no relative or local time
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-28 14:06'
+updated_date: '2026-08-29 02:24'
 labels:
   - ux
   - schedules
@@ -22,3 +23,9 @@ Queue and detail render Next Run as absolute UTC ('2026-08-28 09:00 UTC') with n
 - [ ] #1 Next Run displays include a relative or local-time form alongside the absolute time
 - [ ] #2 The rendering is consistent between the queue column and the detail pane
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Next Run renders a relative form alongside the absolute time, with a compact variant for the queue column. The review round fixed two correctness details: every row took its own datetime.now() so rows in one frame could straddle a bucket boundary (one injected now is now hoisted per render), and the strings were render-time-only with no timer in the module, so '(in 25m)' went stale for hours on an idle screen -- a 60s interval now refreshes them, skipped while the screen is not top-of-stack. PR #2169.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23190 - Settings-log-sink-has-no-redaction-and-redact_secret_text-misses-header-and-query-string-secrets.md
+++ b/backlog/tasks/task-23190 - Settings-log-sink-has-no-redaction-and-redact_secret_text-misses-header-and-query-string-secrets.md
@@ -1,0 +1,29 @@
+---
+id: TASK-23190
+title: >-
+  Settings log sink has no redaction and redact_secret_text misses header and
+  query-string secrets
+status: To Do
+assignee: []
+created_date: '2026-08-29 02:25'
+labels:
+  - security
+  - settings
+  - logging
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-23108 sends users to the log for failure detail ('Details are in Logs (F8)') and its user-facing paths were reduced to logging exception TYPE names only, precisely because message text is not safe to write there. The residual gap is the sink: the rotating file handler in Logging_Config.py applies no redaction (only the in-app Logs buffer runs redact_log_line), and redact_secret_text's _SECRET_ASSIGNMENT_PATTERN matches 'X = value' assignments only -- so an 'Authorization: Bearer sk-...' header or a '?key=<token>' URL reaches disk unchanged from any OTHER caller that logs exception text. Standing project rule (loguru diagnose incident) is to fix this at the sink rather than at each call site. Raised by the Qodo review of PR #2170 and by the TASK-23108 review round.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Secrets in header form ('Authorization: Bearer <token>') and query-string form ('?key=<token>', '?api_key=<token>') are redacted before reaching the rotating file sink
+- [ ] #2 Redaction is applied at the sink so it covers callers that do not opt in, not only paths that call redact_secret_text explicitly
+- [ ] #3 A test writes each secret shape through the real logging configuration and asserts the on-disk record contains no secret material
+- [ ] #4 Existing type-name-only call sites are unaffected and no diagnostic gains new interpolation
+<!-- AC:END -->

--- a/backlog/tasks/task-23191 - Video-Generation-settings-show-State-Unsaved-changes-on-a-fresh-profile-with-no-edits.md
+++ b/backlog/tasks/task-23191 - Video-Generation-settings-show-State-Unsaved-changes-on-a-fresh-profile-with-no-edits.md
@@ -1,0 +1,27 @@
+---
+id: TASK-23191
+title: >-
+  Video Generation settings show 'State: Unsaved changes' on a fresh profile
+  with no edits
+status: To Do
+assignee: []
+created_date: '2026-08-29 02:25'
+labels:
+  - ux
+  - settings
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+On a newly created profile, opening Settings -> Video Generation reports unsaved changes before the user has edited anything, so the dirty indicator cannot be trusted and a Revert appears to be needed on a page nobody touched. Observed during the TASK-23109 verification pass on an isolated profile; the draft for this category appears to initialize dirty rather than adopting the persisted values. The State banner is the sole carrier of the save contract (task-1717, TASK-23104), so a false dirty state undermines the mechanism the whole screen relies on.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening Video Generation on a fresh profile with no user edits reports no unsaved changes
+- [ ] #2 The dirty state appears only after an actual user edit and clears after save or revert
+- [ ] #3 A test mounts the category on a fresh profile and asserts the clean state, so the regression cannot return silently
+<!-- AC:END -->

--- a/backlog/tasks/task-23192 - Settings-Scope-Inspector-Focused-setting-line-names-the-wrong-control.md
+++ b/backlog/tasks/task-23192 - Settings-Scope-Inspector-Focused-setting-line-names-the-wrong-control.md
@@ -1,0 +1,26 @@
+---
+id: TASK-23192
+title: Settings Scope Inspector 'Focused setting' line names the wrong control
+status: To Do
+assignee: []
+created_date: '2026-08-29 02:25'
+labels:
+  - ux
+  - settings
+  - a11y
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Scope Inspector's 'Focused setting' line read 'Appearance defaults' while the Reduce motion control demonstrably held focus (verified by a style-diff showing the focused background on that control). The line exists to tell keyboard users what their focus is currently on, which is exactly the guarantee TASK-23109's setting-level landing depends on -- a wrong name is worse than no line, because it contradicts what the user can see. Observed during the TASK-23109 verification pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The 'Focused setting' line names the control that actually holds focus, including controls reached by search landing and by plain Tab traversal
+- [ ] #2 When focus is on a container or a non-setting control, the line says so rather than naming an unrelated setting
+- [ ] #3 A mounted test focuses at least two distinct settings and asserts the inspector line matches each
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
Close-out for the 2026-08-28 Settings + Schedules UX critique arc. Implementation shipped in #2169 (Schedules) and #2170 (Settings); the task records were filed in #2163.

- **TASK-23100 … TASK-23111 → Done**, each with implementation notes covering what shipped and what the review rounds changed.
- **ADR-099** records the TASK-23103 spike decision: schedule create/edit **stays a modal, upgraded in place**. The deciding constraint is the width cliff — the workbench already hides its detail pane at narrow widths while creation must still work from the 80×24 empty state, so a pane editor needs a modal fallback anyway: two code paths for the single most important interaction.
- **Three follow-ups filed**, ids swept past a true max of **23175** (the CLI offered 23114 — a 61-task collision):
  - **TASK-23190** (high, security): the rotating log sink applies no redaction and `redact_secret_text` matches only `X = value` assignments, so `Authorization: Bearer …` and `?key=…` shapes reach disk from any caller that logs exception text. Surfaced by the TASK-23108 review round and the Qodo review of #2170; the project rule is to fix this at the sink.
  - **TASK-23191**: Video Generation reports "State: Unsaved changes" on a fresh profile with no edits.
  - **TASK-23192**: the Scope Inspector's "Focused setting" line names a control that does not hold focus.
- **Lesson banked** in `lessons-testing-evidence.md`: *a focusable widget can be painting nothing.* The P0 behind TASK-23100 was a cron field that was clipped invisible yet still took Tab focus and keystrokes — a style-value probe and a green `query_one` both pass for a zero-region widget. Includes the measured mechanism (virtual height 17 vs painted 22, `1fr` children measuring ~1 row) and why the first arithmetic fix failed at ~45×24.

## Verification
`./scripts/preflight.sh` — all derived-artifact checks pass. Backlog id uniqueness verified in both namespaces (filename prefix and frontmatter `id:`) on the merged view.

Task-and-docs only; no production code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2WwNRSyk6w9V7b9yh5Yht

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes out the Settings + Schedules UX critique arc by marking TASK-23100–TASK-23111 Done with implementation notes, recording the schedule-editor decision as ADR-099, filing three follow-ups, and banking a testing lesson. Tasks and docs only; no production code.

**Decision recorded**
- Schedule create/edit stays a modal, upgraded in place: the workbench hides its detail pane at narrow widths while creation must work from the 80×24 empty state, so a pane editor would need a modal fallback anyway — two code paths for the most important interaction.

**Follow-ups filed**
- TASK-23190 (high, security): the rotating log sink applies no redaction and `redact_secret_text` matches only `X = value` assignments, so `Authorization: Bearer …` and `?key=…` shapes reach disk from any caller that logs exception text.
- TASK-23191: Video Generation reports "State: Unsaved changes" on a fresh profile with no edits.
- TASK-23192: the Scope Inspector's "Focused setting" line names a control that does not hold focus.

The lesson records that a focusable widget can be painting nothing — a style-value probe and a green `query_one` both pass for a zero-region widget, so paint must be asserted via the compositor. Backlog id uniqueness is verified in both namespaces and the preflight checks pass.

<sup>Written for commit 1f91b7d985d8de0f91c387823365822a3b80c031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

