### PR TITLE
fix(watchlists): make day-header tests clock-independent

### DIFF
--- a/Tests/Watchlists/test_watchlists_article_list.py
+++ b/Tests/Watchlists/test_watchlists_article_list.py
@@ -8,7 +8,7 @@ in-place row repaints, open-item pinning).
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -34,15 +34,7 @@ from tldw_chatbook.UI.Watchlists_Modules.items_pane import (
 pytestmark = pytest.mark.unit
 
 
-def _now() -> datetime:
-    # Keep the relative-date fixtures away from local midnight while
-    # retaining per-call microseconds used to exercise stable newest-first
-    # ordering. Without this, ``now - 1 hour`` is legitimately yesterday
-    # during the first hour of a day and contradicts a fixture named Today.
-    now = datetime.now(timezone.utc)
-    if now.astimezone().hour < 6:
-        return now + timedelta(hours=12)
-    return now
+_REFERENCE_NOW = datetime(2026, 8, 22, 12).astimezone()
 
 
 def _item(
@@ -55,15 +47,20 @@ def _item(
     created_offset_hours: float = 0.5,
     **flags,
 ) -> dict:
-    published = _now() - timedelta(hours=published_offset_hours)
-    created = _now() - timedelta(hours=created_offset_hours)
+    # Preserve the old helper's newest-call-wins tie-break without reading
+    # the real clock: fixture IDs increase with fixture creation order.
+    fixture_order = timedelta(microseconds=item_id)
+    published = _REFERENCE_NOW - timedelta(hours=published_offset_hours) + fixture_order
+    created = _REFERENCE_NOW - timedelta(hours=created_offset_hours) + fixture_order
     return {
         "id": f"local:watchlist_item:{item_id}",
         "item_id": item_id,
         "title": title or f"Article {item_id}",
         "source_name": source_name,
         "status": status,
-        "published_date": published.isoformat() if published_offset_hours >= 0 else None,
+        "published_date": published.isoformat()
+        if published_offset_hours >= 0
+        else None,
         "created_at": created.isoformat(),
         "content": f"Body of article {item_id} with enough text to snippet.",
         "queued_for_briefing": False,
@@ -73,12 +70,13 @@ def _item(
 
 
 class ArticleListHarness(App):
-    def __init__(self):
+    def __init__(self, *, reference_now: datetime = _REFERENCE_NOW):
         super().__init__()
+        self.reference_now = reference_now
         self.captured_messages = []
 
     def compose(self) -> ComposeResult:
-        yield ArticleListPane()
+        yield ArticleListPane(reference_now=self.reference_now)
 
     def on_item_selected(self, message: ItemSelected) -> None:
         self.captured_messages.append(("item_selected", message.item))
@@ -110,12 +108,13 @@ class ProductionCssArticleListHarness(ArticleListHarness):
     )
 
     def compose(self) -> ComposeResult:
-        pane = ArticleListPane(id="watchlists-items-pane")
+        pane = ArticleListPane(
+            id="watchlists-items-pane", reference_now=self.reference_now
+        )
         pane.styles.height = "1fr"
         pane.styles.min_height = 0
         pane.items = [
-            _item(index, published_offset_hours=index * 12 + 1)
-            for index in range(50)
+            _item(index, published_offset_hours=index * 12 + 1) for index in range(50)
         ]
         with Vertical(classes="watchlists-read-mode"):
             yield Vertical(
@@ -144,11 +143,7 @@ def _item_rows(pane: ArticleListPane) -> list:
 
 def _header_texts(pane: ArticleListPane) -> list[str]:
     list_view = pane.query_one("#items-table", ListView)
-    return [
-        str(node.render())
-        for node in list_view.children
-        if node.disabled
-    ]
+    return [str(node.render()) for node in list_view.children if node.disabled]
 
 
 async def test_unread_row_is_bold_with_dot_and_read_row_is_plain():
@@ -268,6 +263,37 @@ async def test_future_dated_item_lands_under_today():
         assert headers == ["Today"]
 
 
+@pytest.mark.parametrize(
+    ("reference_now", "expected_header", "expected_stamp"),
+    [
+        (
+            datetime(2026, 8, 22, 23, 59, 30).astimezone(),
+            "Today",
+            "11:59 PM",
+        ),
+        (
+            datetime(2026, 8, 23, 0, 0, 30).astimezone(),
+            "Yesterday",
+            "Yesterday",
+        ),
+    ],
+)
+async def test_day_header_changes_at_local_midnight(
+    reference_now: datetime, expected_header: str, expected_stamp: str
+):
+    published = datetime(2026, 8, 22, 23, 59).astimezone()
+    app = ArticleListHarness(reference_now=reference_now)
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        item = _item(1)
+        item["published_date"] = published.isoformat()
+        pane.items = [item]
+        await pilot.pause()
+
+        assert _header_texts(pane) == [expected_header]
+        assert expected_stamp in str(_item_rows(pane)[0].render())
+
+
 async def test_displayed_items_excludes_headers_and_preserves_order():
     app = ArticleListHarness()
     async with app.run_test(size=(120, 40)) as pilot:
@@ -357,9 +383,7 @@ async def test_contextual_unread_filter_is_visible_locked_and_explained():
     async with app.run_test(size=(120, 40)) as pilot:
         pane = app.query_one(ArticleListPane)
         pane.status_filter = "unread"
-        pane.status_filter_disabled_reason = (
-            "All Unread always shows unread items."
-        )
+        pane.status_filter_disabled_reason = "All Unread always shows unread items."
         await pilot.pause()
 
         select = pane.query_one("#items-status-select", Select)
@@ -390,7 +414,10 @@ async def test_search_query_narrows_rows():
     app = ArticleListHarness()
     async with app.run_test(size=(120, 40)) as pilot:
         pane = app.query_one(ArticleListPane)
-        pane.items = [_item(1, title="Krebs on security"), _item(2, title="ArXiv digest")]
+        pane.items = [
+            _item(1, title="Krebs on security"),
+            _item(2, title="ArXiv digest"),
+        ]
         await pilot.pause()
 
         search = pane.query_one("#items-search-input", Input)
@@ -583,7 +610,9 @@ async def test_apply_page_items_rebuilds_before_focusing_first_row():
         assert [item["item_id"] for item in pane.displayed_items()] == [2, 1]
         list_view = pane.query_one("#items-table", ListView)
         assert list_view.has_focus
-        assert isinstance(list_view.children[list_view.index], type(_item_rows(pane)[0]))
+        assert isinstance(
+            list_view.children[list_view.index], type(_item_rows(pane)[0])
+        )
         assert not [m for m in app.captured_messages if m[0] == "item_selected"]
 
 
@@ -651,9 +680,7 @@ async def test_repaints_never_write_back_to_the_stored_item_dict():
         assert items[0]["status"] == "new", (
             "the repaint must render the new status without writing it back"
         )
-        assert not items[0].get("queued_for_briefing"), (
-            "same for the queued flag"
-        )
+        assert not items[0].get("queued_for_briefing"), "same for the queued flag"
         rendered = str(_item_rows(pane)[0].render())
         assert "· ingested" in rendered and pane._QUEUED_GLYPH in rendered, (
             "and the row itself must still show both"
@@ -731,7 +758,9 @@ async def test_unread_filter_with_nothing_unread_says_all_caught_up():
         await pilot.pause()
 
         assert pane.query_one("#items-empty-state", Static)
-        assert "caught up" in str(pane.query_one("#items-empty-state", Static).renderable)
+        assert "caught up" in str(
+            pane.query_one("#items-empty-state", Static).renderable
+        )
 
 
 async def test_update_item_starred_cell_toggles_the_glyph_in_place():

--- a/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
+++ b/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
@@ -17,7 +17,7 @@ anything on top of the first:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
@@ -37,11 +37,7 @@ pytestmark = pytest.mark.unit
 # --------------------------------------------------------------------------
 
 
-def _now() -> datetime:
-    now = datetime.now(timezone.utc)
-    if now.astimezone().hour < 6:
-        return now + timedelta(hours=12)
-    return now
+_REFERENCE_NOW = datetime(2026, 8, 22, 12).astimezone()
 
 
 def _item(
@@ -52,7 +48,7 @@ def _item(
     published_offset_hours: float = 1.0,
     **extra: Any,
 ) -> dict[str, Any]:
-    published = _now() - timedelta(hours=published_offset_hours)
+    published = _REFERENCE_NOW - timedelta(hours=published_offset_hours)
     return {
         "id": f"local:watchlist_item:{item_id}",
         "item_id": item_id,
@@ -90,7 +86,7 @@ def _source(
 
 class _ArticleHarness(App):
     def compose(self) -> ComposeResult:
-        yield ArticleListPane()
+        yield ArticleListPane(reference_now=_REFERENCE_NOW)
 
 
 class _ItemsHarness(App):
@@ -148,9 +144,7 @@ def _empty_state_text(pane: ArticleListPane) -> str | None:
 
 
 def _table_column(table: DataTable, column: int = 0) -> list[str]:
-    return [
-        str(table.get_row_at(index)[column]) for index in range(table.row_count)
-    ]
+    return [str(table.get_row_at(index)[column]) for index in range(table.row_count)]
 
 
 class _RecomposeCounter:
@@ -365,8 +359,7 @@ async def test_a_filter_change_during_a_row_rebuild_lands_on_the_new_filter():
         )
         assert "keeper one" in rendered[0]
         assert [item["item_id"] for item in pane.displayed_items()] == [7], (
-            "displayed_items() -- the j/k authority -- must agree with what "
-            "is painted"
+            "displayed_items() -- the j/k authority -- must agree with what is painted"
         )
 
 
@@ -431,8 +424,14 @@ async def test_sources_pane_filters_render_the_same_rows():
         pane = app.query_one(SourcesPane)
         pane.sources = [
             _source(1, name="AI News RSS", tags=["tech", "ai"]),
-            _source(2, name="Tech Atom Feed", source_type="atom", status="error",
-                    active=False, tags=["tech"]),
+            _source(
+                2,
+                name="Tech Atom Feed",
+                source_type="atom",
+                status="error",
+                active=False,
+                tags=["tech"],
+            ),
             _source(3, name="Playlist Watch", source_type="playlist", tags=["video"]),
         ]
         await pilot.pause()

--- a/backlog/tasks/task-19871 - Watchlists day-header tests read the real clock and fail before 02-00 local.md
+++ b/backlog/tasks/task-19871 - Watchlists day-header tests read the real clock and fail before 02-00 local.md
@@ -1,20 +1,22 @@
 ---
 id: TASK-19871
-title: >-
-  Watchlists day-header tests read the real clock and fail before 02:00 local
-status: To Do
-assignee: []
+title: 'Watchlists day-header tests read the real clock and fail before 02:00 local'
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-22'
+updated_date: '2026-08-29 03:06'
 labels:
   - testing
   - flaky-test
   - watchlists
-priority: medium
 dependencies: []
+priority: medium
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Source: a residual red observed during **TASK-19559**'s work, initially taken
 for a code regression. It is a timezone flake: the same commit passes under
 `TZ=UTC` and fails at machine-local time. First seen failing at 00:38 PDT.
@@ -61,23 +63,69 @@ tests passes one. A `TZ=UTC` fixture — as used by
 leaving the tests unable to exercise the boundary behaviour that is the actual
 subject of `day_bucket`, and leaves the next timezone-sensitive test to
 rediscover this.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] The affected tests produce the same result at every local wall-clock
+<!-- AC:BEGIN -->
+- [x] #1 The affected tests produce the same result at every local wall-clock
       time and in every timezone
-- [ ] The tests control the reference instant explicitly rather than depending
+- [x] #2 The tests control the reference instant explicitly rather than depending
       on when they happen to run
-- [ ] A test exercises the day-boundary transitions deliberately — an item just
+- [x] #3 A test exercises the day-boundary transitions deliberately — an item just
       before and just after local midnight — which the current tests cannot do
-- [ ] All five affected tests are covered (one in
+- [x] #4 All five affected tests are covered (one in
       `test_watchlists_pane_filter_in_place.py`, four in
       `test_watchlists_article_list.py`)
-- [ ] The fix is verified by running the affected tests with the process clock
+- [x] #5 The fix is verified by running the affected tests with the process clock
       or `TZ` set to a value inside the previously-failing window and observing
       a pass
-- [ ] Any remaining reliance on the ambient clock in `Tests/Watchlists/` is
+- [x] #6 Any remaining reliance on the ambient clock in `Tests/Watchlists/` is
       either removed or recorded with a reason
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write fixed-reference tests for the five affected Watchlists behaviors and a deliberate local-midnight transition; run them first to prove the missing pane clock seam fails.
+2. Add the smallest optional reference instant to ArticleListPane and thread it through day_bucket and relative_time for initial rows and repaints.
+3. Run the five affected tests under UTC and America/Los_Angeles with a reference instant inside the former failing window, then both focused test modules, modified-file Ruff, and git diff --check.
+4. Audit remaining Tests/Watchlists ambient-clock calls, record why retained uses are not day-boundary-sensitive, self-review, and complete the task notes.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a narrow deterministic-test seam over existing now= parameters and does not change storage, ownership, service, security, dependency, or long-lived UX boundaries.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented deterministic Watchlists day grouping without pinning the process
+timezone.
+
+- Added an optional `ArticleListPane` reference instant and threaded it through
+  `day_bucket()`, `relative_time()`, initial row construction, and in-place row
+  repaints. The production default remains the ambient clock.
+- Replaced both affected test helpers' `datetime.now()` calls with an explicit
+  local-noon reference and preserved their previous newest-first tie-break
+  deterministically.
+- Added a just-before/just-after local-midnight regression that verifies both
+  the day header and relative timestamp.
+- Verified the five affected behaviors plus the boundary test at 00:05 in
+  `America/Argentina/Buenos_Aires` (7 passed), and both focused modules in
+  `America/Los_Angeles` (54 passed). Modified-file Ruff lint/format and
+  `git diff --check` passed. The only test warning was the pre-existing
+  Requests dependency mismatch.
+- Audited the four remaining `Tests/Watchlists` `datetime.now()` calls.
+  `test_startup_reconcile_scheduler_race.py` deliberately creates a source
+  older than the live scheduler threshold;
+  `test_watchlists_artifacts_pane.py` and
+  `test_watchlists_scoped_rebuilds.py` create fresh persisted records relative
+  to the live service clock; `test_watchlists_collections_screen.py` exercises
+  the live Today query boundary itself. None derives day-label expectations
+  from hour offsets, so they remain intentional.
+- ADR required: no. This uses existing `now=` seams and introduces no
+  architectural boundary.
+<!-- SECTION:NOTES:END -->
 
 ## Notes
 

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -363,6 +363,14 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         reference_now: datetime | None = None,
         **kwargs: Any,
     ) -> None:
+        """Create the pane with an optional deterministic clock.
+
+        Args:
+            *args: Positional arguments forwarded to the Textual container.
+            reference_now: Reference instant for day labels and relative times.
+                Uses the ambient clock when omitted.
+            **kwargs: Keyword arguments forwarded to the Textual container.
+        """
         super().__init__(*args, **kwargs)
         self._reference_now = reference_now
         #: The exact sequence `compose()` last turned into rows, headers

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -70,12 +70,16 @@ def _sort_key(item: dict[str, Any]) -> datetime:
     return effective_date(item) or _EPOCH
 
 
-def _render_row(item: dict[str, Any]) -> Text:
+def _render_row(item: dict[str, Any], *, now: datetime | None = None) -> Text:
     """One item as a three-line `Text`: meta, title, snippet.
 
     Appended, never parsed -- see the module docstring. The status-derived
     vocabulary is the filter's own (`_FILTER_OPTIONS`): `new` is "unread",
     `reviewed` is "read", `ingested` renders read-styled with a marker.
+
+    Args:
+        item: The subscription item to render.
+        now: Optional reference instant for deterministic relative timestamps.
     """
     status = str(item.get("status") or "new").lower()
     unread = status == "new"
@@ -86,7 +90,7 @@ def _render_row(item: dict[str, Any]) -> Text:
         out.append(f"{ArticleListPane._UNREAD_DOT} ", style="bold blue")
     source = strip_control_characters(str(item.get("source_name") or "unknown source"))
     out.append(source, style="dim")
-    stamp = relative_time(effective_date(item))
+    stamp = relative_time(effective_date(item), now=now)
     if stamp != "-":
         out.append(f" · {stamp}", style="dim")
     if item.get("is_flagged"):
@@ -173,10 +177,16 @@ class _ArticleRow(ListItem):
     widget that no longer exists.
     """
 
-    def __init__(self, item: dict[str, Any], *, visible: bool = True) -> None:
+    def __init__(
+        self,
+        item: dict[str, Any],
+        *,
+        visible: bool = True,
+        reference_now: datetime | None = None,
+    ) -> None:
         self.item_id_key = str(item.get("id") or "")
         self.display_overrides: dict[str, Any] = {}
-        self._content = _render_row(item)
+        self._content = _render_row(item, now=reference_now)
         super().__init__(classes="article-row")
         self.set_row_visible(visible)
 
@@ -347,8 +357,14 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
             event.stop()
             self.post_message(RefreshItemsRequested())
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        reference_now: datetime | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
+        self._reference_now = reference_now
         #: The exact sequence `compose()` last turned into rows, headers
         #: excluded. Same authority argument as `ItemsPane._rendered_items`:
         #: rows are built once and status/queued repaints mutate item dicts
@@ -490,7 +506,7 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         header: _DayHeader | None = None
         header_has_visible = False
         for item in sorted(self.items, key=_sort_key, reverse=True):
-            bucket = day_bucket(effective_date(item))
+            bucket = day_bucket(effective_date(item), now=self._reference_now)
             if bucket != last_bucket:
                 _set_header_visible(header, header_has_visible)
                 header = _DayHeader(bucket)
@@ -499,7 +515,13 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
                 last_bucket = bucket
             visible = str(item.get("id") or "") in visible_keys
             header_has_visible = header_has_visible or visible
-            rows.append(_ArticleRow(item, visible=visible))
+            rows.append(
+                _ArticleRow(
+                    item,
+                    visible=visible,
+                    reference_now=self._reference_now,
+                )
+            )
         _set_header_visible(header, header_has_visible)
         return rows
 
@@ -629,7 +651,9 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         """
         status_filter = self.status_filter
         query = (
-            "" if self.search_results_authoritative else self.search_query.strip().lower()
+            ""
+            if self.search_results_authoritative
+            else self.search_query.strip().lower()
         )
         selected = self.selected_item
         selected_id: str | None = None
@@ -653,7 +677,14 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
                 # must not be filtered OUT of the page it just arrived on.
                 text = " ".join(
                     str(item.get(key) or "")
-                    for key in ("title", "url", "source_name", "status", "content", "author")
+                    for key in (
+                        "title",
+                        "url",
+                        "source_name",
+                        "status",
+                        "content",
+                        "author",
+                    )
                 ).lower()
                 if query not in text:
                     continue
@@ -801,13 +832,22 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         if row is None:
             return
         item = next(
-            (candidate for candidate in self.items if str(candidate.get("id")) == row.item_id_key),
+            (
+                candidate
+                for candidate in self.items
+                if str(candidate.get("id")) == row.item_id_key
+            ),
             None,
         )
         if item is None:
             return
         row.display_overrides.update(writes)
-        row.update_content(_render_row({**item, **row.display_overrides}))
+        row.update_content(
+            _render_row(
+                {**item, **row.display_overrides},
+                now=self._reference_now,
+            )
+        )
 
     def update_item_status_cell(self, item_id: Any, status: str) -> None:
         """Repaint one row after a status write.


### PR DESCRIPTION
## Summary

- inject an optional reference instant into ArticleListPane day grouping and relative timestamps
- replace real-clock Watchlists fixtures with an explicit deterministic reference
- cover the local-midnight Today-to-Yesterday transition for headers and row timestamps
- document the remaining intentional ambient-clock tests in TASK-19871

## Verification

- 7 affected cases passed at 00:05 in America/Argentina/Buenos_Aires, reproducing the former failure window
- 54 focused tests passed across the two affected Watchlists modules in America/Los_Angeles
- modified-file Ruff lint and format checks passed
- git diff --check passed

The only test warning was the pre-existing Requests dependency-version warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky Watchlists day-header tests that failed near local midnight by making the reference instant explicit. `ArticleListPane` now accepts an optional `reference_now` for day bucketing and relative timestamps; tests pass a fixed reference instead of reading the real clock, and a new regression test covers the local-midnight Today-to-Yesterday transition. Production default (ambient clock) is unchanged, and remaining ambient-clock test uses are documented as intentional in TASK-19871.

<sup>Written for commit 034aebfdeba79a51a2aff3dfc8a82f3900abe352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

