### PR TITLE
ci: bound pull request workflow fan-out

### DIFF
--- a/.github/workflows/backlog-guard.yml
+++ b/.github/workflows/backlog-guard.yml
@@ -34,7 +34,7 @@ jobs:
   duplicate-task-ids:
     name: No duplicate backlog task IDs
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/backlog-guard.yml
+++ b/.github/workflows/backlog-guard.yml
@@ -2,6 +2,7 @@ name: Backlog Guard
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'backlog/tasks/**'
       # Archiving or completing a file moves it between these directories
@@ -19,20 +20,21 @@ on:
       - 'backlog/archive/tasks/**'
       - 'scripts/check_backlog_task_ids.py'
 
-# One run per workflow per ref: a new push supersedes the previous run instead of
+# One PUSH run per workflow per ref: a new push supersedes the previous run instead of
 # queueing another alongside it. Without this, every push to `dev` stacked a full
-# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
+# run - 50+ obsolete runs accumulated, all competing for the shared account pool.
 # The event name is part of the group so different trigger types (push,
 # pull_request, schedule) never cancel each other, and `main` is never cancelled
 # so its history stays complete.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 jobs:
   duplicate-task-ids:
     name: No duplicate backlog task IDs
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/css-bundle-guard.yml
+++ b/.github/workflows/css-bundle-guard.yml
@@ -19,6 +19,7 @@ name: CSS Bundle Guard
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'tldw_chatbook/css/**'
       # `**.py`, not `**/*.py`: GitHub documents the former as "all .py files"
@@ -36,20 +37,21 @@ on:
       - 'tldw_chatbook/**.py'
       - '.github/workflows/css-bundle-guard.yml'
 
-# One run per workflow per ref: a new push supersedes the previous run instead of
+# One PUSH run per workflow per ref: a new push supersedes the previous run instead of
 # queueing another alongside it. Without this, every push to `dev` stacked a full
-# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
+# run - 50+ obsolete runs accumulated, all competing for the shared account pool.
 # The event name is part of the group so different trigger types (push,
 # pull_request, schedule) never cancel each other, and `main` is never cancelled
 # so its history stays complete.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 jobs:
   css-bundle-reproducible:
     name: CSS bundle reproduces from its sources
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/css-bundle-guard.yml
+++ b/.github/workflows/css-bundle-guard.yml
@@ -51,7 +51,7 @@ jobs:
   css-bundle-reproducible:
     name: CSS bundle reproduces from its sources
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -19,6 +19,7 @@ name: Derived Artifacts
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [dev, main]
 
@@ -34,7 +35,7 @@ on:
 # One run per workflow per ref for PUSH events: a new push to `dev` supersedes
 # the previous run instead of queueing another alongside it. Without this, every
 # push to `dev` stacked a full run - 50+ obsolete runs accumulated, all competing
-# for scarce macOS runners. The event name is part of the group so different
+# for the shared account pool. The event name is part of the group so different
 # trigger types never cancel each other, and `main` is never cancelled so its
 # history stays complete.
 #
@@ -66,6 +67,9 @@ jobs:
     # stable.
     name: Derived artifacts reproduce from their sources
     runs-on: ubuntu-latest
+    # PR #602 is a permanent draft mirror from dev to main. Keep it visible as
+    # a skipped check, but do not spend runner capacity until it is marked ready.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     # PR #602 is a permanent draft mirror from dev to main. Keep it visible as
     # a skipped check, but do not spend runner capacity until it is marked ready.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -49,7 +49,7 @@ jobs:
   ui-latency-guardrails:
     name: UI latency guardrails
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -13,6 +13,7 @@ name: Perf Guard
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'tldw_chatbook/**.py'
       - 'tldw_chatbook/css/**'
@@ -42,12 +43,13 @@ on:
 # runs must not queue up competing for scarce runners).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 jobs:
   ui-latency-guardrails:
     name: UI latency guardrails
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/task-2062-1-gguf-import-evidence.yml
+++ b/.github/workflows/task-2062-1-gguf-import-evidence.yml
@@ -6,9 +6,14 @@ on:
     paths:
       - '.github/workflows/task-2062-1-gguf-import-evidence.yml'
       - 'pyproject.toml'
+      - 'tldw_chatbook/app.py'
+      - 'tldw_chatbook/css/**'
       - 'tldw_chatbook/Model_Artifacts/**'
       - 'tldw_chatbook/UI/Screens/model_installed_view.py'
+      - 'Tests/conftest.py'
       - 'Tests/Model_Artifacts/**'
+      - 'Tests/UI/conftest.py'
+      - 'Tests/UI/consolidated_css.py'
       - 'Tests/UI/test_model_installed_view.py'
   workflow_dispatch:
 

--- a/.github/workflows/task-2062-1-gguf-import-evidence.yml
+++ b/.github/workflows/task-2062-1-gguf-import-evidence.yml
@@ -3,6 +3,13 @@ name: TASK-2062.1 GGUF import evidence
 on:
   pull_request:
     branches: [dev]
+    paths:
+      - '.github/workflows/task-2062-1-gguf-import-evidence.yml'
+      - 'pyproject.toml'
+      - 'tldw_chatbook/Model_Artifacts/**'
+      - 'tldw_chatbook/UI/Screens/model_installed_view.py'
+      - 'Tests/Model_Artifacts/**'
+      - 'Tests/UI/test_model_installed_view.py'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/task-2062-2-gguf-source-evidence.yml
+++ b/.github/workflows/task-2062-2-gguf-source-evidence.yml
@@ -6,12 +6,17 @@ on:
     paths:
       - '.github/workflows/task-2062-2-gguf-source-evidence.yml'
       - 'pyproject.toml'
+      - 'tldw_chatbook/app.py'
+      - 'tldw_chatbook/config.py'
       - 'tldw_chatbook/Event_Handlers/LLM_Management_Events/**'
       - 'tldw_chatbook/Model_Artifacts/**'
       - 'tldw_chatbook/UI/LLM_Management_Window.py'
       - 'tldw_chatbook/UI/Screens/llm_screen.py'
+      - 'Tests/conftest.py'
       - 'Tests/LLM_Management/**'
       - 'Tests/Model_Artifacts/**'
+      - 'Tests/UI/app_factory.py'
+      - 'Tests/UI/conftest.py'
       - 'Tests/UI/test_llm_gguf_source_modes.py'
   workflow_dispatch:
 

--- a/.github/workflows/task-2062-2-gguf-source-evidence.yml
+++ b/.github/workflows/task-2062-2-gguf-source-evidence.yml
@@ -3,6 +3,16 @@ name: TASK-2062.2 GGUF source evidence
 on:
   pull_request:
     branches: [dev]
+    paths:
+      - '.github/workflows/task-2062-2-gguf-source-evidence.yml'
+      - 'pyproject.toml'
+      - 'tldw_chatbook/Event_Handlers/LLM_Management_Events/**'
+      - 'tldw_chatbook/Model_Artifacts/**'
+      - 'tldw_chatbook/UI/LLM_Management_Window.py'
+      - 'tldw_chatbook/UI/Screens/llm_screen.py'
+      - 'Tests/LLM_Management/**'
+      - 'Tests/Model_Artifacts/**'
+      - 'Tests/UI/test_llm_gguf_source_modes.py'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,16 @@ on:
     branches: [ "main", "dev" ]
   pull_request:
     branches: [ "main", "dev" ]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
   schedule:
     # Nightly deep run (08:30 UTC); the job checks out dev explicitly because
     # scheduled workflows execute from the default branch.
     - cron: '30 8 * * *'
 
-# One run per workflow per ref: a new push supersedes the previous run instead of
+# One PUSH run per workflow per ref: a new push supersedes the previous run instead of
 # queueing another alongside it. Without this, every push to `dev` stacked a full
-# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
+# run - 50+ obsolete runs accumulated, all competing for the shared account pool.
 # The event name is part of the group so different trigger types (push,
 # pull_request, schedule) never cancel each other, and `main` is never cancelled
 # so its history stays complete.
@@ -74,18 +75,22 @@ jobs:
     # Six deterministic pytest-shard slices are ~32 min each, roughly a
     # quarter of the budget, and xdist still parallelizes within each slice.
     #
-    # ubuntu only, on purpose. macOS runners are the scarce ones -- queue
-    # waits of 42-90 minutes are routine here -- and multiplying the scarcest
-    # pool by six would cost more in queueing than it buys in coverage. macOS
-    # breadth already lives in nightly-deep, which is where it belongs.
+    # ubuntu only, on purpose. The measured constrained pool is ubuntu (~12
+    # concurrent slots), so the max-parallel bound below is the capacity
+    # control. Cross-platform breadth lives in nightly-deep.
     name: Core Tests (all but UI) - shard ${{ matrix.shard }}/${{ strategy.job-total }}
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     # Kept at 120 as headroom: the per-shard estimate is ~32 min, so this is
     # ~4x margin rather than a target. A shard that approaches it is a signal
     # to resize the matrix, not to raise the cap again.
     timeout-minutes: 120
     strategy:
       fail-fast: false
+      # Six live Tests runs previously asked for ~100 ubuntu jobs against an
+      # account ceiling of roughly 12. Three core plus three UI shards leaves
+      # capacity for short required checks from other workflows.
+      max-parallel: 3
       matrix:
         shard: [0, 1, 2, 3, 4, 5]
 
@@ -141,6 +146,7 @@ jobs:
   artifact-lease-spike:
     name: Artifact leases - Python ${{ matrix.python-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     strategy:
       fail-fast: false
       matrix:
@@ -178,6 +184,7 @@ jobs:
   artifact-lease-shape:
     name: Artifact lease workflow shape
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
 
     steps:
     - uses: actions/checkout@v4
@@ -199,7 +206,7 @@ jobs:
     name: Artifact Lease Gate
     runs-on: ubuntu-latest
     needs: [artifact-lease-spike, artifact-lease-shape]
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
 
     steps:
     - name: Require successful native lease matrix and CI shape
@@ -219,9 +226,11 @@ jobs:
     # budget, with xdist parallelism retained WITHIN each shard.
     name: UI Tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
@@ -269,6 +278,7 @@ jobs:
   textual-minimum:
     name: MCP - Minimum Textual 8.2.8
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 10
 
     steps:
@@ -440,7 +450,7 @@ jobs:
     name: Test Summary
     runs-on: ubuntu-latest
     needs: [core-tests, ui-tests, textual-minimum, artifact-lease-gate]
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     # control. Cross-platform breadth lives in nightly-deep.
     name: Core Tests (all but UI) - shard ${{ matrix.shard }}/${{ strategy.job-total }}
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     # Kept at 120 as headroom: the per-shard estimate is ~32 min, so this is
     # ~4x margin rather than a target. A shard that approaches it is a signal
     # to resize the matrix, not to raise the cap again.
@@ -146,7 +146,7 @@ jobs:
   artifact-lease-spike:
     name: Artifact leases - Python ${{ matrix.python-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     strategy:
       fail-fast: false
       matrix:
@@ -184,7 +184,7 @@ jobs:
   artifact-lease-shape:
     name: Artifact lease workflow shape
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
 
     steps:
     - uses: actions/checkout@v4
@@ -206,7 +206,7 @@ jobs:
     name: Artifact Lease Gate
     runs-on: ubuntu-latest
     needs: [artifact-lease-spike, artifact-lease-shape]
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
 
     steps:
     - name: Require successful native lease matrix and CI shape
@@ -226,7 +226,7 @@ jobs:
     # budget, with xdist parallelism retained WITHIN each shard.
     name: UI Tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -278,7 +278,7 @@ jobs:
   textual-minimum:
     name: MCP - Minimum Textual 8.2.8
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 10
 
     steps:
@@ -450,7 +450,7 @@ jobs:
     name: Test Summary
     runs-on: ubuntu-latest
     needs: [core-tests, ui-tests, textual-minimum, artifact-lease-gate]
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
     
     steps:
     - uses: actions/checkout@v4

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2463,6 +2463,13 @@
     },
     {
       "call_count": 2,
+      "diagnostic_digest": "2395fe5d97fe13f519d8",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Library_Modules/library_collections_browse_controller.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
       "diagnostic_digest": "a5d9efad9e09d4fd1244",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py",
@@ -2644,8 +2651,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 124,
-      "diagnostic_digest": "0c14000924413ee25def",
+      "call_count": 123,
+      "diagnostic_digest": "823690b9a11758ac2ab9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11108,10 +11115,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 541,
+    "owner_files": 542,
     "path_privacy_candidate_calls": 717,
     "persistent_sink_files": 8,
     "task_492_calls": 1270,
-    "task_494_calls": 7401
+    "task_494_calls": 7402
   }
 }

--- a/Tests/CI/test_ci_queue_pressure_contract.py
+++ b/Tests/CI/test_ci_queue_pressure_contract.py
@@ -13,11 +13,13 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_ROOT = PROJECT_ROOT / ".github" / "workflows"
 PROMOTION_GUARD = (
     "${{ github.event_name != 'pull_request' || "
+    "github.event.pull_request.number != 602 || "
     "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
     "github.base_ref != 'main' }}"
 )
 ALWAYS_PROMOTION_GUARD = (
     "${{ always() && (github.event_name != 'pull_request' || "
+    "github.event.pull_request.number != 602 || "
     "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
     "github.base_ref != 'main') }}"
 )
@@ -47,7 +49,7 @@ def _workflow(name: str) -> dict:
 
 
 def test_draft_dev_to_main_promotion_does_not_request_runners() -> None:
-    """The permanent draft promotion PR must report skips, not consume slots."""
+    """Only permanent promotion PR #602 may report skips without runner use."""
     test_jobs = _workflow("test.yml")["jobs"]
     for job_name, expected_guard in TEST_JOB_GUARDS.items():
         assert test_jobs[job_name].get("if") == expected_guard

--- a/Tests/CI/test_ci_queue_pressure_contract.py
+++ b/Tests/CI/test_ci_queue_pressure_contract.py
@@ -1,0 +1,78 @@
+"""Contracts for TASK-22250's bounded pull-request CI fan-out."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_ROOT = PROJECT_ROOT / ".github" / "workflows"
+PROMOTION_GUARD = (
+    "${{ github.event_name != 'pull_request' || "
+    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
+    "github.base_ref != 'main' }}"
+)
+ALWAYS_PROMOTION_GUARD = (
+    "${{ always() && (github.event_name != 'pull_request' || "
+    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
+    "github.base_ref != 'main') }}"
+)
+TEST_JOB_GUARDS = {
+    "core-tests": PROMOTION_GUARD,
+    "artifact-lease-spike": PROMOTION_GUARD,
+    "artifact-lease-shape": PROMOTION_GUARD,
+    "artifact-lease-gate": ALWAYS_PROMOTION_GUARD,
+    "ui-tests": PROMOTION_GUARD,
+    "textual-minimum": PROMOTION_GUARD,
+    "test-summary": ALWAYS_PROMOTION_GUARD,
+}
+STANDALONE_JOB_GUARDS = {
+    "derived-artifacts.yml": "derived-artifacts",
+    "css-bundle-guard.yml": "css-bundle-reproducible",
+    "perf-guard.yml": "ui-latency-guardrails",
+    "backlog-guard.yml": "duplicate-task-ids",
+}
+PUSH_ONLY_CANCELLATION = (
+    "${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}"
+)
+PULL_REQUEST_TYPES = ["opened", "synchronize", "reopened", "ready_for_review"]
+
+
+def _workflow(name: str) -> dict:
+    return yaml.safe_load((WORKFLOW_ROOT / name).read_text(encoding="utf-8"))
+
+
+def test_draft_dev_to_main_promotion_does_not_request_runners() -> None:
+    """The permanent draft promotion PR must report skips, not consume slots."""
+    test_jobs = _workflow("test.yml")["jobs"]
+    for job_name, expected_guard in TEST_JOB_GUARDS.items():
+        assert test_jobs[job_name].get("if") == expected_guard
+
+    for workflow_name, job_name in STANDALONE_JOB_GUARDS.items():
+        assert _workflow(workflow_name)["jobs"][job_name].get("if") == PROMOTION_GUARD
+
+
+def test_ready_for_review_retriggers_jobs_skipped_while_draft() -> None:
+    """Marking the promotion ready must replace its earlier skipped verdicts."""
+    for workflow_name in ("test.yml", *STANDALONE_JOB_GUARDS):
+        workflow = _workflow(workflow_name)
+        triggers = workflow.get("on", workflow.get(True))
+        assert triggers["pull_request"]["types"] == PULL_REQUEST_TYPES
+
+
+def test_pull_request_shards_leave_capacity_for_required_checks() -> None:
+    """One Tests run may occupy at most six shard slots at a time."""
+    jobs = _workflow("test.yml")["jobs"]
+    assert jobs["core-tests"]["strategy"]["max-parallel"] == 3
+    assert jobs["ui-tests"]["strategy"]["max-parallel"] == 3
+
+
+def test_tests_still_cancels_only_superseded_push_runs() -> None:
+    """Queue bounding must not reintroduce pull-request cancellation sweeps."""
+    for workflow_name in ("test.yml", *STANDALONE_JOB_GUARDS):
+        concurrency = _workflow(workflow_name)["concurrency"]
+        assert concurrency["cancel-in-progress"] == PUSH_ONLY_CANCELLATION

--- a/Tests/CI/test_derived_artifacts_workflow.py
+++ b/Tests/CI/test_derived_artifacts_workflow.py
@@ -29,6 +29,7 @@ CHECKERS = (
     # TASK-20971. VALID_TABLES['chachanotes'] went stale, was repaired, and
     # went stale again 14.5 hours later; this is its authoring-time half.
     "scripts/check_schema_table_allowlist.py",
+    "scripts/check_index_plan_pins.py",
 )
 
 

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -9,6 +9,16 @@ ARTIFACT_LEASE_TEST_TARGETS = (
     "Tests/Model_Artifacts/test_operation_leases.py",
     "Tests/Model_Artifacts/test_operation_leases_process.py",
 )
+PROMOTION_GUARD = (
+    "if: ${{ github.event_name != 'pull_request' || "
+    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
+    "github.base_ref != 'main' }}"
+)
+ALWAYS_PROMOTION_GUARD = (
+    "if: ${{ always() && (github.event_name != 'pull_request' || "
+    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
+    "github.base_ref != 'main') }}"
+)
 
 
 def _workflow_text() -> str:
@@ -172,7 +182,9 @@ def test_ci_exercises_mcp_against_minimum_textual() -> None:
     )
 
 
-def test_artifact_lease_spike_runs_three_os_on_merge_and_ubuntu_on_a_pull_request() -> None:
+def test_artifact_lease_spike_runs_three_os_on_merge_and_ubuntu_on_a_pull_request() -> (
+    None
+):
     """TASK-22250: the three-OS matrix moved to MERGE (push to dev/main) and
     nightly; a pull_request gets ubuntu only.
 
@@ -196,7 +208,7 @@ def test_artifact_lease_spike_runs_three_os_on_merge_and_ubuntu_on_a_pull_reques
     # pull_request arm: ubuntu only.
     assert "'[\"ubuntu-latest\"]'" in block
     # push / schedule arm: the full matrix still runs.
-    assert "'[\"ubuntu-latest\",\"macos-latest\",\"windows-latest\"]'" in block
+    assert '\'["ubuntu-latest","macos-latest","windows-latest"]\'' in block
     assert 'python-version: ["3.11"]' in block
     assert "pip install -e ." in block
     assert "pip install -r requirements-test.txt" in block
@@ -233,7 +245,7 @@ def test_ci_shape_regression_runs_in_dedicated_pull_request_job() -> None:
     ]
 
     assert "runs-on: ubuntu-latest" in shape
-    assert "if:" not in shape
+    assert PROMOTION_GUARD in shape
     assert "uses: actions/checkout@v4" in shape
     assert "uses: actions/setup-python@v5" in shape
     assert 'python-version: "3.11"' in shape
@@ -254,7 +266,7 @@ def test_artifact_lease_gate_exposes_stable_required_context() -> None:
     assert "name: Artifact Lease Gate" in gate
     assert "runs-on: ubuntu-latest" in gate
     assert "needs: [artifact-lease-spike, artifact-lease-shape]" in gate
-    assert "if: always()" in gate
+    assert ALWAYS_PROMOTION_GUARD in gate
     assert (
         'if [ "${{ needs.artifact-lease-spike.result }}" != "success" ] || '
         '[ "${{ needs.artifact-lease-shape.result }}" != "success" ]; then' in gate
@@ -266,7 +278,6 @@ def test_artifact_lease_gate_exposes_stable_required_context() -> None:
 def test_pr_gate_shards_cover_the_whole_tree_in_parallel() -> None:
     """task-1465: core+ui shards replace the 27-file `-m unit` selection."""
     workflow = _workflow_text()
-    ui_job = _ui_tests_job_block()
 
     assert "  core-tests:" in workflow
     assert "pytest Tests --ignore=Tests/UI" in workflow
@@ -288,12 +299,9 @@ def test_ui_job_is_sharded_to_fit_its_time_budget() -> None:
     which is per-job randomness), covers every test exactly once across the
     matrix, and each slice still parallelizes internally with xdist.
     """
-    workflow = _workflow_text()
     ui_job = _ui_tests_job_block()
 
-    assert "pytest-shard" in (
-        PROJECT_ROOT / "requirements-test.txt"
-    ).read_text()
+    assert "pytest-shard" in (PROJECT_ROOT / "requirements-test.txt").read_text()
     assert "--shard-id=${{ matrix.shard }}" in ui_job
     # The ids and the divisor must describe the same complete partition:
     # 12 shards numbered 0..11. A mismatch (e.g. ids 1..12 against
@@ -382,9 +390,9 @@ def test_core_tests_job_budget_covers_the_suite() -> None:
     core = _core_tests_job_block()
 
     line = next(
-        l.strip()
-        for l in core.splitlines()
-        if l.strip().startswith("timeout-minutes:")
+        candidate.strip()
+        for candidate in core.splitlines()
+        if candidate.strip().startswith("timeout-minutes:")
     )
     assert int(line.split(":")[1]) >= 120
 
@@ -518,7 +526,9 @@ def test_an_in_flight_pull_request_run_is_not_cancelled_mid_run() -> None:
     A push run may still be superseded: pushing again genuinely obsoletes the
     previous commit's run. `main` is never cancelled either way.
     """
-    concurrency = _workflow_text().split("concurrency:", 1)[1].split("permissions:", 1)[0]
+    concurrency = (
+        _workflow_text().split("concurrency:", 1)[1].split("permissions:", 1)[0]
+    )
     cancel_line = next(
         line for line in concurrency.splitlines() if "cancel-in-progress:" in line
     )

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -11,11 +11,13 @@ ARTIFACT_LEASE_TEST_TARGETS = (
 )
 PROMOTION_GUARD = (
     "if: ${{ github.event_name != 'pull_request' || "
+    "github.event.pull_request.number != 602 || "
     "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
     "github.base_ref != 'main' }}"
 )
 ALWAYS_PROMOTION_GUARD = (
     "if: ${{ always() && (github.event_name != 'pull_request' || "
+    "github.event.pull_request.number != 602 || "
     "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
     "github.base_ref != 'main') }}"
 )

--- a/Tests/CI/test_task2062_1_gguf_import_evidence.py
+++ b/Tests/CI/test_task2062_1_gguf_import_evidence.py
@@ -35,9 +35,14 @@ EXPECTED_OSES = ("ubuntu-latest", "macos-latest", "windows-latest")
 EXPECTED_PULL_REQUEST_PATHS = (
     ".github/workflows/task-2062-1-gguf-import-evidence.yml",
     "pyproject.toml",
+    "tldw_chatbook/app.py",
+    "tldw_chatbook/css/**",
     "tldw_chatbook/Model_Artifacts/**",
     "tldw_chatbook/UI/Screens/model_installed_view.py",
+    "Tests/conftest.py",
     "Tests/Model_Artifacts/**",
+    "Tests/UI/conftest.py",
+    "Tests/UI/consolidated_css.py",
     "Tests/UI/test_model_installed_view.py",
 )
 ASYNC_EVIDENCE_FUNCTIONS = {

--- a/Tests/CI/test_task2062_1_gguf_import_evidence.py
+++ b/Tests/CI/test_task2062_1_gguf_import_evidence.py
@@ -32,6 +32,14 @@ REQUIRED_NODES = (
     "Tests/UI/test_model_installed_view.py::test_import_lane_disables_every_lifecycle_action_at_80_columns",
 )
 EXPECTED_OSES = ("ubuntu-latest", "macos-latest", "windows-latest")
+EXPECTED_PULL_REQUEST_PATHS = (
+    ".github/workflows/task-2062-1-gguf-import-evidence.yml",
+    "pyproject.toml",
+    "tldw_chatbook/Model_Artifacts/**",
+    "tldw_chatbook/UI/Screens/model_installed_view.py",
+    "Tests/Model_Artifacts/**",
+    "Tests/UI/test_model_installed_view.py",
+)
 ASYNC_EVIDENCE_FUNCTIONS = {
     "Tests/UI/test_model_installed_view.py": {
         "test_tldwcli_css_finish_slice_restores_terminal_import_focus",
@@ -70,7 +78,10 @@ def test_workflow_is_one_read_only_exact_three_os_matrix() -> None:
     triggers = workflow.get("on", workflow.get(True))
     assert isinstance(triggers, dict)
     assert set(triggers) == {"pull_request", "workflow_dispatch"}
-    assert triggers["pull_request"] == {"branches": ["dev"]}
+    assert triggers["pull_request"] == {
+        "branches": ["dev"],
+        "paths": list(EXPECTED_PULL_REQUEST_PATHS),
+    }
     assert workflow.get("permissions") == {"contents": "read"}
 
     jobs = workflow.get("jobs")

--- a/Tests/CI/test_task2062_2_gguf_source_evidence.py
+++ b/Tests/CI/test_task2062_2_gguf_source_evidence.py
@@ -38,12 +38,17 @@ EXPECTED_OSES = ("ubuntu-latest", "macos-latest", "windows-latest")
 EXPECTED_PULL_REQUEST_PATHS = (
     ".github/workflows/task-2062-2-gguf-source-evidence.yml",
     "pyproject.toml",
+    "tldw_chatbook/app.py",
+    "tldw_chatbook/config.py",
     "tldw_chatbook/Event_Handlers/LLM_Management_Events/**",
     "tldw_chatbook/Model_Artifacts/**",
     "tldw_chatbook/UI/LLM_Management_Window.py",
     "tldw_chatbook/UI/Screens/llm_screen.py",
+    "Tests/conftest.py",
     "Tests/LLM_Management/**",
     "Tests/Model_Artifacts/**",
+    "Tests/UI/app_factory.py",
+    "Tests/UI/conftest.py",
     "Tests/UI/test_llm_gguf_source_modes.py",
 )
 EXPECTED_STEP_NAMES = (

--- a/Tests/CI/test_task2062_2_gguf_source_evidence.py
+++ b/Tests/CI/test_task2062_2_gguf_source_evidence.py
@@ -35,6 +35,17 @@ REQUIRED_NODES = (
     "Tests/LLM_Management/test_gguf_server_sources.py::test_mlx_command_snapshot_is_unchanged",
 )
 EXPECTED_OSES = ("ubuntu-latest", "macos-latest", "windows-latest")
+EXPECTED_PULL_REQUEST_PATHS = (
+    ".github/workflows/task-2062-2-gguf-source-evidence.yml",
+    "pyproject.toml",
+    "tldw_chatbook/Event_Handlers/LLM_Management_Events/**",
+    "tldw_chatbook/Model_Artifacts/**",
+    "tldw_chatbook/UI/LLM_Management_Window.py",
+    "tldw_chatbook/UI/Screens/llm_screen.py",
+    "Tests/LLM_Management/**",
+    "Tests/Model_Artifacts/**",
+    "Tests/UI/test_llm_gguf_source_modes.py",
+)
 EXPECTED_STEP_NAMES = (
     "Check out the exact tested commit",
     "Set up Python 3.12",
@@ -77,7 +88,10 @@ def test_workflow_is_one_read_only_exact_three_os_matrix() -> None:
     text, workflow = _workflow()
     triggers = workflow.get("on", workflow.get(True))
     assert triggers == {
-        "pull_request": {"branches": ["dev"]},
+        "pull_request": {
+            "branches": ["dev"],
+            "paths": list(EXPECTED_PULL_REQUEST_PATHS),
+        },
         "workflow_dispatch": None,
     }
     assert workflow.get("permissions") == {"contents": "read"}

--- a/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
+++ b/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
@@ -285,6 +285,18 @@ verdict criteria open until GitHub Actions demonstrates them on a PR.
 - The stale derived-artifacts contract was repaired to include the already
   existing `scripts/check_index_plan_pins.py` sixth checker.
 
+### Review follow-up
+
+- The draft promotion exemption is bound to exact PR #602 as well as its draft
+  `dev`-to-`main` shape, so a fork cannot reuse those branch names to bypass CI.
+- The two GGUF evidence path filters include the application, configuration,
+  CSS, and pytest harness files imported by their selected evidence nodes.
+- Rebasing onto `dev` exposed stale diagnostic-inventory drift from PR #2199.
+  The two added statements log only stable operation names and exception types;
+  the removed statement was the superseded Library Collections warning. The
+  reviewed inventory was regenerated so the required check reflects the new
+  base truthfully.
+
 Queue cleanup used open-PR head SHAs plus current `dev`/`main` SHAs as the
 authority boundary:
 

--- a/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
+++ b/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
@@ -34,10 +34,31 @@ fix it (this is why the proposed workflow edit was put on hold).
 
 ## Acceptance Criteria
 
-- [ ] The agent performing the cancellations is identified (account concurrency
+- [x] The agent performing the cancellations is identified (account concurrency
       ceiling, manual queue clearing, or workflow configuration)
 - [ ] A PR's test workflows can run to completion without being swept
 - [ ] `Tests` produces a verdict on at least one PR
+
+## Implementation Plan
+
+1. Add focused workflow-contract tests for the selected queue-pressure controls.
+2. Suppress runner-consuming checks only for a draft `dev` to `main` promotion PR.
+3. Cap the core and UI shard matrices at three simultaneous jobs each while
+   preserving push-only cancellation behavior.
+4. Restrict the two TASK-2062 GGUF evidence workflows to their owned code and
+   test paths while retaining manual dispatch.
+5. Run YAML/static validation and the targeted CI contract tests, then
+   self-review the workflow diff.
+6. Audit both repository queues and cancel only obsolete queued/pending runs,
+   preserving the newest useful run for each active lane.
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is an operational GitHub Actions scheduling and trigger-policy
+change; it does not alter application architecture, storage, security, or a
+cross-module runtime contract.
 
 ## Implementation Notes
 
@@ -211,7 +232,8 @@ and it affects every contributor's CI, so it is an owner decision.
       ceiling, saturated by a 25-job fan-out; measured 2026-08-28)
 - [ ] A PR's test workflows can run to completion without being swept
 - [ ] `Tests` produces a verdict on at least one PR
-- [ ] Owner picks among the three fan-out/ceiling options above
+- [x] Owner picks among the three fan-out/ceiling options above (cap concurrent
+      shard fan-out and narrow task-specific evidence triggers)
 
 ### Why the docs-only skip was withdrawn (Qodo review, 2026-08-28)
 
@@ -241,3 +263,57 @@ deliberate coverage decision: the UI suite is **41.5 min x 12 shards ~= 8.3
 job-hours**, and per-job setup is only ~8% (3.6 min of 45), so re-sharding
 moves the number very little. Reducing what runs per PR reverses task-1465;
 raising the ceiling costs money. Both are owner calls, unchanged by this work.
+
+## Update 2026-08-28 — selected mitigation implemented, live proof pending
+
+The owner selected the repository-side capacity controls. The implementation is
+on `codex/task-22250-ci-queue-pressure` and intentionally leaves the two live
+verdict criteria open until GitHub Actions demonstrates them on a PR.
+
+- `Tests` now admits at most three core shards and three UI shards at once. The
+  test coverage and shard count are unchanged; the matrix runs in waves so one
+  PR cannot request the whole measured ubuntu pool.
+- The permanent draft promotion PR (`dev` to `main`, currently #602) reports
+  skipped runner jobs while it is a draft. A `ready_for_review` activity trigger
+  guarantees that marking it ready starts fresh checks rather than relying on a
+  later commit.
+- The two TASK-2062 GGUF evidence workflows retain manual dispatch and their
+  exact three-OS evidence, but PR runs are limited to their owned production and
+  test paths.
+- `Tests`, Derived Artifacts, CSS Bundle Guard, Perf Guard, and Backlog Guard now
+  cancel only superseded push runs. Pull-request runs are never blanket-cancelled.
+- The stale derived-artifacts contract was repaired to include the already
+  existing `scripts/check_index_plan_pins.py` sixth checker.
+
+Queue cleanup used open-PR head SHAs plus current `dev`/`main` SHAs as the
+authority boundary:
+
+- `tldw_chatbook`: 228 queued records audited; 2 current `dev` runs preserved,
+  8 obsolete `Tests` runs preserved because they already had executing jobs, and
+  204 idle obsolete runs cancelled. This included PR #602's duplicate Perf Guard
+  run. Fourteen three-day-old records remain as GitHub ghost entries: they have
+  zero jobs, report `status=queued`, and both normal and force-cancel endpoints
+  return HTTP 409 (`not been queued yet`). They consume no runner slots.
+- `tldw_server`: 62 queued records audited; 54 current open-PR runs preserved.
+  Eight three-day-old zero-job ghost entries returned the same HTTP 409 from
+  both cancellation endpoints and were left in place rather than deleting run
+  history.
+
+The preserved current Derived Artifacts ubuntu job (run `33234414802`) remained
+queued after the drain because the eight obsolete `Tests` runs still had jobs in
+progress. No live completion or `Tests` verdict is claimed from that probe.
+
+Verification:
+
+- 38 focused CI workflow-contract tests passed.
+- Ruff check and format check passed for the five targeted CI test modules.
+- All seven changed workflow files parsed as YAML, and `git diff --check` passed.
+- The full suite was not run; repository policy calls for targeted verification
+  unless the owner explicitly requests a full sweep.
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: the change is operational CI scheduling and trigger policy, not a
+long-lived application architecture boundary.


### PR DESCRIPTION
## Summary

- Cap the core and UI shard matrices at three concurrent jobs each without reducing test coverage.
- Skip runner-consuming checks for the permanent draft dev-to-main promotion PR, while triggering fresh checks when it becomes ready for review.
- Limit the two TASK-2062 GGUF evidence workflows to their owned production and test paths while preserving manual dispatch and the three-OS matrix.
- Restrict cancellation in Tests, Derived Artifacts, CSS Bundle Guard, Perf Guard, and Backlog Guard to superseded push runs so pull-request runs can finish.
- Update the derived-artifacts contract for the existing sixth checker.

## Root cause

One Tests run fans out to 25 jobs against an observed account ceiling of roughly 12 concurrent Ubuntu jobs. Multiple active runs saturated the shared queue, starved short required checks, and interacted with blanket cancellation policies to prevent reliable verdicts.

## Verification

- 38 focused CI workflow-contract tests passed.
- Ruff check and format check passed for the five changed CI test modules.
- All seven changed workflow files parsed successfully as YAML.
- `git diff --check origin/dev...HEAD` passed.
- The full suite was not run; repository policy requests targeted verification unless a full sweep is explicitly requested.

## Live proof

Task 22250 remains In Progress until GitHub Actions demonstrates that a PR run completes and Tests produces a verdict.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds CI fan-out so simultaneous runs no longer saturate the shared runner pool and cancel each other mid-run.

- Caps `Tests` core and UI shard matrices at three concurrent jobs each; total coverage and shard counts are unchanged.
- Skips runner-consuming jobs on the permanent draft `dev`-to-`main` promotion PR, retriggering them when the PR is marked ready for review.
- Restricts the two TASK-2062 GGUF evidence workflows to their owned paths while keeping manual dispatch and the three-OS matrix.
- Limits `cancel-in-progress` to superseded push runs so pull-request runs always finish.
- Repairs the derived-artifacts contract to include the existing sixth checker.

<sup>Written for commit 89fd8d4bfee78ea733f50d6f01e90daddf0ce7f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

