### PR TITLE
fix(settings): trustworthy dirty state and focused-setting line (TASK-23191/23192)

### DIFF
--- a/Tests/UI/test_settings_scope_inspector_focus.py
+++ b/Tests/UI/test_settings_scope_inspector_focus.py
@@ -1,0 +1,127 @@
+"""The Scope Inspector's "Focused setting" line must name the focused control.
+
+TASK-23192: the line read "Appearance defaults" while "Reduce motion"
+demonstrably held focus. The cause was two hand-maintained lists of the
+same thing -- the ``DescendantFocus`` handler's set of ids it will record,
+and the guidance branches that name them -- which drifted. This suite
+mounts the real screen and pins the line against the control that actually
+holds focus, by both routes users reach a control: search landing and
+plain Tab traversal.
+"""
+
+import pytest
+from textual.widgets import Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+    _wait_for_selector,
+)
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+from tldw_chatbook.UI.Screens.settings_screen import NO_FOCUSED_SETTING_COPY
+
+
+def _guide_line(screen, prefix: str) -> str:
+    """The rendered "Focused setting" row of a category's field guide."""
+    return str(screen.query_one(f"#settings-{prefix}-field-guide-0", Static).renderable)
+
+
+async def _tab_to(pilot, widget_id: str, limit: int = 120) -> bool:
+    """Walk focus with real Tab presses until ``widget_id`` holds it."""
+    for _ in range(limit):
+        if str(getattr(pilot.app.focused, "id", "") or "") == widget_id:
+            return True
+        await pilot.press("tab")
+    return str(getattr(pilot.app.focused, "id", "") or "") == widget_id
+
+
+@pytest.mark.asyncio
+async def test_focused_setting_line_names_the_control_that_holds_focus():
+    """AC1/AC3: two distinct settings, one reached each way."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen._select_category(SettingsCategoryId.APPEARANCE.value)
+        await _wait_for_selector(screen, pilot, "#settings-appearance-reduce-motion")
+        await pilot.pause()
+
+        # Route 1: search landing (the guarantee TASK-23109 depends on).
+        screen._land_search_focus_on_field(
+            "settings-appearance-reduce-motion", "Reduce motion"
+        )
+        await pilot.pause()
+        assert (
+            str(getattr(pilot.app.focused, "id", "") or "")
+            == "settings-appearance-reduce-motion"
+        ), "precondition: search landing put focus on Reduce motion"
+        assert _guide_line(screen, "appearance") == "Focused setting: Reduce motion"
+        assert (
+            screen._active_settings_field_id == "settings-appearance-reduce-motion"
+        )
+
+        # Route 2: plain Tab traversal onto a different setting.
+        assert await _tab_to(pilot, "settings-appearance-density"), (
+            "precondition: Tab reaches the Density select"
+        )
+        await pilot.pause()
+        assert _guide_line(screen, "appearance") == "Focused setting: Density"
+
+
+@pytest.mark.asyncio
+async def test_focused_setting_line_says_so_when_focus_is_not_on_a_setting():
+    """AC2: a container or non-setting control must not borrow a name."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen._select_category(SettingsCategoryId.APPEARANCE.value)
+        await _wait_for_selector(screen, pilot, "#settings-appearance-reduce-motion")
+        await pilot.pause()
+
+        screen._land_search_focus_on_field(
+            "settings-appearance-reduce-motion", "Reduce motion"
+        )
+        await pilot.pause()
+        assert _guide_line(screen, "appearance") == "Focused setting: Reduce motion"
+
+        # The category rail button is focusable and is not a setting.
+        rail_button = screen.query_one("#settings-category-appearance")
+        rail_button.focus()
+        await pilot.pause()
+        assert (
+            _guide_line(screen, "appearance")
+            == f"Focused setting: {NO_FOCUSED_SETTING_COPY}"
+        )
+        # ...and the screen must not RECORD it as the focused setting either:
+        # every downstream reader of this id treats it as a named setting.
+        assert screen._active_settings_field_id is None
+
+
+@pytest.mark.asyncio
+async def test_focused_setting_line_names_the_model_context_window():
+    """AC1 on the second category that renders the line.
+
+    ``settings-model-context-window`` has guidance rows of its own but was
+    absent from the Providers focus list, so it reported "Provider setup".
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen._select_category(SettingsCategoryId.PROVIDERS_MODELS.value)
+        await _wait_for_selector(screen, pilot, "#settings-model-context-window")
+        await pilot.pause()
+
+        screen._land_search_focus_on_field(
+            "settings-model-context-window", "Model context window tokens"
+        )
+        await pilot.pause()
+        assert (
+            str(getattr(pilot.app.focused, "id", "") or "")
+            == "settings-model-context-window"
+        ), "precondition: focus landed on the context-window input"
+        assert (
+            _guide_line(screen, "provider") == "Focused setting: Model context window"
+        )

--- a/Tests/UI/test_settings_video_gen_defaults.py
+++ b/Tests/UI/test_settings_video_gen_defaults.py
@@ -172,3 +172,90 @@ async def test_panel_compose_covers_all_sections():
         assert any("Diagnostics" in text for text in section_texts)
         assert any("ffmpeg" in text for text in section_texts)
         assert any("Style templates" in text for text in section_texts)
+
+
+# -- fresh-profile dirty state (TASK-23191) ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_video_gen_opens_clean_on_a_fresh_profile(monkeypatch):
+    """Opening Video Gen with no persisted ``[video_generation]`` is not dirty.
+
+    Regression pin for TASK-23191. Both of the panel's ``Select``s re-post
+    ``Changed`` from Textual's ``_on_mount``, and this category diffs
+    against the RAW config table, so an unguarded echo of a value that is
+    only the effective default reads as an edit. The shipped config
+    template writes no ``[video_generation]`` table at all, so every fresh
+    profile hits exactly that state and the banner read "Unsaved changes"
+    on a page nobody had touched.
+
+    The load patch pins that premise rather than creating it: a fresh
+    profile genuinely has no such table, but this suite shares one config
+    file with the rest of the run, and a sibling that saves Video Gen
+    defaults would otherwise quietly retire the regression this covers.
+    """
+    from textual.widgets import Select, Static
+
+    from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
+    from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+
+    from Tests.UI.test_destination_shells import (
+        DestinationHarness,
+        _active_destination_screen,
+        _build_test_app,
+        _wait_for_selector,
+    )
+
+    real_load = SettingsConfigAdapter.load
+
+    def _load_without_video_generation(self):
+        loaded = dict(real_load(self))
+        loaded.pop("video_generation", None)
+        return loaded
+
+    monkeypatch.setattr(
+        SettingsConfigAdapter, "load", _load_without_video_generation
+    )
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen._select_category(SettingsCategoryId.VIDEO_GENERATION.value)
+        await _wait_for_selector(screen, pilot, "#settings-videogen-panel")
+        await pilot.pause()
+
+        assert not screen._video_gen_raw_section(), "premise: no persisted table"
+
+        def _dirty_keys():
+            draft = screen._settings_drafts.get(SettingsCategoryId.VIDEO_GENERATION)
+            return getattr(draft, "dirty_keys", None)
+
+        def _banner():
+            return str(
+                screen.query_one("#settings-category-state-banner", Static).renderable
+            )
+
+        # AC1: nothing staged, and the banner does not ask for a Save.
+        assert not screen._category_has_unsaved_changes(
+            SettingsCategoryId.VIDEO_GENERATION
+        ), f"fresh profile staged: {_dirty_keys()}"
+        assert "Unsaved changes" not in _banner(), _banner()
+
+        # AC2: a real edit -- through the widget, not the staging helper --
+        # still turns it dirty...
+        retention = screen.query_one("#settings-videogen-retention", Select)
+        retention.value = "ttl"
+        await pilot.pause()
+        assert screen._category_has_unsaved_changes(
+            SettingsCategoryId.VIDEO_GENERATION
+        ), "a genuine retention edit must stage"
+        assert "Unsaved changes" in _banner(), _banner()
+
+        # ...and Revert clears it without the recomposed Selects re-dirtying.
+        await screen._handle_video_gen_revert()
+        await pilot.pause()
+        assert not screen._category_has_unsaved_changes(
+            SettingsCategoryId.VIDEO_GENERATION
+        ), f"revert left staged: {_dirty_keys()}"
+        assert "Unsaved changes" not in _banner(), _banner()

--- a/backlog/tasks/task-23191 - Video-Generation-settings-show-State-Unsaved-changes-on-a-fresh-profile-with-no-edits.md
+++ b/backlog/tasks/task-23191 - Video-Generation-settings-show-State-Unsaved-changes-on-a-fresh-profile-with-no-edits.md
@@ -3,7 +3,7 @@ id: TASK-23191
 title: >-
   Video Generation settings show 'State: Unsaved changes' on a fresh profile
   with no edits
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-29 02:25'
 labels:
@@ -21,7 +21,76 @@ On a newly created profile, opening Settings -> Video Generation reports unsaved
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening Video Generation on a fresh profile with no user edits reports no unsaved changes
-- [ ] #2 The dirty state appears only after an actual user edit and clears after save or revert
-- [ ] #3 A test mounts the category on a fresh profile and asserts the clean state, so the regression cannot return silently
+- [x] #1 Opening Video Generation on a fresh profile with no user edits reports no unsaved changes
+- [x] #2 The dirty state appears only after an actual user edit and clears after save or revert
+- [x] #3 A test mounts the category on a fresh profile and asserts the clean state, so the regression cannot return silently
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the false dirty state in a mounted test before touching production code.
+2. Find WHY the draft initializes dirty, and check whether the cause reaches sibling categories.
+3. Fix at the cause, mutation-check the test in both directions, and verify live on a fresh profile.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Root cause.** A freshly composed Textual `Select` re-posts `Changed` from
+its own `_on_mount` whenever it carries a non-blank value. Video Gen
+composes TWO of them, and this category deliberately diffs the draft
+against the RAW `[video_generation]` TOML table (never the resolved
+config) so an untouched key is never written out -- while the panel itself
+composes from the RESOLVED config. On a fresh profile the shipped config
+template writes no `[video_generation]` table at all (verified live: the
+app's own boot rewrite does not add one), so the retention `Select` mounted
+with the effective default `"session"` and its mount echo was staged as
+`retention: None -> "session"`. That is a difference, but not a user edit.
+`default_backend` was already protected by a suppression queue; retention
+had no guard.
+
+**Fix.** `expected_select_mount_values()` in
+`settings_video_gen_defaults.py` mirrors the panel's compose and reports
+what EVERY Video Gen `Select` will mount with. The screen's suppression
+queue became a per-Select mapping (`_video_gen_select_suppress_queues`,
+`_consume_video_gen_select_mount_echo`) so one Select's echo can never be
+mistaken for the other's, and it is cleared on category leave -- matching
+the image-gen and RAG precedents, since a stale expectation would
+otherwise swallow the first genuine edit of a later visit.
+
+**Sibling check (no other category has this shape).** Image Gen uses the
+same raw-table diff but composes a single, already-suppressed `Select`,
+and its `[image_generation]` section IS in the shipped template. Every
+other staging helper (`_stage_appearance_value`,
+`_stage_console_default_value`, `_stage_library_rag_value`,
+`_stage_storage_value`, ...) takes its "original" from the resolved
+`_*_loaded_values()` -- exactly what the widget mounts with -- so a mount
+echo compares equal there by construction.
+
+**Trade-off.** The suppression queue is a per-Select FIFO rather than a
+general "is this a user gesture?" test, because Textual gives the handler
+no way to tell a mount echo from a real `Changed`. The mirror between
+`expected_select_mount_values()` and the panel's compose must be kept in
+step by hand; it is one function with a docstring saying so, instead of
+the two divergent inline expressions it replaced.
+
+**Verification.** `test_video_gen_opens_clean_on_a_fresh_profile` mounts
+the category with no persisted table and asserts the clean draft AND the
+clean banner, then drives a REAL retention edit through the widget
+(dirty), then Revert (clean again). Mutation-checked both ways: removing
+the guard fails on `fresh profile staged: {'retention'}`; suppressing every
+retention `Changed` fails on `a genuine retention edit must stage`.
+
+Live, isolated fresh profile:
+
+    before:  State: Unsaved changes | Save (s) or Revert (r) - switching
+             categories keeps this draft.
+    after:   State: Draft - save/revert below | Defaults affect future
+             Console video generations.
+
+**Files.** `tldw_chatbook/UI/Screens/settings_video_gen_defaults.py`,
+`tldw_chatbook/UI/Screens/settings_screen.py`,
+`tldw_chatbook/Widgets/settings_video_gen_panel.py`,
+`Tests/UI/test_settings_video_gen_defaults.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23192 - Settings-Scope-Inspector-Focused-setting-line-names-the-wrong-control.md
+++ b/backlog/tasks/task-23192 - Settings-Scope-Inspector-Focused-setting-line-names-the-wrong-control.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-23192
 title: Settings Scope Inspector 'Focused setting' line names the wrong control
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-29 02:25'
 labels:
@@ -20,7 +20,77 @@ The Scope Inspector's 'Focused setting' line read 'Appearance defaults' while th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The 'Focused setting' line names the control that actually holds focus, including controls reached by search landing and by plain Tab traversal
-- [ ] #2 When focus is on a container or a non-setting control, the line says so rather than naming an unrelated setting
-- [ ] #3 A mounted test focuses at least two distinct settings and asserts the inspector line matches each
+- [x] #1 The 'Focused setting' line names the control that actually holds focus, including controls reached by search landing and by plain Tab traversal
+- [x] #2 When focus is on a container or a non-setting control, the line says so rather than naming an unrelated setting
+- [x] #3 A mounted test focuses at least two distinct settings and asserts the inspector line matches each
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Find how the line derives its label and reproduce the wrong name in a mounted test.
+2. Remove the cause rather than patching the one reported control.
+3. Mutation-check, then verify live via both search landing and Tab traversal.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Root cause.** The same set of guided fields was written down twice. The
+`DescendantFocus` handler kept a hand-maintained set of widget ids it would
+record in `_active_settings_field_id`, and the `_*_field_guidance_rows_base`
+methods kept their own `if field_id == ...` branches. They drifted:
+`settings-appearance-reduce-motion`, `settings-appearance-ascii-glyphs` and
+`settings-model-context-window` each had full guidance rows written for
+them but were absent from the focus set, so focusing them recorded `None`
+and the inspector fell through to the category-level fallback.
+
+**Fix.** The second list is deleted. `_guided_field_id()` asks the
+category's own guidance whether it has rows for the focused widget -- a
+field is guided exactly when its rows differ from the no-focus fallback --
+so the guidance branches are the single definition and the two cannot drift
+apart again. Both routes to a control (search landing and plain Tab
+traversal) arrive through the same `DescendantFocus`, so both are covered
+by one mechanism.
+
+**AC2.** The fallback used to name the CATEGORY ("Appearance defaults",
+"Storage defaults", "Provider setup"), which a keyboard user cannot tell
+apart from a setting's name. All three now render the shared
+`NO_FOCUSED_SETTING_COPY` ("None - Tab to a setting"), which says focus is
+not on a setting and names the way back to one.
+
+**Ownership decision.** `settings_search_index.py` was NOT reused as the
+naming path. The guidance branches already carry curated labels, and the
+index's labels differ where both exist ("Model context window tokens" vs
+"Model context window"), so borrowing them would have made the search
+result and the inspector disagree. For Appearance the two coverages are
+identical, so nothing is lost.
+
+**Trade-off.** `_guided_field_id` probes the guidance by setting and
+restoring `_active_settings_field_id`, which is less direct than a
+parameter would be, but it avoids re-threading three ~100-line branch
+methods and their existing test callers. It runs only on focus change.
+
+**Verification.** `Tests/UI/test_settings_scope_inspector_focus.py` mounts
+the real screen and pins the line against two distinct settings reached by
+two different routes, plus the non-setting case and the recorded-id
+contract. Mutation-checked both ways: making nothing guided fails all
+three names; making everything guided fails the non-setting assertion.
+
+Live, isolated fresh profile:
+
+    "/" -> "Reduce motion" -> Enter   Focused setting: Reduce motion
+    Tab                              Focused setting: ASCII glyphs
+    Tab                              Focused setting: Smooth scrolling
+    focus the category rail button   Focused setting: None - Tab to a setting
+    "/" -> "Model context window"    Focused setting: Model context window
+
+**Observed, deliberately not actioned.** Console Behavior's guidance has a
+`settings-console-context-*` branch its own hand-list never admits, so that
+branch is dead today. Its inspector renders no "Focused setting" row, so
+nothing displays a wrong name there, and admitting those ids would change
+guidance for a category outside these ACs.
+
+**Files.** `tldw_chatbook/UI/Screens/settings_screen.py`,
+`Tests/UI/test_settings_scope_inspector_focus.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -288,8 +288,11 @@ from .settings_image_gen_defaults import (
 )
 from .settings_video_gen_defaults import (
     BACKEND_IDS as VIDEO_GEN_BACKEND_IDS,
+    DEFAULT_BACKEND_SELECT_ID as VIDEO_GEN_DEFAULT_BACKEND_SELECT_ID,
+    RETENTION_SELECT_ID as VIDEO_GEN_RETENTION_SELECT_ID,
     VideoGenDraftValues,
     diff_to_sections as video_gen_diff_to_sections,
+    expected_select_mount_values as video_gen_expected_select_mount_values,
     validate_draft as validate_video_gen_draft,
 )
 from ...Widgets.settings_video_gen_panel import VideoGenSettingsPanel
@@ -5648,28 +5651,55 @@ class SettingsScreen(BaseAppScreen):
         draft = self._settings_drafts.get(SettingsCategoryId.VIDEO_GENERATION)
         return dict(draft.values) if draft is not None else {}
 
-    def _video_gen_expected_default_backend_select_value(
-        self, overlay: Mapping[str, object]
-    ) -> object:
-        """Mirror of the panel's compose logic for the suppression queue."""
-        cfg = get_video_generation_config(reload=True)
-        effective = overlay.get("default_backend", cfg.default_backend)
-        return effective if effective in VIDEO_GEN_BACKEND_IDS else Select.NULL
+    def _video_gen_select_suppress_queues(self) -> dict[str, list[object]]:
+        """Per-Select FIFOs of mount-time ``Changed`` values still expected.
+
+        Keyed by widget id: the panel composes two ``Select``s, and a value
+        one of them is about to echo must never be mistaken for the other's
+        (TASK-23191).
+        """
+        queues = getattr(self, "_video_gen_select_suppress_queue", None)
+        if not isinstance(queues, dict):
+            queues = {}
+            self._video_gen_select_suppress_queue = queues
+        return queues
 
     def _queue_video_gen_select_suppression(
         self, overlay: Mapping[str, object]
     ) -> None:
-        """Record the value the about-to-(re)compose default-backend Select
-        will mount with (a fresh Select refires Changed on mount with a
-        non-NULL value) -- the image block's exact idiom."""
-        expected = self._video_gen_expected_default_backend_select_value(overlay)
-        if expected is Select.NULL:
-            return
-        queue = getattr(self, "_video_gen_select_suppress_queue", None)
-        if queue is None:
-            queue = []
-            self._video_gen_select_suppress_queue = queue
-        queue.append(expected)
+        """Record what EVERY about-to-(re)compose Video Gen Select will mount
+        with -- a fresh Select refires Changed on mount with a non-blank
+        value, and this category diffs against the RAW config table, so an
+        unrecorded echo of a value that is merely the effective default
+        reads as an edit (TASK-23191: retention did exactly that, and a
+        never-touched fresh profile opened on "Unsaved changes").
+
+        Call immediately before every ``VideoGenSettingsPanel`` (re)compose:
+        the category-open ``_render_detail_pane`` branch, and the
+        ``panel.recompose()`` calls in ``_apply_video_gen_save_result`` /
+        ``_handle_video_gen_revert``. This is the image block's idiom,
+        widened from its single Select to a per-Select mapping.
+        """
+        queues = self._video_gen_select_suppress_queues()
+        expected = video_gen_expected_select_mount_values(
+            get_video_generation_config(reload=True), overlay
+        )
+        for select_id, value in expected.items():
+            queues.setdefault(select_id, []).append(value)
+
+    def _consume_video_gen_select_mount_echo(
+        self, select_id: str, value: object
+    ) -> bool:
+        """Whether ``value`` is the mount echo queued for ``select_id``.
+
+        Consumes the expectation when it matches, so only the first echo is
+        swallowed and every later ``Changed`` on that Select is a real edit.
+        """
+        queue = self._video_gen_select_suppress_queues().get(select_id)
+        if queue and value == queue[0]:
+            queue.pop(0)
+            return True
+        return False
 
     def _video_gen_stage(self, key: str, original: object, value: object) -> None:
         category = SettingsCategoryId.VIDEO_GENERATION
@@ -5792,9 +5822,9 @@ class SettingsScreen(BaseAppScreen):
     @on(Select.Changed, "#settings-videogen-default_backend")
     def handle_video_gen_default_backend_changed(self, event: Select.Changed) -> None:
         event.stop()
-        queue = getattr(self, "_video_gen_select_suppress_queue", [])
-        if queue and event.value == queue[0]:
-            queue.pop(0)
+        if self._consume_video_gen_select_mount_echo(
+            VIDEO_GEN_DEFAULT_BACKEND_SELECT_ID, event.value
+        ):
             return
         value = event.value if isinstance(event.value, str) else None
         original = self._video_gen_raw_section().get("default_backend")
@@ -5805,6 +5835,10 @@ class SettingsScreen(BaseAppScreen):
     @on(Select.Changed, "#settings-videogen-retention")
     def handle_video_gen_retention_changed(self, event: Select.Changed) -> None:
         event.stop()
+        if self._consume_video_gen_select_mount_echo(
+            VIDEO_GEN_RETENTION_SELECT_ID, event.value
+        ):
+            return
         value = event.value if isinstance(event.value, str) else None
         original = self._video_gen_raw_section().get("retention")
         self._video_gen_stage("retention", original, value)
@@ -18453,6 +18487,13 @@ class SettingsScreen(BaseAppScreen):
             # instead of touching a since-recomposed, unrelated panel.
             self._image_gen_probe_session += 1
             self._image_gen_probe_in_flight = False
+        if category_value != SettingsCategoryId.VIDEO_GENERATION.value:
+            # TASK-23191: same reasoning as the two queue clears above. A
+            # leftover expectation was queued against the (about to be
+            # destroyed) Select instances; the recomposed detail pane mints
+            # brand-new ones, and a stale entry would swallow the FIRST
+            # genuine edit the user makes on a later visit.
+            self._video_gen_select_suppress_queues().clear()
         # Task 2 review (Important): a stale re-index-confirm in-flight
         # guard must never survive navigating away from (or back into) the
         # category -- e.g. the user backs out mid-fetch. Unconditional

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -690,6 +690,22 @@ STAGED_SAVE_BEHAVIOR_COPY = "staged - press s to save, r to revert"
 # Mirrored (with an Enter-to-apply clause) in
 # Widgets/settings_splash_screen_viewer.py, which cannot import this module.
 INSTANT_APPLY_BEHAVIOR_COPY = "applies immediately - no Save needed"
+#: Value of the Scope Inspector's "Focused setting" row while focus sits on
+#: a container, an action button, or anything else that is not a setting.
+#: TASK-23192: the three categories that render the row each named their own
+#: CATEGORY here ("Appearance defaults", "Storage defaults", "Provider
+#: setup"), which a keyboard user cannot tell apart from a setting's name.
+NO_FOCUSED_SETTING_COPY = "None — Tab to a setting"
+#: The categories whose Scope Inspector renders a "Focused setting" row,
+#: mapped to the method that builds those rows. `_guided_field_id` asks the
+#: named method whether a focused widget is one it can name, so the set of
+#: guided fields has exactly one definition (the guidance branches) rather
+#: than a second hand-maintained id list that drifts away from it.
+_FOCUSED_FIELD_GUIDANCE_METHODS: dict[SettingsCategoryId, str] = {
+    SettingsCategoryId.PROVIDERS_MODELS: "_provider_field_guidance_rows_base",
+    SettingsCategoryId.APPEARANCE: "_appearance_field_guidance_rows_base",
+    SettingsCategoryId.STORAGE: "_storage_field_guidance_rows_base",
+}
 # Ids of the instant-persist model-catalog controls (checkboxes plus the
 # stale-hours input) so focus tracking and the inspector can name their
 # commit model instead of falling through to the staged default copy.
@@ -12168,7 +12184,7 @@ class SettingsScreen(BaseAppScreen):
                 ),
             )
         return (
-            ("Focused setting", "Provider setup"),
+            ("Focused setting", NO_FOCUSED_SETTING_COPY),
             (
                 "Purpose",
                 "Configure the default provider, model, endpoint, and credential source.",
@@ -12319,7 +12335,7 @@ class SettingsScreen(BaseAppScreen):
                 ("Validation", "Items width 32–72"),
             )
         return (
-            ("Focused setting", "Appearance defaults"),
+            ("Focused setting", NO_FOCUSED_SETTING_COPY),
             (
                 "Purpose",
                 "Configure global visual defaults without replacing the Theme editor.",
@@ -12351,7 +12367,7 @@ class SettingsScreen(BaseAppScreen):
         key = field_by_id.get(field_id or "")
         if key is None:
             return (
-                ("Focused setting", "Storage defaults"),
+                ("Focused setting", NO_FOCUSED_SETTING_COPY),
                 (
                     "Purpose",
                     "Configure persisted database path defaults for the next launch.",
@@ -18586,42 +18602,15 @@ class SettingsScreen(BaseAppScreen):
         active_category = self._active_category_id()
         widget_id = str(getattr(event.widget, "id", "") or "")
         if active_category is SettingsCategoryId.APPEARANCE:
-            appearance_field_ids = {
-                "settings-appearance-theme",
-                "settings-appearance-palette-theme-limit",
-                "settings-appearance-font-size",
-                "settings-appearance-density",
-                "settings-appearance-transcript-style",
-                "settings-appearance-animations-enabled",
-                "settings-appearance-smooth-scrolling",
-                "settings-appearance-library-media-library-open",
-                "settings-appearance-library-media-custom-widths",
-                "settings-appearance-library-media-library-width",
-                *(
-                    f"settings-appearance-library-{destination}-items-{suffix}"
-                    for destination, _label in LIBRARY_READER_DESTINATIONS
-                    for suffix in ("open", "width")
-                ),
-            }
-            self._active_settings_field_id = (
-                widget_id if widget_id in appearance_field_ids else None
+            self._active_settings_field_id = self._guided_field_id(
+                active_category, widget_id
             )
             self._refresh_appearance_field_guidance()
             self._scroll_impact_pane_to_field_guide(active_category)
             return
         if active_category is SettingsCategoryId.STORAGE:
-            storage_field_ids = {
-                "settings-storage-user-db-base-dir",
-                "settings-storage-chachanotes-db-path",
-                "settings-storage-prompts-db-path",
-                "settings-storage-media-db-path",
-                "settings-storage-research-db-path",
-                "settings-storage-writing-db-path",
-                "settings-storage-library-collections-db-path",
-                "settings-storage-workspaces-db-path",
-            }
-            self._active_settings_field_id = (
-                widget_id if widget_id in storage_field_ids else None
+            self._active_settings_field_id = self._guided_field_id(
+                active_category, widget_id
             )
             self._refresh_storage_field_guidance()
             self._scroll_impact_pane_to_field_guide(active_category)
@@ -18658,38 +18647,46 @@ class SettingsScreen(BaseAppScreen):
         if active_category is not SettingsCategoryId.PROVIDERS_MODELS:
             self._active_settings_field_id = None
             return
-        provider_field_ids = {
-            "settings-provider-value",
-            "settings-provider-manual-value",
-            "settings-model-value",
-            "settings-provider-endpoint-value",
-            "settings-provider-api-mode",
-            "settings-provider-api-key",
-            "settings-provider-api-key-clear",
-            "settings-provider-credential-env-var",
-            "settings-model-profile-temperature",
-            "settings-model-profile-top-p",
-            "settings-model-profile-min-p",
-            "settings-model-profile-top-k",
-            "settings-model-profile-max-tokens",
-            "settings-model-profile-seed",
-            "settings-model-profile-presence-penalty",
-            "settings-model-profile-frequency-penalty",
-            "settings-model-profile-reasoning-effort",
-            "settings-model-profile-reasoning-summary",
-            "settings-model-profile-verbosity",
-            "settings-model-profile-thinking-effort",
-            "settings-model-profile-thinking-budget-tokens",
-            "settings-model-profile-streaming",
-        }
-        # task-1341: model-catalog toggles also surface in the focused-field
-        # inspector so their instant-apply commit model is named (AC3).
-        provider_field_ids |= MODEL_CATALOG_FIELD_IDS
-        self._active_settings_field_id = (
-            widget_id if widget_id in provider_field_ids else None
+        self._active_settings_field_id = self._guided_field_id(
+            active_category, widget_id
         )
         self._refresh_provider_field_guidance()
         self._scroll_impact_pane_to_field_guide(active_category)
+
+    def _guided_field_id(
+        self, category: SettingsCategoryId, widget_id: str
+    ) -> str | None:
+        """``widget_id`` if the inspector can name it, otherwise ``None``.
+
+        The "Focused setting" row is only honest when the id the screen
+        records as focused is one the guidance actually names, so ask the
+        guidance instead of keeping a second list beside it: a field is
+        guided exactly when its rows differ from the category's no-focus
+        fallback. TASK-23192 -- the two lists had drifted, and "Reduce
+        motion" and "Model context window" each held focus while the line
+        named their category.
+
+        Args:
+            category: The active category, which owns the guidance rows.
+            widget_id: The id of the widget that just took focus.
+
+        Returns:
+            ``widget_id`` when the category's guidance has rows of its own
+            for it, else ``None`` (container, action button, or a category
+            whose inspector names no fields).
+        """
+        method_name = _FOCUSED_FIELD_GUIDANCE_METHODS.get(category)
+        if not widget_id or method_name is None:
+            return None
+        guidance_rows = getattr(self, method_name)
+        previous = self._active_settings_field_id
+        try:
+            self._active_settings_field_id = widget_id
+            focused_rows = guidance_rows()
+            self._active_settings_field_id = None
+            return widget_id if focused_rows != guidance_rows() else None
+        finally:
+            self._active_settings_field_id = previous
 
     def _scroll_impact_pane_to_field_guide(self, category: SettingsCategoryId) -> None:
         """Scroll the Scope Inspector so the Focused field guide is visible.

--- a/tldw_chatbook/UI/Screens/settings_video_gen_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_video_gen_defaults.py
@@ -43,6 +43,11 @@ BACKEND_LABELS: dict[str, str] = {
     "stable_diffusion_cpp": "SD.cpp video (local)",
 }
 
+#: Retention modes, in the order the panel offers them. The first entry is
+#: also the value the panel's ``Select`` falls back to when the configured
+#: mode is unrecognized.
+RETENTION_CHOICES: tuple[str, ...] = ("session", "ttl")
+
 
 @dataclass(frozen=True)
 class FieldSpec:
@@ -211,6 +216,50 @@ _GLOBAL_DRAFT_KEYS: tuple[str, ...] = (
 )
 
 
+#: Widget ids of the two ``Select``s the panel composes. Named here because
+#: the screen has to reason about their mount-time echoes before either one
+#: exists (see ``expected_select_mount_values``).
+DEFAULT_BACKEND_SELECT_ID = "settings-videogen-default_backend"
+RETENTION_SELECT_ID = "settings-videogen-retention"
+
+
+def expected_select_mount_values(
+    cfg: VideoGenerationConfig, overlay: Mapping[str, Any]
+) -> dict[str, Any]:
+    """The value each Video Gen ``Select`` will carry when it next mounts.
+
+    A freshly composed Textual ``Select`` re-posts ``Changed`` from its own
+    ``_on_mount`` whenever it carries a non-blank value, so the screen
+    cannot tell that echo apart from a user edit at the point it arrives.
+    It has to know, before the compose, which value each ``Select`` is
+    about to restate. This mirrors ``VideoGenSettingsPanel.compose``
+    exactly -- keep the two in step (TASK-23191: they were not, and the
+    unguarded retention ``Select`` reported "Unsaved changes" on a profile
+    nobody had edited).
+
+    Args:
+        cfg: The effective video-generation config the panel composes from.
+        overlay: The screen's staged (unsaved) draft values.
+
+    Returns:
+        ``select widget id -> mount value``. A ``Select`` that will mount
+        blank -- and so stay silent -- is absent from the mapping.
+    """
+    values: dict[str, Any] = {}
+
+    default_backend = overlay.get("default_backend", cfg.default_backend)
+    if default_backend in BACKEND_IDS:
+        values[DEFAULT_BACKEND_SELECT_ID] = default_backend
+
+    # allow_blank=False, so this one always mounts with a value and always
+    # echoes -- including the fallback when the config value is unknown.
+    retention = str(overlay.get("retention", cfg.retention))
+    values[RETENTION_SELECT_ID] = (
+        retention if retention in RETENTION_CHOICES else RETENTION_CHOICES[0]
+    )
+    return values
+
+
 def canonical_backend_order(backend_ids: Any) -> list[str]:
     """Normalize an ``enabled_backends``-shaped list to ``BACKEND_IDS``'
     canonical order, dropping any unrecognized entries (the list is a set;
@@ -334,7 +383,7 @@ _GLOBAL_INT_FIELD_SPECS: tuple[tuple[str, str, int], ...] = (
     ("max_store_mb", "Store cap (MB)", 1),
 )
 
-_RETENTION_CHOICES = frozenset({"session", "ttl"})
+_RETENTION_CHOICES = frozenset(RETENTION_CHOICES)
 
 
 def validate_draft(draft: VideoGenDraftValues) -> tuple[list[str], list[str]]:

--- a/tldw_chatbook/Widgets/settings_video_gen_panel.py
+++ b/tldw_chatbook/Widgets/settings_video_gen_panel.py
@@ -25,7 +25,10 @@ from textual.widgets import Button, Checkbox, Collapsible, Input, Select, Static
 from tldw_chatbook.UI.Screens.settings_video_gen_defaults import (
     BACKEND_IDS,
     BACKEND_LABELS,
+    DEFAULT_BACKEND_SELECT_ID,
     FIELD_SCHEMA,
+    RETENTION_CHOICES,
+    RETENTION_SELECT_ID,
     build_backend_rows,
     effective_placeholder,
     key_source_after_clear,
@@ -120,7 +123,7 @@ class VideoGenSettingsPanel(Vertical):
                     if effective_default_backend in BACKEND_IDS
                     else Select.NULL
                 ),
-                id="settings-videogen-default_backend",
+                id=DEFAULT_BACKEND_SELECT_ID,
                 classes="settings-compact-select",
                 allow_blank=True,
                 compact=True,
@@ -250,8 +253,12 @@ class VideoGenSettingsPanel(Vertical):
             retention_value = str(overlay.get("retention", cfg.retention))
             yield Select(
                 [("session (wipe on app start)", "session"), ("ttl (keep N hours)", "ttl")],
-                value=retention_value if retention_value in {"session", "ttl"} else "session",
-                id="settings-videogen-retention",
+                value=(
+                    retention_value
+                    if retention_value in RETENTION_CHOICES
+                    else RETENTION_CHOICES[0]
+                ),
+                id=RETENTION_SELECT_ID,
                 classes="settings-compact-select",
                 allow_blank=False,
                 compact=True,


### PR DESCRIPTION
Two Settings-screen mechanisms told the user something false. Both were
observed live during the TASK-23109 verification pass on an isolated
profile; each is fixed at its cause, in its own commit.

## TASK-23191 — Video Generation reported unsaved changes on a fresh profile

**Root cause.** A freshly composed Textual `Select` re-posts `Changed` from
its own `_on_mount` when it carries a non-blank value. Video Gen composes
TWO `Select`s, and this category deliberately diffs the draft against the
RAW `[video_generation]` TOML table (never the resolved config) so an
untouched key is never written out — while the panel composes from the
RESOLVED config. On a fresh profile the shipped config template writes no
`[video_generation]` table at all, so the retention `Select` mounted with
the effective default `"session"` and its mount echo was staged as
`retention: None -> "session"`. A difference, but not a user edit.
`default_backend` was already protected by a suppression queue; retention
had none.

**Fix.** `expected_select_mount_values()` (new, in the data layer) mirrors
the panel's compose and reports what *every* Video Gen `Select` will mount
with. The screen's suppression queue becomes a per-Select mapping, so one
Select's echo can never be mistaken for the other's, and it is cleared on
category leave — matching the image-gen and RAG precedents, since a stale
expectation would otherwise swallow the first genuine edit of a later
visit.

**Does the cause reach siblings? No.** Image Gen uses the same raw-table
diff but composes a single, already-suppressed `Select`, and its
`[image_generation]` section *is* in the shipped template. Every other
staging helper (`_stage_appearance_value`, `_stage_console_default_value`,
`_stage_library_rag_value`, `_stage_storage_value`, …) takes its "original"
from the resolved `_*_loaded_values()` — exactly what the widget mounts
with — so a mount echo compares equal there by construction.

**Runtime evidence** (isolated fresh profile; the app's own boot rewrite
was confirmed *not* to add a `[video_generation]` table):

```
before:  State: Unsaved changes | Save (s) or Revert (r) — switching categories keeps this draft.
after:   State: Draft — save/revert below | Defaults affect future Console video generations.
```

Then, in the fixed build, a real edit (Retention → `ttl`) gives
`State: Unsaved changes | …`, and Revert → Discard changes returns
`State: Draft — save/revert below | …`.

## TASK-23192 — the Scope Inspector named the wrong control

**Root cause.** The same set of guided fields was written down twice: the
`DescendantFocus` handler's hand-maintained id set, and the
`_*_field_guidance_rows_base` methods' own `if field_id == …` branches.
They drifted. `settings-appearance-reduce-motion`,
`settings-appearance-ascii-glyphs` and `settings-model-context-window` each
had full guidance rows written for them but were absent from the focus set,
so focusing them recorded `None` and the inspector fell through to the
category fallback — which is why the line read "Appearance defaults" while
Reduce motion held focus.

**Fix.** The second list is deleted. `_guided_field_id()` asks the
category's own guidance whether it has rows for the focused widget (a field
is guided exactly when its rows differ from the no-focus fallback), so the
guidance branches are the single definition and the two cannot drift again.
Search landing and Tab traversal both arrive through the same
`DescendantFocus`, so one mechanism covers both routes.

The fallback used to name the *category* ("Appearance defaults", "Storage
defaults", "Provider setup"), which a keyboard user cannot tell apart from
a setting's name; all three now render `NO_FOCUSED_SETTING_COPY`.

`settings_search_index.py` was deliberately not reused as the naming path:
the guidance branches already carry curated labels, and the index's differ
where both exist ("Model context window tokens" vs "Model context window"),
so borrowing them would make the search result and the inspector disagree.
For Appearance the two coverages are identical, so nothing is lost.

**Runtime evidence** (same profile, Settings ▸ Appearance):

```
"/" → "Reduce motion" → Enter    Focused setting: Reduce motion
Tab                              Focused setting: ASCII glyphs
Tab                              Focused setting: Smooth scrolling
focus the category rail button   Focused setting: None — Tab to a setting
```

and Settings ▸ Providers & Models, `"/" → "Model context window" → Enter`:

```
Focused setting: Model context window
```

## Verification

- `Tests/UI/test_settings_video_gen_defaults.py` — 14 passed (new:
  `test_video_gen_opens_clean_on_a_fresh_profile`). Mutation-checked both
  ways: removing the guard fails on `fresh profile staged: {'retention'}`;
  suppressing every retention `Changed` fails on
  `a genuine retention edit must stage`.
- `Tests/UI/test_settings_scope_inspector_focus.py` — 3 passed (new file).
  Mutation-checked both ways: making nothing guided fails all three names;
  making everything guided fails the non-setting assertion.
- `Tests/UI/test_settings_configuration_hub.py` — 6 failed, 373 passed;
  the 6 are the documented pre-existing privacy-security failures, no new
  names.
- `test_settings_search_index / appearance_defaults / rag_profile_region /
  qwencloud_api_mode / save_commit_models / footer_hints / category_sweep /
  panel_scoped_updates` — 1 failed, 222 passed. The one failure,
  `test_qwencloud_api_mode_field_search_enter_focuses_selector[mode]`, was
  reproduced **on the base commit `4fb5d38d37` in a clean worktree** and is
  pre-existing, not from this branch.
- `test_settings_image_gen_panel / image_gen_defaults` — 145 passed with
  video gen (the sibling that shares the suppression idiom).
- `ruff check` clean on all touched files; `./scripts/preflight.sh` green.

## Observed, deliberately not actioned

Console Behavior's guidance has a `settings-console-context-*` branch its
own hand-list never admits, so that branch is dead today. Its inspector
renders no "Focused setting" row, so nothing displays a wrong name there,
and admitting those ids would change guidance for a category outside these
ACs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2WwNRSyk6w9V7b9yh5Yht


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Settings-screen mechanisms that told users something false: Video Generation reported unsaved changes on a fresh profile, and the Scope Inspector's "Focused setting" line named the wrong control.

**Bug Fixes**

- Video Generation's retention `Select` echoed its mount value "session" and was staged as an edit against a fresh profile's absent `[video_generation]` table.
- `expected_select_mount_values()` now precomputes each Select's mount value; the suppression queue is per-Select and cleared on category leave, so only genuine edits mark the category dirty.
- Sibling categories are unaffected, since their staging helpers diff against the resolved config the widgets mount with.
- The Scope Inspector's "Focused setting" line named the active category (e.g., "Appearance defaults") instead of the focused control because the focus handler's id set had drifted from the guidance branches.
- `_guided_field_id()` asks the category's own guidance whether it names the focused widget, so the two lists can't drift again.
- The no-focus fallback now reads "None — Tab to a setting" instead of a category name.
- Adds mounted regression tests for both fixes, covering search landing and Tab traversal.

<sup>Written for commit 9ec6dadfcda6744249586ad630d7206c164b7f60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

