### PR TITLE
fix(security): redact secrets at the log file sink (TASK-23190)

### DIFF
--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -801,6 +801,82 @@ def test_redact_secret_text_removes_api_key_like_values():
     assert "OPENAI_API_KEY=<redacted>" in redacted
 
 
+@pytest.mark.parametrize(
+    ("text", "secret", "expected_fragment"),
+    [
+        pytest.param(
+            "rejected: Authorization: Bearer sk-live-abc123",
+            "sk-live-abc123",
+            "Bearer <redacted>",
+            id="authorization-bearer-header",
+        ),
+        pytest.param(
+            "X-Api-Key: sk-live-abc123 was rejected",
+            "sk-live-abc123",
+            "X-Api-Key: <redacted>",
+            id="colon-separated-credential-header",
+        ),
+        pytest.param(
+            "GET https://svc/customsearch/v1?key=AIzaSyLIVE0123456789&cx=017 failed",
+            "AIzaSyLIVE0123456789",
+            "?key=<redacted>&cx=017",
+            id="bare-key-query-parameter",
+        ),
+        pytest.param(
+            "POST https://svc/v1/models?api_key=sk-live-abc123 -> 401",
+            "sk-live-abc123",
+            "api_key=<redacted>",
+            id="api-key-query-parameter",
+        ),
+    ],
+)
+def test_redact_secret_text_removes_header_and_query_string_secrets(
+    text: str,
+    secret: str,
+    expected_fragment: str,
+) -> None:
+    """TASK-23190: the assignment rule alone missed both of these shapes.
+
+    ``_SECRET_ASSIGNMENT_PATTERN`` classifies a value by the *name* to its
+    left, so ``Authorization: Bearer <token>`` (the classifying name is
+    ``Authorization``, which is not in the vocabulary) and ``?key=<token>``
+    (``key`` alone is not either) were both displayed verbatim. Probed before
+    the fix: both strings came back from ``redact_secret_text`` unchanged.
+    """
+    redacted = redact_secret_text(text)
+
+    assert secret not in redacted
+    assert expected_fragment in redacted
+
+
+def test_redact_secret_text_leaves_secret_free_text_intact() -> None:
+    """Negative control: an over-broad rule that redacts everything must fail.
+
+    The bare-``key`` query rule is the risky one -- ``key`` is an ordinary
+    English word, and a TOML parse error says it. It is anchored on ``?``/``&``
+    precisely so prose survives.
+    """
+    intact = (
+        "Model discovery failed (HTTPStatusError). Check the endpoint. "
+        "Details are in Logs (F8). Expected key but found newline at line 3"
+    )
+
+    assert redact_secret_text(intact) == intact
+
+
+def test_failure_status_text_keeps_type_name_only_copy_unchanged() -> None:
+    """AC-4: the TASK-23108 call sites must read exactly as they did."""
+
+    assert failure_status_text(
+        "Model discovery failed",
+        ValueError("secret=sk-live-abc123"),
+        next_step="Check the endpoint.",
+    ) == (
+        "Model discovery failed (ValueError). Check the endpoint. "
+        "Details are in Logs (F8)."
+    )
+
+
 def test_adapter_rejects_non_mapping_toml():
     adapter = SettingsConfigAdapter()
 

--- a/Tests/test_logging_private_files.py
+++ b/Tests/test_logging_private_files.py
@@ -10,10 +10,14 @@ import pytest
 from tldw_chatbook import config
 from tldw_chatbook.Logging_Config import (
     PrivateRotatingFileHandler,
+    RedactingFileFormatter,
     _configure_private_file_logging,
 )
 from tldw_chatbook.Utils.private_paths import PrivatePathError
-from tldw_chatbook.Utils.persistent_diagnostics import PersistentDiagnosticFilter
+from tldw_chatbook.Utils.persistent_diagnostics import (
+    _PERSISTENT_METADATA_MARKER,
+    PersistentDiagnosticFilter,
+)
 
 
 def _mode(path: Path) -> int:
@@ -265,3 +269,223 @@ def test_successful_install_writes_its_own_first_event(
             root_logger.removeHandler(installed_handler)
             installed_handler.close()
         root_logger.setLevel(old_level)
+
+
+# --- TASK-23190: redaction at the private file sink ------------------------
+#
+# The sink has two independent layers and these tests pin both.
+#
+# 1. `PersistentDiagnosticFilter` decides *whether* a record is written. Today
+#    it admits only schema-validated ADR-029 metadata events, so an ordinary
+#    `logger.error("Authorization: Bearer sk-...")` never reaches disk at all
+#    (`test_unmarked_secret_bearing_record_is_not_written_at_all` pins that).
+# 2. `RedactingFileFormatter` decides *what a written record says*. That is the
+#    layer TASK-23190 adds, and the layer that survives any future change to
+#    layer 1 -- including a caller marking its own record, which is the only
+#    way a message body can reach this sink today and therefore how these
+#    tests drive it.
+#
+# Driving layer 2 through the marker is deliberate, not a way around the
+# admission rule: an on-disk assertion made with a record that layer 1 drops
+# would be green with the formatter deleted, which is the "test that cannot
+# fail" trap in backlog/docs/lessons-testing-evidence.md.
+
+_METADATA_MARKED = {_PERSISTENT_METADATA_MARKER: True}
+
+
+@pytest.fixture
+def private_sink(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Install the real private file sink on the real root logger.
+
+    Yields the active log path; the sink is configured through
+    ``_configure_private_file_logging`` -- the same function
+    ``configure_application_logging`` calls -- rather than by building a
+    handler by hand, so a formatter that is wired only in a test cannot pass.
+    """
+    log_path = tmp_path / "tldw_cli_app.log"
+    monkeypatch.setattr(
+        "tldw_chatbook.Logging_Config.get_cli_log_file_path", lambda: log_path
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Logging_Config.get_cli_setting",
+        lambda section, key, default=None: default,
+    )
+    root_logger = logging.getLogger()
+    old_level = root_logger.level
+    root_logger.setLevel(logging.INFO)
+    handler: PrivateRotatingFileHandler | None = None
+    try:
+        assert _configure_private_file_logging(root_logger) is True
+        handler = next(
+            item
+            for item in root_logger.handlers
+            if isinstance(item, PrivateRotatingFileHandler)
+            and item.baseFilename == str(log_path)
+        )
+        yield log_path
+    finally:
+        if handler is not None:
+            handler.flush()
+            root_logger.removeHandler(handler)
+            handler.close()
+        root_logger.setLevel(old_level)
+
+
+def _read_sink(log_path: Path) -> str:
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    return log_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("message", "secret"),
+    [
+        pytest.param(
+            "provider rejected Authorization: Bearer sk-live-abc123",
+            "sk-live-abc123",
+            id="authorization-bearer-header",
+        ),
+        pytest.param(
+            "GET https://svc/customsearch/v1?key=AIzaSyLIVE0123456789012345678901234567 failed",
+            "AIzaSyLIVE0123456789012345678901234567",
+            id="bare-key-query-parameter",
+        ),
+        pytest.param(
+            "POST https://svc/v1/models?api_key=sk-live-abc123 -> 401",
+            "sk-live-abc123",
+            id="api-key-query-parameter",
+        ),
+        pytest.param(
+            "https://svc/v1?page=2&token=sk-live-abc123 timed out",
+            "sk-live-abc123",
+            id="token-query-parameter",
+        ),
+        pytest.param(
+            "OPENAI_API_KEY = sk-abcdefghijklmnopqrstuvwx",
+            "sk-abcdefghijklmnopqrstuvwx",
+            id="assignment-regression",
+        ),
+    ],
+)
+def test_file_sink_redacts_secret_shapes_before_they_reach_disk(
+    private_sink: Path,
+    message: str,
+    secret: str,
+) -> None:
+    """AC-1/AC-3: each shape is written to disk through the real sink, redacted."""
+
+    logging.getLogger("tldw_chatbook.tests.sink").info(
+        message, extra=_METADATA_MARKED
+    )
+
+    written = _read_sink(private_sink)
+
+    assert secret not in written
+    assert "***REDACTED***" in written
+
+
+def test_file_sink_redacts_secrets_inside_exception_text(
+    private_sink: Path,
+) -> None:
+    """A credential in ``str(exc)`` is formatted from ``exc_info``, not ``msg``.
+
+    This is why the redaction is a formatter and not a ``logging.Filter``: a
+    filter rewriting ``record.msg`` leaves the traceback block -- where
+    TASK-23108's provider failures actually carry their URLs -- untouched.
+    """
+    logger = logging.getLogger("tldw_chatbook.tests.sink")
+    try:
+        raise ValueError("connect failed for https://svc/v1?key=AIzaSyLIVE0123")
+    except ValueError:
+        logger.info("provider probe failed", exc_info=True, extra=_METADATA_MARKED)
+
+    written = _read_sink(private_sink)
+
+    assert "AIzaSyLIVE0123" not in written
+    assert "ValueError" in written
+
+
+def test_file_sink_leaves_secret_free_records_intact(private_sink: Path) -> None:
+    """Negative control: a redactor that eats everything must not pass.
+
+    Asserts the message text survives verbatim, so an over-broad pattern that
+    blanked every line would fail here even though every "secret not in
+    written" assertion above would still be green.
+    """
+    message = "ordinary startup record with no credential in it"
+    logging.getLogger("tldw_chatbook.tests.sink").info(
+        message, extra=_METADATA_MARKED
+    )
+
+    written = _read_sink(private_sink)
+
+    assert message in written
+    assert "***REDACTED***" not in written
+
+
+def test_unmarked_secret_bearing_record_is_not_written_at_all(
+    private_sink: Path,
+) -> None:
+    """Layer 1: the admission filter drops an ordinary caller's record entirely.
+
+    Pinned so that a future widening of ``PersistentDiagnosticFilter`` is a
+    visible, deliberate change rather than a silent one -- the redaction layer
+    above is what keeps such a widening from also being a disclosure.
+    """
+    logging.getLogger("tldw_chatbook.tests.sink").error(
+        "Authorization: Bearer sk-live-abc123"
+    )
+    logging.getLogger("httpx").error("GET https://svc/v1?key=AIzaSyLIVE0123")
+
+    written = _read_sink(private_sink)
+
+    assert "sk-live-abc123" not in written
+    assert "AIzaSyLIVE0123" not in written
+    assert "Authorization" not in written
+
+
+def test_installed_sink_uses_the_redacting_formatter(private_sink: Path) -> None:
+    """AC-2: redaction is a property of the handler, not of any call site."""
+
+    handler = next(
+        item
+        for item in logging.getLogger().handlers
+        if isinstance(item, PrivateRotatingFileHandler)
+        and item.baseFilename == str(private_sink)
+    )
+
+    assert isinstance(handler.formatter, RedactingFileFormatter)
+
+
+def test_preexisting_plain_handler_is_upgraded_to_the_redacting_formatter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A handler installed before this change must not keep writing in clear.
+
+    ``_configure_private_file_logging`` returns early when a matching handler
+    is already attached; without reconciliation that branch would leave the
+    old plain formatter in place for the rest of the process.
+    """
+    active = tmp_path / "application.log"
+    monkeypatch.setattr(
+        "tldw_chatbook.Logging_Config.get_cli_log_file_path", lambda: active
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Logging_Config.get_cli_setting",
+        lambda section, key, default=None: default,
+    )
+    root_logger = logging.Logger("preexisting-plain-handler")
+    handler = PrivateRotatingFileHandler(
+        active, maxBytes=100, backupCount=1, encoding="utf-8"
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root_logger.addHandler(handler)
+    try:
+        assert not isinstance(handler.formatter, RedactingFileFormatter)
+
+        assert _configure_private_file_logging(root_logger) is True
+
+        assert isinstance(handler.formatter, RedactingFileFormatter)
+    finally:
+        handler.close()

--- a/backlog/tasks/task-23190 - Settings-log-sink-has-no-redaction-and-redact_secret_text-misses-header-and-query-string-secrets.md
+++ b/backlog/tasks/task-23190 - Settings-log-sink-has-no-redaction-and-redact_secret_text-misses-header-and-query-string-secrets.md
@@ -3,9 +3,10 @@ id: TASK-23190
 title: >-
   Settings log sink has no redaction and redact_secret_text misses header and
   query-string secrets
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-29 02:25'
+updated_date: '2026-08-29 02:52'
 labels:
   - security
   - settings
@@ -22,8 +23,100 @@ TASK-23108 sends users to the log for failure detail ('Details are in Logs (F8)'
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Secrets in header form ('Authorization: Bearer <token>') and query-string form ('?key=<token>', '?api_key=<token>') are redacted before reaching the rotating file sink
-- [ ] #2 Redaction is applied at the sink so it covers callers that do not opt in, not only paths that call redact_secret_text explicitly
-- [ ] #3 A test writes each secret shape through the real logging configuration and asserts the on-disk record contains no secret material
-- [ ] #4 Existing type-name-only call sites are unaffected and no diagnostic gains new interpolation
+- [x] #1 Secrets in header form ('Authorization: Bearer <token>') and query-string form ('?key=<token>', '?api_key=<token>') are redacted before reaching the rotating file sink
+- [x] #2 Redaction is applied at the sink so it covers callers that do not opt in, not only paths that call redact_secret_text explicitly
+- [x] #3 A test writes each secret shape through the real logging configuration and asserts the on-disk record contains no secret material
+- [x] #4 Existing type-name-only call sites are unaffected and no diagnostic gains new interpolation
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Probe what actually reaches the rotating file sink today and what log_sanitizer already covers.
+2. Add a redacting Formatter on the private file handler so every line it writes is sanitized (sink-side, no caller opt-in), reconciling an already-installed handler too.
+3. Close the second half of the title: teach redact_secret_text the header (Bearer / 'X-Api-Key: v') and query-string ('?key=') shapes it misses, keeping the <redacted> marker stable.
+4. On-disk tests through the real _configure_private_file_logging, plus a negative control and the layered no-write assertion.
+5. Mutation-check both guards; run sanitizer/logging/settings suites, ruff, preflight.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Redaction is now a property of the private file sink, and `redact_secret_text`
+recognises the two shapes it was blind to.
+
+**The premise needed correcting first.** The description says an
+`Authorization: Bearer sk-...` header "reaches disk unchanged from any OTHER
+caller". Probed against the real configuration: it does not. The rotating
+handler already carries `PersistentDiagnosticFilter`, which admits *only*
+schema-validated ADR-029 metadata events -- an ordinary
+`logger.error("Authorization: Bearer sk-live-abc123")` and a third-party
+`httpx` record both produced zero bytes. So the sink had no redaction, but it
+also had no unredacted secrets: what was missing was the second layer that
+makes a future widening of that admission rule safe rather than a disclosure.
+The fix is written and tested as that second layer, and
+`test_unmarked_secret_bearing_record_is_not_written_at_all` pins the first one
+so a widening becomes a visible change.
+
+**`log_sanitizer` needed no new patterns.** Probed all four shapes through
+`sanitize_string`/`redact_log_line` before writing anything: `Bearer` (via
+`_BEARER`), `?key=` (via the bare-`key` entry `_LOG_ONLY_SENSITIVE_FIELDS`
+gained in TASK-19558), `?api_key=` and `&token=` (via `is_sensitive_config_key`)
+were all already covered, and a secret-free line passed through untouched. The
+sink simply never called it.
+
+**Approach and trade-offs.**
+
+- `RedactingFileFormatter` wraps `redact_log_line` around the fully formatted
+  record, rather than a `logging.Filter`. Two reasons, both load-bearing: a
+  filter must mutate `record.msg`, and the record is shared with every other
+  handler on the logger (and with whichever thread emitted it); and only the
+  formatted string contains the `exc_info` traceback, where a credential inside
+  `str(exc)` actually lives. The on-disk test for exception text fails against
+  a msg-only redactor.
+- Cost: 33.6 us/record vs 1.4 us for the plain formatter. Handler filters run
+  before `emit`, so this is paid only on records that are actually written --
+  a handful of metadata events per session today.
+- `MAX_REDACTED_LINE_CHARS` is kept, not disabled. Truncation keeps strictly
+  less data, its cut is token-aligned so it cannot slice a credential into an
+  unmatchable fragment, and it is what bounds the per-record cost. Cost of
+  keeping it: a >2,000-char record is truncated on disk too.
+- The already-installed-handler branch reconciles the formatter for the same
+  reason it already reconciles the filter -- otherwise a handler built by an
+  earlier revision keeps writing in clear for the rest of the process.
+- `redact_secret_text` keeps its `<redacted>` marker and its existing
+  name vocabulary (many callers and tests assert the exact `KEY=<redacted>`
+  shape). Three narrow additions: `[:=]` as separator (`X-Api-Key: <token>` is
+  how every credential header is spelled), a `Bearer` prefix rule, and a bare
+  `key` rule anchored to query-string position only. `key` is deliberately not
+  added to the name vocabulary -- it is an ordinary English word and a TOML
+  parse error says it -- so the `?`/`&` anchor is what proves it is a
+  parameter name. Unlike the log sanitizer's redact-to-end-of-line behaviour
+  this preserves the rest of the URL (`?key=<redacted>&cx=017`).
+
+**Mutation checks** (all Edit-based restores). Disabling the redaction call in
+`RedactingFileFormatter.format`: 6 failed / 19 passed, and the negative control
+and admission-layer tests correctly stayed green. Removing the Bearer and
+query-key rules: 2 of my parametrized cases failed. Narrowing the separator
+back to `=`: the colon-header case failed. All green after restore.
+
+**Verification.** `Tests/test_logging_private_files.py` 25 passed;
+logging/diagnostics/sanitizer batch 167 passed; config/websearch/RAG privacy
+batch 92 passed; `Tests/UI/test_settings_configuration_hub.py` +
+`test_settings_provider_test_draft.py` 449 passed / 6 failed -- the identical
+6 fail on the merge-base `4fb5d38d37` (save/revert and category-content
+assertions, no redaction assertion among them). `preflight.sh` all green with
+no diagnostic-inventory drift; ruff clean.
+
+**Also checked, deliberately unchanged.** Loguru `diagnose` is `False` at every
+`logger.add` in the package (`Logging_Config.py`, `__init__.py`,
+`startup_logging.py`, `Metrics/logger_config.py`) -- no finding. Loguru's own
+file sinks are already disabled in `Metrics/logger_config.py`;
+`Chunking/engine/security_logger.py` can open one but only when handed an
+explicit `log_file`, which no production caller does.
+
+**Files.** `tldw_chatbook/Logging_Config.py`,
+`tldw_chatbook/UI/Screens/settings_config_adapter.py`,
+`Tests/test_logging_private_files.py`,
+`Tests/UI/test_settings_configuration_hub.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Logging_Config.py
+++ b/tldw_chatbook/Logging_Config.py
@@ -20,6 +20,7 @@ from textual.widgets import RichLog
 #
 # Local Imports
 from tldw_chatbook.config import get_cli_log_file_path, get_cli_setting
+from tldw_chatbook.Utils.log_sanitizer import redact_log_line
 from tldw_chatbook.Utils.private_paths import (
     PrivatePathError,
     lexical_path,
@@ -262,6 +263,61 @@ class PrivateRotatingFileHandler(RotatingFileHandler):
         self._harden_existing_generations()
 
 
+class RedactingFileFormatter(logging.Formatter):
+    """Formatter that redacts recognised credentials from every line it emits.
+
+    TASK-23190. Redaction here is a property of the *sink*, not of the caller:
+    a record is sanitized on the way to disk whoever logged it and whether or
+    not that code opted in. The standing rule from the loguru ``diagnose``
+    incident is to fix disclosure at the sink rather than at each call site,
+    and TASK-23108 leans on exactly that by telling users "Details are in Logs
+    (F8)" while its own user-facing paths log only exception type names.
+
+    Applied at the format step rather than as a ``logging.Filter`` for two
+    reasons:
+
+    * A filter would have to rewrite ``record.msg``/``record.args``, and the
+      record object is shared with every other handler on the logger. Mutating
+      it changes what the terminal and the in-app Logs screen see, and does so
+      from whichever thread emitted the record.
+    * Only the formatted string contains the exception traceback and stack
+      info. A filter that scrubbed ``record.msg`` would leave a credential
+      embedded in ``str(exc)`` -- the exact shape TASK-23108 was filed about --
+      untouched in the ``exc_info`` block appended after it.
+
+    Cost is paid only on records that are actually written. ``Handler.handle``
+    runs the handler's filters *before* ``emit``, so
+    :class:`PersistentDiagnosticFilter` rejects a record long before this
+    formatter is reached -- and it admits only schema-validated metadata
+    events, a handful per session. Measured on a typical metadata line:
+    33.6 us/record versus 1.4 us for the plain formatter it replaces.
+
+    ``redact_log_line`` is reused verbatim -- the same function the in-app Logs
+    buffer applies -- so the two sinks cannot drift on what counts as a secret.
+    Its ``MAX_REDACTED_LINE_CHARS`` cap is kept rather than disabled: the cap
+    only ever keeps *less* data than the raw line, its cut is token-aligned so
+    it cannot slice a credential into an unmatchable fragment, and it is what
+    bounds that 32 us on whichever thread emitted the record. The cost of
+    keeping it is that a single record longer than 2,000 characters is
+    truncated on disk as well as in the Logs screen; nothing that reaches this
+    sink today comes close.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Return the fully formatted record with recognised secrets removed."""
+
+        return redact_log_line(super().format(record))
+
+
+def _private_file_formatter() -> logging.Formatter:
+    """Return the redacting formatter used by the private file sink."""
+
+    return RedactingFileFormatter(
+        "%(asctime)s [%(levelname)-8s] %(name)s:%(lineno)d - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
 def _configure_private_file_logging(root_logger: logging.Logger) -> bool:
     """Install the private file sink, leaving existing handlers on failure."""
 
@@ -282,6 +338,12 @@ def _configure_private_file_logging(root_logger: logging.Logger) -> bool:
                 for item in existing_handler.filters
             ):
                 existing_handler.addFilter(PersistentDiagnosticFilter())
+            # TASK-23190. Reconciled for the same reason the filter above is:
+            # a handler installed by an earlier revision (or by any other
+            # caller that built one) would otherwise keep writing unredacted
+            # lines for the rest of the process.
+            if not isinstance(existing_handler.formatter, RedactingFileFormatter):
+                existing_handler.setFormatter(_private_file_formatter())
             root_logger.info("Private rotating file logging is already installed.")
             # TASK-1240 (M8). This path returns True exactly like the install
             # path below, so it has to emit exactly like it too. An earlier
@@ -303,12 +365,7 @@ def _configure_private_file_logging(root_logger: logging.Logger) -> bool:
                 encoding="utf-8",
             )
             file_handler.setLevel(file_log_level)
-            file_handler.setFormatter(
-                logging.Formatter(
-                    "%(asctime)s [%(levelname)-8s] %(name)s:%(lineno)d - %(message)s",
-                    datefmt="%Y-%m-%d %H:%M:%S",
-                )
-            )
+            file_handler.setFormatter(_private_file_formatter())
             file_handler.addFilter(PersistentDiagnosticFilter())
             root_logger.addHandler(file_handler)
             root_logger.info(

--- a/tldw_chatbook/UI/Screens/settings_config_adapter.py
+++ b/tldw_chatbook/UI/Screens/settings_config_adapter.py
@@ -29,21 +29,68 @@ from ...config import (
 from .settings_config_models import SettingsValidationResult
 
 
+#: ``NAME = value`` / ``NAME: value`` where the name itself declares a secret.
+#:
+#: TASK-23190 widened the separator from ``=`` to ``[:=]``. The name vocabulary
+#: is unchanged, so this cannot fire on prose that does not already name a
+#: credential -- but it is how every HTTP credential header is written
+#: (``X-Api-Key: <token>``, ``X-Auth-Token: <token>``), and those reached the
+#: Settings surface verbatim while the identical ``=`` spelling was redacted.
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
     r"(?P<key>[A-Za-z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)[A-Za-z0-9_-]*)"
-    r"(?P<sep>\s*=\s*)"
+    r"(?P<sep>\s*[:=]\s*)"
     r"(?P<value>[^\s,;]+)",
+    re.IGNORECASE,
+)
+
+#: ``Authorization: Bearer <token>``. The name that classifies this line is
+#: ``Authorization``, which matches none of the labels above, so before
+#: TASK-23190 the whole header -- token included -- was displayed unchanged.
+#: Anchored on the scheme keyword instead, exactly as ``log_sanitizer._BEARER``
+#: does for the log sinks.
+_BEARER_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_-])(?P<prefix>Bearer\s+)(?P<value>\S+)",
+    re.IGNORECASE,
+)
+
+#: A bare ``key`` query parameter -- ``...?key=<token>&cx=...`` is how Google's
+#: Custom Search credential travels. ``key`` is deliberately NOT added to the
+#: name vocabulary above (it would swallow any prose "key = ..."); it is
+#: recognised only in query-string position, where the preceding ``?``/``&``
+#: proves it is a parameter name rather than a word. ``api_key``/``apikey``
+#: already match the assignment rule wherever they appear.
+_QUERY_KEY_PATTERN = re.compile(
+    r"(?P<prefix>[?&]key=)(?P<value>[^\s&#,;]+)",
     re.IGNORECASE,
 )
 
 
 def redact_secret_text(text: str) -> str:
-    """Redact secret-looking assignment values from visible Settings output."""
+    """Redact secret-looking values from visible Settings output.
 
-    def _replace(match: re.Match[str]) -> str:
+    Covers three shapes: a ``NAME=value``/``NAME: value`` assignment whose name
+    declares a credential, an ``Authorization: Bearer <token>`` header, and a
+    bare ``?key=<token>`` query parameter. This is a denylist and denylists are
+    never complete -- an opaque token in none of those forms survives -- so it
+    remains defence in depth behind ``failure_status_text``, which keeps raw
+    exception text out of user-facing copy in the first place.
+
+    Args:
+        text: Any value destined for a visible Settings surface.
+
+    Returns:
+        ``text`` with recognised credential values replaced by ``<redacted>``.
+    """
+
+    def _replace_assignment(match: re.Match[str]) -> str:
         return f"{match.group('key')}{match.group('sep')}<redacted>"
 
-    return _SECRET_ASSIGNMENT_PATTERN.sub(_replace, str(text))
+    def _replace_prefixed(match: re.Match[str]) -> str:
+        return f"{match.group('prefix')}<redacted>"
+
+    result = _SECRET_ASSIGNMENT_PATTERN.sub(_replace_assignment, str(text))
+    result = _BEARER_PATTERN.sub(_replace_prefixed, result)
+    return _QUERY_KEY_PATTERN.sub(_replace_prefixed, result)
 
 
 def failure_status_text(summary: str, exc: BaseException, *, next_step: str) -> str:


### PR DESCRIPTION
## The gap

TASK-23108 tells users "Details are in Logs (F8)" while reducing its own
user-facing copy to exception type names, on the assumption that the log is the
safe place for the detail. Two things were wrong with that assumption.

**1. The file sink had no redaction.** `Logging_Config.py` installs a
`PrivateRotatingFileHandler` with a plain `logging.Formatter`; only the in-app
Logs buffer ran `redact_log_line` (`app.py`). The sanitizer existed and the sink
simply never called it.

**2. `redact_secret_text` classifies a value by the name to its left.**
`_SECRET_ASSIGNMENT_PATTERN` requires the name to contain
`API_KEY`/`TOKEN`/`SECRET`/`PASSWORD`, so `Authorization: Bearer <token>` (the
classifying name is `Authorization`) and `?key=<token>` (`key` alone) were
displayed on the Settings surface verbatim. Probed before the fix — both came
back unchanged; `?api_key=` and `&token=` were already covered.

### One correction to the filed premise

The task says the header "reaches disk unchanged from any OTHER caller". Probed
against the real configuration: it does not. The handler already carries
`PersistentDiagnosticFilter`, which admits only schema-validated ADR-029
metadata events — an ordinary `logger.error("Authorization: Bearer sk-...")` and
a third-party `httpx` record both produced **zero bytes**. So the sink had no
redaction, but it also had no unredacted secrets. What was missing is the second
layer that makes any future widening of that admission rule safe instead of a
disclosure. This PR adds that layer and pins the first one, so a widening
becomes a visible change rather than a silent one.

## The fix

`RedactingFileFormatter` wraps `redact_log_line` around the fully formatted
record. A `logging.Filter` was rejected for two reasons, both load-bearing:

- a filter must mutate `record.msg`, and the record is shared with every other
  handler on the logger (and with whichever thread emitted it);
- only the formatted string carries the `exc_info` traceback, which is where a
  credential inside `str(exc)` actually lives — exactly the shape TASK-23108 was
  filed about.

`log_sanitizer` needed **no new patterns**: `Bearer`, `?key=` (the bare-`key`
entry added by TASK-19558), `?api_key=` and `&token=` were all already covered,
and it is reused verbatim so the disk sink and the Logs screen cannot drift on
what counts as a secret. The already-installed-handler branch reconciles the
formatter for the same reason it already reconciles the filter.

`redact_secret_text` keeps its `<redacted>` marker and name vocabulary (many
callers assert the exact `KEY=<redacted>` shape). Three narrow additions: `[:=]`
as separator (`X-Api-Key: <token>`), a `Bearer` rule, and a bare `key` rule
anchored to query-string position only — `key` is an ordinary English word and a
TOML parse error says it, so the `?`/`&` anchor is what proves it is a parameter
name.

## On-disk evidence (AC-3)

`Tests/test_logging_private_files.py` drives the real
`_configure_private_file_logging` on the real root logger, logs through a normal
`logging` call, and reads the file back. Verbatim, with the formatter in place:

```
2026-08-28 19:54:13 [INFO ] tldw_chatbook.diagnostics.logging:182 - event=persistent_sink_installed component=logging status=ok
2026-08-28 19:54:13 [INFO ] tldw_chatbook.probe:30 - Authorization: ***REDACTED***
2026-08-28 19:54:13 [INFO ] tldw_chatbook.probe:31 - GET https://x/v1?key=***REDACTED***
2026-08-28 19:54:13 [INFO ] tldw_chatbook.probe:32 - POST /v1?api_key=***REDACTED***
2026-08-28 19:54:13 [INFO ] tldw_chatbook.probe:33 - OPENAI_API_KEY = ***REDACTED***
2026-08-28 19:54:13 [INFO ] tldw_chatbook.probe:34 - ordinary startup message with no secret at all
2026-08-28 19:54:13 [INFO ] tldw_chatbook.probe:38 - provider probe failed
Traceback (most recent call last):
  File ".../probe_sink2.py", line 36, in <module>
    raise ValueError("connect failed for https://svc/v1?key=***REDACTED***
ValueError: connect failed for https://svc/v1?key=***REDACTED***
```

Note the last three lines: the traceback **and** the exception message are
redacted. That is the case a `record.msg` filter would have left in clear.
The negative control (line 6) is intact, so an over-broad rule that blanked
every line cannot pass.

## Mutation check

All restores Edit-based, never `git checkout`.

| mutation | result |
|---|---|
| `RedactingFileFormatter.format` returns `super().format(record)` | **6 failed**, 19 passed — all 5 shapes + the exception-text case; negative control and admission-layer tests correctly stayed green |
| Bearer + query-key rules removed from `redact_secret_text` | **2 failed** (`authorization-bearer-header`, `bare-key-query-parameter`) |
| separator narrowed back to `=` | **1 failed** (`colon-separated-credential-header`) |
| restored | green |

## Verification

- `Tests/test_logging_private_files.py` — **25 passed**
- logging / diagnostics / sanitizer batch (9 files) — **167 passed**
- config-defaults / websearch-credential / RAG-privacy batch — **92 passed**
- `test_settings_configuration_hub.py` + `test_settings_provider_test_draft.py`
  — **449 passed, 6 failed**. The identical 6 fail on the merge-base
  `4fb5d38d37` (`git archive` of the base run against the same venv); they are
  save/revert and category-content assertions, with no redaction assertion among
  them.
- `--collect-only` on both touched test files — 410 collected
- `./scripts/preflight.sh` — all green, **no diagnostic-inventory drift**
  (541 owners, 1262/7397 calls, 8 sink files, unchanged)
- `ruff check` on all four touched files — clean

## Performance

33.6 us/record versus 1.4 us for the plain formatter. `Handler.handle` runs the
handler's filters *before* `emit`, so this is paid only on records actually
written — a handful of metadata events per session. `MAX_REDACTED_LINE_CHARS`
is kept rather than disabled: truncation keeps strictly less data, its cut is
token-aligned so it cannot slice a credential into an unmatchable fragment, and
it is what bounds that 32 us. Cost of keeping it: a >2,000-char record is
truncated on disk as well as in the Logs screen.

## Checked, deliberately unchanged

Loguru `diagnose` is `False` at every `logger.add` in the package
(`Logging_Config.py`, `__init__.py`, `startup_logging.py`,
`Metrics/logger_config.py`) — no finding. Loguru's own file sinks are already
disabled in `Metrics/logger_config.py`; `Chunking/engine/security_logger.py` can
open one but only when handed an explicit `log_file`, which no production caller
does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2WwNRSyk6w9V7b9yh5Yht


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the private rotating file sink so every record written to disk is redacted regardless of caller, and extends `redact_secret_text` to cover the `Authorization: Bearer` header and bare `?key=` query shapes that Settings surfaces were displaying verbatim.

**Bug Fixes**
- Added `RedactingFileFormatter`, which runs `redact_log_line` over the fully formatted record so credentials inside `exc_info` tracebacks are redacted — a filter rewriting `record.msg` would leave those untouched.
- Probed the real config first: the sink's `PersistentDiagnosticFilter` already drops unmarked and third-party records, so no unredacted secrets reach disk today; the formatter is the second layer that makes any future widening of that admission rule safe instead of a disclosure.
- `redact_secret_text` now also redacts `Bearer` values, colon-separated headers (`X-Api-Key: ...`), and bare `key` query parameters, with `key` anchored to `?`/`&` so ordinary prose containing the word stays intact.
- The already-installed-handler branch now upgrades a plain formatter to the redacting one, same as it already reconciles the filter.
- Tests drive the real `_configure_private_file_logging` per secret shape and read the file back, including a negative control and a check that unmarked secret-bearing records are not written at all; both guards were mutation-checked.

<sup>Written for commit e6ca3bf51e2a154eb3f1aa099d0de38823f5b1db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

